### PR TITLE
chore(v1.100.1a): CLI jail surgical rename — 3 operator-visible items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] - v1.100.1a CLI jail surgical rename
+
+### Changed
+
+- **`nftban stats --json` dual-key alias**: output now emits both
+  `top_jails` and `top_filters` keys with the same value. `top_jails`
+  is **deprecated** and will be removed in a later release; downstream
+  consumers should migrate to `top_filters`. One-cycle deprecation per
+  the locked surgical-rename scope (`top_jails` is the only operator-
+  parseable surface affected; internal variable + function names
+  unchanged in this release).
+- **`cli/lib/nftban/cli/cmd_search.sh`** purpose comment: replaced
+  "jails" → "filters". Comment-only change, no behavior impact.
+- **`etc/nftban/conf.d/login/services.conf`** comment narration at
+  9 sites: `[nftban-XXXX] jail` → `[nftban-XXXX] filter`. Comment-
+  only edit; env var convention (`LOGIN_SERVICE_<SERVICE>_<SETTING>`)
+  unchanged.
+
+### Notes
+
+- Internal struct/type renames (`escalation.BanEntry.Jail` field,
+  `nftban_stats_top_jails` function name, etc.) are intentionally
+  **out of scope** of this surgical rename. They will be addressed
+  in a separate later PR if needed.
+- Lifecycle completion work (PR-25 restore execution, PR-26 verification
+  gate, PR-27-30 maintenance) remains explicitly **open** and is not
+  affected by this rename.
+
+---
+
 ## [Unreleased] - v1.100 PR-22A + PR-22B repair cycle
 
 ### Changed

--- a/cli/lib/nftban/cli/cmd_search.sh
+++ b/cli/lib/nftban/cli/cmd_search.sh
@@ -4,7 +4,7 @@
 # NFTBan v1.0.0 - Search CLI Handler
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
-# Purpose: Search for IP/Port across all ban lists, feeds, jails, and whitelists
+# Purpose: Search for IP/Port across all ban lists, feeds, filters, and whitelists
 #
 # meta:name="cmd_search"
 # meta:type="cli"

--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -658,7 +658,8 @@ nftban_stats_cmd_dashboard() {
                     },
                     top_ips: $top_ips,
                     top_countries: $top_countries,
-                    top_jails: $top_jails
+                    top_jails: $top_jails,
+                    top_filters: $top_jails
                 }')
         else
             # Fallback without jq
