### PR TITLE
feat(v1.100 PR-P2-4): exec-trace CI gate (G3-EXEC-TRACE) — process-spawning purity

### DIFF
--- a/.github/workflows/ci-install-canonization.yml
+++ b/.github/workflows/ci-install-canonization.yml
@@ -61,13 +61,13 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y nftables
+          sudo apt-get install -y nftables strace
 
       - name: Install system dependencies (RPM)
         if: matrix.label == 'almalinux-9'
         run: |
           dnf -y install epel-release
-          dnf -y install nftables git tar gzip procps-ng findutils sudo golang
+          dnf -y install nftables git tar gzip procps-ng findutils sudo golang strace
 
       - name: Set up Go (DEB only)
         if: matrix.label == 'ubuntu-24.04'
@@ -111,8 +111,14 @@ jobs:
           # so we can hard-assert they are byte-identical afterward.
           before_ks=$(bash scripts/ci-snapshot-kernel-service.sh)
 
+          # PR-P2-4 (G3-EXEC-TRACE): wrap the refuse-dry-run under strace
+          # so we can assert the binary did NOT spawn any forbidden
+          # mutation process (nft add/flush/delete, systemctl lifecycle
+          # verbs, external firewall binaries, package-manager removal,
+          # user/group deletion) before it exits with its refusal.
           set +e
