### PR TITLE
feat(ruleengine): Event Rule Engine v1 — semantic behavioral matching

### DIFF
--- a/etc/nftban/rules.d/exploit.yml
+++ b/etc/nftban/rules.d/exploit.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="exploit"
+# meta:type="config"
+# meta:version="1.93.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-16"
+# meta:description="Event Rule Engine — exploit indicator detection rules"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# NFTBan Event Rule Engine — Exploit Indicators
+# ================================================
+# Detects path traversal, shell injection, and admin probe patterns.
+# Operates on normalized events only — no payload inspection.
+
+name: exploit
+rules:
+  - id: EX-001
+    name: "path traversal marker"
+    match:
+      event_type: http_attack
+      category: traversal
+    threshold:
+      count: 3
+      window: 300s
+      per: src_ip
+    score: 60
+    action: ban_long
+
+  - id: EX-002
+    name: "shell command in URI"
+    match:
+      event_type: http_attack
+      category: exploit
+      metadata:
+        uri:
+          contains: "/bin/sh"
+    score: 80
+    action: ban_long
+
+  - id: EX-003
+    name: "admin path burst"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          prefix: "/admin"
+    threshold:
+      count: 20
+      window: 60s
+      per: src_ip
+    score: 30
+    action: ban_short

--- a/etc/nftban/rules.d/sqli.yml
+++ b/etc/nftban/rules.d/sqli.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="sqli"
+# meta:type="config"
+# meta:version="1.93.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-16"
+# meta:description="Event Rule Engine — SQLi indicator detection rules"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# NFTBan Event Rule Engine — SQLi Indicators
+# =============================================
+# Detects SQL injection indicators from normalized fields.
+# NOT payload inspection — matches on event category and metadata
+# set by upstream detectors (BotGuard, Suricata adapter).
+
+name: sqli
+rules:
+  - id: SQL-001
+    name: "SQLi indicator from IDS"
+    match:
+      event_type: ids_alert
+      category: sqli
+    threshold:
+      count: 3
+      window: 300s
+      per: src_ip
+    score: 80
+    action: ban_long
+
+  - id: SQL-002
+    name: "SQLi indicator from web"
+    match:
+      event_type: http_attack
+      category: sqli
+    threshold:
+      count: 2
+      window: 120s
+      per: src_ip
+    score: 70
+    action: ban_long

--- a/etc/nftban/rules.d/web_paths.yml
+++ b/etc/nftban/rules.d/web_paths.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="web_paths"
+# meta:type="config"
+# meta:version="1.93.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-16"
+# meta:description="Event Rule Engine — web path probe detection rules"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# NFTBan Event Rule Engine — Web Path Probes
+# ===========================================
+# Detects common web path probing patterns.
+# Operates on normalized events only — no payload inspection.
+
+name: web_paths
+rules:
+  - id: WP-001
+    name: "xmlrpc.php burst"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          contains: "/xmlrpc.php"
+    threshold:
+      count: 10
+      window: 60s
+      per: src_ip
+    score: 30
+    action: ban_short
+
+  - id: WP-002
+    name: "wp-login brute force"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          contains: "/wp-login.php"
+        method:
+          exact: "POST"
+    threshold:
+      count: 20
+      window: 120s
+      per: src_ip
+    score: 50
+    action: ban_long
+
+  - id: WP-003
+    name: "wp-admin probe"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          prefix: "/wp-admin"
+    threshold:
+      count: 15
+      window: 60s
+      per: src_ip
+    score: 25
+    action: ban_short
+
+  - id: WP-004
+    name: "phpmyadmin probe"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          contains: "phpmyadmin"
+    threshold:
+      count: 5
+      window: 60s
+      per: src_ip
+    score: 40
+    action: ban_short
+
+  - id: WP-005
+    name: "env file probe"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          contains: ".env"
+    threshold:
+      count: 3
+      window: 60s
+      per: src_ip
+    score: 50
+    action: ban_long
+
+  - id: WP-006
+    name: "git directory probe"
+    match:
+      event_type: http_probe
+      metadata:
+        uri:
+          contains: "/.git/"
+    threshold:
+      count: 3
+      window: 60s
+      per: src_ip
+    score: 50
+    action: ban_long

