### PR TITLE
fix(installer): stage VERSION file + fix version.sh unbound-var crash (P0 source-install regression)

### DIFF
--- a/cli/lib/nftban/lib/version.sh
+++ b/cli/lib/nftban/lib/version.sh
@@ -23,7 +23,10 @@ set -Eeuo pipefail
 
 # Read version from VERSION file (single source of truth)
 _nftban_read_version() {
-    local version_file
+    # Initialize to empty so `set -u` at line-39 [[ -f "$version_file" ]]
+    # does not crash when none of the lookup paths match (which would otherwise
+    # break every CLI subcommand — version.sh is sourced by all of them).
+    local version_file=""
     # Try multiple possible locations (package path first, then source tree)
     for path in \
         "/usr/lib/nftban/VERSION" \
@@ -36,7 +39,7 @@ _nftban_read_version() {
         fi
     done
 
-    if [[ -f "$version_file" ]]; then
+    if [[ -n "$version_file" && -f "$version_file" ]]; then
         cat "$version_file" | tr -d '[:space:]'
     else
         echo "unknown"  # Fallback if VERSION file not found

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -187,6 +187,13 @@ func buildEntries(distro *detect.DistroInfo) []entry {
 		// never operator-edited here).
 		{srcRel: "cli/lib/nftban/templates/nftables.conf.tpl", dstGlob: "/usr/lib/nftban/templates/nftables.conf.tpl", mode: 0644, policy: policyAlways, optional: true},
 
+		// VERSION file — consumed by cli/lib/nftban/lib/version.sh which is
+		// sourced by every CLI subcommand. Package installs stage it via
+		// packaging/build_nftban.sh (RPM %install line ~368, DEB ~1837);
+		// source install missed it, causing every CLI invocation to crash
+		// with "unbound variable" at version.sh:39.
+		{srcRel: "VERSION", dstGlob: "/usr/lib/nftban/VERSION", mode: 0644, policy: policyAlways},
+
 		// -----------------------------------------------------------------
 		// G-14-D: Configs (/etc/nftban/*)
 		// -----------------------------------------------------------------


### PR DESCRIPTION
## Problem

P0 source-install regression — no CLI subcommand works after a clean source install:

\`\`\`
$ nftban status
/usr/lib/nftban/lib/version.sh: line 39: version_file: unbound variable
$ nftban
/usr/lib/nftban/lib/version.sh: line 39: version_file: unbound variable
\`\`\`

Discovered on lab2 after PR #462 + PR #464 + PR #466 merges, during v1.98.x G2 closure integration test. Every CLI subcommand sources \`cli/lib/nftban/lib/version.sh\` first, so the crash takes down the entire shell CLI surface on source installs.

Package installs (RPM/DEB) are NOT affected because their package scripts stage \`/usr/lib/nftban/VERSION\` directly.

## Two independent bugs — both fixed here

### Bug 1: Payload package missed the VERSION file

\`internal/installer/payload/payload.go\` \`buildEntries()\` table did not include \`VERSION\` → \`/usr/lib/nftban/VERSION\`. Package installs stage it via:

- \`packaging/build_nftban.sh:368\` (RPM %install)
- \`packaging/build_nftban.sh:1837\` (DEB deb_root)

Source install had to rely on the \`$PWD/VERSION\` fallback lookup, which only works if the operator happens to be in the repo root at invocation time. From anywhere else, lookup fails.

**Fix:** Add entry to \`payload.buildEntries()\`:

\`\`\`go
{srcRel: "VERSION", dstGlob: "/usr/lib/nftban/VERSION", mode: 0644, policy: policyAlways},
\`\`\`

### Bug 2: version.sh crashes under \`set -u\` when no lookup path matches

\`cli/lib/nftban/lib/version.sh:26\` declares \`local version_file\` without initialization, then assigns it only if a lookup loop finds a file. When all four paths miss, \`version_file\` stays unbound, and line 39's \`[[ -f "$version_file" ]]\` trips \`set -u\` with:

\`\`\`
version.sh: line 39: version_file: unbound variable
\`\`\`

Version.sh is sourced by \`nftban\`, \`nftban status\`, \`nftban validate\`, and every other CLI entry point. A single missing VERSION file → entire CLI broken.

**Fix:**

\`\`\`bash
-    local version_file
+    local version_file=""
   for path in ...; do
       if [[ -f "$path" ]]; then
           version_file="$path"
           break
       fi
   done
-   if [[ -f "$version_file" ]]; then
+   if [[ -n "$version_file" && -f "$version_file" ]]; then
       cat "$version_file" | tr -d '[:space:]'
   else
       echo "unknown"
   fi
\`\`\`

Even after Bug 1 is fixed, Bug 2 is worth fixing as defense-in-depth: an operator who later accidentally deletes \`/usr/lib/nftban/VERSION\` should see the CLI fall through to an \"unknown\" version instead of crashing.

## Impact assessment

- **Source installs from this PR onward**: CLI works immediately after install
- **Pre-existing installs missing VERSION for any reason** (e.g., bad backup, manual delete): CLI no longer crashes, reports \"unknown\" version
- **Package installs (RPM/DEB)**: zero impact — they already stage VERSION via packaging

## Test plan

- [x] Unit-level bash syntax: \`bash -n cli/lib/nftban/lib/version.sh\`
- [ ] CI green on this branch
- [ ] Post-merge: re-run source install on a fresh lab → \`nftban status\` works

## References

- PR #462 (MERGED) — PR-14-pre Go-side source-install support (where the payload table lives)
- Integration test output on lab2 at 2026-04-19T13:37Z

This is small enough to fast-track. Ready for review + merge.