### PR TITLE
feat(smoke): v1.95 Phase 2 — module-aware smoke + evidence assertions

### DIFF
--- a/cmd/nftban-core/cmd_smoke.go
+++ b/cmd/nftban-core/cmd_smoke.go
@@ -28,31 +28,38 @@ import (
 )
 
 func cmdSmoke(args []string) int {
+	opts := smoke.RunOptions{Group: "all"}
 	jsonOutput := false
-	group := "all"
 
 	// Parse flags
 	for _, arg := range args {
 		switch {
 		case arg == "--json":
 			jsonOutput = true
+		case arg == "--deep":
+			opts.Deep = true
 		case len(arg) > 8 && arg[:8] == "--group=":
-			group = arg[8:]
+			opts.Group = arg[8:]
+		case len(arg) > 9 && arg[:9] == "--module=":
+			opts.Module = arg[9:]
+			opts.Group = "modules"
 		case arg == "--help" || arg == "-h":
-			fmt.Println("Usage: nftban smoke [--json] [--group=truth|daemon|config|metrics|all]")
+			fmt.Println("Usage: nftban smoke [--json] [--group=GROUP] [--module=MODULE] [--deep]")
 			fmt.Println("")
 			fmt.Println("Run registry-driven smoke tests to verify system integrity.")
 			fmt.Println("")
 			fmt.Println("Options:")
-			fmt.Println("  --json          Output results as JSON")
-			fmt.Println("  --group=GROUP   Run only tests in GROUP (default: all)")
-			fmt.Println("                  Groups: truth, daemon, config, metrics")
+			fmt.Println("  --json            Output results as JSON")
+			fmt.Println("  --group=GROUP     Run only tests in GROUP (default: all)")
+			fmt.Println("                    Groups: truth, daemon, config, metrics, modules, deep")
+			fmt.Println("  --module=MODULE   Run only tests for MODULE (ddos, portscan, botguard, loginmon)")
+			fmt.Println("  --deep            Include deep checks (heavier assertions)")
 			return 0
 		}
 	}
 
 	// Run smoke tests
-	summary := smoke.RunSmoke(version.Version, group)
+	summary := smoke.RunSmoke(version.Version, opts)
 
 	// Output
 	if jsonOutput {

--- a/cmd/nftban-core/cmd_smoke.go
+++ b/cmd/nftban-core/cmd_smoke.go
@@ -1,0 +1,70 @@
+// =============================================================================
+// NFTBan - CLI Smoke Command
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cmd_smoke"
+// meta:type="command"
+// meta:version="1.94.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Registry-driven smoke test runner — nftban smoke [--json] [--group GROUP]"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/itcmsgr/nftban/internal/smoke"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+func cmdSmoke(args []string) int {
+	jsonOutput := false
+	group := "all"
+
+	// Parse flags
+	for _, arg := range args {
+		switch {
+		case arg == "--json":
+			jsonOutput = true
+		case len(arg) > 8 && arg[:8] == "--group=":
+			group = arg[8:]
+		case arg == "--help" || arg == "-h":
+			fmt.Println("Usage: nftban smoke [--json] [--group=truth|daemon|config|metrics|all]")
+			fmt.Println("")
+			fmt.Println("Run registry-driven smoke tests to verify system integrity.")
+			fmt.Println("")
+			fmt.Println("Options:")
+			fmt.Println("  --json          Output results as JSON")
+			fmt.Println("  --group=GROUP   Run only tests in GROUP (default: all)")
+			fmt.Println("                  Groups: truth, daemon, config, metrics")
+			return 0
+		}
+	}
+
+	// Run smoke tests
+	summary := smoke.RunSmoke(version.Version, group)
+
+	// Output
+	if jsonOutput {
+		out, err := smoke.FormatJSON(summary)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "JSON format error: %v\n", err)
+			return 2
+		}
+		fmt.Println(out)
+	} else {
+		fmt.Print(smoke.FormatHuman(summary))
+	}
+
+	return smoke.ExitCode(summary)
+}

--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -243,6 +243,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+	case "smoke":
+		os.Exit(cmdSmoke(os.Args[2:]))
 	case "version":
 		fmt.Printf("nftban-core %s (git %s, build %s)\n", version.FullVersion(), GitCommit, BuildDate)
 	case "help", "--help", "-h":

