### PR TITLE
v1.100 PR-22B — lifecycle truth repair (dry-run honesty + history gating + authority alignment + panel consent)

### DIFF
--- a/.github/workflows/ci-install-canonization.yml
+++ b/.github/workflows/ci-install-canonization.yml
@@ -1,0 +1,181 @@
+# =============================================================================
+# NFTBan — CI: Install Canonization Gate (v1.100 PR-22B slice)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# Purpose:
+#   G3-IN-REFUSE-DRY-RUN — `--mode=install --dry-run` must REFUSE with a
+#                          clear error and a non-zero exit code. PR-22B
+#                          does not add install preview capability; it
+#                          removes false dry-run semantics by refusing
+#                          unsupported install dry-run invocations.
+#
+#   G3-IN-FLAG-COMBOS    — operator-error flag combinations are rejected
+#                          up front rather than silently accepted.
+#
+# Audit basis: extended audit §4.A ("install dry-run is dishonest today")
+# and §4.H ("CLI flag semantics").
+#
+# =============================================================================
+
+name: Install Canonization Gate
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'cmd/nftban-installer/**'
+      - 'internal/installer/state/**'
+      - '.github/workflows/ci-install-canonization.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-install-canonization-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install-canonization:
+    name: Install Canonization (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-24.04
+            runner: ubuntu-24.04
+            container: ''
+          - label: almalinux-9
+            runner: ubuntu-24.04
+            container: almalinux:9
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install system dependencies (DEB)
+        if: matrix.label == 'ubuntu-24.04'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y nftables
+
+      - name: Install system dependencies (RPM)
+        if: matrix.label == 'almalinux-9'
+        run: |
+          dnf -y install epel-release
+          dnf -y install nftables git tar gzip procps-ng findutils sudo golang
+
+      - name: Set up Go (DEB only)
+        if: matrix.label == 'ubuntu-24.04'
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.6.0
+        with:
+          go-version: '1.25'
+
+      - name: Build nftban-installer
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p bin
+          go build -trimpath -o bin/nftban-installer ./cmd/nftban-installer/
+          test -x bin/nftban-installer
+
+      - name: Prepare minimal host state
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo install -d /var/lib/nftban/state
+
+      # ------------------------------------------------------------------
+      # G3-IN-REFUSE-DRY-RUN — --mode=install --dry-run must refuse.
+      # Pre-PR-22B behaviour was to silently execute all five install
+      # phases, mutating the host. The fix refuses explicitly and exits
+      # non-zero; the message must reference PR-22B so operators find
+      # the context when grep'ing the error.
+      # ------------------------------------------------------------------
+      - name: G3-IN-REFUSE-DRY-RUN — install dry-run is refused
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Seed a history file so the audit can also assert no pollution
+          # even if the binary accidentally executed any code path.
+          sudo mkdir -p /var/lib/nftban
+          echo '{"schema_version":"1.0","entries":[]}' | sudo tee /var/lib/nftban/update-history.json >/dev/null
+          before_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
+
+          set +e
+          out=$(sudo ./bin/nftban-installer --mode=install --dry-run \
+                --state-dir=/var/lib/nftban/state 2>&1)
+          rc=$?
+          set -e
+          echo "rc=$rc"
+          echo "$out"
+
+          if [[ "$rc" -eq 0 ]]; then
+            echo "::error::G3-IN-REFUSE-DRY-RUN FAIL: install dry-run exited 0 — it must REFUSE, not silently proceed"
+            exit 1
+          fi
+          # Must contain an explicit refusal phrase so operators see why.
+          if ! echo "$out" | grep -qE "install.*--dry-run is not implemented"; then
+            echo "::error::G3-IN-REFUSE-DRY-RUN FAIL: output did not explain the refusal"
+            exit 1
+          fi
+          # No history pollution from the refused run.
+          after_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
+          if [[ "$before_hist" != "$after_hist" ]]; then
+            echo "::error::G3-IN-REFUSE-DRY-RUN FAIL: history file changed on a refused run"
+            exit 1
+          fi
+          echo "G3-IN-REFUSE-DRY-RUN PASS — install dry-run refused cleanly, no pollution"
+
+      # ------------------------------------------------------------------
+      # G3-IN-FLAG-COMBOS — reject operator-error flag combinations.
+      # ------------------------------------------------------------------
+      - name: G3-IN-FLAG-COMBOS — invalid flag combos refused
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          check_refuse() {
+            local tag="$1"; shift
+            set +e
+            out=$(sudo ./bin/nftban-installer "$@" --state-dir=/var/lib/nftban/state 2>&1)
+            rc=$?
+            set -e
+            if [[ "$rc" -eq 0 ]]; then
+              echo "::error::G3-IN-FLAG-COMBOS FAIL [$tag]: should have refused, exited 0"
+              echo "$out"
+              return 1
+            fi
+            echo "[$tag] refused (rc=$rc)"
+          }
+          check_refuse "takeover+dryrun" --mode=upgrade --takeover --dry-run
+          check_refuse "rpm+deb" --mode=upgrade --rpm --deb
+          check_refuse "fdoc-without-purge" --mode=uninstall --force-delete-operator-config
+          echo "G3-IN-FLAG-COMBOS PASS — invalid combinations rejected"
+
+      # ------------------------------------------------------------------
+      # Go unit tests for install-scope behaviour: flag validation,
+      # writeHistory gating, IsApplyTerminal allowlist, StateFile DryRun.
+      # ------------------------------------------------------------------
+      - name: Unit tests — install-scope repair (PR-22B)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          go test -v ./internal/installer/state/... ./internal/installer/authority/... ./cmd/nftban-installer/...
+
+  summary:
+    name: Install Canonization summary
+    needs: install-canonization
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verdict
+        run: |
+          if [[ "${{ needs.install-canonization.result }}" != "success" ]]; then
+            echo "::error::Install Canonization Gate FAILED — see matrix job output"
+            exit 1
+          fi
+          echo "Install Canonization Gate PASSED on all matrix targets"

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -151,8 +151,21 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          # Snapshot state dir before the run.
+          # PR-22B: snapshot ALL protected paths, including the
+          # update-history.json truth surface. The previous version of
+          # this gate whitelisted /var/lib/nftban/state/update_plan.json
+          # and swallowed diff output behind "|| true" — exactly the
+          # shape the audit flagged as "falsely reassuring CI."
           before=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
+
+          # Seed a known update-history.json so the post-run comparison
+          # can falsify "no history pollution." Without the seed, an
+          # empty → empty diff hides the bug.
+          sudo mkdir -p /var/lib/nftban
+          echo '{"schema_version":"1.0","entries":[]}' | sudo tee /var/lib/nftban/update-history.json >/dev/null
+
+          before_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
+          before_state=$(sudo test -f /var/lib/nftban/state/install_state && sudo sha256sum /var/lib/nftban/state/install_state | awk '{print $1}' || echo "missing")
 
           set +e
           sudo ./bin/nftban-installer --mode=upgrade --dry-run \
@@ -171,14 +184,25 @@ jobs:
           # constraint verified in the output, not buried in source).
           grep -q "INV-U-001" /tmp/dryrun.out
 
-          # Snapshot again; the only acceptable mutation is the audit
-          # write of update_plan.json under the state dir (documented).
+          # PR-22B hard assertions — no soft "|| true". Any deviation is a
+          # contract failure that must fail the gate.
           after=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
+          after_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
+          after_state=$(sudo test -f /var/lib/nftban/state/install_state && sudo sha256sum /var/lib/nftban/state/install_state | awk '{print $1}' || echo "missing")
 
-          # Accept: appearance of update_plan.json under state dir only.
-          diff <(echo "$before") <(echo "$after") \
-              | grep -v '/var/lib/nftban/state/update_plan.json' \
-              | grep -v '^---' | grep -v '^[<>] *$' || true
+          if [[ "$before_hist" != "$after_hist" ]]; then
+            echo "::error::G3-U3 FAIL: update-history.json modified by dry-run (before=$before_hist after=$after_hist) — audit finding F regression"
+            exit 1
+          fi
+          if [[ "$before_state" != "$after_state" ]]; then
+            echo "::error::G3-U3 FAIL: install_state modified by dry-run (before=$before_state after=$after_state) — sf.DryRun must suppress Transition persistence"
+            exit 1
+          fi
+          if [[ "$before" != "$after" ]]; then
+            echo "::error::G3-U3 FAIL: filesystem under /var/lib/nftban or /etc/nftban changed during dry-run"
+            diff <(echo "$before") <(echo "$after") || true
+            exit 1
+          fi
 
           # Hard assertion: no file under /etc/nftban/** was modified.
           if ! diff -q <(echo "$before" | grep '^/etc/nftban/') \
@@ -191,7 +215,7 @@ jobs:
           # if preflight fails. Never 2/3/4 for a well-formed run on a
           # host that doesn't have a real daemon.
           case "$rc" in
-            0|1) echo "G3-U3 PASS — exit=$rc (preflight result reflected correctly)" ;;
+            0|1) echo "G3-U3 PASS — exit=$rc (preflight result reflected correctly); history + state + fs all unchanged" ;;
             *) echo "::error::G3-U3 FAIL: unexpected exit code $rc"; exit 1 ;;
           esac
 
@@ -282,39 +306,58 @@ jobs:
       # for forbidden patterns before any runtime test. Fails fast if
       # apply ever gains a direct mutation surface.
       # ------------------------------------------------------------------
-      - name: G3-U5..U10 — structural call-path audit of update_apply.go
+      - name: G3-U5..U10 — structural call-path audit of update scope
         shell: bash
         run: |
           set -Eeuo pipefail
-          src=cmd/nftban-installer/update_apply.go
-          echo "Auditing $src for forbidden patterns..."
+          # PR-22B: widen audit scope from update_apply.go only to the
+          # full update reach set. The audit found dry-run writes that
+          # the narrower scope missed (update_dryrun.go, phaseDetect
+          # reuse in phases.go). Shared dispatchers in main.go are also
+          # checked for direct writes, but are allowed to call the
+          # history writer via the writeHistory helper (guarded by
+          # IsApplyTerminal).
+          srcs=(
+            cmd/nftban-installer/update_apply.go
+            cmd/nftban-installer/update_dryrun.go
+          )
+          echo "Auditing ${srcs[*]} for forbidden patterns..."
           fail=0
-          for pat in \
-              'exec\.Run\("nft"[^)]*add' \
-              'exec\.Run\("nft"[^)]*flush' \
-              'exec\.Run\("nft"[^)]*delete' \
-              'exec\.Run\("systemctl"[^)]*stop' \
-              'exec\.Run\("systemctl"[^)]*start' \
-              'exec\.Run\("systemctl"[^)]*restart' \
-              'exec\.Run\("systemctl"[^)]*reload' \
-              'exec\.Run\("systemctl"[^)]*enable' \
-              'exec\.Run\("systemctl"[^)]*disable' \
-              'exec\.Run\("systemctl"[^)]*mask' \
-              'exec\.Run\("systemctl"[^)]*unmask' \
-              'exec\.Run\("ufw"' \
-              'exec\.Run\("iptables"' \
-              'exec\.Run\("apt-get"[^)]*remove' \
-              'exec\.Run\("dnf"[^)]*remove' \
-              'exec\.WriteFileAtomic\(.*"/etc/nftban/' \
-              'exec\.WriteFileAtomic\(.*"/usr/lib/nftban/' \
-              '\.conf\.local'; do
-            if grep -nE "$pat" "$src" 2>/dev/null; then
-              echo "::error::G3-U5..U10 FAIL: forbidden pattern '$pat' in $src"
-              fail=1
-            fi
+          for src in "${srcs[@]}"; do
+            for pat in \
+                'exec\.Run\("nft"[^)]*add' \
+                'exec\.Run\("nft"[^)]*flush' \
+                'exec\.Run\("nft"[^)]*delete' \
+                'exec\.Run\("nft"[^)]*create' \
+                'exec\.Run\("systemctl"[^)]*stop' \
+                'exec\.Run\("systemctl"[^)]*start' \
+                'exec\.Run\("systemctl"[^)]*restart' \
+                'exec\.Run\("systemctl"[^)]*reload' \
+                'exec\.Run\("systemctl"[^)]*enable' \
+                'exec\.Run\("systemctl"[^)]*disable' \
+                'exec\.Run\("systemctl"[^)]*mask' \
+                'exec\.Run\("systemctl"[^)]*unmask' \
+                'exec\.Run\("ufw"' \
+                'exec\.Run\("iptables"[^-]' \
+                'exec\.Run\("apt-get"[^)]*remove' \
+                'exec\.Run\("apt-get"[^)]*purge' \
+                'exec\.Run\("dnf"[^)]*remove' \
+                'exec\.Run\("dnf"[^)]*erase' \
+                'exec\.WriteFileAtomic\(.*"/etc/nftban/' \
+                'exec\.WriteFileAtomic\(.*"/usr/lib/nftban/' \
+                'os\.WriteFile\(' \
+                'os\.Create\(' \
+                'os\.MkdirAll\(' \
+                'os\.Rename\(' \
+                '\.conf\.local'; do
+              if grep -nE "$pat" "$src" 2>/dev/null; then
+                echo "::error::G3-U5..U10 FAIL: forbidden pattern '$pat' in $src"
+                fail=1
+              fi
+            done
           done
           if (( fail > 0 )); then
-            echo "::error::Structural audit failed — update_apply.go contains forbidden call pattern"
+            echo "::error::Structural audit failed — update scope contains forbidden call pattern"
             exit 1
           fi
           echo "G3-U5..U10 structural audit PASS"

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -156,14 +156,14 @@ jobs:
           # this gate whitelisted /var/lib/nftban/state/update_plan.json
           # and swallowed diff output behind "|| true" — exactly the
           # shape the audit flagged as "falsely reassuring CI."
-          before=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
 
-          # Seed a known update-history.json so the post-run comparison
-          # can falsify "no history pollution." Without the seed, an
-          # empty → empty diff hides the bug.
+          # Seed a known update-history.json FIRST, BEFORE taking the
+          # snapshot, so both before and after include the file. Without
+          # the seed, an empty-to-empty diff hides history pollution.
           sudo mkdir -p /var/lib/nftban
           echo '{"schema_version":"1.0","entries":[]}' | sudo tee /var/lib/nftban/update-history.json >/dev/null
 
+          before=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s\n' 2>/dev/null | sort)
           before_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
           before_state=$(sudo test -f /var/lib/nftban/state/install_state && sudo sha256sum /var/lib/nftban/state/install_state | awk '{print $1}' || echo "missing")
 
@@ -185,8 +185,9 @@ jobs:
           grep -q "INV-U-001" /tmp/dryrun.out
 
           # PR-22B hard assertions — no soft "|| true". Any deviation is a
