### PR TITLE
feat(v1.100 PR-P2-1): prior-authority record hardening — 5-state classification + required RecordedAt/InstallerVersion/ActiveAtInstall

### DIFF
--- a/internal/installer/uninstall/contract.md
+++ b/internal/installer/uninstall/contract.md
@@ -85,6 +85,40 @@ PR-23). PR-22 only reads — it does not write any prior-authority
 artifact (that's install-side expansion per v1.100 Q9, tracked for
 PR-23 or a companion install-mode PR).
 
+### PR-P2-1 hardening (landed pre-PR-23)
+
+The 3-state classification above was tightened to 5 states so PR-24
+restore-enforcement has a stricter foundation:
+
+| State | Meaning |
+|---|---|
+| `NoRecord` | no artifact on disk |
+| `RecordMalformed` | artifact exists but JSON does not parse |
+| `RecordIncomplete` | JSON parses but required fields missing, unknown, or semantically unusable |
+| `RecordUsableActive` | all required fields present AND prior firewall was active at install time |
+| `RecordUsableInactive` | all required fields present AND prior firewall was explicitly NOT active at install time |
+
+"Usable" now requires:
+
+- JSON parses
+- schema version matches
+- firewall type is one of the known types
+- `recorded_at` timestamp present
+- `installer_version` present
+- `active_at_install` explicitly committed (pointer non-nil, not just
+  Go's zero-value false)
+
+**Usable does not imply "restore/re-enable now."** It means the record
+itself is trustworthy — PR-24 will still define its own restoration
+authorization rules on top of that.
+
+**Backward-safety note:** older records from before PR-P2-1 that lack
+`recorded_at` / `installer_version` / explicit `active_at_install` are
+intentionally reclassified as `RecordIncomplete` by the new Probe logic.
+This is safety tightening, not a functional regression. Records
+produced by the install-side writer that lands alongside PR-23 will
+carry all required fields.
+
 ---
 
 ## Plan output — contract-language rendering

--- a/internal/installer/uninstall/plan.go
+++ b/internal/installer/uninstall/plan.go
@@ -78,14 +78,37 @@ type Plan struct {
 	RestoreRequested bool `json:"restore_requested"`
 
 	// RestoreAuthorized is true only when RestoreRequested AND
-	// PriorState == PriorRecordUsable. This is the PR-22 classifier
-	// output; PR-24 enforces it.
+	// PriorState.IsUsable() returns true (both UsableActive and
+	// UsableInactive qualify — active/inactive is a separate semantic
+	// dimension surfaced via PriorActiveAtInstall). PR-24 enforces
+	// this gate.
 	RestoreAuthorized bool `json:"restore_authorized"`
 
-	// PriorState is the 3-state probe result for the prior-authority
-	// record. Populated regardless of RestoreRequested so the operator
-	// always sees the underlying ambiguity.
+	// PriorState is the 5-state probe result for the prior-authority
+	// record (PR-P2-1 hardened). Populated regardless of RestoreRequested
+	// so the operator always sees the underlying ambiguity.
 	PriorState PriorRecordState `json:"prior_state"`
+
+	// PriorIncompleteReason is populated when PriorState ==
+	// RecordIncomplete and gives a machine-consumable reason code so
+	// downstream tooling doesn't have to substring-match human notes.
+	// Empty string when the state is not Incomplete.
+	PriorIncompleteReason IncompleteReason `json:"prior_incomplete_reason,omitempty"`
+
+	// PriorActiveAtInstall surfaces the active-at-install-time
+	// distinction when the record is usable. Three values:
+	//
+	//   *true  — the prior firewall was actively holding authority at
+	//            install time; restore = re-enable a firewall that was
+	//            running
+	//   *false — the prior firewall was present but NOT active at install
+	//            time; restore = enable a firewall that was NOT running
+	//            (a different operation; operator should see this)
+	//   nil    — unknown (usable state not reached)
+	//
+	// PR-24 uses this to decide whether restoration needs a second
+	// confirmation prompt.
+	PriorActiveAtInstall *bool `json:"prior_active_at_install,omitempty"`
 
 	// Warnings is the operator-visible list of concerns that do NOT
 	// abort the plan but should be surfaced. Example: "restore flag
@@ -123,20 +146,30 @@ const PlanSchemaVersion = "1.100.0"
 // --restore-prior-authority flag at call time.
 func BuildPlan(mode Mode, auth *ClassifyResult, prior *ProbeResult, restoreRequested bool) *Plan {
 	p := &Plan{
-		SchemaVersion:     PlanSchemaVersion,
-		RequestedMode:     mode,
-		ArtifactPolicy:    artifactPolicyFor(mode),
-		CurrentAuthority:  auth.State,
-		DetectedExternal:  auth.External,
-		RestoreRequested:  restoreRequested,
-		PriorState:        prior.State,
-		RestoreAuthorized: restoreRequested && prior.State == PriorRecordUsable,
+		SchemaVersion:         PlanSchemaVersion,
+		RequestedMode:         mode,
+		ArtifactPolicy:        artifactPolicyFor(mode),
+		CurrentAuthority:      auth.State,
+		DetectedExternal:      auth.External,
+		RestoreRequested:      restoreRequested,
+		PriorState:            prior.State,
+		PriorIncompleteReason: prior.IncompleteReason,
+		RestoreAuthorized:     restoreRequested && prior.State.IsUsable(),
 		// Scope boundary is carried in the struct so JSON + text both see
 		// it. No text/JSON drift (audit D.5).
 		ScopeBoundary: "PR-22 scope: detect + plan only. No mutation code " +
 			"exists in this release. Running this command does NOT " +
 			"uninstall nftban. Later PRs (PR-23..PR-26) add mutation.",
 		NoMutationPerformed: true,
+	}
+
+	// PR-P2-1: surface the active-at-install distinction when the
+	// record is usable. Populated only when the record parsed and was
+	// classified as UsableActive/UsableInactive — otherwise nil so
+	// downstream consumers see "unknown," not a defaulted false.
+	if prior.State.IsUsable() && prior.Record != nil && prior.Record.ActiveAtInstall != nil {
+		v := *prior.Record.ActiveAtInstall
+		p.PriorActiveAtInstall = &v
 	}
 
 	// TargetAuthority — per Q2=C (frozen), default is None; restore is
@@ -154,9 +187,21 @@ func BuildPlan(mode Mode, auth *ClassifyResult, prior *ProbeResult, restoreReque
 		p.Warnings = append(p.Warnings,
 			"--restore-prior-authority requested but no prior-authority record exists — PR-24 will refuse this combination")
 	}
+	if restoreRequested && prior.State == PriorRecordMalformed {
+		p.Warnings = append(p.Warnings,
+			"--restore-prior-authority requested but prior-authority record is malformed (JSON parse failed) — PR-24 will refuse this combination")
+	}
 	if restoreRequested && prior.State == PriorRecordIncomplete {
 		p.Warnings = append(p.Warnings,
-			"--restore-prior-authority requested but prior-authority record is incomplete/unparseable — PR-24 will refuse this combination")
+			"--restore-prior-authority requested but prior-authority record is incomplete — PR-24 will refuse this combination")
+	}
+	// PR-P2-1: restoring an inactive prior is a semantically different
+	// operation (you're starting a firewall that was NOT running). Flag
+	// it even when restore is authorized so the operator sees the
+	// distinction before PR-24 runs.
+	if restoreRequested && prior.State == PriorRecordUsableInactive {
+		p.Warnings = append(p.Warnings,
+			"--restore-prior-authority requested; prior-authority record is usable but records the prior firewall as NOT active at install time — restoration would re-enable a firewall the operator was not running")
 	}
 	if auth.State == AuthorityAmbiguous {
 		p.Warnings = append(p.Warnings,
@@ -220,6 +265,20 @@ func (p *Plan) Render(w io.Writer) {
 	fmt.Fprintf(w, "  Restore requested           : %s\n", yesNo(p.RestoreRequested))
 	fmt.Fprintf(w, "  Restore authorized          : %s\n", yesNo(p.RestoreAuthorized))
 	fmt.Fprintf(w, "  Prior-authority record      : %s\n", p.PriorState)
+	// PR-P2-1: surface the active-at-install distinction when the
+	// record is usable. Operator must see the semantic difference
+	// between "restore a running firewall" and "enable a firewall that
+	// was not running." Unknown states (non-usable record) intentionally
+	// skip this line rather than display a defaulted value.
+	switch {
+	case p.PriorActiveAtInstall != nil && *p.PriorActiveAtInstall:
+		fmt.Fprintln(w, "  Prior firewall at install   : active (was running when nftban installed)")
+	case p.PriorActiveAtInstall != nil && !*p.PriorActiveAtInstall:
+		fmt.Fprintln(w, "  Prior firewall at install   : inactive (was NOT running when nftban installed)")
+	}
+	if p.PriorIncompleteReason != "" {
+		fmt.Fprintf(w, "  Prior-record issue          : %s\n", p.PriorIncompleteReason)
+	}
 	fmt.Fprintln(w, "")
 
 	if len(p.Warnings) > 0 {

--- a/internal/installer/uninstall/prior.go
+++ b/internal/installer/uninstall/prior.go
@@ -1,12 +1,12 @@
 // =============================================================================
-// NFTBan v1.100 PR-22 — Prior-Authority Record Detector (Read-Only)
+// NFTBan v1.100 PR-P2-1 — Prior-Authority Record Detector (Read-Only)
 // =============================================================================
 // SPDX-License-Identifier: MPL-2.0
 // meta:name="installer-uninstall-prior"
 // meta:type="lib"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-04-19"
-// meta:description="3-state prior-authority record detection for uninstall planning"
+// meta:description="5-state prior-authority record detection for uninstall planning"
 // meta:inventory.files="internal/installer/uninstall/prior.go"
 // meta:inventory.binaries=""
 // meta:inventory.env_vars=""
@@ -16,30 +16,35 @@
 // meta:inventory.privileges="root"
 // =============================================================================
 //
-// PR-22 scope lock: READ-ONLY. This file probes whether a prior-authority
-// artifact exists and, if so, whether its contents are usable for a
-// future --restore-prior-authority decision. It does NOT write any
-// prior-authority record (write-path is install-side, tracked for
-// PR-23 or a companion install-mode PR per V1100 contract §9 Q9).
+// PR-22 scope lock (preserved): READ-ONLY. Probes whether a prior-authority
+// artifact exists and whether its contents are usable for a future
+// --restore-prior-authority decision. Never writes, never deletes.
 //
-// The 3 states are the PR-22-scoped answer to "can a future restore
-// plan trust this data":
+// PR-P2-1 strengthening: PR-24 restore-enforcement cannot trust
+// under-defined records. This file hardens the schema and parsing
+// semantics so "usable" has a stricter meaning:
 //
-//   NoRecord            — no artifact on disk
-//   RecordUsable        — artifact parseable + has the required fields
-//   RecordIncomplete    — artifact exists but missing fields / malformed /
-//                         unrecognized firewall type
+//   NoRecord              — no artifact on disk
+//   RecordMalformed       — artifact exists but JSON does not parse
+//   RecordIncomplete      — JSON parses but required fields are missing,
+//                           unknown, or semantically unusable
+//   RecordUsableActive    — all requirements met AND the prior firewall
+//                           was active at install time
+//   RecordUsableInactive  — all requirements met AND the prior firewall
+//                           was explicitly recorded as NOT active at
+//                           install time
 //
-// PR-22 reports the state; PR-24 enforces "refuse --restore when
-// RecordIncomplete". Keeping the split means the plan renderer can
-// surface ambiguity to the operator instead of silently deciding for
-// them.
+// Backward-safety rule (PR-P2-1): older records from before this tightening
+// that lack recorded_at / installer_version / active_at_install are
+// reclassified as RecordIncomplete by design. This is intentional safety
+// tightening so PR-24 restore logic never trusts under-defined evidence.
 //
 // =============================================================================
 package uninstall
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
@@ -50,9 +55,35 @@ import (
 type PriorRecordState string
 
 const (
-	PriorNoRecord         PriorRecordState = "no_record"
-	PriorRecordUsable     PriorRecordState = "record_usable"
-	PriorRecordIncomplete PriorRecordState = "record_incomplete"
+	PriorNoRecord             PriorRecordState = "no_record"
+	PriorRecordMalformed      PriorRecordState = "record_malformed"
+	PriorRecordIncomplete     PriorRecordState = "record_incomplete"
+	PriorRecordUsableActive   PriorRecordState = "record_usable_active"
+	PriorRecordUsableInactive PriorRecordState = "record_usable_inactive"
+)
+
+// IsUsable reports whether a record-state represents a record that
+// PR-24 may consider authorizing restoration from. The active/inactive
+// distinction is exposed separately so the plan can surface the
+// semantic difference; both are usable-at-this-layer.
+func (s PriorRecordState) IsUsable() bool {
+	return s == PriorRecordUsableActive || s == PriorRecordUsableInactive
+}
+
+// IncompleteReason is a typed enum describing exactly why a record was
+// classified as RecordIncomplete. Machine-consumable so downstream
+// tooling does not have to substring-match human notes.
+type IncompleteReason string
+
+const (
+	IncompleteReasonNone                    IncompleteReason = ""
+	IncompleteReasonUnreadable              IncompleteReason = "unreadable"
+	IncompleteReasonSchemaMismatch          IncompleteReason = "schema_mismatch"
+	IncompleteReasonMissingFirewallType     IncompleteReason = "missing_firewall_type"
+	IncompleteReasonUnknownFirewallType     IncompleteReason = "unknown_firewall_type"
+	IncompleteReasonMissingRecordedAt       IncompleteReason = "missing_recorded_at"
+	IncompleteReasonMissingInstallerVersion IncompleteReason = "missing_installer_version"
+	IncompleteReasonMissingActiveAtInstall  IncompleteReason = "missing_active_at_install"
 )
 
 // PriorAuthorityPath is the canonical on-disk location for the
@@ -64,45 +95,58 @@ const PriorAuthorityPath = "/var/lib/nftban/state/prior_authority.json"
 // authority snapshot. PR-22 consumes this to classify usability; it
 // does NOT construct, write, or mutate this struct.
 //
-// The set of required fields is intentionally minimal (per V1100
-// contract §13 Q9 answer: "narrow snapshot, not a registry"):
+// PR-P2-1 required fields for PriorRecordUsable* classification:
 //
-//   FirewallType   — "ufw" / "firewalld" / "iptables" / "csf"
-//   ActiveAtInstall — was the prior firewall actively holding authority
-//   SchemaVersion  — freezes on-disk contract; reader must match
+//   SchemaVersion     — freezes on-disk contract; reader must match
+//   FirewallType      — "ufw" / "firewalld" / "iptables" / "csf"
+//   RecordedAt        — timestamp when the record was written; enables
+//                       freshness judgement in future tooling
+//   InstallerVersion  — version of the installer that wrote the record;
+//                       enables per-version quirk handling
+//   ActiveAtInstall   — explicit tri-state pointer. nil = field absent
+//                       (record is incomplete); &true = prior firewall
+//                       was active; &false = prior firewall was explicitly
+//                       recorded as NOT active
 //
-// Any extra fields can be added later without breaking backward
-// compatibility because the reader uses json.Unmarshal which tolerates
-// unknown fields.
+// json.Unmarshal tolerates unknown fields, so future additive fields
+// do not break older readers. PR-P2-1 does NOT add signature/checksum
+// infrastructure — that remains out of scope.
 type PriorRecord struct {
-	SchemaVersion   string `json:"schema_version"`
-	FirewallType    string `json:"firewall_type"`
-	ActiveAtInstall bool   `json:"active_at_install"`
+	SchemaVersion    string     `json:"schema_version"`
+	FirewallType     string     `json:"firewall_type"`
+	RecordedAt       *time.Time `json:"recorded_at,omitempty"`
+	InstallerVersion string     `json:"installer_version,omitempty"`
+	ActiveAtInstall  *bool      `json:"active_at_install,omitempty"`
 }
 
 // PriorRecordSchemaVersion is the currently-expected on-disk contract.
-// A record with a different schema_version is RecordIncomplete (PR-22
-// does not attempt migration; Q8 answer = A = no migration unless
-// demonstrated break).
+// A record with a different schema_version is RecordIncomplete.
 const PriorRecordSchemaVersion = "1.100.0"
 
-// ProbeResult is the full classification + parsed record (nil when the
-// classification is NoRecord or RecordIncomplete with no parseable
-// JSON). Plan renderers consume this rather than re-probing.
+// ProbeResult is the full classification + parsed record + typed
+// incomplete reason. Plan renderers consume this rather than re-probing.
 type ProbeResult struct {
-	State  PriorRecordState `json:"state"`
-	Record *PriorRecord     `json:"record,omitempty"`
-	Notes  []string         `json:"notes,omitempty"`
+	State            PriorRecordState `json:"state"`
+	Record           *PriorRecord     `json:"record,omitempty"`
+	IncompleteReason IncompleteReason `json:"incomplete_reason,omitempty"`
+	Notes            []string         `json:"notes,omitempty"`
 }
 
 // Probe classifies the on-disk prior-authority record. READ-ONLY.
 //
-// Inputs (all read-only):
-//   - exec.FileExists(PriorAuthorityPath)
-//   - exec.ReadFile(PriorAuthorityPath)
-//   - json.Unmarshal + field check
+// Decision order (first match wins; fall-through means "acceptable so far"):
 //
-// Never writes. Never deletes. Never mutates.
+//  1. File absent                      → NoRecord
+//  2. File present but unreadable      → Incomplete (Unreadable)
+//  3. File readable but bad JSON       → Malformed
+//  4. JSON parses but schema mismatch  → Incomplete (SchemaMismatch)
+//  5. Required fields missing/invalid  → Incomplete (specific reason)
+//  6. All required fields present AND
+//       ActiveAtInstall=&true          → UsableActive
+//       ActiveAtInstall=&false         → UsableInactive
+//
+// Read-only at every step: exec.FileExists + exec.ReadFile +
+// json.Unmarshal + field check. No writes, no deletes, no mutation.
 func Probe(exec executor.Executor, log *logging.Logger) *ProbeResult {
 	res := &ProbeResult{}
 
@@ -117,6 +161,7 @@ func Probe(exec executor.Executor, log *logging.Logger) *ProbeResult {
 	data, err := exec.ReadFile(PriorAuthorityPath)
 	if err != nil {
 		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonUnreadable
 		res.Notes = append(res.Notes,
 			"prior-authority record present but unreadable: "+err.Error())
 		log.Warn("uninstall/prior: record unreadable: %v", err)
@@ -125,16 +170,17 @@ func Probe(exec executor.Executor, log *logging.Logger) *ProbeResult {
 
 	var rec PriorRecord
 	if err := json.Unmarshal(data, &rec); err != nil {
-		res.State = PriorRecordIncomplete
+		res.State = PriorRecordMalformed
 		res.Notes = append(res.Notes,
 			"prior-authority record present but not valid JSON: "+err.Error())
 		log.Warn("uninstall/prior: record not parseable: %v", err)
 		return res
 	}
 
-	// Schema version check — mismatched schema is Incomplete (Q8 = A)
+	// Schema version check
 	if rec.SchemaVersion != PriorRecordSchemaVersion {
 		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonSchemaMismatch
 		res.Notes = append(res.Notes,
 			"prior-authority record schema_version="+rec.SchemaVersion+
 				" does not match expected "+PriorRecordSchemaVersion+
@@ -143,16 +189,20 @@ func Probe(exec executor.Executor, log *logging.Logger) *ProbeResult {
 		return res
 	}
 
-	// Required fields check
+	// Required field: FirewallType present
 	if rec.FirewallType == "" {
 		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonMissingFirewallType
 		res.Notes = append(res.Notes,
 			"prior-authority record missing firewall_type — not usable for restore")
 		res.Record = &rec
 		return res
 	}
+
+	// Required field: FirewallType known
 	if !knownFirewallType(rec.FirewallType) {
 		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonUnknownFirewallType
 		res.Notes = append(res.Notes,
 			"prior-authority record firewall_type="+rec.FirewallType+
 				" is not one of the known types (ufw / firewalld / iptables / csf)")
@@ -160,12 +210,68 @@ func Probe(exec executor.Executor, log *logging.Logger) *ProbeResult {
 		return res
 	}
 
-	res.State = PriorRecordUsable
+	// PR-P2-1 required field: RecordedAt present AND parseable.
+	//
+	// Older records that pre-date PR-P2-1 omit this field entirely and
+	// are deliberately reclassified as Incomplete here — the safety
+	// tightening that unblocks PR-24 restore-enforcement.
+	if rec.RecordedAt == nil || rec.RecordedAt.IsZero() {
+		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonMissingRecordedAt
+		res.Notes = append(res.Notes,
+			"prior-authority record missing recorded_at — older pre-PR-P2-1 record "+
+				"or record written without a timestamp; not usable for restore")
+		res.Record = &rec
+		return res
+	}
+
+	// PR-P2-1 required field: InstallerVersion present.
+	if rec.InstallerVersion == "" {
+		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonMissingInstallerVersion
+		res.Notes = append(res.Notes,
+			"prior-authority record missing installer_version — not usable for restore")
+		res.Record = &rec
+		return res
+	}
+
+	// PR-P2-1 required field: ActiveAtInstall EXPLICITLY present.
+	//
+	// The *bool pointer is intentional: a record that silently omits
+	// this field cannot be distinguished from one that explicitly set
+	// it to false. Requiring the pointer to be non-nil means the
+	// installer writer committed to a value, and PR-24 can trust that
+	// commitment when deciding whether restore means "re-enable a
+	// firewall that was running" or "enable a firewall that was not
+	// running at install time" (which is a very different operation).
+	if rec.ActiveAtInstall == nil {
+		res.State = PriorRecordIncomplete
+		res.IncompleteReason = IncompleteReasonMissingActiveAtInstall
+		res.Notes = append(res.Notes,
+			"prior-authority record missing active_at_install — the record did not "+
+				"commit to whether the prior firewall was active at install time, "+
+				"so restore would be unsafe")
+		res.Record = &rec
+		return res
+	}
+
+	// All requirements met. Split by active state so the plan renderer
+	// can surface the semantic difference without re-reading Record.
 	res.Record = &rec
-	res.Notes = append(res.Notes,
-		"prior-authority record parseable; firewall_type="+rec.FirewallType+
-			" active_at_install="+boolYN(rec.ActiveAtInstall))
-	log.Debug("uninstall/prior: usable record firewall_type=%s", rec.FirewallType)
+	if *rec.ActiveAtInstall {
+		res.State = PriorRecordUsableActive
+		res.Notes = append(res.Notes,
+			"prior-authority record parseable; firewall_type="+rec.FirewallType+
+				" active_at_install=yes (prior firewall was running at install time)")
+		log.Debug("uninstall/prior: usable-active record firewall_type=%s", rec.FirewallType)
+	} else {
+		res.State = PriorRecordUsableInactive
+		res.Notes = append(res.Notes,
+			"prior-authority record parseable; firewall_type="+rec.FirewallType+
+				" active_at_install=no (prior firewall was NOT running at install time; "+
+				"restore would re-enable a firewall that was not active)")
+		log.Debug("uninstall/prior: usable-inactive record firewall_type=%s", rec.FirewallType)
+	}
 	return res
 }
 
@@ -175,11 +281,4 @@ func knownFirewallType(t string) bool {
 		return true
 	}
 	return false
-}
-
-func boolYN(b bool) string {
-	if b {
-		return "yes"
-	}
-	return "no"
 }

--- a/internal/installer/uninstall/uninstall_test.go
+++ b/internal/installer/uninstall/uninstall_test.go
@@ -21,10 +21,21 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
+
+// ptrBool / ptrTime — tiny helpers for writing PR-P2-1 record fixtures
+// that need pointer fields (nil-vs-explicit distinction).
+func ptrBool(v bool) *bool         { return &v }
+func ptrTime(v time.Time) *time.Time { return &v }
+
+// sampleRecordedAt is a fixed, known-good timestamp for fixture records.
+// Using a package-level constant keeps fixtures reproducible and makes
+// the "missing recorded_at" test distinct from the "zero time" path.
+var sampleRecordedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 func newTestLogger() *logging.Logger {
 	return logging.New("/dev/null", false)
@@ -227,13 +238,23 @@ func TestProbe_NoRecord(t *testing.T) {
 	}
 }
 
-func TestProbe_RecordUsable(t *testing.T) {
+// A complete PR-P2-1 record. All subsequent "missing X" tests derive
+// from this by removing exactly one field — keeps failure attribution
+// unambiguous.
+const fullRecordJSON = `{` +
+	`"schema_version":"1.100.0",` +
+	`"firewall_type":"ufw",` +
+	`"recorded_at":"2026-01-01T00:00:00Z",` +
+	`"installer_version":"1.100.0",` +
+	`"active_at_install":true}`
+
+func TestProbe_RecordUsableActive(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"ufw","active_at_install":true}`)
+	mock.Files[PriorAuthorityPath] = []byte(fullRecordJSON)
 
 	res := Probe(mock, newTestLogger())
-	if res.State != PriorRecordUsable {
-		t.Errorf("State = %q; want %q", res.State, PriorRecordUsable)
+	if res.State != PriorRecordUsableActive {
+		t.Errorf("State = %q; want %q", res.State, PriorRecordUsableActive)
 	}
 	if res.Record == nil {
 		t.Fatal("Record must be populated for Usable state")
@@ -241,45 +262,147 @@ func TestProbe_RecordUsable(t *testing.T) {
 	if res.Record.FirewallType != "ufw" {
 		t.Errorf("FirewallType = %q; want ufw", res.Record.FirewallType)
 	}
+	if res.Record.ActiveAtInstall == nil || !*res.Record.ActiveAtInstall {
+		t.Error("ActiveAtInstall must be explicitly true for UsableActive")
+	}
 }
 
-func TestProbe_RecordIncomplete_MalformedJSON(t *testing.T) {
+// PR-P2-1: active_at_install=false is explicitly distinguished from
+// missing. Both paths are "usable" but they mean different things.
+func TestProbe_RecordUsableInactive(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files[PriorAuthorityPath] = []byte(`{` +
+		`"schema_version":"1.100.0",` +
+		`"firewall_type":"csf",` +
+		`"recorded_at":"2026-01-01T00:00:00Z",` +
+		`"installer_version":"1.100.0",` +
+		`"active_at_install":false}`)
+
+	res := Probe(mock, newTestLogger())
+	if res.State != PriorRecordUsableInactive {
+		t.Errorf("State = %q; want %q (active_at_install=false is usable-but-inactive)", res.State, PriorRecordUsableInactive)
+	}
+	if res.Record == nil || res.Record.ActiveAtInstall == nil {
+		t.Fatal("Record.ActiveAtInstall must be non-nil for UsableInactive (explicit false)")
+	}
+	if *res.Record.ActiveAtInstall {
+		t.Error("ActiveAtInstall must be explicitly false for UsableInactive")
+	}
+}
+
+func TestProbe_RecordMalformed_BadJSON(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Files[PriorAuthorityPath] = []byte(`{not valid json`)
 
 	res := Probe(mock, newTestLogger())
-	if res.State != PriorRecordIncomplete {
-		t.Errorf("State = %q; want %q (malformed JSON)", res.State, PriorRecordIncomplete)
+	if res.State != PriorRecordMalformed {
+		t.Errorf("State = %q; want %q (PR-P2-1 distinguishes malformed JSON from incomplete)", res.State, PriorRecordMalformed)
 	}
 }
 
 func TestProbe_RecordIncomplete_MissingFirewallType(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","active_at_install":true}`)
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","recorded_at":"2026-01-01T00:00:00Z","installer_version":"1.100.0","active_at_install":true}`)
 
 	res := Probe(mock, newTestLogger())
 	if res.State != PriorRecordIncomplete {
 		t.Errorf("State = %q; want %q (missing firewall_type)", res.State, PriorRecordIncomplete)
 	}
+	if res.IncompleteReason != IncompleteReasonMissingFirewallType {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonMissingFirewallType)
+	}
 }
 
 func TestProbe_RecordIncomplete_UnknownFirewallType(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"pf","active_at_install":true}`)
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"pf","recorded_at":"2026-01-01T00:00:00Z","installer_version":"1.100.0","active_at_install":true}`)
 
 	res := Probe(mock, newTestLogger())
 	if res.State != PriorRecordIncomplete {
 		t.Errorf("State = %q; want %q (unknown firewall_type)", res.State, PriorRecordIncomplete)
 	}
+	if res.IncompleteReason != IncompleteReasonUnknownFirewallType {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonUnknownFirewallType)
+	}
 }
 
 func TestProbe_RecordIncomplete_SchemaMismatch(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"0.9.0","firewall_type":"ufw","active_at_install":true}`)
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"0.9.0","firewall_type":"ufw","recorded_at":"2026-01-01T00:00:00Z","installer_version":"1.100.0","active_at_install":true}`)
 
 	res := Probe(mock, newTestLogger())
 	if res.State != PriorRecordIncomplete {
 		t.Errorf("State = %q; want %q (schema mismatch — no migration in v1.100)", res.State, PriorRecordIncomplete)
+	}
+	if res.IncompleteReason != IncompleteReasonSchemaMismatch {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonSchemaMismatch)
+	}
+}
+
+// PR-P2-1 new required field: recorded_at.
+func TestProbe_RecordIncomplete_MissingRecordedAt(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"ufw","installer_version":"1.100.0","active_at_install":true}`)
+
+	res := Probe(mock, newTestLogger())
+	if res.State != PriorRecordIncomplete {
+		t.Errorf("State = %q; want %q (PR-P2-1 requires recorded_at)", res.State, PriorRecordIncomplete)
+	}
+	if res.IncompleteReason != IncompleteReasonMissingRecordedAt {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonMissingRecordedAt)
+	}
+}
+
+// PR-P2-1 new required field: installer_version.
+func TestProbe_RecordIncomplete_MissingInstallerVersion(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"ufw","recorded_at":"2026-01-01T00:00:00Z","active_at_install":true}`)
+
+	res := Probe(mock, newTestLogger())
+	if res.State != PriorRecordIncomplete {
+		t.Errorf("State = %q; want %q (PR-P2-1 requires installer_version)", res.State, PriorRecordIncomplete)
+	}
+	if res.IncompleteReason != IncompleteReasonMissingInstallerVersion {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonMissingInstallerVersion)
+	}
+}
+
+// PR-P2-1: active_at_install MUST be explicitly present. A record that
+// omits the field entirely is Incomplete — distinguishing "writer
+// committed to false" from "writer forgot to commit."
+func TestProbe_RecordIncomplete_MissingActiveAtInstall(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"ufw","recorded_at":"2026-01-01T00:00:00Z","installer_version":"1.100.0"}`)
+
+	res := Probe(mock, newTestLogger())
+	if res.State != PriorRecordIncomplete {
+		t.Errorf("State = %q; want %q (PR-P2-1 requires explicit active_at_install)", res.State, PriorRecordIncomplete)
+	}
+	if res.IncompleteReason != IncompleteReasonMissingActiveAtInstall {
+		t.Errorf("IncompleteReason = %q; want %q", res.IncompleteReason, IncompleteReasonMissingActiveAtInstall)
+	}
+}
+
+// PR-P2-1 backward-safety: records written by pre-P2-1 installers that
+// lack recorded_at + installer_version + explicit active_at_install
+// MUST be reclassified as Incomplete. Migration-style silent upgrade
+// is forbidden.
+func TestProbe_OldStyleRecord_DegradesToIncomplete(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Exact shape that pre-P2-1 tests used: schema + firewall + active.
+	mock.Files[PriorAuthorityPath] = []byte(`{"schema_version":"1.100.0","firewall_type":"ufw","active_at_install":true}`)
+
+	res := Probe(mock, newTestLogger())
+	if res.State == PriorRecordUsableActive || res.State == PriorRecordUsableInactive {
+		t.Errorf("PR-P2-1 safety regression: old-style record silently upgraded to %q — must be Incomplete", res.State)
+	}
+	if res.State != PriorRecordIncomplete {
+		t.Errorf("State = %q; want %q (old record must degrade safely)", res.State, PriorRecordIncomplete)
+	}
+	// The first missing field encountered by Probe is recorded_at, so
+	// that is the expected reason.
+	if res.IncompleteReason != IncompleteReasonMissingRecordedAt {
+		t.Errorf("IncompleteReason = %q; want %q (first missing field)", res.IncompleteReason, IncompleteReasonMissingRecordedAt)
 	}
 }
 
@@ -297,8 +420,31 @@ func noPriorProbe() *ProbeResult {
 
 func usablePriorProbe() *ProbeResult {
 	return &ProbeResult{
-		State:  PriorRecordUsable,
-		Record: &PriorRecord{SchemaVersion: PlanSchemaVersion, FirewallType: "ufw", ActiveAtInstall: true},
+		State: PriorRecordUsableActive,
+		Record: &PriorRecord{
+			SchemaVersion:    PlanSchemaVersion,
+			FirewallType:     "ufw",
+			RecordedAt:       ptrTime(sampleRecordedAt),
+			InstallerVersion: "1.100.0",
+			ActiveAtInstall:  ptrBool(true),
+		},
+	}
+}
+
+// usableInactivePriorProbe is the PR-P2-1 companion: all fields present
+// but active_at_install is explicitly false. BuildPlan should still
+// authorize restore (IsUsable returns true) but render/warnings must
+// surface the active=false distinction.
+func usableInactivePriorProbe() *ProbeResult {
+	return &ProbeResult{
+		State: PriorRecordUsableInactive,
+		Record: &PriorRecord{
+			SchemaVersion:    PlanSchemaVersion,
+			FirewallType:     "csf",
+			RecordedAt:       ptrTime(sampleRecordedAt),
+			InstallerVersion: "1.100.0",
+			ActiveAtInstall:  ptrBool(false),
+		},
 	}
 }
 
@@ -336,6 +482,33 @@ func TestBuildPlan_Restore_UsableRecord_Authorized(t *testing.T) {
 	}
 	if p.TargetAuthority != CurrentAuthority("ufw") {
 		t.Errorf("TargetAuthority = %q; want ufw (restored prior)", p.TargetAuthority)
+	}
+	// PR-P2-1: UsableActive must surface active=true in the plan.
+	if p.PriorActiveAtInstall == nil || !*p.PriorActiveAtInstall {
+		t.Errorf("PriorActiveAtInstall must be explicit true for UsableActive prior")
+	}
+}
+
+// PR-P2-1: UsableInactive is still authorized (record is usable) but
+// the plan must surface the active=false distinction AND warn the
+// operator that restoration would re-enable a firewall that was not
+// active at install time.
+func TestBuildPlan_Restore_UsableInactive_AuthorizedButWarned(t *testing.T) {
+	p := BuildPlan(ModeRemove, happyClassify(), usableInactivePriorProbe(), true)
+	if !p.RestoreAuthorized {
+		t.Error("restore must be authorized for UsableInactive — inactive is still a usable record")
+	}
+	if p.PriorActiveAtInstall == nil || *p.PriorActiveAtInstall {
+		t.Errorf("PriorActiveAtInstall must be explicit false for UsableInactive prior")
+	}
+	var haveInactiveWarning bool
+	for _, w := range p.Warnings {
+		if strings.Contains(w, "NOT active at install time") {
+			haveInactiveWarning = true
+		}
+	}
+	if !haveInactiveWarning {
+		t.Errorf("plan must warn that restoration re-enables a non-active firewall; got warnings: %v", p.Warnings)
 	}
 }
 
@@ -491,7 +664,8 @@ func TestPlan_JSON_RoundTrip_KeyFields(t *testing.T) {
 		`"requested_mode": "purge"`,
 		`"restore_requested": true`,
 		`"restore_authorized": true`,
-		`"prior_state": "record_usable"`,
+		`"prior_state": "record_usable_active"`,
+		`"prior_active_at_install": true`,
 		`"phases_that_would_mutate"`,
 	} {
 		if !strings.Contains(out, needle) {


### PR DESCRIPTION
**Pre-PR-23 blocker #1** of 6. Strengthens prior-authority records so PR-24 restore-enforcement can rely on them without inheriting weak semantics.

## Migration note (required per authorization)

> **Older prior-authority records may now classify as Incomplete by design. This is intentional safety tightening, not a functional regression.**

Records produced by the install-side writer landing with PR-23 will carry all required fields. Until then, existing fixtures / local test records without `recorded_at` / `installer_version` / explicit `active_at_install` will be reclassified as `Incomplete` — this is the explicit backward-safety path.

## Scope-locked (per repair contract)

- ✅ schema additions (`recorded_at`, `installer_version`, `*bool active_at_install`)
- ✅ 5-state classification (`NoRecord` / `Malformed` / `Incomplete` / `UsableActive` / `UsableInactive`)
- ✅ backward-safe degradation of old weak records to `Incomplete`
- ✅ render/JSON symmetry — `PriorActiveAtInstall` field + render line
- ✅ tests + contract/doc updates

**Not in scope:**
- ❌ no restore execution
- ❌ no lifecycle mutation
- ❌ no signature/checksum framework
- ❌ no unrelated refactors

## What \"usable\" now means

Record is usable only if: JSON parses, schema matches, firewall type known, `recorded_at` present + parseable, `installer_version` present, AND `active_at_install` is explicitly committed (pointer non-nil — not just Go's zero-value false). **Usable does not imply \"restore/re-enable now\"** — PR-24 defines its own authorization rules on top.

## 5-state classification

| State | Condition | PR-24 trust level |
|---|---|---|
| `NoRecord` | no artifact on disk | cannot restore |
| `RecordMalformed` | JSON does not parse | cannot restore |
| `RecordIncomplete` | required field missing/invalid | cannot restore (see `IncompleteReason` for why) |
| `RecordUsableActive` | all required + `active_at_install=true` | restore = re-enable a firewall that was running |
| `RecordUsableInactive` | all required + `active_at_install=false` | restore = enable a firewall that was NOT running (warrants prompt) |

`IncompleteReason` enum: `Unreadable` / `SchemaMismatch` / `MissingFirewallType` / `UnknownFirewallType` / `MissingRecordedAt` / `MissingInstallerVersion` / `MissingActiveAtInstall`. Machine-consumable so downstream tooling doesn't have to substring-match notes.

## Plan integration

- `Plan.RestoreAuthorized` now uses `PriorState.IsUsable()` — both `Usable*` variants authorize at this layer
- new `Plan.PriorActiveAtInstall *bool` surfaces the tri-state (nil = unknown, &true/&false = explicit)
- new `Plan.PriorIncompleteReason` surfaces typed reason in JSON
- new render line `Prior firewall at install : active|inactive` — only emitted when record is usable (no defaulted values)
- new warning when restore requested on `UsableInactive` record: \"restoration would re-enable a firewall the operator was not running\"

## Tests (all in `internal/installer/uninstall/uninstall_test.go`)

Added:
- `TestProbe_RecordUsableActive` (rename + tightened) + `TestProbe_RecordUsableInactive`
- `TestProbe_RecordMalformed_BadJSON` (split from Incomplete)
- `TestProbe_RecordIncomplete_MissingRecordedAt` / `MissingInstallerVersion` / `MissingActiveAtInstall` — each asserts both `State` AND typed `IncompleteReason`
- `TestProbe_OldStyleRecord_DegradesToIncomplete` — explicit backward-safety regression guard
- `TestBuildPlan_Restore_UsableInactive_AuthorizedButWarned`

All existing tests updated: fixtures carry the 5 required fields; JSON assertions use `record_usable_active`.

## Doc update

New \"PR-P2-1 hardening\" section in `internal/installer/uninstall/contract.md` under the prior-authority record definition.

## Acceptance checklist (per repair contract §5)

- [x] weak old records are not silently treated as fully usable
- [x] `active_at_install=false` is explicit and test-covered
- [x] `recorded_at` and `installer_version` are required for usable
- [x] no restore behavior added
- [x] no mutation behavior changes
- [x] docs updated
- [x] signature/checksum work NOT added (deferred)

## Test plan

- [ ] `Build & Test` green — all unit tests pass including 8 new probe tests
- [ ] `ci-uninstall-canonization` matrix green — all 3 modes' existing tests still pass (render/JSON/plan structural checks)
- [ ] No CI regression on install/update canonization gates (scope-locked; no touches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)