--- a/internal/smoke/assertions.go
+++ b/internal/smoke/assertions.go
@@ -1,0 +1,133 @@
+// =============================================================================
+// NFTBan - Smoke Framework: Evidence-Aware Assertions
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-assertions"
+// meta:type="package"
+// meta:version="1.95.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Contract-safe assertion helpers for smoke test evidence validation"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package smoke
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Assertion defines a named check on test output.
+type Assertion struct {
+	Name string
+	Fn   func(TestOutput) bool
+}
+
+// AssertJSONValid checks that stdout is valid JSON.
+func AssertJSONValid() Assertion {
+	return Assertion{
+		Name: "json_valid",
+		Fn: func(o TestOutput) bool {
+			var v interface{}
+			return json.Unmarshal([]byte(o.Stdout), &v) == nil
+		},
+	}
+}
+
+// AssertJSONPathExists checks that a top-level key exists in JSON stdout.
+func AssertJSONPathExists(key string) Assertion {
+	return Assertion{
+		Name: "json_path:" + key,
+		Fn: func(o TestOutput) bool {
+			var m map[string]interface{}
+			if err := json.Unmarshal([]byte(o.Stdout), &m); err != nil {
+				return false
+			}
+			_, ok := m[key]
+			return ok
+		},
+	}
+}
+
+// AssertJSONPathEquals checks that a top-level JSON key has an expected string value.
+func AssertJSONPathEquals(key, expected string) Assertion {
+	return Assertion{
+		Name: "json_equals:" + key + "=" + expected,
+		Fn: func(o TestOutput) bool {
+			var m map[string]interface{}
+			if err := json.Unmarshal([]byte(o.Stdout), &m); err != nil {
+				return false
+			}
+			val, ok := m[key]
+			if !ok {
+				return false
+			}
+			s, ok := val.(string)
+			return ok && s == expected
+		},
+	}
+}
+
+// AssertOutputContains checks that stdout contains a substring.
+func AssertOutputContains(s string) Assertion {
+	return Assertion{
+		Name: "contains:" + s,
+		Fn: func(o TestOutput) bool {
+			return strings.Contains(o.Stdout, s)
+		},
+	}
+}
+
+// AssertMetricFamiliesPresent checks that key metric families appear in /metrics output.
+func AssertMetricFamiliesPresent(families []string) Assertion {
+	return Assertion{
+		Name: "metric_families_present",
+		Fn: func(o TestOutput) bool {
+			for _, f := range families {
+				if !strings.Contains(o.Stdout, f) {
+					return false
+				}
+			}
+			return true
+		},
+	}
+}
+
+// AssertNoFatalPatterns checks output against fatal runtime patterns.
+func AssertNoFatalPatterns(patterns []string) Assertion {
+	return Assertion{
+		Name: "no_fatal_patterns",
+		Fn: func(o TestOutput) bool {
+			combined := o.Stdout + o.Stderr
+			for _, p := range patterns {
+				if strings.Contains(combined, p) {
+					return false
+				}
+			}
+			return true
+		},
+	}
+}
+
+// RunAssertions evaluates a list of assertions against test output.
+// Returns counts and the name of the first failed assertion (if any).
+func RunAssertions(assertions []Assertion, output TestOutput) (passed, failed int, firstFailure string) {
+	for _, a := range assertions {
+		if a.Fn(output) {
+			passed++
+		} else {
+			failed++
+			if firstFailure == "" {
+				firstFailure = a.Name
+			}
+		}
+	}
+	return
+}

