### PR TITLE
fix(firewall): BotGuard rebuild gating fix (BOTGUARD-REBUILD-UX)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -899,13 +899,11 @@ firewall_reload() {
         }
     fi
 
-    # Step 4c (v1.50.1): Re-apply botguard if enabled — reload destroys nft rules
-    local _botguard_enabled="false"
-    local _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local"
-    [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    [[ "$_botguard_enabled" != "true" ]] && _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf" && \
-        [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    if [[ "$_botguard_enabled" == "true" ]]; then
+    # Step 4c (v1.50.1, v1.81.0 key fix): Re-apply botguard if enabled — reload
+    # destroys nft rules. Reuses cmd_botguard's enable path which calls
+    # nft_fragment_enable_module "botguard" (idempotent: recreates sets, chain,
+    # jump rule) and restarts nftband.
+    if _firewall_botguard_is_enabled; then
         [[ "$quiet" == "false" ]] && echo "Re-applying BotGuard rules..."
         nftban botguard enable --quiet 2>/dev/null || {
             [[ "$quiet" == "false" ]] && echo "Warning: Failed to re-apply BotGuard rules. Run: nftban botguard enable" || true
@@ -939,6 +937,34 @@ firewall_reload() {
 
 # Validator binary path
 _REBUILD_VALIDATOR_BIN="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
+
+# v1.81.0 BOTGUARD-REBUILD-UX fix:
+# Returns 0 if BotGuard is enabled in config, 1 otherwise.
+#
+# This is a *gating* fix, not a sequencing fix. Step 10 of firewall_rebuild
+# (Re-apply BotGuard) was already correctly placed before POST-rebuild
+# validation. The bug was that all three module-restore sites
+# (firewall_reload, firewall_rebuild Step 10, firewall_reset Step 8) read the
+# wrong config key `BOTGUARD_ENABLED` instead of the canonical
+# `HTTP_BOTGUARD_ENABLED` used everywhere else in the codebase
+# (cmd_botguard.sh, cmd_status.sh, health checks, exporter, doctor,
+# config-schema). The grep returned empty, the local var fell through to
+# "false", the re-init silently no-op'd, BotGuard chains stayed missing,
+# and the existing PROTECTED→degraded rollback fired unnecessarily on srv1.
+#
+# This helper centralises the read of the canonical key so the wrong-key bug
+# cannot recur in any of the three call sites.
+_firewall_botguard_is_enabled() {
+    local conf_dir="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard"
+    local val=""
+    if [[ -f "$conf_dir/main.conf.local" ]]; then
+        val=$(grep -oP '^HTTP_BOTGUARD_ENABLED="\K[^"]+' "$conf_dir/main.conf.local" 2>/dev/null || true)
+    fi
+    if [[ "$val" != "true" && -f "$conf_dir/main.conf" ]]; then
+        val=$(grep -oP '^HTTP_BOTGUARD_ENABLED="\K[^"]+' "$conf_dir/main.conf" 2>/dev/null || true)
+    fi
+    [[ "$val" == "true" ]]
+}
 
 _rebuild_get_validator_state() {
     # Call Go validator and return status (protected/degraded/down)
@@ -1290,14 +1316,13 @@ firewall_rebuild() {
         [[ "$quiet" == "false" ]] && echo "    Portscan: not enabled, skipped" || true
     fi
 
-    # Step 10 (v1.50.1): Re-apply botguard if enabled
+    # Step 10 (v1.50.1, v1.81.0 key fix): Re-apply botguard if enabled.
+    # Sequencing was already correct (this step runs before [POST] validation
+    # so the validator does not see a transient missing-helper-chain state).
+    # The v1.81.0 fix is to the *gating*: Step 10 was previously checked
+    # against the wrong config key and silently skipped on BotGuard hosts.
     [[ "$quiet" == "false" ]] && echo "  [10/12] Re-applying BotGuard..."
-    local _botguard_enabled="false"
-    local _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local"
-    [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    [[ "$_botguard_enabled" != "true" ]] && _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf" && \
-        [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    if [[ "$_botguard_enabled" == "true" ]]; then
+    if _firewall_botguard_is_enabled; then
         nftban botguard enable --quiet 2>/dev/null || {
             [[ "$quiet" == "false" ]] && echo "    Warning: BotGuard enable failed. Run: nftban botguard enable" || true
         }
@@ -1496,14 +1521,9 @@ firewall_reset() {
         nftban portscan enable --quiet 2>/dev/null || [[ "$quiet" == "false" ]] && echo "    Warning: Portscan enable failed"
     fi
 
-    # Step 8 (v1.50.1): Re-apply botguard if enabled
+    # Step 8 (v1.50.1, v1.81.0 key fix): Re-apply botguard if enabled
     [[ "$quiet" == "false" ]] && echo "  [8/11] Re-applying BotGuard..."
-    local _botguard_enabled="false"
-    local _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local"
-    [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    [[ "$_botguard_enabled" != "true" ]] && _botguard_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf" && \
-        [[ -f "$_botguard_conf" ]] && _botguard_enabled=$(grep -oP '^BOTGUARD_ENABLED="\K[^"]+' "$_botguard_conf" 2>/dev/null || echo "false")
-    if [[ "$_botguard_enabled" == "true" ]]; then
+    if _firewall_botguard_is_enabled; then
         nftban botguard enable --quiet 2>/dev/null || [[ "$quiet" == "false" ]] && echo "    Warning: BotGuard enable failed"
     fi
 

--- a/cli/lib/nftban/tests/merge_gate_botguard_rebuild_log.sh
+++ b/cli/lib/nftban/tests/merge_gate_botguard_rebuild_log.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.81.0 — BotGuard rebuild merge-gate (lab/srv1 log assertion)
+# =============================================================================
+# meta:name="merge_gate_botguard_rebuild_log"
+# meta:type="merge-gate"
+# meta:version="1.81.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Merge-gate assertion for BOTGUARD-REBUILD-UX fix: parses a captured rebuild log and proves Step 10 actually fired and rebuild finished PROTECTED with no rollback"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Purpose:
+#   This script is the runnable merge-gate for the BOTGUARD-REBUILD-UX fix.
+#   It does NOT touch nftables. It does NOT need to run on a BotGuard host.
+#   It takes a captured `nftban firewall rebuild` log file (produced on a lab
+#   host with HTTP_BOTGUARD_ENABLED=true) and asserts the invariants that
+#   prove the gating fix is working in real production code paths.
+#
+# Workflow (lab4 first, then srv1):
+#
+#   1. Set HTTP_BOTGUARD_ENABLED="true" on a lab host
+#   2. nftban firewall rebuild 2>&1 | tee /tmp/rebuild_botguard_enabled.log
+#   3. ./merge_gate_botguard_rebuild_log.sh /tmp/rebuild_botguard_enabled.log
+#   4. Exit code 0 = merge gate PASS, non-zero = merge gate BLOCK
+#
+# Negative path (BotGuard disabled — must still no-op cleanly):
+#
+#   1. Ensure HTTP_BOTGUARD_ENABLED="false" (or absent)
+#   2. nftban firewall rebuild 2>&1 | tee /tmp/rebuild_botguard_disabled.log
+#   3. ./merge_gate_botguard_rebuild_log.sh --disabled /tmp/rebuild_botguard_disabled.log
+#   4. Exit code 0 = no-regression confirmed
+#
+# DO NOT MERGE the BOTGUARD-REBUILD-UX patch until BOTH runs pass on lab4.
+# =============================================================================
+
+set -Eeuo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--disabled] <rebuild_log_path>
+
+Asserts BotGuard rebuild gating invariants against a captured rebuild log.
+
+Modes:
+  (default)    Asserts BotGuard ENABLED on the host. Step 10 must FIRE.
+  --disabled   Asserts BotGuard DISABLED on the host. Step 10 must SKIP.
+EOF
+    exit 2
+}
+
+mode="enabled"
+if [[ "${1:-}" == "--disabled" ]]; then
+    mode="disabled"
+    shift
+fi
+
+log_path="${1:-}"
+[[ -z "$log_path" || ! -f "$log_path" ]] && usage
+
+pass=0
+fail=0
+say_pass() { echo "  PASS  $1"; ((pass++)) || true; }
+say_fail() { echo "  FAIL  $1"; ((fail++)) || true; }
+
+echo "============================================================="
+echo "MERGE GATE — BOTGUARD-REBUILD-UX  ($mode mode)"
+echo "Log: $log_path"
+echo "============================================================="
+
+# -----------------------------------------------------------------------------
+# Invariant 1: rebuild ran to completion (no early abort)
+# -----------------------------------------------------------------------------
+if grep -q '\[POST\] Validating post-rebuild state' "$log_path"; then
+    say_pass "rebuild reached POST-validation phase"
+else
+    say_fail "rebuild did NOT reach POST-validation (early abort?)"
+fi
+
+# -----------------------------------------------------------------------------
+# Invariant 2: Step 10 executed and BotGuard re-init message printed
+# -----------------------------------------------------------------------------
+if grep -q '\[10/12\] Re-applying BotGuard' "$log_path"; then
+    say_pass "Step 10 ran (\"[10/12] Re-applying BotGuard\")"
+else
+    say_fail "Step 10 line missing — Step 10 itself did not execute"
+fi
+
+# -----------------------------------------------------------------------------
+# Invariant 3 (mode-dependent): gating decision matches host config
+# -----------------------------------------------------------------------------
+if grep -q 'BotGuard: not enabled, skipped' "$log_path"; then
+    skipped="yes"
+else
+    skipped="no"
+fi
+
+if [[ "$mode" == "enabled" ]]; then
+    if [[ "$skipped" == "no" ]]; then
+        say_pass "BotGuard NOT skipped (HTTP_BOTGUARD_ENABLED=true on host honoured)"
+    else
+        say_fail "Step 10 still printed 'BotGuard: not enabled, skipped' — gating fix not deployed"
+    fi
+else
+    # disabled mode — skip line is REQUIRED to prove no-regression
+    if [[ "$skipped" == "yes" ]]; then
+        say_pass "BotGuard cleanly skipped on non-BotGuard host"
+    else
+        say_fail "expected 'BotGuard: not enabled, skipped' on non-BotGuard host but did not see it"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Invariant 4: rebuild finished PROTECTED, no rollback fired
+# -----------------------------------------------------------------------------
+if grep -q 'Final status: PROTECTED' "$log_path"; then
+    say_pass "Final status: PROTECTED"
+else
+    say_fail "Final status is NOT PROTECTED"
+fi
+
+if grep -qE 'REBUILD FAILED|Rollback successful|Rollback FAILED' "$log_path"; then
+    say_fail "rollback path triggered — rebuild was not clean"
+else
+    say_pass "no rollback path triggered"
+fi
+
+# -----------------------------------------------------------------------------
+# Invariant 5: BotGuard enable warning did NOT fire (enabled mode only)
+# -----------------------------------------------------------------------------
+if [[ "$mode" == "enabled" ]]; then
+    if grep -q 'Warning: BotGuard enable failed' "$log_path"; then
+        say_fail "'nftban botguard enable' raised a warning during rebuild"
+    else
+        say_pass "'nftban botguard enable' completed without warnings"
+    fi
+fi
+
+echo "============================================================="
+echo "Results: $pass passed, $fail failed"
+echo "============================================================="
+
+if [[ "$fail" -eq 0 ]]; then
+    echo "MERGE GATE: PASS  ($mode mode)"
+    exit 0
+else
+    echo "MERGE GATE: BLOCK ($mode mode) — DO NOT MERGE"
+    exit 1
+fi

--- a/cli/lib/nftban/tests/test_botguard_rebuild_sequencing.sh
+++ b/cli/lib/nftban/tests/test_botguard_rebuild_sequencing.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.81.0 — BotGuard rebuild sequencing test
+# =============================================================================
+# meta:name="test_botguard_rebuild_sequencing"
+# meta:type="test"
+# meta:version="1.81.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Verifies BOTGUARD-REBUILD-UX fix: rebuild detects HTTP_BOTGUARD_ENABLED correctly and re-applies BotGuard before final validation"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files="conf.d/botguard/main.conf,conf.d/botguard/main.conf.local"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Background:
+#   Pre-fix, cmd_firewall.sh's three module-restore sites (firewall_reload,
+#   firewall_rebuild, firewall_reset) read the WRONG config key
+#   `BOTGUARD_ENABLED` instead of the canonical `HTTP_BOTGUARD_ENABLED`. As a
+#   result, Step 10 (Re-apply BotGuard) silently no-op'd on every BotGuard host
+#   — including srv1 — and the post-rebuild validator saw transient missing
+#   helper chains and triggered a rollback.
+#
+# This test pins the gating helper `_firewall_botguard_is_enabled` and asserts:
+#   1. true   when HTTP_BOTGUARD_ENABLED="true" in main.conf.local
+#   2. false  when HTTP_BOTGUARD_ENABLED="false" in main.conf.local
+#   3. true   when HTTP_BOTGUARD_ENABLED="true" in main.conf only (no .local)
+#   4. false  when no botguard conf files exist (BotGuard-disabled hosts)
+#   5. local override wins: .local "false" beats main.conf "true"
+#   6. Regression guard: cmd_firewall.sh contains no occurrence of the legacy
+#      `BOTGUARD_ENABLED=` key (only HTTP_BOTGUARD_ENABLED).
+#   7. All three call sites (reload, rebuild, reset) use the helper.
+# =============================================================================
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CMD_FIREWALL="$PROJECT_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+
+if [[ ! -f "$CMD_FIREWALL" ]]; then
+    echo "FATAL: cannot find cmd_firewall.sh at $CMD_FIREWALL" >&2
+    exit 2
+fi
+
+pass_count=0
+fail_count=0
+
+assert() {
+    local name="$1"
+    local expected="$2"   # "pass" or "fail"
+    local actual="$3"     # "pass" or "fail"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS  $name"
+        ((pass_count++)) || true
+    else
+        echo "  FAIL  $name (expected=$expected actual=$actual)"
+        ((fail_count++)) || true
+    fi
+}
+
+# Extract just the helper function from cmd_firewall.sh and source it in
+# isolation. We do not source the whole file because cmd_firewall.sh has heavy
+# dependencies (other libs, runtime side effects). The helper itself is pure
+# bash + grep and depends only on $NFTBAN_CONFIG_DIR.
+load_helper() {
+    local snippet
+    snippet=$(awk '
+        /^_firewall_botguard_is_enabled\(\)/ { in_fn=1 }
+        in_fn { print }
+        in_fn && /^}/ { in_fn=0 }
+    ' "$CMD_FIREWALL")
+    if [[ -z "$snippet" ]]; then
+        echo "FATAL: helper _firewall_botguard_is_enabled not found in $CMD_FIREWALL" >&2
+        exit 2
+    fi
+    eval "$snippet"
+}
+
+load_helper
+
+# Sandbox config dir
+SANDBOX=$(mktemp -d /tmp/nftban_test_botguard_XXXXXX)
+trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_CONFIG_DIR="$SANDBOX"
+mkdir -p "$SANDBOX/conf.d/botguard"
+
+run_helper() {
+    if _firewall_botguard_is_enabled; then echo "pass"; else echo "fail"; fi
+}
+
+reset_botguard_conf() {
+    rm -f "$SANDBOX/conf.d/botguard/main.conf" "$SANDBOX/conf.d/botguard/main.conf.local"
+}
+
+echo "=========================================================="
+echo "BotGuard rebuild sequencing — test_botguard_rebuild_sequencing"
+echo "=========================================================="
+echo ""
+echo "[1] Helper gating tests"
+
+# Test 1: HTTP_BOTGUARD_ENABLED=true in main.conf.local → enabled
+reset_botguard_conf
+echo 'HTTP_BOTGUARD_ENABLED="true"' > "$SANDBOX/conf.d/botguard/main.conf.local"
+assert "enabled when HTTP_BOTGUARD_ENABLED=\"true\" in main.conf.local" "pass" "$(run_helper)"
+
+# Test 2: HTTP_BOTGUARD_ENABLED=false → disabled
+reset_botguard_conf
+echo 'HTTP_BOTGUARD_ENABLED="false"' > "$SANDBOX/conf.d/botguard/main.conf.local"
+assert "disabled when HTTP_BOTGUARD_ENABLED=\"false\" in main.conf.local" "fail" "$(run_helper)"
+
+# Test 3: only main.conf, no .local → enabled
+reset_botguard_conf
+echo 'HTTP_BOTGUARD_ENABLED="true"' > "$SANDBOX/conf.d/botguard/main.conf"
+assert "fallback to main.conf when no .local override" "pass" "$(run_helper)"
+
+# Test 4: no config files at all → disabled (non-BotGuard host, no regression)
+reset_botguard_conf
+assert "disabled when no botguard config files exist (non-BotGuard host)" "fail" "$(run_helper)"
+
+# Test 5: existing fall-through semantics preserved.
+# Pre-fix the inline blocks fell through from .local≠true to main.conf, so an
+# explicit ".local=false" with main.conf=true resolved to ENABLED. This is
+# almost certainly not what most admins would expect, but the BotGuard
+# rebuild-UX fix is not the place to change config-resolution semantics —
+# that belongs in a separate config-doctor follow-up. Pin the existing
+# behavior to keep this patch surgical and to flag any future drift.
+reset_botguard_conf
+echo 'HTTP_BOTGUARD_ENABLED="true"'  > "$SANDBOX/conf.d/botguard/main.conf"
+echo 'HTTP_BOTGUARD_ENABLED="false"' > "$SANDBOX/conf.d/botguard/main.conf.local"
+assert "preserved fall-through: .local=false + main.conf=true → enabled" "pass" "$(run_helper)"
+
+# Test 5b: when .local explicitly says true, that wins regardless of main.conf
+reset_botguard_conf
+echo 'HTTP_BOTGUARD_ENABLED="false"' > "$SANDBOX/conf.d/botguard/main.conf"
+echo 'HTTP_BOTGUARD_ENABLED="true"'  > "$SANDBOX/conf.d/botguard/main.conf.local"
+assert ".local=true wins over main.conf=false" "pass" "$(run_helper)"
+
+# Test 6: legacy wrong key alone is NOT honoured (would still pass pre-fix code,
+# now must be ignored since we read the canonical key only)
+reset_botguard_conf
+echo 'BOTGUARD_ENABLED="true"' > "$SANDBOX/conf.d/botguard/main.conf.local"
+assert "legacy key BOTGUARD_ENABLED alone is ignored" "fail" "$(run_helper)"
+
+echo ""
+echo "[2] Static regression guards on cmd_firewall.sh"
+
+# Regression guard: no functional usage of legacy BOTGUARD_ENABLED= key
+# (the comment block is allowed to mention it as documentation of the bug)
+LEGACY_HITS=$(grep -n 'BOTGUARD_ENABLED=' "$CMD_FIREWALL" \
+              | grep -v 'HTTP_BOTGUARD_ENABLED=' \
+              | grep -v '^[0-9]*:#' || true)
+if [[ -z "$LEGACY_HITS" ]]; then
+    echo "  PASS  no functional BOTGUARD_ENABLED= references remain in cmd_firewall.sh"
+    ((pass_count++)) || true
+else
+    echo "  FAIL  legacy BOTGUARD_ENABLED= still referenced functionally:"
+    echo "$LEGACY_HITS" | sed 's/^/        /'
+    ((fail_count++)) || true
+fi
+
+# All three call sites now go through the helper
+HELPER_CALLS=$(grep -c '_firewall_botguard_is_enabled' "$CMD_FIREWALL" || true)
+# 4 = 3 call sites + the function definition itself
+if [[ "$HELPER_CALLS" -ge 4 ]]; then
+    echo "  PASS  helper called from all three sites (reload/rebuild/reset)"
+    ((pass_count++)) || true
+else
+    echo "  FAIL  expected ≥4 helper occurrences, got $HELPER_CALLS"
+    ((fail_count++)) || true
+fi
+
+# Step 10 BotGuard re-apply must run BEFORE the POST validation block
+STEP10_LINE=$(grep -n '\[10/12\] Re-applying BotGuard' "$CMD_FIREWALL" | head -1 | cut -d: -f1 || echo "")
+POST_LINE=$(grep -n '\[POST\] Validating post-rebuild state' "$CMD_FIREWALL" | head -1 | cut -d: -f1 || echo "")
+if [[ -n "$STEP10_LINE" && -n "$POST_LINE" && "$STEP10_LINE" -lt "$POST_LINE" ]]; then
+    echo "  PASS  BotGuard re-apply (line $STEP10_LINE) precedes POST validation (line $POST_LINE)"
+    ((pass_count++)) || true
+else
+    echo "  FAIL  BotGuard re-apply ordering broken (step10=$STEP10_LINE post=$POST_LINE)"
+    ((fail_count++)) || true
+fi
+
+echo ""
+echo "=========================================================="
+echo "Results: $pass_count passed, $fail_count failed"
+echo "=========================================================="
+
+[[ "$fail_count" -eq 0 ]]


### PR DESCRIPTION
## Summary

**This patch does not change rebuild ordering; it fixes the BotGuard enabled/disabled decision so the existing Step 10 re-init path actually runs on BotGuard hosts.**

Step 10 ordering was already correct; the rebuild path was incorrectly gated by the wrong config key.

## Root cause

Three module-restore sites in `cli/lib/nftban/cli/cmd_firewall.sh` — `firewall_reload`, `firewall_rebuild` Step 10, and `firewall_reset` Step 8 — read the wrong key `BOTGUARD_ENABLED` instead of the canonical `HTTP_BOTGUARD_ENABLED` used everywhere else in the codebase (`cmd_botguard.sh`, `cmd_status.sh`, health checks, exporter, doctor, `data/config-schema.json`).

The grep returned empty → the local fell through to `"false"` → BotGuard re-init silently no-op'd → post-rebuild validation saw transient missing helper chains → the existing PROTECTED→degraded rollback fired unnecessarily on srv1 (the only fleet host with `HTTP_BOTGUARD_ENABLED=true` in production).

## What this patch does

- Adds a single private helper `_firewall_botguard_is_enabled` in `cmd_firewall.sh` that reads the canonical `HTTP_BOTGUARD_ENABLED` key
- Replaces three duplicated inline grep blocks with calls to the helper
- Reuses the existing init path (`nftban botguard enable` → `nft_fragment_enable_module \"botguard\"`) unchanged
- Leaves the existing PROTECTED→degraded rollback safety net unchanged
- Preserves existing config-resolution semantics (the `.local`-falls-through-to-`main.conf` behaviour is pinned by Test 5; changing that would belong in a separate config-doctor follow-up)

## What this patch does NOT do

- Not a parser change
- Not a scoring change
- Not a pipeline change
- Not a BotGuard architecture change
- Not a base firewall enforcement change
- Not a new CLI surface
- Not a new config knob
- Not a config-resolution semantics change
- Not generic cleanup

## Three layers of proof

### 1. Narrow code change

```
 cli/lib/nftban/cli/cmd_firewall.sh | 62 +++++++++++++++++++++++++-------------
 cli/lib/nftban/tests/merge_gate_botguard_rebuild_log.sh | new (~140 lines)
 cli/lib/nftban/tests/test_botguard_rebuild_sequencing.sh | new (~180 lines)
```

### 2. Unit test (`tests/test_botguard_rebuild_sequencing.sh`)

10 hermetic assertions, no nft/systemd dependencies:

- helper returns true when \`HTTP_BOTGUARD_ENABLED=\"true\"\` in `main.conf.local`
- helper returns false when `HTTP_BOTGUARD_ENABLED=\"false\"`
- fall-back to `main.conf` when no `.local` override
- disabled when no botguard config files exist (non-BotGuard host no-regression)
- preserved fall-through: `.local=false` + `main.conf=true` → enabled (existing semantics pinned)
- `.local=true` wins over `main.conf=false`
- legacy key `BOTGUARD_ENABLED` alone is ignored (regression guard)
- no functional `BOTGUARD_ENABLED=` references remain in `cmd_firewall.sh`
- helper called from all three sites (reload/rebuild/reset)
- Step 10 line precedes `[POST]` validation line (ordering invariant pinned)

### 3. Runnable merge gate (`tests/merge_gate_botguard_rebuild_log.sh`)

Parses a captured \`nftban firewall rebuild\` log and asserts:

- rebuild reached `[POST]` validation phase
- `[10/12] Re-applying BotGuard` line present
- gating decision matches host config (enabled mode → must NOT print \"skipped\"; \`--disabled\` mode → MUST print \"skipped\")
- `Final status: PROTECTED`
- no `REBUILD FAILED` / `Rollback successful` / `Rollback FAILED`
- no `Warning: BotGuard enable failed`

Self-tested against three synthetic logs (happy enabled, happy disabled, pre-fix buggy with skip+degraded+rollback) — exit codes 0/0/1 — proves the gate catches the exact pre-fix failure shape.

## Test plan

- [x] CI: unit test (`test_botguard_rebuild_sequencing.sh`) — 10/10 green locally
- [ ] **lab4 disabled** — `nftban firewall rebuild` with `HTTP_BOTGUARD_ENABLED=\"false\"` (no-regression baseline)
- [ ] **lab4 enabled** — `nftban firewall rebuild` with `HTTP_BOTGUARD_ENABLED=\"true\"` — **THIS IS THE BLOCKING MERGE GATE**
- [ ] lab2 disabled — no-regression
- [ ] monitor disabled — no-regression
- [ ] After merge: srv1 install/rebuild — must produce a clean rebuild log that the merge-gate parser accepts

Merge-gate runs will be posted as a comment on this PR before merge.

## Refs

- `V1.80_ROADMAP/MASTER_TODO.md` item `BOTGUARD-REBUILD-UX`
- `V1.80_ROADMAP/PARSER_DECOMMISSION_GATES.md` §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)