### PR TITLE
feat(v1.100 PR-26): code-D post-restore evidence record (§39.3 / §48.6 lock)

### DIFF
--- a/.github/workflows/ci-restore-canonization.yml
+++ b/.github/workflows/ci-restore-canonization.yml
@@ -549,6 +549,130 @@ jobs:
 
           echo "G4-RESTORE-CRON-MANIFEST-INTEGRITY PASS — writer + reader structurally consume the shared sha256 + manifest API"
 
+      # ------------------------------------------------------------------
+      # G4-RESTORE-EVIDENCE-RECORD (PR-26-code-D / §46) — structural
+      # pin on the post-restore evidence-record writer.
+      #
+      # The §39.3 + §48.6 lock requires that ALL evidence-record file
+      # writes route through a SINGLE helper using a NAMED CONSTANT
+      # for the destination directory. This gate structurally
+      # enforces:
+      #
+      #   - cmd/nftban-installer/restore_evidence.go declares the
+      #     restoreEvidenceDir constant verbatim and sets its value
+      #     to /var/lib/nftban/state/restore-evidence
+      #   - the file declares the writeRestoreEvidenceRecord helper
+      #     and the schema_version constant set to "1.0.0"
+      #   - the file contains exactly ONE WriteFileAtomic call (the
+      #     call inside the single helper)
+      #   - the file does NOT reference update-history.json,
+      #     uninstall.Probe, restore.Decide, restore.PlanFromDecision,
+      #     detect.DetectPanel, or any mutation primitive
+      #     (recording-only invariant per §39.3)
+      #   - the dispatcher (cmd/nftban-installer/restore_decide.go)
+      #     calls writeRestoreEvidenceRecord — i.e. evidence is
+      #     actually consumed, not just imported
+      #
+      # §46.1 discipline: production-code-only, comment-stripped.
+      # ------------------------------------------------------------------
+      - name: G4-RESTORE-EVIDENCE-RECORD — single-helper structural pin
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          ev=cmd/nftban-installer/restore_evidence.go
+          dispatcher=cmd/nftban-installer/restore_decide.go
+
+          for f in "$ev" "$dispatcher"; do
+            if [[ ! -f "$f" ]]; then
+              echo "::error::G4-RESTORE-EVIDENCE-RECORD: $f not found"
+              exit 1
+            fi
+          done
+
+          ev_src=$(grep -vE '^[[:space:]]*//' "$ev" || true)
+          disp_src=$(grep -vE '^[[:space:]]*//' "$dispatcher" || true)
+
+          fail=0
+
+          # ---- Required symbols in the evidence module ---------------
+          ev_required=(
+            'restoreEvidenceDir[[:space:]]+=[[:space:]]+"/var/lib/nftban/state/restore-evidence"'
+            'restoreEvidenceSchemaVersion[[:space:]]+=[[:space:]]+"1\.0\.0"'
+            'restoreEvidenceFilenamePrefix[[:space:]]+=[[:space:]]+"restore-evidence-"'
+            'func writeRestoreEvidenceRecord\('
+            'func buildRestoreEvidenceRecord\('
+            'type RestoreEvidenceRecord struct'
+          )
+          for pat in "${ev_required[@]}"; do
+            if ! echo "$ev_src" | grep -qE "$pat"; then
+              echo "::error::G4-RESTORE-EVIDENCE-RECORD: $ev missing required symbol matching '$pat'"
+              fail=1
+            fi
+          done
+
+          # ---- Single-helper invariant -------------------------------
+          # Exactly one WriteFileAtomic call in the evidence module —
+          # the one inside writeRestoreEvidenceRecord. Anything else
+          # is a violation of the §46 single-helper lock.
+          wfa_count=$(echo "$ev_src" | grep -cE '\bWriteFileAtomic\(' || true)
+          if [[ "$wfa_count" -ne 1 ]]; then
+            echo "::error::G4-RESTORE-EVIDENCE-RECORD: $ev contains $wfa_count WriteFileAtomic calls; want exactly 1 (single-helper invariant)"
+            fail=1
+          fi
+
+          # ---- Forbidden recording-only-violation symbols -----------
+          ev_forbidden=(
+            'restore\.Decide\('
+            'restore\.PlanFromDecision\('
+            'uninstall\.Probe\('
+            'detect\.DetectPanel\('
+            'writeHistory\('
+            'update-history\.json'
+            '\bexec\.ServiceStart\('
+            '\bexec\.ServiceStop\('
+            '\bexec\.ServiceEnable\('
+            '\bexec\.ServiceDisable\('
+            '\bexec\.ServiceMask\('
+            '\bexec\.ServiceUnmask\('
+            '\bexec\.NftDeleteTable\('
+            '\bexec\.NftAddElement\('
+            '\bexec\.DaemonReload\('
+            '\bexec\.Rename\('
+            '"os/exec"'
+            '\bexec\.Command\('
+            '\bos\.Rename\('
+            '\bos\.Remove\('
+            '\bos\.WriteFile\('
+            '\bos\.Create\('
+            '\bsyscall\.'
+          )
+          for pat in "${ev_forbidden[@]}"; do
+            if echo "$ev_src" | grep -qE "$pat"; then
+              echo "::error::G4-RESTORE-EVIDENCE-RECORD: $ev contains forbidden pattern '$pat' (recording-only invariant)"
+              fail=1
+            fi
+          done
+
+          # ---- Dispatcher consumption pin ----------------------------
+          # The dispatcher MUST call writeRestoreEvidenceRecord — proves
+          # evidence is consumed, not just imported.
+          if ! echo "$disp_src" | grep -qE '\bwriteRestoreEvidenceRecord\('; then
+            echo "::error::G4-RESTORE-EVIDENCE-RECORD: $dispatcher does not call writeRestoreEvidenceRecord"
+            fail=1
+          fi
+          if ! echo "$disp_src" | grep -qE '\bbuildRestoreEvidenceRecord\('; then
+            echo "::error::G4-RESTORE-EVIDENCE-RECORD: $dispatcher does not call buildRestoreEvidenceRecord"
+            fail=1
+          fi
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo "::error::§39.3 / §46 / §48.6 violation — restore evidence-record writer not structurally enforced."
+            exit 1
+          fi
+
+          echo "G4-RESTORE-EVIDENCE-RECORD PASS — writer + dispatcher structurally consume the single evidence helper"
+
   restore-canonization-summary:
     name: Restore Canonization summary
     runs-on: ubuntu-24.04

