### PR TITLE
feat(v1.99 PR-16): update trigger → lifecycle/rebuild integration (G3-U1..U4)

### DIFF
--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -1,0 +1,251 @@
+# =============================================================================
+# NFTBan — CI: Update Canonization Gate (G3-UPDATE, PR-16 slice)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# Purpose: Enforce v1.99 update canonization invariants, starting with the
+#          PR-16 baseline sub-gates:
+#            G3-U1  update lifecycle entry
+#            G3-U2  current → target version detection
+#            G3-U3  --dry-run correctness (no mutation)
+#            G3-U4  preflight enforcement
+#
+# Future sub-gates (G3-U5 .. G3-U17 + P-1/P-2/P-3 + G3-U-REBUILD-PARITY)
+# are added incrementally by PR-17 .. PR-21 per the gate spec.
+#
+# Architecture constraint enforced here (INV-U-001):
+#   Update is a BOUNDED TRIGGER into the rebuild/lifecycle pipeline —
+#   not a parallel execution path.
+# =============================================================================
+
+name: Update Canonization Gate
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'cmd/nftban-installer/**'
+      - 'internal/installer/**'
+      - 'internal/lifecycle/**'
+      - 'cli/lib/nftban/cli/cmd_update*.sh'
+      - 'VERSION'
+      - '.github/workflows/ci-update-canonization.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-update-canonization-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-canonization:
+    name: Update Canonization (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-24.04
+            runner: ubuntu-24.04
+            container: ''
+          - label: almalinux-9
+            runner: ubuntu-24.04
+            container: almalinux:9
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install system dependencies (DEB)
+        if: matrix.label == 'ubuntu-24.04'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y nftables jq systemd util-linux coreutils
+
+      - name: Install system dependencies (RPM)
+        if: matrix.label == 'almalinux-9'
+        run: |
+          dnf -y install epel-release
+          # coreutils-single is preinstalled on almalinux:9 minimal — omit coreutils.
+          dnf -y install nftables jq systemd util-linux git tar gzip which procps-ng findutils sudo golang
+
+      - name: Set up Go (DEB only)
+        if: matrix.label == 'ubuntu-24.04'
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.6.0
+        with:
+          go-version: '1.25'
+
+      # ------------------------------------------------------------------
+      # Unit tests — close G3-U2 (version detection) + G3-U4 (preflight)
+      # at the function level. This is what makes PR-16 merge-safe: unit
+      # coverage proves the contract before we touch runtime.
+      # ------------------------------------------------------------------
+      - name: G3-U2 + G3-U4 — unit tests for update.{Preflight,DetectVersions,BuildPlan}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          go test -v ./internal/installer/update/...
+
+      # ------------------------------------------------------------------
+      # Build the installer binary so we can exercise the full dry-run
+      # control flow end-to-end.
+      # ------------------------------------------------------------------
+      - name: Build nftban-installer + nftban-validate
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p bin
+          go build -trimpath -o bin/nftban-installer ./cmd/nftban-installer/
+          go build -trimpath -o bin/nftban-validate  ./cmd/nftban-validate/
+          test -x bin/nftban-installer
+          test -x bin/nftban-validate
+
+      # ------------------------------------------------------------------
+      # Stage a minimal VERSION + ip nftban table so preflight has enough
+      # host state to evaluate. We do NOT install nftban fully — that's
+      # out of scope for the update-canonization gate.
+      # ------------------------------------------------------------------
+      - name: Prepare host state for dry-run
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo install -d /usr/lib/nftban /var/lib/nftban/state /etc/nftban
+          # Current version on disk.
+          sudo cp VERSION /usr/lib/nftban/VERSION
+          # Seed a terminal state marker so the stale-in-progress warning
+          # does not fire in the happy path.
+          echo "COMMITTED" | sudo tee /var/lib/nftban/state/install_state >/dev/null
+          # Create an ip nftban table so the authority preflight (P-1) passes.
+          sudo nft add table ip nftban || true
+          # Fake a systemd unit being "active" by pre-seeding a stub we
+          # can control. Actually simpler: the preflight accepts
+          # nftband.service as inactive → critical fail. For the dry-run
+          # happy-path test below we invoke with explicit acceptance that
+          # service_nftband_active may fail. We handle both outcomes.
+
+      # ------------------------------------------------------------------
+      # G3-U3 — --dry-run correctness: no mutation, plan rendered, valid
+      # exit. We run the command, capture its output, and assert (a) plan
+      # header is present, (b) no mutation occurred on the filesystem.
+      # ------------------------------------------------------------------
+      - name: G3-U3 — --dry-run renders plan, no mutation
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Snapshot state dir before the run.
+          before=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
+
+          set +e
+          sudo ./bin/nftban-installer --mode=upgrade --dry-run \
+              --source --source-dir="$PWD" \
+              --state-dir=/var/lib/nftban/state 2>&1 | tee /tmp/dryrun.out
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "dry-run exit code: $rc"
+
+          # Must always render the plan header (G3-U3 output contract).
+          grep -q "NFTBan Update — Plan" /tmp/dryrun.out
+          grep -q "Current version" /tmp/dryrun.out
+          grep -q "Target version"  /tmp/dryrun.out
+
+          # INV-U-001 must be visible in the rendered plan (architectural
+          # constraint verified in the output, not buried in source).
+          grep -q "INV-U-001" /tmp/dryrun.out
+
+          # Snapshot again; the only acceptable mutation is the audit
+          # write of update_plan.json under the state dir (documented).
+          after=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
+
+          # Accept: appearance of update_plan.json under state dir only.
+          diff <(echo "$before") <(echo "$after") \
+              | grep -v '/var/lib/nftban/state/update_plan.json' \
+              | grep -v '^---' | grep -v '^[<>] *$' || true
+
+          # Hard assertion: no file under /etc/nftban/** was modified.
+          if ! diff -q <(echo "$before" | grep '^/etc/nftban/') \
+                       <(echo "$after"  | grep '^/etc/nftban/') >/dev/null; then
+            echo "::error::G3-U3 FAIL: /etc/nftban was modified during --dry-run"
+            exit 1
+          fi
+
+          # Exit code sanity: 0 (committed) if preflight passes, 1 (degraded)
+          # if preflight fails. Never 2/3/4 for a well-formed run on a
+          # host that doesn't have a real daemon.
+          case "$rc" in
+            0|1) echo "G3-U3 PASS — exit=$rc (preflight result reflected correctly)" ;;
+            *) echo "::error::G3-U3 FAIL: unexpected exit code $rc"; exit 1 ;;
+          esac
+
+      # ------------------------------------------------------------------
+      # G3-U1 — update lifecycle entry: the plan output must identify that
+      # the update trigger was observed by the lifecycle-capable installer,
+      # not the legacy shell path.
+      # ------------------------------------------------------------------
+      - name: G3-U1 — update enters installer binary (not shell)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Confirm the installer binary itself printed "mode=upgrade" in
+          # its run header — that is proof the lifecycle-capable entry
+          # point was used for the initial control flow.
+          grep -q "mode=upgrade" /tmp/dryrun.out || {
+            echo "::error::G3-U1 FAIL: run header did not identify mode=upgrade"
+            exit 1
+          }
+          echo "G3-U1 PASS — update mode observed by installer binary"
+
+      # ------------------------------------------------------------------
+      # G3-U2 — current → target version detection: both must be visible
+      # and non-placeholder for source-install case (sourceDir provided).
+      # ------------------------------------------------------------------
+      - name: G3-U2 — current + target versions detected
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          CURRENT=$(grep 'Current version' /tmp/dryrun.out | sed 's/.*:\s*//' | head -1)
+          TARGET=$(grep 'Target version'  /tmp/dryrun.out | sed 's/.*:\s*//' | head -1)
+          echo "Detected — current=[$CURRENT] target=[$TARGET]"
+          if [[ -z "$CURRENT" || "$CURRENT" == "(not detected)" ]]; then
+            echo "::error::G3-U2 FAIL: current version not detected"
+            exit 1
+          fi
+          if [[ -z "$TARGET"  || "$TARGET"  == "(not detected)" ]]; then
+            echo "::error::G3-U2 FAIL: target version not detected (source install)"
+            exit 1
+          fi
+          echo "G3-U2 PASS — current=$CURRENT target=$TARGET"
+
+      # ------------------------------------------------------------------
+      # G3-U4 — preflight enforcement: all five checks must appear in the
+      # plan's Preflight block. We don't require every check to pass —
+      # CI environments don't have nftband running — but every check
+      # MUST be evaluated and reported.
+      # ------------------------------------------------------------------
+      - name: G3-U4 — preflight reports all 5 checks
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          for name in authority_nftban service_nftband_active artifact_version_file dependency_nft state_no_stale_in_progress; do
+            grep -q "$name" /tmp/dryrun.out || {
+              echo "::error::G3-U4 FAIL: preflight check '$name' missing from plan"
+              exit 1
+            }
+          done
+          echo "G3-U4 PASS — all 5 preflight checks reported"
+
+  summary:
+    name: Update Canonization summary
+    needs: update-canonization
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verdict
+        run: |
+          if [[ "${{ needs.update-canonization.result }}" != "success" ]]; then
+            echo "::error::Update Canonization Gate FAILED — see matrix job output"
+            exit 1
+          fi
+          echo "Update Canonization Gate PASSED on all matrix targets"

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -120,13 +120,12 @@ jobs:
           echo "COMMITTED" | sudo tee /var/lib/nftban/state/install_state >/dev/null
           # Create an ip nftban table so the authority preflight (P-1) passes.
           sudo nft add table ip nftban || true
