### PR TITLE
fix(v1.73.1): pipefail crashes on fresh install + login monitor detection

### DIFF
--- a/cli/lib/nftban/core/nftban_geoban.sh
+++ b/cli/lib/nftban/core/nftban_geoban.sh
@@ -1090,9 +1090,9 @@ nftban_geoban_status() {
 
     # Active countries count
     local banned_count
-    banned_count=$(ls -1 "${GEOBAN_FILES_DIR}"/50-ban-*.conf 2>/dev/null | wc -l)
+    banned_count=$(ls -1 "${GEOBAN_FILES_DIR}"/50-ban-*.conf 2>/dev/null | wc -l || true)
     local whitelist_count
-    whitelist_count=$(ls -1 "${GEOBAN_FILES_DIR}"/40-whitelist-*.conf 2>/dev/null | wc -l)
+    whitelist_count=$(ls -1 "${GEOBAN_FILES_DIR}"/40-whitelist-*.conf 2>/dev/null | wc -l || true)
 
     echo "📊 Active Countries:"
     echo "   Banned: ${banned_count}"

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -140,7 +140,7 @@ nftban_report_email_generate() {
     local login_alert_log="${NFTBAN_LOG_DIR}/login_alert.log"
     if [[ -f "$login_alert_log" ]]; then
         # Count actual "Banning" entries from yesterday and today
-        login_bans=$(grep "Banning IP" "$login_alert_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l)
+        login_bans=$(grep "Banning IP" "$login_alert_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l || true)
         login_bans=${login_bans//[^0-9]/}  # Strip non-digits
         login_bans=${login_bans:-0}
     fi
@@ -148,7 +148,7 @@ nftban_report_email_generate() {
     # Count portscan bans
     local portscan_log="${NFTBAN_LOG_DIR}/portscan.log"
     if [[ -f "$portscan_log" ]]; then
-        portscan_bans=$(grep -Ei "ban|block" "$portscan_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l)
+        portscan_bans=$(grep -Ei "ban|block" "$portscan_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l || true)
         portscan_bans=${portscan_bans//[^0-9]/}
         portscan_bans=${portscan_bans:-0}
     fi
@@ -156,7 +156,7 @@ nftban_report_email_generate() {
     # Count DDoS bans
     local ddos_log="${NFTBAN_LOG_DIR}/ddos.log"
     if [[ -f "$ddos_log" ]]; then
-        ddos_bans=$(grep -Ei "ban|block" "$ddos_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l)
+        ddos_bans=$(grep -Ei "ban|block" "$ddos_log" 2>/dev/null | grep -E "^\[${yesterday}|^\[${today}" | wc -l || true)
         ddos_bans=${ddos_bans//[^0-9]/}
         ddos_bans=${ddos_bans:-0}
     fi

--- a/cli/lib/nftban/core/nftban_stats_collect.sh
+++ b/cli/lib/nftban/core/nftban_stats_collect.sh
@@ -324,7 +324,7 @@ nftban_stats_ban_sources() {
         local feeds_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
         if [[ -d "$feeds_dir" ]]; then
             # shellcheck disable=SC2312  # cat in subshell is fine here
-            feed_total=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l)
+            feed_total=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
             feed_total=${feed_total:-0}
         fi
         echo "{\"login\":0,\"portscan\":0,\"ddos\":0,\"manual\":0,\"feeds\":$feed_total,\"suricata\":0}"
@@ -362,7 +362,7 @@ nftban_stats_ban_sources() {
             if [[ -d "$feeds_dir" ]]; then
                 local feed_count
                 # shellcheck disable=SC2312  # cat in subshell is fine here
-                feed_count=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l)
+                feed_count=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
                 feed_count=${feed_count:-0}
                 if [[ "$feed_count" -gt 0 ]]; then
                     result=$(echo "$result" | jq -c ".feeds = $feed_count")

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -571,14 +571,11 @@ nftban_enable_all() {
     echo "[8/10] Enabling login monitor..."
     if declare -f nftban_login_cmd_enable &>/dev/null; then
         nftban_login_cmd_enable >/dev/null 2>&1 && echo "  ✅ Login monitor enabled"
+    elif command -v nftban >/dev/null 2>&1; then
+        # cmd_login.sh may not be loaded in this context — call via CLI
+        nftban login enable >/dev/null 2>&1 && echo "  ✅ Login monitor enabled"
     else
-        if systemctl list-unit-files "$svc_login" &>/dev/null 2>&1; then
-            systemctl enable "$svc_login" 2>/dev/null && \
-            systemctl start "$svc_login" 2>/dev/null && \
-            echo "  ✅ Login monitor enabled"
-        else
-            echo "  ⚠️  Login monitor service not installed (optional)"
-        fi
+        echo "  ⚠️  Login monitor: nftban CLI not available"
     fi
     echo ""
 


### PR DESCRIPTION
## Summary
- Fix `nftban stats` crash on fresh install: `cat feeds/*.txt | wc -l` fails when no feed files exist (glob → cat exit 1 → pipefail)
- Fix `nftban enable` step 8/10 falsely reporting "Login monitor service not installed" — was checking for deleted `nftban-login-monitor.service` instead of calling `nftban login enable`
- Fix same pipefail pattern in `nftban_geoban.sh` and `nftban_report_email.sh`

## Root cause
`set -o pipefail` + empty glob or no-match grep in command substitution → non-zero exit → ERR trap fires

## Test plan
- [x] Reproduced on fresh Rocky 9 install (lab.example.test)
- [ ] Verify `nftban stats` runs clean on fresh install
- [ ] Verify `nftban enable` shows login monitor enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
