### PR TITLE
fix: escape $1 in RPM spec heredoc — unbound variable broke RPM builds

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1538,7 +1538,7 @@ done
 %systemd_postun_with_restart nftband.service nftban-maintenance.service nftban-health.service nftban-health-fix.service nftban-watchdog.service nftban-login-monitor.service nftban-core-geoip.service nftban-core-feeds.service nftban-unified-exporter.service nftban-queue.service nftban-rbl-check.service nftban-rollback.service nftban-snapshot.service nftban-suricata-update.service nftban-suricata.service nftban-suricata-stats.service nftban-pro-inventory.service nftban-pro-license.service nftban-update.service nftban-api.service nftban-firewall-init.service nftban-ui.service nftban-ui-auth.service
 
 # =============================================================================
-# Complete removal ($1 -eq 0) — FULL CLEANUP
+# Complete removal (\$1 -eq 0) — FULL CLEANUP
 # Must match DEB postrm purge section
 # =============================================================================
 if [ \$1 -eq 0 ]; then


### PR DESCRIPTION
## Summary
- The comment `# Complete removal ($1 -eq 0)` in the unquoted `<<EOF` heredoc was expanded by bash
- With `set -u` (nounset), `$1` is unbound → build fails with `$1: unbound variable`
- This broke **all RPM package builds** in CI (el9 + el10)
- Fix: escape as `\$1` in the comment

## Root cause
RPM spec heredocs use `<<EOF` (unquoted) so `${PKG_VERSION}` etc. get expanded at spec-creation time. But RPM scriptlet `$1` arguments and even comments containing `$1` also get expanded by bash, causing failures under `set -u`.

## Test plan
- [x] RPM build should now produce artifacts at `dist/packages/*.rpm`
- [x] RPM install tests (centos-stream9, rocky9, alma9, el10) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)