--- a/internal/smoke/prereqs.go
+++ b/internal/smoke/prereqs.go
@@ -1,0 +1,158 @@
+// =============================================================================
+// NFTBan - Smoke Framework: Prerequisite Evaluators
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-prereqs"
+// meta:type="package"
+// meta:version="1.95.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Reusable prerequisite checks for module-gated smoke tests"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package smoke
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Prerequisite types
+const (
+	PrereqBinary         = "binary"
+	PrereqFile           = "file"
+	PrereqSystemd        = "systemd"
+	PrereqDaemonRunning  = "daemon_running"
+	PrereqModuleEnabled  = "module_enabled"
+	PrereqHTTPEndpoint   = "http_endpoint"
+	PrereqValidatorBin   = "validator_present"
+	PrereqConfigKey      = "config_key"
+	PrereqNFTBinary      = "nft_binary"
+)
+
+// CheckPrerequisite evaluates a single prerequisite.
+// Returns true if met, false if not (test should SKIP).
+func CheckPrerequisite(p Prerequisite) bool {
+	switch p.Type {
+	case PrereqBinary, PrereqValidatorBin, PrereqNFTBinary:
+		_, err := exec.LookPath(p.Name)
+		return err == nil
+
+	case PrereqFile:
+		_, err := os.Stat(p.Name)
+		return err == nil
+
+	case PrereqSystemd:
+		_, err := exec.LookPath("systemctl")
+		return err == nil
+
+	case PrereqDaemonRunning:
+		out, err := exec.Command("systemctl", "is-active", p.Name).Output()
+		return err == nil && strings.TrimSpace(string(out)) == "active"
+
+	case PrereqModuleEnabled:
+		return isModuleEnabled(p.Name)
+
+	case PrereqHTTPEndpoint:
+		return isHTTPReachable(p.Name)
+
+	case PrereqConfigKey:
+		return configKeyExists(p.Name)
+
+	default:
+		return true
+	}
+}
+
+// CheckAllPrerequisites evaluates all prerequisites for a test.
+// Returns the first unmet prerequisite name, or "" if all met.
+func CheckAllPrerequisites(prereqs []Prerequisite) (bool, string) {
+	for _, p := range prereqs {
+		if !CheckPrerequisite(p) {
+			return false, p.Type + ":" + p.Name
+		}
+	}
+	return true, ""
+}
+
+func isModuleEnabled(module string) bool {
+	// Check main module config files
+	paths := []string{
+		"/etc/nftban/conf.d/" + module + "/main.conf.local",
+		"/etc/nftban/conf.d/" + module + "/main.conf",
+		"/etc/nftban/modules/" + module + ".conf.local",
+		"/etc/nftban/modules/" + module + ".conf",
+	}
+
+	enableKeys := map[string]string{
+		"ddos":     "DDOS_ENABLED",
+		"portscan": "PORTSCAN_ENABLED",
+		"botguard": "BOTGUARD_ENABLED",
+		"loginmon": "LOGINMON_ENABLED",
+		"login":    "LOGINMON_ENABLED",
+		"suricata": "SURICATA_ENABLED",
+	}
+
+	key, ok := enableKeys[module]
+	if !ok {
+		return false
+	}
+
+	for _, p := range paths {
+		val := readConfigValue(p, key)
+		if val == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func readConfigValue(path, key string) string {
+	f, err := os.Open(filepath.Clean(path)) // #nosec G304 -- paths from /etc/nftban/ (trusted config dir)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, key+"=") {
+			val := strings.TrimPrefix(line, key+"=")
+			return strings.Trim(val, "\"")
+		}
+	}
+	return ""
+}
+
+func isHTTPReachable(url string) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url) //lint:ignore G107 URL from trusted smoke registry
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == 200
+}
+
+func configKeyExists(keyPath string) bool {
+	// keyPath format: "file:key" e.g. "/etc/nftban/nftban.conf:NFTBAN_ENABLED"
+	parts := strings.SplitN(keyPath, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	val := readConfigValue(parts[0], parts[1])
+	return val != ""
+}

--- a/internal/smoke/registry.go
+++ b/internal/smoke/registry.go
@@ -26,13 +26,17 @@ import "time"
 type SmokeTest struct {
 	ID            string
 	Name          string
-	Category      string   // truth, daemon, config, metrics
+	Category      string   // truth, daemon, config, metrics, modules, deep
+	Module        string   // "", "ddos", "portscan", "botguard", "loginmon"
 	Command       []string // command + args to execute
 	AllowedExit   []int    // exit codes that count as PASS (e.g. [0,1,2])
 	Timeout       time.Duration
 	Prerequisites []Prerequisite
 	FatalPatterns []string              // stderr/stdout patterns that force FAIL
-	Assert        func(TestOutput) bool // custom assertion on output (optional)
+	Assert        func(TestOutput) bool // v1.94 simple assertion (kept for compat)
+	Assertions    []Assertion           // v1.95 structured assertions
+	DeepOnly      bool                  // only run with --deep flag
+	CIEnabled     bool                  // included in G20 CI gate
 	Notes         string
 }
 
@@ -66,9 +70,17 @@ var DefaultFatalPatterns = []string{
 	"nil pointer dereference",
 }
 
-// DefaultRegistry returns the Phase 1 smoke test set.
-// Small, high-value, contract-safe. No module-deep or counter assertions.
+// DefaultRegistry returns the full smoke test set (Phase 1 + Phase 2).
+// Phase 1: truth, daemon, config, metrics (always run)
+// Phase 2: modules (gated on prerequisites, SKIP if disabled)
 func DefaultRegistry() []SmokeTest {
+	base := baseTests()
+	modules := ModuleTests()
+	return append(base, modules...)
+}
+
+// baseTests returns the Phase 1 core tests.
+func baseTests() []SmokeTest {
 	return []SmokeTest{
 		// === TRUTH (validator-backed) ===
 		{

--- a/internal/smoke/registry.go
+++ b/internal/smoke/registry.go
@@ -1,0 +1,169 @@
+// =============================================================================
+// NFTBan - CLI Smoke Framework: Test Registry
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-registry"
+// meta:type="package"
+// meta:version="1.94.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Registry-driven smoke test definitions with strict PASS/FAIL/SKIP semantics"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package smoke
+
+import "time"
+
+// SmokeTest defines a single registered smoke probe.
+// All test execution is driven by this metadata — no ad hoc logic outside the registry.
+type SmokeTest struct {
+	ID            string
+	Name          string
+	Category      string   // truth, daemon, config, metrics
+	Command       []string // command + args to execute
+	AllowedExit   []int    // exit codes that count as PASS (e.g. [0,1,2])
+	Timeout       time.Duration
+	Prerequisites []Prerequisite
+	FatalPatterns []string              // stderr/stdout patterns that force FAIL
+	Assert        func(TestOutput) bool // custom assertion on output (optional)
+	Notes         string
+}
+
+// Prerequisite defines a condition that must be true for a test to run.
+// If not met, the test is SKIP (not FAIL).
+type Prerequisite struct {
+	Type string // "daemon", "file", "binary"
+	Name string // e.g. "nftband.service", "/etc/nftban/main.conf", "nftban-validate"
+}
+
+// TestOutput holds captured output from a test execution.
+type TestOutput struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Duration time.Duration
+}
+
+// DefaultFatalPatterns are runtime errors that always indicate FAIL.
+// These catch shell explosions, Go panics, and missing binaries.
+var DefaultFatalPatterns = []string{
+	"bad array subscript",
+	"unbound variable",
+	"syntax error",
+	"command not found",
+	"No such file or directory",
+	"panic:",
+	"segmentation fault",
+	"traceback",
+	"SIGSEGV",
+	"nil pointer dereference",
+}
+
+// DefaultRegistry returns the Phase 1 smoke test set.
+// Small, high-value, contract-safe. No module-deep or counter assertions.
+func DefaultRegistry() []SmokeTest {
+	return []SmokeTest{
+		// === TRUTH (validator-backed) ===
+		{
+			ID:          "T1",
+			Name:        "validator JSON",
+			Category:    "truth",
+			Command:     []string{"nftban-validate", "--json"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "binary", Name: "nftban-validate"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assert: func(o TestOutput) bool {
+				return len(o.Stdout) > 2 && o.Stdout[0] == '{'
+			},
+			Notes: "Validator must return valid JSON with .status field",
+		},
+		{
+			ID:          "T2",
+			Name:        "health JSON",
+			Category:    "truth",
+			Command:     []string{"nftban", "health", "--json"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "binary", Name: "nftban"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assert: func(o TestOutput) bool {
+				return len(o.Stdout) > 2 && o.Stdout[0] == '{'
+			},
+			Notes: "Health must return valid JSON",
+		},
+		{
+			ID:          "T3",
+			Name:        "status",
+			Category:    "truth",
+			Command:     []string{"nftban", "status"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "binary", Name: "nftban"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Notes:         "Status command must not crash",
+		},
+
+		// === DAEMON ===
+		{
+			ID:       "D1",
+			Name:     "nftband service",
+			Category: "daemon",
+			Command:  []string{"systemctl", "is-active", "nftband.service"},
+			AllowedExit: []int{0},
+			Timeout:     5 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "binary", Name: "systemctl"},
+			},
+			FatalPatterns: nil,
+			Notes:         "Daemon must be active for IPC and ban operations",
+		},
+
+		// === CONFIG ===
+		{
+			ID:       "C1",
+			Name:     "main.conf readable",
+			Category: "config",
+			Command:  []string{"test", "-r", "/etc/nftban/nftban.conf"},
+			AllowedExit: []int{0},
+			Timeout:     2 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "file", Name: "/etc/nftban/nftban.conf"},
+			},
+			FatalPatterns: nil,
+			Notes:         "Main config must exist and be readable",
+		},
+
+		// === METRICS ===
+		{
+			ID:       "M1",
+			Name:     "/metrics reachable",
+			Category: "metrics",
+			Command:  []string{"curl", "-sf", "--max-time", "5", "http://127.0.0.1:9580/metrics"},
+			AllowedExit: []int{0},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: "daemon", Name: "nftband.service"},
+				{Type: "binary", Name: "curl"},
+			},
+			FatalPatterns: nil,
+			Assert: func(o TestOutput) bool {
+				return len(o.Stdout) > 100 // metrics output should be substantial
+			},
+			Notes: "Daemon /metrics endpoint must respond",
+		},
+	}
+}

