### PR TITLE
fix: Prevent install lockout and fix CSF detection

### DIFF
--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -128,13 +128,25 @@ nftban_health_cmd_conflicts() {
         echo "│  ✓ ufw           not installed                            │"
     fi
 
-    # CSF
-    if [[ -f /etc/csf/csf.conf ]] && grep -q "^TESTING = \"0\"" /etc/csf/csf.conf 2>/dev/null; then
-        echo "│  ✗ CSF           ACTIVE (production mode)                 │"
+    # CSF - Check BOTH service status AND config file
+    # Root cause fix: Previously only checked config, not service state
+    # CSF can be disabled (csf -x) but config still has TESTING="0"
+    local csf_service_active=false
+    if systemctl is-active --quiet lfd 2>/dev/null; then
+        csf_service_active=true
+    elif command -v csf &>/dev/null && csf -s 2>&1 | grep -q "csf is enabled"; then
+        csf_service_active=true
+    fi
+
+    if [[ "$csf_service_active" == "true" ]] && [[ -f /etc/csf/csf.conf ]]; then
+        if grep -q "^TESTING = \"0\"" /etc/csf/csf.conf 2>/dev/null; then
+            echo "│  ✗ CSF           ACTIVE (production mode)                 │"
+        else
+            echo "│  ✗ CSF           ACTIVE (testing mode)                    │"
+        fi
         has_conflicts=true
     elif [[ -f /etc/csf/csf.conf ]]; then
-        echo "│  ⚠ CSF           installed (testing mode)                 │"
-        has_conflicts=true
+        echo "│  ✓ CSF           disabled (no conflict)                   │"
     else
         echo "│  ✓ CSF           not installed                            │"
     fi

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -848,15 +848,9 @@ if [ -f /usr/lib/nftban/lib/nftban_distro_config.sh ]; then
     fi
 fi
 
-# Load nftables configuration
-if systemctl is-active nftables >/dev/null 2>&1; then
-    systemctl reload nftables 2>/dev/null || echo "[NFTBan WARN] nftables reload failed"
-else
-    systemctl enable nftables 2>/dev/null || true
-    systemctl start nftables 2>/dev/null || echo "[NFTBan WARN] nftables start failed"
-fi
-
-# STEP 10: Sync whitelist.d files to nftables sets
+# STEP 10: Sync whitelist.d files to nftables sets BEFORE starting nftables
+# ROOT CAUSE FIX: Previously nftables started with DROP policy BEFORE whitelist
+# sync, causing SSH lockout. Now we sync FIRST, then start nftables.
 # The nftables template has only default IPs, this loads the actual detected system IPs
 echo "[NFTBan] Syncing whitelist files to nftables..."
 # Wait for nftband daemon to be ready (socket activation)
@@ -872,6 +866,15 @@ for i in 1 2 3; do
 done
 if [ "\$SYNC_SUCCESS" -eq 0 ]; then
     echo "[NFTBan WARN] Whitelist sync failed (run manually: nftban sync)"
+fi
+
+# STEP 11: Load nftables configuration AFTER whitelist is synced
+# This ensures DROP policy only takes effect when SSH whitelist is in place
+if systemctl is-active nftables >/dev/null 2>&1; then
+    systemctl reload nftables 2>/dev/null || echo "[NFTBan WARN] nftables reload failed"
+else
+    systemctl enable nftables 2>/dev/null || true
+    systemctl start nftables 2>/dev/null || echo "[NFTBan WARN] nftables start failed"
 fi
 
 echo "[NFTBan] Installation complete. Your IP has been auto-whitelisted."

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -469,27 +469,11 @@ case "$1" in
         log_info "Reloading systemd daemon..."
         systemctl daemon-reload
 
-        # Enable and start nftables
-        if systemctl is-active nftables >/dev/null 2>&1; then
-            log_info "Reloading nftables..."
-            systemctl reload nftables 2>/dev/null || log_warn "nftables reload failed"
-        else
-            log_info "Enabling and starting nftables..."
-            systemctl enable nftables 2>/dev/null || true
-            systemctl start nftables 2>/dev/null || log_warn "nftables start failed"
-        fi
-
         # =====================================================================
-        # STEP 10: GeoIP Database (defer to background/first run)
+        # STEP 10: Sync whitelist.d files to nftables sets BEFORE nftables starts
         # =====================================================================
-        # GeoIP download can take 10-30 seconds depending on network
-        # Defer to maintenance timer for faster install
-        log_info "GeoIP database will be downloaded on first maintenance run"
-        log_info "  Manual download: nftban geoip update"
-
-        # =====================================================================
-        # STEP 11: Sync whitelist.d files to nftables sets
-        # =====================================================================
+        # ROOT CAUSE FIX: Previously nftables started with DROP policy BEFORE
+        # whitelist sync, causing SSH lockout. Now we sync FIRST.
         # The nftables template has only default IPs, this loads the actual detected system IPs
         # Use --quick to only sync whitelists/blacklists (skip feeds/geoban for fast install)
         log_info "Syncing whitelist files to nftables..."
@@ -503,7 +487,28 @@ case "$1" in
         fi
 
         # =====================================================================
-        # STEP 12: Enable Login Monitoring (Default Protection)
+        # STEP 11: Enable and start nftables AFTER whitelist is synced
+        # =====================================================================
+        # This ensures DROP policy only takes effect when SSH whitelist is in place
+        if systemctl is-active nftables >/dev/null 2>&1; then
+            log_info "Reloading nftables..."
+            systemctl reload nftables 2>/dev/null || log_warn "nftables reload failed"
+        else
+            log_info "Enabling and starting nftables..."
+            systemctl enable nftables 2>/dev/null || true
+            systemctl start nftables 2>/dev/null || log_warn "nftables start failed"
+        fi
+
+        # =====================================================================
+        # STEP 12: GeoIP Database (defer to background/first run)
+        # =====================================================================
+        # GeoIP download can take 10-30 seconds depending on network
+        # Defer to maintenance timer for faster install
+        log_info "GeoIP database will be downloaded on first maintenance run"
+        log_info "  Manual download: nftban geoip update"
+
+        # =====================================================================
+        # STEP 13: Enable Login Monitoring (Default Protection)
         # =====================================================================
         log_info "Enabling login monitoring (SSH/FTP brute-force protection)..."
         if command -v nftban >/dev/null 2>&1; then
@@ -515,7 +520,7 @@ case "$1" in
         fi
 
         # =====================================================================
-        # STEP 13: Set immutable flags on security-critical files
+        # STEP 14: Set immutable flags on security-critical files
         # =====================================================================
         log_info "Setting immutable flags on security files..."
         for immutable_file in /etc/nftban/nftban.conf /usr/lib/nftban/lib/nft_schema.sh; do


### PR DESCRIPTION
## Summary

Critical fixes for two bugs discovered during lab server deployment:

- **Install lockout (lab4)**: SSH lockout during package installation
- **CSF false positive (lab3)**: CSF reported as ACTIVE when disabled

## Root Cause Analysis

### Bug 1: Install SSH Lockout

| Stage | Before (Buggy) | After (Fixed) |
|-------|----------------|---------------|
| 1 | nftables start (DROP policy) | Whitelist sync (populate sets) |
| 2 | SSH blocked immediately | nftables start (DROP policy) |
| 3 | Whitelist sync never runs | SSH allowed via whitelist |
| Result | **LOCKOUT** | **SAFE** |

### Bug 2: CSF False Positive Detection

| Check | Before | After |
|-------|--------|-------|
| Config exists | ✓ | ✓ |
| TESTING="0" | ✓ | ✓ |
| Service running | ✗ NOT CHECKED | ✓ Required |

## Test Plan

- [ ] Fresh RPM install on clean AlmaLinux 9
- [ ] Fresh DEB install on clean Debian 12
- [ ] Verify SSH remains accessible after install
- [ ] Verify CSF conflict clears after `csf -x`
- [ ] Run `nftban health` shows no false positives

## Files Changed

- `packaging/build_nftban.sh` - RPM %post step reorder
- `packaging/deb/postinst` - DEB postinst step reorder
- `cli/lib/nftban/cli/cmd_health_analysis.sh` - CSF service check

🤖 Generated with [Claude Code](https://claude.com/claude-code)