### PR TITLE
fix(validator): LoginMon AND semantics + comment drift (M84-1 review)

### DIFF
--- a/internal/validator/journal.go
+++ b/internal/validator/journal.go
@@ -15,10 +15,9 @@
 // meta:inventory.network=""
 // meta:inventory.privileges="root"
 //
-// A1-1: Dark code — not wired into any module evaluator yet.
-// This reader provides bounded, fail-safe journal queries for
-// daemon-dependent modules (BotGuard, LoginMon) that need runtime
-// evidence beyond systemctl is-active.
+// A1-1: Bounded journal evidence reader, consumed by BotGuard (A1-2)
+// and LoginMon (A1-3) module evaluators for runtime evidence beyond
+// systemctl is-active.
 //
 // Design contract:
 // - Bounded: time window (-15m) + line count (-n 200), no full scan

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -284,18 +284,28 @@ func evaluateLoginMon(svcState ServiceState) *ModuleHealth {
 	// are actually bound (path resolution succeeded).
 	if svcState.Nftband == RuntimeRunning {
 		h.Runtime = RuntimeRunning
-		// Check for LoginMon module start + source binding
-		evidence := queryJournal(context.Background(), JournalQuery{
-			Patterns: []string{"module_start: loginmon", "resolved_by="},
+		// Check for LoginMon module registration AND source binding.
+		// Both must be present — module_start alone proves the module loaded,
+		// but sources must be bound for LoginMon to actually process events.
+		// Two separate queries with AND semantics (not OR).
+		regEvidence := queryJournal(context.Background(), JournalQuery{
+			Patterns: []string{"module_start: loginmon"},
 			Since:    15 * time.Minute,
 		})
-		if evidence.ErrKind == ErrNone && !evidence.Found {
-			// Daemon running but no recent LoginMon startup/binding evidence.
+		bindEvidence := queryJournal(context.Background(), JournalQuery{
+			Patterns: []string{"resolved_by="},
+			Since:    15 * time.Minute,
+		})
+		// Only emit finding when both queries succeeded (no error) and
+		// at least one required evidence is missing.
+		regOK := regEvidence.ErrKind == ErrNone
+		bindOK := bindEvidence.ErrKind == ErrNone
+		if regOK && bindOK && (!regEvidence.Found || !bindEvidence.Found) {
 			moduleFindings = append(moduleFindings, Finding{
 				Code:      CodeLoginMonNoEvidence,
 				Severity:  SeverityInfo,
 				Component: "module",
-				Message:   "no recent LoginMon runtime evidence in journal (last 15m)",
+				Message:   "no recent LoginMon runtime + source-binding evidence in journal (last 15m)",
 			})
 		}
 	} else {

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -504,7 +504,10 @@ func TestLoginMonEnabledRunning(t *testing.T) {
 		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
 	})
 	defer cleanup()
-	SetJournalReader(mockJournalReader{lines: []string{"module_start: loginmon"}})
+	SetJournalReader(mockJournalReader{lines: []string{
+		"module_start: loginmon",
+		"[LOGINMON] ssh: resolved_by=distroconf",
+	}})
 	defer SetJournalReader(SystemdJournalReader{})
 
 	h := evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
@@ -535,12 +538,14 @@ func TestLoginMonEnabledDaemonStopped(t *testing.T) {
 // =============================================================================
 
 func TestLoginMonJournalEvidencePresent(t *testing.T) {
-	// Source binding evidence present → no finding
+	// Both registration AND binding evidence present → no finding
 	cleanup := setupTestConfig(t, map[string]string{
 		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
 	})
 	defer cleanup()
+	// Mock must contain both patterns (AND semantics)
 	SetJournalReader(mockJournalReader{lines: []string{
+		"module_start: loginmon",
 		"[LOGINMON] ssh: /var/log/secure resolved_by=distroconf",
 	}})
 	defer SetJournalReader(SystemdJournalReader{})
@@ -550,8 +555,34 @@ func TestLoginMonJournalEvidencePresent(t *testing.T) {
 
 	for _, f := range moduleFindings {
 		if f.Code == CodeLoginMonNoEvidence {
-			t.Error("should NOT emit VAL-LOGINMON-001 when binding evidence present")
+			t.Error("should NOT emit VAL-LOGINMON-001 when both registration and binding evidence present")
 		}
+	}
+}
+
+func TestLoginMonJournalOnlyRegistration(t *testing.T) {
+	// Registration present but no source binding → finding emitted (AND semantics)
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+	SetJournalReader(mockJournalReader{lines: []string{
+		"module_start: loginmon",
+		"some other output",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+
+	found := false
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoEvidence {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected VAL-LOGINMON-001 when registration present but binding missing (AND)")
 	}
 }
 


### PR DESCRIPTION
## Summary
Three fixes from code review before M84-2:

1. **LoginMon OR→AND**: Contract says registration AND source binding required. Was single query with two patterns (first-match = OR). Now two separate queries — both must match.
2. **Comment drift**: Removed stale "dark code" comment from journal.go
3. **New test**: `TestLoginMonJournalOnlyRegistration` — registration alone triggers finding

## Test plan
- [x] 7/7 LoginMon tests pass (lab4)
- [x] Full validator suite passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)