### PR TITLE
feat(ruleengine): v1.93 — YAML loader + source adapters + service integration

### DIFF
--- a/internal/ruleengine/adapter.go
+++ b/internal/ruleengine/adapter.go
@@ -1,0 +1,149 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: Source Adapters
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-adapter"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Adapters that produce NormalizedEvents from detection sources"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import (
+	"fmt"
+	"time"
+)
+
+// EventAdapter produces normalized events from a detection source.
+// Each detection module (BotGuard, Suricata, LoginMon) implements this
+// to feed events into the rule engine.
+//
+// The adapter MUST NOT trigger inline behavior (INV-S-012).
+// The adapter MUST NOT inspect raw packets or payloads.
+type EventAdapter interface {
+	// Name returns the adapter source name (e.g. "botguard", "suricata", "loginmon")
+	Name() string
+}
+
+// NewBotGuardEvent creates a normalized event from BotGuard detection data.
+// Called by the BotGuard module when it detects suspicious HTTP behavior.
+func NewBotGuardEvent(srcIP, destIP string, destPort int, uri, method, userAgent, category string, confidence float64) *Event {
+	return &Event{
+		Timestamp:  time.Now(),
+		EventType:  EventHTTPProbe,
+		SourceIP:   srcIP,
+		DestIP:     destIP,
+		DestPort:   destPort,
+		Protocol:   "tcp",
+		Service:    "http",
+		Category:   category,
+		Confidence: confidence,
+		Source:     SourceBotGuard,
+		Metadata: map[string]string{
+			"uri":        uri,
+			"method":     method,
+			"user_agent": userAgent,
+		},
+	}
+}
+
+// NewSuricataEvent creates a normalized event from a Suricata EVE alert.
+// Called by the Suricata adapter when it processes an alert.
+func NewSuricataEvent(srcIP, destIP string, srcPort, destPort int, proto, signature, category string, severity int, sid int) *Event {
+	return &Event{
+		Timestamp:  time.Now(),
+		EventType:  EventIDSAlert,
+		SourceIP:   srcIP,
+		DestIP:     destIP,
+		DestPort:   destPort,
+		Protocol:   proto,
+		Service:    portToService(destPort),
+		Category:   category,
+		Confidence: severityToConfidence(severity),
+		Source:     SourceSuricata,
+		Metadata: map[string]string{
+			"signature": signature,
+			"sid":       fmt.Sprintf("%d", sid),
+			"severity":  fmt.Sprintf("%d", severity),
+		},
+	}
+}
+
+// NewLoginMonEvent creates a normalized event from LoginMon auth failure.
+func NewLoginMonEvent(srcIP, destIP string, destPort int, service, user string) *Event {
+	return &Event{
+		Timestamp:  time.Now(),
+		EventType:  EventAuthFail,
+		SourceIP:   srcIP,
+		DestIP:     destIP,
+		DestPort:   destPort,
+		Protocol:   "tcp",
+		Service:    service,
+		Category:   CategoryBrute,
+		Confidence: 0.8,
+		Source:     SourceLoginMon,
+		Metadata: map[string]string{
+			"user": user,
+		},
+	}
+}
+
+// NewFeedEvent creates a normalized event from threat intel feed match.
+func NewFeedEvent(srcIP, feedName, indicator string, confidence float64) *Event {
+	return &Event{
+		Timestamp:  time.Now(),
+		EventType:  EventRemoteIntel,
+		SourceIP:   srcIP,
+		Category:   "feed",
+		Confidence: confidence,
+		Source:     SourceFeed,
+		Metadata: map[string]string{
+			"feed":      feedName,
+			"indicator": indicator,
+		},
+	}
+}
+
+func portToService(port int) string {
+	switch port {
+	case 22:
+		return "ssh"
+	case 80, 8080:
+		return "http"
+	case 443, 8443:
+		return "https"
+	case 25, 587:
+		return "smtp"
+	case 53:
+		return "dns"
+	case 3306:
+		return "mysql"
+	case 5432:
+		return "postgres"
+	default:
+		return "other"
+	}
+}
+
+func severityToConfidence(severity int) float64 {
+	switch severity {
+	case 1:
+		return 0.95
+	case 2:
+		return 0.8
+	case 3:
+		return 0.6
+	default:
+		return 0.5
+	}
+}

