### PR TITLE
feat(validator): add timer liveness check VAL-TIMER-001 (v1.83 Step 1a)

### DIFF
--- a/internal/validator/health_mapper.go
+++ b/internal/validator/health_mapper.go
@@ -36,6 +36,7 @@ func MapToHealthOutput(r *ValidationResult) HealthOutput {
 		ServiceState: ServiceStateJSON{
 			Nftband:       string(r.ServiceState.Nftband), // UPPERCASE per spec §5: RUNNING|STOPPED|ERROR
 			NftbandDetail: r.ServiceState.NftbandDetail,
+			TimerCount:    r.ServiceState.TimerCount, // v1.83: active timer count
 		},
 		Modules:     mapModules(r.Modules),
 		Consistency: mapConsistency(r.ConsistencyOverall),

--- a/internal/validator/health_mapper_test.go
+++ b/internal/validator/health_mapper_test.go
@@ -29,8 +29,8 @@ func TestMapToHealthOutput_SchemaVersion(t *testing.T) {
 		Timestamp: time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC),
 	}
 	h := MapToHealthOutput(r)
-	if h.SchemaVersion != "1.81.0" {
-		t.Errorf("schema_version = %s, want 1.81.0", h.SchemaVersion)
+	if h.SchemaVersion != "1.83.0" {
+		t.Errorf("schema_version = %s, want 1.83.0", h.SchemaVersion)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestFullOutput_ValidJSON(t *testing.T) {
 	jsonStr := string(data)
 
 	// Schema version present
-	if h.SchemaVersion != "1.81.0" {
+	if h.SchemaVersion != "1.83.0" {
 		t.Errorf("schema_version missing or wrong")
 	}
 

--- a/internal/validator/health_output.go
+++ b/internal/validator/health_output.go
@@ -40,10 +40,11 @@ type HealthOutput struct {
 	Summary       SummaryCounts       `json:"summary"`
 }
 
-// ServiceStateJSON is the JSON representation of daemon state.
+// ServiceStateJSON is the JSON representation of daemon and timer state.
 type ServiceStateJSON struct {
 	Nftband       string `json:"nftband"`                  // RUNNING|STOPPED|ERROR
 	NftbandDetail string `json:"nftband_detail,omitempty"` // raw systemctl output
+	TimerCount    int    `json:"timer_count"`              // v1.83: active nftban-* timer count
 }
 
 // ModulesJSON holds all per-module health in JSON output form.

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -496,7 +496,7 @@ func TestReadConfigBoolMissing(t *testing.T) {
 // =============================================================================
 
 func TestSchemaVersion(t *testing.T) {
-	if SchemaVersionCurrent != "1.81.0" {
-		t.Errorf("schema version = %s, want 1.81.0", SchemaVersionCurrent)
+	if SchemaVersionCurrent != "1.83.0" {
+		t.Errorf("schema version = %s, want 1.83.0", SchemaVersionCurrent)
 	}
 }

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -260,6 +260,7 @@ const (
 	// Service findings (B80-4)
 	CodeServiceDown  = "VAL-SERVICE-001" // required service not active
 	CodeTimerNone    = "VAL-TIMER-001"   // v1.83: no nftban timers active
+	CodeTimerError   = "VAL-TIMER-002"   // v1.83: timer query failed
 
 	// Module-specific findings (M81-4)
 	CodeGeobanDBMissing = "VAL-GEOBAN-001" // geoip database missing/empty

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -59,7 +59,8 @@ type ValidationResult struct {
 }
 
 // SchemaVersionCurrent is the frozen schema version per M81-6.
-const SchemaVersionCurrent = "1.81.0"
+// v1.83: bumped for timer_count addition to service_state.
+const SchemaVersionCurrent = "1.83.0"
 
 // =============================================================================
 // M81-4: Per-module health state types
@@ -138,8 +139,9 @@ const (
 // B80-4: the validator MUST check these before declaring PROTECTED.
 // A system with correct kernel structure but a dead daemon is not protected.
 type ServiceState struct {
-	Nftband      RuntimeState `json:"nftband"`
-	NftbandDetail string      `json:"nftband_detail,omitempty"`
+	Nftband       RuntimeState `json:"nftband"`
+	NftbandDetail string       `json:"nftband_detail,omitempty"`
+	TimerCount    int          `json:"timer_count"`    // v1.83: active nftban-* timer count
 }
 
 // FamilyResult holds validation results for a single address family (ip/ip6).
@@ -256,7 +258,8 @@ const (
 	CodeModuleDegraded = "VAL-MODULE-001"
 
 	// Service findings (B80-4)
-	CodeServiceDown = "VAL-SERVICE-001" // required service not active
+	CodeServiceDown  = "VAL-SERVICE-001" // required service not active
+	CodeTimerNone    = "VAL-TIMER-001"   // v1.83: no nftban timers active
 
 	// Module-specific findings (M81-4)
 	CodeGeobanDBMissing = "VAL-GEOBAN-001" // geoip database missing/empty

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -74,6 +74,40 @@ func SetServiceChecker(sc ServiceChecker) {
 	defaultServiceChecker = sc
 }
 
+// TimerChecker abstracts timer-count queries so unit tests can mock
+// systemd without requiring a real init system.
+type TimerChecker interface {
+	// CountActiveTimers returns the number of active nftban-* timers.
+	// On query error it returns (0, error).
+	CountActiveTimers() (int, error)
+}
+
+// SystemdTimerChecker is the default production TimerChecker.
+type SystemdTimerChecker struct{}
+
+// CountActiveTimers queries systemd for active nftban-* timers.
+// Read-only — zero side effects.
+func (SystemdTimerChecker) CountActiveTimers() (int, error) {
+	out, err := exec.Command("systemctl", "list-timers", "nftban-*", "--no-legend").Output()
+	if err != nil {
+		return 0, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return 0, nil
+	}
+	return len(lines), nil
+}
+
+// defaultTimerChecker is set at package level and can be overridden
+// by tests via SetTimerChecker.
+var defaultTimerChecker TimerChecker = SystemdTimerChecker{}
+
+// SetTimerChecker replaces the timer checker (for testing only).
+func SetTimerChecker(tc TimerChecker) {
+	defaultTimerChecker = tc
+}
+
 // ValidateKernel performs complete kernel state validation.
 // This is the main entrypoint for the validator.
 //
@@ -168,6 +202,19 @@ func ValidateKernel(ctx context.Context) (*ValidationResult, error) {
 			Component:   "service",
 			Message:     "nftband daemon is not running (state: " + string(result.ServiceState.Nftband) + ", detail: " + result.ServiceState.NftbandDetail + ")",
 			Remediation: "Run: systemctl start nftband",
+		})
+	}
+
+	// v1.83: Check timer liveness — a system with zero active nftban timers
+	// is operationally incomplete (maintenance, watchdog, exports won't run).
+	result.ServiceState.TimerCount = checkTimerState()
+	if result.ServiceState.TimerCount == 0 {
+		result.Findings = append(result.Findings, Finding{
+			Code:        CodeTimerNone,
+			Severity:    SeverityError,
+			Component:   "service",
+			Message:     "no active nftban timers found — maintenance, watchdog, and exports will not run",
+			Remediation: "Run: systemctl enable --now nftban-maintenance.timer nftban-watchdog.timer",
 		})
 	}
 
@@ -496,6 +543,15 @@ func checkServiceState() ServiceState {
 	ss.Nftband = state
 	ss.NftbandDetail = detail
 	return ss
+}
+
+// checkTimerState returns the count of active nftban-* timers.
+// v1.83: zero active timers means maintenance/watchdog/exports won't run,
+// which is an operationally degraded state even if kernel structure is correct.
+// On query error, returns 0 (fails safe — no timers assumed).
+func checkTimerState() int {
+	count, _ := defaultTimerChecker.CountActiveTimers()
+	return count
 }
 
 // evaluateOverallStatus determines the final status from results.

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -207,8 +207,17 @@ func ValidateKernel(ctx context.Context) (*ValidationResult, error) {
 
 	// v1.83: Check timer liveness — a system with zero active nftban timers
 	// is operationally incomplete (maintenance, watchdog, exports won't run).
-	result.ServiceState.TimerCount = checkTimerState()
-	if result.ServiceState.TimerCount == 0 {
+	timerCount, timerErr := checkTimerState()
+	result.ServiceState.TimerCount = timerCount
+	if timerErr != nil {
+		result.Findings = append(result.Findings, Finding{
+			Code:        CodeTimerError,
+			Severity:    SeverityWarn,
+			Component:   "service",
+			Message:     "timer liveness query failed: " + timerErr.Error(),
+			Remediation: "Check systemctl access and permissions",
+		})
+	} else if timerCount == 0 {
 		result.Findings = append(result.Findings, Finding{
 			Code:        CodeTimerNone,
 			Severity:    SeverityError,
@@ -545,13 +554,12 @@ func checkServiceState() ServiceState {
 	return ss
 }
 
-// checkTimerState returns the count of active nftban-* timers.
+// checkTimerState returns the count of active nftban-* timers and any query error.
 // v1.83: zero active timers means maintenance/watchdog/exports won't run,
 // which is an operationally degraded state even if kernel structure is correct.
-// On query error, returns 0 (fails safe — no timers assumed).
-func checkTimerState() int {
-	count, _ := defaultTimerChecker.CountActiveTimers()
-	return count
+// On query error, returns (0, err) so callers can distinguish real zero from failure.
+func checkTimerState() (int, error) {
+	return defaultTimerChecker.CountActiveTimers()
 }
 
 // evaluateOverallStatus determines the final status from results.

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -17,6 +17,7 @@
 package validator
 
 import (
+	"os/exec"
 	"testing"
 )
 
@@ -609,6 +610,121 @@ func TestServiceRunningNoFinding(t *testing.T) {
 	for _, f := range result.Findings {
 		if f.Code == CodeServiceDown {
 			t.Error("should NOT have VAL-SERVICE-001 finding when nftband is running")
+		}
+	}
+}
+
+// =============================================================================
+// v1.83: Timer liveness tests (VAL-TIMER-001)
+// =============================================================================
+
+// mockTimerChecker implements TimerChecker for testing.
+type mockTimerChecker struct {
+	count int
+	err   error
+}
+
+func (m mockTimerChecker) CountActiveTimers() (int, error) {
+	return m.count, m.err
+}
+
+func TestTimerStateWithActiveTimers(t *testing.T) {
+	SetTimerChecker(mockTimerChecker{count: 9, err: nil})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	count := checkTimerState()
+	if count != 9 {
+		t.Errorf("expected 9 active timers, got %d", count)
+	}
+}
+
+func TestTimerStateZeroTimers(t *testing.T) {
+	SetTimerChecker(mockTimerChecker{count: 0, err: nil})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	count := checkTimerState()
+	if count != 0 {
+		t.Errorf("expected 0 timers, got %d", count)
+	}
+}
+
+func TestTimerStateQueryError(t *testing.T) {
+	// On query error, checkTimerState returns 0 (fails safe).
+	SetTimerChecker(mockTimerChecker{count: 0, err: exec.ErrNotFound})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	count := checkTimerState()
+	if count != 0 {
+		t.Errorf("expected 0 on error, got %d", count)
+	}
+}
+
+func TestTimerZeroProducesFinding(t *testing.T) {
+	// Zero timers should produce VAL-TIMER-001 finding (severity: error)
+	// which causes DEGRADED through the normal evaluateOverallStatus path.
+	SetTimerChecker(mockTimerChecker{count: 0, err: nil})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	result := &ValidationResult{
+		Families: []FamilyResult{
+			{Status: StatusProtected},
+			{Status: StatusProtected},
+		},
+		Findings: make([]Finding, 0),
+	}
+
+	result.ServiceState.TimerCount = checkTimerState()
+	if result.ServiceState.TimerCount == 0 {
+		result.Findings = append(result.Findings, Finding{
+			Code:     CodeTimerNone,
+			Severity: SeverityError,
+			Component: "service",
+			Message:  "no active nftban timers found",
+		})
+	}
+
+	status := evaluateOverallStatus(result)
+	if status != StatusDegraded {
+		t.Errorf("expected DEGRADED with zero timers, got %s", status)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Code == CodeTimerNone {
+			found = true
+			if f.Severity != SeverityError {
+				t.Errorf("VAL-TIMER-001 severity should be error, got %s", f.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected VAL-TIMER-001 finding when zero timers")
+	}
+}
+
+func TestTimerActiveNoFinding(t *testing.T) {
+	// Active timers should NOT produce VAL-TIMER-001.
+	SetTimerChecker(mockTimerChecker{count: 5, err: nil})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	result := &ValidationResult{
+		Families: []FamilyResult{
+			{Status: StatusProtected},
+		},
+		Findings: make([]Finding, 0),
+	}
+
+	result.ServiceState.TimerCount = checkTimerState()
+	if result.ServiceState.TimerCount == 0 {
+		result.Findings = append(result.Findings, Finding{
+			Code:     CodeTimerNone,
+			Severity: SeverityError,
+		})
+	}
+
+	for _, f := range result.Findings {
+		if f.Code == CodeTimerNone {
+			t.Error("should NOT have VAL-TIMER-001 when timers are active")
 		}
 	}
 }

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -632,7 +632,10 @@ func TestTimerStateWithActiveTimers(t *testing.T) {
 	SetTimerChecker(mockTimerChecker{count: 9, err: nil})
 	defer SetTimerChecker(SystemdTimerChecker{})
 
-	count := checkTimerState()
+	count, err := checkTimerState()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	if count != 9 {
 		t.Errorf("expected 9 active timers, got %d", count)
 	}
@@ -642,18 +645,24 @@ func TestTimerStateZeroTimers(t *testing.T) {
 	SetTimerChecker(mockTimerChecker{count: 0, err: nil})
 	defer SetTimerChecker(SystemdTimerChecker{})
 
-	count := checkTimerState()
+	count, err := checkTimerState()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	if count != 0 {
 		t.Errorf("expected 0 timers, got %d", count)
 	}
 }
 
 func TestTimerStateQueryError(t *testing.T) {
-	// On query error, checkTimerState returns 0 (fails safe).
+	// On query error, checkTimerState returns (0, err).
 	SetTimerChecker(mockTimerChecker{count: 0, err: exec.ErrNotFound})
 	defer SetTimerChecker(SystemdTimerChecker{})
 
-	count := checkTimerState()
+	count, err := checkTimerState()
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
 	if count != 0 {
 		t.Errorf("expected 0 on error, got %d", count)
 	}
@@ -673,13 +682,19 @@ func TestTimerZeroProducesFinding(t *testing.T) {
 		Findings: make([]Finding, 0),
 	}
 
-	result.ServiceState.TimerCount = checkTimerState()
-	if result.ServiceState.TimerCount == 0 {
+	timerCount, timerErr := checkTimerState()
+	result.ServiceState.TimerCount = timerCount
+	if timerErr != nil {
 		result.Findings = append(result.Findings, Finding{
-			Code:     CodeTimerNone,
-			Severity: SeverityError,
+			Code:     CodeTimerError,
+			Severity: SeverityWarn,
+		})
+	} else if timerCount == 0 {
+		result.Findings = append(result.Findings, Finding{
+			Code:      CodeTimerNone,
+			Severity:  SeverityError,
 			Component: "service",
-			Message:  "no active nftban timers found",
+			Message:   "no active nftban timers found",
 		})
 	}
 
@@ -702,8 +717,65 @@ func TestTimerZeroProducesFinding(t *testing.T) {
 	}
 }
 
+func TestTimerQueryErrorProducesFinding(t *testing.T) {
+	// Query error should produce VAL-TIMER-002 (warn), NOT VAL-TIMER-001 (error).
+	// Distinguishes "no timers" from "couldn't check".
+	SetTimerChecker(mockTimerChecker{count: 0, err: exec.ErrNotFound})
+	defer SetTimerChecker(SystemdTimerChecker{})
+
+	result := &ValidationResult{
+		Families: []FamilyResult{
+			{Status: StatusProtected},
+		},
+		Findings: make([]Finding, 0),
+	}
+
+	timerCount, timerErr := checkTimerState()
+	result.ServiceState.TimerCount = timerCount
+	if timerErr != nil {
+		result.Findings = append(result.Findings, Finding{
+			Code:      CodeTimerError,
+			Severity:  SeverityWarn,
+			Component: "service",
+			Message:   "timer liveness query failed: " + timerErr.Error(),
+		})
+	} else if timerCount == 0 {
+		result.Findings = append(result.Findings, Finding{
+			Code:     CodeTimerNone,
+			Severity: SeverityError,
+		})
+	}
+
+	// Should get VAL-TIMER-002 (warn), NOT VAL-TIMER-001 (error)
+	foundError := false
+	foundWarn := false
+	for _, f := range result.Findings {
+		if f.Code == CodeTimerNone {
+			foundError = true
+		}
+		if f.Code == CodeTimerError {
+			foundWarn = true
+			if f.Severity != SeverityWarn {
+				t.Errorf("VAL-TIMER-002 severity should be warn, got %s", f.Severity)
+			}
+		}
+	}
+	if foundError {
+		t.Error("should NOT emit VAL-TIMER-001 on query error — that's VAL-TIMER-002 territory")
+	}
+	if !foundWarn {
+		t.Error("expected VAL-TIMER-002 finding on query error")
+	}
+
+	// Warn finding should NOT cause DEGRADED (only error/critical do)
+	status := evaluateOverallStatus(result)
+	if status == StatusDegraded {
+		t.Error("query error (warn) should not cause DEGRADED — only real zero timers should")
+	}
+}
+
 func TestTimerActiveNoFinding(t *testing.T) {
-	// Active timers should NOT produce VAL-TIMER-001.
+	// Active timers should NOT produce VAL-TIMER-001 or VAL-TIMER-002.
 	SetTimerChecker(mockTimerChecker{count: 5, err: nil})
 	defer SetTimerChecker(SystemdTimerChecker{})
 
@@ -714,8 +786,14 @@ func TestTimerActiveNoFinding(t *testing.T) {
 		Findings: make([]Finding, 0),
 	}
 
-	result.ServiceState.TimerCount = checkTimerState()
-	if result.ServiceState.TimerCount == 0 {
+	timerCount, timerErr := checkTimerState()
+	result.ServiceState.TimerCount = timerCount
+	if timerErr != nil {
+		result.Findings = append(result.Findings, Finding{
+			Code:     CodeTimerError,
+			Severity: SeverityWarn,
+		})
+	} else if timerCount == 0 {
 		result.Findings = append(result.Findings, Finding{
 			Code:     CodeTimerNone,
 			Severity: SeverityError,
@@ -723,8 +801,8 @@ func TestTimerActiveNoFinding(t *testing.T) {
 	}
 
 	for _, f := range result.Findings {
-		if f.Code == CodeTimerNone {
-			t.Error("should NOT have VAL-TIMER-001 when timers are active")
+		if f.Code == CodeTimerNone || f.Code == CodeTimerError {
+			t.Errorf("should NOT have timer finding when timers are active, got %s", f.Code)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add operational timer liveness check to Go validator — a system with zero active `nftban-*` timers is operationally degraded (maintenance, watchdog, exports won't run)
- `TimerChecker` interface + `SystemdTimerChecker` (same mockable pattern as `ServiceChecker`)
- `VAL-TIMER-001` finding (severity: error) flows through normal `evaluateOverallStatus` path → DEGRADED
- `timer_count` field added to `service_state` JSON output
- Schema version bumped `1.81.0` → `1.83.0`
- 5 deterministic tests covering: active timers, zero timers, query error, finding produced, no false finding

## Why
This is the last truth-source gap before the shell override in `cmd_status.sh` can be removed (Step 1b). The Go validator already checks nftband service state (B80-4) — timer liveness is the same class of operational truth. Once this lands, D-DAEMON and D-NOTIMERS shell overrides become redundant.

## Test plan
- [x] `go build ./internal/validator/...` passes (lab4)
- [x] `go test ./internal/validator/... -v` — 65/65 pass (lab4)
- [ ] CI gates pass
- [ ] Live validation on lab4: `nftban-validate --json | jq .service_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)