### PR TITLE
release: v1.97.0 — lifecycle Wave 1 (types + engine + authority + CLI dry-run)

### DIFF
--- a/cmd/nftban-core/cmd_lifecycle.go
+++ b/cmd/nftban-core/cmd_lifecycle.go
@@ -1,0 +1,292 @@
+// =============================================================================
+// NFTBan v1.97 - CLI Lifecycle Command
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cmd_lifecycle"
+// meta:type="command"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Lifecycle planning engine CLI — nftban lifecycle run --mode=X --dry-run"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md §6 PR-05
+// INV-LC-001: Engine is side-effect free. DRY-RUN ONLY in v1.97.
+// INV-LC-005: Dry-run uses same classification logic as real execution.
+// INV-LC-007: No lifecycle command in v1.97 may mutate the system.
+// =============================================================================
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/itcmsgr/nftban/internal/lifecycle"
+	"github.com/itcmsgr/nftban/internal/rebuild"
+)
+
+func cmdLifecycle(args []string) int {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		printLifecycleUsage()
+		return 0
+	}
+
+	subcmd := args[0]
+	subargs := args[1:]
+
+	switch subcmd {
+	case "run":
+		return cmdLifecycleRun(subargs)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown lifecycle subcommand: %s\n", subcmd)
+		printLifecycleUsage()
+		return 1
+	}
+}
+
+func cmdLifecycleRun(args []string) int {
+	var mode string
+	var jsonOutput bool
+	dryRun := true // v1.97: ALWAYS dry-run (INV-LC-001)
+
+	for _, arg := range args {
+		switch {
+		case arg == "--json":
+			jsonOutput = true
+		case len(arg) > 7 && arg[:7] == "--mode=":
+			mode = arg[7:]
+		case arg == "--no-dry-run":
+			// v1.97: refuse real execution (INV-LC-007)
+			fmt.Fprintf(os.Stderr, "Error: real execution is not available in v1.97\n")
+			fmt.Fprintf(os.Stderr, "  Lifecycle execution will be enabled in v1.98+\n")
+			fmt.Fprintf(os.Stderr, "  Use --dry-run (default) for planning\n")
+			return 1
+		case arg == "--dry-run":
+			dryRun = true // explicit, same as default
+		case arg == "--help" || arg == "-h":
+			printLifecycleRunUsage()
+			return 0
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown option: %s\n", arg)
+			return 1
+		}
+	}
+
+	if mode == "" {
+		fmt.Fprintf(os.Stderr, "Error: --mode is required\n")
+		fmt.Fprintf(os.Stderr, "  Valid modes: install, update, uninstall, maintenance\n")
+		return 1
+	}
+
+	lcMode := lifecycle.Mode(mode)
+	if !lifecycle.ValidMode(lcMode) {
+		fmt.Fprintf(os.Stderr, "Error: invalid mode: %s\n", mode)
+		fmt.Fprintf(os.Stderr, "  Valid modes: install, update, uninstall, maintenance\n")
+		return 1
+	}
+
+	// Build snapshot from real system state
+	snap := buildSnapshot(lcMode, dryRun)
+
+	// Run lifecycle engine (pure, no side effects)
+	result := lifecycle.Run(snap)
+
+	// Log evidence
+	logger := lifecycle.NewLogger(os.Stderr, lcMode, dryRun)
+	logger.LogDetect(snap.CurrentAuthority, snap.Detection)
+	logger.LogPlan(result.Plan, result.LastOperation)
+	logger.LogResult(result)
+
+	// Render output
+	if jsonOutput {
+		if err := lifecycle.RenderJSON(os.Stdout, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error rendering JSON: %v\n", err)
+			return 1
+		}
+	} else {
+		if err := lifecycle.RenderText(os.Stdout, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error rendering output: %v\n", err)
+			return 1
+		}
+	}
+
+	// Exit code: 0 for success/plan-valid, non-zero for failures
+	if result.Outcome == lifecycle.OutcomeSuccess {
+		return 0
+	}
+	return 1
+}
+
+// buildSnapshot creates a lifecycle Snapshot from real system state.
+// This reads actual system observations — it does NOT guess or assume.
+func buildSnapshot(mode lifecycle.Mode, dryRun bool) lifecycle.Snapshot {
+	snap := lifecycle.Snapshot{
+		Mode:   mode,
+		DryRun: dryRun,
+	}
+
+	// Detect current authority from validator
+	snap.CurrentAuthority = detectAuthority()
+
+	// Read v1.96 recovery marker
+	snap.LastOperation = readLastOperation()
+
+	// Detect system state
+	snap.Detection = detectSystem()
+
+	return snap
+}
+
+// detectAuthority reads current firewall authority from validator/nft state.
+func detectAuthority() lifecycle.AuthorityState {
+	auth := lifecycle.AuthorityState{
+		Owner:  lifecycle.AuthorityNone,
+		Health: lifecycle.HealthDown,
+	}
+
+	// Check if nftban tables exist in kernel
+	// Use nft list tables to detect presence (read-only, no mutation)
+	if fileExists("/usr/lib/nftban/bin/nftban-validate") || fileExists("/usr/sbin/nftban") {
+		// NFTBan is installed — check if it owns the firewall
+		auth.Owner = lifecycle.AuthorityNFTBan
+
+		// Try to get health from validator
+		health := getValidatorHealth()
+		switch health {
+		case "protected":
+			auth.Health = lifecycle.HealthProtected
+		case "idle":
+			auth.Health = lifecycle.HealthIdle
+		case "degraded":
+			auth.Health = lifecycle.HealthDegraded
+		case "down":
+			auth.Health = lifecycle.HealthDown
+		default:
+			auth.Health = lifecycle.HealthDown
+		}
+	}
+
+	return auth
+}
+
+// readLastOperation reads v1.96 recovery marker for last operation truth.
+func readLastOperation() lifecycle.LastOperation {
+	lo := lifecycle.LastOperation{}
+
+	marker, err := rebuild.ReadMarker()
+	if err != nil || marker == nil {
+		lo.Result = "SUCCESS"
+		return lo
+	}
+
+	lo.Result = string(marker.OperationResult)
+	lo.FailureClass = string(marker.FailureClass)
+	lo.RecoveryPending = marker.ShouldDeferRetry()
+	lo.LastRebuildFailed = marker.OperationResult != rebuild.ResultSuccess
+
+	return lo
+}
+
+// detectSystem checks for conflicting firewalls, kernel validity, etc.
+func detectSystem() lifecycle.Detection {
+	det := lifecycle.Detection{
+		SSHSafe: true, // default safe unless proven otherwise
+	}
+
+	// Check for conflicting firewalls
+	det.ConflictingFirewall = isServiceActive("firewalld") ||
+		isServiceActive("ufw")
+
+	// Check kernel validity (nftban tables exist and are parseable)
+	det.KernelValid = nftTablesExist()
+
+	// Validator consistency (tables match expected schema)
+	det.ValidatorConsistent = det.KernelValid // simplified for v1.97
+
+	return det
+}
+
+// Helper functions for system detection
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func isServiceActive(service string) bool {
+	// Read-only check via systemctl (no mutation)
+	cmd := fmt.Sprintf("systemctl is-active --quiet %s 2>/dev/null", service)
+	return runQuietCmd(cmd) == nil
+}
+
+func nftTablesExist() bool {
+	return runQuietCmd("nft list table ip nftban 2>/dev/null") == nil
+}
+
+func getValidatorHealth() string {
+	// Try nftban-validate if available
+	out, err := runCmdOutput("nftban-validate", "status", "--quiet")
+	if err != nil {
+		return "down"
+	}
+	// Output is the status string
+	for _, status := range []string{"protected", "idle", "degraded", "down"} {
+		if len(out) >= len(status) && out[:len(status)] == status {
+			return status
+		}
+	}
+	return "down"
+}
+
+func runQuietCmd(cmdStr string) error {
+	c := exec.Command("bash", "-c", cmdStr) // #nosec G204 — controlled input
+	return c.Run()
+}
+
+func runCmdOutput(name string, args ...string) (string, error) {
+	c := exec.Command(name, args...) // #nosec G204 — controlled input
+	out, err := c.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func printLifecycleUsage() {
+	fmt.Println("Usage: nftban lifecycle <subcommand> [options]")
+	fmt.Println("")
+	fmt.Println("Subcommands:")
+	fmt.Println("  run    Plan a lifecycle operation (dry-run by default)")
+	fmt.Println("")
+	fmt.Println("Examples:")
+	fmt.Println("  nftban lifecycle run --mode=install --dry-run")
+	fmt.Println("  nftban lifecycle run --mode=update --json")
+}
+
+func printLifecycleRunUsage() {
+	fmt.Println("Usage: nftban lifecycle run --mode=MODE [options]")
+	fmt.Println("")
+	fmt.Println("Plan a lifecycle operation without executing it.")
+	fmt.Println("")
+	fmt.Println("Modes:")
+	fmt.Println("  install       Plan fresh installation")
+	fmt.Println("  update        Plan upgrade of existing installation")
+	fmt.Println("  uninstall     Plan removal")
+	fmt.Println("  maintenance   Plan maintenance operations")
+	fmt.Println("")
+	fmt.Println("Options:")
+	fmt.Println("  --dry-run     Plan only, no changes (default)")
+	fmt.Println("  --json        Output as JSON")
+	fmt.Println("  --help        Show this help")
+	fmt.Println("")
+	fmt.Println("Note: Real execution is not available in v1.97.")
+	fmt.Println("      Lifecycle execution will be enabled in v1.98+.")
+}

--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -245,6 +245,8 @@ func main() {
 		}
 	case "smoke":
 		os.Exit(cmdSmoke(os.Args[2:]))
+	case "lifecycle":
+		os.Exit(cmdLifecycle(os.Args[2:]))
 	case "version":
 		fmt.Printf("nftban-core %s (git %s, build %s)\n", version.FullVersion(), GitCommit, BuildDate)
 	case "help", "--help", "-h":

--- a/internal/lifecycle/authority.go
+++ b/internal/lifecycle/authority.go
@@ -1,0 +1,128 @@
+// =============================================================================
+// NFTBan v1.97 - Authority Model
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-authority"
+// meta:type="lib"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Authority resolution: prior → desired → resulting with health dimension"
+// meta:inventory.files="internal/lifecycle/authority.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md §6 PR-03
+// INV-LC-004: Authority owner and health are independent dimensions.
+//   NFTBAN + DEGRADED is valid ownership — lifecycle must not treat
+//   DEGRADED as "no authority" or trigger unauthorized takeover.
+// =============================================================================
+
+package lifecycle
+
+import "fmt"
+
+// ResolveAuthority determines the resulting authority state given
+// prior state, desired state, and detection observations.
+//
+// Rules:
+//   - NFTBAN + PROTECTED/IDLE → owned and healthy, allow operations
+//   - NFTBAN + DEGRADED → owned but unsafe, proceed with caution
+//   - NFTBAN + DOWN → owned but failed, recovery before new lifecycle
+//   - EXTERNAL + any → may observe but MUST NOT seize without force
+//   - NONE + any → no managed authority, safe for fresh install
+func ResolveAuthority(prior, desired AuthorityState, detection Detection, force bool) (resulting AuthorityState, action Action, err error) {
+	// Normalize NONE authority
+	prior.NormalizeNone()
+
+	// Conflicting firewall blocks all authority changes
+	if detection.ConflictingFirewall && desired.Owner == AuthorityNFTBan {
+		return prior, ActionAbort, fmt.Errorf(
+			"conflicting firewall active — cannot establish NFTBan authority")
+	}
+
+	// ─── EXTERNAL authority ─────────────────────────────────────────────
+	if prior.Owner == AuthorityExternal {
+		if desired.Owner == AuthorityNFTBan {
+			if force {
+				// Explicit takeover requested
+				return desired, ActionTakeAuthority, nil
+			}
+			return prior, ActionAbort, fmt.Errorf(
+				"external firewall controls authority — use --force to override")
+		}
+		// Uninstall or maintenance on external: observe only
+		return prior, ActionNoop, nil
+	}
+
+	// ─── NONE authority ─────────────────────────────────────────────────
+	if prior.Owner == AuthorityNone {
+		if desired.Owner == AuthorityNFTBan {
+			// Fresh install — take authority
+			return desired, ActionTakeAuthority, nil
+		}
+		// Uninstall or maintenance with no authority
+		return prior, ActionNoop, nil
+	}
+
+	// ─── NFTBAN authority ───────────────────────────────────────────────
+	if prior.Owner == AuthorityNFTBan {
+		if desired.Owner == AuthorityNone {
+			// Uninstall — release authority
+			result := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+			return result, ActionTakeAuthority, nil
+		}
+
+		// Preserve authority for update/maintenance
+		if prior.Health == HealthDown {
+			return prior, ActionNeedsRecovery, fmt.Errorf(
+				"NFTBan authority is DOWN — recovery required before lifecycle operation")
+		}
+
+		return prior, ActionPreserveAuthority, nil
+	}
+
+	// Should not reach here
+	return prior, ActionAbort, fmt.Errorf("unexpected authority state: owner=%s", prior.Owner)
+}
+
+// CanProceed returns true if the action allows lifecycle to continue.
+func CanProceed(action Action) bool {
+	switch action {
+	case ActionTakeAuthority, ActionPreserveAuthority, ActionNoop:
+		return true
+	case ActionAbort, ActionNeedsRecovery:
+		return false
+	default:
+		return false
+	}
+}
+
+// TransitionDescription returns a human-readable description of
+// the authority transition for logging/evidence.
+func TransitionDescription(prior, resulting AuthorityState, action Action) string {
+	switch action {
+	case ActionTakeAuthority:
+		if resulting.Owner == AuthorityNone {
+			return fmt.Sprintf("releasing authority from %s to NONE", prior.Owner)
+		}
+		return fmt.Sprintf("taking authority: %s/%s → %s/%s",
+			prior.Owner, prior.Health, resulting.Owner, resulting.Health)
+	case ActionPreserveAuthority:
+		return fmt.Sprintf("preserving authority: %s/%s",
+			prior.Owner, prior.Health)
+	case ActionNoop:
+		return "no authority change needed"
+	case ActionAbort:
+		return "lifecycle aborted — authority change blocked"
+	case ActionNeedsRecovery:
+		return fmt.Sprintf("recovery required before lifecycle — current: %s/%s",
+			prior.Owner, prior.Health)
+	default:
+		return "unknown authority action"
+	}
+}

--- a/internal/lifecycle/authority_test.go
+++ b/internal/lifecycle/authority_test.go
@@ -1,0 +1,205 @@
+// =============================================================================
+// NFTBan v1.97 - Authority Model Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-authority-test"
+// meta:type="test"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Tests for authority resolution logic"
+// meta:inventory.files="internal/lifecycle/authority_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package lifecycle
+
+import "testing"
+
+// Test 1: NONE → NFTBAN (fresh install)
+func TestResolveAuthorityFreshInstall(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	resulting, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if action != ActionTakeAuthority {
+		t.Errorf("action = %s; want TAKE_AUTHORITY", action)
+	}
+	if resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", resulting.Owner)
+	}
+}
+
+// Test 2: NFTBAN + PROTECTED → NFTBAN (update, preserve)
+func TestResolveAuthorityPreserve(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	resulting, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if action != ActionPreserveAuthority {
+		t.Errorf("action = %s; want PRESERVE_AUTHORITY", action)
+	}
+	if resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", resulting.Owner)
+	}
+}
+
+// Test 3: NFTBAN + DEGRADED → still owned (INV-LC-004)
+func TestResolveAuthorityDegradedStillOwned(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNFTBan, Health: HealthDegraded}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	resulting, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if action != ActionPreserveAuthority {
+		t.Errorf("action = %s; want PRESERVE_AUTHORITY (degraded is still owned)", action)
+	}
+	if resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", resulting.Owner)
+	}
+}
+
+// Test 4: EXTERNAL → NFTBAN without force → ABORT
+func TestResolveAuthorityExternalNoForce(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityExternal, Health: HealthProtected}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	_, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err == nil {
+		t.Error("expected error for external authority without force")
+	}
+	if action != ActionAbort {
+		t.Errorf("action = %s; want ABORT", action)
+	}
+}
+
+// Test 5: EXTERNAL → NFTBAN with force → TAKE_AUTHORITY
+func TestResolveAuthorityExternalWithForce(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityExternal, Health: HealthProtected}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	resulting, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, true)
+
+	if err != nil {
+		t.Fatalf("unexpected error with force: %v", err)
+	}
+	if action != ActionTakeAuthority {
+		t.Errorf("action = %s; want TAKE_AUTHORITY (forced)", action)
+	}
+	if resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", resulting.Owner)
+	}
+}
+
+// Test 6: NFTBAN + DOWN → NEEDS_RECOVERY
+func TestResolveAuthorityNFTBanDown(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNFTBan, Health: HealthDown}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	_, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err == nil {
+		t.Error("expected error for DOWN authority")
+	}
+	if action != ActionNeedsRecovery {
+		t.Errorf("action = %s; want NEEDS_RECOVERY", action)
+	}
+}
+
+// Test 7: Conflicting firewall → ABORT
+func TestResolveAuthorityConflict(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	_, action, err := ResolveAuthority(prior, desired, Detection{ConflictingFirewall: true}, false)
+
+	if err == nil {
+		t.Error("expected error for conflicting firewall")
+	}
+	if action != ActionAbort {
+		t.Errorf("action = %s; want ABORT", action)
+	}
+}
+
+// Test 8: Uninstall (NFTBAN → NONE)
+func TestResolveAuthorityUninstall(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	desired := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+
+	resulting, action, err := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if action != ActionTakeAuthority {
+		t.Errorf("action = %s; want TAKE_AUTHORITY (release)", action)
+	}
+	if resulting.Owner != AuthorityNone {
+		t.Errorf("resulting.owner = %s; want NONE", resulting.Owner)
+	}
+}
+
+// Test 9: CanProceed
+func TestCanProceed(t *testing.T) {
+	tests := []struct {
+		action Action
+		want   bool
+	}{
+		{ActionTakeAuthority, true},
+		{ActionPreserveAuthority, true},
+		{ActionNoop, true},
+		{ActionAbort, false},
+		{ActionNeedsRecovery, false},
+	}
+	for _, tt := range tests {
+		if got := CanProceed(tt.action); got != tt.want {
+			t.Errorf("CanProceed(%s) = %v; want %v", tt.action, got, tt.want)
+		}
+	}
+}
+
+// Test 10: TransitionDescription
+func TestTransitionDescription(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	resulting := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	desc := TransitionDescription(prior, resulting, ActionTakeAuthority)
+	if desc == "" {
+		t.Error("description should not be empty")
+	}
+
+	desc2 := TransitionDescription(prior, prior, ActionAbort)
+	if desc2 == "" {
+		t.Error("abort description should not be empty")
+	}
+}
+
+// Test 11: NONE + PROTECTED gets normalized to NONE + DOWN
+func TestResolveAuthorityNoneNormalized(t *testing.T) {
+	prior := AuthorityState{Owner: AuthorityNone, Health: HealthProtected}
+	desired := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	_, action, _ := ResolveAuthority(prior, desired, Detection{SSHSafe: true}, false)
+
+	// After normalization, NONE+PROTECTED → NONE+DOWN, then TAKE_AUTHORITY
+	if action != ActionTakeAuthority {
+		t.Errorf("action = %s; want TAKE_AUTHORITY (NONE normalized to DOWN)", action)
+	}
+}

