### PR TITLE
feat(cli): legacy fallback warning + schema version guard (v1.83 Step 1d)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -398,8 +398,15 @@ nftban_health_cmd_truth() {
     local validator_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
 
     if [[ ! -x "$validator_bin" ]]; then
-        echo "ERROR: Go validator binary not found at $validator_bin" >&2
-        return 1
+        # v1.83: Warn and fall back to diagnostics if Go binary missing.
+        # Target: remove fallback in v1.84.
+        echo "WARNING: Go validator not found at $validator_bin — falling back to diagnostics (deprecated, removal in v1.84)" >&2
+        if [[ "$json_mode" == "true" ]]; then
+            nftban_health_cmd_json
+        else
+            nftban_health_cmd_check
+        fi
+        return
     fi
 
     local output
@@ -407,6 +414,14 @@ nftban_health_cmd_truth() {
     if [[ -z "$output" ]]; then
         echo "ERROR: Go validator returned empty output" >&2
         return 1
+    fi
+
+    # v1.83: Schema version guard
+    local _schema_version
+    _schema_version=$(echo "$output" | jq -r '.schema_version // empty' 2>/dev/null)
+    local _expected_schema="1.83.0"
+    if [[ -n "$_schema_version" && "$_schema_version" != "$_expected_schema" ]]; then
+        echo "WARNING: validator schema $_schema_version does not match expected $_expected_schema" >&2
     fi
 
     if [[ "$json_mode" == "true" ]]; then

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -136,7 +136,8 @@ _nftban_protection_state_validator() {
     # Falls back to legacy detection if validator unavailable.
 
     if [[ ! -x "$_NFTBAN_VALIDATOR_BIN" ]]; then
-        # Validator not installed — use legacy detection
+        # v1.83: Warn when Go validator is missing — legacy fallback is deprecated.
+        echo "WARNING: Go validator not found at $_NFTBAN_VALIDATOR_BIN — using legacy detection (deprecated, removal in v1.84)" >&2
         _nftban_protection_state_legacy
         return
     fi
@@ -146,17 +147,27 @@ _nftban_protection_state_validator() {
     _json=$("$_NFTBAN_VALIDATOR_BIN" --json 2>/dev/null) || _exit_code=$?
 
     if [[ -z "$_json" ]]; then
-        # Validator failed — fallback
+        # v1.83: Warn when validator fails — legacy fallback is deprecated.
+        echo "WARNING: Go validator returned empty output — using legacy detection (deprecated)" >&2
         _nftban_protection_state_legacy
         return
     fi
 
-    # Extract status from JSON
+    # Extract status and schema version from JSON
+    local _status _schema_version
     if command -v jq >/dev/null 2>&1; then
         _status=$(echo "$_json" | jq -r '.status' 2>/dev/null)
+        _schema_version=$(echo "$_json" | jq -r '.schema_version // empty' 2>/dev/null)
     else
-        # Parse without jq - look for "status":"protected" etc
         _status=$(echo "$_json" | grep -oP '"status"\s*:\s*"\K[^"]+' || true)
+        _schema_version=$(echo "$_json" | grep -oP '"schema_version"\s*:\s*"\K[^"]+' || true)
+    fi
+
+    # v1.83: Schema version guard — warn if validator schema doesn't match expected.
+    # Prevents silent breakage if validator binary is from a different version.
+    local _expected_schema="1.83.0"
+    if [[ -n "$_schema_version" && "$_schema_version" != "$_expected_schema" ]]; then
+        echo "WARNING: validator schema $_schema_version does not match expected $_expected_schema — binary may be outdated" >&2
     fi
 
     # Map validator status to display format with reason codes.


### PR DESCRIPTION
## Summary
- Warn on stderr when Go validator binary is missing (legacy fallback deprecated, removal v1.84)
- Warn on stderr when validator schema version doesn't match expected 1.83.0
- Applied to both `cmd_status.sh` (protection state) and `cmd_health.sh` (truth rendering)
- Health truth path falls back to diagnostics output when binary is missing

## Why
Operators need to know when they're running on the deprecated legacy path. The schema guard prevents silent breakage when a mismatched validator binary is installed (e.g., old binary after partial upgrade).

## Test plan
- [ ] Normal path: no warnings when validator present + schema matches
- [ ] Missing binary: WARNING printed, falls back to legacy detection
- [ ] Schema mismatch: WARNING printed, continues with output
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)