### PR TITLE
fix(cli): close argument leak in health and login dispatchers (F1-F3)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -108,15 +108,20 @@ nftban_cmd_health() {
     # Args: subcommand [options]
 
     local subcommand="${1:-check}"
-    local json_mode=false
-
-    # Check for --json flag in arguments
-    for arg in "$@"; do
-        [[ "$arg" == "--json" ]] && json_mode=true && break || true
-    done
-
-    # Shift to get remaining args
     shift || true
+
+    # v1.83 F2 fix: scan for --json AFTER shift, so subcommand position
+    # is excluded. Then build a clean args array without --json so it
+    # is never leaked to downstream functions (F1 fix).
+    local json_mode=false
+    local -a clean_args=()
+    for arg in "$@"; do
+        if [[ "$arg" == "--json" ]]; then
+            json_mode=true
+        else
+            clean_args+=("$arg")
+        fi
+    done
 
     # Load output module (for help banner)
     if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_output.sh" ]]; then
@@ -145,38 +150,38 @@ nftban_cmd_health() {
             # --auto-heal: trigger fixes for detected issues (requires root)
             # --quiet: minimal output (for cron/timer use)
             if [[ "$json_mode" == "true" ]]; then
-                nftban_health_cmd_json "$@"
+                nftban_health_cmd_json "${clean_args[@]}"
             else
-                nftban_health_cmd_check "$@"
+                nftban_health_cmd_check "${clean_args[@]}"
             fi
             ;;
         --auto-heal)
             # Shorthand: nftban health --auto-heal → diagnostics --auto-heal
-            nftban_health_cmd_check "--auto-heal" "$@"
+            nftban_health_cmd_check "--auto-heal" "${clean_args[@]}"
             ;;
         --quiet)
             # Shorthand: nftban health --quiet → diagnostics --quiet
-            nftban_health_cmd_check "--quiet" "$@"
+            nftban_health_cmd_check "--quiet" "${clean_args[@]}"
             ;;
 
         # =================================================================
         # FIX PATH — side effects (auto-heal)
         # =================================================================
         fix|enforce|--fix)
-            nftban_health_cmd_fix "$@"
+            nftban_health_cmd_fix "${clean_args[@]}"
             ;;
 
         # =================================================================
         # MONITORING INTEGRATIONS
         # =================================================================
         --brief|brief)
-            nftban_health_cmd_brief "$@"
+            nftban_health_cmd_brief "${clean_args[@]}"
             ;;
         --nagios|nagios)
-            nftban_health_cmd_nagios "$@"
+            nftban_health_cmd_nagios "${clean_args[@]}"
             ;;
         summary)
-            nftban_health_cmd_summary "$@"
+            nftban_health_cmd_summary "${clean_args[@]}"
             ;;
         json|--json)
             # v1.83: "nftban health json" outputs Go validator truth JSON
@@ -189,47 +194,47 @@ nftban_cmd_health() {
         # DIAGNOSTIC SUBCOMMANDS (environment checks, not truth)
         # =================================================================
         binaries)
-            nftban_health_cmd_binaries "$@"
+            nftban_health_cmd_binaries "${clean_args[@]}"
             ;;
         geoip)
-            nftban_health_cmd_geoip "$@"
+            nftban_health_cmd_geoip "${clean_args[@]}"
             ;;
         pro)
-            nftban_health_cmd_pro "$@"
+            nftban_health_cmd_pro "${clean_args[@]}"
             ;;
         registries|registry)
-            nftban_health_cmd_registries "$@"
+            nftban_health_cmd_registries "${clean_args[@]}"
             ;;
         gui|ui)
-            nftban_health_cmd_gui "$@"
+            nftban_health_cmd_gui "${clean_args[@]}"
             ;;
         install|verify)
-            nftban_health_cmd_install "$@"
+            nftban_health_cmd_install "${clean_args[@]}"
             ;;
         conflicts)
-            nftban_health_cmd_conflicts "$@"
+            nftban_health_cmd_conflicts "${clean_args[@]}"
             ;;
         config)
-            nftban_health_cmd_config "$@"
+            nftban_health_cmd_config "${clean_args[@]}"
             ;;
         rbl)
-            nftban_health_cmd_rbl "$@"
+            nftban_health_cmd_rbl "${clean_args[@]}"
             ;;
         botguard)
