### PR TITLE
fix(v1.100 Amendment 2): code-B — preflight accepts /usr/sbin/csf.disabled for restore-to-CSF

### DIFF
--- a/cmd/nftban-installer/restore_deps.go
+++ b/cmd/nftban-installer/restore_deps.go
@@ -187,11 +187,31 @@ func (p *productionPreflightDep) PreflightTarget(_ context.Context, firewallType
 		}
 	}
 	if binaryFound == "" {
-		if p.log != nil {
-			p.log.Info("restore preflight: refusing firewallType=%q — no canonical binary in PATH (looked for %v)",
-				firewallType, presence.binaries)
+		// Amendment 2 §54: for CSF-only restore-to-CSF, accept the
+		// install-time-disabled binary `/usr/sbin/csf.disabled` as an
+		// acceptable restorable candidate. The Amendment-2 orphan
+		// evidence chain proves NFTBan disabled CSF by renaming
+		// /usr/sbin/csf → /usr/sbin/csf.disabled at install-time
+		// (switchop.DisableConflicts step 4, Amendment 1 §31 A.3).
+		// §32 A.3 later performs the authoritative rename back.
+		// Preflight remains read-only and only verifies that a
+		// restorable candidate is present; it does NOT mutate or
+		// rename here. The .disabled relaxation is CSF-only — ufw,
+		// firewalld, and iptables retain the strict in-PATH check
+		// per Amendment 1 §30.2 (CSF-only inverse-of-install scope).
+		if firewallType == "csf" && p.exec.FileExists("/usr/sbin/csf.disabled") {
+			if p.log != nil {
+				p.log.Info("restore preflight: firewallType=%q canonical binary absent from PATH but /usr/sbin/csf.disabled present — accepting (Amendment 2 §54 / restore-to-CSF)",
+					firewallType)
+			}
+			binaryFound = "/usr/sbin/csf.disabled"
+		} else {
+			if p.log != nil {
+				p.log.Info("restore preflight: refusing firewallType=%q — no canonical binary in PATH (looked for %v)",
+					firewallType, presence.binaries)
+			}
+			return false, ErrPreflightBinaryMissing
 		}
-		return false, ErrPreflightBinaryMissing
 	}
 
 	// Check unit files (OR-list — at least one path must exist).

--- a/cmd/nftban-installer/restore_deps_test.go
+++ b/cmd/nftban-installer/restore_deps_test.go
@@ -899,3 +899,166 @@ func keysOf(m map[string][]byte) []string {
 	}
 	return out
 }
