### PR TITLE
perf(status): cache validator JSON — eliminate redundant binary calls (v1.83 Win 3)

### DIFF
--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -130,6 +130,12 @@ _status_check_binaries() {
 # Go validator binary path
 _NFTBAN_VALIDATOR_BIN="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
 
+# v1.83 Win-3: Validator JSON cache. The validator is called once per
+# nftban status invocation. The result is cached here so downstream
+# functions (banner, health render) can reuse it without re-executing
+# the binary. This eliminates 2 of 3 validator calls per status run.
+_NFTBAN_VALIDATOR_CACHE=""
+
 _nftban_protection_state_validator() {
     # v1.78.0: Call Go kernel validator for authoritative protection state.
     # Returns: PROTECTED | DEGRADED[:reason] | DOWN
@@ -142,9 +148,13 @@ _nftban_protection_state_validator() {
         return
     fi
 
-    # Call validator with JSON output
+    # Call validator with JSON output (or reuse cache)
     local _json _status _exit_code=0
-    _json=$("$_NFTBAN_VALIDATOR_BIN" --json 2>/dev/null) || _exit_code=$?
+    if [[ -n "$_NFTBAN_VALIDATOR_CACHE" ]]; then
+        _json="$_NFTBAN_VALIDATOR_CACHE"
+    else
+        _json=$("$_NFTBAN_VALIDATOR_BIN" --json 2>/dev/null) || _exit_code=$?
+    fi
 
     if [[ -z "$_json" ]]; then
         # v1.83: Warn when validator fails — legacy fallback is deprecated.
@@ -152,6 +162,9 @@ _nftban_protection_state_validator() {
         _nftban_protection_state_legacy
         return
     fi
+
+    # v1.83 Win-3: Cache for downstream reuse (banner, health render)
+    _NFTBAN_VALIDATOR_CACHE="$_json"
 
     # Extract status and schema version from JSON
     local _status _schema_version
@@ -416,6 +429,12 @@ nftban_cmd_status() {
     if [[ $brief_mode -eq 1 ]]; then
         output_brief
         return $?
+    fi
+
+    # v1.83 Win-3: Pre-populate validator cache ONCE before any rendering.
+    # This eliminates 2 of 3 validator calls (banner + health render reuse cache).
+    if [[ -x "$_NFTBAN_VALIDATOR_BIN" && -z "$_NFTBAN_VALIDATOR_CACHE" ]]; then
+        _NFTBAN_VALIDATOR_CACHE=$("$_NFTBAN_VALIDATOR_BIN" --json 2>/dev/null || true)
     fi
 
     # Show unified banner with health indicator (skip for JSON/quiet output)

--- a/cli/lib/nftban/core/nftban_health_render.sh
+++ b/cli/lib/nftban/core/nftban_health_render.sh
@@ -322,10 +322,15 @@ nftban_health_render_json() {
     echo "  },"
 
     # v1.78.0: Kernel validation data from Go validator
-    local _validator_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
-    if [[ -x "$_validator_bin" ]]; then
-        local _kernel_json
-        _kernel_json=$("$_validator_bin" --json 2>/dev/null || echo '{}')
+    # v1.83 Win-3: Reuse cached validator JSON if available.
+    local _kernel_json="${_NFTBAN_VALIDATOR_CACHE:-}"
+    if [[ -z "$_kernel_json" ]]; then
+        local _validator_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
+        if [[ -x "$_validator_bin" ]]; then
+            _kernel_json=$("$_validator_bin" --json 2>/dev/null || echo '{}')
+        fi
+    fi
+    if [[ -n "$_kernel_json" ]]; then
         echo "  \"kernel\": $_kernel_json,"
     else
         echo "  \"kernel\": {\"status\": \"unavailable\", \"reason\": \"validator binary not found\"},"

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -324,13 +324,18 @@ nftban_banner_unified() {
     local health_icon="⚪"
     local health_status="unknown"
 
-    local _validator_bin="/usr/lib/nftban/bin/nftban-validate"
-    if [[ -x "$_validator_bin" ]] && command -v jq >/dev/null 2>&1; then
-        local _validator_json
-        _validator_json=$("$_validator_bin" --json 2>/dev/null || true)
-        if [[ -n "$_validator_json" ]]; then
-            health_status=$(echo "$_validator_json" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+    # v1.83 Win-3: Reuse cached validator JSON if available (set by
+    # _nftban_protection_state_validator in cmd_status.sh). Falls back
+    # to calling the binary directly if cache is empty.
+    local _validator_json="${_NFTBAN_VALIDATOR_CACHE:-}"
+    if [[ -z "$_validator_json" ]]; then
+        local _validator_bin="/usr/lib/nftban/bin/nftban-validate"
+        if [[ -x "$_validator_bin" ]] && command -v jq >/dev/null 2>&1; then
+            _validator_json=$("$_validator_bin" --json 2>/dev/null || true)
         fi
+    fi
+    if [[ -n "$_validator_json" ]] && command -v jq >/dev/null 2>&1; then
+        health_status=$(echo "$_validator_json" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
     fi
 
     case "$health_status" in


### PR DESCRIPTION
## Summary
- Cache `nftban-validate --json` output in `_NFTBAN_VALIDATOR_CACHE` at the top of `nftban_cmd_status()`
- Banner function (`nftban_output.sh`) reuses cached result instead of calling binary
- Health render function (`nftban_health_render.sh`) reuses cached result
- All three call sites fall back to calling the binary if cache is empty (standalone use)

## Performance
| Metric | Before | After |
|--------|--------|-------|
| `nftban status` avg time | 3.6s | **2.7s** |
| Validator binary calls | 3 | 1 |
| Improvement | — | **~25%** |

## Files changed
- `cli/lib/nftban/cli/cmd_status.sh` — cache variable + pre-population
- `cli/lib/nftban/core/nftban_output.sh` — check cache before calling binary
- `cli/lib/nftban/core/nftban_health_render.sh` — check cache before calling binary

## Test plan
- [x] `nftban status` shows correct PROTECTED with green icon (lab4)
- [x] Timing improved from 3.6s → 2.7s (lab4)
- [x] Standalone banner still works (cache empty → fallback)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)