### PR TITLE
feat(validator): add bounded journal evidence reader (v1.84 A1-1)

### DIFF
--- a/internal/validator/journal.go
+++ b/internal/validator/journal.go
@@ -1,0 +1,192 @@
+// =============================================================================
+// NFTBan v1.84 - Bounded Journal Evidence Reader
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="journal-evidence"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Bounded journal query for daemon runtime evidence"
+// meta:inventory.files="internal/validator/journal.go"
+// meta:inventory.binaries="journalctl"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+//
+// A1-1: Dark code — not wired into any module evaluator yet.
+// This reader provides bounded, fail-safe journal queries for
+// daemon-dependent modules (BotGuard, LoginMon) that need runtime
+// evidence beyond systemctl is-active.
+//
+// Design contract:
+// - Bounded: time window (-15m) + line count (-n 200), no full scan
+// - Deterministic: same input → same output, newest-first (-r)
+// - Fail-safe: command failure returns structured error, never panics
+// - Silent: no impact on validator status, findings, or exit code
+//
+// Command shape:
+//   journalctl -u nftband --since "-15m" --no-pager -o cat -r -n 200
+//
+// Pattern matching is done in Go (substring), not journalctl --grep.
+// This avoids repeated subprocess cost and keeps matching deterministic.
+// =============================================================================
+package validator
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// JournalQuery defines a bounded journal search.
+type JournalQuery struct {
+	Unit     string        // systemd unit to filter (e.g. "nftband")
+	Patterns []string      // substring patterns to match (first match wins)
+	Since    time.Duration // how far back to look (default 15m)
+	MaxLines int           // max lines from journalctl -n (default 200)
+	Timeout  time.Duration // exec timeout (default 2s)
+}
+
+// ErrKind classifies journal query failures.
+type ErrKind string
+
+const (
+	ErrNone    ErrKind = ""        // success (may still have Found=false)
+	ErrTimeout ErrKind = "timeout" // context deadline exceeded
+	ErrExec    ErrKind = "exec"    // binary not found / permission denied
+	ErrNonZero ErrKind = "nonzero" // journalctl exited non-zero (not "no matches")
+	ErrEmpty   ErrKind = "empty"   // command succeeded but zero output
+)
+
+// JournalEvidence holds the result of a bounded journal query.
+type JournalEvidence struct {
+	Found        bool    // true if at least one pattern matched
+	MatchedLine  string  // first matching line (newest-first order)
+	MatchedIndex int     // index of matched line in output (0-based)
+	LinesRead    int     // total lines read from journal
+	Truncated    bool    // true if journalctl hit -n limit
+	ErrKind      ErrKind // failure classification
+	Err          error   // underlying error (nil on success)
+}
+
+// JournalReader abstracts journal queries for testability.
+type JournalReader interface {
+	Query(ctx context.Context, q JournalQuery) JournalEvidence
+}
+
+// SystemdJournalReader is the production implementation using journalctl.
+type SystemdJournalReader struct{}
+
+// Query executes a bounded journalctl query and matches patterns in Go.
+//
+// Strategy: fetch bounded output once with -o cat -r -n N, then scan
+// lines for substring matches. No --grep, no shell pipes, no repeated
+// subprocess calls.
+func (SystemdJournalReader) Query(ctx context.Context, q JournalQuery) JournalEvidence {
+	applyDefaults(&q)
+
+	// Apply timeout
+	ctx, cancel := context.WithTimeout(ctx, q.Timeout)
+	defer cancel()
+
+	// Build command: journalctl -u UNIT --since "-Xm" --no-pager -o cat -r -n N
+	sinceArg := fmt.Sprintf("-%dm", int(q.Since.Minutes()))
+	cmd := exec.CommandContext(ctx, "journalctl", // #nosec G204 -- args are bounded, not user-controlled
+		"-u", q.Unit,
+		"--since", sinceArg,
+		"--no-pager",
+		"-o", "cat",
+		"-r",
+		"-n", fmt.Sprintf("%d", q.MaxLines),
+	)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return classifyError(ctx, err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return JournalEvidence{ErrKind: ErrEmpty}
+	}
+
+	lines := strings.Split(raw, "\n")
+	truncated := len(lines) >= q.MaxLines
+
+	// Scan for patterns (substring match, case-sensitive, first match wins)
+	if len(q.Patterns) > 0 {
+		for i, line := range lines {
+			for _, pattern := range q.Patterns {
+				if strings.Contains(line, pattern) {
+					return JournalEvidence{
+						Found:        true,
+						MatchedLine:  line,
+						MatchedIndex: i,
+						LinesRead:    len(lines),
+						Truncated:    truncated,
+					}
+				}
+			}
+		}
+	}
+
+	// No pattern match (or no patterns specified)
+	return JournalEvidence{
+		Found:     false,
+		LinesRead: len(lines),
+		Truncated: truncated,
+	}
+}
+
+// classifyError maps exec errors to structured ErrKind.
+func classifyError(ctx context.Context, err error) JournalEvidence {
+	if ctx.Err() != nil {
+		return JournalEvidence{ErrKind: ErrTimeout, Err: err}
+	}
+	if _, ok := err.(*exec.Error); ok {
+		// Binary not found / permission denied
+		return JournalEvidence{ErrKind: ErrExec, Err: err}
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		// journalctl exits 1 on no matches with some configurations
+		if exitErr.ExitCode() == 1 {
+			return JournalEvidence{ErrKind: ErrEmpty}
+		}
+		return JournalEvidence{ErrKind: ErrNonZero, Err: err}
+	}
+	return JournalEvidence{ErrKind: ErrExec, Err: err}
+}
+
+// applyDefaults sets safe defaults for zero-value query fields.
+func applyDefaults(q *JournalQuery) {
+	if q.Since <= 0 {
+		q.Since = 15 * time.Minute
+	}
+	if q.MaxLines <= 0 {
+		q.MaxLines = 200
+	}
+	if q.Timeout <= 0 {
+		q.Timeout = 2 * time.Second
+	}
+	if q.Unit == "" {
+		q.Unit = "nftband"
+	}
+}
+
+// defaultJournalReader is the package-level reader, overridable for tests.
+var defaultJournalReader JournalReader = SystemdJournalReader{}
+
+// SetJournalReader replaces the journal reader (for testing only).
+func SetJournalReader(r JournalReader) {
+	defaultJournalReader = r
+}
+
+// queryJournal runs a bounded journal query using the default reader.
+// This is the function module evaluators will call (when wired in A1-2/A1-3).
+func queryJournal(ctx context.Context, q JournalQuery) JournalEvidence {
+	return defaultJournalReader.Query(ctx, q)
+}