+
+// =============================================================================
+// =============================================================================
+// Amendment 2 code-B — preflight csf.disabled acceptance
+// =============================================================================
+// =============================================================================
+//
+// Amendment 2 §54 + §53 G1/AuthorityNFTBan/OrphanProceed path requires
+// preflight to accept /usr/sbin/csf.disabled as a restorable candidate
+// when /usr/sbin/csf is absent. The .disabled relaxation is CSF-only;
+// ufw / firewalld / iptables retain the strict in-PATH check per
+// Amendment 1 §30.2 (CSF-only inverse-of-install scope).
+//
+// pf4B1MockWith already supports adding arbitrary file paths to the
+// mock; we extend the test fixture set with explicit
+// /usr/sbin/csf.disabled presence/absence variations.
+
+// pfAMD2MockWith builds a MockExecutor with the given binary in PATH
+// (or empty for absent), unit-file paths, and an optional
+// /usr/sbin/csf.disabled presence flag.
+func pfAMD2MockWith(binary string, unitFiles []string, csfDisabledPresent bool) *executor.MockExecutor {
+	mock := pf4B1MockWith(binary, unitFiles)
+	if csfDisabledPresent {
+		mock.Files["/usr/sbin/csf.disabled"] = []byte{}
+	}
+	return mock
+}
+
+// AMD2-1: csf in PATH + unit present + .disabled absent → PASS.
+// Pinned to confirm the §54 relaxation does NOT regress the existing
+// happy path that 4B-1.1 already covers.
+func TestPreflightTarget_AMD2_CSF_InPath_DisabledAbsent_Pass(t *testing.T) {
+	mock := pfAMD2MockWith("csf", []string{"/etc/systemd/system/csf.service"}, false)
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "csf")
+	if !ok || err != nil {
+		t.Errorf("PreflightTarget(csf) ok=%v err=%v; want ok=true err=nil", ok, err)
+	}
+}
+
+// AMD2-2: csf absent + /usr/sbin/csf.disabled present + unit present → PASS.
+// This is the load-bearing Amendment 2 §54 case.
+func TestPreflightTarget_AMD2_CSF_Absent_DisabledPresent_Pass(t *testing.T) {
+	mock := pfAMD2MockWith("", []string{"/etc/systemd/system/csf.service"}, true)
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "csf")
+	if !ok {
+		t.Errorf("PreflightTarget(csf) = false; want true (Amendment 2 §54 csf.disabled relaxation)")
+	}
+	if err != nil {
+		t.Errorf("PreflightTarget(csf) returned err: %v", err)
+	}
+}
+
+// AMD2-3: csf absent + .disabled absent + unit present → REFUSE
+// ErrPreflightBinaryMissing. Both restorable candidates are missing.
+func TestPreflightTarget_AMD2_CSF_BothAbsent_Refuse(t *testing.T) {
+	mock := pfAMD2MockWith("", []string{"/etc/systemd/system/csf.service"}, false)
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "csf")
+	if ok {
+		t.Errorf("PreflightTarget(csf) accepted with both csf and csf.disabled absent; want refusal")
+	}
+	if !errors.Is(err, ErrPreflightBinaryMissing) {
+		t.Errorf("err = %v; want ErrPreflightBinaryMissing", err)
+	}
+}
+
+// AMD2-4: csf in PATH AND .disabled present + unit present → PASS at
+// preflight. The "ambiguous-both-present" state is A.3's responsibility
+// per Amendment 1 §31 A.3 ("Refuse the entire restore if both
+// /usr/sbin/csf and /usr/sbin/csf.disabled are present"). Preflight
+// remains read-only and only verifies presence of a restorable
+// candidate; the ambiguity is detected and refused later in §32 step 3.
+func TestPreflightTarget_AMD2_CSF_BothPresent_Pass_AmbiguityIsA3(t *testing.T) {
+	mock := pfAMD2MockWith("csf", []string{"/etc/systemd/system/csf.service"}, true)
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "csf")
+	if !ok || err != nil {
+		t.Errorf("PreflightTarget(csf) ok=%v err=%v; want preflight PASS (ambiguity is A.3 territory)", ok, err)
+	}
+}
+
+// AMD2-5: csf in PATH + unit ABSENT → REFUSE ErrPreflightUnitMissing.
+// Existing unit-file presence check remains unchanged by §54.
+func TestPreflightTarget_AMD2_CSF_InPath_UnitAbsent_Refuse(t *testing.T) {
+	mock := pfAMD2MockWith("csf", nil, false)
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "csf")
+	if ok {
+		t.Errorf("PreflightTarget(csf) accepted with no unit file; want refusal")
+	}
+	if !errors.Is(err, ErrPreflightUnitMissing) {
+		t.Errorf("err = %v; want ErrPreflightUnitMissing", err)
+	}
+}
+
+// AMD2-6/7/8: non-CSF firewalls do NOT receive the .disabled relaxation.
+// Even if a hypothetical "<binary>.disabled" file exists, preflight
+// still refuses with ErrPreflightBinaryMissing. CSF-only scope per
+// Amendment 1 §30.2.
+func TestPreflightTarget_AMD2_NonCSF_NoDisabledRelaxation(t *testing.T) {
+	cases := []struct {
+		fwt          string
+		unitPath     string
+		disabledPath string // hypothetical .disabled filename for the firewall
+	}{
+		{"ufw", "/usr/lib/systemd/system/ufw.service", "/usr/sbin/ufw.disabled"},
+		{"firewalld", "/usr/lib/systemd/system/firewalld.service", "/usr/bin/firewall-cmd.disabled"},
+		{"iptables", "/usr/lib/systemd/system/iptables.service", "/usr/sbin/iptables.disabled"},
+	}
+	for _, c := range cases {
+		t.Run(c.fwt, func(t *testing.T) {
+			mock := pf4B1MockWith("", []string{c.unitPath})
+			// Add a hypothetical .disabled for this non-CSF firewall.
+			// Must NOT be accepted by preflight under any rationale.
+			mock.Files[c.disabledPath] = []byte{}
+			// Also seed /usr/sbin/csf.disabled to prove the CSF-only
+			// branch does not bleed into non-CSF paths.
+			mock.Files["/usr/sbin/csf.disabled"] = []byte{}
+			d := &productionPreflightDep{exec: mock}
+			ok, err := d.PreflightTarget(context.Background(), c.fwt)
+			if ok {
+				t.Errorf("PreflightTarget(%q) accepted with a hypothetical %q present — Amendment 1 §30.2 CSF-only scope violated",
+					c.fwt, c.disabledPath)
+			}
+			if !errors.Is(err, ErrPreflightBinaryMissing) {
+				t.Errorf("PreflightTarget(%q) err = %v; want ErrPreflightBinaryMissing", c.fwt, err)
+			}
+		})
+	}
+}
+
+// AMD2-9: unknown firewallType still refuses with
+// ErrPreflightUnknownFirewall regardless of any .disabled file
+// presence on disk.
+func TestPreflightTarget_AMD2_UnknownFirewall_StillRefuse(t *testing.T) {
+	mock := pf4B1MockWith("", nil)
+	mock.Files["/usr/sbin/csf.disabled"] = []byte{} // red herring
+	d := &productionPreflightDep{exec: mock}
+	ok, err := d.PreflightTarget(context.Background(), "shorewall")
+	if ok {
+		t.Errorf("PreflightTarget(shorewall) accepted; want refusal")
+	}
+	if !errors.Is(err, ErrPreflightUnknownFirewall) {
+		t.Errorf("err = %v; want ErrPreflightUnknownFirewall", err)
+	}
+}
+
+// AMD2-10: preflight remains read-only on the .disabled-acceptance
+// branch. Calling PreflightTarget with the §54 relaxation active must
+// still record ZERO commands (FileExists is a typed read; no Run).
+func TestPreflightTarget_AMD2_CSF_DisabledBranch_NoMutationCalls(t *testing.T) {
+	mock := pfAMD2MockWith("", []string{"/etc/systemd/system/csf.service"}, true)
+	d := &productionPreflightDep{exec: mock}
+	_, err := d.PreflightTarget(context.Background(), "csf")
+	if err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+	if len(mock.Commands) != 0 {
+		t.Errorf("§54 relaxation branch recorded mutation commands: %+v", mock.Commands)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the preflight contract bug surfaced by the Amendment-2-code-E srv3 destructive run (2026-04-28T21:06:03Z).

The dispatcher reached `G1/AuthorityNFTBan/OrphanProceed PROCEED` correctly, but failed at `RESTORE_FAILED_EXECUTION` (stage=preflight, exit=8) because the existing PR-25 §23.1 preflight requires the canonical `csf` binary in PATH. The Amendment-2 orphan-restore scenario specifically has `/usr/sbin/csf` ABSENT and `/usr/sbin/csf.disabled` PRESENT (the install-time-disabled state from `switchop.DisableConflicts` step 4), which the dispatcher restores via §32 A.3 rename later.

This is a contract gap in PR-25 preflight, **not** in Amendment 2's decision layer. Code-A (#519) and Amendment 2 §53 + §54 work as designed.

## Surgical patch

In `productionPreflightDep.PreflightTarget`:
- For `firewallType == "csf"`: if no canonical csf binary in PATH, accept `/usr/sbin/csf.disabled` as a restorable candidate.
- For non-CSF firewalls (`ufw` / `firewalld` / `iptables`): existing strict in-PATH check unchanged. **No `.disabled` relaxation.** Per Amendment 1 §30.2 (CSF-only inverse-of-install scope).
- Existing unit-file presence check unchanged.
- Preflight remains read-only — uses existing `exec.FileExists`.

A.3 (Amendment 1 §31) remains the authoritative rename and detects the ambiguous-both-present state for refusal at §32 step 1.

## Tests added (10 new test functions)

| Test | Scenario | Expected |
|---|---|---|
| `AMD2_CSF_InPath_DisabledAbsent_Pass` | csf in PATH, .disabled absent | PASS |
| `AMD2_CSF_Absent_DisabledPresent_Pass` | csf absent, .disabled present | **PASS (§54 case)** |
| `AMD2_CSF_BothAbsent_Refuse` | both absent | REFUSE `ErrPreflightBinaryMissing` |
| `AMD2_CSF_BothPresent_Pass_AmbiguityIsA3` | both present | PASS (ambiguity is A.3's job) |
| `AMD2_CSF_InPath_UnitAbsent_Refuse` | csf in PATH, unit absent | REFUSE `ErrPreflightUnitMissing` |
| `AMD2_NonCSF_NoDisabledRelaxation` | ufw/firewalld/iptables `.disabled` present | REFUSE (CSF-only scope) |
| `AMD2_UnknownFirewall_StillRefuse` | unknown firewallType | REFUSE `ErrPreflightUnknownFirewall` |
| `AMD2_CSF_DisabledBranch_NoMutationCalls` | §54 branch | zero mutation commands |

## Test results (lab4 build host)

- `go test ./cmd/nftban-installer/... -run 'Preflight|RestoreDeps'` → **PASS**
- `go test ./cmd/nftban-installer/...` → **PASS**
- `go test ./internal/installer/restore/...` → **PASS**
- `go test ./...` → **64 packages PASS, 0 FAIL**

## Files changed

| File | Change |
|---|---|
| `cmd/nftban-installer/restore_deps.go` | +24 / -4 (CSF-only `.disabled` branch in `PreflightTarget`) |
| `cmd/nftban-installer/restore_deps_test.go` | +163 (10 new test functions) |

## Files NOT touched

- `internal/installer/restore/contract.md` ✅
- `internal/installer/restore/engine.go` ✅
- `internal/installer/restore/execute.go` ✅
- `internal/installer/state/machine.go` ✅
- `cmd/nftban-installer/flags.go` ✅
- `cmd/nftban-installer/main.go` ✅
- `.github/workflows/*` ✅
- All other files ✅

## Invariants preserved

- §23.1 preflight read-only: unchanged.
- `INV-PR26-NEW-MUTATION-SURFACES-BOUNDED`: zero new surfaces.
- §32 ordering: unchanged. A.3 still authoritative rename.
- §22 / §19.4 terminals + exit codes: unchanged.
- Amendment 1 §30.2 CSF-only scope: preserved (non-CSF `.disabled` files explicitly refuse — pinned in tests).
- §19.2 layer 4 / `main.go:132` history gate: untouched.
- Existing 4B-1 fixture matrix: unchanged behavior, all pass.

## Out of scope

- No new lattice rule.
- No new state terminal.
- No new exit code.
- No new mutation surface.
- No CI workflow edit.
- No host action.

## Test plan

- [ ] CI passes
- [ ] Auditor verifies CSF-only scope (non-CSF `.disabled` paths still REFUSE)
- [ ] Auditor verifies preflight remains read-only (zero `Run`/`Service*`/`Nft*` calls in changed branch)
- [ ] Auditor verifies A.3 ambiguity-detection at §32 step 1 unchanged

## After merge

Fresh Tier 1 binary build → fresh srv3 H2/H3 attestation → fresh auditor `CONDITIONAL PRE-EXECUTION GO` → one new srv3 destructive attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)