### PR TITLE
fix: Add botguard BUILDROOT directories for RPM packaging

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -490,8 +490,9 @@ find cli/lib/nftban/tests -type f -name "*.sh" -exec install -m 0755 {} %{buildr
 
 # Config directories (must match %files section)
 mkdir -p %{buildroot}/etc/nftban/{conf.d,distros,whitelist.d,blacklist.d,ports.d,rules.d}
-mkdir -p %{buildroot}/var/lib/nftban/{feeds,geoip,staging,reports}
-mkdir -p %{buildroot}/var/log/nftban
+mkdir -p %{buildroot}/etc/nftban/conf.d/botguard
+mkdir -p %{buildroot}/var/lib/nftban/{feeds,geoip,staging,reports,botguard}
+mkdir -p %{buildroot}/var/log/nftban/botguard
 mkdir -p %{buildroot}/var/cache/nftban
 mkdir -p %{buildroot}/run/nftban
 


### PR DESCRIPTION
## Summary
- RPM build failed because %files references `/var/lib/nftban/botguard`, `/var/log/nftban/botguard`, and `/etc/nftban/conf.d/botguard` but these were only created in %post (runtime), not in %install (build time)
- Adds mkdir commands to %install section of `packaging/build_nftban.sh`

## Test plan
- [ ] RPM build passes in CI (el9, el10)
- [ ] Release packages workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)