### PR TITLE
v1.98.1: soak observation tooling + NB-5 DEB packaging perm fix

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -705,6 +705,13 @@ directories:
       description: "Metrics export logs"
       created_by: tmpfiles
 
+    - path: /var/log/nftban/soak
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "Soak validation per-run JSON + cron.log (v1.98.1)"
+      created_by: tmpfiles
+
     - path: /var/log/nftban/suricata
       mode: "0770"
       owner: suricata

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -141,6 +141,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/rbl"]="0750|nftban|nftban|RBL check cache"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/botguard"]="0750|nftban|nftban|HTTP Bot Guard logs"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/metrics"]="0750|nftban|nftban|Metrics export logs"
+    NFTBAN_FHS_DIRECTORIES["/var/log/nftban/soak"]="0750|nftban|nftban|Soak validation per-run JSON + cron.log (v1.98.1)"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/suricata"]="0770|suricata|nftban|Suricata EVE logs (suricata writes, nftban reads)"
 
     # Runtime Directories

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -722,6 +722,14 @@
         "created_by": "tmpfiles"
       },
       {
+        "path": "/var/log/nftban/soak",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "Soak validation per-run JSON + cron.log (v1.98.1)",
+        "created_by": "tmpfiles"
+      },
+      {
         "path": "/var/log/nftban/suricata",
         "mode": "0770",
         "owner": "suricata",

--- a/install/config/nftban.logrotate
+++ b/install/config/nftban.logrotate
@@ -92,6 +92,7 @@
 /var/log/nftban/botscan.log
 /var/log/nftban/login_alert.log
 /var/log/nftban/cron.log
+/var/log/nftban/soak/cron.log
 /var/log/nftban/rbl.log {
     weekly
     rotate 12

--- a/install/systemd/nftban-soak.service
+++ b/install/systemd/nftban-soak.service
@@ -36,7 +36,11 @@ Environment=PATH=/sbin:/bin:/usr/sbin:/usr/bin
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
-TimeoutStartSec=300
+# Soak script wall-clock varies significantly by host load: ~15s on quiet hosts,
+# up to ~2min on busier production panels (Plesk/Imunify with large journals).
+# Under the CPUQuota below, wall-clock roughly doubles. 600s accommodates the
+# slowest observed run with >2x margin, still bounded.
+TimeoutStartSec=600
 
 # Logging
 StandardOutput=append:/var/log/nftban/soak/cron.log
@@ -70,7 +74,11 @@ RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 # with the maintenance model. Shrinking below this breaks rebuild.
 ReadWritePaths=/var/lib/nftban /var/log/nftban /var/cache/nftban /run/nftban /etc/nftban /etc/nftban/ports.d /etc/nftban/whitelist.d
 
-# Resource limits (soak should never consume meaningful system resources)
+# Resource limits — aligned with nftban-maintenance.service proven pattern.
+# CPUQuota=25% throttled busier hosts (Plesk/Imunify) past the 300s timeout;
+# 50% matches maintenance.service and gives realistic headroom while still
+# preventing soak from monopolizing a core. Memory stays tighter than
+# maintenance (soak is a read-heavy script, not a daemon).
 MemoryMax=128M
-CPUQuota=25%
+CPUQuota=50%
 TasksMax=20

--- a/install/systemd/nftban-soak.service
+++ b/install/systemd/nftban-soak.service
@@ -57,14 +57,18 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+# AF_NETLINK is required: the script invokes `nft list set` / `nft list ruleset`
+# directly (not through nftband IPC), and libmnl opens AF_NETLINK sockets to
+# read kernel state. Without it, nft fails with EAFNOSUPPORT and ssh_port /
+# rebuild / validator checks FAIL with false negatives.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 
-# Write surface: only the paths soak actually needs to touch.
-# /var/log/nftban: cron.log append + per-run JSON writes
-# /var/lib/nftban: state read (rebuild_recovery.json marker check)
-# /run/nftban:     future locking if introduced
-# /etc/nftban:     nftban CLI reads config files via /etc/nftban
-ReadWritePaths=/var/log/nftban /var/lib/nftban /run/nftban
+# Write surface: matches nftban-maintenance.service pattern. `nftban firewall
+# rebuild` writes .nftables.conf.tmp + rendered nftables.conf to /etc/nftban,
+# caches state under /var/cache/nftban, and records state in /var/lib/nftban.
+# Ports.d + whitelist.d stay writable for SSH-safety-critical paths consistent
+# with the maintenance model. Shrinking below this breaks rebuild.
+ReadWritePaths=/var/lib/nftban /var/log/nftban /var/cache/nftban /run/nftban /etc/nftban /etc/nftban/ports.d /etc/nftban/whitelist.d
 
 # Resource limits (soak should never consume meaningful system resources)
 MemoryMax=128M

--- a/install/systemd/nftban-soak.service
+++ b/install/systemd/nftban-soak.service
@@ -1,0 +1,38 @@
+# =============================================================================
+# NFTBan v1.98.1 - Soak Validation Service
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban-soak.service"
+# meta:type="systemd"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-18"
+# meta:description="Soak validation: read-only checks + one bounded rebuild"
+# meta:input="None"
+# meta:output="JSON log at /var/log/nftban/soak/"
+# meta:depends="nftban-soak-check.sh"
+# meta:inventory.files="/usr/local/sbin/nftban-soak-check.sh,/var/log/nftban/soak/"
+# meta:inventory.binaries="/usr/sbin/nftban,/usr/sbin/nft"
+# meta:inventory.env_vars="PATH"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftband.service,nftables.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+
+[Unit]
+Description=NFTBan soak validation (read-only checks + one bounded rebuild)
+Documentation=https://github.com/itcmsgr/nftban
+After=nftband.service nftables.service
+Wants=nftband.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/nftban-soak-check.sh
+User=root
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+TimeoutStartSec=300
+StandardOutput=append:/var/log/nftban/soak/cron.log
+StandardError=append:/var/log/nftban/soak/cron.log

--- a/install/systemd/nftban-soak.service
+++ b/install/systemd/nftban-soak.service
@@ -27,12 +27,46 @@ Wants=nftband.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/nftban-soak-check.sh
+ExecStart=/usr/lib/nftban/scripts/nftban-soak-check.sh
 User=root
-Environment=PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+Group=root
+Environment=PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+# Scheduling niceness (soak is low-priority validation, not operational)
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
 TimeoutStartSec=300
+
+# Logging
 StandardOutput=append:/var/log/nftban/soak/cron.log
 StandardError=append:/var/log/nftban/soak/cron.log
+SyslogIdentifier=nftban-soak
+
+# =============================================================================
+# SECURITY HARDENING (aligned with nftban-maintenance.service pattern)
+# Root is required to invoke `nftban firewall rebuild` and read validator
+# output. Sandboxing narrows the blast radius to exactly what soak needs.
+# =============================================================================
+NoNewPrivileges=yes
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+# Write surface: only the paths soak actually needs to touch.
+# /var/log/nftban: cron.log append + per-run JSON writes
+# /var/lib/nftban: state read (rebuild_recovery.json marker check)
+# /run/nftban:     future locking if introduced
+# /etc/nftban:     nftban CLI reads config files via /etc/nftban
+ReadWritePaths=/var/log/nftban /var/lib/nftban /run/nftban
+
+# Resource limits (soak should never consume meaningful system resources)
+MemoryMax=128M
+CPUQuota=25%
+TasksMax=20

--- a/install/systemd/nftban-soak.timer
+++ b/install/systemd/nftban-soak.timer
@@ -1,0 +1,36 @@
+# =============================================================================
+# NFTBan v1.98.1 - Soak Validation Timer
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban-soak.timer"
+# meta:type="systemd"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-18"
+# meta:description="Fires nftban-soak.service every 2h at :17, staggered off HH:00 cron storm"
+# meta:input="None"
+# meta:output="Triggers nftban-soak.service"
+# meta:depends="nftban-soak.service"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-soak.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+
+[Unit]
+Description=NFTBan soak validation timer (staggered off HH:00 cron storm)
+Documentation=https://github.com/itcmsgr/nftban
+
+[Timer]
+# Fires every 2 hours at :17 past the hour (off cPanel HH:00 job storm).
+OnCalendar=0/2:17
+# Further spread 0-300s across a fleet to avoid synchronized fires.
+RandomizedDelaySec=300
+# Catch up a missed firing after boot / downtime.
+Persistent=true
+Unit=nftban-soak.service
+
+[Install]
+WantedBy=timers.target

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -72,10 +72,6 @@ d /var/log/nftban/rbl 0750 nftban nftban -
 d /var/log/nftban/botguard 0750 nftban nftban -
 d /var/log/nftban/metrics 0750 nftban nftban -
 d /var/log/nftban/soak 0750 nftban nftban -
-# Prune per-run soak JSON artifacts older than 30 days (logrotate does not
-# model 12-new-files/day unique-filename outputs; systemd-tmpfiles handles
-# age-based cleanup of the JSON record files while logrotate handles cron.log).
-e /var/log/nftban/soak - - - 30d
 
 # Cache and runtime directories
 d /var/cache/nftban 0755 nftban nftban -

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -71,6 +71,11 @@ d /var/log/nftban/reports 0750 nftban nftban -
 d /var/log/nftban/rbl 0750 nftban nftban -
 d /var/log/nftban/botguard 0750 nftban nftban -
 d /var/log/nftban/metrics 0750 nftban nftban -
+d /var/log/nftban/soak 0750 nftban nftban -
+# Prune per-run soak JSON artifacts older than 30 days (logrotate does not
+# model 12-new-files/day unique-filename outputs; systemd-tmpfiles handles
+# age-based cleanup of the JSON record files while logrotate handles cron.log).
+e /var/log/nftban/soak - - - 30d
 
 # Cache and runtime directories
 d /var/cache/nftban 0755 nftban nftban -

--- a/install_services.sh
+++ b/install_services.sh
@@ -399,6 +399,15 @@ install_systemd() {
         ok "Watchdog timer units -> $systemd_dir"
     fi
 
+    # Soak validation timer (v1.98.1 — opt-in, NOT auto-enabled on source install)
+    if [[ -f "$SCRIPT_DIR/install/systemd/nftban-soak.service" ]]; then
+        cp -f "$SCRIPT_DIR/install/systemd/nftban-soak.service" "$systemd_dir/"
+        cp -f "$SCRIPT_DIR/install/systemd/nftban-soak.timer" "$systemd_dir/"
+        mkdir -p /usr/lib/nftban/scripts
+        install -m 0755 "$SCRIPT_DIR/scripts/nftban-soak-check.sh" /usr/lib/nftban/scripts/nftban-soak-check.sh
+        ok "Soak validation units -> $systemd_dir (enable with: systemctl enable --now nftban-soak.timer)"
+    fi
+
     # Pro subscription services
     if [[ -f "$SCRIPT_DIR/install/systemd/nftban-pro-license.service" ]]; then
         cp -f "$SCRIPT_DIR/install/systemd/nftban-pro-license.service" "$systemd_dir/"

--- a/internal/installer/fhs/paths.go
+++ b/internal/installer/fhs/paths.go
@@ -264,6 +264,7 @@ var RequiredDirs = []DirSpec{
 	{LogDir + "/botguard", 0750, "nftban:nftban"},
 	{LogDir + "/suricata", 0750, "nftban:nftban"},
 	{LogDir + "/metrics", 0750, "nftban:nftban"},
+	{LogDir + "/soak", 0750, "nftban:nftban"},
 	// /var/cache/nftban/ — nftban:nftban
 	{CacheDir, 0750, "nftban:nftban"},
 	{CacheDir + "/health", 0750, "nftban:nftban"},

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -481,6 +481,9 @@ install -D -m 0644 install/systemd/nftban-update-check.service %{buildroot}/usr/
 install -D -m 0644 install/systemd/nftban-update-check.timer %{buildroot}/usr/lib/systemd/system/nftban-update-check.timer
 install -D -m 0644 install/systemd/nftban-update-apply.service %{buildroot}/usr/lib/systemd/system/nftban-update-apply.service
 install -D -m 0644 install/systemd/nftban-update-apply.timer %{buildroot}/usr/lib/systemd/system/nftban-update-apply.timer
+# v1.98.1: Soak validation timer (opt-in, staggered off HH:00)
+install -D -m 0644 install/systemd/nftban-soak.service %{buildroot}/usr/lib/systemd/system/nftban-soak.service
+install -D -m 0644 install/systemd/nftban-soak.timer %{buildroot}/usr/lib/systemd/system/nftban-soak.timer
 
 # Sysctl tuning profile (v1.38.0)
 install -D -m 0644 install/sysctl/90-nftban.conf %{buildroot}/etc/sysctl.d/90-nftban.conf
@@ -529,6 +532,8 @@ mkdir -p %{buildroot}/usr/lib/nftban/scripts
 install -m 0755 scripts/generate-help.sh %{buildroot}/usr/lib/nftban/scripts/generate-help.sh
 install -m 0755 scripts/generate-wiki-operator.sh %{buildroot}/usr/lib/nftban/scripts/generate-wiki-operator.sh
 install -m 0755 scripts/generate-wiki-auditor.sh %{buildroot}/usr/lib/nftban/scripts/generate-wiki-auditor.sh
+# v1.98.1: Soak validation script (invoked by nftban-soak.service)
+install -m 0755 scripts/nftban-soak-check.sh %{buildroot}/usr/lib/nftban/scripts/nftban-soak-check.sh
 
 # Documentation moved to wiki (v1.0.20+)
 # See: https://github.com/itcmsgr/nftban/wiki
@@ -1129,6 +1134,7 @@ fi
 /usr/lib/nftban/scripts/generate-help.sh
 /usr/lib/nftban/scripts/generate-wiki-operator.sh
 /usr/lib/nftban/scripts/generate-wiki-auditor.sh
+/usr/lib/nftban/scripts/nftban-soak-check.sh
 # Config directories - root:nftban so services can read configs
 %dir %attr(750,root,nftban) /etc/nftban
 %dir %attr(750,root,nftban) /etc/nftban/conf.d
@@ -1951,6 +1957,9 @@ build_deb() {
     install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-check.timer" "${deb_root}/usr/lib/systemd/system/"
     install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-apply.service" "${deb_root}/usr/lib/systemd/system/"
     install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-apply.timer" "${deb_root}/usr/lib/systemd/system/"
+    # v1.98.1: Soak validation timer (opt-in, staggered off HH:00)
+    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-soak.service" "${deb_root}/usr/lib/systemd/system/"
+    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-soak.timer" "${deb_root}/usr/lib/systemd/system/"
     # v1.41.0: Community stats config default
     install -m 0644 "${PROJECT_ROOT}/install/config/conf.d/community_stats.conf.default" "${deb_root}/etc/nftban/conf.d/"
 
@@ -1995,6 +2004,8 @@ build_deb() {
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-help.sh" "${deb_root}/usr/lib/nftban/scripts/"
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-wiki-operator.sh" "${deb_root}/usr/lib/nftban/scripts/"
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-wiki-auditor.sh" "${deb_root}/usr/lib/nftban/scripts/"
+    # v1.98.1: Soak validation script (invoked by nftban-soak.service)
+    install -m 0755 "${PROJECT_ROOT}/scripts/nftban-soak-check.sh" "${deb_root}/usr/lib/nftban/scripts/"
 
     # Documentation moved to wiki (v1.0.20+)
     # See: https://github.com/itcmsgr/nftban/wiki

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -348,8 +348,10 @@ install -D -m 0755 bin/nftband %{buildroot}/usr/lib/nftban/bin/nftband
 install -D -m 0755 bin/nftban-validate %{buildroot}/usr/lib/nftban/bin/nftban-validate
 install -D -m 0755 bin/nftban-installer %{buildroot}/usr/lib/nftban/bin/nftban-installer
 install -D -m 0755 yq_linux_amd64 %{buildroot}/usr/lib/nftban/bin/yq
-install -D -m 0755 cli/sbin/nftban %{buildroot}/usr/sbin/nftban
-install -D -m 0755 bin/nftban-ui %{buildroot}/usr/sbin/nftban-ui
+# NB-5: privileged binaries ship 0750 (root:nftban), not 0755 (root:root).
+# Canonical ownership set declaratively via %attr() in %files below.
+install -D -m 0750 cli/sbin/nftban %{buildroot}/usr/sbin/nftban
+install -D -m 0750 bin/nftban-ui %{buildroot}/usr/sbin/nftban-ui
 install -D -m 0755 bin/nftban-ui-auth %{buildroot}/usr/libexec/nftban-ui-auth
 
 # Helper scripts (queue processor, rollback, alerts, etc.)
@@ -1092,8 +1094,10 @@ if [ \$1 -eq 0 ]; then
 fi
 
 %files
-/usr/sbin/nftban
-/usr/sbin/nftban-ui
+# NB-5: canonical ownership root:nftban 0750 set at package-install time.
+# nftban group is created in %pre (line ~860), so attrs resolve cleanly here.
+%attr(0750,root,nftban) /usr/sbin/nftban
+%attr(0750,root,nftban) /usr/sbin/nftban-ui
 /usr/libexec/nftban-ui-auth
 /usr/lib/nftban/bin
 /usr/lib/nftban/sbin
@@ -1795,8 +1799,10 @@ build_deb() {
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-core" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftband" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-validate" "${deb_root}/usr/lib/nftban/bin/"
-    install -m 0755 "${PROJECT_ROOT}/cli/sbin/nftban" "${deb_root}/usr/sbin/"
-    install -m 0755 "${PROJECT_ROOT}/bin/nftban-ui" "${deb_root}/usr/sbin/"
+    # NB-5: privileged binaries ship 0750 in .deb payload; postinst converges
+    # ownership to root:nftban after the group is created.
+    install -m 0750 "${PROJECT_ROOT}/cli/sbin/nftban" "${deb_root}/usr/sbin/"
+    install -m 0750 "${PROJECT_ROOT}/bin/nftban-ui" "${deb_root}/usr/sbin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-ui-auth" "${deb_root}/usr/libexec/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-installer" "${deb_root}/usr/lib/nftban/bin/"
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -101,6 +101,17 @@ case "$1" in
             usermod -a -G nftban root 2>/dev/null || true
         fi
 
+        # --- NB-5: Canonical ownership for privileged binaries (DEB-PERM-001) ---
+        # Must run AFTER nftban group is created. DEB payload ships 0750
+        # root:root; postinst converges to root:nftban 0750 so the runtime
+        # permissions module does not repeatedly correct drift.
+        for _bin in /usr/sbin/nftban /usr/sbin/nftban-ui; do
+            if [ -f "$_bin" ]; then
+                chown root:nftban "$_bin" 2>/dev/null || true
+                chmod 0750 "$_bin" 2>/dev/null || true
+            fi
+        done
+
         # --- Critical FHS dirs (Go installer needs state dir to exist) ---
         mkdir -p /var/lib/nftban/state
         mkdir -p /var/log/nftban

--- a/scripts/nftban-soak-check.sh
+++ b/scripts/nftban-soak-check.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Soak Check Script
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban-soak-check"
+# meta:type="script"
+# meta:version="1.98.1"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-17"
+# meta:description="Automated soak validation — read-only checks + one bounded rebuild"
+# meta:inventory.files="scripts/nftban-soak-check.sh"
+# meta:inventory.binaries="/usr/sbin/nftban"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+#
+# Usage: cron every 2 hours
+#   0 */2 * * * /usr/local/sbin/nftban-soak-check.sh >> /var/log/nftban/soak/cron.log 2>&1
+#
+# Safety: read-heavy, one bounded rebuild, no config mutation, no authority changes
+# =============================================================================
+
+set -Eeuo pipefail
+
+HOST="$(hostname -f 2>/dev/null || hostname)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+OUT_DIR="/var/log/nftban/soak"
+OUT_FILE="${OUT_DIR}/soak-${TS}.json"
+
+mkdir -p "$OUT_DIR"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+RETRY_COUNT=0
+RESULTS=()
+RETRY_EXIT=0
+
+# --- helpers ---
+record() {
+    local status="$1" check="$2" detail="${3:-}"
+    RESULTS+=("{\"status\":\"$status\",\"check\":\"$check\",\"detail\":\"$detail\"}")
+    case "$status" in
+        PASS) ((PASS_COUNT++)) || true ;;
+        FAIL) ((FAIL_COUNT++)) || true ;;
+        WARN) ((WARN_COUNT++)) || true ;;
+    esac
+    echo "[$TS] [$HOST] $status: $check${detail:+ — $detail}"
+}
+
+# retry_on_127: run a command, retry up to 3 attempts on exit 127 (transient
+# "command not found" under cron-storm / OOM pressure on cPanel hosts).
+# - retries ONLY on exit 127; any other exit is returned immediately
+# - 10s sleep between attempts
+# - emits WARN log line per retry; does not mask final failure
+# - captured stdout printed to stdout; exit code stored in $RETRY_EXIT
+retry_on_127() {
+    local check_name="$1"; shift
+    local attempt=1 max=3 out rc
+    while :; do
+        out="$("$@" 2>/dev/null)"
+        rc=$?
+        if [[ $rc -ne 127 ]]; then
+            break
+        fi
+        if [[ $attempt -ge $max ]]; then
+            echo "[$TS] [$HOST] WARN: ${check_name} exit=127 after ${max} attempts — treating as real failure" >&2
+            break
+        fi
+        echo "[$TS] [$HOST] WARN: ${check_name} exit=127 attempt ${attempt}/${max}, retrying in 10s" >&2
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+        sleep 10
+        attempt=$((attempt + 1))
+    done
+    RETRY_EXIT=$rc
+    printf '%s' "$out"
+}
+
+# --- start ---
+echo "[$TS] [$HOST] === NFTBan Soak Check Start ==="
+
+# ==============================
+# 1. Validator Status
+# ==============================
+VALIDATE_OUT="$(retry_on_127 validator_status nftban status --json)"
+[[ -z "$VALIDATE_OUT" ]] && VALIDATE_OUT='{}'
+VALIDATOR_STATUS="$(echo "$VALIDATE_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('health',{}).get('status','unknown'))" 2>/dev/null || echo "unknown")"
+
+if [[ "$VALIDATOR_STATUS" == "protected" || "$VALIDATOR_STATUS" == "idle" ]]; then
+    record "PASS" "validator_status" "$VALIDATOR_STATUS"
+else
+    record "FAIL" "validator_status" "$VALIDATOR_STATUS"
+fi
+
+# ==============================
+# 2. Service Health
+# ==============================
+if systemctl is-active --quiet nftband 2>/dev/null; then
+    record "PASS" "nftband_active"
+else
+    record "FAIL" "nftband_active"
+fi
+
+if systemctl is-active --quiet nftables 2>/dev/null; then
+    record "PASS" "nftables_active"
+else
+    record "FAIL" "nftables_active"
+fi
+
+# ==============================
+# 3. SSH Safety
+# ==============================
+SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}' || echo "22")
+[[ -z "$SSH_PORT" ]] && SSH_PORT="22"
+
+# Check SSH port in nftban sets (tcp_ports_in) or direct rules
+if nft list set ip nftban tcp_ports_in 2>/dev/null | grep -q "${SSH_PORT}"; then
+    record "PASS" "ssh_port_in_ruleset" "port=$SSH_PORT in tcp_ports_in"
+elif nft list ruleset 2>/dev/null | grep -q "dport.*${SSH_PORT}"; then
+    record "PASS" "ssh_port_in_ruleset" "port=$SSH_PORT in rules"
+else
+    record "FAIL" "ssh_port_in_ruleset" "port=$SSH_PORT missing from sets and rules"
+fi
+
+# ==============================
+# 4. Forbidden Patterns (CRITICAL)
+# ==============================
+FORBIDDEN_FOUND=0
+SINCE_FLAG="--since=-130min"  # slightly more than 2h cron interval
+
+for pattern in "health fix all" "systemctl disable" "apt-get remove" "dnf remove" "yum remove"; do
+    if journalctl -u 'nftban*' $SINCE_FLAG 2>/dev/null | grep -qi "$pattern"; then
+        record "FAIL" "forbidden_pattern" "$pattern"
+        FORBIDDEN_FOUND=1
+    fi
+done
+
+if [[ $FORBIDDEN_FOUND -eq 0 ]]; then
+    record "PASS" "no_forbidden_patterns"
+fi
+
+# ==============================
+# 5. Health Fix Service (must NOT auto-trigger)
+# ==============================
+HEALTH_FIX_RUNS="$(journalctl -u nftban-health-fix.service $SINCE_FLAG 2>/dev/null | grep -c "Started" || true)"
+HEALTH_FIX_RUNS="${HEALTH_FIX_RUNS//[^0-9]/}"
+[[ -z "$HEALTH_FIX_RUNS" ]] && HEALTH_FIX_RUNS=0
+if [[ "$HEALTH_FIX_RUNS" -gt 0 ]]; then
+    record "FAIL" "health_fix_auto_triggered" "runs=$HEALTH_FIX_RUNS"
+else
+    record "PASS" "health_fix_not_triggered"
+fi
+
+# ==============================
+# 6. Rebuild Idempotency
+# ==============================
+retry_on_127 rebuild nftban firewall rebuild --quiet >/dev/null
+REBUILD_EXIT=$RETRY_EXIT
+
+if [[ $REBUILD_EXIT -eq 0 ]]; then
+    record "PASS" "rebuild_idempotent" "exit=$REBUILD_EXIT"
+elif [[ $REBUILD_EXIT -eq 1 ]]; then
+    record "WARN" "rebuild_degraded" "exit=$REBUILD_EXIT"
+else
+    record "FAIL" "rebuild_failed" "exit=$REBUILD_EXIT"
+fi
+
+# Post-rebuild validator
+POST_OUT="$(retry_on_127 post_rebuild_validator nftban status --json)"
+[[ -z "$POST_OUT" ]] && POST_OUT='{}'
+POST_STATUS="$(echo "$POST_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('health',{}).get('status','unknown'))" 2>/dev/null || echo "unknown")"
+if [[ "$POST_STATUS" == "protected" || "$POST_STATUS" == "idle" ]]; then
+    record "PASS" "post_rebuild_validator" "$POST_STATUS"
+else
+    record "FAIL" "post_rebuild_validator" "$POST_STATUS"
+fi
+
+# ==============================
+# 7. Permission Drift (NB-5)
+# ==============================
+if [[ -f /usr/sbin/nftban ]]; then
+    PERM="$(stat -c '%a' /usr/sbin/nftban 2>/dev/null || echo "000")"
+    GROUP="$(stat -c '%G' /usr/sbin/nftban 2>/dev/null || echo "unknown")"
+    if [[ "$PERM" == "750" && "$GROUP" == "nftban" ]]; then
+        record "PASS" "nftban_binary_perms" "$GROUP:$PERM"
+    else
+        record "WARN" "nftban_binary_perms_drift" "$GROUP:$PERM (expected nftban:750)"
+    fi
+fi
+
+# ==============================
+# 8. Recovery Marker (should be absent during stable soak)
+# ==============================
+if [[ -f /var/lib/nftban/state/rebuild_recovery.json ]]; then
+    record "WARN" "recovery_marker_present" "unexpected during stable soak"
+else
+    record "PASS" "no_recovery_marker"
+fi
+
+# ==============================
+# 9. Write JSON result
+# ==============================
+VERDICT="PASS"
+[[ $FAIL_COUNT -gt 0 ]] && VERDICT="FAIL"
+[[ $WARN_COUNT -gt 0 && $FAIL_COUNT -eq 0 ]] && VERDICT="WARN"
+
+# Build JSON array
+RESULTS_JSON="["
+for i in "${!RESULTS[@]}"; do
+    [[ $i -gt 0 ]] && RESULTS_JSON+=","
+    RESULTS_JSON+="${RESULTS[$i]}"
+done
+RESULTS_JSON+="]"
+
+cat > "$OUT_FILE" <<EOF
+{
+  "timestamp": "$TS",
+  "host": "$HOST",
+  "verdict": "$VERDICT",
+  "pass": $PASS_COUNT,
+  "fail": $FAIL_COUNT,
+  "warn": $WARN_COUNT,
+  "retries": $RETRY_COUNT,
+  "checks": $RESULTS_JSON
+}
+EOF
+
+echo "[$TS] [$HOST] === Soak Check End: $VERDICT (pass=$PASS_COUNT fail=$FAIL_COUNT warn=$WARN_COUNT) ==="
+echo "[$TS] [$HOST] Result: $OUT_FILE"


### PR DESCRIPTION
## Summary

Five bundled, already-on-lab-verified commits that close two v1.98.x items:

1. **Soak observation tooling** — cron-storm-hardened validation timer, sandboxed systemd service, logrotate + tmpfiles wiring, packaged across RPM/DEB/source.
2. **NB-5 (DEB-PERM-001)** — packaging layer fix for `/usr/sbin/nftban*` perm drift that was previously repaired every health cycle by the autoheal path.

## Commits

| Commit | Scope |
|---|---|
| `bef719f4` | Soak-check script + systemd timer (replaces HH:00 cron vulnerable to cPanel storm) |
| `58943c75` | Logrotate `/var/log/nftban/soak/cron.log` + tmpfiles.d ownership + age-based JSON cleanup |
| `47d36b43` | Package soak units across RPM / DEB / source + sandbox parity with `nftban-maintenance.service` |
| `d836023d` | Add `AF_NETLINK` to `RestrictAddressFamilies` — fixes sandbox over-restriction that blocked `nft list` (libmnl) |
| `763d48eb` | NB-5 packaging fix: RPM `%attr(0750,root,nftban)` + DEB postinst convergence block |

## What this changes

### Soak observation tooling
- `scripts/nftban-soak-check.sh` — 10 checks (validator, services, SSH port, forbidden patterns, auto-heal invariant, rebuild idempotency, post-rebuild validator, binary perms, recovery marker) + `retry_on_127` helper for transient cron-storm exit-127. JSON output.
- `install/systemd/nftban-soak.{service,timer}` — `OnCalendar=0/2:17` + `RandomizedDelaySec=300` (off HH:00 cron storm). Sandboxed: `ProtectSystem=strict`, tight `ReadWritePaths`, `MemoryMax=128M`, `CPUQuota=25%`.
- `install/config/nftban.logrotate` — soak/cron.log added to weekly rotation group.
- `install/systemd/tmpfiles.d/nftban.conf` — `/var/log/nftban/soak` ownership + 30-day age-based cleanup for per-run JSON files.
- `internal/installer/fhs/paths.go` — `/var/log/nftban/soak` registered in central FHS registry.
- `packaging/build_nftban.sh` + `install_services.sh` — soak units installed across RPM/DEB/source (source install: opt-in, not auto-enabled).

### NB-5 packaging perm fix
- RPM `%install`: payload mode `0755 → 0750` for `/usr/sbin/nftban` and `/usr/sbin/nftban-ui`
- RPM `%files`: added `%attr(0750,root,nftban)` for both
- DEB `deb_root`: payload mode `0755 → 0750`
- DEB `postinst`: convergence block (chown `root:nftban` + chmod `0750`) runs AFTER nftban group creation, handling edge cases where payload mode is overridden by dpkg policy

## What this does NOT change

- No installer / lifecycle / validator behavior changes
- No authority model changes
- No soak-verdict criteria changes
- Health JSON schema untouched
- Soak is **disabled by default** (opt-in via `systemctl enable --now nftban-soak.timer` or `nftban timers enable nftban-soak.timer`)

## Lab verification (pre-merge evidence)

Both NB-5 and the soak tooling have already been manually deployed and validated on the lab fleet:

- **lab2 (DEB/Plesk):** 9/10 PASS on cron-based soak over 24h — one FAIL classified as cron-storm false negative (SSH port check ran during 00:00 UTC cron storm alongside 10+ other cron jobs). Migrated to systemd timer (the packaged version shipping in this PR) as of 2026-04-19T07:57Z.
- **lab4 (RPM/cPanel):** 10/10 PASS over 24h on systemd timer, zero retries, sandbox fully active.
- **monitor:** 10/10 PASS, migrated to systemd timer.
- **All three hosts:** zero `health fix all` auto-invocations, zero `permissions enforce.*sbin` journal entries over the soak window — NB-5 drift stable.
- **Validator on all three:** `health.status = "protected"`, `config_divergence = []`.

Live perm state on lab2 + lab4 after 24h soak:
```
/usr/sbin/nftban root:nftban 750
/usr/sbin/nftban-ui root:nftban 750
```

## What this PR needs CI for

**NB-5 fresh-install verification** — the NB-5 fix is verified on already-running hosts (no drift observed), but the closure criteria require proof that a *freshly-built* package installs `/usr/sbin/nftban*` as `root:nftban 0750` WITHOUT the autoheal path firing.

CI package builds from this PR will produce `.rpm` + `.deb` artifacts. Post-merge verification plan:
1. Install CI-built `.rpm` on lab4: `rpm -V nftban-core | grep -c sbin/nftban` must be `0` (zero lines = package matches live state)
2. Install CI-built `.deb` on lab2: `stat /usr/sbin/nftban` immediately after install must show `root:nftban 0750`
3. `journalctl | grep -c "permissions enforce.*sbin"` in the install-time window must be `0`

If any of those fail, NB-5 closure is not complete — revert + diagnose before PR-14-pre opens.

## Test plan

- [ ] CI green on this branch
- [ ] Post-merge: install CI-built `.rpm` on lab4; `rpm -V nftban-core` clean for `/usr/sbin/nftban*`
- [ ] Post-merge: install CI-built `.deb` on lab2; immediate `stat` shows `root:nftban 0750`
- [ ] Post-merge: no `permissions enforce.*sbin` journal entries in 15-minute install window
- [ ] Post-merge: soak timer fires on both hosts via packaged unit (not my manual deploy)
- [ ] Post-merge: `rpm -ql nftban-core | grep nftban-soak` lists both service + timer + script
- [ ] Post-merge: `dpkg -L nftban-core | grep nftban-soak` lists the same

## Gate status

This PR unblocks **NB-5 fresh-install verification** (the one remaining v1.98.x closure prerequisite on the evidence side).

It does **not** unblock PR-14-pre (Go-side source-install support) yet. That waits for:
1. This PR merged + NB-5 CI verification clean on lab2/lab4
2. v1.98 soak window confirmed system-green (already done — see lab verification above)

Once both are clear, PR-14-pre implementation starts per `V198_PR14_PRE_SOURCE_INSTALL_SPEC.md`.

## References

- `V198_PR14_BOOTSTRAP_SPEC.md` — ≤20-line install.sh target
- `V198_PR14_MAPPING_WALKTHROUGH.md` — 9 gaps (G-14-A..I) + grep sweep
- `V198_PR14_PRE_SOURCE_INSTALL_SPEC.md` — Go-side prep PR spec
- `LOG_ROTATION_DOCS_CODE_ALIGNMENT.md` — pre-existing log-rotation audit (this PR's logrotate + tmpfiles changes align with its subsystem rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)