### PR TITLE
feat(metrics): v1.87 complete evidence layer (M87-2 through M87-10)

### DIFF
--- a/cli/lib/nftban/cli/cmd_metrics.sh
+++ b/cli/lib/nftban/cli/cmd_metrics.sh
@@ -371,6 +371,14 @@ nftban_cmd_metrics() {
     echo ""
 
     case "$subcommand" in
+        evidence)
+            # v1.87: Kernel evidence snapshot (human-readable)
+            "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core" metrics evidence
+            ;;
+        evidence-json)
+            # v1.87: Kernel evidence snapshot (canonical JSON)
+            "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core" metrics evidence-json
+            ;;
         enable)
             nftban_metrics_enable "$@"
             ;;
@@ -387,9 +395,11 @@ nftban_cmd_metrics() {
             nftban_print_pipeline_report $json_flag
             ;;
         help|--help|-h)
-            echo "Usage: nftban metrics {enable|disable|status|pipeline} [options]"
+            echo "Usage: nftban metrics {evidence|evidence-json|enable|disable|status|pipeline} [options]"
             echo ""
             echo "Commands:"
+            echo "  evidence        Show kernel evidence snapshot (operator-first)"
+            echo "  evidence-json   Show kernel evidence snapshot (canonical JSON)"
             echo "  enable          Enable Prometheus metrics collection"
             echo "  disable         Disable metrics collection"
             echo "  status          Show metrics services status"

--- a/cmd/nftban-core/cmd_metrics.go
+++ b/cmd/nftban-core/cmd_metrics.go
@@ -22,6 +22,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -29,10 +30,17 @@ import (
 	"github.com/itcmsgr/nftban/internal/nftbanconf"
 )
 
-// cmdMetrics handles the metrics export command
+// cmdMetrics handles the metrics command family
 func cmdMetrics(action string, cfg *nftbanconf.Config) error {
-	if action != "export" {
-		return fmt.Errorf("unknown metrics action: %s (use 'export')", action)
+	switch action {
+	case "evidence", "snapshot":
+		return cmdMetricsEvidence()
+	case "evidence-json", "snapshot-json":
+		return cmdMetricsEvidenceJSON()
+	case "export":
+		// existing Prometheus textfile export — falls through below
+	default:
+		return fmt.Errorf("unknown metrics action: %s (use 'export', 'evidence', or 'evidence-json')", action)
 	}
 
 	// Get output file from environment or use default
@@ -77,5 +85,30 @@ func cmdMetrics(action string, cfg *nftbanconf.Config) error {
 	}
 
 	fmt.Printf("Metrics exported successfully to %s\n", outputFile)
+	return nil
+}
+
+// v1.87 M87-9: Evidence snapshot commands
+func cmdMetricsEvidence() error {
+	ctx := context.Background()
+	snap, err := metrics.CollectEvidenceSnapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to collect evidence: %w", err)
+	}
+	metrics.RenderHuman(snap, os.Stdout)
+	return nil
+}
+
+func cmdMetricsEvidenceJSON() error {
+	ctx := context.Background()
+	snap, err := metrics.CollectEvidenceSnapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to collect evidence: %w", err)
+	}
+	data, err := metrics.RenderJSON(snap)
+	if err != nil {
+		return fmt.Errorf("failed to render JSON: %w", err)
+	}
+	fmt.Println(string(data))
 	return nil
 }

--- a/internal/metrics/evidence_chains.go
+++ b/internal/metrics/evidence_chains.go
@@ -1,0 +1,104 @@
+// =============================================================================
+// NFTBan v1.87 - Chain Presence Evidence Collector (M87-4)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_chains"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Collects chain presence for Phase 1 evidence"
+// meta:inventory.files="internal/metrics/evidence_chains.go"
+// meta:inventory.binaries="nft"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+//
+// Collects chain presence per family. Returns ChainInfo (exists bool).
+// =============================================================================
+package metrics
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ChainInfo holds presence information for a kernel chain.
+// Three states:
+//   Exists=true, Unknown=false → confirmed present
+//   Exists=false, Unknown=false → confirmed absent
+//   Unknown=true → collection failure; absence not known
+type ChainInfo struct {
+	Exists  bool `json:"exists"`
+	Unknown bool `json:"unknown,omitempty"`
+}
+
+// Phase1Chains defines the chains checked in Phase 1.
+var Phase1Chains = []string{
+	"input", "forward", "output",
+	"ddos_sanity", "ddos_penalty", "ddos_prefix", "ddos_protection",
+	"portscan_detection", "http_bot_guard",
+}
+
+// CollectChainPresence checks which chains exist per family.
+// Keys use stable format: "<family>:<chain_name>".
+// If collection fails for a family, all chains in that family are marked Unknown.
+func CollectChainPresence(ctx context.Context) map[string]ChainInfo {
+	chains := make(map[string]ChainInfo)
+
+	for _, family := range []string{"ip", "ip6"} {
+		existing, failed := listChains(ctx, family)
+		for _, chain := range Phase1Chains {
+			key := family + ":" + chain
+			if failed {
+				// Collection failed → unknown, not absent
+				chains[key] = ChainInfo{Exists: false, Unknown: true}
+			} else {
+				_, exists := existing[chain]
+				chains[key] = ChainInfo{Exists: exists}
+			}
+		}
+	}
+
+	return chains
+}
+
+// listChains returns a set of chain names present in a given family.
+// Returns (chains, failed): failed=true means command error, not empty result.
+func listChains(ctx context.Context, family string) (map[string]bool, bool) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	output, err := nftListChains(ctx, family)
+	if err != nil {
+		return nil, true // collection failed
+	}
+
+	result := make(map[string]bool)
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "chain ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				result[parts[1]] = true
+			}
+		}
+	}
+	return result, false
+}
+
+// nftListChains runs nft list chains for a specific family.
+func nftListChains(ctx context.Context, family string) ([]byte, error) {
+	switch family {
+	case "ip":
+		return exec.CommandContext(ctx, "nft", "list", "chains", "ip", "nftban").Output() // #nosec G204
+	case "ip6":
+		return exec.CommandContext(ctx, "nft", "list", "chains", "ip6", "nftban").Output() // #nosec G204
+	default:
+		return nil, nil
+	}
+}

--- a/internal/metrics/evidence_chains_test.go
+++ b/internal/metrics/evidence_chains_test.go
@@ -1,0 +1,154 @@
+// =============================================================================
+// NFTBan v1.87 - Chain Presence Evidence Tests (M87-4)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_chains_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Tests for chain presence evidence collection"
+// meta:inventory.files="internal/metrics/evidence_chains_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// parseChainList exercises the same parsing logic as listChains
+// but from a string fixture instead of exec.
+func parseChainList(output string) map[string]bool {
+	result := make(map[string]bool)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "chain ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				result[parts[1]] = true
+			}
+		}
+	}
+	return result
+}
+
+func TestParseChains_FullOutput(t *testing.T) {
+	fixture := `table ip nftban {
+	chain input {
+	}
+	chain forward {
+	}
+	chain output {
+	}
+	chain ddos_sanity {
+	}
+	chain ddos_penalty {
+	}
+	chain ddos_prefix {
+	}
+	chain ddos_protection {
+	}
+	chain portscan_detection {
+	}
+	chain http_bot_guard {
+	}
+}`
+
+	chains := parseChainList(fixture)
+	for _, name := range Phase1Chains {
+		if !chains[name] {
+			t.Errorf("expected chain %q to be present", name)
+		}
+	}
+}
+
+func TestParseChains_PartialOutput(t *testing.T) {
+	fixture := `table ip nftban {
+	chain input {
+	}
+	chain forward {
+	}
+	chain output {
+	}
+}`
+
+	chains := parseChainList(fixture)
+	if !chains["input"] || !chains["forward"] || !chains["output"] {
+		t.Error("base chains should be present")
+	}
+	if chains["ddos_protection"] {
+		t.Error("ddos_protection should not be present in partial output")
+	}
+}
+
+func TestParseChains_EmptyOutput(t *testing.T) {
+	chains := parseChainList("")
+	if len(chains) != 0 {
+		t.Errorf("empty output should produce 0 chains, got %d", len(chains))
+	}
+}
+
+func TestChainInfo_Present(t *testing.T) {
+	ci := ChainInfo{Exists: true, Unknown: false}
+	if ci.Unknown {
+		t.Error("present chain should not be unknown")
+	}
+}
+
+func TestChainInfo_ConfirmedAbsent(t *testing.T) {
+	ci := ChainInfo{Exists: false, Unknown: false}
+	if ci.Unknown || ci.Exists {
+		t.Error("confirmed absent: Exists=false, Unknown=false")
+	}
+}
+
+func TestChainInfo_CollectionFailed(t *testing.T) {
+	ci := ChainInfo{Exists: false, Unknown: true}
+	if !ci.Unknown {
+		t.Error("collection failure should be Unknown=true")
+	}
+}
+
+func TestChainInfo_JSONRoundTrip(t *testing.T) {
+	original := ChainInfo{Exists: true}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded ChainInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded != original {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestChainInfo_UnknownOmittedWhenFalse(t *testing.T) {
+	ci := ChainInfo{Exists: true}
+	data, _ := json.Marshal(ci)
+	if strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=false should be omitted, got: %s", data)
+	}
+}
+
+func TestChainInfo_UnknownPresentWhenTrue(t *testing.T) {
+	ci := ChainInfo{Exists: false, Unknown: true}
+	data, _ := json.Marshal(ci)
+	if !strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=true should be present, got: %s", data)
+	}
+}
+
+func TestPhase1Chains_Coverage(t *testing.T) {
+	if len(Phase1Chains) != 9 {
+		t.Errorf("expected 9 Phase 1 chains, got %d", len(Phase1Chains))
+	}
+}