-          out=$(sudo ./bin/nftban-installer --mode=install --dry-run \
+          out=$(sudo bash scripts/ci-exec-trace-assert.sh \
+                ./bin/nftban-installer --mode=install --dry-run \
                 --state-dir=/var/lib/nftban/state 2>&1)
           rc=$?
           set -e

--- a/.github/workflows/ci-uninstall-canonization.yml
+++ b/.github/workflows/ci-uninstall-canonization.yml
@@ -60,13 +60,13 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y nftables jq
+          sudo apt-get install -y nftables jq strace
 
       - name: Install system dependencies (RPM)
         if: matrix.label == 'almalinux-9'
         run: |
           dnf -y install epel-release
-          dnf -y install nftables jq git tar gzip procps-ng findutils sudo golang
+          dnf -y install nftables jq git tar gzip procps-ng findutils sudo golang strace
 
       - name: Set up Go (DEB only)
         if: matrix.label == 'ubuntu-24.04'
@@ -214,8 +214,14 @@ jobs:
           # mutates kernel tables or service states without touching
           # tracked files — exactly the class of drift this gate closes.
           before_ks=$(bash scripts/ci-snapshot-kernel-service.sh)
+          # PR-P2-4 (G3-EXEC-TRACE): wrap the dry-run under strace.
+          # Uninstall is the most scope-sensitive mode — verifying that
+          # no mutation process ever spawns during dry-run is the
+          # strongest proof that PR-23's future mutation code will be
+          # the ONLY mutation surface.
           set +e
-          sudo ./bin/nftban-installer --mode=uninstall --dry-run \
+          sudo bash scripts/ci-exec-trace-assert.sh \
+              ./bin/nftban-installer --mode=uninstall --dry-run \
               --state-dir=/var/lib/nftban/state 2>&1 | tee /tmp/uninstall-dryrun.out
           rc=${PIPESTATUS[0]}
           set -e

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -63,14 +63,14 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y nftables jq systemd util-linux coreutils
+          sudo apt-get install -y nftables jq systemd util-linux coreutils strace
 
       - name: Install system dependencies (RPM)
         if: matrix.label == 'almalinux-9'
         run: |
           dnf -y install epel-release
           # coreutils-single is preinstalled on almalinux:9 minimal — omit coreutils.
-          dnf -y install nftables jq systemd util-linux git tar gzip which procps-ng findutils sudo golang
+          dnf -y install nftables jq systemd util-linux git tar gzip which procps-ng findutils sudo golang strace
 
       - name: Set up Go (DEB only)
         if: matrix.label == 'ubuntu-24.04'
@@ -171,8 +171,13 @@ jobs:
           # around the update dry-run.
           before_ks=$(bash scripts/ci-snapshot-kernel-service.sh)
 
+          # PR-P2-4 (G3-EXEC-TRACE): wrap the dry-run under strace so we
+          # can hard-assert the process did NOT spawn any forbidden
+          # mutator. Falsifiability at the syscall layer, not just the
+          # Go-function-call layer.
           set +e
-          sudo ./bin/nftban-installer --mode=upgrade --dry-run \
+          sudo bash scripts/ci-exec-trace-assert.sh \
+              ./bin/nftban-installer --mode=upgrade --dry-run \
               --source --source-dir="$PWD" \
               --state-dir=/var/lib/nftban/state 2>&1 | tee /tmp/dryrun.out
           rc=${PIPESTATUS[0]}

--- a/internal/installer/uninstall/contract.md
+++ b/internal/installer/uninstall/contract.md
@@ -282,6 +282,7 @@ discipline.
 |---|---|---|---|
 | 1 | Prior-authority record hardening | PR #484 / `3b834033` | Added `recorded_at`, `installer_version`, explicit `active_at_install=false` handling to `prior.go`; 5-state classification |
 | 2 | External-firewall detection unification | PR #486 / `49d98fc1` | `internal/installer/extfw` canonical detector; Option A CSF config-file signal shared across install/update/uninstall; multi-active → `Ambiguous` (no silent collapse); cross-caller consistency test locked as regression guard |
+| 3 | Kernel/service snapshot CI gate | PR #487 / (tracked post-merge) | `G3-KS-SNAPSHOT` added to all 3 canonization workflows; `scripts/ci-snapshot-kernel-service.sh` helper; hard-asserts kernel nft tables + firewall-adjacent service states byte-identical after every dry-run path |
 
 ### Behavioral / semantic blockers (code contract changes)
 
@@ -293,7 +294,6 @@ discipline.
 
 | # | PR | Scope | Blocking because |
 |---|---|---|---|
-| 3 | Kernel/service snapshot CI gate | Before/after `nft list tables` + `systemctl is-active` diff around every dry-run path; hard-assert equal | Filesystem snapshot alone cannot prove process/kernel purity |
 | 4 | Exec-trace CI gate | `strace -f -e trace=execve` (or equivalent) around dry-run paths; assert no forbidden mutators spawned | Strictest purity guarantee; catches dynamically-constructed commands that source grep cannot see |
 | 5 | Auto-elevate shim removal gate | CI rule: PR-23-class changes blocked while the shim block in `flags.go` still exists when any mutation code lands in `internal/installer/uninstall/` | Prevents scaffold-era UX semantics leaking into mutation-era behavior |
 

--- a/scripts/ci-exec-trace-assert.sh
+++ b/scripts/ci-exec-trace-assert.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.100 PR-P2-4 — CI exec-trace assertion helper
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ci-exec-trace-assert"
+# meta:type="script"
+# meta:version="1.100.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-04-20"
+# meta:description="Wrap a dry-run command under strace and fail if any forbidden mutation process was spawned"
+# meta:inventory.files="scripts/ci-exec-trace-assert.sh"
+# meta:inventory.binaries="/usr/bin/strace"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+#
+# Usage: ci-exec-trace-assert.sh <command args...>
+#
+# Runs the given command under `strace -f -e trace=execve`, captures
+# every process spawn, then asserts no forbidden mutation binary was
+# invoked. Passes through the wrapped command's exit code on success;
+# exits non-zero if any forbidden execve is detected OR if the wrapped
+# command itself failed.
+#
+# Contract (PR-P2-4, frozen 2026-04-20):
+#   - Only fires on execve syscalls — does not depend on Go-level mocks
+#   - Independent of source-grep patterns (catches dynamically-
+#     constructed commands that grep cannot see)
+#   - Minimal surface — focused grep pass on the trace file
+#   - Degrades gracefully: if strace is unavailable, the command runs
+#     unwrapped with a CI warning (never silently weakens)
+#
+# Falsifiability: every regex in FORBIDDEN below matches a specific
+# execve shape the test expects to NEVER see during a dry-run. Any
+# match = gate failure. The dry-run paths must be observational at
+# the process-spawning level, not just the Go-function-call level.
+#
+# =============================================================================
+set -Eeuo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <command args...>" >&2
+    exit 2
+fi
+
+# Graceful degrade: if strace isn't present (should not happen in CI
+# after the explicit install step, but possible on developer laptops),
+# run the command unwrapped. Emit a GitHub-Actions warning so CI logs
+# flag the missing coverage.
+if ! command -v strace >/dev/null 2>&1; then
+    echo "::warning::strace not available — exec-trace assertion skipped for this invocation"
+    exec "$@"
+fi
+
+TRACE=$(mktemp /tmp/ci-exec-trace.XXXXXX)
+trap 'rm -f "$TRACE"' EXIT
+
+# Wrap the caller's command. -f follows forks (so Go subprocess spawns
+# are caught); -e trace=execve restricts to the one syscall that spawns
+# a new binary. Output goes to $TRACE, the actual command runs against
+# the real terminal so its output is still visible in the CI log.
+set +e
+strace -f -e trace=execve -o "$TRACE" -- "$@"
+rc=$?
+set -e
+
+# FORBIDDEN patterns — each is an extended regex; a match = gate
+# failure. Every pattern targets a specific mutation-flavored invocation
+# shape. Read-only calls (nft list, systemctl is-active, iptables-save)
+# do NOT match and are allowed.
+FORBIDDEN=(
+    # nft with mutation verbs. Read-only "nft list ..." does not match.
+    'execve\("[^"]*", \["nft", "(add|create|delete|flush)"'
+    # systemctl lifecycle verbs anywhere in argv. Read-only
+    # "is-active"/"is-enabled"/"status"/"show" do not match.
+    'execve\("[^"]*", \["systemctl"[^]]*"(start|stop|restart|reload|enable|disable|mask|unmask)"'
+    # External firewall binaries — any invocation is mutation intent
+    # (these tools have no read-only subcommands our dry-run could
+    # legitimately need). Match on argv[0].
+    'execve\("[^"]*", \["ufw"'
+    'execve\("[^"]*", \["firewall-cmd"'
+    'execve\("[^"]*", \["iptables-restore"'
+    'execve\("[^"]*", \["ip6tables-restore"'
+    # CSF invocations with destructive flags.
+    'execve\("[^"]*", \["csf"[^]]*"(-e|-x|--enable|--disable)"'
+    # Package-manager mutation verbs.
+    'execve\("[^"]*", \["apt-get"[^]]*"(remove|purge)"'
+    'execve\("[^"]*", \["dnf"[^]]*"(remove|erase)"'
+    'execve\("[^"]*", \["rpm"[^]]*"-e"'
+    'execve\("[^"]*", \["dpkg"[^]]*"(--remove|--purge)"'
+    # User/group deletion.
+    'execve\("[^"]*", \["userdel"'
+    'execve\("[^"]*", \["groupdel"'
+)
+
+fail=0
+for pat in "${FORBIDDEN[@]}"; do
+    if grep -nE "$pat" "$TRACE" >/dev/null 2>&1; then
+        echo "::error::G3-EXEC-TRACE FAIL: forbidden mutator spawned during dry-run"
+        echo "  pattern: $pat"
+        echo "  matched execve calls (up to 5):"
+        grep -nE "$pat" "$TRACE" | head -5 | sed 's/^/    /'
+        fail=1
+    fi
+done
+
+if (( fail > 0 )); then
+    echo "::error::G3-EXEC-TRACE: dry-run spawned one or more forbidden mutation binaries (see patterns above)"
+    exit 1
+fi
+
+# Propagate the wrapped command's exit code unchanged. The trace
+# assertion is purely additive — it neither rescues a failing command
+# nor masks a passing one.
+exit $rc


### PR DESCRIPTION
**Pre-PR-23 assurance blocker #4** of 4 remaining. Adds process-spawn-level truth check to every dry-run CI path. Wraps the dry-run binary under \`strace -f -e trace=execve\`, captures every process spawn, fails the gate if any forbidden mutation binary was invoked — regardless of whether the call was statically visible in the source (grep-based) or dynamically constructed (only visible at runtime).

## Why

The existing gates cover different layers of purity:

| Layer | Catches |
|---|---|
| \`G3-UN-NO-MUTATION\` structural grep | Source code with forbidden patterns |
| \`G3-U3\` / filesystem snapshot | Writes under \`/var/lib/nftban/\` or \`/etc/nftban/\` |
| \`G3-KS-SNAPSHOT\` (PR-P2-3) | Kernel nft table / service state changes |
| **\`G3-EXEC-TRACE\` (this PR)** | **ANY forbidden binary spawning at all — even dynamically-constructed invocations that grep cannot see** |

The classes are additive. A regression that somehow avoided filesystem AND kernel-state changes but still forked a forbidden binary now fails at the execve syscall boundary.

## Scope (locked per authorization 2026-04-20)

- ✅ strace-based wrap of dry-run paths
- ✅ fail on forbidden spawned mutators
- ✅ minimal implementation — one shell helper, focused regex list
- ✅ graceful degrade when strace unavailable (warning, not silent skip)

**Not in scope:**
- ❌ NO shell refactor
- ❌ NO command-wrapper redesign
- ❌ NO broad syscall observability platform
- ❌ NO inference beyond \"spawned or not spawned\"

## Implementation

### NEW: \`scripts/ci-exec-trace-assert.sh <command args...>\`

Wraps its argv under strace, propagates exit code unchanged, fails if any FORBIDDEN pattern matches in the trace. Contract:

- read-only on the system (only syscall it observes is \`execve\`)
- exit 0 if wrapped command succeeded AND no forbidden spawns
- exit != 0 if EITHER the wrapped command failed OR forbidden spawns detected
- graceful degrade: if strace unavailable, wrapped command runs with a CI warning

### Wired into 3 gates

| Workflow | Gate | Role |
|---|---|---|
| \`ci-install-canonization.yml\` | \`G3-IN-REFUSE-DRY-RUN\` | Refusal must exit before spawning anything forbidden |
| \`ci-update-canonization.yml\` | \`G3-U3\` | Purity assertion layered on top of filesystem + KS snapshots |
| \`ci-uninstall-canonization.yml\` | \`G3-UN-PLAN-RENDERS\` | Uninstall is the most scope-sensitive mode — strongest PR-23 precondition |

### Forbidden patterns (strace execve regex)

- **nft** with mutation verbs: \`add | create | delete | flush\` (list/save allowed)
- **systemctl** lifecycle verbs anywhere in argv: \`start | stop | restart | reload | enable | disable | mask | unmask\` (is-active/is-enabled/status/show allowed)
- **External firewall binaries** — any invocation: \`ufw\`, \`firewall-cmd\`, \`iptables-restore\`, \`ip6tables-restore\`
- **CSF** with destructive flags: \`-e\`, \`-x\`, \`--enable\`, \`--disable\`
- **Package-manager mutation**: \`apt-get remove|purge\`, \`dnf remove|erase\`, \`rpm -e\`, \`dpkg --remove|--purge\`
- **User/group deletion**: \`userdel\`, \`groupdel\`

Each pattern targets a specific execve shape. Match = gate failure.

## Also: tracking update

Marks blocker #3 (kernel/service snapshot CI gate, PR #487) as LANDED. **Remaining pre-PR-23 blockers: 3** (this PR = P2-4, plus P2-5 auto-elevate shim removal gate + P2-6 payload integrity).

## Test plan

- [ ] \`Build & Test\` green — no Go code changes
- [ ] \`ci-install-canonization\` matrix green — refuse-dry-run traced, no forbidden spawns
- [ ] \`ci-update-canonization\` matrix green — dry-run traced, no forbidden spawns
- [ ] \`ci-uninstall-canonization\` matrix green — dry-run traced, no forbidden spawns
- [ ] strace installs cleanly on both runner types
- [ ] Falsifiability: if a forbidden execve were deliberately introduced, gate fails (validated by the regex specificity — each pattern targets a specific execve line shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)