### PR TITLE
fix(v1.100 PR-P2-2A): iptables ghost-table requires corroboration (Path B)

### DIFF
--- a/internal/installer/detect/conflicts.go
+++ b/internal/installer/detect/conflicts.go
@@ -55,8 +55,21 @@ type Conflict struct {
 
 // DetectConflicts returns the conflict list for the current host.
 // Read-only; delegates to extfw.Detect for the underlying signals.
+//
+// PR-P2-2A: only observations whose Name is in the canonical Active
+// list become Conflicts. Observations from informational-only signals
+// (e.g. iptables ghost-table alone, which does NOT corroborate to a
+// real iptables presence under the Path B rule) are recorded in
+// res.Observations for transparency but excluded from the Conflict
+// list because they do not classify external authority.
 func DetectConflicts(exec executor.Executor, log *logging.Logger) []Conflict {
 	res := extfw.Detect(exec, log)
+
+	// Build the set of Names that extfw classified as active.
+	activeNames := make(map[extfw.Name]bool, len(res.Active))
+	for _, n := range res.Active {
+		activeNames[n] = true
+	}
 
 	var conflicts []Conflict
 	// De-dup by (Name + Service) so that ghost-table + service for the
@@ -65,6 +78,13 @@ func DetectConflicts(exec executor.Executor, log *logging.Logger) []Conflict {
 	// their Service fields differ.
 	seen := make(map[string]bool)
 	for _, obs := range res.Observations {
+		// PR-P2-2A: skip observations whose Name is not in the
+		// classified Active set. This prevents ghost-table-alone
+		// iptables observations from leaking into the Conflict list
+		// on stock Ubuntu hosts.
+		if !activeNames[obs.Name] {
+			continue
+		}
 		key := obs.DisplayName() + "|" + obs.Unit
 		if seen[key] {
 			continue

--- a/internal/installer/detect/conflicts_test.go
+++ b/internal/installer/detect/conflicts_test.go
@@ -61,18 +61,51 @@ func TestDetectConflicts_Firewalld(t *testing.T) {
 	}
 }
 
-func TestDetectConflicts_GhostTables(t *testing.T) {
+// TestDetectConflicts_GhostTablesOnly — PR-P2-2A: a host with ONLY
+// `ip filter` / `ip nat` / `ip mangle` ghost nft tables and NO
+// corroborating iptables signal (no service, no live rules) is NOT
+// a conflict. Stock Ubuntu nftables ships a benign baseline `inet
+// filter` that was false-positiving as an iptables conflict before
+// this fix, causing Abort/Takeover decisions on every clean Ubuntu
+// host with nftban.
+func TestDetectConflicts_GhostTablesOnly_NotConflict(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.ExistingCommands["nft"] = true
 	mock.RunResults["nft:list:tables"] = executor.Result{
 		ExitCode: 0,
 		Stdout: "table ip nftban\ntable ip6 nftban\ntable ip filter\ntable ip nat\n",
 	}
+	// Explicitly: no iptables.service, no iptables-save rules.
 
 	conflicts := DetectConflicts(mock, newTestLogger())
-	names := ConflictNames(conflicts)
-	if len(names) != 1 || names[0] != "iptables-nft" {
-		t.Errorf("expected [iptables-nft] for ghost filter+nat, got %v", names)
+	for _, c := range conflicts {
+		if c.Name == "iptables-nft" || c.Name == "iptables" {
+			t.Errorf("ghost-table-only iptables must NOT be a conflict (PR-P2-2A); got %+v", c)
+		}
+	}
+}
+
+// TestDetectConflicts_GhostPlusService_IsConflict — inverse of the
+// regression guard: a ghost table corroborated by iptables.service
+// IS a legitimate conflict.
+func TestDetectConflicts_GhostPlusService_IsConflict(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.ExistingCommands["nft"] = true
+	mock.Services["iptables.service"] = true
+	mock.RunResults["nft:list:tables"] = executor.Result{
+		ExitCode: 0,
+		Stdout: "table ip nftban\ntable ip filter\n",
+	}
+
+	conflicts := DetectConflicts(mock, newTestLogger())
+	var sawIptables bool
+	for _, c := range conflicts {
+		if c.Name == "iptables" || c.Name == "iptables-nft" {
+			sawIptables = true
+		}
+	}
+	if !sawIptables {
+		t.Errorf("expected iptables conflict when ghost table + service both present; got %+v", conflicts)
 	}
 }
 
@@ -91,7 +124,11 @@ func TestDetectConflicts_FirewalldGhostTable(t *testing.T) {
 	}
 }
 
-func TestDetectConflicts_Multiple(t *testing.T) {
+// TestDetectConflicts_Multiple — PR-P2-2A: a host with real UFW AND
+// a ghost `ip filter` table (no iptables corroboration) yields just
+// one conflict (UFW). The ghost table alone no longer counts per the
+// corroboration rule.
+func TestDetectConflicts_UFWPlusUnqualifiedGhost_OneConflict(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Services["ufw.service"] = true
 	mock.ExistingCommands["nft"] = true
@@ -102,8 +139,49 @@ func TestDetectConflicts_Multiple(t *testing.T) {
 
 	conflicts := DetectConflicts(mock, newTestLogger())
 	names := ConflictNames(conflicts)
-	if len(names) != 2 {
-		t.Errorf("expected 2 conflicts (UFW + iptables-nft), got %d: %v", len(names), names)
+	// UFW must be counted; iptables/iptables-nft must NOT be (ghost-alone).
+	var sawUFW, sawIptables bool
+	for _, n := range names {
+		if n == "UFW" {
+			sawUFW = true
+		}
+		if n == "iptables" || n == "iptables-nft" {
+			sawIptables = true
+		}
+	}
+	if !sawUFW {
+		t.Errorf("expected UFW in conflicts; got %v", names)
+	}
+	if sawIptables {
+		t.Errorf("ghost-table-only iptables must NOT be a conflict; got %v", names)
+	}
+}
+
+// TestDetectConflicts_Multiple_WithIptablesService — ghost `ip filter`
+// + iptables.service active + UFW → both conflicts counted.
+func TestDetectConflicts_Multiple_WithIptablesService(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Services["ufw.service"] = true
+	mock.Services["iptables.service"] = true
+	mock.ExistingCommands["nft"] = true
+	mock.RunResults["nft:list:tables"] = executor.Result{
+		ExitCode: 0,
+		Stdout: "table ip nftban\ntable ip filter\n",
+	}
+
+	conflicts := DetectConflicts(mock, newTestLogger())
+	names := ConflictNames(conflicts)
+	var sawUFW, sawIptables bool
+	for _, n := range names {
+		if n == "UFW" {
+			sawUFW = true
+		}
+		if n == "iptables" || n == "iptables-nft" {
+			sawIptables = true
+		}
+	}
+	if !sawUFW || !sawIptables {
+		t.Errorf("expected UFW + iptables (service corroborates ghost); got %v", names)
 	}
 }
 

--- a/internal/installer/extfw/detect.go
+++ b/internal/installer/extfw/detect.go
@@ -42,9 +42,12 @@
 //   UFW:       ufw.service active
 //   Firewalld: firewalld.service active, OR a ghost nft table whose
 //              name contains "firewalld"
-//   Iptables:  iptables.service active, OR iptables-save reports ≥3
-//              non-comment rule lines, OR a ghost nft table named
-//              filter/nat/mangle
+//   Iptables:  iptables.service active OR iptables-save reports ≥3
+//              non-comment rule lines. A ghost nft table named
+//              filter/nat/mangle is RECORDED as an observation but
+//              does NOT classify iptables authority alone — it must
+//              be corroborated by service or live rules. See
+//              PR-P2-2A rationale in the iptables block below.
 //   CSF:       csf.service active, OR lfd.service active, OR
 //              /etc/csf/csf.conf present on disk
 //
@@ -201,16 +204,43 @@ func Detect(exec executor.Executor, log *logging.Logger) *DetectionResult {
 	}
 
 	// ── Iptables ───────────────────────────────────────────────────────
-	// Signal 1: iptables.service is active.
+	//
+	// PR-P2-2A (2026-04-20): iptables ghost-table signal alone is NOT
+	// sufficient to classify external iptables authority. Stock Ubuntu
+	// nftables packages ship a benign `table inet filter` with empty
+	// accept-policy chains — it satisfied the pre-PR-P2-2A rule
+	// (base ∈ {filter,nat,mangle}) and caused AuthorityAmbiguous on
+	// every Ubuntu host with nftban installed. Surfaced by real-host
+	// evidence on lab2.
+	//
+	// Post-PR-P2-2A rule: ghost-table is recorded as an observation
+	// (for transparency in logs / plan rendering) but does NOT
+	// contribute to the "is iptables active?" decision unless a
+	// corroborating signal also fires:
+	//   - iptables.service is active, OR
+	//   - iptables-save reports live rules (≥3 non-comment lines)
+	//
+	// Paths: ghost-table-alone → informational, not counted.
+	//         service OR rules → counted (with ghost-table observation
+	//                              kept in the audit trail for context).
+	var (
+		iptablesService bool
+		iptablesRules   bool
+		iptablesGhost   bool
+	)
+
+	// Collect signal 1: iptables.service is active.
 	if exec.ServiceActive("iptables.service") {
 		res.Observations = append(res.Observations, Observation{
 			Name: NameIptables, Source: SourceService, Unit: "iptables.service",
 			Detail: "iptables.service active",
 		})
-		seen[NameIptables] = true
+		iptablesService = true
 	}
-	// Signal 2: ghost nft table named filter/nat/mangle (iptables-nft
-	// compatibility tables).
+	// Collect signal 2: ghost nft table named filter/nat/mangle
+	// (iptables-nft compatibility tables). Recorded as an observation
+	// even when it turns out to be stock-nftables noise — so plan
+	// rendering can still surface "we saw this, but did not count it."
 	for _, t := range listGhostNftTables(exec) {
 		base := strings.TrimPrefix(t, "ip ")
 		base = strings.TrimPrefix(base, "ip6 ")
@@ -220,22 +250,34 @@ func Detect(exec executor.Executor, log *logging.Logger) *DetectionResult {
 		if base == "filter" || base == "nat" || base == "mangle" {
 			res.Observations = append(res.Observations, Observation{
 				Name: NameIptables, Source: SourceGhostTable,
-				Detail: "ghost nft table: " + t,
+				Detail: "ghost nft table: " + t + " (informational — alone is not sufficient to classify iptables authority)",
 			})
-			seen[NameIptables] = true
+			iptablesGhost = true
 		}
 	}
-	// Signal 3: iptables-save reports ≥3 non-comment rule lines.
-	// Preserved from the uninstall-side heuristic — nftban itself
-	// does not use legacy iptables, so live rules imply external
-	// authority.
+	// Collect signal 3: iptables-save reports ≥3 non-comment rule lines.
+	// Preserved from the uninstall-side heuristic — nftban itself does
+	// not use legacy iptables, so live rules imply external authority.
 	if hasActiveIptablesRules(exec) {
 		res.Observations = append(res.Observations, Observation{
 			Name: NameIptables, Source: SourceIptablesRules,
 			Detail: "iptables-save: ≥3 non-comment rule lines present",
 		})
+		iptablesRules = true
+	}
+	// Apply the corroboration rule.
+	//
+	// Ghost-table contributes IFF another signal corroborates. This
+	// avoids false-positive on stock nftables baselines (see above)
+	// while keeping the legitimate iptables-nft detection path intact
+	// for hosts that actually have service + ghost tables together.
+	if iptablesService || iptablesRules {
 		seen[NameIptables] = true
 	}
+	// Silence "declared and not used" — iptablesGhost is read above
+	// only to register the observation; its role as a contributor is
+	// intentionally gated on corroboration.
+	_ = iptablesGhost
 
 	// ── CSF ────────────────────────────────────────────────────────────
 	// Signal 1: csf.service active.

--- a/internal/installer/extfw/detect_test.go
+++ b/internal/installer/extfw/detect_test.go
@@ -93,22 +93,20 @@ func TestDetect_Firewalld_Alone_BothSignals(t *testing.T) {
 	}
 }
 
-func TestDetect_Iptables_AllThreeSignals(t *testing.T) {
-	// Service signal
+// TestDetect_Iptables_CorroboratedSignals covers the two signals that
+// independently classify iptables authority: service active, and
+// iptables-save live rules. Per PR-P2-2A, ghost-table alone is NOT
+// one of them — see TestDetect_Iptables_GhostTableAlone_NotClassified
+// for the regression guard.
+func TestDetect_Iptables_CorroboratedSignals(t *testing.T) {
+	// Signal 1: iptables.service active.
 	m := cleanMock()
 	m.Services["iptables.service"] = true
 	if res := Detect(m, newTestLogger()); res.Authoritative != NameIptables {
 		t.Errorf("service: Authoritative = %q; want iptables", res.Authoritative)
 	}
 
-	// Ghost-table signal (filter table, common iptables-nft case)
-	m2 := cleanMock()
-	m2.RunResults["nft:list:tables"] = executor.Result{ExitCode: 0, Stdout: "table ip filter\n"}
-	if res := Detect(m2, newTestLogger()); res.Authoritative != NameIptables {
-		t.Errorf("ghost-table: Authoritative = %q; want iptables", res.Authoritative)
-	}
-
-	// Active-rules signal (iptables-save)
+	// Signal 3: iptables-save live rules.
 	m3 := cleanMock()
 	m3.RunResults["iptables-save:"] = executor.Result{
 		ExitCode: 0,
@@ -116,6 +114,79 @@ func TestDetect_Iptables_AllThreeSignals(t *testing.T) {
 	}
 	if res := Detect(m3, newTestLogger()); res.Authoritative != NameIptables {
 		t.Errorf("iptables-save: Authoritative = %q; want iptables", res.Authoritative)
+	}
+
+	// Ghost table + corroborating service → still classified.
+	m4 := cleanMock()
+	m4.RunResults["nft:list:tables"] = executor.Result{ExitCode: 0, Stdout: "table ip filter\n"}
+	m4.Services["iptables.service"] = true
+	if res := Detect(m4, newTestLogger()); res.Authoritative != NameIptables {
+		t.Errorf("ghost + service: Authoritative = %q; want iptables (service corroborates)", res.Authoritative)
+	}
+}
+
+// TestDetect_Iptables_GhostTableAlone_NotClassified — PR-P2-2A
+// regression guard. A `inet filter` / `ip filter` / `ip nat` / `ip
+// mangle` ghost nft table by itself must NOT classify iptables
+// authority. This is the stock Ubuntu nftables baseline (shipped
+// empty-accept-policy `table inet filter` by the `nftables` package)
+// and was false-positiving pre-correction, blocking uninstall on
+// every clean Ubuntu host.
+func TestDetect_Iptables_GhostTableAlone_NotClassified(t *testing.T) {
+	tests := []struct {
+		name  string
+		stdin string
+	}{
+		// The exact shape from lab2's stock Ubuntu 24.04 nftables install.
+		{"inet_filter_ubuntu_baseline", "table inet filter\n"},
+		{"ip_filter", "table ip filter\n"},
+		{"ip_nat", "table ip nat\n"},
+		{"ip_mangle", "table ip mangle\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := cleanMock()
+			m.RunResults["nft:list:tables"] = executor.Result{
+				ExitCode: 0,
+				Stdout:   tc.stdin,
+			}
+			// Critically: no iptables.service, no iptables-save rules.
+
+			res := Detect(m, newTestLogger())
+			if res.Authoritative == NameIptables {
+				t.Errorf("ghost-table-only (%s): Authoritative = %q; must NOT classify iptables without corroboration", tc.name, res.Authoritative)
+			}
+			for _, n := range res.Active {
+				if n == NameIptables {
+					t.Errorf("ghost-table-only (%s): NameIptables appeared in Active list without service/rule corroboration", tc.name)
+				}
+			}
+			// The observation itself should still be recorded (for
+			// plan-render transparency) — just not counted as authority.
+			var sawGhostObs bool
+			for _, o := range res.Observations {
+				if o.Name == NameIptables && o.Source == SourceGhostTable {
+					sawGhostObs = true
+				}
+			}
+			if !sawGhostObs {
+				t.Errorf("ghost-table-only (%s): observation should still be recorded for transparency, got none", tc.name)
+			}
+		})
+	}
+}
+
+// TestDetect_Iptables_GhostTable_PlusService_Classifies — inverse of
+// the regression guard: when the ghost table IS corroborated by a
+// live signal, classification proceeds as before.
+func TestDetect_Iptables_GhostTable_PlusService_Classifies(t *testing.T) {
+	m := cleanMock()
+	m.RunResults["nft:list:tables"] = executor.Result{ExitCode: 0, Stdout: "table ip filter\n"}
+	m.Services["iptables.service"] = true
+
+	res := Detect(m, newTestLogger())
+	if res.Authoritative != NameIptables {
+		t.Errorf("ghost + service: Authoritative = %q; want iptables", res.Authoritative)
 	}
 }
 


### PR DESCRIPTION
**Narrow fast-follow before PR-23 merge.** Fixes the classifier false-positive surfaced by lab2 real-host evidence during PR-23 Step 2 dry-run diagnostic.

## The bug

\`extfw.Detect\` classified any ghost nft table named \`filter\`/\`nat\`/\`mangle\` as external iptables authority. Stock Ubuntu \`nftables\` package ships a benign \`table inet filter\` with empty accept-policy chains — this triggered the rule, producing \`AuthorityAmbiguous\` + \`AmbiguityConflictExternal\` on **every clean Ubuntu host with nftban installed**. Under PR-23 that would refuse every uninstall on Ubuntu.

## The rule (Path B, locked 2026-04-20)

Iptables external authority is classified **IFF**:

- \`iptables.service\` is active, **OR**
- \`iptables-save\` reports ≥3 non-comment rule lines

A ghost \`filter\`/\`nat\`/\`mangle\` table **alone** is recorded as an observation (for plan-render transparency + operator logs) but does **not** contribute to the classification decision.

## Behavior summary

| Host shape | Pre-P2-2A | Post-P2-2A |
|---|---|---|
| Stock Ubuntu (nftban + \`inet filter\` baseline) | iptables conflict → Ambiguous | no conflict → clean NFTBan |
| Real iptables (iptables.service active) | classified | **classified (no change)** |
| Real iptables-nft (service + ghost) | classified | **classified (no change)** |
| Live iptables rules (no service) | classified | **classified (no change)** |

Direction is safer: stock baselines no longer block legitimate lifecycle actions. Real iptables presence still requires observable corroboration beyond a bare table name match.

## Tests

### \`extfw/detect_test.go\`
- Renamed \`TestDetect_Iptables_AllThreeSignals\` → \`_CorroboratedSignals\`
- **NEW:** \`TestDetect_Iptables_GhostTableAlone_NotClassified\` — 4 sub-cases (\`inet filter\`, \`ip filter\`, \`ip nat\`, \`ip mangle\`). Asserts \`Authoritative != iptables\` AND ghost observation **is** recorded for transparency. First sub-case uses the exact shape from lab2's stock Ubuntu 24.04 baseline.
- **NEW:** \`TestDetect_Iptables_GhostTable_PlusService_Classifies\` — inverse invariant.

### \`detect/conflicts_test.go\` (same rule, install-side adapter)
- Renamed \`TestDetectConflicts_GhostTables\` → \`_GhostTablesOnly_NotConflict\`
- **NEW:** \`TestDetectConflicts_GhostPlusService_IsConflict\`
- Renamed \`TestDetectConflicts_Multiple\` → \`_UFWPlusUnqualifiedGhost_OneConflict\`
- **NEW:** \`TestDetectConflicts_Multiple_WithIptablesService\`

## Scope lock (per user's Path B decision)

- ✅ Path B: corroboration rule (ghost-table is informational alone)
- ❌ NOT Path A: table-content parsing
- ❌ NOT Path C: ship with known false-positive
- ✅ Only iptables detection changed — firewalld ghost-table rule unchanged (\"firewalld\" in a table name is a strong signal, not a routine baseline)

## Follow-up

Once this merges, PR-23 (\`feat/v1.100-pr-23-uninstall-mutation-authority-release\`, commit \`6a20ea80\`) needs to rebase onto updated main, CI re-run green, and lab2 real-host evidence re-attempted. Same classifier fix path applies to lab2 + lab4 + monitor + srv1 in the locked execution order.

## Test plan

- [ ] Build & Test green
- [ ] ci-install-canonization green
- [ ] ci-update-canonization green
- [ ] ci-uninstall-canonization green
- [ ] Test count in \`extfw\` + \`detect\` packages increased as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)