--- a/internal/validator/journal_test.go
+++ b/internal/validator/journal_test.go
@@ -1,0 +1,393 @@
+// =============================================================================
+// NFTBan v1.84 - Journal Evidence Reader Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="journal-evidence-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:inventory.files="internal/validator/journal_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Test matrix from A1-1 audit specification:
+// A: Happy-path matching (T1-T3)
+// B: No match (T4-T5)
+// C: Execution failure (T6-T8)
+// D: Bounds/truncation (T9-T10)
+// E: Pattern correctness (T11-T12)
+// F: Integration-safety semantics (T13-T14)
+// =============================================================================
+package validator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mockJournalReader returns a fixed result for deterministic testing.
+// The mock simulates the SystemdJournalReader output contract without exec.
+type mockJournalReader struct {
+	lines   []string // raw journal output lines (newest-first)
+	errKind ErrKind
+	err     error
+}
+
+func (m mockJournalReader) Query(_ context.Context, q JournalQuery) JournalEvidence {
+	// Simulate error conditions
+	if m.errKind != ErrNone {
+		return JournalEvidence{ErrKind: m.errKind, Err: m.err}
+	}
+
+	if len(m.lines) == 0 {
+		return JournalEvidence{ErrKind: ErrEmpty}
+	}
+
+	applyDefaults(&q)
+	truncated := len(m.lines) >= q.MaxLines
+
+	// Scan for patterns (same logic as production reader)
+	if len(q.Patterns) > 0 {
+		for i, line := range m.lines {
+			for _, pattern := range q.Patterns {
+				if containsSubstring(line, pattern) {
+					return JournalEvidence{
+						Found:        true,
+						MatchedLine:  line,
+						MatchedIndex: i,
+						LinesRead:    len(m.lines),
+						Truncated:    truncated,
+					}
+				}
+			}
+		}
+	}
+
+	return JournalEvidence{
+		Found:     false,
+		LinesRead: len(m.lines),
+		Truncated: truncated,
+	}
+}
+
+// containsSubstring is a test helper matching production behavior.
+func containsSubstring(line, pattern string) bool {
+	return len(pattern) > 0 && len(line) >= len(pattern) && indexOf(line, pattern) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// =============================================================================
+// Category A — Happy-path matching
+// =============================================================================
+
+func TestT1_FirstLineMatches(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"module_start: botguard",
+		"some other line",
+		"another line",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start: botguard"},
+	})
+	if !r.Found {
+		t.Fatal("expected Found=true")
+	}
+	if r.MatchedIndex != 0 {
+		t.Errorf("expected MatchedIndex=0, got %d", r.MatchedIndex)
+	}
+	if r.MatchedLine != "module_start: botguard" {
+		t.Errorf("wrong matched line: %s", r.MatchedLine)
+	}
+}
+
+func TestT2_LaterLineMatches(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"startup complete",
+		"loading modules",
+		"[LOGINMON] ssh: /var/log/secure resolved_by=distroconf",
+		"other stuff",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"resolved_by=distroconf"},
+	})
+	if !r.Found {
+		t.Fatal("expected Found=true")
+	}
+	if r.MatchedIndex != 2 {
+		t.Errorf("expected MatchedIndex=2, got %d", r.MatchedIndex)
+	}
+}
+
+func TestT3_MultipleMatches_FirstWins(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"[BOTGUARD] classifier started (newest)",
+		"other line",
+		"[BOTGUARD] classifier started (older)",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"classifier started"},
+	})
+	if !r.Found {
+		t.Fatal("expected Found=true")
+	}
+	if r.MatchedIndex != 0 {
+		t.Errorf("expected first match (index 0), got %d", r.MatchedIndex)
+	}
+	if r.MatchedLine != "[BOTGUARD] classifier started (newest)" {
+		t.Errorf("expected newest line, got: %s", r.MatchedLine)
+	}
+}
+
+// =============================================================================
+// Category B — No match
+// =============================================================================
+
+func TestT4_OutputPresent_NoPatternMatch(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"startup complete",
+		"loading config",
+		"ready",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start: botguard"},
+	})
+	if r.Found {
+		t.Error("expected Found=false")
+	}
+	if r.LinesRead != 3 {
+		t.Errorf("expected LinesRead=3, got %d", r.LinesRead)
+	}
+	if r.ErrKind != ErrNone {
+		t.Errorf("expected no error, got %s", r.ErrKind)
+	}
+}
+
+func TestT5_EmptyOutput(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: nil})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"anything"},
+	})
+	if r.Found {
+		t.Error("expected Found=false on empty output")
+	}
+	if r.ErrKind != ErrEmpty {
+		t.Errorf("expected ErrKind=empty, got %s", r.ErrKind)
+	}
+}
+
+// =============================================================================
+// Category C — Execution failure
+// =============================================================================
+
+func TestT6_BinaryMissing(t *testing.T) {
+	SetJournalReader(mockJournalReader{
+		errKind: ErrExec,
+		err:     errors.New("exec: \"journalctl\": executable file not found in $PATH"),
+	})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{})
+	if r.Found {
+		t.Error("must not report found on exec error")
+	}
+	if r.ErrKind != ErrExec {
+		t.Errorf("expected ErrKind=exec, got %s", r.ErrKind)
+	}
+}
+
+func TestT7_NonZeroExit(t *testing.T) {
+	SetJournalReader(mockJournalReader{
+		errKind: ErrNonZero,
+		err:     errors.New("exit status 2"),
+	})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{})
+	if r.Found {
+		t.Error("must not report found on non-zero exit")
+	}
+	if r.ErrKind != ErrNonZero {
+		t.Errorf("expected ErrKind=nonzero, got %s", r.ErrKind)
+	}
+}
+
+func TestT8_Timeout(t *testing.T) {
+	SetJournalReader(mockJournalReader{
+		errKind: ErrTimeout,
+		err:     context.DeadlineExceeded,
+	})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{})
+	if r.Found {
+		t.Error("must not report found on timeout")
+	}
+	if r.ErrKind != ErrTimeout {
+		t.Errorf("expected ErrKind=timeout, got %s", r.ErrKind)
+	}
+}
+
+// =============================================================================
+// Category D — Bounds / truncation
+// =============================================================================
+
+func TestT9_Truncated(t *testing.T) {
+	// Simulate MaxLines=3, output has exactly 3 lines (at limit)
+	lines := make([]string, 3)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	SetJournalReader(mockJournalReader{lines: lines})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		MaxLines: 3,
+		Patterns: []string{"nonexistent"},
+	})
+	if r.Truncated != true {
+		t.Error("expected Truncated=true when lines >= MaxLines")
+	}
+}
+
+func TestT10_LargeOutput_MatchNearBeginning(t *testing.T) {
+	// 200 lines, match at line 0 (newest-first = fast path)
+	lines := make([]string, 200)
+	lines[0] = "module_start: botguard"
+	for i := 1; i < 200; i++ {
+		lines[i] = "noise line"
+	}
+	SetJournalReader(mockJournalReader{lines: lines})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start: botguard"},
+	})
+	if !r.Found {
+		t.Fatal("expected Found=true")
+	}
+	if r.MatchedIndex != 0 {
+		t.Errorf("expected match at index 0 (newest), got %d", r.MatchedIndex)
+	}
+}
+
+// =============================================================================
+// Category E — Pattern correctness
+// =============================================================================
+
+func TestT11_SubstringFalsePositiveGuard(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"module_start: botguard_legacy",  // near-match
+		"module_started: botguard",       // near-match (different verb)
+		"xmodule_start: botguard",        // prefix noise
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start: botguard"},
+	})
+	// "module_start: botguard_legacy" DOES contain "module_start: botguard"
+	// as a substring — this is expected behavior for substring matching.
+	// A1-2 must use sufficiently specific patterns.
+	if !r.Found {
+		t.Fatal("substring match should find 'module_start: botguard' in 'module_start: botguard_legacy'")
+	}
+}
+
+func TestT12_CaseSensitive(t *testing.T) {
+	SetJournalReader(mockJournalReader{lines: []string{
+		"MODULE_START: BOTGUARD",
+		"Module_Start: BotGuard",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start: botguard"},
+	})
+	if r.Found {
+		t.Error("case-sensitive matching should NOT match uppercase input")
+	}
+}
+
+// =============================================================================
+// Category F — Integration-safety semantics
+// =============================================================================
+
+func TestT13_FailureMustNotFabricateEvidence(t *testing.T) {
+	// Every error kind must result in Found=false
+	for _, ek := range []ErrKind{ErrTimeout, ErrExec, ErrNonZero, ErrEmpty} {
+		SetJournalReader(mockJournalReader{errKind: ek, err: errors.New("test")})
+		r := queryJournal(context.Background(), JournalQuery{
+			Patterns: []string{"anything"},
+		})
+		if r.Found {
+			t.Errorf("ErrKind=%s must not fabricate evidence (Found=true)", ek)
+		}
+	}
+	SetJournalReader(SystemdJournalReader{})
+}
+
+func TestT14_EmptyOutputNotImplyingStopped(t *testing.T) {
+	// Empty journal output = evidence unavailable, NOT daemon state
+	SetJournalReader(mockJournalReader{lines: nil})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	r := queryJournal(context.Background(), JournalQuery{
+		Patterns: []string{"module_start"},
+	})
+
+	// Result must be neutral — no Found, no fabricated error beyond "empty"
+	if r.Found {
+		t.Error("empty output must not report found")
+	}
+	// The caller (A1-2/A1-3) decides what "empty" means for module state.
+	// The reader must not pre-interpret it.
+	if r.ErrKind != ErrEmpty {
+		t.Errorf("expected ErrKind=empty, got %s", r.ErrKind)
+	}
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+func TestDefaults(t *testing.T) {
+	q := JournalQuery{}
+	applyDefaults(&q)
+
+	if q.Unit != "nftband" {
+		t.Errorf("default unit = %s, want nftband", q.Unit)
+	}
+	if q.Since != 15*time.Minute {
+		t.Errorf("default since = %v, want 15m", q.Since)
+	}
+	if q.MaxLines != 200 {
+		t.Errorf("default maxlines = %d, want 200", q.MaxLines)
+	}
+	if q.Timeout != 2*time.Second {
+		t.Errorf("default timeout = %v, want 2s", q.Timeout)
+	}
+}


### PR DESCRIPTION
## Summary
Infrastructure for daemon-dependent module runtime evidence. **Dark code** — not wired into any module evaluator. No impact on validator output, health state, or exit codes.

- `JournalReader` interface + `SystemdJournalReader` production implementation
- `JournalEvidence` result struct: Found, Lines, Truncated, Err
- `JournalQuery`: Unit, Pattern, Since, MaxLines
- `mockJournalReader` for deterministic testing
- `queryJournal()` package-level function (future consumer: A1-2/A1-3)

## Design contract
- **Bounded**: time window + line count limit, no full journal scan
- **Deterministic**: same input → same output
- **Fail-safe**: command failure → structured error, never panic
- **Silent**: zero impact on running system

## Test plan
- [x] 7 deterministic tests pass (lab4): found/not-found/error/truncated/format
- [x] Full validator suite: 75/75 pass, no regressions
- [ ] CI passes

## Next
A1-2 (BotGuard journal evidence) and A1-3 (LoginMon source-binding) will consume this after v1.83.1 soak confirms stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)