### PR TITLE
fix(validator): close 5 module contract gaps (GAP-BL1/D1/P1/BL3/BL5)

### DIFF
--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ConfigDir is the base config directory. Overridable for testing.
@@ -146,13 +147,24 @@ func evaluateDDoS(doc *RulesetDocument) *ModuleHealth {
 	// Config axis
 	h.Config = readConfigBool("conf.d/ddos/main.conf.local", "conf.d/ddos/main.conf", "DDOS_ENABLED")
 
-	// Structural axis: 4 required chains
+	// Structural axis: 4 required chains in IPv4.
+	// GAP-D1: Also check IPv6 if ip6 table exists — DDoS chains should
+	// be present in both families for full dual-stack protection.
 	ddosChains := []string{"ddos_sanity", "ddos_penalty", "ddos_prefix", "ddos_protection"}
 	allPresent := true
 	for _, c := range ddosChains {
 		if !doc.ChainExists("ip", "nftban", c) {
 			allPresent = false
 			break
+		}
+	}
+	// Check IPv6 if table exists
+	if allPresent && doc.TableExists("ip6", "nftban") {
+		for _, c := range ddosChains {
+			if !doc.ChainExists("ip6", "nftban", c) {
+				allPresent = false
+				break
+			}
 		}
 	}
 	if allPresent {
@@ -205,8 +217,13 @@ func evaluatePortscan(doc *RulesetDocument) *ModuleHealth {
 
 	h.Config = readConfigBool("conf.d/portscan/main.conf.local", "conf.d/portscan/main.conf", "PORTSCAN_ENABLED")
 
+	// GAP-P1: Check both IPv4 and IPv6 (if ip6 table exists).
 	if doc.ChainExists("ip", "nftban", "portscan_detection") {
-		h.Structural = StructuralPresent
+		if doc.TableExists("ip6", "nftban") && !doc.ChainExists("ip6", "nftban", "portscan_detection") {
+			h.Structural = StructuralMissing // IPv4 present but IPv6 missing
+		} else {
+			h.Structural = StructuralPresent
+		}
 	} else {
 		h.Structural = StructuralMissing
 	}
@@ -263,11 +280,17 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 	bh := &BlacklistHealth{}
 
 	// Manual blacklist
+	// GAP-BL1 fix: Read dedicated counter to distinguish ENFORCING from PRIMED.
+	// input_blacklist_manual_drop is a dedicated counter for manual bans
+	// (shared with LoginMon + portscan bans that land in the same set).
+	// elements > 0 + drops > 0 = ENFORCING (traffic is being blocked)
+	// elements > 0 + drops = 0 = PRIMED (rules loaded, no matches yet)
+	// elements = 0 = IDLE
 	manualElements := countSetElements("ip", "blacklist_manual_ipv4")
-	// We don't have counter values from doc (counters are in the raw ruleset
-	// but not currently extracted to RulesetDocument). For now, use element
-	// count as the primary evidence.
-	if manualElements > 0 {
+	manualDrops := doc.GetCounter("ip", "nftban", "input_blacklist_manual_drop")
+	if manualElements > 0 && manualDrops > 0 {
+		bh.Manual = BlacklistSubHealth{State: "enforcing", Entries: manualElements, Drops: manualDrops}
+	} else if manualElements > 0 {
 		bh.Manual = BlacklistSubHealth{State: "primed", Entries: manualElements}
 	} else {
 		bh.Manual = BlacklistSubHealth{State: "idle", Entries: 0}
@@ -280,11 +303,16 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 	if !feedsConfigured {
 		bh.Feeds = BlacklistSubHealth{State: "disabled"}
 	} else {
-		// Feed files exist → data pipeline is configured.
-		// We cannot distinguish feed-originated elements from geoban-originated
-		// in the shared blacklist_ipv4 set (per M81-3 shared counter rule).
-		// Report as LOADED if feeds are configured, regardless of set element count.
-		bh.Feeds = BlacklistSubHealth{State: "loaded"}
+		// Feed config exists → check data freshness.
+		// GAP-BL5: Check feed data directory for actual downloaded data.
+		// If no data files or all data > 7 days old → stale sync.
+		feedDataDir := "/var/lib/nftban/feeds"
+		feedFresh := feedDataIsFresh(feedDataDir, 7*24*time.Hour)
+		if feedFresh {
+			bh.Feeds = BlacklistSubHealth{State: "loaded"}
+		} else {
+			bh.Feeds = BlacklistSubHealth{State: "stale"}
+		}
 	}
 
 	// Geoban
@@ -309,8 +337,17 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 				Message:     "GeoIP database missing or empty — geoban enforcement unavailable",
 				Remediation: "Run: nftban geoban sync",
 			})
+		} else if time.Since(info.ModTime()) > 45*24*time.Hour {
+			// GAP-BL3: DB exists but older than 45 days → stale data
+			bh.Geoban = BlacklistSubHealth{State: "stale"}
+			moduleFindings = append(moduleFindings, Finding{
+				Code:        CodeGeobanDBMissing,
+				Severity:    SeverityWarn,
+				Component:   "module",
+				Message:     "GeoIP database older than 45 days — data may be inaccurate",
+				Remediation: "Run: nftban geoban sync",
+			})
 		} else {
-			// DB exists. Future: check mtime > 45 days → "stale".
 			bh.Geoban = BlacklistSubHealth{State: "loaded"}
 		}
 	}
@@ -360,6 +397,28 @@ func readKeyFromFile(path, key string) string {
 		}
 	}
 	return ""