@@ -666,7 +667,7 @@ nftban_stats_cmd_dashboard() {
             [[ "$portscan_enabled" == "true" ]] && portscan_enabled_json="true"
             local ddos_enabled_json="false"
             [[ "$ddos_enabled" == "true" ]] && ddos_enabled_json="true"
-            data="{\"period\":{\"since\":\"$since\",\"until\":\"$until\"},\"summary\":{\"total_bans\":$total_bans,\"active_bans\":$active_bans,\"total_countries\":$total_countries},\"breakdown\":{\"temporary\":{\"total\":$total_temp,\"ipv4\":$temp_v4,\"ipv6\":$temp_v6},\"blacklist\":{\"total\":$total_black,\"ipv4\":$black_v4,\"ipv6\":$black_v6},\"feeds\":{\"total\":$total_feed,\"ipv4\":$feed_v4,\"ipv6\":$feed_v6},\"whitelist\":{\"total\":$total_whitelist,\"ipv4\":$whitelist_v4,\"ipv6\":$whitelist_v6}},\"portscan\":{\"monitored_ports\":$portscan_monitored_ports,\"blocked_24h\":$portscan_blocked_24h,\"blocked_total\":$portscan_blocked_total,\"enabled\":$portscan_enabled_json},\"ddos\":{\"packets_dropped\":$ddos_packets_dropped,\"bytes_dropped\":$ddos_bytes_dropped,\"blocked_24h\":$ddos_blocked_24h,\"blocked_total\":$ddos_blocked_total,\"enabled\":$ddos_enabled_json},\"shared_state\":{\"feeds_active\":$feeds_active,\"feeds_ips\":$feeds_ips,\"rules_total\":$rules_total},\"top_ips\":$top_ips,\"top_countries\":$top_countries,\"top_jails\":$top_jails}"
+            data="{\"period\":{\"since\":\"$since\",\"until\":\"$until\"},\"summary\":{\"total_bans\":$total_bans,\"active_bans\":$active_bans,\"total_countries\":$total_countries},\"breakdown\":{\"temporary\":{\"total\":$total_temp,\"ipv4\":$temp_v4,\"ipv6\":$temp_v6},\"blacklist\":{\"total\":$total_black,\"ipv4\":$black_v4,\"ipv6\":$black_v6},\"feeds\":{\"total\":$total_feed,\"ipv4\":$feed_v4,\"ipv6\":$feed_v6},\"whitelist\":{\"total\":$total_whitelist,\"ipv4\":$whitelist_v4,\"ipv6\":$whitelist_v6}},\"portscan\":{\"monitored_ports\":$portscan_monitored_ports,\"blocked_24h\":$portscan_blocked_24h,\"blocked_total\":$portscan_blocked_total,\"enabled\":$portscan_enabled_json},\"ddos\":{\"packets_dropped\":$ddos_packets_dropped,\"bytes_dropped\":$ddos_bytes_dropped,\"blocked_24h\":$ddos_blocked_24h,\"blocked_total\":$ddos_blocked_total,\"enabled\":$ddos_enabled_json},\"shared_state\":{\"feeds_active\":$feeds_active,\"feeds_ips\":$feeds_ips,\"rules_total\":$rules_total},\"top_ips\":$top_ips,\"top_countries\":$top_countries,\"top_jails\":$top_jails,\"top_filters\":$top_jails}"
         fi
 
         json_output "true" "$data"

--- a/etc/nftban/conf.d/login/services.conf
+++ b/etc/nftban/conf.d/login/services.conf
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------------
 # Monitors: sshd login failures
 # Source: journalctl -u sshd / journalctl -u ssh
-# NFTBan native [nftban-sshd] jail
+# NFTBan native [nftban-sshd] filter
 
 LOGIN_SERVICE_SSH_ENABLED="true"
 
@@ -60,7 +60,7 @@ LOGIN_SERVICE_SSH_ROOT_PENALTY="0.25"
 # -----------------------------------------------------------------------------
 # Monitors: dovecot auth failures
 # Source: journalctl -u dovecot / /var/log/mail.log
-# NFTBan native [nftban-dovecot] jail
+# NFTBan native [nftban-dovecot] filter
 
 LOGIN_SERVICE_DOVECOT_ENABLED="true"
 
@@ -92,7 +92,7 @@ LOGIN_SERVICE_DOVECOT_RISK_MULTIPLIER="1.0"
 # -----------------------------------------------------------------------------
 # Monitors: exim SMTP auth failures
 # Source: journalctl -u exim / /var/log/exim/mainlog
-# NFTBan native [nftban-exim] jail
+# NFTBan native [nftban-exim] filter
 
 LOGIN_SERVICE_EXIM_ENABLED="true"
 
@@ -132,7 +132,7 @@ LOGIN_SERVICE_EXIM_RISK_MULTIPLIER="1.1"
 # -----------------------------------------------------------------------------
 # Monitors: postfix SMTP auth failures
 # Source: journalctl -u postfix / /var/log/mail.log
-# NFTBan native [nftban-postfix] jail
+# NFTBan native [nftban-postfix] filter
 
 LOGIN_SERVICE_POSTFIX_ENABLED="true"
 
@@ -164,7 +164,7 @@ LOGIN_SERVICE_POSTFIX_RISK_MULTIPLIER="1.0"
 # -----------------------------------------------------------------------------
 # Monitors: roundcube login failures
 # Source: journalctl -u php-fpm / /var/log/roundcube/errors
-# NFTBan native [nftban-roundcube] jail
+# NFTBan native [nftban-roundcube] filter
 
 LOGIN_SERVICE_ROUNDCUBE_ENABLED="true"
 
@@ -211,7 +211,7 @@ LOGIN_SERVICE_ROUNDCUBE_RISK_MULTIPLIER="0.9"
 # Monitors: xmlrpc.php abuse (brute force, amplification attacks)
 # Source: Apache/Nginx access logs
 # Confidence: HIGH - xmlrpc abuse is rarely legitimate at scale
-# NFTBan native [nftban-apache-xmlrpc] jail
+# NFTBan native [nftban-apache-xmlrpc] filter
 #
 # Why HIGH confidence:
 #   - system.multicall allows 1000s of password attempts per request
@@ -252,7 +252,7 @@ LOGIN_SERVICE_WP_XMLRPC_CONFIDENCE="high"
 # Monitors: wp-login.php request rate (velocity-based detection)
 # Source: Apache/Nginx access logs
 # Confidence: MEDIUM - cannot distinguish success/fail from access logs
-# NFTBan native [nftban-apache-wp-login] jail
+# NFTBan native [nftban-apache-wp-login] filter
 #
 # Why MEDIUM confidence:
 #   - HTTP 200/302 can be success OR failure
@@ -390,7 +390,7 @@ LOGIN_SERVICE_DRUPAL_CONFIDENCE="medium"
 # -----------------------------------------------------------------------------
 # Monitors: DirectAdmin login failures
 # Source: /var/log/directadmin/login.log
-# NFTBan native [nftban-directadmin] jail
+# NFTBan native [nftban-directadmin] filter
 
 LOGIN_SERVICE_DIRECTADMIN_ENABLED="true"
 
@@ -526,7 +526,7 @@ LOGIN_SERVICE_PLESK_MARKER_BIN="/usr/local/psa/admin/bin/httpdmng"
 # -----------------------------------------------------------------------------
 # Monitors: Pure-FTPd auth failures
 # Source: journalctl -u pure-ftpd / /var/log/pureftpd.log
-# NFTBan native [nftban-pure-ftpd] jail
+# NFTBan native [nftban-pure-ftpd] filter
 
 LOGIN_SERVICE_PUREFTPD_ENABLED="true"
 


### PR DESCRIPTION
First step of the v1.100.x stabilization train. Surgical CLI jail-terminology rename, scoped to **3 operator-visible items only** per `V190_JAIL_RENAME_CHALLENGE §5.2`.

## Scope (locked surgical, NOT a blanket rename)

### 1. `cli/lib/nftban/cli/cmd_stats.sh` — dual-key alias

`nftban stats --json` output now emits BOTH `top_jails` AND `top_filters` keys with the same value.

- `top_jails` is **deprecated** — will be removed in a later release
- `top_filters` is the new canonical key
- Both jq path (line 661) and jq-fallback path (line 669) updated
- Internal variable name (`$top_jails`) and function name (`nftban_stats_top_jails`) **unchanged** in this PR

This is **Option B** per the rename challenge audit: deprecation alias for one cycle, then later rename, instead of silent rename.

### 2. `cli/lib/nftban/cli/cmd_search.sh:7` purpose comment

```diff
-# Purpose: Search for IP/Port across all ban lists, feeds, jails, and whitelists
+# Purpose: Search for IP/Port across all ban lists, feeds, filters, and whitelists
```

Comment-only change. No behavior impact.

### 3. `etc/nftban/conf.d/login/services.conf` — 9 comment sites

```diff
-# NFTBan native [nftban-sshd] jail
+# NFTBan native [nftban-sshd] filter
```

Same edit applied to: sshd, dovecot, exim, postfix, roundcube, apache-xmlrpc, apache-wp-login, directadmin, pure-ftpd (9 sites).

Comments only. The env var convention (`LOGIN_SERVICE_<SERVICE>_<SETTING>`) is **unchanged**.

## Out of scope (deliberately deferred)

- ❌ Internal struct/field renames (`escalation.BanEntry.Jail` field, `tracker.LogTempBan(...,jail,...)` parameters)
- ❌ Function name renames (`nftban_stats_top_jails`)
- ❌ Internal local variable renames in shell
- ❌ Removing `top_jails` JSON key (only deprecated this release)
- ❌ Anything under `internal/installer/restore/*` or `cmd/nftban-installer/uninstall_apply.go` (PR-24 validated surfaces)
- ❌ GOTH PR-D4 (queued as 1.100.1b)
- ❌ Repo hygiene Phase A (queued as 1.100.3+)
- ❌ All deferred lifecycle completion items (PR-25-30)

## Why this PR is small by design

This is the first stabilization step in the v1.100.x train (locked 2026-04-26). The intent is to validate the train pattern (small focused PRs, one concern per PR) before progressing to larger items like GOTH removal (1.100.1b).

## Locked authoritative inputs

- `V190_UX_CLI_CHECK/V190_JAIL_RENAME_CHALLENGE.md` §5.2 (surgical scope: 3 operator-visible items)
- `V190_UX_CLI_CHECK/V190_JAIL_CONCEPT_AUDIT.md` (REMOVE verdict on `nftban jail` CLI; current CLI does not have such a command)
- `V190_UX_CLI_CHECK/V190_V2_0_UX_SPRINT.md` §3.2 (surgical-only rule)

## Verification

```bash
# top_filters present in JSON output
nftban stats --json | jq -r 'has("top_jails"), has("top_filters")'
# expects: true / true

# Comment edits applied
grep -c "jail" etc/nftban/conf.d/login/services.conf  # → 0
grep -c "] filter" etc/nftban/conf.d/login/services.conf  # → 9
grep "Purpose:" cli/lib/nftban/cli/cmd_search.sh  # → contains "filters", not "jails"
```

## Lifecycle completion remains open (per locked plan)

PR-25 (restore execution), PR-26 (verification gate), PR-27-30 (maintenance) are **explicitly open lifecycle completion work**. Sequenced after stabilization. Not affected by this PR.

## Test plan

- [ ] `Build & Test` green
- [ ] `Shell Quality` green (3 shell files modified)
- [ ] `Docs Quality` green (CHANGELOG update)
- [ ] `nftban stats --json` regression smoke (manual): both `top_jails` and `top_filters` present in output
- [ ] No CI gate weakening
- [ ] No test changes needed (this is comment + JSON-key surface only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)