### PR TITLE
fix: INV-F-003 whitelist check fails on small sets

### DIFF
--- a/cli/lib/nftban/core/nftban_invariant_validator.sh
+++ b/cli/lib/nftban/core/nftban_invariant_validator.sh
@@ -387,8 +387,8 @@ _validate_safety() {
     local wl_set wl_count
     wl_set=$(nft list set ip nftban whitelist_ipv4 2>/dev/null) || wl_set=""
     if [[ -n "$wl_set" ]]; then
-        # Count element lines (lines with IP addresses between { and })
-        wl_count=$(echo "$wl_set" | grep -cE '^\s+[0-9]+\.' || true)
+        # Count IPs — check both multi-line (large sets) and inline elements format
+        wl_count=$(echo "$wl_set" | grep -coE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' || true)
         if [[ "$wl_count" -gt 0 ]]; then
             _inv_record "INV-F-003" "PASS" "Whitelist has ${wl_count} entries"
         else


### PR DESCRIPTION
## Summary
- INV-F-003 falsely reports "Whitelist is empty" when whitelist has entries
- Root cause: nft formats small sets inline (`elements = { 1.2.3.4, 5.6.7.8 }`) but the grep pattern only matched multi-line format
- Fix: count IPv4 addresses anywhere in the output

## Test plan
- [x] Reproduced on fresh Rocky 9 install (lab.example.test)
- [ ] Verify `nftban firewall validate --strict` shows INV-F-003 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
