### PR TITLE
fix(v1.99): validator bin path — use constants.ValidatorBinPath single authority

### DIFF
--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -112,9 +112,16 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          sudo install -d /usr/lib/nftban /var/lib/nftban/state /etc/nftban /etc/ssh
+          sudo install -d /usr/lib/nftban/bin /var/lib/nftban/state /etc/nftban /etc/ssh
           # Current version on disk.
           sudo cp VERSION /usr/lib/nftban/VERSION
+          # Stage the validator binary at its FHS home so runUpdateApply
+          # can invoke it (fhs.NftbanValidateBin absolute path — NOT on
+          # default $PATH). This was caught by the G3-U-REBUILD-PARITY
+          # gate FC-1 on 2026-04-19 and fixed in the Go apply path.
+          # Staging here future-proofs against any non-dry-run CI step
+          # that exercises the real validator invocation.
+          sudo install -m 0755 bin/nftban-validate /usr/lib/nftban/bin/nftban-validate
           # Seed a terminal state marker so the stale-in-progress warning
           # does not fire in the happy path.
           echo "COMMITTED" | sudo tee /var/lib/nftban/state/install_state >/dev/null

--- a/cmd/nftban-core/cmd_lifecycle.go
+++ b/cmd/nftban-core/cmd_lifecycle.go
@@ -29,6 +29,8 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/itcmsgr/nftban/internal/constants"
+
 	"github.com/itcmsgr/nftban/internal/lifecycle"
 	"github.com/itcmsgr/nftban/internal/rebuild"
 )
