### PR TITLE
feat(cleanup): decommission fail2ban as active data source

### DIFF
--- a/cli/lib/nftban/data/metrics-registry.json
+++ b/cli/lib/nftban/data/metrics-registry.json
@@ -654,7 +654,7 @@
       "labels": {
         "component": {
           "type": "enum",
-          "values": ["nftables", "polkit", "ssh", "fail2ban"],
+          "values": ["nftables", "polkit", "ssh"],
           "description": "System component"
         }
       },

--- a/cmd/nftban-core/cmd_analytics.go
+++ b/cmd/nftban-core/cmd_analytics.go
@@ -329,9 +329,6 @@ func cmdAnalyticsIP() error {
 		fmt.Printf("City:         %s\n", origin.City)
 	}
 	fmt.Printf("Banned At:    %s\n", origin.BannedAt.Format("2006-01-02 15:04:05"))
-	if origin.Jail != "" {
-		fmt.Printf("Jail:         %s\n", origin.Jail)
-	}
 	if origin.Reason != "" {
 		fmt.Printf("Reason:       %s\n", origin.Reason)
 	}

--- a/internal/analytics/state.go
+++ b/internal/analytics/state.go
@@ -226,11 +226,10 @@ func (s *State) RecordBan(ip, country, city, source, reason string, t time.Time)
 			Country:  country,
 			City:     city,
 			BannedAt: t,
-			Jail:     source,   // Legacy compatibility
-			Source:   source,   // New: suricata, login-monitor, manual, feeds
-			Service:  service,  // New: Dynamic service extracted from reason
+			Source:   source,
+			Service:  service,
 			Reason:   reason,
-			Duration: 0,        // TODO: Add duration parameter if needed
+			Duration: 0,
 		}
 		s.ipOrigins[ip] = origin
 		origin.lruElement = s.ipOriginsLRU.PushFront(ip)

--- a/internal/analytics/state.go
+++ b/internal/analytics/state.go
@@ -336,7 +336,6 @@ func extractServiceFromSource(source string) string {
 	case "manual":
 		return "manual"
 	default:
-		// Legacy fail2ban jail names
 		return source
 	}
 }

--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -38,7 +38,6 @@ type IPOrigin struct {
 	Country  string    `json:"country"`
 	City     string    `json:"city,omitempty"`
 	BannedAt time.Time `json:"banned_at"`
-	Jail     string    `json:"jail,omitempty"`    // Legacy: fail2ban jail name
 	Source   string    `json:"source,omitempty"`  // suricata, login-monitor, manual, feeds
 	Service  string    `json:"service,omitempty"` // ssh, http, wordpress, malware, etc.
 	Reason   string    `json:"reason,omitempty"`
@@ -56,7 +55,6 @@ type DailySummary struct {
 	TopCountries   []CountryStats          `json:"top_countries"`
 	BySource       map[string]int          `json:"by_source"`   // suricata, login-monitor, manual, feeds
 	ByService      map[string]int          `json:"by_service"`  // Dynamic from filters.conf
-	ByJail         map[string]int          `json:"by_jail"`     // Legacy fail2ban compatibility
 	GeneratedAt    time.Time               `json:"generated_at"`
 }
 

--- a/internal/api/handlers_analytics.go
+++ b/internal/api/handlers_analytics.go
@@ -280,8 +280,6 @@ func RecentActivityHandler(w http.ResponseWriter, r *http.Request) {
 				activity.Type = "Port scan"
 			case "ddos":
 				activity.Type = "DDoS blocked"
-			case "fail2ban":
-				activity.Type = "Fail2Ban"
 			case "feeds", "feed":
 				activity.Type = "Feed update"
 			case "manual":

--- a/internal/banlog/banlog.go
+++ b/internal/banlog/banlog.go
@@ -55,7 +55,6 @@ const (
 	SourceDDoS      = "ddos"
 	SourceFeeds     = "feeds"
 	SourceSuricata  = "suricata"
-	SourceFail2ban  = "fail2ban" // Legacy compatibility
 )
 
 // Status constants
@@ -193,8 +192,6 @@ func normalizeSource(source string) string {
 		return SourceFeeds
 	case "suricata", "ids":
 		return SourceSuricata
-	case "fail2ban":
-		return SourceFail2ban
 	default:
 		// Keep original for unknown sources
 		return source


### PR DESCRIPTION
## Summary
- Remove fail2ban as an ingestion/analytics dimension
- No active code path produces fail2ban data (verified: zero writers)
- Conflict detection code is explicitly KEPT (required for safe install)

## Removed
| File | What | Lines |
|---|---|---|
| `analytics/types.go` | `Jail` field + `ByJail` map | 2 |
| `analytics/state.go` | Legacy jail comment | 1 |
| `banlog/banlog.go` | `SourceFail2ban` constant + `case "fail2ban"` | 3 |
| `handlers_analytics.go` | `case "fail2ban"` display mapping | 2 |
| `metrics-registry.json` | `"fail2ban"` from health_status labels | 1 |

## Kept (conflict detection)
- `nftban_firewall_conflicts.sh` (~50 refs)
- `nftban_checks.sh`, `cmd_firewall.sh`, `cmd_health_analysis.sh`
- `nftbanconf/services.go` `Fail2banService` field

## Test plan
- [ ] `grep -rn 'SourceFail2ban' internal/` → 0 matches
- [ ] `grep -rn '\.Jail\b' internal/analytics/` → 0 matches
- [ ] `grep -rn 'ByJail' internal/analytics/` → 0 matches
- [ ] `grep -c 'fail2ban' cli/lib/nftban/core/nftban_firewall_conflicts.sh` → still ~50
- [ ] Go builds clean, all tests pass

Ref: V191_FAIL2BAN_DECOMMISSION_PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)