### PR TITLE
chore(v1.100.3b): H-01/H-02/H-03 — strip dev-machine paths from 6 tracked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] - v1.100.3b Repo hygiene Phase A slice 1b (H-01 / H-02 / H-03)
+
+Mechanical dev-machine path cleanup across 6 files. Closes audit findings **H-01**, **H-02**, and **H-03**: hardcoded `/home/gituser/github/...nftban-v1.0-dev` and `/home/gituser/github/nftban-dev` defaults that leak the maintainer's filesystem layout and break non-author runs.
+
+### Changed
+
+- `scripts/export_cli_inventory.sh:35` (H-01) — replace hardcoded `/home/gituser/...` dev fallback with repo-relative resolution via `readlink -f "$0"` + `../cli/lib/nftban/cli`.
+- `scripts/validate_cli_help.sh:32` (H-01) — same pattern.
+- `cli/lib/nftban/tests/selftest.sh:1875` (H-01) — same pattern, using `BASH_SOURCE[0]`.
+- `cli/lib/nftban/core/nftban_health_checks_config.sh:386` (H-02) — drop `/home/gituser/github/nftban-dev` from the auto-heal completion-source search list. Use `/usr/share/nftban/src` (canonical install-time source location) and add `${NFTBAN_DEV_SRC_DIR:-}` as opt-in env var for maintainers running out of a repo clone.
+- `cli/lib/nftban/core/nftban_health_checks_services.sh:520` (H-02) — same pattern for the timer auto-install path.
+- `tools/expand-config-schema.sh:22-23` (H-03) — make `INPUT_SKELETON` (positional `$1`) required via `:?` syntax (no public default for the internal skeleton path); resolve `OUTPUT_SCHEMA` (positional `$2`) repo-relative from the script's own location.
+
+### Verification
+
+Locked gate `git grep -nE "/home/gituser|/home/commonfolder|nftban-v1.0-dev" -- ':(exclude).claude/*'` produces only intentionally-deferred hits:
+
+- 3 × H-04 sites (locked to slice 1c): `cli/lib/nftban/lib/nftban_distro_config.sh:296`, `packaging/polkit-1/rules.d/30-nftban-panel.rules:243`, `tests/review/05_feeds_test.sh:28`.
+- 1 × `scripts/test_server_cleanup.sh:121` (`/root/nftban-v1.0-dev` in a one-shot dev cleanup script, not in the audit's H-list — handled separately).
+
+### Out of scope (deferred)
+
+- H-04 / H-05 / H-07 / H-08 / H-09 / H-16 / H-19 — separate Phase A slices.
+- Larger Phase A items (H-06 / H-11 / H-12 / H-13 / H-14 / H-15 / H-17 / H-18) — separate planning.
+
+Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.
+
+---
+
 ## [Unreleased] - v1.100.3a Repo hygiene Phase A slice 1a (H-10)
 
 Smallest possible doc-only fix from the repo hygiene audit. Closes audit finding **H-10**: broken `[HEADER_SPEC.md]` link in `CONTRIBUTING.md:242` (file does not exist at repo root) and matching dangling reference in `tools/validate-headers.sh`.

--- a/cli/lib/nftban/core/nftban_health_checks_config.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_config.sh
@@ -381,9 +381,14 @@ nftban_health_check_bash_completion() {
         if [[ ! -f "$nftban_completion" ]]; then
             # Try to auto-install if auto-heal enabled
             if [[ "${NFTBAN_HEALTH_AUTO_HEAL:-false}" == "true" ]]; then
-                # Try to find source file
+                # Try to find source file. /usr/share/nftban/src is the
+                # canonical install-time source location; NFTBAN_DEV_SRC_DIR
+                # is an opt-in env var for maintainers running out of a
+                # repo clone.
                 local completion_src=""
-                for dir in "/home/gituser/github/nftban-dev" "/usr/src/nftban" "/opt/nftban"; do
+                local _search_dirs=("/usr/share/nftban/src" "/usr/src/nftban" "/opt/nftban")
+                [[ -n "${NFTBAN_DEV_SRC_DIR:-}" ]] && _search_dirs=("${NFTBAN_DEV_SRC_DIR}" "${_search_dirs[@]}")
+                for dir in "${_search_dirs[@]}"; do
                     if [[ -f "$dir/install/bash-completion/nftban" ]]; then
                         completion_src="$dir/install/bash-completion/nftban"
                         break

--- a/cli/lib/nftban/core/nftban_health_checks_services.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_services.sh
@@ -515,10 +515,21 @@ nftban_health_check_timers() {
             missing=$((missing + 1))
             [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
 
-            # Auto-heal: Try to install if from systemd directory
+            # Auto-heal: Try to install from canonical source location.
+            # /usr/share/nftban/src is the install-time source dir;
+            # NFTBAN_DEV_SRC_DIR is an opt-in env var for maintainers
+            # running out of a repo clone.
             if [[ $auto_heal -eq 1 ]]; then
-                local timer_file="/home/gituser/github/nftban-dev/install/systemd/$timer"
-                if [[ -f "$timer_file" ]]; then
+                local timer_file=""
+                local _src_dirs=("/usr/share/nftban/src")
+                [[ -n "${NFTBAN_DEV_SRC_DIR:-}" ]] && _src_dirs=("${NFTBAN_DEV_SRC_DIR}" "${_src_dirs[@]}")
+                for _src in "${_src_dirs[@]}"; do
+                    if [[ -f "$_src/install/systemd/$timer" ]]; then
+                        timer_file="$_src/install/systemd/$timer"
+                        break
+                    fi
+                done
+                if [[ -n "$timer_file" ]]; then
                     echo "  🔧 Auto-heal: Installing $timer..."
                     if cp "$timer_file" /etc/systemd/system/ 2>/dev/null && systemctl daemon-reload 2>/dev/null; then
                         timer_issues+=("✓ Installed $timer")

--- a/cli/lib/nftban/tests/selftest.sh
+++ b/cli/lib/nftban/tests/selftest.sh
@@ -1870,9 +1870,12 @@ run_all_cli_tests() {
 
     local cli_dir="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/cli"
 
-    # Fallback for dev environment
+    # Fallback for dev environment: resolve repo-relative cli/lib path
+    # from the script's own location so this works on any clone.
     if [[ ! -d "$cli_dir" ]]; then
-        cli_dir="/home/gituser/github/nftban-v1.0-dev/cli/lib/nftban/cli"
+        local _self_dir
+        _self_dir="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+        cli_dir="${_self_dir}/../cli"
     fi
 
     if [[ ! -d "$cli_dir" ]]; then

--- a/scripts/export_cli_inventory.sh
+++ b/scripts/export_cli_inventory.sh
@@ -30,9 +30,11 @@ set -Eeuo pipefail
 CLI_DIR="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/cli"
 FORMAT="${1:-table}"
 
-# Fallback for development environment
+# Fallback for development environment: resolve repo-relative cli/lib path
+# from the script's own location so this works on any clone.
 if [[ ! -d "$CLI_DIR" ]]; then
-    CLI_DIR="/home/gituser/github/nftban-v1.0-dev/cli/lib/nftban/cli"
+    _self_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+    CLI_DIR="${_self_dir}/../cli/lib/nftban/cli"
 fi
 
 if [[ ! -d "$CLI_DIR" ]]; then

--- a/scripts/validate_cli_help.sh
+++ b/scripts/validate_cli_help.sh
@@ -27,9 +27,11 @@ set -Eeuo pipefail
 
 CLI_DIR="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/cli"
 
-# Fallback for development environment
+# Fallback for development environment: resolve repo-relative cli/lib path
+# from the script's own location so this works on any clone.
 if [[ ! -d "$CLI_DIR" ]]; then
-    CLI_DIR="/home/gituser/github/nftban-v1.0-dev/cli/lib/nftban/cli"
+    _self_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+    CLI_DIR="${_self_dir}/../cli/lib/nftban/cli"
 fi
 
 if [[ ! -d "$CLI_DIR" ]]; then

--- a/tools/expand-config-schema.sh
+++ b/tools/expand-config-schema.sh
@@ -19,8 +19,12 @@
 
 set -Eeuo pipefail
 
-INPUT_SKELETON="${1:-/home/commonfolder/NFTBAN_RECONFIGURATION_JAN_2026/data/registry-skeleton.json}"
-OUTPUT_SCHEMA="${2:-/home/gituser/github/nftban/cli/lib/nftban/data/config-schema.json}"
+# H-03: skeleton path has no public default — caller must pass it. Output
+# defaults to the canonical repo-relative location, resolved from this
+# script's own directory so the tool works on any clone.
+_self_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+INPUT_SKELETON="${1:?usage: $0 <skeleton.json> [output-schema.json]}"
+OUTPUT_SCHEMA="${2:-${_self_dir}/../cli/lib/nftban/data/config-schema.json}"
 
 echo "Expanding config schema from: $INPUT_SKELETON"
 echo "Output to: $OUTPUT_SCHEMA"


### PR DESCRIPTION
## Summary

Repo hygiene Phase A — slice 1b. Mechanical dev-machine path cleanup across 6 files.

Closes audit findings **H-01**, **H-02**, **H-03**: hardcoded \`/home/gituser/github/...nftban-v1.0-dev\` and \`/home/gituser/github/nftban-dev\` defaults that leaked the maintainer's filesystem layout and broke non-author runs.

## Files (locked scope — exactly 6)

| File | Finding | Fix |
|---|---|---|
| \`scripts/export_cli_inventory.sh\` | H-01 | dev fallback resolved via \`readlink -f "$0"\` |
| \`scripts/validate_cli_help.sh\` | H-01 | same pattern |
| \`cli/lib/nftban/tests/selftest.sh\` | H-01 | same pattern using \`BASH_SOURCE[0]\` |
| \`cli/lib/nftban/core/nftban_health_checks_config.sh\` | H-02 | drop \`/home/gituser/...nftban-dev\` from auto-heal completion-source search; use \`/usr/share/nftban/src\` + \`\${NFTBAN_DEV_SRC_DIR:-}\` opt-in |
| \`cli/lib/nftban/core/nftban_health_checks_services.sh\` | H-02 | same pattern for timer auto-install path |
| \`tools/expand-config-schema.sh\` | H-03 | \`INPUT_SKELETON\` required (\`:?\`); \`OUTPUT_SCHEMA\` repo-relative |

7 files changed, 69 insertions(+), 13 deletions(-) — most of the diff is the CHANGELOG entry.

## Locked verification gate

\`\`\`bash
git grep -nE "/home/gituser|/home/commonfolder|nftban-v1.0-dev" -- ':(exclude).claude/*'
\`\`\`

After this PR, the gate produces only **intentionally-deferred hits**:

- 3 × **H-04** sites (locked to slice 1c): \`cli/lib/nftban/lib/nftban_distro_config.sh:296\`, \`packaging/polkit-1/rules.d/30-nftban-panel.rules:243\`, \`tests/review/05_feeds_test.sh:28\`.
- 1 × \`scripts/test_server_cleanup.sh:121\` (\`/root/nftban-v1.0-dev\` in a one-shot dev cleanup script — not in the audit's H-list, handled separately).

This matches the user's locked acceptance: *"empty, or only hits that are intentionally deferred and explicitly excluded from this slice if any remain outside the targeted files."*

## Out of scope (deferred)

- H-04 / H-05 / H-07 / H-08 / H-09 / H-16 / H-19 — separate Phase A slices.
- Larger Phase A items (H-06 / H-11..H-19) — separate planning.

Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.

## Test plan

- [ ] CI \`Build & Test\` PASS
- [ ] CI \`Build Docker Image\` PASS
- [ ] CI \`Build RPM\` × 2 PASS
- [ ] CI \`Build DEB\` × 4 PASS
- [ ] CI \`Test DEB install\` × 4 PASS
- [ ] CI \`Test RPM install\` × 4 PASS
- [ ] CI \`CLI Smoke Test\` PASS
- [ ] CI \`ShellCheck\` (×2) + Shell Quality + Docs PASS
- [ ] CI \`Policy Gates\` PASS
- [ ] No regression in \`scripts/export_cli_inventory.sh\` / \`validate_cli_help.sh\` resolved paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)