--- a/cmd/nftban-installer/restore_decide.go
+++ b/cmd/nftban-installer/restore_decide.go
@@ -300,19 +300,44 @@ func runRestoreExecutionFromProceed(
 	if execRes.Err != nil {
 		reason = execRes.Err.Error()
 	}
-	_ = sf.Transition(execRes.Terminal, state.PhaseDetect, reason)
 
-	// Step D — Operator-facing output reflects the executed terminal.
-	switch execRes.Terminal {
+	// Step D — PR-26-code-D evidence record. Recording-only; no
+	// re-derivation of TargetAuthority, no PR-24 re-decision, no
+	// validator/module-health probe, no update-history write
+	// (§19.2 layer 4 / main.go:132 mode-gate retained).
+	//
+	// The §48.6 lock requires that, if evidence-write fails AFTER a
+	// successful StateRestoreExecuted, we MUST NOT claim "executed"
+	// without recording the evidence. The state model already
+	// supports StateRestoreDegraded (state/machine.go:152) so we
+	// downgrade the terminal in that case.
+	finalTerminal := execRes.Terminal
+	finalReason := reason
+	rec := buildRestoreEvidenceRecord(exec, log, target, execRes)
+	evidenceErr := writeRestoreEvidenceRecord(ctx, exec, rec, log)
+	if evidenceErr != nil {
+		log.Warn("restore evidence: write failed: %v", evidenceErr)
+		if execRes.Terminal == state.StateRestoreExecuted {
+			finalTerminal = state.StateRestoreDegraded
+			finalReason = "restore executed but evidence-write failed: " + evidenceErr.Error()
+			log.Warn("restore evidence: downgrading StateRestoreExecuted -> StateRestoreDegraded — successful restore cannot claim executed without recorded evidence")
+		}
+	}
+
+	_ = sf.Transition(finalTerminal, state.PhaseDetect, finalReason)
+
+	// Step E — Operator-facing output reflects the (possibly
+	// downgraded) terminal.
+	switch finalTerminal {
 	case state.StateRestoreExecuted:
 		log.Result("[NFTBan] restore execution: COMPLETED — authorized restore is in effect")
 	case state.StateRestoreDegraded:
-		log.Result("[NFTBan] restore execution: COMPLETED with warnings — review inline-verify result")
+		log.Result("[NFTBan] restore execution: COMPLETED with warnings — %s", finalReason)
 	case state.StateRestoreFailedExecution:
-		log.Result("[NFTBan] restore execution: FAILED at %s — %s", execRes.Stage, reason)
+		log.Result("[NFTBan] restore execution: FAILED at %s — %s", execRes.Stage, finalReason)
 	case state.StateRestoreFailedVerification:
 		log.Result("[NFTBan] restore execution: FAILED VERIFICATION at %s — safety net retained — %s",
-			execRes.Stage, reason)
+			execRes.Stage, finalReason)
 	}
 
 	return sf.State.ExitCode()

--- a/cmd/nftban-installer/restore_decide_test.go
+++ b/cmd/nftban-installer/restore_decide_test.go
@@ -948,3 +948,210 @@ func TestProductionMutationDep_4B3pre_NoSetterMethods(t *testing.T) {
 		}
 	}
 }
+
+// =============================================================================
+// =============================================================================
+// PR-26-code-D — dispatcher evidence-record semantics tests
+//
+// Per auditor checkpoint on 849b372a: the dispatcher's new Step D
+// changes terminal behavior on a successful StateRestoreExecuted
+// when the evidence writer fails (downgrade to StateRestoreDegraded).
+// These 5 tests pin that semantic delta + the parallel preserved-
+// terminal cases on failure-path execution.
+// =============================================================================
+// =============================================================================
+
+// writeFailExec wraps a MockExecutor and forces every WriteFileAtomic
+// to fail with a simulated error. Used by the evidence-failure tests
+// to exercise the dispatcher's Step D failure handling without
+// changing MockExecutor itself.
+type writeFailExec struct {
+	*executor.MockExecutor
+}
+
+func (w *writeFailExec) WriteFileAtomic(_ string, _ []byte, _ os.FileMode) error {
+	return errors.New("simulated WriteFileAtomic failure for evidence-write")
+}
+
+// =============================================================================
+// PR-26-code-D test #1: Execute returns StateRestoreExecuted +
+// evidence writer fails → dispatcher persists StateRestoreDegraded;
+// exit code is the Degraded code; no Executed claim.
+// =============================================================================
+
+func TestRunRestoreExecutionFromProceed_PR26D_ExecutedPlusEvidenceFail_DowngradesToDegraded(t *testing.T) {
+	fake := &fakeDispatcherDeps{
+		preflightOK:  true,
+		activeRet:    true,
+		authorityRet: uninstall.AuthorityExternal,
+		safeRet:      true,
+	}
+	withFakeDeps(t, fake)
+
+	sf := newTestStateFile(t)
+	log := newTestLogger(t)
+	dr, in, rec, panel := procRecordedPriorFixture()
+
+	exec := &writeFailExec{MockExecutor: executor.NewMockExecutor()}
+	exit := runRestoreExecutionFromProceed(context.Background(), exec, sf, log, dr, in, rec, panel)
+
+	if sf.State != state.StateRestoreDegraded {
+		t.Errorf("State = %q; want StateRestoreDegraded (evidence-write failure must downgrade Executed)", sf.State)
+	}
+	if exit != state.StateRestoreDegraded.ExitCode() {
+		t.Errorf("exit = %d; want %d (Degraded exit code)", exit, state.StateRestoreDegraded.ExitCode())
+	}
+	if sf.State == state.StateRestoreExecuted {
+		t.Errorf("dispatcher claimed StateRestoreExecuted despite evidence-write failure")
+	}
+	// Note: sf.FailureReason is only populated by Transition when
+	// newState.IsFailed() is true (state/file.go:118). StateRestoreDegraded
+	// is intentionally NOT a failed state (it is success-with-warnings),
+	// so FailureReason stays empty. The evidence-write failure surfaces
+	// via the operator-facing log.Result line ("COMPLETED with warnings
+	// — restore executed but evidence-write failed: …") which is the
+	// authoritative operator channel for Degraded outcomes.
+}
+
+// =============================================================================
+// PR-26-code-D test #2: Execute returns StateRestoreFailedExecution +
+// evidence writer fails → original FailedExecution terminal preserved;
+// evidence failure is warning-only.
+// =============================================================================
+
+func TestRunRestoreExecutionFromProceed_PR26D_FailedExecutionPlusEvidenceFail_TerminalPreserved(t *testing.T) {
+	fake := &fakeDispatcherDeps{
+		preflightOK: true,
+		mutateErr:   errors.New("simulated mutation failure"),
+	}
+	withFakeDeps(t, fake)
+
+	sf := newTestStateFile(t)
+	log := newTestLogger(t)
+	dr, in, rec, panel := procRecordedPriorFixture()
+
+	exec := &writeFailExec{MockExecutor: executor.NewMockExecutor()}
+	exit := runRestoreExecutionFromProceed(context.Background(), exec, sf, log, dr, in, rec, panel)
+
+	// Original FailedExecution terminal preserved — evidence failure
+	// does NOT downgrade a non-Executed terminal.
+	if sf.State != state.StateRestoreFailedExecution {
+		t.Errorf("State = %q; want StateRestoreFailedExecution (terminal must be preserved on non-Executed paths)", sf.State)
+	}
+	if exit != state.StateRestoreFailedExecution.ExitCode() {
+		t.Errorf("exit = %d; want %d", exit, state.StateRestoreFailedExecution.ExitCode())
+	}
+}
+
+// =============================================================================
+// PR-26-code-D test #3: Execute returns StateRestoreFailedVerification +
+// evidence writer fails → original FailedVerification terminal
+// preserved; evidence failure is warning-only.
+// =============================================================================
+
+func TestRunRestoreExecutionFromProceed_PR26D_FailedVerificationPlusEvidenceFail_TerminalPreserved(t *testing.T) {
+	fake := &fakeDispatcherDeps{
+		preflightOK:  true,
+		activeRet:    false, // inline-verify assertion 1 returns false → SafeToRemove false
+		authorityRet: uninstall.AuthorityExternal,
+		safeRet:      true,
+	}
+	withFakeDeps(t, fake)
+
+	sf := newTestStateFile(t)
+	log := newTestLogger(t)
+	dr, in, rec, panel := procRecordedPriorFixture()
+
+	exec := &writeFailExec{MockExecutor: executor.NewMockExecutor()}
+	exit := runRestoreExecutionFromProceed(context.Background(), exec, sf, log, dr, in, rec, panel)
+
+	if sf.State != state.StateRestoreFailedVerification {
+		t.Errorf("State = %q; want StateRestoreFailedVerification (terminal must be preserved on non-Executed paths)", sf.State)
+	}
+	if exit != state.StateRestoreFailedVerification.ExitCode() {
+		t.Errorf("exit = %d; want %d", exit, state.StateRestoreFailedVerification.ExitCode())
+	}
+}
+
+// =============================================================================
+// PR-26-code-D test #4: Execute returns StateRestoreExecuted +
+// evidence writer succeeds → StateRestoreExecuted preserved; evidence
+// file written under restoreEvidenceDir.
+// =============================================================================
+
+func TestRunRestoreExecutionFromProceed_PR26D_ExecutedPlusEvidenceOk_PreservesExecuted(t *testing.T) {
+	fake := &fakeDispatcherDeps{
+		preflightOK:  true,
+		activeRet:    true,
+		authorityRet: uninstall.AuthorityExternal,
+		safeRet:      true,
+	}
+	withFakeDeps(t, fake)
+
+	sf := newTestStateFile(t)
+	log := newTestLogger(t)
+	dr, in, rec, panel := procRecordedPriorFixture()
+
+	exec := executor.NewMockExecutor()
+	exit := runRestoreExecutionFromProceed(context.Background(), exec, sf, log, dr, in, rec, panel)
+
+	if sf.State != state.StateRestoreExecuted {
+		t.Errorf("State = %q; want StateRestoreExecuted (clean evidence-write must preserve terminal)", sf.State)
+	}
+	if exit != state.StateRestoreExecuted.ExitCode() {
+		t.Errorf("exit = %d; want %d", exit, state.StateRestoreExecuted.ExitCode())
+	}
+	// Exactly one evidence file under restoreEvidenceDir.
+	count := 0
+	for path := range exec.WrittenFiles {
+		if strings.HasPrefix(path, restoreEvidenceDir+"/") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("evidence file count under %s = %d; want 1", restoreEvidenceDir, count)
+	}
+	// No write outside restoreEvidenceDir from the dispatcher path
+	// (the fake deps don't write anything; the only file the
+	// dispatcher writes itself is the evidence record).
+	for path := range exec.WrittenFiles {
+		if !strings.HasPrefix(path, restoreEvidenceDir+"/") {
+			t.Errorf("dispatcher wrote unexpected path: %s", path)
+		}
+	}
+}
+
+// =============================================================================
+// PR-26-code-D test #5: Dispatcher path does NOT write update-history.
+// File-scan against restore_decide.go pins the §19.2 layer-4 invariant
+// stays untouched by the new Step D evidence record.
+// =============================================================================
+
+func TestDispatcher_PR26D_NoUpdateHistoryWrite_FileScan(t *testing.T) {
+	body, err := os.ReadFile("restore_decide.go")
+	if err != nil {
+		t.Fatalf("read restore_decide.go: %v", err)
+	}
+	src := string(body)
+
+	// Strip line-leading // comments per §46.1 discipline.
+	var prodLines []string
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		prodLines = append(prodLines, line)
+	}
+	prodSrc := strings.Join(prodLines, "\n")
+
+	forbidden := []string{
+		"writeHistory(",
+		"update-history.json",
+	}
+	for _, pat := range forbidden {
+		if strings.Contains(prodSrc, pat) {
+			t.Errorf("restore_decide.go references %q (§19.2 layer-4 invariant breached — restore mode must NOT write update-history)", pat)
+		}
+	}
+}

