### PR TITLE
fix(portscan): SIGPIPE + unbound array in classic process_logs

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -177,12 +177,13 @@ _nftban_portscan_verify_prefix() {
 # STATE TRACKING
 # =============================================================================
 
-# In-memory tracking arrays
-declare -gA _PORTSCAN_CLASSIC_IP_PORTS       # IP -> ports seen (space-separated)
-declare -gA _PORTSCAN_CLASSIC_IP_TIMESTAMPS  # IP -> timestamps (space-separated)
-declare -gA _PORTSCAN_CLASSIC_IP_TARGETS     # IP -> target IPs (space-separated)
-declare -gA _PORTSCAN_CLASSIC_IP_BLOCKED     # IP -> block timestamp
-declare -gA _PORTSCAN_CLASSIC_IP_BAN_COUNT   # IP -> number of times banned
+# In-memory tracking arrays (initialized empty to prevent unbound-variable
+# errors under set -u when accessed before nftban_portscan_classic_init_state)
+declare -gA _PORTSCAN_CLASSIC_IP_PORTS=()       # IP -> ports seen (space-separated)
+declare -gA _PORTSCAN_CLASSIC_IP_TIMESTAMPS=()  # IP -> timestamps (space-separated)
+declare -gA _PORTSCAN_CLASSIC_IP_TARGETS=()     # IP -> target IPs (space-separated)
+declare -gA _PORTSCAN_CLASSIC_IP_BLOCKED=()     # IP -> block timestamp
+declare -gA _PORTSCAN_CLASSIC_IP_BAN_COUNT=()   # IP -> number of times banned
 
 # Initialize state tracking
 nftban_portscan_classic_init_state() {
@@ -530,7 +531,9 @@ nftban_portscan_classic_process_logs() {
             # Record this connection for realtime detection
             nftban_portscan_classic_record_connection "$src_ip" "$dst_ip" "$dst_port" "$current_time"
 
-        done < <({ journalctl -k --since "${time_window} seconds ago" --no-pager 2>/dev/null | grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" || true; } | tail -1000)
+        # SIGPIPE fix: tail in a pipeline under pipefail can exit 141 when the
+        # reader (while loop) closes. Trap SIGPIPE to prevent fatal exit.
+        done < <({ journalctl -k --since "${time_window} seconds ago" --no-pager 2>/dev/null | grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" || true; } | { tail -1000 || true; })
     else
         # grep returns 1 when no matches found - use || true to handle this
         _nftban_portscan_classic_log "DEBUG" "Reading from file: $log_source"
@@ -553,7 +556,8 @@ nftban_portscan_classic_process_logs() {
             # Record this connection for realtime detection
             nftban_portscan_classic_record_connection "$src_ip" "$dst_ip" "$dst_port" "$current_time"
 
-        done < <({ grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" "$log_source" 2>/dev/null || true; } | tail -1000)
+        # SIGPIPE fix: same as journalctl path above.
+        done < <({ grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" "$log_source" 2>/dev/null || true; } | { tail -1000 || true; })
     fi
 
     # Analyze and block if needed


### PR DESCRIPTION
## Summary

Two pre-existing bugs in portscan classic that crash the maintenance timer at step 7.

1. **SIGPIPE (exit 141):** `tail -1000` in pipeline under `pipefail`. Fix: `{ tail -1000 || true; }`
2. **Unbound variable:** tracking arrays declared but not initialized. Fix: `declare -gA ... =()`

Verified on monitor + lab2 + lab4. Maintenance no longer crashes.

For v1.81.1 hotfix or main inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)