### PR TITLE
feat(validator): B80-3 empty-chain detection (INV-S-008)

### DIFF
--- a/internal/validator/nftjson.go
+++ b/internal/validator/nftjson.go
@@ -295,6 +295,13 @@ func (d *RulesetDocument) CountChains(family string) int {
 	return count
 }
 
+// CountRulesInChain returns the number of rules in a specific chain.
+// Returns 0 if the chain has no rules or does not exist.
+func (d *RulesetDocument) CountRulesInChain(family, table, chain string) int {
+	key := family + ":" + table + ":" + chain
+	return len(d.rules[key])
+}
+
 // CountSets returns total set count for a family's nftban table.
 func (d *RulesetDocument) CountSets(family string) int {
 	prefix := family + ":nftban:"

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -151,6 +151,7 @@ const (
 	CodeChainMissing       = "VAL-CHAIN-001"
 	CodeHelperChainMissing = "VAL-CHAIN-002"
 	CodeChainCountDrop     = "VAL-CHAIN-003"
+	CodeChainEmpty         = "VAL-CHAIN-004" // B80-3: chain exists but has no rules
 
 	// Anchor findings
 	CodeAnchorMissing  = "VAL-ANCHOR-001"

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -155,6 +155,27 @@ func validateFamily(doc *RulesetDocument, family string, result *ValidationResul
 		}
 	}
 
+	// B80-3 (INV-S-008): Detect empty helper chains.
+	// A helper chain that exists but has zero rules is a no-op jump target —
+	// traffic enters, nothing happens, traffic exits. This silently defeats
+	// the protection the chain is supposed to provide. The chain is present
+	// so the "chain missing" check passes, but the protection is absent.
+	// This MUST report DEGRADED, not PROTECTED.
+	for _, found := range fr.HelperChains.Found {
+		ruleCount := doc.CountRulesInChain(family, "nftban", found)
+		if ruleCount == 0 {
+			fr.Status = StatusDegraded
+			result.Findings = append(result.Findings, Finding{
+				Code:      CodeChainEmpty,
+				Severity:  SeverityError,
+				Component: "chain",
+				Family:    family,
+				Message:   "Helper chain exists but has no rules: " + found + " (no-op jump target)",
+				Remediation: "Run: nftban ddos enable (or nftban portscan enable)",
+			})
+		}
+	}
+
 	// Validate anchors
 	fr.Anchors = validateAnchors(doc, family, result)
 	if !fr.Anchors.Ordered || fr.Anchors.FoundCount < fr.Anchors.RequiredCount {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -289,6 +289,120 @@ func TestModuleTruth(t *testing.T) {
 	}
 }
 
+// B80-3 (INV-S-008): Empty helper chain detection.
+func TestEmptyHelperChain(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []NftObject
+		wantStatus Status
+		wantCode   string
+	}{
+		{
+			name: "helper chain with rules → PROTECTED",
+			objects: helperChainObjects(
+				withRulesInChain("ddos_sanity", 3),
+				withRulesInChain("ddos_penalty", 2),
+				withRulesInChain("ddos_prefix", 1),
+				withRulesInChain("ddos_protection", 5),
+				withRulesInChain("portscan_detection", 2),
+			),
+			wantStatus: StatusProtected,
+			wantCode:   "",
+		},
+		{
+			name: "helper chain exists but empty → DEGRADED",
+			objects: helperChainObjects(
+				withRulesInChain("ddos_sanity", 3),
+				withRulesInChain("ddos_penalty", 2),
+				withRulesInChain("ddos_prefix", 1),
+				withRulesInChain("ddos_protection", 0),
+				withRulesInChain("portscan_detection", 2),
+			),
+			wantStatus: StatusDegraded,
+			wantCode:   CodeChainEmpty,
+		},
+		{
+			name: "multiple empty chains → multiple findings",
+			objects: helperChainObjects(
+				withRulesInChain("ddos_sanity", 0),
+				withRulesInChain("ddos_penalty", 0),
+				withRulesInChain("ddos_prefix", 1),
+				withRulesInChain("ddos_protection", 5),
+				withRulesInChain("portscan_detection", 0),
+			),
+			wantStatus: StatusDegraded,
+			wantCode:   CodeChainEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := &NftRuleset{Nftables: tt.objects}
+			doc := ParseRuleset(raw)
+			result := &ValidationResult{Findings: make([]Finding, 0)}
+			fr := validateFamily(doc, "ip", result)
+
+			if fr.Status != tt.wantStatus {
+				t.Errorf("status = %s, want %s", fr.Status, tt.wantStatus)
+			}
+
+			if tt.wantCode != "" {
+				found := false
+				for _, f := range result.Findings {
+					if f.Code == tt.wantCode {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected finding code %s not found in %d findings", tt.wantCode, len(result.Findings))
+					for _, f := range result.Findings {
+						t.Logf("  finding: %s %s %s", f.Code, f.Severity, f.Message)
+					}
+				}
+			}
+		})
+	}
+}
+
+func helperChainObjects(chainSpecs ...chainSpec) []NftObject {
+	objects := []NftObject{
+		{Table: &NftTable{Family: "ip", Name: "nftban"}},
+		{Chain: &NftChain{Family: "ip", Table: "nftban", Name: "input", Type: "filter", Hook: "input", Policy: "drop"}},
+		{Chain: &NftChain{Family: "ip", Table: "nftban", Name: "forward", Type: "filter", Hook: "forward", Policy: "drop"}},
+		{Chain: &NftChain{Family: "ip", Table: "nftban", Name: "output", Type: "filter", Hook: "output", Policy: "accept"}},
+	}
+	for _, anchor := range RequiredAnchors {
+		objects = append(objects, NftObject{Rule: &NftRule{
+			Family: "ip", Table: "nftban", Chain: "input",
+			Comment: "NFTBAN_ANCHOR:" + anchor,
+		}})
+	}
+	for _, setName := range RequiredSetsIPv4 {
+		objects = append(objects, NftObject{Set: &NftSet{Family: "ip", Table: "nftban", Name: setName}})
+	}
+	for _, spec := range chainSpecs {
+		objects = append(objects, NftObject{Chain: &NftChain{
+			Family: "ip", Table: "nftban", Name: spec.name,
+		}})
+		for i := 0; i < spec.ruleCount; i++ {
+			objects = append(objects, NftObject{Rule: &NftRule{
+				Family: "ip", Table: "nftban", Chain: spec.name,
+			}})
+		}
+	}
+	return objects
+}
+
+type chainSpec struct {
+	name      string
+	ruleCount int
+}
+
+func withRulesInChain(name string, count int) chainSpec {
+	return chainSpec{name: name, ruleCount: count}
+}
+
 func TestModuleTruthMissing(t *testing.T) {
 	// Create mock doc WITHOUT DDoS chains
 	raw := &NftRuleset{


### PR DESCRIPTION
## Summary

A helper chain that exists but has zero rules is a no-op jump target. The validator must report DEGRADED, not PROTECTED.

## Changes

- `VAL-CHAIN-004` finding code (types.go)
- `CountRulesInChain()` method (nftjson.go)
- Empty-chain detection loop in `validateFamily()` after helper chain presence check (validator.go)
- `TestEmptyHelperChain` — 3 sub-cases with full mock setup (validator_test.go)

## Scope

4 files in `internal/validator/` only. No shell. No CLI. No runtime. No pipeline.

## Test plan

- [x] `go test ./internal/validator/ -v` on lab4: 8/8 PASS, 0 regressions
- [ ] CI

## Validation (post-merge, on lab)

```bash
# Create controlled broken state
nft flush chain ip nftban ddos_protection
nftban-validate --json | jq .status
# expect: "degraded"

# Restore
nftban ddos enable
nftban-validate --json | jq .status
# expect: "protected"
```

Refs: V1.80_ROADMAP/MASTER_TODO.md B80-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)