### PR TITLE
fix(cli): runtime bug fixes + CLI smoke gate (v1.87.1 hotfix)

### DIFF
--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -184,7 +184,9 @@ _nftban_prefetch_unit_states() {
 # Lookup: returns 0 if unit is active, 1 otherwise.
 # Drop-in replacement for: systemctl is-active <unit> >/dev/null 2>&1
 _unit_is_active() {
-    local unit="$1"
+    local unit="${1:-}"
+    # Empty unit name = inactive (not a bash error)
+    [[ -z "$unit" ]] && return 1
     # Prefetch on first call (lazy init)
     [[ "$_UNIT_STATE_LOADED" != "true" ]] && _nftban_prefetch_unit_states
     [[ "${_UNIT_STATE[$unit]:-inactive}" == "active" ]]

--- a/cli/lib/nftban/tests/smoke_test.sh
+++ b/cli/lib/nftban/tests/smoke_test.sh
@@ -1945,15 +1945,18 @@ run_runtime_tests() {
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 
-    # Check both families have FINAL anchor
+    # Check both families have FINAL anchor via direct kernel query.
+    # Note: validator --json uses HealthOutput schema which does not include
+    # per-family anchor details. Check kernel directly.
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
-    local final_count
-    final_count=$(/usr/lib/nftban/bin/nftban-validate --json 2>/dev/null | jq '[.families[].anchors.final_present] | map(select(. == true)) | length' 2>/dev/null || echo "0")
-    if [[ "$final_count" == "2" ]]; then
+    local _final_ipv4=false _final_ipv6=false
+    nft list chain ip nftban input 2>/dev/null | grep -q "ANCHOR_FINAL" && _final_ipv4=true
+    nft list chain ip6 nftban input 2>/dev/null | grep -q "ANCHOR_FINAL" && _final_ipv6=true
+    if [[ "$_final_ipv4" == "true" && "$_final_ipv6" == "true" ]]; then
         log_pass "kernel truth — FINAL anchor present on both families"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
-        log_fail "kernel truth — FINAL anchor missing on $((2 - final_count)) family/families"
+        log_fail "kernel truth — FINAL anchor missing (ipv4=$_final_ipv4 ipv6=$_final_ipv6)"
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 

--- a/cli/lib/nftban/tests/test_cli_runtime.sh
+++ b/cli/lib/nftban/tests/test_cli_runtime.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.87 — CLI Runtime Smoke Gate
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="test_cli_runtime"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-15"
+# meta:description="Verify all primary CLI commands execute without bash runtime errors"
+# meta:inventory.files="cli/lib/nftban/tests/test_cli_runtime.sh"
+# meta:inventory.binaries="nftban"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+#
+# This test runs on deployed hosts (not CI containers).
+# It verifies crash-free execution — not semantic correctness.
+# Nonzero exit codes are allowed for commands with valid contract meanings
+# (e.g., health diagnostics exit 2 = errors found).
+#
+# What this catches:
+# - bad array subscript (empty variable in associative array)
+# - unbound variable (set -u violations)
+# - syntax errors
+# - command not found
+# - shell runtime crashes
+#
+# What this does NOT check:
+# - output correctness (that's validator/health tests)
+# - exit code semantics (that's test_exit_code_consistency.sh)
+# =============================================================================
+set -Eeuo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+echo "=========================================================="
+echo "CLI Runtime Smoke Gate"
+echo "=========================================================="
+
+# Skip if nftban not installed
+if ! command -v nftban >/dev/null 2>&1; then
+    echo "SKIP: nftban not found"
+    exit 0
+fi
+
+# run_safe: execute command, check for bash runtime errors (not exit code)
+run_safe() {
+    local cmd="$1"
+    TOTAL=$((TOTAL + 1))
+    local output
+    output=$(eval "$cmd" 2>&1) || true
+    # Check for bash runtime errors in stderr output
+    if echo "$output" | grep -qE "bad array subscript|unbound variable|syntax error|command not found|: line [0-9]+:.*Error"; then
+        echo "  FAIL  $cmd"
+        echo "$output" | grep -E "bad array|unbound variable|syntax error|command not found|: line [0-9]" | head -2 | sed 's/^/         /'
+        FAIL=$((FAIL + 1))
+    else
+        echo "  OK    $cmd"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo ""
+echo "Core Commands"
+echo "────────────────────────────────────────"
+run_safe "nftban version"
+run_safe "nftban status"
+run_safe "nftban status --brief"
+run_safe "nftban status --json"
+run_safe "nftban health"
+run_safe "nftban health --json"
+run_safe "nftban health truth"
+run_safe "nftban health diagnostics --quiet"
+
+echo ""
+echo "Module Commands"
+echo "────────────────────────────────────────"
+run_safe "nftban ddos status"
+run_safe "nftban portscan status"
+run_safe "nftban login status"
+run_safe "nftban botguard status"
+run_safe "nftban blacklist list"
+run_safe "nftban feeds list"
+run_safe "nftban geoban status"
+run_safe "nftban tunnel status"
+
+echo ""
+echo "Firewall & Services"
+echo "────────────────────────────────────────"
+run_safe "nftban firewall validate"
+run_safe "nftban services"
+run_safe "nftban timers"
+
+echo ""
+echo "Search & List"
+echo "────────────────────────────────────────"
+run_safe "nftban list banned"
+run_safe "nftban list whitelist"
+run_safe "nftban search 127.0.0.1"
+
+echo ""
+echo "Metrics"
+echo "────────────────────────────────────────"
+run_safe "nftban metrics status"
+
+echo ""
+echo "Health Diagnostics"
+echo "────────────────────────────────────────"
+run_safe "nftban health binaries"
+run_safe "nftban health config"
+run_safe "nftban health install"
+run_safe "nftban health posture"
+
+echo ""
+echo "=========================================================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=========================================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "FAIL: $FAIL CLI command(s) have bash runtime errors"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Fixes
1. **_unit_is_active() empty string** — "bad array subscript" on nftban status (all hosts, both distros)
2. **Smoke test FINAL anchor** — was checking .families (not in HealthOutput), now checks kernel directly

## New
- **test_cli_runtime.sh** — host-side CLI smoke gate, 27 commands, catches bash runtime errors

## Verification
- 27/27 CLI commands pass on lab4 (AlmaLinux 9) + monitor (Ubuntu)
- Both fixes verified cross-distro before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)