### PR TITLE
feat(v1.100 PR-P2-6): payload integrity minimum checks — FINAL Phase 2 blocker

### DIFF
--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -238,7 +238,7 @@ var criticalConfigs = []criticalConfig{
 		},
 	},
 	{
-		Path:    "/etc/nftables.conf",
+		Path:    "/etc/nftban/nftables.conf",
 		MinSize: 512, // Shipped template renders to ~830 lines (~25KB)
 		// after SSH-port / CT-limit substitutions; 512 bytes is a
 		// conservative floor that catches render-output truncation or

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -196,6 +196,116 @@ func VerifyInventory(exec executor.Executor) (ok bool, missing []string) {
 	return len(missing) == 0, missing
 }
 
+// ConfigIntegrityIssue describes one minimum-sanity failure on a
+// critical config file. PR-P2-6 scope: minimum-size + required-header/
+// token check only — not a full integrity/checksum framework.
+type ConfigIntegrityIssue struct {
+	Path   string
+	Reason string
+}
+
+// criticalConfig describes one file that VerifyConfigIntegrity probes.
+// Each entry is intentionally bounded — this is a sanity guard, not a
+// validation system.
+type criticalConfig struct {
+	// Path is the on-disk location to probe.
+	Path string
+	// MinSize is the minimum byte count the file MUST have. Set to a
+	// conservative floor so legitimate operator edits pass but
+	// trivially-broken files (empty / truncated / stub) fail.
+	MinSize int
+	// RequiredTokens are plain substrings — EVERY one must appear in
+	// the file. Tokens are chosen to be the most stable parts of the
+	// shipped template so normal operator editing does not break them.
+	RequiredTokens []string
+}
+
+// criticalConfigs is the frozen PR-P2-6 sanity check set. Adding a
+// new entry requires a contract update — the set is deliberately
+// minimal (nftban.conf + nftables.conf), per the PR-P2-6 contract
+// seed's explicit "do not expand into validation framework" rule.
+var criticalConfigs = []criticalConfig{
+	{
+		Path:    "/etc/nftban/nftban.conf",
+		MinSize: 256, // Shipped template is ~450 lines (~15KB); 256
+		// bytes is a conservative floor that catches empty / 2-line
+		// stub / truncated-to-preamble regressions without false-
+		// positive on aggressively-edited operator configs.
+		RequiredTokens: []string{
+			// License header is present in every shipped config file
+			// and no responsible operator edit would strip it.
+			"SPDX-License-Identifier",
+		},
+	},
+	{
+		Path:    "/etc/nftables.conf",
+		MinSize: 512, // Shipped template renders to ~830 lines (~25KB)
+		// after SSH-port / CT-limit substitutions; 512 bytes is a
+		// conservative floor that catches render-output truncation or
+		// accidental overwrite with a placeholder.
+		RequiredTokens: []string{
+			// Shebang is functionally required — without it the file
+			// cannot be executed by nftables.service's ExecStart.
+			"#!/usr/sbin/nft",
+			// At least one nftban-owned table declaration must be
+			// present, otherwise the firewall ruleset is meaningless.
+			"table ip nftban",
+		},
+	},
+}
+
+// VerifyConfigIntegrity runs the PR-P2-6 sanity checks on the set of
+// critical config files. Each file must exist, meet a minimum byte
+// count, and contain every required token/header. Returns a list of
+// every failing check so the caller can surface all issues at once
+// rather than first-fails-wins.
+//
+// Scope lock (PR-P2-6, 2026-04-20):
+//   - Presence + minimum size + required-substring only
+//   - No checksums, no signatures, no semantic config parsing
+//   - Fixed list of two critical files (nftban.conf + nftables.conf)
+//
+// Adding a new file or a new signal beyond min-size/required-token
+// requires an explicit contract update; this function deliberately
+// does NOT grow into a validation framework.
+func VerifyConfigIntegrity(exec executor.Executor) (ok bool, issues []ConfigIntegrityIssue) {
+	for _, cc := range criticalConfigs {
+		if !exec.FileExists(cc.Path) {
+			issues = append(issues, ConfigIntegrityIssue{
+				Path: cc.Path, Reason: "file missing (presence check failed)",
+			})
+			continue
+		}
+		data, err := exec.ReadFile(cc.Path)
+		if err != nil {
+			issues = append(issues, ConfigIntegrityIssue{
+				Path: cc.Path, Reason: "unreadable: " + err.Error(),
+			})
+			continue
+		}
+		if len(data) < cc.MinSize {
+			issues = append(issues, ConfigIntegrityIssue{
+				Path: cc.Path,
+				Reason: fmt.Sprintf("undersized: %d bytes < minimum %d (file appears truncated or stub)",
+					len(data), cc.MinSize),
+			})
+			// Size failure is sufficient to declare the file broken;
+			// skip token checks on a truncated file to avoid noise.
+			continue
+		}
+		text := string(data)
+		for _, tok := range cc.RequiredTokens {
+			if !strings.Contains(text, tok) {
+				issues = append(issues, ConfigIntegrityIssue{
+					Path:   cc.Path,
+					Reason: "missing required token/header: " + tok,
+				})
+			}
+		}
+	}
+	return len(issues) == 0, issues
+}
+
 // dirIsEmpty reports whether dir exists and contains no regular entries.
 // dir is always one of the canonical FHS paths declared in VerifyInventory —
 // no user-controlled input reaches this function.

--- a/internal/installer/payload/payload_test.go
+++ b/internal/installer/payload/payload_test.go
@@ -351,3 +351,212 @@ func TestStageAll_OperatorConfigPreserved(t *testing.T) {
 		t.Errorf("operator-edited nftban.conf was overwritten (noreplace policy violated)")
 	}
 }
