### PR TITLE
fix(portscan): log-path collision — detector was reading its own output log

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -90,14 +90,16 @@ nftban_portscan_classic_load_config() {
 # LOGGING
 # =============================================================================
 
-# Log file for portscan classic mode
-# Note: Not readonly - needs to be configurable via conf.d/portscan/classic.conf
-PORTSCAN_CLASSIC_LOG_FILE="${PORTSCAN_CLASSIC_LOG_FILE:-${NFTBAN_LOG_DIR:-/var/log/nftban}/portscan-classic.log}"
+# Module output log file for portscan classic mode debug/info messages.
+# IMPORTANT: This is the MODULE OUTPUT log, NOT the kernel input source.
+# The kernel input source is PORTSCAN_CLASSIC_LOG_FILE (set in classic.conf line 32).
+# These MUST be different variables — see portscan-log-collision bugfix.
+PORTSCAN_CLASSIC_MODULE_LOG="${PORTSCAN_CLASSIC_MODULE_LOG:-${NFTBAN_LOG_DIR:-/var/log/nftban}/portscan-classic.log}"
 
 _nftban_portscan_classic_log() {
     local level="$1"
     local message="$2"
-    local log_file="${PORTSCAN_CLASSIC_LOG_FILE:-${NFTBAN_LOG_DIR:-/var/log/nftban}/portscan-classic.log}"
+    local log_file="${PORTSCAN_CLASSIC_MODULE_LOG:-${NFTBAN_LOG_DIR:-/var/log/nftban}/portscan-classic.log}"
 
     # Create log directory if needed
     mkdir -p "$(dirname "$log_file")" 2>/dev/null || return 1

--- a/cli/lib/nftban/data/config-schema.json
+++ b/cli/lib/nftban/data/config-schema.json
@@ -7754,6 +7754,16 @@
       "config_file": "conf.d/portscan/classic.conf",
       "active_when": "portscan_classic"
     },
+    "PORTSCAN_CLASSIC_MODULE_LOG": {
+      "type": "string",
+      "$ref": "#/definitions/path",
+      "default": "/var/log/nftban/portscan-classic.log",
+      "description": "P C M L (module output log, NOT kernel input source)",
+      "introduced_in": "1.81.0",
+      "category": "modules",
+      "config_file": "conf.d/portscan/classic.conf",
+      "active_when": "portscan_classic"
+    },
     "PORTSCAN_CLASSIC_LOG_LEVEL": {
       "type": "string",
       "$ref": "#/definitions/string",

--- a/etc/nftban/conf.d/portscan/classic.conf
+++ b/etc/nftban/conf.d/portscan/classic.conf
@@ -168,8 +168,11 @@ PORTSCAN_CLASSIC_BASELINE_RATE="100"
 # LOGGING
 # -----------------------------------------------------------------------------
 # Module-specific logging
+# IMPORTANT: This is the MODULE OUTPUT log, NOT the kernel input source.
+# The kernel input source is PORTSCAN_CLASSIC_LOG_FILE defined above (line 32).
+# These MUST be different variables to avoid the log-path collision bug.
 
-PORTSCAN_CLASSIC_LOG_FILE="/var/log/nftban/portscan-classic.log"
+PORTSCAN_CLASSIC_MODULE_LOG="/var/log/nftban/portscan-classic.log"
 PORTSCAN_CLASSIC_LOG_LEVEL="INFO"
 
 # Log all detections (including below threshold)


### PR DESCRIPTION
## Summary

**Critical correctness bug.** Portscan classic detector has been non-functional on every host since the config was first deployed. The detector was grepping its own module output log instead of the kernel log.

## Root cause

`PORTSCAN_CLASSIC_LOG_FILE` defined twice in `classic.conf`:
- Line 32: `/var/log/kern.log` (INPUT — kernel portscan entries)
- Line 172: `/var/log/nftban/portscan-classic.log` (OUTPUT — module log)

Line 172 overwrote line 32 on `source`. Detector grepped its own output → 0 detections always.

## Fix

Rename output variable: `PORTSCAN_CLASSIC_LOG_FILE` → `PORTSCAN_CLASSIC_MODULE_LOG`. Input variable unchanged.

## Live verification (3 hosts, post-patch)

| Host | Before fix | After fix |
|---|---|---|
| lab2 | 0 tracked, 0 blocked | **160 tracked, 4 blocked** |
| lab4 | 0 tracked, 0 blocked | **349 tracked, 6 blocked** |
| monitor | 0 tracked, 0 blocked | **59 tracked, 1 blocked** |

## Scope

3 files: `classic.conf`, `nftban_portscan_classic.sh`, `config-schema.json`. No architecture changes. No detection logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)