### PR TITLE
fix(validator): correct GeoIP database path — /var/lib not /var/cache

### DIFF
--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -383,7 +383,9 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 		// Per CF-2 resolution: geoban DB missing uses "stale" (in allowed enum)
 		// and emits a finding for visibility. "degraded" is not in the blacklist
 		// sub-state enum (enforcing|primed|idle|loaded|stale|disabled).
-		dbPath := "/var/cache/nftban/geoban/dbip-country-lite.mmdb"
+		// Canonical path: ${NFTBAN_DATA_DIR}/geoip/dbip-country-lite.mmdb
+		// Downloaded by nftban-core-geoip.timer → nftban geoip sync
+		dbPath := "/var/lib/nftban/geoip/dbip-country-lite.mmdb"
 		info, err := os.Stat(dbPath)
 		if err != nil || info.Size() == 0 {
 			bh.Geoban = BlacklistSubHealth{State: "stale"} // missing DB = stale data


### PR DESCRIPTION
## Summary
Fix wrong hardcoded GeoIP database path in validator.

**Was:** `/var/cache/nftban/geoban/dbip-country-lite.mmdb`
**Should be:** `/var/lib/nftban/geoip/dbip-country-lite.mmdb`

## Impact
- VAL-GEOBAN-001 was firing on **ALL 6 fleet hosts** even though the DB existed
- Every host: GEOBAN_ENABLED=true, timer active, DB present at correct path
- Validator was looking in the wrong directory

## Root cause
Hardcoded path in `evaluateBlacklist()` was never verified against the actual FHS download destination (`${NFTBAN_DATA_DIR}/geoip/`).

## Verification
```
find / -name "*.mmdb" → /var/lib/nftban/geoip/dbip-country-lite.mmdb (all hosts)
validator checked → /var/cache/nftban/geoban/ (wrong)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)