### PR TITLE
fix(whitelist): resolve conflict detection with blacklist_manual sets

### DIFF
--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -135,18 +135,20 @@ nftban_whitelist_add_ip() {
     fi
 
     # Validate IP format and determine family
-    local table set_name blacklist_set family
+    local table set_name blacklist_set blacklist_manual_set family
     if [[ "$ip" =~ : ]]; then
         # IPv6
         table="ip6 nftban"
         set_name="whitelist_ipv6"
         blacklist_set="blacklist_ipv6"
+        blacklist_manual_set="blacklist_manual_ipv6"
         family="IPv6"
     else
         # IPv4
         table="ip nftban"
         set_name="whitelist_ipv4"
         blacklist_set="blacklist_ipv4"
+        blacklist_manual_set="blacklist_manual_ipv4"
         family="IPv4"
     fi
 
@@ -160,12 +162,31 @@ nftban_whitelist_add_ip() {
     fi
 
     # v1.18.7: First remove from blacklist if present (prevents whitelist/blacklist conflict)
-    if nft get element ${table} ${blacklist_set} "{ $ip }" &>/dev/null; then
-        if [[ $ipc_mode -eq 0 ]]; then
-            nft_ipc_delete_element "$table" "$blacklist_set" "$ip" 2>/dev/null || true
+    # v1.38.0: Check both blacklist_manual_* (hash) and blacklist_* (interval) sets
+    # v1.38.0: Use nftban-core unban to remove from BOTH nft sets AND blacklist conf files
+    #          (nft-only delete was insufficient — daemon reconciliation re-adds from conf)
+    local _bl_set _is_banned=false
+    for _bl_set in "$blacklist_manual_set" "$blacklist_set"; do
+        if nft get element ${table} ${_bl_set} "{ $ip }" &>/dev/null; then
+            _is_banned=true
+            break
+        fi
+    done
+    if [[ "$_is_banned" == "true" ]]; then
+        local _core_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core"
+        if [[ -x "$_core_bin" ]]; then
+            "$_core_bin" unban "$ip" &>/dev/null || true
         else
-            # Emergency direct nft access (daemon down, emergency unlock present)
-            nft delete element ${table} ${blacklist_set} "{ $ip }" 2>/dev/null || true
+            # Fallback: direct nft delete (won't remove from conf files)
+            for _bl_set in "$blacklist_manual_set" "$blacklist_set"; do
+                if nft get element ${table} ${_bl_set} "{ $ip }" &>/dev/null; then
+                    if [[ $ipc_mode -eq 0 ]]; then
+                        nft_ipc_delete_element "$table" "$_bl_set" "$ip" 2>/dev/null || true
+                    else
+                        nft delete element ${table} ${_bl_set} "{ $ip }" 2>/dev/null || true
+                    fi
+                fi
+            done
         fi
         echo "Removed $ip from blacklist (was banned)"
     fi


### PR DESCRIPTION
## Summary
- **Bug:** `nftban whitelist add` failed to remove IPs from `blacklist_manual_ipv4/ipv6` (v1.33.0 hash sets) — only checked old `blacklist_ipv4/ipv6` interval sets
- **Root cause:** v1.33.0 set separation moved manual bans to new hash sets, but `cmd_whitelist.sh` conflict resolution was never updated
- **Additional fix:** Previous nft-only delete was insufficient — daemon reconciliation re-adds IPs from `99-manual.conf`. Now calls `nftban-core unban` to remove from BOTH nft sets AND conf files

## Test plan
- [x] Manual test: ban → whitelist add → verify IP removed from both nft set AND `99-manual.conf`
- [x] `nftban smoke all` — 153/153 PASS on lab (DEB, Debian 13)
- [x] `nftban smoke all` — 153/153 PASS on lab1 (RPM, Rocky 10.1)
- [x] `nftban health check` — EXIT=0 on both labs

🤖 Generated with [Claude Code](https://claude.com/claude-code)