-          # CI containers do not run sshd. Provide a minimal sshd_config so
-          # phaseDetect's SSH-port detector finds a value (the real upgrade
-          # flow always has one of the 4 SSH sources available on a host
-          # that nftban was previously installed on).
-          if [[ ! -f /etc/ssh/sshd_config ]]; then
-            echo "Port 22" | sudo tee /etc/ssh/sshd_config >/dev/null
-          fi
+          # CI containers do not run sshd, and the Ubuntu runner's default
+          # sshd_config has Port commented out, so the SSH-port detector
+          # falls through all 4 sources. Seed the state-file source
+          # directly — source 3 in the detection chain, which is exactly
+          # what a post-install upgrade host would have.
+          echo "22" | sudo tee /var/lib/nftban/state/ssh_port_active.state >/dev/null
           # phaseDetect does not require nftband to be running for dry-run,
           # only preflight does — and preflight reports the failure as one
           # of the five checks rather than aborting phaseDetect.

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          sudo install -d /usr/lib/nftban /var/lib/nftban/state /etc/nftban
+          sudo install -d /usr/lib/nftban /var/lib/nftban/state /etc/nftban /etc/ssh
           # Current version on disk.
           sudo cp VERSION /usr/lib/nftban/VERSION
           # Seed a terminal state marker so the stale-in-progress warning
@@ -120,11 +120,16 @@ jobs:
           echo "COMMITTED" | sudo tee /var/lib/nftban/state/install_state >/dev/null
           # Create an ip nftban table so the authority preflight (P-1) passes.
           sudo nft add table ip nftban || true
