### PR TITLE
docs(v1.100.3a): H-10 — fix broken HEADER_SPEC.md link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] - v1.100.3a Repo hygiene Phase A slice 1a (H-10)
+
+Smallest possible doc-only fix from the repo hygiene audit. Closes audit finding **H-10**: broken `[HEADER_SPEC.md]` link in `CONTRIBUTING.md:242` (file does not exist at repo root) and matching dangling reference in `tools/validate-headers.sh`.
+
+### Changed
+
+- `CONTRIBUTING.md`: section heading retitled from "HEADER_SPEC.md (File Headers)" to "File Headers". Removed the broken `[HEADER_SPEC.md](HEADER_SPEC.md)` link. Added a sentence noting that the inline section is itself the authoritative spec and that CI enforces it via `tools/validate-headers.sh`.
+- `tools/validate-headers.sh`: error message no longer references the non-existent `HEADER_SPEC.md`. Pointer text now says "CONTRIBUTING.md, section 'File Headers' (authoritative spec)". Header comment updated to match.
+
+### Out of scope (deferred to slice 1b)
+
+- H-01 / H-02 / H-03 — dev-path cleanup. Separate micro-PR.
+
+Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.
+
+---
+
 ## [Unreleased] - v1.100.2 SF-1 health CLI fix (released-host case)
 
 Post-soak correctness fix derived directly from the PR-24 7-day passive soak. Side finding **SF-1** was logged on Day 6 (2026-04-26) on the released/no-tables host (lab4): `nftban health` printed a spurious `ERROR: Script failed` block on top of its own DOWN-status output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Any AI (Claude, etc.) must obey:
 
 All contributions **must** comply with these authoritative standards:
 
-### 1. HEADER_SPEC.md (File Headers)
+### 1. File Headers
 
 Every source file must have a compliant header with:
 - **SPDX-License-Identifier: MPL-2.0** (exactly one per file)
@@ -239,7 +239,7 @@ Every source file must have a compliant header with:
   meta:inventory.privileges=""
   ```
 
-See [HEADER_SPEC.md](HEADER_SPEC.md) for complete specification.
+This section is the authoritative header spec. CI enforces it via `tools/validate-headers.sh`.
 
 ### 2. Coding Standards
 

--- a/tools/validate-headers.sh
+++ b/tools/validate-headers.sh
@@ -20,7 +20,8 @@
 set -Eeuo pipefail
 
 # Validate SPDX + meta quoting + required inventory keys + bash set flags.
-# Fails commit if any tracked file violates HEADER_SPEC.
+# Fails commit if any tracked file violates the file-header spec
+# defined in CONTRIBUTING.md section 'File Headers'.
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -170,11 +171,11 @@ done
 if [[ "$fail" -ne 0 ]]; then
   echo
   echo "=========================================="
-  echo "Commit blocked: HEADER_SPEC / coding standards validation failed."
+  echo "Commit blocked: header / coding standards validation failed."
   echo "Fix headers/metadata or inventory lines, then re-stage and commit."
   echo
   echo "References:"
-  echo "  - HEADER_SPEC.md"
+  echo "  - CONTRIBUTING.md, section 'File Headers' (authoritative spec)"
   echo "  - https://nftban.com/coding-standards.html"
   echo "=========================================="
   exit 1


### PR DESCRIPTION
## Summary

Repo hygiene Phase A — slice 1a. Smallest possible doc-only fix.

Closes audit finding **H-10**: \`CONTRIBUTING.md:242\` linked to \`[HEADER_SPEC.md](HEADER_SPEC.md)\` which does not exist at repo root. \`tools/validate-headers.sh\` also referenced the missing file in its error message.

## Why this is the smallest possible slice

The header-spec content already lives inline in \`CONTRIBUTING.md\` (section "File Headers" — SPDX-License-Identifier, all \`meta:\` tags with quoted values, all mandatory inventory keys). The broken link was a "see also" pointer to a phantom file. No new spec authoring is needed — just remove the broken pointer and clarify that the inline section is itself the authoritative spec.

## Changes

- \`CONTRIBUTING.md\` — section heading retitled from "HEADER_SPEC.md (File Headers)" to plain "File Headers"; broken self-link replaced by a sentence noting the inline section is authoritative and CI enforces it via \`tools/validate-headers.sh\`.
- \`tools/validate-headers.sh\` — error message and header comment updated; no more dangling \`HEADER_SPEC.md\` references.

3 files changed, 23 insertions(+), 5 deletions(-) — most of the diff is the CHANGELOG entry.

## Out of scope (deferred to slice 1b)

- H-01 / H-02 / H-03 — dev-path cleanup. Separate micro-PR.

Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.

## Test plan

- [ ] CI \`Build & Test\` PASS
- [ ] CI \`Build Docker Image\` PASS
- [ ] CI \`Build RPM\` × 2 PASS
- [ ] CI \`Build DEB\` × 4 PASS
- [ ] CI \`Test DEB install\` × 4 PASS
- [ ] CI \`Test RPM install\` × 4 PASS
- [ ] CI \`Docs Quality\` PASS
- [ ] CI \`ShellCheck\` (×2) + Shell Quality PASS
- [ ] CI \`Policy Gates\` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)