### PR TITLE
fix(ci): make STATUS.md auto-commit non-fatal on protected branches

### DIFF
--- a/.github/workflows/project-health.yml
+++ b/.github/workflows/project-health.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Auto-commit STATUS.md (main branch only)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
         run: |
           if ! git diff --quiet -- STATUS.md; then
             git config user.name "github-actions[bot]"
@@ -79,5 +80,5 @@ jobs:
             git add STATUS.md
             git commit -m "chore: update STATUS.md [skip ci]"
             REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-            git push "${REPO_URL}" HEAD:main
+            git push "${REPO_URL}" HEAD:main || echo "::warning::STATUS.md auto-commit skipped (branch protection requires PR)"
           fi


### PR DESCRIPTION
## Summary
- Project Health workflow fails because auto-commit step tries to push directly to main
- Branch protection rejects the push (requires PR)
- All health checks pass — only the auto-commit push fails
- Fix: `continue-on-error: true` + warning message instead of hard failure

## Test plan
- [ ] Project Health workflow completes without failure on main
- [ ] STATUS.md artifact still uploaded
- [ ] Warning logged when push is blocked by branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)