### PR TITLE
fix(validator): split helper chains into required vs module-scoped

### DIFF
--- a/internal/validator/schema_generated.go
+++ b/internal/validator/schema_generated.go
@@ -36,8 +36,12 @@ var GeneratedRequiredBaseChains = []string{
 	"output",
 }
 
-// GeneratedRequiredHelperChains merges shell NFTBAN_IPV4_HELPER_CHAINS + DDoS fragment sub-chains (ddos_sanity, ddos_penalty, ddos_prefix).
+// GeneratedRequiredHelperChains — helper chains universally required for base PROTECTED. Currently empty: all helper chains are module-scoped.
 var GeneratedRequiredHelperChains = []string{
+}
+
+// GeneratedAllHelperChains — all known helper chains (shell-declared + DDoS fragment sub-chains). Module-scoped: only required when their module is enabled.
+var GeneratedAllHelperChains = []string{
 	"ddos_penalty",
 	"ddos_prefix",
 	"ddos_protection",

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -213,9 +213,15 @@ var RequiredAnchors = []string{
 // B80-5/6: sourced from schema_generated.go (canonical: cli/lib/nftban/lib/nft_schema.sh).
 var RequiredBaseChains = GeneratedRequiredBaseChains
 
-// Required helper chains per family (6 total: 3 shell-declared + 3 DDoS fragment sub-chains).
-// B80-5/6: sourced from schema_generated.go (includes DDoS fragment sub-chains).
+// Required helper chains per family. Currently EMPTY — all helper chains are
+// module-scoped (only exist when their module is enabled). Base PROTECTED
+// does not require any helper chains. Module-level chain validation is
+// handled by deriveModuleTruth() which checks presence per-module.
 var RequiredHelperChains = GeneratedRequiredHelperChains
+
+// AllHelperChains lists all known helper chains for module-truth derivation
+// and informational reporting. Not used for base structural validation.
+var AllHelperChains = GeneratedAllHelperChains
 
 // Required sets for IPv4.
 // B80-5/6: sourced from schema_generated.go (core required sets only).

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -226,24 +226,26 @@ func validateFamily(doc *RulesetDocument, family string, result *ValidationResul
 		}
 	}
 
-	// B80-3 (INV-S-008): Detect empty helper chains.
-	// A helper chain that exists but has zero rules is a no-op jump target —
-	// traffic enters, nothing happens, traffic exits. This silently defeats
-	// the protection the chain is supposed to provide. The chain is present
-	// so the "chain missing" check passes, but the protection is absent.
-	// This MUST report DEGRADED, not PROTECTED.
-	for _, found := range fr.HelperChains.Found {
-		ruleCount := doc.CountRulesInChain(family, "nftban", found)
-		if ruleCount == 0 {
-			fr.Status = StatusDegraded
-			result.Findings = append(result.Findings, Finding{
-				Code:      CodeChainEmpty,
-				Severity:  SeverityError,
-				Component: "chain",
-				Family:    family,
-				Message:   "Helper chain exists but has no rules: " + found + " (no-op jump target)",
-				Remediation: "Run: nftban ddos enable (or nftban portscan enable)",
-			})
+	// B80-3 (INV-S-008): Detect empty helper chains among ALL known helpers.
+	// Helper chains are module-scoped (not base-required), so a MISSING chain
+	// is fine (module disabled). But a chain that EXISTS with zero rules is a
+	// no-op jump target — traffic enters, nothing happens, traffic exits.
+	// That silently defeats the protection the module was supposed to provide.
+	// This MUST report DEGRADED via SeverityError.
+	for _, chain := range AllHelperChains {
+		if doc.ChainExists(family, "nftban", chain) {
+			ruleCount := doc.CountRulesInChain(family, "nftban", chain)
+			if ruleCount == 0 {
+				fr.Status = StatusDegraded
+				result.Findings = append(result.Findings, Finding{
+					Code:        CodeChainEmpty,
+					Severity:    SeverityError,
+					Component:   "chain",
+					Family:      family,
+					Message:     "Helper chain exists but has no rules: " + chain + " (no-op jump target)",
+					Remediation: "Run: nftban ddos enable (or nftban portscan enable)",
+				})
+			}
 		}
 	}
 

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -336,6 +336,23 @@ func TestEmptyHelperChain(t *testing.T) {
 			wantStatus: StatusDegraded,
 			wantCode:   CodeChainEmpty,
 		},
+		{
+			name: "module disabled (no helper chains at all) → PROTECTED",
+			objects: helperChainObjects(),
+			wantStatus: StatusProtected,
+			wantCode:   "",
+		},
+		{
+			name: "BotGuard disabled (only DDoS chains present with rules) → PROTECTED",
+			objects: helperChainObjects(
+				withRulesInChain("ddos_sanity", 3),
+				withRulesInChain("ddos_penalty", 2),
+				withRulesInChain("ddos_prefix", 1),
+				withRulesInChain("ddos_protection", 5),
+			),
+			wantStatus: StatusProtected,
+			wantCode:   "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/scripts/generate-go-schema.sh
+++ b/scripts/generate-go-schema.sh
@@ -78,20 +78,29 @@ extract_sorted_keys() {
 # Base chains (same for v4 and v6)
 base_chains=$(extract_sorted_keys NFTBAN_IPV4_CHAINS)
 
-# Helper chains from the shell schema
+# Helper chains from the shell schema. ALL shell-declared helper chains are
+# marked "optional" in nft_schema.sh — they only exist when their module is
+# enabled. No helper chain is universally required for base PROTECTED state.
+# Base protection = tables + base chains + required sets + anchors.
 shell_helper_chains=$(extract_sorted_keys NFTBAN_IPV4_HELPER_CHAINS)
 
-# DDoS fragment-created sub-chains. These are NOT in the shell schema's
-# helper chain array because they are created by nft_fragment.sh at enable
-# time, not by the base nftables.conf template. However, the validator MUST
-# require them when DDoS is enabled, because they are jump targets from the
-# input chain. We add them as a known extension.
+# DDoS fragment-created sub-chains. NOT in the shell schema's helper chain
+# array because they are created by nft_fragment.sh at enable time. These
+# are module-scoped (DDoS must be enabled) — they are NOT base-required.
 ddos_fragment_chains="ddos_penalty
 ddos_prefix
 ddos_sanity"
 
-# Merge shell helpers + DDoS fragment chains, deduplicate, sort
+# All known helper chains = shell-declared + DDoS fragments. All are
+# module-scoped/optional. The validator uses these for module-truth
+# derivation and informational reporting, NOT for base structural checks.
 all_helper_chains=$(printf '%s\n%s' "$shell_helper_chains" "$ddos_fragment_chains" | sort -u)
+
+# No helper chains are universally required. This empty list exists so
+# the Generated* naming pattern is consistent across chains and sets.
+# If a future product decision makes a helper chain mandatory for base
+# protection, add it here explicitly — do not auto-promote from shell schema.
+required_helper_chains=""
 
 # Required sets: the core sets that MUST exist for base protection.
 # BotGuard/module sets are optional (validator warns, not errors).
@@ -180,8 +189,12 @@ go_string_slice "GeneratedRequiredBaseChains" "$base_chains" \
     "GeneratedRequiredBaseChains from NFTBAN_IPV4_CHAINS keys." \
     >> "$OUTPUT_FILE"
 
-go_string_slice "GeneratedRequiredHelperChains" "$all_helper_chains" \
-    "GeneratedRequiredHelperChains merges shell NFTBAN_IPV4_HELPER_CHAINS + DDoS fragment sub-chains (ddos_sanity, ddos_penalty, ddos_prefix)." \
+go_string_slice "GeneratedRequiredHelperChains" "$required_helper_chains" \
+    "GeneratedRequiredHelperChains — helper chains universally required for base PROTECTED. Currently empty: all helper chains are module-scoped." \
+    >> "$OUTPUT_FILE"
+
+go_string_slice "GeneratedAllHelperChains" "$all_helper_chains" \
+    "GeneratedAllHelperChains — all known helper chains (shell-declared + DDoS fragment sub-chains). Module-scoped: only required when their module is enabled." \
     >> "$OUTPUT_FILE"
 
 go_string_slice "GeneratedRequiredSetsIPv4" "$required_sets_v4" \


### PR DESCRIPTION
## Summary

Helper chains are module-scoped, not universally required for base PROTECTED. Fixes lab4 false DEGRADED after v1.80.0 install (BotGuard disabled, http_bot_guard chain absent).

## Root cause

B80-5 generator merged all shell-declared helper chains into `GeneratedRequiredHelperChains`. The shell schema marks all helpers as `optional`, but the generator treated them as required.

## Fix

- Generator emits: `GeneratedRequiredHelperChains = []` (empty) + `GeneratedAllHelperChains = [6]` (full)
- B80-3 empty-chain detection now scans `AllHelperChains` for chains that EXIST in kernel:
  - missing chain = module disabled = skip (neutral)
  - existing chain with 0 rules = DEGRADED (B80-3 preserved)

## Semantic contract

```
base PROTECTED = tables + base chains + required sets + anchors
module PROTECTED = base + module helper chains present + rules loaded
missing helper chain = module disabled (neutral)
existing empty helper chain = broken module (DEGRADED)
```

## Tests

15/15 PASS on lab4. 2 new cases:
- module disabled (no helpers) -> PROTECTED
- BotGuard disabled (DDoS only) -> PROTECTED

## Scope

5 files in `internal/validator/` + `scripts/`. No shell. No CLI. No runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)