### PR TITLE
fix(validator): B80-1 shim — validate_structure() → Go validator authority

### DIFF
--- a/cli/lib/nftban/core/nftban_validator.sh
+++ b/cli/lib/nftban/core/nftban_validator.sh
@@ -101,204 +101,215 @@ get_live_ruleset() {
 # =============================================================================
 
 validate_structure() {
-    # Validate nftables structure against spec
-    # Args: $1 = output_json (true/false)
-    # Returns: 0 if OK, 1 if errors found
+    # =========================================================================
+    # NOTE (v1.80, B80-1 — truth consolidation):
+    # This function is now a THIN SHIM over the Go validator (nftban-validate).
+    # It exists ONLY for backward compatibility with existing CLI callers:
+    #   - cli/lib/nftban/cli/cmd_validate.sh:103  (nftban validate)
+    #   - cli/lib/nftban/cli/cmd_firewall.sh:453+ (firewall reload/rebuild/reset
+    #                                             validation fallback paths)
     #
-    # PERFORMANCE: All validation checks use batch jq operations to avoid
-    # spawning jq processes inside loops (which can cause 10,000+ process
-    # spawns and 30+ second timeouts on large rulesets).
+    # It MUST NOT contain independent validation logic (no jq on nftables JSON,
+    # no nft list ruleset, no spec loading). The single source of truth is the
+    # Go validator binary at ${NFTBAN_LIB_DIR}/bin/nftban-validate — see
+    # internal/validator/validator.go and the v1.78.0 kernel truth alignment.
+    #
+    # Output contract (MUST match legacy shell format byte-for-byte for callers):
+    #   JSON: {status:"OK"|"WARNING"|"ERROR", errors:[], warnings:[], info:[]}
+    #   Text: "NFTBan Structure Validation" header + status + error/warning lists
+    #   Exit: 0 if status=="OK" or "WARNING", 1 if status=="ERROR"
+    #
+    # Full removal of this shell file (including the still-independent
+    # check_ip_or_port and get_firewall_stats below) is v1.81 scope — see
+    # V1.80_ROADMAP/MASTER_TODO.md B80-1 discussion dated 2026-04-11.
+    # =========================================================================
+    #
+    # Args: $1 = output_json (true/false)
+    # Returns: 0 if OK/WARNING, 1 if ERROR
 
     local output_json="${1:-false}"
-    local spec ruleset
-    local errors=() warnings=() info=()
+    local validator_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
 
-    # Load spec
-    spec=$(load_spec) || return 1
-
-    # Get live ruleset
-    ruleset=$(get_live_ruleset) || return 1
-
-    # ==========================================================================
-    # BATCH CHECK: Required tables
-    # Single jq call checks all required tables at once, outputs missing ones
-    # NOTE: Uses --slurpfile with process substitution to avoid "Argument list
-    # too long" errors when spec/ruleset exceed shell argument limits (~128KB)
-    # ==========================================================================
-    local missing_tables
-    missing_tables=$(jq -r -n \
-        --slurpfile spec <(printf '%s' "$spec") \
-        --slurpfile ruleset <(printf '%s' "$ruleset") '
-        # First arg ($spec[0]) provides required tables, second ($ruleset[0]) provides live state
-        $spec[0].expected_structure.validation_checks.required_tables // [] |
-        . as $required |
-        # Build set of existing tables as "family name" strings
-        # Handle both formats: {"nftables": [...]} or direct array [...]
-        (($ruleset[0].nftables // $ruleset[0]) | if type == "array" then . else [] end | map(select(.table?) | "\(.table.family) \(.table.name)")) as $existing |
-        # Output only tables that are required but not existing
-        $required[] | select(. as $r | $existing | index($r) | not)
-    ')
-
-    while IFS= read -r table; do
-        [[ -z "$table" ]] && continue
-        errors+=("CRITICAL: Missing required table: $table")
-    done <<< "$missing_tables"
-
-    # ==========================================================================
-    # BATCH CHECK: Priority safety (other firewall chains)
-    # Single jq call finds all chains that might bypass NFTBan, outputs as TSV
-    # NOTE: Uses --slurpfile with process substitution to avoid "Argument list
-    # too long" errors when ruleset exceeds shell argument limits (~128KB)
-    # v1.18.0: Changed to priority 0 (standard filter priority)
-    # ==========================================================================
-    local nftban_priority=0
-    local chain_issues
-    chain_issues=$(jq -r -n \
-        --argjson nftban_prio "$nftban_priority" \
-        --slurpfile ruleset <(printf '%s' "$ruleset") '
-        # Find all base chains on input/forward hooks (excluding nftban table)
-        # Skip chains with policy=accept — they are pass-through (e.g. Ubuntu/UFW default inet filter)
-        # Handle both formats: {"nftables": [...]} or direct array [...]
-        (($ruleset[0].nftables // $ruleset[0]) | if type == "array" then . else [] end) |
-        map(select(.chain? and .chain.table != "nftban" and
-                   (.chain.hook == "input" or .chain.hook == "forward") and
-                   (.chain.policy != "accept"))) |
-        # Output as tab-separated: family, table, name, hook, prio, severity
-        map([
-            .chain.family,
-            .chain.table,
-            .chain.name,
-            .chain.hook,
-            (.chain.prio // 0 | tostring),
-            (if (.chain.prio // 0) <= $nftban_prio then "critical" else "warning" end)
-        ] | join("\t")) |
-        .[]
-    ')
-
-    # Process chain issues (no jq in loop - uses tab-separated values)
-    while IFS=$'\t' read -r family table name hook prio severity; do
-        [[ -z "$family" ]] && continue
-        if [[ "$severity" == "critical" ]]; then
-            errors+=("CRITICAL: $family $table $name (priority $prio) runs before/with NFTBan (priority $nftban_priority) on $hook hook!")
+    # Guardrail: the Go validator binary MUST exist. If it doesn't, we fail
+    # closed with exit code 2 (distinct from generic validation failure so
+    # callers can distinguish "tool missing" from "tool ran but validation
+    # failed"). No independent fallback validation logic — that would
+    # re-create the exact drift risk B80-1 is closing.
+    #
+    # NOTE: this fail-closed path must work WITHOUT jq. We use printf with
+    # hand-escaped JSON because jq itself may be missing (the jq-missing
+    # fallback below handles the happy path; here we must report the error
+    # even on a broken-environment host).
+    if [[ ! -x "$validator_bin" ]]; then
+        local missing_msg="CRITICAL: Go validator binary not found at $validator_bin — reinstall nftban package"
+        if [[ "$output_json" == "true" ]]; then
+            # Hand-build JSON without jq: escape backslashes then double-quotes.
+            local _escaped
+            _escaped=$(printf '%s' "$missing_msg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+            printf '{"status":"ERROR","errors":["%s"],"warnings":[],"info":[]}\n' "$_escaped"
         else
-            warnings+=("WARNING: Other firewall chain detected: $family $table $name (priority $prio) - NFTBan runs first (safe)")
+            echo "NFTBan Structure Validation"
+            echo "============================"
+            echo ""
+            echo "Status: ERROR"
+            echo ""
+            echo "❌ ERRORS (1):"
+            echo "  $missing_msg"
         fi
-    done <<< "$chain_issues"
-
-    # Informational: detect pass-through chains (policy accept) — harmless but worth noting
-    local passthrough_chains
-    passthrough_chains=$(jq -r -n \
-        --slurpfile ruleset <(printf '%s' "$ruleset") '
-        (($ruleset[0].nftables // $ruleset[0]) | if type == "array" then . else [] end) |
-        map(select(.chain? and .chain.table != "nftban" and
-                   (.chain.hook == "input" or .chain.hook == "forward") and
-                   .chain.policy == "accept")) |
-        map("\(.chain.family) \(.chain.table) \(.chain.name) \(.chain.hook)") | .[]
-    ')
-    while IFS= read -r pt_chain; do
-        [[ -z "$pt_chain" ]] && continue
-        warnings+=("INFO: Pass-through chain detected: $pt_chain (policy accept — no impact on NFTBan)")
-    done <<< "$passthrough_chains"
-
-    # ==========================================================================
-    # BATCH CHECK: Required sets
-    # Single jq call checks all required sets at once, outputs missing ones
-    # NOTE: Uses --slurpfile with process substitution to avoid "Argument list
-    # too long" errors when spec/ruleset exceed shell argument limits (~128KB)
-    # ==========================================================================
-    local missing_sets
-    missing_sets=$(jq -r -n \
-        --slurpfile spec <(printf '%s' "$spec") \
-        --slurpfile ruleset <(printf '%s' "$ruleset") '
-        $spec[0].expected_structure.validation_checks.required_sets // [] |
-        . as $required |
-        # Build set of existing sets as "family table name" strings
-        # Handle both formats: {"nftables": [...]} or direct array [...]
-        (($ruleset[0].nftables // $ruleset[0]) | if type == "array" then . else [] end | map(select(.set?) | "\(.set.family) \(.set.table) \(.set.name)")) as $existing |
-        # Output only sets that are required but not existing
-        $required[] | select(. as $r | $existing | index($r) | not)
-    ')
-
-    while IFS= read -r set_path; do
-        [[ -z "$set_path" ]] && continue
-        warnings+=("WARNING: Missing required set: $set_path")
-    done <<< "$missing_sets"
-
-    # ==========================================================================
-    # BATCH CHECK: Chain policies
-    # Single jq call checks all policy requirements, outputs mismatches as TSV
-    # NOTE: Uses --slurpfile with process substitution to avoid "Argument list
-    # too long" errors when spec/ruleset exceed shell argument limits (~128KB)
-    # ==========================================================================
-    local policy_issues
-    policy_issues=$(jq -r -n \
-        --slurpfile spec <(printf '%s' "$spec") \
-        --slurpfile ruleset <(printf '%s' "$ruleset") '
-        # Build lookup of actual chain policies: key="family table chain", value=policy
-        # Handle both formats: {"nftables": [...]} or direct array [...]
-        (($ruleset[0].nftables // $ruleset[0]) | if type == "array" then . else [] end |
-            map(select(.chain? and .chain.policy?) |
-                {key: "\(.chain.family) \(.chain.table) \(.chain.name)", value: .chain.policy}) |
-            from_entries
-        ) as $actual_policies |
-        # Check each expected policy, output mismatches as tab-separated
-        ($spec[0].expected_structure.validation_checks.policy_checks // {}) |
-        to_entries |
-        map(
-            select($actual_policies[.key] != null and $actual_policies[.key] != .value) |
-            [.key, .value, $actual_policies[.key]] | join("\t")
-        ) |
-        .[]
-    ')
-
-    while IFS=$'\t' read -r chain_path expected_policy actual_policy; do
-        [[ -z "$chain_path" ]] && continue
-        errors+=("CRITICAL: Wrong policy on $chain_path: expected '$expected_policy', got '$actual_policy'")
-    done <<< "$policy_issues"
-
-    # Determine overall status
-    local status="OK"
-    if [[ ${#errors[@]} -gt 0 ]]; then
-        status="ERROR"
-    elif [[ ${#warnings[@]} -gt 0 ]]; then
-        status="WARNING"
+        return 2
     fi
 
-    # Output results
+    # Call the Go validator. Ignore its exit code — we translate status into
+    # shell schema via jq below, and derive the shell exit code from that.
+    local go_output
+    go_output=$("$validator_bin" --json 2>/dev/null) || true
+
+    if [[ -z "$go_output" ]]; then
+        local empty_msg="CRITICAL: Go validator returned empty output"
+        if [[ "$output_json" == "true" ]]; then
+            local _escaped
+            _escaped=$(printf '%s' "$empty_msg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+            printf '{"status":"ERROR","errors":["%s"],"warnings":[],"info":[]}\n' "$_escaped"
+        else
+            echo "NFTBan Structure Validation"
+            echo "============================"
+            echo ""
+            echo "Status: ERROR"
+            echo ""
+            echo "❌ ERRORS (1):"
+            echo "  $empty_msg"
+        fi
+        return 1
+    fi
+
+    # --- jq-missing fallback ---
+    # When jq is not installed on this host (a broken-environment case —
+    # jq is a declared nftban dependency) we cannot do schema translation
+    # or preserve the full legacy output format, but we MUST preserve the
+    # exit-code contract so callers see the right behaviour.
+    #
+    # Conservative grep on the Go output: protected → 0, anything else → 1.
+    # Emit a minimal text banner so the caller is never silent.
+    if ! command -v jq >/dev/null 2>&1; then
+        if printf '%s' "$go_output" | grep -qi '"status"[[:space:]]*:[[:space:]]*"protected"'; then
+            if [[ "$output_json" == "true" ]]; then
+                printf '{"status":"OK","errors":[],"warnings":[],"info":[]}\n'
+            else
+                echo "NFTBan Structure Validation"
+                echo "============================"
+                echo ""
+                echo "Status: OK (jq unavailable — reduced reporting)"
+                echo ""
+                echo "✅ All validation checks passed!"
+            fi
+            return 0
+        else
+            if [[ "$output_json" == "true" ]]; then
+                printf '{"status":"ERROR","errors":["CRITICAL: validation failed (jq unavailable — reduced reporting; run %s for details)"],"warnings":[],"info":[]}\n' \
+                    "$validator_bin"
+            else
+                echo "NFTBan Structure Validation"
+                echo "============================"
+                echo ""
+                echo "Status: ERROR (jq unavailable — reduced reporting)"
+                echo ""
+                echo "❌ ERRORS (1):"
+                echo "  Validation failed. Run: $validator_bin for details."
+            fi
+            return 1
+        fi
+    fi
+
+    # Translate Go validator schema → legacy shell schema.
+    #
+    # Go schema (internal/validator/types.go):
+    #   {status:"protected"|"degraded"|"down", findings:[{severity,message,...}], ...}
+    #
+    # Shell schema (legacy contract this shim MUST preserve):
+    #   {status:"OK"|"WARNING"|"ERROR", errors:[], warnings:[], info:[]}
+    #
+    # Rules:
+    #   Go severity "critical" or "error" → shell errors[] with "CRITICAL: " prefix
+    #   Go severity "warn"                → shell warnings[] with "WARNING: " prefix
+    #   shell status derived from counts:
+    #     errors>0   → "ERROR"
+    #     warnings>0 → "WARNING"
+    #     else       → "OK"
+    local shell_json
+    shell_json=$(printf '%s' "$go_output" | jq '
+        . as $go |
+        (($go.findings // [])
+            | map(select(.severity == "critical" or .severity == "error"))
+            | map("CRITICAL: " + (.message // "unknown error"))) as $errors |
+        (($go.findings // [])
+            | map(select(.severity == "warn"))
+            | map("WARNING: " + (.message // "unknown warning"))) as $warnings |
+        (if ($errors | length) > 0 then "ERROR"
+         elif ($warnings | length) > 0 then "WARNING"
+         else "OK" end) as $shell_status |
+        {
+            status: $shell_status,
+            errors: $errors,
+            warnings: $warnings,
+            info: []
+        }
+    ')
+
+    if [[ -z "$shell_json" ]]; then
+        # jq failed to parse Go output — fail closed
+        local parse_msg="CRITICAL: Go validator output could not be parsed (jq failed)"
+        if [[ "$output_json" == "true" ]]; then
+            jq -n --arg m "$parse_msg" \
+                '{status:"ERROR",errors:[$m],warnings:[],info:[]}'
+        else
+            echo "NFTBan Structure Validation"
+            echo "============================"
+            echo ""
+            echo "Status: ERROR"
+            echo ""
+            echo "❌ ERRORS (1):"
+            echo "  $parse_msg"
+        fi
+        return 1
+    fi
+
+    # Extract status + counts in a single jq call (shim discipline: one jq
+    # per distinct rendering purpose, not one jq per field).
+    local status errors_count warnings_count
+    {
+        read -r status
+        read -r errors_count
+        read -r warnings_count
+    } < <(printf '%s' "$shell_json" | jq -r '.status, (.errors | length), (.warnings | length)')
+
     if [[ "$output_json" == "true" ]]; then
-        jq -n \
-            --arg status "$status" \
-            --argjson errors "$(printf '%s\n' "${errors[@]}" | jq -R . | jq -s .)" \
-            --argjson warnings "$(printf '%s\n' "${warnings[@]}" | jq -R . | jq -s .)" \
-            --argjson info "$(printf '%s\n' "${info[@]}" | jq -R . | jq -s .)" \
-            '{status: $status, errors: $errors, warnings: $warnings, info: $info}'
+        printf '%s\n' "$shell_json"
     else
-        # Human-readable output
         echo "NFTBan Structure Validation"
         echo "============================"
         echo ""
         echo "Status: $status"
         echo ""
 
-        if [[ ${#errors[@]} -gt 0 ]]; then
-            echo "❌ ERRORS (${#errors[@]}):"
-            printf '  %s\n' "${errors[@]}"
+        if [[ "$errors_count" -gt 0 ]]; then
+            echo "❌ ERRORS (${errors_count}):"
+            printf '%s' "$shell_json" | jq -r '.errors[] | "  " + .'
             echo ""
         fi
 
-        if [[ ${#warnings[@]} -gt 0 ]]; then
-            echo "⚠️  WARNINGS (${#warnings[@]}):"
-            printf '  %s\n' "${warnings[@]}"
+        if [[ "$warnings_count" -gt 0 ]]; then
+            echo "⚠️  WARNINGS (${warnings_count}):"
+            printf '%s' "$shell_json" | jq -r '.warnings[] | "  " + .'
             echo ""
         fi
 
-        if [[ ${#errors[@]} -eq 0 && ${#warnings[@]} -eq 0 ]]; then
+        if [[ "$errors_count" -eq 0 && "$warnings_count" -eq 0 ]]; then
             echo "✅ All validation checks passed!"
         fi
     fi
 
-    # v1.39.0: Return explicit exit code (avoid implicit test-as-return-value)
-    if [[ ${#errors[@]} -gt 0 ]]; then
+    # Exit code: 1 if any errors, 0 otherwise (matches legacy behaviour).
+    if [[ "$errors_count" -gt 0 ]]; then
         return 1
     fi
     return 0

--- a/cli/lib/nftban/tests/smoke_test.sh
+++ b/cli/lib/nftban/tests/smoke_test.sh
@@ -1957,6 +1957,46 @@ run_runtime_tests() {
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 
+    # --- INV-CONS-001: CLI truth surface agrees with Go validator ---
+    # Added 2026-04-13 as part of B80-1 truth consolidation (see test
+    # tests/test_validate_structure_is_shim.sh for the static guard).
+    # The top-level `nftban status --json` output MUST agree with the Go
+    # validator on the protection state. Divergence is a consistency-axis
+    # violation (INV-CONS-001) and MUST be a smoke failure, not a warning.
+    #
+    # Extraction hierarchy (intended truth order):
+    #   .status          — canonical key name (not currently emitted)
+    #   .protection_state — alternate canonical key (not currently emitted)
+    #   .health          — alternate health key (not currently emitted)
+    #   .state           — ACTUAL key emitted by output_json() in cmd_status.sh
+    #                      as of 2026-04-13 (see cmd_status.sh:1562)
+    #
+    # The fall-through order is preserved so that if the shell key is later
+    # renamed to the canonical .status / .protection_state / .health, this
+    # test automatically picks up the rename without code change.
+    # Comparison is uppercase-normalized to handle case differences between
+    # the Go validator ("protected"/"degraded"/"down") and any future case
+    # convention change on the shell side.
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local cli_status_json cli_state validator_state
+    cli_status_json=$(nftban status --json 2>/dev/null || echo "")
+    cli_state=$(printf '%s' "$cli_status_json" | jq -r '.status // .protection_state // .health // .state // empty' 2>/dev/null | tr '[:lower:]' '[:upper:]')
+    validator_state=$(/usr/lib/nftban/bin/nftban-validate --json 2>/dev/null | jq -r '.status // empty' 2>/dev/null | tr '[:lower:]' '[:upper:]')
+
+    if [[ -z "$cli_state" ]]; then
+        log_fail "INV-CONS-001 — nftban status --json has no state key (.status/.protection_state/.health/.state all missing)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    elif [[ -z "$validator_state" ]]; then
+        log_fail "INV-CONS-001 — nftban-validate --json has no .status field"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    elif [[ "$cli_state" == "$validator_state" ]]; then
+        log_pass "INV-CONS-001 — nftban status ($cli_state) agrees with validator ($validator_state)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_fail "INV-CONS-001 — nftban status=$cli_state, validator=$validator_state (DIVERGENCE)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
     # --- 2. Daemon stability ---
     log ""
     log "─── Daemon Stability ───"

--- a/cli/lib/nftban/tests/test_validate_structure_is_shim.sh
+++ b/cli/lib/nftban/tests/test_validate_structure_is_shim.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.80 — B80-1 validate_structure shim regression guard
+# =============================================================================
+# meta:name="test_validate_structure_is_shim"
+# meta:type="test"
+# meta:version="1.80.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Pins the B80-1 invariant: validate_structure() in nftban_validator.sh MUST be a thin shim over nftban-validate and MUST NOT contain independent validation logic"
+# meta:inventory.files="cli/lib/nftban/core/nftban_validator.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Background:
+#   B80-1 closes the "two validator authorities" drift risk (shell validator
+#   alongside Go validator). The v1.81 cleanup will remove the shell file
+#   entirely, but during v1.80 hardening the file stays in place for
+#   backward compatibility with existing CLI callers (cmd_validate.sh,
+#   cmd_firewall.sh rebuild/reload/reset fallback paths). Instead, the
+#   function body is rewritten as a thin shim over the Go validator binary.
+#
+#   This test is the invariant pin: validate_structure() must remain a shim.
+#   If anyone re-adds independent validation logic (jq on nftables JSON,
+#   nft list ruleset, spec loading, etc.) this test must fail in CI before
+#   the PR lands. That is the entire point — the shell code must not
+#   accidentally become a parallel truth authority again.
+#
+# Scope:
+#   Static analysis of the file. Hermetic. No runtime dependencies beyond
+#   bash, awk, and grep. Safe to run anywhere.
+#
+# What this test does NOT check:
+#   - runtime behaviour (that's covered by the INV-CONS-001 smoke check in
+#     cli/lib/nftban/tests/smoke_test.sh run_runtime_tests())
+#   - check_ip_or_port / get_firewall_stats in the same file (those are
+#     not in B80-1 scope and are v1.81 cleanup targets)
+#   - the shell file's existence (it is intentionally kept for backward
+#     compat; its DELETION is v1.81 scope, not v1.80)
+# =============================================================================
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+TARGET_FILE="$PROJECT_ROOT/cli/lib/nftban/core/nftban_validator.sh"
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "FATAL: target file not found at $TARGET_FILE" >&2
+    exit 2
+fi
+
+pass_count=0
+fail_count=0
+
+assert() {
+    local name="$1"
+    local ok="$2"
+    if [[ "$ok" == "yes" ]]; then
+        echo "  PASS  $name"
+        ((pass_count++)) || true
+    else
+        echo "  FAIL  $name"
+        ((fail_count++)) || true
+    fi
+}
+
+# Extract the body of validate_structure() only. We do NOT check the rest
+# of the file because check_ip_or_port and get_firewall_stats legitimately
+# contain nft/jq parsing — that's not in B80-1 scope.
+body=$(awk '
+    /^validate_structure\(\)/ { in_fn=1; depth=0 }
+    in_fn {
+        print
+        # Track brace depth to find the matching closing brace
+        n=gsub(/\{/, "{"); depth+=n
+        n=gsub(/\}/, "}"); depth-=n
+        if (depth == 0 && /\}/) { exit }
+    }
+' "$TARGET_FILE")
+
+if [[ -z "$body" ]]; then
+    echo "FATAL: could not extract validate_structure() body from $TARGET_FILE" >&2
+    exit 2
+fi
+
+body_lines=$(printf '%s\n' "$body" | wc -l)
+
+echo "=========================================================="
+echo "B80-1 validate_structure shim regression guard"
+echo "  target: cli/lib/nftban/core/nftban_validator.sh"
+echo "  body lines: $body_lines"
+echo "=========================================================="
+echo ""
+echo "[1] Positive invariants — the shim MUST do these things"
+
+# P1: body must call the Go validator binary
+if printf '%s' "$body" | grep -q 'nftban-validate'; then
+    assert "body calls the Go validator binary (nftban-validate)" "yes"
+else
+    assert "body calls the Go validator binary (nftban-validate)" "no"
+fi
+
+# P2: body must use NFTBAN_LIB_DIR/bin/ path style for the validator
+if printf '%s' "$body" | grep -qE 'NFTBAN_LIB_DIR.*/bin/nftban-validate'; then
+    assert "body builds validator path via \$NFTBAN_LIB_DIR/bin/nftban-validate" "yes"
+else
+    assert "body builds validator path via \$NFTBAN_LIB_DIR/bin/nftban-validate" "no"
+fi
+
+# P3: body must contain a B80-1 NOTE comment block so future readers understand
+#     this is a shim, not a standalone validator
+if printf '%s' "$body" | grep -q 'B80-1'; then
+    assert "body contains the B80-1 NOTE comment explaining the shim intent" "yes"
+else
+    assert "body contains the B80-1 NOTE comment explaining the shim intent" "no"
+fi
+
+# P4: body must emit the legacy shell JSON schema
+#     {status,errors,warnings,info} — this is the preserved output contract
+if printf '%s' "$body" | grep -qE 'status.*errors.*warnings.*info'; then
+    assert "body preserves legacy shell JSON schema {status,errors,warnings,info}" "yes"
+else
+    assert "body preserves legacy shell JSON schema {status,errors,warnings,info}" "no"
+fi
+
+# P5: body must map Go status strings (protected/degraded/down) to shell
+#     severity words via jq (critical/error/warn → ERROR/WARNING)
+if printf '%s' "$body" | grep -qE '(critical|error|warn)'; then
+    assert "body maps Go severity levels to shell schema" "yes"
+else
+    assert "body maps Go severity levels to shell schema" "no"
+fi
+
+echo ""
+echo "[2] Negative invariants — the shim MUST NOT do these things"
+
+# N1: body must NOT call load_spec() (spec loading belongs to the old path)
+if printf '%s' "$body" | grep -vE '^\s*#' | grep -q 'load_spec'; then
+    assert "body does NOT call load_spec() (spec loading is Go-side only)" "no"
+else
+    assert "body does NOT call load_spec() (spec loading is Go-side only)" "yes"
+fi
+
+# N2: body must NOT call get_live_ruleset() (nft list ruleset wrapping is
+#     Go-side only now)
+if printf '%s' "$body" | grep -vE '^\s*#' | grep -q 'get_live_ruleset'; then
+    assert "body does NOT call get_live_ruleset() (kernel read is Go-side only)" "no"
+else
+    assert "body does NOT call get_live_ruleset() (kernel read is Go-side only)" "yes"
+fi
+
+# N3: body must NOT run `nft list ruleset` directly
+if printf '%s' "$body" | grep -vE '^\s*#' | grep -qE 'nft[[:space:]]+list[[:space:]]+ruleset'; then
+    assert "body does NOT run 'nft list ruleset' directly" "no"
+else
+    assert "body does NOT run 'nft list ruleset' directly" "yes"
+fi
+
+# N4: body must NOT use --slurpfile pattern (that was the old batch-jq
+#     validation shape — a smoking gun for independent validation logic)
+if printf '%s' "$body" | grep -q -- '--slurpfile'; then
+    assert "body does NOT use --slurpfile batch validation pattern" "no"
+else
+    assert "body does NOT use --slurpfile batch validation pattern" "yes"
+fi
+
+# N5: body must NOT reference required_tables / required_sets / policy_checks
+#     (spec field names — unmistakably independent validation logic)
+if printf '%s' "$body" | grep -qE 'required_tables|required_sets|policy_checks|expected_structure'; then
+    assert "body does NOT reference spec field names (required_tables etc.)" "no"
+else
+    assert "body does NOT reference spec field names (required_tables etc.)" "yes"
+fi
+
+# N6: body must NOT be too long — a shim grew into a validator is the
+#     exact failure mode this test is preventing. 260 lines accommodates:
+#       NOTE comment block           ~30 lines
+#       missing-binary fail-closed   ~20 lines (printf-based, no jq)
+#       empty-output fail-closed     ~20 lines (printf-based, no jq)
+#       jq-missing fallback branch   ~35 lines (both modes × both paths)
+#       main Go→shell translation    ~30 lines
+#       parse-fail fail-closed       ~15 lines (jq -n, jq is present here)
+#       status+counts extraction     ~15 lines
+#       text rendering               ~30 lines
+#       closing exit-code logic      ~10 lines
+#     Total realistic ceiling ~205; cap at 260 for headroom, stays well
+#     under the old batch validator's ~200 lines of independent validation.
+if [[ "$body_lines" -le 260 ]]; then
+    assert "body length $body_lines ≤ 260 lines (shim discipline)" "yes"
+else
+    assert "body length $body_lines ≤ 260 lines (shim discipline)" "no"
+fi
+
+# N7: body must use a bounded number of jq invocations. The shim shape after
+# Amend-2 (jq-missing fallback) is:
+#     1 jq for main Go→shell schema translation
+#     1 jq for status+counts extraction (consolidated)
+#     2 jq for text rendering (errors[] + warnings[])
+#     1 jq -n for parse-fail fail-closed output shaping
+#     1 command -v jq (counts as a jq mention)
+#     = 6 functional + 1 fallback gate
+#     Cap at 12 to leave headroom for the jq-missing path's future growth
+#     but still catch re-introduction of per-field validation logic. The
+#     old batch validator used 12+ jq calls DIRECTLY on raw nftables JSON —
+#     the shape this cap catches is unmistakably different even at 10-11.
+jq_count=$(printf '%s' "$body" | grep -vE '^\s*#' | grep -cE '\bjq[[:space:]]' || true)
+if [[ "$jq_count" -le 12 ]]; then
+    assert "body uses ≤12 jq invocations (jq_count=$jq_count)" "yes"
+else
+    assert "body uses ≤12 jq invocations (jq_count=$jq_count, too many)" "no"
+fi
+
+# N8: body must have a jq-missing fallback — Amend-2 contract enforcement
+if printf '%s' "$body" | grep -q 'command -v jq'; then
+    assert "body checks 'command -v jq' for jq-missing fallback (Amend-2)" "yes"
+else
+    assert "body checks 'command -v jq' for jq-missing fallback (Amend-2)" "no"
+fi
+
+# N9: body must use 'return 2' for missing-binary path — Amend-1 contract
+if printf '%s' "$body" | grep -qE '^\s*return 2\b'; then
+    assert "body uses 'return 2' for missing-binary fail (Amend-1)" "yes"
+else
+    assert "body uses 'return 2' for missing-binary fail (Amend-1)" "no"
+fi
+
+echo ""
+echo "[3] Static guardrails on the file surface"
+
+# S1: the file still exists (B80-1 does NOT delete it — that's v1.81 scope)
+if [[ -f "$TARGET_FILE" ]]; then
+    assert "nftban_validator.sh still exists (deletion is v1.81 scope)" "yes"
+else
+    assert "nftban_validator.sh still exists (deletion is v1.81 scope)" "no"
+fi
+
+# S2: the other two non-B80-1 functions are still defined (scope fence proof)
+if grep -q '^check_ip_or_port()' "$TARGET_FILE"; then
+    assert "check_ip_or_port() preserved (scope fence)" "yes"
+else
+    assert "check_ip_or_port() preserved (scope fence)" "no"
+fi
+if grep -q '^get_firewall_stats()' "$TARGET_FILE"; then
+    assert "get_firewall_stats() preserved (scope fence)" "yes"
+else
+    assert "get_firewall_stats() preserved (scope fence)" "no"
+fi
+
+echo ""
+echo "=========================================================="
+echo "Results: $pass_count passed, $fail_count failed"
+echo "=========================================================="
+
+[[ "$fail_count" -eq 0 ]]


### PR DESCRIPTION
## Summary

**B80-1 is closed behaviorally, not structurally.** Full shell-file deletion and responsibility split (`check_ip_or_port` / `get_firewall_stats` / `load_spec` / `get_live_ruleset`) are deferred to v1.81.

This patch does not change rebuild ordering, CLI output format, or caller interfaces. It replaces the *body* of `validate_structure()` in `cli/lib/nftban/core/nftban_validator.sh` with a thin compatibility shim over the Go validator binary (`nftban-validate`), making validation authority Go-only at runtime while preserving backward compatibility for all existing callers.

## What this patch does

- `validate_structure()` now calls `${NFTBAN_LIB_DIR}/bin/nftban-validate --json` and translates the Go schema into the legacy shell schema `{status:OK|WARNING|ERROR, errors[], warnings[], info[]}`
- Legacy text output format preserved byte-for-byte (header, status line, error/warning lists) — `cmd_validate.sh:103` prints this directly to the user
- `$1` preserved as `output_json` boolean flag (true/false) controlling text vs JSON mode
- Exit codes: `0` (OK / warnings-only), `1` (validation errors / parse failure), `2` (Go binary missing — Amend-1, distinguishes "tool absent" from "tool ran but validation failed")
- jq-missing fallback (Amend-2): when jq is not installed, shim falls back to grep-based protected-detection with minimal text output, preserving the exit-code contract
- Fail-closed paths for missing-binary and empty-output use `printf` (not `jq -n`) so they work without jq
- No independent validation logic — no `load_spec`, no `get_live_ruleset`, no `nft list ruleset`, no spec-field references

## JSON field mismatch — intentional, documented

`nftban status --json` currently emits `.state` (see `cmd_status.sh:1562`). The new INV-CONS-001 smoke assertion prefers canonical keys first (`.status // .protection_state // .health`) and falls through to `.state` for current-main compatibility. If the shell key is later renamed to a canonical form, the test picks it up automatically without code change.

## Scope fence

```
TOUCHED:
  validate_structure() body in nftban_validator.sh   (ONLY this function)
  smoke_test.sh — ONE new assertion block            (INV-CONS-001)
  NEW test file test_validate_structure_is_shim.sh   (static regression guard)

NOT TOUCHED:
  check_ip_or_port() / get_firewall_stats()          (v1.81 targets)
  load_spec() / get_live_ruleset()                   (left defined, now unused)
  cmd_check.sh / cmd_firewall.sh / cmd_status.sh     (zero caller changes)
  cmd_validate.sh                                    (zero changes — it calls validate_structure as before)
  internal/nftbanconf/commands.go ValidatorScript()   (unchanged)
  no file rename, no file deletion
```

## Patch-size framing

The raw diff reads 477 / -167, but the runtime behavioral change is narrow:

- `~60 lines` actual functional shim body
- `~50 lines` Amend-2 jq-missing fallback path (compatibility scaffolding)
- `~30 lines` NOTE comment block inside the shim
- `~40 lines` new INV-CONS-001 smoke assertion in `smoke_test.sh`
- `~260 lines` new `test_validate_structure_is_shim.sh` (17-assertion regression guardrail)
- `~130 lines` removed from the old batch-jq `validate_structure()` body

Risk surface = the 60-line shim body. Everything else is guardrail, comment, or test.

## Tests (three layers of proof)

### 1. Static regression guard — `tests/test_validate_structure_is_shim.sh` (17 assertions)

**Positive:** body calls Go binary, builds path via `$NFTBAN_LIB_DIR`, contains B80-1 NOTE, preserves legacy JSON schema, maps severity levels

**Negative:** body does NOT call `load_spec`/`get_live_ruleset`, does NOT use `--slurpfile`/`nft list ruleset`/spec field names, body ≤260 lines, jq ≤12 invocations, has jq-missing fallback (Amend-2 contract), uses `return 2` on missing binary (Amend-1 contract)

**Scope fence:** file still exists, `check_ip_or_port()` and `get_firewall_stats()` preserved

### 2. Runtime INV-CONS-001 smoke — added to `smoke_test.sh run_runtime_tests`

Compares `nftban status --json` state (extraction: `.status // .protection_state // .health // .state // empty`) against `nftban-validate --json` `.status`, uppercase-normalized. First positive enforcement of INV-CONS-001 at the top-level CLI truth surface.

### 3. Behavioural equivalence — verified locally via fake Go binary

| Go input | Shell output | Exit |
|---|---|---|
| `protected, findings=[]` | `{status:OK, errors:[], warnings:[]}` | 0 |
| `degraded, findings=[critical, error]` | `{status:ERROR, errors:[CRITICAL:…]}` | 1 |
| `protected, findings=[warn]` | `{status:WARNING, warnings:[WARNING:…]}` | 0 |
| (binary missing) | `{status:ERROR, errors:[CRITICAL: Go validator not found…]}` | 2 |

Text rendering preserved (header + `❌ ERRORS (N):` + message lines).

## Test plan

- [x] Static regression guard: 17/17 PASS locally
- [x] Behavioural equivalence: 15/15 PASS locally (hermetic, offline)
- [x] BotGuard rebuild sequencing (cross-regression check): 10/10 PASS
- [ ] CI pipeline
- [ ] lab2 Day-6 rebuild (GATE 8 — separate workstream, not a merge gate for this PR)
- [ ] srv1 72h anchor observation (ongoing soak, not gated by this PR)

## Refs

- `V1.80_ROADMAP/MASTER_TODO.md` B80-1 (truth consolidation)
- `V1.80_ROADMAP/10_EXECUTION_PLAN.md` Day 2 (legacy validator removal)
- B80-2 is separately a no-op: `cmd_status.sh` already calls Go binary only (line 131). Marked CLOSED as already-satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)