--- a/internal/metrics/evidence_correlate.go
+++ b/internal/metrics/evidence_correlate.go
@@ -1,0 +1,200 @@
+// =============================================================================
+// NFTBan v1.87 - Correlation Engine (M87-6)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_correlate"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Evidence correlation engine for metrics Phase 1"
+// meta:inventory.files="internal/metrics/evidence_correlate.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Pure function. No exec calls. No side effects. No health derivation.
+//
+// Correlation is DIAGNOSTIC only:
+// - Cannot map to PROTECTED/DEGRADED/DOWN
+// - Cannot influence exit codes
+// - Cannot produce aggregate system state
+// - Cannot be summarized as "healthy/unhealthy"
+//
+// It answers: "does kernel evidence agree with validator interpretation?"
+// =============================================================================
+package metrics
+
+// Correlation result values.
+const (
+	CorrelationMatch              = "match"
+	CorrelationExpectedLimitation = "expected_limitation"
+	CorrelationWarning            = "warning"
+	CorrelationMismatch           = "mismatch"
+	CorrelationUnknown            = "unknown"
+)
+
+// CorrelateEvidence compares kernel evidence against validator interpretation.
+// Pure function — no exec, no side effects, no state mutation.
+//
+// Inputs:
+//   counters: from CollectNamedCounters() — may be nil
+//   sets: from CollectSetElements() — may be nil
+//   validator: from CollectValidatorSnapshot() — may be nil
+//
+// Returns: module → correlation result
+func CorrelateEvidence(
+	counters map[string]CounterValue,
+	sets map[string]SetInfo,
+	validator *ValidatorSnapshot,
+) map[string]string {
+	results := make(map[string]string)
+
+	// If validator is unavailable, all correlations are unknown
+	if validator == nil || validator.Unknown {
+		results["ddos"] = CorrelationUnknown
+		results["botguard"] = CorrelationUnknown
+		results["portscan"] = CorrelationUnknown
+		results["loginmon"] = CorrelationUnknown
+		results["blacklist_manual"] = CorrelationUnknown
+		return results
+	}
+
+	results["ddos"] = correlateDDoS(counters, validator)
+	results["botguard"] = correlateBotGuard(sets, validator)
+	results["portscan"] = correlatePortscan(validator)
+	results["loginmon"] = correlateLoginMon()
+	results["blacklist_manual"] = correlateBlacklistManual(counters, sets, validator)
+
+	return results
+}
+
+// correlateDDoS: dedicated counters vs validator effective state.
+func correlateDDoS(counters map[string]CounterValue, val *ValidatorSnapshot) string {
+	if counters == nil {
+		return CorrelationUnknown
+	}
+
+	ddosCounterKeys := []string{
+		"ip:input_ct_ssh_drop", "ip:input_ct_http_drop", "ip:input_ct_mail_drop",
+		"ip:input_syn_rate_exceeded", "ip6:input_syn_prefix_drop",
+	}
+
+	hasEvidence := false
+	for _, key := range ddosCounterKeys {
+		if cv, ok := counters[key]; ok && cv.Packets > 0 {
+			hasEvidence = true
+			break
+		}
+	}
+
+	valState := val.Modules["ddos"]
+
+	switch {
+	case hasEvidence && valState == "enforcing":
+		return CorrelationMatch
+	case !hasEvidence && (valState == "idle" || valState == ""):
+		return CorrelationMatch
+	case hasEvidence && (valState == "idle" || valState == ""):
+		return CorrelationMismatch
+	case !hasEvidence && valState == "enforcing":
+		// Validator says enforcing but counters are zero — possible counter reset
+		return CorrelationWarning
+	default:
+		return CorrelationUnknown
+	}
+}
+
+// correlateBotGuard: enforcement set population vs validator state.
+func correlateBotGuard(sets map[string]SetInfo, val *ValidatorSnapshot) string {
+	if sets == nil {
+		return CorrelationUnknown
+	}
+
+	// If any relevant enforcement set is Unknown, correlation is unknown
+	enforcementSets := []string{"ip:http_bot_ban", "ip:http_bot_grey", "ip:http_bot_emergency"}
+	for _, key := range enforcementSets {
+		if si, ok := sets[key]; ok && si.Unknown {
+			return CorrelationUnknown
+		}
+	}
+
+	hasEvidence := false
+	for _, key := range enforcementSets {
+		if si, ok := sets[key]; ok && si.Exists && si.Count > 0 {
+			hasEvidence = true
+			break
+		}
+	}
+
+	valState := val.Modules["botguard"]
+
+	switch {
+	case hasEvidence && (valState == "enforcing" || valState == "observing"):
+		return CorrelationMatch
+	case !hasEvidence && (valState == "idle" || valState == ""):
+		return CorrelationMatch
+	case hasEvidence && (valState == "idle" || valState == ""):
+		return CorrelationMismatch
+	default:
+		return CorrelationUnknown
+	}
+}
+
+// correlatePortscan: structural only, no enforcement counter.
+func correlatePortscan(_ *ValidatorSnapshot) string {
+	// Portscan has no dedicated enforcement counter.
+	// Cannot prove enforcement from kernel metrics.
+	return CorrelationExpectedLimitation
+}
+
+// correlateLoginMon: no Phase 1 journal evidence collection.
+func correlateLoginMon() string {
+	// LoginMon enforcement is through shared blacklist sets.
+	// Journal evidence not collected in Phase 1.
+	return CorrelationExpectedLimitation
+}
+
+// correlateBlacklistManual: elements + drops vs validator state.
+func correlateBlacklistManual(
+	counters map[string]CounterValue,
+	sets map[string]SetInfo,
+	val *ValidatorSnapshot,
+) string {
+	if counters == nil || sets == nil {
+		return CorrelationUnknown
+	}
+
+	// If the relevant set is Unknown, correlation is unknown
+	if si, ok := sets["ip:blacklist_manual_ipv4"]; ok && si.Unknown {
+		return CorrelationUnknown
+	}
+
+	hasElements := false
+	if si, ok := sets["ip:blacklist_manual_ipv4"]; ok && si.Exists && si.Count > 0 {
+		hasElements = true
+	}
+
+	hasDrops := false
+	if cv, ok := counters["ip:input_blacklist_manual_drop"]; ok && cv.Packets > 0 {
+		hasDrops = true
+	}
+
+	valState := val.Modules["blacklist_manual"]
+
+	switch {
+	case hasElements && hasDrops && valState == "enforcing":
+		return CorrelationMatch
+	case hasElements && !hasDrops && valState == "primed":
+		return CorrelationMatch
+	case !hasElements && valState == "idle":
+		return CorrelationMatch
+	case hasElements && hasDrops && valState == "primed":
+		return CorrelationWarning
+	default:
+		return CorrelationUnknown
+	}
+}

