### PR TITLE
v1.98.x PR-14: reduce install.sh to ≤20-line bootstrap

### DIFF
--- a/cli/lib/nftban/README.md
+++ b/cli/lib/nftban/README.md
@@ -63,12 +63,14 @@ cli/              <- Repo organization: "Bash CLI component" (vs pkg/ for Go)
 
 ## Install Script Reference
 
-From `install_binaries.sh`:
-```bash
-cp -r "$SCRIPT_DIR/cli/lib/nftban/lib/"* "$LIB_DIR/lib/"
-cp -r "$SCRIPT_DIR/cli/lib/nftban/cli/"* "$LIB_DIR/cli/"
-cp -r "$SCRIPT_DIR/cli/lib/nftban/core/"* "$LIB_DIR/core/"
-# ... etc
-```
+Source-install payload staging is implemented in the Go installer at
+`internal/installer/payload/` (PR-14-pre, PR #462). The destination
+contract (source path → FHS destination, mode, overwrite policy) lives
+in a single data-driven entry table in
+`internal/installer/payload/payload.go` `buildEntries()`.
 
-Where `$LIB_DIR=/usr/lib/nftban`
+For package installs (RPM/DEB) the same destinations are populated by
+the package payload; see `packaging/build_nftban.sh` `%install` and the
+DEB `deb_root` install blocks.
+
+Where `$LIB_DIR=/usr/lib/nftban`.

--- a/cli/lib/nftban/cli/cmd_selftest.sh
+++ b/cli/lib/nftban/cli/cmd_selftest.sh
@@ -559,11 +559,8 @@ nftban_selftest_verify_configs() {
         else
             ((++failed))
         fi
-        if _verify_install_configs_sources "$project_root"; then
-            ((++passed))
-        else
-            ((++failed))
-        fi
+        # PR-14: legacy config-source verification removed. Source-install
+        # payload staging is canonical now (Go installer --source, PR #462).
         if _verify_build_script_sources "$project_root"; then
             ((++passed))
         else
@@ -716,54 +713,6 @@ _verify_conffiles_sources() {
 
     echo ""
     printf "  Checked: %d entries, Errors: %d\n" "$checked" "$errors"
-
-    [[ $errors -eq 0 ]]
-}
-
-_verify_install_configs_sources() {
-    local project_root="$1"
-    local install_configs="${project_root}/install_configs.sh"
-
-    echo "CHECK: install_configs.sh Source Verification"
-    echo "───────────────────────────────────────────────────────────────"
-
-    if [[ ! -f "$install_configs" ]]; then
-        echo "  ⚠️  SKIP: install_configs.sh not found: $install_configs"
-        return 0
-    fi
-
-    local errors=0
-    local checked=0
-    local line=""
-    local relative_path=""
-    local source_path=""
-
-    # Extract _install_config_file calls and check sources exist
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        # Skip function definition line and comments
-        [[ "$line" == _install_config_file\(\)* ]] && continue
-        [[ "$line" =~ ^[[:space:]]*# ]] && continue
-
-        # Match: _install_config_file "$SCRIPT_DIR/path/to/file" ...
-        # Extract the path after $SCRIPT_DIR/
-        if [[ "$line" == *'_install_config_file "$SCRIPT_DIR/'* ]]; then
-            # Extract path between $SCRIPT_DIR/ and the next "
-            relative_path="${line#*\$SCRIPT_DIR/}"
-            relative_path="${relative_path%%\"*}"
-            source_path="${project_root}/${relative_path}"
-
-            ((checked++)) || true
-            if [[ -f "$source_path" ]]; then
-                printf "     ✅ %s\n" "$relative_path"
-            else
-                printf "     ❌ MISSING: %s\n" "$relative_path"
-                ((errors++)) || true
-            fi
-        fi
-    done < "$install_configs"
-
-    echo ""
-    printf "  Checked: %d files, Errors: %d\n" "$checked" "$errors"
 
     [[ $errors -eq 0 ]]
 }

--- a/cli/lib/nftban/core/nftban_login_alert.sh
+++ b/cli/lib/nftban/core/nftban_login_alert.sh
@@ -1090,8 +1090,10 @@ nftban_login_track_failed() {
                 else
                     nftban_login_alert_log "Banning IP $ip for ${ban_reason}"
 
-                    # Use NFTBAN_BIN from central config (set during install by install_configs.sh)
-                    # Config is single source of truth - no runtime detection
+                    # Use NFTBAN_BIN from central config (set during install
+                    # by the installer's Configure phase — RPM/DEB scriptlets
+                    # or the Go installer's --source payload staging).
+                    # Config is single source of truth - no runtime detection.
                     local nftban_cmd="${NFTBAN_BIN:-/usr/sbin/nftban}"
 
                     # Pre-flight checks with clear error messages

--- a/install.sh
+++ b/install.sh
@@ -1,401 +1,67 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090  # Dynamic paths, cannot follow
 # =============================================================================
-# NFTBan v1.9.3 - Installation Script (Loader)
+# NFTBan v1.98.x - Installation Bootstrap (≤20-line entry point)
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
-# Purpose: Install NFTBan on the local system
+# Purpose: Thin bootstrap that hands off to the Go installer for source install
 #
 # meta:name="nftban_install"
 # meta:type="cli"
-# meta:header="NFTBan Installer"
-# meta:version="1.7.0"
+# meta:header="NFTBan Installer Bootstrap"
+# meta:version="1.98.0"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 # meta:homepage="https://nftban.com"
 #
-# **Description & Purpose**
-# meta:description="Main installation script for NFTBan firewall management system (loader)"
-# meta:input="Interactive prompts for configuration options"
-# meta:output="Installed NFTBan system with binaries, configs, and systemd units"
-# meta:depends="bash,curl,systemctl,useradd,chmod,chown,mkdir,cp,ln"
+# meta:description="Thin bootstrap: root+Linux preflight, locate nftban-installer, exec --source"
+# meta:input="CLI args forwarded to nftban-installer"
+# meta:output="Exec'd nftban-installer process (see /var/log/nftban/installer.log)"
+# meta:depends="bash"
 # meta:created_date="2025-10-26"
-# meta:updated_date="2026-02-04"
+# meta:updated_date="2026-04-19"
 #
-# **Inventory & Requirements**
 # meta:inventory.files=""
-# meta:inventory.binaries="curl,systemctl,useradd,groupadd,chmod,chown,mkdir,cp,ln,tput,id"
-# meta:inventory.env_vars=""
-# meta:inventory.config_files="/etc/nftban/nftban.conf"
-# meta:inventory.systemd_units="nftban.service,nftban-watchdog.timer,nftban-queue.timer"
+# meta:inventory.binaries="nftban-installer"
+# meta:inventory.env_vars="NFTBAN_SOURCE_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="root"
 #
-# Installs:
-#   - Go binaries (nftban-core, nftband, nftban-ui)
-#   - CLI modules and libraries
-#   - Polkit rules
-#   - Systemd timers
-#   - NFTables base config
-#   - GeoIP database (free)
+# =============================================================================
+# PR-14: bootstrap reduction
+#
+# Previously 401 lines of orchestration (install_dependencies,
+# create_users_groups, install_core, install_cli, install_libraries,
+# install_completion, install_configs, install_nftables, install_tmpfiles,
+# install_polkit, install_logrotate, install_systemd, download_geoip_database,
+# auto-enable-features, ...).
+#
+# All of that logic now lives in the Go installer's phaseDetect/Prepare/Switch/
+# Configure/Validate with the --source flag (PR-14-pre / PR #462). This
+# bootstrap is a thin handoff: preflight checks + locate the installer
+# binary + exec.
+#
+# Non-goals (strict — review rejects violations):
+#   - No installer logic (users/groups, payload copy, systemd enable, etc.)
+#   - No fallback logic ("if Go fails, do X the old way")
+#   - No config decisions (sed/interactive prompts)
+#   - No lifecycle branching (detect install vs upgrade — Go does that)
+#   - No authority expansion (systemctl disable, package removal, nft flushes)
 # =============================================================================
 
 set -Eeuo pipefail
 
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+[[ $EUID -eq 0 ]] || { echo "Error: install.sh must run as root" >&2; exit 1; }
+[[ "$(uname -s)" == "Linux" ]] || { echo "Error: Linux only" >&2; exit 1; }
 
-log()   { echo -e "${BLUE}[INSTALL]${NC} $*"; }
-ok()    { echo -e "${GREEN}[  OK   ]${NC} $*"; }
-warn()  { echo -e "${YELLOW}[ WARN  ]${NC} $*"; }
-error() { echo -e "${RED}[ ERROR ]${NC} $*" >&2; }
-info()  { echo -e "${CYAN}[  INFO ]${NC} $*"; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$SCRIPT_DIR/bin/nftban-installer"
+[[ -x "$INSTALLER" ]] || INSTALLER="/usr/lib/nftban/bin/nftban-installer"
+[[ -x "$INSTALLER" ]] || {
+    echo "Error: nftban-installer not found." >&2
+    echo "Run: $SCRIPT_DIR/install/download-binaries.sh" >&2
+    exit 1
+}
 
-# Get script directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || SCRIPT_DIR="$(pwd)"
-cd "$SCRIPT_DIR"
-
-# Configuration (exported for submodules)
-export BIN_DIR="$SCRIPT_DIR/bin"
-
-# Installation paths (exported for submodules)
-export CORE_BIN_DIR="/usr/lib/nftban/bin"
-export CORE_INSTALL_PATH="$CORE_BIN_DIR/nftban-core"
-export CLI_INSTALL_PATH="/usr/sbin/nftban"
-export GUI_INSTALL_PATH="/usr/sbin/nftban-ui"
-export LIB_DIR="/usr/lib/nftban"
-export COMPLETION_PATH="/usr/share/bash-completion/completions/nftban"
-export POLKIT_ACTIONS_DIR="/usr/share/polkit-1/actions"
-export POLKIT_RULES_DIR_SHARE="/usr/share/polkit-1/rules.d"
-export POLKIT_RULES_DIR_ETC="/etc/polkit-1/rules.d"
-
-# =============================================================================
-# MODULE LOADER
-# =============================================================================
-# Installation functions are split into separate files for maintainability:
-#
-# install_prerequisites.sh  - Prerequisite checks, firewall detection, GeoIP
-# install_binaries.sh       - Binary/CLI/library installation, users/groups
-# install_configs.sh        - Configuration files, templates, dependencies
-# install_services.sh       - Systemd units, polkit, post-install tasks
-# =============================================================================
-
-_install_modules=(
-    "install_prerequisites.sh"
-    "install_binaries.sh"
-    "install_configs.sh"
-    "install_services.sh"
-)
-
-for _module in "${_install_modules[@]}"; do
-    _module_path="${SCRIPT_DIR}/${_module}"
-    if [[ -f "$_module_path" ]]; then
-        source "$_module_path" || {
-            error "Failed to load install module: $_module"
-            exit 1
-        }
-    else
-        error "Install module not found: $_module_path"
-        exit 1
-    fi
-done
-
-# Cleanup temporary variables
-unset _install_modules _module _module_path
-
-# =============================================================================
-# MAIN INSTALLATION LOGIC
-# =============================================================================
-
-# Installation flags (can be set via CLI or environment)
-SKIP_XTABLES_FIX="${NFTBAN_SKIP_XTABLES_FIX:-0}"
-NFTBAN_QUIET="${NFTBAN_QUIET:-0}"
-
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --help|-h|help)
-            show_usage
-            exit 0
-            ;;
-        --quiet|--yes|-y)
-            NFTBAN_QUIET=1
-            shift
-            ;;
-        --skip-xtables-fix)
-            SKIP_XTABLES_FIX=1
-            shift
-            ;;
-        *)
-            warn "Unknown option: $1"
-            show_usage
-            exit 1
-            ;;
-    esac
-done
-
-# Print banner
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  NFTBan Installation"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
-
-# =============================================================================
-# STEP 1: Prerequisites
-# =============================================================================
-log "Step 1: Checking prerequisites..."
-echo ""
-
-check_prerequisites
-check_root
-check_nftables
-check_yq
-check_pam
-check_conflicting_firewalls
-
-if [[ "$SKIP_XTABLES_FIX" == "1" ]]; then
-    info "Skipping xtables compat fix (--skip-xtables-fix)"
-else
-    check_xtables_compat
-fi
-
-check_go_binaries
-
-echo ""
-
-# =============================================================================
-# STEP 2: Ask about metrics
-# =============================================================================
-ask_metrics_question
-
-# =============================================================================
-# STEP 3: Install everything
-# =============================================================================
-log "Step 2: Installing NFTBan..."
-echo ""
-
-install_dependencies || warn "Dependency installation failed (non-critical)"
-echo ""
-
-cleanup_obsolete_files || warn "Cleanup had some errors (non-critical)"
-echo ""
-
-create_users_groups || exit 1
-echo ""
-
-install_core || exit 1
-echo ""
-
-install_cli || exit 1
-echo ""
-
-install_libraries || exit 1
-echo ""
-
-install_completion || exit 1
-echo ""
-
-install_configs || exit 1
-echo ""
-
-install_nftables || exit 1
-echo ""
-
-install_safety_whitelist || warn "Auto-whitelist failed (non-critical)"
-echo ""
-
-install_tmpfiles || warn "tmpfiles.d installation failed (non-critical)"
-echo ""
-
-install_polkit || exit 1
-echo ""
-
-install_logrotate || warn "Logrotate installation failed (non-critical)"
-echo ""
-
-install_systemd || exit 1
-echo ""
-
-# =============================================================================
-# STEP 4: Download GeoIP database
-# =============================================================================
-download_geoip_database
-echo ""
-
-# =============================================================================
-# STEP 5: Configure metrics if enabled
-# =============================================================================
-if [[ "${NFTBAN_METRICS_ENABLED:-false}" == "true" ]]; then
-    log "Configuring metrics (${NFTBAN_METRICS_BACKEND})..."
-
-    if [[ -f /etc/nftban/nftban.conf ]]; then
-        sed -i "s/^NFTBAN_METRICS_ENABLED=.*/NFTBAN_METRICS_ENABLED=\"true\"/" /etc/nftban/nftban.conf
-        sed -i "s/^NFTBAN_METRICS_BACKEND=.*/NFTBAN_METRICS_BACKEND=\"${NFTBAN_METRICS_BACKEND}\"/" /etc/nftban/nftban.conf
-        ok "Metrics configuration updated"
-    fi
-
-    if [[ -f /etc/systemd/system/nftban-unified-exporter.timer ]]; then
-        systemctl enable --now nftban-unified-exporter.timer 2>/dev/null || true
-        ok "Unified exporter timer enabled"
-    fi
-    echo ""
-fi
-
-# =============================================================================
-# STEP 6: Auto-enable default features (login, geoip)
-# =============================================================================
-log "Enabling default features..."
-
-# Enable login monitoring
-if [[ ! -f /etc/nftban/conf.d/login_alert.conf ]]; then
-    mkdir -p /etc/nftban/conf.d
-    cat > /etc/nftban/conf.d/login_alert.conf << 'LOGIN_CONF'
-# NFTBan Login Alert Configuration
-# Auto-generated by installer
-
-# Enable login alerts (SSH, etc.)
-NFTBAN_LOGIN_ALERT_ENABLED="YES"
-
-# Alert methods: mail, webhook, both
-NFTBAN_LOGIN_ALERT_METHOD="mail"
-
-# Alert on successful logins (in addition to failures)
-NFTBAN_LOGIN_ALERT_SUCCESS="NO"
-LOGIN_CONF
-    chmod 640 /etc/nftban/conf.d/login_alert.conf
-    chown root:nftban /etc/nftban/conf.d/login_alert.conf
-fi
-
-# Enable GeoIP
-if [[ -f /etc/nftban/conf.d/geoip/main.conf ]]; then
-    if ! grep -q "^NFTBAN_GEOIP_ENABLED=" /etc/nftban/conf.d/geoip/main.conf 2>/dev/null; then
-        echo 'NFTBAN_GEOIP_ENABLED="YES"' >> /etc/nftban/conf.d/geoip/main.conf
-    fi
-fi
-if systemctl list-unit-files nftban-core-geoip.timer &>/dev/null 2>&1; then
-    systemctl enable nftban-core-geoip.timer 2>/dev/null || true
-    systemctl start nftban-core-geoip.timer 2>/dev/null || true
-    ok "GeoIP auto-update enabled"
-fi
-
-echo ""
-
-# =============================================================================
-# STEP 7: Panel Detection and Auto-Enable
-# =============================================================================
-log "Checking for web hosting panels..."
-
-PANEL_ENABLED=""
-
-# cPanel/WHM detection
-if [[ -d /usr/local/cpanel ]]; then
-    PANEL_ENABLED="cpanel"
-    ok "Detected: cPanel/WHM"
-    info "cPanel ports will be auto-whitelisted"
-fi
-
-# Plesk detection
-if [[ -d /usr/local/psa ]]; then
-    PANEL_ENABLED="plesk"
-    ok "Detected: Plesk"
-fi
-
-# DirectAdmin detection
-if [[ -d /usr/local/directadmin ]]; then
-    PANEL_ENABLED="directadmin"
-    ok "Detected: DirectAdmin"
-fi
-
-# CyberPanel detection
-if [[ -d /usr/local/CyberCP ]]; then
-    PANEL_ENABLED="cyberpanel"
-    ok "Detected: CyberPanel"
-fi
-
-if [[ -n "$PANEL_ENABLED" ]]; then
-    info "Panel integration: $PANEL_ENABLED"
-    info "Run 'nftban panel $PANEL_ENABLED enable' to configure"
-    echo ""
-else
-    ok "No web hosting panel detected (standalone server)"
-fi
-
-# Security: rpcbind exposure check
-if ss -lunpt 2>/dev/null | grep -q ':111 '; then
-    echo ""
-    warn "Security: Port 111 (rpcbind) is exposed"
-    info "Consider: nftban port block 111  OR  systemctl disable rpcbind"
-fi
-
-echo ""
-
-# =============================================================================
-# STEP 8: Post-install and verification
-# =============================================================================
-run_post_install || exit 1
-echo ""
-
-# Run verification
-log "Verifying installation..."
-if [[ -f "$SCRIPT_DIR/install/verify_installation.sh" ]]; then
-    bash "$SCRIPT_DIR/install/verify_installation.sh"
-    VERIFY_EXIT=$?
-    echo ""
-    if [[ $VERIFY_EXIT -eq 0 ]]; then
-        ok "Installation verification PASSED"
-    else
-        warn "Some verification checks failed (review output above)"
-    fi
-fi
-
-# =============================================================================
-# COMPLETE
-# =============================================================================
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  NFTBan Installation Complete!"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
-echo "Auto-enabled:"
-echo "  Login monitoring (SSH alerts)"
-echo "  GeoIP blocking"
-echo "  Core timers (health, maintenance)"
-if [[ "${NFTBAN_METRICS_ENABLED:-false}" == "true" ]]; then
-    echo "  Metrics (${NFTBAN_METRICS_BACKEND})"
-    echo "  Watchdog (system monitoring)"
-fi
-if [[ -n "${PANEL_ENABLED:-}" ]]; then
-    echo "  ${PANEL_ENABLED^} panel ports"
-fi
-echo ""
-
-# Panel-specific instructions
-if [[ -n "${PANEL_ENABLED:-}" ]]; then
-    echo "Panel commands:"
-    echo "  nftban panel $PANEL_ENABLED status   # Check panel port status"
-    echo "  nftban panel $PANEL_ENABLED test     # Test panel connectivity"
-    echo "  nftban port status                   # View all port rules"
-    echo ""
-fi
-
-echo "Enable optional features:"
-echo "  nftban feeds enable      # Threat intel feeds"
-echo "  nftban portscan enable   # Port scan detection"
-echo "  nftban ddos enable       # DDoS protection"
-echo "  nftban gui enable        # Web GUI"
-echo "  nftban suricata setup    # IDS integration"
-if [[ "${NFTBAN_METRICS_ENABLED:-false}" != "true" ]]; then
-    echo "  nftban metrics enable    # Metrics collection"
-    echo "  nftban watchdog enable   # System monitoring"
-fi
-echo ""
-echo "Check status:"
-echo "  nftban status            # System status"
-echo "  nftban health            # Health check"
-echo "  nftban port status       # Port/firewall status"
-echo ""
+export NFTBAN_SOURCE_DIR="$SCRIPT_DIR"
+exec "$INSTALLER" --source --mode=install "$@"

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -226,9 +226,10 @@ func buildEntries(distro *detect.DistroInfo) []entry {
 		{srcRel: "packaging/polkit-1/rules.d", srcGlob: "*.rules", dstGlob: polkitDst, mode: 0644, policy: policyAlways, isDir: true, optional: true},
 
 		// -----------------------------------------------------------------
-		// G-14-G: Logrotate (resolves pre-existing source-install drift —
-		// uses canonical shipped config instead of install_services.sh's
-		// auto-generated wildcard config).
+		// G-14-G: Logrotate — uses the canonical shipped config. Resolves the
+		// pre-existing source-install drift where a legacy wildcard logrotate
+		// config was auto-generated at install time (see
+		// LOG_ROTATION_DOCS_CODE_ALIGNMENT.md).
 		// -----------------------------------------------------------------
 		{srcRel: "install/config/nftban.logrotate", dstGlob: "/etc/logrotate.d/nftban", mode: 0644, policy: policyAlways},
 		{srcRel: "install/config/nftban-suricata.logrotate", dstGlob: "/etc/nftban/templates/nftban-suricata.logrotate", mode: 0644, policy: policyAlways, optional: true},

--- a/internal/installer/safety/whitelist.go
+++ b/internal/installer/safety/whitelist.go
@@ -19,16 +19,15 @@
 // Why this package exists:
 //
 // Package installs (RPM/DEB) ship the 99-manual.conf template as a
-// %config(noreplace) / conffile entry. On fresh installs, the template is
-// dropped unchanged (header comments only) and is populated later by the
-// operator or by the legacy install_services.sh install_safety_whitelist()
-// helper when source-installed.
+// %config(noreplace) / conffile entry. On fresh installs the template is
+// dropped unchanged (header comments only) and later populated either by
+// the operator or by a legacy shell helper that ran pre-canonization.
 //
 // Source install via --source has no shell helper. This package runs during
-// phaseConfigure (gated behind pd.source) to seed the same IPs that
-// install_safety_whitelist does: interface IPs + SSH-client IP. The
-// authoritative SSH-port safety path stays separate — switchop.InjectEmergencySSH
-// handles port-level protection in phaseSwitch; this package only touches the
+// phaseConfigure (gated behind pd.source) to seed the same IPs the legacy
+// flow used to: interface IPs + SSH-client IP. The authoritative SSH-port
+// safety path stays separate — switchop.InjectEmergencySSH handles
+// port-level protection in phaseSwitch; this package only touches the
 // IP-level whitelist file.
 //
 // Operator content is authoritative: if 99-manual.conf already exists with


### PR DESCRIPTION
## Summary

Replaces 401 lines of source-install orchestration in `install.sh` with a 13-line body that hands off to `nftban-installer --source` (the canonical source-install path implemented in PR-14-pre / PR #462).

Closes `V198_PR14_BOOTSTRAP_SPEC.md`. Unblocks PR-15 (pure deletion of legacy scripts).

## Before vs after

| | Before | After |
|---|---|---|
| Body lines | 401 | 13 |
| Total lines (incl. header) | 401 | 67 |
| Responsibilities | 12+ install steps + orchestration | preflight + locate + exec |
| Dependencies | `install_binaries.sh`, `install_configs.sh`, `install_services.sh` | — |

Bootstrap body:
```bash
set -Eeuo pipefail

[[ $EUID -eq 0 ]] || { echo "Error: install.sh must run as root" >&2; exit 1; }
[[ "$(uname -s)" == "Linux" ]] || { echo "Error: Linux only" >&2; exit 1; }

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
INSTALLER="$SCRIPT_DIR/bin/nftban-installer"
[[ -x "$INSTALLER" ]] || INSTALLER="/usr/lib/nftban/bin/nftban-installer"
[[ -x "$INSTALLER" ]] || {
    echo "Error: nftban-installer not found." >&2
    echo "Run: $SCRIPT_DIR/install/download-binaries.sh" >&2
    exit 1
}

export NFTBAN_SOURCE_DIR="$SCRIPT_DIR"
exec "$INSTALLER" --source --mode=install "$@"
```

## Non-goals (spec §3, strictly enforced)

- ❌ No installer logic (users/groups, payload copy, systemd enable, etc.)
- ❌ No fallback logic ("if Go fails, do X the old way")
- ❌ No config decisions (sed/interactive prompts)
- ❌ No lifecycle branching (detect install vs upgrade — Go does that)
- ❌ No authority expansion (systemctl disable, package removal, nft flushes)

Every one of these rejected behaviors now lives in the Go installer phases (Detect/Prepare/Switch/Configure/Validate) under the `--source` flag path shipped in PR #462.

## PR-15 precondition — VERIFIED at commit time

Per `V198_PR14_BOOTSTRAP_SPEC.md` §6, PR-15 requires zero external references to the three legacy scripts before pure-deletion. This PR bundles the three bundleable cleanups so PR-15 becomes one-line `git rm`:

```bash
$ grep -rFl 'install_binaries.sh' cli/ internal/ cmd/ scripts/ install/ install.sh packaging/ docs/ | wc -l
0
$ grep -rFl 'install_configs.sh'  cli/ internal/ cmd/ scripts/ install/ install.sh packaging/ docs/ | wc -l
0
$ grep -rFl 'install_services.sh' cli/ internal/ cmd/ scripts/ install/ install.sh packaging/ docs/ | wc -l
0
```

Cleanups bundled into this PR:
- `cli/lib/nftban/README.md` §"Install Script Reference": replaced stale `install_binaries.sh` doc mention with reference to the Go installer's `internal/installer/payload/` + data-driven `buildEntries()` table
- `cli/lib/nftban/cli/cmd_selftest.sh`: removed dead `_verify_install_configs_sources()` function (~50 LOC) + its single caller block in `nftban selftest verify-configs` — the function would have always SKIP'd after PR-15 deletion anyway
- `cli/lib/nftban/core/nftban_login_alert.sh:1093`: comment update to reference the installer's Configure phase instead of the legacy shell script name
- `internal/installer/payload/payload.go` + `safety/whitelist.go`: scrubbed incidental historical references from narrative source comments

## Evidence from PR #462 lab integration test

`nftban-installer --source --mode=install` produces the same end-state as a fresh RPM/DEB install on both:

| | lab2 (Ubuntu 24.04 DEB/Plesk) | lab4 (AlmaLinux 9 RPM/cPanel) |
|---|---|---|
| Payload wrote/skipped/failed | 287 / 3 / 0 | 287 / 3 / 0 |
| 8/8 post-install assertions | ✅ | ✅ |
| Final state | COMMITTED / PROTECTED / NFTBAN | ✅ same |
| `/usr/lib/nftban` file count | 196 | 196 |
| `/etc/nftban` file count | 38 | 38 |
| NB-5 perms on `/usr/sbin/nftban` | `root:nftban 0750` | `root:nftban 0750` |
| Distro-aware polkit | `/usr/share/polkit-1/rules.d/` | `/etc/polkit-1/rules.d/` |
| Safety whitelist seeded | SSH client + eth0 v4+v6 | SSH client + eth0 v4+v6 |
| Idempotent re-run (0 writes) | ✅ | ✅ |

The Go installer's `--source` path has already been proven on both distros by PR #462 lab evidence. This PR is a purely mechanical simplification of the caller.

## Regression risk for package installs (RPM/DEB)

**Zero.** RPM postinst and DEB postinst call `/usr/lib/nftban/bin/nftban-installer --rpm` / `--deb` directly; neither ever invokes `install.sh`. This PR's changes touch only the source-install entry point. Package installs are byte-for-byte unchanged.

## Test plan

- [x] Body ≤ 20 lines (13 lines measured)
- [x] `bash -n install.sh` clean
- [x] `bash -n cli/lib/nftban/cli/cmd_selftest.sh` clean
- [x] `bash -n cli/lib/nftban/core/nftban_login_alert.sh` clean
- [x] PR-15 precondition grep all = 0
- [x] Header validation clean
- [ ] CI green on this branch
- [ ] Post-merge: source install on a clean VM via `./install.sh` matches PR #462 evidence

## What this unblocks

- **PR-15**: `git rm install_binaries.sh install_configs.sh install_services.sh` — pure deletion, no logic change
- **G2 parity gate**: all three install paths (RPM / DEB / source via bootstrap) proven equivalent end-state
- **v1.98.x closure tag**: landing PR-15 after this PR closes the install canonization track

## Stats

```
 6 files changed, 71 insertions(+), 452 deletions(-)
```

Net −381 lines. Bundle of cleanups + bootstrap reduction.

## References

- `V198_PR14_BOOTSTRAP_SPEC.md` — the spec this implements
- `V198_PR14_PRE_SOURCE_INSTALL_SPEC.md` — prerequisite spec (PR #462, merged)
- `V198_PR14_MAPPING_WALKTHROUGH.md` — original walkthrough that identified the 9 gaps
- PR #461 (MERGED) — soak tooling + NB-5 packaging
- PR #462 (MERGED) — Go-side source-install support (G-14-A..I)
- Issue #463 — follow-up: tighten payload-failure escalation + inventory assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)