### PR TITLE
feat(v1.100 Amendment 2): code-A — G1/AuthorityNFTBan split + §54 evidence predicate

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -58,6 +58,16 @@ type config struct {
 	// behind an explicit default-off flag. Operators that relied on the
 	// prior behaviour must now pass --panel-auto-takeover.
 	panelAutoTakeover bool // --panel-auto-takeover: allow panel presence to auto-approve takeover (default OFF)
+	// v1.100 Amendment 2: --accept-orphan-nftban — explicit operator
+	// intent for the narrow restore-from-orphan-NFTBan-on-DirectAdmin
+	// path (contract.md §52–61). MUST be CLI argv only — no env-var
+	// fallback, no config-file key, no implicit default. Activates the
+	// G1/AuthorityNFTBan split's orphan-intent candidate row only when
+	// combined with --panel-auto-takeover, Panel=DirectAdmin,
+	// Authority=AuthorityNFTBan, Prior=NoRecord, and ALL §54.1
+	// evidence rows true. Standalone or under any other classifier the
+	// flag has zero effect — REFUSE remains.
+	acceptOrphanNFTBan bool // --accept-orphan-nftban: explicit-intent CSF restore from orphan NFTBan on DirectAdmin (Amendment 2)
 	// v1.100 PR-23: --confirm-mutation replaces the PR-22 auto-elevate
 	// shim. --mode=uninstall now requires exactly one of:
 	//   --dry-run          (observational plan)
@@ -97,6 +107,10 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.restorePriorAuthority, "restore-prior-authority", false, "Restore pre-install external firewall authority. Requires recorded prior-authority record. Plan-only in PR-22.")
 	// v1.100 PR-22B: explicit panel-auto-takeover gate (see config field doc).
 	flag.BoolVar(&cfg.panelAutoTakeover, "panel-auto-takeover", false, "Allow control-panel presence to auto-approve takeover of conflicting firewalls. Default OFF. Set explicitly to preserve pre-PR-22B behaviour.")
+	// v1.100 Amendment 2: --accept-orphan-nftban — explicit-intent
+	// orphan restore. CLI argv only; no env mirror; help text MUST NOT
+	// include "force" or "override" (Amendment 2 §55).
+	flag.BoolVar(&cfg.acceptOrphanNFTBan, "accept-orphan-nftban", false, "Explicit-intent CSF restore on a DirectAdmin host where NFTBan is the current authority and no prior-authority record exists. Requires --mode=restore AND --panel-auto-takeover AND DirectAdmin AND on-disk evidence that NFTBan previously took over from CSF. Without all preconditions the restore refuses (Amendment 2).")
 	// v1.100 PR-23: --confirm-mutation — explicit uninstall mutation entry.
 	flag.BoolVar(&cfg.confirmMutation, "confirm-mutation", false, "Authorize uninstall authority release (real kernel + service mutation). Required for --mode=uninstall without --dry-run. Mutually exclusive with --dry-run.")
 
@@ -161,6 +175,11 @@ func parseFlags() *config {
 				fmt.Fprintln(os.Stderr, "       --mode=restore invokes the PR-24 decision engine; it performs NO mutation.")
 				os.Exit(state.ExitFatal)
 			}
