### PR TITLE
fix(ci): RPM macro escaping + binary detection fix

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -247,6 +247,15 @@ create_rpm_spec_nftban_core() {
 %global debug_package %{nil}
 %global _missing_build_ids_terminate_build 0
 
+# CRITICAL: Disable ALL post-build processing that modifies binaries
+# Pre-built Go binaries must remain UNCHANGED for hash verification
+# Without this, rpmbuild adds .note.gnu.build-id sections (+~300 bytes)
+%define _build_id_links none
+%define __brp_strip %{nil}
+%define __brp_strip_static_archive %{nil}
+%define __brp_strip_comment_note %{nil}
+%define __os_install_post %{nil}
+
 Name:           nftban-core
 Version:        ${PKG_VERSION}
 Release:        ${PKG_RELEASE}%{?dist}


### PR DESCRIPTION
## Summary
Three fixes for RPM build issues:
1. **RPM Macro Fix**: Escape `%systemd_post` → `%%systemd_post` in spec comments to prevent RPM from interpreting them as macro calls
2. **Binary Detection Fix**: Use `-f` (file exists) instead of `-x` (executable) for pre-built binary detection, as Docker volume mounts can lose executable permissions
3. **Binary Hash Preservation**: Disable RPM post-build processing (`__brp_*` macros) that was adding `.note.gnu.build-id` sections to binaries

## Problem
1. RPM builds failed with `Unknown option e in systemd_post()` because `%systemd_post` in comments was being interpreted as a macro call
2. Binary consistency check failed because `build_nftban.sh` was incorrectly rebuilding binaries — the `-x` check failed due to Docker volume permission handling
3. Binary consistency check STILL failed because rpmbuild was modifying pre-built binaries by adding build-id sections (+316 bytes), changing their SHA256 hashes

## Root Cause Analysis
The DEB packages passed consistency checks while RPM failed:
- Source nftband: 10363172 bytes, hash `15bd50da...`
- RPM nftband: 10363488 bytes (+316), hash `60dd6908...` ← Modified!
- DEB nftband: 10363172 bytes, hash `15bd50da...` ← Unchanged

The ~300 byte difference was caused by RPM's `brp-strip` processing adding `.note.gnu.build-id` sections.

## Changes
### `packaging/build_nftban.sh`
- Lines 66, 168: Changed `-x` to `-f` for binary detection
- Added explicit `chmod +x` after detection
- Added debug logging (bin/ contents, SHA256 hashes)
- Validate binaries are valid ELF before using
- Fixed 4 RPM macro escaping issues in spec heredoc comments
- Added macros to disable RPM post-build processing:
  - `%define _build_id_links none`
  - `%define __brp_strip %{nil}`
  - `%define __brp_strip_static_archive %{nil}`
  - `%define __brp_strip_comment_note %{nil}`
  - `%define __os_install_post %{nil}`

## Test Plan
- [ ] PR checks pass (build, lint)
- [ ] RPM binary hashes match source hashes
- [ ] DEB binary hashes match source hashes
- [ ] All 6 packages (2 RPM + 4 DEB) pass consistency check

🤖 Generated with [Claude Code](https://claude.com/claude-code)