### PR TITLE
feat(exporter): align shell/collector metrics to daemon canonical names

### DIFF
--- a/cli/lib/nftban/data/metrics-registry.json
+++ b/cli/lib/nftban/data/metrics-registry.json
@@ -883,7 +883,7 @@
       "go_var": "nftablesActiveGauge",
       "description": "NFTables service status (1=active, 0=inactive)"
     },
-    "nftban_conntrack_entries": {
+    "nftban_conntrack_used": {
       "type": "gauge",
       "unit": "",
       "category": "connections",
@@ -1479,7 +1479,7 @@
       "category": "nftables",
       "phase": 3
     },
-    "nftban_nftables_rules_total": {
+    "nftban_nft_rules_total": {
       "type": "gauge",
       "help": "Total nftables rules",
       "labels": [],
@@ -1842,7 +1842,7 @@
       "added_version": "1.4.0",
       "phase": 1
     },
-    "nftban_memory_rss_bytes": {
+    "nftban_proc_rss_bytes": {
       "type": "gauge",
       "unit": "bytes",
       "category": "runtime",
@@ -2216,12 +2216,12 @@
       "added_version": "1.4.0",
       "phase": 1
     },
-    "nftban_watchdog_cpu_score": {
+    "nftban_pressure_score": {
       "type": "gauge",
       "unit": "percent",
       "category": "watchdog",
       "source": "shell_prometheus",
-      "description": "Watchdog CPU pressure score (0-100)",
+      "description": "Watchdog pressure score (0-100), label dim=cpu|mem|io|net",
       "labels": {},
       "added_version": "1.4.0",
       "phase": 1
@@ -2995,15 +2995,15 @@
       "nftban_daemon_up": "nftban.daemon.up",
       "nftban_daemon_uptime_seconds": "nftban.uptime",
       "nftban_watchdog_up": "nftban.watchdog.up",
-      "nftban_watchdog_cpu_score": "nftban.watchdog.cpu.score",
-      "nftban_watchdog_mem_score": "nftban.watchdog.mem.score",
-      "nftban_watchdog_io_score": "nftban.watchdog.io.score",
+      "nftban_pressure_score{dim=cpu}": "nftban.watchdog.cpu.score",
+      "nftban_pressure_score{dim=mem}": "nftban.watchdog.mem.score",
+      "nftban_pressure_score{dim=io}": "nftban.watchdog.io.score",
       "nftban_blocks_total": "nftban.blocks.total",
       "nftban_bans_last_24h": "nftban.bans.last.24h",
       "nftban_bans_last_1h": "nftban.bans.last.1h",
       "nftban_throughput_bans_per_minute": "nftban.throughput.bans.per.minute",
       "nftban_runtime_goroutines": "nftban.goroutines",
-      "nftban_conntrack_entries": "nftban.conntrack.entries",
+      "nftban_conntrack_used": "nftban.conntrack.entries",
       "nftban_conntrack_max": "nftban.conntrack.max",
       "nftban_conntrack_utilization": "nftban.conntrack.utilization",
       "nftban_softnet_drops_total": "nftban.softnet.drops.total",
@@ -3046,8 +3046,8 @@
       "nftban_modules_active": "nftban.modules.active",
       "nftban_modules_failed": "nftban.modules.failed",
       "nftban_watchdog_status": "nftban.watchdog.status",
-      "nftban_watchdog_mode": "nftban.watchdog.mode",
-      "nftban_watchdog_net_score": "nftban.watchdog.net_score",
+      "nftban_operating_mode": "nftban.watchdog.mode",
+      "nftban_pressure_score{dim=net}": "nftban.watchdog.net_score",
       "nftban_watchdog_actions_taken": "nftban.watchdog.actions_taken",
       "nftban_watchdog_last_action": "nftban.watchdog.last_action",
       "nftban_watchdog_mode_changes": "nftban.watchdog.mode_changes",

--- a/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
@@ -449,7 +449,7 @@ collect_all_metrics() {
             fds=${fds//[[:space:]]/}  # strip whitespace from wc -l
             threads=$(awk '/Threads/ {print $2}' "/proc/$pid/status" 2>/dev/null || echo "0")
 
-            metrics+="nftban_memory_rss_bytes $rss $timestamp\n"
+            metrics+="nftban_proc_rss_bytes $rss $timestamp\n"
             metrics+="nftban_open_fds $fds $timestamp\n"
             metrics+="nftban_threads $threads $timestamp\n"
 
@@ -474,7 +474,7 @@ collect_all_metrics() {
             fi
             # Fallback: use thread count as approximation if goroutines not available
             [[ "$goroutines" == "0" || -z "$goroutines" ]] && goroutines=$threads
-            metrics+="nftban_goroutines $goroutines $timestamp\n"
+            metrics+="nftban_runtime_goroutines $goroutines $timestamp\n"
 
             # --- Memory Leak Detection Metrics ---
             # Calculate memory growth rate (MB/hour) for leak detection
@@ -591,7 +591,7 @@ collect_all_metrics() {
             fi
             metrics+="nftban_nftables_apply_errors_total $nft_apply_errors $timestamp\n"
 
-            # nftban_nftables_rules_total - count rules in nftban table
+            # nftban_nft_rules_total - count rules in nftban table
             local nft_rules_total=0
             local table_output
             table_output=$(nft list table ${NFTBAN_TABLE_IPV4} 2>/dev/null || echo "")
@@ -600,7 +600,7 @@ collect_all_metrics() {
                 nft_rules_total=$(echo "$table_output" | grep -cE '^\s+(accept|drop|reject|jump|goto|counter|log|limit|ct )' 2>/dev/null | tr -d '[:space:]') || true
                 [[ -z "$nft_rules_total" || ! "$nft_rules_total" =~ ^[0-9]+$ ]] && nft_rules_total=0
             fi
-            metrics+="nftban_nftables_rules_total $nft_rules_total $timestamp\n"
+            metrics+="nftban_nft_rules_total $nft_rules_total $timestamp\n"
 
             # nftban_nftables_sets_total - count sets in nftban table
             local nft_sets_total=0
@@ -856,17 +856,20 @@ collect_all_metrics() {
                     net_score=$(jq -r '.net_score // 0' "${NFTBAN_RUN_DIR}/watchdog.status" 2>/dev/null || echo "0")
                     watchdog_mode=$(jq -r '.mode // "NORMAL"' "${NFTBAN_RUN_DIR}/watchdog.status" 2>/dev/null || echo "NORMAL")
 
-                    metrics+="nftban_watchdog_cpu_score $cpu_score $timestamp\n"
-                    metrics+="nftban_watchdog_mem_score $mem_score $timestamp\n"
-                    metrics+="nftban_watchdog_io_score $io_score $timestamp\n"
-                    metrics+="nftban_watchdog_net_score $net_score $timestamp\n"
-                    # Mode as numeric: 0=NORMAL, 1=DEGRADED, 2=SURVIVAL
-                    local mode_num=0
+                    metrics+="nftban_pressure_score{dim=\"cpu\"} $cpu_score $timestamp\n"
+                    metrics+="nftban_pressure_score{dim=\"mem\"} $mem_score $timestamp\n"
+                    metrics+="nftban_pressure_score{dim=\"io\"} $io_score $timestamp\n"
+                    metrics+="nftban_pressure_score{dim=\"net\"} $net_score $timestamp\n"
+                    # Mode as one-hot vector matching daemon nftban_operating_mode{mode=X}
+                    local mode_normal=0 mode_degraded=0 mode_survival=0
                     case "$watchdog_mode" in
-                        DEGRADED) mode_num=1 ;;
-                        SURVIVAL) mode_num=2 ;;
+                        NORMAL)   mode_normal=1 ;;
+                        DEGRADED) mode_degraded=1 ;;
+                        SURVIVAL) mode_survival=1 ;;
                     esac
-                    metrics+="nftban_watchdog_mode $mode_num $timestamp\n"
+                    metrics+="nftban_operating_mode{mode=\"normal\"} $mode_normal $timestamp\n"
+                    metrics+="nftban_operating_mode{mode=\"degraded\"} $mode_degraded $timestamp\n"
+                    metrics+="nftban_operating_mode{mode=\"survival\"} $mode_survival $timestamp\n"
                 fi
                 metrics+="nftban_watchdog_up 1 $timestamp\n"
             else
@@ -908,7 +911,7 @@ collect_all_metrics() {
                         metrics+="nftban_daemon_uptime_seconds $d_uptime $timestamp\n"
                         metrics+="nftban_daemon_memory_heap_mb $d_heap $timestamp\n"
                         metrics+="nftban_daemon_memory_sys_mb $d_sys $timestamp\n"
-                        metrics+="nftban_daemon_goroutines $d_goroutines $timestamp\n"
+                        metrics+="nftban_runtime_goroutines $d_goroutines $timestamp\n"
                         metrics+="nftban_daemon_gc_cycles_total $d_gc_cycles $timestamp\n"
                         metrics+="nftban_daemon_gc_pause_ms $d_gc_pause $timestamp\n"
 
@@ -1266,7 +1269,7 @@ collect_all_metrics() {
             if [[ $conntrack_max -gt 0 ]]; then
                 conntrack_utilization=$(awk -v e="$conntrack_entries" -v m="$conntrack_max" 'BEGIN {printf "%.2f", (e/m)*100}')
             fi
-            metrics+="nftban_conntrack_entries $conntrack_entries $timestamp\n"
+            metrics+="nftban_conntrack_used $conntrack_entries $timestamp\n"
             metrics+="nftban_conntrack_max $conntrack_max $timestamp\n"
             metrics+="nftban_conntrack_utilization $conntrack_utilization $timestamp\n"
         fi

--- a/cli/lib/nftban/exporters/nftban_unified_exporter_export.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_export.sh
@@ -177,8 +177,8 @@ export_prometheus() {
 # TYPE nftban_feeds_enabled gauge
 # HELP nftban_feeds_loaded Number of successfully loaded feeds
 # TYPE nftban_feeds_loaded gauge
-# HELP nftban_memory_rss_bytes Daemon RSS memory in bytes
-# TYPE nftban_memory_rss_bytes gauge
+# HELP nftban_proc_rss_bytes Daemon RSS memory in bytes
+# TYPE nftban_proc_rss_bytes gauge
 # HELP nftban_export_attempts_total Number of export attempts by target
 # TYPE nftban_export_attempts_total counter
 # HELP nftban_export_success_total Number of successful exports by target

--- a/install/grafana/dashboards/nftban_performance.json
+++ b/install/grafana/dashboards/nftban_performance.json
@@ -153,7 +153,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "nftban_nftables_rules_total",
+          "expr": "nftban_nft_rules_total",
           "legendFormat": "Rules Count",
           "range": true,
           "refId": "A"
@@ -484,7 +484,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "nftban_nftables_rules_total",
+          "expr": "nftban_nft_rules_total",
           "legendFormat": "Rules Count",
           "range": true,
           "refId": "A"

--- a/install/prometheus/alerts/nftban-metrics.yml
+++ b/install/prometheus/alerts/nftban-metrics.yml
@@ -152,7 +152,7 @@ groups:
     rules:
       # Alert if nftables rule count is very high
       - alert: NFTBanHighRuleCount
-        expr: nftban_nftables_rules_total > 10000
+        expr: nftban_nft_rules_total > 10000
         for: 10m
         labels:
           severity: warning

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -257,9 +257,9 @@ func (c *Collector) writeNFTablesMetrics(f *os.File) error {
 		ruleCount = 0
 	}
 
-	fmt.Fprintf(f, "# HELP nftban_nftables_rules_total Total number of nftables rules\n")
-	fmt.Fprintf(f, "# TYPE nftban_nftables_rules_total gauge\n")
-	fmt.Fprintf(f, "nftban_nftables_rules_total %d\n\n", ruleCount)
+	fmt.Fprintf(f, "# HELP nftban_nft_rules_total Total number of nftables rules\n")
+	fmt.Fprintf(f, "# TYPE nftban_nft_rules_total gauge\n")
+	fmt.Fprintf(f, "nftban_nft_rules_total %d\n\n", ruleCount)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Unifies metric names across all export surfaces to match daemon /metrics contract (v1.90.0)
- Shell exporter is a relay of daemon vocabulary, not a parallel namespace
- 7 metric concepts renamed, dashboards and alerts updated

## Renames
| Finding | Old Shell Name | New Canonical Name |
|---|---|---|
| P-1 | `nftban_goroutines` | `nftban_runtime_goroutines` |
| P-1b | `nftban_daemon_goroutines` | `nftban_runtime_goroutines` |
| P-2 | `nftban_conntrack_entries` | `nftban_conntrack_used` |
| P-3 | `nftban_memory_rss_bytes` | `nftban_proc_rss_bytes` |
| P-4 | `nftban_watchdog_{cpu,mem,io,net}_score` | `nftban_pressure_score{dim=X}` |
| P-5 | `nftban_watchdog_mode` (integer) | `nftban_operating_mode{mode=X}` (one-hot) |
| P-6 | `nftban_nftables_rules_total` | `nftban_nft_rules_total` |

## Files changed
- `nftban_unified_exporter_collect.sh` — all metric renames
- `nftban_unified_exporter_export.sh` — HELP/TYPE header update
- `internal/metrics/collector.go` — Go textfile collector P-6 rename
- `nftban_performance.json` — dashboard query update
- `nftban-metrics.yml` — alert expression update
- `metrics-registry.json` — registry entries + Zabbix mappings

## Test plan
- [ ] `grep -R "nftban_nftables_rules_total" .` → 0 active emitters
- [ ] `grep -R "nftban_watchdog_cpu_score" cli/lib/` → 0 active emitters
- [ ] `grep -R "nftban_goroutines\b" cli/lib/` → 0 (only nftban_runtime_goroutines)
- [ ] ShellCheck passes
- [ ] Go builds clean
- [ ] Lab host: compare .prom output before/after

Ref: V191_PIPELINE_INTEGRITY_AUDIT.md (P-1 through P-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)