--- a/internal/ruleengine/loader.go
+++ b/internal/ruleengine/loader.go
@@ -118,11 +118,7 @@ func loadRuleFile(path string) ([]Rule, error) {
 		if len(rs.Match.Metadata) > 0 {
 			r.Match.Metadata = make(map[string]FieldMatch)
 			for k, v := range rs.Match.Metadata {
-				r.Match.Metadata[k] = FieldMatch{
-					Exact:    v.Exact,
-					Contains: v.Contains,
-					Prefix:   v.Prefix,
-				}
+				r.Match.Metadata[k] = FieldMatch(v)
 			}
 		}
 

--- a/internal/ruleengine/loader.go
+++ b/internal/ruleengine/loader.go
@@ -1,0 +1,147 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: YAML Rule Loader
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-loader"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Loads rule packs from /etc/nftban/rules.d/*.yml"
+// meta:inventory.files="/etc/nftban/rules.d/"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ruleFileSchema is the on-disk YAML format for rule packs.
+type ruleFileSchema struct {
+	Name  string           `yaml:"name"`
+	Rules []ruleYAMLSchema `yaml:"rules"`
+}
+
+type ruleYAMLSchema struct {
+	ID    string `yaml:"id"`
+	Name  string `yaml:"name"`
+	Match struct {
+		EventType string                       `yaml:"event_type,omitempty"`
+		Category  string                       `yaml:"category,omitempty"`
+		Service   string                       `yaml:"service,omitempty"`
+		Metadata  map[string]fieldMatchYAML    `yaml:"metadata,omitempty"`
+	} `yaml:"match"`
+	Threshold *thresholdYAML `yaml:"threshold,omitempty"`
+	Score     int            `yaml:"score"`
+	Action    string         `yaml:"action"`
+}
+
+type fieldMatchYAML struct {
+	Exact    string `yaml:"exact,omitempty"`
+	Contains string `yaml:"contains,omitempty"`
+	Prefix   string `yaml:"prefix,omitempty"`
+}
+
+type thresholdYAML struct {
+	Count  int    `yaml:"count"`
+	Window string `yaml:"window"` // "60s", "5m", etc.
+	Per    string `yaml:"per"`
+}
+
+// LoadRulesFromDir loads all .yml rule packs from a directory.
+// Returns the combined list of rules from all packs.
+func LoadRulesFromDir(dir string) ([]Rule, error) {
+	pattern := filepath.Join(dir, "*.yml")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", pattern, err)
+	}
+
+	if len(files) == 0 {
+		log.Printf("[ruleengine] no rule files found in %s", dir)
+		return nil, nil
+	}
+
+	var allRules []Rule
+	for _, f := range files {
+		rules, err := loadRuleFile(f)
+		if err != nil {
+			log.Printf("[ruleengine] skip %s: %v", f, err)
+			continue
+		}
+		allRules = append(allRules, rules...)
+		log.Printf("[ruleengine] loaded %d rules from %s", len(rules), filepath.Base(f))
+	}
+
+	return allRules, nil
+}
+
+func loadRuleFile(path string) ([]Rule, error) {
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- paths from /etc/nftban/rules.d/ (trusted config dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var schema ruleFileSchema
+	if err := yaml.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+
+	var rules []Rule
+	for _, rs := range schema.Rules {
+		r := Rule{
+			ID:     rs.ID,
+			Name:   rs.Name,
+			Score:  rs.Score,
+			Action: rs.Action,
+			Match: RuleMatch{
+				EventType: rs.Match.EventType,
+				Category:  rs.Match.Category,
+				Service:   rs.Match.Service,
+			},
+		}
+
+		// Convert metadata matches
+		if len(rs.Match.Metadata) > 0 {
+			r.Match.Metadata = make(map[string]FieldMatch)
+			for k, v := range rs.Match.Metadata {
+				r.Match.Metadata[k] = FieldMatch{
+					Exact:    v.Exact,
+					Contains: v.Contains,
+					Prefix:   v.Prefix,
+				}
+			}
+		}
+
+		// Convert threshold
+		if rs.Threshold != nil {
+			window, err := time.ParseDuration(rs.Threshold.Window)
+			if err != nil {
+				log.Printf("[ruleengine] rule %s: invalid threshold window %q, skipping threshold", rs.ID, rs.Threshold.Window)
+			} else {
+				r.Threshold = &RuleThreshold{
+					Count:  rs.Threshold.Count,
+					Window: window,
+					Per:    rs.Threshold.Per,
+				}
+			}
+		}
+
+		rules = append(rules, r)
+	}
+
+	return rules, nil
+}

--- a/internal/ruleengine/service.go
+++ b/internal/ruleengine/service.go
@@ -1,0 +1,143 @@
+// =============================================================================
+// NFTBan - Event Rule Engine: Service (integration layer)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="ruleengine-service"
+// meta:type="package"
+// meta:version="1.93.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Integrates rule engine with daemon — loads rules, processes events, produces actions"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="/etc/nftban/rules.d/"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ruleengine
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// Service is the main integration point for the rule engine.
+// It loads rules from disk, processes incoming events, and returns
+// ban/observe decisions. The daemon wires this into the event pipeline.
+//
+// All enforcement flows through daemon IPC → nftables (INV-S-004).
+// The service MUST NOT trigger inline behavior (INV-S-012).
+type Service struct {
+	engine   *Engine
+	rulesDir string
+	enabled  atomic.Bool
+
+	// Metrics
+	eventsProcessed atomic.Int64
+	rulesMatched    atomic.Int64
+	bansProduced    atomic.Int64
+}
+
+// NewService creates a rule engine service.
+// rulesDir is typically /etc/nftban/rules.d/
+func NewService(rulesDir string) *Service {
+	s := &Service{
+		engine:   New(),
+		rulesDir: rulesDir,
+	}
+	return s
+}
+
+// Start loads rules and enables the service.
+func (s *Service) Start() error {
+	rules, err := LoadRulesFromDir(s.rulesDir)
+	if err != nil {
+		return err
+	}
+
+	s.engine.LoadRules(rules)
+	s.enabled.Store(true)
+
+	log.Printf("[ruleengine] service started with %d rules from %s", s.engine.RuleCount(), s.rulesDir)
+
+	// Start cleanup goroutine (evict expired score/threshold entries every 5 min)
+	go s.cleanupLoop()
+
+	return nil
+}
+
+// Stop disables the service.
+func (s *Service) Stop() {
+	s.enabled.Store(false)
+	log.Printf("[ruleengine] service stopped (processed=%d matched=%d bans=%d)",
+		s.eventsProcessed.Load(), s.rulesMatched.Load(), s.bansProduced.Load())
+}
+
+// Reload reloads rules from disk without stopping.
+func (s *Service) Reload() error {
+	rules, err := LoadRulesFromDir(s.rulesDir)
+	if err != nil {
+		return err
+	}
+	s.engine.LoadRules(rules)
+	log.Printf("[ruleengine] reloaded %d rules", s.engine.RuleCount())
+	return nil
+}
+
+// ProcessEvent evaluates an event against loaded rules.
+// Returns a Result with the action to take.
+// If the service is disabled or no rules match, returns ActionObserve.
+func (s *Service) ProcessEvent(ev *Event) *Result {
+	if !s.enabled.Load() {
+		return &Result{Action: ActionObserve}
+	}
+
+	s.eventsProcessed.Add(1)
+
+	result := s.engine.Evaluate(ev)
+
+	if result.Matched {
+		s.rulesMatched.Add(1)
+		if result.Action != ActionObserve && result.Action != ActionScore {
+			s.bansProduced.Add(1)
+		}
+	}
+
+	return result
+}
+
+// Stats returns current service statistics.
+func (s *Service) Stats() ServiceStats {
+	return ServiceStats{
+		Enabled:         s.enabled.Load(),
+		RuleCount:       s.engine.RuleCount(),
+		EventsProcessed: s.eventsProcessed.Load(),
+		RulesMatched:    s.rulesMatched.Load(),
+		BansProduced:    s.bansProduced.Load(),
+	}
+}
+
+// ServiceStats holds runtime statistics for the rule engine.
+type ServiceStats struct {
+	Enabled         bool  `json:"enabled"`
+	RuleCount       int   `json:"rule_count"`
+	EventsProcessed int64 `json:"events_processed"`
+	RulesMatched    int64 `json:"rules_matched"`
+	BansProduced    int64 `json:"bans_produced"`
+}
+
+func (s *Service) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if !s.enabled.Load() {
+			return
+		}
+		s.engine.Cleanup(1 * time.Hour)
+	}
+}


### PR DESCRIPTION
## Summary — v1.93 Rule Engine Integration (+439 LOC)

Wires the Event Rule Engine (v1.92) into the daemon event pipeline.

### New files

| File | LOC | Purpose |
|---|---|---|
| `loader.go` | 147 | Loads .yml rule packs from `/etc/nftban/rules.d/` |
| `adapter.go` | 149 | Event factories: BotGuard, Suricata, LoginMon, Feeds |
| `service.go` | 143 | Service layer: Start/Stop/Reload/ProcessEvent/Stats |

### Integration flow
```
daemon starts → service.Start() → loads rules from /etc/nftban/rules.d/
detection event → NewBotGuardEvent() / NewSuricataEvent() / etc.
  → service.ProcessEvent(event) → Result{Action, Score}
  → daemon IPC → nftables (INV-S-004)
```

### Lab verification
- lab4: `go build + go vet` PASS

> **Build & Integrity Status:** [STATUS.md](https://github.com/itcmsgr/nftban/blob/main/STATUS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)