--- a/cmd/nftban-installer/restore_decide_test.go
+++ b/cmd/nftban-installer/restore_decide_test.go
@@ -218,7 +218,11 @@ func TestRunRestoreExecutionFromProceed_PanelNative_UnmappedPanel_FailsExecution
 	log := newTestLogger(t)
 	dr, in, rec, panel := procPanelNativeUnmappedFixture()
 
-	exit := runRestoreExecutionFromProceed(context.Background(), nil, sf, log, dr, in, rec, panel)
+	// PR-26-code-D: dispatcher now writes a post-restore evidence
+	// record via writeRestoreEvidenceRecord which requires a non-nil
+	// executor. Inject a MockExecutor so the writer succeeds and the
+	// terminal stays at StateRestoreExecuted (fake happy path).
+	exit := runRestoreExecutionFromProceed(context.Background(), executor.NewMockExecutor(), sf, log, dr, in, rec, panel)
 
 	if sf.State != state.StateRestoreFailedExecution {
 		t.Errorf("State = %q; want StateRestoreFailedExecution (unmapped panel)", sf.State)
@@ -251,7 +255,11 @@ func TestRunRestoreExecutionFromProceed_NonProceedAccident_PlannerErrors(t *test
 		Reason: "fixture",
 	}
 
-	exit := runRestoreExecutionFromProceed(context.Background(), nil, sf, log, dr, in, rec, panel)
+	// PR-26-code-D: dispatcher now writes a post-restore evidence
+	// record via writeRestoreEvidenceRecord which requires a non-nil
+	// executor. Inject a MockExecutor so the writer succeeds and the
+	// terminal stays at StateRestoreExecuted (fake happy path).
+	exit := runRestoreExecutionFromProceed(context.Background(), executor.NewMockExecutor(), sf, log, dr, in, rec, panel)
 
 	if sf.State != state.StateRestoreFailedExecution {
 		t.Errorf("State = %q; want StateRestoreFailedExecution (planner refused non-PROCEED)", sf.State)
@@ -374,7 +382,11 @@ func TestRunRestoreExecutionFromProceed_FakeDeps_HappyPath_PersistsExecuted(t *t
 	log := newTestLogger(t)
 	dr, in, rec, panel := procRecordedPriorFixture()
 
-	exit := runRestoreExecutionFromProceed(context.Background(), nil, sf, log, dr, in, rec, panel)
+	// PR-26-code-D: dispatcher now writes a post-restore evidence
+	// record via writeRestoreEvidenceRecord which requires a non-nil
+	// executor. Inject a MockExecutor so the writer succeeds and the
+	// terminal stays at StateRestoreExecuted (fake happy path).
+	exit := runRestoreExecutionFromProceed(context.Background(), executor.NewMockExecutor(), sf, log, dr, in, rec, panel)
 
 	if sf.State != state.StateRestoreExecuted {
 		t.Errorf("State = %q; want StateRestoreExecuted (fake happy path)", sf.State)
@@ -407,7 +419,11 @@ func TestRunRestoreExecutionFromProceed_FakeDeps_MutateFailure(t *testing.T) {
 	log := newTestLogger(t)
 	dr, in, rec, panel := procRecordedPriorFixture()
 
-	exit := runRestoreExecutionFromProceed(context.Background(), nil, sf, log, dr, in, rec, panel)
+	// PR-26-code-D: dispatcher now writes a post-restore evidence
+	// record via writeRestoreEvidenceRecord which requires a non-nil
+	// executor. Inject a MockExecutor so the writer succeeds and the
+	// terminal stays at StateRestoreExecuted (fake happy path).
+	exit := runRestoreExecutionFromProceed(context.Background(), executor.NewMockExecutor(), sf, log, dr, in, rec, panel)
 
 	if sf.State != state.StateRestoreFailedExecution {
 		t.Errorf("State = %q; want StateRestoreFailedExecution", sf.State)
@@ -439,7 +455,11 @@ func TestRunRestoreExecutionFromProceed_FakeDeps_VerifyFailure_NoRemove(t *testi
 	log := newTestLogger(t)
 	dr, in, rec, panel := procRecordedPriorFixture()
 
-	exit := runRestoreExecutionFromProceed(context.Background(), nil, sf, log, dr, in, rec, panel)
+	// PR-26-code-D: dispatcher now writes a post-restore evidence
+	// record via writeRestoreEvidenceRecord which requires a non-nil
+	// executor. Inject a MockExecutor so the writer succeeds and the
+	// terminal stays at StateRestoreExecuted (fake happy path).
+	exit := runRestoreExecutionFromProceed(context.Background(), executor.NewMockExecutor(), sf, log, dr, in, rec, panel)
 
 	if sf.State != state.StateRestoreFailedVerification {
 		t.Errorf("State = %q; want StateRestoreFailedVerification", sf.State)

--- a/cmd/nftban-installer/restore_evidence.go
+++ b/cmd/nftban-installer/restore_evidence.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MPL-2.0
+// =============================================================================
+// NFTBan v1.100 PR-26-code-D — restore evidence record
+// =============================================================================
+// meta:name="nftban-installer-restore-evidence"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="Post-restore evidence-record writer per §39.3 + §48.6 lock. Writes a structured JSON record under /var/lib/nftban/state/restore-evidence/ on every restore-mode terminal so a fresh reader can reconstruct the post-mutation state without consulting private memory or the host's runtime state. Recording-only — does NOT re-run PR-24 decisions, rebuild TargetAuthority, run the validator, or probe module health. Separate artefact from update-history.json (§19.2 layer 4 / main.go:132 mode-gate retained)."
+// meta:depends="github.com/itcmsgr/nftban/internal/installer/detect,github.com/itcmsgr/nftban/internal/installer/executor,github.com/itcmsgr/nftban/internal/installer/logging,github.com/itcmsgr/nftban/internal/installer/restore,github.com/itcmsgr/nftban/internal/installer/state,github.com/itcmsgr/nftban/internal/installer/uninstall"
+// meta:inventory.files="/var/lib/nftban/state/restore-evidence/restore-evidence-<UTC>-<rand>.json"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Recording-only invariant (operator design call, §39.3):
+//
+//   This module RECORDS the output of §21 / §32 verification. It MUST
+//   NOT become a second truth engine:
+//
+//     - no calls to restore.Decide / restore.PlanFromDecision
+//     - no calls to uninstall.Probe (Classify is permitted only via
+//       the existing inline-verify dep's CurrentAuthorityClass — we
+//       consume the value already produced, never re-derive)
+//     - no calls to detect.DetectPanel
+//     - no validator full-sweep / module-health probes
+//     - no rebuild / cleanup invocations
+//     - no update-history.json write (the §19.2 layer 4 mode-gate at
+//       main.go:132 already excludes restore mode; this module
+//       inherits that invariant)
+//
+// All evidence-record writes route through the SINGLE helper
+// writeRestoreEvidenceRecord, which uses the named constant
+// restoreEvidenceDir for its destination directory. The CI gate
+// G4-RESTORE-EVIDENCE-RECORD enforces this structurally.
+// =============================================================================
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/restore"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+// =============================================================================
+// Constants — paths and schema
+// =============================================================================
+
+const (
+	// restoreEvidenceSchemaVersion is the on-disk schema version of
+	// every record this module writes. Readers parse it before
+	// trusting fields. Bumping is a contract event.
+	restoreEvidenceSchemaVersion = "1.0.0"
+
+	// restoreEvidenceDir is the named constant the CI gate
+	// G4-RESTORE-EVIDENCE-RECORD pins. ALL evidence-record file
+	// writes in this module MUST resolve their destination through
+	// this constant. No write outside this directory is permitted
+	// by writeRestoreEvidenceRecord.
+	restoreEvidenceDir = "/var/lib/nftban/state/restore-evidence"
+
+	// restoreEvidenceFilenamePrefix is the basename prefix; full
+	// filename is restoreEvidenceFilenamePrefix + "<UTC-RFC3339-basic>"
+	// + "-" + "<short-random>" + ".json".
+	restoreEvidenceFilenamePrefix = "restore-evidence-"
+
+	// restoreEvidenceMode is the file mode applied to evidence-record
+	// files. 0640 — root-readable + group-readable, no world access.
+	restoreEvidenceMode = 0o640
+
+	// restoreEvidenceDirMode is the directory mode applied to
+	// restoreEvidenceDir on first write.
+	restoreEvidenceDirMode = 0o750
+)
+
+// =============================================================================
+// Schema types — the §48.6 lock
+// =============================================================================
+
+// RestoreEvidenceRecord is the on-disk JSON shape. Schema_version is
+// the gate; consumers reject mismatches.
+type RestoreEvidenceRecord struct {
+	SchemaVersion string                  `json:"schema_version"`
+	TimestampUTC  time.Time               `json:"timestamp_utc"`
+	Mode          string                  `json:"mode"`  // always "restore"
+	Phase         string                  `json:"phase"` // always "post_restore_verify"
+	Target        RestoreEvidenceTarget   `json:"target"`
+	Result        RestoreEvidenceResult   `json:"result"`
+	Verification  RestoreEvidenceVerify   `json:"verification"`
+	HistoryGate   RestoreEvidenceHistory  `json:"history_gate"`
+	Warnings      []string                `json:"warnings,omitempty"`
+}
+
+// RestoreEvidenceTarget records the planner-resolved target identity.
+// Recording-only — never re-derived.
+type RestoreEvidenceTarget struct {
+	Kind         string `json:"kind"`          // "recorded_prior" | "panel_native" | "none"
+	FirewallType string `json:"firewall_type"` // "csf" | "" (empty for non-csf paths under Amendment 1)
+	Panel        string `json:"panel"`         // "directadmin" | "none" | other detect.PanelType
+}
+
+// RestoreEvidenceResult records the §22 terminal + §19.4 exit code.
+type RestoreEvidenceResult struct {
+	State    string `json:"state"`     // state.InstallState string form
+	ExitCode int    `json:"exit_code"` // §19.4 exit code mapped from State
+	Stage    string `json:"stage"`     // execRes.Stage from §23
+	Success  bool   `json:"success"`   // true iff State == StateRestoreExecuted
+}
+
+// RestoreEvidenceVerify records the §21.1 + §32 post-mutation
+// observations. Source values come from execRes.VerifyResult AND
+// from read-only kernel/service queries the dispatcher performs at
+// record time (NftTableExists for emergency + nftban tables;
+// detect.SSHPortWithSource for sshd port + which source yielded it).
+type RestoreEvidenceVerify struct {
+	TargetFirewallActive       bool   `json:"target_firewall_active"`
+	AuthorityClass             string `json:"authority_class"` // from inline-verify CurrentAuthorityClass
+	SafetyNetRemovalSafe       bool   `json:"safety_net_removal_safe"`
+	EmergencyTablePresentAfter bool   `json:"emergency_table_present_after"`
+	NftbanTablesPresentAfter   bool   `json:"nftban_tables_present_after"`
+	SSHPort                    int    `json:"ssh_port"`
+	SSHPortSource              string `json:"ssh_port_source"` // "ss" | "sshd_config" | "state" | "config" | ""
+}
+
+// RestoreEvidenceHistory pins the §19.2 layer-4 invariant in the
+// record itself. Both flags are constant true because main.go:132
+// excludes restore mode; the record makes that pinning machine-
+// auditable.
+type RestoreEvidenceHistory struct {
+	UpdateHistoryUnchanged           bool `json:"update_history_unchanged"`
+	RestoreModeHistoryWriteForbidden bool `json:"restore_mode_history_write_forbidden"`
+}
+
+// =============================================================================
+// Sentinels
+// =============================================================================
+
+var (
+	// ErrEvidenceWriteFailed wraps any underlying mkdir / marshal /
+	// WriteFileAtomic failure. The dispatcher consumes this to
+	// decide whether to downgrade a successful StateRestoreExecuted
+	// terminal to StateRestoreDegraded (per the §48.6 rule:
+	// failure-to-write-evidence after a successful restore is a
+	// degraded outcome, not a clean success).
+	ErrEvidenceWriteFailed = errors.New("restore evidence: write failed")
+
+	// ErrEvidenceNilExecutor / ErrEvidenceNilRecord are defensive
+	// guards on the writer.
+	ErrEvidenceNilExecutor = errors.New("restore evidence: executor is nil")
+	ErrEvidenceNilRecord   = errors.New("restore evidence: record is nil")
+)
+
+// =============================================================================
+// Single-helper writer — the only function authorized to write under
+// restoreEvidenceDir. Per the §46 G4-RESTORE-EVIDENCE-RECORD gate,
+// no other function in this module (or in any other PR-26 production
+// file) may call exec.WriteFileAtomic with a /var/lib/nftban/state/
+// restore-evidence/* literal.
+// =============================================================================
+
+// writeRestoreEvidenceRecord is the SINGLE helper authorized to write
+// a RestoreEvidenceRecord under restoreEvidenceDir. Filename is
+// generated from a UTC RFC3339-basic timestamp + short random hex
+// suffix to keep concurrent writes from colliding.
+//
+// Returns ErrEvidenceWriteFailed wrapping the underlying error on
+// any failure (mkdir / marshal / write).
+//
+// Recording-only: this helper does not consult the host runtime or
+// re-derive anything. It serializes the record the caller already
+// assembled and persists it.
+func writeRestoreEvidenceRecord(
+	_ context.Context,
+	exec executor.Executor,
+	rec *RestoreEvidenceRecord,
+	log *logging.Logger,
+) error {
+	if exec == nil {
+		return ErrEvidenceNilExecutor
+	}
+	if rec == nil {
+		return ErrEvidenceNilRecord
+	}
+
+	if err := exec.MkdirAll(restoreEvidenceDir, restoreEvidenceDirMode); err != nil {
+		return fmt.Errorf("%w: mkdir %s: %v", ErrEvidenceWriteFailed, restoreEvidenceDir, err)
+	}
+
+	body, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%w: marshal: %v", ErrEvidenceWriteFailed, err)
+	}
+	body = append(body, '\n')
+
+	suffix, err := evidenceShortRandom()
+	if err != nil {
+		return fmt.Errorf("%w: random suffix: %v", ErrEvidenceWriteFailed, err)
+	}
+	stamp := rec.TimestampUTC.UTC().Format("20060102T150405Z")
+	abs := restoreEvidenceDir + "/" + restoreEvidenceFilenamePrefix + stamp + "-" + suffix + ".json"
+
+	if err := exec.WriteFileAtomic(abs, body, restoreEvidenceMode); err != nil {
+		return fmt.Errorf("%w: write %s: %v", ErrEvidenceWriteFailed, abs, err)
+	}
+	if log != nil {
+		log.Info("restore evidence: recorded %s (%d bytes, schema_version=%s)",
+			abs, len(body), rec.SchemaVersion)
+	}
+	return nil
+}
+
+// evidenceShortRandom returns 8 hex characters from crypto/rand — used
+// as the per-file random suffix so two evidence writes within the
+// same UTC second do not collide.
+func evidenceShortRandom() (string, error) {
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+// =============================================================================
+// Record assembler — translates dispatcher state into a record.
+// Recording-only: every field is sourced from a value the dispatcher
+// already has + a small set of read-only kernel/service queries.
+// =============================================================================
+
+// buildRestoreEvidenceRecord assembles a RestoreEvidenceRecord from
+// the dispatcher's existing state (target, execRes, panel) and a
+// small set of read-only queries (NftTableExists for the two
+// table families + the emergency table; detect.SSHPortWithSource).
+//
+// Does NOT call uninstall.Probe / restore.Decide / restore.PlanFromDecision /
+// detect.DetectPanel — INV-PR26-VERIFICATION-IS-PROOF-NOT-DECISION.
+func buildRestoreEvidenceRecord(
+	exec executor.Executor,
+	log *logging.Logger,
+	target restore.TargetAuthority,
+	execRes restore.ExecuteResult,
+) *RestoreEvidenceRecord {
+	now := time.Now().UTC()
+
+	rec := &RestoreEvidenceRecord{
+		SchemaVersion: restoreEvidenceSchemaVersion,
+		TimestampUTC:  now,
+		Mode:          "restore",
+		Phase:         "post_restore_verify",
+		Target: RestoreEvidenceTarget{
+			Kind:         string(target.Kind()),
+			FirewallType: target.FirewallType(),
+			Panel:        string(target.Panel()),
+		},
+		Result: RestoreEvidenceResult{
+			State:    string(execRes.Terminal),
+			ExitCode: execRes.Terminal.ExitCode(),
+			Stage:    execRes.Stage,
+			Success:  execRes.Terminal == state.StateRestoreExecuted,
+		},
+		Verification: RestoreEvidenceVerify{
+			TargetFirewallActive: execRes.VerifyResult.TargetFirewallActive,
+			AuthorityClass:       string(execRes.VerifyResult.ObservedAuthority),
+			SafetyNetRemovalSafe: execRes.VerifyResult.SafetyNetRemovalSafe,
+		},
+		HistoryGate: RestoreEvidenceHistory{
+			// §19.2 layer 4 / main.go:132 mode-gate excludes restore
+			// from update-history writes; both flags are constants
+			// pinned by the contract.
+			UpdateHistoryUnchanged:           true,
+			RestoreModeHistoryWriteForbidden: true,
+		},
+	}
+
+	// Post-mutation kernel-table observations. Read-only.
+	if exec != nil {
+		rec.Verification.EmergencyTablePresentAfter = exec.NftTableExists("inet", "nftban_install_emergency")
+		rec.Verification.NftbanTablesPresentAfter =
+			exec.NftTableExists("ip", "nftban") || exec.NftTableExists("ip6", "nftban")
+	}
+
+	// SSH port + source (read-only typed introspection per §51.5-A2).
+	if exec != nil {
+		port, source, err := detect.SSHPortWithSource(exec, log)
+		if err == nil {
+			rec.Verification.SSHPort = port
+			rec.Verification.SSHPortSource = source
+		} else {
+			rec.Warnings = append(rec.Warnings,
+				"ssh port not resolvable at evidence-record time: "+err.Error())
+		}
+	}
+
+	// Surface verify-result classification correctness as an
+	// authority-class warning when CurrentAuthorityClass diverges
+	// from AuthorityExternal (the expected post-mutation class for
+	// csf restore).
+	expected := uninstall.AuthorityExternal
+	if string(execRes.VerifyResult.ObservedAuthority) != "" &&
+		execRes.VerifyResult.ObservedAuthority != expected {
+		rec.Warnings = append(rec.Warnings,
+			fmt.Sprintf("authority-class observed %q diverges from expected %q",
+				execRes.VerifyResult.ObservedAuthority, expected))
+	}
+
+	return rec
+}

--- a/cmd/nftban-installer/restore_evidence_test.go
+++ b/cmd/nftban-installer/restore_evidence_test.go
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MPL-2.0
+// =============================================================================
+// NFTBan v1.100 PR-26-code-D — restore evidence record tests
+// =============================================================================
+// meta:name="nftban-installer-restore-evidence-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="Tests for the post-restore evidence-record writer. Pins §48.6 invariants: writes only under restoreEvidenceDir, single helper enforcement (file-scan), schema_version + required fields populated, no update-history writes, recording-only (no Decide / Probe / DetectPanel calls)."
+// meta:depends="github.com/itcmsgr/nftban/internal/installer/executor,github.com/itcmsgr/nftban/internal/installer/restore"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/restore"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+func newEvidenceTestRecord(now time.Time, terminal state.InstallState, fwt string) *RestoreEvidenceRecord {
+	return &RestoreEvidenceRecord{
+		SchemaVersion: restoreEvidenceSchemaVersion,
+		TimestampUTC:  now,
+		Mode:          "restore",
+		Phase:         "post_restore_verify",
+		Target: RestoreEvidenceTarget{
+			Kind:         string(restore.TargetAuthorityKindRecordedPrior),
+			FirewallType: fwt,
+			Panel:        string(detect.PanelNone),
+		},
+		Result: RestoreEvidenceResult{
+			State:    string(terminal),
+			ExitCode: terminal.ExitCode(),
+			Stage:    "complete",
+			Success:  terminal == state.StateRestoreExecuted,
+		},
+		Verification: RestoreEvidenceVerify{
+			TargetFirewallActive: true,
+			AuthorityClass:       string(uninstall.AuthorityExternal),
+			SafetyNetRemovalSafe: true,
+			SSHPort:              22,
+			SSHPortSource:        "ss",
+		},
+		HistoryGate: RestoreEvidenceHistory{
+			UpdateHistoryUnchanged:           true,
+			RestoreModeHistoryWriteForbidden: true,
+		},
+	}
+}
+
+// =============================================================================
+// Writer tests
+// =============================================================================
+
+func TestWriteRestoreEvidence_HappyPath(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	rec := newEvidenceTestRecord(time.Date(2026, 4, 28, 13, 45, 0, 0, time.UTC),
+		state.StateRestoreExecuted, "csf")
+
+	err := writeRestoreEvidenceRecord(context.Background(), mock, rec, pf4B2TestLogger(t))
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+
+	// Exactly one file written under restoreEvidenceDir.
+	count := 0
+	var path string
+	for k := range mock.WrittenFiles {
+		if strings.HasPrefix(k, restoreEvidenceDir+"/") {
+			count++
+			path = k
+		}
+	}
+	if count != 1 {
+		t.Errorf("evidence file count = %d; want 1", count)
+	}
+	// Filename pattern: prefix + UTC stamp + - + 8-hex + .json.
+	base := filepath.Base(path)
+	if !strings.HasPrefix(base, restoreEvidenceFilenamePrefix) {
+		t.Errorf("filename %q does not start with %q", base, restoreEvidenceFilenamePrefix)
+	}
+	if !strings.HasSuffix(base, ".json") {
+		t.Errorf("filename %q does not end with .json", base)
+	}
+	if !strings.Contains(base, "20260428T134500Z") {
+		t.Errorf("filename %q does not contain expected UTC stamp", base)
+	}
+}
+
+func TestWriteRestoreEvidence_RoundTripsJSON(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	rec := newEvidenceTestRecord(time.Now().UTC(), state.StateRestoreExecuted, "csf")
+
+	if err := writeRestoreEvidenceRecord(context.Background(), mock, rec, pf4B2TestLogger(t)); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	var path string
+	for k := range mock.WrittenFiles {
+		if strings.HasPrefix(k, restoreEvidenceDir+"/") {
+			path = k
+		}
+	}
+	if path == "" {
+		t.Fatal("no evidence file written")
+	}
+
+	var decoded RestoreEvidenceRecord
+	if err := json.Unmarshal(mock.WrittenFiles[path], &decoded); err != nil {
+		t.Fatalf("evidence file does not parse as JSON: %v", err)
+	}
+	if decoded.SchemaVersion != restoreEvidenceSchemaVersion {
+		t.Errorf("schema_version = %q; want %q", decoded.SchemaVersion, restoreEvidenceSchemaVersion)
+	}
+	if decoded.Mode != "restore" {
+		t.Errorf("mode = %q; want %q", decoded.Mode, "restore")
+	}
+	if decoded.Phase != "post_restore_verify" {
+		t.Errorf("phase = %q; want %q", decoded.Phase, "post_restore_verify")
+	}
+	if !decoded.HistoryGate.UpdateHistoryUnchanged || !decoded.HistoryGate.RestoreModeHistoryWriteForbidden {
+		t.Errorf("history_gate flags must both be true; got %+v", decoded.HistoryGate)
+	}
+}
+
+func TestWriteRestoreEvidence_NilExecutor(t *testing.T) {
+	rec := newEvidenceTestRecord(time.Now().UTC(), state.StateRestoreExecuted, "csf")
+	err := writeRestoreEvidenceRecord(context.Background(), nil, rec, nil)
+	if !errors.Is(err, ErrEvidenceNilExecutor) {
+		t.Errorf("err = %v; want ErrEvidenceNilExecutor", err)
+	}
+}
+
+func TestWriteRestoreEvidence_NilRecord(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	err := writeRestoreEvidenceRecord(context.Background(), mock, nil, nil)
+	if !errors.Is(err, ErrEvidenceNilRecord) {
+		t.Errorf("err = %v; want ErrEvidenceNilRecord", err)
+	}
+}
+
+// =============================================================================
+// Single-helper invariant + path containment — file-scan
+// =============================================================================
+
+func TestWriteRestoreEvidence_OnlyHelperWritesUnderEvidenceDir_FileScan(t *testing.T) {
+	body, err := os.ReadFile("restore_evidence.go")
+	if err != nil {
+		t.Fatalf("read restore_evidence.go: %v", err)
+	}
+	src := string(body)
+
+	// Strip line-leading // comments per §46.1 discipline.
+	var prodLines []string
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		prodLines = append(prodLines, line)
+	}
+	prodSrc := strings.Join(prodLines, "\n")
+
+	// The single helper writeRestoreEvidenceRecord MUST be the only
+	// function in this file that calls exec.WriteFileAtomic AND uses
+	// restoreEvidenceDir. Detect both:
+	//   - any WriteFileAtomic call: count must be exactly 1
+	//   - any restoreEvidenceDir reference outside the helper /
+	//     constant declaration must be 0
+	wfa := strings.Count(prodSrc, "WriteFileAtomic(")
+	if wfa != 1 {
+		t.Errorf("WriteFileAtomic( call count in restore_evidence.go = %d; want exactly 1 (the single helper)", wfa)
+	}
+}
+
+func TestWriteRestoreEvidence_NoForbiddenSurfaces_FileScan(t *testing.T) {
+	body, err := os.ReadFile("restore_evidence.go")
+	if err != nil {
+		t.Fatalf("read restore_evidence.go: %v", err)
+	}
+	src := string(body)
+
+	var prodLines []string
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		prodLines = append(prodLines, line)
+	}
+	prodSrc := strings.Join(prodLines, "\n")
+
+	// Recording-only invariant — the evidence module must not call
+	// any decision/redetection API.
+	forbidden := []string{
+		"restore.Decide(",
+		"restore.PlanFromDecision(",
+		"uninstall.Probe(",
+		"detect.DetectPanel(",
+		// History gate: evidence is a SEPARATE artefact from
+		// update-history.json. The evidence module must not write
+		// update-history.json itself.
+		"writeHistory(",
+		"update-history.json",
+		// No mutation primitives allowed (recording is read-only).
+		"ServiceStart(",
+		"ServiceStop(",
+		"ServiceEnable(",
+		"ServiceDisable(",
+		"ServiceMask(",
+		"ServiceUnmask(",
+		"NftDeleteTable(",
+		"NftAddElement(",
+		"DaemonReload(",
+		"Rename(",
+		// Direct OS bypass.
+		"os/exec",
+		"exec.Command(",
+		"os.Rename(",
+		"os.Remove(",
+		"os.WriteFile(",
+		"os.Create(",
+		"syscall.",
+	}
+	for _, pat := range forbidden {
+		if strings.Contains(prodSrc, pat) {
+			t.Errorf("restore_evidence.go references forbidden pattern %q (recording-only invariant)", pat)
+		}
+	}
+}
+
+// =============================================================================
+// Builder — recording-only assembly from existing dispatcher state
+// =============================================================================
+
+func TestBuildRestoreEvidenceRecord_RecordedPriorHappy(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-tlnp"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   "LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=1,fd=3))\n",
+	}
+
+	target, _ := restore.TargetRecordedPrior("csf")
+	execRes := restore.ExecuteResult{
+		Terminal: state.StateRestoreExecuted,
+		Stage:    "complete",
+		VerifyResult: restore.VerifyResult{
+			TargetFirewallActive:  true,
+			AuthorityClassCorrect: true,
+			SafetyNetRemovalSafe:  true,
+			SafeToRemove:          true,
+			ObservedAuthority:     uninstall.AuthorityExternal,
+		},
+	}
+
+	rec := buildRestoreEvidenceRecord(mock, pf4B2TestLogger(t), target, execRes)
+	if rec.SchemaVersion != restoreEvidenceSchemaVersion {
+		t.Errorf("schema_version = %q", rec.SchemaVersion)
+	}
+	if rec.Result.State != string(state.StateRestoreExecuted) {
+		t.Errorf("result.state = %q", rec.Result.State)
+	}
+	if !rec.Result.Success {
+		t.Errorf("result.success = false; want true")
+	}
+	if rec.Result.ExitCode != state.StateRestoreExecuted.ExitCode() {
+		t.Errorf("result.exit_code = %d; want %d", rec.Result.ExitCode, state.StateRestoreExecuted.ExitCode())
+	}
+	if rec.Verification.SSHPort != 22 || rec.Verification.SSHPortSource != "ss" {
+		t.Errorf("verification.ssh_port=%d source=%q; want 22 / ss",
+			rec.Verification.SSHPort, rec.Verification.SSHPortSource)
+	}
+	if !rec.HistoryGate.UpdateHistoryUnchanged || !rec.HistoryGate.RestoreModeHistoryWriteForbidden {
+		t.Errorf("history_gate flags must both be true; got %+v", rec.HistoryGate)
+	}
+}
+
+func TestBuildRestoreEvidenceRecord_NftbanTablesPresent_Recorded(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-tlnp"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   "LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=1,fd=3))\n",
+	}
+	mock.NftTables["ip:nftban"] = true
+
+	target, _ := restore.TargetRecordedPrior("csf")
+	execRes := restore.ExecuteResult{Terminal: state.StateRestoreFailedExecution, Stage: "mutate"}
+
+	rec := buildRestoreEvidenceRecord(mock, pf4B2TestLogger(t), target, execRes)
+	if !rec.Verification.NftbanTablesPresentAfter {
+		t.Errorf("nftban_tables_present_after = false; want true (ip:nftban seeded)")
+	}
+}
+
+func TestBuildRestoreEvidenceRecord_AuthorityClassDivergenceWarning(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-tlnp"] = executor.Result{ExitCode: 0, Stdout: "LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=1,fd=3))\n"}
+
+	target, _ := restore.TargetRecordedPrior("csf")
+	execRes := restore.ExecuteResult{
+		Terminal: state.StateRestoreExecuted,
+		Stage:    "complete",
+		VerifyResult: restore.VerifyResult{
+			ObservedAuthority: uninstall.AuthorityNFTBan, // diverges from expected External
+		},
+	}
+
+	rec := buildRestoreEvidenceRecord(mock, pf4B2TestLogger(t), target, execRes)
+	found := false
+	for _, w := range rec.Warnings {
+		if strings.Contains(w, "authority-class observed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("authority-class divergence not surfaced as warning; got warnings = %v", rec.Warnings)
+	}
+}
+
+// =============================================================================
+// Path constant — pinned to §48.6
+// =============================================================================
+
+func TestRestoreEvidenceConstants_LockPin(t *testing.T) {
+	if restoreEvidenceDir != "/var/lib/nftban/state/restore-evidence" {
+		t.Errorf("restoreEvidenceDir = %q; §48.6 lock requires %q",
+			restoreEvidenceDir, "/var/lib/nftban/state/restore-evidence")
+	}
+	if restoreEvidenceSchemaVersion != "1.0.0" {
+		t.Errorf("restoreEvidenceSchemaVersion = %q; §48.6 lock requires %q",
+			restoreEvidenceSchemaVersion, "1.0.0")
+	}
+	if restoreEvidenceFilenamePrefix != "restore-evidence-" {
+		t.Errorf("restoreEvidenceFilenamePrefix = %q; want %q",
+			restoreEvidenceFilenamePrefix, "restore-evidence-")
+	}
+}

