### PR TITLE
test: v1.26 Go test coverage PR2 — 415 tests, 20 packages

### DIFF
--- a/cmd/nftband/daemon_dispatch_test.go
+++ b/cmd/nftband/daemon_dispatch_test.go
@@ -1,0 +1,167 @@
+// =============================================================================
+// NFTBan v1.0 - nftband Daemon Dispatch Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="daemon_dispatch_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for IPC request dispatch routing"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/pkg/eventbus"
+	"github.com/itcmsgr/nftban/pkg/module"
+	"github.com/itcmsgr/nftban/pkg/nftbackend"
+	"github.com/itcmsgr/nftban/pkg/stats"
+)
+
+// newTestDaemon creates a minimal Daemon for dispatch testing.
+// Only the fields needed by handleSocketRequest and its simple handlers are populated.
+func newTestDaemon() *Daemon {
+	return &Daemon{
+		bus:      eventbus.New(),
+		registry: module.NewRegistry(),
+		backend:  nftbackend.New(),
+		stats:    stats.NewCollector(stats.DefaultConfig()),
+		connSem:  make(chan struct{}, MaxConcurrentIPCConns),
+	}
+}
+
+// =============================================================================
+// Dispatch Routing Tests
+// =============================================================================
+
+func TestHandleSocketRequest_Ping(t *testing.T) {
+	d := newTestDaemon()
+	defer d.bus.Close()
+
+	resp := d.handleSocketRequest(SocketRequest{Method: "ping"})
+
+	if !resp.Success {
+		t.Error("expected Success=true for ping")
+	}
+	if resp.Data != "pong" {
+		t.Errorf("expected Data=%q, got %v", "pong", resp.Data)
+	}
+}
+
+func TestHandleSocketRequest_UnknownMethod(t *testing.T) {
+	d := newTestDaemon()
+	defer d.bus.Close()
+
+	resp := d.handleSocketRequest(SocketRequest{Method: "nonexistent"})
+
+	if resp.Success {
+		t.Error("expected Success=false for unknown method")
+	}
+	if resp.Error != "unknown method: nonexistent" {
+		t.Errorf("expected error %q, got %q", "unknown method: nonexistent", resp.Error)
+	}
+}
+
+func TestHandleSocketRequest_EmptyMethod(t *testing.T) {
+	d := newTestDaemon()
+	defer d.bus.Close()
+
+	resp := d.handleSocketRequest(SocketRequest{Method: ""})
+
+	if resp.Success {
+		t.Error("expected Success=false for empty method")
+	}
+	if resp.Error != "unknown method: " {
+		t.Errorf("expected error %q, got %q", "unknown method: ", resp.Error)
+	}
+}
+
+// =============================================================================
+// Method Routing Coverage Tests
+// Verify that known methods are routed (not rejected as unknown)
+// =============================================================================
+
+func TestHandleSocketRequest_KnownMethodsNotRejected(t *testing.T) {
+	// These methods should NOT return "unknown method" error.
+	// They may fail due to missing params or nil subsystems, but the
+	// important thing is that the dispatch routes them correctly.
+	knownMethods := []string{
+		"ping",
+		// Note: We only test ping here because other methods need
+		// properly initialized subsystems (backend, opQueue, etc.)
+		// to avoid nil pointer panics. The key test is that "unknown
+		// method" is returned only for truly unknown methods.
+	}
+
+	d := newTestDaemon()
+	defer d.bus.Close()
+
+	for _, method := range knownMethods {
+		t.Run(method, func(t *testing.T) {
+			resp := d.handleSocketRequest(SocketRequest{
+				Method: method,
+				Params: map[string]any{},
+			})
+
+			if resp.Error == "unknown method: "+method {
+				t.Errorf("method %q was rejected as unknown, but should be a known method", method)
+			}
+		})
+	}
+}
+
+func TestHandleSocketRequest_AllMethodsDefined(t *testing.T) {
+	// Verify that all documented IPC methods are handled
+	// (not returned as "unknown method")
+	expectedMethods := []string{
+		"status", "modules", "ban", "unban",
+		"add_element", "delete_element", "flush_set", "apply_ruleset",
+		"check", "persist_ban", "unpersist_ban",
+		"sync", "load_ports", "add_port_element", "delete_port_element",
+		"load_cidrs", "stats", "stats_history", "snapshot_profile",
+		"ping", "watchdog_status", "watchdog_pressure", "watchdog_events",
+		"protect_ban", "unprotect_ban", "get_evictable_bans", "evict_old_bans",
+		"permanent_ban_stats", "replace_set", "flush_source", "queue_status",
+		"reload",
+	}
+
+	d := newTestDaemon()
+	defer d.bus.Close()
+
+	for _, method := range expectedMethods {
+		t.Run(method, func(t *testing.T) {
+			// We use recover to catch panics from nil subsystems
+			// The test passes if the method is recognized (no "unknown method" error)
+			var resp SocketResponse
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						// Panic from nil subsystem is OK - method was recognized and routed
+						resp = SocketResponse{Success: false, Error: "panic (expected - nil subsystem)"}
+					}
+				}()
+				resp = d.handleSocketRequest(SocketRequest{
+					Method: method,
+					Params: map[string]any{},
+				})
+			}()
+
+			if resp.Error == "unknown method: "+method {
+				t.Errorf("method %q is not handled in dispatch switch", method)
+			}
+		})
+	}
+}

--- a/cmd/nftband/daemon_dispatch_test.go
+++ b/cmd/nftband/daemon_dispatch_test.go
@@ -27,17 +27,17 @@ import (
 
 	"github.com/itcmsgr/nftban/pkg/eventbus"
 	"github.com/itcmsgr/nftban/pkg/module"
-	"github.com/itcmsgr/nftban/pkg/nftbackend"
 	"github.com/itcmsgr/nftban/pkg/stats"
 )
 
 // newTestDaemon creates a minimal Daemon for dispatch testing.
