### PR TITLE
fix(v1.72.0): postinst quote-stripping syntax error in heredoc

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1509,8 +1509,8 @@ _nftban_conf_value() {
     [ -n "\$_ncv_line" ] || { printf '%s\n' ""; return 0; }
 
     _ncv_val="\${_ncv_line#*=}"
-    _ncv_val="\${_ncv_val#\\\"}"
-    _ncv_val="\${_ncv_val%\\\"}"
+    case "\$_ncv_val" in '"'*) _ncv_val="\${_ncv_val#?}" ;; esac
+    case "\$_ncv_val" in *'"') _ncv_val="\${_ncv_val%?}" ;; esac
     printf '%s\n' "\$_ncv_val"
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `${var#\"}` inside unquoted `<<EOF` heredoc produces `${var#\"}` in spec — bash sees escaped quote, unclosed brace expansion → syntax error at line 1061
- **Fix:** Replace with `case`-based single-char strip — fully POSIX, no escaping issues

## Test plan

- [x] `bash -n` on generated spec `%post` body — PASS
- [x] Regression tests T1+T2 PASS
- [ ] Clean RPM install on lab (Rocky 9) + 192.0.2.224 (Rocky 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
