### PR TITLE
feat: v1.98 PR-13 — lifecycle feature flag (NFTBAN_LIFECYCLE)

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -9,7 +9,7 @@
 // meta:description="CLI flag definitions and environment variable overrides"
 // meta:inventory.files="cmd/nftban-installer/flags.go"
 // meta:inventory.binaries=""
-// meta:inventory.env_vars="NFTBAN_TAKEOVER, NFTBAN_INSTALLER_LOG"
+// meta:inventory.env_vars="NFTBAN_TAKEOVER, NFTBAN_INSTALLER_LOG, NFTBAN_LIFECYCLE"
 // meta:inventory.config_files=""
 // meta:inventory.systemd_units=""
 // meta:inventory.network=""
@@ -41,6 +41,7 @@ type config struct {
 	stateDir    string // override state directory
 	logPath     string // override log file path
 	showVersion bool   // print version and exit
+	lifecycle   bool   // v1.98: use canonized lifecycle flow (feature flag)
 }
 
 func parseFlags() *config {
@@ -69,6 +70,9 @@ func parseFlags() *config {
 	if envLog := os.Getenv("NFTBAN_INSTALLER_LOG"); envLog != "" {
 		cfg.logPath = envLog
 	}
+	// v1.98 Phase 2: Canonized lifecycle feature flag
+	// Default: ON. Set NFTBAN_LIFECYCLE=0 to use legacy path.
+	cfg.lifecycle = os.Getenv("NFTBAN_LIFECYCLE") != "0"
 
 	// Validate
 	if !cfg.showVersion && !cfg.repair {

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -131,8 +131,14 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 
 // runInstall runs all phases in order for a fresh install or upgrade.
 func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *config, log *logging.Logger) int {
-	// v1.98: Initialize lifecycle bridge (observational only — INV-I-004)
-	lb := newLifecycleBridge(cfg.mode, log)
+	// v1.98 Phase 2: Feature flag controls lifecycle bridge activation
+	var lb *lifecycleBridge
+	if cfg.lifecycle {
+		log.Info("lifecycle_mode=canonized (NFTBAN_LIFECYCLE=on)")
+		lb = newLifecycleBridge(cfg.mode, log)
+	} else {
+		log.Info("lifecycle_mode=legacy (NFTBAN_LIFECYCLE=0)")
+	}
 
 	phases := []struct {
 		phase state.Phase
@@ -151,7 +157,9 @@ func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile
 		if ctx.Err() != nil {
 			log.Error("installer timed out or cancelled during phase %s", p.name)
 			sf.Transition(state.StateFailedRebuild, p.phase, "timeout")
-			lb.observeResult(sf) // v1.98: record failure
+			if lb != nil {
+				lb.observeResult(sf)
+			}
 			return report(sf, log)
 		}
 
@@ -160,25 +168,30 @@ func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile
 			log.Error("phase %s failed: %v", p.name, err)
 			log.PhaseEnd(p.name)
 
-			// v1.98: Emit lifecycle observations for the phase that completed before failure
-			if p.phase == state.PhaseDetect {
-				lb.observeDetect(&globalPhaseData, sf)
-				lb.observePlan(&globalPhaseData)
+			if lb != nil {
+				if p.phase == state.PhaseDetect {
+					lb.observeDetect(&globalPhaseData, sf)
+					lb.observePlan(&globalPhaseData)
+				}
+				lb.observeResult(sf)
 			}
-			lb.observeResult(sf) // record failure outcome
 			return report(sf, log)
 		}
 
-		// v1.98: Lifecycle observations at phase boundaries
-		switch p.phase {
-		case state.PhaseDetect:
-			lb.observeDetect(&globalPhaseData, sf)
-			lb.observePlan(&globalPhaseData)
+		// Lifecycle observations at phase boundaries (only when flag is on)
+		if lb != nil {
+			switch p.phase {
+			case state.PhaseDetect:
+				lb.observeDetect(&globalPhaseData, sf)
+				lb.observePlan(&globalPhaseData)
+			}
 		}
 	}
 
-	// v1.98: Record final lifecycle result
-	lb.observeResult(sf)
+	// Record final lifecycle result (only when flag is on)
+	if lb != nil {
+		lb.observeResult(sf)
+	}
 
 	log.PhaseEnd("Validate")
 	return report(sf, log)


### PR DESCRIPTION
## Summary

Controlled activation of canonized lifecycle flow. Activation only — no new behavior.

### What this PR adds
- `NFTBAN_LIFECYCLE` env var: default **ON**, set `=0` for legacy path
- When ON: lifecycle bridge emits events at all installer phases
- When OFF: lifecycle bridge not initialized, installer runs identically to pre-v1.98
- All lifecycle bridge calls guarded by nil check (no panic on legacy path)
- Log line: `lifecycle_mode=canonized` or `lifecycle_mode=legacy`

### What this PR does NOT add
- No new fix targets (only `permissions enforce`, INV-I-011)
- No new systemd triggers (regression guard from V198_PR13_GO_DECISION.md §10)
- No new execution paths
- No authority expansion
- Lifecycle remains observational only (INV-I-004)

## Lab4 Validation

| Path | Log | Phases | Assertions | State |
|------|-----|--------|------------|-------|
| Flag ON (default) | `lifecycle_mode=canonized` | 5/5 | 8/8 PASS | COMMITTED |
| Flag OFF (`NFTBAN_LIFECYCLE=0`) | `lifecycle_mode=legacy` | 5/5 | 8/8 PASS | COMMITTED |

Both paths produce identical functional results. No regression.

## Gate Reference
- V198_PR13_GO_DECISION.md: CONDITIONAL GO → GO (P0s closed, NB-6 passed)
- Regression guard: no automatic path may invoke `health fix all`

## Test plan
- [x] Flag ON: installer builds and runs (8/8 assertions, COMMITTED)
- [x] Flag OFF: installer builds and runs identically (8/8, COMMITTED)
- [x] Build succeeds on lab4
- [x] Pre-commit hooks pass
- [x] No new fix targets, no new systemd units, no new timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)