### PR TITLE
v1.98.x PR-14-pre: Go-side source-install support

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -9,7 +9,7 @@
 // meta:description="CLI flag definitions and environment variable overrides"
 // meta:inventory.files="cmd/nftban-installer/flags.go"
 // meta:inventory.binaries=""
-// meta:inventory.env_vars="NFTBAN_TAKEOVER, NFTBAN_INSTALLER_LOG, NFTBAN_LIFECYCLE"
+// meta:inventory.env_vars="NFTBAN_TAKEOVER, NFTBAN_INSTALLER_LOG, NFTBAN_LIFECYCLE, NFTBAN_SOURCE_DIR"
 // meta:inventory.config_files=""
 // meta:inventory.systemd_units=""
 // meta:inventory.network=""
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
@@ -42,6 +43,8 @@ type config struct {
 	logPath     string // override log file path
 	showVersion bool   // print version and exit
 	lifecycle   bool   // v1.98: use canonized lifecycle flow (feature flag)
+	source      bool   // v1.98.x PR-14-pre: source install (stage payload + users from repo tree)
+	sourceDir   string // v1.98.x PR-14-pre: source tree root for --source (resolved in parseFlags)
 }
 
 func parseFlags() *config {
@@ -60,6 +63,11 @@ func parseFlags() *config {
 	flag.StringVar(&cfg.stateDir, "state-dir", state.DefaultStateDir, "State directory path")
 	flag.StringVar(&cfg.logPath, "log", logging.DefaultLogPath, "Log file path")
 	flag.BoolVar(&cfg.showVersion, "version", false, "Print version and exit")
+	// v1.98.x PR-14-pre: source-install support (gated behind --source; mutually
+	// exclusive with --rpm / --deb). Enables user/group creation, payload staging
+	// from a repo/tarball tree, and safety-whitelist seeding during Prepare/Configure.
+	flag.BoolVar(&cfg.source, "source", false, "Source install from repo/tarball (stages payload from --source-dir). Mutually exclusive with --rpm and --deb.")
+	flag.StringVar(&cfg.sourceDir, "source-dir", "", "Source tree root (repo clone or extracted tarball). Falls back to $NFTBAN_SOURCE_DIR then binary-relative discovery.")
 
 	flag.Parse()
 
@@ -74,6 +82,18 @@ func parseFlags() *config {
 	// Default: ON. Set NFTBAN_LIFECYCLE=0 to use legacy path.
 	cfg.lifecycle = os.Getenv("NFTBAN_LIFECYCLE") != "0"
 
+	// v1.98.x PR-14-pre: Source-tree root resolution.
+	// Priority: --source-dir > NFTBAN_SOURCE_DIR > binary-relative fallback.
+	if cfg.source && cfg.sourceDir == "" {
+		cfg.sourceDir = os.Getenv("NFTBAN_SOURCE_DIR")
+	}
+	if cfg.source && cfg.sourceDir == "" {
+		// Derive from binary location: .../<srcdir>/bin/nftban-installer => sourceDir = <srcdir>
+		if exe, err := os.Executable(); err == nil {
+			cfg.sourceDir = filepath.Dir(filepath.Dir(exe))
+		}
+	}
+
 	// Validate
 	if !cfg.showVersion && !cfg.repair {
 		if cfg.mode != "install" && cfg.mode != "upgrade" {
@@ -82,6 +102,18 @@ func parseFlags() *config {
 			fmt.Fprintf(os.Stderr, "       nftban-installer --repair [flags]\n")
 			os.Exit(state.ExitFatal)
 		}
+	}
+
+	// --source is mutually exclusive with packaging-origin flags.
+	if cfg.source && (cfg.rpm || cfg.deb) {
+		fmt.Fprintln(os.Stderr, "error: --source cannot be combined with --rpm or --deb")
+		os.Exit(state.ExitFatal)
+	}
+
+	// --source requires a resolvable source directory.
+	if cfg.source && cfg.sourceDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --source requires --source-dir, $NFTBAN_SOURCE_DIR, or a discoverable binary location")
+		os.Exit(state.ExitFatal)
 	}
 
 	return cfg

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -89,6 +89,13 @@ func main() {
 		os.Setenv("NFTBAN_TAKEOVER", "1")
 	}
 
+	// v1.98.x PR-14-pre: propagate source-install mode to phase data so
+	// Prepare/Configure can branch into the source-install path when gated.
+	// Package installs (cfg.source == false) leave these as zero-value and
+	// never reach the gated code in phasePrepare/phaseConfigure.
+	globalPhaseData.source = cfg.source
+	globalPhaseData.sourceDir = cfg.sourceDir
+
 	exitCode := run(ctx, exec, sf, cfg, log)
 
 	// Write JSON update history (compatible with nftban update history --json)

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -128,30 +128,20 @@ func phaseDetect(_ context.Context, exec executor.Executor, sf *state.StateFile,
 func phasePrepare(_ context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
 	pd := &globalPhaseData
 
-	// v1.98.x PR-14-pre (G-14-A + G-14-B..G): Source-install path.
+	// v1.98.x PR-14-pre (G-14-A): Source-install user/group creation.
 	//
-	// Package installs (RPM/DEB) extract users/groups and files via package
-	// payload; cfg.source is false and this block is skipped entirely.
+	// Runs first because everything downstream (fhs.EnsureDirectories,
+	// fhs.SetPermissions, payload staging, chown to nftban:nftban) depends
+	// on the nftban user and group existing.
 	//
-	// Source installs (cfg.source=true) must create users/groups before any
-	// ownership-dependent step and stage payload before fhs.EnsureDirectories
-	// and fhs.SetPermissions run (those enforce FHS rules on already-present
-	// files).
+	// Package installs (RPM/DEB) create users/groups in %pre / postinst
+	// before this phase runs, so pd.source=false here and this block is
+	// skipped entirely.
 	if pd.source {
-		// 0a. Users/groups (must run before deps install and before any chown
-		// targeting nftban:nftban).
 		if err := users.Ensure(exec, pd.distro, log); err != nil {
 			log.Error("user/group creation failed: %v", err)
 			return sf.Transition(state.StateFailedRender, state.PhasePrepare,
 				"user/group creation failed: "+err.Error())
-		}
-
-		// 0b. Payload staging from source tree to FHS destinations. Idempotent,
-		// respects .conf.local (invariant #9) and %config(noreplace) semantics.
-		if err := payload.StageAll(exec, pd.sourceDir, pd.distro, log); err != nil {
-			log.Error("source payload staging failed: %v", err)
-			return sf.Transition(state.StateFailedRender, state.PhasePrepare,
-				"source payload staging failed: "+err.Error())
 		}
 	}
 
@@ -169,6 +159,23 @@ func phasePrepare(_ context.Context, exec executor.Executor, sf *state.StateFile
 
 	// 2. Ensure FHS directories exist
 	fhs.EnsureDirectories(exec, log)
+
+	// v1.98.x PR-14-pre (G-14-B..G): Source-install payload staging.
+	//
+	// Must run AFTER fhs.EnsureDirectories (destination parent dirs like
+	// /usr/lib/nftban/*, /etc/nftban/* must exist before WriteFileAtomic
+	// can land files there). Must run BEFORE fhs.SetPermissions (so
+	// enforcement has files to chown/chmod).
+	//
+	// Idempotent: copyIfChanged skips unchanged files, %config(noreplace)
+	// entries preserve operator-edited configs, .conf.local never touched.
+	if pd.source {
+		if err := payload.StageAll(exec, pd.sourceDir, pd.distro, log); err != nil {
+			log.Error("source payload staging failed: %v", err)
+			return sf.Transition(state.StateFailedRender, state.PhasePrepare,
+				"source payload staging failed: "+err.Error())
+		}
+	}
 
 	// 3. Set FHS permissions
 	fhs.SetPermissions(exec, log)

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -29,10 +29,13 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/fhs"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/payload"
 	"github.com/itcmsgr/nftban/internal/installer/render"
+	"github.com/itcmsgr/nftban/internal/installer/safety"
 	"github.com/itcmsgr/nftban/internal/installer/services"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 	"github.com/itcmsgr/nftban/internal/installer/switchop"
+	"github.com/itcmsgr/nftban/internal/installer/users"
 	"github.com/itcmsgr/nftban/internal/installer/validate"
 )
 
@@ -124,6 +127,33 @@ func phaseDetect(_ context.Context, exec executor.Executor, sf *state.StateFile,
 // phasePrepare runs dep install, stale cleanup, FHS setup, template rendering, config persistence.
 func phasePrepare(_ context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
 	pd := &globalPhaseData
+
+	// v1.98.x PR-14-pre (G-14-A + G-14-B..G): Source-install path.
+	//
+	// Package installs (RPM/DEB) extract users/groups and files via package
+	// payload; cfg.source is false and this block is skipped entirely.
+	//
+	// Source installs (cfg.source=true) must create users/groups before any
+	// ownership-dependent step and stage payload before fhs.EnsureDirectories
+	// and fhs.SetPermissions run (those enforce FHS rules on already-present
+	// files).
+	if pd.source {
+		// 0a. Users/groups (must run before deps install and before any chown
+		// targeting nftban:nftban).
+		if err := users.Ensure(exec, pd.distro, log); err != nil {
+			log.Error("user/group creation failed: %v", err)
+			return sf.Transition(state.StateFailedRender, state.PhasePrepare,
+				"user/group creation failed: "+err.Error())
+		}
+
+		// 0b. Payload staging from source tree to FHS destinations. Idempotent,
+		// respects .conf.local (invariant #9) and %config(noreplace) semantics.
+		if err := payload.StageAll(exec, pd.sourceDir, pd.distro, log); err != nil {
+			log.Error("source payload staging failed: %v", err)
+			return sf.Transition(state.StateFailedRender, state.PhasePrepare,
+				"source payload staging failed: "+err.Error())
+		}
+	}
 
 	// 0. Install missing dependencies (dpkg/rpm lock is released by now)
 	if pd.distro != nil {
@@ -251,6 +281,18 @@ func phaseConfigure(_ context.Context, exec executor.Executor, sf *state.StateFi
 
 	// 4. Enable login monitoring
 	services.EnableLogin(exec, log)
+
+	// v1.98.x PR-14-pre (G-14-H): Safety whitelist seed for source install.
+	// Must run BEFORE SyncWhitelist so the file exists before the sync reads
+	// it. Package installs skip this block (pd.source=false) because their
+	// 99-manual.conf comes through the package payload (%config(noreplace)).
+	// Non-fatal: SSH safety backstop (switchop.InjectEmergencySSH) runs in
+	// phaseSwitch independently.
+	if pd.source {
+		if err := safety.SeedManualWhitelist(exec, log); err != nil {
+			log.Warn("safety whitelist seed failed (non-fatal): %v", err)
+		}
+	}
 
 	// 5. Whitelist sync (loads whitelists and feeds)
 	services.SyncWhitelist(exec, log)

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -39,12 +39,19 @@ import (
 // phaseData holds state accumulated across phases (detect→prepare→switch etc.)
 // Stored on the config struct or passed via state file fields.
 type phaseData struct {
-	sshPort    int
-	panel      detect.PanelType
-	conflicts  []detect.Conflict
-	decision   authority.Decision
-	distro     *detect.DistroInfo
-	ctLimits   detect.CTLimits
+	sshPort   int
+	panel     detect.PanelType
+	conflicts []detect.Conflict
+	decision  authority.Decision
+	distro    *detect.DistroInfo
+	ctLimits  detect.CTLimits
+	// v1.98.x PR-14-pre: source-install fields. Populated from cfg in main()
+	// before phases run. When source is true, Prepare and Configure take
+	// additional branches for user/group creation, payload staging from
+	// sourceDir, and safety-whitelist seeding. Package installs leave these
+	// as zero-value and never reach the gated code.
+	source    bool
+	sourceDir string
 }
 
 // globalPhaseData is set by phaseDetect and consumed by later phases.

--- a/internal/installer/payload/idempotency.go
+++ b/internal/installer/payload/idempotency.go
@@ -33,6 +33,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
@@ -79,6 +80,18 @@ func copyIfChanged(exec executor.Executor, srcContent []byte, dst string, mode o
 		if err == nil && bytes.Equal(existing, srcContent) {
 			log.Debug("payload: unchanged %s (%d bytes)", dst, len(srcContent))
 			return false, nil
+		}
+	}
+
+	// Defensive MkdirAll: fhs.EnsureDirectories covers the canonical FHS registry
+	// but not every payload-destination subdirectory (e.g. /usr/lib/nftban/cli,
+	// /usr/lib/nftban/sbin, /etc/nftban/templates). Creating the parent here
+	// keeps payload staging self-sufficient. 0755 is a safe default for system
+	// directories; fhs.SetPermissions runs after payload and corrects ownership
+	// per the canonical registry where entries exist.
+	if parent := filepath.Dir(dst); parent != "" && parent != "/" {
+		if err := exec.MkdirAll(parent, 0755); err != nil {
+			return false, fmt.Errorf("mkdir %s: %w", parent, err)
 		}
 	}
 

--- a/internal/installer/payload/idempotency.go
+++ b/internal/installer/payload/idempotency.go
@@ -1,0 +1,119 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer Payload Staging Helpers (PR-14-pre)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-payload-idempotency"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Copy-if-changed + .conf.local / %config(noreplace) semantics"
+// meta:inventory.files="internal/installer/payload/idempotency.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Shared helpers for the payload package:
+//   - copyIfChanged:     skip write when src and dst are byte-identical.
+//   - isConfigLocal:     filter that refuses to touch .conf.local files.
+//   - shouldPreserveCfg: %config(noreplace) semantics for template configs.
+//
+// These guard the two hardest invariants for source-install payload staging:
+//   1. Invariant #9: never read/write .conf.local (override model preserved).
+//   2. %config(noreplace) parity: operator-edited template configs preserved.
+//
+// =============================================================================
+
+package payload
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// overwritePolicy controls when an existing destination is preserved vs replaced.
+type overwritePolicy int
+
+const (
+	// policyAlways replaces the destination regardless of existing content.
+	// Used for product artifacts (binaries, systemd units, polkit rules,
+	// logrotate config, bash completion, templates, .default reference files).
+	policyAlways overwritePolicy = iota
+
+	// policyConfigNoReplace mimics RPM's %config(noreplace) and DEB's conffile
+	// semantics: if the destination exists, preserve it (operator may have
+	// edited it). Used for /etc/nftban/nftban.conf, conf.d/*.conf, and the
+	// 99-manual.conf templates.
+	policyConfigNoReplace
+)
+
+// copyIfChanged writes src-content to dst only if the content differs from
+// what is already at dst (or if dst does not exist). Returns wrote=true if
+// a write actually occurred.
+//
+// Skips writes when bytes are identical — preserves mtime for unchanged
+// files, reduces installer-log noise on re-runs, and makes source-install
+// idempotency observable at the file-system level.
+//
+// The mode is applied on write. Ownership is NOT set here — payload relies
+// on fhs.SetPermissions() in phasePrepare to enforce the central FHS
+// registry rules after all files are in place.
+func copyIfChanged(exec executor.Executor, srcContent []byte, dst string, mode os.FileMode, log *logging.Logger) (wrote bool, err error) {
+	// Safety: never stage into a .conf.local path. Invariant #9 violation if
+	// this slips through the caller's filtering.
+	if isConfigLocal(dst) {
+		log.Debug("payload.copyIfChanged: refusing to write .conf.local destination: %s", dst)
+		return false, nil
+	}
+
+	if exec.FileExists(dst) {
+		existing, err := exec.ReadFile(dst)
+		if err == nil && bytes.Equal(existing, srcContent) {
+			log.Debug("payload: unchanged %s (%d bytes)", dst, len(srcContent))
+			return false, nil
+		}
+	}
+
+	if err := exec.WriteFileAtomic(dst, srcContent, mode); err != nil {
+		return false, fmt.Errorf("write %s: %w", dst, err)
+	}
+	log.Debug("payload: wrote %s (%d bytes, mode %o)", dst, len(srcContent), mode)
+	return true, nil
+}
+
+// isConfigLocal returns true if the path is a .conf.local override file.
+// Invariant #9: installer code must never read or write these — they are
+// operator-owned.
+//
+// Matches both:
+//   - .conf.local suffix (e.g. nftban.conf.local, ddos.conf.local)
+//   - .local.conf suffix (defensive — either spelling is treated as operator
+//     territory)
+func isConfigLocal(path string) bool {
+	return strings.HasSuffix(path, ".conf.local") ||
+		strings.HasSuffix(path, ".local.conf")
+}
+
+// shouldPreserveConfig implements %config(noreplace) semantics: returns true
+// when dst exists and should NOT be overwritten (operator content preserved).
+//
+// Called only for entries with policyConfigNoReplace. Always returns false
+// for policyAlways entries regardless of destination state.
+func shouldPreserveConfig(exec executor.Executor, dst string, policy overwritePolicy, log *logging.Logger) bool {
+	if policy != policyConfigNoReplace {
+		return false
+	}
+	if !exec.FileExists(dst) {
+		return false
+	}
+	log.Debug("payload: preserving existing config (noreplace semantics): %s", dst)
+	return true
+}

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -1,0 +1,356 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer Payload Staging (PR-14-pre G-14-B..G)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-payload"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Source-install payload staging from repo/tarball to FHS destinations"
+// meta:inventory.files="internal/installer/payload/payload.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Package installs (RPM/DEB) extract files into FHS destinations via the
+// package payload. The Go installer then only enforces FHS permissions on
+// already-present files. For source install (cfg.source == true), there is
+// no package manager — this package stages the files from a source tree
+// (repo clone or extracted tarball) to the canonical destinations.
+//
+// Scope: gaps G-14-B through G-14-G per V198_PR14_PRE_SOURCE_INSTALL_SPEC.md:
+//   G-14-B: Go binaries (nftban-core, nftband, nftban-validate, nftban-installer,
+//           /usr/sbin/nftban, /usr/sbin/nftban-ui, /usr/libexec/nftban-ui-auth)
+//   G-14-C: Shell scripts (cli/lib/nftban/{cli,core,helpers,lib,data,health}/*)
+//   G-14-D: Configs (/etc/nftban/*, patterns.d, templates)
+//   G-14-E: Systemd units + tmpfiles.d
+//   G-14-F: Polkit rules (distro-conditional destination)
+//   G-14-G: Logrotate (canonical — resolves pre-existing source-install drift)
+//
+// Gating: StageAll is invoked from phasePrepare ONLY when pd.source == true.
+// The cfg.source == false path (RPM/DEB) never reaches this code.
+//
+// UI staging: nftban-ui + nftban-ui-auth + PAM config are included but marked
+// with REMOVE-IN-V2.0.0 comments. v2.0.0 PR-D4 removes these mechanically.
+//
+// =============================================================================
+
+package payload
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// StageAll stages every source-install payload from srcDir to its FHS
+// destination. Idempotent: copyIfChanged skips unchanged files, and
+// %config(noreplace) entries preserve existing operator-edited content.
+//
+// srcDir must be the root of a repo clone or extracted release tarball
+// (i.e. the directory that contains bin/, cli/, install/, etc.).
+//
+// Returns an error only on unrecoverable failures. Individual file-copy
+// failures are logged and counted; the orchestrator continues so one bad
+// entry does not abort the whole staging pass.
+func StageAll(exec executor.Executor, srcDir string, distro *detect.DistroInfo, log *logging.Logger) error {
+	if srcDir == "" {
+		return fmt.Errorf("payload.StageAll: srcDir is empty")
+	}
+	if !exec.FileExists(srcDir) {
+		return fmt.Errorf("payload.StageAll: srcDir does not exist: %s", srcDir)
+	}
+
+	log.Info("payload: staging from %s", srcDir)
+
+	entries := buildEntries(distro)
+	var wrote, skipped, failed int
+
+	for _, e := range entries {
+		if e.uiRemoveInV2 {
+			log.Debug("payload: staging UI-related entry (REMOVE-IN-V2.0.0): %s", e.dstGlob)
+		}
+		ew, es, ef := stageEntry(exec, srcDir, e, log)
+		wrote += ew
+		skipped += es
+		failed += ef
+	}
+
+	log.Info("payload: staging complete — wrote=%d skipped=%d failed=%d", wrote, skipped, failed)
+	if failed > 0 {
+		// Failures are non-fatal during staging — log count for visibility
+		// but let phaseValidate catch any downstream breakage.
+		log.Warn("payload: %d file(s) failed to stage (non-fatal, see earlier log entries)", failed)
+	}
+	return nil
+}
+
+// entry describes one source-to-destination staging rule.
+//
+// One entry can represent either a single file pair or a directory with a
+// glob pattern — the stageEntry dispatcher inspects isDir and srcGlob to
+// pick the right copy path.
+type entry struct {
+	// srcRel is the source path relative to srcDir. For glob entries it
+	// is the source-directory root (e.g. "install/systemd").
+	srcRel string
+
+	// srcGlob is the glob pattern within srcRel for multi-file entries
+	// (e.g. "*.service", "*.timer"). Empty for single-file entries.
+	srcGlob string
+
+	// dstGlob is the destination directory for multi-file entries or the
+	// exact destination path for single-file entries.
+	dstGlob string
+
+	// mode is the file mode applied at write time.
+	mode os.FileMode
+
+	// policy controls overwrite behavior for existing destinations.
+	policy overwritePolicy
+
+	// isDir indicates a directory-glob entry (vs single file).
+	isDir bool
+
+	// optional indicates the source may be absent without error (e.g. man
+	// page files that are not always shipped).
+	optional bool
+
+	// uiRemoveInV2 marks UI-related entries that must be removed in v2.0.0
+	// as part of PR-D4. CI can grep for this marker pre-decommission.
+	//
+	// REMOVE-IN-V2.0.0: UI decommission (PR-D4)
+	uiRemoveInV2 bool
+}
+
+// buildEntries constructs the full payload destination table.
+//
+// The table encodes the destination contract from
+// V198_PR14_PRE_SOURCE_INSTALL_SPEC.md §3.2. Distro-conditional entries
+// (currently only polkit) branch on distro.ID via distroPolkitDir().
+func buildEntries(distro *detect.DistroInfo) []entry {
+	polkitDst := "/etc/polkit-1/rules.d"
+	if distro != nil && isDebianFamily(distro.ID) {
+		// Debian policy: third-party polkit rules go under /usr/share/polkit-1/
+		// per packaging/deb/postinst convention (v1.0.19 Bug #18 fix).
+		polkitDst = "/usr/share/polkit-1/rules.d"
+	}
+
+	return []entry{
+		// -----------------------------------------------------------------
+		// G-14-B: Go binaries + CLI sbin entries
+		// -----------------------------------------------------------------
+		{srcRel: "bin/nftban-core", dstGlob: "/usr/lib/nftban/bin/nftban-core", mode: 0755, policy: policyAlways},
+		{srcRel: "bin/nftband", dstGlob: "/usr/lib/nftban/bin/nftband", mode: 0755, policy: policyAlways},
+		{srcRel: "bin/nftban-validate", dstGlob: "/usr/lib/nftban/bin/nftban-validate", mode: 0755, policy: policyAlways},
+		{srcRel: "bin/nftban-installer", dstGlob: "/usr/lib/nftban/bin/nftban-installer", mode: 0755, policy: policyAlways},
+
+		// Canonical privileged CLI binary (NB-5 perms).
+		{srcRel: "cli/sbin/nftban", dstGlob: "/usr/sbin/nftban", mode: 0750, policy: policyAlways},
+
+		// Auxiliary CLI helpers.
+		{srcRel: "cli/sbin/nftban-apply", dstGlob: "/usr/lib/nftban/sbin/nftban-apply", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-confirm", dstGlob: "/usr/lib/nftban/sbin/nftban-confirm", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-panelctl", dstGlob: "/usr/lib/nftban/sbin/nftban-panelctl", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-queue-processor", dstGlob: "/usr/lib/nftban/sbin/nftban-queue-processor", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-rollback", dstGlob: "/usr/lib/nftban/sbin/nftban-rollback", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-service-alert", dstGlob: "/usr/lib/nftban/sbin/nftban-service-alert", mode: 0755, policy: policyAlways},
+		{srcRel: "cli/sbin/nftban-botscan-processor", dstGlob: "/usr/lib/nftban/sbin/nftban-botscan-processor", mode: 0755, policy: policyAlways},
+
+		// -----------------------------------------------------------------
+		// REMOVE-IN-V2.0.0: UI decommission (PR-D4)
+		// -----------------------------------------------------------------
+		{srcRel: "bin/nftban-ui", dstGlob: "/usr/sbin/nftban-ui", mode: 0750, policy: policyAlways, uiRemoveInV2: true, optional: true},
+		{srcRel: "bin/nftban-ui-auth", dstGlob: "/usr/libexec/nftban-ui-auth", mode: 0755, policy: policyAlways, uiRemoveInV2: true, optional: true},
+		// END-REMOVE-IN-V2.0.0
+
+		// -----------------------------------------------------------------
+		// G-14-C: Shell payload under /usr/lib/nftban/
+		// -----------------------------------------------------------------
+		{srcRel: "cli/lib/nftban/cli", srcGlob: "*.sh", dstGlob: "/usr/lib/nftban/cli", mode: 0755, policy: policyAlways, isDir: true},
+		{srcRel: "cli/lib/nftban/core", srcGlob: "*.sh", dstGlob: "/usr/lib/nftban/core", mode: 0755, policy: policyAlways, isDir: true},
+		{srcRel: "cli/lib/nftban/helpers", srcGlob: "*.sh", dstGlob: "/usr/lib/nftban/helpers", mode: 0755, policy: policyAlways, isDir: true},
+		{srcRel: "cli/lib/nftban/lib", srcGlob: "*.sh", dstGlob: "/usr/lib/nftban/lib", mode: 0755, policy: policyAlways, isDir: true},
+		{srcRel: "cli/lib/nftban/data", srcGlob: "*", dstGlob: "/usr/lib/nftban/data", mode: 0644, policy: policyAlways, isDir: true},
+		{srcRel: "cli/lib/nftban/health", srcGlob: "*.sh", dstGlob: "/usr/lib/nftban/health", mode: 0755, policy: policyAlways, isDir: true},
+
+		// Shipped nftables template (always overwrite — installer-managed,
+		// never operator-edited here).
+		{srcRel: "cli/lib/nftban/templates/nftables.conf.tpl", dstGlob: "/usr/lib/nftban/templates/nftables.conf.tpl", mode: 0644, policy: policyAlways, optional: true},
+
+		// -----------------------------------------------------------------
+		// G-14-D: Configs (/etc/nftban/*)
+		// -----------------------------------------------------------------
+		// Template configs with %config(noreplace) semantics.
+		{srcRel: "install/config/nftban.conf", dstGlob: "/etc/nftban/nftban.conf", mode: 0640, policy: policyConfigNoReplace},
+		{srcRel: "install/config/conf.d", srcGlob: "*.conf", dstGlob: "/etc/nftban/conf.d", mode: 0640, policy: policyConfigNoReplace, isDir: true},
+
+		// Default reference templates (.default files — always overwrite).
+		{srcRel: "install/config/conf.d", srcGlob: "*.conf.default", dstGlob: "/etc/nftban/conf.d", mode: 0640, policy: policyAlways, isDir: true},
+
+		// Distro-aware path registry (always overwrite — installer-owned).
+		{srcRel: "etc/nftban/distros", srcGlob: "*.conf", dstGlob: "/etc/nftban/distros", mode: 0640, policy: policyAlways, isDir: true},
+
+		// Manual whitelist/blacklist templates (%config(noreplace)).
+		// safety.SeedManualWhitelist runs in phaseConfigure after these land.
+		{srcRel: "etc/nftban/whitelist.d/99-manual.conf", dstGlob: "/etc/nftban/whitelist.d/99-manual.conf", mode: 0640, policy: policyConfigNoReplace, optional: true},
+		{srcRel: "etc/nftban/blacklist.d/99-manual.conf", dstGlob: "/etc/nftban/blacklist.d/99-manual.conf", mode: 0640, policy: policyConfigNoReplace, optional: true},
+
+		// Commands registry.
+		{srcRel: "commands.registry.yml", dstGlob: "/etc/nftban/commands.registry.yml", mode: 0644, policy: policyConfigNoReplace, optional: true},
+
+		// -----------------------------------------------------------------
+		// G-14-E: Systemd units + tmpfiles.d
+		// -----------------------------------------------------------------
+		{srcRel: "install/systemd", srcGlob: "*.service", dstGlob: "/usr/lib/systemd/system", mode: 0644, policy: policyAlways, isDir: true},
+		{srcRel: "install/systemd", srcGlob: "*.timer", dstGlob: "/usr/lib/systemd/system", mode: 0644, policy: policyAlways, isDir: true},
+		{srcRel: "install/systemd", srcGlob: "*.socket", dstGlob: "/usr/lib/systemd/system", mode: 0644, policy: policyAlways, isDir: true},
+		{srcRel: "install/systemd/tmpfiles.d/nftban.conf", dstGlob: "/usr/lib/tmpfiles.d/nftban.conf", mode: 0644, policy: policyAlways},
+
+		// -----------------------------------------------------------------
+		// G-14-F: Polkit rules (distro-conditional destination)
+		// -----------------------------------------------------------------
+		{srcRel: "packaging/polkit-1/rules.d", srcGlob: "*.rules", dstGlob: polkitDst, mode: 0644, policy: policyAlways, isDir: true, optional: true},
+
+		// -----------------------------------------------------------------
+		// G-14-G: Logrotate (resolves pre-existing source-install drift —
+		// uses canonical shipped config instead of install_services.sh's
+		// auto-generated wildcard config).
+		// -----------------------------------------------------------------
+		{srcRel: "install/config/nftban.logrotate", dstGlob: "/etc/logrotate.d/nftban", mode: 0644, policy: policyAlways},
+		{srcRel: "install/config/nftban-suricata.logrotate", dstGlob: "/etc/nftban/templates/nftban-suricata.logrotate", mode: 0644, policy: policyAlways, optional: true},
+
+		// -----------------------------------------------------------------
+		// Other shipped artifacts: bash completion, man page (optional)
+		// -----------------------------------------------------------------
+		{srcRel: "install/bash-completion/nftban", dstGlob: "/usr/share/bash-completion/completions/nftban", mode: 0644, policy: policyAlways, optional: true},
+		{srcRel: "install/man/nftban.8", dstGlob: "/usr/share/man/man8/nftban.8", mode: 0644, policy: policyAlways, optional: true},
+	}
+}
+
+// stageEntry copies a single entry (file or directory glob) to its destination.
+// Returns (wrote, skipped, failed) counters for the orchestrator.
+func stageEntry(exec executor.Executor, srcDir string, e entry, log *logging.Logger) (wrote, skipped, failed int) {
+	if e.isDir {
+		return stageGlob(exec, srcDir, e, log)
+	}
+	return stageSingleFile(exec, srcDir, e, log)
+}
+
+// stageSingleFile handles one source→dest file pair.
+func stageSingleFile(exec executor.Executor, srcDir string, e entry, log *logging.Logger) (wrote, skipped, failed int) {
+	srcPath := filepath.Join(srcDir, e.srcRel)
+
+	if !exec.FileExists(srcPath) {
+		if e.optional {
+			log.Debug("payload: optional source missing, skipping: %s", srcPath)
+			return 0, 1, 0
+		}
+		log.Warn("payload: required source missing: %s", srcPath)
+		return 0, 0, 1
+	}
+
+	if shouldPreserveConfig(exec, e.dstGlob, e.policy, log) {
+		return 0, 1, 0
+	}
+
+	content, err := exec.ReadFile(srcPath)
+	if err != nil {
+		log.Warn("payload: read %s: %v", srcPath, err)
+		return 0, 0, 1
+	}
+
+	w, err := copyIfChanged(exec, content, e.dstGlob, e.mode, log)
+	if err != nil {
+		log.Warn("payload: %v", err)
+		return 0, 0, 1
+	}
+	if w {
+		return 1, 0, 0
+	}
+	return 0, 1, 0
+}
+
+// stageGlob handles a directory entry with a glob pattern (e.g. *.service).
+// Uses filepath.Glob on the real filesystem — srcDir is a real repo tree.
+func stageGlob(exec executor.Executor, srcDir string, e entry, log *logging.Logger) (wrote, skipped, failed int) {
+	srcRoot := filepath.Join(srcDir, e.srcRel)
+
+	if !exec.FileExists(srcRoot) {
+		if e.optional {
+			log.Debug("payload: optional source dir missing: %s", srcRoot)
+			return 0, 1, 0
+		}
+		log.Warn("payload: required source dir missing: %s", srcRoot)
+		return 0, 0, 1
+	}
+
+	matches, err := filepath.Glob(filepath.Join(srcRoot, e.srcGlob))
+	if err != nil {
+		log.Warn("payload: glob %s/%s: %v", srcRoot, e.srcGlob, err)
+		return 0, 0, 1
+	}
+
+	for _, match := range matches {
+		// Skip directories — glob may return subdirs for patterns like "*"
+		info, err := os.Stat(match)
+		if err != nil || info.IsDir() {
+			continue
+		}
+
+		// Skip .conf.local files defensively (invariant #9).
+		if isConfigLocal(match) {
+			log.Debug("payload: skipping .conf.local source file: %s", match)
+			continue
+		}
+
+		base := filepath.Base(match)
+		dstPath := filepath.Join(e.dstGlob, base)
+
+		// Apply %config(noreplace) semantics per-file.
+		if shouldPreserveConfig(exec, dstPath, e.policy, log) {
+			skipped++
+			continue
+		}
+
+		content, err := exec.ReadFile(match)
+		if err != nil {
+			log.Warn("payload: read %s: %v", match, err)
+			failed++
+			continue
+		}
+
+		w, err := copyIfChanged(exec, content, dstPath, e.mode, log)
+		if err != nil {
+			log.Warn("payload: %v", err)
+			failed++
+			continue
+		}
+		if w {
+			wrote++
+		} else {
+			skipped++
+		}
+	}
+	return wrote, skipped, failed
+}
+
+// isDebianFamily matches detect.DistroInfo.ID values that use Debian's
+// third-party polkit rules location (/usr/share/polkit-1/rules.d/).
+func isDebianFamily(id string) bool {
+	switch strings.ToLower(id) {
+	case "debian", "ubuntu":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -192,6 +192,10 @@ func buildEntries(distro *detect.DistroInfo) []entry {
 		// -----------------------------------------------------------------
 		// Template configs with %config(noreplace) semantics.
 		{srcRel: "install/config/nftban.conf", dstGlob: "/etc/nftban/nftban.conf", mode: 0640, policy: policyConfigNoReplace},
+		// nftables.conf is a template with __SSH_PORT__ / __CT_LIMIT_*__
+		// placeholders. render.RenderNftablesConf (Prepare step 6) reads
+		// this, substitutes, and writes back. Must be staged before render.
+		{srcRel: "install/nftables/nftables.conf", dstGlob: "/etc/nftban/nftables.conf", mode: 0640, policy: policyConfigNoReplace},
 		{srcRel: "install/config/conf.d", srcGlob: "*.conf", dstGlob: "/etc/nftban/conf.d", mode: 0640, policy: policyConfigNoReplace, isDir: true},
 
 		// Default reference templates (.default files — always overwrite).

--- a/internal/installer/payload/payload_test.go
+++ b/internal/installer/payload/payload_test.go
@@ -1,0 +1,353 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer Payload Staging Tests (PR-14-pre)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-payload-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Tests for source-install payload staging + idempotency helpers"
+// meta:inventory.files="internal/installer/payload/payload_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package payload
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("", false)
+}
+
+// -----------------------------------------------------------------------------
+// idempotency.go tests — no filesystem needed
+// -----------------------------------------------------------------------------
+
+func TestIsConfigLocal(t *testing.T) {
+	cases := map[string]bool{
+		"/etc/nftban/nftban.conf.local":        true,
+		"/etc/nftban/conf.d/ddos.conf.local":   true,
+		"/etc/nftban/nftban.local.conf":        true,
+		"/etc/nftban/nftban.conf":              false,
+		"/etc/nftban/conf.d/ddos.conf":         false,
+		"/usr/lib/nftban/scripts/foo.sh":       false,
+		"nftban.conf.local":                    true,
+		"":                                     false,
+	}
+	for path, want := range cases {
+		if got := isConfigLocal(path); got != want {
+			t.Errorf("isConfigLocal(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestCopyIfChanged_WritesWhenMissing(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	content := []byte("hello")
+	wrote, err := copyIfChanged(mock, content, "/etc/nftban/nftban.conf", 0640, newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrote {
+		t.Errorf("expected wrote=true for new file")
+	}
+	if string(mock.WrittenFiles["/etc/nftban/nftban.conf"]) != "hello" {
+		t.Errorf("file content not written correctly")
+	}
+}
+
+func TestCopyIfChanged_SkipsIdenticalContent(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/etc/nftban/nftban.conf"] = []byte("same")
+	wrote, err := copyIfChanged(mock, []byte("same"), "/etc/nftban/nftban.conf", 0640, newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wrote {
+		t.Errorf("expected wrote=false for identical content")
+	}
+	if _, ok := mock.WrittenFiles["/etc/nftban/nftban.conf"]; ok {
+		t.Errorf("WriteFileAtomic was called for identical content")
+	}
+}
+
+func TestCopyIfChanged_WritesWhenContentDiffers(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/etc/nftban/nftban.conf"] = []byte("old")
+	wrote, err := copyIfChanged(mock, []byte("new"), "/etc/nftban/nftban.conf", 0640, newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrote {
+		t.Errorf("expected wrote=true for different content")
+	}
+}
+
+func TestCopyIfChanged_RefusesConfLocalDestination(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	wrote, err := copyIfChanged(mock, []byte("x"), "/etc/nftban/nftban.conf.local", 0640, newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wrote {
+		t.Errorf("copyIfChanged wrote to .conf.local destination — invariant #9 violated")
+	}
+	if _, ok := mock.WrittenFiles["/etc/nftban/nftban.conf.local"]; ok {
+		t.Errorf("WriteFileAtomic called on .conf.local path")
+	}
+}
+
+func TestShouldPreserveConfig_NoReplaceWithExisting(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/etc/nftban/nftban.conf"] = []byte("operator edits")
+	if !shouldPreserveConfig(mock, "/etc/nftban/nftban.conf", policyConfigNoReplace, newTestLogger()) {
+		t.Errorf("expected true for existing noreplace config")
+	}
+}
+
+func TestShouldPreserveConfig_NoReplaceMissing(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	if shouldPreserveConfig(mock, "/etc/nftban/nftban.conf", policyConfigNoReplace, newTestLogger()) {
+		t.Errorf("expected false when destination is missing")
+	}
+}
+
+func TestShouldPreserveConfig_AlwaysPolicyIgnoresExisting(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/usr/lib/nftban/bin/nftban-core"] = []byte("old binary")
+	if shouldPreserveConfig(mock, "/usr/lib/nftban/bin/nftban-core", policyAlways, newTestLogger()) {
+		t.Errorf("expected false for policyAlways regardless of existing content")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// payload.go tests — buildEntries table validation
+// -----------------------------------------------------------------------------
+
+func TestBuildEntries_CoversCanonicalBinaryPaths(t *testing.T) {
+	entries := buildEntries(&detect.DistroInfo{ID: "ubuntu"})
+	// Every Go-installer-authored binary destination must be present.
+	required := []string{
+		"/usr/lib/nftban/bin/nftban-core",
+		"/usr/lib/nftban/bin/nftband",
+		"/usr/lib/nftban/bin/nftban-validate",
+		"/usr/lib/nftban/bin/nftban-installer",
+		"/usr/sbin/nftban",
+	}
+	dsts := make(map[string]bool)
+	for _, e := range entries {
+		dsts[e.dstGlob] = true
+	}
+	for _, r := range required {
+		if !dsts[r] {
+			t.Errorf("buildEntries missing required destination: %s", r)
+		}
+	}
+}
+
+func TestBuildEntries_UserSbinNftbanIsRootNftban0750(t *testing.T) {
+	entries := buildEntries(&detect.DistroInfo{ID: "ubuntu"})
+	var found bool
+	for _, e := range entries {
+		if e.dstGlob == "/usr/sbin/nftban" {
+			found = true
+			if e.mode != 0750 {
+				t.Errorf("/usr/sbin/nftban mode = %o, want 0750 (NB-5 match)", e.mode)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no entry for /usr/sbin/nftban")
+	}
+}
+
+func TestBuildEntries_PolkitDestinationPerDistro(t *testing.T) {
+	cases := map[string]string{
+		"ubuntu":    "/usr/share/polkit-1/rules.d",
+		"debian":    "/usr/share/polkit-1/rules.d",
+		"almalinux": "/etc/polkit-1/rules.d",
+		"centos":    "/etc/polkit-1/rules.d",
+		"rocky":     "/etc/polkit-1/rules.d",
+	}
+	for distroID, wantDst := range cases {
+		entries := buildEntries(&detect.DistroInfo{ID: distroID})
+		var found bool
+		for _, e := range entries {
+			if e.srcRel == "packaging/polkit-1/rules.d" {
+				found = true
+				if e.dstGlob != wantDst {
+					t.Errorf("polkit dst for %s = %s, want %s", distroID, e.dstGlob, wantDst)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("no polkit entry for distro %s", distroID)
+		}
+	}
+}
+
+func TestBuildEntries_AllConfNoReplaceEntriesAreTemplateConfigs(t *testing.T) {
+	entries := buildEntries(&detect.DistroInfo{ID: "ubuntu"})
+	for _, e := range entries {
+		if e.policy != policyConfigNoReplace {
+			continue
+		}
+		// noreplace entries must live under /etc/nftban or be the commands.registry.yml
+		if !strings.HasPrefix(e.dstGlob, "/etc/nftban/") {
+			t.Errorf("noreplace entry %s not under /etc/nftban/", e.dstGlob)
+		}
+	}
+}
+
+func TestBuildEntries_UIRemoveInV2MarkersPresent(t *testing.T) {
+	entries := buildEntries(&detect.DistroInfo{ID: "ubuntu"})
+	var uiCount int
+	for _, e := range entries {
+		if e.uiRemoveInV2 {
+			uiCount++
+		}
+	}
+	// Expected: nftban-ui binary + nftban-ui-auth libexec (2 UI binaries).
+	if uiCount < 2 {
+		t.Errorf("expected at least 2 UI entries marked REMOVE-IN-V2.0.0, got %d", uiCount)
+	}
+}
+
+func TestIsDebianFamily(t *testing.T) {
+	cases := map[string]bool{
+		"debian":    true,
+		"ubuntu":    true,
+		"UBUNTU":    true,
+		"almalinux": false,
+		"centos":    false,
+		"rocky":     false,
+		"":          false,
+	}
+	for id, want := range cases {
+		if got := isDebianFamily(id); got != want {
+			t.Errorf("isDebianFamily(%q) = %v, want %v", id, got, want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// stageEntry / StageAll — real-filesystem integration test
+// -----------------------------------------------------------------------------
+
+func TestStageAll_EmptySrcDirReturnsError(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	err := StageAll(mock, "", &detect.DistroInfo{ID: "ubuntu"}, newTestLogger())
+	if err == nil {
+		t.Errorf("expected error for empty srcDir")
+	}
+}
+
+func TestStageAll_NonexistentSrcDirReturnsError(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	err := StageAll(mock, "/nonexistent/path", &detect.DistroInfo{ID: "ubuntu"}, newTestLogger())
+	if err == nil {
+		t.Errorf("expected error for nonexistent srcDir")
+	}
+}
+
+// setupFakeSrcTree builds a minimal source tree with one file per known
+// single-file entry we want to exercise. Uses t.TempDir() so it's cleaned
+// up automatically.
+func setupFakeSrcTree(t *testing.T) string {
+	t.Helper()
+	srcDir := t.TempDir()
+
+	writeFile := func(rel, content string) {
+		p := filepath.Join(srcDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile("bin/nftban-core", "binary-core")
+	writeFile("bin/nftband", "binary-daemon")
+	writeFile("bin/nftban-validate", "binary-validate")
+	writeFile("bin/nftban-installer", "binary-installer")
+	writeFile("cli/sbin/nftban", "cli-entry")
+	writeFile("install/config/nftban.conf", "base config")
+	writeFile("install/config/nftban.logrotate", "logrotate rules")
+	writeFile("install/systemd/tmpfiles.d/nftban.conf", "tmpfiles rules")
+	return srcDir
+}
+
+func TestStageAll_StagesFromRealTree(t *testing.T) {
+	srcDir := setupFakeSrcTree(t)
+
+	mock := executor.NewMockExecutor()
+	// Mark the srcDir as existing in mock so StageAll passes its FileExists gate.
+	mock.Dirs[srcDir] = true
+	// Mark individual source files as existing in the mock view too. stageSingleFile
+	// uses exec.FileExists before ReadFile.
+	for _, rel := range []string{
+		"bin/nftban-core", "bin/nftband", "bin/nftban-validate", "bin/nftban-installer",
+		"cli/sbin/nftban", "install/config/nftban.conf", "install/config/nftban.logrotate",
+		"install/systemd/tmpfiles.d/nftban.conf",
+	} {
+		abs := filepath.Join(srcDir, rel)
+		data, _ := os.ReadFile(abs)
+		mock.Files[abs] = data
+	}
+
+	if err := StageAll(mock, srcDir, &detect.DistroInfo{ID: "ubuntu"}, newTestLogger()); err != nil {
+		t.Fatalf("StageAll returned error: %v", err)
+	}
+
+	// Verify critical destinations were written
+	critical := []string{
+		"/usr/lib/nftban/bin/nftban-core",
+		"/usr/lib/nftban/bin/nftband",
+		"/usr/lib/nftban/bin/nftban-validate",
+		"/usr/lib/nftban/bin/nftban-installer",
+		"/usr/sbin/nftban",
+		"/etc/nftban/nftban.conf",
+		"/etc/logrotate.d/nftban",
+		"/usr/lib/tmpfiles.d/nftban.conf",
+	}
+	for _, dst := range critical {
+		if _, ok := mock.WrittenFiles[dst]; !ok {
+			t.Errorf("expected %s to be written, but was not", dst)
+		}
+	}
+}
+
+func TestStageAll_OperatorConfigPreserved(t *testing.T) {
+	srcDir := setupFakeSrcTree(t)
+
+	mock := executor.NewMockExecutor()
+	mock.Dirs[srcDir] = true
+	// Pre-seed an existing /etc/nftban/nftban.conf with operator edits
+	mock.Files["/etc/nftban/nftban.conf"] = []byte("operator edits here")
+	abs := filepath.Join(srcDir, "install/config/nftban.conf")
+	data, _ := os.ReadFile(abs)
+	mock.Files[abs] = data
+
+	if err := StageAll(mock, srcDir, &detect.DistroInfo{ID: "ubuntu"}, newTestLogger()); err != nil {
+		t.Fatalf("StageAll returned error: %v", err)
+	}
+
+	// noreplace policy must preserve the existing content — no write.
+	if _, wrote := mock.WrittenFiles["/etc/nftban/nftban.conf"]; wrote {
+		t.Errorf("operator-edited nftban.conf was overwritten (noreplace policy violated)")
+	}
+}

--- a/internal/installer/safety/whitelist.go
+++ b/internal/installer/safety/whitelist.go
@@ -1,0 +1,238 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer Safety Whitelist Seeding (PR-14-pre G-14-H)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-safety"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Seed /etc/nftban/whitelist.d/99-manual.conf with system IPs for source install"
+// meta:inventory.files="internal/installer/safety/whitelist.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="SSH_CLIENT"
+// meta:inventory.config_files="/etc/nftban/whitelist.d/99-manual.conf"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Why this package exists:
+//
+// Package installs (RPM/DEB) ship the 99-manual.conf template as a
+// %config(noreplace) / conffile entry. On fresh installs, the template is
+// dropped unchanged (header comments only) and is populated later by the
+// operator or by the legacy install_services.sh install_safety_whitelist()
+// helper when source-installed.
+//
+// Source install via --source has no shell helper. This package runs during
+// phaseConfigure (gated behind pd.source) to seed the same IPs that
+// install_safety_whitelist does: interface IPs + SSH-client IP. The
+// authoritative SSH-port safety path stays separate — switchop.InjectEmergencySSH
+// handles port-level protection in phaseSwitch; this package only touches the
+// IP-level whitelist file.
+//
+// Operator content is authoritative: if 99-manual.conf already exists with
+// any non-comment content, SeedManualWhitelist is a no-op and the operator's
+// content is preserved.
+//
+// =============================================================================
+
+package safety
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// manualWhitelistPath is the canonical path for operator-owned IP whitelist
+// entries. Per invariant #9, installer code reads this path only to detect
+// "file exists and non-empty" idempotency — it never rewrites an existing
+// operator-edited file.
+const manualWhitelistPath = "/etc/nftban/whitelist.d/99-manual.conf"
+
+// manualWhitelistHeader is the canonical header written to newly-seeded files.
+// Matches the shipped template shape so operators see a consistent format
+// whether they got the file via package install or source install.
+//
+// Note: the shipped package template carries a license header; this seeded
+// variant intentionally omits one because, once seeded, the file becomes
+// operator-owned content (not a product artifact). Operators who want a
+// license marker in their own whitelist may add one.
+const manualWhitelistHeader = `# =============================================================================
+# NFTBan Manual Whitelist - User-Added IPs
+# =============================================================================
+#
+# Seeded by nftban-installer --source (v1.98.x PR-14-pre).
+# Edit freely: subsequent installer runs will not overwrite this file.
+#
+# FORMAT:  <ip_address>   # Optional comment
+# EXAMPLES:
+#   192.168.1.100        # Office gateway
+#   10.0.0.0/8           # Internal network
+#   2001:db8::1          # IPv6 host
+#
+# =============================================================================
+
+`
+
+// SeedManualWhitelist ensures /etc/nftban/whitelist.d/99-manual.conf exists
+// and contains the minimum entries needed to prevent accidental SSH lockout
+// on a fresh source install.
+//
+// Contract:
+//   - If the file exists and contains any non-comment / non-blank line, the
+//     function is a no-op: the operator's content is preserved.
+//   - If the file does not exist OR contains only header/blank lines, the
+//     function writes a new file with the canonical header + detected system
+//     IPs (interface IPs + SSH-client IP from $SSH_CLIENT if set).
+//   - File mode and ownership match the shipped template:
+//     root:nftban 0640 (the payload package will set this; this package only
+//     writes content — ownership enforcement is payload's job).
+//
+// Non-fatal: errors detecting individual IPs are logged at Debug level and
+// the seed proceeds with whatever was detected. If NO IPs are detected at
+// all, the file is still created with the header only — the operator retains
+// control and switchop.InjectEmergencySSH provides port-level protection
+// independently.
+func SeedManualWhitelist(exec executor.Executor, log *logging.Logger) error {
+	// Idempotency: if the file already has operator content, do nothing.
+	if hasOperatorContent(exec, manualWhitelistPath) {
+		log.Debug("safety.SeedManualWhitelist: %s has operator content — preserving", manualWhitelistPath)
+		return nil
+	}
+
+	// Detect IPs to seed.
+	ips := detectSystemIPs(exec, log)
+
+	// Build file content.
+	var b strings.Builder
+	b.WriteString(manualWhitelistHeader)
+	if len(ips) == 0 {
+		b.WriteString("# No system IPs auto-detected. Add entries manually as needed.\n")
+		log.Warn("safety.SeedManualWhitelist: no system IPs detected; seeding file with header only")
+	} else {
+		for _, entry := range ips {
+			fmt.Fprintf(&b, "%s   # %s\n", entry.ip, entry.comment)
+		}
+	}
+
+	// Atomic write. File mode is 0640; ownership adjusted by payload package
+	// which holds the destination contract for /etc/nftban/*.
+	if err := exec.WriteFileAtomic(manualWhitelistPath, []byte(b.String()), 0640); err != nil {
+		return fmt.Errorf("write %s: %w", manualWhitelistPath, err)
+	}
+
+	log.Info("seeded safety whitelist %s with %d IP entries", manualWhitelistPath, len(ips))
+	return nil
+}
+
+// ipEntry is one line of the manual whitelist: an IP/CIDR plus a human comment.
+type ipEntry struct {
+	ip      string
+	comment string
+}
+
+// hasOperatorContent returns true if the file exists AND contains at least
+// one line that is neither blank nor a comment. This is the "don't overwrite
+// operator edits" check.
+func hasOperatorContent(exec executor.Executor, path string) bool {
+	if !exec.FileExists(path) {
+		return false
+	}
+	data, err := exec.ReadFile(path)
+	if err != nil {
+		// Unreadable file: conservative — treat as "has content" so we don't
+		// overwrite something we can't inspect.
+		return true
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// detectSystemIPs returns a deduplicated list of interface IPs + the SSH
+// client IP (from $SSH_CLIENT). Best-effort: failures are logged at Debug
+// and skipped. Loopback and link-local addresses are excluded.
+func detectSystemIPs(exec executor.Executor, log *logging.Logger) []ipEntry {
+	seen := make(map[string]bool)
+	var out []ipEntry
+
+	add := func(ip, comment string) {
+		ip = strings.TrimSpace(ip)
+		if ip == "" || seen[ip] {
+			return
+		}
+		seen[ip] = true
+		out = append(out, ipEntry{ip: ip, comment: comment})
+	}
+
+	// 1. SSH_CLIENT env (set by sshd for interactive sessions; format:
+	//    "client_ip client_port server_port"). Present when an admin is
+	//    installing over SSH — exactly the lockout-prevention target.
+	if sshClient := os.Getenv("SSH_CLIENT"); sshClient != "" {
+		fields := strings.Fields(sshClient)
+		if len(fields) > 0 && isRoutableIP(fields[0]) {
+			add(fields[0], "SSH installer client IP (auto-detected)")
+		}
+	}
+
+	// 2. Interface IPs via Go's net package. Filters to global-unicast
+	//    addresses (no loopback, no link-local) and excludes RFC 1918-only
+	//    environments from being seeded as public addresses — the file
+	//    format doesn't distinguish, but the comment text does.
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		log.Debug("safety.SeedManualWhitelist: net.Interfaces failed: %v", err)
+		return out
+	}
+	for _, iface := range ifaces {
+		// Skip down / loopback interfaces
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			log.Debug("safety.SeedManualWhitelist: addrs for %s failed: %v", iface.Name, err)
+			continue
+		}
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip := ipnet.IP
+			if !isRoutableIP(ip.String()) {
+				continue
+			}
+			add(ip.String(), fmt.Sprintf("Interface %s IP (auto-detected)", iface.Name))
+		}
+	}
+
+	return out
+}
+
+// isRoutableIP returns true if the IP string parses cleanly and is not
+// loopback, multicast, link-local, or unspecified (0.0.0.0 / ::).
+func isRoutableIP(s string) bool {
+	ip := net.ParseIP(strings.TrimSpace(s))
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	if ip.IsMulticast() || ip.IsUnspecified() {
+		return false
+	}
+	return true
+}

--- a/internal/installer/safety/whitelist_test.go
+++ b/internal/installer/safety/whitelist_test.go
@@ -1,0 +1,193 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer Safety Whitelist Tests (PR-14-pre G-14-H)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-safety-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Tests for source-install safety whitelist seeding"
+// meta:inventory.files="internal/installer/safety/whitelist_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="SSH_CLIENT"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package safety
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("", false)
+}
+
+// onlyHeaderContent returns what the seeded file looks like when no IPs are
+// detected — header + "no system IPs auto-detected" line. Used as a sentinel
+// for "file was just seeded, not populated by operator."
+const onlyHeaderContent = manualWhitelistHeader + "# No system IPs auto-detected. Add entries manually as needed.\n"
+
+func TestSeedManualWhitelist_CreatesFileWhenAbsent(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// File does not exist
+	t.Setenv("SSH_CLIENT", "") // ensure deterministic (no env leakage)
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	written, ok := mock.WrittenFiles[manualWhitelistPath]
+	if !ok {
+		t.Fatalf("expected %s to be written, but no atomic write recorded", manualWhitelistPath)
+	}
+	if !strings.Contains(string(written), "NFTBan Manual Whitelist") {
+		t.Errorf("seeded file missing canonical header")
+	}
+}
+
+func TestSeedManualWhitelist_PreservesOperatorContent(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Existing file with operator content (a non-comment line)
+	mock.Files[manualWhitelistPath] = []byte(`# NFTBan Manual Whitelist - User-Added IPs
+192.168.42.99   # Operator added this
+`)
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Nothing should have been written — operator content preserved
+	if _, wrote := mock.WrittenFiles[manualWhitelistPath]; wrote {
+		t.Errorf("SeedManualWhitelist overwrote existing operator content")
+	}
+}
+
+func TestSeedManualWhitelist_SeedsWhenFileHasOnlyComments(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// File exists but only has comments and blank lines (e.g., shipped template
+	// that hasn't been populated yet)
+	mock.Files[manualWhitelistPath] = []byte(`# =============================================================================
+# NFTBan Manual Whitelist - User-Added IPs
+# =============================================================================
+#
+#   some explanation
+#
+`)
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// File should be rewritten since it had no operator content
+	if _, wrote := mock.WrittenFiles[manualWhitelistPath]; !wrote {
+		t.Errorf("SeedManualWhitelist did not seed a comments-only template")
+	}
+}
+
+func TestSeedManualWhitelist_IncludesSSHClientIP(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Set SSH_CLIENT env — simulating admin session
+	t.Setenv("SSH_CLIENT", "203.0.113.42 54321 22")
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(mock.WrittenFiles[manualWhitelistPath])
+	if !strings.Contains(content, "203.0.113.42") {
+		t.Errorf("seeded file missing SSH client IP 203.0.113.42")
+	}
+	if !strings.Contains(content, "SSH installer client IP") {
+		t.Errorf("seeded file missing expected SSH client comment")
+	}
+}
+
+func TestSeedManualWhitelist_SkipsMalformedSSHClient(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Malformed SSH_CLIENT — should not crash or add garbage
+	t.Setenv("SSH_CLIENT", "not-an-ip 0 0")
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(mock.WrittenFiles[manualWhitelistPath])
+	if strings.Contains(content, "not-an-ip") {
+		t.Errorf("seeded file contains malformed SSH client value")
+	}
+}
+
+func TestSeedManualWhitelist_SkipsLoopbackSSHClient(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	t.Setenv("SSH_CLIENT", "127.0.0.1 0 0")
+
+	if err := SeedManualWhitelist(mock, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(mock.WrittenFiles[manualWhitelistPath])
+	if strings.Contains(content, "127.0.0.1") {
+		t.Errorf("seeded file contains loopback IP (should be filtered)")
+	}
+}
+
+func TestIsRoutableIP(t *testing.T) {
+	cases := map[string]bool{
+		"8.8.8.8":         true,
+		"192.168.1.1":     true, // RFC1918 is still routable per net.IP
+		"203.0.113.42":    true,
+		"2001:db8::1":     true,
+		"127.0.0.1":       false, // loopback
+		"::1":             false, // v6 loopback
+		"169.254.1.1":     false, // link-local v4
+		"fe80::1":         false, // link-local v6
+		"224.0.0.1":       false, // multicast
+		"0.0.0.0":         false, // unspecified
+		"::":              false, // v6 unspecified
+		"not-an-ip":       false,
+		"":                false,
+		" 8.8.8.8 ":       true, // whitespace trimmed
+	}
+	for in, want := range cases {
+		if got := isRoutableIP(in); got != want {
+			t.Errorf("isRoutableIP(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestHasOperatorContent(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	// Case 1: file absent
+	if hasOperatorContent(mock, manualWhitelistPath) {
+		t.Errorf("expected false for absent file, got true")
+	}
+
+	// Case 2: only comments / blanks
+	mock.Files[manualWhitelistPath] = []byte("# header\n#\n   \n")
+	if hasOperatorContent(mock, manualWhitelistPath) {
+		t.Errorf("expected false for comments-only file, got true")
+	}
+
+	// Case 3: operator line
+	mock.Files[manualWhitelistPath] = []byte("# header\n192.168.1.1\n")
+	if !hasOperatorContent(mock, manualWhitelistPath) {
+		t.Errorf("expected true for file with operator content, got false")
+	}
+
+	// Case 4: inline comment on operator line still counts as operator content
+	mock.Files[manualWhitelistPath] = []byte("# header\n10.0.0.1  # my box\n")
+	if !hasOperatorContent(mock, manualWhitelistPath) {
+		t.Errorf("expected true for operator line with inline comment, got false")
+	}
+}
+
+// avoid unused import when the test helper isn't used directly
+var _ = newTestLogger

--- a/internal/installer/safety/whitelist_test.go
+++ b/internal/installer/safety/whitelist_test.go
@@ -29,11 +29,6 @@ func newTestLogger() *logging.Logger {
 	return logging.New("", false)
 }
 
-// onlyHeaderContent returns what the seeded file looks like when no IPs are
-// detected — header + "no system IPs auto-detected" line. Used as a sentinel
-// for "file was just seeded, not populated by operator."
-const onlyHeaderContent = manualWhitelistHeader + "# No system IPs auto-detected. Add entries manually as needed.\n"
-
 func TestSeedManualWhitelist_CreatesFileWhenAbsent(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	// File does not exist
@@ -189,5 +184,3 @@ func TestHasOperatorContent(t *testing.T) {
 	}
 }
 
-// avoid unused import when the test helper isn't used directly
-var _ = newTestLogger

--- a/internal/installer/users/ensure.go
+++ b/internal/installer/users/ensure.go
@@ -1,0 +1,207 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer User/Group Ensure (PR-14-pre G-14-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-users"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Idempotent creation of NFTBan system users/groups for source install"
+// meta:inventory.files="internal/installer/users/ensure.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Why this package exists:
+//
+// Package installs (RPM/DEB) create the nftban user and groups via maintainer
+// scripts: RPM %pre `useradd -r`, DEB postinst `adduser --system`. The Go
+// installer then runs AFTER users/groups already exist and only enforces
+// FHS permissions on already-present files.
+//
+// Source install has no package manager. Before the Go installer's Prepare
+// phase can stage payload (and before any chown can target `nftban:nftban`),
+// users and groups must be created. This package does that — idempotently,
+// so re-running is a no-op — and is called ONLY when cfg.source is true
+// from within phasePrepare.
+//
+// Behavior parity: the created users/groups match what RPM %pre and DEB
+// postinst produce today. No new users, no new groups, no new membership —
+// only source-install-path equivalence to the package path.
+//
+// =============================================================================
+
+package users
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// nftbanHome is the home directory for the nftban system user.
+// Must match what fhs.EnsureDirectories will create during Prepare.
+const nftbanHome = "/var/lib/nftban"
+
+// nftbanShell is the login shell for the nftban system user.
+// nologin prevents interactive login while still allowing systemd units
+// to run as this user.
+const nftbanShell = "/usr/sbin/nologin"
+
+// nftbanGecos is the human-readable description of the nftban user.
+const nftbanGecos = "NFTBan system user"
+
+// systemGroups are the groups that source install must ensure exist.
+// Order matters: nftban must be first because the nftban user belongs to it.
+var systemGroups = []string{
+	"nftban",
+	"nftban-auditor",
+	"nftban-panel",
+	"suricata",
+}
+
+// Ensure creates all NFTBan system users and groups idempotently.
+//
+// Creates (in order):
+//  1. system groups: nftban, nftban-auditor, nftban-panel, suricata
+//  2. nftban system user (primary group: nftban, home: /var/lib/nftban, shell: nologin)
+//  3. adds root to the nftban group (for config-read access)
+//
+// Idempotent: each step skips creation if the entity already exists. Safe to
+// run on hosts where package installs previously created the same entities.
+//
+// Returns an error only if a creation command fails on a missing entity.
+// Distro dispatch uses distro.ID (normalized by detect.DetectDistro).
+func Ensure(exec executor.Executor, distro *detect.DistroInfo, log *logging.Logger) error {
+	if distro == nil {
+		return fmt.Errorf("users.Ensure: distro info is nil (Detect phase must run first)")
+	}
+
+	family := distroFamily(distro.ID)
+	log.Debug("users.Ensure: distro=%s family=%s", distro.ID, family)
+
+	// 1. Groups
+	for _, group := range systemGroups {
+		if exec.GroupExists(group) {
+			log.Debug("users.Ensure: group %s already exists (skip)", group)
+			continue
+		}
+		if err := createGroup(exec, family, group, log); err != nil {
+			return fmt.Errorf("create group %s: %w", group, err)
+		}
+		log.Info("created system group: %s", group)
+	}
+
+	// 2. nftban user
+	if !exec.UserExists("nftban") {
+		if err := createNftbanUser(exec, family, log); err != nil {
+			return fmt.Errorf("create nftban user: %w", err)
+		}
+		log.Info("created system user: nftban")
+	} else {
+		log.Debug("users.Ensure: user nftban already exists (skip)")
+	}
+
+	// 3. root → nftban group
+	if err := ensureRootInNftbanGroup(exec, log); err != nil {
+		// Non-fatal: root can still function without being in the group on most
+		// hosts. Log and continue.
+		log.Warn("could not add root to nftban group: %v", err)
+	}
+
+	return nil
+}
+
+// distroFamily classifies the distro ID into "debian" or "rhel".
+// Returns "debian" for debian/ubuntu, "rhel" for rhel/centos/fedora/rocky/almalinux.
+// Unknown distros fall back to "rhel" behavior (useradd/groupadd are more portable
+// than adduser/addgroup, which is Debian-specific).
+func distroFamily(id string) string {
+	switch strings.ToLower(id) {
+	case "debian", "ubuntu":
+		return "debian"
+	case "rhel", "centos", "fedora", "rocky", "almalinux":
+		return "rhel"
+	default:
+		return "rhel"
+	}
+}
+
+// createGroup creates a system group using the distro-appropriate command.
+func createGroup(exec executor.Executor, family, group string, log *logging.Logger) error {
+	var res executor.Result
+	switch family {
+	case "debian":
+		res = exec.Run("addgroup", "--system", group)
+	default: // rhel and fallback
+		res = exec.Run("groupadd", "--system", group)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("exit %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+// createNftbanUser creates the nftban system user with the canonical shape.
+//
+// Debian/Ubuntu uses adduser (Debian-specific wrapper around useradd).
+// RHEL-family uses useradd directly with -r (system user) + -g nftban
+// (primary group must already exist — the group creation step above ensures it).
+func createNftbanUser(exec executor.Executor, family string, log *logging.Logger) error {
+	var res executor.Result
+	switch family {
+	case "debian":
+		res = exec.Run("adduser",
+			"--system",
+			"--group",
+			"--home", nftbanHome,
+			"--no-create-home",
+			"--disabled-login",
+			"--gecos", nftbanGecos,
+			"nftban",
+		)
+	default: // rhel and fallback
+		res = exec.Run("useradd",
+			"-r",
+			"-g", "nftban",
+			"-d", nftbanHome,
+			"-s", nftbanShell,
+			"-c", nftbanGecos,
+			"nftban",
+		)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("exit %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+// ensureRootInNftbanGroup adds the root user to the nftban group if not
+// already a member. Idempotent. Non-fatal on failure (caller decides).
+func ensureRootInNftbanGroup(exec executor.Executor, log *logging.Logger) error {
+	// Check current membership via `id -nG root`.
+	res := exec.Run("id", "-nG", "root")
+	if res.ExitCode == 0 {
+		for _, g := range strings.Fields(res.Stdout) {
+			if g == "nftban" {
+				log.Debug("users.Ensure: root already in nftban group (skip)")
+				return nil
+			}
+		}
+	}
+
+	// Add root to nftban group via usermod -a -G.
+	add := exec.Run("usermod", "-a", "-G", "nftban", "root")
+	if add.ExitCode != 0 {
+		return fmt.Errorf("usermod exit %d: %s", add.ExitCode, strings.TrimSpace(add.Stderr))
+	}
+	log.Info("added root to nftban group")
+	return nil
+}

--- a/internal/installer/users/ensure_test.go
+++ b/internal/installer/users/ensure_test.go
@@ -1,0 +1,197 @@
+// =============================================================================
+// NFTBan v1.98.x - Installer User/Group Ensure Tests (PR-14-pre G-14-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-users-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Tests for source-install user/group creation"
+// meta:inventory.files="internal/installer/users/ensure_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package users
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("", false)
+}
+
+// countCommand returns how many times the mock saw a given command name.
+func countCommand(mock *executor.MockExecutor, name string) int {
+	n := 0
+	for _, c := range mock.Commands {
+		if c.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// hasArg returns true if any invocation of name includes the given arg.
+func hasArg(mock *executor.MockExecutor, name, arg string) bool {
+	for _, c := range mock.Commands {
+		if c.Name != name {
+			continue
+		}
+		for _, a := range c.Args {
+			if a == arg {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestEnsure_DebianFamily_CreatesAllEntities(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Nothing exists yet — fresh VM state
+	mock.ExistingCommands["addgroup"] = true
+	mock.ExistingCommands["adduser"] = true
+	mock.ExistingCommands["usermod"] = true
+	mock.ExistingCommands["id"] = true
+
+	distro := &detect.DistroInfo{ID: "ubuntu", VersionID: "24.04"}
+	if err := Ensure(mock, distro, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 4 groups created (via addgroup --system)
+	if got := countCommand(mock, "addgroup"); got != 4 {
+		t.Errorf("addgroup: got %d calls, want 4", got)
+	}
+	// 1 user created (via adduser)
+	if got := countCommand(mock, "adduser"); got != 1 {
+		t.Errorf("adduser: got %d calls, want 1", got)
+	}
+	// 1 usermod -a -G to add root to nftban
+	if !hasArg(mock, "usermod", "-a") || !hasArg(mock, "usermod", "-G") {
+		t.Errorf("usermod -a -G not invoked")
+	}
+	// Debian-family: must NOT invoke useradd or groupadd
+	if countCommand(mock, "useradd") != 0 {
+		t.Errorf("debian family unexpectedly used useradd")
+	}
+	if countCommand(mock, "groupadd") != 0 {
+		t.Errorf("debian family unexpectedly used groupadd")
+	}
+}
+
+func TestEnsure_RHELFamily_CreatesAllEntities(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.ExistingCommands["groupadd"] = true
+	mock.ExistingCommands["useradd"] = true
+	mock.ExistingCommands["usermod"] = true
+	mock.ExistingCommands["id"] = true
+
+	distro := &detect.DistroInfo{ID: "almalinux", VersionID: "9"}
+	if err := Ensure(mock, distro, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := countCommand(mock, "groupadd"); got != 4 {
+		t.Errorf("groupadd: got %d calls, want 4", got)
+	}
+	if got := countCommand(mock, "useradd"); got != 1 {
+		t.Errorf("useradd: got %d calls, want 1", got)
+	}
+	// RHEL-family: must NOT invoke adduser/addgroup (Debian-specific)
+	if countCommand(mock, "adduser") != 0 {
+		t.Errorf("rhel family unexpectedly used adduser")
+	}
+	if countCommand(mock, "addgroup") != 0 {
+		t.Errorf("rhel family unexpectedly used addgroup")
+	}
+}
+
+func TestEnsure_Idempotent_SkipsExisting(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// All groups + user already exist — e.g., re-running after a prior install
+	for _, g := range systemGroups {
+		mock.Groups[g] = true
+	}
+	mock.Users["nftban"] = true
+	// Simulate root already in nftban group so usermod is skipped.
+	// Mock.RunResults is keyed by "name:arg1:arg2".
+	mock.RunResults["id:-nG:root"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   "root wheel nftban",
+	}
+
+	distro := &detect.DistroInfo{ID: "ubuntu", VersionID: "24.04"}
+	if err := Ensure(mock, distro, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Nothing should have been created
+	if got := countCommand(mock, "addgroup"); got != 0 {
+		t.Errorf("idempotent run still called addgroup %d times", got)
+	}
+	if got := countCommand(mock, "adduser"); got != 0 {
+		t.Errorf("idempotent run still called adduser %d times", got)
+	}
+	if got := countCommand(mock, "usermod"); got != 0 {
+		t.Errorf("idempotent run still called usermod %d times", got)
+	}
+}
+
+func TestEnsure_NilDistro_ReturnsError(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	err := Ensure(mock, nil, newTestLogger())
+	if err == nil {
+		t.Fatalf("expected error for nil distro, got nil")
+	}
+}
+
+func TestEnsure_UnknownDistro_FallsBackToRHEL(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.ExistingCommands["groupadd"] = true
+	mock.ExistingCommands["useradd"] = true
+	mock.ExistingCommands["usermod"] = true
+	mock.ExistingCommands["id"] = true
+
+	// Unknown distro should fall through to rhel-family commands (more portable)
+	distro := &detect.DistroInfo{ID: "exotic-linux", VersionID: "1.0"}
+	if err := Ensure(mock, distro, newTestLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if countCommand(mock, "groupadd") != 4 {
+		t.Errorf("unknown distro did not fall back to groupadd")
+	}
+	if countCommand(mock, "adduser") != 0 {
+		t.Errorf("unknown distro used adduser (debian-only)")
+	}
+}
+
+func TestDistroFamily(t *testing.T) {
+	cases := map[string]string{
+		"debian":    "debian",
+		"ubuntu":    "debian",
+		"UBUNTU":    "debian", // case-insensitive
+		"rhel":      "rhel",
+		"centos":    "rhel",
+		"fedora":    "rhel",
+		"rocky":     "rhel",
+		"almalinux": "rhel",
+		"arch":      "rhel", // unknown fallback
+		"":          "rhel",
+	}
+	for id, want := range cases {
+		if got := distroFamily(id); got != want {
+			t.Errorf("distroFamily(%q) = %q, want %q", id, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements `V198_PR14_PRE_SOURCE_INSTALL_SPEC.md`. Closes the nine Go-installer gaps (G-14-A through G-14-I) that block PR-14 (≤20-line `install.sh` bootstrap) by making `nftban-installer --source --mode=install` produce the same end-state as a fresh RPM/DEB install.

## What this PR does

**Four new installer packages** (all gated behind `cfg.source` — package installs are byte-for-byte unchanged):

- **`internal/installer/users/`** (G-14-A) — idempotent creation of nftban/nftban-auditor/nftban-panel/suricata groups + nftban system user + root-in-nftban membership. Distro dispatch: adduser/addgroup on Debian/Ubuntu, useradd/groupadd on RHEL-family.
- **`internal/installer/payload/`** (G-14-B..G) — staging of 287 files from repo/tarball to FHS destinations. Data-driven entry table encodes the destination contract from spec §3.2: Go binaries, CLI sbin + shell modules, /etc/nftban configs with `%config(noreplace)` semantics, systemd units, tmpfiles.d, distro-conditional polkit rules, canonical logrotate config. `.conf.local` invariant #9 enforced at two layers. UI staging marked with `REMOVE-IN-V2.0.0` comments for mechanical PR-D4 deletion.
- **`internal/installer/safety/`** (G-14-H) — seeds `/etc/nftban/whitelist.d/99-manual.conf` with auto-detected SSH-client IP + interface IPs. Respects operator content (no-op if file has non-comment lines).
- **`--source` flag + phaseData plumbing** (G-14-I) in `cmd/nftban-installer/{flags,phases,main}.go`. Mutually exclusive with `--rpm`/`--deb`, validated at parseFlags with exit ExitFatal. Source-dir resolution: `--source-dir` > `NFTBAN_SOURCE_DIR` env > binary-relative discovery.

**Phase integration:** exactly two `if pd.source { ... }` branches — `users.Ensure` at start of Prepare; `payload.StageAll` after `fhs.EnsureDirectories` (so destination parents exist) and before `fhs.SetPermissions`; `safety.SeedManualWhitelist` in Configure before `SyncWhitelist`.

**Bonus wins:**
- G-14-G logrotate staging uses the canonical `install/config/nftban.logrotate`, resolving the pre-existing source-install-logrotate drift that `install_services.sh` produced via its wildcard auto-generator (flagged months ago in `LOG_ROTATION_DOCS_CODE_ALIGNMENT.md`).
- UI-related entries carry `REMOVE-IN-V2.0.0` markers so `grep -r REMOVE-IN-V2.0.0` gives PR-D4 the exact deletion map.

## Lab integration test — both distros, clean snapshots

Tested on **lab2 (Ubuntu 24.04 / Plesk / DEB)** and **lab4 (AlmaLinux 9 / cPanel / RPM)** after rolling both to clean snapshots with zero NFTBan state.

### Clean install (P1-P12 parity — all green)

| Metric | lab2 (DEB) | lab4 (RPM) |
|---|---|---|
| Phase progression | Detect → Prepare → Switch → Configure → Validate | ✅ same |
| Payload wrote/skipped/failed | **287 / 3 / 0** | **287 / 3 / 0** |
| Post-install assertions | 8/8 | 8/8 |
| Final state | COMMITTED / PROTECTED / NFTBAN | ✅ same |
| `/usr/lib/nftban` file count | 196 | 196 |
| `/etc/nftban` file count | 38 | 38 |
| `/usr/lib/nftban/cli` + `/core` + `/helpers` + `/sbin` | 78/60/8/7 | 78/60/8/7 |
| systemd units installed | 51 | 51 |
| NB-5 `/usr/sbin/nftban` perms | `root:nftban 0750` | `root:nftban 0750` |
| Polkit rules destination | `/usr/share/polkit-1/rules.d/` (Debian-style) | `/etc/polkit-1/rules.d/` (RHEL-style) |
| Safety whitelist seeded | SSH client + eth0 v4+v6 | SSH client + eth0 v4+v6 |
| Logrotate installed | canonical 7379 B | canonical 7379 B |
| Daemon + nftables | active + active | active + active |
| Wall-clock | 16 s | 39 s |

### Idempotency re-run (zero writes on second run)

| Run | lab2 wrote/skipped/failed | lab4 wrote/skipped/failed |
|---|---|---|
| 1st (clean install) | 287 / 3 / 0 | 287 / 3 / 0 |
| **2nd (same hosts, re-run)** | **0 / 290 / 0** | **0 / 290 / 0** |

copyIfChanged semantics verified: every file byte-identical, every check marked skip-unchanged. Both hosts remain COMMITTED / PROTECTED after re-run.

## Iteration history — bugs caught and fixed during lab testing

The lab integration test surfaced three real bugs not caught by unit tests:

1. **`605842b5` → `3bb91f68`:** Initial phase ordering put `payload.StageAll` BEFORE `fhs.EnsureDirectories`, causing 225 writes to fail (destination parent dirs didn't exist). Fixed by splitting gated branches — `users.Ensure` at start of Prepare, `payload.StageAll` after `fhs.EnsureDirectories`.
2. **Same commit:** `/etc/nftban/nftables.conf` template was missing from payload entry table. `render.RenderNftablesConf` reads this file (template with `__SSH_PORT__` placeholders), substitutes, and writes back — source install couldn't get past Prepare step 6. Added entry sourcing from `install/nftables/nftables.conf`.
3. **`3bb91f68` → `828e375d`:** Even with correct ordering, 193 writes still failed because `fhs.EnsureDirectories` does not create every payload-destination subdirectory (missing: `/usr/lib/nftban/{cli,core,helpers,lib,data,health,sbin}`, `/etc/nftban/templates`). Fixed by adding defensive `exec.MkdirAll(filepath.Dir(dst), 0755)` in `copyIfChanged` — payload becomes self-sufficient regardless of fhs registry coverage.
4. **`8c8e9c94` staticcheck cleanup** (`fcc5bbd1`): unused const `onlyHeaderContent` in safety test. Pure cleanup.

Each bug was caught, diagnosed, fixed, and re-verified on both labs before marking this PR ready.

## Mystery observation — resolved benign

The evidence pass found one `.conf.local` file on both labs post-install:

- Path: `/etc/nftban/nftban.conf.local` (65 bytes, `root:root 640`)
- Content: `# NFTBan local overrides (machine-generated entries)\nSSH_PORT=22`
- Created timestamp: **AFTER** the installer COMMITTED state, during/after the idempotency re-run
- **Zero mentions in `/var/log/nftban/installer.log` on either host**
- Identical filename and content on lab2 (DEB) and lab4 (RPM)

**Verdict: NOT created by PR-14-pre.** This is pre-existing post-install behavior (likely `nftban-maintenance.service` 15-minute timer or daemon startup writing SSH port detection to `.conf.local` for safety monitoring). Would appear identically on a package install and is explicitly *not* installer-touched per invariant #9. Documenting here as a resolved observation, not a regression.

**Bonus verification:** the repo tree contains `etc/nftban/conf.d/rbl/main.conf.local` (tracked in git). My payload correctly **skipped** it — it's not present at `/etc/nftban/conf.d/rbl/main.conf.local` on either lab after install. Two layers of defense (`*.conf` glob + `isConfigLocal` filter) worked.

## Non-blocking findings

1. **`/usr/sbin/nftban-ui` ownership drift**: `root:root 750` instead of the spec-ideal `root:nftban 0750`. Cause: no fhs.SetPermissions registry entry for this path (it's on v2.0.0 death row anyway). Not blocking — PR-D4 removes this entry entirely rather than fixing ownership.
2. **`nftban status --json` stdout empty on lab check**: runtime CLI oddity, not an installer issue. Validator reached PROTECTED internally (confirmed via daemon logs and `systemctl is-active`).

Neither is a v1.98.x closure blocker.

## Gating discipline — CI verifiable

Every call site of `users.*`, `payload.*`, `safety.*` is lexically inside an `if pd.source` block. Regression guard grep:

```bash
$ grep -rE 'users\.Ensure|payload\.StageAll|safety\.SeedManualWhitelist' cmd/nftban-installer/ internal/installer/
# Only 3 call sites, all inside gated branches in cmd/nftban-installer/phases.go
```

Package installs (`--rpm` / `--deb`, `cfg.source == false`) never reach any of the new code. RPM+DEB install tests on 8 distro matrix (alma9, centos-stream9, centos-stream10, rocky9, ubuntu22.04, ubuntu24.04, debian12, debian13) all pass in CI as regression coverage.

## Commits

| SHA | Scope |
|---|---|
| `5cb36db5` | G-14-I: `--source` flag + phaseData plumbing |
| `8c8e9c94` | G-14-A: `internal/installer/users/` |
| `0c40a0ac` | G-14-H: `internal/installer/safety/` |
| `45ad547e` | G-14-B..G: `internal/installer/payload/` |
| `605842b5` | Phase wiring (users + payload + safety) |
| `fcc5bbd1` | staticcheck cleanup (unused test const) |
| `3bb91f68` | Lab-test fix 1: phase ordering + missing `nftables.conf` entry |
| `828e375d` | Lab-test fix 2: MkdirAll defensive parent-dir creation |

~1,800 LOC Go across 8 commits. All CI gates green. Lab-verified on both distros with parity + idempotency.

## What remains for PR-14 (separate, follows this)

With PR-14-pre merged, the bootstrap `install.sh` can be reduced to ≤20 lines:

```bash
#!/usr/bin/env bash
set -Eeuo pipefail
[[ $EUID -eq 0 ]] || { echo "Error: install.sh must run as root" >&2; exit 1; }
[[ "$(uname -s)" == "Linux" ]] || { echo "Error: Linux only" >&2; exit 1; }
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
INSTALLER="$SCRIPT_DIR/bin/nftban-installer"
[[ ! -x "$INSTALLER" ]] && INSTALLER="/usr/lib/nftban/bin/nftban-installer"
[[ -x "$INSTALLER" ]] || { echo "Error: nftban-installer not found" >&2; exit 1; }
export NFTBAN_SOURCE_DIR="$SCRIPT_DIR"
exec "$INSTALLER" --source --mode=install "\$@"
```

(Final body line count ~10-15 lines, well within the ≤20-line spec target.)

## References

- `V198_PR14_PRE_SOURCE_INSTALL_SPEC.md` — the contract this PR implements
- `V198_PR14_BOOTSTRAP_SPEC.md` — the PR-14 target this unblocks
- `V198_PR14_MAPPING_WALKTHROUGH.md` — the walkthrough that found the 9 gaps
- PR #461 (MERGED) — soak tooling + NB-5 packaging fix (closure-support for v1.98.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)