--- a/internal/lifecycle/engine.go
+++ b/internal/lifecycle/engine.go
@@ -1,0 +1,243 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle State Machine Engine
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-engine"
+// meta:type="lib"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Pure state machine engine — input snapshot, output plan. No side effects."
+// meta:inventory.files="internal/lifecycle/engine.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md
+// INV-LC-001: Engine MUST NOT mutate system state.
+// INV-LC-002: Engine is NOT a truth source. It plans based on observed state.
+// INV-LC-003: v1.96 operation results are consumed, never redefined.
+// INV-LC-008: FAILED_RECOVERED + PROTECTED is preserved as two distinct truths.
+// =============================================================================
+
+package lifecycle
+
+import "time"
+
+// Run executes the lifecycle state machine against a snapshot.
+// It is a PURE function — no side effects, no system mutation (INV-LC-001).
+// The engine consumes observed state and produces a plan.
+func Run(snap Snapshot) RunResult {
+	result := RunResult{
+		SchemaVersion: OutputSchemaVersion,
+		Mode:          snap.Mode,
+		DryRun:        snap.DryRun,
+		Detection:     snap.Detection,
+		LastOperation:  snap.LastOperation,
+		Timestamp:     time.Now(),
+	}
+
+	// Set authority prior from snapshot
+	result.Authority.Prior = snap.CurrentAuthority
+
+	// Desired authority depends on mode
+	result.Authority.Desired = desiredAuthority(snap.Mode)
+
+	// ─── DETECT stage ───────────────────────────────────────────────────
+	result.Stage = StageDetect
+
+	// Check: conflicting firewall blocks NFTBan authority
+	if snap.Detection.ConflictingFirewall && result.Authority.Desired.Owner == AuthorityNFTBan {
+		result.Stage = StageDetect
+		result.Outcome = OutcomeFailed
+		result.Plan.Actions = []Action{ActionAbort}
+		result.Plan.Errors = append(result.Plan.Errors,
+			"conflicting firewall active — cannot take NFTBan authority")
+		result.Authority.Resulting = snap.CurrentAuthority
+		return result
+	}
+
+	// Check: v1.96 recovery pending — must resolve before new lifecycle operation
+	if snap.LastOperation.RecoveryPending {
+		result.Stage = StageDetect
+		result.Outcome = OutcomeFailed
+		result.Plan.Actions = []Action{ActionNeedsRecovery}
+		result.Plan.Errors = append(result.Plan.Errors,
+			"v1.96 recovery pending — resolve before lifecycle operation")
+		result.Authority.Resulting = snap.CurrentAuthority
+		return result
+	}
+
+	// Check: mode validity
+	if !ValidMode(snap.Mode) {
+		result.Stage = StageDetect
+		result.Outcome = OutcomeFailed
+		result.Plan.Actions = []Action{ActionAbort}
+		result.Plan.Errors = append(result.Plan.Errors,
+			"invalid lifecycle mode: "+string(snap.Mode))
+		result.Authority.Resulting = snap.CurrentAuthority
+		return result
+	}
+
+	// ─── PLAN stage ─────────────────────────────────────────────────────
+	result.Stage = StagePlan
+
+	action, warnings := resolveAction(snap)
+	result.Plan.Actions = []Action{action}
+	result.Plan.Warnings = warnings
+
+	// Check: action is ABORT
+	if action == ActionAbort {
+		result.Outcome = OutcomeFailed
+		result.Authority.Resulting = snap.CurrentAuthority
+		return result
+	}
+
+	// Check: action requires recovery first
+	if action == ActionNeedsRecovery {
+		result.Outcome = OutcomeFailed
+		result.Authority.Resulting = snap.CurrentAuthority
+		return result
+	}
+
+	// ─── In v1.97, dry-run stops here (INV-LC-001) ──────────────────────
+	// APPLY and VERIFY stages are planned but not executed.
+	result.Stage = StageFinal
+
+	// Determine resulting authority
+	switch action {
+	case ActionTakeAuthority:
+		result.Authority.Resulting = result.Authority.Desired
+	case ActionPreserveAuthority, ActionNoop:
+		result.Authority.Resulting = snap.CurrentAuthority
+	default:
+		result.Authority.Resulting = snap.CurrentAuthority
+	}
+
+	// Determine outcome based on resulting authority, not prior
+	// For TAKE_AUTHORITY (fresh install), resulting is the target state
+	// INV-LC-008: preserve two truths if last rebuild failed but recovered
+	if snap.LastOperation.LastRebuildFailed && snap.CurrentAuthority.IsHealthy() {
+		result.Outcome = OutcomeSuccess
+		result.Plan.Warnings = append(result.Plan.Warnings,
+			"last rebuild failed but rollback restored service — both truths preserved")
+	} else if action == ActionTakeAuthority {
+		// Taking authority = plan to reach desired state (SUCCESS as a plan)
+		result.Outcome = OutcomeSuccess
+	} else if snap.CurrentAuthority.Health == HealthDown {
+		result.Outcome = OutcomeFailed
+	} else {
+		result.Outcome = OutcomeSuccess
+	}
+
+	return result
+}
+
+// desiredAuthority returns the target authority state for a given mode.
+func desiredAuthority(mode Mode) AuthorityState {
+	switch mode {
+	case ModeInstall:
+		return AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	case ModeUpdate:
+		return AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	case ModeUninstall:
+		return AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	case ModeMaintenance:
+		// Maintenance preserves current authority
+		return AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	default:
+		return AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	}
+}
+
+// resolveAction determines the appropriate action based on current state.
+func resolveAction(snap Snapshot) (Action, []string) {
+	var warnings []string
+	prior := snap.CurrentAuthority
+
+	switch snap.Mode {
+	case ModeInstall:
+		return resolveInstallAction(prior, snap, &warnings), warnings
+	case ModeUpdate:
+		return resolveUpdateAction(prior, snap, &warnings), warnings
+	case ModeUninstall:
+		return resolveUninstallAction(prior, &warnings), warnings
+	case ModeMaintenance:
+		return resolveMaintenanceAction(prior, snap, &warnings), warnings
+	default:
+		return ActionAbort, append(warnings, "unknown mode")
+	}
+}
+
+func resolveInstallAction(prior AuthorityState, snap Snapshot, warnings *[]string) Action {
+	switch prior.Owner {
+	case AuthorityNone:
+		// No existing authority — safe to take
+		return ActionTakeAuthority
+
+	case AuthorityExternal:
+		// External firewall — abort unless explicit takeover
+		*warnings = append(*warnings, "external firewall detected — will not override without explicit takeover")
+		return ActionAbort
+
+	case AuthorityNFTBan:
+		// Already owned — this is a reinstall
+		if prior.Health == HealthDegraded {
+			*warnings = append(*warnings, "existing NFTBan installation is degraded — reinstall may fix")
+		}
+		if prior.Health == HealthDown {
+			*warnings = append(*warnings, "existing NFTBan installation is down — reinstall recommended")
+		}
+		return ActionPreserveAuthority
+	}
+	return ActionAbort
+}
+
+func resolveUpdateAction(prior AuthorityState, snap Snapshot, warnings *[]string) Action {
+	if prior.Owner != AuthorityNFTBan {
+		*warnings = append(*warnings, "cannot update — NFTBan does not own firewall authority")
+		return ActionAbort
+	}
+
+	if prior.Health == HealthDown {
+		*warnings = append(*warnings, "NFTBan is DOWN — update may not succeed, consider recovery first")
+		return ActionNeedsRecovery
+	}
+
+	if prior.Health == HealthDegraded {
+		*warnings = append(*warnings, "NFTBan is DEGRADED — update will proceed with caution")
+	}
+
+	return ActionPreserveAuthority
+}
+
+func resolveUninstallAction(prior AuthorityState, warnings *[]string) Action {
+	if prior.Owner == AuthorityNone {
+		*warnings = append(*warnings, "no authority to release — nothing to uninstall")
+		return ActionNoop
+	}
+
+	if prior.Owner == AuthorityExternal {
+		*warnings = append(*warnings, "external firewall — NFTBan components may be removed but authority is not NFTBan's")
+	}
+
+	// Release authority
+	return ActionTakeAuthority // semantically: release authority to NONE
+}
+
+func resolveMaintenanceAction(prior AuthorityState, snap Snapshot, warnings *[]string) Action {
+	if prior.Owner != AuthorityNFTBan {
+		*warnings = append(*warnings, "cannot perform maintenance — NFTBan does not own authority")
+		return ActionAbort
+	}
+
+	if prior.Health == HealthDown {
+		*warnings = append(*warnings, "NFTBan is DOWN — maintenance cannot proceed")
+		return ActionNeedsRecovery
+	}
+
+	return ActionPreserveAuthority
+}