--- a/internal/installer/detect/ssh.go
+++ b/internal/installer/detect/ssh.go
@@ -68,6 +68,38 @@ func SSHPort(exec executor.Executor, log *logging.Logger) (int, error) {
 	return 0, fmt.Errorf("cannot determine SSH port from any source (ss, sshd_config, state file, conf.local)")
 }
 
+// SSHPortWithSource returns the resolved SSH port AND a short string
+// identifying which source yielded it: "ss" / "sshd_config" /
+// "state" / "config" — matching the schema enum required by the
+// PR-26-code-D restore evidence record (§39.1 / §48.6 lock).
+//
+// Same priority chain as SSHPort. Read-only typed introspection;
+// no mutation. Per §51.5-A2 invariant, this is OUTSIDE the bounded
+// mutation surface cap. Added in PR-26-code-D.
+func SSHPortWithSource(exec executor.Executor, log *logging.Logger) (port int, source string, err error) {
+	if p := sshFromListener(exec); p > 0 {
+		log.Detect("ssh", "source", "ss-listener")
+		log.Detect("ssh", "port", strconv.Itoa(p))
+		return p, "ss", nil
+	}
+	if p := sshFromConfig(exec); p > 0 {
+		log.Detect("ssh", "source", "sshd_config")
+		log.Detect("ssh", "port", strconv.Itoa(p))
+		return p, "sshd_config", nil
+	}
+	if p := sshFromStateFile(exec); p > 0 {
+		log.Detect("ssh", "source", "state-file")
+		log.Detect("ssh", "port", strconv.Itoa(p))
+		return p, "state", nil
+	}
+	if p := sshFromConfLocal(exec); p > 0 {
+		log.Detect("ssh", "source", "conf.local")
+		log.Detect("ssh", "port", strconv.Itoa(p))
+		return p, "config", nil
+	}
+	return 0, "", fmt.Errorf("cannot determine SSH port from any source (ss, sshd_config, state file, conf.local)")
+}
+
 // portRe matches a trailing port number after a colon.
 var portRe = regexp.MustCompile(`:(\d+)\s*$`)
 