-          # contract failure that must fail the gate.
-          after=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s %T@\n' 2>/dev/null | sort)
+          # contract failure that must fail the gate. Size-only snapshot
+          # (no mtime) so touch-style no-op reopens don't trigger.
+          after=$(find /var/lib/nftban /etc/nftban -type f -printf '%p %s\n' 2>/dev/null | sort)
           after_hist=$(sudo sha256sum /var/lib/nftban/update-history.json | awk '{print $1}')
           after_state=$(sudo test -f /var/lib/nftban/state/install_state && sudo sha256sum /var/lib/nftban/state/install_state | awk '{print $1}' || echo "missing")
 

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -51,6 +51,13 @@ type config struct {
 	purge                     bool // --purge: stronger uninstall mode (preserves .conf.local by default)
 	forceDeleteOperatorConfig bool // --force-delete-operator-config: with --purge, also delete .conf.local
 	restorePriorAuthority     bool // --restore-prior-authority: opt into restoring pre-install external firewall (requires recorded prior state)
+	// v1.100 PR-22B: panel-auto-takeover gate. Previously implicit: any
+	// detected control panel (cPanel/Plesk/DA/etc.) silently auto-approved
+	// takeover of conflicting firewalls. The audit flagged this as
+	// "silent authority takeover" and scope-locked PR-22B to gate it
+	// behind an explicit default-off flag. Operators that relied on the
+	// prior behaviour must now pass --panel-auto-takeover.
+	panelAutoTakeover bool // --panel-auto-takeover: allow panel presence to auto-approve takeover (default OFF)
 }
 
 func parseFlags() *config {
@@ -78,6 +85,8 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.purge, "purge", false, "Uninstall in purge mode (stronger deletion; preserves .conf.local unless --force-delete-operator-config is also set). Plan-only in PR-22.")
 	flag.BoolVar(&cfg.forceDeleteOperatorConfig, "force-delete-operator-config", false, "With --purge, also delete .conf.local. Explicit destructive-intent flag. Plan-only in PR-22.")
 	flag.BoolVar(&cfg.restorePriorAuthority, "restore-prior-authority", false, "Restore pre-install external firewall authority. Requires recorded prior-authority record. Plan-only in PR-22.")
+	// v1.100 PR-22B: explicit panel-auto-takeover gate (see config field doc).
+	flag.BoolVar(&cfg.panelAutoTakeover, "panel-auto-takeover", false, "Allow control-panel presence to auto-approve takeover of conflicting firewalls. Default OFF. Set explicitly to preserve pre-PR-22B behaviour.")
 
 	flag.Parse()
 
@@ -87,6 +96,12 @@ func parseFlags() *config {
 	}
 	if envLog := os.Getenv("NFTBAN_INSTALLER_LOG"); envLog != "" {
 		cfg.logPath = envLog
+	}
+	// v1.100 PR-22B: env mirror for panel auto-takeover. Same default-off
+	// policy — only "1" enables. Any other value (including unset) leaves
+	// whatever the CLI flag supplied, which defaults to false.
+	if os.Getenv("NFTBAN_PANEL_AUTO_TAKEOVER") == "1" {
+		cfg.panelAutoTakeover = true
 	}
 	// v1.98 Phase 2: Canonized lifecycle feature flag
 	// Default: ON. Set NFTBAN_LIFECYCLE=0 to use legacy path.