-          # Fake a systemd unit being "active" by pre-seeding a stub we
-          # can control. Actually simpler: the preflight accepts
-          # nftband.service as inactive → critical fail. For the dry-run
-          # happy-path test below we invoke with explicit acceptance that
-          # service_nftband_active may fail. We handle both outcomes.
+          # CI containers do not run sshd. Provide a minimal sshd_config so
+          # phaseDetect's SSH-port detector finds a value (the real upgrade
+          # flow always has one of the 4 SSH sources available on a host
+          # that nftban was previously installed on).
+          if [[ ! -f /etc/ssh/sshd_config ]]; then
+            echo "Port 22" | sudo tee /etc/ssh/sshd_config >/dev/null
+          fi
+          # phaseDetect does not require nftband to be running for dry-run,
+          # only preflight does — and preflight reports the failure as one
+          # of the five checks rather than aborting phaseDetect.
 
       # ------------------------------------------------------------------
       # G3-U3 — --dry-run correctness: no mutation, plan rendered, valid

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -118,7 +118,12 @@ jobs:
           # Seed a terminal state marker so the stale-in-progress warning
           # does not fire in the happy path.
           echo "COMMITTED" | sudo tee /var/lib/nftban/state/install_state >/dev/null
-          # Create an ip nftban table so the authority preflight (P-1) passes.
+          # Simulate a host where nftban is already authoritative:
+          #  - Disable UFW (real install took authority long ago)
+          #  - Flush iptables-nft ghost tables (filter/nat/mangle)
+          #  - Create ip nftban so authority preflight P-1 passes
+          sudo systemctl disable --now ufw 2>/dev/null || true
+          sudo nft flush ruleset || true
           sudo nft add table ip nftban || true
           # CI containers do not run sshd, and the Ubuntu runner's default
           # sshd_config has Port commented out, so the SSH-port detector

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -133,6 +133,14 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 	if cfg.repair {
 		return runRepair(ctx, exec, sf, log)
 	}
+	// v1.99 PR-16 (G3-U1/U2/U3/U4): update-mode dry-run short-circuits to
+	// preflight + version-detect + plan render. No mutation — all apply
+	// logic is deferred to PR-18 and reuses the rebuild pipeline per
+	// INV-U-001. Install-mode dry-run falls through to the existing path
+	// (behaviour preserved).
+	if cfg.mode == "upgrade" && cfg.dryRun {
+		return runUpdateDryRun(ctx, exec, sf, cfg, log)
+	}
 	return runInstall(ctx, exec, sf, cfg, log)
 }
 

--- a/cmd/nftban-installer/update_dryrun.go
+++ b/cmd/nftban-installer/update_dryrun.go
@@ -1,0 +1,129 @@
+// =============================================================================
+// NFTBan v1.99 PR-16 — Update Dry-Run Orchestrator
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-update-dryrun"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="--mode=upgrade --dry-run: preflight + plan, no mutation"
+// meta:inventory.files="cmd/nftban-installer/update_dryrun.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// PR-16 closes G3-U1 (lifecycle entry), G3-U2 (current→target versions),
+// G3-U3 (--dry-run correctness), G3-U4 (preflight enforcement).
+//
+// This entry point is intentionally narrow. It does NOT run phasePrepare /
+// phaseSwitch / phaseConfigure / phaseValidate — those remain the property
+// of install mode in PR-16. Update apply (PR-18) will wire update mode
+// back into the same phase pipeline (INV-U-001: update = rebuild with
+// controlled input delta, not a separate engine).
+//
+// =============================================================================
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/installer/update"
+)
+
+// runUpdateDryRun runs the update-trigger dry-run path:
+//
+//  1. phaseDetect (reused from install — same detection surface)
+//  2. update.Preflight (P-1..P-5)
+//  3. update.DetectVersions
+//  4. update.BuildPlan + render
+//
+// No mutation; no phasePrepare / phaseSwitch / phaseConfigure / phaseValidate.
+//
+// Exit code contract:
+//
+//	0 — preflight passed, plan rendered cleanly
+//	1 — preflight failed (critical check), plan rendered with failures
+//	2 — phaseDetect failed (cannot even reason about the host)
+//	4 — fatal (I/O error, etc.)
+func runUpdateDryRun(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *config, log *logging.Logger) int {
+	log.Info("update dry-run starting (mode=upgrade, dry-run=true)")
+
+	// 1. Reuse phaseDetect so the update trigger sees the same detection
+	// surface that a real install/upgrade would. This is the first step
+	// in routing update through the shared pipeline.
+	log.Phase("Detect")
+	if err := phaseDetect(ctx, exec, sf, log); err != nil {
+		log.Error("update dry-run: phaseDetect failed: %v", err)
+		log.PhaseEnd("Detect")
+		return state.ExitFailed
+	}
+	log.PhaseEnd("Detect")
+
+	// 2. Update-specific preflight (P-1 through P-5).
+	log.Phase("Preflight")
+	pre := update.Preflight(exec, log)
+	log.PhaseEnd("Preflight")
+
+	// 3. Version detection. sourceDir is empty in the package-install case;
+	// the update package treats that as non-fatal for PR-16 (package-install
+	// target detection lands in PR-17).
+	current, target, err := update.DetectVersions(exec, cfg.sourceDir, log)
+	if err != nil {
+		log.Error("update dry-run: version detection failed: %v", err)
+		return state.ExitFailed
+	}
+
+	// 4. Install origin — drives which apply path PR-18 will use.
+	origin := detectInstallOrigin(cfg)
+
+	// 5. Assemble + render plan.
+	plan := update.BuildPlan(pre, current, target, origin)
+	plan.Render(os.Stdout)
+
+	// 6. Write a copy of the plan JSON to the state dir for audit/history
+	// traceability. Not a hard requirement for PR-16 but closes G3-U12
+	// (update history integrity) early.
+	dst := cfg.stateDir + "/update_plan.json"
+	if werr := plan.WriteJSONToFile(dst); werr != nil {
+		log.Warn("update dry-run: could not persist plan to %s: %v", dst, werr)
+	} else {
+		log.Info("update dry-run: plan written to %s", dst)
+	}
+
+	// 7. Exit contract.
+	if !pre.Passed {
+		fmt.Fprintln(os.Stderr, "update dry-run: preflight FAILED — apply would abort (see plan)")
+		return state.ExitDegraded
+	}
+	log.Info("update dry-run complete — no mutation, plan valid")
+	return state.ExitCommitted
+}
+
+// detectInstallOrigin produces the install origin label for the plan.
+// PR-16 reads it from the cfg flags the operator passed; heuristic detection
+// against package databases is a PR-17 enhancement.
+func detectInstallOrigin(cfg *config) string {
+	switch {
+	case cfg.source:
+		return "source"
+	case cfg.rpm:
+		return "rpm"
+	case cfg.deb:
+		return "deb"
+	default:
+		// PR-17 will detect origin by inspecting rpm -q / dpkg -s when no
+		// flag is provided. For now, report it as unknown so operators can
+		// see the detection gap.
+		return ""
+	}
+}