--- a/internal/ruleengine/engine.go
+++ b/internal/ruleengine/engine.go
@@ -1,0 +1,247 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: Core Engine
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-engine"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Semantic event rule engine — matches normalized events against rules"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="/etc/nftban/rules.d/*.rules"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// Engine is the event rule engine. It matches normalized events against
+// loaded rules and produces actions (observe, score, ban_*).
+//
+// The engine operates at the semantic/behavioral layer ONLY.
+// It MUST NOT trigger inline Suricata behavior (INV-S-012).
+// It MUST NOT inspect raw packets or payloads.
+// All enforcement goes through daemon IPC → nftables (INV-S-004).
+type Engine struct {
+	mu       sync.RWMutex
+	rules    []Rule
+	scores   map[string]*ipScore // per-IP score tracker
+	counters map[string]*thresholdCounter // per-IP per-rule threshold counters
+}
+
+type ipScore struct {
+	score     int
+	lastEvent time.Time
+}
+
+type thresholdCounter struct {
+	events []time.Time
+}
+
+// Result is the engine's decision for an event.
+type Result struct {
+	Matched  bool   `json:"matched"`
+	RuleID   string `json:"rule_id,omitempty"`
+	RuleName string `json:"rule_name,omitempty"`
+	Action   string `json:"action"`           // observe, score, ban_short, ban_long, ban_permanent
+	Score    int    `json:"score,omitempty"`   // points added
+	TotalScore int  `json:"total_score"`      // accumulated per-IP score
+}
+
+// New creates a new rule engine.
+func New() *Engine {
+	return &Engine{
+		rules:    nil,
+		scores:   make(map[string]*ipScore),
+		counters: make(map[string]*thresholdCounter),
+	}
+}
+
+// LoadRules replaces the current rule set.
+func (e *Engine) LoadRules(rules []Rule) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.rules = rules
+	log.Printf("[ruleengine] loaded %d rules", len(rules))
+}
+
+// RuleCount returns the number of loaded rules.
+func (e *Engine) RuleCount() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.rules)
+}
+
+// Evaluate processes an event against all loaded rules.
+// Returns the highest-priority matching result.
+func (e *Engine) Evaluate(ev *Event) *Result {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if len(e.rules) == 0 {
+		return &Result{Action: ActionObserve}
+	}
+
+	var bestResult *Result
+
+	for i := range e.rules {
+		r := &e.rules[i]
+		if !r.Matches(ev) {
+			continue
+		}
+
+		// Check threshold if defined
+		if r.Threshold != nil {
+			key := ev.SourceIP + ":" + r.ID
+			if !e.checkThreshold(key, r.Threshold) {
+				continue // threshold not met
+			}
+		}
+
+		// Apply score
+		e.addScore(ev.SourceIP, r.Score)
+		total := e.getScore(ev.SourceIP)
+
+		result := &Result{
+			Matched:    true,
+			RuleID:     r.ID,
+			RuleName:   r.Name,
+			Action:     r.Action,
+			Score:      r.Score,
+			TotalScore: total,
+		}
+
+		// Score-based escalation (if action is "score")
+		if r.Action == ActionScore {
+			result.Action = e.scoreToAction(total)
+		}
+
+		// Keep highest-priority result
+		if bestResult == nil || actionPriority(result.Action) > actionPriority(bestResult.Action) {
+			bestResult = result
+		}
+	}
+
+	if bestResult == nil {
+		return &Result{Action: ActionObserve}
+	}
+
+	return bestResult
+}
+
+// checkThreshold verifies the event count exceeds the threshold within the window.
+func (e *Engine) checkThreshold(key string, t *RuleThreshold) bool {
+	now := time.Now()
+	cutoff := now.Add(-t.Window)
+
+	tc, ok := e.counters[key]
+	if !ok {
+		tc = &thresholdCounter{}
+		e.counters[key] = tc
+	}
+
+	// Add current event
+	tc.events = append(tc.events, now)
+
+	// Evict old events
+	valid := tc.events[:0]
+	for _, ts := range tc.events {
+		if ts.After(cutoff) {
+			valid = append(valid, ts)
+		}
+	}
+	tc.events = valid
+
+	return len(tc.events) >= t.Count
+}
+
+// addScore adds points to an IP's score tracker.
+func (e *Engine) addScore(ip string, points int) {
+	s, ok := e.scores[ip]
+	if !ok {
+		s = &ipScore{}
+		e.scores[ip] = s
+	}
+
+	// Decay: 1 point per minute since last event
+	if !s.lastEvent.IsZero() {
+		elapsed := time.Since(s.lastEvent)
+		decay := int(elapsed.Minutes())
+		s.score -= decay
+		if s.score < 0 {
+			s.score = 0
+		}
+	}
+
+	s.score += points
+	s.lastEvent = time.Now()
+}
+
+func (e *Engine) getScore(ip string) int {
+	s, ok := e.scores[ip]
+	if !ok {
+		return 0
+	}
+	return s.score
+}
+
+// scoreToAction maps accumulated score to an action.
+func (e *Engine) scoreToAction(score int) string {
+	switch {
+	case score >= 100:
+		return ActionBanPermanent
+	case score >= 50:
+		return ActionBanLong
+	case score >= 25:
+		return ActionBanShort
+	default:
+		return ActionObserve
+	}
+}
+
+// actionPriority returns a numeric priority for action comparison.
+func actionPriority(action string) int {
+	switch action {
+	case ActionBanPermanent:
+		return 4
+	case ActionBanLong:
+		return 3
+	case ActionBanShort:
+		return 2
+	case ActionScore:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Cleanup removes expired entries from scores and counters.
+// Call periodically (e.g. every 5 minutes).
+func (e *Engine) Cleanup(maxAge time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cutoff := time.Now().Add(-maxAge)
+
+	for ip, s := range e.scores {
+		if s.lastEvent.Before(cutoff) {
+			delete(e.scores, ip)
+		}
+	}
+
+	for key, tc := range e.counters {
+		if len(tc.events) == 0 || tc.events[len(tc.events)-1].Before(cutoff) {
+			delete(e.counters, key)
+		}
+	}
+}

--- a/internal/ruleengine/event.go
+++ b/internal/ruleengine/event.go
@@ -1,0 +1,70 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: Normalized Event Schema
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-event"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Normalized event schema for semantic/behavioral rule matching"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import "time"
+
+// Event is the normalized event format consumed by the rule engine.
+// All detection sources (BotGuard, Suricata, LoginMon, future adapters)
+// produce events in this format. The rule engine never sees raw packets,
+// payloads, or protocol-specific data (INV-S-012).
+type Event struct {
+	Timestamp time.Time         `json:"timestamp"`
+	EventType string            `json:"event_type"` // http_probe, http_attack, ids_alert, auth_fail, remote_intel
+	SourceIP  string            `json:"src_ip"`
+	DestIP    string            `json:"dest_ip"`
+	DestPort  int               `json:"dest_port"`
+	Protocol  string            `json:"proto"`       // tcp, udp, icmp
+	Service   string            `json:"service"`     // ssh, http, smtp, dns
+	Category  string            `json:"category"`    // sqli, traversal, probe, brute, c2, exploit
+	Confidence float64          `json:"confidence"`  // 0.0-1.0
+	Source    string            `json:"source"`      // botguard, suricata, loginmon, rule_engine
+	Metadata  map[string]string `json:"metadata"`    // uri, method, status, user_agent, signature, sid
+}
+
+// Event type constants
+const (
+	EventHTTPProbe   = "http_probe"
+	EventHTTPAttack  = "http_attack"
+	EventIDSAlert    = "ids_alert"
+	EventAuthFail    = "auth_fail"
+	EventRemoteIntel = "remote_intel"
+)
+
+// Category constants
+const (
+	CategorySQLi      = "sqli"
+	CategoryTraversal = "traversal"
+	CategoryProbe     = "probe"
+	CategoryBrute     = "brute"
+	CategoryC2        = "c2"
+	CategoryExploit   = "exploit"
+	CategoryMalware   = "malware"
+	CategoryXSS       = "xss"
+)
+
+// Source constants
+const (
+	SourceBotGuard   = "botguard"
+	SourceSuricata   = "suricata"
+	SourceLoginMon   = "loginmon"
+	SourceRuleEngine = "rule_engine"
+	SourceFeed       = "feed"
+)

--- a/internal/ruleengine/rule.go
+++ b/internal/ruleengine/rule.go
@@ -1,0 +1,113 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: Rule Definition
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-rule"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Rule grammar for semantic/behavioral event matching"
+// meta:inventory.files="/etc/nftban/rules.d/*.rules"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import (
+	"strings"
+	"time"
+)
+
+// Rule defines a single matching rule.
+type Rule struct {
+	ID        string            `yaml:"id" json:"id"`
+	Name      string            `yaml:"name" json:"name"`
+	Match     RuleMatch         `yaml:"match" json:"match"`
+	Threshold *RuleThreshold    `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+	Score     int               `yaml:"score" json:"score"`
+	Action    string            `yaml:"action" json:"action"` // observe, score, ban_short, ban_long, ban_permanent
+}
+
+// RuleMatch defines the event matching criteria.
+type RuleMatch struct {
+	EventType string            `yaml:"event_type,omitempty" json:"event_type,omitempty"`
+	Category  string            `yaml:"category,omitempty" json:"category,omitempty"`
+	Service   string            `yaml:"service,omitempty" json:"service,omitempty"`
+	Metadata  map[string]FieldMatch `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+}
+
+// FieldMatch defines how a single field is matched.
+type FieldMatch struct {
+	Exact    string `yaml:"exact,omitempty" json:"exact,omitempty"`
+	Contains string `yaml:"contains,omitempty" json:"contains,omitempty"`
+	Prefix   string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+}
+
+// RuleThreshold defines count-over-time-window thresholds.
+type RuleThreshold struct {
+	Count  int           `yaml:"count" json:"count"`
+	Window time.Duration `yaml:"window" json:"window"`
+	Per    string        `yaml:"per" json:"per"` // "src_ip" (always per source IP)
+}
+
+// RulePack is a collection of rules loaded from a .rules file.
+type RulePack struct {
+	Name  string `yaml:"name" json:"name"`
+	Rules []Rule `yaml:"rules" json:"rules"`
+}
+
+// Matches checks if an event matches this rule's criteria.
+// This is pure field matching — no payload inspection (INV-S-012).
+func (r *Rule) Matches(e *Event) bool {
+	m := r.Match
+
+	if m.EventType != "" && m.EventType != e.EventType {
+		return false
+	}
+	if m.Category != "" && m.Category != e.Category {
+		return false
+	}
+	if m.Service != "" && m.Service != e.Service {
+		return false
+	}
+
+	for key, fm := range m.Metadata {
+		val, ok := e.Metadata[key]
+		if !ok {
+			return false
+		}
+		if !fm.matches(val) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (fm *FieldMatch) matches(val string) bool {
+	if fm.Exact != "" {
+		return val == fm.Exact
+	}
+	if fm.Contains != "" {
+		return strings.Contains(strings.ToLower(val), strings.ToLower(fm.Contains))
+	}
+	if fm.Prefix != "" {
+		return strings.HasPrefix(strings.ToLower(val), strings.ToLower(fm.Prefix))
+	}
+	return true // no criteria = match all
+}
+
+// Action constants
+const (
+	ActionObserve      = "observe"
+	ActionScore        = "score"
+	ActionBanShort     = "ban_short"
+	ActionBanLong      = "ban_long"
+	ActionBanPermanent = "ban_permanent"
+)


### PR DESCRIPTION
## Summary — Event Rule Engine v1

Semantic/behavioral rule engine operating on normalized events.
NOT DPI, NOT payload inspection, NOT Suricata-lite (INV-S-012).

### New package: internal/ruleengine (+596 LOC)

| File | LOC | Purpose |
|---|---|---|
| event.go | 70 | Normalized event schema |
| rule.go | 113 | Rule grammar (exact/contains/prefix, threshold) |
| engine.go | 247 | Core engine (evaluate, score, decay, cleanup) |

### Score system
- `>= 100` → ban_permanent
- `>= 50` → ban_long
- `>= 25` → ban_short
- `< 25` → observe
- Decay: 1 point/minute

### Initial rule packs (+166 LOC)
- web_paths.yml: xmlrpc, wp-login, wp-admin, phpmyadmin, .env, .git
- exploit.yml: path traversal, shell injection, admin probe
- sqli.yml: SQLi indicators from IDS/web events

### Integration model
```
BotGuard/Suricata/LoginMon → NormalizedEvent → Engine → Action → daemon IPC → nftables
```

### Lab verification
- lab4: `go build + go vet` PASS

> **Build & Integrity Status:** [STATUS.md](https://github.com/itcmsgr/nftban/blob/main/STATUS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)