@@ -107,6 +122,15 @@ func parseFlags() *config {
 	// Validate
 	if !cfg.showVersion && !cfg.repair {
 		if cfg.mode == "uninstall" {
+			// PR-22B: flag combos that are only meaningful for uninstall
+			// are validated here, because the uninstall block early-returns
+			// before the general-validation block below.
+			if cfg.forceDeleteOperatorConfig && !cfg.purge {
+				fmt.Fprintln(os.Stderr, "error: --force-delete-operator-config requires --purge")
+				fmt.Fprintln(os.Stderr, "       this flag is the escape hatch for deleting .conf.local during purge mode.")
+				fmt.Fprintln(os.Stderr, "       it has no effect on remove mode and cannot be passed alone.")
+				os.Exit(state.ExitFatal)
+			}
 			// v1.100 PR-22: uninstall mode is accepted; current release
 			// is detect + dry-run plan only. Mutation phases land in
 			// PR-23+.
@@ -142,6 +166,40 @@ func parseFlags() *config {
 			fmt.Fprintf(os.Stderr, "       nftban-installer --repair [flags]\n")
 			os.Exit(state.ExitFatal)
 		}
+
+		// v1.100 PR-22B: install dry-run is REFUSED, not silently
+		// proceeding to real install. Until an honest install dry-run
+		// orchestrator lands (deferred — out of PR-22B scope), the flag
+		// combination has no truthful meaning and must be rejected. This
+		// closes the audit finding that --mode=install --dry-run silently
+		// executed all five mutating phases.
+		//
+		// PR-22B does not add install preview capability; it removes
+		// false dry-run semantics by refusing unsupported install dry-run
+		// invocations.
+		if cfg.mode == "install" && cfg.dryRun {
+			fmt.Fprintln(os.Stderr, "error: --mode=install --dry-run is not implemented in this release")
+			fmt.Fprintln(os.Stderr, "       an honest install dry-run orchestrator is out of scope for v1.100 PR-22B")
+			fmt.Fprintln(os.Stderr, "       run without --dry-run to execute install, or use --mode=upgrade --dry-run to preview an upgrade")
+			os.Exit(state.ExitFatal)
+		}
+
+		// --takeover --dry-run is incoherent: dry-run is observational,
+		// takeover is an explicit mutation consent. Reject rather than
+		// silently drop either meaning.
+		if cfg.takeover && cfg.dryRun {
+			fmt.Fprintln(os.Stderr, "error: --takeover cannot be combined with --dry-run")
+			fmt.Fprintln(os.Stderr, "       --takeover authorises mutation; --dry-run refuses it. Pick one.")
+			os.Exit(state.ExitFatal)
+		}
+	}
+
+	// --rpm and --deb are mutually exclusive package-origin flags. The
+	// dispatcher in main.go routes differently for each; setting both
+	// would silently pick one and ignore the other.
+	if cfg.rpm && cfg.deb {
+		fmt.Fprintln(os.Stderr, "error: --rpm and --deb cannot both be set")
+		os.Exit(state.ExitFatal)
 	}
 
 	// --source is mutually exclusive with packaging-origin flags.
@@ -153,6 +211,18 @@ func parseFlags() *config {
 	// --source requires a resolvable source directory.
 	if cfg.source && cfg.sourceDir == "" {
 		fmt.Fprintln(os.Stderr, "error: --source requires --source-dir, $NFTBAN_SOURCE_DIR, or a discoverable binary location")
+		os.Exit(state.ExitFatal)
+	}
+
+	// v1.100 PR-22B: --force-delete-operator-config only has meaning with
+	// --purge (it is the escape hatch that allows the purge mode to also
+	// delete .conf.local, the operator-owned override file). Passing it
+	// alone previously caused modeFromFlags to silently drop it, which
+	// obscured the operator's intent. Reject explicitly.
+	if cfg.forceDeleteOperatorConfig && !cfg.purge {
+		fmt.Fprintln(os.Stderr, "error: --force-delete-operator-config requires --purge")
+		fmt.Fprintln(os.Stderr, "       this flag is the escape hatch for deleting .conf.local during purge mode.")
+		fmt.Fprintln(os.Stderr, "       it has no effect on remove mode and cannot be passed alone.")
 		os.Exit(state.ExitFatal)
 	}
 

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -120,6 +120,21 @@ func parseFlags() *config {
 	}
 
 	// Validate
+	//
+	// PR-22B audit finding N-1: --repair --dry-run must be refused. The
+	// previous validation block was skipped entirely for repair mode,
+	// so --dry-run was silently accepted even though phaseSwitch's nft
+	// and systemctl calls still mutate. sf.DryRun=true suppresses only
+	// state-file writes, not kernel/service mutation. Refuse rather
+	// than silently proceed.
+	if cfg.repair && cfg.dryRun {
+		fmt.Fprintln(os.Stderr, "error: --repair --dry-run is not implemented in this release")
+		fmt.Fprintln(os.Stderr, "       repair mode runs the full phase pipeline, which mutates kernel and service state.")
+		fmt.Fprintln(os.Stderr, "       an honest repair dry-run is out of scope for v1.100 PR-22B.")
+		fmt.Fprintln(os.Stderr, "       run --repair without --dry-run, or use --mode=upgrade --dry-run to preview an upgrade.")
+		os.Exit(state.ExitFatal)
+	}
+
 	if !cfg.showVersion && !cfg.repair {
 		if cfg.mode == "uninstall" {
 			// PR-22B: flag combos that are only meaningful for uninstall

--- a/cmd/nftban-installer/history_test.go
+++ b/cmd/nftban-installer/history_test.go
@@ -34,6 +34,51 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/state"
 )
 
+// PR-22B regression guard: the guard that gates writeHistory at main.go
+// uses (!cfg.dryRun) && state.IsApplyTerminal(sf.State). These tests
+// verify each half of the predicate produces the expected skip/write
+// decision. We test the predicate directly rather than invoking
+// writeHistory because that function writes to /var/lib/nftban/ — the
+// gate must refuse to reach it for non-apply-terminal states.
+func TestHistoryWriteGate_DryRunAlwaysSkips(t *testing.T) {
+	// Apply-terminal state + dry-run → must still skip.
+	dryRun := true
+	s := state.StateCommitted
+	if shouldWrite := !dryRun && s.IsApplyTerminal(); shouldWrite {
+		t.Errorf("dry-run + Committed must NOT write history; gate produced write=true")
+	}
+}
+
+func TestHistoryWriteGate_NonApplyTerminalAlwaysSkips(t *testing.T) {
+	cases := []state.InstallState{
+		state.StateDetectComplete,
+		state.StatePrepareComplete,
+		state.StateSwitchComplete,
+		state.StateServicesComplete,
+		state.StateUninstallPlanning,
+		state.StateFilesInstalled,
+	}
+	for _, s := range cases {
+		if shouldWrite := !false && s.IsApplyTerminal(); shouldWrite {
+			t.Errorf("non-apply-terminal state %s must NOT write history; gate produced write=true", s)
+		}
+	}
+}
+
+func TestHistoryWriteGate_ApplyTerminalNonDryRunWrites(t *testing.T) {
+	cases := []state.InstallState{
+		state.StateCommitted,
+		state.StateDegraded,
+		state.StateFailedRebuild,
+		state.StateFailedAbort,
+	}
+	for _, s := range cases {
+		if shouldWrite := !false && s.IsApplyTerminal(); !shouldWrite {
+			t.Errorf("apply-terminal state %s in non-dry-run must write history; gate produced write=false", s)
+		}
+	}
+}
+
 // historyStatusForState ───────────────────────────────────────────────────
 
 func TestHistoryStatusForState_Committed_IsSuccess(t *testing.T) {

--- a/cmd/nftban-installer/lifecycle_bridge.go
+++ b/cmd/nftban-installer/lifecycle_bridge.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/itcmsgr/nftban/internal/installer/authority"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 	"github.com/itcmsgr/nftban/internal/lifecycle"
@@ -40,18 +41,24 @@ import (
 type lifecycleBridge struct {
 	logger *lifecycle.Logger
 	mode   lifecycle.Mode
+	// dryRun is the operator's actual --dry-run flag value. PR-22B
+	// replaced the previously hard-coded DryRun:false in observeResult
+	// with this wired-through value so lifecycle consumers see the real
+	// run shape instead of an implicit false.
+	dryRun bool
 }
 
 // newLifecycleBridge creates a bridge that writes lifecycle events to stderr.
-func newLifecycleBridge(installerMode string, log *logging.Logger) *lifecycleBridge {
+func newLifecycleBridge(installerMode string, dryRun bool, log *logging.Logger) *lifecycleBridge {
 	mode := mapInstallerMode(installerMode)
 
 	lb := &lifecycleBridge{
 		logger: lifecycle.NewLogger(os.Stderr, mode, false),
 		mode:   mode,
+		dryRun: dryRun,
 	}
 
-	log.Info("lifecycle bridge initialized (mode=%s, observational only)", mode)
+	log.Info("lifecycle bridge initialized (mode=%s, dry_run=%v, observational only)", mode, dryRun)
 	return lb
 }
 
@@ -73,17 +80,29 @@ func (lb *lifecycleBridge) observeDetect(pd *phaseData, sf *state.StateFile) {
 }
 
 // observePlan records the PLAN stage from authority decision.
+//
+// PR-22B fix: the previous switch compared pd.decision (authority.Decision,
+// UPPERCASE values like "TAKEOVER") against lowercase string literals, so
+// the switch silently hit the default case in every run — meaning every
+// lifecycle consumer saw "PreserveAuthority" regardless of what the
+// installer actually decided. This is the exact class of lifecycle truth
+// drift the audit flagged. Now pinned to the authority package constants.
 func (lb *lifecycleBridge) observePlan(pd *phaseData) {
 	var actions []lifecycle.Action
 	switch pd.decision {
-	case "takeover":
+	case authority.Takeover, authority.Fresh:
 		actions = []lifecycle.Action{lifecycle.ActionTakeAuthority}
-	case "fresh":
-		actions = []lifecycle.Action{lifecycle.ActionTakeAuthority}
-	case "update":
+	case authority.Update:
 		actions = []lifecycle.Action{lifecycle.ActionPreserveAuthority}
-	case "abort":
+	case authority.Abort:
 		actions = []lifecycle.Action{lifecycle.ActionAbort}
+	case authority.Ambiguous:
+		// PR-22B: Ambiguous hosts cannot be assumed preserving OR taking —
+		// the plan action that best reflects reality is "take authority"
+		// (nftban will claim the firewall via rebuild) plus a conservative
+		// emergency-SSH injection, but downstream lifecycle consumers
+		// should see it as a Takeover-class action, not Preserve.
+		actions = []lifecycle.Action{lifecycle.ActionTakeAuthority}
 	default:
 		actions = []lifecycle.Action{lifecycle.ActionPreserveAuthority}
 	}
@@ -99,11 +118,16 @@ func (lb *lifecycleBridge) observePlan(pd *phaseData) {
 }
 
 // observeResult records the FINAL stage from installer outcome.
+//
+// PR-22B fix: DryRun is now wired from the operator's actual flag (see
+// newLifecycleBridge). Previously hard-coded to false, which meant every
+// lifecycle consumer saw the same misleading "real run" signal regardless
+// of how the installer was invoked.
 func (lb *lifecycleBridge) observeResult(sf *state.StateFile) {
 	result := lifecycle.RunResult{
 		SchemaVersion: lifecycle.OutputSchemaVersion,
 		Mode:          lb.mode,
-		DryRun:        false,
+		DryRun:        lb.dryRun,
 		Timestamp:     time.Now(),
 	}
 
@@ -149,16 +173,26 @@ func mapInstallerMode(mode string) lifecycle.Mode {
 }
 
 // mapAuthority converts installer authority decision to lifecycle owner.
+//
+// PR-22B fix: input values are authority.Decision strings ("TAKEOVER",
+// "FRESH", "UPDATE", "ABORT", "AMBIGUOUS" — all uppercase). Previously
+// compared against lowercase string literals, so the switch always hit
+// the default case. Now pinned to authority constants.
 func mapAuthority(decision string) lifecycle.AuthorityOwner {
-	switch decision {
-	case "takeover":
+	switch authority.Decision(decision) {
+	case authority.Takeover:
 		return lifecycle.AuthorityExternal // was external, taking over
-	case "fresh":
+	case authority.Fresh:
 		return lifecycle.AuthorityNone
-	case "update":
+	case authority.Update:
 		return lifecycle.AuthorityNFTBan
-	case "abort":
+	case authority.Abort:
 		return lifecycle.AuthorityExternal
+	case authority.Ambiguous:
+		// Ambiguous: the host's kernel state is inconsistent. Report it as
+		// "unknown" to lifecycle consumers rather than silently collapsing
+		// to nftban or external ownership.
+		return lifecycle.AuthorityUnknown
 	default:
 		return lifecycle.AuthorityNone
 	}

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -70,6 +70,12 @@ func main() {
 
 	exec := &executor.RealExecutor{}
 	sf := state.NewStateFile(cfg.stateDir)
+	// PR-22B: wire the dry-run flag into the state-file layer so that
+	// Transition() is in-memory-only for every dry-run path, regardless
+	// of which orchestrator invoked it. This closes the audit finding
+	// that shared phase functions (phaseDetect in particular) persisted
+	// install_state during update dry-run.
+	sf.DryRun = cfg.dryRun
 
 	// Read previous version before overwriting (for history tracking)
 	previousVersion := ""
@@ -95,18 +101,26 @@ func main() {
 	// never reach the gated code in phasePrepare/phaseConfigure.
 	globalPhaseData.source = cfg.source
 	globalPhaseData.sourceDir = cfg.sourceDir
+	// PR-22B: propagate panel-auto-takeover to phase data so phaseDetect's
+	// authority classifier honours the operator's explicit opt-in. Default
+	// false — panel presence alone no longer implicitly approves takeover.
+	globalPhaseData.panelAutoApprove = cfg.panelAutoTakeover
 
 	exitCode := run(ctx, exec, sf, cfg, log)
 
 	// Write JSON update history (compatible with nftban update history --json).
 	//
-	// PR-22A boundary repair (audit finding A.3): uninstall-mode dry-run
-	// is strictly observational and must not create install/update history
-	// entries. Before this guard, a successful uninstall dry-run would
-	// reach historyStatusForState(StateUninstallPlanning), fall through to
-	// the default case, and be recorded as "install_fail" — poisoning the
-	// audit trail and any dashboard that alerts on install_fail.
-	if cfg.mode != "uninstall" {
+	// PR-22B boundary repair: history writes are gated on an explicit
+	// allowlist of apply-terminal states AND the absence of --dry-run.
+	// This replaces the earlier mode-name heuristic with a structural
+	// predicate — dry-runs, intermediate states, and planning-terminal
+	// states (e.g. StateUninstallPlanning) never produce history entries.
+	//
+	// Audit finding F (history / audit-trail truth): update dry-runs used
+	// to be recorded as install_fail because StateDetectComplete has no
+	// "success" mapping; now they are not recorded at all. Automation that
+	// consumes update-history.json is no longer polluted by preview runs.
+	if !cfg.dryRun && state.IsApplyTerminal(sf.State) {
 		writeHistory(sf, cfg, previousVersion, hostname, log)
 	}
 
@@ -178,7 +192,7 @@ func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile
 	var lb *lifecycleBridge
 	if cfg.lifecycle {
 		log.Info("lifecycle_mode=canonized (NFTBAN_LIFECYCLE=on)")
-		lb = newLifecycleBridge(cfg.mode, log)
+		lb = newLifecycleBridge(cfg.mode, cfg.dryRun, log)
 	} else {
 		log.Info("lifecycle_mode=legacy (NFTBAN_LIFECYCLE=0)")
 	}

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -55,6 +55,10 @@ type phaseData struct {
 	// as zero-value and never reach the gated code.
 	source    bool
 	sourceDir string
+	// v1.100 PR-22B: panel auto-takeover opt-in. Propagated from
+	// cfg.panelAutoTakeover in main() before phases run. Default false —
+	// panel detection alone no longer auto-approves takeover.
+	panelAutoApprove bool
 }
 
 // globalPhaseData is set by phaseDetect and consumed by later phases.
@@ -110,7 +114,7 @@ func phaseDetect(_ context.Context, exec executor.Executor, sf *state.StateFile,
 	// 6. Authority classification
 	// Read takeover flag from environment or config
 	forceApprove := exec.Getenv("NFTBAN_TAKEOVER") == "1"
-	pd.decision = authority.Classify(exec, pd.conflicts, pd.panel, forceApprove, log)
+	pd.decision = authority.Classify(exec, pd.conflicts, pd.panel, forceApprove, pd.panelAutoApprove, log)
 	sf.Authority = string(pd.decision)
 	log.Detect("authority", "decision", string(pd.decision))
 	log.StateChange(string(sf.State), string(state.StateDetectComplete), "authority="+string(pd.decision))
@@ -217,9 +221,16 @@ func phaseSwitch(_ context.Context, exec executor.Executor, sf *state.StateFile,
 	pd := &globalPhaseData
 	emergencyInjected := false
 
-	// 1. TAKEOVER / FRESH: inject emergency SSH table BEFORE any destructive action.
+	// 1. TAKEOVER / FRESH / AMBIGUOUS: inject emergency SSH table BEFORE any destructive action.
 	// On UPDATE, nftban tables already exist with SSH in sets — no emergency needed.
-	if pd.decision == authority.Takeover || pd.decision == authority.Fresh {
+	//
+	// PR-22B audit fix: AMBIGUOUS (orphan table, daemon-down, etc.) is
+	// added to this branch. A host in ambiguous state cannot be trusted
+	// to already carry a SSH-safe nftban load, so the emergency-SSH
+	// injection must run before rebuild. Omitting Ambiguous here would
+	// silently continue with whatever stale kernel state the prior run
+	// left — the exact regression class the audit flagged.
+	if pd.decision == authority.Takeover || pd.decision == authority.Fresh || pd.decision == authority.Ambiguous {
 		if err := switchop.InjectEmergencySSH(exec, pd.sshPort, log); err != nil {
 			log.Error("cannot inject emergency SSH table: %v", err)
 			return sf.Transition(state.StateFailedNoFirewall, state.PhaseSwitch,
@@ -228,7 +239,10 @@ func phaseSwitch(_ context.Context, exec executor.Executor, sf *state.StateFile,
 		emergencyInjected = true
 	}
 
-	// 2. TAKEOVER: disable conflicting firewalls (emergency table protects SSH)
+	// 2. TAKEOVER: disable conflicting firewalls (emergency table protects SSH).
+	// Ambiguous intentionally does NOT disable conflicts — the audit logic says
+	// we can't prove who owns the firewall, so a conflict-disable could
+	// strip the host of its actual active authority.
 	if pd.decision == authority.Takeover {
 		if err := switchop.DisableConflicts(exec, pd.conflicts, pd.panel, log); err != nil {
 			// Emergency table LEFT IN PLACE — SSH still safe

--- a/cmd/nftban-installer/uninstall_dryrun_test.go
+++ b/cmd/nftban-installer/uninstall_dryrun_test.go
@@ -18,93 +18,40 @@
 //
 // Closes audit R4: the original PR-22 test suite verified shapes
 // (classifier states, probe states, plan render) but never exercised
-// the orchestrator runUninstallDryRun itself. The audit found three
-// writes under /var/lib/nftban/ during a "no-mutation" dry-run that
-// unit tests could not have caught.
+// the orchestrator runUninstallDryRun itself.
 //
-// This test calls runUninstallDryRun directly with a MockExecutor and
-// a real temp directory, and asserts:
+// PR-22B follow-up (audit N-2): migrated from a local forbidden-pattern
+// list to the shared audit.PurityHarness so future mutation patterns
+// added to one list propagate to all three lifecycle modes' tests.
 //
-//   1. zero executor writes (WriteFileAtomic)
-//   2. zero directory creates through the executor
-//   3. zero forbidden exec commands (nft add/delete/flush, systemctl
-//      lifecycle verbs, ufw/firewall-cmd/iptables-restore, package
-//      manager removal)
-//   4. zero files created on disk under the temp state dir
-//
-// If any future change reintroduces a write path, this test fails
-// before the binary ever ships.
 // =============================================================================
 package main
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 
+	"github.com/itcmsgr/nftban/internal/installer/audit"
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 )
 
-// forbiddenCommandPatterns lists command fragments that must NEVER appear
-// in the recorded command trace of a PR-22 uninstall dry-run. Each entry
-// is matched as a substring against "name + args" joined with spaces.
-//
-// This list mirrors the CI G3-UN-NO-MUTATION grep patterns but operates
-// at runtime rather than source-grep time — so a dynamically-constructed
-// argument (which grep would miss) is still caught.
-var forbiddenCommandPatterns = []string{
-	"nft add",
-	"nft delete",
-	"nft flush",
-	"nft create",
-	"systemctl start",
-	"systemctl stop",
-	"systemctl restart",
-	"systemctl reload",
-	"systemctl enable",
-	"systemctl disable",
-	"systemctl mask",
-	"systemctl unmask",
-	"ufw ",
-	"firewall-cmd",
-	"iptables-restore",
-	"ip6tables-restore",
-	"apt-get remove",
-	"apt-get purge",
-	"dnf remove",
-	"dnf erase",
-	"rpm -e",
-	"dpkg --remove",
-	"dpkg --purge",
-	"userdel",
-	"groupdel",
-}
-
-// readOnlyCommandPrefixes are the command names legitimately issued by
-// PR-22's read-only classification + probe code. Any other command is
-// either a bug or scope creep.
-var readOnlyCommandPrefixes = []string{
-	"iptables-save",
-	"ip6tables-save",
-	"nft list",
-	"systemctl is-active",
-}
-
 // TestRunUninstallDryRun_Purity_NoMutation is the R4 falsifiable guard.
 //
-// It exercises runUninstallDryRun with a MockExecutor and a fresh temp
-// directory as stateDir, then asserts that no mutation of any kind
-// occurred through the executor interface or the filesystem.
+// Calls runUninstallDryRun with a MockExecutor + real temp directory as
+// stateDir, then asserts via audit.PurityHarness that:
+//
+//  1. zero executor writes (WriteFileAtomic)
+//  2. zero executor MkdirAll calls
+//  3. zero mutation-flavored commands (nft add/flush/delete, systemctl
+//     lifecycle verbs, ufw/firewall-cmd/iptables-restore, package-manager
+//     removal, userdel/groupdel)
+//  4. zero files on disk under temp stateDir — catches direct os.*
+//     filesystem writes that bypass the executor
 func TestRunUninstallDryRun_Purity_NoMutation(t *testing.T) {
 	tmp := t.TempDir()
 
-	// MockExecutor with no nftban authority and no external firewall —
-	// the simplest "host" the dry-run encounters. Classify should return
-	// AuthorityNone; plan should render; zero mutation commands should
-	// be issued.
 	mock := executor.NewMockExecutor()
 	mock.RunResults["iptables-save"] = executor.Result{
 		ExitCode: 0,
@@ -112,6 +59,7 @@ func TestRunUninstallDryRun_Purity_NoMutation(t *testing.T) {
 	}
 
 	sf := state.NewStateFile(tmp)
+	sf.DryRun = true
 	log := logging.New("/dev/null", false)
 
 	cfg := &config{
@@ -125,67 +73,12 @@ func TestRunUninstallDryRun_Purity_NoMutation(t *testing.T) {
 		t.Fatalf("runUninstallDryRun rc = %d; want %d (ExitCommitted)", rc, state.ExitCommitted)
 	}
 
-	// (1) Executor-level writes: must be zero.
-	if n := len(mock.WrittenFiles); n != 0 {
-		t.Errorf("WriteFileAtomic called %d times; want 0. files: %v", n, writtenFilePaths(mock.WrittenFiles))
-	}
-
-	// (2) Executor-level directory creates: must be zero.
-	if n := len(mock.Dirs); n != 0 {
-		t.Errorf("MkdirAll called %d times; want 0. dirs: %v", n, dirPaths(mock.Dirs))
-	}
-
-	// (3) Command trace: forbidden patterns must not appear.
-	for _, cmd := range mock.Commands {
-		joined := cmd.Name + " " + strings.Join(cmd.Args, " ")
-		for _, forbid := range forbiddenCommandPatterns {
-			if strings.Contains(joined, forbid) {
-				t.Errorf("forbidden mutation command detected: %q (matched pattern %q)", joined, forbid)
-			}
-		}
-	}
-
-	// (3b) Command trace: every command issued must match a read-only
-	// prefix. A command outside that set is either a bug or scope creep.
-	for _, cmd := range mock.Commands {
-		name := cmd.Name
-		matched := false
-		for _, allow := range readOnlyCommandPrefixes {
-			// Match by exact name or by "name + first arg".
-			if name == allow || strings.HasPrefix(allow, name+" ") ||
-				(len(cmd.Args) > 0 && name+" "+cmd.Args[0] == allow) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			t.Errorf("unexpected command in dry-run trace (not in read-only whitelist): name=%q args=%v", name, cmd.Args)
-		}
-	}
-
-	// (4) Filesystem: the temp state dir must be empty. This catches any
-	// direct os.WriteFile / os.Create call that bypasses the executor —
-	// exactly the class of bug PR-22A exists to repair.
-	//
-	// Note: the dir itself was created by t.TempDir(); we assert it has
-	// zero entries after the dry-run.
-	entries, err := os.ReadDir(tmp)
-	if err != nil {
-		t.Fatalf("could not read temp state dir: %v", err)
-	}
-	if len(entries) != 0 {
-		var names []string
-		for _, e := range entries {
-			names = append(names, e.Name())
-		}
-		t.Errorf("temp state dir must be empty after dry-run; found: %v", names)
-	}
+	audit.NewPurityHarness(mock, tmp).AssertAllPurity(t)
 }
 
 // TestRunUninstallDryRun_Purity_WithAmbiguousHost covers the repaired
 // classifier path: partial nftban (table only) with no external must
-// route through the new AuthorityAmbiguous branch, and the run must
-// still be observationally pure.
+// route through AuthorityAmbiguous, and the run must still be pure.
 func TestRunUninstallDryRun_Purity_WithAmbiguousHost(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -199,6 +92,7 @@ func TestRunUninstallDryRun_Purity_WithAmbiguousHost(t *testing.T) {
 	}
 
 	sf := state.NewStateFile(tmp)
+	sf.DryRun = true
 	log := logging.New("/dev/null", false)
 	cfg := &config{mode: "uninstall", dryRun: true, stateDir: tmp}
 
@@ -207,32 +101,5 @@ func TestRunUninstallDryRun_Purity_WithAmbiguousHost(t *testing.T) {
 		t.Fatalf("dry-run rc = %d; want ExitCommitted even for Ambiguous host", rc)
 	}
 
-	if len(mock.WrittenFiles) != 0 {
-		t.Errorf("Ambiguous host path wrote files via executor: %v", writtenFilePaths(mock.WrittenFiles))
-	}
-
-	entries, _ := os.ReadDir(tmp)
-	if len(entries) != 0 {
-		var names []string
-		for _, e := range entries {
-			names = append(names, e.Name())
-		}
-		t.Errorf("Ambiguous host path wrote files to state dir: %v", names)
-	}
-}
-
-func writtenFilePaths(m map[string][]byte) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
-}
-
-func dirPaths(m map[string]bool) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
+	audit.NewPurityHarness(mock, tmp).AssertAllPurity(t)
 }

--- a/cmd/nftban-installer/update_dryrun.go
+++ b/cmd/nftban-installer/update_dryrun.go
@@ -95,15 +95,12 @@ func runUpdateDryRun(ctx context.Context, exec executor.Executor, sf *state.Stat
 	plan.AttachRecovery(update.BuildRecoveryPlan(exec))
 	plan.Render(os.Stdout)
 
-	// 6. Write a copy of the plan JSON to the state dir for audit/history
-	// traceability. Not a hard requirement for PR-16 but closes G3-U12
-	// (update history integrity) early.
-	dst := cfg.stateDir + "/update_plan.json"
-	if werr := plan.WriteJSONToFile(dst); werr != nil {
-		log.Warn("update dry-run: could not persist plan to %s: %v", dst, werr)
-	} else {
-		log.Info("update dry-run: plan written to %s", dst)
-	}
+	// 6. Plan persistence was removed in PR-22B. Operators that need a
+	// machine-consumable plan can capture stdout or use plan.ToJSON(); the
+	// dry-run is strictly observational per the audit's "dry-run must be
+	// truly observational" rule. Install-state persistence during this
+	// run is handled by sf.DryRun at the StateFile layer (set in main.go)
+	// — phaseDetect's Transition calls are in-memory-only.
 
 	// 7. Exit contract.
 	if !pre.Passed {

--- a/cmd/nftban-installer/update_dryrun_test.go
+++ b/cmd/nftban-installer/update_dryrun_test.go
@@ -1,0 +1,95 @@
+// =============================================================================
+// NFTBan v1.100 PR-22B — runUpdateDryRun Purity Test (Lifecycle Truth Repair)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-update-dryrun-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Falsifiable purity test: runUpdateDryRun must not mutate"
+// meta:inventory.files="cmd/nftban-installer/update_dryrun_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Closes audit item I (install/update audit) and audit item N-2
+// (post-PR-22B re-audit): before this test, the update dry-run was
+// defended only at CI filesystem-snapshot granularity. A future subtle
+// write gated on $LANG / hostname / time could pass CI unnoticed. This
+// unit test exercises runUpdateDryRun under a MockExecutor and applies
+// the shared audit.PurityHarness.
+//
+// The preflight inside runUpdateDryRun may or may not pass depending on
+// mock setup — that is irrelevant to this test. Whatever the preflight
+// decision, the observational contract is: zero writes, zero mutation
+// commands, zero new files in stateDir.
+//
+// =============================================================================
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/audit"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+)
+
+// TestRunUpdateDryRun_Purity_NoMutation invokes runUpdateDryRun with a
+// MockExecutor and asserts the observational contract holds regardless
+// of preflight outcome.
+func TestRunUpdateDryRun_Purity_NoMutation(t *testing.T) {
+	tmp := t.TempDir()
+
+	mock := executor.NewMockExecutor()
+	// Seed a plausible authoritative host so preflight passes — this
+	// exercises the success path. The purity contract must hold whether
+	// preflight passes or fails; we use the pass path because it runs
+	// more of the orchestrator code before returning.
+	mock.NftTables["ip:nftban"] = true
+	mock.Services["nftband.service"] = true
+	mock.Files["/usr/lib/nftban/VERSION"] = []byte("1.99.0\n")
+	mock.RunResults["sh:-c:command -v nft >/dev/null 2>&1"] = executor.Result{ExitCode: 0}
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("COMMITTED\n")
+
+	sf := state.NewStateFile(tmp)
+	sf.DryRun = true
+	log := logging.New("/dev/null", false)
+
+	cfg := &config{
+		mode:     "upgrade",
+		dryRun:   true,
+		stateDir: tmp,
+	}
+
+	// rc is not asserted — preflight result drives it. What matters is
+	// the purity contract below, which must hold regardless of the rc.
+	_ = runUpdateDryRun(context.Background(), mock, sf, cfg, log)
+
+	audit.NewPurityHarness(mock, tmp).AssertAllPurity(t)
+}
+
+// TestRunUpdateDryRun_Purity_PreflightFail covers the branch where
+// preflight fails (no authoritative nftban). The run must still be
+// observationally pure.
+func TestRunUpdateDryRun_Purity_PreflightFail(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Intentionally empty mock — nftban is not present, preflight fails.
+	mock := executor.NewMockExecutor()
+
+	sf := state.NewStateFile(tmp)
+	sf.DryRun = true
+	log := logging.New("/dev/null", false)
+	cfg := &config{mode: "upgrade", dryRun: true, stateDir: tmp}
+
+	_ = runUpdateDryRun(context.Background(), mock, sf, cfg, log)
+
+	audit.NewPurityHarness(mock, tmp).AssertAllPurity(t)
+}

--- a/internal/installer/audit/harness.go
+++ b/internal/installer/audit/harness.go
@@ -25,23 +25,12 @@
 //   - zero mutation-flavored commands in the executor trace
 //   - zero new files in the caller-supplied state directory
 //
-// The harness is intentionally narrow. It does NOT run orchestrators
-// itself — it is an assertion kit. Callers run their own dry-run under
-// a MockExecutor and then pipe the results through the harness.
+// Check* methods return []string violation messages (empty when clean);
+// Assert* methods call them and report via t.Errorf. Self-tests can
+// exercise Check* directly without needing to implement testing.TB
+// (which has an unexported method and cannot be satisfied outside the
+// testing package).
 //
-// Usage:
-//
-//	mock := executor.NewMockExecutor()
-//	stateDir := t.TempDir()
-//	// ... run the observational orchestrator ...
-//	h := audit.NewPurityHarness(mock, stateDir)
-//	h.AssertNoExecutorWrites(t)
-//	h.AssertNoMutationCommands(t)
-//	h.AssertNoStateDirEntries(t)
-//
-// Any new mode (install-refuse, update-dry-run, uninstall-dry-run,
-// future modes) should use the same harness so the assertion shape does
-// not drift.
 // =============================================================================
 package audit
 
@@ -53,13 +42,13 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 )
 
-// ForbiddenCommandPatterns is the shared deny-list used by
-// AssertNoMutationCommands. Substring-matched against the joined form
+// ForbiddenCommandPatterns is the shared deny-list used by the
+// mutation-command check. Substring-matched against the joined form
 // of "command-name arg1 arg2 …".
 //
-// The list mirrors the CI G3-UN-NO-MUTATION / G3-U5..U10 grep patterns
-// but operates at runtime — a command constructed dynamically (which
-// source grep cannot see) is still caught here.
+// Mirrors the CI structural-grep patterns but operates at runtime — a
+// dynamically-constructed argument (which source grep cannot see) is
+// still caught here.
 var ForbiddenCommandPatterns = []string{
 	// nftables mutation
 	"nft add",
@@ -106,66 +95,90 @@ func NewPurityHarness(exec *executor.MockExecutor, stateDir string) *PurityHarne
 	return &PurityHarness{Exec: exec, StateDir: stateDir}
 }
 
-// AssertNoExecutorWrites fails the test if the mock recorded any call to
-// WriteFileAtomic (recorded as entries in Exec.WrittenFiles).
-func (h *PurityHarness) AssertNoExecutorWrites(t testing.TB) {
-	t.Helper()
-	if n := len(h.Exec.WrittenFiles); n != 0 {
-		var names []string
-		for k := range h.Exec.WrittenFiles {
-			names = append(names, k)
-		}
-		t.Errorf("observational path made %d executor writes (contract: zero): %v", n, names)
+// CheckExecutorWrites returns one violation message per executor write
+// recorded (zero when clean).
+func (h *PurityHarness) CheckExecutorWrites() []string {
+	var out []string
+	for path := range h.Exec.WrittenFiles {
+		out = append(out, "executor.WriteFileAtomic("+path+")")
 	}
+	return out
 }
 
-// AssertNoDirectoryCreations fails the test if the mock recorded any
-// MkdirAll.
-func (h *PurityHarness) AssertNoDirectoryCreations(t testing.TB) {
-	t.Helper()
-	if n := len(h.Exec.Dirs); n != 0 {
-		var names []string
-		for k := range h.Exec.Dirs {
-			names = append(names, k)
-		}
-		t.Errorf("observational path made %d executor MkdirAll calls (contract: zero): %v", n, names)
+// CheckDirectoryCreations returns one violation message per executor
+// MkdirAll recorded (zero when clean).
+func (h *PurityHarness) CheckDirectoryCreations() []string {
+	var out []string
+	for path := range h.Exec.Dirs {
+		out = append(out, "executor.MkdirAll("+path+")")
 	}
+	return out
 }
 
-// AssertNoMutationCommands fails the test if any recorded command
-// matches one of the forbidden substrings.
-func (h *PurityHarness) AssertNoMutationCommands(t testing.TB) {
-	t.Helper()
+// CheckMutationCommands returns one violation per forbidden command in
+// the recorded trace (zero when clean).
+func (h *PurityHarness) CheckMutationCommands() []string {
+	var out []string
 	for _, cmd := range h.Exec.Commands {
 		joined := cmd.Name + " " + strings.Join(cmd.Args, " ")
 		for _, forbid := range ForbiddenCommandPatterns {
 			if strings.Contains(joined, forbid) {
-				t.Errorf("forbidden mutation command %q (matched pattern %q) in observational-path trace", joined, forbid)
+				out = append(out, "forbidden command "+joined+" (pattern "+forbid+")")
 			}
 		}
 	}
+	return out
 }
 
-// AssertNoStateDirEntries fails the test if any files or directories
-// exist under the harness-owned state directory. This catches direct
+// CheckStateDirEntries returns one violation per file/dir in the
+// harness-owned state directory (zero when clean). Catches direct
 // os.WriteFile / os.MkdirAll calls that bypass the mock executor —
 // exactly the class that escaped PR-22's original review.
-func (h *PurityHarness) AssertNoStateDirEntries(t testing.TB) {
-	t.Helper()
+func (h *PurityHarness) CheckStateDirEntries() []string {
 	entries, err := os.ReadDir(h.StateDir)
 	if err != nil {
-		// Non-existent state dir is fine for a purely observational run.
 		if os.IsNotExist(err) {
-			return
+			return nil
 		}
-		t.Fatalf("read state dir %s: %v", h.StateDir, err)
+		return []string{"read state dir " + h.StateDir + ": " + err.Error()}
 	}
-	if len(entries) != 0 {
-		var names []string
-		for _, e := range entries {
-			names = append(names, e.Name())
-		}
-		t.Errorf("observational path created files in state dir %s: %v", h.StateDir, names)
+	var out []string
+	for _, e := range entries {
+		out = append(out, "state-dir entry: "+e.Name())
+	}
+	return out
+}
+
+// AssertNoExecutorWrites fails the test for each executor write.
+func (h *PurityHarness) AssertNoExecutorWrites(t testing.TB) {
+	t.Helper()
+	for _, v := range h.CheckExecutorWrites() {
+		t.Errorf("observational path: %s", v)
+	}
+}
+
+// AssertNoDirectoryCreations fails the test for each MkdirAll.
+func (h *PurityHarness) AssertNoDirectoryCreations(t testing.TB) {
+	t.Helper()
+	for _, v := range h.CheckDirectoryCreations() {
+		t.Errorf("observational path: %s", v)
+	}
+}
+
+// AssertNoMutationCommands fails the test for each forbidden command.
+func (h *PurityHarness) AssertNoMutationCommands(t testing.TB) {
+	t.Helper()
+	for _, v := range h.CheckMutationCommands() {
+		t.Errorf("observational path: %s", v)
+	}
+}
+
+// AssertNoStateDirEntries fails the test for each entry in the state
+// directory.
+func (h *PurityHarness) AssertNoStateDirEntries(t testing.TB) {
+	t.Helper()
+	for _, v := range h.CheckStateDirEntries() {
+		t.Errorf("observational path: %s", v)
 	}
 }
 

--- a/internal/installer/audit/harness.go
+++ b/internal/installer/audit/harness.go
@@ -1,0 +1,179 @@
+// =============================================================================
+// NFTBan v1.100 PR-22B — Lifecycle Purity Audit Harness
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-audit-harness"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Reusable purity-check helpers for dry-run / observational paths"
+// meta:inventory.files="internal/installer/audit/harness.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Per audit item 12 ("A post-repair verification harness"): a small
+// reusable harness that each lifecycle mode can use to assert that a
+// dry-run / observational invocation produced:
+//
+//   - zero writes through the executor interface
+//   - zero MkdirAll calls through the executor
+//   - zero mutation-flavored commands in the executor trace
+//   - zero new files in the caller-supplied state directory
+//
+// The harness is intentionally narrow. It does NOT run orchestrators
+// itself — it is an assertion kit. Callers run their own dry-run under
+// a MockExecutor and then pipe the results through the harness.
+//
+// Usage:
+//
+//	mock := executor.NewMockExecutor()
+//	stateDir := t.TempDir()
+//	// ... run the observational orchestrator ...
+//	h := audit.NewPurityHarness(mock, stateDir)
+//	h.AssertNoExecutorWrites(t)
+//	h.AssertNoMutationCommands(t)
+//	h.AssertNoStateDirEntries(t)
+//
+// Any new mode (install-refuse, update-dry-run, uninstall-dry-run,
+// future modes) should use the same harness so the assertion shape does
+// not drift.
+// =============================================================================
+package audit
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// ForbiddenCommandPatterns is the shared deny-list used by
+// AssertNoMutationCommands. Substring-matched against the joined form
+// of "command-name arg1 arg2 …".
+//
+// The list mirrors the CI G3-UN-NO-MUTATION / G3-U5..U10 grep patterns
+// but operates at runtime — a command constructed dynamically (which
+// source grep cannot see) is still caught here.
+var ForbiddenCommandPatterns = []string{
+	// nftables mutation
+	"nft add",
+	"nft create",
+	"nft delete",
+	"nft flush",
+	// systemd lifecycle
+	"systemctl start",
+	"systemctl stop",
+	"systemctl restart",
+	"systemctl reload",
+	"systemctl enable",
+	"systemctl disable",
+	"systemctl mask",
+	"systemctl unmask",
+	// external firewall binaries
+	"ufw ",
+	"firewall-cmd",
+	"iptables-restore",
+	"ip6tables-restore",
+	"csf ",
+	// package manager removal
+	"apt-get remove",
+	"apt-get purge",
+	"dnf remove",
+	"dnf erase",
+	"rpm -e",
+	"dpkg --remove",
+	"dpkg --purge",
+	// user/group removal
+	"userdel",
+	"groupdel",
+}
+
+// PurityHarness bundles a MockExecutor and a temp state directory into
+// an assertion kit for observational-path tests.
+type PurityHarness struct {
+	Exec     *executor.MockExecutor
+	StateDir string
+}
+
+// NewPurityHarness creates a harness for a specific run.
+func NewPurityHarness(exec *executor.MockExecutor, stateDir string) *PurityHarness {
+	return &PurityHarness{Exec: exec, StateDir: stateDir}
+}
+
+// AssertNoExecutorWrites fails the test if the mock recorded any call to
+// WriteFileAtomic (recorded as entries in Exec.WrittenFiles).
+func (h *PurityHarness) AssertNoExecutorWrites(t *testing.T) {
+	t.Helper()
+	if n := len(h.Exec.WrittenFiles); n != 0 {
+		var names []string
+		for k := range h.Exec.WrittenFiles {
+			names = append(names, k)
+		}
+		t.Errorf("observational path made %d executor writes (contract: zero): %v", n, names)
+	}
+}
+
+// AssertNoDirectoryCreations fails the test if the mock recorded any
+// MkdirAll.
+func (h *PurityHarness) AssertNoDirectoryCreations(t *testing.T) {
+	t.Helper()
+	if n := len(h.Exec.Dirs); n != 0 {
+		var names []string
+		for k := range h.Exec.Dirs {
+			names = append(names, k)
+		}
+		t.Errorf("observational path made %d executor MkdirAll calls (contract: zero): %v", n, names)
+	}
+}
+
+// AssertNoMutationCommands fails the test if any recorded command
+// matches one of the forbidden substrings.
+func (h *PurityHarness) AssertNoMutationCommands(t *testing.T) {
+	t.Helper()
+	for _, cmd := range h.Exec.Commands {
+		joined := cmd.Name + " " + strings.Join(cmd.Args, " ")
+		for _, forbid := range ForbiddenCommandPatterns {
+			if strings.Contains(joined, forbid) {
+				t.Errorf("forbidden mutation command %q (matched pattern %q) in observational-path trace", joined, forbid)
+			}
+		}
+	}
+}
+
+// AssertNoStateDirEntries fails the test if any files or directories
+// exist under the harness-owned state directory. This catches direct
+// os.WriteFile / os.MkdirAll calls that bypass the mock executor —
+// exactly the class that escaped PR-22's original review.
+func (h *PurityHarness) AssertNoStateDirEntries(t *testing.T) {
+	t.Helper()
+	entries, err := os.ReadDir(h.StateDir)
+	if err != nil {
+		// Non-existent state dir is fine for a purely observational run.
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("read state dir %s: %v", h.StateDir, err)
+	}
+	if len(entries) != 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("observational path created files in state dir %s: %v", h.StateDir, names)
+	}
+}
+
+// AssertAllPurity runs every assertion in one call — the common case.
+func (h *PurityHarness) AssertAllPurity(t *testing.T) {
+	t.Helper()
+	h.AssertNoExecutorWrites(t)
+	h.AssertNoDirectoryCreations(t)
+	h.AssertNoMutationCommands(t)
+	h.AssertNoStateDirEntries(t)
+}

--- a/internal/installer/audit/harness.go
+++ b/internal/installer/audit/harness.go
@@ -108,7 +108,7 @@ func NewPurityHarness(exec *executor.MockExecutor, stateDir string) *PurityHarne
 
 // AssertNoExecutorWrites fails the test if the mock recorded any call to
 // WriteFileAtomic (recorded as entries in Exec.WrittenFiles).
-func (h *PurityHarness) AssertNoExecutorWrites(t *testing.T) {
+func (h *PurityHarness) AssertNoExecutorWrites(t testing.TB) {
 	t.Helper()
 	if n := len(h.Exec.WrittenFiles); n != 0 {
 		var names []string
@@ -121,7 +121,7 @@ func (h *PurityHarness) AssertNoExecutorWrites(t *testing.T) {
 
 // AssertNoDirectoryCreations fails the test if the mock recorded any
 // MkdirAll.
-func (h *PurityHarness) AssertNoDirectoryCreations(t *testing.T) {
+func (h *PurityHarness) AssertNoDirectoryCreations(t testing.TB) {
 	t.Helper()
 	if n := len(h.Exec.Dirs); n != 0 {
 		var names []string
@@ -134,7 +134,7 @@ func (h *PurityHarness) AssertNoDirectoryCreations(t *testing.T) {
 
 // AssertNoMutationCommands fails the test if any recorded command
 // matches one of the forbidden substrings.
-func (h *PurityHarness) AssertNoMutationCommands(t *testing.T) {
+func (h *PurityHarness) AssertNoMutationCommands(t testing.TB) {
 	t.Helper()
 	for _, cmd := range h.Exec.Commands {
 		joined := cmd.Name + " " + strings.Join(cmd.Args, " ")
@@ -150,7 +150,7 @@ func (h *PurityHarness) AssertNoMutationCommands(t *testing.T) {
 // exist under the harness-owned state directory. This catches direct
 // os.WriteFile / os.MkdirAll calls that bypass the mock executor —
 // exactly the class that escaped PR-22's original review.
-func (h *PurityHarness) AssertNoStateDirEntries(t *testing.T) {
+func (h *PurityHarness) AssertNoStateDirEntries(t testing.TB) {
 	t.Helper()
 	entries, err := os.ReadDir(h.StateDir)
 	if err != nil {
@@ -170,7 +170,7 @@ func (h *PurityHarness) AssertNoStateDirEntries(t *testing.T) {
 }
 
 // AssertAllPurity runs every assertion in one call — the common case.
-func (h *PurityHarness) AssertAllPurity(t *testing.T) {
+func (h *PurityHarness) AssertAllPurity(t testing.TB) {
 	t.Helper()
 	h.AssertNoExecutorWrites(t)
 	h.AssertNoDirectoryCreations(t)

--- a/internal/installer/audit/harness_test.go
+++ b/internal/installer/audit/harness_test.go
@@ -16,10 +16,11 @@
 // meta:inventory.privileges="none"
 // =============================================================================
 //
-// These tests confirm that the harness fails (via t.Errorf / t.Fatalf)
-// on each of the contract violations it exists to detect, and passes
-// when the contract is respected. Use a recording *testing.T substitute
-// to observe failure behaviour without failing this test itself.
+// These tests confirm the harness fires (via t.Errorf) on each of the
+// contract violations it exists to detect, and passes when the contract
+// is respected. The trick: testing.TB cannot be implemented outside the
+// testing package (it has an unexported method), so we use t.Run's
+// return value to observe whether an inner subtest failed.
 //
 // =============================================================================
 package audit
@@ -32,27 +33,31 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 )
 
-// recordingT implements enough of testing.TB to let us observe the
-// number of Errorf / Fatalf calls an assertion made without marking the
-// real test as failed.
-type recordingT struct {
-	testing.TB
-	errors int
-	fatals int
+// expectInnerFail runs the given assertion inside a subtest and reports
+// whether the inner subtest failed (which is what we want, for each
+// "harness must catch X" test). If the inner test PASSED, this helper
+// marks the outer test failed — meaning the harness missed a violation.
+func expectInnerFail(t *testing.T, name string, assertion func(tb testing.TB)) {
+	t.Helper()
+	innerPassed := t.Run(name, func(innerT *testing.T) {
+		assertion(innerT)
+	})
+	if innerPassed {
+		t.Errorf("%s: harness assertion did NOT fail as expected — contract violation went undetected", name)
+	}
 }
-
-func (r *recordingT) Errorf(format string, args ...interface{}) { r.errors++ }
-func (r *recordingT) Fatalf(format string, args ...interface{}) { r.fatals++ }
-func (r *recordingT) Helper()                                   {}
 
 func TestHarness_CleanRunPasses(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	dir := t.TempDir()
 	h := NewPurityHarness(mock, dir)
-	rec := &recordingT{}
-	h.AssertAllPurity(rec)
-	if rec.errors != 0 || rec.fatals != 0 {
-		t.Errorf("clean run flagged %d errors / %d fatals", rec.errors, rec.fatals)
+
+	// Clean run must not fail any assertion.
+	innerPassed := t.Run("clean", func(innerT *testing.T) {
+		h.AssertAllPurity(innerT)
+	})
+	if !innerPassed {
+		t.Error("harness flagged a clean run as violating — false positive")
 	}
 }
 
@@ -60,33 +65,27 @@ func TestHarness_CatchesExecutorWrites(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	_ = mock.WriteFileAtomic("/var/lib/nftban/state/install_state", []byte("x"), 0600)
 	h := NewPurityHarness(mock, t.TempDir())
-	rec := &recordingT{}
-	h.AssertNoExecutorWrites(rec)
-	if rec.errors == 0 {
-		t.Error("harness must flag executor WriteFileAtomic call")
-	}
+	expectInnerFail(t, "executor-write", func(tb testing.TB) {
+		h.AssertNoExecutorWrites(tb)
+	})
 }
 
 func TestHarness_CatchesMkdirAll(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	_ = mock.MkdirAll("/var/lib/nftban/state", 0750)
 	h := NewPurityHarness(mock, t.TempDir())
-	rec := &recordingT{}
-	h.AssertNoDirectoryCreations(rec)
-	if rec.errors == 0 {
-		t.Error("harness must flag executor MkdirAll call")
-	}
+	expectInnerFail(t, "mkdirall", func(tb testing.TB) {
+		h.AssertNoDirectoryCreations(tb)
+	})
 }
 
 func TestHarness_CatchesForbiddenCommand(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Run("nft", "add", "rule", "ip", "nftban", "input", "accept")
 	h := NewPurityHarness(mock, t.TempDir())
-	rec := &recordingT{}
-	h.AssertNoMutationCommands(rec)
-	if rec.errors == 0 {
-		t.Error("harness must flag 'nft add' command")
-	}
+	expectInnerFail(t, "forbidden-cmd", func(tb testing.TB) {
+		h.AssertNoMutationCommands(tb)
+	})
 }
 
 func TestHarness_CatchesDirectFilesystemWrite(t *testing.T) {
@@ -100,9 +99,7 @@ func TestHarness_CatchesDirectFilesystemWrite(t *testing.T) {
 
 	mock := executor.NewMockExecutor()
 	h := NewPurityHarness(mock, dir)
-	rec := &recordingT{}
-	h.AssertNoStateDirEntries(rec)
-	if rec.errors == 0 {
-		t.Error("harness must flag direct filesystem write under state dir")
-	}
+	expectInnerFail(t, "direct-fs-write", func(tb testing.TB) {
+		h.AssertNoStateDirEntries(tb)
+	})
 }

--- a/internal/installer/audit/harness_test.go
+++ b/internal/installer/audit/harness_test.go
@@ -16,11 +16,9 @@
 // meta:inventory.privileges="none"
 // =============================================================================
 //
-// These tests confirm the harness fires (via t.Errorf) on each of the
-// contract violations it exists to detect, and passes when the contract
-// is respected. The trick: testing.TB cannot be implemented outside the
-// testing package (it has an unexported method), so we use t.Run's
-// return value to observe whether an inner subtest failed.
+// These tests exercise the Check* methods directly (which return
+// violation lists) and verify that each contract violation produces a
+// non-empty list. No testing.TB mock required.
 //
 // =============================================================================
 package audit
@@ -33,31 +31,20 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 )
 
-// expectInnerFail runs the given assertion inside a subtest and reports
-// whether the inner subtest failed (which is what we want, for each
-// "harness must catch X" test). If the inner test PASSED, this helper
-// marks the outer test failed — meaning the harness missed a violation.
-func expectInnerFail(t *testing.T, name string, assertion func(tb testing.TB)) {
-	t.Helper()
-	innerPassed := t.Run(name, func(innerT *testing.T) {
-		assertion(innerT)
-	})
-	if innerPassed {
-		t.Errorf("%s: harness assertion did NOT fail as expected — contract violation went undetected", name)
-	}
-}
-
-func TestHarness_CleanRunPasses(t *testing.T) {
+func TestHarness_CleanRun_NoViolations(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	dir := t.TempDir()
-	h := NewPurityHarness(mock, dir)
-
-	// Clean run must not fail any assertion.
-	innerPassed := t.Run("clean", func(innerT *testing.T) {
-		h.AssertAllPurity(innerT)
-	})
-	if !innerPassed {
-		t.Error("harness flagged a clean run as violating — false positive")
+	h := NewPurityHarness(mock, t.TempDir())
+	if v := h.CheckExecutorWrites(); len(v) != 0 {
+		t.Errorf("clean run: CheckExecutorWrites returned %v", v)
+	}
+	if v := h.CheckDirectoryCreations(); len(v) != 0 {
+		t.Errorf("clean run: CheckDirectoryCreations returned %v", v)
+	}
+	if v := h.CheckMutationCommands(); len(v) != 0 {
+		t.Errorf("clean run: CheckMutationCommands returned %v", v)
+	}
+	if v := h.CheckStateDirEntries(); len(v) != 0 {
+		t.Errorf("clean run: CheckStateDirEntries returned %v", v)
 	}
 }
 
@@ -65,27 +52,27 @@ func TestHarness_CatchesExecutorWrites(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	_ = mock.WriteFileAtomic("/var/lib/nftban/state/install_state", []byte("x"), 0600)
 	h := NewPurityHarness(mock, t.TempDir())
-	expectInnerFail(t, "executor-write", func(tb testing.TB) {
-		h.AssertNoExecutorWrites(tb)
-	})
+	if v := h.CheckExecutorWrites(); len(v) == 0 {
+		t.Error("harness must flag executor WriteFileAtomic call; returned no violations")
+	}
 }
 
 func TestHarness_CatchesMkdirAll(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	_ = mock.MkdirAll("/var/lib/nftban/state", 0750)
 	h := NewPurityHarness(mock, t.TempDir())
-	expectInnerFail(t, "mkdirall", func(tb testing.TB) {
-		h.AssertNoDirectoryCreations(tb)
-	})
+	if v := h.CheckDirectoryCreations(); len(v) == 0 {
+		t.Error("harness must flag executor MkdirAll call; returned no violations")
+	}
 }
 
 func TestHarness_CatchesForbiddenCommand(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Run("nft", "add", "rule", "ip", "nftban", "input", "accept")
 	h := NewPurityHarness(mock, t.TempDir())
-	expectInnerFail(t, "forbidden-cmd", func(tb testing.TB) {
-		h.AssertNoMutationCommands(tb)
-	})
+	if v := h.CheckMutationCommands(); len(v) == 0 {
+		t.Error("harness must flag 'nft add' command; returned no violations")
+	}
 }
 
 func TestHarness_CatchesDirectFilesystemWrite(t *testing.T) {
@@ -99,7 +86,7 @@ func TestHarness_CatchesDirectFilesystemWrite(t *testing.T) {
 
 	mock := executor.NewMockExecutor()
 	h := NewPurityHarness(mock, dir)
-	expectInnerFail(t, "direct-fs-write", func(tb testing.TB) {
-		h.AssertNoStateDirEntries(tb)
-	})
+	if v := h.CheckStateDirEntries(); len(v) == 0 {
+		t.Error("harness must flag direct filesystem write under state dir; returned no violations")
+	}
 }

--- a/internal/installer/audit/harness_test.go
+++ b/internal/installer/audit/harness_test.go
@@ -1,0 +1,108 @@
+// =============================================================================
+// NFTBan v1.100 PR-22B — Purity Harness Self-Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-audit-harness-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-19"
+// meta:description="Self-tests for the purity-harness assertion kit"
+// meta:inventory.files="internal/installer/audit/harness_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// These tests confirm that the harness fails (via t.Errorf / t.Fatalf)
+// on each of the contract violations it exists to detect, and passes
+// when the contract is respected. Use a recording *testing.T substitute
+// to observe failure behaviour without failing this test itself.
+//
+// =============================================================================
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// recordingT implements enough of testing.TB to let us observe the
+// number of Errorf / Fatalf calls an assertion made without marking the
+// real test as failed.
+type recordingT struct {
+	testing.TB
+	errors int
+	fatals int
+}
+
+func (r *recordingT) Errorf(format string, args ...interface{}) { r.errors++ }
+func (r *recordingT) Fatalf(format string, args ...interface{}) { r.fatals++ }
+func (r *recordingT) Helper()                                   {}
+
+func TestHarness_CleanRunPasses(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	dir := t.TempDir()
+	h := NewPurityHarness(mock, dir)
+	rec := &recordingT{}
+	h.AssertAllPurity(rec)
+	if rec.errors != 0 || rec.fatals != 0 {
+		t.Errorf("clean run flagged %d errors / %d fatals", rec.errors, rec.fatals)
+	}
+}
+
+func TestHarness_CatchesExecutorWrites(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	_ = mock.WriteFileAtomic("/var/lib/nftban/state/install_state", []byte("x"), 0600)
+	h := NewPurityHarness(mock, t.TempDir())
+	rec := &recordingT{}
+	h.AssertNoExecutorWrites(rec)
+	if rec.errors == 0 {
+		t.Error("harness must flag executor WriteFileAtomic call")
+	}
+}
+
+func TestHarness_CatchesMkdirAll(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	_ = mock.MkdirAll("/var/lib/nftban/state", 0750)
+	h := NewPurityHarness(mock, t.TempDir())
+	rec := &recordingT{}
+	h.AssertNoDirectoryCreations(rec)
+	if rec.errors == 0 {
+		t.Error("harness must flag executor MkdirAll call")
+	}
+}
+
+func TestHarness_CatchesForbiddenCommand(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Run("nft", "add", "rule", "ip", "nftban", "input", "accept")
+	h := NewPurityHarness(mock, t.TempDir())
+	rec := &recordingT{}
+	h.AssertNoMutationCommands(rec)
+	if rec.errors == 0 {
+		t.Error("harness must flag 'nft add' command")
+	}
+}
+
+func TestHarness_CatchesDirectFilesystemWrite(t *testing.T) {
+	dir := t.TempDir()
+	// Direct os.WriteFile bypassing the executor — the bug class that
+	// escaped PR-22.
+	path := filepath.Join(dir, "uninstall_plan.json")
+	if err := os.WriteFile(path, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := executor.NewMockExecutor()
+	h := NewPurityHarness(mock, dir)
+	rec := &recordingT{}
+	h.AssertNoStateDirEntries(rec)
+	if rec.errors == 0 {
+		t.Error("harness must flag direct filesystem write under state dir")
+	}
+}

--- a/internal/installer/authority/classify.go
+++ b/internal/installer/authority/classify.go
@@ -6,10 +6,10 @@
 // meta:type="lib"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-04-04"
-// meta:description="Authority decision tree: UPDATE/TAKEOVER/FRESH/ABORT"
+// meta:description="Authority decision tree: UPDATE/TAKEOVER/FRESH/ABORT/AMBIGUOUS"
 // meta:inventory.files="internal/installer/authority/classify.go"
 // meta:inventory.binaries=""
-// meta:inventory.env_vars="NFTBAN_TAKEOVER"
+// meta:inventory.env_vars="NFTBAN_TAKEOVER, NFTBAN_PANEL_AUTO_TAKEOVER"
 // meta:inventory.config_files=""
 // meta:inventory.systemd_units=""
 // meta:inventory.network=""
@@ -23,77 +23,143 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
+// NftbanDaemonUnit is the systemd unit name of the nftban daemon. Kept
+// as a package-level constant so the shared authoritative predicate and
+// any future consumer cannot drift apart on unit-name spelling.
+const NftbanDaemonUnit = "nftband.service"
+
+// IsNftbanAuthoritative is the CANONICAL predicate for "nftban currently
+// owns the firewall on this host." It is the single source of truth; any
+// other module that needs to answer the question (e.g. update.Preflight
+// P-1) must call this function rather than re-implementing it.
+//
+// The predicate requires THREE conditions to hold simultaneously:
+//
+//  1. The ip nftban table exists in the kernel.
+//  2. The input chain inside that table exists.
+//  3. The nftband.service unit is currently active.
+//
+// Previous versions of this package checked only (1) and (2). PR-22B
+// tightened it: an orphan table left by a crashed prior install used
+// to satisfy the predicate and classify the host as Update, causing
+// phaseSwitch to skip the emergency SSH injection path. Requiring the
+// active daemon forces that case into the Ambiguous branch instead.
+//
+// All three probes are read-only.
+func IsNftbanAuthoritative(exec executor.Executor) bool {
+	if !exec.NftTableExists("ip", "nftban") {
+		return false
+	}
+	if exec.Run("nft", "list", "chain", "ip", "nftban", "input").ExitCode != 0 {
+		return false
+	}
+	if !exec.ServiceActive(NftbanDaemonUnit) {
+		return false
+	}
+	return true
+}
+
+// hasOrphanNftbanArtifacts reports whether any nftban kernel or service
+// artifact is present without all three constituting an authoritative
+// install. Used to distinguish "clean Fresh host" from "half-installed
+// Ambiguous host." Read-only.
+func hasOrphanNftbanArtifacts(exec executor.Executor) bool {
+	if exec.NftTableExists("ip", "nftban") {
+		return true
+	}
+	if exec.ServiceActive(NftbanDaemonUnit) {
+		return true
+	}
+	return false
+}
+
 // Classify determines the installation authority based on the current system state.
 //
-// Decision tree (matches shell %post _check_authority exactly):
+// Decision tree (PR-22B tightened):
 //
-//  1. UPDATE — NFTBan already owns the firewall:
-//     nft list table ip nftban succeeds AND nft list chain ip nftban input succeeds
+//  1. UPDATE — nftban currently owns the firewall (IsNftbanAuthoritative
+//     returns true — table + chain + active daemon).
 //
-//  2. FRESH — No conflicting firewalls detected (conflicts slice is empty)
+//  2. AMBIGUOUS — nftban artifacts are present but not all three conditions
+//     hold (orphan table, daemon without table, etc.). Never silent-continue —
+//     phaseSwitch must inject emergency SSH before any mutation.
 //
-//  3. TAKEOVER — Conflicts exist, but takeover is approved:
-//     a. NFTBAN_TAKEOVER=1 environment variable, OR
-//     b. Panel is detected (auto-approve for managed hosting), OR
-//     c. forceApprove flag is true (from --takeover CLI flag)
+//  3. FRESH — No conflicting firewalls detected AND no nftban artifacts
+//     observed.
 //
-//  4. ABORT — Conflicts exist, no approval granted
+//  4. TAKEOVER — Conflicts exist, AND takeover is explicitly approved via one
+//     of:
+//     a. NFTBAN_TAKEOVER=1 environment variable
+//     b. --takeover CLI flag (forceApprove=true)
+//     c. Panel auto-approve ONLY when panelAutoApprove=true
+//     (default is panelAutoApprove=false per PR-22B).
+//
+//  5. ABORT — Conflicts exist and no takeover approval was granted.
+//
+// PR-22B change: panel auto-approve is no longer implicit. An operator who
+// wants the old behaviour must pass --panel-auto-takeover (or set
+// NFTBAN_PANEL_AUTO_TAKEOVER=1). This closes the audit finding that a
+// panel-managed host disabled its own firewall silently on install.
 func Classify(
 	exec executor.Executor,
 	conflicts []detect.Conflict,
 	panel detect.PanelType,
 	forceApprove bool,
+	panelAutoApprove bool,
 	log *logging.Logger,
 ) Decision {
-	// 1. Check if NFTBan already owns the firewall (UPDATE)
-	if nftbanAuthoritative(exec) {
+	// 1. NFTBan fully authoritative — UPDATE.
+	if IsNftbanAuthoritative(exec) {
 		log.Detect("authority", "decision", string(Update))
-		log.Detect("authority", "reason", "nftban table+chain exist")
+		log.Detect("authority", "reason", "nftban table+chain+daemon all present")
 		return Update
 	}
 
-	// 2. No conflicts → FRESH install
+	// 2. Orphan nftban artifacts without full authority — AMBIGUOUS.
+	// A later phase must NOT treat this as a clean Fresh or ignore it:
+	// the operator needs to see that the host carries stale state, and
+	// the emergency-SSH path must kick in before any mutation.
+	if hasOrphanNftbanArtifacts(exec) {
+		log.Detect("authority", "decision", string(Ambiguous))
+		log.Detect("authority", "reason", "nftban artifact present but not authoritative (table or daemon in partial state)")
+		return Ambiguous
+	}
+
+	// 3. No conflicts → FRESH install
 	if len(conflicts) == 0 {
 		log.Detect("authority", "decision", string(Fresh))
-		log.Detect("authority", "reason", "no conflicts")
+		log.Detect("authority", "reason", "no conflicts; no nftban artifacts")
 		return Fresh
 	}
 
-	// 3. Conflicts exist — check takeover approval
-	// 3a. Environment variable
+	// 4. Conflicts exist — check explicit takeover approval
+	// 4a. Environment variable
 	if exec.Getenv("NFTBAN_TAKEOVER") == "1" {
 		log.Detect("authority", "decision", string(Takeover))
 		log.Detect("authority", "reason", "NFTBAN_TAKEOVER=1")
 		return Takeover
 	}
 
-	// 3b. CLI --takeover flag
+	// 4b. CLI --takeover flag
 	if forceApprove {
 		log.Detect("authority", "decision", string(Takeover))
 		log.Detect("authority", "reason", "--takeover flag")
 		return Takeover
 	}
 
-	// 3c. Panel auto-approve (managed hosting systems)
-	if detect.HasPanel(panel) {
+	// 4c. Panel auto-approve — PR-22B requires explicit opt-in.
+	if panelAutoApprove && detect.HasPanel(panel) {
 		log.Detect("authority", "decision", string(Takeover))
-		log.Detect("authority", "reason", "panel auto-approve ("+string(panel)+")")
+		log.Detect("authority", "reason", "panel auto-approve ("+string(panel)+") with --panel-auto-takeover")
 		return Takeover
 	}
 
-	// 4. No approval → ABORT
+	// 5. No approval → ABORT
 	log.Detect("authority", "decision", string(Abort))
-	log.Detect("authority", "reason", "conflicts detected, no takeover approval")
-	return Abort
-}
-
-// nftbanAuthoritative returns true if NFTBan already owns the firewall.
-// Checks: nft list table ip nftban AND nft list chain ip nftban input.
-func nftbanAuthoritative(exec executor.Executor) bool {
-	if !exec.NftTableExists("ip", "nftban") {
-		return false
+	if detect.HasPanel(panel) && !panelAutoApprove {
+		log.Detect("authority", "reason", "conflicts + panel detected; --panel-auto-takeover not set (PR-22B: implicit panel auto-approve removed)")
+	} else {
+		log.Detect("authority", "reason", "conflicts detected, no takeover approval")
 	}
-	// Also verify the input chain exists (not just an empty table)
-	res := exec.Run("nft", "list", "chain", "ip", "nftban", "input")
-	return res.ExitCode == 0
+	return Abort
 }

--- a/internal/installer/authority/classify_test.go
+++ b/internal/installer/authority/classify_test.go
@@ -29,13 +29,18 @@ func newTestLogger() *logging.Logger {
 	return logging.New("/dev/null", false)
 }
 
-func TestClassify_Update(t *testing.T) {
-	mock := executor.NewMockExecutor()
-	// NFTBan table + chain exist
-	mock.NftTables["ip:nftban"] = true
-	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+// authoritativeMock returns a MockExecutor pre-wired with table+chain+daemon
+// all present. PR-22B tightened IsNftbanAuthoritative to require all three.
+func authoritativeMock() *executor.MockExecutor {
+	m := executor.NewMockExecutor()
+	m.NftTables["ip:nftban"] = true
+	m.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	m.Services[NftbanDaemonUnit] = true
+	return m
+}
 
-	decision := Classify(mock, nil, detect.PanelNone, false, newTestLogger())
+func TestClassify_Update(t *testing.T) {
+	decision := Classify(authoritativeMock(), nil, detect.PanelNone, false, false, newTestLogger())
 	if decision != Update {
 		t.Errorf("decision = %s, want UPDATE", decision)
 	}
@@ -43,21 +48,18 @@ func TestClassify_Update(t *testing.T) {
 
 func TestClassify_Update_WithConflicts(t *testing.T) {
 	// UPDATE takes priority even if conflicts exist
-	mock := executor.NewMockExecutor()
-	mock.NftTables["ip:nftban"] = true
-	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
-
+	mock := authoritativeMock()
 	conflicts := []detect.Conflict{{Name: "firewalld", Active: true}}
-	decision := Classify(mock, conflicts, detect.PanelNone, false, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelNone, false, false, newTestLogger())
 	if decision != Update {
-		t.Errorf("decision = %s, want UPDATE (table+chain exist, ignoring conflicts)", decision)
+		t.Errorf("decision = %s, want UPDATE (table+chain+daemon exist, ignoring conflicts)", decision)
 	}
 }
 
 func TestClassify_Fresh(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	// No NFTBan table, no conflicts
-	decision := Classify(mock, nil, detect.PanelNone, false, newTestLogger())
+	// No NFTBan table, no daemon, no conflicts
+	decision := Classify(mock, nil, detect.PanelNone, false, false, newTestLogger())
 	if decision != Fresh {
 		t.Errorf("decision = %s, want FRESH", decision)
 	}
@@ -68,7 +70,7 @@ func TestClassify_Takeover_EnvVar(t *testing.T) {
 	mock.Env["NFTBAN_TAKEOVER"] = "1"
 
 	conflicts := []detect.Conflict{{Name: "CSF", Active: true}}
-	decision := Classify(mock, conflicts, detect.PanelNone, false, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelNone, false, false, newTestLogger())
 	if decision != Takeover {
 		t.Errorf("decision = %s, want TAKEOVER (env var)", decision)
 	}
@@ -78,19 +80,32 @@ func TestClassify_Takeover_Flag(t *testing.T) {
 	mock := executor.NewMockExecutor()
 
 	conflicts := []detect.Conflict{{Name: "UFW", Active: true}}
-	decision := Classify(mock, conflicts, detect.PanelNone, true, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelNone, true, false, newTestLogger())
 	if decision != Takeover {
 		t.Errorf("decision = %s, want TAKEOVER (--takeover flag)", decision)
 	}
 }
 
-func TestClassify_Takeover_PanelAutoApprove(t *testing.T) {
+// PR-22B: panel detection ALONE no longer auto-approves takeover.
+// Operators must pass --panel-auto-takeover explicitly.
+func TestClassify_PanelDetected_NoFlag_Aborts(t *testing.T) {
 	mock := executor.NewMockExecutor()
 
 	conflicts := []detect.Conflict{{Name: "firewalld", Active: true}}
-	decision := Classify(mock, conflicts, detect.PanelCPanel, false, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelCPanel, false, false /* panelAutoApprove */, newTestLogger())
+	if decision != Abort {
+		t.Errorf("decision = %s, want ABORT — panel alone must not grant takeover (PR-22B audit fix)", decision)
+	}
+}
+
+// PR-22B: panel auto-approve works ONLY when the explicit flag is set.
+func TestClassify_PanelDetected_WithFlag_Takesover(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	conflicts := []detect.Conflict{{Name: "firewalld", Active: true}}
+	decision := Classify(mock, conflicts, detect.PanelCPanel, false, true /* panelAutoApprove */, newTestLogger())
 	if decision != Takeover {
-		t.Errorf("decision = %s, want TAKEOVER (cPanel auto-approve)", decision)
+		t.Errorf("decision = %s, want TAKEOVER (panel + explicit --panel-auto-takeover)", decision)
 	}
 }
 
@@ -98,37 +113,97 @@ func TestClassify_Abort(t *testing.T) {
 	mock := executor.NewMockExecutor()
 
 	conflicts := []detect.Conflict{{Name: "CSF", Active: true}}
-	decision := Classify(mock, conflicts, detect.PanelNone, false, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelNone, false, false, newTestLogger())
 	if decision != Abort {
 		t.Errorf("decision = %s, want ABORT (conflicts, no approval)", decision)
 	}
 }
 
-func TestClassify_TableWithoutChain(t *testing.T) {
-	// Table exists but chain doesn't → not authoritative → check conflicts
+// PR-22B: orphan ip nftban table WITHOUT active daemon (crashed prior
+// install) must NOT classify as Update. It used to slip through the
+// legacy predicate and cause phaseSwitch to skip emergency SSH injection.
+// The new predicate routes this case to Ambiguous.
+func TestClassify_Ambiguous_OrphanTable(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.NftTables["ip:nftban"] = true
+	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	// Daemon NOT active.
+
+	decision := Classify(mock, nil, detect.PanelNone, false, false, newTestLogger())
+	if decision != Ambiguous {
+		t.Errorf("decision = %s, want AMBIGUOUS (orphan table without active daemon) — PR-22B audit fix", decision)
+	}
+}
+
+// PR-22B: daemon-up without the ip nftban table also triggers Ambiguous.
+// Symmetric case to the orphan-table one.
+func TestClassify_Ambiguous_DaemonWithoutTable(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Services[NftbanDaemonUnit] = true
+	// No table.
+
+	decision := Classify(mock, nil, detect.PanelNone, false, false, newTestLogger())
+	if decision != Ambiguous {
+		t.Errorf("decision = %s, want AMBIGUOUS (daemon active without kernel table)", decision)
+	}
+}
+
+// Table without chain → not authoritative, but no daemon either; table
+// presence alone is still an orphan artifact → Ambiguous (PR-22B). Prior
+// behaviour was Fresh, which hid the orphan from the operator.
+func TestClassify_Ambiguous_TableWithoutChain(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.NftTables["ip:nftban"] = true
 	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 1, Stderr: "no such chain"}
 
-	decision := Classify(mock, nil, detect.PanelNone, false, newTestLogger())
-	if decision != Fresh {
-		t.Errorf("decision = %s, want FRESH (table without chain = not authoritative)", decision)
+	decision := Classify(mock, nil, detect.PanelNone, false, false, newTestLogger())
+	if decision != Ambiguous {
+		t.Errorf("decision = %s, want AMBIGUOUS (table without chain is orphan) — PR-22B audit fix", decision)
 	}
 }
 
 func TestClassify_Priority_UpdateOverConflicts(t *testing.T) {
 	// Even with every conflict active, UPDATE wins if NFTBan owns the firewall
-	mock := executor.NewMockExecutor()
-	mock.NftTables["ip:nftban"] = true
-	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	mock := authoritativeMock()
 
 	conflicts := []detect.Conflict{
 		{Name: "CSF", Active: true},
 		{Name: "UFW", Active: true},
 		{Name: "firewalld", Active: true},
 	}
-	decision := Classify(mock, conflicts, detect.PanelCPanel, true, newTestLogger())
+	decision := Classify(mock, conflicts, detect.PanelCPanel, true, true, newTestLogger())
 	if decision != Update {
 		t.Errorf("decision = %s, want UPDATE (overrides everything)", decision)
+	}
+}
+
+// PR-22B regression guard: IsNftbanAuthoritative must require ALL THREE
+// (table + chain + daemon). Drop any one and the predicate must return
+// false.
+func TestIsNftbanAuthoritative_RequiresAllThree(t *testing.T) {
+	// Baseline — all three present.
+	if !IsNftbanAuthoritative(authoritativeMock()) {
+		t.Fatal("baseline authoritativeMock must satisfy the predicate")
+	}
+
+	// Drop table.
+	m1 := authoritativeMock()
+	m1.NftTables["ip:nftban"] = false
+	if IsNftbanAuthoritative(m1) {
+		t.Error("predicate must return false when table is missing")
+	}
+
+	// Drop chain (exit code non-zero).
+	m2 := authoritativeMock()
+	m2.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 1}
+	if IsNftbanAuthoritative(m2) {
+		t.Error("predicate must return false when chain probe fails")
+	}
+
+	// Drop daemon.
+	m3 := authoritativeMock()
+	m3.Services[NftbanDaemonUnit] = false
+	if IsNftbanAuthoritative(m3) {
+		t.Error("predicate must return false when daemon is inactive (PR-22B tightening)")
 	}
 }

--- a/internal/installer/authority/types.go
+++ b/internal/installer/authority/types.go
@@ -21,16 +21,28 @@ package authority
 type Decision string
 
 const (
-	// Update means NFTBan already owns the firewall (table + chain exist).
+	// Update means NFTBan already owns the firewall (table + chain + daemon).
+	// PR-22B tightened this predicate — a table or chain without an active
+	// nftband.service is NOT Update; it is Ambiguous.
 	Update Decision = "UPDATE"
 
 	// Fresh means no conflicting firewalls — clean slate.
 	Fresh Decision = "FRESH"
 
 	// Takeover means conflicts exist but takeover is approved
-	// (via env var, panel auto-approve, or user confirmation).
+	// (via env var, --takeover flag, or panel auto-approve when explicitly
+	// enabled by --panel-auto-takeover).
 	Takeover Decision = "TAKEOVER"
 
 	// Abort means conflicts exist and takeover is not approved.
 	Abort Decision = "ABORT"
+
+	// Ambiguous means the host is in a half-installed / crashed state —
+	// an ip nftban table exists in the kernel but the daemon is not
+	// active, OR the detection is inconclusive. PR-22B added this state
+	// on the install side to close the audit finding that orphan-table
+	// hosts silently classified as Update and skipped the emergency SSH
+	// injection path. phaseSwitch must treat Ambiguous with the same
+	// pre-switch safety as Takeover — never silent-continue.
+	Ambiguous Decision = "AMBIGUOUS"
 )

--- a/internal/installer/state/file.go
+++ b/internal/installer/state/file.go
@@ -71,6 +71,19 @@ type StateFile struct {
 	ServicesEnabled   string
 	ServicesFailed    string
 
+	// DryRun, when true, makes Transition update in-memory fields only
+	// and skip the atomic file write. PR-22B introduced this so that
+	// dry-run paths sharing phase functions with real install/upgrade
+	// (e.g. phaseDetect reused by runUpdateDryRun) do not persist
+	// install_state during observational runs.
+	//
+	// Callers that need to force a real persistence during a dry-run
+	// (none exist today, but reserved for future audit artifacts) can
+	// set this to false temporarily and call Transition, but that is
+	// discouraged — the expected contract is DryRun=cfg.dryRun at the
+	// start of the run and never toggled.
+	DryRun bool
+
 	stateDir string
 }
 
@@ -94,6 +107,11 @@ func (sf *StateFile) Path() string {
 // Transition validates and applies a state transition.
 // It updates the state, phase, and optional failure reason, then persists atomically.
 // For failure states, it always returns an error (the reason) so phase runners halt.
+//
+// When sf.DryRun is true, the in-memory fields are updated but the
+// filesystem is NOT written. This allows dry-run orchestrators to reuse
+// phase functions that call Transition without tripping the
+// observational-path Stop Condition (PR-22B boundary repair).
 func (sf *StateFile) Transition(newState InstallState, phase Phase, reason string) error {
 	sf.State = newState
 	sf.PhaseReached = string(phase)
@@ -101,8 +119,10 @@ func (sf *StateFile) Transition(newState InstallState, phase Phase, reason strin
 		sf.FailureReason = reason
 	}
 	sf.Timestamp = time.Now().UTC()
-	if err := sf.WriteAtomic(); err != nil {
-		return err
+	if !sf.DryRun {
+		if err := sf.WriteAtomic(); err != nil {
+			return err
+		}
 	}
 	// Failure states must return an error so the phase runner stops execution.
 	if newState.IsFailed() {

--- a/internal/installer/state/machine.go
+++ b/internal/installer/state/machine.go
@@ -103,9 +103,10 @@ func (s InstallState) IsApplyTerminal() bool {
 	return false
 }
 
-// IsApplyTerminal is a non-method alias for IsApplyTerminal so consumers
-// that have the state as a variable rather than a method receiver can
-// call it symmetrically with the other helpers in this file.
+// IsApplyTerminal is a package-level alias for the (InstallState)
+// IsApplyTerminal method, kept so consumers that hold the state as a
+// plain value can call it symmetrically with the other helpers in this
+// file.
 func IsApplyTerminal(s InstallState) bool { return s.IsApplyTerminal() }
 
 // IsFailed returns true if the state represents a failure.

--- a/internal/installer/state/machine.go
+++ b/internal/installer/state/machine.go
@@ -75,6 +75,39 @@ const (
 	ExitFatal     = 4
 )
 
+// IsApplyTerminal reports whether a state represents the terminal
+// outcome of a real apply operation (install or upgrade). Only these
+// states should produce an entry in update-history.json — preview /
+// planning / dry-run states must not.
+//
+// Explicit allowlist, not a default catch-all. PR-22B introduced this
+// after the previous audit found that any non-Committed/Degraded state
+// was silently mapped to "install_fail" in history — including
+// dry-run-terminal states that never attempted mutation.
+//
+// Consumers that need to distinguish "apply succeeded / apply failed /
+// apply was never attempted" must base the decision on IsApplyTerminal
+// and NOT on the string value of the state.
+func (s InstallState) IsApplyTerminal() bool {
+	switch s {
+	case StateCommitted,
+		StateDegraded,
+		StateFailedSSH,
+		StateFailedAbort,
+		StateFailedRender,
+		StateFailedRebuild,
+		StateFailedNoFirewall,
+		StateFailedTakeover:
+		return true
+	}
+	return false
+}
+
+// IsApplyTerminal is a non-method alias for IsApplyTerminal so consumers
+// that have the state as a variable rather than a method receiver can
+// call it symmetrically with the other helpers in this file.
+func IsApplyTerminal(s InstallState) bool { return s.IsApplyTerminal() }
+
 // IsFailed returns true if the state represents a failure.
 func (s InstallState) IsFailed() bool {
 	switch s {

--- a/internal/installer/state/machine_test.go
+++ b/internal/installer/state/machine_test.go
@@ -218,3 +218,81 @@ func TestStateFile_Transition(t *testing.T) {
 		t.Errorf("Persisted State = %s, want FAILED_REBUILD", sf2.State)
 	}
 }
+
+// PR-22B: DryRun=true must not create any files under stateDir. This
+// test falsifies the boundary claim at the state layer — any regression
+// that reintroduces a write during dry-run fails here before it can
+// reach an orchestrator.
+func TestStateFile_Transition_DryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	sf := NewStateFile(dir)
+	sf.DryRun = true
+	sf.Mode = "upgrade"
+	sf.Version = "1.100.0"
+
+	if err := sf.Transition(StateDetectComplete, PhaseDetect, ""); err != nil {
+		t.Fatalf("Transition under DryRun: %v", err)
+	}
+	if sf.State != StateDetectComplete {
+		t.Errorf("in-memory State = %s, want DETECT_COMPLETE", sf.State)
+	}
+	// No file should have been created in stateDir.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("DryRun Transition created files in stateDir: %v", names)
+	}
+
+	// A failure state under DryRun must still return the error (so phase
+	// runners halt) but must NOT persist.
+	if err := sf.Transition(StateFailedRebuild, PhaseSwitch, "simulated"); err == nil {
+		t.Error("Transition to failure under DryRun must still return error to halt runners")
+	}
+	entries2, _ := os.ReadDir(dir)
+	if len(entries2) != 0 {
+		t.Errorf("DryRun failure Transition persisted state")
+	}
+}
+
+// PR-22B: IsApplyTerminal is an explicit allowlist, not a catch-all.
+// Every state must be either apply-terminal or not-apply-terminal; there
+// are no unlisted "edge" states.
+func TestInstallState_IsApplyTerminal(t *testing.T) {
+	applyTerminal := []InstallState{
+		StateCommitted,
+		StateDegraded,
+		StateFailedSSH,
+		StateFailedAbort,
+		StateFailedRender,
+		StateFailedRebuild,
+		StateFailedNoFirewall,
+		StateFailedTakeover,
+	}
+	notApplyTerminal := []InstallState{
+		StateFilesInstalled,
+		StateDetectComplete,
+		StatePrepareComplete,
+		StateSwitchComplete,
+		StateServicesComplete,
+		StateUninstallPlanning,
+	}
+	for _, s := range applyTerminal {
+		if !s.IsApplyTerminal() {
+			t.Errorf("%s should be apply-terminal (completed apply outcome)", s)
+		}
+		if !IsApplyTerminal(s) {
+			t.Errorf("IsApplyTerminal(%s) disagrees with method form", s)
+		}
+	}
+	for _, s := range notApplyTerminal {
+		if s.IsApplyTerminal() {
+			t.Errorf("%s must NOT be apply-terminal (not a real apply outcome)", s)
+		}
+	}
+}

--- a/internal/installer/uninstall/uninstall_test.go
+++ b/internal/installer/uninstall/uninstall_test.go
@@ -499,3 +499,101 @@ func TestPlan_JSON_RoundTrip_KeyFields(t *testing.T) {
 		}
 	}
 }
+
+// PR-22B audit item 11 (render ↔ JSON equivalence): prove that core
+// facts surface in BOTH human text and JSON. A future drift (render
+// grows a line with no JSON backing, or JSON grows a field that's never
+// rendered) fails here.
+func TestPlan_RenderAndJSON_ExposeSameCoreFacts(t *testing.T) {
+	grid := []struct {
+		name         string
+		mode         Mode
+		restore      bool
+		priorState   PriorRecordState
+		authState    CurrentAuthority
+		wantInRender []string
+		wantInJSON   []string
+	}{
+		{
+			name:       "remove/no-restore/no-record/nftban",
+			mode:       ModeRemove,
+			restore:    false,
+			priorState: PriorNoRecord,
+			authState:  AuthorityNFTBan,
+			wantInRender: []string{
+				"Requested mode              : remove",
+				"Current authority           : nftban",
+				"Restore requested           : no",
+				"Restore authorized          : no",
+				"Prior-authority record      : no_record",
+			},
+			wantInJSON: []string{
+				`"requested_mode": "remove"`,
+				`"current_authority": "nftban"`,
+				`"restore_requested": false`,
+				`"restore_authorized": false`,
+				`"prior_state": "no_record"`,
+				`"no_mutation_performed": true`,
+			},
+		},
+		{
+			name:       "purge/restore-requested/record-incomplete/ambiguous",
+			mode:       ModePurge,
+			restore:    true,
+			priorState: PriorRecordIncomplete,
+			authState:  AuthorityAmbiguous,
+			wantInRender: []string{
+				"Requested mode              : purge",
+				"Current authority           : ambiguous",
+				"Restore requested           : yes",
+				"Restore authorized          : no",
+				"Prior-authority record      : record_incomplete",
+			},
+			wantInJSON: []string{
+				`"requested_mode": "purge"`,
+				`"current_authority": "ambiguous"`,
+				`"restore_requested": true`,
+				`"restore_authorized": false`,
+				`"prior_state": "record_incomplete"`,
+			},
+		},
+	}
+	for _, tc := range grid {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &ClassifyResult{State: tc.authState}
+			prior := &ProbeResult{State: tc.priorState}
+			p := BuildPlan(tc.mode, auth, prior, tc.restore)
+
+			var buf bytes.Buffer
+			p.Render(&buf)
+			rendered := buf.String()
+			for _, needle := range tc.wantInRender {
+				if !strings.Contains(rendered, needle) {
+					t.Errorf("render missing %q:\n%s", needle, rendered)
+				}
+			}
+
+			data, err := p.JSON()
+			if err != nil {
+				t.Fatalf("JSON: %v", err)
+			}
+			jsonOut := string(data)
+			for _, needle := range tc.wantInJSON {
+				if !strings.Contains(jsonOut, needle) {
+					t.Errorf("JSON missing %q:\n%s", needle, jsonOut)
+				}
+			}
+
+			// Scope-boundary invariant must appear in BOTH forms.
+			if !strings.Contains(rendered, "Scope boundary:") {
+				t.Errorf("render missing scope-boundary block")
+			}
+			if !strings.Contains(jsonOut, `"scope_boundary"`) {
+				t.Errorf("JSON missing scope_boundary field")
+			}
+			if !strings.Contains(jsonOut, `"no_mutation_performed": true`) {
+				t.Errorf("JSON missing no_mutation_performed=true invariant")
+			}
+		})
+	}
+}

--- a/internal/installer/update/apply_contract.go
+++ b/internal/installer/update/apply_contract.go
@@ -65,6 +65,11 @@ var ApplyWhitelist = map[string]bool{
 	"nft list table ip6 nftban":           true,
 	"systemctl is-active nftband.service": true,
 	"systemctl is-active nftables":        true,
+
+	// v1.100 PR-22B: authority.IsNftbanAuthoritative tightened its
+	// predicate to also probe the input chain. Read-only; the probe is
+	// part of preflight P-1 and runs on every apply entry point.
+	"nft list chain ip nftban input": true,
 }
 
 // ApplyForbiddenSubstring names a class of calls that must never appear

--- a/internal/installer/update/preflight.go
+++ b/internal/installer/update/preflight.go
@@ -37,6 +37,7 @@
 package update
 
 import (
+	"github.com/itcmsgr/nftban/internal/installer/authority"
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
@@ -67,19 +68,19 @@ type PreflightResult struct {
 func Preflight(exec executor.Executor, log *logging.Logger, origin string) *PreflightResult {
 	res := &PreflightResult{Passed: true}
 
-	// P-1 authority — the existing authority.Detect would give us a full
-	// picture, but for the preflight scope we just need to know whether
-	// nftban currently owns the firewall. We proxy via the presence of
-	// the ip nftban table: if it exists, nftban is authoritative.
+	// P-1 authority — PR-22B uses the canonical predicate from the
+	// authority package. Requires table + chain + active daemon — a
+	// weaker check (table-only) used to let a half-installed host pass
+	// preflight and then behave inconsistently under apply.
 	{
-		ok := exec.NftTableExists("ip", "nftban")
+		ok := authority.IsNftbanAuthoritative(exec)
 		c := PreflightCheck{
 			Name:     "authority_nftban",
 			Passed:   ok,
 			Severity: "critical",
 		}
 		if !ok {
-			c.Detail = "ip nftban table absent — nftban does not own firewall authority (INV-U-003)"
+			c.Detail = "nftban not authoritative (requires ip nftban table + input chain + active nftband.service) — INV-U-003"
 			res.Passed = false
 		}
 		res.Checks = append(res.Checks, c)

--- a/internal/lifecycle/types.go
+++ b/internal/lifecycle/types.go
@@ -117,6 +117,12 @@ const (
 	// AuthorityNone means no managed firewall authority exists.
 	// Health should normally be DOWN when owner is NONE.
 	AuthorityNone AuthorityOwner = "NONE"
+
+	// AuthorityUnknown means the detection layer could not produce a
+	// consistent ownership read. Introduced in PR-22B so the bridge
+	// between installer and lifecycle can report Ambiguous host state
+	// without silently collapsing it to NFTBAN / EXTERNAL / NONE.
+	AuthorityUnknown AuthorityOwner = "UNKNOWN"
 )
 
 // LifecycleHealth represents the health dimension of authority.


### PR DESCRIPTION
## Why this PR exists

Second independent audit of the install/update lifecycle found systemic issues beyond what PR-22A fixed for uninstall. The install path silently ignored `--dry-run`. The update path wrote three files under `/var/lib/nftban/` during every "dry-run" and recorded successful previews as `install_fail`. The authority classifier had no `Ambiguous` state on the install side and implicitly auto-approved takeover on panel-managed hosts. Two different definitions of "nftban authoritative" coexisted. CI whitelisted writes under `/var/lib/nftban/state/` and never snapshot the history file.

This PR is **boundary-repair ONLY**. It does not advance uninstall mutation, does not add install preview capability, does not begin PR-23 work.

> **PR-22B does not add install preview capability; it removes false dry-run semantics by refusing unsupported install dry-run invocations.**

**Depends on:** #481 (PR-22A uninstall boundary repair).
**Scope lock:** 12 items from the repair contract seed — nothing else.

---

## What changed (12-item mapping)

### 1. Dry-run honesty

| Surface | Before | After |
|---|---|---|
| `--mode=install --dry-run` | Silently ignored — all 5 mutating phases executed | **Refused** with explicit error + non-zero exit |
| `update_dryrun.go` → `os.WriteFile(update_plan.json)` | Written every run | **Removed** — stdout only |
| `phaseDetect` → `sf.Transition(StateDetectComplete)` during update dry-run | Wrote `install_state` | **In-memory only** — `StateFile.DryRun=true` suppresses `WriteAtomic` |

### 2. History gating

- New `state.IsApplyTerminal(s)` helper — explicit allowlist of states representing a completed apply attempt (Committed / Degraded / FailedSSH / FailedAbort / FailedRender / FailedRebuild / FailedNoFirewall / FailedTakeover).
- `main.go` gate: `if !cfg.dryRun && state.IsApplyTerminal(sf.State) { writeHistory(...) }`. Structural, not mode-based. Every dry-run + every non-terminal state is excluded by construction.

### 3. Authority predicate + Ambiguous + panel consent

- `authority.IsNftbanAuthoritative(exec)` — canonical shared predicate requiring **table + chain + active daemon**. `update.Preflight` P-1 now uses this single source of truth. Previously two weaker definitions existed.
- `authority.Decision` gains `Ambiguous`. Orphan table or daemon-without-table routes here. `phaseSwitch` treats `Ambiguous` with the same emergency-SSH injection as `Takeover`/`Fresh` — never silent-continue.
- `authority.Classify` now takes a `panelAutoApprove bool` parameter (wired from `cfg.panelAutoTakeover`). **Panel detection alone no longer auto-approves takeover.** Operators must pass `--panel-auto-takeover` or `NFTBAN_PANEL_AUTO_TAKEOVER=1`.

### 4. Lifecycle bridge truthfulness

- `observeResult.DryRun` now wired from `cfg.dryRun` (was hard-coded `false`).
- `observePlan` / `mapAuthority` switches: compared `authority.Decision` values (UPPERCASE) against lowercase literals — every switch silently hit `default`, so every consumer saw `PreserveAuthority` regardless of the real decision. Now pinned to `authority` package constants. `Ambiguous` routes through `ActionTakeAuthority` + new `AuthorityUnknown` owner.

### 5. Flag validation

| Combination | Before | After |
|---|---|---|
| `--mode=install --dry-run` | Silently proceeds as real install | Refused |
| `--takeover --dry-run` | Both applied (meaningless) | Refused |
| `--rpm --deb` | Silently picks one | Refused |
| `--force-delete-operator-config` without `--purge` | Silently dropped | Refused |

### 6. CI truth surfaces

- `ci-update-canonization.yml G3-U3`: seeds `update-history.json`, snapshots `install_state`, **hard-asserts** byte-identical after dry-run. Removed `|| true` soft diff handling. Widened `G3-U5..U10` structural grep scope to include `update_dryrun.go`; extended pattern list (`os.WriteFile`, `os.Create`, `os.MkdirAll`, `os.Rename`, `nft create`, `apt-get purge`, `dnf erase`).
- `ci-install-canonization.yml` **NEW**: `G3-IN-REFUSE-DRY-RUN` (install dry-run exits non-zero with refusal message; history untouched). `G3-IN-FLAG-COMBOS` (invalid combos rejected).

### 7. Purity tests + reusable audit harness

- `internal/installer/audit/harness.go` **NEW**: reusable `PurityHarness` with `AssertNoExecutorWrites` / `AssertNoDirectoryCreations` / `AssertNoMutationCommands` / `AssertNoStateDirEntries` + `AssertAllPurity` convenience method. Self-tests prove it catches each class.
- `state.IsApplyTerminal` allowlist tests + `DryRun` Transition regression test.
- `authority.Classify` ambiguous-on-orphan-table + symmetric daemon-without-table + table-without-chain + predicate-requires-all-three tests.
- `uninstall.Plan` render ↔ JSON equivalence grid (audit item 11).
- `history_test.go` write-gate predicate unit tests.

---

## Falsifiability proof

Could the audit's install/update findings pass this CI? **No.**

| Previous bug | Gate that would now catch it |
|---|---|
| `--mode=install --dry-run` silently proceeds | `G3-IN-REFUSE-DRY-RUN` |
| `update_dryrun.go` writes `update_plan.json` | `G3-U5..U10` extended `os.WriteFile(` grep |
| `phaseDetect` → `Transition` writes install_state during update dry-run | `G3-U3` hard assertion on `install_state` sha256 |
| `writeHistory` records update dry-run as `install_fail` | `G3-U3` hard assertion on `update-history.json` sha256 |
| Orphan nftban table classifies as `Update` | `TestClassify_Ambiguous_OrphanTable` |
| Panel silently auto-approves takeover | `TestClassify_PanelDetected_NoFlag_Aborts` |
| Two "nftban authoritative" predicates drift | `update.Preflight` now imports `authority.IsNftbanAuthoritative` — single source |

---

## Explicit non-goals

This PR does **not** add uninstall mutation, does **not** add install preview capability, does **not** change purge/remove semantics, does **not** redesign installer history generally (only the write-gate predicate), does **not** tighten `PriorRecordUsable` semantics (deferred), does **not** add an exec-trace CI gate (deferred), and does **not** begin PR-23 work.

---

## Acceptance criteria (repair contract §6 extended)

- [x] All dry-run paths are observational or explicitly refused
- [x] No dry-run writes history or install_state by default
- [x] Authority ambiguity is surfaced conservatively (`Ambiguous` + emergency-SSH in `phaseSwitch`)
- [x] Silent panel takeover removed; explicit opt-in required
- [x] Canonical authority predicate; no duplicate definitions
- [x] Reusable purity harness exists + proves itself in self-tests
- [x] CI would fail on the exact bugs the audit found

---

## Test plan

- [ ] `ci-install-canonization` matrix green (ubuntu-24.04 + almalinux-9)
- [ ] `ci-update-canonization` matrix green (including new hard-asserts)
- [ ] `ci-uninstall-canonization` matrix green (regression-safe)
- [ ] `Runtime Truth` matrix green
- [ ] `Build & Test` green (all unit tests including new harness self-tests)
- [ ] Classifier tests pass with new 5-state enum
- [ ] Flag-combo CI refusals assert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)