+
+// =============================================================================
+// PR-P2-6 — VerifyConfigIntegrity tests
+// =============================================================================
+
+// validNftbanConf returns a byte slice that satisfies every
+// VerifyConfigIntegrity constraint for /etc/nftban/nftban.conf.
+// Tests that want to break a single constraint start from this and
+// mutate exactly one dimension.
+func validNftbanConf() []byte {
+	// 512 bytes of realistic content with the SPDX-License-Identifier
+	// token — comfortably above the 256-byte minimum.
+	body := "# =============================================================================\n"
+	body += "# NFTBan - Main Configuration File\n"
+	body += "# =============================================================================\n"
+	body += "# SPDX-License-Identifier: MPL-2.0\n"
+	body += "# Purpose: operator configuration\n"
+	body += "# Some amount of pretend configuration follows so this file is\n"
+	body += "# comfortably above the integrity minimum-size floor. A real\n"
+	body += "# nftban.conf is tens of kilobytes; this stub represents the\n"
+	body += "# smallest operator-edited variant we still want to pass.\n"
+	for len(body) < 512 {
+		body += "# filler line to exceed the integrity minimum-size floor\n"
+	}
+	return []byte(body)
+}
+
+// validNftablesConf returns a byte slice that satisfies every
+// VerifyConfigIntegrity constraint for /etc/nftables.conf.
+func validNftablesConf() []byte {
+	body := "#!/usr/sbin/nft -f\n"
+	body += "# NFTBan firewall ruleset\n"
+	body += "# SPDX-License-Identifier: MPL-2.0\n"
+	body += "table ip nftban {\n"
+	body += "    chain input {\n"
+	body += "        type filter hook input priority 0; policy drop;\n"
+	body += "    }\n"
+	body += "}\n"
+	body += "table ip6 nftban {\n"
+	body += "    chain input {\n"
+	body += "        type filter hook input priority 0; policy drop;\n"
+	body += "    }\n"
+	body += "}\n"
+	for len(body) < 1024 {
+		body += "# filler so the rendered file exceeds the integrity floor\n"
+	}
+	return []byte(body)
+}
+
+// seedIntegrityHappyPath populates a mock with both critical configs
+// in their happy-path shape. Used as the base for every integrity test.
+func seedIntegrityHappyPath(mock *executor.MockExecutor) {
+	mock.Files["/etc/nftban/nftban.conf"] = validNftbanConf()
+	mock.Files["/etc/nftables.conf"] = validNftablesConf()
+}
+
+func TestVerifyConfigIntegrity_HappyPath(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	ok, issues := VerifyConfigIntegrity(mock)
+	if !ok {
+		t.Errorf("happy path should pass; got issues: %+v", issues)
+	}
+	if len(issues) != 0 {
+		t.Errorf("happy path must produce zero issues; got %d", len(issues))
+	}
+}
+
+func TestVerifyConfigIntegrity_MissingNftbanConf(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	delete(mock.Files, "/etc/nftban/nftban.conf")
+
+	ok, issues := VerifyConfigIntegrity(mock)
+	if ok {
+		t.Fatal("missing nftban.conf must fail integrity check")
+	}
+	var sawMissing bool
+	for _, i := range issues {
+		if i.Path == "/etc/nftban/nftban.conf" && strings.Contains(i.Reason, "missing") {
+			sawMissing = true
+		}
+	}
+	if !sawMissing {
+		t.Errorf("expected 'missing' reason for nftban.conf; got %+v", issues)
+	}
+}
+
+func TestVerifyConfigIntegrity_UndersizedNftbanConf(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	// Stub shorter than the 256-byte minimum — simulates a truncated
+	// file or an empty-stub regression.
+	mock.Files["/etc/nftban/nftban.conf"] = []byte("# SPDX-License-Identifier: MPL-2.0\n")
+
+	ok, issues := VerifyConfigIntegrity(mock)
+	if ok {
+		t.Fatal("undersized nftban.conf must fail integrity check")
+	}
+	var sawUndersized bool
+	for _, i := range issues {
+		if i.Path == "/etc/nftban/nftban.conf" && strings.Contains(i.Reason, "undersized") {
+			sawUndersized = true
+		}
+	}
+	if !sawUndersized {
+		t.Errorf("expected 'undersized' reason for nftban.conf; got %+v", issues)
+	}
+}
+
+func TestVerifyConfigIntegrity_NftbanConfMissingLicenseToken(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	// Large enough but stripped of the SPDX header — simulates operator
+	// edit that removed license / shipped config overwritten by
+	// something unrelated.
+	body := make([]byte, 600)
+	for i := range body {
+		body[i] = '#'
+	}
+	mock.Files["/etc/nftban/nftban.conf"] = body
+
+	ok, issues := VerifyConfigIntegrity(mock)
+	if ok {
+		t.Fatal("nftban.conf without SPDX header must fail integrity check")
+	}
+	var sawMissingToken bool
+	for _, i := range issues {
+		if i.Path == "/etc/nftban/nftban.conf" && strings.Contains(i.Reason, "SPDX-License-Identifier") {
+			sawMissingToken = true
+		}
+	}
+	if !sawMissingToken {
+		t.Errorf("expected missing-SPDX token reason for nftban.conf; got %+v", issues)
+	}
+}
+
+func TestVerifyConfigIntegrity_NftablesConfMissingShebang(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	// Replace shebang with a comment — file is still large, still has
+	// the table declaration, but missing the functional shebang that
+	// nftables.service needs to ExecStart it.
+	body := strings.Replace(string(validNftablesConf()), "#!/usr/sbin/nft -f", "# NOT A SHEBANG", 1)
+	mock.Files["/etc/nftables.conf"] = []byte(body)
+
+	ok, issues := VerifyConfigIntegrity(mock)
+	if ok {
+		t.Fatal("nftables.conf without shebang must fail integrity check")
+	}
+	var sawMissingToken bool
+	for _, i := range issues {
+		if i.Path == "/etc/nftables.conf" && strings.Contains(i.Reason, "#!/usr/sbin/nft") {
+			sawMissingToken = true
+		}
+	}
+	if !sawMissingToken {
+		t.Errorf("expected missing-shebang reason for nftables.conf; got %+v", issues)
+	}
+}
+
+func TestVerifyConfigIntegrity_NftablesConfMissingTableDecl(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedIntegrityHappyPath(mock)
+	// Strip the nftban table declaration — file is large + has shebang
+	// but is functionally meaningless (no nftban-owned ruleset).
+	body := strings.ReplaceAll(string(validNftablesConf()), "table ip nftban", "table ip other")
+	mock.Files["/etc/nftables.conf"] = []byte(body)
+
+	ok, issues := VerifyConfigIntegrity(mock)
+	if ok {
+		t.Fatal("nftables.conf without 'table ip nftban' must fail integrity check")
+	}
+	var sawMissingToken bool
+	for _, i := range issues {
+		if i.Path == "/etc/nftables.conf" && strings.Contains(i.Reason, "table ip nftban") {
+			sawMissingToken = true
+		}
+	}
+	if !sawMissingToken {
+		t.Errorf("expected missing-table-decl reason for nftables.conf; got %+v", issues)
+	}
+}
+
+// PR-P2-6 scope-lock regression guard: the integrity check set MUST be
+// exactly two files (nftban.conf + nftables.conf). Adding a third file
+// requires an explicit contract update — this test is the falsifiable
+// record that the set is frozen.
+func TestCriticalConfigs_FrozenTwoFileSet(t *testing.T) {
+	if len(criticalConfigs) != 2 {
+		t.Errorf("criticalConfigs must be frozen at 2 entries (nftban.conf + nftables.conf); got %d — a contract update is required to extend the set", len(criticalConfigs))
+	}
+	wantPaths := map[string]bool{
+		"/etc/nftban/nftban.conf": false,
+		"/etc/nftables.conf":      false,
+	}
+	for _, cc := range criticalConfigs {
+		if _, ok := wantPaths[cc.Path]; !ok {
+			t.Errorf("unexpected path in criticalConfigs: %q (scope-lock violation)", cc.Path)
+			continue
+		}
+		wantPaths[cc.Path] = true
+	}
+	for path, seen := range wantPaths {
+		if !seen {
+			t.Errorf("expected %s in criticalConfigs; not found", path)
+		}
+	}
+}