+}
+
+// feedDataIsFresh checks if the feed data directory has files newer than maxAge.
+// GAP-BL5: detects stale feed sync (no data or old data = sync not working).
+func feedDataIsFresh(dir string, maxAge time.Duration) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false // no data directory = not fresh
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) < maxAge {
+			return true // at least one recent file
+		}
+	}
+	return false // no recent files
 }
 
 // feedsExist checks if any feed config files exist.

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -452,6 +452,65 @@ func TestBlacklistManualPrimed(t *testing.T) {
 	}
 }
 
+func TestBlacklistManualEnforcing(t *testing.T) {
+	// GAP-BL1: elements > 0 + drops > 0 = ENFORCING
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="false"`,
+	})
+	defer cleanup()
+	// Mock: manual set has 3 entries
+	old := countSetElementsFunc
+	countSetElementsFunc = func(_, _ string) int { return 3 }
+	defer func() { countSetElementsFunc = old }()
+
+	// Build doc with manual drop counter > 0
+	objects := []NftObject{
+		{Table: &NftTable{Family: "ip", Name: "nftban"}},
+		{Set: &NftSet{Family: "ip", Table: "nftban", Name: "blacklist_ipv4"}},
+		{Set: &NftSet{Family: "ip", Table: "nftban", Name: "blacklist_manual_ipv4"}},
+		{Counter: &NftCounter{Family: "ip", Table: "nftban", Name: "input_blacklist_manual_drop", Packets: 42}},
+	}
+	raw := &NftRuleset{Nftables: objects}
+	doc := ParseRuleset(raw)
+
+	bh := evaluateBlacklist(doc)
+	if bh.Manual.State != "enforcing" {
+		t.Errorf("manual state = %s, want enforcing (elements > 0, drops > 0)", bh.Manual.State)
+	}
+	if bh.Manual.Entries != 3 {
+		t.Errorf("manual entries = %d, want 3", bh.Manual.Entries)
+	}
+	if bh.Manual.Drops != 42 {
+		t.Errorf("manual drops = %d, want 42", bh.Manual.Drops)
+	}
+}
+
+func TestBlacklistManualPrimedZeroDrops(t *testing.T) {
+	// elements > 0 but drops = 0 → PRIMED (not ENFORCING)
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="false"`,
+	})
+	defer cleanup()
+	old := countSetElementsFunc
+	countSetElementsFunc = func(_, _ string) int { return 2 }
+	defer func() { countSetElementsFunc = old }()
+
+	// Counter exists but zero packets
+	objects := []NftObject{
+		{Table: &NftTable{Family: "ip", Name: "nftban"}},
+		{Set: &NftSet{Family: "ip", Table: "nftban", Name: "blacklist_ipv4"}},
+		{Set: &NftSet{Family: "ip", Table: "nftban", Name: "blacklist_manual_ipv4"}},
+		{Counter: &NftCounter{Family: "ip", Table: "nftban", Name: "input_blacklist_manual_drop", Packets: 0}},
+	}
+	raw := &NftRuleset{Nftables: objects}
+	doc := ParseRuleset(raw)
+
+	bh := evaluateBlacklist(doc)
+	if bh.Manual.State != "primed" {
+		t.Errorf("manual state = %s, want primed (elements > 0, drops = 0)", bh.Manual.State)
+	}
+}
+
 // =============================================================================
 // Config helper tests
 // =============================================================================


### PR DESCRIPTION
## Summary
Evidence fidelity fixes from V1.90 module contract audits:

- **GAP-BL1** (HIGH): Manual blacklist counter read → ENFORCING state now reachable
- **GAP-D1** (MEDIUM): IPv6 chain check added to DDoS structural evaluation
- **GAP-P1** (MEDIUM): IPv6 chain check added to Portscan structural evaluation
- **GAP-BL3** (MEDIUM): GeoIP DB mtime check — files > 45 days report "stale"
- **GAP-BL5** (MEDIUM): Feed data freshness check — no recent data = "stale"

GAP-B4/L2 (journal-based checks) deferred — require new exec pattern, not suitable for hotfix.

## Why
These are evidence accuracy fixes. The validator can observe more than it was reporting. Every host with active bans was affected by GAP-BL1 (showing PRIMED instead of ENFORCING). IPv6 structural parity (D1/P1) was never checked. GeoIP and feed freshness had no time-based validation.

## Test plan
- [x] 68/68 validator tests pass (lab4)
- [x] TestBlacklistManualEnforcing — elements > 0, drops > 0 = ENFORCING
- [x] TestBlacklistManualPrimedZeroDrops — elements > 0, drops = 0 = PRIMED
- [ ] CI passes
- [ ] Live verification on lab4/monitor after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)