### PR TITLE
fix(export): filter dot-notation metrics from Prometheus textfile

### DIFF
--- a/cli/lib/nftban/exporters/nftban_unified_exporter_export.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_export.sh
@@ -198,6 +198,10 @@ PROM_HEADER
         # Skip Zabbix string metrics (containing |STRING| prefix)
         if (index($2, "|STRING|") == 1) next
 
+        # Skip dot-notation metrics (Zabbix format, invalid Prometheus names)
+        # Valid Prometheus: [a-zA-Z_:][a-zA-Z0-9_:]*
+        if (index($1, ".") > 0) next
+
         if (NF >= 2) {
             # Handle metrics with labels
             if ($1 ~ /{.*}/) {


### PR DESCRIPTION
## Summary
- Shell exporter collects ~25 Zabbix dot-notation metrics (`nftban.daemon.cpu_percent`, `nftban.server.load_1m`)
- `export_prometheus()` awk filter stripped `|STRING|` lines but not dot-notation names
- Dots are invalid Prometheus metric names (`[a-zA-Z_:][a-zA-Z0-9_:]*`)
- If `NFTBAN_EXPORT_PROMETHEUS=true`, these would leak into `nftban.prom`
- Currently latent (Prometheus export defaults to `false`), but closes the gap

**Pipeline audit finding:** P-8 (V191_PIPELINE_INTEGRITY_AUDIT.md)

## Change
One filter line added to `export_prometheus()` awk in `nftban_unified_exporter_export.sh`:
```awk
if (index($1, ".") > 0) next
```

## Test plan
- [ ] ShellCheck passes
- [ ] Valid `nftban_*` metrics unaffected (no dots in underscore names)
- [ ] Dot-notation lines filtered: `echo 'nftban.daemon.cpu 3.2 123' | awk '{if (index($1,".") > 0) next; print}'` → no output
- [ ] Labeled metrics preserved: `echo 'nftban_pressure{dim="cpu"} 42 123' | awk '{if (index($1,".") > 0) next; print}'` → output preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)