### PR TITLE
feat: Add --takeover flag to auto-disable conflicting firewalls

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -748,50 +748,123 @@ echo "[NFTBan] Obsolete file cleanup complete"
 # =============================================================================
 echo "[NFTBan] Checking for conflicting firewalls..."
 
-CONFLICT=""
+CONFLICTS=""
 
 # Check CSF (ConfigServer Firewall)
 if systemctl is-active csf.service &>/dev/null 2>&1 || [[ -f /etc/csf/csf.conf ]]; then
-    CONFLICT="CSF (ConfigServer Firewall)"
+    CONFLICTS="\${CONFLICTS}CSF "
 fi
 
 # Check cPHulk (cPanel brute force)
 if systemctl is-active cphulkd.service &>/dev/null 2>&1; then
-    CONFLICT="cPHulk (cPanel brute force protection)"
+    CONFLICTS="\${CONFLICTS}cPHulk "
 fi
 
 # Check UFW
 if systemctl is-active ufw.service &>/dev/null 2>&1; then
-    CONFLICT="UFW (Uncomplicated Firewall)"
+    CONFLICTS="\${CONFLICTS}UFW "
 fi
 
 # Check firewalld
 if systemctl is-active firewalld.service &>/dev/null 2>&1; then
-    CONFLICT="firewalld"
+    CONFLICTS="\${CONFLICTS}firewalld "
 fi
 
-# Abort if conflict found
-if [[ -n "\$CONFLICT" ]]; then
-    echo ""
-    echo "[NFTBan ERROR] =========================================="
-    echo "[NFTBan ERROR]  CONFLICTING FIREWALL DETECTED"
-    echo "[NFTBan ERROR] =========================================="
-    echo "[NFTBan ERROR] Found: \$CONFLICT"
-    echo ""
-    echo "[NFTBan ERROR] NFTBan requires exclusive firewall control."
-    echo "[NFTBan ERROR] You cannot run two firewalls simultaneously."
-    echo ""
-    echo "[NFTBan ERROR] To use NFTBan, first remove the conflict:"
-    echo "[NFTBan ERROR]   - CSF: csf -x && yum remove csf lfd"
-    echo "[NFTBan ERROR]   - cPHulk: whmapi1 configureservice service=cphulkd enabled=0"
-    echo "[NFTBan ERROR]   - UFW: ufw disable && apt remove ufw"
-    echo "[NFTBan ERROR]   - firewalld: systemctl disable --now firewalld"
-    echo ""
-    echo "[NFTBan ERROR] Then reinstall NFTBan."
-    exit 1
+# Check iptables service
+if systemctl is-active iptables.service &>/dev/null 2>&1; then
+    CONFLICTS="\${CONFLICTS}iptables "
 fi
 
