### PR TITLE
fix: v1.17.1 - CRITICAL: Persist SKIP_DROP_CHAINS to prevent cPanel lockout

### DIFF
--- a/cli/lib/nftban/core/nftban_health_fixes.sh
+++ b/cli/lib/nftban/core/nftban_health_fixes.sh
@@ -40,6 +40,14 @@ _NFTBAN_HEALTH_FIXES_LOADED=1
 
 # Default paths (for direct sourcing compatibility)
 : "${NFTBAN_LIB_DIR:=/usr/lib/nftban}"
+: "${NFTBAN_CONFIG_DIR:=/etc/nftban}"
+
+# Load firewall config if exists (CRITICAL: SKIP_DROP_CHAINS for cPanel/panel servers)
+# v1.17.0: This prevents lockout on panel servers by respecting coexist mode
+if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/firewall.conf" ]]; then
+    # shellcheck source=/dev/null
+    source "${NFTBAN_CONFIG_DIR}/conf.d/firewall.conf"
+fi
 
 # AUTO-FIX FUNCTIONS
 # =============================================================================

--- a/cli/lib/nftban/core/nftban_sync.sh
+++ b/cli/lib/nftban/core/nftban_sync.sh
@@ -76,6 +76,15 @@ nftban_sync_full() {
         dry_run="--dry-run"
     fi
 
+    # Load firewall config for SKIP_DROP_CHAINS (v1.17.0: cPanel lockout prevention)
+    local firewall_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/firewall.conf"
+    if [[ -f "$firewall_conf" ]]; then
+        # shellcheck source=/dev/null
+        source "$firewall_conf"
+        export SKIP_DROP_CHAINS="${SKIP_DROP_CHAINS:-false}"
+        export FIREWALL_MODE="${FIREWALL_MODE:-standalone}"
+    fi
+
     # Check if Go binary exists
     if [[ ! -x "$NFTBAN_CORE_BIN" ]]; then
         nftban_output "error" "nftban-core binary not found: $NFTBAN_CORE_BIN"

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -803,6 +803,22 @@ export NFTBAN_CPANEL_MODE=\$CPANEL_MODE
 if [ \$SKIP_DROP_CHAINS -eq 1 ]; then
     echo "[NFTBan WARN] Safety mode: Hook chains with DROP policy will NOT be created"
     echo "[NFTBan WARN] NFTBan sets/tables will be created but firewall won't block traffic"
+
+    # CRITICAL v1.17.0: Persist SKIP_DROP_CHAINS to config file
+    # Without this, nftban sync/reboot would recreate DROP chains and lock out server!
+    mkdir -p /etc/nftban/conf.d
+    cat > /etc/nftban/conf.d/firewall.conf << 'FIREWALL_EOF'
+# NFTBan Firewall Configuration
+# Auto-generated during install - DO NOT EDIT unless you know what you're doing
+#
+# SKIP_DROP_CHAINS=true prevents NFTBan from creating chains with DROP policy
+# This is required for cPanel/Plesk/DirectAdmin servers where panel manages firewall
+
+SKIP_DROP_CHAINS=true
+FIREWALL_MODE=coexist
+FIREWALL_EOF
+    chmod 0644 /etc/nftban/conf.d/firewall.conf
+    echo "[NFTBan]   Created /etc/nftban/conf.d/firewall.conf with SKIP_DROP_CHAINS=true"
 fi
 
 # =============================================================================

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -192,6 +192,22 @@ case "$1" in
         if [[ $SKIP_DROP_CHAINS -eq 1 ]]; then
             log_warn "Safety mode: Hook chains with DROP policy will NOT be created"
             log_warn "NFTBan sets/tables will be created but firewall won't block traffic"
+
+            # CRITICAL v1.17.0: Persist SKIP_DROP_CHAINS to config file
+            # Without this, nftban sync/reboot would recreate DROP chains and lock out server!
+            mkdir -p /etc/nftban/conf.d
+            cat > /etc/nftban/conf.d/firewall.conf << 'FIREWALL_EOF'
+# NFTBan Firewall Configuration
+# Auto-generated during install - DO NOT EDIT unless you know what you're doing
+#
+# SKIP_DROP_CHAINS=true prevents NFTBan from creating chains with DROP policy
+# This is required for cPanel/Plesk/DirectAdmin servers where panel manages firewall
+
+SKIP_DROP_CHAINS=true
+FIREWALL_MODE=coexist
+FIREWALL_EOF
+            chmod 0644 /etc/nftban/conf.d/firewall.conf
+            log_info "Created /etc/nftban/conf.d/firewall.conf with SKIP_DROP_CHAINS=true"
         fi
 
         # =====================================================================


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX** - cPanel servers were getting locked out after v1.17.0 update.

### Root Cause
`SKIP_DROP_CHAINS=1` was set during install but **NEVER persisted** to config file. After reboot or `nftban sync`, `nftban-core` created DROP policy chains without accept rules, causing SSH lockout.

### Evidence (lab4.example.test)
```nft
chain input {
    type filter hook input priority -100; policy drop;
    # NO ACCEPT RULES - just drops everything!
}
```

### Fix
1. **RPM/DEB postinst**: Create `/etc/nftban/conf.d/firewall.conf` with `SKIP_DROP_CHAINS=true`
2. **nftban_sync.sh**: Load firewall.conf before calling nftban-core
3. **nftban_health_fixes.sh**: Load firewall.conf at startup

### Also Included
- BUG-004: ACL conditional for EL10/Fedora only (not EL9)
- BUG-005: Queue timer added to package install
- BUG-006: Polkit added to DEB Recommends

## Test plan
- [ ] Install on cPanel server (lab4)
- [ ] Verify `/etc/nftban/conf.d/firewall.conf` created with `SKIP_DROP_CHAINS=true`
- [ ] Run `nftban sync` - should NOT create DROP chains
- [ ] Reboot - should NOT lock out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
