### PR TITLE
docs(v1.100.3e): H-07/H-08 — sync visible version surfaces with /VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] - v1.100.3e Repo hygiene Phase A slice 1e (H-07 + H-08)
+
+Closes audit findings **H-07** (STATUS.md version drift) and **H-08** (README.md badge version drift). Both displayed visible-version strings that no longer matched `/VERSION` (1.98.2). STATUS.md claimed v1.89.0 (-9 minor versions); README badge pinned 1.95.0 (-3 patches).
+
+### Changed
+
+- `README.md:5` — replace static shield.io `version-1.95.0-blue` badge with auto-updating GitHub-tag form `https://img.shields.io/github/v/tag/itcmsgr/nftban?label=version&sort=semver&color=blue`. The badge now resolves to the latest semver tag at render time; future releases self-correct without a manual edit.
+- `STATUS.md:6` — replace `**Current version:** v1.89.0` with `**Version (this commit):** v1.98.2 — sourced from [\`/VERSION\`](VERSION); static per commit, not auto-updated. For the current released tag see [GitHub releases] or the README badge.` This makes the source-of-truth explicit and clarifies the static-per-commit nature so future drift is harder.
+
+### Out of scope (locked)
+
+- No version bump. No tag decision.
+- No CI gate / `bump-version.sh` automation. The badge is now self-updating; STATUS.md remains a manual touch-up at release time.
+- No broader README cleanup.
+- H-09 / H-16 / H-19 — separate slices (or deferred entirely).
+
+Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.
+
+---
+
 ## [Unreleased] - v1.100.3d Repo hygiene Phase A slice 1d (H-05)
 
 Closes audit finding **H-05**: 3 internal-roadmap references in tracked code/docs that are not resolvable by a public reader.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Linux Intrusion Prevention System & nftables Firewall Manager**
 
-[![Version](https://img.shields.io/badge/version-1.95.0-blue)](https://github.com/itcmsgr/nftban/releases)
+[![Version](https://img.shields.io/github/v/tag/itcmsgr/nftban?label=version&sort=semver&color=blue)](https://github.com/itcmsgr/nftban/releases)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8.svg)](https://go.dev/)
 [![FHS Compliant](https://img.shields.io/badge/FHS-Compliant-success)]()

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Policy:** Main branch is always green. Failed CI blocks merge.
 > No manual overrides for truth-critical checks. Evidence over claims.
 
-**Current version:** v1.89.0
+**Version (this commit):** v1.98.2 — sourced from [`/VERSION`](VERSION); static per commit, not auto-updated. For the current released tag see [GitHub releases](https://github.com/itcmsgr/nftban/releases) or the README badge.
 **Truth model:** Kernel → Validator → CLI
 **Enforcement:** [Design Principles](docs/DESIGN_PRINCIPLES.md)
 


### PR DESCRIPTION
## Summary

Repo hygiene Phase A — slice 1e. Closes audit findings **H-07** (STATUS.md version drift) and **H-08** (README.md badge version drift).

Both displayed visible-version strings that no longer matched \`/VERSION\` (current = 1.98.2):

| Surface | Was | After |
|---|---|---|
| README.md:5 badge | static \`version-1.95.0-blue\` (-3 patches) | auto-updating GitHub-tag form |
| STATUS.md:6 | \`**Current version:** v1.89.0\` (-9 minor versions) | \`**Version (this commit):** v1.98.2\` + source-of-truth annotation |

## Changes

### README.md:5

Old: \`![Version](https://img.shields.io/badge/version-1.95.0-blue)\`

New: \`![Version](https://img.shields.io/github/v/tag/itcmsgr/nftban?label=version&sort=semver&color=blue)\`

Shield.io reads the latest semver tag at render time. **No tooling change needed** — future releases self-correct.

### STATUS.md:6

Replace \`**Current version:** v1.89.0\` with:

> **Version (this commit):** v1.98.2 — sourced from [\`/VERSION\`](VERSION); static per commit, not auto-updated. For the current released tag see [GitHub releases] or the README badge.

Source-of-truth is now explicit and the static-per-commit nature is called out so future drift is harder to introduce silently.

## Verification

\`\`\`bash
grep -nE "version-1\.|v1\.[0-9]" README.md STATUS.md
\`\`\`

→ only legitimate historical references remain (\`"As of v1.89..."\`, \`"post v1.90 freeze"\`) — not current-version claims.

## Out of scope (locked)

- **No version bump. No tag decision.**
- **No \`bump-version.sh\` CI automation.** Badge is self-updating; STATUS.md remains a manual touch-up at release time.
- **No broader README cleanup.**
- H-09 / H-16 / H-19 — separate slices (or deferred entirely).

Lifecycle completion lane (PR-25..PR-30) remains explicitly **OPEN**.

3 files changed, 22 insertions(+), 2 deletions(-) — most of the diff is the CHANGELOG entry.

## Test plan

- [ ] CI \`Build & Test\` PASS
- [ ] CI \`Build Docker Image\` PASS
- [ ] CI \`Build RPM\` × 2 PASS
- [ ] CI \`Build DEB\` × 4 PASS
- [ ] CI \`Test DEB install\` × 4 PASS
- [ ] CI \`Test RPM install\` × 4 PASS
- [ ] CI \`Docs Quality\` PASS
- [ ] CI \`Policy Gates\` PASS
- [ ] No URL-validation lychee complaint about the new GitHub-tag shield URL
- [ ] (After merge) verify the rendered README badge shows the latest tag at https://github.com/itcmsgr/nftban

🤖 Generated with [Claude Code](https://claude.com/claude-code)