### PR TITLE
fix(update): Accept 'force' without dashes as alias for --force

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1279,7 +1279,7 @@ nftban_cmd_update() {
             local version_arg=""
             while [[ $# -gt 0 ]]; do
                 case "$1" in
-                    --force|-f) _NFTBAN_UPDATE_FORCE=1; shift ;;
+                    --force|-f|force) _NFTBAN_UPDATE_FORCE=1; shift ;;
                     -*) shift ;;  # Skip unknown flags
                     *) version_arg="$1"; shift ;;
                 esac
@@ -1291,7 +1291,7 @@ nftban_cmd_update() {
             local branch_arg=""
             while [[ $# -gt 0 ]]; do
                 case "$1" in
-                    --force|-f) _NFTBAN_UPDATE_FORCE=1; shift ;;
+                    --force|-f|force) _NFTBAN_UPDATE_FORCE=1; shift ;;
                     -*) shift ;;
                     *) branch_arg="$1"; shift ;;
                 esac
@@ -1303,7 +1303,7 @@ nftban_cmd_update() {
             local path_arg=""
             while [[ $# -gt 0 ]]; do
                 case "$1" in
-                    --force|-f) _NFTBAN_UPDATE_FORCE=1; shift ;;
+                    --force|-f|force) _NFTBAN_UPDATE_FORCE=1; shift ;;
                     -*) shift ;;
                     *) path_arg="$1"; shift ;;
                 esac


### PR DESCRIPTION
## Summary
- 'nftban update github force' was treating 'force' as version tag
- Now 'force' is accepted as alias for '--force' in github/git/local update methods

## Test
```bash
nftban update github force   # Works now
nftban update github --force # Still works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)