--- a/internal/metrics/evidence_correlate_test.go
+++ b/internal/metrics/evidence_correlate_test.go
@@ -1,0 +1,235 @@
+// =============================================================================
+// NFTBan v1.87 - Correlation Engine Tests (M87-6)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_correlate_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Tests for evidence correlation engine"
+// meta:inventory.files="internal/metrics/evidence_correlate_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import "testing"
+
+func TestCorrelate_ValidatorUnavailable(t *testing.T) {
+	results := CorrelateEvidence(nil, nil, nil)
+	for mod, result := range results {
+		if result != CorrelationUnknown {
+			t.Errorf("module %s: expected unknown when validator nil, got %s", mod, result)
+		}
+	}
+}
+
+func TestCorrelate_ValidatorUnknown(t *testing.T) {
+	val := &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	results := CorrelateEvidence(nil, nil, val)
+	for mod, result := range results {
+		if result != CorrelationUnknown {
+			t.Errorf("module %s: expected unknown when validator Unknown=true, got %s", mod, result)
+		}
+	}
+}
+
+// DDoS correlation tests
+func TestCorrelate_DDoS_CounterPositive_Enforcing(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_ct_ssh_drop": {Packets: 42, Bytes: 1234},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"ddos": "enforcing"},
+	}
+	results := CorrelateEvidence(counters, nil, val)
+	if results["ddos"] != CorrelationMatch {
+		t.Errorf("ddos: counter>0 + enforcing should be match, got %s", results["ddos"])
+	}
+}
+
+func TestCorrelate_DDoS_CounterPositive_Idle(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_syn_rate_exceeded": {Packets: 100, Bytes: 5000},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"ddos": "idle"},
+	}
+	results := CorrelateEvidence(counters, nil, val)
+	if results["ddos"] != CorrelationMismatch {
+		t.Errorf("ddos: counter>0 + idle should be mismatch, got %s", results["ddos"])
+	}
+}
+
+func TestCorrelate_DDoS_ZeroCounters_Idle(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_ct_ssh_drop": {Packets: 0, Bytes: 0},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"ddos": "idle"},
+	}
+	results := CorrelateEvidence(counters, nil, val)
+	if results["ddos"] != CorrelationMatch {
+		t.Errorf("ddos: zero counters + idle should be match, got %s", results["ddos"])
+	}
+}
+
+func TestCorrelate_DDoS_NilCounters(t *testing.T) {
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"ddos": "enforcing"},
+	}
+	results := CorrelateEvidence(nil, nil, val)
+	if results["ddos"] != CorrelationUnknown {
+		t.Errorf("ddos: nil counters should be unknown, got %s", results["ddos"])
+	}
+}
+
+// BotGuard correlation tests
+func TestCorrelate_BotGuard_SetsPopulated_Enforcing(t *testing.T) {
+	sets := map[string]SetInfo{
+		"ip:http_bot_ban": {Exists: true, Count: 5},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"botguard": "enforcing"},
+	}
+	results := CorrelateEvidence(nil, sets, val)
+	if results["botguard"] != CorrelationMatch {
+		t.Errorf("botguard: populated + enforcing should be match, got %s", results["botguard"])
+	}
+}
+
+func TestCorrelate_BotGuard_SetsPopulated_Idle(t *testing.T) {
+	sets := map[string]SetInfo{
+		"ip:http_bot_ban": {Exists: true, Count: 3},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"botguard": "idle"},
+	}
+	results := CorrelateEvidence(nil, sets, val)
+	if results["botguard"] != CorrelationMismatch {
+		t.Errorf("botguard: populated + idle should be mismatch, got %s", results["botguard"])
+	}
+}
+
+func TestCorrelate_BotGuard_UnknownSets(t *testing.T) {
+	sets := map[string]SetInfo{
+		"ip:http_bot_ban": {Exists: false, Unknown: true},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"botguard": "enforcing"},
+	}
+	results := CorrelateEvidence(nil, sets, val)
+	// Unknown sets → correlation is unknown (not match, not mismatch)
+	if results["botguard"] != CorrelationUnknown {
+		t.Errorf("botguard: unknown sets should be unknown, got %s", results["botguard"])
+	}
+}
+
+func TestCorrelate_BlacklistManual_UnknownSets(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_blacklist_manual_drop": {Packets: 10, Bytes: 500},
+	}
+	sets := map[string]SetInfo{
+		"ip:blacklist_manual_ipv4": {Exists: false, Unknown: true},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"blacklist_manual": "enforcing"},
+	}
+	results := CorrelateEvidence(counters, sets, val)
+	if results["blacklist_manual"] != CorrelationUnknown {
+		t.Errorf("blacklist_manual: unknown sets should be unknown, got %s", results["blacklist_manual"])
+	}
+}
+
+// Portscan — always expected_limitation
+func TestCorrelate_Portscan(t *testing.T) {
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"portscan": "idle"},
+	}
+	results := CorrelateEvidence(nil, nil, val)
+	if results["portscan"] != CorrelationExpectedLimitation {
+		t.Errorf("portscan should always be expected_limitation, got %s", results["portscan"])
+	}
+}
+
+// LoginMon — always expected_limitation in Phase 1
+func TestCorrelate_LoginMon(t *testing.T) {
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"loginmon": "idle"},
+	}
+	results := CorrelateEvidence(nil, nil, val)
+	if results["loginmon"] != CorrelationExpectedLimitation {
+		t.Errorf("loginmon should always be expected_limitation in Phase 1, got %s", results["loginmon"])
+	}
+}
+
+// Blacklist manual correlation tests
+func TestCorrelate_BlacklistManual_Enforcing(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_blacklist_manual_drop": {Packets: 42, Bytes: 1234},
+	}
+	sets := map[string]SetInfo{
+		"ip:blacklist_manual_ipv4": {Exists: true, Count: 3},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"blacklist_manual": "enforcing"},
+	}
+	results := CorrelateEvidence(counters, sets, val)
+	if results["blacklist_manual"] != CorrelationMatch {
+		t.Errorf("blacklist_manual: elements+drops+enforcing should be match, got %s", results["blacklist_manual"])
+	}
+}
+
+func TestCorrelate_BlacklistManual_DropsButPrimed(t *testing.T) {
+	counters := map[string]CounterValue{
+		"ip:input_blacklist_manual_drop": {Packets: 10, Bytes: 500},
+	}
+	sets := map[string]SetInfo{
+		"ip:blacklist_manual_ipv4": {Exists: true, Count: 2},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"blacklist_manual": "primed"},
+	}
+	results := CorrelateEvidence(counters, sets, val)
+	if results["blacklist_manual"] != CorrelationWarning {
+		t.Errorf("blacklist_manual: drops+primed should be warning, got %s", results["blacklist_manual"])
+	}
+}
+
+func TestCorrelate_BlacklistManual_Idle(t *testing.T) {
+	counters := map[string]CounterValue{}
+	sets := map[string]SetInfo{
+		"ip:blacklist_manual_ipv4": {Exists: true, Count: 0},
+	}
+	val := &ValidatorSnapshot{
+		Modules: map[string]string{"blacklist_manual": "idle"},
+	}
+	results := CorrelateEvidence(counters, sets, val)
+	if results["blacklist_manual"] != CorrelationMatch {
+		t.Errorf("blacklist_manual: empty+idle should be match, got %s", results["blacklist_manual"])
+	}
+}
+
+// Completeness check
+func TestCorrelate_AllModulesPresent(t *testing.T) {
+	val := &ValidatorSnapshot{
+		Status:  "protected",
+		Modules: map[string]string{},
+	}
+	results := CorrelateEvidence(
+		map[string]CounterValue{},
+		map[string]SetInfo{},
+		val,
+	)
+
+	required := []string{"ddos", "botguard", "portscan", "loginmon", "blacklist_manual"}
+	for _, mod := range required {
+		if _, ok := results[mod]; !ok {
+			t.Errorf("missing correlation result for module %s", mod)
+		}
+	}
+}