--- a/internal/installer/update/plan.go
+++ b/internal/installer/update/plan.go
@@ -1,0 +1,242 @@
+// =============================================================================
+// NFTBan v1.99 PR-16 — Update Plan + Version Detection
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-update-plan"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Update trigger: current→target version detection + plan struct"
+// meta:inventory.files="internal/installer/update/plan.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// PR-16 closes G3-U2 (current→target version detection) and G3-U3 (--dry-run).
+//
+// INV-U-001 reminder: update is a BOUNDED TRIGGER into the rebuild/lifecycle
+// pipeline — not a parallel execution path. This package only provides the
+// PLAN structure and VERSION DETECTION for the update trigger. Apply work
+// (PR-18) routes through the existing rebuild semantics.
+//
+// =============================================================================
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// Plan describes the intended update transition. Produced by `nftban-installer
+// --mode=upgrade --dry-run`; consumed by the shell update dispatcher for
+// lifecycle recording and by CI for the G3-U2/U3 assertions.
+//
+// PR-16 scope: Plan is purely descriptive. Apply logic lands in PR-18.
+type Plan struct {
+	// SchemaVersion locks the on-wire contract. Bump on any breaking change.
+	SchemaVersion string `json:"schema_version"`
+
+	// CurrentVersion is the version currently installed on the host,
+	// read from /usr/lib/nftban/VERSION (or the canonical lookup chain
+	// documented in cli/lib/nftban/lib/version.sh).
+	CurrentVersion string `json:"current_version"`
+
+	// TargetVersion is the version that would be installed if apply ran.
+	// For source installs this is the VERSION file in the source tree;
+	// for package installs this is the package's Version field.
+	TargetVersion string `json:"target_version"`
+
+	// InstallOrigin is "rpm", "deb", or "source" — determines which apply
+	// path would execute in PR-18.
+	InstallOrigin string `json:"install_origin"`
+
+	// NeedsUpdate is true when CurrentVersion != TargetVersion. False means
+	// a run would be a bounded no-op per G3-U16 (idempotency).
+	NeedsUpdate bool `json:"needs_update"`
+
+	// Preflight records the preflight result that was folded into this plan.
+	Preflight *PreflightResult `json:"preflight"`
+
+	// Warnings are non-fatal notes the operator should see (e.g. "current
+	// state is DEGRADED — update will proceed with caution").
+	Warnings []string `json:"warnings,omitempty"`
+
+	// Actions is a human-oriented list of what apply would do. PR-16 keeps
+	// this abstract ("reuse rebuild pipeline"); PR-18 fills in concrete
+	// steps.
+	Actions []string `json:"actions,omitempty"`
+}
+
+// PlanSchemaVersion is the current wire contract for Plan. Consumers should
+// reject plans with unexpected schema versions.
+const PlanSchemaVersion = "1.99.0"
+
+// DetectVersions reads the current installed version from the FHS VERSION
+// file and the target version from the source-tree VERSION (for source
+// installs) or from the package metadata path.
+//
+// For PR-16 we support source-install detection; package-install target
+// detection is handled in PR-17.
+func DetectVersions(exec executor.Executor, sourceDir string, log *logging.Logger) (current, target string, err error) {
+	current = readCurrentVersion(exec, log)
+
+	// Source install: target VERSION lives at <sourceDir>/VERSION.
+	if sourceDir != "" {
+		tPath := filepath.Join(sourceDir, "VERSION")
+		if data, rErr := exec.ReadFile(tPath); rErr == nil {
+			target = strings.TrimSpace(string(data))
+		} else {
+			log.Debug("update: source VERSION not readable at %s: %v", tPath, rErr)
+		}
+	}
+
+	if current == "" {
+		return current, target, fmt.Errorf("update: cannot detect current version (no VERSION file)")
+	}
+	if target == "" {
+		// PR-16: target detection for package installs lands in PR-17.
+		// For now, missing target is non-fatal — the plan records it and
+		// the preflight flags it as a warning.
+		log.Info("update: target version not yet detected (package-install detection lands in PR-17)")
+	}
+	return current, target, nil
+}
+
+// readCurrentVersion implements the same lookup chain as
+// cli/lib/nftban/lib/version.sh (/usr/lib/nftban/VERSION first, then
+// ${NFTBAN_ROOT}/VERSION). We keep this Go-side implementation simple; the
+// shell entry point guarantees VERSION is present before calling us.
+func readCurrentVersion(exec executor.Executor, log *logging.Logger) string {
+	for _, p := range []string{
+		"/usr/lib/nftban/VERSION",
+		"/etc/nftban/VERSION", // legacy fallback
+	} {
+		if !exec.FileExists(p) {
+			continue
+		}
+		data, err := exec.ReadFile(p)
+		if err != nil {
+			log.Debug("update: read %s failed: %v", p, err)
+			continue
+		}
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}
+
+// Render prints a human-readable plan. Used by --dry-run text mode.
+func (p *Plan) Render(w io.Writer) {
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "NFTBan Update — Plan")
+	fmt.Fprintln(w, "════════════════════════════════════════════════════════════")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "  Current version : %s\n", displayVersion(p.CurrentVersion))
+	fmt.Fprintf(w, "  Target version  : %s\n", displayVersion(p.TargetVersion))
+	fmt.Fprintf(w, "  Install origin  : %s\n", displayString(p.InstallOrigin))
+	fmt.Fprintf(w, "  Needs update    : %v\n", p.NeedsUpdate)
+	fmt.Fprintln(w, "")
+
+	if p.Preflight != nil {
+		fmt.Fprintln(w, "  Preflight:")
+		for _, c := range p.Preflight.Checks {
+			mark := "✓"
+			if !c.Passed {
+				mark = "✗"
+			}
+			fmt.Fprintf(w, "    %s %s", mark, c.Name)
+			if c.Detail != "" {
+				fmt.Fprintf(w, " — %s", c.Detail)
+			}
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, "")
+	}
+
+	if len(p.Warnings) > 0 {
+		fmt.Fprintln(w, "  Warnings:")
+		for _, wmsg := range p.Warnings {
+			fmt.Fprintf(w, "    ⚠ %s\n", wmsg)
+		}
+		fmt.Fprintln(w, "")
+	}
+
+	if len(p.Actions) > 0 {
+		fmt.Fprintln(w, "  Actions (dry-run — no mutation):")
+		for _, a := range p.Actions {
+			fmt.Fprintf(w, "    • %s\n", a)
+		}
+		fmt.Fprintln(w, "")
+	}
+}
+
+// JSON returns the plan as pretty-printed JSON. Used by --dry-run --json.
+func (p *Plan) JSON() ([]byte, error) {
+	return json.MarshalIndent(p, "", "  ")
+}
+
+// BuildPlan assembles a Plan from a preflight result + detected versions.
+// It is the single constructor for Plan so that SchemaVersion and default
+// fields are always set consistently.
+func BuildPlan(pre *PreflightResult, current, target, origin string) *Plan {
+	p := &Plan{
+		SchemaVersion:  PlanSchemaVersion,
+		CurrentVersion: current,
+		TargetVersion:  target,
+		InstallOrigin:  origin,
+		NeedsUpdate:    current != target && target != "",
+		Preflight:      pre,
+	}
+	// Authoritative architectural reminder (INV-U-001) — render it so the
+	// operator always sees the model, not just the outcome.
+	p.Actions = append(p.Actions,
+		"update reuses the rebuild/lifecycle pipeline (INV-U-001)",
+		"no parallel staging / validation / switch logic is executed",
+	)
+	if pre != nil && !pre.Passed {
+		p.Warnings = append(p.Warnings, "preflight failed — apply would abort")
+	}
+	if target == "" {
+		p.Warnings = append(p.Warnings,
+			"target version not detected (package-install target detection lands in PR-17)")
+	}
+	return p
+}
+
+// displayVersion returns a placeholder for empty versions so the rendered
+// table doesn't print blank cells that look like a bug.
+func displayVersion(v string) string {
+	if v == "" {
+		return "(not detected)"
+	}
+	return v
+}
+
+func displayString(s string) string {
+	if s == "" {
+		return "(unknown)"
+	}
+	return s
+}
+
+// WriteJSONToFile writes the plan as JSON to dst. Caller is responsible for
+// destination path safety. Intended for history/audit records, NOT for
+// operator-visible files.
+func (p *Plan) WriteJSONToFile(dst string) error {
+	data, err := p.JSON()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Clean(dst), data, 0600) // #nosec G306 -- history file
+}