--- a/internal/lifecycle/engine_test.go
+++ b/internal/lifecycle/engine_test.go
@@ -1,0 +1,323 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Engine Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-engine-test"
+// meta:type="test"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Tests for lifecycle state machine engine"
+// meta:inventory.files="internal/lifecycle/engine_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package lifecycle
+
+import "testing"
+
+// Test 1: NFTBAN + PROTECTED + no recovery → SUCCESS + PRESERVE
+func TestEngineNFTBanProtectedNoRecovery(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeUpdate,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNFTBan, Health: HealthProtected,
+		},
+		LastOperation: LastOperation{Result: "SUCCESS"},
+		Detection:     Detection{KernelValid: true, ValidatorConsistent: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeSuccess {
+		t.Errorf("outcome = %s; want SUCCESS", r.Outcome)
+	}
+	if r.Plan.HasAbort() {
+		t.Error("should not abort")
+	}
+	if len(r.Plan.Actions) == 0 || r.Plan.Actions[0] != ActionPreserveAuthority {
+		t.Errorf("actions = %v; want [PRESERVE_AUTHORITY]", r.Plan.Actions)
+	}
+}
+
+// Test 2: NFTBAN + DEGRADED + recovery pending → NEEDS_RECOVERY
+func TestEngineRecoveryPending(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeUpdate,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNFTBan, Health: HealthDegraded,
+		},
+		LastOperation: LastOperation{
+			Result:          "FAILED_DEGRADED",
+			RecoveryPending: true,
+		},
+		Detection: Detection{KernelValid: true, ValidatorConsistent: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasRecovery() {
+		t.Error("should have NEEDS_RECOVERY action")
+	}
+}
+
+// Test 3: EXTERNAL + healthy → ABORT
+func TestEngineExternalAuthority(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityExternal, Health: HealthProtected,
+		},
+		LastOperation: LastOperation{Result: "SUCCESS"},
+		Detection:     Detection{KernelValid: true, ValidatorConsistent: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasAbort() {
+		t.Error("should ABORT when external authority exists")
+	}
+}
+
+// Test 4: NONE + DOWN → TAKE_AUTHORITY
+func TestEngineNoneDown(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNone, Health: HealthDown,
+		},
+		LastOperation: LastOperation{Result: ""},
+		Detection:     Detection{KernelValid: false, ValidatorConsistent: false, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeSuccess {
+		t.Errorf("outcome = %s; want SUCCESS", r.Outcome)
+	}
+	if len(r.Plan.Actions) == 0 || r.Plan.Actions[0] != ActionTakeAuthority {
+		t.Errorf("actions = %v; want [TAKE_AUTHORITY]", r.Plan.Actions)
+	}
+	if r.Authority.Resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", r.Authority.Resulting.Owner)
+	}
+}
+
+// Test 5: NFTBAN + PROTECTED + last_op=FAILED_RECOVERED → SUCCESS with warning (INV-LC-008)
+func TestEngineFailedRecoveredPreserveTwoTruths(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeUpdate,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNFTBan, Health: HealthProtected,
+		},
+		LastOperation: LastOperation{
+			Result:            "FAILED_RECOVERED",
+			FailureClass:      "POSTVALIDATION_REGRESSION",
+			RecoveryPending:   false,
+			LastRebuildFailed: true,
+		},
+		Detection: Detection{KernelValid: true, ValidatorConsistent: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeSuccess {
+		t.Errorf("outcome = %s; want SUCCESS (current state is healthy)", r.Outcome)
+	}
+
+	// Must preserve both truths
+	if r.LastOperation.Result != "FAILED_RECOVERED" {
+		t.Errorf("last_operation.result = %s; want FAILED_RECOVERED", r.LastOperation.Result)
+	}
+	if !r.LastOperation.LastRebuildFailed {
+		t.Error("last_rebuild_failed should be true")
+	}
+
+	// Must have warning about recovery
+	hasRecoveryWarning := false
+	for _, w := range r.Plan.Warnings {
+		if len(w) > 0 {
+			hasRecoveryWarning = true
+		}
+	}
+	if !hasRecoveryWarning {
+		t.Error("should have warning about recovered rebuild failure")
+	}
+}
+
+// Test 6: ConflictingFirewall=true → ABORT
+func TestEngineConflictingFirewall(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNone, Health: HealthDown,
+		},
+		Detection: Detection{ConflictingFirewall: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasAbort() {
+		t.Error("should ABORT when conflicting firewall detected")
+	}
+	if len(r.Plan.Errors) == 0 {
+		t.Error("should have error message about conflicting firewall")
+	}
+}
+
+// Test 7: DryRun=true, all healthy → SUCCESS, plan rendered, no mutation
+func TestEngineDryRunNoMutation(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNone, Health: HealthDown,
+		},
+		Detection: Detection{KernelValid: false, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if !r.DryRun {
+		t.Error("result should reflect dry_run=true")
+	}
+	if r.Outcome != OutcomeSuccess {
+		t.Errorf("outcome = %s; want SUCCESS", r.Outcome)
+	}
+	// Engine is pure — no side effects to verify, but result must be complete
+	if r.SchemaVersion != OutputSchemaVersion {
+		t.Errorf("schema_version = %s; want %s", r.SchemaVersion, OutputSchemaVersion)
+	}
+	if r.Stage != StageFinal {
+		t.Errorf("stage = %s; want FINAL", r.Stage)
+	}
+}
+
+// Test 8: Update with DOWN authority → NEEDS_RECOVERY
+func TestEngineUpdateDown(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeUpdate,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNFTBan, Health: HealthDown,
+		},
+		LastOperation: LastOperation{Result: "FAILED_FATAL"},
+		Detection:     Detection{KernelValid: false, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasRecovery() {
+		t.Error("update on DOWN authority should require recovery")
+	}
+}
+
+// Test 9: Maintenance with non-NFTBAN authority → ABORT
+func TestEngineMaintenanceNoAuthority(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeMaintenance,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityExternal, Health: HealthProtected,
+		},
+		Detection: Detection{KernelValid: true, SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasAbort() {
+		t.Error("maintenance without NFTBAN authority should abort")
+	}
+}
+
+// Test 10: Uninstall with NONE authority → NOOP
+func TestEngineUninstallNone(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeUninstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNone, Health: HealthDown,
+		},
+		Detection: Detection{SSHSafe: true},
+	}
+
+	r := Run(snap)
+
+	if len(r.Plan.Actions) == 0 || r.Plan.Actions[0] != ActionNoop {
+		t.Errorf("actions = %v; want [NOOP] for uninstall with no authority", r.Plan.Actions)
+	}
+}
+
+// Test 11: Invalid mode → ABORT
+func TestEngineInvalidMode(t *testing.T) {
+	snap := Snapshot{
+		Mode:   "deploy",
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner: AuthorityNone, Health: HealthDown,
+		},
+	}
+
+	r := Run(snap)
+
+	if r.Outcome != OutcomeFailed {
+		t.Errorf("outcome = %s; want FAILED", r.Outcome)
+	}
+	if !r.Plan.HasAbort() {
+		t.Error("invalid mode should abort")
+	}
+}
+
+// Test 12: Schema version is set
+func TestEngineSchemaVersion(t *testing.T) {
+	r := Run(Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{Owner: AuthorityNone, Health: HealthDown},
+		Detection:        Detection{SSHSafe: true},
+	})
+
+	if r.SchemaVersion != "1.0" {
+		t.Errorf("schema_version = %s; want 1.0", r.SchemaVersion)
+	}
+}
+
+// Test 13: Timestamp is set
+func TestEngineTimestamp(t *testing.T) {
+	r := Run(Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{Owner: AuthorityNone, Health: HealthDown},
+		Detection:        Detection{SSHSafe: true},
+	})
+
+	if r.Timestamp.IsZero() {
+		t.Error("timestamp should be set")
+	}
+}

