### PR TITLE
v1.19.30: HTTP/HTTPS CT differentiation + rate meters

### DIFF
--- a/cli/lib/nftban/lib/nft_fragment.sh
+++ b/cli/lib/nftban/lib/nft_fragment.sh
@@ -885,10 +885,18 @@ nft_fragment_render_ddos_classic() {
     local https_limit="${DDOS_CLASSIC_HTTPS_CONN_LIMIT:-100}"
     local smtp_limit="${DDOS_CLASSIC_SMTP_CONN_LIMIT:-20}"
 
+    # HTTP new connection rate limits (per source IP)
+    local http_new_rate="${DDOS_CLASSIC_HTTP_NEW_RATE:-50/second}"
+    local http_new_burst="${DDOS_CLASSIC_HTTP_NEW_BURST:-100}"
+    local https_new_rate="${DDOS_CLASSIC_HTTPS_NEW_RATE:-50/second}"
+    local https_new_burst="${DDOS_CLASSIC_HTTPS_NEW_BURST:-100}"
+
     # Meter names
     local syn_meter="${DDOS_CLASSIC_SYN_METER:-ddos_syn_flood}"
     local icmp_meter="${DDOS_CLASSIC_ICMP_METER:-ddos_icmp_flood}"
     local udp_meter="${DDOS_CLASSIC_UDP_METER:-ddos_udp_flood}"
+    local http_meter="${DDOS_CLASSIC_HTTP_METER:-ddos_http_rate}"
+    local https_meter="${DDOS_CLASSIC_HTTPS_METER:-ddos_https_rate}"
 
     nft_fragment_init || return 1
 
@@ -906,7 +914,8 @@ nft_fragment_render_ddos_classic() {
 # Thresholds:
 #   SYN Rate: ${syn_rate} burst ${syn_burst}
 #   SSH Conn: max ${ssh_limit}/IP
-#   HTTP Conn: max ${http_limit}/IP
+#   HTTP Conn: max ${http_limit}/IP, New rate: ${http_new_rate} burst ${http_new_burst}
+#   HTTPS Conn: max ${https_limit}/IP, New rate: ${https_new_rate} burst ${https_new_burst}
 #   ICMP Rate: ${icmp_rate} burst ${icmp_burst}
 #   UDP Rate: ${udp_rate} burst ${udp_burst}
 
@@ -923,6 +932,12 @@ add rule ${table_ipv4} ${chain} tcp dport 22 ct state new ct count over ${ssh_li
 add rule ${table_ipv4} ${chain} tcp dport 80 ct state new ct count over ${http_limit} counter drop comment "HTTP: max ${http_limit} conn/IP"
 add rule ${table_ipv4} ${chain} tcp dport 443 ct state new ct count over ${https_limit} counter drop comment "HTTPS: max ${https_limit} conn/IP"
 add rule ${table_ipv4} ${chain} tcp dport 25 ct state new ct count over ${smtp_limit} counter drop comment "SMTP: max ${smtp_limit} conn/IP"
+
+# HTTP/HTTPS New Connection Rate Limiting (per source IP)
+add rule ${table_ipv4} ${chain} tcp dport 80 ct state new meter ${http_meter} { ip saddr limit rate ${http_new_rate} burst ${http_new_burst} packets } return comment "HTTP: new rate OK"
+add rule ${table_ipv4} ${chain} tcp dport 80 ct state new counter drop comment "HTTP: new rate exceeded"
+add rule ${table_ipv4} ${chain} tcp dport 443 ct state new meter ${https_meter} { ip saddr limit rate ${https_new_rate} burst ${https_new_burst} packets } return comment "HTTPS: new rate OK"
+add rule ${table_ipv4} ${chain} tcp dport 443 ct state new counter drop comment "HTTPS: new rate exceeded"
 
 # ICMP Rate Limiting
 add rule ${table_ipv4} ${chain} ip protocol icmp meter ${icmp_meter} { ip saddr limit rate ${icmp_rate} burst ${icmp_burst} packets } return comment "ICMP: rate OK"
@@ -943,9 +958,16 @@ flush chain ${table_ipv6} ${chain}
 add rule ${table_ipv6} ${chain} tcp flags syn meter ${syn_meter}6 { ip6 saddr limit rate ${syn_rate} burst ${syn_burst} packets } return comment "SYN: rate OK"
 add rule ${table_ipv6} ${chain} tcp flags syn counter drop comment "SYN flood: rate exceeded"
 
-# Connection Limits
+# Connection Limits per Service
 add rule ${table_ipv6} ${chain} tcp dport 22 ct state new ct count over ${ssh_limit} counter drop comment "SSH: max ${ssh_limit} conn/IP"
-add rule ${table_ipv6} ${chain} tcp dport { 80, 443 } ct state new ct count over ${http_limit} counter drop comment "HTTP(S): max ${http_limit} conn/IP"
+add rule ${table_ipv6} ${chain} tcp dport 80 ct state new ct count over ${http_limit} counter drop comment "HTTP: max ${http_limit} conn/IP"
+add rule ${table_ipv6} ${chain} tcp dport 443 ct state new ct count over ${https_limit} counter drop comment "HTTPS: max ${https_limit} conn/IP"
+
+# HTTP/HTTPS New Connection Rate Limiting (per source IP)
+add rule ${table_ipv6} ${chain} tcp dport 80 ct state new meter ${http_meter}6 { ip6 saddr limit rate ${http_new_rate} burst ${http_new_burst} packets } return comment "HTTP: new rate OK"
+add rule ${table_ipv6} ${chain} tcp dport 80 ct state new counter drop comment "HTTP: new rate exceeded"
+add rule ${table_ipv6} ${chain} tcp dport 443 ct state new meter ${https_meter}6 { ip6 saddr limit rate ${https_new_rate} burst ${https_new_burst} packets } return comment "HTTPS: new rate OK"
+add rule ${table_ipv6} ${chain} tcp dport 443 ct state new counter drop comment "HTTPS: new rate exceeded"
 
 # ICMPv6 Rate Limiting
 add rule ${table_ipv6} ${chain} meta l4proto icmpv6 meter ${icmp_meter}6 { ip6 saddr limit rate ${icmpv6_rate} burst ${icmpv6_burst} packets } return comment "ICMPv6: rate OK"

--- a/etc/nftban/conf.d/ddos/classic.conf
+++ b/etc/nftban/conf.d/ddos/classic.conf
@@ -43,6 +43,15 @@ DDOS_CLASSIC_DNS_CONN_LIMIT="50"
 # Generic connection limit for unlisted ports
 DDOS_CLASSIC_GENERIC_CONN_LIMIT="50"
 
+# HTTP/HTTPS New Connection Rate Limits (per source IP)
+# ---------------------------------
+# Maximum new connections per second per source IP (rate meter)
+# These complement the concurrent ct count limits above
+DDOS_CLASSIC_HTTP_NEW_RATE="50/second"
+DDOS_CLASSIC_HTTP_NEW_BURST="100"
+DDOS_CLASSIC_HTTPS_NEW_RATE="50/second"
+DDOS_CLASSIC_HTTPS_NEW_BURST="100"
+
 # ICMP Rate Limiting
 # ------------------
 # Rate limit for ICMP echo requests (ping flood protection)
@@ -99,6 +108,8 @@ DDOS_CLASSIC_SYN_METER="ddos_syn_flood"
 DDOS_CLASSIC_ICMP_METER="ddos_icmp_flood"
 DDOS_CLASSIC_UDP_METER="ddos_udp_flood"
 DDOS_CLASSIC_PORT_METER="ddos_port_flood"
+DDOS_CLASSIC_HTTP_METER="ddos_http_rate"
+DDOS_CLASSIC_HTTPS_METER="ddos_https_rate"
 
 # Set name for blocked IPs
 DDOS_CLASSIC_BLOCK_SET="ddos_blocked"

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -62,12 +62,18 @@
 #     /etc/nftban/conf.d/<module>/<module>.conf.local  (user overrides)
 #
 # CT LIMITS (configurable via ddos.conf):
-#   SSH:  DDOS_CLASSIC_SSH_CONN_LIMIT  (default: 10)
-#   HTTP: DDOS_CLASSIC_HTTP_CONN_LIMIT (default: 100)
-#   SYN:  DDOS_CLASSIC_SYN_RATE        (default: 25/second)
+#   SSH:   DDOS_CLASSIC_SSH_CONN_LIMIT   (default: 10)
+#   HTTP:  DDOS_CLASSIC_HTTP_CONN_LIMIT  (default: 100)
+#   HTTPS: DDOS_CLASSIC_HTTPS_CONN_LIMIT (default: 100)
+#   SYN:   DDOS_CLASSIC_SYN_RATE         (default: 25/second)
+#
+# HTTP/HTTPS NEW RATE (configurable via ddos.conf):
+#   HTTP:  DDOS_CLASSIC_HTTP_NEW_RATE    (default: 50/second)
+#   HTTPS: DDOS_CLASSIC_HTTPS_NEW_RATE   (default: 50/second)
 #
 #   Override in /etc/nftban/conf.d/ddos/classic.conf.local:
 #     DDOS_CLASSIC_HTTP_CONN_LIMIT="200"
+#     DDOS_CLASSIC_HTTP_NEW_RATE="100/second"
 #
 # =============================================================================
 
@@ -165,10 +171,17 @@ table ip nftban {
             parameter-problem
         } accept
 
-        # 6. CT LIMITS - DDoS protection (per source IP limits)
+        # 6. CT LIMITS - DDoS protection (per source IP concurrent limits)
         ct state new tcp dport 22 ct count over 15 counter drop comment "SSH: max 15 concurrent per IP"
-        ct state new tcp dport { 80, 443 } ct count over 150 counter drop comment "HTTP(S): max 150 concurrent per IP"
+        ct state new tcp dport 80 ct count over 150 counter drop comment "HTTP: max 150 concurrent per IP"
+        ct state new tcp dport 443 ct count over 150 counter drop comment "HTTPS: max 150 concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over 150 counter drop comment "MAIL: max 150 concurrent per IP"
+
+        # 6b. HTTP/HTTPS new connection rate limiting (per source IP)
+        ct state new tcp dport 80 meter ddos_http_rate { ip saddr limit rate 50/second burst 100 packets } accept comment "HTTP: new rate OK"
+        ct state new tcp dport 80 counter drop comment "HTTP: new rate exceeded"
+        ct state new tcp dport 443 meter ddos_https_rate { ip saddr limit rate 50/second burst 100 packets } accept comment "HTTPS: new rate OK"
+        ct state new tcp dport 443 counter drop comment "HTTPS: new rate exceeded"
 
         # 7. SYN RATE LIMIT - Portscan detection
         tcp flags syn ct state new limit rate 100/second burst 200 packets log prefix "NFTBAN_PORTSCAN: "
@@ -299,10 +312,17 @@ table ip6 nftban {
             nd-redirect
         } accept
 
-        # 6. CT LIMITS - DDoS protection (per source IP limits)
+        # 6. CT LIMITS - DDoS protection (per source IP concurrent limits)
         ct state new tcp dport 22 ct count over 15 counter drop comment "SSH: max 15 concurrent per IP"
-        ct state new tcp dport { 80, 443 } ct count over 150 counter drop comment "HTTP(S): max 150 concurrent per IP"
+        ct state new tcp dport 80 ct count over 150 counter drop comment "HTTP: max 150 concurrent per IP"
+        ct state new tcp dport 443 ct count over 150 counter drop comment "HTTPS: max 150 concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over 150 counter drop comment "MAIL: max 150 concurrent per IP"
+
+        # 6b. HTTP/HTTPS new connection rate limiting (per source IP)
+        ct state new tcp dport 80 meter ddos_http_rate6 { ip6 saddr limit rate 50/second burst 100 packets } accept comment "HTTP: new rate OK"
+        ct state new tcp dport 80 counter drop comment "HTTP: new rate exceeded"
+        ct state new tcp dport 443 meter ddos_https_rate6 { ip6 saddr limit rate 50/second burst 100 packets } accept comment "HTTPS: new rate OK"
+        ct state new tcp dport 443 counter drop comment "HTTPS: new rate exceeded"
 
         # 7. SYN RATE LIMIT - Portscan detection
         tcp flags syn ct state new limit rate 100/second burst 200 packets log prefix "NFTBAN_PORTSCAN: "

--- a/tests/review/09_portscan_ddos_test.sh
+++ b/tests/review/09_portscan_ddos_test.sh
@@ -261,7 +261,7 @@ else
 fi
 
 # Verify thresholds also exist in config
-for var in SYN_RATE SYN_BURST SSH_CONN_LIMIT HTTP_CONN_LIMIT ICMP_RATE UDP_RATE; do
+for var in SYN_RATE SYN_BURST SSH_CONN_LIMIT HTTP_CONN_LIMIT HTTPS_CONN_LIMIT HTTP_NEW_RATE HTTP_NEW_BURST HTTPS_NEW_RATE HTTPS_NEW_BURST ICMP_RATE UDP_RATE; do
     if _has "^DDOS_CLASSIC_${var}=" "$CONF_DDOS_CLASSIC"; then
         check "DDOS_CLASSIC_${var} declared in ddos classic.conf" 0
     else


### PR DESCRIPTION
## Summary
- Split combined `HTTP(S)` ct count rules into separate HTTP (port 80) and HTTPS (port 443) rules for independent per-service tuning
- Add per-source-IP new connection rate meters (`ddos_http_rate`/`ddos_https_rate`) for both IPv4 and IPv6
- Add config variables: `DDOS_CLASSIC_HTTP_NEW_RATE`, `DDOS_CLASSIC_HTTPS_NEW_RATE`, `DDOS_CLASSIC_HTTP_METER`, `DDOS_CLASSIC_HTTPS_METER`
- Update fragment generator to render separate rules and meters for both address families
- Update test to validate new config variables

## Test plan
- [ ] Verify `nftban ddos enable` generates separate HTTP/HTTPS ct count rules (not combined)
- [ ] Verify rate meters `ddos_http_rate` and `ddos_https_rate` are created for IPv4
- [ ] Verify rate meters `ddos_http_rate6` and `ddos_https_rate6` are created for IPv6
- [ ] Run `tests/review/09_portscan_ddos_test.sh` — all new config variables validated
- [ ] Verify safe mode (`nftables-safe.conf`) is unchanged (by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)