### PR TITLE
fix(ci): add checkout step to release verify job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -650,6 +650,14 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+      # Checkout required for gh CLI to know the repository context
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            VERSION
+          sparse-checkout-cone-mode: false
+
       - name: Wait for release to be available
         run: sleep 30  # GitHub needs time to make assets available
 


### PR DESCRIPTION
## Summary
Fix verify-release job failing with "fatal: not a git repository"

## Problem
The verify-release job in release.yml was failing because `gh release download` needs git context to know which repository to use. Without a checkout step, the job runs in an empty directory.

## Fix
Added sparse checkout step (only VERSION file) before the verify commands. This provides git context with minimal overhead.

## Error Fixed
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)