--- a/internal/installer/update/preflight.go
+++ b/internal/installer/update/preflight.go
@@ -1,0 +1,206 @@
+// =============================================================================
+// NFTBan v1.99 PR-16 — Update Preflight
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-update-preflight"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Update trigger preflight — authority, service, artifact, deps"
+// meta:inventory.files="internal/installer/update/preflight.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// PR-16 closes G3-U4 (preflight enforcement).
+//
+// Preflight aborts the update BEFORE any mutation if any critical
+// precondition is not met:
+//
+//   P-1 authority       nftban must currently own firewall authority
+//   P-2 service         nftband.service must be running (allow DEGRADED
+//                       with a warning; abort only on DOWN)
+//   P-3 artifact        /usr/lib/nftban/VERSION must exist (we must know
+//                       what "current" is before transitioning)
+//   P-4 dependencies    nft binary must be present and executable
+//   P-5 state locality  no stale in-progress install_state marker
+//
+// This aligns with INV-U-002 (rollbackability) — we refuse to enter a
+// transition we cannot safely reason about.
+//
+// =============================================================================
+
+package update
+
+import (
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// PreflightCheck is one named precondition.
+type PreflightCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
+	// Severity is "critical" (abort) or "warning" (continue with warning).
+	// Only "critical" failures contribute to Passed=false at the result level.
+	Severity string `json:"severity"`
+}
+
+// PreflightResult is the aggregate outcome.
+type PreflightResult struct {
+	Passed bool             `json:"passed"`
+	Checks []PreflightCheck `json:"checks"`
+}
+
+// Preflight runs all update preconditions and returns an aggregate result.
+// Called by phaseDetect when cfg.mode == "upgrade".
+//
+// The function is READ-ONLY. It must never mutate host state.
+func Preflight(exec executor.Executor, log *logging.Logger) *PreflightResult {
+	res := &PreflightResult{Passed: true}
+
+	// P-1 authority — the existing authority.Detect would give us a full
+	// picture, but for the preflight scope we just need to know whether
+	// nftban currently owns the firewall. We proxy via the presence of
+	// the ip nftban table: if it exists, nftban is authoritative.
+	{
+		ok := exec.NftTableExists("ip", "nftban")
+		c := PreflightCheck{
+			Name:     "authority_nftban",
+			Passed:   ok,
+			Severity: "critical",
+		}
+		if !ok {
+			c.Detail = "ip nftban table absent — nftban does not own firewall authority (INV-U-003)"
+			res.Passed = false
+		}
+		res.Checks = append(res.Checks, c)
+		logCheck(log, c)
+	}
+
+	// P-2 service — nftband.service must be at least degraded/running.
+	{
+		active := exec.ServiceActive("nftband.service")
+		c := PreflightCheck{
+			Name:     "service_nftband_active",
+			Passed:   active,
+			Severity: "critical",
+		}
+		if !active {
+			c.Detail = "nftband.service not active — update cannot verify post-state safely"
+			res.Passed = false
+		}
+		res.Checks = append(res.Checks, c)
+		logCheck(log, c)
+	}
+
+	// P-3 artifact — VERSION file must be readable. Without it we cannot
+	// identify the current version, so we cannot reason about the transition.
+	{
+		has := exec.FileExists("/usr/lib/nftban/VERSION")
+		c := PreflightCheck{
+			Name:     "artifact_version_file",
+			Passed:   has,
+			Severity: "critical",
+		}
+		if !has {
+			c.Detail = "/usr/lib/nftban/VERSION missing — cannot identify current version"
+			res.Passed = false
+		}
+		res.Checks = append(res.Checks, c)
+		logCheck(log, c)
+	}
+
+	// P-4 dependencies — nft must be executable.
+	{
+		r := exec.Run("sh", "-c", "command -v nft >/dev/null 2>&1")
+		ok := r.ExitCode == 0
+		c := PreflightCheck{
+			Name:     "dependency_nft",
+			Passed:   ok,
+			Severity: "critical",
+		}
+		if !ok {
+			c.Detail = "nft binary not found in PATH"
+			res.Passed = false
+		}
+		res.Checks = append(res.Checks, c)
+		logCheck(log, c)
+	}
+
+	// P-5 state locality — if an install_state marker shows an in-progress
+	// install, we refuse to start an update on top of it. Let the operator
+	// resolve the prior state first.
+	{
+		stale := isStaleInProgress(exec)
+		c := PreflightCheck{
+			Name:     "state_no_stale_in_progress",
+			Passed:   !stale,
+			Severity: "warning", // not critical — warn but allow override
+		}
+		if stale {
+			c.Detail = "install_state marks a prior run as in-progress — investigate before apply"
+		}
+		res.Checks = append(res.Checks, c)
+		logCheck(log, c)
+	}
+
+	return res
+}
+
+// isStaleInProgress returns true if install_state exists AND is not a
+// terminal state (COMMITTED / DEGRADED / FAILED_*). We treat an in-progress
+// marker as a caution.
+func isStaleInProgress(exec executor.Executor) bool {
+	const p = "/var/lib/nftban/state/install_state"
+	if !exec.FileExists(p) {
+		return false
+	}
+	data, err := exec.ReadFile(p)
+	if err != nil {
+		return false
+	}
+	s := trim(string(data))
+	switch s {
+	case "", "COMMITTED", "DEGRADED",
+		"FAILED_SSH_UNKNOWN", "FAILED_AUTHORITY_ABORT", "FAILED_RENDER",
+		"FAILED_REBUILD", "FAILED_NO_FIREWALL", "FAILED_TAKEOVER":
+		return false
+	}
+	return true
+}
+
+// trim is a tiny wrapper — avoids importing strings just for TrimSpace
+// everywhere in this file.
+func trim(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && isSpace(s[start]) {
+		start++
+	}
+	for end > start && isSpace(s[end-1]) {
+		end--
+	}
+	return s[start:end]
+}
+
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+func logCheck(log *logging.Logger, c PreflightCheck) {
+	if c.Passed {
+		log.Debug("update-preflight: %-28s PASS", c.Name)
+		return
+	}
+	if c.Severity == "critical" {
+		log.Warn("update-preflight: %-28s FAIL — %s", c.Name, c.Detail)
+	} else {
+		log.Info("update-preflight: %-28s warn — %s", c.Name, c.Detail)
+	}
+}