### PR DESCRIPTION
## PR-26-code-D adds post-restore evidence recording

After every `--mode=restore` execution, the dispatcher writes a structured JSON evidence record under `/var/lib/nftban/state/restore-evidence/` so the post-mutation state is captured truthfully and machine-auditably without consulting private memory or live host introspection.

## Key guarantees

- **Single evidence writer helper** — `writeRestoreEvidenceRecord(ctx, exec, record, log)`. Exactly one `WriteFileAtomic` call in `restore_evidence.go`; structurally enforced by `G4-RESTORE-EVIDENCE-RECORD`.
- **Evidence path locked** to `/var/lib/nftban/state/restore-evidence/` via the `restoreEvidenceDir` named constant. No write outside this directory is permitted.
- **Schema version `"1.0.0"`** pinned by `restoreEvidenceSchemaVersion`. Filename: `restore-evidence-<UTC-RFC3339-basic>-<short-random-hex>.json`.
- **No `update-history.json` writes.** §19.2 layer-4 invariant retained — `main.go:132` mode-gate untouched. File-scan test `TestDispatcher_PR26D_NoUpdateHistoryWrite_FileScan` pins this.
- **No decision re-entry.** Recording-only invariant (operator design call): no `restore.Decide`, no `restore.PlanFromDecision`, no `uninstall.Probe`, no `detect.DetectPanel`. Structurally enforced by both the file-scan test and `G4-RESTORE-EVIDENCE-RECORD`.
- **No validator / module-health sweep.** Evidence is recorded from values the dispatcher already has (target / execRes / VerifyResult) plus a small set of read-only kernel/service queries (`NftTableExists`, `detect.SSHPortWithSource`).
- **Evidence write failure after `StateRestoreExecuted` downgrades to `StateRestoreDegraded`.** The state model already supports `StateRestoreDegraded` (no machine change). Successful restore that cannot be recorded is success-with-warnings, not clean success. Pinned by `TestRunRestoreExecutionFromProceed_PR26D_ExecutedPlusEvidenceFail_DowngradesToDegraded`.
- **Evidence write failure after non-success restore terminals is warning-only.** `StateRestoreFailedExecution` and `StateRestoreFailedVerification` terminals are preserved unchanged; evidence failure is logged but does not alter the outcome. Pinned by tests #2 and #3 of the dispatcher semantics suite.
- **`G4-RESTORE-EVIDENCE-RECORD` structural gate added** (§46). Pins the named-constant + single-helper invariant + recording-only forbidden-symbol scan + dispatcher-consumption check.