+			// Amendment 2 §55 — `--accept-orphan-nftban` is a
+			// restore-mode-only flag. Reject early in any other mode.
+			// (`cfg.mode == "restore"` here, but ANY mode other than
+			// restore that received the flag must refuse before the
+			// fall-through return below.)
 			if cfg.dryRun {
 				fmt.Fprintln(os.Stderr, "error: --dry-run is not valid with --mode=restore")
 				fmt.Fprintln(os.Stderr, "       --mode=restore is ALWAYS pure policy decision — no mutation path exists.")
@@ -267,6 +286,14 @@ func parseFlags() *config {
 	// nonsense interaction with install/upgrade takeover semantics.
 	if cfg.confirmMutation && cfg.mode != "uninstall" {
 		fmt.Fprintln(os.Stderr, "error: --confirm-mutation is only valid with --mode=uninstall")
+		os.Exit(state.ExitFatal)
+	}
+
+	// Amendment 2 §55: --accept-orphan-nftban is restore-mode only.
+	// Reject explicitly so operators don't get a silent no-op in
+	// install / upgrade / uninstall.
+	if cfg.acceptOrphanNFTBan && cfg.mode != "restore" {
+		fmt.Fprintln(os.Stderr, "error: --accept-orphan-nftban is only valid with --mode=restore")
 		os.Exit(state.ExitFatal)
 	}
 

--- a/cmd/nftban-installer/restore_decide.go
+++ b/cmd/nftban-installer/restore_decide.go
@@ -128,10 +128,28 @@ func runRestoreDecide(ctx context.Context, exec executor.Executor, sf *state.Sta
 		Ambiguity: auth.Ambiguity,
 		Prior:     priorState,
 		Flags: restore.Flags{
-			Restore:           cfg.restorePriorAuthority,
-			PanelAutoTakeover: cfg.panelAutoTakeover,
+			Restore:            cfg.restorePriorAuthority,
+			PanelAutoTakeover:  cfg.panelAutoTakeover,
+			AcceptOrphanNFTBan: cfg.acceptOrphanNFTBan,
 		},
 		PanelPresent: panelPresent,
+		Panel:        panel,
+	}
+
+	// 6b. Amendment 2 §54.3: gather orphan-restore evidence ONLY when
+	// the candidate triple is otherwise present. This avoids
+	// unnecessary live reads on every restore-mode invocation, and
+	// preserves the §51.3 Option B boundary (no iptables introspection)
+	// by only running the predicate where it matters.
+	if auth.State == uninstall.AuthorityNFTBan &&
+		priorState == restore.PriorStateNoRecord &&
+		panel == detect.PanelDirectAdmin &&
+		cfg.panelAutoTakeover &&
+		cfg.acceptOrphanNFTBan {
+		ev := gatherOrphanEvidence(exec, log, panel, auth, probe, cfg)
+		input.OrphanEvidence = &ev
+		log.Info("restore decide: orphan-evidence gathered all_true=%v failed_row=%q",
+			ev.AllTrue(), ev.FailedRowID())
 	}
 
 	// 7. Evaluate — pure, deterministic, no side effects.

--- a/cmd/nftban-installer/restore_decide_evidence.go
+++ b/cmd/nftban-installer/restore_decide_evidence.go
@@ -1,0 +1,160 @@
+// =============================================================================
+// NFTBan v1.100 Amendment 2 — Orphan-NFTBan restore evidence reader
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-restore-decide-evidence"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="§54.1 read-only evidence predicate for the G1 orphan-intent split"
+// meta:inventory.files="cmd/nftban-installer/restore_decide_evidence.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Amendment 2 (contract.md §§52–61) defines a 13-row evidence predicate
+// (§54.1) that gates the G1/AuthorityNFTBan/OrphanProceed sub-rule. This
+// file implements the predicate as a pure read-only reader against the
+// live host state.
+//
+// Discipline:
+//   - Read-only only. NO mutating systemctl verbs (start/stop/enable/
+//     disable/mask/unmask/restart/daemon-reload). NO file writes. NO
+//     nft mutation. NO iptables introspection (preserves §51.3 Option B).
+//   - Read failures map to false on the failing row, NOT to
+//     REQUIRE_EXPLICIT_INTENT (§54.2 final bullet).
+//   - Caller (`runRestoreDecide`) invokes this only when the candidate
+//     triple is present, to avoid unnecessary live reads.
+//
+// =============================================================================
+package main
+
+import (
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/restore"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+const (
+	csfServiceUnitForEvidence = "csf.service"
+	nftbandServiceUnit        = "nftband.service"
+	csfBinaryPath             = "/usr/sbin/csf"
+	csfDisabledBinaryPath     = "/usr/sbin/csf.disabled"
+)
+
+// gatherOrphanEvidence reads the 13 §54.1 rows from the live host
+// using only read-only executor surfaces. Returns a populated
+// restore.OrphanEvidence struct; AllTrue() reports whether every row
+// holds.
+//
+// Rows E.1, E.2, E.3, E.4, E.5 are derived from inputs the dispatcher
+// already gathered (`detect.DetectPanel`, `uninstall.Classify`,
+// `uninstall.Probe`, CLI flags). Rows E.6–E.13 are read from the
+// kernel/service/file surfaces.
+func gatherOrphanEvidence(
+	exec executor.Executor,
+	log *logging.Logger,
+	panel detect.PanelType,
+	auth *uninstall.ClassifyResult,
+	probe *uninstall.ProbeResult,
+	cfg *config,
+) restore.OrphanEvidence {
+	ev := restore.OrphanEvidence{}
+
+	// E.1 panel = DirectAdmin
+	ev.E1PanelDirectAdmin = panel == detect.PanelDirectAdmin
+
+	// E.2 authority = AuthorityNFTBan
+	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityNFTBan
+
+	// E.3 prior = NoRecord
+	ev.E3PriorNoRecord = probe.State == uninstall.PriorNoRecord
+
+	// E.4 --panel-auto-takeover present
+	ev.E4PanelAutoTakeover = cfg.panelAutoTakeover
+
+	// E.5 --accept-orphan-nftban present (CLI argv only — env-var
+	// fallback is rejected at flag-parse time per §55).
+	ev.E5AcceptOrphanNFTBan = cfg.acceptOrphanNFTBan
+
+	// E.6 csf.service exists AND not active AND is-enabled in {masked, disabled}.
+	// Three sub-checks. Any failure → E6 false.
+	ev.E6CSFServiceDisabled = csfServiceIsDisabledOrMasked(exec, log)
+
+	// E.7 /usr/sbin/csf.disabled exists
+	ev.E7CSFDisabledExists = exec.FileExists(csfDisabledBinaryPath)
+
+	// E.8 /usr/sbin/csf does NOT exist
+	ev.E8CSFAbsent = !exec.FileExists(csfBinaryPath)
+
+	// E.9 ip:nftban table present
+	ev.E9NftIPNftbanPresent = exec.NftTableExists("ip", "nftban")
+
+	// E.10 ip6:nftban table present
+	ev.E10NftIP6NftbanPres = exec.NftTableExists("ip6", "nftban")
+
+	// E.11 nftband.service active
+	ev.E11NftbandActive = exec.ServiceActive(nftbandServiceUnit)
+
+	// E.12 no AuthorityExternal / no AmbiguityConflictExternal.
+	// Classifier output already established AuthorityNFTBan (caller),
+	// so this is implicit; recorded explicitly per §54.1 to avoid
+	// inferential gaps.
+	ev.E12NoConflictExternal = auth.State != uninstall.AuthorityExternal &&
+		auth.Ambiguity != uninstall.AmbiguityConflictExternal
+
+	// E.13 no Ambiguous classification
+	ev.E13NoAmbiguous = auth.State != uninstall.AuthorityAmbiguous
+
+	return ev
+}
+
+// csfServiceIsDisabledOrMasked returns true iff csf.service:
+//   - exists (systemctl status is parseable, not "could not be found")
+//   - is NOT active (is-active returns "inactive" or "failed")
+//   - is-enabled is one of {"masked", "disabled"}; "enabled" or
+//     "static" or anything else returns false.
+//
+// Routes through the executor's Run abstraction for read-only
+// systemctl probes (§43.3 — raw Run permitted in restore deps for
+// read-only probes only). NO mutating systemctl verb is invoked.
+func csfServiceIsDisabledOrMasked(exec executor.Executor, log *logging.Logger) bool {
+	// Sub-check 1: existence via `systemctl status csf.service`.
+	statusRes := exec.Run("systemctl", "status", "--no-pager", "--lines=0", csfServiceUnitForEvidence)
+	combined := statusRes.Stdout + statusRes.Stderr
+	if strings.Contains(combined, "could not be found") || strings.Contains(combined, "not-found") {
+		log.Info("amd2-evidence: E.6 csf.service not present on host")
+		return false
+	}
+
+	// Sub-check 2: must NOT be active. Use the typed read-only seam.
+	if exec.ServiceActive(csfServiceUnitForEvidence) {
+		log.Info("amd2-evidence: E.6 csf.service is active — orphan precondition violated")
+		return false
+	}
+
+	// Sub-check 3: is-enabled must be in {masked, disabled}. Reject
+	// {enabled, static, anything else}. Forbidden values:
+	//   - "enabled"  — csf would return at next boot
+	//   - "static"   — csf has no install dependency relations; would
+	//                  re-arm via Wants= at boot
+	enabledRes := exec.Run("systemctl", "is-enabled", csfServiceUnitForEvidence)
+	enabledState := strings.TrimSpace(enabledRes.Stdout)
+	switch enabledState {
+	case "masked", "disabled":
+		// Acceptable. (masked = strongest, matches install-time
+		// switchop.DisableConflicts; disabled = acceptable fallback.)
+		return true
+	default:
+		log.Info("amd2-evidence: E.6 csf.service is-enabled=%q (forbidden; want masked or disabled)", enabledState)
+		return false
+	}
+}

--- a/cmd/nftban-installer/restore_decide_evidence_helper_test.go
+++ b/cmd/nftban-installer/restore_decide_evidence_helper_test.go
@@ -1,0 +1,26 @@
+// =============================================================================
+// NFTBan v1.100 Amendment 2 — Test helper: read source files for invariants
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-restore-decide-evidence-test-helper"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="Filesystem reader for source-scan invariants (§56.3 / §56.4)"
+// meta:inventory.files="cmd/nftban-installer/restore_decide_evidence_test_helper.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package main
+
+import "os"
+
+// readFileImpl reads a file path relative to the test working
+// directory. Used by the Amendment 2 source-scan invariant tests.
+func readFileImpl(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/cmd/nftban-installer/restore_decide_evidence_test.go
+++ b/cmd/nftban-installer/restore_decide_evidence_test.go
@@ -1,0 +1,274 @@
+// =============================================================================
+// NFTBan v1.100 Amendment 2 — Evidence reader unit tests (§56.5)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-restore-decide-evidence-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="Per-row coverage for gatherOrphanEvidence + dispatcher integration"
+// meta:inventory.files="cmd/nftban-installer/restore_decide_evidence_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package main
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+// happyExec returns a MockExecutor pre-seeded so every §54.1 row holds.
+func happyExec() *executor.MockExecutor {
+	exec := executor.NewMockExecutor()
+	// E.6: csf.service exists, not active, is-enabled=masked.
+	exec.Services["csf.service"] = false // inactive
+	exec.RunResults["systemctl:status:--no-pager:--lines=0:csf.service"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   "● csf.service\n     Loaded: masked (Reason: Unit csf.service is masked.)\n     Active: inactive (dead)\n",
+	}
+	exec.RunResults["systemctl:is-enabled:csf.service"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   "masked\n",
+	}
+	// E.7: /usr/sbin/csf.disabled exists.
+	exec.Files["/usr/sbin/csf.disabled"] = []byte("dummy-binary")
+	// E.8: /usr/sbin/csf absent — ensured by not putting it in Files.
+	// E.9, E.10: nft tables present.
+	exec.NftTables["ip:nftban"] = true
+	exec.NftTables["ip6:nftban"] = true
+	// E.11: nftband.service active.
+	exec.Services["nftband.service"] = true
+	return exec
+}
+
+func happyAuth() *uninstall.ClassifyResult {
+	return &uninstall.ClassifyResult{
+		State:     uninstall.AuthorityNFTBan,
+		Ambiguity: uninstall.AmbiguityNone,
+	}
+}
+
+func happyProbe() *uninstall.ProbeResult {
+	return &uninstall.ProbeResult{State: uninstall.PriorNoRecord}
+}
+
+func happyCfg() *config {
+	return &config{
+		mode:               "restore",
+		panelAutoTakeover:  true,
+		acceptOrphanNFTBan: true,
+	}
+}
+
+// TestGatherOrphanEvidence_AllTrue confirms the happy-path returns
+// every row true.
+func TestGatherOrphanEvidence_AllTrue(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, happyAuth(), happyProbe(), happyCfg())
+	if !ev.AllTrue() {
+		t.Errorf("AllTrue=false; failed row=%s", ev.FailedRowID())
+	}
+}
+
+// TestGatherOrphanEvidence_PerRowFailure confirms each row fails
+// independently when its precondition is removed. This is §56.5 row
+// coverage.
+func TestGatherOrphanEvidence_PerRowFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*executor.MockExecutor, *uninstall.ClassifyResult, *uninstall.ProbeResult, *config, *detect.PanelType)
+		wantFail string
+	}{
+		{
+			name: "E1_panel_not_directadmin",
+			mutate: func(_ *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, p *detect.PanelType) {
+				*p = detect.PanelCPanel
+			},
+			wantFail: "AMD2-E.1",
+		},
+		{
+			name: "E2_authority_not_nftban",
+			mutate: func(_ *executor.MockExecutor, a *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				a.State = uninstall.AuthorityNone
+			},
+			wantFail: "AMD2-E.2",
+		},
+		{
+			name: "E3_prior_not_norecord",
+			mutate: func(_ *executor.MockExecutor, _ *uninstall.ClassifyResult, p *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				p.State = uninstall.PriorRecordIncomplete
+			},
+			wantFail: "AMD2-E.3",
+		},
+		{
+			name: "E4_panel_auto_off",
+			mutate: func(_ *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, c *config, _ *detect.PanelType) {
+				c.panelAutoTakeover = false
+			},
+			wantFail: "AMD2-E.4",
+		},
+		{
+			name: "E5_orphan_flag_off",
+			mutate: func(_ *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, c *config, _ *detect.PanelType) {
+				c.acceptOrphanNFTBan = false
+			},
+			wantFail: "AMD2-E.5",
+		},
+		{
+			name: "E6_csf_active",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.Services["csf.service"] = true
+			},
+			wantFail: "AMD2-E.6",
+		},
+		{
+			name: "E6_csf_not_found",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.RunResults["systemctl:status:--no-pager:--lines=0:csf.service"] = executor.Result{
+					ExitCode: 4,
+					Stderr:   "Unit csf.service could not be found.\n",
+				}
+			},
+			wantFail: "AMD2-E.6",
+		},
+		{
+			name: "E6_csf_enabled_forbidden",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.RunResults["systemctl:is-enabled:csf.service"] = executor.Result{
+					ExitCode: 0,
+					Stdout:   "enabled\n",
+				}
+			},
+			wantFail: "AMD2-E.6",
+		},
+		{
+			name: "E6_csf_static_forbidden",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.RunResults["systemctl:is-enabled:csf.service"] = executor.Result{
+					ExitCode: 0,
+					Stdout:   "static\n",
+				}
+			},
+			wantFail: "AMD2-E.6",
+		},
+		{
+			name: "E6_csf_disabled_acceptable_fallback",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.RunResults["systemctl:is-enabled:csf.service"] = executor.Result{
+					ExitCode: 1, // systemctl exits non-zero for "disabled" but we only read stdout
+					Stdout:   "disabled\n",
+				}
+			},
+			wantFail: "", // disabled is acceptable fallback per AMD2-E.6
+		},
+		{
+			name: "E7_csf_disabled_absent",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				delete(e.Files, "/usr/sbin/csf.disabled")
+			},
+			wantFail: "AMD2-E.7",
+		},
+		{
+			name: "E8_csf_present",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.Files["/usr/sbin/csf"] = []byte("dummy")
+			},
+			wantFail: "AMD2-E.8",
+		},
+		{
+			name: "E9_ip_nftban_absent",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.NftTables["ip:nftban"] = false
+			},
+			wantFail: "AMD2-E.9",
+		},
+		{
+			name: "E10_ip6_nftban_absent",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.NftTables["ip6:nftban"] = false
+			},
+			wantFail: "AMD2-E.10",
+		},
+		{
+			name: "E11_nftband_inactive",
+			mutate: func(e *executor.MockExecutor, _ *uninstall.ClassifyResult, _ *uninstall.ProbeResult, _ *config, _ *detect.PanelType) {
+				e.Services["nftband.service"] = false
+			},
+			wantFail: "AMD2-E.11",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := happyExec()
+			auth := happyAuth()
+			probe := happyProbe()
+			cfg := happyCfg()
+			panel := detect.PanelDirectAdmin
+			tc.mutate(exec, auth, probe, cfg, &panel)
+			log := logging.New("/dev/null", false)
+			ev := gatherOrphanEvidence(exec, log, panel, auth, probe, cfg)
+			got := ev.FailedRowID()
+			if got != tc.wantFail {
+				t.Errorf("FailedRowID = %q, want %q (AllTrue=%v)", got, tc.wantFail, ev.AllTrue())
+			}
+		})
+	}
+}
+
+// TestAcceptOrphanNFTBan_NoEnvVarFallback (Amendment 2 §55, §56.1 row 20):
+// the dispatcher uses cfg.acceptOrphanNFTBan exclusively. Even if the
+// env var NFTBAN_ACCEPT_ORPHAN is set, the engine sees
+// AcceptOrphanNFTBan=false unless the CLI parser explicitly set it.
+//
+// This test is structural: it asserts that the flags.go source does
+// NOT contain any os.Getenv path that mirrors NFTBAN_ACCEPT_ORPHAN
+// onto cfg.acceptOrphanNFTBan.
+func TestAcceptOrphanNFTBan_NoEnvVarFallback(t *testing.T) {
+	const forbidden = "NFTBAN_ACCEPT_ORPHAN"
+	data, err := readFileBytes("flags.go")
+	if err != nil {
+		t.Fatalf("read flags.go: %v", err)
+	}
+	if contains(data, forbidden) {
+		t.Errorf("Amendment 2 §55: flags.go contains forbidden env-var %q (CLI argv only)", forbidden)
+	}
+	// Defensive: also assert no env-var path in restore_decide.go.
+	data2, err := readFileBytes("restore_decide.go")
+	if err == nil {
+		if contains(data2, forbidden) {
+			t.Errorf("Amendment 2 §55: restore_decide.go contains forbidden env-var %q", forbidden)
+		}
+	}
+}
+
+// readFileBytes is a tiny helper kept inline to avoid pulling in
+// os/ioutil at top of file.
+func readFileBytes(path string) ([]byte, error) {
+	return readFileImpl(path)
+}
+
+// contains is a substring check. Plain bytes.Contains-like behavior.
+func contains(haystack []byte, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/installer/restore/engine.go
+++ b/internal/installer/restore/engine.go
@@ -33,7 +33,10 @@
 // =============================================================================
 package restore
 
-import "github.com/itcmsgr/nftban/internal/installer/uninstall"
+import (
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
 
 // Rule identifiers. Stable strings; fixtures and CI gates assert on
 // these. Keep in sync with seed §6 group numbering.
@@ -42,6 +45,12 @@ const (
 	RuleG1AuthorityNFTBan          = "G1/AuthorityNFTBan"
 	RuleG1AuthorityExternal        = "G1/AuthorityExternal"
 	RuleG1AmbiguityConflictExt     = "G1/AmbiguityConflictExternal"
+
+	// Group 1 — Amendment 2 split sub-rules (§53). These live ENTIRELY
+	// within Group 1; no later group ever defeats a Group 1 outcome.
+	RuleG1NFTBanDefault       = "G1/AuthorityNFTBan/default"
+	RuleG1NFTBanOrphanProceed = "G1/AuthorityNFTBan/OrphanProceed"
+	RuleG1EvidenceMismatch    = "G1/EvidenceMismatch"
 
 	// Group 2 — input/flag validity
 	RuleG2PanelAutoWithoutPanel    = "G2/PanelAutoTakeoverWithoutPanel"
@@ -93,11 +102,7 @@ func Decide(in DecisionInput) DecisionResult {
 
 	switch in.Authority {
 	case uninstall.AuthorityNFTBan:
-		return DecisionResult{
-			Output: OutputRefuse,
-			Rule:   RuleG1AuthorityNFTBan,
-			Reason: "nftban is already authoritative on this host; no restore needed",
-		}
+		return decideAuthorityNFTBan(in)
 	case uninstall.AuthorityExternal:
 		return DecisionResult{
 			Output: OutputRefuse,
@@ -317,4 +322,95 @@ func decideAmbiguityOrphan(in DecisionInput) DecisionResult {
 	}
 
 	panic("restore.decideAmbiguityOrphan: unhandled PriorState — contract regression")
+}
+
+// decideAuthorityNFTBan implements Amendment 2 §53 Group 1 split for
+// Authority=AuthorityNFTBan. The split is ENTIRELY within Group 1; no
+// later group ever defeats a Group 1 outcome. §5 precedence holds.
+//
+// Evaluation order (§53.2):
+//
+//  1. Pre-condition triple check — only the specific combination
+//     `Prior=NoRecord + Panel=DirectAdmin + PanelAutoTakeover +
+//     AcceptOrphanNFTBan` (and Group 2 not interfering) is the
+//     "orphan-intent candidate". Any other combination → REFUSE
+//     with `G1/AuthorityNFTBan/default`.
+//  2. §54 evidence predicate evaluation — if all 13 rows hold,
+//     PROCEED with `G1/AuthorityNFTBan/OrphanProceed`. If any row
+//     is false, REFUSE with `G1/EvidenceMismatch` (NOT
+//     REQUIRE_EXPLICIT_INTENT — see §54.2).
+//
+// Group 2 precedence preserved: `--restore-prior-authority +
+// --panel-auto-takeover` (both set) emits `G2/RestoreAndPanelAutoBothSet`;
+// `--panel-auto-takeover` with `PanelPresent=false` emits
+// `G2/PanelAutoTakeoverWithoutPanel`. Both Group 2 rules win over
+// the Amendment 2 split because they're checked here before the
+// candidate-triple delegation, in that exact precedence order.
+//
+// All other AuthorityNFTBan flag patterns (no flags, only Restore,
+// only PanelAutoTakeover, AcceptOrphanNFTBan without PanelAutoTakeover,
+// Panel != DirectAdmin, Prior != NoRecord, etc.) emit
+// `G1/AuthorityNFTBan/default` REFUSE — the Amendment 2 split's
+// "default" sub-rule that preserves the original PR-24 G1 semantics.
+func decideAuthorityNFTBan(in DecisionInput) DecisionResult {
+	// Group 2 precedence: both flags set is an input-validity REFUSE.
+	// Pinned by Amendment 2 §56.1 row 19.
+	if in.Flags.Restore && in.Flags.PanelAutoTakeover {
+		return DecisionResult{
+			Output: OutputRefuse,
+			Rule:   RuleG2BothRestoreFlags,
+			Reason: "--restore-prior-authority and --panel-auto-takeover are mutually exclusive; pick one",
+		}
+	}
+
+	// Group 2 precedence: panel-auto without a panel is an input-
+	// validity REFUSE. Pinned by Amendment 2 §56.1 row 4.
+	if in.Flags.PanelAutoTakeover && !in.PanelPresent {
+		return DecisionResult{
+			Output: OutputRefuse,
+			Rule:   RuleG2PanelAutoWithoutPanel,
+			Reason: "--panel-auto-takeover requires a control panel on the host; none detected",
+		}
+	}
+
+	// Candidate-triple check for the Amendment 2 orphan-intent path.
+	// Every condition must hold, else fall through to the default
+	// REFUSE. The triple is composite: classifier already established
+	// AuthorityNFTBan (caller); we additionally require
+	// Prior=NoRecord, Panel=DirectAdmin, --panel-auto-takeover, and
+	// --accept-orphan-nftban.
+	triplePresent := in.Prior == PriorStateNoRecord &&
+		in.Panel == detect.PanelDirectAdmin &&
+		in.Flags.PanelAutoTakeover &&
+		in.Flags.AcceptOrphanNFTBan
+
+	if !triplePresent {
+		return DecisionResult{
+			Output: OutputRefuse,
+			Rule:   RuleG1NFTBanDefault,
+			Reason: "nftban is already authoritative on this host; no restore needed (default G1 hard-stop)",
+		}
+	}
+
+	// Triple present — delegate to the §54 evidence predicate. The
+	// dispatcher MUST have populated in.OrphanEvidence; nil is treated
+	// as "evidence not gathered" → REFUSE/EvidenceMismatch with
+	// AMD2-E.0 (defensive — should never happen if dispatcher follows
+	// §54.3).
+	if in.OrphanEvidence == nil || !in.OrphanEvidence.AllTrue() {
+		return DecisionResult{
+			Output: OutputRefuse,
+			Rule:   RuleG1EvidenceMismatch,
+			Reason: "amendment-2 evidence predicate did not hold; failing-row=" + in.OrphanEvidence.FailedRowID(),
+		}
+	}
+
+	// All §54.1 rows hold. PROCEED PanelNative/csf — same target the
+	// existing G3.3 NoRecord+PanelAuto path resolves to. PlanFromDecision
+	// reuses the existing panel-static-map (§20.1: PanelDirectAdmin → "csf").
+	return DecisionResult{
+		Output: OutputProceed,
+		Rule:   RuleG1NFTBanOrphanProceed,
+		Reason: "amendment-2 orphan-intent: AuthorityNFTBan + DirectAdmin + strong CSF-disabled evidence; restoring CSF per §53.1",
+	}
 }

--- a/internal/installer/restore/engine_amendment2_test.go
+++ b/internal/installer/restore/engine_amendment2_test.go
@@ -1,0 +1,620 @@
+// =============================================================================
+// NFTBan v1.100 Amendment 2 — Engine fixture matrix (§§56.1 + 56.2 + 56.4)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-restore-engine-amendment2-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-28"
+// meta:description="Amendment 2 §56.1 + §56.2 + §56.4 coverage for the G1 split"
+// meta:inventory.files="internal/installer/restore/engine_amendment2_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Amendment 2 (contract.md §§52–61) defines the G1/AuthorityNFTBan
+// split. This file exercises every row of §56.1 (unit tests) + §56.2
+// (regression) + §56.4 (mutation-surface invariant) directly against
+// `restore.Decide`. The dispatcher integration test for §56.5 lives in
+// cmd/nftban-installer/restore_decide_amendment2_test.go.
+//
+// =============================================================================
+package restore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+// allEvidenceTrue returns an OrphanEvidence struct with every §54.1
+// row set true, simulating a real host that satisfies the candidate
+// triple precondition.
+func allEvidenceTrue() *OrphanEvidence {
+	return &OrphanEvidence{
+		E1PanelDirectAdmin:    true,
+		E2AuthorityNFTBan:     true,
+		E3PriorNoRecord:       true,
+		E4PanelAutoTakeover:   true,
+		E5AcceptOrphanNFTBan:  true,
+		E6CSFServiceDisabled:  true,
+		E7CSFDisabledExists:   true,
+		E8CSFAbsent:           true,
+		E9NftIPNftbanPresent:  true,
+		E10NftIP6NftbanPres:   true,
+		E11NftbandActive:      true,
+		E12NoConflictExternal: true,
+		E13NoAmbiguous:        true,
+	}
+}
+
+// TestAmd2_Section56_1_SplitFixtures exercises every row of contract
+// §56.1 against the engine.
+func TestAmd2_Section56_1_SplitFixtures(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    DecisionInput
+		wantOut  Output
+		wantRule string
+	}{
+		// Row 1 — AuthorityNFTBan + NoRecord + no flags → G1/default
+		{
+			name: "row01_no_flags",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 2 — only --panel-auto-takeover → G1/default
+		{
+			name: "row02_panel_auto_only",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 3 — only --accept-orphan-nftban → G1/default
+		{
+			name: "row03_orphan_only",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 4 — both flags + Panel=None → G2/PanelAutoNoPanel (existing rule wins)
+		{
+			name: "row04_panel_none",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelNone,
+				PanelPresent: false,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG2PanelAutoWithoutPanel,
+		},
+		// Row 5 — Panel=cPanel → G1/default (candidate triple absent)
+		{
+			name: "row05_panel_cpanel",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelCPanel,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 6 — DirectAdmin + csf.service ABSENT (E.6 false) → G1/EvidenceMismatch
+		{
+			name: "row06_csf_absent",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E6CSFServiceDisabled = false
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 7 — csf.service ACTIVE → G1/EvidenceMismatch (E.6 false; E.6 row collapses csf-active into the disabled-or-masked check)
+		{
+			name: "row07_csf_active",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E6CSFServiceDisabled = false // active
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 7d — csf inactive + disabled (acceptable fallback) → PROCEED
+		{
+			name: "row07d_csf_disabled_inactive_proceed",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				// E.6 true semantically covers both masked+inactive and disabled+inactive
+				// per AMD2-E.6; the engine just sees the boolean true.
+				OrphanEvidence: allEvidenceTrue(),
+			},
+			wantOut:  OutputProceed,
+			wantRule: RuleG1NFTBanOrphanProceed,
+		},
+		// Row 8 — /usr/sbin/csf.disabled ABSENT (E.7 false)
+		{
+			name: "row08_csf_disabled_absent",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E7CSFDisabledExists = false
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 9 — /usr/sbin/csf PRESENT (E.8 false; ambiguous-both-present)
+		{
+			name: "row09_csf_present_ambiguous",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E8CSFAbsent = false
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 10 — ip:nftban ABSENT (E.9 false)
+		{
+			name: "row10_ip_nftban_absent",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E9NftIPNftbanPresent = false
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 11 — nftband.service INACTIVE (E.11 false)
+		{
+			name: "row11_nftband_inactive",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: func() *OrphanEvidence {
+					ev := allEvidenceTrue()
+					ev.E11NftbandActive = false
+					return ev
+				}(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1EvidenceMismatch,
+		},
+		// Row 12 — ALL §54.1 rows true → PROCEED (strongest variant)
+		{
+			name: "row12_all_evidence_true_proceed",
+			input: DecisionInput{
+				Authority:      uninstall.AuthorityNFTBan,
+				Prior:          PriorStateNoRecord,
+				Panel:          detect.PanelDirectAdmin,
+				PanelPresent:   true,
+				Flags:          Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: allEvidenceTrue(),
+			},
+			wantOut:  OutputProceed,
+			wantRule: RuleG1NFTBanOrphanProceed,
+		},
+		// Row 13 — Prior=Complete → G1/default (candidate triple absent)
+		{
+			name: "row13_prior_complete",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateCompleteActive,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 14 — Prior=Incomplete → G1/default
+		{
+			name: "row14_prior_incomplete",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateIncomplete,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 15 — Prior=Stale → G1/default
+		{
+			name: "row15_prior_stale",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateStale,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+		// Row 16 — AuthorityExternal + orphan flag + everything-else true → REFUSE/G1/AuthorityExternal (no bypass)
+		{
+			name: "row16_authority_external_no_bypass",
+			input: DecisionInput{
+				Authority:      uninstall.AuthorityExternal,
+				Prior:          PriorStateNoRecord,
+				Panel:          detect.PanelDirectAdmin,
+				PanelPresent:   true,
+				Flags:          Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+				OrphanEvidence: allEvidenceTrue(),
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1AuthorityExternal,
+		},
+		// Row 17 — AmbiguityConflictExternal + orphan flag → REFUSE/G1/AmbiguityConflictExternal (no bypass)
+		{
+			name: "row17_ambiguity_conflict_no_bypass",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityAmbiguous,
+				Ambiguity:    uninstall.AmbiguityConflictExternal,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1AmbiguityConflictExt,
+		},
+		// Row 18 — AmbiguityOrphanNFTBan + panel-auto + orphan-flag → REFUSE/G4.3 (locked by §59 Q2)
+		{
+			name: "row18_ambiguity_orphan_panelauto_locked_refuse",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityAmbiguous,
+				Ambiguity:    uninstall.AmbiguityOrphanNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG4_3OrphanPanelAuto,
+		},
+		// Row 19 — both --panel-auto-takeover AND --restore-prior-authority + orphan-flag → REFUSE/G2/BothFlags
+		{
+			name: "row19_both_flags_set",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{Restore: true, PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG2BothRestoreFlags,
+		},
+		// Row 20 — orphan-flag absent (env-var-only would simulate this);
+		// engine sees Flags.AcceptOrphanNFTBan=false → G1/default. The
+		// CLI argv-only constraint is enforced at flag-parse layer; the
+		// engine's contract is that Flags is the truth.
+		{
+			name: "row20_no_env_var_fallback_simulation",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				// AcceptOrphanNFTBan deliberately false even though
+				// PanelAutoTakeover is true and other conditions hold —
+				// simulates the env-var-only path correctly producing
+				// AcceptOrphanNFTBan=false.
+				Flags: Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: false},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.input)
+			if got.Output != tc.wantOut {
+				t.Errorf("Output: got=%s want=%s (rule=%s reason=%q)",
+					got.Output, tc.wantOut, got.Rule, got.Reason)
+			}
+			if got.Rule != tc.wantRule {
+				t.Errorf("Rule: got=%s want=%s", got.Rule, tc.wantRule)
+			}
+		})
+	}
+}
+
+// TestAmd2_Section56_2_RegressionsPreserved confirms that pre-Amendment-2
+// rules continue to fire identically. R1–R6 from contract §56.2.
+func TestAmd2_Section56_2_RegressionsPreserved(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    DecisionInput
+		wantOut  Output
+		wantRule string
+	}{
+		// R1: AuthorityNone + NoRecord + --panel-auto-takeover + DirectAdmin → G3.3 PROCEED
+		{
+			name: "R1_AuthorityNone_NoRecord_PanelAuto_DirectAdmin",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNone,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true},
+			},
+			wantOut:  OutputProceed,
+			wantRule: RuleG3_3NoRecordPanelAuto,
+		},
+		// R2: AuthorityNone + strong prior + --restore → G3.1 PROCEED
+		{
+			name: "R2_AuthorityNone_StrongPrior_Restore",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityNone,
+				Prior:        PriorStateCompleteActive,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{Restore: true},
+			},
+			wantOut:  OutputProceed,
+			wantRule: RuleG3_1StrongPriorRestore,
+		},
+		// R3: AuthorityNone + NoRecord + --restore → G3.3 REQUIRE_EXPLICIT_INTENT
+		{
+			name: "R3_AuthorityNone_NoRecord_Restore_RequireIntent",
+			input: DecisionInput{
+				Authority: uninstall.AuthorityNone,
+				Prior:     PriorStateNoRecord,
+				Flags:     Flags{Restore: true},
+			},
+			wantOut:  OutputRequireExplicitIntent,
+			wantRule: RuleG3_3NoRecordRestore,
+		},
+		// R4: AmbiguityOrphanNFTBan + strong prior + --restore → G4.1 PROCEED
+		{
+			name: "R4_AmbiguityOrphan_StrongPrior_Restore",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityAmbiguous,
+				Ambiguity:    uninstall.AmbiguityOrphanNFTBan,
+				Prior:        PriorStateCompleteActive,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{Restore: true},
+			},
+			wantOut:  OutputProceed,
+			wantRule: RuleG4_1OrphanStrongRestore,
+		},
+		// R5: AmbiguityOrphanNFTBan + --panel-auto-takeover → G4.3 REFUSE
+		{
+			name: "R5_AmbiguityOrphan_PanelAuto_Refuse",
+			input: DecisionInput{
+				Authority:    uninstall.AuthorityAmbiguous,
+				Ambiguity:    uninstall.AmbiguityOrphanNFTBan,
+				Prior:        PriorStateNoRecord,
+				Panel:        detect.PanelDirectAdmin,
+				PanelPresent: true,
+				Flags:        Flags{PanelAutoTakeover: true},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG4_3OrphanPanelAuto,
+		},
+		// R6: AuthorityNFTBan + no orphan-flag → G1/default REFUSE (umbrella behavior preserved)
+		{
+			name: "R6_AuthorityNFTBan_NoOrphanFlag_Default",
+			input: DecisionInput{
+				Authority: uninstall.AuthorityNFTBan,
+				Prior:     PriorStateNoRecord,
+				Flags:     Flags{},
+			},
+			wantOut:  OutputRefuse,
+			wantRule: RuleG1NFTBanDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.input)
+			if got.Output != tc.wantOut {
+				t.Errorf("Output: got=%s want=%s (rule=%s reason=%q)",
+					got.Output, tc.wantOut, got.Rule, got.Reason)
+			}
+			if got.Rule != tc.wantRule {
+				t.Errorf("Rule: got=%s want=%s", got.Rule, tc.wantRule)
+			}
+		})
+	}
+}
+
+// TestAmd2_OrphanEvidence_FailedRowID confirms FailedRowID() returns the
+// stable per-row ID for the first failing row, used by structured logs.
+func TestAmd2_OrphanEvidence_FailedRowID(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*OrphanEvidence)
+		want string
+	}{
+		{"all_true_returns_empty", func(e *OrphanEvidence) {}, ""},
+		{"e1_first_failing", func(e *OrphanEvidence) { e.E1PanelDirectAdmin = false }, "AMD2-E.1"},
+		{"e6_first_failing", func(e *OrphanEvidence) { e.E6CSFServiceDisabled = false }, "AMD2-E.6"},
+		{"e8_first_failing", func(e *OrphanEvidence) { e.E8CSFAbsent = false }, "AMD2-E.8"},
+		{"e13_first_failing", func(e *OrphanEvidence) { e.E13NoAmbiguous = false }, "AMD2-E.13"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := allEvidenceTrue()
+			tc.mut(ev)
+			got := ev.FailedRowID()
+			if got != tc.want {
+				t.Errorf("FailedRowID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	t.Run("nil_receiver", func(t *testing.T) {
+		var ev *OrphanEvidence
+		if got := ev.FailedRowID(); got != "AMD2-E.0" {
+			t.Errorf("nil receiver FailedRowID = %q, want AMD2-E.0", got)
+		}
+		if ev.AllTrue() {
+			t.Errorf("nil receiver AllTrue = true, want false")
+		}
+	})
+}
+
+// TestAmd2_Section56_4_NoMutationSurfacesInDecisionLayer is the §56.4
+// structural invariant: the engine.go file (the decision layer) must
+// reference ZERO mutating executor methods. Any reference to a
+// mutating method in this file is a contract violation against
+// INV-PR26-NEW-MUTATION-SURFACES-BOUNDED and Amendment 2 §55.
+func TestAmd2_Section56_4_NoMutationSurfacesInDecisionLayer(t *testing.T) {
+	mutatingMethods := []string{
+		"ServiceMask", "ServiceUnmask", "ServiceStop", "ServiceStart",
+		"ServiceEnable", "ServiceDisable",
+		"Rename", "RemoveFile", "WriteFileAtomic", "MkdirAll",
+		"NftDeleteTable",
+	}
+
+	enginePath, err := filepath.Abs("engine.go")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, enginePath, nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parser.ParseFile %s: %v", enginePath, err)
+	}
+
+	var hits []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		for _, m := range mutatingMethods {
+			if sel.Sel.Name == m {
+				pos := fset.Position(sel.Pos())
+				hits = append(hits, m+" at "+pos.String())
+			}
+		}
+		return true
+	})
+	if len(hits) > 0 {
+		t.Errorf("engine.go references %d mutating method(s) — Amendment 2 §55 violation: %v",
+			len(hits), hits)
+	}
+}
+
+// TestAmd2_Section56_3_NoForceOrOverrideInFlagText scans the engine.go
+// file and the new evidence file for any "force" or "override"
+// substring in human-facing strings, per Amendment 2 §55 forbidden
+// behavior "no force semantics". (CLI flag text is checked separately
+// in the cmd-package test.)
+func TestAmd2_Section56_3_NoForceOrOverrideInFlagText(t *testing.T) {
+	files := []string{"engine.go", "types.go"}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			path, err := filepath.Abs(file)
+			if err != nil {
+				t.Fatalf("filepath.Abs: %v", err)
+			}
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, parser.AllErrors)
+			if err != nil {
+				t.Fatalf("parser.ParseFile %s: %v", path, err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				s := strings.ToLower(lit.Value)
+				// Match only against amendment-2-specific contexts:
+				// the orphan-restore reasoning. Skip strings that
+				// don't relate to the new path.
+				if !strings.Contains(s, "amendment-2") &&
+					!strings.Contains(s, "orphan") &&
+					!strings.Contains(s, "accept-orphan-nftban") {
+					return true
+				}
+				if strings.Contains(s, "force") || strings.Contains(s, "override") {
+					t.Errorf("Amendment 2 §55: forbidden 'force'/'override' in amendment-2-context string at %s: %s",
+						fset.Position(lit.Pos()), lit.Value)
+				}
+				return true
+			})
+		})
+	}
+}

--- a/internal/installer/restore/engine_test.go
+++ b/internal/installer/restore/engine_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/itcmsgr/nftban/internal/installer/detect"
 	"github.com/itcmsgr/nftban/internal/installer/uninstall"
 )
 
@@ -41,6 +42,11 @@ type fixture struct {
 var allFixtures = []fixture{
 	// ───────────────────────── Group 1 hard-stops ────────────────────
 	{
+		// Amendment 2 §53 split: the umbrella RuleG1AuthorityNFTBan is
+		// retained for grep / log parents, but every concrete fixture
+		// resolves to a sub-rule. With Restore=true the candidate-triple
+		// for orphan-intent does NOT hold (the orphan path requires
+		// PanelAutoTakeover, not Restore), so the default sub-rule fires.
 		name: "G1_AuthorityNFTBan_refuses_any_flag",
 		input: DecisionInput{
 			Authority: uninstall.AuthorityNFTBan,
@@ -48,7 +54,65 @@ var allFixtures = []fixture{
 			Flags:     Flags{Restore: true, PanelAutoTakeover: false},
 		},
 		wantOut:  OutputRefuse,
-		wantRule: RuleG1AuthorityNFTBan,
+		wantRule: RuleG1NFTBanDefault,
+	},
+	// Amendment 2 §53 — Group 1 split sub-rules. These two fixtures
+	// pin RuleG1NFTBanOrphanProceed and RuleG1EvidenceMismatch for the
+	// coverage assertion. The full §56.1 matrix lives in
+	// engine_amendment2_test.go.
+	{
+		name: "G1_AuthorityNFTBan_OrphanProceed_all_evidence_true",
+		input: DecisionInput{
+			Authority:    uninstall.AuthorityNFTBan,
+			Prior:        PriorStateNoRecord,
+			Panel:        detect.PanelDirectAdmin,
+			PanelPresent: true,
+			Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			OrphanEvidence: &OrphanEvidence{
+				E1PanelDirectAdmin:    true,
+				E2AuthorityNFTBan:     true,
+				E3PriorNoRecord:       true,
+				E4PanelAutoTakeover:   true,
+				E5AcceptOrphanNFTBan:  true,
+				E6CSFServiceDisabled:  true,
+				E7CSFDisabledExists:   true,
+				E8CSFAbsent:           true,
+				E9NftIPNftbanPresent:  true,
+				E10NftIP6NftbanPres:   true,
+				E11NftbandActive:      true,
+				E12NoConflictExternal: true,
+				E13NoAmbiguous:        true,
+			},
+		},
+		wantOut:  OutputProceed,
+		wantRule: RuleG1NFTBanOrphanProceed,
+	},
+	{
+		name: "G1_EvidenceMismatch_one_row_false",
+		input: DecisionInput{
+			Authority:    uninstall.AuthorityNFTBan,
+			Prior:        PriorStateNoRecord,
+			Panel:        detect.PanelDirectAdmin,
+			PanelPresent: true,
+			Flags:        Flags{PanelAutoTakeover: true, AcceptOrphanNFTBan: true},
+			OrphanEvidence: &OrphanEvidence{
+				E1PanelDirectAdmin:    true,
+				E2AuthorityNFTBan:     true,
+				E3PriorNoRecord:       true,
+				E4PanelAutoTakeover:   true,
+				E5AcceptOrphanNFTBan:  true,
+				E6CSFServiceDisabled:  false, // <-- single row false
+				E7CSFDisabledExists:   true,
+				E8CSFAbsent:           true,
+				E9NftIPNftbanPresent:  true,
+				E10NftIP6NftbanPres:   true,
+				E11NftbandActive:      true,
+				E12NoConflictExternal: true,
+				E13NoAmbiguous:        true,
+			},
+		},
+		wantOut:  OutputRefuse,
+		wantRule: RuleG1EvidenceMismatch,
 	},
 	{
 		name: "G1_AuthorityExternal_refuses_any_flag",
@@ -389,7 +453,12 @@ func TestRuleCoverage_EveryRuleExercised(t *testing.T) {
 // Keep in sync when new rules are added.
 func declaredRules() []string {
 	return []string{
-		RuleG1AuthorityNFTBan,
+		// Amendment 2 §53 split: RuleG1AuthorityNFTBan is now an umbrella
+		// const retained for log-parent grep; concrete fixtures resolve
+		// to the three sub-rules below.
+		RuleG1NFTBanDefault,
+		RuleG1NFTBanOrphanProceed,
+		RuleG1EvidenceMismatch,
 		RuleG1AuthorityExternal,
 		RuleG1AmbiguityConflictExt,
 

--- a/internal/installer/restore/types.go
+++ b/internal/installer/restore/types.go
@@ -29,7 +29,10 @@
 // =============================================================================
 package restore
 
-import "github.com/itcmsgr/nftban/internal/installer/uninstall"
+import (
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
 
 // Output is the closed enum of the three (and only three) outputs of
 // the PR-24 decision engine. Per seed §4 (merged), no fourth value
@@ -96,6 +99,18 @@ type Flags struct {
 	// panel, not the prior record — this asymmetry is the policy
 	// hinge in seed §3.3 / §4.2.
 	PanelAutoTakeover bool
+	// AcceptOrphanNFTBan corresponds to --accept-orphan-nftban
+	// (Amendment 2, locked 2026-04-28). Semantic: "explicit operator
+	// intent to restore CSF on a DirectAdmin host where NFTBan is the
+	// current authority and no prior-authority record exists." Combined
+	// with PanelAutoTakeover + DirectAdmin + strong CSF-disabled
+	// evidence, this activates the §53 G1 split orphan-intent path.
+	// Standalone (without PanelAutoTakeover, or under any other
+	// classifier) the flag has no effect — REFUSE remains.
+	//
+	// MUST be supplied via CLI argv only. No env-var, no config-file,
+	// no implicit default — see Amendment 2 §55.
+	AcceptOrphanNFTBan bool
 }
 
 // DecisionInput is the pure-function input to Decide. Every axis is
@@ -123,8 +138,109 @@ type DecisionInput struct {
 	// PanelPresent is a single boolean rather than the raw panel type.
 	// The lattice treats panel context as "panel or no panel"; any
 	// specific panel (DA / cPanel / Plesk / Hestia / etc.) is
-	// equivalent for policy purposes.
+	// equivalent for policy purposes for §6 Groups 1–5.
 	PanelPresent bool
+
+	// Panel is the typed panel identity. Required by Amendment 2 §54
+	// evidence row E.1 (the orphan-intent PROCEED path activates only
+	// for Panel == detect.PanelDirectAdmin). Outside the Amendment 2
+	// G1/AuthorityNFTBan split, the lattice ignores this field —
+	// PanelPresent remains the sole panel input for §6 Groups 3 and 4.
+	Panel detect.PanelType
+
+	// OrphanEvidence carries the §54.1 read-only evidence predicate
+	// result, populated by the dispatcher only when the candidate
+	// triple (AuthorityNFTBan + Prior=NoRecord + Panel=DirectAdmin +
+	// Flags.PanelAutoTakeover + Flags.AcceptOrphanNFTBan) is present.
+	// Nil for every other input pattern — the engine MUST NOT
+	// dereference it outside the Amendment 2 split.
+	OrphanEvidence *OrphanEvidence
+}
+
+// OrphanEvidence is the §54.1 evidence predicate result. All 13 rows
+// are read-only observations of the live host state. The engine
+// consumes a pre-evaluated struct; the dispatcher (`gatherOrphanEvidence`)
+// does the live reads.
+//
+// `AllTrue()` returns true iff every row is satisfied; `FailedRowID()`
+// returns the first failing row's stable ID (e.g. "AMD2-E.6") for
+// structured logging. The struct is value-type so a nil pointer at
+// DecisionInput is unambiguous ("evidence not gathered").
+type OrphanEvidence struct {
+	E1PanelDirectAdmin    bool // detect.DetectPanel == PanelDirectAdmin
+	E2AuthorityNFTBan     bool // uninstall.Classify == AuthorityNFTBan
+	E3PriorNoRecord       bool // uninstall.Probe == PriorNoRecord
+	E4PanelAutoTakeover   bool // --panel-auto-takeover present
+	E5AcceptOrphanNFTBan  bool // --accept-orphan-nftban present (CLI argv only)
+	E6CSFServiceDisabled  bool // csf.service exists AND not active AND is-enabled in {masked, disabled}
+	E7CSFDisabledExists   bool // /usr/sbin/csf.disabled exists
+	E8CSFAbsent           bool // /usr/sbin/csf does NOT exist
+	E9NftIPNftbanPresent  bool // nft table ip nftban present
+	E10NftIP6NftbanPres   bool // nft table ip6 nftban present
+	E11NftbandActive      bool // nftband.service active
+	E12NoConflictExternal bool // classifier did not return AmbiguityConflictExternal
+	E13NoAmbiguous        bool // classifier did not return AuthorityAmbiguous
+}
+
+// AllTrue reports whether every §54.1 row is satisfied. Read failures
+// in the dispatcher MUST set the corresponding row to false — never
+// REQUIRE_EXPLICIT_INTENT — per Amendment 2 §54.2.
+func (e *OrphanEvidence) AllTrue() bool {
+	if e == nil {
+		return false
+	}
+	return e.E1PanelDirectAdmin &&
+		e.E2AuthorityNFTBan &&
+		e.E3PriorNoRecord &&
+		e.E4PanelAutoTakeover &&
+		e.E5AcceptOrphanNFTBan &&
+		e.E6CSFServiceDisabled &&
+		e.E7CSFDisabledExists &&
+		e.E8CSFAbsent &&
+		e.E9NftIPNftbanPresent &&
+		e.E10NftIP6NftbanPres &&
+		e.E11NftbandActive &&
+		e.E12NoConflictExternal &&
+		e.E13NoAmbiguous
+}
+
+// FailedRowID returns the stable ID of the first false row (e.g.
+// "AMD2-E.6"), or empty string if all rows are true. Nil receiver
+// returns "AMD2-E.0" so structured logs distinguish "evidence not
+// gathered" from "every row evaluated false".
+func (e *OrphanEvidence) FailedRowID() string {
+	if e == nil {
+		return "AMD2-E.0"
+	}
+	switch {
+	case !e.E1PanelDirectAdmin:
+		return "AMD2-E.1"
+	case !e.E2AuthorityNFTBan:
+		return "AMD2-E.2"
+	case !e.E3PriorNoRecord:
+		return "AMD2-E.3"
+	case !e.E4PanelAutoTakeover:
+		return "AMD2-E.4"
+	case !e.E5AcceptOrphanNFTBan:
+		return "AMD2-E.5"
+	case !e.E6CSFServiceDisabled:
+		return "AMD2-E.6"
+	case !e.E7CSFDisabledExists:
+		return "AMD2-E.7"
+	case !e.E8CSFAbsent:
+		return "AMD2-E.8"
+	case !e.E9NftIPNftbanPresent:
+		return "AMD2-E.9"
+	case !e.E10NftIP6NftbanPres:
+		return "AMD2-E.10"
+	case !e.E11NftbandActive:
+		return "AMD2-E.11"
+	case !e.E12NoConflictExternal:
+		return "AMD2-E.12"
+	case !e.E13NoAmbiguous:
+		return "AMD2-E.13"
+	}
+	return ""
 }
 
 // DecisionResult is the pure-function output of Decide. Contains the


### PR DESCRIPTION
## Summary

Decision-layer implementation of Amendment 2 (`internal/installer/restore/contract.md` §§52–61, merged in #518).

Splits the existing `G1/AuthorityNFTBan` row into two evaluated-within-Group-1 sub-rules. The split is **ENTIRELY within Group 1**; no later group ever defeats a Group 1 outcome and §5 precedence is preserved.

| Sub-rule | Condition | Output |
|---|---|---|
| `G1/AuthorityNFTBan/default` | candidate triple absent | REFUSE |
| `G1/AuthorityNFTBan/orphan-intent-candidate` → `OrphanProceed` | `AuthorityNFTBan + NoRecord + DirectAdmin + --panel-auto-takeover + --accept-orphan-nftban + ALL §54.1 evidence rows true` | **PROCEED** PanelNative/csf |
| `G1/EvidenceMismatch` | candidate triple present + any §54.1 row false | REFUSE |

## What this changes

**Decision layer only.** Zero mutation surfaces added.

- New CLI flag `--accept-orphan-nftban` (`flags.go`). Restore-mode only. CLI argv only — no env-var fallback per §55. Help text contains zero "force"/"override" tokens.
- Extended `restore.Flags` + `restore.DecisionInput` with `AcceptOrphanNFTBan`, `Panel detect.PanelType`, `OrphanEvidence *OrphanEvidence`.
- New `OrphanEvidence` struct (13 boolean rows + `AllTrue()` + `FailedRowID()`).
- New `decideAuthorityNFTBan` in `restore/engine.go`: candidate-triple gate → §54 evidence predicate → PROCEED or REFUSE.
- New `cmd/nftban-installer/restore_decide_evidence.go` (read-only §54 reader). Uses existing typed surfaces (`FileExists`, `ServiceActive`, `NftTableExists`). E.6 csf.service state uses raw `Run("systemctl","status"|"is-enabled","csf.service")` per §43.3 (read-only probes authorized). No mutating systemctl verbs.
- Dispatcher gathers evidence ONLY when candidate triple is otherwise present, avoiding unnecessary live reads on every restore-mode invocation.

## Tests

- `engine_amendment2_test.go` — §56.1 unit fixtures (rows 01–20 + 7d fallback variant), §56.2 regression (R1–R6), §56.4 mutation-surface AST scan, FailedRowID per-row coverage.
- `restore_decide_evidence_test.go` — `gatherOrphanEvidence` per-row coverage (15 cases including E.6 sub-variants: active forbidden, not-found forbidden, enabled forbidden, static forbidden, disabled-acceptable). `NFTBAN_ACCEPT_ORPHAN` env-var-fallback source-scan invariant.
- `engine_test.go` — existing `G1/AuthorityNFTBan` fixture re-pinned to `G1/AuthorityNFTBan/default`; `declaredRules` updated; two new `allFixtures` entries pin `OrphanProceed` and `EvidenceMismatch`.

CI gates (§56.3) implemented as **in-process Go tests, NOT as GitHub Actions edits** — per operator direction.

## Test results (lab4 build host)

- `go test ./internal/installer/restore/...` → **PASS**
- `go test ./cmd/nftban-installer/...` → **PASS**
- `go test ./...` → **64 packages PASS, 0 FAIL**

## §56.3 grep gates (scoped to Amendment 2 changed files)

- `iptables-(save|restore|nft)` → **0 hits → PASS**
- `build[ -]set[ ]+csf` → **0 hits → PASS**
- `WriteFileAtomic.*update-history|openat.*O_WRONLY.*update-history|WriteUpdateHistory` → **0 hits → PASS**
- `force|override` in `--accept-orphan-nftban` CLI text → **0 hits → PASS**

## Invariants preserved

- §5 precedence: split entirely within Group 1.
- `INV-PR25-AUTHORITY-IMMUTABILITY`: §54 read once at decision time.
- §19.2 layer 4 / `main.go:132` history gate: untouched.
- §20.1 panel mapping: PROCEED resolves PanelNative/csf via existing static map.
- §22 / §19.4 terminals + exit codes: unchanged (zero new).
- §32 11-step ordering: unchanged.
- §43.3 read-only Run policy: E.6 uses status/is-enabled only.
- §51.3 Option B: zero iptables introspection.
- `INV-PR26-NEW-MUTATION-SURFACES-BOUNDED`: zero new surfaces.
- `INV-AMD2-EXPLICIT-INTENT-IS-NARROW`: §53.4 13 REFUSE rows test-pinned.

## Out of scope

- §59 Q3/Q4 — typed read-only `ServiceListed`/`ServiceEnabled`/`NftListTables` deferred; raw `Run` for E.6 + existing `NftTableExists` used instead.
- amendment-2-code-E real-host srv3 destructive evidence — separate PR after this merges.

## Locked rules respected

- No srv3 action.
- No `nftban-installer` invocation on srv3.
- No manual host mutation.
- No §32 mutation-path change.
- No new state terminals.
- No new exit codes.
- No update-history writes.
- No iptables introspection.
- No DirectAdmin custombuild rewrite.
- No cPanel/Plesk/standalone expansion.
- No env/config fallback for `--accept-orphan-nftban`.
- No CI workflow edit.

## Remaining blockers before amendment-2-code-E

1. Auditor on-PR review of this code-A.
2. This PR merged to main.
3. Fresh Tier 1 binary built (the prior `a3e283ed…` binary is **superseded**).
4. Fresh `srv3/operator-signoff.txt` recorded (operator-side, not assistant).
5. Fresh `srv3/pre/` snapshot captured.
6. Fresh auditor `CONDITIONAL PRE-EXECUTION GO FOR AMENDMENT-2-CODE-E` issued.

## Test plan

- [ ] CI passes
- [ ] Auditor review
- [ ] Verify zero mutation-surface additions in this diff
- [ ] Verify §53.4 explicit-REFUSE row coverage in §56.1 test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)