--- a/internal/metrics/evidence_counters_test.go
+++ b/internal/metrics/evidence_counters_test.go
@@ -1,0 +1,188 @@
+// =============================================================================
+// NFTBan v1.87 - Named Counter Evidence Tests (M87-2)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_counters_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Tests for named counter evidence collection"
+// meta:inventory.files="internal/metrics/evidence_counters_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// =============================================================================
+// A. Parsing tests — exercise parseNamedCountersJSON directly
+// =============================================================================
+
+func TestParse_ValidJSON_MultipleCounters(t *testing.T) {
+	fixture := `{"nftables": [
+		{"metainfo": {"version": "1.0.9"}},
+		{"counter": {"family": "ip", "table": "nftban", "name": "input_ct_ssh_drop", "packets": 42, "bytes": 1234}},
+		{"counter": {"family": "ip", "table": "nftban", "name": "input_ct_http_drop", "packets": 0, "bytes": 0}},
+		{"counter": {"family": "ip", "table": "nftban", "name": "input_syn_rate_exceeded", "packets": 2166, "bytes": 105678}}
+	]}`
+
+	counters, err := parseNamedCountersJSON([]byte(fixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(counters) != 3 {
+		t.Errorf("expected 3 counters, got %d", len(counters))
+	}
+	if counters["input_ct_ssh_drop"].Packets != 42 {
+		t.Errorf("input_ct_ssh_drop packets = %d, want 42", counters["input_ct_ssh_drop"].Packets)
+	}
+	if counters["input_syn_rate_exceeded"].Bytes != 105678 {
+		t.Errorf("input_syn_rate_exceeded bytes = %d, want 105678", counters["input_syn_rate_exceeded"].Bytes)
+	}
+}
+
+func TestParse_ZeroValuesPreserved(t *testing.T) {
+	fixture := `{"nftables": [
+		{"counter": {"family": "ip", "table": "nftban", "name": "input_whitelist_accept", "packets": 0, "bytes": 0}}
+	]}`
+
+	counters, err := parseNamedCountersJSON([]byte(fixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v, ok := counters["input_whitelist_accept"]
+	if !ok {
+		t.Fatal("zero-valued counter must be present in result")
+	}
+	if v.Packets != 0 || v.Bytes != 0 {
+		t.Errorf("zero values must be preserved, got packets=%d bytes=%d", v.Packets, v.Bytes)
+	}
+}
+
+func TestParse_ForeignTableIgnored(t *testing.T) {
+	fixture := `{"nftables": [
+		{"counter": {"family": "ip", "table": "nftban", "name": "input_drop", "packets": 10, "bytes": 100}},
+		{"counter": {"family": "ip", "table": "filter", "name": "foreign_counter", "packets": 999, "bytes": 9999}}
+	]}`
+
+	counters, err := parseNamedCountersJSON([]byte(fixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(counters) != 1 {
+		t.Errorf("expected 1 counter (filter table excluded), got %d", len(counters))
+	}
+	if _, exists := counters["foreign_counter"]; exists {
+		t.Error("foreign table counter must be excluded")
+	}
+}
+
+func TestParse_MalformedJSON(t *testing.T) {
+	_, err := parseNamedCountersJSON([]byte(`{"nftables": [INVALID`))
+	if err == nil {
+		t.Error("malformed JSON should return error")
+	}
+}
+
+func TestParse_EmptyValidResult(t *testing.T) {
+	fixture := `{"nftables": [{"metainfo": {"version": "1.0.9"}}]}`
+	counters, err := parseNamedCountersJSON([]byte(fixture))
+	if err != nil {
+		t.Fatalf("empty valid result should not error: %v", err)
+	}
+	if len(counters) != 0 {
+		t.Errorf("expected 0 counters, got %d", len(counters))
+	}
+}
+
+func TestParse_EmptyNameExcluded(t *testing.T) {
+	fixture := `{"nftables": [
+		{"counter": {"family": "ip", "table": "nftban", "name": "", "packets": 5, "bytes": 50}}
+	]}`
+	counters, err := parseNamedCountersJSON([]byte(fixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(counters) != 0 {
+		t.Errorf("empty-name counter should be excluded, got %d", len(counters))
+	}
+}
+
+// =============================================================================
+// B. Public key contract tests — verify family-prefixed stable keys
+// =============================================================================
+
+func TestKeyContract_FamilyPrefix(t *testing.T) {
+	// Simulate what CollectNamedCounters does: add family prefix to parsed names
+	parsed := map[string]CounterValue{
+		"input_ct_ssh_drop":       {Packets: 42, Bytes: 1234},
+		"input_syn_rate_exceeded": {Packets: 0, Bytes: 0},
+	}
+
+	result := &NamedCountersResult{
+		Counters: make(map[string]CounterValue),
+	}
+	for name, val := range parsed {
+		result.Counters["ip:"+name] = val
+	}
+	for name, val := range parsed {
+		result.Counters["ip6:"+name] = val
+	}
+
+	// Verify all keys have family prefix
+	for key := range result.Counters {
+		if key[:3] != "ip:" && key[:4] != "ip6:" {
+			t.Errorf("key %q missing family prefix", key)
+		}
+	}
+	if len(result.Counters) != 4 {
+		t.Errorf("expected 4 keys (2 families × 2 counters), got %d", len(result.Counters))
+	}
+}
+
+// =============================================================================
+// C. JSON round-trip tests
+// =============================================================================
+
+func TestCounterValue_JSONRoundTrip(t *testing.T) {
+	original := CounterValue{Packets: 12345, Bytes: 678901}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded CounterValue
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded != original {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestNamedCountersResult_JSONRoundTrip(t *testing.T) {
+	result := &NamedCountersResult{
+		Counters: map[string]CounterValue{
+			"ip:input_ct_ssh_drop":  {Packets: 42, Bytes: 1234},
+			"ip6:input_ct_ssh_drop": {Packets: 0, Bytes: 0},
+		},
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded NamedCountersResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(decoded.Counters) != 2 {
+		t.Errorf("expected 2 counters after round-trip, got %d", len(decoded.Counters))
+	}
+}

--- a/internal/metrics/evidence_sets.go
+++ b/internal/metrics/evidence_sets.go
@@ -1,0 +1,141 @@
+// =============================================================================
+// NFTBan v1.87 - Set Element Evidence Collector (M87-3)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_sets"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Collects set element counts for Phase 1 evidence"
+// meta:inventory.files="internal/metrics/evidence_sets.go"
+// meta:inventory.binaries="nft"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+//
+// Collects per-set element counts using nft JSON output.
+// Returns structured SetInfo (exists + count) per set.
+// =============================================================================
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+)
+
+// SetInfo holds element count for a kernel set.
+// Three states:
+//   Exists=true, Count>=0, Unknown=false → collected successfully
+//   Exists=false, Count=0, Unknown=false → confirmed absent
+//   Unknown=true → collection failure/timeout/parse error; absence not known
+type SetInfo struct {
+	Exists  bool `json:"exists"`
+	Count   int  `json:"count"`
+	Unknown bool `json:"unknown,omitempty"`
+}
+
+// Phase1Sets defines the sets collected in Phase 1.
+var Phase1Sets = map[string][]string{
+	"ip": {
+		"blacklist_manual_ipv4", "blacklist_ipv4",
+		"http_bot_suspect", "http_bot_pending", "http_bot_allow",
+		"http_bot_grey", "http_bot_ban", "http_bot_emergency",
+	},
+	"ip6": {
+		"blacklist_manual_ipv6", "blacklist_ipv6",
+		"http_bot_suspect6", "http_bot_pending6", "http_bot_allow6",
+		"http_bot_grey6", "http_bot_ban6", "http_bot_emergency6",
+	},
+}
+
+// CollectSetElements returns element counts for Phase 1 sets.
+// Keys use stable format: "<family>:<set_name>".
+func CollectSetElements(ctx context.Context) map[string]SetInfo {
+	sets := make(map[string]SetInfo)
+
+	for family, setNames := range Phase1Sets {
+		for _, name := range setNames {
+			key := family + ":" + name
+			count, exists, unknown := countSetElementsJSON(ctx, family, name)
+			sets[key] = SetInfo{Exists: exists, Count: count, Unknown: unknown}
+		}
+	}
+
+	return sets
+}
+
+// countSetElementsJSON counts elements in a set using nft JSON output.
+// Returns (count, exists, unknown):
+//   count>0, exists=true, unknown=false → set present with elements
+//   count=0, exists=true, unknown=false → set present, empty
+//   count=0, exists=false, unknown=false → set confirmed absent
+//   count=0, exists=false, unknown=true → collection failed
+func countSetElementsJSON(ctx context.Context, family, name string) (count int, exists bool, unknown bool) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	output, err := nftListSet(ctx, family, name)
+	if err != nil {
+		// Command failure: could be absent OR could be timeout/permission.
+		// nft exits non-zero for missing sets — but also for other errors.
+		// Mark as unknown so callers don't treat failure as confirmed absence.
+		return 0, false, true
+	}
+
+	c, found := parseSetElementCount(output)
+	if !found {
+		// Valid JSON but no set object for this name → confirmed absent
+		return 0, false, false
+	}
+	return c, true, false
+}
+
+// nftListSet runs nft -j list set for a specific family and set name.
+func nftListSet(ctx context.Context, family, name string) ([]byte, error) {
+	// Use string literals for family to satisfy gosec G204.
+	// Set name is from our own Phase1Sets constant, not user input.
+	var cmd *exec.Cmd
+	switch family {
+	case "ip":
+		cmd = exec.CommandContext(ctx, "nft", "-j", "list", "set", "ip", "nftban", name) // #nosec G204
+	case "ip6":
+		cmd = exec.CommandContext(ctx, "nft", "-j", "list", "set", "ip6", "nftban", name) // #nosec G204
+	default:
+		return nil, nil
+	}
+	return cmd.Output()
+}
+
+// parseSetElementCount extracts element count from nft JSON set output.
+// Returns (count, found):
+//   found=true → a set object was present in the JSON
+//   found=false → no set object found (set absent or parse mismatch)
+func parseSetElementCount(data []byte) (int, bool) {
+	var result struct {
+		NFTables []json.RawMessage `json:"nftables"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return 0, false
+	}
+
+	for _, raw := range result.NFTables {
+		var setWrapper struct {
+			Set *struct {
+				Elem []json.RawMessage `json:"elem"`
+			} `json:"set,omitempty"`
+		}
+		if err := json.Unmarshal(raw, &setWrapper); err != nil || setWrapper.Set == nil {
+			continue
+		}
+		// Set object found — count elements (may be 0)
+		return len(setWrapper.Set.Elem), true
+	}
+
+	// No set object found in valid JSON → absent
+	return 0, false
+}

--- a/internal/metrics/evidence_sets_test.go
+++ b/internal/metrics/evidence_sets_test.go
@@ -1,0 +1,158 @@
+// =============================================================================
+// NFTBan v1.87 - Set Element Evidence Tests (M87-3)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_sets_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Tests for set element evidence collection"
+// meta:inventory.files="internal/metrics/evidence_sets_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseSet_WithElements(t *testing.T) {
+	fixture := `{"nftables": [
+		{"metainfo": {"version": "1.0.9"}},
+		{"set": {"family": "ip", "table": "nftban", "name": "blacklist_manual_ipv4",
+			"elem": ["1.2.3.4", "5.6.7.8", "10.0.0.1"]}}
+	]}`
+
+	count, found := parseSetElementCount([]byte(fixture))
+	if !found {
+		t.Fatal("set should be found")
+	}
+	if count != 3 {
+		t.Errorf("expected 3 elements, got %d", count)
+	}
+}
+
+func TestParseSet_EmptySet(t *testing.T) {
+	// Set object exists but no elem field → found=true, count=0
+	fixture := `{"nftables": [
+		{"metainfo": {"version": "1.0.9"}},
+		{"set": {"family": "ip", "table": "nftban", "name": "blacklist_manual_ipv4"}}
+	]}`
+
+	count, found := parseSetElementCount([]byte(fixture))
+	if !found {
+		t.Fatal("set object exists → found should be true")
+	}
+	if count != 0 {
+		t.Errorf("expected 0 elements, got %d", count)
+	}
+}
+
+func TestParseSet_NoSetWrapper(t *testing.T) {
+	// Valid JSON but no set object → found=false (absent, not empty-present)
+	fixture := `{"nftables": [{"metainfo": {"version": "1.0.9"}}]}`
+
+	_, found := parseSetElementCount([]byte(fixture))
+	if found {
+		t.Error("no set wrapper → found should be false (absent)")
+	}
+}
+
+func TestParseSet_MalformedJSON(t *testing.T) {
+	_, found := parseSetElementCount([]byte(`INVALID`))
+	if found {
+		t.Error("malformed JSON should return found=false")
+	}
+}
+
+func TestSetInfo_PresentWithElements(t *testing.T) {
+	si := SetInfo{Exists: true, Count: 42, Unknown: false}
+	if si.Unknown {
+		t.Error("present set should not be unknown")
+	}
+}
+
+func TestSetInfo_ConfirmedAbsent(t *testing.T) {
+	si := SetInfo{Exists: false, Count: 0, Unknown: false}
+	if si.Unknown {
+		t.Error("confirmed absent should not be unknown")
+	}
+	if si.Exists {
+		t.Error("absent set should have Exists=false")
+	}
+}
+
+func TestSetInfo_CollectionFailed(t *testing.T) {
+	si := SetInfo{Exists: false, Count: 0, Unknown: true}
+	if !si.Unknown {
+		t.Error("collection failure should be Unknown=true")
+	}
+}
+
+func TestSetInfo_JSONRoundTrip(t *testing.T) {
+	original := SetInfo{Exists: true, Count: 42}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded SetInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Exists != original.Exists || decoded.Count != original.Count {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestSetInfo_UnknownOmittedWhenFalse(t *testing.T) {
+	si := SetInfo{Exists: true, Count: 5}
+	data, err := json.Marshal(si)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	// Unknown=false should be omitted from JSON (omitempty)
+	str := string(data)
+	if contains(str, "unknown") {
+		t.Errorf("Unknown=false should be omitted from JSON, got: %s", str)
+	}
+}
+
+func TestSetInfo_UnknownPresentWhenTrue(t *testing.T) {
+	si := SetInfo{Exists: false, Unknown: true}
+	data, err := json.Marshal(si)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	str := string(data)
+	if !contains(str, "unknown") {
+		t.Errorf("Unknown=true should be present in JSON, got: %s", str)
+	}
+}
+
+func TestPhase1Sets_Coverage(t *testing.T) {
+	if len(Phase1Sets["ip"]) != 8 {
+		t.Errorf("expected 8 IPv4 Phase 1 sets, got %d", len(Phase1Sets["ip"]))
+	}
+	if len(Phase1Sets["ip6"]) != 8 {
+		t.Errorf("expected 8 IPv6 Phase 1 sets, got %d", len(Phase1Sets["ip6"]))
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && json.Valid([]byte(s)) && indexOf187(s, substr) >= 0
+}
+
+func indexOf187(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/metrics/evidence_snapshot.go
+++ b/internal/metrics/evidence_snapshot.go
@@ -1,0 +1,195 @@
+// =============================================================================
+// NFTBan v1.87 - Evidence Snapshot Builder + Renderers (M87-7/8)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_snapshot"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Builds and renders Phase 1 evidence snapshots"
+// meta:inventory.files="internal/metrics/evidence_snapshot.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+//
+// Collect once → render many.
+// Metrics report evidence; validator reports interpretation.
+// =============================================================================
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+)
+
+// EvidenceSnapshot is the canonical Phase 1 metrics model.
+// Collected once, rendered as JSON or human-readable text.
+//
+// This is NOT a truth object. Validator remains sole authority.
+// Correlation is diagnostic only — cannot affect exit codes.
+type EvidenceSnapshot struct {
+	SchemaVersion  string                  `json:"schema_version"`
+	CollectedAt    time.Time               `json:"collected_at"`
+	TruthAuthority string                  `json:"truth_authority"`
+
+	Kernel struct {
+		Counters map[string]CounterValue `json:"counters"`
+		Sets     map[string]SetInfo      `json:"sets"`
+		Chains   map[string]ChainInfo    `json:"chains"`
+	} `json:"kernel"`
+
+	Validator *ValidatorSnapshot   `json:"validator"`
+	Correlation map[string]string  `json:"correlation"`
+}
+
+const EvidenceSchemaVersion = "1.87.0"
+
+// CollectEvidenceSnapshot gathers all Phase 1 evidence.
+// Single entry point: collect once, render many.
+func CollectEvidenceSnapshot(ctx context.Context) (*EvidenceSnapshot, error) {
+	snap := &EvidenceSnapshot{
+		SchemaVersion:  EvidenceSchemaVersion,
+		CollectedAt:    time.Now(),
+		TruthAuthority: "kernel",
+	}
+
+	// Kernel plane
+	// Counter collection failure → nil (not empty map).
+	// nil signals "unknown/unavailable" to correlation and renderer.
+	// Empty map signals "collected successfully, no active counters."
+	counters, err := CollectNamedCounters(ctx)
+	if err != nil {
+		snap.Kernel.Counters = nil // collection failed — unknown
+	} else {
+		snap.Kernel.Counters = counters.Counters
+	}
+
+	snap.Kernel.Sets = CollectSetElements(ctx)
+	snap.Kernel.Chains = CollectChainPresence(ctx)
+
+	// Validator plane
+	snap.Validator = CollectValidatorSnapshot(ctx)
+
+	// Correlation plane
+	snap.Correlation = CorrelateEvidence(snap.Kernel.Counters, snap.Kernel.Sets, snap.Validator)
+
+	return snap, nil
+}
+
+// =============================================================================
+// M87-7: JSON Renderer
+// =============================================================================
+
+// RenderJSON serializes the snapshot as canonical Phase 1 JSON.
+func RenderJSON(snap *EvidenceSnapshot) ([]byte, error) {
+	return json.MarshalIndent(snap, "", "  ")
+}
+
+// =============================================================================
+// M87-8: Human Renderer
+// =============================================================================
+
+// RenderHuman writes operator-first human-readable output.
+func RenderHuman(snap *EvidenceSnapshot, w io.Writer) {
+	fmt.Fprintf(w, "NFTBan Metrics — Evidence Summary\n")
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Truth authority: %s\n", snap.TruthAuthority)
+	fmt.Fprintf(w, "Collected at:    %s\n", snap.CollectedAt.UTC().Format("2006-01-02T15:04:05Z"))
+
+	// Validator status
+	if snap.Validator != nil && !snap.Validator.Unknown {
+		fmt.Fprintf(w, "Validator:       %s\n", snap.Validator.Status)
+	} else {
+		fmt.Fprintf(w, "Validator:       unavailable\n")
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Enforcement counters
+	fmt.Fprintf(w, "Enforcement Evidence\n")
+	fmt.Fprintf(w, "────────────────────────────────────────\n")
+	if snap.Kernel.Counters == nil {
+		// Collection failed — unknown, not "no evidence"
+		fmt.Fprintf(w, "  (counter evidence unavailable)\n")
+	} else {
+		enforcementKeys := []string{
+			"ip:input_ct_ssh_drop", "ip:input_ct_http_drop", "ip:input_ct_mail_drop",
+			"ip:input_syn_rate_exceeded", "ip6:input_syn_prefix_drop",
+			"ip:input_blacklist_manual_drop", "ip:input_blacklist_drop",
+		}
+		anyEnforcement := false
+		for _, key := range enforcementKeys {
+			if cv, ok := snap.Kernel.Counters[key]; ok && cv.Packets > 0 {
+				fmt.Fprintf(w, "  %-38s %d packets\n", key, cv.Packets)
+				anyEnforcement = true
+			}
+		}
+		if !anyEnforcement {
+			fmt.Fprintf(w, "  (no enforcement counters active)\n")
+		}
+	}
+	fmt.Fprintf(w, "\n")
+
+	// BotGuard sets (non-zero)
+	fmt.Fprintf(w, "BotGuard Sets\n")
+	fmt.Fprintf(w, "────────────────────────────────────────\n")
+	bgKeys := []string{
+		"ip:http_bot_suspect", "ip:http_bot_pending", "ip:http_bot_allow",
+		"ip:http_bot_grey", "ip:http_bot_ban", "ip:http_bot_emergency",
+	}
+	anyBG := false
+	for _, key := range bgKeys {
+		if si, ok := snap.Kernel.Sets[key]; ok {
+			if si.Unknown {
+				fmt.Fprintf(w, "  %-38s unknown\n", key)
+				anyBG = true
+			} else if si.Exists {
+				fmt.Fprintf(w, "  %-38s %d elements\n", key, si.Count)
+				anyBG = true
+			}
+		}
+	}
+	if !anyBG {
+		fmt.Fprintf(w, "  (not present)\n")
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Correlation
+	fmt.Fprintf(w, "Correlation\n")
+	fmt.Fprintf(w, "────────────────────────────────────────\n")
+	modules := make([]string, 0, len(snap.Correlation))
+	for mod := range snap.Correlation {
+		modules = append(modules, mod)
+	}
+	sort.Strings(modules)
+	for _, mod := range modules {
+		result := snap.Correlation[mod]
+		fmt.Fprintf(w, "  %-20s %s\n", mod, result)
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Findings
+	if snap.Validator != nil && len(snap.Validator.Findings) > 0 {
+		fmt.Fprintf(w, "Validator Findings\n")
+		fmt.Fprintf(w, "────────────────────────────────────────\n")
+		for _, code := range snap.Validator.Findings {
+			fmt.Fprintf(w, "  %s\n", code)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Notes
+	fmt.Fprintf(w, "Notes\n")
+	fmt.Fprintf(w, "────────────────────────────────────────\n")
+	fmt.Fprintf(w, "  - Zero counters are neutral, not failure.\n")
+	fmt.Fprintf(w, "  - Shared counters are family-level only; no source attribution.\n")
+	fmt.Fprintf(w, "  - Portscan has no dedicated enforcement counter.\n")
+	fmt.Fprintf(w, "  - Correlation is diagnostic only — does not determine protection state.\n")
+}

--- a/internal/metrics/evidence_snapshot_schema_test.go
+++ b/internal/metrics/evidence_snapshot_schema_test.go
@@ -1,0 +1,307 @@
+// =============================================================================
+// NFTBan v1.87 - Evidence Snapshot Schema Tests (M87-10)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_snapshot_schema_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="CI schema validation for EvidenceSnapshot JSON contract"
+// meta:inventory.files="internal/metrics/evidence_snapshot_schema_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var fixedTime = time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+// =============================================================================
+// Fixture builders
+// =============================================================================
+
+func buildFullSnapshotFixture() *EvidenceSnapshot {
+	snap := &EvidenceSnapshot{
+		SchemaVersion:  EvidenceSchemaVersion,
+		CollectedAt:    fixedTime,
+		TruthAuthority: "kernel",
+	}
+	snap.Kernel.Counters = map[string]CounterValue{
+		"ip:input_ct_ssh_drop":          {Packets: 42, Bytes: 1234},
+		"ip:input_syn_rate_exceeded":    {Packets: 2166, Bytes: 105678},
+		"ip:input_blacklist_manual_drop": {Packets: 14, Bytes: 700},
+	}
+	snap.Kernel.Sets = map[string]SetInfo{
+		"ip:blacklist_manual_ipv4": {Exists: true, Count: 3},
+		"ip:http_bot_ban":          {Exists: true, Count: 5},
+		"ip:http_bot_suspect":      {Exists: true, Count: 0},
+		"ip6:blacklist_ipv6":       {Exists: true, Count: 847},
+	}
+	snap.Kernel.Chains = map[string]ChainInfo{
+		"ip:input":             {Exists: true},
+		"ip:ddos_protection":   {Exists: true},
+		"ip:portscan_detection": {Exists: true},
+		"ip6:input":            {Exists: true},
+	}
+	snap.Validator = &ValidatorSnapshot{
+		Status:   "protected",
+		Modules:  map[string]string{"ddos": "enforcing", "botguard": "observing", "portscan": "idle"},
+		Findings: []string{"VAL-GEOBAN-001"},
+	}
+	snap.Correlation = map[string]string{
+		"ddos":             CorrelationMatch,
+		"botguard":         CorrelationMatch,
+		"portscan":         CorrelationExpectedLimitation,
+		"loginmon":         CorrelationExpectedLimitation,
+		"blacklist_manual": CorrelationMatch,
+	}
+	return snap
+}
+
+func buildMinimalSnapshotFixture() *EvidenceSnapshot {
+	snap := &EvidenceSnapshot{
+		SchemaVersion:  EvidenceSchemaVersion,
+		CollectedAt:    fixedTime,
+		TruthAuthority: "kernel",
+	}
+	snap.Kernel.Counters = nil // collection failed
+	snap.Kernel.Sets = map[string]SetInfo{}
+	snap.Kernel.Chains = map[string]ChainInfo{}
+	snap.Validator = &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	snap.Correlation = map[string]string{
+		"ddos":             CorrelationUnknown,
+		"botguard":         CorrelationUnknown,
+		"portscan":         CorrelationUnknown,
+		"loginmon":         CorrelationUnknown,
+		"blacklist_manual": CorrelationUnknown,
+	}
+	return snap
+}
+
+// =============================================================================
+// A. Top-level schema presence
+// =============================================================================
+
+func TestSchema_TopLevelFields(t *testing.T) {
+	snap := buildFullSnapshotFixture()
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal to map failed: %v", err)
+	}
+
+	required := []string{"schema_version", "collected_at", "truth_authority", "kernel", "validator", "correlation"}
+	for _, field := range required {
+		if _, ok := m[field]; !ok {
+			t.Errorf("missing required top-level field: %s", field)
+		}
+	}
+
+	kernel, ok := m["kernel"].(map[string]interface{})
+	if !ok {
+		t.Fatal("kernel field is not an object")
+	}
+	for _, sub := range []string{"counters", "sets", "chains"} {
+		if _, ok := kernel[sub]; !ok {
+			t.Errorf("missing kernel sub-field: %s", sub)
+		}
+	}
+}
+
+// =============================================================================
+// B. Schema version lock
+// =============================================================================
+
+func TestSchema_VersionLock(t *testing.T) {
+	if EvidenceSchemaVersion != "1.87.0" {
+		t.Errorf("EvidenceSchemaVersion = %s, want 1.87.0", EvidenceSchemaVersion)
+	}
+
+	snap := buildFullSnapshotFixture()
+	data, _ := json.Marshal(snap)
+	if !strings.Contains(string(data), `"schema_version":"1.87.0"`) {
+		t.Error("JSON must contain schema_version: 1.87.0")
+	}
+}
+
+// =============================================================================
+// C. Counters nil vs empty semantics
+// =============================================================================
+
+func TestSchema_CountersNil(t *testing.T) {
+	snap := buildMinimalSnapshotFixture()
+	data, _ := json.Marshal(snap)
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	kernel := m["kernel"].(map[string]interface{})
+	if kernel["counters"] != nil {
+		t.Error("nil counters must marshal as null, not empty object")
+	}
+}
+
+func TestSchema_CountersEmpty(t *testing.T) {
+	snap := buildFullSnapshotFixture()
+	snap.Kernel.Counters = map[string]CounterValue{}
+	data, _ := json.Marshal(snap)
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	kernel := m["kernel"].(map[string]interface{})
+	counters := kernel["counters"]
+	if counters == nil {
+		t.Error("empty counters map must marshal as {}, not null")
+	}
+}
+
+// =============================================================================
+// D. unknown,omitempty semantics
+// =============================================================================
+
+func TestSchema_SetInfo_UnknownOmitted(t *testing.T) {
+	si := SetInfo{Exists: true, Count: 5}
+	data, _ := json.Marshal(si)
+	if strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=false should be omitted: %s", data)
+	}
+}
+
+func TestSchema_SetInfo_UnknownPresent(t *testing.T) {
+	si := SetInfo{Unknown: true}
+	data, _ := json.Marshal(si)
+	if !strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=true must be present: %s", data)
+	}
+}
+
+func TestSchema_ChainInfo_UnknownOmitted(t *testing.T) {
+	ci := ChainInfo{Exists: false}
+	data, _ := json.Marshal(ci)
+	if strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=false should be omitted: %s", data)
+	}
+}
+
+func TestSchema_ChainInfo_UnknownPresent(t *testing.T) {
+	ci := ChainInfo{Unknown: true}
+	data, _ := json.Marshal(ci)
+	if !strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=true must be present: %s", data)
+	}
+}
+
+func TestSchema_Validator_UnknownOmitted(t *testing.T) {
+	v := ValidatorSnapshot{Status: "protected"}
+	data, _ := json.Marshal(v)
+	if strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=false should be omitted: %s", data)
+	}
+}
+
+func TestSchema_Validator_UnknownPresent(t *testing.T) {
+	v := ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	data, _ := json.Marshal(v)
+	if !strings.Contains(string(data), "unknown") {
+		t.Errorf("Unknown=true must be present: %s", data)
+	}
+}
+
+// =============================================================================
+// E. Required validator semantics
+// =============================================================================
+
+func TestSchema_ValidatorRequiredFields(t *testing.T) {
+	v := ValidatorSnapshot{Status: "protected", Modules: map[string]string{}, Findings: []string{}}
+	data, _ := json.Marshal(v)
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	if _, ok := m["status"]; !ok {
+		t.Error("status must always be present")
+	}
+	if _, ok := m["modules"]; !ok {
+		t.Error("modules must always be present")
+	}
+	if _, ok := m["findings"]; !ok {
+		t.Error("findings must always be present")
+	}
+}
+
+// =============================================================================
+// F. Correlation enum safety
+// =============================================================================
+
+func TestSchema_CorrelationEnumValues(t *testing.T) {
+	allowed := map[string]bool{
+		CorrelationMatch:              true,
+		CorrelationMismatch:           true,
+		CorrelationWarning:            true,
+		CorrelationExpectedLimitation: true,
+		CorrelationUnknown:            true,
+	}
+
+	snap := buildFullSnapshotFixture()
+	for mod, val := range snap.Correlation {
+		if !allowed[val] {
+			t.Errorf("module %s has invalid correlation value: %s", mod, val)
+		}
+	}
+
+	snapMin := buildMinimalSnapshotFixture()
+	for mod, val := range snapMin.Correlation {
+		if !allowed[val] {
+			t.Errorf("module %s has invalid correlation value: %s", mod, val)
+		}
+	}
+}
+
+// =============================================================================
+// G. Golden snapshot fixture
+// =============================================================================
+
+func TestSchema_GoldenSnapshot(t *testing.T) {
+	snap := buildFullSnapshotFixture()
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "evidence_snapshot_v1.87.golden.json")
+
+	// If golden file doesn't exist, create it (first run only)
+	if _, err := os.Stat(goldenPath); os.IsNotExist(err) {
+		if err := os.WriteFile(goldenPath, data, 0644); err != nil {
+			t.Fatalf("failed to create golden file: %v", err)
+		}
+		t.Logf("Created golden file: %s", goldenPath)
+		return
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if string(data) != string(expected) {
+		t.Errorf("JSON schema drift detected.\n\nExpected (golden):\n%s\n\nActual:\n%s", expected, data)
+	}
+}

--- a/internal/metrics/evidence_types.go
+++ b/internal/metrics/evidence_types.go
@@ -1,0 +1,39 @@
+// =============================================================================
+// NFTBan v1.87 - Evidence Types (Phase 1 Canonical Model)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_types"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Canonical evidence types for metrics Phase 1"
+// meta:inventory.files="internal/metrics/evidence_types.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Types only. No collection logic. No rendering logic.
+// Metrics report evidence; validator reports interpretation.
+// =============================================================================
+package metrics
+
+import "time"
+
+// CounterValue holds a single named counter's packets and bytes.
+type CounterValue struct {
+	Packets int64 `json:"packets"`
+	Bytes   int64 `json:"bytes"`
+}
+
+// NamedCountersResult holds all named counters from a single collection.
+// Keys use stable format: "<family>:<counter_name>" (e.g. "ip:input_ct_ssh_drop").
+// An empty Counters map is valid (no counters found, not an error).
+// A nil result with non-nil error means collection failed.
+type NamedCountersResult struct {
+	CollectedAt time.Time               `json:"collected_at"`
+	Counters    map[string]CounterValue `json:"counters"`
+}

--- a/internal/metrics/evidence_validator.go
+++ b/internal/metrics/evidence_validator.go
@@ -1,0 +1,125 @@
+// =============================================================================
+// NFTBan v1.87 - Validator Snapshot Bridge (M87-5)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_validator"
+// meta:type="package"
+// meta:version="1.87.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Read-only bridge to validator JSON for metrics evidence"
+// meta:inventory.files="internal/metrics/evidence_validator.go"
+// meta:inventory.binaries="nftban-validate"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+//
+// Read-only bridge: calls nftban-validate --json once and extracts
+// status, module effective states, and finding codes.
+// Metrics MUST NOT modify validator truth. This is observation only.
+// =============================================================================
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+)
+
+// ValidatorSnapshot holds extracted validator state for metrics enrichment.
+// This is NOT a truth object — it is a read-only observation of validator output.
+// Metrics cannot modify, override, or reinterpret these values.
+type ValidatorSnapshot struct {
+	Status   string            `json:"status"`   // protected/idle/degraded/down/unavailable
+	Modules  map[string]string `json:"modules"`  // module → effective state
+	Findings []string          `json:"findings"` // finding codes only
+	Unknown  bool              `json:"unknown,omitempty"` // true if collection failed
+}
+
+// ValidatorBinPath is the default validator binary path.
+// Configurable for testing; production uses package default.
+var ValidatorBinPath = "/usr/lib/nftban/bin/nftban-validate"
+
+// CollectValidatorSnapshot calls nftban-validate --json and extracts
+// status, module states, and finding codes.
+// Returns ValidatorSnapshot with Unknown=true on any failure.
+func CollectValidatorSnapshot(ctx context.Context) *ValidatorSnapshot {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	output, err := runValidator(ctx)
+	if err != nil {
+		return &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	}
+
+	return parseValidatorJSON(output)
+}
+
+// runValidator executes the validator binary.
+func runValidator(ctx context.Context) ([]byte, error) {
+	return exec.CommandContext(ctx, ValidatorBinPath, "--json").Output() // #nosec G204 -- fixed binary path
+}
+
+// parseValidatorJSON extracts metrics-relevant fields from validator JSON.
+// Package-internal; testable via fixture inputs in evidence_validator_test.go.
+func parseValidatorJSON(data []byte) *ValidatorSnapshot {
+	var val struct {
+		Status  string `json:"status"`
+		Modules struct {
+			BotGuard  *struct{ Effective string `json:"effective"` } `json:"botguard,omitempty"`
+			DDoS      *struct{ Effective string `json:"effective"` } `json:"ddos,omitempty"`
+			Portscan  *struct{ Effective string `json:"effective"` } `json:"portscan,omitempty"`
+			LoginMon  *struct{ Effective string `json:"effective"` } `json:"loginmon,omitempty"`
+			Blacklist *struct {
+				Manual struct{ State string `json:"state"` } `json:"manual"`
+				Feeds  struct{ State string `json:"state"` } `json:"feeds"`
+				Geoban struct{ State string `json:"state"` } `json:"geoban"`
+			} `json:"blacklist,omitempty"`
+		} `json:"modules"`
+		Findings []struct {
+			Code string `json:"code"`
+		} `json:"findings"`
+	}
+
+	if err := json.Unmarshal(data, &val); err != nil {
+		return &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	}
+
+	// Status is required for a valid snapshot. If missing, the validator
+	// output is structurally incomplete and cannot be trusted.
+	if val.Status == "" {
+		return &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	}
+
+	snap := &ValidatorSnapshot{
+		Status:  val.Status,
+		Modules: make(map[string]string),
+	}
+
+	if val.Modules.DDoS != nil {
+		snap.Modules["ddos"] = val.Modules.DDoS.Effective
+	}
+	if val.Modules.BotGuard != nil {
+		snap.Modules["botguard"] = val.Modules.BotGuard.Effective
+	}
+	if val.Modules.Portscan != nil {
+		snap.Modules["portscan"] = val.Modules.Portscan.Effective
+	}
+	if val.Modules.LoginMon != nil {
+		snap.Modules["loginmon"] = val.Modules.LoginMon.Effective
+	}
+	if val.Modules.Blacklist != nil {
+		snap.Modules["blacklist_manual"] = val.Modules.Blacklist.Manual.State
+		snap.Modules["blacklist_feeds"] = val.Modules.Blacklist.Feeds.State
+		snap.Modules["blacklist_geoban"] = val.Modules.Blacklist.Geoban.State
+	}
+
+	for _, f := range val.Findings {
+		snap.Findings = append(snap.Findings, f.Code)
+	}
+
+	return snap
+}

--- a/internal/metrics/evidence_validator_test.go
+++ b/internal/metrics/evidence_validator_test.go
@@ -1,0 +1,170 @@
+// =============================================================================
+// NFTBan v1.87 - Validator Snapshot Bridge Tests (M87-5)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="evidence_validator_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-15"
+// meta:description="Tests for validator snapshot bridge"
+// meta:inventory.files="internal/metrics/evidence_validator_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package metrics
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseValidator_ProtectedWithModules(t *testing.T) {
+	fixture := `{
+		"status": "protected",
+		"modules": {
+			"ddos": {"config": "enabled", "structural": "present", "effective": "enforcing"},
+			"botguard": {"config": "disabled"},
+			"portscan": {"config": "enabled", "structural": "present", "effective": "idle"},
+			"loginmon": {"config": "enabled", "structural": "present", "runtime": "running", "effective": "idle"},
+			"blacklist": {
+				"manual": {"state": "enforcing", "entries": 3, "drops": 42},
+				"feeds": {"state": "disabled"},
+				"geoban": {"state": "loaded"}
+			}
+		},
+		"findings": [
+			{"code": "VAL-GEOBAN-001", "severity": "warn", "message": "test"}
+		]
+	}`
+
+	snap := parseValidatorJSON([]byte(fixture))
+
+	if snap.Status != "protected" {
+		t.Errorf("status = %s, want protected", snap.Status)
+	}
+	if snap.Unknown {
+		t.Error("should not be unknown")
+	}
+	if snap.Modules["ddos"] != "enforcing" {
+		t.Errorf("ddos effective = %s, want enforcing", snap.Modules["ddos"])
+	}
+	if snap.Modules["botguard"] != "" {
+		t.Errorf("disabled botguard should have empty effective, got %s", snap.Modules["botguard"])
+	}
+	if snap.Modules["blacklist_manual"] != "enforcing" {
+		t.Errorf("blacklist_manual = %s, want enforcing", snap.Modules["blacklist_manual"])
+	}
+	if snap.Modules["blacklist_geoban"] != "loaded" {
+		t.Errorf("blacklist_geoban = %s, want loaded", snap.Modules["blacklist_geoban"])
+	}
+	if len(snap.Findings) != 1 || snap.Findings[0] != "VAL-GEOBAN-001" {
+		t.Errorf("findings = %v, want [VAL-GEOBAN-001]", snap.Findings)
+	}
+}
+
+func TestParseValidator_Degraded(t *testing.T) {
+	fixture := `{
+		"status": "degraded",
+		"modules": {
+			"ddos": {"config": "enabled", "structural": "missing"}
+		},
+		"findings": [
+			{"code": "VAL-CHAIN-001"},
+			{"code": "VAL-SERVICE-001"}
+		]
+	}`
+
+	snap := parseValidatorJSON([]byte(fixture))
+
+	if snap.Status != "degraded" {
+		t.Errorf("status = %s, want degraded", snap.Status)
+	}
+	if len(snap.Findings) != 2 {
+		t.Errorf("expected 2 findings, got %d", len(snap.Findings))
+	}
+}
+
+func TestParseValidator_MalformedJSON(t *testing.T) {
+	snap := parseValidatorJSON([]byte(`INVALID`))
+
+	if snap.Status != "unavailable" {
+		t.Errorf("malformed JSON should produce status=unavailable, got %s", snap.Status)
+	}
+	if !snap.Unknown {
+		t.Error("malformed JSON should be Unknown=true")
+	}
+}
+
+func TestParseValidator_EmptyJSON(t *testing.T) {
+	// Valid JSON but missing required status field → unknown
+	snap := parseValidatorJSON([]byte(`{}`))
+
+	if snap.Status != "unavailable" {
+		t.Errorf("empty JSON (no status) should produce status=unavailable, got %s", snap.Status)
+	}
+	if !snap.Unknown {
+		t.Error("empty JSON with no status should be Unknown=true")
+	}
+}
+
+func TestParseValidator_NoFindings(t *testing.T) {
+	fixture := `{"status": "protected", "modules": {}, "findings": []}`
+	snap := parseValidatorJSON([]byte(fixture))
+
+	if len(snap.Findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(snap.Findings))
+	}
+}
+
+func TestValidatorSnapshot_JSONRoundTrip(t *testing.T) {
+	original := &ValidatorSnapshot{
+		Status:   "protected",
+		Modules:  map[string]string{"ddos": "enforcing"},
+		Findings: []string{"VAL-GEOBAN-001"},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded ValidatorSnapshot
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Status != original.Status {
+		t.Errorf("status mismatch")
+	}
+	if decoded.Modules["ddos"] != "enforcing" {
+		t.Errorf("module mismatch")
+	}
+}
+
+func TestValidatorSnapshot_UnknownOmitted(t *testing.T) {
+	snap := &ValidatorSnapshot{Status: "protected"}
+	data, _ := json.Marshal(snap)
+	str := string(data)
+	if jsonContains(str, "unknown") {
+		t.Errorf("Unknown=false should be omitted, got: %s", str)
+	}
+}
+
+func TestValidatorSnapshot_UnknownPresent(t *testing.T) {
+	snap := &ValidatorSnapshot{Status: "unavailable", Unknown: true}
+	data, _ := json.Marshal(snap)
+	str := string(data)
+	if !jsonContains(str, "unknown") {
+		t.Errorf("Unknown=true should be present, got: %s", str)
+	}
+}
+
+func jsonContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metrics/rule_counters.go
+++ b/internal/metrics/rule_counters.go
@@ -19,11 +19,13 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -109,31 +111,110 @@ func CollectRuleCounters() {
 	ruleCounterMu.Lock()
 	defer ruleCounterMu.Unlock()
 
+	// Note: context.Background() is intentional here — this is the legacy
+	// sampler-driven Prometheus path, not the new evidence CLI path.
+	// Timeout is bounded per-family (2s) inside collectNamedCountersStructured.
 	for _, family := range []string{"ip", "ip6"} {
-		// v1.41.0: Try named counters first (simpler, more efficient)
-		if !collectNamedCounters(family) {
+		counters, err := collectNamedCountersStructured(context.Background(), family)
+		if err == nil && len(counters) > 0 {
+			updatePrometheusFromNamedCounters(family, counters)
+		} else {
 			// Fallback to anonymous counter extraction (pre-v1.41.0 schemas)
 			collectFamilyCounters(family)
 		}
 	}
 }
 
-// collectNamedCounters extracts named counter values via `nft -j list counters`.
-// Returns true if at least one named counter was found (schema has named counters).
-func collectNamedCounters(family string) bool {
-	cmd := exec.Command("nft", "-j", "list", "counters", family, "nftban")
-	output, err := cmd.Output()
+// CollectNamedCounters returns all named counters as structured evidence data.
+// v1.87 M87-2: This is the canonical evidence collection function.
+// Collect once → render many (JSON, human, Prometheus).
+//
+// Semantics:
+// - Empty Counters map = valid (no counters found, not an error)
+// - Non-nil error = collection failed (command error, parse error)
+// - Zero-valued counters are preserved (neutral, not failure)
+func CollectNamedCounters(ctx context.Context) (*NamedCountersResult, error) {
+	ruleCounterMu.Lock()
+	defer ruleCounterMu.Unlock()
+
+	result := &NamedCountersResult{
+		CollectedAt: time.Now(),
+		Counters:    make(map[string]CounterValue),
+	}
+
+	var lastErr error
+	familiesSucceeded := 0
+
+	for _, family := range []string{"ip", "ip6"} {
+		counters, err := collectNamedCountersStructured(ctx, family)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		familiesSucceeded++
+		for name, val := range counters {
+			key := family + ":" + name
+			result.Counters[key] = val
+		}
+	}
+
+	// Both families failed → return error (contract: non-nil error = collection failed)
+	// At least one succeeded → return result, nil (may be partial)
+	if familiesSucceeded == 0 && lastErr != nil {
+		return nil, lastErr
+	}
+
+	return result, nil
+}
+
+// collectNamedCountersStructured executes nft and parses the result.
+// Does NOT update Prometheus — caller decides.
+func collectNamedCountersStructured(ctx context.Context, family string) (map[string]CounterValue, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	output, err := nftListCounters(ctx, family)
 	if err != nil {
-		return false // Table or counters not available
+		return nil, err
 	}
 
+	return parseNamedCountersJSON(output)
+}
+
+// nftListCounters runs nft -j list counters for a specific family.
+func nftListCounters(ctx context.Context, family string) ([]byte, error) {
+	switch family {
+	case "ip":
+		return exec.CommandContext(ctx, "nft", "-j", "list", "counters", "ip", "nftban").Output() // #nosec G204
+	case "ip6":
+		return exec.CommandContext(ctx, "nft", "-j", "list", "counters", "ip6", "nftban").Output() // #nosec G204
+	default:
+		return nil, nil
+	}
+}
+
+// nftListTable runs nft -j list table for a specific family.
+func nftListTable(family string) ([]byte, error) {
+	switch family {
+	case "ip":
+		return exec.Command("nft", "-j", "list", "table", "ip", "nftban").Output() // #nosec G204
+	case "ip6":
+		return exec.Command("nft", "-j", "list", "table", "ip6", "nftban").Output() // #nosec G204
+	default:
+		return nil, nil
+	}
+}
+
+// parseNamedCountersJSON is the pure parsing logic, testable without exec.
+// Returns counter names as bare names (without family prefix).
+// Caller adds the family prefix when building NamedCountersResult keys.
+func parseNamedCountersJSON(data []byte) (map[string]CounterValue, error) {
 	var nft nftJSON
-	if err := json.Unmarshal(output, &nft); err != nil {
-		log.Printf("[METRICS] Failed to parse named counters JSON for %s nftban: %v", family, err)
-		return false
+	if err := json.Unmarshal(data, &nft); err != nil {
+		return nil, err
 	}
 
-	found := 0
+	counters := make(map[string]CounterValue)
 	for _, raw := range nft.NFTables {
 		var wrapper nftNamedCounterWrapper
 		if err := json.Unmarshal(raw, &wrapper); err != nil || wrapper.Counter == nil {
@@ -145,19 +226,28 @@ func collectNamedCounters(family string) bool {
 			continue
 		}
 
-		nftNamedCounterPackets.WithLabelValues(family, c.Name).Set(float64(c.Packets))
-		nftNamedCounterBytes.WithLabelValues(family, c.Name).Set(float64(c.Bytes))
-		found++
+		counters[c.Name] = CounterValue{
+			Packets: int64(c.Packets),
+			Bytes:   int64(c.Bytes),
+		}
 	}
 
-	return found > 0
+	return counters, nil
+}
+
+// updatePrometheusFromNamedCounters writes structured counter data to Prometheus gauges.
+// Preserves existing Prometheus exporter behavior.
+func updatePrometheusFromNamedCounters(family string, counters map[string]CounterValue) {
+	for name, val := range counters {
+		nftNamedCounterPackets.WithLabelValues(family, name).Set(float64(val.Packets))
+		nftNamedCounterBytes.WithLabelValues(family, name).Set(float64(val.Bytes))
+	}
 }
 
 // collectFamilyCounters collects rule counters for a single nftables family
 // using anonymous counter extraction (pre-v1.41.0 fallback)
 func collectFamilyCounters(family string) {
-	cmd := exec.Command("nft", "-j", "list", "table", family, "nftban")
-	output, err := cmd.Output()
+	output, err := nftListTable(family)
 	if err != nil {
 		// Table may not exist for this family — not an error
 		return

--- a/internal/metrics/testdata/evidence_snapshot_v1.87.golden.json
+++ b/internal/metrics/testdata/evidence_snapshot_v1.87.golden.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.87.0",
+  "collected_at": "2026-04-15T12:00:00Z",
+  "truth_authority": "kernel",
+  "kernel": {
+    "counters": {
+      "ip:input_blacklist_manual_drop": {
+        "packets": 14,
+        "bytes": 700
+      },
+      "ip:input_ct_ssh_drop": {
+        "packets": 42,
+        "bytes": 1234
+      },
+      "ip:input_syn_rate_exceeded": {
+        "packets": 2166,
+        "bytes": 105678
+      }
+    },
+    "sets": {
+      "ip6:blacklist_ipv6": {
+        "exists": true,
+        "count": 847
+      },
+      "ip:blacklist_manual_ipv4": {
+        "exists": true,
+        "count": 3
+      },
+      "ip:http_bot_ban": {
+        "exists": true,
+        "count": 5
+      },
+      "ip:http_bot_suspect": {
+        "exists": true,
+        "count": 0
+      }
+    },
+    "chains": {
+      "ip6:input": {
+        "exists": true
+      },
+      "ip:ddos_protection": {
+        "exists": true
+      },
+      "ip:input": {
+        "exists": true
+      },
+      "ip:portscan_detection": {
+        "exists": true
+      }
+    }
+  },
+  "validator": {
+    "status": "protected",
+    "modules": {
+      "botguard": "observing",
+      "ddos": "enforcing",
+      "portscan": "idle"
+    },
+    "findings": [
+      "VAL-GEOBAN-001"
+    ]
+  },
+  "correlation": {
+    "blacklist_manual": "match",
+    "botguard": "match",
+    "ddos": "match",
+    "loginmon": "expected_limitation",
+    "portscan": "expected_limitation"
+  }
+}


### PR DESCRIPTION
## Summary
Complete v1.87 metrics evidence layer — 7 commits, M87-2 through M87-10.

**M87-2:** Named counter collector (structured data, Prometheus preserved)
**M87-3:** Set element collector (three-state: present/absent/unknown)
**M87-4:** Chain presence collector (three-state, family-level failure)
**M87-5:** Validator snapshot bridge (read-only, status required)
**M87-6:** Correlation engine (pure function, conservative unknown handling)
**M87-7/8:** EvidenceSnapshot + JSON/human renderers
**M87-9:** CLI wiring (nftban metrics evidence / evidence-json)
**M87-10:** Schema validation tests + golden fixture (13 tests)

Evidence contract: accurate or unknown, never guessed. ~85 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)