--- a/internal/installer/payload/payload_test.go
+++ b/internal/installer/payload/payload_test.go
@@ -379,7 +379,7 @@ func validNftbanConf() []byte {
 }
 
 // validNftablesConf returns a byte slice that satisfies every
-// VerifyConfigIntegrity constraint for /etc/nftables.conf.
+// VerifyConfigIntegrity constraint for /etc/nftban/nftables.conf.
 func validNftablesConf() []byte {
 	body := "#!/usr/sbin/nft -f\n"
 	body += "# NFTBan firewall ruleset\n"
@@ -404,7 +404,7 @@ func validNftablesConf() []byte {
 // in their happy-path shape. Used as the base for every integrity test.
 func seedIntegrityHappyPath(mock *executor.MockExecutor) {
 	mock.Files["/etc/nftban/nftban.conf"] = validNftbanConf()
-	mock.Files["/etc/nftables.conf"] = validNftablesConf()
+	mock.Files["/etc/nftban/nftables.conf"] = validNftablesConf()
 }
 
 func TestVerifyConfigIntegrity_HappyPath(t *testing.T) {
@@ -495,7 +495,7 @@ func TestVerifyConfigIntegrity_NftablesConfMissingShebang(t *testing.T) {
 	// the table declaration, but missing the functional shebang that
 	// nftables.service needs to ExecStart it.
 	body := strings.Replace(string(validNftablesConf()), "#!/usr/sbin/nft -f", "# NOT A SHEBANG", 1)
-	mock.Files["/etc/nftables.conf"] = []byte(body)
+	mock.Files["/etc/nftban/nftables.conf"] = []byte(body)
 
 	ok, issues := VerifyConfigIntegrity(mock)
 	if ok {
@@ -503,7 +503,7 @@ func TestVerifyConfigIntegrity_NftablesConfMissingShebang(t *testing.T) {
 	}
 	var sawMissingToken bool
 	for _, i := range issues {
-		if i.Path == "/etc/nftables.conf" && strings.Contains(i.Reason, "#!/usr/sbin/nft") {
+		if i.Path == "/etc/nftban/nftables.conf" && strings.Contains(i.Reason, "#!/usr/sbin/nft") {
 			sawMissingToken = true
 		}
 	}
@@ -518,7 +518,7 @@ func TestVerifyConfigIntegrity_NftablesConfMissingTableDecl(t *testing.T) {
 	// Strip the nftban table declaration — file is large + has shebang
 	// but is functionally meaningless (no nftban-owned ruleset).
 	body := strings.ReplaceAll(string(validNftablesConf()), "table ip nftban", "table ip other")
-	mock.Files["/etc/nftables.conf"] = []byte(body)
+	mock.Files["/etc/nftban/nftables.conf"] = []byte(body)
 
 	ok, issues := VerifyConfigIntegrity(mock)
 	if ok {
@@ -526,7 +526,7 @@ func TestVerifyConfigIntegrity_NftablesConfMissingTableDecl(t *testing.T) {
 	}
 	var sawMissingToken bool
 	for _, i := range issues {
-		if i.Path == "/etc/nftables.conf" && strings.Contains(i.Reason, "table ip nftban") {
+		if i.Path == "/etc/nftban/nftables.conf" && strings.Contains(i.Reason, "table ip nftban") {
 			sawMissingToken = true
 		}
 	}
@@ -545,7 +545,7 @@ func TestCriticalConfigs_FrozenTwoFileSet(t *testing.T) {
 	}
 	wantPaths := map[string]bool{
 		"/etc/nftban/nftban.conf": false,
-		"/etc/nftables.conf":      false,
+		"/etc/nftban/nftables.conf":      false,
 	}
 	for _, cc := range criticalConfigs {
 		if _, ok := wantPaths[cc.Path]; !ok {

--- a/internal/installer/uninstall/contract.md
+++ b/internal/installer/uninstall/contract.md
@@ -284,18 +284,19 @@ discipline.
 | 2 | External-firewall detection unification | PR #486 / `49d98fc1` | `internal/installer/extfw` canonical detector; Option A CSF config-file signal shared across install/update/uninstall; multi-active → `Ambiguous` (no silent collapse); cross-caller consistency test locked as regression guard |
 | 3 | Kernel/service snapshot CI gate | PR #487 / (tracked post-merge) | `G3-KS-SNAPSHOT` added to all 3 canonization workflows; `scripts/ci-snapshot-kernel-service.sh` helper; hard-asserts kernel nft tables + firewall-adjacent service states byte-identical after every dry-run path |
 | 4 | Exec-trace CI gate | PR #488 / (tracked post-merge) | `G3-EXEC-TRACE` added to all 3 canonization workflows; `scripts/ci-exec-trace-assert.sh` wraps dry-runs under `strace -f -e trace=execve`; fails if any forbidden mutator (nft add/flush/delete, systemctl lifecycle verbs, ufw/firewall-cmd/iptables-restore, package-manager removal, userdel/groupdel) is spawned |
+| 5 | Auto-elevate shim removal gate | PR #489 / (tracked post-merge) | `G3-UN-SHIM-LOCK` CI rule in uninstall workflow: fails if the auto-elevate shim in `flags.go` and any mutation pattern in `internal/installer/uninstall/*.go` coexist; see §"G3-UN-SHIM-LOCK" below for the decision table |
+| 6 | Payload integrity minimum checks | (this PR) | `payload.VerifyConfigIntegrity` — minimum-size + required-token check for `/etc/nftban/nftban.conf` and `/etc/nftables.conf`; wired into `validate.assertConfigIntegrity`; scope-locked two-file set + token-only signals (no checksums/signatures/semantic parsing) |
 
-### Behavioral / semantic blockers (code contract changes)
+### All pre-PR-23 blockers landed
 
-| # | PR | Scope | Blocking because |
-|---|---|---|---|
-| 6 | Payload integrity minimum checks | Minimum-size + required-header/token check for `/etc/nftban/nftban.conf` and `/etc/nftban/nftables.conf`; wire into existing `payload.VerifyInventory` | Presence-only validation lets a truncated-or-empty critical config pass |
+No remaining items. PR-23 (uninstall mutation phase 1: authority release
+core) is unblocked pending the final verification audit per Phase 3
+gating — four focused questions only:
 
-### Assurance / gate blockers (CI and scope-lock enforcement)
-
-| # | PR | Scope | Blocking because |
-|---|---|---|---|
-| 5 | Auto-elevate shim removal gate | `G3-UN-SHIM-LOCK` CI rule: PR-23-class changes blocked while the shim block in `flags.go` still exists when any mutation code lands in `internal/installer/uninstall/` | Prevents scaffold-era UX semantics leaking into mutation-era behavior |
+1. Is dry-run still pure across install / update / uninstall?
+2. Any history / state drift?
+3. Is the authority predicate still consistent across all callers?
+4. Do CI gates catch the exact regressions the prior audits found?
 
 ### G3-UN-SHIM-LOCK (PR-P2-5) — how the gate decides
 

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -48,6 +48,7 @@ func RunAssertions(exec executor.Executor, sshPort int, log *logging.Logger) []A
 	results = append(results, assertDaemonActive(exec, log))
 	results = append(results, assertInstallStateFile(exec, log))
 	results = append(results, assertPayloadInventory(exec, log))
+	results = append(results, assertConfigIntegrity(exec, log))
 
 	passed := 0
 	for _, r := range results {
@@ -192,6 +193,35 @@ func assertPayloadInventory(exec executor.Executor, log *logging.Logger) Asserti
 			len(missing), strings.Join(missing, ", "))
 	} else {
 		log.Debug("ASSERT payload_inventory_ok: PASS")
+	}
+	return r
+}
+
+// assertConfigIntegrity (v1.100 PR-P2-6): minimum-sanity integrity check
+// on the critical config files that the rest of the install depends on.
+//
+// Complements assertPayloadInventory:
+//   - inventory checks presence — "the file exists"
+//   - integrity checks minimum viability — "the file is not empty /
+//     truncated and still carries its required header tokens"
+//
+// Scope lock (per PR-P2-6 contract): minimum-size + required-token only.
+// No checksum, no signature, no semantic parse. The fixed two-file set
+// (nftban.conf + nftables.conf) lives in payload.criticalConfigs; adding
+// a file or a signal type requires an explicit contract update.
+func assertConfigIntegrity(exec executor.Executor, log *logging.Logger) AssertionResult {
+	ok, issues := payload.VerifyConfigIntegrity(exec)
+	r := AssertionResult{Name: "config_integrity_ok", Passed: ok}
+	if !ok {
+		parts := make([]string, 0, len(issues))
+		for _, i := range issues {
+			parts = append(parts, i.Path+": "+i.Reason)
+		}
+		r.Detail = "config integrity issues: " + strings.Join(parts, "; ")
+		log.Warn("ASSERT config_integrity_ok: FAIL — %d issue(s): %s",
+			len(issues), strings.Join(parts, "; "))
+	} else {
+		log.Debug("ASSERT config_integrity_ok: PASS")
 	}
 	return r
 }

--- a/internal/installer/validate/validate_test.go
+++ b/internal/installer/validate/validate_test.go
@@ -29,6 +29,28 @@ func newTestLogger() *logging.Logger {
 	return logging.New("/dev/null", false)
 }
 
+// seedNftbanConfContent returns a byte slice that satisfies PR-P2-6
+// config_integrity_ok checks for nftban.conf: >= 256 bytes AND contains
+// the SPDX-License-Identifier token.
+func seedNftbanConfContent() []byte {
+	body := "# SPDX-License-Identifier: MPL-2.0\n# NFTBan operator config\n"
+	for len(body) < 400 {
+		body += "# filler line\n"
+	}
+	return []byte(body)
+}
+
+// seedNftablesConfContent returns a byte slice that satisfies PR-P2-6
+// config_integrity_ok checks for nftables.conf: >= 512 bytes AND
+// contains both "#!/usr/sbin/nft" and "table ip nftban".
+func seedNftablesConfContent() []byte {
+	body := "#!/usr/sbin/nft -f\n# SPDX-License-Identifier: MPL-2.0\ntable ip nftban { }\n"
+	for len(body) < 700 {
+		body += "# filler line\n"
+	}
+	return []byte(body)
+}
+
 // seedCompletePayloadInventory populates the mock with every destination
 // required by payload.VerifyInventory so assertPayloadInventory passes.
 // Tests that want to exercise the inventory failure path can simply omit
@@ -40,8 +62,10 @@ func seedCompletePayloadInventory(mock *executor.MockExecutor) {
 	mock.Files["/usr/lib/nftban/bin/nftban-validate"] = []byte("x")
 	mock.Files["/usr/lib/nftban/bin/nftban-installer"] = []byte("x")
 	mock.Files["/usr/lib/nftban/VERSION"] = []byte("1.98.2\n")
-	mock.Files["/etc/nftban/nftban.conf"] = []byte("x")
-	mock.Files["/etc/nftban/nftables.conf"] = []byte("x")
+	// PR-P2-6: content must also satisfy config_integrity_ok — minimum
+	// size + required-header tokens. Build fixtures above the floor.
+	mock.Files["/etc/nftban/nftban.conf"] = seedNftbanConfContent()
+	mock.Files["/etc/nftban/nftables.conf"] = seedNftablesConfContent()
 	mock.Files["/etc/logrotate.d/nftban"] = []byte("x")
 	// Shell dirs must exist AND contain at least one file — mock.FileExists
 	// checks Files+Dirs; dirIsEmpty in payload.VerifyInventory opens the


### PR DESCRIPTION
**Pre-PR-23 behavioral blocker #6** — **THE LAST ONE**. Closes the Phase 2 pre-PR-23 blocker sequence.

Strengthens payload truth slightly beyond file presence without introducing checksum / signature / full-semantic validation infrastructure. Catches the class of regression where a critical config is materially broken (empty, truncated, or stripped of its required header) but present-only validation passes it.

This is **sanity**, not integrity system.

## Scope (locked per authorization 2026-04-20)

- ✅ Two files only: \`/etc/nftban/nftban.conf\`, \`/etc/nftables.conf\`
- ✅ Two signals only: minimum-size + required-substring/header
- ✅ Fixed set frozen in code (\`payload.criticalConfigs\`); adding a file or signal requires an explicit contract update

**Not in scope** (hard rules from the contract seed):
- ❌ NO checksums
- ❌ NO signatures
- ❌ NO full config semantic parsing
- ❌ NO validation framework expansion

## Rules

| File | MinSize | RequiredTokens |
|---|---|---|
| \`/etc/nftban/nftban.conf\` | 256 bytes | \`SPDX-License-Identifier\` |
| \`/etc/nftables.conf\` | 512 bytes | \`#!/usr/sbin/nft\`, \`table ip nftban\` |

Minimum sizes are conservative floors — shipped templates are ~15KB and ~25KB respectively, so 256 and 512 catch truncated / empty / stub regressions without false-positive on aggressive operator edits.

Required tokens are the most stable parts of the shipped templates:
- SPDX license line is in every shipped nftban config — no responsible edit strips it
- nft shebang is functionally required by \`nftables.service\` ExecStart
- \`table ip nftban\` is the actual nftban-owned table declaration (renaming makes the ruleset meaningless)

## Implementation

\`internal/installer/payload/payload.go\`:
- \`ConfigIntegrityIssue\` struct — typed failure record
- \`criticalConfig\` struct — per-file rule
- \`criticalConfigs\` — frozen slice of exactly 2 entries
- \`VerifyConfigIntegrity(exec) (ok, issues)\` — runs every rule, returns all issues (not first-fails-wins) so operator sees the full picture

\`internal/installer/validate/assertions.go\`:
- new \`assertConfigIntegrity\` assertion alongside \`assertPayloadInventory\` in \`RunAssertions\`
- Complementary: inventory checks \"the file exists\"; integrity checks \"the file is not empty/truncated and still carries its required header tokens\"

## Tests

Seven new tests in \`payload_test.go\`:

1. \`TestVerifyConfigIntegrity_HappyPath\` — both files valid → pass
2. \`TestVerifyConfigIntegrity_MissingNftbanConf\` — presence fail surfaced
3. \`TestVerifyConfigIntegrity_UndersizedNftbanConf\` — size fail surfaced
4. \`TestVerifyConfigIntegrity_NftbanConfMissingLicenseToken\` — token fail
5. \`TestVerifyConfigIntegrity_NftablesConfMissingShebang\` — token fail
6. \`TestVerifyConfigIntegrity_NftablesConfMissingTableDecl\` — token fail
7. \`TestCriticalConfigs_FrozenTwoFileSet\` — scope-lock regression guard asserting exactly 2 entries; adding a third requires updating both the contract and this test

## Also: tracking update

- Marks blocker #5 (auto-elevate shim removal gate, PR #489) as LANDED
- Marks this PR (#6) as the final Phase 2 entry
- Adds an \"All pre-PR-23 blockers landed\" section in the contract doc

## Phase 2 complete after merge

**Next authorized step** per the Phase 3 gating rule: a focused verification audit with the 4 frozen questions:

1. Is dry-run still pure across install / update / uninstall?
2. Any history / state drift?
3. Is the authority predicate still consistent across all callers?
4. Do CI gates catch the exact regressions the prior audits found?

PR-23 starts only after that audit returns green.

## Test plan

- [ ] \`Build & Test\` green — 7 new unit tests pass
- [ ] Install / Update / Uninstall Canonization matrices still green (payload.go change is additive; existing VerifyInventory + assertPayloadInventory behavior unchanged)
- [ ] Runtime Truth matrix still green — \`assertConfigIntegrity\` now runs alongside existing assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)