--- a/internal/smoke/report.go
+++ b/internal/smoke/report.go
@@ -1,0 +1,108 @@
+// =============================================================================
+// NFTBan - CLI Smoke Framework: Report Formatter
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-report"
+// meta:type="package"
+// meta:version="1.94.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Human and JSON output formatters for smoke test results"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FormatHuman returns a human-readable smoke report.
+func FormatHuman(s Summary) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("NFTBan Smoke — v%s\n", s.Version))
+	b.WriteString(strings.Repeat("=", 30) + "\n\n")
+
+	// Group by category
+	categories := []string{"truth", "daemon", "config", "metrics"}
+	for _, cat := range categories {
+		tests := filterByCategory(s.Tests, cat)
+		if len(tests) == 0 {
+			continue
+		}
+
+		b.WriteString(fmt.Sprintf("  %s:\n", cat))
+		for _, t := range tests {
+			icon := statusIcon(t.Status)
+			line := fmt.Sprintf("    %s %s", icon, t.Name)
+			if t.Detail != "" && t.Status != StatusPass {
+				line += fmt.Sprintf(" (%s)", t.Detail)
+			}
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("\n")
+	}
+
+	total := s.Counts.Pass + s.Counts.Fail + s.Counts.Skip
+	b.WriteString(fmt.Sprintf("Result: %s (%d/%d PASS", s.Result, s.Counts.Pass, total))
+	if s.Counts.Skip > 0 {
+		b.WriteString(fmt.Sprintf(", %d SKIP", s.Counts.Skip))
+	}
+	if s.Counts.Fail > 0 {
+		b.WriteString(fmt.Sprintf(", %d FAIL", s.Counts.Fail))
+	}
+	b.WriteString(")\n")
+
+	return b.String()
+}
+
+// FormatJSON returns a JSON smoke report.
+func FormatJSON(s Summary) (string, error) {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// ExitCode returns the process exit code for a smoke summary.
+// 0 = all PASS (SKIPs don't count as failure)
+// 1 = any FAIL
+func ExitCode(s Summary) int {
+	if s.Counts.Fail > 0 {
+		return 1
+	}
+	return 0
+}
+
+func filterByCategory(tests []TestResult, cat string) []TestResult {
+	var out []TestResult
+	for _, t := range tests {
+		if t.Category == cat {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func statusIcon(status string) string {
+	switch status {
+	case StatusPass:
+		return "ok"
+	case StatusFail:
+		return "FAIL"
+	case StatusSkip:
+		return "skip"
+	default:
+		return "?"
+	}
+}

--- a/internal/smoke/smoke.go
+++ b/internal/smoke/smoke.go
@@ -1,0 +1,230 @@
+// =============================================================================
+// NFTBan - CLI Smoke Framework: Runner
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-runner"
+// meta:type="package"
+// meta:version="1.94.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Executes registered smoke tests with prerequisite checking and fatal error detection"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package smoke
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Status constants for test results.
+const (
+	StatusPass = "PASS"
+	StatusFail = "FAIL"
+	StatusSkip = "SKIP"
+)
+
+// TestResult holds the outcome of a single smoke test.
+type TestResult struct {
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	Category   string        `json:"category"`
+	Status     string        `json:"status"` // PASS, FAIL, SKIP
+	DurationMs int64         `json:"duration_ms"`
+	Detail     string        `json:"detail,omitempty"`
+}
+
+// Summary holds the overall smoke run result.
+type Summary struct {
+	Version string        `json:"version"`
+	Result  string        `json:"result"` // PASS or FAIL
+	Counts  SummaryCounts `json:"summary"`
+	Tests   []TestResult  `json:"tests"`
+}
+
+// SummaryCounts holds pass/fail/skip counts.
+type SummaryCounts struct {
+	Pass int `json:"pass"`
+	Fail int `json:"fail"`
+	Skip int `json:"skip"`
+}
+
+// RunSmoke executes all registered tests, optionally filtered by group.
+// Returns a Summary with PASS/FAIL/SKIP per test.
+func RunSmoke(version string, group string) Summary {
+	registry := DefaultRegistry()
+
+	s := Summary{
+		Version: version,
+		Result:  StatusPass,
+	}
+
+	for _, test := range registry {
+		if group != "" && group != "all" && test.Category != group {
+			continue
+		}
+
+		result := executeTest(test)
+		s.Tests = append(s.Tests, result)
+
+		switch result.Status {
+		case StatusPass:
+			s.Counts.Pass++
+		case StatusFail:
+			s.Counts.Fail++
+			s.Result = StatusFail
+		case StatusSkip:
+			s.Counts.Skip++
+		}
+	}
+
+	return s
+}
+
+func executeTest(t SmokeTest) TestResult {
+	result := TestResult{
+		ID:       t.ID,
+		Name:     t.Name,
+		Category: t.Category,
+	}
+
+	// Check prerequisites
+	for _, p := range t.Prerequisites {
+		if !checkPrerequisite(p) {
+			result.Status = StatusSkip
+			result.Detail = "prerequisite not met: " + p.Type + ":" + p.Name
+			return result
+		}
+	}
+
+	// Execute command with timeout
+	start := time.Now()
+	output := runCommand(t.Command, t.Timeout)
+	result.DurationMs = time.Since(start).Milliseconds()
+
+	// Check fatal patterns first (always FAIL)
+	if pattern := matchFatalPattern(output, t.FatalPatterns); pattern != "" {
+		result.Status = StatusFail
+		result.Detail = "fatal runtime error: " + pattern
+		return result
+	}
+
+	// Check exit code
+	if !isAllowedExit(output.ExitCode, t.AllowedExit) {
+		result.Status = StatusFail
+		result.Detail = "exit code " + itoa(output.ExitCode) + " not in allowed set"
+		return result
+	}
+
+	// Run custom assertion
+	if t.Assert != nil && !t.Assert(output) {
+		result.Status = StatusFail
+		result.Detail = "assertion failed"
+		return result
+	}
+
+	result.Status = StatusPass
+	return result
+}
+
+func checkPrerequisite(p Prerequisite) bool {
+	switch p.Type {
+	case "binary":
+		_, err := exec.LookPath(p.Name)
+		return err == nil
+	case "file":
+		_, err := os.Stat(p.Name)
+		return err == nil
+	case "daemon":
+		out, err := exec.Command("systemctl", "is-active", p.Name).Output()
+		return err == nil && strings.TrimSpace(string(out)) == "active"
+	default:
+		return true
+	}
+}
+
+func runCommand(args []string, timeout time.Duration) TestOutput {
+	if len(args) == 0 {
+		return TestOutput{ExitCode: -1}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // commands from trusted registry
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return TestOutput{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		Duration: duration,
+	}
+}
+
+func matchFatalPattern(o TestOutput, patterns []string) string {
+	combined := o.Stdout + o.Stderr
+	for _, p := range patterns {
+		if strings.Contains(combined, p) {
+			return p
+		}
+	}
+	return ""
+}
+
+func isAllowedExit(code int, allowed []int) bool {
+	if len(allowed) == 0 {
+		return code == 0 // default: only 0 is success
+	}
+	for _, a := range allowed {
+		if code == a {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := ""
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	if neg {
+		s = "-" + s
+	}
+	return s
+}

--- a/internal/smoke/smoke.go
+++ b/internal/smoke/smoke.go
@@ -161,7 +161,7 @@ func runCommand(args []string, timeout time.Duration) TestOutput {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // commands from trusted registry
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //lint:ignore G204 commands from trusted smoke registry, not user input
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/smoke/smoke.go
+++ b/internal/smoke/smoke.go
@@ -21,7 +21,6 @@ package smoke
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -59,9 +58,16 @@ type SummaryCounts struct {
 	Skip int `json:"skip"`
 }
 
-// RunSmoke executes all registered tests, optionally filtered by group.
+// RunOptions controls smoke execution filtering.
+type RunOptions struct {
+	Group  string // truth, daemon, config, metrics, modules, deep, all
+	Module string // filter by specific module (ddos, portscan, etc.)
+	Deep   bool   // include DeepOnly tests
+}
+
+// RunSmoke executes all registered tests, filtered by options.
 // Returns a Summary with PASS/FAIL/SKIP per test.
-func RunSmoke(version string, group string) Summary {
+func RunSmoke(version string, opts RunOptions) Summary {
 	registry := DefaultRegistry()
 
 	s := Summary{
@@ -70,7 +76,16 @@ func RunSmoke(version string, group string) Summary {
 	}
 
 	for _, test := range registry {
-		if group != "" && group != "all" && test.Category != group {
+		// Filter by group
+		if opts.Group != "" && opts.Group != "all" && test.Category != opts.Group {
+			continue
+		}
+		// Filter by module
+		if opts.Module != "" && test.Module != opts.Module {
+			continue
+		}
+		// Skip deep-only tests unless --deep
+		if test.DeepOnly && !opts.Deep {
 			continue
 		}
 
@@ -98,13 +113,12 @@ func executeTest(t SmokeTest) TestResult {
 		Category: t.Category,
 	}
 
-	// Check prerequisites
-	for _, p := range t.Prerequisites {
-		if !checkPrerequisite(p) {
-			result.Status = StatusSkip
-			result.Detail = "prerequisite not met: " + p.Type + ":" + p.Name
-			return result
-		}
+	// Check prerequisites using Phase 2 evaluators
+	met, unmet := CheckAllPrerequisites(t.Prerequisites)
+	if !met {
+		result.Status = StatusSkip
+		result.Detail = "prerequisite not met: " + unmet
+		return result
 	}
 
 	// Execute command with timeout
@@ -126,31 +140,25 @@ func executeTest(t SmokeTest) TestResult {
 		return result
 	}
 
-	// Run custom assertion
+	// Run v1.94 simple assertion (backward compat)
 	if t.Assert != nil && !t.Assert(output) {
 		result.Status = StatusFail
 		result.Detail = "assertion failed"
 		return result
 	}
 
+	// Run v1.95 structured assertions
+	if len(t.Assertions) > 0 {
+		_, failed, firstFail := RunAssertions(t.Assertions, output)
+		if failed > 0 {
+			result.Status = StatusFail
+			result.Detail = "assertion failed: " + firstFail
+			return result
+		}
+	}
+
 	result.Status = StatusPass
 	return result
-}
-
-func checkPrerequisite(p Prerequisite) bool {
-	switch p.Type {
-	case "binary":
-		_, err := exec.LookPath(p.Name)
-		return err == nil
-	case "file":
-		_, err := os.Stat(p.Name)
-		return err == nil
-	case "daemon":
-		out, err := exec.Command("systemctl", "is-active", p.Name).Output()
-		return err == nil && strings.TrimSpace(string(out)) == "active"
-	default:
-		return true
-	}
 }
 
 func runCommand(args []string, timeout time.Duration) TestOutput {

--- a/internal/smoke/tests_modules.go
+++ b/internal/smoke/tests_modules.go
@@ -1,0 +1,111 @@
+// =============================================================================
+// NFTBan - Smoke Framework: Module-Aware Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="smoke-tests-modules"
+// meta:type="package"
+// meta:version="1.95.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-16"
+// meta:description="Module-gated smoke tests — SKIP when module disabled, not FAIL"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package smoke
+
+import "time"
+
+// ModuleTests returns the Phase 2 module-aware smoke test set.
+// Each test is gated on module_enabled prerequisite — SKIP if disabled.
+// These do NOT claim enforcement or protection — only that commands run
+// and produce contract-safe output.
+func ModuleTests() []SmokeTest {
+	return []SmokeTest{
+		// === DDoS ===
+		{
+			ID:       "MOD-DDOS-001",
+			Name:     "ddos status",
+			Category: "modules",
+			Module:   "ddos",
+			Command:  []string{"nftban", "ddos", "status"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: PrereqBinary, Name: "nftban"},
+				{Type: PrereqModuleEnabled, Name: "ddos"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assertions: []Assertion{
+				AssertNoFatalPatterns(DefaultFatalPatterns),
+			},
+			Notes: "DDoS status must not crash when module is enabled",
+		},
+
+		// === Portscan ===
+		{
+			ID:       "MOD-PSCAN-001",
+			Name:     "portscan status",
+			Category: "modules",
+			Module:   "portscan",
+			Command:  []string{"nftban", "portscan", "status"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: PrereqBinary, Name: "nftban"},
+				{Type: PrereqModuleEnabled, Name: "portscan"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assertions: []Assertion{
+				AssertNoFatalPatterns(DefaultFatalPatterns),
+			},
+			Notes: "Portscan status must not crash when module is enabled",
+		},
+
+		// === BotGuard ===
+		{
+			ID:       "MOD-BOTGUARD-001",
+			Name:     "botguard status",
+			Category: "modules",
+			Module:   "botguard",
+			Command:  []string{"nftban", "botguard", "status"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: PrereqBinary, Name: "nftban"},
+				{Type: PrereqModuleEnabled, Name: "botguard"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assertions: []Assertion{
+				AssertNoFatalPatterns(DefaultFatalPatterns),
+			},
+			Notes: "BotGuard status must not crash when module is enabled",
+		},
+
+		// === LoginMon ===
+		{
+			ID:       "MOD-LOGIN-001",
+			Name:     "login status",
+			Category: "modules",
+			Module:   "loginmon",
+			Command:  []string{"nftban", "login", "status"},
+			AllowedExit: []int{0, 1, 2},
+			Timeout:     10 * time.Second,
+			Prerequisites: []Prerequisite{
+				{Type: PrereqBinary, Name: "nftban"},
+				{Type: PrereqModuleEnabled, Name: "login"},
+				{Type: PrereqDaemonRunning, Name: "nftband.service"},
+			},
+			FatalPatterns: DefaultFatalPatterns,
+			Assertions: []Assertion{
+				AssertNoFatalPatterns(DefaultFatalPatterns),
+			},
+			Notes: "LoginMon status must not crash when module is enabled and daemon running",
+		},
+	}
+}


### PR DESCRIPTION
## v1.95 Smoke Framework Phase 2 (+468 LOC)

Extends v1.94 core with module-aware smoke and evidence-based assertions.

### New files
| File | LOC | Purpose |
|---|---|---|
| prereqs.go | 158 | Prerequisite evaluators (binary, daemon, module_enabled, HTTP, config) |
| assertions.go | 133 | Contract-safe assertions (JSON valid, path exists, metrics families) |
| tests_modules.go | 111 | Module-gated tests (ddos, portscan, botguard, loginmon) |

### Extended
- registry.go: Module, Assertions, DeepOnly, CIEnabled fields
- smoke.go: RunOptions (group + module + deep), structured assertion pipeline
- cmd_smoke.go: --module=MODULE and --deep flags

### Module tests SKIP when disabled, not FAIL
Tests do NOT claim enforcement — only that commands run without fatal errors.

### CLI
```
nftban smoke --module=ddos
nftban smoke --deep
nftban smoke --group=modules --json
```

Lab4 build: PASS

> **Build & Integrity Status:** [STATUS.md](https://github.com/itcmsgr/nftban/blob/main/STATUS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)