### PR TITLE
fix: Autoheal removes inet filter table (CVE-2025-NFTBAN-001)

### DIFF
--- a/cli/lib/nftban/helpers/autoheal.sh
+++ b/cli/lib/nftban/helpers/autoheal.sh
@@ -389,8 +389,9 @@ fi
 # These interfere with NFTBan and cause schema corruption
 log_info "Checking for rogue nftables tables..."
 
-# Allowed tables (NFTBan + system default)
-ALLOWED_TABLES_PATTERN="^table (ip|ip6) nftban$|^table inet (filter|nftban)$"
+# Allowed tables (v1.18.0: ONLY ip/ip6 nftban - NO inet tables!)
+# CVE-2025-NFTBAN-001: inet filter at priority 0 bypasses NFTBan protection
+ALLOWED_TABLES_PATTERN="^table (ip|ip6) nftban$"
 
 # Get all tables
 ALL_TABLES=$(nft list tables 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Autoheal now correctly removes `inet filter` table
- CVE-2025-NFTBAN-001: `inet filter` at priority 0 bypasses NFTBan protection

## Changes
- `autoheal.sh`: Removed `inet filter` and `inet nftban` from allowed tables pattern
- Only `ip nftban` and `ip6 nftban` are now allowed

## Security Impact
**CRITICAL**: `inet filter` table with `policy accept` at priority 0 allows ALL banned IPs to connect, completely bypassing NFTBan blocking.

## Test Plan
- [x] Verified on lab.example.test after manual fix
- [x] Schema validation passes after inet filter removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