--- a/internal/lifecycle/logger.go
+++ b/internal/lifecycle/logger.go
@@ -1,0 +1,123 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Evidence Logger
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-logger"
+// meta:type="lib"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Structured lifecycle event logging for detect/plan/result"
+// meta:inventory.files="internal/lifecycle/logger.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md §6 PR-06
+// Logs describe PLANNING, not execution. No misleading "success" claims
+// if only planning happened (INV-LC-001).
+// =============================================================================
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// EventType classifies lifecycle log events.
+type EventType string
+
+const (
+	EventDetect EventType = "detect"
+	EventPlan   EventType = "plan"
+	EventResult EventType = "result"
+)
+
+// LogEvent is a structured lifecycle log entry.
+type LogEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+	Event     EventType `json:"event"`
+	Mode      Mode      `json:"mode"`
+	DryRun    bool      `json:"dry_run"`
+	Data      any       `json:"data"`
+}
+
+// Logger writes structured lifecycle events.
+type Logger struct {
+	w    io.Writer
+	mode Mode
+	dry  bool
+}
+
+// NewLogger creates a lifecycle logger.
+func NewLogger(w io.Writer, mode Mode, dryRun bool) *Logger {
+	return &Logger{w: w, mode: mode, dry: dryRun}
+}
+
+// LogDetect records the DETECT stage observations.
+func (l *Logger) LogDetect(authority AuthorityState, detection Detection) {
+	l.emit(EventDetect, map[string]any{
+		"authority": map[string]string{
+			"owner":  string(authority.Owner),
+			"health": string(authority.Health),
+		},
+		"detection": detection,
+	})
+}
+
+// LogPlan records the PLAN stage decisions.
+func (l *Logger) LogPlan(plan Plan, lastOp LastOperation) {
+	actions := make([]string, len(plan.Actions))
+	for i, a := range plan.Actions {
+		actions[i] = string(a)
+	}
+	l.emit(EventPlan, map[string]any{
+		"actions":        actions,
+		"warnings":       plan.Warnings,
+		"errors":         plan.Errors,
+		"last_operation": lastOp,
+	})
+}
+
+// LogResult records the final lifecycle outcome.
+// Explicitly marks whether this was a plan-only or real execution.
+func (l *Logger) LogResult(result RunResult) {
+	label := "plan_completed"
+	if !l.dry {
+		label = "execution_completed"
+	}
+	l.emit(EventResult, map[string]any{
+		"label":   label,
+		"outcome": string(result.Outcome),
+		"stage":   string(result.Stage),
+		"authority_resulting": map[string]string{
+			"owner":  string(result.Authority.Resulting.Owner),
+			"health": string(result.Authority.Resulting.Health),
+		},
+	})
+}
+
+func (l *Logger) emit(event EventType, data any) {
+	entry := LogEvent{
+		Timestamp: time.Now(),
+		Event:     event,
+		Mode:      l.mode,
+		DryRun:    l.dry,
+		Data:      data,
+	}
+
+	out, err := json.Marshal(entry)
+	if err != nil {
+		fmt.Fprintf(l.w, `{"event":"%s","error":"marshal failed: %v"}`+"\n", event, err)
+		return
+	}
+
+	l.w.Write(out)    //nolint:errcheck
+	l.w.Write([]byte("\n")) //nolint:errcheck
+}

--- a/internal/lifecycle/logger.go
+++ b/internal/lifecycle/logger.go
@@ -118,6 +118,6 @@ func (l *Logger) emit(event EventType, data any) {
 		return
 	}
 
-	l.w.Write(out)    //nolint:errcheck
-	l.w.Write([]byte("\n")) //nolint:errcheck
+	_, _ = l.w.Write(out)
+	_, _ = l.w.Write([]byte("\n"))
 }