-// Only the fields needed by handleSocketRequest and its simple handlers are populated.
+// Backend is nil — nftbackend.New() requires nftables kernel support
+// which is unavailable in CI containers. Methods that need backend
+// will panic, caught by recover() in TestHandleSocketRequest_AllMethodsDefined.
 func newTestDaemon() *Daemon {
 	return &Daemon{
 		bus:      eventbus.New(),
 		registry: module.NewRegistry(),
-		backend:  nftbackend.New(),
 		stats:    stats.NewCollector(stats.DefaultConfig()),
 		connSem:  make(chan struct{}, MaxConcurrentIPCConns),
 	}

--- a/cmd/nftband/daemon_types_test.go
+++ b/cmd/nftband/daemon_types_test.go
@@ -1,0 +1,311 @@
+// =============================================================================
+// NFTBan v1.0 - nftband Daemon Types and Validation Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="daemon_types_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for daemon type validation, timeout helpers, and dispatch"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// validNFTBanTable Tests
+// =============================================================================
+
+func TestValidNFTBanTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		want  bool
+	}{
+		{"ip_nftban", "ip nftban", true},
+		{"ip6_nftban", "ip6 nftban", true},
+		{"inet_nftban", "inet nftban", false},
+		{"empty", "", false},
+		{"just_nftban", "nftban", false},
+		{"ip_other", "ip other", false},
+		{"ip6_other", "ip6 other", false},
+		{"random", "random table", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validNFTBanTable(tt.table)
+			if got != tt.want {
+				t.Errorf("validNFTBanTable(%q) = %v, want %v", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// validNFTBanSet Tests
+// =============================================================================
+
+func TestValidNFTBanSet(t *testing.T) {
+	validSets := []string{
+		"blacklist_ipv4", "blacklist_ipv6",
+		"whitelist_ipv4", "whitelist_ipv6",
+		"persistent_offenders_ipv4", "persistent_offenders_ipv6",
+		"bogon_ipv4", "bogon_ipv6",
+		"geoban_ipv4", "geoban_ipv6",
+		"tcp_ports_in", "tcp_ports_out",
+		"udp_ports_in", "udp_ports_out",
+		// HTTP Bot Guard sets
+		"http_bot_suspect", "http_bot_suspect6",
+		"http_bot_allow", "http_bot_allow6",
+		"http_bot_ban", "http_bot_ban6",
+		"http_bot_grey", "http_bot_grey6",
+		"http_bot_emergency", "http_bot_emergency6",
+		"http_bot_pending", "http_bot_pending6",
+	}
+
+	for _, set := range validSets {
+		t.Run("valid_"+set, func(t *testing.T) {
+			if !validNFTBanSet(set) {
+				t.Errorf("validNFTBanSet(%q) = false, want true", set)
+			}
+		})
+	}
+
+	invalidSets := []string{
+		"", "random", "blacklist", "whitelist",
+		"ipv4", "ipv6", "iptables", "filter",
+		"http_bot_unknown", "some_new_set",
+	}
+
+	for _, set := range invalidSets {
+		t.Run("invalid_"+set, func(t *testing.T) {
+			if validNFTBanSet(set) {
+				t.Errorf("validNFTBanSet(%q) = true, want false", set)
+			}
+		})
+	}
+}
+
+func TestKnownNFTBanSets_Count(t *testing.T) {
+	// Verify we have the expected number of known sets
+	// 4 blacklist/whitelist + 2 persistent + 2 bogon + 2 geoban + 4 ports + 12 botguard = 26
+	if len(knownNFTBanSets) != 26 {
+		t.Errorf("expected 26 known sets, got %d", len(knownNFTBanSets))
+	}
+}
+
+// =============================================================================
+// getIPCSocketTimeout Tests
+// =============================================================================
+
+func TestGetIPCSocketTimeout_Default(t *testing.T) {
+	// Ensure env var is not set
+	os.Unsetenv("NFTBAN_TIMEOUT_IPC_SOCKET")
+
+	timeout := getIPCSocketTimeout()
+	expected := 300 * time.Second
+	if timeout != expected {
+		t.Errorf("getIPCSocketTimeout() = %v, want %v", timeout, expected)
+	}
+}
+
+func TestGetIPCSocketTimeout_CustomValue(t *testing.T) {
+	os.Setenv("NFTBAN_TIMEOUT_IPC_SOCKET", "60")
+	defer os.Unsetenv("NFTBAN_TIMEOUT_IPC_SOCKET")
+
+	timeout := getIPCSocketTimeout()
+	expected := 60 * time.Second
+	if timeout != expected {
+		t.Errorf("getIPCSocketTimeout() = %v, want %v", timeout, expected)
+	}
+}
+
+func TestGetIPCSocketTimeout_InvalidValue(t *testing.T) {
+	os.Setenv("NFTBAN_TIMEOUT_IPC_SOCKET", "not_a_number")
+	defer os.Unsetenv("NFTBAN_TIMEOUT_IPC_SOCKET")
+
+	timeout := getIPCSocketTimeout()
+	expected := 300 * time.Second
+	if timeout != expected {
+		t.Errorf("getIPCSocketTimeout() with invalid value = %v, want default %v", timeout, expected)
+	}
+}
+
+func TestGetIPCSocketTimeout_NegativeValue(t *testing.T) {
+	os.Setenv("NFTBAN_TIMEOUT_IPC_SOCKET", "-10")
+	defer os.Unsetenv("NFTBAN_TIMEOUT_IPC_SOCKET")
+
+	timeout := getIPCSocketTimeout()
+	expected := 300 * time.Second
+	if timeout != expected {
+		t.Errorf("getIPCSocketTimeout() with negative value = %v, want default %v", timeout, expected)
+	}
+}
+
+func TestGetIPCSocketTimeout_ZeroValue(t *testing.T) {
+	os.Setenv("NFTBAN_TIMEOUT_IPC_SOCKET", "0")
+	defer os.Unsetenv("NFTBAN_TIMEOUT_IPC_SOCKET")
+
+	timeout := getIPCSocketTimeout()
+	expected := 300 * time.Second
+	if timeout != expected {
+		t.Errorf("getIPCSocketTimeout() with zero value = %v, want default %v", timeout, expected)
+	}
+}
+
+// =============================================================================
+// getAutoSyncDelay Tests
+// =============================================================================
+
+func TestGetAutoSyncDelay_Default(t *testing.T) {
+	os.Unsetenv("NFTBAN_AUTO_SYNC_DELAY")
+
+	delay := getAutoSyncDelay()
+	expected := 60 * time.Second
+	if delay != expected {
+		t.Errorf("getAutoSyncDelay() = %v, want %v", delay, expected)
+	}
+}
+
+func TestGetAutoSyncDelay_CustomValue(t *testing.T) {
+	os.Setenv("NFTBAN_AUTO_SYNC_DELAY", "120")
+	defer os.Unsetenv("NFTBAN_AUTO_SYNC_DELAY")
+
+	delay := getAutoSyncDelay()
+	expected := 120 * time.Second
+	if delay != expected {
+		t.Errorf("getAutoSyncDelay() = %v, want %v", delay, expected)
+	}
+}
+
+func TestGetAutoSyncDelay_ZeroValid(t *testing.T) {
+	os.Setenv("NFTBAN_AUTO_SYNC_DELAY", "0")
+	defer os.Unsetenv("NFTBAN_AUTO_SYNC_DELAY")
+
+	delay := getAutoSyncDelay()
+	expected := 0 * time.Second
+	if delay != expected {
+		t.Errorf("getAutoSyncDelay() with 0 = %v, want %v", delay, expected)
+	}
+}
+
+func TestGetAutoSyncDelay_InvalidValue(t *testing.T) {
+	os.Setenv("NFTBAN_AUTO_SYNC_DELAY", "abc")
+	defer os.Unsetenv("NFTBAN_AUTO_SYNC_DELAY")
+
+	delay := getAutoSyncDelay()
+	expected := 60 * time.Second
+	if delay != expected {
+		t.Errorf("getAutoSyncDelay() with invalid = %v, want default %v", delay, expected)
+	}
+}
+
+func TestGetAutoSyncDelay_NegativeValue(t *testing.T) {
+	os.Setenv("NFTBAN_AUTO_SYNC_DELAY", "-5")
+	defer os.Unsetenv("NFTBAN_AUTO_SYNC_DELAY")
+
+	delay := getAutoSyncDelay()
+	expected := 60 * time.Second
+	if delay != expected {
+		t.Errorf("getAutoSyncDelay() with negative = %v, want default %v", delay, expected)
+	}
+}
+
+// =============================================================================
+// SocketRequest/SocketResponse Types Tests
+// =============================================================================
+
+func TestSocketRequest_Structure(t *testing.T) {
+	req := SocketRequest{
+		Method: "ban",
+		Params: map[string]any{
+			"ip":     "1.2.3.4",
+			"reason": "portscan",
+		},
+	}
+
+	if req.Method != "ban" {
+		t.Errorf("expected Method=%q, got %q", "ban", req.Method)
+	}
+	if req.Params["ip"] != "1.2.3.4" {
+		t.Errorf("expected Params[ip]=%q, got %v", "1.2.3.4", req.Params["ip"])
+	}
+}
+
+func TestSocketResponse_Structure(t *testing.T) {
+	resp := SocketResponse{
+		Success: true,
+		Data:    "pong",
+	}
+
+	if !resp.Success {
+		t.Error("expected Success=true")
+	}
+	if resp.Data != "pong" {
+		t.Errorf("expected Data=%q, got %v", "pong", resp.Data)
+	}
+	if resp.Error != "" {
+		t.Errorf("expected empty Error, got %q", resp.Error)
+	}
+}
+
+func TestSocketResponse_Error(t *testing.T) {
+	resp := SocketResponse{
+		Success: false,
+		Error:   "unknown method: foo",
+	}
+
+	if resp.Success {
+		t.Error("expected Success=false for error response")
+	}
+	if resp.Error != "unknown method: foo" {
+		t.Errorf("expected Error=%q, got %q", "unknown method: foo", resp.Error)
+	}
+}
+
+// =============================================================================
+// Build Variables Tests
+// =============================================================================
+
+func TestBuildVariables_Defaults(t *testing.T) {
+	// Default values when not set by ldflags
+	if GitCommit != "dev" {
+		t.Errorf("expected default GitCommit=%q, got %q", "dev", GitCommit)
+	}
+	if BuildDate != "unknown" {
+		t.Errorf("expected default BuildDate=%q, got %q", "unknown", BuildDate)
+	}
+}
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+func TestConstants(t *testing.T) {
+	if DefaultHTTPAddr != "127.0.0.1:8080" {
+		t.Errorf("DefaultHTTPAddr = %q, want %q", DefaultHTTPAddr, "127.0.0.1:8080")
+	}
+	if PprofAddr != "127.0.0.1:6060" {
+		t.Errorf("PprofAddr = %q, want %q", PprofAddr, "127.0.0.1:6060")
+	}
+	if MaxConcurrentIPCConns != 100 {
+		t.Errorf("MaxConcurrentIPCConns = %d, want 100", MaxConcurrentIPCConns)
+	}
+}

--- a/pkg/eventbus/bus_test.go
+++ b/pkg/eventbus/bus_test.go
@@ -1,0 +1,669 @@
+// =============================================================================
+// NFTBan v1.0 - Event Bus Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="bus_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for event bus pub/sub, worker pool, and metrics"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package eventbus
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Severity Tests
+// =============================================================================
+
+func TestSeverity_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity Severity
+		want     string
+	}{
+		{"debug", SeverityDebug, "DEBUG"},
+		{"info", SeverityInfo, "INFO"},
+		{"warning", SeverityWarning, "WARNING"},
+		{"critical", SeverityCritical, "CRITICAL"},
+		{"unknown", Severity(99), "UNKNOWN"},
+		{"negative", Severity(-1), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.severity.String()
+			if got != tt.want {
+				t.Errorf("Severity(%d).String() = %q, want %q", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Event Builder Tests
+// =============================================================================
+
+func TestNewEvent(t *testing.T) {
+	e := NewEvent(EventBan, "test-source")
+
+	if e.Type != EventBan {
+		t.Errorf("expected event type %q, got %q", EventBan, e.Type)
+	}
+	if e.Source != "test-source" {
+		t.Errorf("expected source %q, got %q", "test-source", e.Source)
+	}
+	if e.Severity != SeverityInfo {
+		t.Errorf("expected default severity INFO, got %v", e.Severity)
+	}
+	if e.ID == "" {
+		t.Error("expected non-empty event ID")
+	}
+	if e.Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp")
+	}
+	if e.Data == nil {
+		t.Error("expected non-nil Data map")
+	}
+}
+
+func TestEvent_WithIP(t *testing.T) {
+	e := NewEvent(EventBan, "test").WithIP("1.2.3.4")
+	if e.IP != "1.2.3.4" {
+		t.Errorf("expected IP %q, got %q", "1.2.3.4", e.IP)
+	}
+}
+
+func TestEvent_WithUser(t *testing.T) {
+	e := NewEvent(EventLoginFail, "test").WithUser("admin")
+	if e.User != "admin" {
+		t.Errorf("expected User %q, got %q", "admin", e.User)
+	}
+}
+
+func TestEvent_WithMessage(t *testing.T) {
+	e := NewEvent(EventBan, "test").WithMessage("blocked for scanning")
+	if e.Message != "blocked for scanning" {
+		t.Errorf("expected Message %q, got %q", "blocked for scanning", e.Message)
+	}
+}
+
+func TestEvent_WithSeverity(t *testing.T) {
+	e := NewEvent(EventBan, "test").WithSeverity(SeverityCritical)
+	if e.Severity != SeverityCritical {
+		t.Errorf("expected severity CRITICAL, got %v", e.Severity)
+	}
+}
+
+func TestEvent_WithData(t *testing.T) {
+	e := NewEvent(EventBan, "test").
+		WithData("reason", "portscan").
+		WithData("count", 5)
+
+	if e.Data["reason"] != "portscan" {
+		t.Errorf("expected Data[reason]=%q, got %q", "portscan", e.Data["reason"])
+	}
+	if e.Data["count"] != 5 {
+		t.Errorf("expected Data[count]=5, got %v", e.Data["count"])
+	}
+}
+
+func TestEvent_WithDataNilMap(t *testing.T) {
+	// Test that WithData handles nil Data map gracefully
+	e := Event{}
+	e = e.WithData("key", "value")
+	if e.Data == nil {
+		t.Error("expected Data map to be created")
+	}
+	if e.Data["key"] != "value" {
+		t.Errorf("expected Data[key]=%q, got %q", "value", e.Data["key"])
+	}
+}
+
+func TestEvent_BuilderChaining(t *testing.T) {
+	e := NewEvent(EventBan, "test-module").
+		WithIP("10.0.0.1").
+		WithUser("attacker").
+		WithMessage("banned for DDoS").
+		WithSeverity(SeverityCritical).
+		WithData("duration", "1h")
+
+	if e.IP != "10.0.0.1" {
+		t.Errorf("IP = %q, want %q", e.IP, "10.0.0.1")
+	}
+	if e.User != "attacker" {
+		t.Errorf("User = %q, want %q", e.User, "attacker")
+	}
+	if e.Message != "banned for DDoS" {
+		t.Errorf("Message = %q, want %q", e.Message, "banned for DDoS")
+	}
+	if e.Severity != SeverityCritical {
+		t.Errorf("Severity = %v, want CRITICAL", e.Severity)
+	}
+	if e.Data["duration"] != "1h" {
+		t.Errorf("Data[duration] = %v, want %q", e.Data["duration"], "1h")
+	}
+}
+
+// =============================================================================
+// generateID Tests
+// =============================================================================
+
+func TestGenerateID_Uniqueness(t *testing.T) {
+	ids := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id := generateID()
+		if id == "" {
+			t.Fatal("generated empty ID")
+		}
+		if ids[id] {
+			t.Fatalf("duplicate ID generated: %s", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestGenerateID_Length(t *testing.T) {
+	id := generateID()
+	// 8 bytes hex-encoded = 16 characters
+	if len(id) != 16 {
+		t.Errorf("expected ID length 16, got %d: %q", len(id), id)
+	}
+}
+
+// =============================================================================
+// Bus Creation Tests
+// =============================================================================
+
+func TestNew(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	stats := bus.Stats()
+	if stats.Workers != DefaultWorkerCount {
+		t.Errorf("expected %d workers, got %d", DefaultWorkerCount, stats.Workers)
+	}
+	if stats.QueueSize != DefaultQueueSize {
+		t.Errorf("expected queue size %d, got %d", DefaultQueueSize, stats.QueueSize)
+	}
+	if stats.Subscriptions != 0 {
+		t.Errorf("expected 0 subscriptions, got %d", stats.Subscriptions)
+	}
+}
+
+func TestNewWithConfig(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	stats := bus.Stats()
+	if stats.Workers != 4 {
+		t.Errorf("expected 4 workers, got %d", stats.Workers)
+	}
+	if stats.QueueSize != 64 {
+		t.Errorf("expected queue size 64, got %d", stats.QueueSize)
+	}
+}
+
+func TestNewWithConfig_InvalidValues(t *testing.T) {
+	// Zero/negative values should use defaults
+	bus := NewWithConfig(0, -1)
+	defer bus.Close()
+
+	stats := bus.Stats()
+	if stats.Workers != DefaultWorkerCount {
+		t.Errorf("expected default workers %d, got %d", DefaultWorkerCount, stats.Workers)
+	}
+	if stats.QueueSize != DefaultQueueSize {
+		t.Errorf("expected default queue size %d, got %d", DefaultQueueSize, stats.QueueSize)
+	}
+}
+
+// =============================================================================
+// Subscribe/Unsubscribe Tests
+// =============================================================================
+
+func TestSubscribe(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	id := bus.Subscribe(EventBan, func(e Event) {})
+
+	if id == "" {
+		t.Error("expected non-empty subscription ID")
+	}
+
+	stats := bus.Stats()
+	if stats.Subscriptions != 1 {
+		t.Errorf("expected 1 subscription, got %d", stats.Subscriptions)
+	}
+}
+
+func TestSubscribeAll(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	id := bus.SubscribeAll(func(e Event) {})
+
+	if id == "" {
+		t.Error("expected non-empty subscription ID")
+	}
+
+	stats := bus.Stats()
+	if stats.Subscriptions != 1 {
+		t.Errorf("expected 1 subscription, got %d", stats.Subscriptions)
+	}
+}
+
+func TestSubscribeMultiple(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	ids := bus.SubscribeMultiple(
+		[]EventType{EventBan, EventUnban, EventLoginFail},
+		func(e Event) {},
+	)
+
+	if len(ids) != 3 {
+		t.Errorf("expected 3 subscription IDs, got %d", len(ids))
+	}
+
+	stats := bus.Stats()
+	if stats.Subscriptions != 3 {
+		t.Errorf("expected 3 subscriptions, got %d", stats.Subscriptions)
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	id := bus.Subscribe(EventBan, func(e Event) {})
+	ok := bus.Unsubscribe(id)
+
+	if !ok {
+		t.Error("expected successful unsubscribe")
+	}
+
+	stats := bus.Stats()
+	if stats.Subscriptions != 0 {
+		t.Errorf("expected 0 subscriptions after unsubscribe, got %d", stats.Subscriptions)
+	}
+}
+
+func TestUnsubscribe_NotFound(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	ok := bus.Unsubscribe("nonexistent-id")
+	if ok {
+		t.Error("expected false for nonexistent subscription")
+	}
+}
+
+// =============================================================================
+// Publish Tests
+// =============================================================================
+
+func TestPublish_TypeMatching(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var received int64
+	bus.Subscribe(EventBan, func(e Event) {
+		atomic.AddInt64(&received, 1)
+	})
+
+	// Publish matching event
+	bus.Publish(NewEvent(EventBan, "test"))
+	// Publish non-matching event
+	bus.Publish(NewEvent(EventUnban, "test"))
+
+	// Wait for async processing
+	time.Sleep(50 * time.Millisecond)
+
+	if atomic.LoadInt64(&received) != 1 {
+		t.Errorf("expected 1 received event, got %d", atomic.LoadInt64(&received))
+	}
+}
+
+func TestPublish_SubscribeAll(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var received int64
+	bus.SubscribeAll(func(e Event) {
+		atomic.AddInt64(&received, 1)
+	})
+
+	// SubscribeAll should receive all event types
+	bus.Publish(NewEvent(EventBan, "test"))
+	bus.Publish(NewEvent(EventUnban, "test"))
+	bus.Publish(NewEvent(EventLoginFail, "test"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if atomic.LoadInt64(&received) != 3 {
+		t.Errorf("expected 3 received events, got %d", atomic.LoadInt64(&received))
+	}
+}
+
+func TestPublish_MultipleSubscribers(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var count1, count2 int64
+	bus.Subscribe(EventBan, func(e Event) {
+		atomic.AddInt64(&count1, 1)
+	})
+	bus.Subscribe(EventBan, func(e Event) {
+		atomic.AddInt64(&count2, 1)
+	})
+
+	bus.Publish(NewEvent(EventBan, "test"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if atomic.LoadInt64(&count1) != 1 {
+		t.Errorf("subscriber 1: expected 1 event, got %d", atomic.LoadInt64(&count1))
+	}
+	if atomic.LoadInt64(&count2) != 1 {
+		t.Errorf("subscriber 2: expected 1 event, got %d", atomic.LoadInt64(&count2))
+	}
+}
+
+func TestPublish_AutoSetsIDAndTimestamp(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var receivedEvent Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventBan, func(e Event) {
+		receivedEvent = e
+		wg.Done()
+	})
+
+	// Publish event without ID or timestamp
+	bus.Publish(Event{Type: EventBan})
+
+	wg.Wait()
+
+	if receivedEvent.ID == "" {
+		t.Error("expected auto-generated ID")
+	}
+	if receivedEvent.Timestamp.IsZero() {
+		t.Error("expected auto-set timestamp")
+	}
+}
+
+func TestPublish_ClosedBus(t *testing.T) {
+	bus := New()
+	bus.Close()
+
+	// Should not panic when publishing to closed bus
+	bus.Publish(NewEvent(EventBan, "test"))
+}
+
+// =============================================================================
+// PublishSync Tests
+// =============================================================================
+
+func TestPublishSync(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	received := false
+	bus.Subscribe(EventBan, func(e Event) {
+		received = true
+	})
+
+	bus.PublishSync(NewEvent(EventBan, "test"))
+
+	// Should be synchronous - no need to wait
+	if !received {
+		t.Error("expected synchronous delivery")
+	}
+}
+
+func TestPublishSync_ClosedBus(t *testing.T) {
+	bus := New()
+	bus.Close()
+
+	// Should not panic when publishing sync to closed bus
+	bus.PublishSync(NewEvent(EventBan, "test"))
+}
+
+func TestPublishSync_AutoSetsIDAndTimestamp(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var receivedEvent Event
+	bus.Subscribe(EventBan, func(e Event) {
+		receivedEvent = e
+	})
+
+	bus.PublishSync(Event{Type: EventBan})
+
+	if receivedEvent.ID == "" {
+		t.Error("expected auto-generated ID")
+	}
+	if receivedEvent.Timestamp.IsZero() {
+		t.Error("expected auto-set timestamp")
+	}
+}
+
+// =============================================================================
+// Panic Recovery Tests
+// =============================================================================
+
+func TestPublish_HandlerPanicRecovery(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	bus.Subscribe(EventBan, func(e Event) {
+		panic("test panic")
+	})
+
+	// Should not crash
+	bus.Publish(NewEvent(EventBan, "test"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	stats := bus.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected 1 error from panic, got %d", stats.Errors)
+	}
+}
+
+func TestPublishSync_HandlerPanicRecovery(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	bus.Subscribe(EventBan, func(e Event) {
+		panic("test panic")
+	})
+
+	// Should not crash
+	bus.PublishSync(NewEvent(EventBan, "test"))
+
+	stats := bus.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected 1 error from panic, got %d", stats.Errors)
+	}
+}
+
+// =============================================================================
+// Close Tests
+// =============================================================================
+
+func TestClose(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	bus.Close()
+
+	// Stats should still be queryable after close
+	stats := bus.Stats()
+	if stats.Workers != 4 {
+		t.Errorf("expected 4 workers, got %d", stats.Workers)
+	}
+}
+
+func TestClose_DoubleClose(t *testing.T) {
+	bus := New()
+	bus.Close()
+	// Should not panic on double close
+	bus.Close()
+}
+
+// =============================================================================
+// Stats Tests
+// =============================================================================
+
+func TestStats_PublishMetrics(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	bus.Subscribe(EventBan, func(e Event) {})
+
+	bus.Publish(NewEvent(EventBan, "test"))
+	bus.Publish(NewEvent(EventBan, "test"))
+
+	time.Sleep(50 * time.Millisecond)
+
+	stats := bus.Stats()
+	if stats.Published != 2 {
+		t.Errorf("expected 2 published, got %d", stats.Published)
+	}
+	if stats.Delivered != 2 {
+		t.Errorf("expected 2 delivered, got %d", stats.Delivered)
+	}
+}
+
+// =============================================================================
+// Backpressure Tests
+// =============================================================================
+
+func TestPublish_Backpressure(t *testing.T) {
+	// Create a bus with very small queue
+	bus := NewWithConfig(1, 1)
+	defer bus.Close()
+
+	// Subscribe with a slow handler to fill the queue
+	bus.Subscribe(EventBan, func(e Event) {
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	// Rapidly publish many events - some should be dropped
+	for i := 0; i < 50; i++ {
+		bus.Publish(NewEvent(EventBan, "test"))
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	stats := bus.Stats()
+	// At least some should have been dropped
+	if stats.Published < 50 {
+		t.Errorf("expected 50 published, got %d", stats.Published)
+	}
+	// Dropped + Delivered should equal Published (for matched subscriptions)
+	total := stats.Delivered + stats.Dropped
+	if total != stats.Published {
+		t.Errorf("delivered(%d) + dropped(%d) = %d, want %d (published)",
+			stats.Delivered, stats.Dropped, total, stats.Published)
+	}
+}
+
+// =============================================================================
+// Event Types Constants Tests
+// =============================================================================
+
+func TestEventTypes_Defined(t *testing.T) {
+	// Verify all expected event types are defined and unique
+	eventTypes := []EventType{
+		EventBan, EventUnban,
+		EventLoginFail, EventLoginFailed, EventLoginSuccess, EventLoginAlert,
+		EventSuricataAlert, EventDDoSDetected, EventPortscan,
+		EventFeedSync, EventFeedUpdate,
+		EventHealthCheck, EventModuleStart, EventModuleStop, EventConfigReload, EventError,
+		EventGeoIPUpdate, EventCountryBan,
+	}
+
+	seen := make(map[EventType]bool)
+	for _, et := range eventTypes {
+		if et == "" {
+			t.Error("empty event type found")
+		}
+		// EventLoginFail and EventLoginFailed are aliases, skip uniqueness check for them
+		if et != EventLoginFailed {
+			if seen[et] {
+				t.Errorf("duplicate event type: %q", et)
+			}
+		}
+		seen[et] = true
+	}
+}
+
+// =============================================================================
+// Concurrency Tests
+// =============================================================================
+
+func TestBus_ConcurrentPublish(t *testing.T) {
+	bus := NewWithConfig(8, 256)
+	defer bus.Close()
+
+	var received int64
+	bus.Subscribe(EventBan, func(e Event) {
+		atomic.AddInt64(&received, 1)
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Publish(NewEvent(EventBan, "test"))
+		}()
+	}
+	wg.Wait()
+
+	time.Sleep(100 * time.Millisecond)
+
+	stats := bus.Stats()
+	if stats.Published != 100 {
+		t.Errorf("expected 100 published, got %d", stats.Published)
+	}
+}
+
+func TestBus_ConcurrentSubscribeUnsubscribe(t *testing.T) {
+	bus := NewWithConfig(4, 64)
+	defer bus.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := bus.Subscribe(EventBan, func(e Event) {})
+			bus.Unsubscribe(id)
+		}()
+	}
+	wg.Wait()
+
+	// Should not deadlock or crash
+}

--- a/pkg/exporters/connectors/connectors_test.go
+++ b/pkg/exporters/connectors/connectors_test.go
@@ -1,0 +1,1167 @@
+// =============================================================================
+// NFTBan - Connectors Package Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="connectors_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Tests for ES/Kafka/NDJSON connectors: records, config, formatting, base connector"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package connectors
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Record Tests
+// =============================================================================
+
+func TestRecord_ToJSON(t *testing.T) {
+	r := Record{
+		Timestamp: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Host:      "testhost",
+		Type:      "metrics",
+		Source:    "nftban",
+		Version:   "1.0",
+		Data: map[string]interface{}{
+			"bans_total": 100,
+			"version":    "1.25.0",
+		},
+	}
+
+	data, err := r.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() error = %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("JSON unmarshal error = %v", err)
+	}
+
+	if parsed["host"] != "testhost" {
+		t.Errorf("host = %v, want %q", parsed["host"], "testhost")
+	}
+	if parsed["type"] != "metrics" {
+		t.Errorf("type = %v, want %q", parsed["type"], "metrics")
+	}
+	if parsed["source"] != "nftban" {
+		t.Errorf("source = %v, want %q", parsed["source"], "nftban")
+	}
+}
+
+func TestRecord_ToNDJSON(t *testing.T) {
+	r := Record{
+		Timestamp: time.Now(),
+		Host:      "h1",
+		Type:      "metrics",
+		Source:    "nftban",
+		Version:   "1.0",
+		Data:      map[string]interface{}{"k": "v"},
+	}
+
+	data, err := r.ToNDJSON()
+	if err != nil {
+		t.Fatalf("ToNDJSON() error = %v", err)
+	}
+
+	// Must end with newline
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Error("NDJSON should end with newline")
+	}
+
+	// Should be a single line (strip trailing newline, check no other newlines)
+	trimmed := bytes.TrimSuffix(data, []byte("\n"))
+	if bytes.Contains(trimmed, []byte("\n")) {
+		t.Error("NDJSON should be a single line")
+	}
+
+	// Should be valid JSON
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		t.Fatalf("NDJSON content should be valid JSON, got error = %v", err)
+	}
+}
+
+func TestNewMetricsRecord(t *testing.T) {
+	data := map[string]interface{}{"bans": 100}
+	r := NewMetricsRecord("myhost", data)
+
+	if r.Host != "myhost" {
+		t.Errorf("host = %q, want %q", r.Host, "myhost")
+	}
+	if r.Type != "metrics" {
+		t.Errorf("type = %q, want %q", r.Type, "metrics")
+	}
+	if r.Source != "nftban" {
+		t.Errorf("source = %q, want %q", r.Source, "nftban")
+	}
+	if r.Version != "1.0" {
+		t.Errorf("version = %q, want %q", r.Version, "1.0")
+	}
+	if r.Timestamp.IsZero() {
+		t.Error("timestamp should not be zero")
+	}
+	if r.Data["bans"] != 100 {
+		t.Errorf("data[bans] = %v, want 100", r.Data["bans"])
+	}
+}
+
+func TestNewEventRecord(t *testing.T) {
+	data := map[string]interface{}{"ip": "1.2.3.4", "reason": "portscan"}
+	r := NewEventRecord("myhost", "ban", data)
+
+	if r.Type != "event" {
+		t.Errorf("type = %q, want %q", r.Type, "event")
+	}
+	if r.Tags["event_type"] != "ban" {
+		t.Errorf("tags[event_type] = %q, want %q", r.Tags["event_type"], "ban")
+	}
+}
+
+func TestNewAlertRecord(t *testing.T) {
+	data := map[string]interface{}{"ip": "5.6.7.8"}
+	r := NewAlertRecord("myhost", "critical", "DDoS attack detected", data)
+
+	if r.Type != "alert" {
+		t.Errorf("type = %q, want %q", r.Type, "alert")
+	}
+	if r.Tags["severity"] != "critical" {
+		t.Errorf("tags[severity] = %q, want %q", r.Tags["severity"], "critical")
+	}
+	if r.Meta["message"] != "DDoS attack detected" {
+		t.Errorf("meta[message] = %v, want %q", r.Meta["message"], "DDoS attack detected")
+	}
+}
+
+func TestRecord_WithTags(t *testing.T) {
+	r := Record{
+		Timestamp: time.Now(),
+		Host:      "h1",
+		Type:      "metrics",
+		Source:    "nftban",
+		Version:   "1.0",
+		Data:      map[string]interface{}{"k": "v"},
+		Tags:      map[string]string{"env": "prod", "region": "eu"},
+	}
+
+	data, err := r.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() error = %v", err)
+	}
+
+	if !strings.Contains(string(data), "prod") {
+		t.Error("JSON should contain tags")
+	}
+}
+
+func TestRecord_EmptyData(t *testing.T) {
+	r := Record{
+		Timestamp: time.Now(),
+		Host:      "h1",
+		Type:      "metrics",
+		Source:    "nftban",
+		Version:   "1.0",
+		Data:      map[string]interface{}{},
+	}
+
+	data, err := r.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() error = %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("JSON output should not be empty")
+	}
+}
+
+// =============================================================================
+// ConnectorType Constants Tests
+// =============================================================================
+
+func TestConnectorTypeConstants(t *testing.T) {
+	tests := []struct {
+		ct   ConnectorType
+		want string
+	}{
+		{ConnectorTypeElasticsearch, "elasticsearch"},
+		{ConnectorTypeKafka, "kafka"},
+		{ConnectorTypeFile, "file"},
+		{ConnectorTypeWebhook, "webhook"},
+		{ConnectorTypeNDJSON, "ndjson"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.ct) != tt.want {
+			t.Errorf("ConnectorType = %q, want %q", tt.ct, tt.want)
+		}
+	}
+}
+
+// =============================================================================
+// BaseConnector Tests
+// =============================================================================
+
+func TestBaseConnector_New(t *testing.T) {
+	bc := NewBaseConnector("test-es", ConnectorTypeElasticsearch)
+
+	if bc.Name() != "test-es" {
+		t.Errorf("Name() = %q, want %q", bc.Name(), "test-es")
+	}
+	if bc.Type() != ConnectorTypeElasticsearch {
+		t.Errorf("Type() = %q, want %q", bc.Type(), ConnectorTypeElasticsearch)
+	}
+	if bc.IsConnected() {
+		t.Error("initial state should be disconnected")
+	}
+}
+
+func TestBaseConnector_SetConnected(t *testing.T) {
+	bc := NewBaseConnector("test", ConnectorTypeFile)
+
+	bc.SetConnected(true)
+	if !bc.IsConnected() {
+		t.Error("should be connected after SetConnected(true)")
+	}
+
+	bc.SetConnected(false)
+	if bc.IsConnected() {
+		t.Error("should be disconnected after SetConnected(false)")
+	}
+}
+
+func TestBaseConnector_RecordSend(t *testing.T) {
+	bc := NewBaseConnector("test", ConnectorTypeNDJSON)
+
+	bc.RecordSend(10, 1024, 50*time.Millisecond)
+	bc.RecordSend(5, 512, 30*time.Millisecond)
+
+	status := bc.Status()
+	if status.RecordsSent != 15 {
+		t.Errorf("RecordsSent = %d, want 15", status.RecordsSent)
+	}
+	if status.BytesSent != 1536 {
+		t.Errorf("BytesSent = %d, want 1536", status.BytesSent)
+	}
+	if status.AvgLatencyMs <= 0 {
+		t.Error("AvgLatencyMs should be positive after sends")
+	}
+}
+
+func TestBaseConnector_RecordError(t *testing.T) {
+	bc := NewBaseConnector("test", ConnectorTypeKafka)
+
+	bc.RecordError(errors.New("connection refused"))
+	bc.RecordError(errors.New("timeout"))
+
+	status := bc.Status()
+	if status.ErrorCount != 2 {
+		t.Errorf("ErrorCount = %d, want 2", status.ErrorCount)
+	}
+	if status.LastErrorMsg != "timeout" {
+		t.Errorf("LastErrorMsg = %q, want %q", status.LastErrorMsg, "timeout")
+	}
+}
+
+func TestBaseConnector_Status(t *testing.T) {
+	bc := NewBaseConnector("my-connector", ConnectorTypeElasticsearch)
+	bc.SetConnected(true)
+	bc.RecordSend(5, 100, 10*time.Millisecond)
+
+	status := bc.Status()
+	if status.Name != "my-connector" {
+		t.Errorf("Name = %q, want %q", status.Name, "my-connector")
+	}
+	if status.Type != ConnectorTypeElasticsearch {
+		t.Errorf("Type = %q, want %q", status.Type, ConnectorTypeElasticsearch)
+	}
+	if !status.Connected {
+		t.Error("Connected should be true")
+	}
+	if status.RecordsSent != 5 {
+		t.Errorf("RecordsSent = %d, want 5", status.RecordsSent)
+	}
+}
+
+func TestBaseConnector_LatencyCalculation(t *testing.T) {
+	bc := NewBaseConnector("test", ConnectorTypeNDJSON)
+
+	// Send with 100ms latency
+	bc.RecordSend(1, 100, 100*time.Millisecond)
+	// Send with 200ms latency
+	bc.RecordSend(1, 100, 200*time.Millisecond)
+
+	status := bc.Status()
+	// Average should be 150ms
+	expectedAvg := 150.0
+	tolerance := 1.0
+	if status.AvgLatencyMs < expectedAvg-tolerance || status.AvgLatencyMs > expectedAvg+tolerance {
+		t.Errorf("AvgLatencyMs = %f, want ~%f", status.AvgLatencyMs, expectedAvg)
+	}
+}
+
+func TestBaseConnector_ZeroSendsLatency(t *testing.T) {
+	bc := NewBaseConnector("test", ConnectorTypeNDJSON)
+
+	status := bc.Status()
+	if status.AvgLatencyMs != 0 {
+		t.Errorf("AvgLatencyMs with no sends = %f, want 0", status.AvgLatencyMs)
+	}
+}
+
+// =============================================================================
+// Manager Tests
+// =============================================================================
+
+// mockConnector implements Connector for testing
+type mockConnector struct {
+	*BaseConnector
+	connectErr    error
+	disconnectErr error
+	sendErr       error
+	sendCalled    int
+}
+
+func newMockConnector(name string, ct ConnectorType) *mockConnector {
+	return &mockConnector{
+		BaseConnector: NewBaseConnector(name, ct),
+	}
+}
+
+func (m *mockConnector) Connect(ctx context.Context) error {
+	if m.connectErr != nil {
+		return m.connectErr
+	}
+	m.SetConnected(true)
+	return nil
+}
+
+func (m *mockConnector) Disconnect() error {
+	m.SetConnected(false)
+	return m.disconnectErr
+}
+
+func (m *mockConnector) Send(ctx context.Context, records []Record) error {
+	m.sendCalled++
+	if m.sendErr != nil {
+		m.RecordError(m.sendErr)
+		return m.sendErr
+	}
+	m.RecordSend(len(records), int64(len(records)*100), time.Millisecond)
+	return nil
+}
+
+func TestManager_New(t *testing.T) {
+	m := NewManager()
+	if m == nil {
+		t.Fatal("NewManager() returned nil")
+	}
+
+	names := m.List()
+	if len(names) != 0 {
+		t.Errorf("initial List() = %v, want empty", names)
+	}
+}
+
+func TestManager_Register(t *testing.T) {
+	m := NewManager()
+	c := newMockConnector("es1", ConnectorTypeElasticsearch)
+
+	if err := m.Register(c); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// Duplicate registration should fail
+	if err := m.Register(c); err == nil {
+		t.Error("duplicate Register() should return error")
+	}
+}
+
+func TestManager_Get(t *testing.T) {
+	m := NewManager()
+	c := newMockConnector("kafka1", ConnectorTypeKafka)
+	m.Register(c)
+
+	got, ok := m.Get("kafka1")
+	if !ok {
+		t.Error("Get() should find registered connector")
+	}
+	if got.Name() != "kafka1" {
+		t.Errorf("Get() name = %q, want %q", got.Name(), "kafka1")
+	}
+
+	_, ok = m.Get("nonexistent")
+	if ok {
+		t.Error("Get() should not find nonexistent connector")
+	}
+}
+
+func TestManager_Unregister(t *testing.T) {
+	m := NewManager()
+	c := newMockConnector("file1", ConnectorTypeFile)
+	m.Register(c)
+
+	if err := m.Unregister("file1"); err != nil {
+		t.Fatalf("Unregister() error = %v", err)
+	}
+
+	_, ok := m.Get("file1")
+	if ok {
+		t.Error("connector should not be found after Unregister")
+	}
+
+	// Unregister nonexistent should fail
+	if err := m.Unregister("nonexistent"); err == nil {
+		t.Error("Unregister(nonexistent) should return error")
+	}
+}
+
+func TestManager_List(t *testing.T) {
+	m := NewManager()
+	m.Register(newMockConnector("a", ConnectorTypeElasticsearch))
+	m.Register(newMockConnector("b", ConnectorTypeKafka))
+	m.Register(newMockConnector("c", ConnectorTypeNDJSON))
+
+	names := m.List()
+	if len(names) != 3 {
+		t.Errorf("List() len = %d, want 3", len(names))
+	}
+}
+
+func TestManager_ConnectAll(t *testing.T) {
+	m := NewManager()
+	c1 := newMockConnector("ok", ConnectorTypeElasticsearch)
+	c2 := newMockConnector("fail", ConnectorTypeKafka)
+	c2.connectErr = errors.New("connection refused")
+
+	m.Register(c1)
+	m.Register(c2)
+
+	errs := m.ConnectAll(context.Background())
+	if len(errs) != 1 {
+		t.Errorf("ConnectAll() errors = %d, want 1", len(errs))
+	}
+	if errs["fail"] == nil {
+		t.Error("ConnectAll() should have error for 'fail'")
+	}
+	if !c1.IsConnected() {
+		t.Error("'ok' connector should be connected")
+	}
+}
+
+func TestManager_DisconnectAll(t *testing.T) {
+	m := NewManager()
+	c1 := newMockConnector("c1", ConnectorTypeElasticsearch)
+	c1.SetConnected(true)
+	m.Register(c1)
+
+	errs := m.DisconnectAll()
+	if len(errs) != 0 {
+		t.Errorf("DisconnectAll() errors = %v, want none", errs)
+	}
+	if c1.IsConnected() {
+		t.Error("connector should be disconnected")
+	}
+}
+
+func TestManager_SendToAll(t *testing.T) {
+	m := NewManager()
+	c1 := newMockConnector("ok", ConnectorTypeElasticsearch)
+	c1.SetConnected(true)
+	c2 := newMockConnector("err", ConnectorTypeKafka)
+	c2.SetConnected(true)
+	c2.sendErr = errors.New("send error")
+	c3 := newMockConnector("disconnected", ConnectorTypeNDJSON)
+	// c3 not connected
+
+	m.Register(c1)
+	m.Register(c2)
+	m.Register(c3)
+
+	records := []Record{
+		NewMetricsRecord("h1", map[string]interface{}{"k": "v"}),
+	}
+
+	errs := m.SendToAll(context.Background(), records)
+	// Only connected connectors should be tried, 'err' should have error
+	if errs["err"] == nil {
+		t.Error("SendToAll() should have error for 'err'")
+	}
+	if c1.sendCalled != 1 {
+		t.Errorf("ok connector send count = %d, want 1", c1.sendCalled)
+	}
+	if c3.sendCalled != 0 {
+		t.Errorf("disconnected connector should not be called, got %d", c3.sendCalled)
+	}
+}
+
+func TestManager_Status(t *testing.T) {
+	m := NewManager()
+	c1 := newMockConnector("es", ConnectorTypeElasticsearch)
+	c1.SetConnected(true)
+	m.Register(c1)
+
+	statuses := m.Status()
+	if len(statuses) != 1 {
+		t.Fatalf("Status() len = %d, want 1", len(statuses))
+	}
+	if s, ok := statuses["es"]; !ok || !s.Connected {
+		t.Error("Status should show 'es' as connected")
+	}
+}
+
+func TestManager_Close(t *testing.T) {
+	m := NewManager()
+	c := newMockConnector("c1", ConnectorTypeFile)
+	c.SetConnected(true)
+	m.Register(c)
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if c.IsConnected() {
+		t.Error("connector should be disconnected after Close()")
+	}
+}
+
+// =============================================================================
+// StreamWriter Tests
+// =============================================================================
+
+func TestStreamWriter_Write(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewStreamWriter(&buf)
+
+	records := []Record{
+		NewMetricsRecord("h1", map[string]interface{}{"bans": 10}),
+		NewMetricsRecord("h1", map[string]interface{}{"bans": 20}),
+	}
+
+	if err := sw.Write(context.Background(), records); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Errorf("output lines = %d, want 2", len(lines))
+	}
+
+	// Each line should be valid JSON
+	for i, line := range lines {
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			t.Errorf("line %d is not valid JSON: %v", i, err)
+		}
+	}
+}
+
+func TestStreamWriter_WriteEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewStreamWriter(&buf)
+
+	if err := sw.Write(context.Background(), []Record{}); err != nil {
+		t.Fatalf("Write(empty) error = %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Error("empty records should produce empty output")
+	}
+}
+
+func TestStreamWriter_ContextCancellation(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewStreamWriter(&buf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	records := make([]Record, 100)
+	for i := range records {
+		records[i] = NewMetricsRecord("h1", map[string]interface{}{"i": i})
+	}
+
+	err := sw.Write(ctx, records)
+	if err == nil {
+		t.Error("Write() should return error when context is cancelled")
+	}
+}
+
+func TestStreamWriter_Flush(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewStreamWriter(&buf)
+
+	// Flush on a plain bytes.Buffer (no Flush method) should be no-op
+	if err := sw.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+}
+
+func TestStreamWriter_Close(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewStreamWriter(&buf)
+
+	// Close on a plain bytes.Buffer (no Close method) should be no-op
+	if err := sw.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+// =============================================================================
+// Elasticsearch Config Tests
+// =============================================================================
+
+func TestDefaultESConfig(t *testing.T) {
+	cfg := DefaultESConfig()
+
+	if len(cfg.Addresses) != 1 || cfg.Addresses[0] != "http://localhost:9200" {
+		t.Errorf("Addresses = %v, want [http://localhost:9200]", cfg.Addresses)
+	}
+	if cfg.Index != "nftban-metrics" {
+		t.Errorf("Index = %q, want %q", cfg.Index, "nftban-metrics")
+	}
+	if cfg.BulkSize != 1000 {
+		t.Errorf("BulkSize = %d, want 1000", cfg.BulkSize)
+	}
+	if cfg.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want 30s", cfg.Timeout)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	}
+}
+
+func TestNewElasticsearchConnector(t *testing.T) {
+	cfg := DefaultESConfig()
+	c := NewElasticsearchConnector("es-primary", cfg)
+
+	if c.Name() != "es-primary" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "es-primary")
+	}
+	if c.Type() != ConnectorTypeElasticsearch {
+		t.Errorf("Type() = %q, want %q", c.Type(), ConnectorTypeElasticsearch)
+	}
+	if c.IsConnected() {
+		t.Error("should not be connected initially")
+	}
+}
+
+func TestElasticsearchConnector_ResolveIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		index   string
+		ts      time.Time
+		want    string
+	}{
+		{
+			name:    "pattern with date",
+			pattern: "nftban-metrics-%Y.%m.%d",
+			ts:      time.Date(2026, 3, 20, 0, 0, 0, 0, time.UTC),
+			want:    "nftban-metrics-2026.03.20",
+		},
+		{
+			name:    "pattern with hour",
+			pattern: "nftban-%Y.%m.%d.%H",
+			ts:      time.Date(2026, 3, 20, 14, 30, 0, 0, time.UTC),
+			want:    "nftban-2026.03.20.14",
+		},
+		{
+			name:  "no pattern uses index",
+			index: "nftban-static",
+			ts:    time.Now(),
+			want:  "nftban-static",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ESConfig{
+				Index:        tt.index,
+				IndexPattern: tt.pattern,
+			}
+			c := NewElasticsearchConnector("test", cfg)
+
+			got := c.resolveIndex(tt.ts)
+			if got != tt.want {
+				t.Errorf("resolveIndex() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestElasticsearchConnector_AddAuth_APIKey(t *testing.T) {
+	cfg := ESConfig{APIKey: "mykey123"}
+	c := NewElasticsearchConnector("test", cfg)
+
+	// We can test the addAuth method indirectly by verifying the config is stored
+	if c.config.APIKey != "mykey123" {
+		t.Errorf("APIKey = %q, want %q", c.config.APIKey, "mykey123")
+	}
+}
+
+func TestElasticsearchConnector_AddAuth_BasicAuth(t *testing.T) {
+	cfg := ESConfig{Username: "admin", Password: "secret"}
+	c := NewElasticsearchConnector("test", cfg)
+
+	if c.config.Username != "admin" {
+		t.Errorf("Username = %q, want %q", c.config.Username, "admin")
+	}
+}
+
+func TestElasticsearchConnector_Disconnect_NotConnected(t *testing.T) {
+	cfg := DefaultESConfig()
+	c := NewElasticsearchConnector("test", cfg)
+
+	// Disconnect when not connected should not error
+	if err := c.Disconnect(); err != nil {
+		t.Fatalf("Disconnect() error = %v", err)
+	}
+}
+
+func TestElasticsearchConnector_SendEmpty(t *testing.T) {
+	cfg := DefaultESConfig()
+	c := NewElasticsearchConnector("test", cfg)
+
+	// Send empty records should be no-op
+	err := c.Send(context.Background(), []Record{})
+	if err != nil {
+		t.Errorf("Send(empty) error = %v", err)
+	}
+}
+
+func TestElasticsearchConnector_SendNotConnected(t *testing.T) {
+	cfg := DefaultESConfig()
+	c := NewElasticsearchConnector("test", cfg)
+
+	records := []Record{NewMetricsRecord("h1", map[string]interface{}{"k": "v"})}
+	err := c.Send(context.Background(), records)
+	if err == nil {
+		t.Error("Send() should error when not connected")
+	}
+}
+
+// =============================================================================
+// Kafka Config Tests
+// =============================================================================
+
+func TestDefaultKafkaConfig(t *testing.T) {
+	cfg := DefaultKafkaConfig()
+
+	if len(cfg.Brokers) != 1 || cfg.Brokers[0] != "localhost:9092" {
+		t.Errorf("Brokers = %v, want [localhost:9092]", cfg.Brokers)
+	}
+	if cfg.Topic != "nftban-metrics" {
+		t.Errorf("Topic = %q, want %q", cfg.Topic, "nftban-metrics")
+	}
+	if cfg.Acks != 1 {
+		t.Errorf("Acks = %d, want 1", cfg.Acks)
+	}
+	if cfg.BatchSize != 16384 {
+		t.Errorf("BatchSize = %d, want 16384", cfg.BatchSize)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	}
+	if cfg.Partition != -1 {
+		t.Errorf("Partition = %d, want -1", cfg.Partition)
+	}
+}
+
+func TestNewKafkaConnector(t *testing.T) {
+	cfg := DefaultKafkaConfig()
+	c := NewKafkaConnector("kafka-primary", cfg)
+
+	if c.Name() != "kafka-primary" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "kafka-primary")
+	}
+	if c.Type() != ConnectorTypeKafka {
+		t.Errorf("Type() = %q, want %q", c.Type(), ConnectorTypeKafka)
+	}
+	if c.IsConnected() {
+		t.Error("should not be connected initially")
+	}
+}
+
+func TestKafkaConnector_SendEmpty(t *testing.T) {
+	cfg := DefaultKafkaConfig()
+	c := NewKafkaConnector("test", cfg)
+
+	err := c.Send(context.Background(), []Record{})
+	if err != nil {
+		t.Errorf("Send(empty) error = %v", err)
+	}
+}
+
+func TestKafkaConnector_SendNotConnected(t *testing.T) {
+	cfg := DefaultKafkaConfig()
+	c := NewKafkaConnector("test", cfg)
+
+	records := []Record{NewMetricsRecord("h1", map[string]interface{}{"k": "v"})}
+	err := c.Send(context.Background(), records)
+	if err == nil {
+		t.Error("Send() should error when not connected")
+	}
+}
+
+func TestKafkaConnector_Disconnect_NotConnected(t *testing.T) {
+	cfg := DefaultKafkaConfig()
+	c := NewKafkaConnector("test", cfg)
+
+	if err := c.Disconnect(); err != nil {
+		t.Fatalf("Disconnect() error = %v", err)
+	}
+}
+
+func TestKafkaConnector_WriteVarint(t *testing.T) {
+	c := NewKafkaConnector("test", DefaultKafkaConfig())
+
+	tests := []struct {
+		name  string
+		value int64
+	}{
+		{"zero", 0},
+		{"one", 1},
+		{"small positive", 127},
+		{"medium positive", 300},
+		{"large positive", 100000},
+		{"negative one", -1},
+		{"negative large", -50000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			c.writeVarint(&buf, tt.value)
+			if buf.Len() == 0 {
+				t.Error("writeVarint should write at least 1 byte")
+			}
+		})
+	}
+}
+
+func TestKafkaConnector_BuildRecordBatch(t *testing.T) {
+	c := NewKafkaConnector("test", DefaultKafkaConfig())
+
+	messages := []kafkaMessage{
+		{Key: []byte("host1"), Value: []byte(`{"test": 1}`)},
+		{Key: []byte("host1"), Value: []byte(`{"test": 2}`)},
+	}
+
+	batch := c.buildRecordBatch(messages)
+	if len(batch) == 0 {
+		t.Error("buildRecordBatch should return non-empty bytes")
+	}
+
+	// Verify it starts with base offset (int64 = 0)
+	baseOffset := int64(binary.BigEndian.Uint64(batch[0:8]))
+	if baseOffset != 0 {
+		t.Errorf("base offset = %d, want 0", baseOffset)
+	}
+}
+
+func TestKafkaConnector_BuildRecordBatch_SingleMessage(t *testing.T) {
+	c := NewKafkaConnector("test", DefaultKafkaConfig())
+
+	messages := []kafkaMessage{
+		{Key: []byte("k"), Value: []byte(`{"v": 1}`)},
+	}
+
+	batch := c.buildRecordBatch(messages)
+	if len(batch) < 50 { // minimum overhead bytes
+		t.Errorf("batch too small: %d bytes", len(batch))
+	}
+}
+
+// =============================================================================
+// NDJSON Config Tests
+// =============================================================================
+
+func TestDefaultNDJSONConfig(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+
+	if cfg.Directory != "/var/log/nftban/metrics" {
+		t.Errorf("Directory = %q, want %q", cfg.Directory, "/var/log/nftban/metrics")
+	}
+	if cfg.Prefix != "nftban" {
+		t.Errorf("Prefix = %q, want %q", cfg.Prefix, "nftban")
+	}
+	if !cfg.RotateDaily {
+		t.Error("RotateDaily should be true by default")
+	}
+	if cfg.RotateSize != 100*1024*1024 {
+		t.Errorf("RotateSize = %d, want %d", cfg.RotateSize, 100*1024*1024)
+	}
+	if cfg.RetentionDays != 30 {
+		t.Errorf("RetentionDays = %d, want 30", cfg.RetentionDays)
+	}
+	if !cfg.Compress {
+		t.Error("Compress should be true by default")
+	}
+}
+
+func TestNewNDJSONConnector(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+	c := NewNDJSONConnector("ndjson-logs", cfg)
+
+	if c.Name() != "ndjson-logs" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "ndjson-logs")
+	}
+	if c.Type() != ConnectorTypeNDJSON {
+		t.Errorf("Type() = %q, want %q", c.Type(), ConnectorTypeNDJSON)
+	}
+}
+
+func TestNDJSONConnector_SendEmpty(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+	c := NewNDJSONConnector("test", cfg)
+
+	err := c.Send(context.Background(), []Record{})
+	if err != nil {
+		t.Errorf("Send(empty) error = %v", err)
+	}
+}
+
+func TestNDJSONConnector_GenerateFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		compress bool
+		wantExt  string
+	}{
+		{"uncompressed", "nftban", false, ".ndjson"},
+		{"compressed", "nftban", true, ".ndjson.gz"},
+		{"custom prefix", "myapp", false, ".ndjson"},
+		{"empty prefix defaults", "", false, ".ndjson"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NDJSONConfig{
+				Directory: "/tmp/nftban-test-nonexistent",
+				Prefix:    tt.prefix,
+				Compress:  tt.compress,
+			}
+			c := NewNDJSONConnector("test", cfg)
+
+			filename := c.generateFilename()
+			if !strings.HasSuffix(filename, tt.wantExt) {
+				t.Errorf("filename = %q, should end with %q", filename, tt.wantExt)
+			}
+
+			expectedPrefix := tt.prefix
+			if expectedPrefix == "" {
+				expectedPrefix = "nftban"
+			}
+			if !strings.HasPrefix(filename, expectedPrefix+"-") {
+				t.Errorf("filename = %q, should start with %q-", filename, expectedPrefix)
+			}
+		})
+	}
+}
+
+func TestNDJSONConnector_CurrentFile_NotConnected(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+	c := NewNDJSONConnector("test", cfg)
+
+	if c.CurrentFile() != "" {
+		t.Error("CurrentFile() should be empty when not connected")
+	}
+}
+
+func TestNDJSONConnector_BytesWritten_Initial(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+	c := NewNDJSONConnector("test", cfg)
+
+	if c.BytesWritten() != 0 {
+		t.Error("BytesWritten() should be 0 initially")
+	}
+}
+
+func TestNDJSONConnector_Status(t *testing.T) {
+	cfg := DefaultNDJSONConfig()
+	c := NewNDJSONConnector("test", cfg)
+
+	status := c.Status()
+	if status.Name != "test" {
+		t.Errorf("status.Name = %q, want %q", status.Name, "test")
+	}
+	if status.Type != ConnectorTypeNDJSON {
+		t.Errorf("status.Type = %q, want %q", status.Type, ConnectorTypeNDJSON)
+	}
+}
+
+// =============================================================================
+// BulkResponse Tests
+// =============================================================================
+
+func TestBulkResponse_NoErrors(t *testing.T) {
+	resp := BulkResponse{
+		Took:   5,
+		Errors: false,
+		Items: []BulkResponseItem{
+			{Index: BulkResponseItemDetail{Status: 201, Result: "created"}},
+		},
+	}
+
+	if resp.Errors {
+		t.Error("Errors should be false")
+	}
+}
+
+func TestBulkResponse_WithErrors(t *testing.T) {
+	resp := BulkResponse{
+		Took:   5,
+		Errors: true,
+		Items: []BulkResponseItem{
+			{Index: BulkResponseItemDetail{Status: 201, Result: "created"}},
+			{Index: BulkResponseItemDetail{
+				Status: 400,
+				Error:  &BulkItemError{Type: "mapper_parsing_exception", Reason: "bad field"},
+			}},
+		},
+	}
+
+	if !resp.Errors {
+		t.Error("Errors should be true")
+	}
+
+	errorCount := 0
+	for _, item := range resp.Items {
+		if item.Index.Error != nil {
+			errorCount++
+		}
+	}
+	if errorCount != 1 {
+		t.Errorf("error count = %d, want 1", errorCount)
+	}
+}
+
+func TestBulkResponse_JSON_RoundTrip(t *testing.T) {
+	resp := BulkResponse{
+		Took:   10,
+		Errors: false,
+		Items: []BulkResponseItem{
+			{Index: BulkResponseItemDetail{
+				Index:   "nftban-metrics-2026.03.20",
+				ID:      "abc123",
+				Version: 1,
+				Result:  "created",
+				Status:  201,
+			}},
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+
+	var parsed BulkResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if parsed.Took != 10 {
+		t.Errorf("Took = %d, want 10", parsed.Took)
+	}
+	if len(parsed.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1", len(parsed.Items))
+	}
+	if parsed.Items[0].Index.Result != "created" {
+		t.Errorf("Result = %q, want %q", parsed.Items[0].Index.Result, "created")
+	}
+}
+
+// =============================================================================
+// ConnectorStatus JSON Tests
+// =============================================================================
+
+func TestConnectorStatus_JSON(t *testing.T) {
+	status := ConnectorStatus{
+		Name:         "test-es",
+		Type:         ConnectorTypeElasticsearch,
+		Connected:    true,
+		RecordsSent:  500,
+		BytesSent:    1024000,
+		ErrorCount:   2,
+		AvgLatencyMs: 15.5,
+	}
+
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+
+	var parsed ConnectorStatus
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if parsed.Name != "test-es" {
+		t.Errorf("Name = %q, want %q", parsed.Name, "test-es")
+	}
+	if parsed.RecordsSent != 500 {
+		t.Errorf("RecordsSent = %d, want 500", parsed.RecordsSent)
+	}
+}
+
+// =============================================================================
+// Record JSON Serialization Tests
+// =============================================================================
+
+func TestRecord_JSON_RoundTrip(t *testing.T) {
+	original := Record{
+		Timestamp: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Host:      "testhost",
+		Type:      "metrics",
+		Source:    "nftban",
+		Version:   "1.0",
+		Data: map[string]interface{}{
+			"bans_total": float64(100), // JSON numbers decode as float64
+		},
+		Tags: map[string]string{"env": "test"},
+		Meta: map[string]interface{}{"note": "test record"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+
+	var parsed Record
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if parsed.Host != original.Host {
+		t.Errorf("Host = %q, want %q", parsed.Host, original.Host)
+	}
+	if parsed.Type != original.Type {
+		t.Errorf("Type = %q, want %q", parsed.Type, original.Type)
+	}
+	if parsed.Tags["env"] != "test" {
+		t.Errorf("Tags[env] = %q, want %q", parsed.Tags["env"], "test")
+	}
+}

--- a/pkg/exporters/zabbix/zabbix_test.go
+++ b/pkg/exporters/zabbix/zabbix_test.go
@@ -1,0 +1,1862 @@
+// =============================================================================
+// NFTBan - Zabbix Exporter Package Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="zabbix_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Tests for Zabbix exporter: protocol encode/decode, discovery, sender, config, types"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package zabbix
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Protocol Encode Tests
+// =============================================================================
+
+func TestEncode_BasicRequest(t *testing.T) {
+	req := &TrapperRequest{
+		Request: "sender data",
+		Data: []TrapperItem{
+			{Host: "host1", Key: "nftban.test", Value: "42", Clock: 1000, Ns: 0},
+		},
+		Clock: 1000,
+		Ns:    0,
+	}
+
+	data, err := Encode(req)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	// Verify header bytes
+	if !bytes.Equal(data[0:5], headerBytes) {
+		t.Errorf("header = %x, want %x", data[0:5], headerBytes)
+	}
+
+	// Verify length field
+	payloadLen := binary.LittleEndian.Uint64(data[5:13])
+	actualPayloadLen := uint64(len(data) - headerSize)
+	if payloadLen != actualPayloadLen {
+		t.Errorf("payload length = %d, want %d", payloadLen, actualPayloadLen)
+	}
+
+	// Verify payload is valid JSON
+	var decoded TrapperRequest
+	if err := json.Unmarshal(data[13:], &decoded); err != nil {
+		t.Fatalf("payload JSON unmarshal error = %v", err)
+	}
+	if decoded.Request != "sender data" {
+		t.Errorf("decoded request = %q, want %q", decoded.Request, "sender data")
+	}
+	if len(decoded.Data) != 1 {
+		t.Fatalf("decoded data len = %d, want 1", len(decoded.Data))
+	}
+	if decoded.Data[0].Host != "host1" {
+		t.Errorf("decoded host = %q, want %q", decoded.Data[0].Host, "host1")
+	}
+}
+
+func TestEncode_EmptyData(t *testing.T) {
+	req := &TrapperRequest{
+		Request: "sender data",
+		Data:    []TrapperItem{},
+	}
+
+	data, err := Encode(req)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if len(data) <= headerSize {
+		t.Error("encoded data should be larger than header")
+	}
+}
+
+func TestEncode_MultipleItems(t *testing.T) {
+	items := make([]TrapperItem, 50)
+	for i := range items {
+		items[i] = TrapperItem{
+			Host:  "testhost",
+			Key:   fmt.Sprintf("nftban.metric.%d", i),
+			Value: fmt.Sprintf("%d", i*10),
+			Clock: 1000,
+		}
+	}
+
+	req := &TrapperRequest{
+		Request: "sender data",
+		Data:    items,
+		Clock:   1000,
+	}
+
+	data, err := Encode(req)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	// Decode the payload and verify item count
+	var decoded TrapperRequest
+	if err := json.Unmarshal(data[13:], &decoded); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	if len(decoded.Data) != 50 {
+		t.Errorf("decoded item count = %d, want 50", len(decoded.Data))
+	}
+}
+
+// =============================================================================
+// Protocol Decode Tests
+// =============================================================================
+
+func TestDecode_ValidResponse(t *testing.T) {
+	// Build a valid protocol message
+	payload := []byte(`{"response":"success","info":"processed: 10; failed: 0; total: 10; seconds spent: 0.001"}`)
+
+	buf := &bytes.Buffer{}
+	buf.Write(headerBytes)
+	lenBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(lenBuf, uint64(len(payload)))
+	buf.Write(lenBuf)
+	buf.Write(payload)
+
+	resp, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if resp.Response != "success" {
+		t.Errorf("response = %q, want %q", resp.Response, "success")
+	}
+	if !resp.IsSuccess() {
+		t.Error("IsSuccess() = false, want true")
+	}
+}
+
+func TestDecode_FailureResponse(t *testing.T) {
+	payload := []byte(`{"response":"failed","info":"processed: 0; failed: 5; total: 5; seconds spent: 0.000"}`)
+
+	buf := &bytes.Buffer{}
+	buf.Write(headerBytes)
+	lenBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(lenBuf, uint64(len(payload)))
+	buf.Write(lenBuf)
+	buf.Write(payload)
+
+	resp, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if resp.IsSuccess() {
+		t.Error("IsSuccess() = true, want false")
+	}
+}
+
+func TestDecode_InvalidHeader(t *testing.T) {
+	buf := bytes.NewBufferString("INVALID_HEADER_DATA_HERE!")
+	_, err := Decode(buf)
+	if err == nil {
+		t.Error("Decode() should return error for invalid header")
+	}
+}
+
+func TestDecode_TruncatedHeader(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{0x5A, 0x42}) // partial header
+	_, err := Decode(buf)
+	if err == nil {
+		t.Error("Decode() should return error for truncated header")
+	}
+}
+
+func TestDecode_OversizedPayload(t *testing.T) {
+	buf := &bytes.Buffer{}
+	buf.Write(headerBytes)
+	lenBuf := make([]byte, 8)
+	// Set length to exceed maxResponseSize (1MB)
+	binary.LittleEndian.PutUint64(lenBuf, uint64(maxResponseSize+1))
+	buf.Write(lenBuf)
+
+	_, err := Decode(buf)
+	if err == nil {
+		t.Error("Decode() should return error for oversized payload")
+	}
+}
+
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	req := &TrapperRequest{
+		Request: "sender data",
+		Data: []TrapperItem{
+			{Host: "h1", Key: "k1", Value: "v1", Clock: 1234, Ns: 5678},
+		},
+		Clock: 1234,
+		Ns:    5678,
+	}
+
+	encoded, err := Encode(req)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	// Build a "response" message using the same encoding scheme
+	// to simulate a server response
+	respJSON := []byte(`{"response":"success","info":"processed: 1; failed: 0; total: 1; seconds spent: 0.001"}`)
+	respBuf := &bytes.Buffer{}
+	respBuf.Write(headerBytes)
+	lenBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(lenBuf, uint64(len(respJSON)))
+	respBuf.Write(lenBuf)
+	respBuf.Write(respJSON)
+
+	resp, err := Decode(respBuf)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if !resp.IsSuccess() {
+		t.Error("response should be success")
+	}
+
+	// Verify request payload can be re-parsed
+	var decoded TrapperRequest
+	if err := json.Unmarshal(encoded[headerSize:], &decoded); err != nil {
+		t.Fatalf("re-parse error = %v", err)
+	}
+	if decoded.Data[0].Key != "k1" {
+		t.Errorf("key = %q, want %q", decoded.Data[0].Key, "k1")
+	}
+}
+
+// =============================================================================
+// ParseInfoString Tests
+// =============================================================================
+
+func TestParseInfoString(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      string
+		processed int
+		failed    int
+		total     int
+		seconds   float64
+	}{
+		{
+			name:      "standard success",
+			info:      "processed: 10; failed: 0; total: 10; seconds spent: 0.001234",
+			processed: 10, failed: 0, total: 10, seconds: 0.001234,
+		},
+		{
+			name:      "with failures",
+			info:      "processed: 8; failed: 2; total: 10; seconds spent: 0.500",
+			processed: 8, failed: 2, total: 10, seconds: 0.5,
+		},
+		{
+			name:      "large numbers",
+			info:      "processed: 100000; failed: 50; total: 100050; seconds spent: 5.123",
+			processed: 100000, failed: 50, total: 100050, seconds: 5.123,
+		},
+		{
+			name:      "zero everything",
+			info:      "processed: 0; failed: 0; total: 0; seconds spent: 0.000",
+			processed: 0, failed: 0, total: 0, seconds: 0,
+		},
+		{
+			name:      "invalid format",
+			info:      "something else entirely",
+			processed: 0, failed: 0, total: 0, seconds: 0,
+		},
+		{
+			name:      "empty string",
+			info:      "",
+			processed: 0, failed: 0, total: 0, seconds: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseInfoString(tt.info)
+			if result.Processed != tt.processed {
+				t.Errorf("Processed = %d, want %d", result.Processed, tt.processed)
+			}
+			if result.Failed != tt.failed {
+				t.Errorf("Failed = %d, want %d", result.Failed, tt.failed)
+			}
+			if result.Total != tt.total {
+				t.Errorf("Total = %d, want %d", result.Total, tt.total)
+			}
+			if result.Seconds != tt.seconds {
+				t.Errorf("Seconds = %f, want %f", result.Seconds, tt.seconds)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// FormatValue / StringValue Tests
+// =============================================================================
+
+func TestMetric_StringValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"string", "hello", "hello"},
+		{"int", 42, "42"},
+		{"int32", int32(100), "100"},
+		{"int64", int64(9999), "9999"},
+		{"uint", uint(7), "7"},
+		{"uint32", uint32(255), "255"},
+		{"uint64", uint64(12345678), "12345678"},
+		{"float32", float32(3.14), "3.14"},
+		{"float64", float64(2.71828), "2.71828"},
+		{"bool true", true, "1"},
+		{"bool false", false, "0"},
+		{"nil via json", nil, "null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Metric{Value: tt.value}
+			got := m.StringValue()
+			if got != tt.want {
+				t.Errorf("StringValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"string", "test", "test"},
+		{"bytes", []byte("data"), "data"},
+		{"int", 42, "42"},
+		{"int8", int8(7), "7"},
+		{"int16", int16(300), "300"},
+		{"int32", int32(-1), "-1"},
+		{"int64", int64(1234567890), "1234567890"},
+		{"uint", uint(100), "100"},
+		{"uint8", uint8(255), "255"},
+		{"uint16", uint16(65535), "65535"},
+		{"uint32", uint32(4294967295), "4294967295"},
+		{"uint64", uint64(18446744073709551615), "18446744073709551615"},
+		{"float32", float32(1.5), "1.5"},
+		{"float64", float64(3.14159), "3.14159"},
+		{"bool true", true, "1"},
+		{"bool false", false, "0"},
+		{"nil", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatValue(tt.value)
+			if got != tt.want {
+				t.Errorf("formatValue(%v) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BuildKey / ParseKey Tests
+// =============================================================================
+
+func TestBuildKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		params []string
+		want   string
+	}{
+		{"no params", "nftban.test", nil, "nftban.test"},
+		{"empty params", "nftban.test", []string{}, "nftban.test"},
+		{"one param", "nftban.module.status", []string{"portscan"}, "nftban.module.status[portscan]"},
+		{"two params", "nftban.metric", []string{"a", "b"}, "nftban.metric[a,b]"},
+		{"three params", "nftban.x", []string{"1", "2", "3"}, "nftban.x[1,2,3]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildKey(tt.base, tt.params...)
+			if got != tt.want {
+				t.Errorf("BuildKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		wantBase   string
+		wantParams []string
+	}{
+		{"no params", "nftban.test", "nftban.test", nil},
+		{"one param", "nftban.module.status[portscan]", "nftban.module.status", []string{"portscan"}},
+		{"two params", "nftban.metric[a,b]", "nftban.metric", []string{"a", "b"}},
+		{"empty brackets", "nftban.test[]", "nftban.test", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, params := ParseKey(tt.key)
+			if base != tt.wantBase {
+				t.Errorf("base = %q, want %q", base, tt.wantBase)
+			}
+			if tt.wantParams == nil && params != nil {
+				t.Errorf("params = %v, want nil", params)
+			}
+			if tt.wantParams != nil {
+				if len(params) != len(tt.wantParams) {
+					t.Fatalf("params len = %d, want %d", len(params), len(tt.wantParams))
+				}
+				for i, p := range params {
+					if p != tt.wantParams[i] {
+						t.Errorf("params[%d] = %q, want %q", i, p, tt.wantParams[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBuildParseKey_RoundTrip(t *testing.T) {
+	tests := []struct {
+		base   string
+		params []string
+	}{
+		{"nftban.module.status", []string{"portscan"}},
+		{"nftban.metric", []string{"a", "b", "c"}},
+	}
+
+	for _, tt := range tests {
+		key := BuildKey(tt.base, tt.params...)
+		gotBase, gotParams := ParseKey(key)
+		if gotBase != tt.base {
+			t.Errorf("round-trip base = %q, want %q", gotBase, tt.base)
+		}
+		if len(gotParams) != len(tt.params) {
+			t.Errorf("round-trip params len = %d, want %d", len(gotParams), len(tt.params))
+		}
+	}
+}
+
+// =============================================================================
+// ValidateKey Tests
+// =============================================================================
+
+func TestValidateKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{"valid simple", "nftban.test", false},
+		{"valid with params", "nftban.module[portscan]", false},
+		{"valid with multiple params", "nftban.x[a,b]", false},
+		{"valid with hyphens", "nftban.my-key", false},
+		{"valid with underscore", "nftban.my_key", false},
+		{"empty", "", true},
+		{"too long", strings.Repeat("a", 2049), true},
+		{"invalid chars space", "nftban test", true},
+		{"invalid chars exclamation", "nftban!", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKey(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateKey(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ValidateHostname Tests
+// =============================================================================
+
+func TestValidateHostname(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantErr bool
+	}{
+		{"valid", "myhost.example.com", false},
+		{"valid short", "h", false},
+		{"empty", "", true},
+		{"too long", strings.Repeat("x", 129), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHostname(tt.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHostname(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// SplitIntoBatches Tests
+// =============================================================================
+
+func TestSplitIntoBatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		count     int
+		batchSize int
+		wantLen   int
+		wantLast  int // size of last batch
+	}{
+		{"exact fit", 10, 5, 2, 5},
+		{"remainder", 11, 5, 3, 1},
+		{"single item", 1, 5, 1, 1},
+		{"empty", 0, 5, 0, 0},
+		{"batch larger than input", 3, 10, 1, 3},
+		{"batch size 1", 5, 1, 5, 1},
+		{"zero batch size uses default", 5, 0, 1, 5},
+		{"negative batch size uses default", 5, -1, 1, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := make([]Metric, tt.count)
+			for i := range metrics {
+				metrics[i] = Metric{Name: fmt.Sprintf("m%d", i), Value: i}
+			}
+
+			batches := SplitIntoBatches(metrics, tt.batchSize)
+			if len(batches) != tt.wantLen {
+				t.Errorf("batches count = %d, want %d", len(batches), tt.wantLen)
+			}
+			if tt.wantLen > 0 && len(batches[len(batches)-1]) != tt.wantLast {
+				t.Errorf("last batch size = %d, want %d", len(batches[len(batches)-1]), tt.wantLast)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// FormatDiscoveryData Tests
+// =============================================================================
+
+func TestFormatDiscoveryData(t *testing.T) {
+	items := []map[string]string{
+		{"{#MODULE}": "portscan", "{#MODE}": "active"},
+		{"{#MODULE}": "ddos", "{#MODE}": "passive"},
+	}
+
+	result, err := FormatDiscoveryData(items)
+	if err != nil {
+		t.Fatalf("FormatDiscoveryData() error = %v", err)
+	}
+
+	// Verify JSON structure
+	var parsed struct {
+		Data []map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("JSON parse error = %v", err)
+	}
+	if len(parsed.Data) != 2 {
+		t.Errorf("data len = %d, want 2", len(parsed.Data))
+	}
+	if parsed.Data[0]["{#MODULE}"] != "portscan" {
+		t.Errorf("first module = %q, want %q", parsed.Data[0]["{#MODULE}"], "portscan")
+	}
+}
+
+func TestFormatDiscoveryData_Empty(t *testing.T) {
+	result, err := FormatDiscoveryData([]map[string]string{})
+	if err != nil {
+		t.Fatalf("FormatDiscoveryData() error = %v", err)
+	}
+
+	var parsed struct {
+		Data []map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("JSON parse error = %v", err)
+	}
+	if len(parsed.Data) != 0 {
+		t.Errorf("data len = %d, want 0", len(parsed.Data))
+	}
+}
+
+func TestFormatModuleDiscovery(t *testing.T) {
+	modules := []DiscoveredModule{
+		{Module: "portscan", Mode: "active", Enabled: 1},
+		{Module: "ddos", Mode: "passive", Enabled: 0},
+	}
+
+	result, err := FormatModuleDiscovery(modules)
+	if err != nil {
+		t.Fatalf("FormatModuleDiscovery() error = %v", err)
+	}
+	if !strings.Contains(result, "portscan") {
+		t.Error("result should contain 'portscan'")
+	}
+	if !strings.Contains(result, `"{#ENABLED}"`) || !strings.Contains(result, `"1"`) {
+		t.Error("result should contain enabled status")
+	}
+}
+
+func TestFormatInterfaceDiscovery(t *testing.T) {
+	interfaces := []DiscoveredInterface{
+		{Interface: "eth0", Zone: "public"},
+	}
+
+	result, err := FormatInterfaceDiscovery(interfaces)
+	if err != nil {
+		t.Fatalf("FormatInterfaceDiscovery() error = %v", err)
+	}
+	if !strings.Contains(result, "eth0") {
+		t.Error("result should contain 'eth0'")
+	}
+}
+
+func TestFormatCountryDiscovery(t *testing.T) {
+	countries := []DiscoveredCountry{
+		{Country: "CN", CountryName: "China", Blocked: 1},
+		{Country: "US", CountryName: "United States", Blocked: 0},
+	}
+
+	result, err := FormatCountryDiscovery(countries)
+	if err != nil {
+		t.Fatalf("FormatCountryDiscovery() error = %v", err)
+	}
+	if !strings.Contains(result, "CN") || !strings.Contains(result, "China") {
+		t.Error("result should contain country data")
+	}
+}
+
+func TestFormatFeedDiscovery(t *testing.T) {
+	feeds := []DiscoveredFeed{
+		{Feed: "spamhaus", URL: "https://example.com/drop.txt", Enabled: 1},
+	}
+
+	result, err := FormatFeedDiscovery(feeds)
+	if err != nil {
+		t.Fatalf("FormatFeedDiscovery() error = %v", err)
+	}
+	if !strings.Contains(result, "spamhaus") {
+		t.Error("result should contain feed name")
+	}
+}
+
+func TestFormatTimerDiscovery(t *testing.T) {
+	timers := []DiscoveredTimer{
+		{Timer: "nftban-sync", Duration: "60s"},
+	}
+
+	result, err := FormatTimerDiscovery(timers)
+	if err != nil {
+		t.Fatalf("FormatTimerDiscovery() error = %v", err)
+	}
+	if !strings.Contains(result, "nftban-sync") {
+		t.Error("result should contain timer name")
+	}
+}
+
+// =============================================================================
+// Config Tests
+// =============================================================================
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Enabled {
+		t.Error("default config should be disabled")
+	}
+	if cfg.Hostname == "" {
+		t.Error("default hostname should not be empty")
+	}
+	if cfg.Interval != 60*time.Second {
+		t.Errorf("default interval = %v, want 60s", cfg.Interval)
+	}
+	if cfg.BatchSize != 100 {
+		t.Errorf("default batch_size = %d, want 100", cfg.BatchSize)
+	}
+	if cfg.RetryCount != 3 {
+		t.Errorf("default retry_count = %d, want 3", cfg.RetryCount)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("default log_level = %q, want %q", cfg.LogLevel, "info")
+	}
+	if !cfg.BufferEnabled {
+		t.Error("default buffer should be enabled")
+	}
+	if !cfg.DiscoveryEnabled {
+		t.Error("default discovery should be enabled")
+	}
+}
+
+func TestDefaultTargetConfig(t *testing.T) {
+	tc := DefaultTargetConfig("primary", "10.0.0.1")
+
+	if tc.Name != "primary" {
+		t.Errorf("name = %q, want %q", tc.Name, "primary")
+	}
+	if tc.Address != "10.0.0.1" {
+		t.Errorf("address = %q, want %q", tc.Address, "10.0.0.1")
+	}
+	if tc.Port != DefaultPort {
+		t.Errorf("port = %d, want %d", tc.Port, DefaultPort)
+	}
+	if !tc.Enabled {
+		t.Error("default target should be enabled")
+	}
+}
+
+func TestConfig_Validate_Disabled(t *testing.T) {
+	cfg := &Config{Enabled: false}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("disabled config should not fail validation, got %v", err)
+	}
+}
+
+func TestConfig_Validate_NoTargets(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("enabled config with no targets should fail")
+	}
+	if !strings.Contains(err.Error(), "at least one target") {
+		t.Errorf("error should mention targets, got %q", err.Error())
+	}
+}
+
+func TestConfig_Validate_IntervalTooSmall(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+	cfg.Interval = 5 * time.Second
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("interval < 10s should fail validation")
+	}
+	if !strings.Contains(err.Error(), "interval must be at least 10 seconds") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_IntervalTooLarge(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+	cfg.Interval = 2 * time.Hour
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("interval > 1 hour should fail validation")
+	}
+}
+
+func TestConfig_Validate_BatchSizeBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		batchSize int
+		wantErr   bool
+	}{
+		{"too small", 0, true},
+		{"minimum", 1, false},
+		{"normal", 100, false},
+		{"maximum", 10000, false},
+		{"too large", 10001, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Enabled = true
+			cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+			cfg.BatchSize = tt.batchSize
+
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_InvalidLogLevel(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+	cfg.LogLevel = "trace"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("invalid log level should fail validation")
+	}
+}
+
+func TestConfig_Validate_ValidLogLevels(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		cfg := DefaultConfig()
+		cfg.Enabled = true
+		cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+		cfg.LogLevel = level
+
+		err := cfg.Validate()
+		if err != nil {
+			t.Errorf("log level %q should be valid, got %v", level, err)
+		}
+	}
+}
+
+func TestConfig_Validate_RetryCountBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{"negative", -1, true},
+		{"zero", 0, false},
+		{"normal", 3, false},
+		{"max", 10, false},
+		{"too high", 11, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Enabled = true
+			cfg.Targets = []TargetConfig{DefaultTargetConfig("t1", "127.0.0.1")}
+			cfg.RetryCount = tt.count
+
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTargetConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  TargetConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid IP",
+			target:  TargetConfig{Name: "t1", Address: "10.0.0.1", Port: 10051},
+			wantErr: false,
+		},
+		{
+			name:    "valid hostname",
+			target:  TargetConfig{Name: "t1", Address: "zabbix.example.com", Port: 10051},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			target:  TargetConfig{Address: "10.0.0.1", Port: 10051},
+			wantErr: true,
+		},
+		{
+			name:    "missing address",
+			target:  TargetConfig{Name: "t1", Port: 10051},
+			wantErr: true,
+		},
+		{
+			name:    "invalid port zero",
+			target:  TargetConfig{Name: "t1", Address: "10.0.0.1", Port: 0},
+			wantErr: true,
+		},
+		{
+			name:    "invalid port too high",
+			target:  TargetConfig{Name: "t1", Address: "10.0.0.1", Port: 70000},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.target.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfig_GetEnabledTargets(t *testing.T) {
+	cfg := &Config{
+		Targets: []TargetConfig{
+			{Name: "low-prio", Enabled: true, Priority: 3, Address: "a", Port: 10051},
+			{Name: "disabled", Enabled: false, Priority: 1, Address: "b", Port: 10051},
+			{Name: "high-prio", Enabled: true, Priority: 1, Address: "c", Port: 10051},
+			{Name: "mid-prio", Enabled: true, Priority: 2, Address: "d", Port: 10051},
+		},
+	}
+
+	enabled := cfg.GetEnabledTargets()
+	if len(enabled) != 3 {
+		t.Fatalf("enabled count = %d, want 3", len(enabled))
+	}
+	// Should be sorted by priority
+	if enabled[0].Name != "high-prio" {
+		t.Errorf("first enabled = %q, want %q", enabled[0].Name, "high-prio")
+	}
+	if enabled[1].Name != "mid-prio" {
+		t.Errorf("second enabled = %q, want %q", enabled[1].Name, "mid-prio")
+	}
+	if enabled[2].Name != "low-prio" {
+		t.Errorf("third enabled = %q, want %q", enabled[2].Name, "low-prio")
+	}
+}
+
+func TestConfig_ApplyDefaults(t *testing.T) {
+	cfg := &Config{
+		Targets: []TargetConfig{
+			{Name: "t1", Address: "10.0.0.1"},
+		},
+	}
+	cfg.ApplyDefaults()
+
+	if cfg.Hostname == "" {
+		t.Error("hostname should be set after ApplyDefaults")
+	}
+	if cfg.Interval != 60*time.Second {
+		t.Errorf("interval = %v, want 60s", cfg.Interval)
+	}
+	if cfg.Targets[0].Port != DefaultPort {
+		t.Errorf("target port = %d, want %d", cfg.Targets[0].Port, DefaultPort)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
+	}
+}
+
+func TestTargetConfig_ToTarget(t *testing.T) {
+	tc := TargetConfig{
+		Name:    "primary",
+		Address: "10.0.0.1",
+		Port:    10051,
+		Enabled: true,
+	}
+
+	target := tc.ToTarget()
+	if target.Name != "primary" {
+		t.Errorf("name = %q, want %q", target.Name, "primary")
+	}
+	if target.TLS != nil {
+		t.Error("TLS should be nil when not enabled")
+	}
+}
+
+func TestTargetConfig_ToTarget_WithTLS(t *testing.T) {
+	tc := TargetConfig{
+		Name:    "secure",
+		Address: "10.0.0.1",
+		Port:    10051,
+		TLS: TLSTargetConfig{
+			Enabled:  true,
+			CertFile: "/path/cert",
+			KeyFile:  "/path/key",
+			CAFile:   "/path/ca",
+		},
+	}
+
+	target := tc.ToTarget()
+	if target.TLS == nil {
+		t.Fatal("TLS should not be nil when enabled")
+	}
+	if !target.TLS.Enabled {
+		t.Error("TLS.Enabled should be true")
+	}
+	if target.TLS.CertFile != "/path/cert" {
+		t.Errorf("CertFile = %q, want %q", target.TLS.CertFile, "/path/cert")
+	}
+}
+
+// =============================================================================
+// Type Tests
+// =============================================================================
+
+func TestTrapperResponse_IsSuccess(t *testing.T) {
+	tests := []struct {
+		response string
+		want     bool
+	}{
+		{"success", true},
+		{"failed", false},
+		{"error", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		resp := &TrapperResponse{Response: tt.response}
+		if got := resp.IsSuccess(); got != tt.want {
+			t.Errorf("IsSuccess(%q) = %v, want %v", tt.response, got, tt.want)
+		}
+	}
+}
+
+func TestBatch_Size(t *testing.T) {
+	b := &Batch{
+		Metrics: make([]Metric, 5),
+	}
+	if b.Size() != 5 {
+		t.Errorf("Size() = %d, want 5", b.Size())
+	}
+}
+
+func TestBatch_ToTrapperRequest(t *testing.T) {
+	ts := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
+	b := &Batch{
+		Metrics: []Metric{
+			{Name: "nftban.test", Value: 42},
+			{Name: "nftban.version", Value: "1.25.0"},
+		},
+		Host:      "testhost",
+		Timestamp: ts,
+	}
+
+	req := b.ToTrapperRequest()
+	if req.Request != "sender data" {
+		t.Errorf("Request = %q, want %q", req.Request, "sender data")
+	}
+	if len(req.Data) != 2 {
+		t.Fatalf("Data len = %d, want 2", len(req.Data))
+	}
+	if req.Data[0].Host != "testhost" {
+		t.Errorf("Data[0].Host = %q, want %q", req.Data[0].Host, "testhost")
+	}
+	if req.Data[0].Key != "nftban.test" {
+		t.Errorf("Data[0].Key = %q, want %q", req.Data[0].Key, "nftban.test")
+	}
+	if req.Data[0].Value != "42" {
+		t.Errorf("Data[0].Value = %q, want %q", req.Data[0].Value, "42")
+	}
+	if req.Clock != ts.Unix() {
+		t.Errorf("Clock = %d, want %d", req.Clock, ts.Unix())
+	}
+}
+
+func TestSendError(t *testing.T) {
+	// Error without cause
+	e1 := &SendError{Target: "primary", Message: "connection refused"}
+	if !strings.Contains(e1.Error(), "primary") {
+		t.Error("error should contain target name")
+	}
+	if !strings.Contains(e1.Error(), "connection refused") {
+		t.Error("error should contain message")
+	}
+	if e1.Unwrap() != nil {
+		t.Error("Unwrap should return nil when no cause")
+	}
+
+	// Error with cause
+	cause := errors.New("timeout")
+	e2 := &SendError{Target: "secondary", Message: "send failed", Cause: cause}
+	if !strings.Contains(e2.Error(), "secondary") {
+		t.Error("error should contain target name")
+	}
+	if !strings.Contains(e2.Error(), "timeout") {
+		t.Error("error should contain cause")
+	}
+	if e2.Unwrap() != cause {
+		t.Error("Unwrap should return the cause")
+	}
+}
+
+func TestDiscoveryError(t *testing.T) {
+	// Without cause
+	e1 := &DiscoveryError{Key: "nftban.discovery.modules", Message: "not found"}
+	if !strings.Contains(e1.Error(), "modules") {
+		t.Error("error should contain key")
+	}
+	if e1.Unwrap() != nil {
+		t.Error("Unwrap should return nil when no cause")
+	}
+
+	// With cause
+	cause := errors.New("network error")
+	e2 := &DiscoveryError{Key: "nftban.discovery.feeds", Message: "refresh failed", Cause: cause}
+	if !strings.Contains(e2.Error(), "feeds") {
+		t.Error("error should contain key")
+	}
+	if e2.Unwrap() != cause {
+		t.Error("Unwrap should return the cause")
+	}
+}
+
+// =============================================================================
+// EncodeMetrics Tests
+// =============================================================================
+
+func TestEncodeMetrics(t *testing.T) {
+	metrics := []Metric{
+		{Name: "nftban.bans.total", Value: int64(100), Timestamp: time.Now()},
+		{Name: "nftban.version", Value: "1.25.0", Timestamp: time.Now()},
+	}
+
+	data, err := EncodeMetrics("testhost", metrics)
+	if err != nil {
+		t.Fatalf("EncodeMetrics() error = %v", err)
+	}
+
+	// Verify header
+	if !bytes.Equal(data[0:5], headerBytes) {
+		t.Error("invalid header")
+	}
+
+	// Verify payload
+	var req TrapperRequest
+	if err := json.Unmarshal(data[headerSize:], &req); err != nil {
+		t.Fatalf("JSON unmarshal error = %v", err)
+	}
+	if len(req.Data) != 2 {
+		t.Errorf("data len = %d, want 2", len(req.Data))
+	}
+	if req.Data[0].Host != "testhost" {
+		t.Errorf("host = %q, want %q", req.Data[0].Host, "testhost")
+	}
+}
+
+// =============================================================================
+// isValidHostname Tests
+// =============================================================================
+
+func TestIsValidHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{"simple", "myhost", true},
+		{"fqdn", "host.example.com", true},
+		{"with hyphens", "my-host.example.com", true},
+		{"single char", "a", true},
+		{"empty", "", false},
+		{"starts with hyphen", "-host", false},
+		{"ends with hyphen", "host-", false},
+		{"dot only", ".", false},
+		{"double dot", "host..com", false},
+		{"too long label", strings.Repeat("a", 64), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidHostname(tt.hostname)
+			if got != tt.want {
+				t.Errorf("isValidHostname(%q) = %v, want %v", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Discovery Manager Tests (with mock source)
+// =============================================================================
+
+// mockMetricsSource implements MetricsSource for testing
+type mockMetricsSource struct {
+	discovery DiscoveryInfo
+}
+
+func (m *mockMetricsSource) GetDaemonInfo() DaemonInfo {
+	return DaemonInfo{Version: "1.25.0", Mode: "normal", PID: 1234, StartTime: time.Now()}
+}
+func (m *mockMetricsSource) GetRuntimeMetrics() RuntimeInfo {
+	return RuntimeInfo{HeapAlloc: 1024, Goroutines: 10}
+}
+func (m *mockMetricsSource) GetBanStats() BanStats {
+	return BanStats{Total: 100, ActiveCount: 50}
+}
+func (m *mockMetricsSource) GetEventStats() EventStats {
+	return EventStats{Total: 500, RatePerSec: 1.5}
+}
+func (m *mockMetricsSource) GetIPCStats() IPCStats {
+	return IPCStats{Requests: 1000}
+}
+func (m *mockMetricsSource) GetModuleStatus() map[string]ModuleInfo {
+	return map[string]ModuleInfo{
+		"portscan": {Name: "portscan", Enabled: true, Status: 1},
+	}
+}
+func (m *mockMetricsSource) GetWatchdogStatus() WatchdogInfo {
+	return WatchdogInfo{Status: 1, Mode: "normal"}
+}
+func (m *mockMetricsSource) GetNFTablesStats() NFTablesInfo {
+	return NFTablesInfo{RulesTotal: 50, SetsTotal: 10}
+}
+func (m *mockMetricsSource) GetFeedStats() FeedStats {
+	return FeedStats{Enabled: 5, Loaded: 5}
+}
+func (m *mockMetricsSource) GetGeoIPStats() GeoIPStats {
+	return GeoIPStats{DatabaseAge: 5}
+}
+func (m *mockMetricsSource) GetSuricataStats() SuricataInfo {
+	return SuricataInfo{Enabled: true}
+}
+func (m *mockMetricsSource) GetAPIStats() APIStats {
+	return APIStats{RequestsTotal: 100}
+}
+func (m *mockMetricsSource) GetDiscoveryData() DiscoveryInfo {
+	return m.discovery
+}
+
+func TestDiscoveryManager_GetUnknownKey(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	_, err := dm.Get("nftban.discovery.unknown")
+	if err == nil {
+		t.Error("Get() should return error for unknown key")
+	}
+}
+
+func TestDiscoveryManager_RefreshModules(t *testing.T) {
+	source := &mockMetricsSource{
+		discovery: DiscoveryInfo{
+			Modules: []ModuleDiscovery{
+				{Name: "portscan", Mode: "active", Enabled: true},
+				{Name: "ddos", Mode: "passive", Enabled: false},
+			},
+		},
+	}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	dm.RefreshModules()
+
+	data, err := dm.Get(DiscoveryKeyModules)
+	if err != nil {
+		t.Fatalf("Get(modules) error = %v", err)
+	}
+	if !strings.Contains(data, "portscan") {
+		t.Error("module data should contain 'portscan'")
+	}
+}
+
+func TestDiscoveryManager_GetAll(t *testing.T) {
+	source := &mockMetricsSource{
+		discovery: DiscoveryInfo{
+			Modules:    []ModuleDiscovery{{Name: "m1", Enabled: true}},
+			Interfaces: []InterfaceDiscovery{{Name: "eth0", Zone: "public"}},
+			Feeds:      []FeedDiscovery{{Name: "spamhaus", URL: "http://example.com", Enabled: true}},
+		},
+	}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	dm.RefreshAll()
+
+	all := dm.GetAll()
+	if len(all) == 0 {
+		t.Error("GetAll() should return cached data after RefreshAll()")
+	}
+}
+
+func TestDiscoveryManager_GetStatus(t *testing.T) {
+	source := &mockMetricsSource{
+		discovery: DiscoveryInfo{
+			Modules: []ModuleDiscovery{{Name: "m1", Enabled: true}},
+		},
+	}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	dm.RefreshModules()
+
+	statuses := dm.GetStatus()
+	if len(statuses) == 0 {
+		t.Error("GetStatus() should return non-empty after refresh")
+	}
+	found := false
+	for _, s := range statuses {
+		if s.Key == DiscoveryKeyModules {
+			found = true
+			if s.Items != 1 {
+				t.Errorf("items = %d, want 1", s.Items)
+			}
+		}
+	}
+	if !found {
+		t.Error("GetStatus should include modules key")
+	}
+}
+
+func TestDiscoveryManager_ToMetrics(t *testing.T) {
+	source := &mockMetricsSource{
+		discovery: DiscoveryInfo{
+			Modules: []ModuleDiscovery{{Name: "m1", Enabled: true}},
+			Feeds:   []FeedDiscovery{{Name: "f1", Enabled: true}},
+		},
+	}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	dm.RefreshAll()
+
+	metrics := dm.ToMetrics()
+	if len(metrics) == 0 {
+		t.Error("ToMetrics() should return metrics after RefreshAll()")
+	}
+	for _, m := range metrics {
+		if m.Type != MetricTypeDiscovery {
+			t.Errorf("metric type = %q, want %q", m.Type, MetricTypeDiscovery)
+		}
+	}
+}
+
+func TestDiscoveryManager_NilSource(t *testing.T) {
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(nil, cfg)
+
+	// Should not panic
+	dm.RefreshAll()
+	dm.RefreshModules()
+	dm.RefreshInterfaces()
+	dm.RefreshCountries()
+	dm.RefreshFeeds()
+	dm.RefreshTimers()
+}
+
+func TestDiscoveryManager_StartStop(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	cfg.DiscoveryEnabled = true
+	cfg.DiscoveryInterval = 100 * time.Millisecond
+
+	dm := NewDiscoveryManager(source, cfg)
+	dm.Start()
+
+	// Give it a moment to run at least once
+	time.Sleep(50 * time.Millisecond)
+
+	dm.Stop()
+}
+
+func TestDiscoveryManager_StartDisabled(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	cfg.DiscoveryEnabled = false
+
+	dm := NewDiscoveryManager(source, cfg)
+	dm.Start() // Should be a no-op
+	dm.Stop()
+}
+
+// =============================================================================
+// Discovery Metrics Generation Tests
+// =============================================================================
+
+func TestDiscoveryManager_GenerateModuleMetrics(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	modules := map[string]ModuleStatus{
+		"portscan": {Status: 1, Events: 100, Bans: 50, Errors: 0, Latency: 1.5},
+		"ddos":     {Status: 0, Events: 200, Bans: 10, Errors: 5, Latency: 2.0},
+	}
+
+	metrics := dm.GenerateModuleMetrics(modules)
+	// 5 metrics per module * 2 modules = 10
+	if len(metrics) != 10 {
+		t.Errorf("metrics count = %d, want 10", len(metrics))
+	}
+}
+
+func TestDiscoveryManager_GenerateCountryMetrics(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	countries := map[string]CountryStats{
+		"CN": {ActiveBans: 100, Bans24h: 50, UniqueIPs: 80},
+	}
+
+	metrics := dm.GenerateCountryMetrics(countries)
+	// 3 metrics per country
+	if len(metrics) != 3 {
+		t.Errorf("metrics count = %d, want 3", len(metrics))
+	}
+}
+
+func TestDiscoveryManager_GenerateFeedMetrics(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	feeds := map[string]FeedStatus{
+		"spamhaus": {Status: 1, IPCount: 5000, LastUpdate: time.Now()},
+	}
+
+	metrics := dm.GenerateFeedMetrics(feeds)
+	// 4 metrics per feed
+	if len(metrics) != 4 {
+		t.Errorf("metrics count = %d, want 4", len(metrics))
+	}
+}
+
+func TestDiscoveryManager_GenerateInterfaceMetrics(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	interfaces := map[string]InterfaceStats{
+		"eth0": {BytesIn: 1000, BytesOut: 2000, Dropped: 5},
+	}
+
+	metrics := dm.GenerateInterfaceMetrics(interfaces)
+	// 3 metrics per interface
+	if len(metrics) != 3 {
+		t.Errorf("metrics count = %d, want 3", len(metrics))
+	}
+}
+
+func TestDiscoveryManager_GenerateTimerMetrics(t *testing.T) {
+	source := &mockMetricsSource{}
+	cfg := DefaultConfig()
+	dm := NewDiscoveryManager(source, cfg)
+
+	timers := map[string]TimerStats{
+		"ban-1h": {ActiveCount: 10, ExpiresIn1h: 3},
+	}
+
+	metrics := dm.GenerateTimerMetrics(timers)
+	// 2 metrics per timer
+	if len(metrics) != 2 {
+		t.Errorf("metrics count = %d, want 2", len(metrics))
+	}
+}
+
+// =============================================================================
+// Collector Tests
+// =============================================================================
+
+func TestCollector_Collect_NilSource(t *testing.T) {
+	c := NewCollector(nil)
+	snapshot := c.Collect()
+	if snapshot == nil {
+		t.Fatal("Collect() should return non-nil snapshot even with nil source")
+	}
+	if snapshot.Timestamp.IsZero() {
+		t.Error("timestamp should be set")
+	}
+}
+
+func TestCollector_Collect_WithSource(t *testing.T) {
+	source := &mockMetricsSource{
+		discovery: DiscoveryInfo{
+			Modules: []ModuleDiscovery{{Name: "portscan", Enabled: true}},
+		},
+	}
+	c := NewCollector(source)
+	snapshot := c.Collect()
+
+	if snapshot.Daemon.Version != "1.25.0" {
+		t.Errorf("version = %q, want %q", snapshot.Daemon.Version, "1.25.0")
+	}
+	if snapshot.Bans.Total != 100 {
+		t.Errorf("bans total = %d, want 100", snapshot.Bans.Total)
+	}
+	if snapshot.Events.Total != 500 {
+		t.Errorf("events total = %d, want 500", snapshot.Events.Total)
+	}
+	if snapshot.Modules.Enabled != 1 {
+		t.Errorf("modules enabled = %d, want 1", snapshot.Modules.Enabled)
+	}
+}
+
+func TestCollector_GetLastSnapshot(t *testing.T) {
+	source := &mockMetricsSource{}
+	c := NewCollector(source)
+
+	// Before collect, should be nil
+	if c.GetLastSnapshot() != nil {
+		t.Error("GetLastSnapshot() should be nil before Collect()")
+	}
+
+	c.Collect()
+
+	if c.GetLastSnapshot() == nil {
+		t.Error("GetLastSnapshot() should not be nil after Collect()")
+	}
+}
+
+func TestCollector_GetLastCollectTime(t *testing.T) {
+	source := &mockMetricsSource{}
+	c := NewCollector(source)
+
+	if !c.GetLastCollectTime().IsZero() {
+		t.Error("GetLastCollectTime() should be zero before Collect()")
+	}
+
+	before := time.Now()
+	c.Collect()
+	after := time.Now()
+
+	lastCollect := c.GetLastCollectTime()
+	if lastCollect.Before(before) || lastCollect.After(after) {
+		t.Error("GetLastCollectTime() should be between before and after Collect()")
+	}
+}
+
+// =============================================================================
+// MetricsSnapshot.ToMetrics Tests
+// =============================================================================
+
+func TestMetricsSnapshot_ToMetrics_Count(t *testing.T) {
+	snapshot := &MetricsSnapshot{
+		Timestamp: time.Now(),
+		Daemon:    DaemonMetrics{Version: "1.25.0", Status: 1},
+		Bans:      BanMetrics{Total: 100},
+	}
+
+	metrics := snapshot.ToMetrics()
+	// Should generate a large number of metrics (all categories)
+	if len(metrics) < 50 {
+		t.Errorf("metrics count = %d, want at least 50", len(metrics))
+	}
+}
+
+func TestMetricsSnapshot_ToMetrics_ContainsExpectedKeys(t *testing.T) {
+	snapshot := &MetricsSnapshot{
+		Timestamp: time.Now(),
+		Daemon:    DaemonMetrics{Version: "1.25.0"},
+		Bans:      BanMetrics{Total: 100},
+		Events:    EventMetrics{Total: 500},
+	}
+
+	metrics := snapshot.ToMetrics()
+
+	expectedKeys := []string{
+		"nftban.version",
+		"nftban.bans.total",
+		"nftban.events.total",
+		"nftban.memory.heap",
+		"nftban.watchdog.status",
+		"nftban.feeds.enabled",
+		"nftban.server.hostname",
+		"nftban.filter.total",
+	}
+
+	metricMap := make(map[string]bool)
+	for _, m := range metrics {
+		metricMap[m.Name] = true
+	}
+
+	for _, key := range expectedKeys {
+		if !metricMap[key] {
+			t.Errorf("missing expected metric key: %q", key)
+		}
+	}
+}
+
+// =============================================================================
+// Multi-Sender Target Health Tests
+// =============================================================================
+
+func TestTargetHealth_InitialState(t *testing.T) {
+	th := &TargetHealth{Name: "test", Healthy: true}
+	if !th.Healthy {
+		t.Error("initial state should be healthy")
+	}
+	if th.ConsecFailures != 0 {
+		t.Error("initial ConsecFailures should be 0")
+	}
+}
+
+// =============================================================================
+// MultiSendResult Tests
+// =============================================================================
+
+func TestMultiSendResult(t *testing.T) {
+	result := &MultiSendResult{
+		Success:     true,
+		Results:     map[string]*TargetResult{},
+		TotalSent:   2,
+		TotalFailed: 1,
+	}
+
+	if !result.Success {
+		t.Error("Success should be true")
+	}
+	if result.TotalSent != 2 {
+		t.Errorf("TotalSent = %d, want 2", result.TotalSent)
+	}
+}
+
+// =============================================================================
+// Send Mode Constants Tests
+// =============================================================================
+
+func TestSendModeConstants(t *testing.T) {
+	if SendModeAll != "all" {
+		t.Errorf("SendModeAll = %q, want %q", SendModeAll, "all")
+	}
+	if SendModePrimary != "primary" {
+		t.Errorf("SendModePrimary = %q, want %q", SendModePrimary, "primary")
+	}
+	if SendModeFailover != "failover" {
+		t.Errorf("SendModeFailover = %q, want %q", SendModeFailover, "failover")
+	}
+}
+
+// =============================================================================
+// Helper Function Tests
+// =============================================================================
+
+func TestBoolToInt(t *testing.T) {
+	if boolToInt(true) != 1 {
+		t.Error("boolToInt(true) should be 1")
+	}
+	if boolToInt(false) != 0 {
+		t.Error("boolToInt(false) should be 0")
+	}
+}
+
+func TestIsAlphanumeric(t *testing.T) {
+	tests := []struct {
+		c    byte
+		want bool
+	}{
+		{'a', true}, {'z', true}, {'A', true}, {'Z', true},
+		{'0', true}, {'9', true},
+		{'-', false}, {'_', false}, {' ', false}, {'.', false},
+	}
+
+	for _, tt := range tests {
+		if got := isAlphanumeric(tt.c); got != tt.want {
+			t.Errorf("isAlphanumeric(%q) = %v, want %v", tt.c, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidKeyChar(t *testing.T) {
+	validChars := "abcABC012_.-[],xyz"
+	for _, c := range validChars {
+		if !isValidKeyChar(byte(c)) {
+			t.Errorf("isValidKeyChar(%q) should be true", c)
+		}
+	}
+
+	invalidChars := " !@#$%^&*()+={}"
+	for _, c := range invalidChars {
+		if isValidKeyChar(byte(c)) {
+			t.Errorf("isValidKeyChar(%q) should be false", c)
+		}
+	}
+}
+
+// =============================================================================
+// Sender Status Tests
+// =============================================================================
+
+func TestSenderStatus_Defaults(t *testing.T) {
+	status := SenderStatus{}
+	if status.Connected {
+		t.Error("default Connected should be false")
+	}
+	if status.SendCount != 0 {
+		t.Error("default SendCount should be 0")
+	}
+}
+
+// =============================================================================
+// Exporter Status Tests
+// =============================================================================
+
+func TestExporterStatus_Defaults(t *testing.T) {
+	status := ExporterStatus{}
+	if status.Enabled {
+		t.Error("default Enabled should be false")
+	}
+	if status.Running {
+		t.Error("default Running should be false")
+	}
+}
+
+// =============================================================================
+// Context Cancellation (sender closed) Test
+// =============================================================================
+
+func TestSender_ClosedBehavior(t *testing.T) {
+	target := &Target{
+		Name:    "test",
+		Address: "127.0.0.1",
+		Port:    10051,
+		Enabled: true,
+	}
+	cfg := DefaultConfig()
+	cfg.Hostname = "testhost"
+
+	sender, err := NewSender(target, cfg)
+	if err != nil {
+		t.Fatalf("NewSender() error = %v", err)
+	}
+
+	// Close the sender
+	if err := sender.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Double-close should be fine
+	if err := sender.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+
+	// Send should fail after close
+	_, err = sender.Send(context.Background(), []Metric{{Name: "test", Value: 1}})
+	if err == nil {
+		t.Error("Send() should return error after Close()")
+	}
+}
+
+func TestSender_Status(t *testing.T) {
+	target := &Target{
+		Name:    "test-target",
+		Address: "127.0.0.1",
+		Port:    10051,
+		Enabled: true,
+	}
+	cfg := DefaultConfig()
+	cfg.Hostname = "testhost"
+
+	sender, err := NewSender(target, cfg)
+	if err != nil {
+		t.Fatalf("NewSender() error = %v", err)
+	}
+	defer sender.Close()
+
+	status := sender.Status()
+	if status.Target != "test-target" {
+		t.Errorf("target = %q, want %q", status.Target, "test-target")
+	}
+	if status.Connected {
+		t.Error("should not be connected initially")
+	}
+	if status.SendCount != 0 {
+		t.Error("initial send count should be 0")
+	}
+}
+
+func TestSender_Target(t *testing.T) {
+	target := &Target{Name: "t1", Address: "127.0.0.1", Port: 10051}
+	cfg := DefaultConfig()
+	cfg.Hostname = "h1"
+
+	sender, err := NewSender(target, cfg)
+	if err != nil {
+		t.Fatalf("NewSender() error = %v", err)
+	}
+	defer sender.Close()
+
+	if sender.Target().Name != "t1" {
+		t.Errorf("Target().Name = %q, want %q", sender.Target().Name, "t1")
+	}
+}
+
+func TestSender_SendEmptyMetrics(t *testing.T) {
+	target := &Target{Name: "t1", Address: "127.0.0.1", Port: 10051}
+	cfg := DefaultConfig()
+	cfg.Hostname = "h1"
+
+	sender, err := NewSender(target, cfg)
+	if err != nil {
+		t.Fatalf("NewSender() error = %v", err)
+	}
+	defer sender.Close()
+
+	resp, err := sender.Send(context.Background(), []Metric{})
+	if err != nil {
+		t.Fatalf("Send(empty) error = %v", err)
+	}
+	if !resp.IsSuccess() {
+		t.Error("empty metrics should return success")
+	}
+}
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+func TestProtocolConstants(t *testing.T) {
+	if ProtocolHeader != "ZBXD\x01" {
+		t.Errorf("ProtocolHeader = %q, want %q", ProtocolHeader, "ZBXD\x01")
+	}
+	if DefaultPort != 10051 {
+		t.Errorf("DefaultPort = %d, want 10051", DefaultPort)
+	}
+	if MaxPayloadSize != 64*1024*1024 {
+		t.Errorf("MaxPayloadSize = %d, want %d", MaxPayloadSize, 64*1024*1024)
+	}
+	if DefaultTimeout != 30*time.Second {
+		t.Errorf("DefaultTimeout = %v, want 30s", DefaultTimeout)
+	}
+	if DefaultInterval != 60*time.Second {
+		t.Errorf("DefaultInterval = %v, want 60s", DefaultInterval)
+	}
+	if DefaultBatchSize != 100 {
+		t.Errorf("DefaultBatchSize = %d, want 100", DefaultBatchSize)
+	}
+}
+
+func TestMetricTypeConstants(t *testing.T) {
+	if MetricTypeGauge != "gauge" {
+		t.Errorf("MetricTypeGauge = %q, want %q", MetricTypeGauge, "gauge")
+	}
+	if MetricTypeCounter != "counter" {
+		t.Errorf("MetricTypeCounter = %q, want %q", MetricTypeCounter, "counter")
+	}
+	if MetricTypeText != "text" {
+		t.Errorf("MetricTypeText = %q, want %q", MetricTypeText, "text")
+	}
+	if MetricTypeDiscovery != "discovery" {
+		t.Errorf("MetricTypeDiscovery = %q, want %q", MetricTypeDiscovery, "discovery")
+	}
+}
+
+func TestDiscoveryKeyConstants(t *testing.T) {
+	keys := map[string]string{
+		"modules":    DiscoveryKeyModules,
+		"interfaces": DiscoveryKeyInterfaces,
+		"countries":  DiscoveryKeyCountries,
+		"feeds":      DiscoveryKeyFeeds,
+		"timers":     DiscoveryKeyTimers,
+	}
+
+	for name, key := range keys {
+		if !strings.HasPrefix(key, "nftban.discovery.") {
+			t.Errorf("discovery key %q = %q, should start with nftban.discovery.", name, key)
+		}
+	}
+}

--- a/pkg/geoban/geoban_test.go
+++ b/pkg/geoban/geoban_test.go
@@ -1,0 +1,507 @@
+// =============================================================================
+// NFTBan v1.0 - Geographic IP Banning Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="geoban_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for geoban constants, directory listing, and build"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package geoban
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+func TestBanFilePrefix(t *testing.T) {
+	if BanFilePrefix != "50-ban-" {
+		t.Errorf("BanFilePrefix = %q, want %q", BanFilePrefix, "50-ban-")
+	}
+}
+
+func TestWhitelistFilePrefix(t *testing.T) {
+	if WhitelistFilePrefix != "40-whitelist-" {
+		t.Errorf("WhitelistFilePrefix = %q, want %q", WhitelistFilePrefix, "40-whitelist-")
+	}
+}
+
+// =============================================================================
+// Stats Struct Tests
+// =============================================================================
+
+func TestStats_Struct(t *testing.T) {
+	stats := Stats{
+		Countries:     2,
+		TotalCIDRs:    100,
+		IPv4CIDRs:     80,
+		IPv6CIDRs:     20,
+		BannedList:    []string{"CN", "RU"},
+		WhitelistList: []string{"US"},
+	}
+
+	if stats.Countries != 2 {
+		t.Errorf("Countries = %d, want 2", stats.Countries)
+	}
+	if stats.TotalCIDRs != 100 {
+		t.Errorf("TotalCIDRs = %d, want 100", stats.TotalCIDRs)
+	}
+	if stats.IPv4CIDRs != 80 {
+		t.Errorf("IPv4CIDRs = %d, want 80", stats.IPv4CIDRs)
+	}
+	if stats.IPv6CIDRs != 20 {
+		t.Errorf("IPv6CIDRs = %d, want 20", stats.IPv6CIDRs)
+	}
+	if len(stats.BannedList) != 2 {
+		t.Errorf("BannedList length = %d, want 2", len(stats.BannedList))
+	}
+	if len(stats.WhitelistList) != 1 {
+		t.Errorf("WhitelistList length = %d, want 1", len(stats.WhitelistList))
+	}
+}
+
+// =============================================================================
+// ListBannedCountries Tests
+// =============================================================================
+
+func TestListBannedCountries_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	countries, err := ListBannedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 0 {
+		t.Errorf("expected 0 countries, got %d", len(countries))
+	}
+}
+
+func TestListBannedCountries_WithBanFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create ban files
+	for _, cc := range []string{"CN", "RU", "KP"} {
+		f := filepath.Join(dir, BanFilePrefix+cc+".conf")
+		if err := os.WriteFile(f, []byte("# test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+	}
+
+	countries, err := ListBannedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 3 {
+		t.Errorf("expected 3 countries, got %d: %v", len(countries), countries)
+	}
+
+	// Check all expected countries are present
+	found := make(map[string]bool)
+	for _, c := range countries {
+		found[c] = true
+	}
+	for _, expected := range []string{"CN", "RU", "KP"} {
+		if !found[expected] {
+			t.Errorf("expected country %q in result, got %v", expected, countries)
+		}
+	}
+}
+
+func TestListBannedCountries_IgnoresNonBanFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a ban file
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("# test"), 0644)
+
+	// Create non-ban files that should be ignored
+	os.WriteFile(filepath.Join(dir, "40-whitelist-US.conf"), []byte("# test"), 0644)
+	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# docs"), 0644)
+	os.WriteFile(filepath.Join(dir, "50-ban-RU.txt"), []byte("# wrong extension"), 0644)
+
+	countries, err := ListBannedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 1 {
+		t.Errorf("expected 1 country, got %d: %v", len(countries), countries)
+	}
+	if len(countries) > 0 && countries[0] != "CN" {
+		t.Errorf("expected country CN, got %q", countries[0])
+	}
+}
+
+func TestListBannedCountries_IgnoresDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a subdirectory that looks like a ban file
+	os.MkdirAll(filepath.Join(dir, "50-ban-XX.conf"), 0755)
+
+	// Create a real ban file
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("# test"), 0644)
+
+	countries, err := ListBannedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 1 {
+		t.Errorf("expected 1 country (directory should be ignored), got %d: %v", len(countries), countries)
+	}
+}
+
+func TestListBannedCountries_NonexistentDir(t *testing.T) {
+	_, err := ListBannedCountries("/nonexistent/path/geoban.d")
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
+}
+
+// =============================================================================
+// ListWhitelistedCountries Tests
+// =============================================================================
+
+func TestListWhitelistedCountries_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	countries, err := ListWhitelistedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 0 {
+		t.Errorf("expected 0 countries, got %d", len(countries))
+	}
+}
+
+func TestListWhitelistedCountries_WithWhitelistFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create whitelist files
+	for _, cc := range []string{"US", "GB"} {
+		f := filepath.Join(dir, WhitelistFilePrefix+cc+".conf")
+		if err := os.WriteFile(f, []byte("# test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+	}
+
+	countries, err := ListWhitelistedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 2 {
+		t.Errorf("expected 2 countries, got %d: %v", len(countries), countries)
+	}
+}
+
+func TestListWhitelistedCountries_IgnoresBanFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create both types
+	os.WriteFile(filepath.Join(dir, "40-whitelist-US.conf"), []byte("# test"), 0644)
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("# test"), 0644)
+
+	countries, err := ListWhitelistedCountries(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(countries) != 1 {
+		t.Errorf("expected 1 whitelisted country, got %d: %v", len(countries), countries)
+	}
+	if len(countries) > 0 && countries[0] != "US" {
+		t.Errorf("expected country US, got %q", countries[0])
+	}
+}
+
+func TestListWhitelistedCountries_NonexistentDir(t *testing.T) {
+	_, err := ListWhitelistedCountries("/nonexistent/path/geoban.d")
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
+}
+
+// =============================================================================
+// Build Tests
+// =============================================================================
+
+func TestBuild_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	data, err := Build(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected non-nil SetData")
+	}
+	if data.Count != 0 {
+		t.Errorf("expected 0 CIDRs, got %d", data.Count)
+	}
+}
+
+func TestBuild_WithIPv4CIDRs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a country file with IPv4 CIDRs
+	content := `# China IPv4
+1.0.0.0/24
+1.0.1.0/24
+1.0.2.0/23
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	data, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 3 {
+		t.Errorf("expected 3 IPv4 CIDRs, got %d: %v", len(data.IPv4), data.IPv4)
+	}
+	if len(data.IPv6) != 0 {
+		t.Errorf("expected 0 IPv6 CIDRs, got %d", len(data.IPv6))
+	}
+}
+
+func TestBuild_WithIPv6CIDRs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a country file with IPv6 CIDRs
+	content := `# China IPv6
+2001:250::/32
+2001:da8::/32
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	data, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 0 {
+		t.Errorf("expected 0 IPv4 CIDRs, got %d", len(data.IPv4))
+	}
+	if len(data.IPv6) != 2 {
+		t.Errorf("expected 2 IPv6 CIDRs, got %d: %v", len(data.IPv6), data.IPv6)
+	}
+}
+
+func TestBuild_MixedIPv4IPv6(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `# Mixed CIDRs
+1.0.0.0/24
+2001:250::/32
+1.0.1.0/24
+2001:da8::/32
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	data, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 2 {
+		t.Errorf("expected 2 IPv4 CIDRs, got %d", len(data.IPv4))
+	}
+	if len(data.IPv6) != 2 {
+		t.Errorf("expected 2 IPv6 CIDRs, got %d", len(data.IPv6))
+	}
+}
+
+func TestBuild_SkipsCommentsAndEmptyLines(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `# This is a comment
+; This is also a comment
+
+1.0.0.0/24
+
+# Another comment
+1.0.1.0/24
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	data, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 2 {
+		t.Errorf("expected 2 IPv4 CIDRs (comments/blanks skipped), got %d", len(data.IPv4))
+	}
+}
+
+func TestBuild_MultipleCountries(t *testing.T) {
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("1.0.0.0/24\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "50-ban-RU.conf"), []byte("5.0.0.0/24\n"), 0644)
+
+	data, err := Build(dir, []string{"CN", "RU"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 2 {
+		t.Errorf("expected 2 IPv4 CIDRs from 2 countries, got %d", len(data.IPv4))
+	}
+}
+
+func TestBuild_AutoDiscoverCountries(t *testing.T) {
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("1.0.0.0/24\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "50-ban-RU.conf"), []byte("5.0.0.0/24\n"), 0644)
+	// Non-ban file should be ignored
+	os.WriteFile(filepath.Join(dir, "40-whitelist-US.conf"), []byte("8.0.0.0/24\n"), 0644)
+
+	// Pass nil countries to auto-discover from directory
+	data, err := Build(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 2 {
+		t.Errorf("expected 2 IPv4 CIDRs from auto-discovered countries, got %d", len(data.IPv4))
+	}
+}
+
+func TestBuild_CountryCodeNormalization(t *testing.T) {
+	dir := t.TempDir()
+
+	// File has uppercase country code
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte("1.0.0.0/24\n"), 0644)
+
+	// Pass lowercase -- loadCountry normalizes to uppercase
+	data, err := Build(dir, []string{"cn"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data.IPv4) != 1 {
+		t.Errorf("expected 1 IPv4 CIDR (lowercase country code normalized), got %d", len(data.IPv4))
+	}
+}
+
+func TestBuild_MissingCountryFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Request a country that has no file -- should not error (logs warning, continues)
+	data, err := Build(dir, []string{"XX"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.Count != 0 {
+		t.Errorf("expected 0 CIDRs for missing country, got %d", data.Count)
+	}
+}
+
+func TestBuild_NonexistentDir(t *testing.T) {
+	// With nil countries, Build tries to read the directory
+	_, err := Build("/nonexistent/path/geoban.d", nil)
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
+}
+
+// =============================================================================
+// loadCountry Tests
+// =============================================================================
+
+func TestLoadCountry_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `1.0.0.0/24
+1.0.1.0/24
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	data := &Stats{} // Just for reference, not using directly
+	_ = data
+
+	// Use the model.NewSetData via Build
+	result, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.IPv4) != 2 {
+		t.Errorf("expected 2 IPv4 entries, got %d", len(result.IPv4))
+	}
+}
+
+func TestLoadCountry_InvalidCIDR(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mix of valid and invalid CIDRs
+	content := `1.0.0.0/24
+not-a-cidr
+1.0.1.0/24
+`
+	os.WriteFile(filepath.Join(dir, "50-ban-CN.conf"), []byte(content), 0644)
+
+	// Should still load valid CIDRs despite invalid ones
+	result, err := Build(dir, []string{"CN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Valid CIDRs should still be loaded (invalid ones logged as warnings)
+	if len(result.IPv4) < 2 {
+		t.Errorf("expected at least 2 valid IPv4 entries, got %d", len(result.IPv4))
+	}
+}
+
+// =============================================================================
+// File Naming Convention Tests
+// =============================================================================
+
+func TestFileNamingConvention_BanFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		isBan    bool
+	}{
+		{"valid_cn", "50-ban-CN.conf", true},
+		{"valid_ru", "50-ban-RU.conf", true},
+		{"whitelist", "40-whitelist-US.conf", false},
+		{"wrong_prefix", "60-ban-CN.conf", false},
+		{"wrong_extension", "50-ban-CN.txt", false},
+		{"no_extension", "50-ban-CN", false},
+		{"directory_listing", "README.md", false},
+	}
+
+	dir := t.TempDir()
+
+	for _, tt := range tests {
+		// Create the file
+		os.WriteFile(filepath.Join(dir, tt.filename), []byte("# test"), 0644)
+	}
+
+	countries, _ := ListBannedCountries(dir)
+	banned := make(map[string]bool)
+	for _, c := range countries {
+		banned[c] = true
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Extract expected country code from filename
+			if tt.isBan {
+				// The country code extraction pattern
+				cc := tt.filename[len(BanFilePrefix) : len(tt.filename)-len(".conf")]
+				if !banned[cc] {
+					t.Errorf("expected %q to be detected as banned country", cc)
+				}
+			}
+		})
+	}
+}

--- a/pkg/logx/logx_test.go
+++ b/pkg/logx/logx_test.go
@@ -1,0 +1,86 @@
+// =============================================================================
+// NFTBan v1.0 - Structured Logging Wrappers Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="logx_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for logx Sprintf and category logging helpers"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package logx
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// Sprintf Tests
+// =============================================================================
+
+func TestSprintf(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		format   string
+		args     []any
+		want     string
+	}{
+		{
+			name:     "simple_message",
+			category: "AUTH",
+			format:   "User %s logged in",
+			args:     []any{"admin"},
+			want:     "[AUTH] User admin logged in",
+		},
+		{
+			name:     "no_args",
+			category: "FIREWALL",
+			format:   "Rules loaded successfully",
+			args:     nil,
+			want:     "[FIREWALL] Rules loaded successfully",
+		},
+		{
+			name:     "multiple_args",
+			category: "SECURITY",
+			format:   "IP %s blocked (count: %d, reason: %s)",
+			args:     []any{"1.2.3.4", 5, "portscan"},
+			want:     "[SECURITY] IP 1.2.3.4 blocked (count: 5, reason: portscan)",
+		},
+		{
+			name:     "empty_category",
+			category: "",
+			format:   "test message",
+			args:     nil,
+			want:     "[] test message",
+		},
+		{
+			name:     "numeric_format",
+			category: "METRICS",
+			format:   "Processed %d events in %.2fs",
+			args:     []any{1000, 1.5},
+			want:     "[METRICS] Processed 1000 events in 1.50s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sprintf(tt.category, tt.format, tt.args...)
+			if got != tt.want {
+				t.Errorf("Sprintf(%q, %q, ...) = %q, want %q", tt.category, tt.format, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,179 @@
+// =============================================================================
+// NFTBan - Metrics Package Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="metrics_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Tests for metrics package: collector types, recording functions, status code helper"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package metrics
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// statusCodeString Tests
+// =============================================================================
+
+func TestStatusCodeString(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		want string
+	}{
+		{"200 OK", 200, "2xx"},
+		{"201 Created", 201, "2xx"},
+		{"204 No Content", 204, "2xx"},
+		{"299 upper bound", 299, "2xx"},
+		{"301 Redirect", 301, "3xx"},
+		{"304 Not Modified", 304, "3xx"},
+		{"400 Bad Request", 400, "4xx"},
+		{"401 Unauthorized", 401, "4xx"},
+		{"403 Forbidden", 403, "4xx"},
+		{"404 Not Found", 404, "4xx"},
+		{"429 Rate Limited", 429, "4xx"},
+		{"499 upper bound", 499, "4xx"},
+		{"500 Internal Error", 500, "5xx"},
+		{"502 Bad Gateway", 502, "5xx"},
+		{"503 Unavailable", 503, "5xx"},
+		{"0 unknown", 0, "unknown"},
+		{"100 unknown", 100, "unknown"},
+		{"199 unknown", 199, "unknown"},
+		{"-1 unknown", -1, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusCodeString(tt.code)
+			if got != tt.want {
+				t.Errorf("statusCodeString(%d) = %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// InterfaceStats Type Tests
+// =============================================================================
+
+func TestInterfaceStats_Defaults(t *testing.T) {
+	stats := InterfaceStats{}
+	if stats.RxBytes != 0 || stats.TxBytes != 0 || stats.RxPackets != 0 || stats.TxPackets != 0 {
+		t.Error("default InterfaceStats should have all zero values")
+	}
+}
+
+// =============================================================================
+// TCPStats Type Tests
+// =============================================================================
+
+func TestTCPStats_Defaults(t *testing.T) {
+	stats := TCPStats{}
+	if stats.InSegs != 0 || stats.OutSegs != 0 {
+		t.Error("default TCPStats should have all zero values")
+	}
+}
+
+// =============================================================================
+// UDPStats Type Tests
+// =============================================================================
+
+func TestUDPStats_Defaults(t *testing.T) {
+	stats := UDPStats{}
+	if stats.InDatagrams != 0 || stats.OutDatagrams != 0 {
+		t.Error("default UDPStats should have all zero values")
+	}
+}
+
+// =============================================================================
+// ConnectionStats Type Tests
+// =============================================================================
+
+func TestConnectionStats_Defaults(t *testing.T) {
+	stats := ConnectionStats{}
+	if stats.TCP != 0 {
+		t.Error("default ConnectionStats should have zero TCP")
+	}
+}
+
+// =============================================================================
+// Sample Type Tests
+// =============================================================================
+
+func TestSample_Defaults(t *testing.T) {
+	s := Sample{}
+	if s.BlockedIPs != 0 || s.RuleCount != 0 || s.FeedsActive != 0 {
+		t.Error("default Sample should have all zero values")
+	}
+	if s.HealthOK {
+		t.Error("default Sample HealthOK should be false")
+	}
+	if s.Timestamp.IsZero() != true {
+		t.Error("default Sample Timestamp should be zero")
+	}
+}
+
+// =============================================================================
+// basicStatsFromAPI Type Tests
+// =============================================================================
+
+func TestBasicStatsFromAPI_Defaults(t *testing.T) {
+	stats := basicStatsFromAPI{}
+	if stats.BannedIPv4 != 0 || stats.BannedIPv6 != 0 {
+		t.Error("default basicStatsFromAPI should have zero banned counts")
+	}
+	if stats.WhitelistIPv4 != 0 || stats.WhitelistIPv6 != 0 {
+		t.Error("default basicStatsFromAPI should have zero whitelist counts")
+	}
+	if stats.RulesTotal != 0 {
+		t.Error("default basicStatsFromAPI should have zero rules")
+	}
+	if stats.FeedsActive != 0 {
+		t.Error("default basicStatsFromAPI should have zero feeds")
+	}
+	if stats.FeedsIPs != 0 {
+		t.Error("default basicStatsFromAPI should have zero feeds IPs")
+	}
+}
+
+// =============================================================================
+// NewCollector Tests
+// =============================================================================
+
+func TestNewCollector(t *testing.T) {
+	c := NewCollector("/tmp/test.prom", "/tmp/state", "/tmp/log")
+	if c == nil {
+		t.Fatal("NewCollector() returned nil")
+	}
+	if c.outputFile != "/tmp/test.prom" {
+		t.Errorf("outputFile = %q, want %q", c.outputFile, "/tmp/test.prom")
+	}
+	if c.stateDir != "/tmp/state" {
+		t.Errorf("stateDir = %q, want %q", c.stateDir, "/tmp/state")
+	}
+	if c.logDir != "/tmp/log" {
+		t.Errorf("logDir = %q, want %q", c.logDir, "/tmp/log")
+	}
+}
+
+func TestNewCollector_EmptyPaths(t *testing.T) {
+	c := NewCollector("", "", "")
+	if c == nil {
+		t.Fatal("NewCollector() with empty paths returned nil")
+	}
+}

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -1,0 +1,585 @@
+// =============================================================================
+// NFTBan v1.0 - Module Interface Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="module_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for module registry, status methods, and error types"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package module
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/pkg/eventbus"
+)
+
+// =============================================================================
+// Mock Module for Testing
+// =============================================================================
+
+type mockModule struct {
+	name      string
+	initErr   error
+	startErr  error
+	stopErr   error
+	status    Status
+	initCalls int
+	startCalls int
+	stopCalls  int
+}
+
+func (m *mockModule) Name() string { return m.name }
+func (m *mockModule) Init(bus *eventbus.Bus) error {
+	m.initCalls++
+	return m.initErr
+}
+func (m *mockModule) Start(ctx context.Context) error {
+	m.startCalls++
+	return m.startErr
+}
+func (m *mockModule) Stop() error {
+	m.stopCalls++
+	return m.stopErr
+}
+func (m *mockModule) Status() Status {
+	return m.status
+}
+
+// =============================================================================
+// NewStatus Tests
+// =============================================================================
+
+func TestNewStatus(t *testing.T) {
+	s := NewStatus("test-module")
+
+	if s.Name != "test-module" {
+		t.Errorf("expected name %q, got %q", "test-module", s.Name)
+	}
+	if !s.Enabled {
+		t.Error("expected Enabled=true by default")
+	}
+	if !s.Healthy {
+		t.Error("expected Healthy=true by default")
+	}
+	if s.Running {
+		t.Error("expected Running=false by default")
+	}
+	if s.Extra == nil {
+		t.Error("expected non-nil Extra map")
+	}
+}
+
+// =============================================================================
+// GetStatus Tests
+// =============================================================================
+
+func TestGetStatus_NilReceiver(t *testing.T) {
+	var s *Status
+	result := s.GetStatus()
+
+	if result.Name != "unknown" {
+		t.Errorf("expected name %q for nil receiver, got %q", "unknown", result.Name)
+	}
+	if result.Enabled {
+		t.Error("expected Enabled=false for nil receiver")
+	}
+	if result.Running {
+		t.Error("expected Running=false for nil receiver")
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false for nil receiver")
+	}
+	if result.Extra == nil {
+		t.Error("expected non-nil Extra map for nil receiver")
+	}
+}
+
+func TestGetStatus_NonNil(t *testing.T) {
+	s := NewStatus("test")
+	s.Running = true
+
+	result := s.GetStatus()
+	if result.Name != "test" {
+		t.Errorf("expected name %q, got %q", "test", result.Name)
+	}
+	if !result.Running {
+		t.Error("expected Running=true")
+	}
+}
+
+// =============================================================================
+// Status Method Tests
+// =============================================================================
+
+func TestMarkRunning(t *testing.T) {
+	s := NewStatus("test")
+	s.MarkRunning()
+
+	if !s.Running {
+		t.Error("expected Running=true after MarkRunning")
+	}
+	if s.StartTime.IsZero() {
+		t.Error("expected non-zero StartTime after MarkRunning")
+	}
+}
+
+func TestMarkRunning_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.MarkRunning()
+}
+
+func TestMarkStopped(t *testing.T) {
+	s := NewStatus("test")
+	s.MarkRunning()
+	s.MarkStopped()
+
+	if s.Running {
+		t.Error("expected Running=false after MarkStopped")
+	}
+}
+
+func TestMarkStopped_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.MarkStopped()
+}
+
+func TestRecordError(t *testing.T) {
+	s := NewStatus("test")
+	err := errors.New("test error")
+	s.RecordError(err)
+
+	if s.ErrorCount != 1 {
+		t.Errorf("expected ErrorCount=1, got %d", s.ErrorCount)
+	}
+	if s.LastError != "test error" {
+		t.Errorf("expected LastError=%q, got %q", "test error", s.LastError)
+	}
+	if s.Healthy {
+		t.Error("expected Healthy=false after error")
+	}
+}
+
+func TestRecordError_Nil(t *testing.T) {
+	s := NewStatus("test")
+	s.RecordError(nil)
+
+	// nil error should increment count but not set message
+	if s.ErrorCount != 1 {
+		t.Errorf("expected ErrorCount=1, got %d", s.ErrorCount)
+	}
+	if s.LastError != "" {
+		t.Errorf("expected empty LastError for nil error, got %q", s.LastError)
+	}
+}
+
+func TestRecordError_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.RecordError(errors.New("test"))
+}
+
+func TestRecordEvent(t *testing.T) {
+	s := NewStatus("test")
+	s.RecordEvent()
+	s.RecordEvent()
+	s.RecordEvent()
+
+	if s.EventCount != 3 {
+		t.Errorf("expected EventCount=3, got %d", s.EventCount)
+	}
+	if s.LastRun.IsZero() {
+		t.Error("expected non-zero LastRun after RecordEvent")
+	}
+}
+
+func TestRecordEvent_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.RecordEvent()
+}
+
+func TestClearError(t *testing.T) {
+	s := NewStatus("test")
+	s.RecordError(errors.New("test error"))
+	s.ClearError()
+
+	if s.LastError != "" {
+		t.Errorf("expected empty LastError, got %q", s.LastError)
+	}
+	if !s.Healthy {
+		t.Error("expected Healthy=true after ClearError")
+	}
+}
+
+func TestClearError_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.ClearError()
+}
+
+func TestUpdateUptime_NotRunning(t *testing.T) {
+	s := NewStatus("test")
+	s.UpdateUptime()
+
+	if s.Uptime != "-" {
+		t.Errorf("expected Uptime=%q for non-running module, got %q", "-", s.Uptime)
+	}
+}
+
+func TestUpdateUptime_ZeroStartTime(t *testing.T) {
+	s := NewStatus("test")
+	s.Running = true
+	// StartTime is zero
+	s.UpdateUptime()
+
+	if s.Uptime != "-" {
+		t.Errorf("expected Uptime=%q for zero start time, got %q", "-", s.Uptime)
+	}
+}
+
+func TestUpdateUptime_NilReceiver(t *testing.T) {
+	var s *Status
+	// Should not panic
+	s.UpdateUptime()
+}
+
+func TestUpdateUptime_Running(t *testing.T) {
+	s := NewStatus("test")
+	s.Running = true
+	s.StartTime = time.Now().Add(-5 * time.Second)
+	s.UpdateUptime()
+
+	if s.Uptime == "-" || s.Uptime == "" {
+		t.Errorf("expected non-empty uptime for running module, got %q", s.Uptime)
+	}
+}
+
+// =============================================================================
+// formatDuration Tests
+// =============================================================================
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     string
+	}{
+		{"seconds", 30 * time.Second, "30s"},
+		{"one_minute", 1 * time.Minute, "1m0s"},
+		{"minutes", 5*time.Minute + 30*time.Second, "6m0s"}, // Rounded to minute
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDuration(tt.duration)
+			if got != tt.want {
+				t.Errorf("formatDuration(%v) = %q, want %q", tt.duration, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDuration_Hours(t *testing.T) {
+	d := 2*time.Hour + 30*time.Minute
+	result := formatDuration(d)
+	// Should contain "hour" and "min" keywords
+	if result == "" {
+		t.Error("expected non-empty result for hours")
+	}
+}
+
+func TestFormatDuration_Days(t *testing.T) {
+	d := 3*24*time.Hour + 5*time.Hour
+	result := formatDuration(d)
+	// Should contain "day" and "hour" keywords
+	if result == "" {
+		t.Error("expected non-empty result for days")
+	}
+}
+
+// =============================================================================
+// Registry Tests
+// =============================================================================
+
+func TestNewRegistry(t *testing.T) {
+	r := NewRegistry()
+	if r == nil {
+		t.Fatal("expected non-nil Registry")
+	}
+	if len(r.Names()) != 0 {
+		t.Errorf("expected empty registry, got %d modules", len(r.Names()))
+	}
+}
+
+func TestRegistry_Register(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "test-module"}
+	d := Descriptor{Name: "test-module", Version: "1.0.0"}
+
+	r.Register(m, d)
+
+	names := r.Names()
+	if len(names) != 1 {
+		t.Errorf("expected 1 module, got %d", len(names))
+	}
+}
+
+func TestRegistry_Get(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "test-module"}
+	r.Register(m, Descriptor{Name: "test-module"})
+
+	got, ok := r.Get("test-module")
+	if !ok {
+		t.Error("expected to find module")
+	}
+	if got.Name() != "test-module" {
+		t.Errorf("expected module name %q, got %q", "test-module", got.Name())
+	}
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	r := NewRegistry()
+	_, ok := r.Get("nonexistent")
+	if ok {
+		t.Error("expected module not found")
+	}
+}
+
+func TestRegistry_GetDescriptor(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "test-module"}
+	desc := Descriptor{
+		Name:        "test-module",
+		Version:     "1.0.0",
+		Description: "A test module",
+		Optional:    true,
+	}
+	r.Register(m, desc)
+
+	got, ok := r.GetDescriptor("test-module")
+	if !ok {
+		t.Error("expected to find descriptor")
+	}
+	if got.Version != "1.0.0" {
+		t.Errorf("expected version %q, got %q", "1.0.0", got.Version)
+	}
+	if got.Description != "A test module" {
+		t.Errorf("expected description %q, got %q", "A test module", got.Description)
+	}
+	if !got.Optional {
+		t.Error("expected Optional=true")
+	}
+}
+
+func TestRegistry_GetDescriptor_NotFound(t *testing.T) {
+	r := NewRegistry()
+	_, ok := r.GetDescriptor("nonexistent")
+	if ok {
+		t.Error("expected descriptor not found")
+	}
+}
+
+func TestRegistry_All(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockModule{name: "mod1"}, Descriptor{Name: "mod1"})
+	r.Register(&mockModule{name: "mod2"}, Descriptor{Name: "mod2"})
+
+	all := r.All()
+	if len(all) != 2 {
+		t.Errorf("expected 2 modules, got %d", len(all))
+	}
+}
+
+func TestRegistry_Names(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockModule{name: "alpha"}, Descriptor{Name: "alpha"})
+	r.Register(&mockModule{name: "beta"}, Descriptor{Name: "beta"})
+
+	names := r.Names()
+	if len(names) != 2 {
+		t.Errorf("expected 2 names, got %d", len(names))
+	}
+
+	// Should contain both names (order not guaranteed)
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	if !nameSet["alpha"] || !nameSet["beta"] {
+		t.Errorf("expected names alpha and beta, got %v", names)
+	}
+}
+
+// =============================================================================
+// Registry Lifecycle Tests
+// =============================================================================
+
+func TestRegistry_InitAll(t *testing.T) {
+	r := NewRegistry()
+	m1 := &mockModule{name: "mod1"}
+	m2 := &mockModule{name: "mod2"}
+	r.Register(m1, Descriptor{Name: "mod1"})
+	r.Register(m2, Descriptor{Name: "mod2"})
+
+	bus := eventbus.New()
+	defer bus.Close()
+
+	err := r.InitAll(bus)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m1.initCalls != 1 {
+		t.Errorf("expected 1 init call for mod1, got %d", m1.initCalls)
+	}
+	if m2.initCalls != 1 {
+		t.Errorf("expected 1 init call for mod2, got %d", m2.initCalls)
+	}
+}
+
+func TestRegistry_InitAll_Error(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "failing", initErr: errors.New("init failed")}
+	r.Register(m, Descriptor{Name: "failing"})
+
+	bus := eventbus.New()
+	defer bus.Close()
+
+	err := r.InitAll(bus)
+	if err == nil {
+		t.Error("expected error from InitAll")
+	}
+
+	var moduleErr *ModuleError
+	if !errors.As(err, &moduleErr) {
+		t.Error("expected ModuleError type")
+	}
+}
+
+func TestRegistry_StartAll(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "mod1"}
+	r.Register(m, Descriptor{Name: "mod1"})
+
+	ctx := context.Background()
+	err := r.StartAll(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.startCalls != 1 {
+		t.Errorf("expected 1 start call, got %d", m.startCalls)
+	}
+}
+
+func TestRegistry_StartAll_Error(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "failing", startErr: errors.New("start failed")}
+	r.Register(m, Descriptor{Name: "failing"})
+
+	ctx := context.Background()
+	err := r.StartAll(ctx)
+	if err == nil {
+		t.Error("expected error from StartAll")
+	}
+}
+
+func TestRegistry_StopAll(t *testing.T) {
+	r := NewRegistry()
+	m1 := &mockModule{name: "mod1"}
+	m2 := &mockModule{name: "mod2"}
+	r.Register(m1, Descriptor{Name: "mod1"})
+	r.Register(m2, Descriptor{Name: "mod2"})
+
+	err := r.StopAll()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m1.stopCalls != 1 {
+		t.Errorf("expected 1 stop call for mod1, got %d", m1.stopCalls)
+	}
+	if m2.stopCalls != 1 {
+		t.Errorf("expected 1 stop call for mod2, got %d", m2.stopCalls)
+	}
+}
+
+func TestRegistry_StopAll_Error(t *testing.T) {
+	r := NewRegistry()
+	m := &mockModule{name: "failing", stopErr: errors.New("stop failed")}
+	r.Register(m, Descriptor{Name: "failing"})
+
+	err := r.StopAll()
+	if err == nil {
+		t.Error("expected error from StopAll")
+	}
+}
+
+func TestRegistry_StatusAll(t *testing.T) {
+	r := NewRegistry()
+	m1 := &mockModule{name: "mod1", status: NewStatus("mod1")}
+	m2 := &mockModule{name: "mod2", status: NewStatus("mod2")}
+	m1.status.Running = true
+	r.Register(m1, Descriptor{Name: "mod1"})
+	r.Register(m2, Descriptor{Name: "mod2"})
+
+	statuses := r.StatusAll()
+	if len(statuses) != 2 {
+		t.Errorf("expected 2 statuses, got %d", len(statuses))
+	}
+	if !statuses["mod1"].Running {
+		t.Error("expected mod1 Running=true")
+	}
+	if statuses["mod2"].Running {
+		t.Error("expected mod2 Running=false")
+	}
+}
+
+// =============================================================================
+// ModuleError Tests
+// =============================================================================
+
+func TestModuleError_Error(t *testing.T) {
+	inner := errors.New("connection refused")
+	err := &ModuleError{
+		Module: "suricata",
+		Op:     "start",
+		Err:    inner,
+	}
+
+	expected := "module suricata start: connection refused"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestModuleError_Unwrap(t *testing.T) {
+	inner := errors.New("test error")
+	err := &ModuleError{
+		Module: "test",
+		Op:     "init",
+		Err:    inner,
+	}
+
+	if !errors.Is(err, inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+}

--- a/pkg/network/detect_test.go
+++ b/pkg/network/detect_test.go
@@ -1,0 +1,171 @@
+// =============================================================================
+// NFTBan v1.0 - Network IP Family Detection Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="detect_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for IPFamilySupport methods"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package network
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// IPFamilySupport.String() Tests
+// =============================================================================
+
+func TestIPFamilySupport_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		support IPFamilySupport
+		want    string
+	}{
+		{
+			name:    "dual_stack",
+			support: IPFamilySupport{HasIPv4: true, HasIPv6: true},
+			want:    "IPv4 + IPv6 (dual-stack)",
+		},
+		{
+			name:    "ipv4_only",
+			support: IPFamilySupport{HasIPv4: true, HasIPv6: false},
+			want:    "IPv4 only",
+		},
+		{
+			name:    "ipv6_only",
+			support: IPFamilySupport{HasIPv4: false, HasIPv6: true},
+			want:    "IPv6 only",
+		},
+		{
+			name:    "no_connectivity",
+			support: IPFamilySupport{HasIPv4: false, HasIPv6: false},
+			want:    "No IP connectivity detected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.support.String()
+			if got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ShouldCreateIPv4Rules Tests
+// =============================================================================
+
+func TestShouldCreateIPv4Rules(t *testing.T) {
+	tests := []struct {
+		name    string
+		support IPFamilySupport
+		want    bool
+	}{
+		{"dual_stack", IPFamilySupport{HasIPv4: true, HasIPv6: true}, true},
+		{"ipv4_only", IPFamilySupport{HasIPv4: true, HasIPv6: false}, true},
+		{"ipv6_only", IPFamilySupport{HasIPv4: false, HasIPv6: true}, false},
+		{"none", IPFamilySupport{HasIPv4: false, HasIPv6: false}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.support.ShouldCreateIPv4Rules()
+			if got != tt.want {
+				t.Errorf("ShouldCreateIPv4Rules() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ShouldCreateIPv6Rules Tests
+// =============================================================================
+
+func TestShouldCreateIPv6Rules(t *testing.T) {
+	tests := []struct {
+		name    string
+		support IPFamilySupport
+		want    bool
+	}{
+		{"dual_stack", IPFamilySupport{HasIPv4: true, HasIPv6: true}, true},
+		{"ipv4_only", IPFamilySupport{HasIPv4: true, HasIPv6: false}, false},
+		{"ipv6_only", IPFamilySupport{HasIPv4: false, HasIPv6: true}, true},
+		{"none", IPFamilySupport{HasIPv4: false, HasIPv6: false}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.support.ShouldCreateIPv6Rules()
+			if got != tt.want {
+				t.Errorf("ShouldCreateIPv6Rules() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// GetActiveFamilies Tests
+// =============================================================================
+
+func TestGetActiveFamilies(t *testing.T) {
+	tests := []struct {
+		name    string
+		support IPFamilySupport
+		want    []string
+	}{
+		{
+			name:    "dual_stack",
+			support: IPFamilySupport{HasIPv4: true, HasIPv6: true},
+			want:    []string{"IPv4", "IPv6"},
+		},
+		{
+			name:    "ipv4_only",
+			support: IPFamilySupport{HasIPv4: true, HasIPv6: false},
+			want:    []string{"IPv4"},
+		},
+		{
+			name:    "ipv6_only",
+			support: IPFamilySupport{HasIPv4: false, HasIPv6: true},
+			want:    []string{"IPv6"},
+		},
+		{
+			name:    "none",
+			support: IPFamilySupport{HasIPv4: false, HasIPv6: false},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.support.GetActiveFamilies()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("GetActiveFamilies() returned %d families, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, family := range got {
+				if family != tt.want[i] {
+					t.Errorf("GetActiveFamilies()[%d] = %q, want %q", i, family, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/ports/ports_test.go
+++ b/pkg/ports/ports_test.go
@@ -1,0 +1,316 @@
+// =============================================================================
+// NFTBan v1.0 - Port Configuration Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ports_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for port parsing, deduplication, and configuration loading"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ports
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// parsePortList Tests
+// =============================================================================
+
+func TestParsePortList_SinglePort(t *testing.T) {
+	ports, err := parsePortList("22")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 1 || ports[0] != 22 {
+		t.Errorf("expected [22], got %v", ports)
+	}
+}
+
+func TestParsePortList_MultiplePort(t *testing.T) {
+	ports, err := parsePortList("22,80,443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 3 {
+		t.Fatalf("expected 3 ports, got %d", len(ports))
+	}
+	expected := []int{22, 80, 443}
+	for i, want := range expected {
+		if ports[i] != want {
+			t.Errorf("ports[%d] = %d, want %d", i, ports[i], want)
+		}
+	}
+}
+
+func TestParsePortList_WithSpaces(t *testing.T) {
+	ports, err := parsePortList("22 , 80 , 443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 3 {
+		t.Errorf("expected 3 ports, got %d", len(ports))
+	}
+}
+
+func TestParsePortList_PortRange(t *testing.T) {
+	ports, err := parsePortList("35000-35005")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 6 {
+		t.Fatalf("expected 6 ports (35000-35005), got %d", len(ports))
+	}
+	if ports[0] != 35000 {
+		t.Errorf("expected first port 35000, got %d", ports[0])
+	}
+	if ports[5] != 35005 {
+		t.Errorf("expected last port 35005, got %d", ports[5])
+	}
+}
+
+func TestParsePortList_MixedPortsAndRanges(t *testing.T) {
+	ports, err := parsePortList("22,80,35000-35002,443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 22, 80, 35000, 35001, 35002, 443 = 6
+	if len(ports) != 6 {
+		t.Errorf("expected 6 ports, got %d: %v", len(ports), ports)
+	}
+}
+
+func TestParsePortList_EmptyString(t *testing.T) {
+	ports, err := parsePortList("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 0 {
+		t.Errorf("expected 0 ports for empty string, got %d", len(ports))
+	}
+}
+
+func TestParsePortList_EmptyParts(t *testing.T) {
+	ports, err := parsePortList("22,,80,,")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 2 {
+		t.Errorf("expected 2 ports, got %d: %v", len(ports), ports)
+	}
+}
+
+func TestParsePortList_InvalidPort(t *testing.T) {
+	_, err := parsePortList("abc")
+	if err == nil {
+		t.Error("expected error for invalid port")
+	}
+}
+
+func TestParsePortList_PortOutOfRange(t *testing.T) {
+	_, err := parsePortList("0")
+	if err == nil {
+		t.Error("expected error for port 0")
+	}
+
+	_, err = parsePortList("70000")
+	if err == nil {
+		t.Error("expected error for port 70000")
+	}
+}
+
+func TestParsePortList_InvalidRange(t *testing.T) {
+	// Start > End
+	_, err := parsePortList("100-50")
+	if err == nil {
+		t.Error("expected error for inverted range")
+	}
+}
+
+func TestParsePortList_RangeTooLarge(t *testing.T) {
+	_, err := parsePortList("1-20000")
+	if err == nil {
+		t.Error("expected error for range > 10000")
+	}
+}
+
+func TestParsePortList_RangeOutOfBounds(t *testing.T) {
+	_, err := parsePortList("0-100")
+	if err == nil {
+		t.Error("expected error for range starting at 0")
+	}
+
+	_, err = parsePortList("60000-70000")
+	if err == nil {
+		t.Error("expected error for range ending above 65535")
+	}
+}
+
+// =============================================================================
+// deduplicatePorts Tests
+// =============================================================================
+
+func TestDeduplicatePorts_TCPOnly(t *testing.T) {
+	config := &PortConfig{
+		AllRules: []PortRule{
+			{Port: 22, Protocol: "T", Direction: "I"},
+			{Port: 80, Protocol: "T", Direction: "I"},
+			{Port: 22, Protocol: "T", Direction: "I"}, // Duplicate
+		},
+		PortMap: make(map[int][]string),
+	}
+
+	config.deduplicatePorts()
+
+	// TCPPorts should contain 22 and 80 (no duplicates)
+	if len(config.TCPPorts) != 2 {
+		t.Errorf("expected 2 TCP ports, got %d: %v", len(config.TCPPorts), config.TCPPorts)
+	}
+	if len(config.UDPPorts) != 0 {
+		t.Errorf("expected 0 UDP ports, got %d", len(config.UDPPorts))
+	}
+}
+
+func TestDeduplicatePorts_UDPOnly(t *testing.T) {
+	config := &PortConfig{
+		AllRules: []PortRule{
+			{Port: 53, Protocol: "U", Direction: "I"},
+		},
+		PortMap: make(map[int][]string),
+	}
+
+	config.deduplicatePorts()
+
+	if len(config.UDPPorts) != 1 {
+		t.Errorf("expected 1 UDP port, got %d", len(config.UDPPorts))
+	}
+	if len(config.TCPPorts) != 0 {
+		t.Errorf("expected 0 TCP ports, got %d", len(config.TCPPorts))
+	}
+}
+
+func TestDeduplicatePorts_BothProtocol(t *testing.T) {
+	config := &PortConfig{
+		AllRules: []PortRule{
+			{Port: 53, Protocol: "B", Direction: "I"},
+		},
+		PortMap: make(map[int][]string),
+	}
+
+	config.deduplicatePorts()
+
+	if len(config.TCPPorts) != 1 {
+		t.Errorf("expected 1 TCP port for Both, got %d", len(config.TCPPorts))
+	}
+	if len(config.UDPPorts) != 1 {
+		t.Errorf("expected 1 UDP port for Both, got %d", len(config.UDPPorts))
+	}
+}
+
+func TestDeduplicatePorts_Directional(t *testing.T) {
+	config := &PortConfig{
+		AllRules: []PortRule{
+			{Port: 22, Protocol: "T", Direction: "I"},   // TCP input
+			{Port: 443, Protocol: "T", Direction: "O"},  // TCP output
+			{Port: 80, Protocol: "T", Direction: "IO"},  // TCP both directions
+			{Port: 53, Protocol: "U", Direction: "I"},   // UDP input
+		},
+		PortMap: make(map[int][]string),
+	}
+
+	config.deduplicatePorts()
+
+	// TCPPortsIn should have 22 and 80
+	tcpInSet := make(map[int]bool)
+	for _, p := range config.TCPPortsIn {
+		tcpInSet[p] = true
+	}
+	if !tcpInSet[22] || !tcpInSet[80] {
+		t.Errorf("expected TCPPortsIn to contain 22 and 80, got %v", config.TCPPortsIn)
+	}
+
+	// TCPPortsOut should have 443 and 80
+	tcpOutSet := make(map[int]bool)
+	for _, p := range config.TCPPortsOut {
+		tcpOutSet[p] = true
+	}
+	if !tcpOutSet[443] || !tcpOutSet[80] {
+		t.Errorf("expected TCPPortsOut to contain 443 and 80, got %v", config.TCPPortsOut)
+	}
+
+	// UDPPortsIn should have 53
+	udpInSet := make(map[int]bool)
+	for _, p := range config.UDPPortsIn {
+		udpInSet[p] = true
+	}
+	if !udpInSet[53] {
+		t.Errorf("expected UDPPortsIn to contain 53, got %v", config.UDPPortsIn)
+	}
+}
+
+// =============================================================================
+// GetAllPorts Tests
+// =============================================================================
+
+func TestGetAllPorts(t *testing.T) {
+	config := &PortConfig{
+		TCPPorts: []int{22, 80, 443},
+		UDPPorts: []int{53, 80}, // 80 overlaps with TCP
+	}
+
+	all := config.GetAllPorts()
+	portSet := make(map[int]bool)
+	for _, p := range all {
+		portSet[p] = true
+	}
+
+	if len(portSet) != 4 {
+		t.Errorf("expected 4 unique ports, got %d: %v", len(portSet), all)
+	}
+
+	expected := []int{22, 53, 80, 443}
+	for _, port := range expected {
+		if !portSet[port] {
+			t.Errorf("expected port %d in GetAllPorts result", port)
+		}
+	}
+}
+
+// =============================================================================
+// PortRule Tests
+// =============================================================================
+
+func TestPortRule_Struct(t *testing.T) {
+	rule := PortRule{
+		Port:      22,
+		Protocol:  "T",
+		Direction: "I",
+		Source:    "test.conf",
+	}
+
+	if rule.Port != 22 {
+		t.Errorf("expected Port=22, got %d", rule.Port)
+	}
+	if rule.Protocol != "T" {
+		t.Errorf("expected Protocol=%q, got %q", "T", rule.Protocol)
+	}
+	if rule.Direction != "I" {
+		t.Errorf("expected Direction=%q, got %q", "I", rule.Direction)
+	}
+	if rule.Source != "test.conf" {
+		t.Errorf("expected Source=%q, got %q", "test.conf", rule.Source)
+	}
+}

--- a/pkg/portscan/module_test.go
+++ b/pkg/portscan/module_test.go
@@ -1,0 +1,246 @@
+// =============================================================================
+// NFTBan v1.0 - Port Scan Detection Module Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="module_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for portscan config parsing"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package portscan
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestModule creates a Module without calling nftbanconf.MustLoad() so
+// tests can run without production configuration files.
+func newTestModule() *Module {
+	return &Module{
+		config: portscanConfig{
+			Enabled:      true,
+			Mode:         "auto",
+			BanThreshold: 3,
+			BanDuration:  30 * time.Minute,
+			TrackWindow:  5 * time.Minute,
+		},
+		mode:    "auto",
+		enabled: true,
+	}
+}
+
+// =============================================================================
+// parseMainConfig Tests
+// =============================================================================
+
+func TestParseMainConfig_Enabled(t *testing.T) {
+	m := newTestModule()
+
+	m.parseMainConfig("PORTSCAN_ENABLED=true")
+	if !m.config.Enabled {
+		t.Error("expected Enabled=true")
+	}
+
+	m.parseMainConfig("PORTSCAN_ENABLED=false")
+	if m.config.Enabled {
+		t.Error("expected Enabled=false")
+	}
+}
+
+func TestParseMainConfig_Mode(t *testing.T) {
+	m := newTestModule()
+
+	m.parseMainConfig("PORTSCAN_MODE=classic")
+	if m.config.Mode != "classic" {
+		t.Errorf("expected mode %q, got %q", "classic", m.config.Mode)
+	}
+
+	m.parseMainConfig("PORTSCAN_MODE=suricata")
+	if m.config.Mode != "suricata" {
+		t.Errorf("expected mode %q, got %q", "suricata", m.config.Mode)
+	}
+
+	m.parseMainConfig("PORTSCAN_MODE=hybrid")
+	if m.config.Mode != "hybrid" {
+		t.Errorf("expected mode %q, got %q", "hybrid", m.config.Mode)
+	}
+}
+
+func TestParseMainConfig_MultipleSettings(t *testing.T) {
+	m := newTestModule()
+
+	content := `# Portscan module config
+PORTSCAN_ENABLED=true
+PORTSCAN_MODE=classic
+`
+
+	m.parseMainConfig(content)
+
+	if !m.config.Enabled {
+		t.Error("expected Enabled=true")
+	}
+	if m.config.Mode != "classic" {
+		t.Errorf("expected mode %q, got %q", "classic", m.config.Mode)
+	}
+}
+
+func TestParseMainConfig_SkipsComments(t *testing.T) {
+	m := newTestModule()
+
+	content := `# This is a comment
+# PORTSCAN_ENABLED=false
+PORTSCAN_ENABLED=true
+`
+
+	m.parseMainConfig(content)
+
+	if !m.config.Enabled {
+		t.Error("expected Enabled=true (comment should be skipped)")
+	}
+}
+
+func TestParseMainConfig_SkipsEmptyLines(t *testing.T) {
+	m := newTestModule()
+
+	content := `
+
+PORTSCAN_MODE=suricata
+
+`
+
+	m.parseMainConfig(content)
+
+	if m.config.Mode != "suricata" {
+		t.Errorf("expected mode %q, got %q", "suricata", m.config.Mode)
+	}
+}
+
+func TestParseMainConfig_StripsQuotes(t *testing.T) {
+	m := newTestModule()
+
+	m.parseMainConfig(`PORTSCAN_MODE="classic"`)
+	if m.config.Mode != "classic" {
+		t.Errorf("expected mode %q (double-quoted), got %q", "classic", m.config.Mode)
+	}
+
+	m.parseMainConfig(`PORTSCAN_MODE='hybrid'`)
+	if m.config.Mode != "hybrid" {
+		t.Errorf("expected mode %q (single-quoted), got %q", "hybrid", m.config.Mode)
+	}
+}
+
+func TestParseMainConfig_InvalidLine(t *testing.T) {
+	m := newTestModule()
+	original := m.config.Mode
+
+	// Lines without = should be ignored
+	m.parseMainConfig("PORTSCAN_MODE_NO_EQUALS")
+
+	if m.config.Mode != original {
+		t.Errorf("expected mode unchanged, got %q", m.config.Mode)
+	}
+}
+
+// =============================================================================
+// parseModeConfig Tests
+// =============================================================================
+
+func TestParseModeConfig_ClassicThresholds(t *testing.T) {
+	m := newTestModule()
+
+	content := `PORTSCAN_CLASSIC_MIN_PORTS=10
+PORTSCAN_CLASSIC_TIME_WINDOW=300
+PORTSCAN_CLASSIC_BAN_DEFAULT=3600
+`
+
+	m.parseModeConfig(content)
+
+	if m.config.BanThreshold != 10 {
+		t.Errorf("expected BanThreshold=10, got %d", m.config.BanThreshold)
+	}
+	if m.config.TrackWindow != 300*time.Second {
+		t.Errorf("expected TrackWindow=300s, got %v", m.config.TrackWindow)
+	}
+	if m.config.BanDuration != 3600*time.Second {
+		t.Errorf("expected BanDuration=3600s, got %v", m.config.BanDuration)
+	}
+}
+
+func TestParseModeConfig_SuricataBanDuration(t *testing.T) {
+	m := newTestModule()
+
+	content := `PORTSCAN_SURICATA_BAN_DURATION_SHORT=600`
+
+	m.parseModeConfig(content)
+
+	if m.config.BanDuration != 600*time.Second {
+		t.Errorf("expected BanDuration=600s, got %v", m.config.BanDuration)
+	}
+}
+
+func TestParseModeConfig_InvalidValues(t *testing.T) {
+	m := newTestModule()
+	original := m.config.BanThreshold
+
+	// Invalid integer should be ignored
+	m.parseModeConfig("PORTSCAN_CLASSIC_MIN_PORTS=not_a_number")
+
+	if m.config.BanThreshold != original {
+		t.Errorf("expected BanThreshold unchanged at %d, got %d", original, m.config.BanThreshold)
+	}
+}
+
+func TestParseModeConfig_SkipsComments(t *testing.T) {
+	m := newTestModule()
+
+	content := `# PORTSCAN_CLASSIC_MIN_PORTS=999
+PORTSCAN_CLASSIC_MIN_PORTS=5
+`
+
+	m.parseModeConfig(content)
+
+	if m.config.BanThreshold != 5 {
+		t.Errorf("expected BanThreshold=5 (comment skipped), got %d", m.config.BanThreshold)
+	}
+}
+
+// =============================================================================
+// Module Constants Tests
+// =============================================================================
+
+func TestModuleConstants(t *testing.T) {
+	if ModuleName != "portscan" {
+		t.Errorf("ModuleName = %q, want %q", ModuleName, "portscan")
+	}
+	if ModuleVersion != "1.0.0" {
+		t.Errorf("ModuleVersion = %q, want %q", ModuleVersion, "1.0.0")
+	}
+	if DefaultCheckInterval != 60*time.Second {
+		t.Errorf("DefaultCheckInterval = %v, want 60s", DefaultCheckInterval)
+	}
+}
+
+// =============================================================================
+// Module.Name() Tests
+// =============================================================================
+
+func TestModule_Name(t *testing.T) {
+	m := newTestModule()
+	if m.Name() != "portscan" {
+		t.Errorf("Name() = %q, want %q", m.Name(), "portscan")
+	}
+}

--- a/pkg/suricata/config/generator_test.go
+++ b/pkg/suricata/config/generator_test.go
@@ -1,0 +1,319 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata Config Generator Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="generator_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for mergeUnique, applyFilters, and config loading"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// =============================================================================
+// mergeUnique Tests
+// =============================================================================
+
+func TestMergeUnique(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		wantLen  int
+		wantAll  []string
+	}{
+		{
+			name:    "no_overlap",
+			a:       []string{"a", "b"},
+			b:       []string{"c", "d"},
+			wantLen: 4,
+			wantAll: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:    "with_duplicates",
+			a:       []string{"a", "b", "c"},
+			b:       []string{"b", "c", "d"},
+			wantLen: 4,
+			wantAll: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:    "identical",
+			a:       []string{"a", "b"},
+			b:       []string{"a", "b"},
+			wantLen: 2,
+			wantAll: []string{"a", "b"},
+		},
+		{
+			name:    "empty_a",
+			a:       []string{},
+			b:       []string{"a", "b"},
+			wantLen: 2,
+			wantAll: []string{"a", "b"},
+		},
+		{
+			name:    "empty_b",
+			a:       []string{"a", "b"},
+			b:       []string{},
+			wantLen: 2,
+			wantAll: []string{"a", "b"},
+		},
+		{
+			name:    "both_empty",
+			a:       []string{},
+			b:       []string{},
+			wantLen: 0,
+			wantAll: []string{},
+		},
+		{
+			name:    "nil_a",
+			a:       nil,
+			b:       []string{"a"},
+			wantLen: 1,
+			wantAll: []string{"a"},
+		},
+		{
+			name:    "nil_b",
+			a:       []string{"a"},
+			b:       nil,
+			wantLen: 1,
+			wantAll: []string{"a"},
+		},
+		{
+			name:    "preserves_order",
+			a:       []string{"c", "a"},
+			b:       []string{"b", "d"},
+			wantLen: 4,
+			wantAll: []string{"c", "a", "b", "d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeUnique(tt.a, tt.b)
+			if len(got) != tt.wantLen {
+				t.Errorf("mergeUnique() len = %d, want %d; got %v", len(got), tt.wantLen, got)
+				return
+			}
+
+			// Check all expected items are present
+			gotSet := make(map[string]bool)
+			for _, item := range got {
+				gotSet[item] = true
+			}
+			for _, want := range tt.wantAll {
+				if !gotSet[want] {
+					t.Errorf("mergeUnique() missing expected item %q; got %v", want, got)
+				}
+			}
+
+			// For order-sensitive test, check exact match
+			if tt.name == "preserves_order" {
+				for i, want := range tt.wantAll {
+					if got[i] != want {
+						t.Errorf("mergeUnique()[%d] = %q, want %q", i, got[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// applyFilters Tests
+// =============================================================================
+
+func TestApplyFilters_WhitelistOnly(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+	whitelist := []string{"a", "c"}
+	blacklist := []string{}
+
+	got := applyFilters(items, whitelist, blacklist)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items, got %d: %v", len(got), got)
+	}
+
+	gotSet := make(map[string]bool)
+	for _, item := range got {
+		gotSet[item] = true
+	}
+	if !gotSet["a"] || !gotSet["c"] {
+		t.Errorf("expected a and c, got %v", got)
+	}
+}
+
+func TestApplyFilters_BlacklistOnly(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+	whitelist := []string{}
+	blacklist := []string{"b", "d"}
+
+	got := applyFilters(items, whitelist, blacklist)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items, got %d: %v", len(got), got)
+	}
+
+	gotSet := make(map[string]bool)
+	for _, item := range got {
+		gotSet[item] = true
+	}
+	if !gotSet["a"] || !gotSet["c"] {
+		t.Errorf("expected a and c, got %v", got)
+	}
+}
+
+func TestApplyFilters_WhitelistAndBlacklist(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	whitelist := []string{"a", "b", "c"} // Only keep a, b, c
+	blacklist := []string{"b"}            // Then remove b
+
+	got := applyFilters(items, whitelist, blacklist)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items, got %d: %v", len(got), got)
+	}
+
+	gotSet := make(map[string]bool)
+	for _, item := range got {
+		gotSet[item] = true
+	}
+	if !gotSet["a"] || !gotSet["c"] {
+		t.Errorf("expected a and c, got %v", got)
+	}
+}
+
+func TestApplyFilters_NoFilters(t *testing.T) {
+	items := []string{"a", "b", "c"}
+	whitelist := []string{}
+	blacklist := []string{}
+
+	got := applyFilters(items, whitelist, blacklist)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items (unchanged), got %d: %v", len(got), got)
+	}
+}
+
+func TestApplyFilters_EmptyItems(t *testing.T) {
+	items := []string{}
+	whitelist := []string{"a"}
+	blacklist := []string{"b"}
+
+	got := applyFilters(items, whitelist, blacklist)
+
+	if len(got) != 0 {
+		t.Fatalf("expected 0 items, got %d: %v", len(got), got)
+	}
+}
+
+// =============================================================================
+// LoadConfig (with temp files) Tests
+// =============================================================================
+
+func TestLoadConfig_NonexistentFile(t *testing.T) {
+	cfg := LoadConfig("/nonexistent/path/config.conf")
+
+	// Should return empty config (not crash)
+	if len(cfg.EnabledCategories) != 0 {
+		t.Errorf("expected 0 enabled categories, got %d", len(cfg.EnabledCategories))
+	}
+	if len(cfg.DisabledCategories) != 0 {
+		t.Errorf("expected 0 disabled categories, got %d", len(cfg.DisabledCategories))
+	}
+}
+
+func TestLoadConfig_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	confFile := filepath.Join(tmpDir, "test.conf")
+
+	content := `# Test config
+ENABLE_CATEGORY=emerging-exploit
+ENABLE_CATEGORY=emerging-malware
+DISABLE_CATEGORY=emerging-policy
+ENABLE_SID=2100001
+DISABLE_SID=2200001
+`
+
+	if err := os.WriteFile(confFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	cfg := LoadConfig(confFile)
+
+	if len(cfg.EnabledCategories) != 2 {
+		t.Errorf("expected 2 enabled categories, got %d", len(cfg.EnabledCategories))
+	}
+	if len(cfg.DisabledCategories) != 1 {
+		t.Errorf("expected 1 disabled category, got %d", len(cfg.DisabledCategories))
+	}
+	if len(cfg.EnabledSIDs) != 1 {
+		t.Errorf("expected 1 enabled SID, got %d", len(cfg.EnabledSIDs))
+	}
+	if len(cfg.DisabledSIDs) != 1 {
+		t.Errorf("expected 1 disabled SID, got %d", len(cfg.DisabledSIDs))
+	}
+}
+
+func TestLoadConfig_SkipsComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	confFile := filepath.Join(tmpDir, "test.conf")
+
+	content := `# This is a comment
+# ENABLE_CATEGORY=should-not-be-loaded
+ENABLE_CATEGORY=real-category
+`
+
+	if err := os.WriteFile(confFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	cfg := LoadConfig(confFile)
+
+	if len(cfg.EnabledCategories) != 1 {
+		t.Errorf("expected 1 enabled category, got %d", len(cfg.EnabledCategories))
+	}
+	if cfg.EnabledCategories[0] != "real-category" {
+		t.Errorf("expected %q, got %q", "real-category", cfg.EnabledCategories[0])
+	}
+}
+
+func TestLoadConfig_SkipsEmptyLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	confFile := filepath.Join(tmpDir, "test.conf")
+
+	content := `
+
+ENABLE_CATEGORY=cat1
+
+ENABLE_CATEGORY=cat2
+
+`
+
+	if err := os.WriteFile(confFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	cfg := LoadConfig(confFile)
+
+	if len(cfg.EnabledCategories) != 2 {
+		t.Errorf("expected 2 enabled categories, got %d", len(cfg.EnabledCategories))
+	}
+}

--- a/pkg/suricata/customrules/validator_test.go
+++ b/pkg/suricata/customrules/validator_test.go
@@ -1,0 +1,390 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata Custom Rule Validator Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="validator_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for rule validation, SID extraction, and sanitization"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package customrules
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+func TestSIDRangeConstants(t *testing.T) {
+	if MinCustomSID != 9000000 {
+		t.Errorf("MinCustomSID = %d, want 9000000", MinCustomSID)
+	}
+	if MaxCustomSID != 9999999 {
+		t.Errorf("MaxCustomSID = %d, want 9999999", MaxCustomSID)
+	}
+	if MinCustomSID >= MaxCustomSID {
+		t.Error("MinCustomSID should be less than MaxCustomSID")
+	}
+}
+
+// =============================================================================
+// ValidateRule Tests
+// =============================================================================
+
+func TestValidateRule_EmptyRule(t *testing.T) {
+	result, err := ValidateRule("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected invalid for empty rule")
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected errors for empty rule")
+	}
+}
+
+func TestValidateRule_CommentedOut(t *testing.T) {
+	result, err := ValidateRule("# alert tcp any any -> any any (msg:\"Test\"; sid:9000001; rev:1;)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected invalid for commented rule")
+	}
+}
+
+func TestValidateRule_ValidRule(t *testing.T) {
+	rule := `alert tcp any any -> any any (msg:"NFTBan Test Rule"; sid:9000001; rev:1;)`
+	result, err := ValidateRule(rule)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Note: validateWithSuricata may add a warning if suricata binary is not found,
+	// which would cause result.Valid to be false. We check specific fields instead.
+	if result.SID != 9000001 {
+		t.Errorf("expected SID 9000001, got %d", result.SID)
+	}
+	if result.Action != "alert" {
+		t.Errorf("expected action %q, got %q", "alert", result.Action)
+	}
+	if result.Message != "NFTBan Test Rule" {
+		t.Errorf("expected message %q, got %q", "NFTBan Test Rule", result.Message)
+	}
+}
+
+func TestValidateRule_DropAction(t *testing.T) {
+	rule := `drop tcp any any -> any any (msg:"Drop Rule"; sid:9000002; rev:1;)`
+	result, err := ValidateRule(rule)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Action != "drop" {
+		t.Errorf("expected action %q, got %q", "drop", result.Action)
+	}
+}
+
+func TestValidateRule_RejectAction(t *testing.T) {
+	rule := `reject tcp any any -> any any (msg:"Reject Rule"; sid:9000003; rev:1;)`
+	result, err := ValidateRule(rule)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Action != "reject" {
+		t.Errorf("expected action %q, got %q", "reject", result.Action)
+	}
+}
+
+func TestValidateRule_PassAction(t *testing.T) {
+	rule := `pass tcp any any -> any any (msg:"Pass Rule"; sid:9000004; rev:1;)`
+	result, err := ValidateRule(rule)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Action != "pass" {
+		t.Errorf("expected action %q, got %q", "pass", result.Action)
+	}
+}
+
+// =============================================================================
+// validateBasicStructure Tests
+// =============================================================================
+
+func TestValidateBasicStructure_InvalidAction(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateBasicStructure("invalid tcp any any -> any any (msg:\"test\"; sid:9000001;)", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must start with action: alert, drop, reject, or pass" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected action error, got: ", result.Errors)
+	}
+}
+
+func TestValidateBasicStructure_MissingProtocol(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	// No valid protocol
+	err := validateBasicStructure("alert xyz any any -> any any (msg:\"test\"; sid:9000001;)", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must specify protocol (tcp, udp, icmp, ip, http, etc.)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected protocol error, got: ", result.Errors)
+	}
+}
+
+func TestValidateBasicStructure_MissingParentheses(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateBasicStructure("alert tcp any any -> any any msg:\"test\"; sid:9000001;", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must contain options in parentheses" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected parentheses error, got: ", result.Errors)
+	}
+}
+
+func TestValidateBasicStructure_UnbalancedParentheses(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	// Rule with opening ( but no closing ) — validator catches as missing parentheses
+	err := validateBasicStructure("alert tcp any any -> any any (msg:\"test\"; sid:9000001;", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Errors) == 0 {
+		t.Error("expected validation error for unbalanced parentheses")
+	}
+	// Validator reports "Rule must contain options in parentheses" for malformed option blocks
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must contain options in parentheses" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected parentheses error, got: ", result.Errors)
+	}
+}
+
+func TestValidateBasicStructure_MissingMsg(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateBasicStructure("alert tcp any any -> any any (sid:9000001;)", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must contain 'msg:' field" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected msg error, got: ", result.Errors)
+	}
+}
+
+func TestValidateBasicStructure_ExtractsMessage(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateBasicStructure(`alert tcp any any -> any any (msg:"My Custom Rule"; sid:9000001; rev:1;)`, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Message != "My Custom Rule" {
+		t.Errorf("expected message %q, got %q", "My Custom Rule", result.Message)
+	}
+}
+
+// =============================================================================
+// validateSID Tests
+// =============================================================================
+
+func TestValidateSID_ValidSID(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateSID(`alert tcp any any -> any any (msg:"test"; sid:9000001; rev:1;)`, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.SID != 9000001 {
+		t.Errorf("expected SID 9000001, got %d", result.SID)
+	}
+	// Should have no SID-related errors
+	for _, e := range result.Errors {
+		t.Errorf("unexpected error: %s", e)
+	}
+}
+
+func TestValidateSID_OutOfRange(t *testing.T) {
+	tests := []struct {
+		name string
+		rule string
+		sid  int
+	}{
+		{"too_low", `alert tcp any any -> any any (msg:"test"; sid:1000; rev:1;)`, 1000},
+		{"too_high", `alert tcp any any -> any any (msg:"test"; sid:10000000; rev:1;)`, 10000000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+			err := validateSID(tt.rule, result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.SID != tt.sid {
+				t.Errorf("expected SID %d, got %d", tt.sid, result.SID)
+			}
+
+			// Should have range error
+			found := false
+			for _, e := range result.Errors {
+				if len(e) > 10 { // Basic check for error message
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Error("expected SID range error")
+			}
+		})
+	}
+}
+
+func TestValidateSID_MissingSID(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateSID(`alert tcp any any -> any any (msg:"test"; rev:1;)`, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule must contain 'sid:' field" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected missing SID error")
+	}
+}
+
+func TestValidateSID_MissingRev(t *testing.T) {
+	result := &ValidationResult{Valid: true, Errors: make([]string, 0)}
+	err := validateSID(`alert tcp any any -> any any (msg:"test"; sid:9000001;)`, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e == "Rule should contain 'rev:' field (recommended)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected missing rev warning")
+	}
+}
+
+// =============================================================================
+// SanitizeRule Tests
+// =============================================================================
+
+func TestSanitizeRule(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trim_whitespace",
+			input: "  alert tcp any any -> any any (msg:\"test\"; sid:9000001;)  ",
+			want:  `alert tcp any any -> any any (msg:"test"; sid:9000001;)`,
+		},
+		{
+			name:  "normalize_spaces",
+			input: "alert  tcp   any  any  ->  any  any  (msg:\"test\";  sid:9000001;)",
+			want:  `alert tcp any any -> any any (msg:"test"; sid:9000001;)`,
+		},
+		{
+			name:  "remove_space_before_semicolon",
+			input: "alert tcp any any -> any any (msg:\"test\" ; sid:9000001 ;)",
+			want:  `alert tcp any any -> any any (msg:"test"; sid:9000001;)`,
+		},
+		{
+			name:  "already_clean",
+			input: `alert tcp any any -> any any (msg:"test"; sid:9000001; rev:1;)`,
+			want:  `alert tcp any any -> any any (msg:"test"; sid:9000001; rev:1;)`,
+		},
+		{
+			name:  "empty_string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "only_whitespace",
+			input: "   ",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeRule(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeRule(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/suricata/filter_test.go
+++ b/pkg/suricata/filter_test.go
@@ -1,0 +1,404 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata Filter Matcher Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="filter_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for filter matching logic (signature, category, event)"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package suricata
+
+import (
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Helper: create test Config with filters
+// =============================================================================
+
+func testConfig(filters map[string]*FilterConfig) *Config {
+	return &Config{
+		GlobalEnabled:    true,
+		DefaultThreshold: 100,
+		DefaultBanTime:   30 * time.Minute,
+		DefaultAction:    "ban",
+		ScoreDecay:       1 * time.Hour,
+		Filters:          filters,
+	}
+}
+
+// =============================================================================
+// MatchSignature Tests
+// =============================================================================
+
+func TestMatchSignature_Match(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  true,
+			Keywords: []string{"exploit", "shellcode"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.MatchSignature("ET EXPLOIT Apache Struts RCE")
+
+	if name != "exploit" {
+		t.Errorf("expected filter name %q, got %q", "exploit", name)
+	}
+	if filter == nil {
+		t.Error("expected non-nil filter")
+	}
+}
+
+func TestMatchSignature_CaseInsensitive(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  true,
+			Keywords: []string{"exploit"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, _ := fm.MatchSignature("ET EXPLOIT APACHE STRUTS")
+
+	if name != "exploit" {
+		t.Errorf("expected case-insensitive match, got %q", name)
+	}
+}
+
+func TestMatchSignature_NoMatch(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  true,
+			Keywords: []string{"exploit"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.MatchSignature("ET MALWARE Trojan Activity")
+
+	if name != "" {
+		t.Errorf("expected empty name for no match, got %q", name)
+	}
+	if filter != nil {
+		t.Error("expected nil filter for no match")
+	}
+}
+
+func TestMatchSignature_DisabledFilter(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  false, // Disabled
+			Keywords: []string{"exploit"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.MatchSignature("ET EXPLOIT Apache Struts RCE")
+
+	if name != "" {
+		t.Errorf("expected no match for disabled filter, got %q", name)
+	}
+	if filter != nil {
+		t.Error("expected nil filter for disabled filter")
+	}
+}
+
+func TestMatchSignature_MultipleKeywords(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"malware": {
+			Name:     "malware",
+			Enabled:  true,
+			Keywords: []string{"malware", "trojan", "backdoor"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+
+	tests := []struct {
+		signature string
+		want      string
+	}{
+		{"ET MALWARE Known C&C", "malware"},
+		{"ET TROJAN Activity Detected", "malware"},
+		{"Backdoor shell detected", "malware"},
+		{"ET SCAN Nmap SYN", ""},
+	}
+
+	for _, tt := range tests {
+		name, _ := fm.MatchSignature(tt.signature)
+		if name != tt.want {
+			t.Errorf("MatchSignature(%q) = %q, want %q", tt.signature, name, tt.want)
+		}
+	}
+}
+
+// =============================================================================
+// MatchCategory Tests
+// =============================================================================
+
+func TestMatchCategory_Match(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"scan": {
+			Name:     "scan",
+			Enabled:  true,
+			Keywords: []string{"scan", "reconnaissance"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.MatchCategory("Network Scan Detection")
+
+	if name != "scan" {
+		t.Errorf("expected filter name %q, got %q", "scan", name)
+	}
+	if filter == nil {
+		t.Error("expected non-nil filter")
+	}
+}
+
+func TestMatchCategory_CaseInsensitive(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"scan": {
+			Name:     "scan",
+			Enabled:  true,
+			Keywords: []string{"scan"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, _ := fm.MatchCategory("NETWORK SCAN DETECTION")
+
+	if name != "scan" {
+		t.Errorf("expected case-insensitive match, got %q", name)
+	}
+}
+
+func TestMatchCategory_NoMatch(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"scan": {
+			Name:     "scan",
+			Enabled:  true,
+			Keywords: []string{"scan"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.MatchCategory("Attempted Admin Privilege Gain")
+
+	if name != "" {
+		t.Errorf("expected empty name, got %q", name)
+	}
+	if filter != nil {
+		t.Error("expected nil filter")
+	}
+}
+
+// =============================================================================
+// GetFilterForEvent Tests
+// =============================================================================
+
+func TestGetFilterForEvent_SignatureFirst(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  true,
+			Keywords: []string{"exploit"},
+		},
+		"scan": {
+			Name:     "scan",
+			Enabled:  true,
+			Keywords: []string{"scan"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	// Signature matches "exploit", category matches "scan"
+	name, filter := fm.GetFilterForEvent("ET EXPLOIT Apache Struts", "Scan Detection")
+
+	// Signature match should take priority
+	if name != "exploit" {
+		t.Errorf("expected signature match %q, got %q", "exploit", name)
+	}
+	if filter == nil {
+		t.Error("expected non-nil filter")
+	}
+}
+
+func TestGetFilterForEvent_FallbackToCategory(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"scan": {
+			Name:     "scan",
+			Enabled:  true,
+			Keywords: []string{"scan"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	// Signature doesn't match, but category does
+	name, filter := fm.GetFilterForEvent("ET POLICY Something", "Scan Detection")
+
+	if name != "scan" {
+		t.Errorf("expected category fallback %q, got %q", "scan", name)
+	}
+	if filter == nil {
+		t.Error("expected non-nil filter")
+	}
+}
+
+func TestGetFilterForEvent_NoMatch(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {
+			Name:     "exploit",
+			Enabled:  true,
+			Keywords: []string{"exploit"},
+		},
+	})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.GetFilterForEvent("ET INFO Something", "Policy Violation")
+
+	if name != "" {
+		t.Errorf("expected no match, got %q", name)
+	}
+	if filter != nil {
+		t.Error("expected nil filter")
+	}
+}
+
+func TestGetFilterForEvent_EmptyFilters(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{})
+
+	fm := NewFilterMatcher(cfg)
+	name, filter := fm.GetFilterForEvent("ET EXPLOIT Something", "Attack")
+
+	if name != "" {
+		t.Errorf("expected no match with empty filters, got %q", name)
+	}
+	if filter != nil {
+		t.Error("expected nil filter")
+	}
+}
+
+// =============================================================================
+// Config.GetEnabledFilters Tests
+// =============================================================================
+
+func TestGetEnabledFilters(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {Name: "exploit", Enabled: true},
+		"scan":    {Name: "scan", Enabled: true},
+		"policy":  {Name: "policy", Enabled: false},
+	})
+
+	enabled := cfg.GetEnabledFilters()
+	if len(enabled) != 2 {
+		t.Errorf("expected 2 enabled filters, got %d", len(enabled))
+	}
+	if _, ok := enabled["exploit"]; !ok {
+		t.Error("expected exploit in enabled filters")
+	}
+	if _, ok := enabled["scan"]; !ok {
+		t.Error("expected scan in enabled filters")
+	}
+	if _, ok := enabled["policy"]; ok {
+		t.Error("policy should not be in enabled filters")
+	}
+}
+
+// =============================================================================
+// Config.GetFilter Tests
+// =============================================================================
+
+func TestGetFilter(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{
+		"exploit": {Name: "exploit", Enabled: true},
+	})
+
+	filter, ok := cfg.GetFilter("exploit")
+	if !ok {
+		t.Error("expected to find filter")
+	}
+	if filter.Name != "exploit" {
+		t.Errorf("expected filter name %q, got %q", "exploit", filter.Name)
+	}
+}
+
+func TestGetFilter_NotFound(t *testing.T) {
+	cfg := testConfig(map[string]*FilterConfig{})
+
+	_, ok := cfg.GetFilter("nonexistent")
+	if ok {
+		t.Error("expected filter not found")
+	}
+}
+
+// =============================================================================
+// Config.parseGlobalSetting Tests
+// =============================================================================
+
+func TestParseGlobalSetting(t *testing.T) {
+	cfg := &Config{
+		GlobalEnabled:    true,
+		DefaultThreshold: 100,
+		Filters:          make(map[string]*FilterConfig),
+	}
+
+	// Test enabled parsing
+	cfg.parseGlobalSetting("enabled", "false")
+	if cfg.GlobalEnabled {
+		t.Error("expected GlobalEnabled=false after setting 'false'")
+	}
+
+	cfg.parseGlobalSetting("enabled", "true")
+	if !cfg.GlobalEnabled {
+		t.Error("expected GlobalEnabled=true after setting 'true'")
+	}
+
+	cfg.parseGlobalSetting("enabled", "yes")
+	if !cfg.GlobalEnabled {
+		t.Error("expected GlobalEnabled=true after setting 'yes'")
+	}
+
+	cfg.parseGlobalSetting("enabled", "1")
+	if !cfg.GlobalEnabled {
+		t.Error("expected GlobalEnabled=true after setting '1'")
+	}
+
+	// Test threshold parsing
+	cfg.parseGlobalSetting("default_threshold", "200")
+	if cfg.DefaultThreshold != 200 {
+		t.Errorf("expected DefaultThreshold=200, got %d", cfg.DefaultThreshold)
+	}
+
+	// Invalid threshold should not change value
+	cfg.parseGlobalSetting("default_threshold", "not_a_number")
+	if cfg.DefaultThreshold != 200 {
+		t.Errorf("expected DefaultThreshold unchanged at 200, got %d", cfg.DefaultThreshold)
+	}
+
+	// Test default_action
+	cfg.parseGlobalSetting("default_action", "observe")
+	if cfg.DefaultAction != "observe" {
+		t.Errorf("expected DefaultAction=%q, got %q", "observe", cfg.DefaultAction)
+	}
+}

--- a/pkg/suricata/profile/detector_test.go
+++ b/pkg/suricata/profile/detector_test.go
@@ -1,0 +1,257 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata Profile Detector Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="detector_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for profile types, parsing, and specifications"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package profile
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// ProfileType.String() Tests
+// =============================================================================
+
+func TestProfileType_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile ProfileType
+		want    string
+	}{
+		{"minimal", ProfileMinimal, "minimal"},
+		{"standard", ProfileStandard, "standard"},
+		{"maximum", ProfileMaximum, "maximum"},
+		{"unknown", ProfileType(99), "unknown"},
+		{"negative", ProfileType(-1), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.profile.String()
+			if got != tt.want {
+				t.Errorf("ProfileType(%d).String() = %q, want %q", tt.profile, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ProfileFromString Tests
+// =============================================================================
+
+func TestProfileFromString(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      ProfileType
+		wantErr   bool
+	}{
+		// Minimal aliases
+		{"minimal", "minimal", ProfileMinimal, false},
+		{"min", "min", ProfileMinimal, false},
+		{"low", "low", ProfileMinimal, false},
+		{"a", "a", ProfileMinimal, false},
+
+		// Standard aliases
+		{"standard", "standard", ProfileStandard, false},
+		{"std", "std", ProfileStandard, false},
+		{"medium", "medium", ProfileStandard, false},
+		{"b", "b", ProfileStandard, false},
+		{"default", "default", ProfileStandard, false},
+
+		// Maximum aliases
+		{"maximum", "maximum", ProfileMaximum, false},
+		{"max", "max", ProfileMaximum, false},
+		{"high", "high", ProfileMaximum, false},
+		{"c", "c", ProfileMaximum, false},
+
+		// Case insensitive
+		{"case_minimal", "MINIMAL", ProfileMinimal, false},
+		{"case_standard", "Standard", ProfileStandard, false},
+		{"case_maximum", "MAXIMUM", ProfileMaximum, false},
+
+		// Unknown (returns standard with error)
+		{"unknown", "invalid", ProfileStandard, true},
+		{"empty", "", ProfileStandard, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProfileFromString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ProfileFromString(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ProfileFromString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// GetProfileSpec Tests
+// =============================================================================
+
+func TestGetProfileSpec(t *testing.T) {
+	tests := []struct {
+		name       string
+		profile    ProfileType
+		wantName   string
+		wantMinCPU int
+	}{
+		{"minimal", ProfileMinimal, "minimal", 2},
+		{"standard", ProfileStandard, "standard", 4},
+		{"maximum", ProfileMaximum, "maximum", 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := GetProfileSpec(tt.profile)
+
+			if spec.Name != tt.wantName {
+				t.Errorf("GetProfileSpec(%v).Name = %q, want %q", tt.profile, spec.Name, tt.wantName)
+			}
+			if spec.MinCPU != tt.wantMinCPU {
+				t.Errorf("GetProfileSpec(%v).MinCPU = %d, want %d", tt.profile, spec.MinCPU, tt.wantMinCPU)
+			}
+			if spec.Profile != tt.profile {
+				t.Errorf("GetProfileSpec(%v).Profile = %v, want %v", tt.profile, spec.Profile, tt.profile)
+			}
+		})
+	}
+}
+
+func TestGetProfileSpec_UnknownDefault(t *testing.T) {
+	// Unknown profile type should default to standard
+	spec := GetProfileSpec(ProfileType(99))
+	if spec.Name != "standard" {
+		t.Errorf("expected standard for unknown profile, got %q", spec.Name)
+	}
+}
+
+func TestGetProfileSpec_MinimalValues(t *testing.T) {
+	spec := GetProfileSpec(ProfileMinimal)
+
+	if spec.MinRAMGB != 2 {
+		t.Errorf("minimal MinRAMGB = %.1f, want 2", spec.MinRAMGB)
+	}
+	if spec.RingSize != 50000 {
+		t.Errorf("minimal RingSize = %d, want 50000", spec.RingSize)
+	}
+	if spec.FlowTimeout != 60 {
+		t.Errorf("minimal FlowTimeout = %d, want 60", spec.FlowTimeout)
+	}
+	if spec.DetectProfile != "low" {
+		t.Errorf("minimal DetectProfile = %q, want %q", spec.DetectProfile, "low")
+	}
+}
+
+func TestGetProfileSpec_StandardValues(t *testing.T) {
+	spec := GetProfileSpec(ProfileStandard)
+
+	if spec.MinRAMGB != 4 {
+		t.Errorf("standard MinRAMGB = %.1f, want 4", spec.MinRAMGB)
+	}
+	if spec.RingSize != 100000 {
+		t.Errorf("standard RingSize = %d, want 100000", spec.RingSize)
+	}
+	if spec.FlowTimeout != 120 {
+		t.Errorf("standard FlowTimeout = %d, want 120", spec.FlowTimeout)
+	}
+	if spec.DetectProfile != "medium" {
+		t.Errorf("standard DetectProfile = %q, want %q", spec.DetectProfile, "medium")
+	}
+}
+
+func TestGetProfileSpec_MaximumValues(t *testing.T) {
+	spec := GetProfileSpec(ProfileMaximum)
+
+	if spec.MinRAMGB != 8 {
+		t.Errorf("maximum MinRAMGB = %.1f, want 8", spec.MinRAMGB)
+	}
+	if spec.RingSize != 300000 {
+		t.Errorf("maximum RingSize = %d, want 300000", spec.RingSize)
+	}
+	if spec.FlowTimeout != 300 {
+		t.Errorf("maximum FlowTimeout = %d, want 300", spec.FlowTimeout)
+	}
+	if spec.DetectProfile != "high" {
+		t.Errorf("maximum DetectProfile = %q, want %q", spec.DetectProfile, "high")
+	}
+}
+
+// =============================================================================
+// GetAllProfiles Tests
+// =============================================================================
+
+func TestGetAllProfiles(t *testing.T) {
+	profiles := GetAllProfiles()
+
+	if len(profiles) != 3 {
+		t.Fatalf("expected 3 profiles, got %d", len(profiles))
+	}
+
+	// Should be in order: minimal, standard, maximum
+	expected := []string{"minimal", "standard", "maximum"}
+	for i, p := range profiles {
+		if p.Name != expected[i] {
+			t.Errorf("profiles[%d].Name = %q, want %q", i, p.Name, expected[i])
+		}
+	}
+}
+
+func TestGetAllProfiles_IncreasingResources(t *testing.T) {
+	profiles := GetAllProfiles()
+
+	// Each profile should require more resources than the previous
+	for i := 1; i < len(profiles); i++ {
+		if profiles[i].MinCPU <= profiles[i-1].MinCPU {
+			t.Errorf("expected increasing MinCPU: profile[%d].MinCPU=%d <= profile[%d].MinCPU=%d",
+				i, profiles[i].MinCPU, i-1, profiles[i-1].MinCPU)
+		}
+		if profiles[i].MinRAMGB <= profiles[i-1].MinRAMGB {
+			t.Errorf("expected increasing MinRAMGB: profile[%d].MinRAMGB=%.1f <= profile[%d].MinRAMGB=%.1f",
+				i, profiles[i].MinRAMGB, i-1, profiles[i-1].MinRAMGB)
+		}
+		if profiles[i].RingSize <= profiles[i-1].RingSize {
+			t.Errorf("expected increasing RingSize: profile[%d].RingSize=%d <= profile[%d].RingSize=%d",
+				i, profiles[i].RingSize, i-1, profiles[i-1].RingSize)
+		}
+	}
+}
+
+// =============================================================================
+// ProfileType Constants Tests
+// =============================================================================
+
+func TestProfileTypeConstants(t *testing.T) {
+	// Verify the iota ordering
+	if ProfileMinimal != 0 {
+		t.Errorf("ProfileMinimal = %d, want 0", ProfileMinimal)
+	}
+	if ProfileStandard != 1 {
+		t.Errorf("ProfileStandard = %d, want 1", ProfileStandard)
+	}
+	if ProfileMaximum != 2 {
+		t.Errorf("ProfileMaximum = %d, want 2", ProfileMaximum)
+	}
+}

--- a/pkg/suricata/recommendations/analyzer_test.go
+++ b/pkg/suricata/recommendations/analyzer_test.go
@@ -1,0 +1,140 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata Recommendations Analyzer Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="analyzer_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for isAttackCategoryMatch and recommendation type constants"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package recommendations
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// isAttackCategoryMatch Tests
+// =============================================================================
+
+func TestIsAttackCategoryMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		want     bool
+	}{
+		// Direct matches
+		{"exploit", "exploit", true},
+		{"attack", "attack", true},
+		{"shellcode", "shellcode", true},
+		{"trojan", "trojan", true},
+		{"malware", "malware", true},
+		{"web_app_attack", "web-application-attack", true},
+		{"sql_injection", "sql-injection", true},
+
+		// Case insensitive
+		{"case_exploit", "EXPLOIT", true},
+		{"case_malware", "Malware", true},
+		{"case_trojan", "TROJAN", true},
+
+		// Compound categories (substring match)
+		{"emerging_exploit", "emerging-exploit", true},
+		{"et_trojan", "ET TROJAN Activity", true},
+		{"web_attack", "web-application-attack-attempt", true},
+
+		// Non-attack categories
+		{"policy", "policy", false},
+		{"info", "info", false},
+		{"dns", "dns", false},
+		{"scan", "scan", false},
+		{"empty", "", false},
+		{"benign", "normal-traffic", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAttackCategoryMatch(tt.category)
+			if got != tt.want {
+				t.Errorf("isAttackCategoryMatch(%q) = %v, want %v", tt.category, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// RecommendationType Constants Tests
+// =============================================================================
+
+func TestRecommendationTypeConstants(t *testing.T) {
+	// Verify all types are unique and non-empty
+	types := []RecommendationType{
+		FalsePositive,
+		NoiseReduction,
+		DropMode,
+		DisableRule,
+		InvestigateFurther,
+	}
+
+	seen := make(map[RecommendationType]bool)
+	for _, rt := range types {
+		if rt == "" {
+			t.Error("empty RecommendationType found")
+		}
+		if seen[rt] {
+			t.Errorf("duplicate RecommendationType: %q", rt)
+		}
+		seen[rt] = true
+	}
+}
+
+func TestRecommendationTypeValues(t *testing.T) {
+	if FalsePositive != "false_positive" {
+		t.Errorf("FalsePositive = %q, want %q", FalsePositive, "false_positive")
+	}
+	if NoiseReduction != "noise_reduction" {
+		t.Errorf("NoiseReduction = %q, want %q", NoiseReduction, "noise_reduction")
+	}
+	if DropMode != "drop_mode" {
+		t.Errorf("DropMode = %q, want %q", DropMode, "drop_mode")
+	}
+	if DisableRule != "disable_rule" {
+		t.Errorf("DisableRule = %q, want %q", DisableRule, "disable_rule")
+	}
+	if InvestigateFurther != "investigate" {
+		t.Errorf("InvestigateFurther = %q, want %q", InvestigateFurther, "investigate")
+	}
+}
+
+// =============================================================================
+// attackCategorySet Tests
+// =============================================================================
+
+func TestAttackCategorySet_Populated(t *testing.T) {
+	if len(attackCategorySet) == 0 {
+		t.Error("attackCategorySet should not be empty")
+	}
+
+	expectedKeys := []string{
+		"exploit", "attack", "shellcode", "trojan",
+		"malware", "web-application-attack", "sql-injection",
+	}
+
+	for _, key := range expectedKeys {
+		if _, ok := attackCategorySet[key]; !ok {
+			t.Errorf("attackCategorySet missing key %q", key)
+		}
+	}
+}

--- a/pkg/suricata/scanner/detector_test.go
+++ b/pkg/suricata/scanner/detector_test.go
@@ -1,0 +1,317 @@
+// =============================================================================
+// NFTBan v1.0 - Network Service Detector Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="detector_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for service detection by port, category mapping, and TLS version"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package scanner
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+// =============================================================================
+// detectServiceByPort Tests
+// =============================================================================
+
+func TestDetectServiceByPort(t *testing.T) {
+	tests := []struct {
+		port int
+		want string
+	}{
+		{21, "ftp"},
+		{22, "ssh"},
+		{25, "smtp"},
+		{53, "dns"},
+		{80, "http"},
+		{110, "pop3"},
+		{143, "imap"},
+		{443, "https"},
+		{465, "smtps"},
+		{587, "smtp-submission"},
+		{993, "imaps"},
+		{995, "pop3s"},
+		{3306, "mysql"},
+		{5432, "postgresql"},
+		{6379, "redis"},
+		{8080, "http-alt"},
+		{8443, "https-alt"},
+		{9000, "php-fpm"},
+		{11211, "memcached"},
+		{12345, "unknown"},
+		{0, "unknown"},
+		{65535, "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := detectServiceByPort(tt.port)
+		if got != tt.want {
+			t.Errorf("detectServiceByPort(%d) = %q, want %q", tt.port, got, tt.want)
+		}
+	}
+}
+
+// =============================================================================
+// mapServicesToCategories Tests
+// =============================================================================
+
+func TestMapServicesToCategories_HTTP(t *testing.T) {
+	services := []Service{{Port: 80, Name: "http", Protocol: "tcp"}}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	expected := []string{
+		"emerging-web_server",
+		"emerging-web_client",
+		"emerging-exploit",
+		"emerging-scan",
+		// Always included
+		"emerging-attack_response",
+		"emerging-dos",
+		"emerging-policy",
+	}
+
+	for _, exp := range expected {
+		if !catSet[exp] {
+			t.Errorf("expected category %q for HTTP service, not found in %v", exp, categories)
+		}
+	}
+}
+
+func TestMapServicesToCategories_SSH(t *testing.T) {
+	services := []Service{{Port: 22, Name: "ssh", Protocol: "tcp"}}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	if !catSet["emerging-ssh"] {
+		t.Error("expected emerging-ssh for SSH service")
+	}
+	if !catSet["emerging-exploit"] {
+		t.Error("expected emerging-exploit for SSH service")
+	}
+}
+
+func TestMapServicesToCategories_DNS(t *testing.T) {
+	services := []Service{{Port: 53, Name: "dns", Protocol: "udp"}}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	if !catSet["emerging-dns"] {
+		t.Error("expected emerging-dns for DNS service")
+	}
+	if !catSet["emerging-malware"] {
+		t.Error("expected emerging-malware for DNS service")
+	}
+}
+
+func TestMapServicesToCategories_MySQL(t *testing.T) {
+	services := []Service{{Port: 3306, Name: "mysql", Protocol: "tcp"}}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	if !catSet["emerging-sql"] {
+		t.Error("expected emerging-sql for MySQL service")
+	}
+}
+
+func TestMapServicesToCategories_AlwaysIncluded(t *testing.T) {
+	// Even with no services, critical categories should be included
+	services := []Service{}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	alwaysIncluded := []string{
+		"emerging-attack_response",
+		"emerging-dos",
+		"emerging-policy",
+	}
+
+	for _, exp := range alwaysIncluded {
+		if !catSet[exp] {
+			t.Errorf("expected always-included category %q, not found in %v", exp, categories)
+		}
+	}
+}
+
+func TestMapServicesToCategories_MultipleServices(t *testing.T) {
+	services := []Service{
+		{Port: 80, Name: "http", Protocol: "tcp"},
+		{Port: 443, Name: "https", Protocol: "tcp"},
+		{Port: 22, Name: "ssh", Protocol: "tcp"},
+		{Port: 25, Name: "smtp", Protocol: "tcp"},
+	}
+	categories := mapServicesToCategories(services)
+
+	catSet := make(map[string]bool)
+	for _, c := range categories {
+		catSet[c] = true
+	}
+
+	expectedCategories := []string{
+		"emerging-web_server",
+		"emerging-tls",
+		"emerging-ssh",
+		"emerging-smtp",
+		"emerging-malware",
+	}
+
+	for _, exp := range expectedCategories {
+		if !catSet[exp] {
+			t.Errorf("expected category %q for multiple services, not found in %v", exp, categories)
+		}
+	}
+}
+
+func TestMapServicesToCategories_NoDuplicates(t *testing.T) {
+	// HTTP and HTTP-Alt should both map to emerging-web_server but only once
+	services := []Service{
+		{Port: 80, Name: "http", Protocol: "tcp"},
+		{Port: 8080, Name: "http-alt", Protocol: "tcp"},
+	}
+	categories := mapServicesToCategories(services)
+
+	// Count occurrences
+	counts := make(map[string]int)
+	for _, c := range categories {
+		counts[c]++
+	}
+
+	for cat, count := range counts {
+		if count > 1 {
+			t.Errorf("category %q appears %d times (expected at most 1)", cat, count)
+		}
+	}
+}
+
+// =============================================================================
+// getTLSVersion Tests
+// =============================================================================
+
+func TestGetTLSVersion(t *testing.T) {
+	tests := []struct {
+		version uint16
+		want    string
+	}{
+		{tls.VersionTLS10, "1.0"},
+		{tls.VersionTLS11, "1.1"},
+		{tls.VersionTLS12, "1.2"},
+		{tls.VersionTLS13, "1.3"},
+		{0, "unknown"},
+		{9999, "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := getTLSVersion(tt.version)
+		if got != tt.want {
+			t.Errorf("getTLSVersion(%d) = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}
+
+// =============================================================================
+// ScanResult.GetServiceSummary Tests
+// =============================================================================
+
+func TestGetServiceSummary_NoServices(t *testing.T) {
+	sr := &ScanResult{
+		Services:       []Service{},
+		RuleCategories: []string{},
+	}
+
+	summary := sr.GetServiceSummary()
+	if summary != "No services detected" {
+		t.Errorf("expected %q, got %q", "No services detected", summary)
+	}
+}
+
+func TestGetServiceSummary_WithServices(t *testing.T) {
+	sr := &ScanResult{
+		Services: []Service{
+			{Port: 80, Name: "http", Protocol: "tcp"},
+			{Port: 22, Name: "ssh", Protocol: "tcp", Banner: "OpenSSH_8.0"},
+		},
+		RuleCategories: []string{"emerging-web_server", "emerging-ssh"},
+	}
+
+	summary := sr.GetServiceSummary()
+	if summary == "No services detected" {
+		t.Error("expected service summary, got empty message")
+	}
+	if len(summary) < 20 {
+		t.Errorf("expected meaningful summary, got %q", summary)
+	}
+}
+
+// =============================================================================
+// CommonPorts Tests
+// =============================================================================
+
+func TestCommonPorts_NotEmpty(t *testing.T) {
+	if len(CommonPorts) == 0 {
+		t.Error("expected non-empty CommonPorts list")
+	}
+}
+
+func TestCommonPorts_ContainsEssentialPorts(t *testing.T) {
+	essential := []int{22, 80, 443, 25, 53}
+	portSet := make(map[int]bool)
+	for _, p := range CommonPorts {
+		portSet[p] = true
+	}
+
+	for _, port := range essential {
+		if !portSet[port] {
+			t.Errorf("CommonPorts missing essential port %d", port)
+		}
+	}
+}
+
+// =============================================================================
+// DefaultProbeConfig Tests
+// =============================================================================
+
+func TestDefaultProbeConfig(t *testing.T) {
+	if !DefaultProbeConfig.TLSSkipVerify {
+		t.Error("expected TLSSkipVerify=true for default probe config")
+	}
+	if !DefaultProbeConfig.DevMode {
+		t.Error("expected DevMode=true for default probe config")
+	}
+}

--- a/pkg/suricata/scorer_test.go
+++ b/pkg/suricata/scorer_test.go
@@ -1,0 +1,451 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata IP Threat Scorer Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="scorer_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for scorer calculateScore, LRU eviction, and memory bounds"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package suricata
+
+import (
+	"container/list"
+	"testing"
+	"time"
+)
+
+// newTestScorer creates a Scorer without calling safety.GetMemoryLimits()
+// so tests can run without the production configuration files.
+func newTestScorer(maxIPs, maxEvents int) *Scorer {
+	return &Scorer{
+		scores:      make(map[string]*IPScore),
+		config:      &Config{ScoreDecay: 1 * time.Hour},
+		decayTicker: time.NewTicker(1 * time.Hour),
+		stopChan:    make(chan struct{}),
+		lruList:     list.New(),
+		maxIPs:      maxIPs,
+		maxEvents:   maxEvents,
+	}
+}
+
+// =============================================================================
+// calculateScore Tests
+// =============================================================================
+
+func TestCalculateScore_SeverityScores(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	tests := []struct {
+		name     string
+		severity int
+		want     int
+	}{
+		{"high_severity", 1, 40},
+		{"medium_severity", 2, 30},
+		{"low_severity", 3, 20},
+		{"info_severity", 4, 10},
+		{"unknown_severity", 5, 0},
+		{"zero_severity", 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &Event{Severity: tt.severity, Timestamp: time.Now()}
+			ipScore := &IPScore{Events: []time.Time{}}
+			got := s.calculateScore(event, ipScore)
+			if got != tt.want {
+				t.Errorf("calculateScore(severity=%d) = %d, want %d", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateScore_RepetitionBonus(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		recentEvents  int
+		severity      int
+		wantMinScore  int
+	}{
+		// Base score (severity 4 = 10) + no repetition bonus
+		{"no_repetition", 1, 4, 10},
+		// 5 events in 2 min = +20 bonus
+		{"moderate_repetition", 5, 4, 30},
+		// 10 events in 2 min = +30 bonus
+		{"high_repetition", 10, 4, 40},
+		// 20+ events in 2 min = +50 bonus
+		{"extreme_repetition", 25, 4, 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := make([]time.Time, tt.recentEvents)
+			for i := range events {
+				events[i] = now.Add(-time.Duration(i) * time.Second)
+			}
+
+			event := &Event{Severity: tt.severity, Timestamp: now}
+			ipScore := &IPScore{Events: events}
+			got := s.calculateScore(event, ipScore)
+			if got < tt.wantMinScore {
+				t.Errorf("calculateScore(recentEvents=%d) = %d, want >= %d",
+					tt.recentEvents, got, tt.wantMinScore)
+			}
+		})
+	}
+}
+
+func TestCalculateScore_OldEventsNotCounted(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	// Events older than 2 minutes should not contribute to repetition bonus
+	oldEvents := []time.Time{
+		time.Now().Add(-5 * time.Minute),
+		time.Now().Add(-10 * time.Minute),
+		time.Now().Add(-15 * time.Minute),
+	}
+
+	event := &Event{Severity: 4, Timestamp: time.Now()}
+	ipScore := &IPScore{Events: oldEvents}
+	got := s.calculateScore(event, ipScore)
+
+	// Only base severity score (10), no repetition bonus
+	if got != 10 {
+		t.Errorf("calculateScore with old events = %d, want 10", got)
+	}
+}
+
+// =============================================================================
+// AddEvent Tests
+// =============================================================================
+
+func TestAddEvent_NewIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	event := &Event{
+		SrcIP:     "1.2.3.4",
+		Severity:  1,
+		Timestamp: time.Now(),
+	}
+
+	score := s.AddEvent(event)
+	if score <= 0 {
+		t.Errorf("expected positive score, got %d", score)
+	}
+
+	// Check the IP is tracked
+	ipScore := s.GetIPScore("1.2.3.4")
+	if ipScore == nil {
+		t.Fatal("expected IP to be tracked")
+	}
+	if ipScore.TotalEvents != 1 {
+		t.Errorf("expected TotalEvents=1, got %d", ipScore.TotalEvents)
+	}
+}
+
+func TestAddEvent_ExistingIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	event := &Event{
+		SrcIP:     "1.2.3.4",
+		Severity:  2,
+		Timestamp: time.Now(),
+	}
+
+	s.AddEvent(event)
+	s.AddEvent(event)
+	s.AddEvent(event)
+
+	ipScore := s.GetIPScore("1.2.3.4")
+	if ipScore == nil {
+		t.Fatal("expected IP to be tracked")
+	}
+	if ipScore.TotalEvents != 3 {
+		t.Errorf("expected TotalEvents=3, got %d", ipScore.TotalEvents)
+	}
+	if len(ipScore.Events) != 3 {
+		t.Errorf("expected 3 events, got %d", len(ipScore.Events))
+	}
+}
+
+// =============================================================================
+// LRU Eviction Tests
+// =============================================================================
+
+func TestAddEvent_LRUEviction(t *testing.T) {
+	s := newTestScorer(3, 100) // Max 3 IPs
+	defer s.Stop()
+
+	// Add 3 IPs
+	for _, ip := range []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"} {
+		s.AddEvent(&Event{SrcIP: ip, Severity: 1, Timestamp: time.Now()})
+	}
+
+	// All 3 should exist
+	stats := s.GetStats()
+	if stats["tracked_ips"] != 3 {
+		t.Errorf("expected 3 tracked IPs, got %d", stats["tracked_ips"])
+	}
+
+	// Add a 4th IP - oldest should be evicted
+	s.AddEvent(&Event{SrcIP: "4.4.4.4", Severity: 1, Timestamp: time.Now()})
+
+	stats = s.GetStats()
+	if stats["tracked_ips"] != 3 {
+		t.Errorf("expected 3 tracked IPs after eviction, got %d", stats["tracked_ips"])
+	}
+
+	// The first IP (1.1.1.1) should have been evicted (it's oldest in LRU)
+	if s.GetScore("1.1.1.1") != 0 {
+		t.Error("expected evicted IP to have score 0")
+	}
+	if s.GetScore("4.4.4.4") == 0 {
+		t.Error("expected new IP to have non-zero score")
+	}
+}
+
+// =============================================================================
+// Event Cap Tests
+// =============================================================================
+
+func TestAddEvent_EventCap(t *testing.T) {
+	s := newTestScorer(1000, 5) // Max 5 events per IP
+	defer s.Stop()
+
+	// Add 10 events for the same IP
+	for i := 0; i < 10; i++ {
+		s.AddEvent(&Event{
+			SrcIP:     "1.2.3.4",
+			Severity:  1,
+			Timestamp: time.Now(),
+		})
+	}
+
+	ipScore := s.GetIPScore("1.2.3.4")
+	if ipScore == nil {
+		t.Fatal("expected IP to be tracked")
+	}
+	if len(ipScore.Events) > 5 {
+		t.Errorf("expected max 5 events, got %d", len(ipScore.Events))
+	}
+	if ipScore.TotalEvents != 10 {
+		t.Errorf("expected TotalEvents=10, got %d", ipScore.TotalEvents)
+	}
+}
+
+// =============================================================================
+// GetScore Tests
+// =============================================================================
+
+func TestGetScore_UnknownIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	score := s.GetScore("9.9.9.9")
+	if score != 0 {
+		t.Errorf("expected 0 for unknown IP, got %d", score)
+	}
+}
+
+func TestGetScore_KnownIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.2.3.4", Severity: 1, Timestamp: time.Now()})
+
+	score := s.GetScore("1.2.3.4")
+	if score == 0 {
+		t.Error("expected non-zero score for tracked IP")
+	}
+}
+
+// =============================================================================
+// GetIPScore Tests
+// =============================================================================
+
+func TestGetIPScore_ReturnsACopy(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.2.3.4", Severity: 1, Timestamp: time.Now()})
+
+	ipScore := s.GetIPScore("1.2.3.4")
+	if ipScore == nil {
+		t.Fatal("expected non-nil IPScore")
+	}
+
+	// Modifying the returned copy should not affect the scorer
+	ipScore.CurrentScore = 9999
+	original := s.GetIPScore("1.2.3.4")
+	if original.CurrentScore == 9999 {
+		t.Error("expected GetIPScore to return a copy, not a reference")
+	}
+}
+
+func TestGetIPScore_UnknownIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	ipScore := s.GetIPScore("9.9.9.9")
+	if ipScore != nil {
+		t.Error("expected nil for unknown IP")
+	}
+}
+
+// =============================================================================
+// GetAllScores Tests
+// =============================================================================
+
+func TestGetAllScores(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.1.1.1", Severity: 1, Timestamp: time.Now()})
+	s.AddEvent(&Event{SrcIP: "2.2.2.2", Severity: 2, Timestamp: time.Now()})
+
+	all := s.GetAllScores()
+	if len(all) != 2 {
+		t.Errorf("expected 2 scores, got %d", len(all))
+	}
+	if _, ok := all["1.1.1.1"]; !ok {
+		t.Error("expected 1.1.1.1 in all scores")
+	}
+	if _, ok := all["2.2.2.2"]; !ok {
+		t.Error("expected 2.2.2.2 in all scores")
+	}
+}
+
+func TestGetAllScores_Empty(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	all := s.GetAllScores()
+	if len(all) != 0 {
+		t.Errorf("expected 0 scores, got %d", len(all))
+	}
+}
+
+// =============================================================================
+// ResetScore Tests
+// =============================================================================
+
+func TestResetScore(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.2.3.4", Severity: 1, Timestamp: time.Now()})
+	s.ResetScore("1.2.3.4")
+
+	score := s.GetScore("1.2.3.4")
+	if score != 0 {
+		t.Errorf("expected 0 after ResetScore, got %d", score)
+	}
+
+	ipScore := s.GetIPScore("1.2.3.4")
+	if ipScore != nil {
+		t.Error("expected nil after ResetScore")
+	}
+}
+
+func TestResetScore_UnknownIP(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	defer s.Stop()
+
+	// Should not panic
+	s.ResetScore("9.9.9.9")
+}
+
+// =============================================================================
+// GetStats Tests
+// =============================================================================
+
+func TestGetStats(t *testing.T) {
+	s := newTestScorer(1000, 50)
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.1.1.1", Severity: 1, Timestamp: time.Now()})
+	s.AddEvent(&Event{SrcIP: "1.1.1.1", Severity: 2, Timestamp: time.Now()})
+	s.AddEvent(&Event{SrcIP: "2.2.2.2", Severity: 3, Timestamp: time.Now()})
+
+	stats := s.GetStats()
+	if stats["tracked_ips"] != 2 {
+		t.Errorf("expected tracked_ips=2, got %d", stats["tracked_ips"])
+	}
+	if stats["max_ips"] != 1000 {
+		t.Errorf("expected max_ips=1000, got %d", stats["max_ips"])
+	}
+	if stats["total_events"] != 3 {
+		t.Errorf("expected total_events=3, got %d", stats["total_events"])
+	}
+	if stats["max_events_per"] != 50 {
+		t.Errorf("expected max_events_per=50, got %d", stats["max_events_per"])
+	}
+	if stats["lru_size"] != 2 {
+		t.Errorf("expected lru_size=2, got %d", stats["lru_size"])
+	}
+}
+
+// =============================================================================
+// applyDecay Tests
+// =============================================================================
+
+func TestApplyDecay_RemovesOldEvents(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	s.config.ScoreDecay = 1 * time.Minute // Very short decay for testing
+	defer s.Stop()
+
+	// Manually add an IP with old events
+	s.mu.Lock()
+	s.scores["1.2.3.4"] = &IPScore{
+		IP:         "1.2.3.4",
+		Events:     []time.Time{time.Now().Add(-5 * time.Minute)},
+		LastUpdate: time.Now().Add(-5 * time.Minute),
+	}
+	s.scores["1.2.3.4"].lruElement = s.lruList.PushFront("1.2.3.4")
+	s.mu.Unlock()
+
+	s.applyDecay()
+
+	// Old IP should be removed
+	if s.GetScore("1.2.3.4") != 0 {
+		t.Error("expected old IP to be removed after decay")
+	}
+}
+
+func TestApplyDecay_KeepsRecentEvents(t *testing.T) {
+	s := newTestScorer(1000, 100)
+	s.config.ScoreDecay = 1 * time.Hour
+	defer s.Stop()
+
+	s.AddEvent(&Event{SrcIP: "1.2.3.4", Severity: 1, Timestamp: time.Now()})
+
+	s.applyDecay()
+
+	// Recent IP should still be tracked
+	if s.GetScore("1.2.3.4") == 0 {
+		t.Error("expected recent IP to still be tracked after decay")
+	}
+}

--- a/pkg/suricata/stats/cache_test.go
+++ b/pkg/suricata/stats/cache_test.go
@@ -1,0 +1,435 @@
+// =============================================================================
+// NFTBan v1.0 - Suricata SID Statistics Cache Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cache_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-03-20"
+// meta:description="Unit tests for SID stats cache: recording, eviction, retrieval"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package stats
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestCache creates a Cache without calling nftbanconf.MustLoad() or
+// safety.GetMemoryLimits() so tests can run without production config files.
+func newTestCache(maxSIDs, maxSourcesPerSID int) *Cache {
+	return &Cache{
+		stats:            make(map[string]*SIDStats),
+		snapshotPath:     "/tmp/nftban-test-sid-stats.json",
+		maxSIDs:          maxSIDs,
+		maxSourcesPerSID: maxSourcesPerSID,
+	}
+}
+
+// =============================================================================
+// RecordTrigger Tests
+// =============================================================================
+
+func TestRecordTrigger_NewSID(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "1.2.3.4", now)
+
+	stats, ok := c.GetSIDStats("2100001")
+	if !ok {
+		t.Fatal("expected SID to be tracked")
+	}
+	if stats.SID != "2100001" {
+		t.Errorf("expected SID %q, got %q", "2100001", stats.SID)
+	}
+	if stats.Category != "exploit" {
+		t.Errorf("expected category %q, got %q", "exploit", stats.Category)
+	}
+	if stats.Signature != "ET EXPLOIT Test" {
+		t.Errorf("expected signature %q, got %q", "ET EXPLOIT Test", stats.Signature)
+	}
+	if stats.TriggerCount != 1 {
+		t.Errorf("expected TriggerCount=1, got %d", stats.TriggerCount)
+	}
+	if stats.SourceCount != 1 {
+		t.Errorf("expected SourceCount=1, got %d", stats.SourceCount)
+	}
+}
+
+func TestRecordTrigger_ExistingSID(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "1.2.3.4", now)
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "1.2.3.4", now.Add(1*time.Second))
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "5.6.7.8", now.Add(2*time.Second))
+
+	stats, ok := c.GetSIDStats("2100001")
+	if !ok {
+		t.Fatal("expected SID to be tracked")
+	}
+	if stats.TriggerCount != 3 {
+		t.Errorf("expected TriggerCount=3, got %d", stats.TriggerCount)
+	}
+	if stats.SourceCount != 2 {
+		t.Errorf("expected SourceCount=2 (unique sources), got %d", stats.SourceCount)
+	}
+}
+
+func TestRecordTrigger_EmptySourceIP(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "", now)
+
+	stats, ok := c.GetSIDStats("2100001")
+	if !ok {
+		t.Fatal("expected SID to be tracked")
+	}
+	if stats.TriggerCount != 1 {
+		t.Errorf("expected TriggerCount=1, got %d", stats.TriggerCount)
+	}
+	if stats.SourceCount != 0 {
+		t.Errorf("expected SourceCount=0 (empty IP), got %d", stats.SourceCount)
+	}
+}
+
+func TestRecordTrigger_UpdatesTimestamps(t *testing.T) {
+	c := newTestCache(1000, 100)
+	first := time.Now().Add(-5 * time.Minute)
+	second := time.Now()
+
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "1.2.3.4", first)
+	c.RecordTrigger("2100001", "exploit", "ET EXPLOIT Test", "1.2.3.4", second)
+
+	stats, ok := c.GetSIDStats("2100001")
+	if !ok {
+		t.Fatal("expected SID to be tracked")
+	}
+	if !stats.FirstTrigger.Equal(first) {
+		t.Errorf("expected FirstTrigger=%v, got %v", first, stats.FirstTrigger)
+	}
+	if !stats.LastTrigger.Equal(second) {
+		t.Errorf("expected LastTrigger=%v, got %v", second, stats.LastTrigger)
+	}
+}
+
+// =============================================================================
+// SID Capacity Eviction Tests
+// =============================================================================
+
+func TestRecordTrigger_SIDEviction(t *testing.T) {
+	c := newTestCache(3, 100) // Max 3 SIDs
+
+	now := time.Now()
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now.Add(-3*time.Minute))
+	c.RecordTrigger("sid2", "cat2", "sig2", "2.2.2.2", now.Add(-2*time.Minute))
+	c.RecordTrigger("sid3", "cat3", "sig3", "3.3.3.3", now.Add(-1*time.Minute))
+
+	if c.GetSize() != 3 {
+		t.Errorf("expected 3 SIDs, got %d", c.GetSize())
+	}
+
+	// Adding 4th SID should evict the oldest (sid1)
+	c.RecordTrigger("sid4", "cat4", "sig4", "4.4.4.4", now)
+
+	if c.GetSize() != 3 {
+		t.Errorf("expected 3 SIDs after eviction, got %d", c.GetSize())
+	}
+
+	// sid1 (oldest) should be gone
+	_, ok := c.GetSIDStats("sid1")
+	if ok {
+		t.Error("expected sid1 to be evicted")
+	}
+
+	// sid4 should exist
+	_, ok = c.GetSIDStats("sid4")
+	if !ok {
+		t.Error("expected sid4 to exist")
+	}
+}
+
+// =============================================================================
+// Source IP Cap Tests
+// =============================================================================
+
+func TestRecordTrigger_SourceIPCap(t *testing.T) {
+	c := newTestCache(1000, 3) // Max 3 sources per SID
+
+	now := time.Now()
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "2.2.2.2", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "3.3.3.3", now)
+	// 4th unique source should be ignored (at cap)
+	c.RecordTrigger("sid1", "cat1", "sig1", "4.4.4.4", now)
+
+	stats, _ := c.GetSIDStats("sid1")
+	if stats.SourceCount != 3 {
+		t.Errorf("expected SourceCount=3 (capped), got %d", stats.SourceCount)
+	}
+	if stats.TriggerCount != 4 {
+		t.Errorf("expected TriggerCount=4, got %d", stats.TriggerCount)
+	}
+}
+
+// =============================================================================
+// GetTopSIDs Tests
+// =============================================================================
+
+func TestGetTopSIDs(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	// sid1 = 5 triggers, sid2 = 10 triggers, sid3 = 1 trigger
+	for i := 0; i < 5; i++ {
+		c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	}
+	for i := 0; i < 10; i++ {
+		c.RecordTrigger("sid2", "cat2", "sig2", "2.2.2.2", now)
+	}
+	c.RecordTrigger("sid3", "cat3", "sig3", "3.3.3.3", now)
+
+	top := c.GetTopSIDs(2)
+	if len(top) != 2 {
+		t.Fatalf("expected 2 top SIDs, got %d", len(top))
+	}
+
+	// First should be sid2 (most triggers)
+	if top[0].SID != "sid2" {
+		t.Errorf("expected top[0]=sid2, got %s", top[0].SID)
+	}
+	if top[0].TriggerCount != 10 {
+		t.Errorf("expected top[0].TriggerCount=10, got %d", top[0].TriggerCount)
+	}
+
+	// Second should be sid1
+	if top[1].SID != "sid1" {
+		t.Errorf("expected top[1]=sid1, got %s", top[1].SID)
+	}
+}
+
+func TestGetTopSIDs_AllItems(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid2", "cat2", "sig2", "2.2.2.2", now)
+
+	// Request more than available
+	top := c.GetTopSIDs(10)
+	if len(top) != 2 {
+		t.Errorf("expected 2 SIDs (all available), got %d", len(top))
+	}
+
+	// Request all with -1
+	all := c.GetTopSIDs(-1)
+	if len(all) != 2 {
+		t.Errorf("expected 2 SIDs with -1, got %d", len(all))
+	}
+}
+
+// =============================================================================
+// GetRecentSIDs Tests
+// =============================================================================
+
+func TestGetRecentSIDs(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	// Recent SID
+	c.RecordTrigger("recent", "cat1", "sig1", "1.1.1.1", now)
+
+	// Old SID (manually set)
+	c.mu.Lock()
+	c.stats["old"] = &SIDStats{
+		SID:           "old",
+		Category:      "cat2",
+		Signature:     "sig2",
+		TriggerCount:  1,
+		LastTrigger:   now.Add(-2 * time.Hour),
+		FirstTrigger:  now.Add(-2 * time.Hour),
+		UniqueSources: map[string]bool{"2.2.2.2": true},
+		SourceCount:   1,
+	}
+	c.mu.Unlock()
+
+	recent := c.GetRecentSIDs(1 * time.Hour)
+	if len(recent) != 1 {
+		t.Fatalf("expected 1 recent SID, got %d", len(recent))
+	}
+	if recent[0].SID != "recent" {
+		t.Errorf("expected recent SID, got %s", recent[0].SID)
+	}
+}
+
+// =============================================================================
+// GetSize / GetTotalTriggers / GetUniqueSources Tests
+// =============================================================================
+
+func TestGetSize(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	if c.GetSize() != 0 {
+		t.Errorf("expected size 0, got %d", c.GetSize())
+	}
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid2", "cat2", "sig2", "2.2.2.2", now)
+
+	if c.GetSize() != 2 {
+		t.Errorf("expected size 2, got %d", c.GetSize())
+	}
+}
+
+func TestGetUniqueSIDs(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "2.2.2.2", now) // Same SID
+
+	if c.GetUniqueSIDs() != 1 {
+		t.Errorf("expected 1 unique SID, got %d", c.GetUniqueSIDs())
+	}
+}
+
+func TestGetTotalTriggers(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "2.2.2.2", now)
+	c.RecordTrigger("sid2", "cat2", "sig2", "3.3.3.3", now)
+
+	total := c.GetTotalTriggers()
+	if total != 3 {
+		t.Errorf("expected 3 total triggers, got %d", total)
+	}
+}
+
+func TestGetUniqueSources(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "2.2.2.2", now)
+	c.RecordTrigger("sid2", "cat2", "sig2", "1.1.1.1", now) // Same source IP
+	c.RecordTrigger("sid2", "cat2", "sig2", "3.3.3.3", now)
+
+	sources := c.GetUniqueSources()
+	if sources != 3 {
+		t.Errorf("expected 3 unique sources, got %d", sources)
+	}
+}
+
+// =============================================================================
+// Clear Tests
+// =============================================================================
+
+func TestClear(t *testing.T) {
+	c := newTestCache(1000, 100)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid2", "cat2", "sig2", "2.2.2.2", now)
+
+	c.Clear()
+
+	if c.GetSize() != 0 {
+		t.Errorf("expected size 0 after Clear, got %d", c.GetSize())
+	}
+	if c.GetTotalTriggers() != 0 {
+		t.Errorf("expected 0 triggers after Clear, got %d", c.GetTotalTriggers())
+	}
+}
+
+// =============================================================================
+// GetStats Tests
+// =============================================================================
+
+func TestCacheGetStats(t *testing.T) {
+	c := newTestCache(500, 50)
+	now := time.Now()
+
+	c.RecordTrigger("sid1", "cat1", "sig1", "1.1.1.1", now)
+	c.RecordTrigger("sid1", "cat1", "sig1", "2.2.2.2", now)
+
+	stats := c.GetStats()
+	if stats["sids"] != 1 {
+		t.Errorf("expected sids=1, got %d", stats["sids"])
+	}
+	if stats["max_sids"] != 500 {
+		t.Errorf("expected max_sids=500, got %d", stats["max_sids"])
+	}
+	if stats["total_sources"] != 2 {
+		t.Errorf("expected total_sources=2, got %d", stats["total_sources"])
+	}
+	if stats["max_sources_per_sid"] != 50 {
+		t.Errorf("expected max_sources_per_sid=50, got %d", stats["max_sources_per_sid"])
+	}
+}
+
+// =============================================================================
+// getTopSourceIPs Tests
+// =============================================================================
+
+func TestGetTopSourceIPs(t *testing.T) {
+	c := newTestCache(1000, 100)
+
+	sources := map[string]bool{
+		"3.3.3.3": true,
+		"1.1.1.1": true,
+		"2.2.2.2": true,
+	}
+
+	ips := c.getTopSourceIPs(sources, 10)
+	if len(ips) != 3 {
+		t.Errorf("expected 3 IPs, got %d", len(ips))
+	}
+
+	// Should be sorted alphabetically
+	if ips[0] != "1.1.1.1" {
+		t.Errorf("expected first IP %q, got %q", "1.1.1.1", ips[0])
+	}
+}
+
+func TestGetTopSourceIPs_Limit(t *testing.T) {
+	c := newTestCache(1000, 100)
+
+	sources := map[string]bool{
+		"1.1.1.1": true,
+		"2.2.2.2": true,
+		"3.3.3.3": true,
+		"4.4.4.4": true,
+		"5.5.5.5": true,
+	}
+
+	ips := c.getTopSourceIPs(sources, 3)
+	if len(ips) != 3 {
+		t.Errorf("expected 3 IPs (limited), got %d", len(ips))
+	}
+}
+
+func TestGetTopSourceIPs_Empty(t *testing.T) {
+	c := newTestCache(1000, 100)
+
+	ips := c.getTopSourceIPs(map[string]bool{}, 10)
+	if len(ips) != 0 {
+		t.Errorf("expected 0 IPs for empty sources, got %d", len(ips))
+	}
+}


### PR DESCRIPTION
## Summary
- 20 new test files covering daemon, exporters (zabbix/connectors), suricata (6 sub-packages), eventbus, module, network, ports, portscan, geoban, logx, and metrics
- 415 new test functions (8,979 LOC)
- All tests verified on Debian 12 (lab) and AlmaLinux 10 (lab1) with Go 1.24.0
- Fixed 1 test expectation in suricata/customrules (unbalanced parens error message mismatch)

## Combined v1.26 test stats (with PR1 #202)
- **962 test functions** across **51 test files**
- **2,323 test runs** (including subtests)
- Up from 180 tests at v1.25.0

## Test plan
- [x] `go test ./...` passes on Debian 12 (lab.example.test)
- [x] `go test ./...` passes on AlmaLinux 10 (lab1.example.test)
- [x] Pre-commit header validation passes
- [ ] CI checks (47 workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
