### PR TITLE
fix(installer): update cascade fix — rebuild exit codes + daemon recovery + dpkg resilience

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1292,7 +1292,31 @@ firewall_rebuild() {
     [[ "$quiet" == "false" && "$restored_count" -eq 0 ]] && echo "    No blacklist entries to restore"
 
     # Step 8 (v1.50.1): Re-apply DDoS protection if enabled
+    # Preflight: module re-enable requires daemon IPC. If daemon is down
+    # (e.g. start-limit-hit from update cycles), attempt recovery first.
+    # Without this, module commands fail silently and POST validation sees
+    # missing chains → DEGRADED → installer treats as FAILED.
     [[ "$quiet" == "false" ]] && echo "  [8/12] Re-applying protection modules..."
+    if ! systemctl is-active --quiet nftband.service 2>/dev/null; then
+        [[ "$quiet" == "false" ]] && echo "    Daemon not running — attempting recovery..."
+        # Clear start-limit-hit then try to start
+        if command -v nftban_service_clear_failed &>/dev/null; then
+            nftban_service_clear_failed "nftband.service" 2>/dev/null || true
+            nftban_service_clear_failed "nftband.socket" 2>/dev/null || true
+        else
+            systemctl reset-failed nftband.service 2>/dev/null || true
+            systemctl reset-failed nftband.socket 2>/dev/null || true
+        fi
+        systemctl start nftband.service 2>/dev/null || true
+        sleep 2
+        if systemctl is-active --quiet nftband.service 2>/dev/null; then
+            [[ "$quiet" == "false" ]] && echo "    Daemon recovered — proceeding with module re-enable"
+        else
+            echo "    WARNING: Daemon still down — module re-enable will fail." >&2
+            echo "    Module chains will be absent. POST validation may report DEGRADED." >&2
+            echo "    After install: systemctl reset-failed nftband && systemctl start nftband" >&2
+        fi
+    fi
     local _ddos_enabled="false"
     local _ddos_local_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/ddos/main.conf.local"
     if [[ -f "$_ddos_local_conf" ]]; then

--- a/cli/lib/nftban/core/nftban_health_checks_services.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_services.sh
@@ -99,8 +99,9 @@ nftban_health_check_daemon() {
             daemon_issues+=("nftband.socket not active")
             [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
 
-            # Auto-heal: Start socket
+            # Auto-heal: Start socket (clear start-limit-hit first)
             if [[ $auto_heal -eq 1 ]] || [[ "${NFTBAN_HEALTH_AUTO_HEAL:-false}" == "true" ]]; then
+                nftban_service_clear_failed "nftband.socket" 2>/dev/null || true
                 if systemctl start nftband.socket 2>/dev/null; then
                     daemon_issues+=("AUTO-FIXED: Started nftband.socket")
                 else
@@ -123,8 +124,9 @@ nftban_health_check_daemon() {
             daemon_issues+=("CRITICAL: nftband daemon not running - feeds and bans will not work!")
             status=$HEALTH_ERROR
 
-            # Auto-heal: Start daemon
+            # Auto-heal: Start daemon (clear start-limit-hit first)
             if [[ $auto_heal -eq 1 ]] || [[ "${NFTBAN_HEALTH_AUTO_HEAL:-false}" == "true" ]]; then
+                nftban_service_clear_failed "nftband.service" 2>/dev/null || true
                 if systemctl start nftband.service 2>/dev/null; then
                     sleep 2
                     if _health_service_active "nftband.service"; then

--- a/cli/lib/nftban/core/nftban_health_fixes.sh
+++ b/cli/lib/nftban/core/nftban_health_fixes.sh
@@ -1586,6 +1586,7 @@ nftban_health_fix_daemon_memory() {
         # Log the event
         logger -t nftban-health "Memory leak detected: RSS=${current_mb}MB, Growth=${mb_per_hour}MB/h, Pressure=${memory_pressure}%. Restarting nftband."
 
+        nftban_service_clear_failed "nftband.service" 2>/dev/null || true
         if systemctl restart nftband 2>/dev/null; then
             sleep 2
             local new_pid new_rss

--- a/cli/lib/nftban/helpers/autoheal.sh
+++ b/cli/lib/nftban/helpers/autoheal.sh
@@ -314,6 +314,7 @@ log_info "Checking nftband daemon status..."
 if systemctl list-unit-files nftband.socket &>/dev/null 2>&1; then
     if ! systemctl is-active --quiet nftband.socket 2>/dev/null; then
         log_warn "nftband.socket not active - attempting to start..."
+        nftban_service_clear_failed "nftband.socket" 2>/dev/null || true
         if systemctl start nftband.socket 2>/dev/null; then
             log_info "AUTO-FIXED: Started nftband.socket"
         else
@@ -329,6 +330,7 @@ if systemctl list-unit-files nftband.service &>/dev/null 2>&1; then
     if ! systemctl is-active --quiet nftband.service 2>/dev/null; then
         log_warn "nftband daemon not running - feeds and bans will not work!"
         log_warn "Attempting to start nftband.service..."
+        nftban_service_clear_failed "nftband.service" 2>/dev/null || true
         if systemctl start nftband.service 2>/dev/null; then
             sleep 2
             if systemctl is-active --quiet nftband.service 2>/dev/null; then

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -786,6 +786,37 @@ nftban_disable_all() {
     return 0
 }
 
+# Clear systemd start-limit-hit state before starting a service.
+# When a service crashes repeatedly, systemd stops retrying and marks
+# it as failed with 'start-limit-hit'. A subsequent 'systemctl start'
+# will fail silently. This function clears that state first.
+# Usage: nftban_service_clear_failed "nftband.service"
+nftban_service_clear_failed() {
+    local unit="$1"
+    local state
+    state=$(systemctl show -p ActiveState --value "$unit" 2>/dev/null) || return 0
+    if [[ "$state" == "failed" ]]; then
+        systemctl reset-failed "$unit" 2>/dev/null || true
+    fi
+}
+
+# Safe daemon restart: clear start-limit-hit then restart.
+# This is the ONLY correct way to restart nftband after a crash loop.
+# Usage: nftban_daemon_restart
+nftban_daemon_restart() {
+    nftban_service_clear_failed "nftband.service"
+    nftban_service_clear_failed "nftband.socket"
+    systemctl restart nftband.service
+}
+
+# Safe daemon start: clear start-limit-hit then start.
+# Usage: nftban_daemon_start
+nftban_daemon_start() {
+    nftban_service_clear_failed "nftband.service"
+    nftban_service_clear_failed "nftband.socket"
+    systemctl start nftband.service
+}
+
 # Start a specific service if enabled
 # Usage: nftban_service_start "suricata"
 nftban_service_start() {
@@ -813,10 +844,10 @@ nftban_service_start() {
             # v1.48.0: Login monitoring handled by nftband daemon loginmon module
             echo "Login monitoring is part of the nftband daemon (loginmon module)"
             echo "Starting nftband daemon..."
-            systemctl start nftband.service
+            nftban_daemon_start
             ;;
         nftban|nftband)
-            systemctl start nftband.service
+            nftban_daemon_start
             ;;
         *)
             echo "Unknown service: $service" >&2
@@ -990,6 +1021,9 @@ export -f nftban_service_is_enabled
 export -f nftban_service_auto_start
 export -f nftban_enable_all
 export -f nftban_disable_all
+export -f nftban_service_clear_failed
+export -f nftban_daemon_restart
+export -f nftban_daemon_start
 export -f nftban_service_start
 export -f nftban_service_stop
 export -f nftban_services_status

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -190,6 +190,17 @@ func runRepair(ctx context.Context, exec executor.Executor, sf *state.StateFile,
 		{state.PhaseValidate, "Validate", phaseValidate},
 	}
 
+	// Always run Detect first — later phases depend on distro/panel/conflict
+	// detection results (e.g. Switch needs pd.distro for xt-compat cleanup).
+	// Without this, repair from SWITCH/CONFIGURE/VALIDATE would crash on nil
+	// distro because Detect was skipped.
+	if startPhase != state.PhaseDetect {
+		log.Phase("Detect")
+		if err := phaseDetect(ctx, exec, sf, log); err != nil {
+			log.Warn("detect during repair: %v (continuing)", err)
+		}
+	}
+
 	started := false
 	lastName := ""
 	for _, p := range phases {

--- a/install/systemd/nftband.service
+++ b/install/systemd/nftband.service
@@ -51,8 +51,11 @@ After=network.target nftables.service nftban-firewall-init.service
 Wants=nftables.service
 
 # Restart rate limiting (must be in [Unit], not [Service])
-StartLimitBurst=5
-StartLimitIntervalSec=300
+# v1.90.1: Increased from 5/300s to 10/600s — socket activation and
+# update/install cycles can exhaust a tight limit. If the daemon
+# genuinely crashes 10 times in 10 minutes, there is a real problem.
+StartLimitBurst=10
+StartLimitIntervalSec=600
 
 # Alert on failure (v1.43.0: moved from [Service] — OnFailure is a Unit-level directive)
 OnFailure=nftban-alert@%n.service

--- a/internal/installer/services/daemon.go
+++ b/internal/installer/services/daemon.go
@@ -37,6 +37,13 @@ func StartDaemon(exec executor.Executor, log *logging.Logger) {
 		log.Warn("daemon-reload: %v", err)
 	}
 
+	// Clear start-limit-hit before attempting start. During update/install
+	// cycles the daemon may have been stopped/started repeatedly, exhausting
+	// systemd's StartLimitBurst. Without reset-failed, all start attempts
+	// will fail with "start request repeated too quickly."
+	_ = exec.Run("systemctl", "reset-failed", "nftband.service")
+	_ = exec.Run("systemctl", "reset-failed", "nftband.socket")
+
 	// Enable socket (primary activation method)
 	if err := exec.ServiceEnable("nftband.socket"); err != nil {
 		log.Warn("enable nftband.socket: %v", err)

--- a/internal/installer/switchop/enable.go
+++ b/internal/installer/switchop/enable.go
@@ -31,7 +31,9 @@ import (
 // Runs cleanXtCompat() first to remove stale xt target rules that would
 // prevent nftables from starting (common on CSF/cPanel servers).
 func EnableNftables(exec executor.Executor, distro *detect.DistroInfo, log *logging.Logger) error {
-	cleanXtCompat(exec, distro, log)
+	if distro != nil {
+		cleanXtCompat(exec, distro, log)
+	}
 
 	if err := exec.ServiceEnable("nftables"); err != nil {
 		log.Warn("enable nftables: %v", err)

--- a/internal/installer/switchop/rebuild.go
+++ b/internal/installer/switchop/rebuild.go
@@ -30,23 +30,37 @@ import (
 const rebuildTimeout = 60 * time.Second
 
 // Rebuild runs "nftban firewall rebuild" and returns an error if it fails.
-// No retry, no fallback. Failure is FATAL (v1.70.0 invariant: rebuild failure
-// must not be silently converted to reload).
+// Shell rebuild exit code contract (authoritative — do not redefine):
+//   0 = PROTECTED (all checks passed)
+//   1 = DEGRADED  (firewall operational, some module checks failed)
+//   2 = FAILED    (rollback happened)
+//   3 = FATAL     (rollback also failed)
+//
+// Exit 1 (DEGRADED) is expected during upgrade: module-scoped chains
+// require the daemon to be running, which may not be the case yet.
+// Only exit 2+ is treated as a fatal rebuild failure.
 func Rebuild(exec executor.Executor, log *logging.Logger) error {
 	log.Info("running nftban firewall rebuild (timeout=%s)", rebuildTimeout)
 
 	res := exec.RunTimeout(rebuildTimeout, fhs.NftbanCLI, "firewall", "rebuild")
 	log.CmdResult("nftban firewall rebuild", res.ExitCode, res.Stderr)
 
-	if res.ExitCode != 0 {
-		// Write install-failed marker for runtime CLI
+	if res.ExitCode == 1 {
+		// DEGRADED: firewall base schema is loaded but module chains may be
+		// missing (daemon was down during module re-enable). This is recoverable
+		// — module chains will be re-created when daemon starts with modules enabled.
+		log.Warn("firewall rebuild DEGRADED (exit 1): %s", res.Stderr)
+		log.Warn("module chains may be absent — will be created on daemon start")
+		// Continue — do not fail the install for a degraded rebuild
+	} else if res.ExitCode >= 2 {
+		// FAILED or FATAL: real rebuild failure, rollback may have happened
 		if err := exec.WriteFileAtomic(fhs.InstallFailedMarker, []byte("NFTBAN_INSTALL_FAILED=1\n"), 0644); err != nil {
 			log.Warn("failed to write install-failed marker: %v", err)
 		}
 		return fmt.Errorf("nftban firewall rebuild failed (exit %d): %s", res.ExitCode, res.Stderr)
 	}
 
-	log.Info("firewall rebuild completed successfully")
+	log.Info("firewall rebuild completed (exit %d)", res.ExitCode)
 
 	// Write schema version file (G7 parity with shell postinst).
 	// The shell postinst wrote: echo "$CURRENT_SCHEMA" > /etc/nftban/.schema_version

--- a/internal/installer/switchop/rebuild_test.go
+++ b/internal/installer/switchop/rebuild_test.go
@@ -38,13 +38,31 @@ func TestRebuild_Success(t *testing.T) {
 	}
 }
 
-func TestRebuild_Failure(t *testing.T) {
+func TestRebuild_Degraded(t *testing.T) {
+	// Exit 1 = DEGRADED: firewall operational but module checks failed.
+	// This is expected during upgrade and must NOT return an error.
 	mock := executor.NewMockExecutor()
-	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{ExitCode: 1, Stderr: "rebuild failed"}
+	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{ExitCode: 1, Stderr: "DEGRADED"}
+
+	err := Rebuild(mock, newTestLogger())
+	if err != nil {
+		t.Fatalf("exit 1 (DEGRADED) should not return error, got: %v", err)
+	}
+
+	// Verify install-failed marker was NOT written for degraded
+	if mock.FileExists("/run/nftban/install_failed") {
+		t.Error("install_failed marker should not be written for DEGRADED")
+	}
+}
+
+func TestRebuild_Failure(t *testing.T) {
+	// Exit 2 = FAILED: rebuild failed, rollback happened.
+	mock := executor.NewMockExecutor()
+	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{ExitCode: 2, Stderr: "rebuild failed"}
 
 	err := Rebuild(mock, newTestLogger())
 	if err == nil {
-		t.Fatal("expected error, got nil")
+		t.Fatal("exit 2 (FAILED) should return error, got nil")
 	}
 
 	// Verify install-failed marker was written

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -140,8 +140,13 @@ case "$1" in
         if [ -x "$NFTBAN_INSTALLER" ]; then
             log_info "Running nftban-installer --deb (mode=$INSTALL_MODE)..."
 
-            "$NFTBAN_INSTALLER" --deb --mode="$INSTALL_MODE"
-            INSTALLER_EXIT=$?
+            # Run installer and capture exit code. The || true prevents set -e
+            # from aborting the postinst on non-zero exit. Without this, set -e
+            # kills the script before INSTALLER_EXIT is assigned, making the
+            # if/elif error handling below dead code and causing dpkg to mark
+            # the package as broken (iF) even for DEGRADED (exit 1) results.
+            INSTALLER_EXIT=0
+            "$NFTBAN_INSTALLER" --deb --mode="$INSTALL_MODE" || INSTALLER_EXIT=$?
 
             if [ $INSTALLER_EXIT -eq 0 ]; then
                 log_info "========================================"


### PR DESCRIPTION
## Summary — 4 P0 fixes for the update failure cascade

Root cause chain (lab2 v1.87.1 → v1.90.0):
1. Daemon hits start-limit-hit from restart cycles during update
2. Module re-enable commands fail silently (daemon down)
3. POST validation sees missing chains → DEGRADED (exit 1)
4. Go installer treats exit 1 as FAILED_REBUILD
5. postinst `set -e` aborts on non-zero → dpkg marks package broken (iF)
6. Repair crashes on nil distro (Detect phase skipped)

### Fix 1: rebuild.go — align with shell exit-code contract
- Shell contract: 0=PROTECTED, 1=DEGRADED, 2=FAILED, 3=FATAL
- Before: any non-zero → FAILED_REBUILD
- After: exit 1 → log warning, continue. Exit 2+ → FAILED_REBUILD

### Fix 2: daemon.go — reset-failed before start retry loop
- Before: raw ServiceStart retries, fails on start-limit-hit
- After: `systemctl reset-failed nftband.{service,socket}` first

### Fix 3: postinst — capture exit without set -e abort
- Before: `set -e` kills script on installer exit 1, if/elif dead code
- After: `|| INSTALLER_EXIT=$?` captures exit code, script continues

### Fix 4: cmd_firewall.sh — preflight daemon liveness before module re-enable
- Detects daemon down, attempts reset-failed + restart recovery
- If still down, warns explicitly instead of failing silently

### Also included (from earlier commits)
- Shell-side `nftban_service_clear_failed()` helper + safe restart wrappers
- systemd StartLimitBurst 5→10, Interval 300→600s
- Repair nil-pointer fix (always run Detect before resume)

## Lab verification
- lab4: Go build PASS (installer + daemon + go vet)
- lab2: dpkg --configure PASS → COMMITTED → PROTECTED

## Acceptance criteria
- [x] Update with daemon in start-limit-hit does not leave dpkg broken
- [x] Rebuild exit 1 logged as DEGRADED, not FAILED_REBUILD
- [x] Module re-enable succeeds after daemon recovery or warns explicitly
- [x] End state is never broken-package + dead-daemon + stuck-repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)