@@ -154,7 +156,7 @@ func detectAuthority() lifecycle.AuthorityState {
 
 	// Check if nftban tables exist in kernel
 	// Use nft list tables to detect presence (read-only, no mutation)
-	if fileExists("/usr/lib/nftban/bin/nftban-validate") || fileExists("/usr/sbin/nftban") {
+	if fileExists(constants.ValidatorBinPath) || fileExists("/usr/sbin/nftban") {
 		// NFTBan is installed — check if it owns the firewall
 		auth.Owner = lifecycle.AuthorityNFTBan
 
@@ -232,8 +234,12 @@ func nftTablesExist() bool {
 }
 
 func getValidatorHealth() string {
-	// Try nftban-validate if available
-	out, err := runCmdOutput("nftban-validate", "status", "--quiet")
+	// Absolute path via constants.ValidatorBinPath — /usr/lib/nftban/bin
+	// is NOT in default $PATH. Parity gate FC-1 (2026-04-19) found the
+	// bare-name bug in the installer's update_apply.go; aligning this
+	// site with the same single authority closes the defect class
+	// repo-wide on the Go surface.
+	out, err := runCmdOutput(constants.ValidatorBinPath, "status", "--quiet")
 	if err != nil {
 		return "down"
 	}

--- a/cmd/nftban-installer/update_apply.go
+++ b/cmd/nftban-installer/update_apply.go
@@ -47,6 +47,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/itcmsgr/nftban/internal/constants"
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
@@ -66,8 +67,23 @@ const (
 
 	// Validator gate. Read-only; governs apply's exit contract per
 	// G3-U8 ("validator result GOVERNS lifecycle outcome").
-	validatorCmd  = "nftban-validate"
+	//
+	// Absolute path via constants.ValidatorBinPath — /usr/lib/nftban/bin
+	// is NOT in default $PATH on Ubuntu or AlmaLinux, so a bare name
+	// ("nftban-validate") fails to resolve. Found by the post-PR-20
+	// parity gate FC-1 on 2026-04-19. constants.ValidatorBinPath is the
+	// single authority for this path (four pre-existing consumers in
+	// internal/metrics + internal/smoke); this PR aligns the two
+	// previously bare-name Go call sites (here + cmd_lifecycle.go) with
+	// that single authority rather than introducing a second one.
 	validatorArg1 = "--json"
+)
+
+var (
+	// validatorCmd is a var, not const, because it references the
+	// constants package. Kept parallel to rebuildCmd (still a const
+	// string because nftban IS on $PATH at /usr/sbin/nftban).
+	validatorCmd = constants.ValidatorBinPath
 )
 
 // runUpdateApply is the update-mode apply orchestrator. Invoked when

--- a/cmd/nftban-installer/update_apply_logging_test.go
+++ b/cmd/nftban-installer/update_apply_logging_test.go
@@ -171,7 +171,7 @@ func TestUpdateApplyLog_TrailerFiresOnEveryBranch(t *testing.T) {
 			m.RunResults["nftban:firewall:rebuild"] = executor.Result{ExitCode: 2}
 		}},
 		{"validator-fail", func(m *executor.MockExecutor) {
-			m.RunResults["nftban-validate:--json"] = executor.Result{ExitCode: 2}
+			m.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{ExitCode: 2}
 		}},
 	}
 	for _, b := range branches {

--- a/cmd/nftban-installer/update_apply_test.go
+++ b/cmd/nftban-installer/update_apply_test.go
@@ -72,7 +72,7 @@ func seedHappyApplyHost(mock *executor.MockExecutor) {
 	mock.RunResults["nftban:firewall:rebuild"] = executor.Result{ExitCode: 0, Stdout: "rebuild ok"}
 
 	// Validator gate — success with a plausible JSON body.
-	mock.RunResults["nftban-validate:--json"] = executor.Result{
+	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{
 		ExitCode: 0,
 		Stdout:   `{"schema_version":"1.83.0","status":"protected"}`,
 	}
@@ -168,9 +168,10 @@ func TestUpdateApply_RebuildFail_DoesNotInvokeValidator(t *testing.T) {
 	}
 
 	// Validator must never have been invoked — apply must not try to
-	// "confirm" a failed rebuild.
+	// "confirm" a failed rebuild. (Check by the absolute path we use now
+	// so this regression guard survives the validator-path fix.)
 	for _, c := range mock.Commands {
-		if c.Name == "nftban-validate" {
+		if c.Name == "/usr/lib/nftban/bin/nftban-validate" {
 			t.Error("validator invoked after rebuild failure — contract violated")
 		}
 	}
@@ -184,7 +185,7 @@ func TestUpdateApply_ValidatorFail_OverridesRebuildSuccess(t *testing.T) {
 	seedHappyApplyHost(mock)
 	// Rebuild succeeds, but validator rejects post-state.
 	mock.RunResults["nftban:firewall:rebuild"] = executor.Result{ExitCode: 0}
-	mock.RunResults["nftban-validate:--json"] = executor.Result{
+	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{
 		ExitCode: 2, // validator exits 2 when state is "down"
 		Stderr:   "post-state rejected",
 	}
@@ -296,7 +297,7 @@ func TestUpdateApply_DoesNotReinterpretValidatorOutput(t *testing.T) {
 	seedHappyApplyHost(mock)
 	// Exit says FAIL (2), but JSON says "protected". Apply must honour
 	// the exit code, not the body.
-	mock.RunResults["nftban-validate:--json"] = executor.Result{
+	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{
 		ExitCode: 2,
 		Stdout:   `{"schema_version":"1.83.0","status":"protected"}`,
 	}
@@ -320,7 +321,7 @@ func TestUpdateApply_DoesNotReinterpretValidatorOutput(t *testing.T) {
 func TestUpdateApply_ValidatorExit1_TransitionsToStateDegraded(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	seedHappyApplyHost(mock)
-	mock.RunResults["nftban-validate:--json"] = executor.Result{ExitCode: 1}
+	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{ExitCode: 1}
 
 	cfg := &config{mode: "upgrade", stateDir: t.TempDir()}
 	sf := state.NewStateFile(cfg.stateDir)
@@ -343,7 +344,7 @@ func TestUpdateApply_ValidatorExit1_TransitionsToStateDegraded(t *testing.T) {
 func TestUpdateApply_ValidatorExit2_TransitionsToStateFailedRebuild(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	seedHappyApplyHost(mock)
-	mock.RunResults["nftban-validate:--json"] = executor.Result{ExitCode: 2}
+	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{ExitCode: 2}
 
 	cfg := &config{mode: "upgrade", stateDir: t.TempDir()}
 	sf := state.NewStateFile(cfg.stateDir)

--- a/internal/installer/fhs/paths.go
+++ b/internal/installer/fhs/paths.go
@@ -192,6 +192,12 @@ const (
 	NftbanCLI = "/usr/sbin/nftban"
 )
 
+// NOTE: the validator binary path is NOT defined here. It already has a
+// canonical home at internal/constants/paths.go::ValidatorBinPath with
+// four existing consumers (metrics + smoke). Adding a second constant
+// here would create duplicate authority plumbing — post-PR-20 parity
+// gate FC-1 (2026-04-19) fix uses constants.ValidatorBinPath instead.
+
 // DirSpec describes a required directory with path, mode, and owner.
 type DirSpec struct {
 	Path  string

--- a/internal/installer/update/apply_contract.go
+++ b/internal/installer/update/apply_contract.go
@@ -54,7 +54,10 @@ var ApplyWhitelist = map[string]bool{
 	"nftban firewall rebuild": true,
 
 	// Validator gate — read-only; blocks success on failure.
-	"nftban-validate --json": true,
+	// Absolute path because /usr/lib/nftban/bin is NOT in default $PATH
+	// on Ubuntu or AlmaLinux. Parity gate FC-1 (2026-04-19) caught the
+	// bare-name form failing with "executable file not found in $PATH".
+	"/usr/lib/nftban/bin/nftban-validate --json": true,
 
 	// Post-state kernel/service inspection — read-only. Whitelisted
 	// explicitly so a reviewer sees every boundary.

--- a/internal/installer/update/apply_contract.md
+++ b/internal/installer/update/apply_contract.md
@@ -28,7 +28,9 @@ runUpdateApply  (new — orchestration only)
      │             ├── nftban_rebuild_recovery.sh  (existing — recovery)
      │             └── rebuild/marker.go            (existing — classification)
      │
-     ├── exec.Run("nftban-validate")   (existing — validator gate)
+     ├── exec.Run("/usr/lib/nftban/bin/nftban-validate", "--json")   (validator gate)
+     │    ↑ absolute path via fhs.NftbanValidateBin — /usr/lib/nftban/bin
+     │      is NOT in default $PATH. Parity gate FC-1 (2026-04-19).
      │
      └── sf.Transition(...)            (existing — lifecycle state machine)
 ```

--- a/internal/installer/update/apply_contract_test.go
+++ b/internal/installer/update/apply_contract_test.go
@@ -65,7 +65,7 @@ func TestApplyContract_ForbiddenListsWellFormed(t *testing.T) {
 func TestApplyAudit_CommandsHappyPath(t *testing.T) {
 	cmds := []string{
 		"nftban firewall rebuild",
-		"nftban-validate --json",
+		"/usr/lib/nftban/bin/nftban-validate --json",
 		"nft list table ip nftban",
 	}
 	v := AuditRecordedCommands(cmds)


### PR DESCRIPTION
## Summary

PR-18/19/20 follow-up fix caught by the post-PR-20 **G3-U-REBUILD-PARITY** gate on lab2 (2026-04-19, evidence at `/tmp/parity-lab2.tar.gz` + mirror `V1.90_AUDIT_WIKI_CODE/G3_U_REBUILD_PARITY_EVIDENCE.md` §8).

**The bug:** `runUpdateApply` invoked `exec.Run("nftban-validate", "--json")` — bare name via `$PATH`. `/usr/lib/nftban/bin` is NOT in default `$PATH` on Ubuntu or AlmaLinux, so every operator-initiated apply failed at the validator phase and persisted `StateFailedRebuild` even when rebuild itself succeeded.

**The gate's positive result:** rebuild pipeline parity held — normalized kernel ruleset + protected filesystem sha256 set identical across baseline / Path A's rebuild phase / Path B. The divergence was purely in apply's validator invocation.

## Fix shape (narrow, single-authority)

`internal/constants/paths.go::ValidatorBinPath` already defined the canonical path with 4 existing consumers (`internal/metrics` + `internal/smoke`). Two Go call sites had missed it:

- `cmd/nftban-installer/update_apply.go` — `exec.Run("nftban-validate", …)`
- `cmd/nftban-core/cmd_lifecycle.go` — `runCmdOutput("nftban-validate", …)` + `fileExists("/usr/lib/nftban/bin/nftban-validate")`

All three now use `constants.ValidatorBinPath`. **No new authority added.**

### Explicit non-addition

An earlier draft added `fhs.NftbanValidateBin` which would have created a second authority alongside `constants.ValidatorBinPath` — exactly the duplicate-authority pattern the review forbids. A marker comment now sits in `internal/installer/fhs/paths.go` pointing at the canonical location.

## Scope boundaries

- ✅ Go-side only
- ✅ No state/exit semantics change
- ✅ No mutation/recovery/authority path change
- ❌ Shell-side hardcoded sites (5 exist) — out of scope; cosmetic hygiene for a separate PR if desired
- ❌ No new abstractions, no new constants

## Aligned surfaces

| File | Change |
|---|---|
| `cmd/nftban-installer/update_apply.go` | use `constants.ValidatorBinPath` |
| `cmd/nftban-core/cmd_lifecycle.go` | use `constants.ValidatorBinPath` at 2 sites |
| `internal/installer/fhs/paths.go` | marker comment (intentionally NOT adding a duplicate constant) |
| `internal/installer/update/apply_contract.go` | `ApplyWhitelist` entry updated to absolute path |
| `internal/installer/update/apply_contract.md` | call graph updated |
| `internal/installer/update/apply_contract_test.go` | harness happy-path string |
| `cmd/nftban-installer/update_apply_test.go` | 6 mock keys |
| `cmd/nftban-installer/update_apply_logging_test.go` | 1 mock key |
| `.github/workflows/ci-update-canonization.yml` | stage validator at `/usr/lib/nftban/bin/` in host prep |

## Required post-merge action (gates PR-21)

Re-run **G3-U-REBUILD-PARITY** on **both lab2 AND lab4** per `V1.90_AUDIT_WIKI_CODE/G3_U_REBUILD_PARITY_EVIDENCE.md`. Template's §2 matrix requires both representative hosts before PR-21 can open.

**PR-21 stays blocked** until the parity gate signs off PASS on both hosts with captured artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)