### PR TITLE
refactor(cli): M84-3 presentation cleanup — vocabulary + contract alignment

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -459,7 +459,7 @@ firewall_validate() {
         if [[ -n "$_val_json" ]] && command -v jq >/dev/null 2>&1; then
             local _val_status
             _val_status=$(echo "$_val_json" | jq -r '.status' 2>/dev/null)
-            echo "Structural Validation: $(echo "$_val_status" | tr '[:lower:]' '[:upper:]')"
+            echo "Validator Status: $(echo "$_val_status" | tr '[:lower:]' '[:upper:]')"
             echo "$_val_json" | jq -r '.findings[] | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null || true
         elif [[ -n "$_val_json" ]]; then
             echo "$_val_json"
@@ -1146,7 +1146,7 @@ firewall_rebuild() {
         # Legacy migration: template not installed yet (pre-v1.50.0 package)
         if [[ -f "$nftban_conf" ]]; then
             if grep -qE '__SSH_PORT__|__CT_LIMIT_' "$nftban_conf" 2>/dev/null; then
-                echo "WARNING: [LEGACY] Using live config as template source — run 'dnf reinstall nftban' to install template" >&2
+                echo "WARNING: [COMPAT] Using live config as template source — run 'dnf reinstall nftban' to install template" >&2
                 source_file="$nftban_conf"
             else
                 # Pre-v1.49.0 hardcoded config, no placeholders → load directly

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -144,7 +144,7 @@ nftban_cmd_health() {
         # v1.83: DIAGNOSTICS PATH — shell environment checks
         # =================================================================
         diagnostics|detailed)
-            # v1.83: Extended environment/UX checks (legacy shell health).
+            # v1.84: Extended environment/UX diagnostic checks.
             # These are NOT protection truth — they check packaging,
             # permissions, integrations, and optional features.
             # --auto-heal: trigger fixes for detected issues (requires root)
@@ -184,9 +184,8 @@ nftban_cmd_health() {
             nftban_health_cmd_summary "${clean_args[@]}"
             ;;
         json|--json)
-            # v1.83: "nftban health json" outputs Go validator truth JSON
-            # (same as "nftban health --json" on the default truth path).
-            # For legacy shell diagnostics JSON, use: nftban health diagnostics --json
+            # v1.84: "nftban health json" outputs Go validator truth JSON.
+            # For diagnostics JSON, use: nftban health diagnostics --json
             nftban_health_cmd_truth "true"
             ;;
 

--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -952,7 +952,7 @@ nftban_health_cmd_botguard() {
         echo "  Result: ⚠️  $warnings warning(s)"
         return 1
     else
-        echo "  Result: ✅ Healthy"
+        echo "  Result: ✅ OK"
         return 0
     fi
 }

--- a/cli/lib/nftban/cli/cmd_health_core.sh
+++ b/cli/lib/nftban/cli/cmd_health_core.sh
@@ -102,7 +102,7 @@ nftban_health_cmd_check() {
     local error_count="${NFTBAN_HEALTH_ERROR_COUNT:-0}"
     local warning_count="${NFTBAN_HEALTH_WARNING_COUNT:-0}"
 
-    # Standardized exit codes: 0=OK/WARNING, 1=WARNING(strict), 2=ERROR
+    # Diagnostics exit codes: 0=OK, 1=WARNING(strict), 2=ERROR
     # v1.37.1: Warnings about OPTIONAL features (Web GUI, metrics, etc.)
     # must NOT cause non-zero exit. Only real errors (broken firewall,
     # missing binaries, failed checks) should fail.
@@ -161,9 +161,9 @@ nftban_health_cmd_check() {
 # =============================================================================
 
 nftban_health_cmd_brief() {
-    # v1.24.0: One-line health output for CI/fleet/monitoring
-    # Output: HEALTHY | 26 checks passed | 4 info
-    # Returns: 0=healthy (including warnings), 1=warning(strict), 2=errors
+    # v1.24.0: One-line diagnostics output for CI/fleet/monitoring
+    # Output: OK | 26 checks passed | 4 info
+    # Returns: 0=OK (including warnings), 1=warning(strict), 2=errors
     # v1.39.0: Supports --strict flag (warnings → exit 1)
 
     local strict_mode=0
@@ -211,12 +211,12 @@ nftban_health_cmd_brief() {
         if [[ -z "$reasons" ]]; then
             reasons="optional-features"
         fi
-        echo "HEALTHY | ${ok_count} checks passed | ${info_count} info (${reasons})"
+        echo "OK | ${ok_count} checks passed | ${info_count} info (${reasons})"
         # v1.39.0: --strict makes warnings fail
         [[ $strict_mode -eq 1 ]] && return 1
         return 0
     else
-        echo "HEALTHY | ${total_checks} checks passed | 0 info"
+        echo "OK | ${total_checks} checks passed | 0 info"
         return 0
     fi
 }

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -812,7 +812,7 @@ CONF
         return 1
     elif [[ $issues_found -eq 0 ]]; then
         echo ""
-        echo "✅ Login monitor is healthy"
+        echo "✅ Login monitor: OK (no issues)"
     fi
 
     return 0

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -117,9 +117,8 @@ _status_check_binaries() {
 # =============================================================================
 # PROTECTION STATE — Go Validator Integration (v1.78.0)
 # =============================================================================
-# v1.78.0: Uses Go kernel validator as single source of truth.
-# Falls back to legacy shell detection if validator unavailable.
-# v1.66.0: 3-state model with kernel-first detection and reason codes.
+# v1.84: Go validator is the sole authority for protection state.
+# No legacy fallback. Missing validator = DOWN.
 # Returns: PROTECTED | DEGRADED[:reason] | DOWN
 # Exit code contract:
 #   0 = PROTECTED    — everything works
@@ -405,7 +404,7 @@ nftban_cmd_status() {
 
 output_brief() {
     # v1.66.0: One-line status output for CI/fleet/monitoring
-    # Format: PROTECTED | v1.66.0 | 26 banned | 9 whitelisted | healthy
+    # Format: PROTECTED | v1.84.0 | 26 banned | 9 whitelisted | protected
     # Exit codes: 0=PROTECTED, 1=DEGRADED, 2=DOWN
 
     local protection_state_raw

--- a/cli/lib/nftban/cli/cmd_watchdog.sh
+++ b/cli/lib/nftban/cli/cmd_watchdog.sh
@@ -1054,7 +1054,7 @@ nftban_watchdog_cmd_trends() {
         # Formatted output
         echo "Recent Watchdog Trends (last $last_count entries)"
         echo "═══════════════════════════════════════════════════════════════"
-        echo "STATUS: OK=healthy  WARN=degraded  CRIT=critical"
+        echo "STATUS: OK=protected  WARN=degraded  CRIT=down"
         echo ""
         printf "%-25s  %-8s  %5s  %5s  %5s  %7s\n" "TIMESTAMP" "STATUS" "CPU%" "MEM%" "IO%" "ACTIONS"
         echo "───────────────────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary
Remove all remaining shell-era terminology from user-visible CLI output. No logic changes.

**Banned terms removed (5 instances):**
- `HEALTHY` → `OK` in health diagnostics brief
- `healthy` → `OK (no issues)` in login monitor
- `Healthy` → `OK` in botguard health check
- `OK=healthy` → `OK=protected` in watchdog legend

**Stale comments cleaned (3 instances):**
- "Falls back to legacy" removed (M84-2 deleted fallback)
- "legacy shell health" → "diagnostic checks"

**Output contract aligned (3 instances):**
- "Structural Validation:" → "Validator Status:" in firewall validate
- "[LEGACY]" → "[COMPAT]" in template warning
- Exit code comments: "0=healthy" → "0=OK"

## Why
M84-2 changed the truth model. M84-3 aligns the user-facing surface so CI gates (M84-4) freeze a clean contract, not a transitional one.

## Test plan
- [ ] CI passes (ShellCheck, banned phrases)
- [ ] No "healthy" in user-visible CLI output
- [ ] `nftban health diagnostics --brief` shows "OK" not "HEALTHY"

🤖 Generated with [Claude Code](https://claude.com/claude-code)