## Authority

- PR #512 / `contract.md` Part IV §§37–50
- PR #513 / §51 lock record
- PR #514 / code-A merge `4e98ff56`
- PR #515 / code-B merge `45fc63ef`
- PR #516 / code-C merge `6d8386d8`
- §39 Q1 BLOCKING evidence rows (target FW active / authority class / SSH protection / kernel-table presence / history unchanged / terminal correct)
- §39.3 evidence-record file requirement
- §46 CI gate requirements
- **§48.6 (operator-locked at code-D entry):**
  - path: `/var/lib/nftban/state/restore-evidence/`
  - filename: `restore-evidence-<UTC-RFC3339-basic>-<short-random>.json`
  - schema: `"1.0.0"`
  - writer helper: `writeRestoreEvidenceRecord(ctx, exec, record)`
  - path constant: `restoreEvidenceDir`
- §51.5-A2 (read-only typed introspection outside the bounded mutation cap — covers `detect.SSHPortWithSource`)

## Behavior delta

| Outcome | Before (PR-26-code-C) | After (PR-26-code-D) |
|---|---|---|
| `StateRestoreExecuted` + clean write | terminal preserved | terminal preserved + evidence file written |
| `StateRestoreExecuted` + write failure | terminal preserved (no evidence) | **downgraded to `StateRestoreDegraded`** with warning |
| `StateRestoreFailedExecution` + any write outcome | terminal preserved | terminal preserved (evidence failure warning-only) |
| `StateRestoreFailedVerification` + any write outcome | terminal preserved | terminal preserved (evidence failure warning-only) |
| `update-history.json` | unchanged for restore mode | unchanged for restore mode (file-scan-pinned) |