-echo "[NFTBan] No conflicting firewalls found"
+# Handle conflicts
+if [[ -n "\$CONFLICTS" ]]; then
+    echo ""
+    echo "[NFTBan WARN] =========================================="
+    echo "[NFTBan WARN]  CONFLICTING FIREWALLS DETECTED"
+    echo "[NFTBan WARN] =========================================="
+    echo "[NFTBan WARN] Found: \$CONFLICTS"
+    echo ""
+
+    # Check for --takeover flag (env variable set by user)
+    if [[ "\${NFTBAN_TAKEOVER:-0}" == "1" ]]; then
+        echo "[NFTBan] --takeover mode: Disabling conflicting firewalls..."
+        echo ""
+
+        # Disable CSF
+        if [[ "\$CONFLICTS" == *"CSF"* ]]; then
+            echo "[NFTBan]   Disabling CSF..."
+            csf -x 2>/dev/null || true
+            systemctl disable csf lfd 2>/dev/null || true
+            systemctl stop csf lfd 2>/dev/null || true
+            echo "[NFTBan]   ✓ CSF disabled"
+        fi
+
+        # Disable cPHulk
+        if [[ "\$CONFLICTS" == *"cPHulk"* ]]; then
+            echo "[NFTBan]   Disabling cPHulk..."
+            if command -v whmapi1 &>/dev/null; then
+                whmapi1 configureservice service=cphulkd enabled=0 2>/dev/null || true
+            fi
+            systemctl disable cphulkd 2>/dev/null || true
+            systemctl stop cphulkd 2>/dev/null || true
+            echo "[NFTBan]   ✓ cPHulk disabled"
+        fi
+
+        # Disable UFW
+        if [[ "\$CONFLICTS" == *"UFW"* ]]; then
+            echo "[NFTBan]   Disabling UFW..."
+            ufw disable 2>/dev/null || true
+            systemctl disable ufw 2>/dev/null || true
+            systemctl stop ufw 2>/dev/null || true
+            echo "[NFTBan]   ✓ UFW disabled"
+        fi
+
+        # Disable firewalld
+        if [[ "\$CONFLICTS" == *"firewalld"* ]]; then
+            echo "[NFTBan]   Disabling firewalld..."
+            systemctl disable firewalld 2>/dev/null || true
+            systemctl stop firewalld 2>/dev/null || true
+            echo "[NFTBan]   ✓ firewalld disabled"
+        fi
+
+        # Disable iptables service
+        if [[ "\$CONFLICTS" == *"iptables"* ]]; then
+            echo "[NFTBan]   Disabling iptables service..."
+            systemctl disable iptables ip6tables 2>/dev/null || true
+            systemctl stop iptables ip6tables 2>/dev/null || true
+            echo "[NFTBan]   ✓ iptables service disabled"
+        fi
+
+        # Flush any remaining rules
+        echo "[NFTBan]   Flushing legacy rules..."
+        nft flush ruleset 2>/dev/null || true
+        iptables -F 2>/dev/null || true
+        iptables -X 2>/dev/null || true
+        ip6tables -F 2>/dev/null || true
+        ip6tables -X 2>/dev/null || true
+        echo "[NFTBan]   ✓ Legacy rules flushed"
+        echo ""
+        echo "[NFTBan] ✓ All conflicts removed. NFTBan is now THE firewall."
+        echo ""
+    else
+        # No takeover - abort with instructions
+        echo "[NFTBan ERROR] NFTBan requires exclusive firewall control."
+        echo "[NFTBan ERROR] You cannot run two firewalls simultaneously."
+        echo ""
+        echo "[NFTBan ERROR] Options:"
+        echo "[NFTBan ERROR]   1. Auto-takeover: NFTBAN_TAKEOVER=1 dnf install ./nftban-*.rpm"
+        echo "[NFTBan ERROR]   2. Manual removal:"
+        echo "[NFTBan ERROR]      - CSF: csf -x && yum remove csf lfd"
+        echo "[NFTBan ERROR]      - cPHulk: whmapi1 configureservice service=cphulkd enabled=0"
+        echo "[NFTBan ERROR]      - UFW: ufw disable && apt remove ufw"
+        echo "[NFTBan ERROR]      - firewalld: systemctl disable --now firewalld"
+        echo "[NFTBan ERROR]      - iptables: systemctl disable --now iptables"
+        echo ""
+        echo "[NFTBan ERROR] Then reinstall NFTBan."
+        exit 1
+    fi
+else
+    echo "[NFTBan] No conflicting firewalls found"
+fi
 echo "[NFTBan] Configuring NFTBan v%{version}..."
 
 # STEP 1: Remove old systemd overrides (prevent conflicts with new package files)

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -144,50 +144,123 @@ case "$1" in
         log_info "Checking for conflicting firewalls..."
 
         NFTABLES_SAFE=1
-        CONFLICT=""
+        CONFLICTS=""
 
         # Check CSF (ConfigServer Firewall)
         if systemctl is-active csf.service &>/dev/null 2>&1 || [[ -f /etc/csf/csf.conf ]]; then
-            CONFLICT="CSF (ConfigServer Firewall)"
+            CONFLICTS="${CONFLICTS}CSF "
         fi
 
         # Check cPHulk (cPanel brute force)
         if systemctl is-active cphulkd.service &>/dev/null 2>&1; then
-            CONFLICT="cPHulk (cPanel brute force protection)"
+            CONFLICTS="${CONFLICTS}cPHulk "
         fi
 
         # Check UFW
         if systemctl is-active ufw.service &>/dev/null 2>&1; then
-            CONFLICT="UFW (Uncomplicated Firewall)"
+            CONFLICTS="${CONFLICTS}UFW "
         fi
 
         # Check firewalld
         if systemctl is-active firewalld.service &>/dev/null 2>&1; then
-            CONFLICT="firewalld"
+            CONFLICTS="${CONFLICTS}firewalld "
         fi
 
-        # Abort if conflict found
-        if [[ -n "$CONFLICT" ]]; then
-            log_error ""
-            log_error "=========================================="
-            log_error " CONFLICTING FIREWALL DETECTED"
-            log_error "=========================================="
-            log_error "Found: $CONFLICT"
-            log_error ""
-            log_error "NFTBan requires exclusive firewall control."
-            log_error "You cannot run two firewalls simultaneously."
-            log_error ""
-            log_error "To use NFTBan, first remove the conflict:"
-            log_error "  - CSF: csf -x && apt remove csf lfd"
-            log_error "  - cPHulk: whmapi1 configureservice service=cphulkd enabled=0"
-            log_error "  - UFW: ufw disable && apt remove ufw"
-            log_error "  - firewalld: systemctl disable --now firewalld"
-            log_error ""
-            log_error "Then reinstall NFTBan."
-            exit 1
+        # Check iptables service
+        if systemctl is-active iptables.service &>/dev/null 2>&1; then
+            CONFLICTS="${CONFLICTS}iptables "
         fi
 