-            nftban_health_cmd_botguard "$@"
+            nftban_health_cmd_botguard "${clean_args[@]}"
             ;;
         fhs)
             if [[ -f "${NFTBAN_LIB_DIR}/cli/cmd_fhs.sh" ]]; then
                 # shellcheck source=/dev/null
                 source "${NFTBAN_LIB_DIR}/cli/cmd_fhs.sh"
-                nftban_cmd_fhs "$@"
+                nftban_cmd_fhs "${clean_args[@]}"
             else
                 echo "ERROR: cmd_fhs.sh not found" >&2
                 return 1
             fi
             ;;
         posture|security)
-            nftban_health_cmd_posture "$@"
+            nftban_health_cmd_posture "${clean_args[@]}"
             ;;
 
         # =================================================================

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -1170,12 +1170,19 @@ EOF
 nftban_cmd_login() {
     # Main login CLI handler
     local subcommand="${1:-status}"
-    local json_mode=false
     shift || true
 
-    # Check for --json flag
+    # v1.83 F3 fix: scan for --json and build clean args array.
+    # --json is consumed by the dispatcher and must not leak to
+    # downstream functions that don't understand it.
+    local json_mode=false
+    local -a clean_args=()
     for arg in "$@"; do
-        [[ "$arg" == "--json" ]] && json_mode=true && break || true
+        if [[ "$arg" == "--json" ]]; then
+            json_mode=true
+        else
+            clean_args+=("$arg")
+        fi
     done
 
     # Load output module (for help banner)
@@ -1195,16 +1202,16 @@ nftban_cmd_login() {
             nftban_login_cmd_config "$json_mode"
             ;;
         install)
-            nftban_login_cmd_install "$@"
+            nftban_login_cmd_install "${clean_args[@]}"
             ;;
         enable)
-            nftban_login_cmd_enable "$@"
+            nftban_login_cmd_enable "${clean_args[@]}"
             ;;
         disable)
-            nftban_login_cmd_disable "$@"
+            nftban_login_cmd_disable "${clean_args[@]}"
             ;;
         restart)
-            nftban_login_cmd_restart "$@"
+            nftban_login_cmd_restart "${clean_args[@]}"
             ;;
         health-fix)
             echo "NOTE: Login health checks are now part of the main autoheal system."
@@ -1213,19 +1220,19 @@ nftban_cmd_login() {
             echo ""
             ;;
         logs)
-            nftban_login_cmd_logs "$@"
+            nftban_login_cmd_logs "${clean_args[@]}"
             ;;
         test)
-            nftban_login_cmd_test "$@"
+            nftban_login_cmd_test "${clean_args[@]}"
             ;;
         run)
-            nftban_login_cmd_run "$@"
+            nftban_login_cmd_run "${clean_args[@]}"
             ;;
         mode)
-            nftban_login_cmd_mode "$@"
+            nftban_login_cmd_mode "${clean_args[@]}"
             ;;
         digest)
-            nftban_login_cmd_digest "$@"
+            nftban_login_cmd_digest "${clean_args[@]}"
             ;;
         help|--help|-h)
             nftban_login_cmd_help


### PR DESCRIPTION
## Summary
Fix 3 argument-leak bugs found by code auditor (SHELL_ARGUMENT_LEAK_AUDIT.md):

- **F1 (HIGH)**: `nftban health --auto-heal --json` leaked `--json` to `nftban_health_cmd_check` → ERROR
- **F2 (MEDIUM)**: `--json` scan ran on pre-shift `$@` including subcommand position
- **F3 (MEDIUM)**: `nftban login install --json` leaked `--json` to non-JSON-aware functions

Root cause: `--json` captured into local variable but NOT removed from `$@` before forwarding.

Fix pattern (applied to both `cmd_health.sh` and `cmd_login.sh`):
1. Extract subcommand, shift
2. Build `clean_args` array — captures `--json` into `json_mode`, excludes it from array
3. Forward `${clean_args[@]}` (never raw `$@`) to downstream functions

## Test plan
- [x] `nftban health --auto-heal --json` → runs auto-heal (was ERROR)
- [x] `nftban health --quiet --json` → runs quiet check (was ERROR)
- [x] `nftban login install --json` → runs install cleanly
- [x] `nftban login enable --json` → runs enable cleanly
- [x] `nftban health` → unchanged (Go truth)
- [x] `nftban health diagnostics` → unchanged (shell checks)
- [x] `nftban login status --json` → unchanged (JSON output)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)