--- a/internal/lifecycle/logger_test.go
+++ b/internal/lifecycle/logger_test.go
@@ -1,0 +1,141 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Logger Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-logger-test"
+// meta:type="test"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Tests for lifecycle evidence logging"
+// meta:inventory.files="internal/lifecycle/logger_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package lifecycle
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLogDetect(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf, ModeInstall, true)
+
+	l.LogDetect(
+		AuthorityState{Owner: AuthorityNone, Health: HealthDown},
+		Detection{KernelValid: false, SSHSafe: true},
+	)
+
+	output := buf.String()
+	if !strings.Contains(output, `"event":"detect"`) {
+		t.Error("log must contain event=detect")
+	}
+	if !strings.Contains(output, `"dry_run":true`) {
+		t.Error("log must contain dry_run flag")
+	}
+	if !strings.Contains(output, `"mode":"install"`) {
+		t.Error("log must contain mode")
+	}
+
+	// Must be valid JSON
+	var event LogEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &event); err != nil {
+		t.Fatalf("log output not valid JSON: %v", err)
+	}
+}
+
+func TestLogPlan(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf, ModeUpdate, true)
+
+	l.LogPlan(
+		Plan{
+			Actions:  []Action{ActionPreserveAuthority},
+			Warnings: []string{"degraded state"},
+		},
+		LastOperation{
+			Result:            "FAILED_RECOVERED",
+			LastRebuildFailed: true,
+		},
+	)
+
+	output := buf.String()
+	if !strings.Contains(output, `"event":"plan"`) {
+		t.Error("log must contain event=plan")
+	}
+	if !strings.Contains(output, "PRESERVE_AUTHORITY") {
+		t.Error("log must contain action")
+	}
+	if !strings.Contains(output, "FAILED_RECOVERED") {
+		t.Error("log must contain v1.96 operation result")
+	}
+}
+
+func TestLogResult(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf, ModeInstall, true)
+
+	result := RunResult{
+		Outcome: OutcomeSuccess,
+		Stage:   StageFinal,
+	}
+	result.Authority.Resulting = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	l.LogResult(result)
+
+	output := buf.String()
+	if !strings.Contains(output, `"event":"result"`) {
+		t.Error("log must contain event=result")
+	}
+	if !strings.Contains(output, "plan_completed") {
+		t.Error("dry-run result must say plan_completed, not execution_completed")
+	}
+	if !strings.Contains(output, "SUCCESS") {
+		t.Error("log must contain outcome")
+	}
+}
+
+func TestLogResultExecution(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf, ModeInstall, false) // NOT dry-run
+
+	result := RunResult{Outcome: OutcomeSuccess, Stage: StageFinal}
+	result.Authority.Resulting = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	l.LogResult(result)
+
+	output := buf.String()
+	if !strings.Contains(output, "execution_completed") {
+		t.Error("non-dry-run result must say execution_completed")
+	}
+}
+
+func TestLogOutputIsJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf, ModeInstall, true)
+
+	l.LogDetect(AuthorityState{Owner: AuthorityNone, Health: HealthDown}, Detection{})
+	l.LogPlan(Plan{Actions: []Action{ActionTakeAuthority}}, LastOperation{})
+	l.LogResult(RunResult{Outcome: OutcomeSuccess, Stage: StageFinal})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 JSONL lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var event LogEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Errorf("line %d not valid JSON: %v", i+1, err)
+		}
+	}
+}