-        log_info "No conflicting firewalls found"
+        # Handle conflicts
+        if [[ -n "$CONFLICTS" ]]; then
+            log_warn ""
+            log_warn "=========================================="
+            log_warn " CONFLICTING FIREWALLS DETECTED"
+            log_warn "=========================================="
+            log_warn "Found: $CONFLICTS"
+            log_warn ""
+
+            # Check for --takeover flag (env variable set by user)
+            if [[ "${NFTBAN_TAKEOVER:-0}" == "1" ]]; then
+                log_info "--takeover mode: Disabling conflicting firewalls..."
+                log_info ""
+
+                # Disable CSF
+                if [[ "$CONFLICTS" == *"CSF"* ]]; then
+                    log_info "  Disabling CSF..."
+                    csf -x 2>/dev/null || true
+                    systemctl disable csf lfd 2>/dev/null || true
+                    systemctl stop csf lfd 2>/dev/null || true
+                    log_info "  ✓ CSF disabled"
+                fi
+
+                # Disable cPHulk
+                if [[ "$CONFLICTS" == *"cPHulk"* ]]; then
+                    log_info "  Disabling cPHulk..."
+                    if command -v whmapi1 &>/dev/null; then
+                        whmapi1 configureservice service=cphulkd enabled=0 2>/dev/null || true
+                    fi
+                    systemctl disable cphulkd 2>/dev/null || true
+                    systemctl stop cphulkd 2>/dev/null || true
+                    log_info "  ✓ cPHulk disabled"
+                fi
+
+                # Disable UFW
+                if [[ "$CONFLICTS" == *"UFW"* ]]; then
+                    log_info "  Disabling UFW..."
+                    ufw disable 2>/dev/null || true
+                    systemctl disable ufw 2>/dev/null || true
+                    systemctl stop ufw 2>/dev/null || true
+                    log_info "  ✓ UFW disabled"
+                fi
+
+                # Disable firewalld
+                if [[ "$CONFLICTS" == *"firewalld"* ]]; then
+                    log_info "  Disabling firewalld..."
+                    systemctl disable firewalld 2>/dev/null || true
+                    systemctl stop firewalld 2>/dev/null || true
+                    log_info "  ✓ firewalld disabled"
+                fi
+
+                # Disable iptables service
+                if [[ "$CONFLICTS" == *"iptables"* ]]; then
+                    log_info "  Disabling iptables service..."
+                    systemctl disable iptables ip6tables 2>/dev/null || true
+                    systemctl stop iptables ip6tables 2>/dev/null || true
+                    log_info "  ✓ iptables service disabled"
+                fi
+
+                # Flush any remaining rules
+                log_info "  Flushing legacy rules..."
+                nft flush ruleset 2>/dev/null || true
+                iptables -F 2>/dev/null || true
+                iptables -X 2>/dev/null || true
+                ip6tables -F 2>/dev/null || true
+                ip6tables -X 2>/dev/null || true
+                log_info "  ✓ Legacy rules flushed"
+                log_info ""
+                log_info "✓ All conflicts removed. NFTBan is now THE firewall."
+                log_info ""
+            else
+                # No takeover - abort with instructions
+                log_error "NFTBan requires exclusive firewall control."
+                log_error "You cannot run two firewalls simultaneously."
+                log_error ""
+                log_error "Options:"
+                log_error "  1. Auto-takeover: NFTBAN_TAKEOVER=1 apt install ./nftban-*.deb"
+                log_error "  2. Manual removal:"
+                log_error "     - CSF: csf -x && apt remove csf lfd"
+                log_error "     - cPHulk: whmapi1 configureservice service=cphulkd enabled=0"
+                log_error "     - UFW: ufw disable && apt remove ufw"
+                log_error "     - firewalld: systemctl disable --now firewalld"
+                log_error "     - iptables: systemctl disable --now iptables"
+                log_error ""
+                log_error "Then reinstall NFTBan."
+                exit 1
+            fi
+        else
+            log_info "No conflicting firewalls found"
+        fi
 
         # =====================================================================
         # STEP 0.5: Link bundled yq v4 (mikefarah/yq) - REQUIRED


### PR DESCRIPTION
## Summary

Adds `NFTBAN_TAKEOVER=1` environment variable to automatically disable all conflicting firewalls during install.

## Usage

```bash
# RPM (Rocky/Alma/RHEL)
NFTBAN_TAKEOVER=1 dnf install ./nftban-*.rpm

# DEB (Ubuntu/Debian)
NFTBAN_TAKEOVER=1 apt install ./nftban-*.deb
```

## What it handles

| Firewall | Action |
|----------|--------|
| CSF | `csf -x`, disable service |
| cPHulk | `whmapi1 disable`, stop service |
| UFW | `ufw disable`, stop service |
| firewalld | disable and stop |
| iptables service | disable and stop |
| Legacy rules | `nft flush ruleset`, `iptables -F` |

## Behavior

- **Without --takeover**: Shows clear error with manual removal instructions
- **With --takeover**: Auto-disables all conflicts and continues install

## Test plan

- [ ] Install with UFW active + NFTBAN_TAKEOVER=1 - should disable UFW
- [ ] Install with firewalld active + NFTBAN_TAKEOVER=1 - should disable firewalld
- [ ] Install with CSF active + NFTBAN_TAKEOVER=1 - should disable CSF
- [ ] Install without flag on conflicting system - should abort with instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)