## Schema (§48.6 lock)

```json
{
  "schema_version": "1.0.0",
  "timestamp_utc": "2026-04-28T13:45:00Z",
  "mode": "restore",
  "phase": "post_restore_verify",
  "target": { "kind": "...", "firewall_type": "csf", "panel": "..." },
  "result": { "state": "...", "exit_code": 7, "stage": "...", "success": true },
  "verification": {
    "target_firewall_active": true,
    "authority_class": "external",
    "safety_net_removal_safe": true,
    "emergency_table_present_after": false,
    "nftban_tables_present_after": false,
    "ssh_port": 22,
    "ssh_port_source": "ss"
  },
  "history_gate": {
    "update_history_unchanged": true,
    "restore_mode_history_write_forbidden": true
  },
  "warnings": ["…"]
}
```

## Files changed (6)

- **NEW** `cmd/nftban-installer/restore_evidence.go` — schema types + sentinels + single-helper writer + recording-only assembler
- **NEW** `cmd/nftban-installer/restore_evidence_test.go` — 10 writer/builder/lock-pin tests
- `internal/installer/detect/ssh.go` — read-only `SSHPortWithSource` helper (§51.5-A2)
- `cmd/nftban-installer/restore_decide.go` — Step D added (build → write → downgrade-on-failure-after-Executed)
- `cmd/nftban-installer/restore_decide_test.go` — 5 existing dispatcher tests updated to inject `MockExecutor`; 5 new `PR26D_*` dispatcher semantics tests added
- `.github/workflows/ci-restore-canonization.yml` — new `G4-RESTORE-EVIDENCE-RECORD` structural gate