--- a/internal/lifecycle/output.go
+++ b/internal/lifecycle/output.go
@@ -1,0 +1,146 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle JSON Output
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-output"
+// meta:type="lib"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Stable JSON output rendering for lifecycle engine results"
+// meta:inventory.files="internal/lifecycle/output.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md §4, §6 PR-04
+// INV-LC-003: v1.96 operation results are consumed, never redefined.
+// INV-LC-006: Output schema is stable, versioned, and additive-only.
+// INV-LC-008: FAILED_RECOVERED + PROTECTED preserved as two truths.
+// =============================================================================
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// RenderJSON writes the RunResult as stable, versioned JSON.
+// Schema version is always set to OutputSchemaVersion.
+// Fields are ordered for readability and stability.
+func RenderJSON(w io.Writer, result RunResult) error {
+	result.SchemaVersion = OutputSchemaVersion
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal lifecycle result: %w", err)
+	}
+
+	_, err = w.Write(data)
+	if err != nil {
+		return fmt.Errorf("write lifecycle result: %w", err)
+	}
+
+	_, _ = w.Write([]byte("\n"))
+	return nil
+}
+
+// RenderText writes a human-readable summary of the RunResult.
+func RenderText(w io.Writer, result RunResult) error {
+	// Header
+	fmt.Fprintf(w, "Lifecycle %s (%s)\n", result.Mode, modeLabel(result.Mode))
+	if result.DryRun {
+		fmt.Fprintf(w, "  Mode: DRY-RUN (no changes applied)\n")
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Authority
+	fmt.Fprintf(w, "Authority\n")
+	fmt.Fprintf(w, "  Prior:     %s / %s\n", result.Authority.Prior.Owner, result.Authority.Prior.Health)
+	fmt.Fprintf(w, "  Desired:   %s / %s\n", result.Authority.Desired.Owner, result.Authority.Desired.Health)
+	fmt.Fprintf(w, "  Resulting: %s / %s\n", result.Authority.Resulting.Owner, result.Authority.Resulting.Health)
+	fmt.Fprintf(w, "\n")
+
+	// Detection
+	fmt.Fprintf(w, "Detection\n")
+	fmt.Fprintf(w, "  Conflicting firewall: %s\n", boolStatus(result.Detection.ConflictingFirewall, true))
+	fmt.Fprintf(w, "  Kernel valid:         %s\n", boolStatus(result.Detection.KernelValid, false))
+	fmt.Fprintf(w, "  Validator consistent: %s\n", boolStatus(result.Detection.ValidatorConsistent, false))
+	fmt.Fprintf(w, "  SSH safe:             %s\n", boolStatus(result.Detection.SSHSafe, false))
+	fmt.Fprintf(w, "\n")
+
+	// Last operation (v1.96 truth)
+	if result.LastOperation.Result != "" {
+		fmt.Fprintf(w, "Last Operation (v1.96)\n")
+		fmt.Fprintf(w, "  Result:           %s\n", result.LastOperation.Result)
+		if result.LastOperation.FailureClass != "" {
+			fmt.Fprintf(w, "  Failure class:    %s\n", result.LastOperation.FailureClass)
+		}
+		fmt.Fprintf(w, "  Recovery pending: %v\n", result.LastOperation.RecoveryPending)
+		fmt.Fprintf(w, "  Last rebuild failed: %v\n", result.LastOperation.LastRebuildFailed)
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Plan
+	fmt.Fprintf(w, "Plan\n")
+	for _, a := range result.Plan.Actions {
+		fmt.Fprintf(w, "  Action: %s\n", a)
+	}
+	for _, warn := range result.Plan.Warnings {
+		fmt.Fprintf(w, "  Warning: %s\n", warn)
+	}
+	for _, e := range result.Plan.Errors {
+		fmt.Fprintf(w, "  Error: %s\n", e)
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Outcome
+	fmt.Fprintf(w, "Outcome: %s\n", result.Outcome)
+	fmt.Fprintf(w, "Stage:   %s\n", result.Stage)
+
+	return nil
+}
+
+// ParseRunResult deserializes a RunResult from JSON.
+func ParseRunResult(data []byte) (*RunResult, error) {
+	var r RunResult
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse lifecycle result: %w", err)
+	}
+	return &r, nil
+}
+
+func modeLabel(m Mode) string {
+	switch m {
+	case ModeInstall:
+		return "Fresh Installation"
+	case ModeUpdate:
+		return "Upgrade"
+	case ModeUninstall:
+		return "Removal"
+	case ModeMaintenance:
+		return "Maintenance"
+	default:
+		return string(m)
+	}
+}
+
+func boolStatus(val bool, invertMeaning bool) string {
+	if invertMeaning {
+		// For "conflicting firewall": true=bad, false=good
+		if val {
+			return "YES (blocking)"
+		}
+		return "no"
+	}
+	// For "kernel valid": true=good, false=bad
+	if val {
+		return "yes"
+	}
+	return "NO"
+}

--- a/internal/lifecycle/output_test.go
+++ b/internal/lifecycle/output_test.go
@@ -1,0 +1,247 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Output Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-output-test"
+// meta:type="test"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Tests for lifecycle JSON and text output rendering"
+// meta:inventory.files="internal/lifecycle/output_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package lifecycle
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeTestResult() RunResult {
+	r := RunResult{
+		SchemaVersion: OutputSchemaVersion,
+		Mode:          ModeInstall,
+		DryRun:        true,
+		Stage:         StageFinal,
+		Outcome:       OutcomeSuccess,
+		LastOperation: LastOperation{
+			Result:            "SUCCESS",
+			RecoveryPending:   false,
+			LastRebuildFailed: false,
+		},
+		Plan: Plan{
+			Actions:  []Action{ActionTakeAuthority},
+			Warnings: []string{"first install"},
+		},
+		Detection: Detection{
+			KernelValid:         true,
+			ValidatorConsistent: true,
+			SSHSafe:             true,
+		},
+		Timestamp: time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC),
+	}
+	r.Authority.Prior = AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	r.Authority.Desired = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	r.Authority.Resulting = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	return r
+}
+
+func TestRenderJSON(t *testing.T) {
+	var buf bytes.Buffer
+	result := makeTestResult()
+
+	if err := RenderJSON(&buf, result); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+
+	output := buf.String()
+
+	// Must contain schema version
+	if !strings.Contains(output, `"schema_version": "1.0"`) {
+		t.Error("JSON must contain schema_version 1.0")
+	}
+
+	// Must contain outcome
+	if !strings.Contains(output, `"outcome": "SUCCESS"`) {
+		t.Error("JSON must contain outcome")
+	}
+
+	// Must contain authority
+	if !strings.Contains(output, `"owner": "NFTBAN"`) {
+		t.Error("JSON must contain authority owner")
+	}
+
+	// Must parse back
+	var parsed RunResult
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("roundtrip parse: %v", err)
+	}
+	if parsed.Outcome != OutcomeSuccess {
+		t.Errorf("parsed outcome = %s; want SUCCESS", parsed.Outcome)
+	}
+}
+
+func TestRenderJSONPreservesV196Truths(t *testing.T) {
+	var buf bytes.Buffer
+	result := makeTestResult()
+	result.LastOperation = LastOperation{
+		Result:            "FAILED_RECOVERED",
+		FailureClass:      "POSTVALIDATION_REGRESSION",
+		RecoveryPending:   false,
+		LastRebuildFailed: true,
+	}
+
+	if err := RenderJSON(&buf, result); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+
+	output := buf.String()
+
+	// INV-LC-003: v1.96 results must be present
+	if !strings.Contains(output, `"result": "FAILED_RECOVERED"`) {
+		t.Error("must contain v1.96 operation result")
+	}
+	if !strings.Contains(output, `"failure_class": "POSTVALIDATION_REGRESSION"`) {
+		t.Error("must contain v1.96 failure class")
+	}
+	if !strings.Contains(output, `"last_rebuild_failed": true`) {
+		t.Error("must contain last_rebuild_failed flag")
+	}
+}
+
+func TestRenderText(t *testing.T) {
+	var buf bytes.Buffer
+	result := makeTestResult()
+
+	if err := RenderText(&buf, result); err != nil {
+		t.Fatalf("RenderText: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, "DRY-RUN") {
+		t.Error("text must indicate dry-run")
+	}
+	if !strings.Contains(output, "TAKE_AUTHORITY") {
+		t.Error("text must contain action")
+	}
+	if !strings.Contains(output, "Outcome: SUCCESS") {
+		t.Error("text must contain outcome")
+	}
+	if !strings.Contains(output, "NFTBAN") {
+		t.Error("text must contain authority owner")
+	}
+}
+
+func TestRenderTextWithV196Recovery(t *testing.T) {
+	var buf bytes.Buffer
+	result := makeTestResult()
+	result.LastOperation = LastOperation{
+		Result:            "FAILED_RECOVERED",
+		FailureClass:      "MODULE_RESTORE_INCOMPLETE",
+		RecoveryPending:   true,
+		LastRebuildFailed: true,
+	}
+
+	if err := RenderText(&buf, result); err != nil {
+		t.Fatalf("RenderText: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "FAILED_RECOVERED") {
+		t.Error("text must show v1.96 operation result")
+	}
+	if !strings.Contains(output, "MODULE_RESTORE_INCOMPLETE") {
+		t.Error("text must show failure class")
+	}
+}
+
+func TestParseRunResult(t *testing.T) {
+	result := makeTestResult()
+	data, _ := json.MarshalIndent(result, "", "  ")
+
+	parsed, err := ParseRunResult(data)
+	if err != nil {
+		t.Fatalf("ParseRunResult: %v", err)
+	}
+	if parsed.Outcome != OutcomeSuccess {
+		t.Errorf("parsed outcome = %s; want SUCCESS", parsed.Outcome)
+	}
+	if parsed.Authority.Resulting.Owner != AuthorityNFTBan {
+		t.Errorf("parsed resulting owner = %s; want NFTBAN", parsed.Authority.Resulting.Owner)
+	}
+}
+
+func TestParseRunResultInvalid(t *testing.T) {
+	_, err := ParseRunResult([]byte("not json"))
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSchemaVersionAlwaysSet(t *testing.T) {
+	var buf bytes.Buffer
+	result := RunResult{} // empty result, no schema version set
+	if err := RenderJSON(&buf, result); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+
+	var parsed RunResult
+	json.Unmarshal(buf.Bytes(), &parsed)
+	if parsed.SchemaVersion != OutputSchemaVersion {
+		t.Errorf("schema_version = %s; want %s (must always be set by RenderJSON)", parsed.SchemaVersion, OutputSchemaVersion)
+	}
+}
+
+func TestJSONFieldStability(t *testing.T) {
+	// Snapshot test: verify specific field names exist in JSON output.
+	// This prevents accidental field renames that would break consumers.
+	var buf bytes.Buffer
+	result := makeTestResult()
+	RenderJSON(&buf, result)
+	output := buf.String()
+
+	requiredFields := []string{
+		`"schema_version"`,
+		`"mode"`,
+		`"dry_run"`,
+		`"stage"`,
+		`"outcome"`,
+		`"authority"`,
+		`"prior"`,
+		`"desired"`,
+		`"resulting"`,
+		`"owner"`,
+		`"health"`,
+		`"last_operation"`,
+		`"result"`,
+		`"failure_class"`,
+		`"recovery_pending"`,
+		`"last_rebuild_failed"`,
+		`"plan"`,
+		`"actions"`,
+		`"warnings"`,
+		`"detection"`,
+		`"conflicting_firewall"`,
+		`"kernel_valid"`,
+		`"validator_consistent"`,
+		`"ssh_safe"`,
+		`"timestamp"`,
+	}
+
+	for _, field := range requiredFields {
+		if !strings.Contains(output, field) {
+			t.Errorf("JSON output missing required field: %s", field)
+		}
+	}
+}

--- a/internal/lifecycle/types.go
+++ b/internal/lifecycle/types.go
@@ -1,0 +1,326 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Types
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-types"
+// meta:type="lib"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Type definitions for lifecycle orchestration: stages, outcomes, authority, detection"
+// meta:inventory.files="internal/lifecycle/types.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Contract: V197_LIFECYCLE_CONTRACT.md
+// Invariants: INV-LC-001 through INV-LC-008
+//
+// Architecture:
+//   Lifecycle is an ORCHESTRATION layer. It plans and describes.
+//   It is NOT a truth source. Validator is truth. Kernel is authority.
+//   v1.96 rebuild/recovery provides ground-truth operation results.
+//   Lifecycle consumes those results — it never redefines them.
+// =============================================================================
+
+package lifecycle
+
+import "time"
+
+// =============================================================================
+// Stages — phases of lifecycle execution
+// =============================================================================
+
+// Stage represents a phase in the lifecycle execution pipeline.
+// Stages are sequential: DETECT → PLAN → APPLY → VERIFY → FINAL.
+type Stage string
+
+const (
+	StageDetect Stage = "DETECT"
+	StagePlan   Stage = "PLAN"
+	StageApply  Stage = "APPLY"
+	StageVerify Stage = "VERIFY"
+	StageFinal  Stage = "FINAL"
+)
+
+// =============================================================================
+// Outcomes — results of lifecycle execution
+// =============================================================================
+
+// Outcome represents the high-level result of a lifecycle operation.
+//
+// Lifecycle Outcome is a high-level orchestration result. Detailed failure
+// semantics remain in v1.96 operation result and failure class fields
+// (rebuild.OperationResult, rebuild.FailureClass). Do not conflate
+// lifecycle FAILED with rebuild FAILED_DEGRADED or FAILED_FATAL —
+// those are distinct levels of specificity.
+type Outcome string
+
+const (
+	// OutcomeSuccess means all stages completed and verification passed.
+	OutcomeSuccess Outcome = "SUCCESS"
+
+	// OutcomeFailed means execution failed with no recovery.
+	// For detailed failure class, see LastOperation.FailureClass.
+	OutcomeFailed Outcome = "FAILED"
+
+	// OutcomeFailedRecovered means execution failed but recovery
+	// restored a validated prior state. System may be healthy
+	// even though the operation did not achieve its goal.
+	OutcomeFailedRecovered Outcome = "FAILED_RECOVERED"
+)
+
+// =============================================================================
+// Modes — types of lifecycle operation
+// =============================================================================
+
+// Mode represents the type of lifecycle operation being performed.
+type Mode string
+
+const (
+	ModeInstall     Mode = "install"
+	ModeUpdate      Mode = "update"
+	ModeUninstall   Mode = "uninstall"
+	ModeMaintenance Mode = "maintenance"
+)
+
+// ValidMode returns true if m is a recognized lifecycle mode.
+func ValidMode(m Mode) bool {
+	switch m {
+	case ModeInstall, ModeUpdate, ModeUninstall, ModeMaintenance:
+		return true
+	}
+	return false
+}
+
+// =============================================================================
+// Authority — who controls the firewall and in what state
+// =============================================================================
+
+// AuthorityOwner identifies who currently controls the firewall.
+type AuthorityOwner string
+
+const (
+	// AuthorityNFTBan means NFTBan owns the firewall authority.
+	// This is valid even when health is DEGRADED — ownership and
+	// health are independent dimensions (INV-LC-004).
+	AuthorityNFTBan AuthorityOwner = "NFTBAN"
+
+	// AuthorityExternal means another firewall (CSF, UFW, firewalld)
+	// controls the system. Lifecycle may observe but MUST NOT seize
+	// authority without explicit operator instruction.
+	AuthorityExternal AuthorityOwner = "EXTERNAL"
+
+	// AuthorityNone means no managed firewall authority exists.
+	// Health should normally be DOWN when owner is NONE.
+	AuthorityNone AuthorityOwner = "NONE"
+)
+
+// LifecycleHealth represents the health dimension of authority.
+// These values mirror validator.Status but are defined here to avoid
+// import cycles. The lifecycle engine consumes health from the validator
+// and maps it to these values.
+type LifecycleHealth string
+
+const (
+	HealthProtected LifecycleHealth = "PROTECTED"
+	HealthIdle      LifecycleHealth = "IDLE"
+	HealthDegraded  LifecycleHealth = "DEGRADED"
+	HealthDown      LifecycleHealth = "DOWN"
+)
+
+// AuthorityState combines ownership and health into a single assessment.
+// These are INDEPENDENT dimensions — NFTBAN + DEGRADED is a valid state
+// meaning "NFTBan owns the firewall but protection is partial."
+type AuthorityState struct {
+	Owner  AuthorityOwner  `json:"owner"`
+	Health LifecycleHealth `json:"health"`
+}
+
+// IsOwned returns true if NFTBan has authority (regardless of health).
+func (a AuthorityState) IsOwned() bool {
+	return a.Owner == AuthorityNFTBan
+}
+
+// IsHealthy returns true if health is PROTECTED or IDLE.
+func (a AuthorityState) IsHealthy() bool {
+	return a.Health == HealthProtected || a.Health == HealthIdle
+}
+
+// NormalizeNone ensures that Owner=NONE has health=DOWN unless
+// there is a specific reason otherwise. This prevents confusing
+// states like NONE + PROTECTED.
+func (a *AuthorityState) NormalizeNone() {
+	if a.Owner == AuthorityNone && a.Health != HealthDown {
+		a.Health = HealthDown
+	}
+}
+
+// =============================================================================
+// Actions — what the lifecycle engine recommends
+// =============================================================================
+
+// Action represents a lifecycle recommendation or decision.
+type Action string
+
+const (
+	// ActionNoop means no action needed — current state is acceptable.
+	ActionNoop Action = "NOOP"
+
+	// ActionTakeAuthority means lifecycle should take firewall ownership.
+	ActionTakeAuthority Action = "TAKE_AUTHORITY"
+
+	// ActionPreserveAuthority means keep current NFTBan ownership.
+	ActionPreserveAuthority Action = "PRESERVE_AUTHORITY"
+
+	// ActionAbort means lifecycle cannot proceed safely.
+	ActionAbort Action = "ABORT"
+
+	// ActionNeedsRecovery means v1.96 recovery must complete first.
+	ActionNeedsRecovery Action = "NEEDS_RECOVERY"
+)
+
+// =============================================================================
+// Detection — what was observed about the system
+// =============================================================================
+
+// Detection captures system observations during the DETECT stage.
+type Detection struct {
+	// ConflictingFirewall is true if another firewall (CSF/UFW/firewalld) is active.
+	ConflictingFirewall bool `json:"conflicting_firewall"`
+
+	// KernelValid is true if nftables kernel state passes structural checks.
+	KernelValid bool `json:"kernel_valid"`
+
+	// ValidatorConsistent is true if validator agrees with kernel state.
+	ValidatorConsistent bool `json:"validator_consistent"`
+
+	// SSHSafe is true if SSH port is protected and accessible.
+	SSHSafe bool `json:"ssh_safe"`
+}
+
+// =============================================================================
+// LastOperation — v1.96 ground truth (consumed, not redefined)
+// =============================================================================
+
+// LastOperation carries v1.96 operation-result truth into lifecycle output.
+// Lifecycle MUST consume these values from rebuild.RecoveryMarker and
+// validator state — it MUST NOT reinterpret or override them (INV-LC-003).
+type LastOperation struct {
+	// Result is the v1.96 operation result (SUCCESS, FAILED_RECOVERED, etc.)
+	Result string `json:"result"`
+
+	// FailureClass is the v1.96 failure classification (if non-success).
+	FailureClass string `json:"failure_class"`
+
+	// RecoveryPending is true if a v1.96 recovery marker exists and is not exhausted.
+	RecoveryPending bool `json:"recovery_pending"`
+
+	// LastRebuildFailed is true if the most recent rebuild was non-success.
+	// This flag exists for dashboard clarity: health=PROTECTED + last_rebuild_failed=true
+	// means "healthy now but just recovered from failure."
+	LastRebuildFailed bool `json:"last_rebuild_failed"`
+}
+
+// =============================================================================
+// Plan — what the engine recommends
+// =============================================================================
+
+// Plan captures the engine's recommended actions, warnings, and errors.
+type Plan struct {
+	Actions  []Action `json:"actions"`
+	Warnings []string `json:"warnings"`
+	Errors   []string `json:"errors"`
+}
+
+// HasAbort returns true if the plan contains an ABORT action.
+func (p Plan) HasAbort() bool {
+	for _, a := range p.Actions {
+		if a == ActionAbort {
+			return true
+		}
+	}
+	return false
+}
+
+// HasRecovery returns true if the plan requires v1.96 recovery first.
+func (p Plan) HasRecovery() bool {
+	for _, a := range p.Actions {
+		if a == ActionNeedsRecovery {
+			return true
+		}
+	}
+	return false
+}
+
+// =============================================================================
+// Snapshot — engine input (current system state)
+// =============================================================================
+
+// Snapshot captures the current system state as input to the lifecycle engine.
+// All fields must be populated from real system observations (validator,
+// recovery marker, service state, conflict detection) — never guessed.
+type Snapshot struct {
+	// Mode is the requested lifecycle operation.
+	Mode Mode `json:"mode"`
+
+	// DryRun is true if this is a planning-only run (INV-LC-001).
+	DryRun bool `json:"dry_run"`
+
+	// CurrentAuthority is the observed authority state.
+	CurrentAuthority AuthorityState `json:"current_authority"`
+
+	// LastOperation carries v1.96 operation-result ground truth.
+	LastOperation LastOperation `json:"last_operation"`
+
+	// Detection carries system observations from the DETECT stage.
+	Detection Detection `json:"detection"`
+}
+
+// =============================================================================
+// RunResult — engine output
+// =============================================================================
+
+// RunResult is the complete output of a lifecycle engine run.
+// It represents a PLAN, not an execution result (in v1.97).
+type RunResult struct {
+	// SchemaVersion for output stability.
+	SchemaVersion string `json:"schema_version"`
+
+	// Mode that was requested.
+	Mode Mode `json:"mode"`
+
+	// DryRun indicates this was a planning-only run.
+	DryRun bool `json:"dry_run"`
+
+	// Stage reached during execution/planning.
+	Stage Stage `json:"stage"`
+
+	// Outcome of the lifecycle operation.
+	Outcome Outcome `json:"outcome"`
+
+	// Authority shows prior, desired, and resulting authority states.
+	Authority struct {
+		Prior     AuthorityState `json:"prior"`
+		Desired   AuthorityState `json:"desired"`
+		Resulting AuthorityState `json:"resulting"`
+	} `json:"authority"`
+
+	// LastOperation from v1.96 (passed through, not reinterpreted).
+	LastOperation LastOperation `json:"last_operation"`
+
+	// Plan contains recommended actions, warnings, and errors.
+	Plan Plan `json:"plan"`
+
+	// Detection from the DETECT stage.
+	Detection Detection `json:"detection"`
+
+	// Timestamp of when the result was produced.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// OutputSchemaVersion is the current version of the lifecycle JSON schema.
+const OutputSchemaVersion = "1.0"

--- a/internal/lifecycle/types_test.go
+++ b/internal/lifecycle/types_test.go
@@ -1,0 +1,279 @@
+// =============================================================================
+// NFTBan v1.97 - Lifecycle Types Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="lifecycle-types-test"
+// meta:type="test"
+// meta:version="1.97.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-17"
+// meta:description="Tests for lifecycle type definitions, enums, helpers"
+// meta:inventory.files="internal/lifecycle/types_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidMode(t *testing.T) {
+	valid := []Mode{ModeInstall, ModeUpdate, ModeUninstall, ModeMaintenance}
+	for _, m := range valid {
+		if !ValidMode(m) {
+			t.Errorf("ValidMode(%s) = false; want true", m)
+		}
+	}
+
+	invalid := []Mode{"", "deploy", "rollback", "INSTALL"}
+	for _, m := range invalid {
+		if ValidMode(m) {
+			t.Errorf("ValidMode(%s) = true; want false", m)
+		}
+	}
+}
+
+func TestAuthorityStateIsOwned(t *testing.T) {
+	tests := []struct {
+		owner AuthorityOwner
+		want  bool
+	}{
+		{AuthorityNFTBan, true},
+		{AuthorityExternal, false},
+		{AuthorityNone, false},
+	}
+	for _, tt := range tests {
+		a := AuthorityState{Owner: tt.owner}
+		if got := a.IsOwned(); got != tt.want {
+			t.Errorf("AuthorityState{Owner: %s}.IsOwned() = %v; want %v", tt.owner, got, tt.want)
+		}
+	}
+}
+
+func TestAuthorityStateIsHealthy(t *testing.T) {
+	tests := []struct {
+		health LifecycleHealth
+		want   bool
+	}{
+		{HealthProtected, true},
+		{HealthIdle, true},
+		{HealthDegraded, false},
+		{HealthDown, false},
+	}
+	for _, tt := range tests {
+		a := AuthorityState{Health: tt.health}
+		if got := a.IsHealthy(); got != tt.want {
+			t.Errorf("AuthorityState{Health: %s}.IsHealthy() = %v; want %v", tt.health, got, tt.want)
+		}
+	}
+}
+
+func TestDegradedOwnershipIsStillOwned(t *testing.T) {
+	// INV-LC-004: NFTBAN + DEGRADED is valid ownership.
+	// Lifecycle must not treat DEGRADED as "no authority."
+	a := AuthorityState{Owner: AuthorityNFTBan, Health: HealthDegraded}
+
+	if !a.IsOwned() {
+		t.Error("NFTBAN + DEGRADED must still be owned (INV-LC-004)")
+	}
+	if a.IsHealthy() {
+		t.Error("DEGRADED must not be healthy")
+	}
+}
+
+func TestNormalizeNone(t *testing.T) {
+	// Owner=NONE should normalize health to DOWN
+	a := AuthorityState{Owner: AuthorityNone, Health: HealthProtected}
+	a.NormalizeNone()
+	if a.Health != HealthDown {
+		t.Errorf("NormalizeNone: health = %s; want DOWN", a.Health)
+	}
+
+	// NFTBAN should NOT be affected
+	b := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	b.NormalizeNone()
+	if b.Health != HealthProtected {
+		t.Errorf("NormalizeNone should not affect NFTBAN: health = %s; want PROTECTED", b.Health)
+	}
+
+	// NONE + DOWN stays DOWN
+	c := AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	c.NormalizeNone()
+	if c.Health != HealthDown {
+		t.Errorf("NormalizeNone: NONE+DOWN should stay DOWN: health = %s", c.Health)
+	}
+}
+
+func TestPlanHasAbort(t *testing.T) {
+	p := Plan{Actions: []Action{ActionPreserveAuthority, ActionAbort}}
+	if !p.HasAbort() {
+		t.Error("plan with ABORT should return HasAbort=true")
+	}
+
+	p2 := Plan{Actions: []Action{ActionNoop}}
+	if p2.HasAbort() {
+		t.Error("plan without ABORT should return HasAbort=false")
+	}
+}
+
+func TestPlanHasRecovery(t *testing.T) {
+	p := Plan{Actions: []Action{ActionNeedsRecovery}}
+	if !p.HasRecovery() {
+		t.Error("plan with NEEDS_RECOVERY should return HasRecovery=true")
+	}
+
+	p2 := Plan{Actions: []Action{ActionTakeAuthority}}
+	if p2.HasRecovery() {
+		t.Error("plan without NEEDS_RECOVERY should return HasRecovery=false")
+	}
+}
+
+func TestLastOperationCanRepresentRecoveredProtected(t *testing.T) {
+	// INV-LC-008: FAILED_RECOVERED + PROTECTED must coexist without contradiction.
+	lo := LastOperation{
+		Result:            "FAILED_RECOVERED",
+		FailureClass:      "POSTVALIDATION_REGRESSION",
+		RecoveryPending:   false,
+		LastRebuildFailed: true,
+	}
+	auth := AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	// Both truths must be representable simultaneously
+	if lo.Result != "FAILED_RECOVERED" {
+		t.Error("LastOperation must preserve FAILED_RECOVERED")
+	}
+	if !auth.IsOwned() || !auth.IsHealthy() {
+		t.Error("authority must be owned and healthy despite failed operation")
+	}
+	if !lo.LastRebuildFailed {
+		t.Error("LastRebuildFailed must be true for dashboard clarity")
+	}
+}
+
+func TestSnapshotJSONRoundtrip(t *testing.T) {
+	snap := Snapshot{
+		Mode:   ModeInstall,
+		DryRun: true,
+		CurrentAuthority: AuthorityState{
+			Owner:  AuthorityNone,
+			Health: HealthDown,
+		},
+		LastOperation: LastOperation{
+			Result:            "SUCCESS",
+			FailureClass:      "",
+			RecoveryPending:   false,
+			LastRebuildFailed: false,
+		},
+		Detection: Detection{
+			ConflictingFirewall: false,
+			KernelValid:         true,
+			ValidatorConsistent: true,
+			SSHSafe:             true,
+		},
+	}
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var snap2 Snapshot
+	if err := json.Unmarshal(data, &snap2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if snap2.Mode != ModeInstall {
+		t.Errorf("mode = %s; want install", snap2.Mode)
+	}
+	if snap2.CurrentAuthority.Owner != AuthorityNone {
+		t.Errorf("owner = %s; want NONE", snap2.CurrentAuthority.Owner)
+	}
+	if snap2.Detection.KernelValid != true {
+		t.Error("kernel_valid should be true")
+	}
+}
+
+func TestRunResultJSONRoundtrip(t *testing.T) {
+	result := RunResult{
+		SchemaVersion: OutputSchemaVersion,
+		Mode:          ModeInstall,
+		DryRun:        true,
+		Stage:         StageFinal,
+		Outcome:       OutcomeSuccess,
+		LastOperation: LastOperation{
+			Result:          "SUCCESS",
+			RecoveryPending: false,
+		},
+		Plan: Plan{
+			Actions:  []Action{ActionTakeAuthority},
+			Warnings: []string{"first install"},
+			Errors:   nil,
+		},
+		Detection: Detection{
+			ConflictingFirewall: false,
+			KernelValid:         true,
+			ValidatorConsistent: true,
+			SSHSafe:             true,
+		},
+	}
+	result.Authority.Prior = AuthorityState{Owner: AuthorityNone, Health: HealthDown}
+	result.Authority.Desired = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+	result.Authority.Resulting = AuthorityState{Owner: AuthorityNFTBan, Health: HealthProtected}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var result2 RunResult
+	if err := json.Unmarshal(data, &result2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if result2.SchemaVersion != "1.0" {
+		t.Errorf("schema_version = %s; want 1.0", result2.SchemaVersion)
+	}
+	if result2.Outcome != OutcomeSuccess {
+		t.Errorf("outcome = %s; want SUCCESS", result2.Outcome)
+	}
+	if result2.Authority.Prior.Owner != AuthorityNone {
+		t.Errorf("prior.owner = %s; want NONE", result2.Authority.Prior.Owner)
+	}
+	if result2.Authority.Resulting.Owner != AuthorityNFTBan {
+		t.Errorf("resulting.owner = %s; want NFTBAN", result2.Authority.Resulting.Owner)
+	}
+	if len(result2.Plan.Actions) != 1 || result2.Plan.Actions[0] != ActionTakeAuthority {
+		t.Errorf("plan.actions = %v; want [TAKE_AUTHORITY]", result2.Plan.Actions)
+	}
+}
+
+func TestStageValues(t *testing.T) {
+	stages := []Stage{StageDetect, StagePlan, StageApply, StageVerify, StageFinal}
+	for _, s := range stages {
+		if s == "" {
+			t.Error("stage value must not be empty")
+		}
+	}
+}
+
+func TestOutcomeValues(t *testing.T) {
+	outcomes := []Outcome{OutcomeSuccess, OutcomeFailed, OutcomeFailedRecovered}
+	for _, o := range outcomes {
+		if o == "" {
+			t.Error("outcome value must not be empty")
+		}
+	}
+}
+
+func TestOutputSchemaVersion(t *testing.T) {
+	if OutputSchemaVersion != "1.0" {
+		t.Errorf("OutputSchemaVersion = %s; want 1.0", OutputSchemaVersion)
+	}
+}


### PR DESCRIPTION
## Summary

Implements v1.97 Lifecycle Wave 1 — the lifecycle foundation for v1.98+ installer/update canonization.

**Side-effect free by contract (INV-LC-001).** No nftables mutation, no installer replacement, no truth drift.

### Core additions (6 PRs)
- **PR-01:** Lifecycle types — Stage, Outcome, Mode, AuthorityOwner, LifecycleHealth, Action enums + structs
- **PR-02:** Pure state machine engine — `Run(Snapshot) → RunResult`, deterministic, no side effects
- **PR-03:** Authority resolution — prior → desired → resulting with health dimension (INV-LC-004)
- **PR-04:** JSON output schema v1.0 — stable, versioned, 25 required fields snapshot-tested
- **PR-05:** CLI dry-run — `nftban lifecycle run --mode=X [--json]`, refuses `--no-dry-run`
- **PR-06:** Evidence logging — structured JSONL events (detect/plan/result)

### Key architectural decisions
- **FAILED_RECOVERED + PROTECTED preserved correctly:** Lifecycle output carries both truths — operation failed but system is healthy after rollback (INV-LC-008)
- **Degraded ownership is still ownership:** NFTBAN + DEGRADED = owned but unsafe, NOT "no authority" (INV-LC-004)
- **v1.96 truths consumed, never redefined:** last_operation.result, failure_class, recovery_pending, last_rebuild_failed all embedded in lifecycle output from rebuild.RecoveryMarker (INV-LC-003)
- **Real execution refused:** `--no-dry-run` prints "not available in v1.97" and exits 1 (INV-LC-007)

## Contract

`V197_LIFECYCLE_CONTRACT.md` (locked 2026-04-17)

8 invariants (INV-LC-001 through INV-LC-008):
1. Engine is side-effect free
2. Lifecycle is not a truth source
3. v1.96 operation results are canonical
4. Authority owner and health are separate dimensions
5. Dry-run uses same logic as real execution planning
6. Output schema is stable and versioned
7. No lifecycle command in v1.97 may mutate the system
8. Recovery truth (FAILED_RECOVERED + PROTECTED) is preserved

## Lab4 Validation

### Unit tests (50 PASS)
| Suite | Tests | Status |
|-------|-------|--------|
| types | 13 | PASS |
| engine | 13 | PASS |
| authority | 11 | PASS |
| output | 8 | PASS |
| logger | 5 | PASS |

### CLI tests (5 PASS on lab4)
| Test | Result |
|------|--------|
| Text output (--mode=install) | Authority/detection/plan/outcome rendered correctly |
| JSON output (--mode=update --json) | Schema v1.0, all fields present |
| --no-dry-run rejected | "real execution is not available in v1.97" exit 1 |
| Invalid mode (--mode=deploy) | "invalid mode" exit 1 |
| Help (--help) | Usage rendered |

### Build
- Go binary builds successfully on lab4 (AlmaLinux 9)
- All pre-commit hooks pass

## Files Changed

**New files (8):**
- `internal/lifecycle/types.go` — enums + structs
- `internal/lifecycle/types_test.go`
- `internal/lifecycle/engine.go` — pure state machine
- `internal/lifecycle/engine_test.go`
- `internal/lifecycle/authority.go` — authority resolution
- `internal/lifecycle/authority_test.go`
- `internal/lifecycle/output.go` — JSON + text rendering
- `internal/lifecycle/output_test.go`
- `internal/lifecycle/logger.go` — evidence logging
- `internal/lifecycle/logger_test.go`
- `cmd/nftban-core/cmd_lifecycle.go` — CLI command

**Modified files (1):**
- `cmd/nftban-core/main.go` — added `lifecycle` command dispatch

## Test plan
- [x] 50/50 Go unit tests PASS on lab4
- [x] 5/5 CLI tests PASS on lab4
- [x] Go binary builds on lab4
- [x] Pre-commit hooks pass (SPDX, inventory)
- [x] INV-LC-001: no side effects (pure function engine)
- [x] INV-LC-003: v1.96 truths preserved in output
- [x] INV-LC-004: DEGRADED ownership modeled correctly
- [x] INV-LC-007: --no-dry-run refused
- [x] INV-LC-008: FAILED_RECOVERED + PROTECTED coexist
- [x] JSON field stability: 25 fields snapshot-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)