--- a/internal/installer/update/update_test.go
+++ b/internal/installer/update/update_test.go
@@ -1,0 +1,294 @@
+// =============================================================================
+// NFTBan v1.99 PR-16 — Update Package Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-update-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Unit tests for update preflight + plan + version detection"
+// meta:inventory.files="internal/installer/update/update_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package update
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("/dev/null", false)
+}
+
+// seedHappyPreflight populates a mock with all P-1..P-5 passing.
+func seedHappyPreflight(mock *executor.MockExecutor) {
+	mock.NftTables["ip:nftban"] = true
+	mock.Services["nftband.service"] = true
+	mock.Files["/usr/lib/nftban/VERSION"] = []byte("1.98.2\n")
+	// nft in PATH — mock the sh -c command-v check
+	mock.RunResults["sh:-c:command -v nft >/dev/null 2>&1"] = executor.Result{ExitCode: 0}
+	// state marker is terminal
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("COMMITTED\n")
+}
+
+// Tests for Preflight ────────────────────────────────────────────────────────
+
+func TestPreflight_AllPass(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+
+	res := Preflight(mock, newTestLogger())
+	if !res.Passed {
+		t.Errorf("expected preflight to pass, got failing checks:")
+		for _, c := range res.Checks {
+			if !c.Passed {
+				t.Logf("  %s: %s", c.Name, c.Detail)
+			}
+		}
+	}
+	// All 5 checks should be present regardless of outcome.
+	if len(res.Checks) != 5 {
+		t.Errorf("expected 5 preflight checks, got %d", len(res.Checks))
+	}
+}
+
+// G3-U4: authority failure must fail preflight critically.
+// Covers the INV-U-003 intuition: if nftban doesn't own authority, update
+// must not enter a transition that might implicitly take it.
+func TestPreflight_NoAuthority_Fails(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+	delete(mock.NftTables, "ip:nftban")
+
+	res := Preflight(mock, newTestLogger())
+	if res.Passed {
+		t.Error("preflight should fail when nftban does not own authority")
+	}
+	if !hasCheckFailed(res, "authority_nftban") {
+		t.Error("authority_nftban check should be failed")
+	}
+}
+
+func TestPreflight_DaemonDown_Fails(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+	mock.Services["nftband.service"] = false
+
+	res := Preflight(mock, newTestLogger())
+	if res.Passed {
+		t.Error("preflight should fail when nftband is down")
+	}
+	if !hasCheckFailed(res, "service_nftband_active") {
+		t.Error("service_nftband_active check should be failed")
+	}
+}
+
+func TestPreflight_MissingVERSION_Fails(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+	delete(mock.Files, "/usr/lib/nftban/VERSION")
+
+	res := Preflight(mock, newTestLogger())
+	if res.Passed {
+		t.Error("preflight should fail when VERSION is missing")
+	}
+	if !hasCheckFailed(res, "artifact_version_file") {
+		t.Error("artifact_version_file check should be failed")
+	}
+}
+
+func TestPreflight_MissingNft_Fails(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+	mock.RunResults["sh:-c:command -v nft >/dev/null 2>&1"] = executor.Result{ExitCode: 127}
+
+	res := Preflight(mock, newTestLogger())
+	if res.Passed {
+		t.Error("preflight should fail when nft is missing")
+	}
+	if !hasCheckFailed(res, "dependency_nft") {
+		t.Error("dependency_nft check should be failed")
+	}
+}
+
+// A stale in-progress marker is a WARNING (non-critical) — preflight still
+// passes but the plan should carry a warning downstream.
+func TestPreflight_StaleInProgress_IsWarning(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedHappyPreflight(mock)
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("PREPARE_COMPLETE\n")
+
+	res := Preflight(mock, newTestLogger())
+	if !res.Passed {
+		t.Error("preflight should still pass when only a warning-severity check fails")
+	}
+	var found bool
+	for _, c := range res.Checks {
+		if c.Name == "state_no_stale_in_progress" && !c.Passed {
+			found = true
+			if c.Severity != "warning" {
+				t.Errorf("stale state check severity = %q; want warning", c.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("state_no_stale_in_progress should report a failed warning check")
+	}
+}
+
+// Tests for DetectVersions ──────────────────────────────────────────────────
+
+func TestDetectVersions_HappyPath(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/usr/lib/nftban/VERSION"] = []byte("1.98.2\n")
+	mock.Files["/tmp/srcdir/VERSION"] = []byte("1.99.0\n")
+
+	current, target, err := DetectVersions(mock, "/tmp/srcdir", newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if current != "1.98.2" {
+		t.Errorf("current = %q; want 1.98.2", current)
+	}
+	if target != "1.99.0" {
+		t.Errorf("target = %q; want 1.99.0", target)
+	}
+}
+
+func TestDetectVersions_MissingCurrent_Errors(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Deliberately no /usr/lib/nftban/VERSION seeded.
+
+	_, _, err := DetectVersions(mock, "", newTestLogger())
+	if err == nil {
+		t.Error("expected error when VERSION file is missing")
+	}
+}
+
+func TestDetectVersions_MissingTarget_IsNonFatal(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files["/usr/lib/nftban/VERSION"] = []byte("1.98.2\n")
+
+	current, target, err := DetectVersions(mock, "", newTestLogger())
+	if err != nil {
+		t.Fatalf("missing target should be non-fatal for PR-16, got: %v", err)
+	}
+	if current != "1.98.2" {
+		t.Errorf("current = %q; want 1.98.2", current)
+	}
+	if target != "" {
+		t.Errorf("target = %q; want empty (package-install detection is PR-17)", target)
+	}
+}
+
+// Tests for BuildPlan + rendering ───────────────────────────────────────────
+
+func TestBuildPlan_NeedsUpdate(t *testing.T) {
+	pre := &PreflightResult{Passed: true}
+	p := BuildPlan(pre, "1.98.2", "1.99.0", "source")
+
+	if p.SchemaVersion != PlanSchemaVersion {
+		t.Errorf("schema_version = %q; want %q", p.SchemaVersion, PlanSchemaVersion)
+	}
+	if !p.NeedsUpdate {
+		t.Error("plan should say NeedsUpdate when current != target")
+	}
+	if len(p.Actions) == 0 {
+		t.Error("plan should carry at least one Action describing the architectural model")
+	}
+	// INV-U-001 must be visible in the rendered plan.
+	var foundInvariantNote bool
+	for _, a := range p.Actions {
+		if strings.Contains(a, "INV-U-001") {
+			foundInvariantNote = true
+		}
+	}
+	if !foundInvariantNote {
+		t.Error("Actions should reference INV-U-001 so operators see the architectural constraint")
+	}
+}
+
+func TestBuildPlan_SameVersion_NoUpdateNeeded(t *testing.T) {
+	pre := &PreflightResult{Passed: true}
+	p := BuildPlan(pre, "1.98.2", "1.98.2", "source")
+
+	if p.NeedsUpdate {
+		t.Error("NeedsUpdate should be false when current == target")
+	}
+}
+
+func TestBuildPlan_EmptyTarget_WarnsNotFatal(t *testing.T) {
+	pre := &PreflightResult{Passed: true}
+	p := BuildPlan(pre, "1.98.2", "", "rpm")
+
+	if p.NeedsUpdate {
+		t.Error("empty target must not imply NeedsUpdate=true")
+	}
+	var foundWarning bool
+	for _, w := range p.Warnings {
+		if strings.Contains(w, "target version not detected") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Error("empty target should produce an operator-visible warning")
+	}
+}
+
+func TestBuildPlan_PreflightFailed_AddsWarning(t *testing.T) {
+	pre := &PreflightResult{Passed: false}
+	p := BuildPlan(pre, "1.98.2", "1.99.0", "source")
+
+	var found bool
+	for _, w := range p.Warnings {
+		if strings.Contains(w, "preflight failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("failing preflight should add a warning to the plan")
+	}
+}
+
+func TestPlan_JSON_RoundTrip(t *testing.T) {
+	pre := &PreflightResult{Passed: true, Checks: []PreflightCheck{{Name: "x", Passed: true, Severity: "critical"}}}
+	p := BuildPlan(pre, "1.98.2", "1.99.0", "source")
+
+	data, err := p.JSON()
+	if err != nil {
+		t.Fatalf("JSON encode: %v", err)
+	}
+	out := string(data)
+	// Contract surface — must contain these field names.
+	for _, needle := range []string{
+		`"schema_version"`,
+		`"current_version"`,
+		`"target_version"`,
+		`"needs_update"`,
+		`"preflight"`,
+	} {
+		if !strings.Contains(out, needle) {
+			t.Errorf("JSON output missing %s:\n%s", needle, out)
+		}
+	}
+}
+
+// Helpers ────────────────────────────────────────────────────────────────────
+
+func hasCheckFailed(res *PreflightResult, name string) bool {
+	for _, c := range res.Checks {
+		if c.Name == name && !c.Passed {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

First PR in the **v1.99 Update Engine Canonization** track. Establishes the contract + first wiring layer so that `nftban update` is treated as a **bounded state transition through the lifecycle engine**, not a parallel installer.

**Draft** — depends on `v1.98.2` tag (already shipped as of this PR), and a companion-spec review pass before landing.

## Architecture constraint (INV-U-001)

> Update is a **bounded trigger** into the rebuild/lifecycle pipeline.
> No separate update-only staging/validation/switch logic. Apply work lands in PR-18 and reuses existing rebuild semantics.

The plan rendered by `--dry-run` prints this reminder so operators see the architectural model, not just the outcome.

## Scope of this PR (explicit)

### In scope — closes G3-U1..U4

| Gate | What this PR does |
|------|------------------|
| G3-U1 lifecycle entry | `nftban-installer --mode=upgrade --dry-run` routes to `runUpdateDryRun`; installer binary header records `mode=upgrade` |
| G3-U2 version detection | `update.DetectVersions` reads `/usr/lib/nftban/VERSION` (current) + `<sourceDir>/VERSION` (target). Package-install target detection deferred to PR-17. |
| G3-U3 `--dry-run` correctness | `runUpdateDryRun` renders plan, persists plan JSON to state dir for audit, exits 0/1. No mutation of `/etc/nftban/**`. |
| G3-U4 preflight enforcement | `update.Preflight` runs five checks P-1..P-5. Critical failures flip plan.Warnings; warning-severity failures stay informational. |

### Out of scope (explicit)

- No shell update path deletion (PR-21)
- No update apply logic (PR-18)
- No package-install target detection (PR-17)
- No uninstall / config-registry / hardening work

## What landed

**New package `internal/installer/update/`**
- `preflight.go` — 5 preconditions P-1 authority, P-2 service, P-3 artifact, P-4 nft dep, P-5 stale-state warning
- `plan.go` — `Plan` struct + `DetectVersions` + `BuildPlan` + `Render` + JSON round-trip. Schema version `1.99.0`.
- `update_test.go` — 14 tests covering happy path + each preflight failure mode + version detection edge cases + JSON schema contract

**Installer binary**
- `cmd/nftban-installer/update_dryrun.go` — new orchestrator; reuses `phaseDetect`, then runs Preflight + DetectVersions + BuildPlan, renders + persists JSON
- `cmd/nftban-installer/main.go` — dispatch: `--mode=upgrade + --dry-run` → `runUpdateDryRun`

**CI gate (new, blocking)**
- `.github/workflows/ci-update-canonization.yml` — matrix Ubuntu 24.04 + AlmaLinux 9. Enforces G3-U1/U2/U3/U4. Future sub-gates (G3-U5..U17 + P-1/P-2/P-3 + G3-U-REBUILD-PARITY) added incrementally by PR-17..PR-21 per spec.

## Specs

- `V1.90_AUDIT_WIKI_CODE/V199_PR16_UPDATE_TRIGGER_SPEC.md` (draft)
- `V1.90_AUDIT_WIKI_CODE/G3_UPDATE_GATE_SPEC.md` (v1.99 rev)

Both live in the internal planning tree — not mirrored into this repo.

## Test plan

- [x] Go unit tests for `update.Preflight` + `DetectVersions` + `BuildPlan`
- [x] `ci-update-canonization.yml` runs on this PR (G3-U1..U4)
- [ ] Manual lab run: `sudo ./bin/nftban-installer --mode=upgrade --dry-run --source --source-dir=\$PWD` on Ubuntu 24.04 + AlmaLinux 9
- [ ] Review pass on PR-16 spec before un-drafting

## Follow-ups

| PR | Gate sub-section |
|----|------------------|
| PR-17 | package-install target detection (G3-U4 deepen) |
| PR-18 | update apply reuses rebuild (G3-U5..U10) |
| PR-19 | update validation (G3-U11..U13) |
| PR-20 | update logging (G3-U15..U17) |
| PR-21 | remove shell update paths + parity gates |

🤖 Generated with [Claude Code](https://claude.com/claude-code)