## Out of scope (and untouched)

- Destructive real-host CSF soak (PR-26-code-E)
- A.4 cron changes (already shipped in code-C)
- Executor new mutation methods (Stat is read-only, scoped to this PR)
- `IptablesRuleExists` / iptables introspection (Option B lock)
- `main.go` history gate / state-machine / exit codes
- Restore planner / `TargetAuthority` / PR-24 lattice
- `contract.md`
- Repo hygiene / UX / GOTH / metrics / module cleanup

## Lab2 verification (head `8b713085`)

- `go build ./...` clean
- `go test ./...` PASS (full repo, 64 packages)
- `go test -race -count=1` cmd + restore + state + switchop + detect PASS
- `go vet ./...` clean
- `go mod tidy` no-op
- 10 evidence-module tests + 5 dispatcher semantics tests = 15 new PR-26-code-D tests, all PASS
- All 3 G4 gates (`NO-OUT-OF-TARGET` + `CRON-MANIFEST-INTEGRITY` + `EVIDENCE-RECORD`) local replay: `FAIL=0`

## Test plan

- [ ] `Restore Canonization Gate` matrix (ubuntu-24.04 + almalinux-9 + summary) green
- [ ] `G4-RESTORE-EXEC-NO-OUT-OF-TARGET` green
- [ ] `G4-RESTORE-CRON-MANIFEST-INTEGRITY` green
- [ ] `G4-RESTORE-EVIDENCE-RECORD` (NEW) green
- [ ] `G4-RESTORE-NO-IMPLICIT-EXEC` green
- [ ] `Architecture Policy / Policy Gates` green
- [ ] `Go Build & Test` + race + full DEB+RPM matrix + CodeQL / Semgrep / Secure Go / OSV / Gitleaks / GitGuardian green
- [ ] `ShellCheck` / `Bash Validation` / `Docs Quality` green

**No extra labs needed for code-D — GitHub CI carries the matrix; audit any failures before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)