### PR TITLE
feat(v1.100 Amendment 3): code-B — dispatcher wires ExternalIndicator + Amendment-3 OrphanEvidence gathering

### DIFF
--- a/cmd/nftban-installer/restore_decide.go
+++ b/cmd/nftban-installer/restore_decide.go
@@ -173,15 +173,17 @@ func runRestoreDecide(ctx context.Context, exec executor.Executor, sf *state.Sta
 		panel == detect.PanelDirectAdmin &&
 		cfg.panelAutoTakeover &&
 		cfg.acceptOrphanNFTBan
-	if amd2Candidate || amd3Candidate {
+	switch {
+	case amd2Candidate:
 		ev := gatherOrphanEvidence(exec, log, panel, auth, probe, cfg)
 		input.OrphanEvidence = &ev
-		// Log each predicate's result. Both AllTrue() (Amendment 2)
-		// and AllTrueAmendment3() (Amendment 3) are evaluated for
-		// observability; the engine consumes whichever is appropriate
-		// per the entry condition (decided in engine.go, not here).
-		log.Info("restore decide: orphan-evidence gathered amd2_all_true=%v amd2_failed_row=%q amd3_all_true=%v amd3_failed_row=%q",
-			ev.AllTrue(), ev.FailedRowID(), ev.AllTrueAmendment3(), ev.FailedRowIDAmendment3())
+		log.Info("restore decide: orphan-evidence gathered (amendment-2 path) all_true=%v failed_row=%q",
+			ev.AllTrue(), ev.FailedRowID())
+	case amd3Candidate:
+		ev := gatherOrphanEvidenceAmendment3(exec, log, panel, auth, probe, cfg)
+		input.OrphanEvidence = &ev
+		log.Info("restore decide: orphan-evidence gathered (amendment-3 path) all_true=%v failed_row=%q",
+			ev.AllTrueAmendment3(), ev.FailedRowIDAmendment3())
 	}
 
 	// 7. Evaluate — pure, deterministic, no side effects.

--- a/cmd/nftban-installer/restore_decide.go
+++ b/cmd/nftban-installer/restore_decide.go
@@ -134,22 +134,54 @@ func runRestoreDecide(ctx context.Context, exec executor.Executor, sf *state.Sta
 		},
 		PanelPresent: panelPresent,
 		Panel:        panel,
+		// Amendment 3 §62 entry condition: the engine consumes the
+		// classifier's external-authority string so the
+		// G1/AmbiguityConflictExternal/orphan-intent-candidate-csf
+		// sub-row can gate on `external == "csf"` (single, exact).
+		// Carrying it on every restore-mode invocation is cheap; the
+		// engine ignores it on every lattice path other than the
+		// Amendment 3 quintuple.
+		ExternalIndicator: auth.External,
 	}
 
-	// 6b. Amendment 2 §54.3: gather orphan-restore evidence ONLY when
-	// the candidate triple is otherwise present. This avoids
-	// unnecessary live reads on every restore-mode invocation, and
-	// preserves the §51.3 Option B boundary (no iptables introspection)
-	// by only running the predicate where it matters.
-	if auth.State == uninstall.AuthorityNFTBan &&
+	// 6b. Gather orphan-restore evidence ONLY when an orphan-intent
+	// candidate quintuple is otherwise present. Two entry conditions
+	// trigger evidence-gathering:
+	//
+	//   (i) Amendment 2 §54.3 — AuthorityNFTBan + NoRecord + DirectAdmin
+	//       + --panel-auto-takeover + --accept-orphan-nftban
+	//   (ii) Amendment 3 §62 — AuthorityAmbiguous + AmbiguityConflictExternal
+	//       + external=="csf" + NoRecord + DirectAdmin
+	//       + --panel-auto-takeover + --accept-orphan-nftban
+	//
+	// Both candidates share the same flag pair, the same panel, the
+	// same prior state, the same evidence-row set (§54 = §54/§64 except
+	// E.2 reframed and E.12 omitted — handled by the dispatcher inside
+	// gatherOrphanEvidence). The dispatcher avoids unnecessary live
+	// reads on every restore-mode invocation by only running the
+	// predicate where it matters, preserving the §51.3 Option B
+	// boundary (no iptables introspection).
+	amd2Candidate := auth.State == uninstall.AuthorityNFTBan &&
 		priorState == restore.PriorStateNoRecord &&
 		panel == detect.PanelDirectAdmin &&
 		cfg.panelAutoTakeover &&
-		cfg.acceptOrphanNFTBan {
+		cfg.acceptOrphanNFTBan
+	amd3Candidate := auth.State == uninstall.AuthorityAmbiguous &&
+		auth.Ambiguity == uninstall.AmbiguityConflictExternal &&
+		auth.External == "csf" &&
+		priorState == restore.PriorStateNoRecord &&
+		panel == detect.PanelDirectAdmin &&
+		cfg.panelAutoTakeover &&
+		cfg.acceptOrphanNFTBan
+	if amd2Candidate || amd3Candidate {
 		ev := gatherOrphanEvidence(exec, log, panel, auth, probe, cfg)
 		input.OrphanEvidence = &ev
-		log.Info("restore decide: orphan-evidence gathered all_true=%v failed_row=%q",
-			ev.AllTrue(), ev.FailedRowID())
+		// Log each predicate's result. Both AllTrue() (Amendment 2)
+		// and AllTrueAmendment3() (Amendment 3) are evaluated for
+		// observability; the engine consumes whichever is appropriate
+		// per the entry condition (decided in engine.go, not here).
+		log.Info("restore decide: orphan-evidence gathered amd2_all_true=%v amd2_failed_row=%q amd3_all_true=%v amd3_failed_row=%q",
+			ev.AllTrue(), ev.FailedRowID(), ev.AllTrueAmendment3(), ev.FailedRowIDAmendment3())
 	}
 
 	// 7. Evaluate — pure, deterministic, no side effects.

--- a/cmd/nftban-installer/restore_decide_amendment3_test.go
+++ b/cmd/nftban-installer/restore_decide_amendment3_test.go
@@ -1,0 +1,193 @@
+// =============================================================================
+// NFTBan v1.100 Amendment 3 — Dispatcher integration tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-restore-decide-amendment3-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="Amendment 3 dispatcher-side wiring (ExternalIndicator + reframed E.2)"
+// meta:inventory.files="cmd/nftban-installer/restore_decide_amendment3_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Confirms the dispatcher correctly:
+//
+//   1. Plumbs ClassifyResult.External into DecisionInput.ExternalIndicator
+//      so the engine's G1/AmbiguityConflictExternal split sees the entry
+//      condition string.
+//
+//   2. Triggers gatherOrphanEvidence on the Amendment 3 quintuple shape
+//      (AuthorityAmbiguous + AmbiguityConflictExternal + external=="csf"
+//      + DirectAdmin + NoRecord + --panel-auto-takeover + --accept-orphan-nftban),
+//      not only on the Amendment 2 triple.
+//
+//   3. Reframes E.2 in the Amendment 3 path so AllTrueAmendment3() returns
+//      true on the happy path (per §64.1 + the dispatcher reframing).
+//
+// =============================================================================
+package main
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/uninstall"
+)
+
+// amd3HappyAuth returns a ClassifyResult shaped for the §62 Amendment 3
+// entry condition: AuthorityAmbiguous + AmbiguityConflictExternal +
+// external=="csf". Mirrors how dns2 looks post-canonical-install.
+func amd3HappyAuth() *uninstall.ClassifyResult {
+	return &uninstall.ClassifyResult{
+		State:     uninstall.AuthorityAmbiguous,
+		Ambiguity: uninstall.AmbiguityConflictExternal,
+		External:  "csf",
+	}
+}
+
+// TestAmd3Dispatcher_E2Reframed_AllTrueAmendment3_True confirms that
+// gatherOrphanEvidence sets E.2=true on the Amendment 3 entry condition
+// (so AllTrueAmendment3() is satisfied on the happy path).
+func TestAmd3Dispatcher_E2Reframed_AllTrueAmendment3_True(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+
+	// E.2 must be true under the Amendment 3 entry condition (reframed
+	// per §64.1).
+	if !ev.E2AuthorityNFTBan {
+		t.Errorf("E.2 = false on Amendment 3 entry condition; want true (reframed per §64.1)")
+	}
+
+	// AllTrueAmendment3() must be true (E.12 omitted; E.2 reframed-true).
+	if !ev.AllTrueAmendment3() {
+		t.Errorf("AllTrueAmendment3() = false; failed row=%s", ev.FailedRowIDAmendment3())
+	}
+
+	// E.12 (NoConflictExternal) must be FALSE because the entry condition
+	// IS AmbiguityConflictExternal — this is Amendment 3 by construction.
+	if ev.E12NoConflictExternal {
+		t.Errorf("E.12 = true on Amendment 3 entry; want false (entry condition IS AmbiguityConflictExternal)")
+	}
+
+	// Amendment 2's AllTrue() must return false on this fixture because
+	// E.12 is required-true by §54.1 but the Amendment 3 entry condition
+	// makes that impossible. This proves the two predicates are
+	// independently scoped.
+	if ev.AllTrue() {
+		t.Errorf("AllTrue() = true on Amendment 3 entry; want false (Amendment 2 predicate requires E.12=true)")
+	}
+}
+
+// TestAmd3Dispatcher_E2_FalseWhenMisclassified confirms the E.2
+// reframing is conservative: it only fires when the FULL quintuple
+// shape is present in the classifier output. Empty external,
+// non-csf external, and OrphanNFTBan ambiguity all keep E.2 false.
+func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
+	cases := []struct {
+		name string
+		auth *uninstall.ClassifyResult
+		want bool
+	}{
+		{
+			name: "amd2_path_authority_nftban",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityNFTBan,
+				Ambiguity: uninstall.AmbiguityNone,
+				External:  "",
+			},
+			want: true, // Amendment 2's classic E.2
+		},
+		{
+			name: "amd3_path_authority_ambiguous_csf",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityConflictExternal,
+				External:  "csf",
+			},
+			want: true, // Amendment 3 reframed E.2
+		},
+		{
+			name: "external_empty_defensive",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityConflictExternal,
+				External:  "",
+			},
+			want: false, // empty external — not a §62 candidate
+		},
+		{
+			name: "external_ufw_out_of_scope",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityConflictExternal,
+				External:  "ufw",
+			},
+			want: false, // non-csf external — not a §62 candidate
+		},
+		{
+			name: "external_multi_csf_ufw",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityConflictExternal,
+				External:  "csf,ufw",
+			},
+			want: false, // multi-external — not a §62 candidate
+		},
+		{
+			name: "ambiguity_orphan_nftban",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityOrphanNFTBan,
+				External:  "csf",
+			},
+			want: false, // wrong sub-classifier — not a §62 candidate
+		},
+		{
+			name: "authority_external",
+			auth: &uninstall.ClassifyResult{
+				State:    uninstall.AuthorityExternal,
+				External: "csf",
+			},
+			want: false, // AuthorityExternal — locked-REFUSE, not §62
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			log := logging.New("/dev/null", false)
+			ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, c.auth, happyProbe(), happyCfg())
+			if ev.E2AuthorityNFTBan != c.want {
+				t.Errorf("E.2 = %v; want %v", ev.E2AuthorityNFTBan, c.want)
+			}
+		})
+	}
+}
+
+// TestAmd3Dispatcher_FailedRow_Amendment3 confirms FailedRowIDAmendment3()
+// returns AMD3-E.{N} on per-row failures from the Amendment 3 path.
+// E.12 is omitted from the Amendment 3 walk so its falseness must not
+// trigger a failed-row return.
+func TestAmd3Dispatcher_FailedRow_Amendment3(t *testing.T) {
+	log := logging.New("/dev/null", false)
+
+	// Happy path: AllTrueAmendment3 holds, FailedRowIDAmendment3 is empty.
+	ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+	if id := ev.FailedRowIDAmendment3(); id != "" {
+		t.Errorf("FailedRowIDAmendment3 on happy path = %q; want \"\"", id)
+	}
+
+	// Failure path: kill E.7 (csf.disabled absent).
+	exec := happyExec()
+	delete(exec.Files, "/usr/sbin/csf.disabled")
+	ev = gatherOrphanEvidence(exec, log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+	if id := ev.FailedRowIDAmendment3(); id != "AMD3-E.7" {
+		t.Errorf("FailedRowIDAmendment3 with E.7 absent = %q; want %q", id, "AMD3-E.7")
+	}
+}

--- a/cmd/nftban-installer/restore_decide_amendment3_test.go
+++ b/cmd/nftban-installer/restore_decide_amendment3_test.go
@@ -6,7 +6,7 @@
 // meta:type="test"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-04-29"
-// meta:description="Amendment 3 dispatcher-side wiring (ExternalIndicator + reframed E.2)"
+// meta:description="Amendment 3 dispatcher-side wiring (ExternalIndicator + reframed E.2 + separate helper)"
 // meta:inventory.files="cmd/nftban-installer/restore_decide_amendment3_test.go"
 // meta:inventory.binaries=""
 // meta:inventory.env_vars=""
@@ -19,16 +19,22 @@
 // Confirms the dispatcher correctly:
 //
 //   1. Plumbs ClassifyResult.External into DecisionInput.ExternalIndicator
-//      so the engine's G1/AmbiguityConflictExternal split sees the entry
-//      condition string.
+//      so the engine's G1/AmbiguityConflictExternal split sees the
+//      §62 entry condition string.
 //
-//   2. Triggers gatherOrphanEvidence on the Amendment 3 quintuple shape
-//      (AuthorityAmbiguous + AmbiguityConflictExternal + external=="csf"
-//      + DirectAdmin + NoRecord + --panel-auto-takeover + --accept-orphan-nftban),
-//      not only on the Amendment 2 triple.
+//   2. Calls the Amendment 3 evidence helper (gatherOrphanEvidenceAmendment3)
+//      on the Amendment 3 quintuple shape, NOT the Amendment 2 helper
+//      (auditor-recommended separate-helper structure).
 //
-//   3. Reframes E.2 in the Amendment 3 path so AllTrueAmendment3() returns
-//      true on the happy path (per §64.1 + the dispatcher reframing).
+//   3. Calls the Amendment 2 evidence helper (gatherOrphanEvidence)
+//      on the Amendment 2 quintuple shape (regression — Amendment 2
+//      path unchanged).
+//
+//   4. Reframes E.2 in the Amendment 3 helper so AllTrueAmendment3()
+//      returns true on the §62 happy path.
+//
+//   5. Keeps gatherOrphanEvidence's E.2 strictly evaluating
+//      AuthorityNFTBan (Amendment 2 unchanged).
 //
 // =============================================================================
 package main
@@ -52,58 +58,40 @@ func amd3HappyAuth() *uninstall.ClassifyResult {
 	}
 }
 
-// TestAmd3Dispatcher_E2Reframed_AllTrueAmendment3_True confirms that
-// gatherOrphanEvidence sets E.2=true on the Amendment 3 entry condition
-// (so AllTrueAmendment3() is satisfied on the happy path).
-func TestAmd3Dispatcher_E2Reframed_AllTrueAmendment3_True(t *testing.T) {
+// TestGatherOrphanEvidenceAmendment3_E2Reframed_AllTrueAmendment3_True
+// confirms the Amendment 3 helper sets E.2=true on the §62 entry
+// condition and AllTrueAmendment3() returns true on the happy path.
+// Also verifies E.12 is correctly false (entry condition IS
+// AmbiguityConflictExternal) and that AllTrue() (Amendment 2 predicate)
+// returns false on this fixture (because E.12 is required-true by §54.1).
+func TestGatherOrphanEvidenceAmendment3_E2Reframed_AllTrueAmendment3_True(t *testing.T) {
 	log := logging.New("/dev/null", false)
-	ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+	ev := gatherOrphanEvidenceAmendment3(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
 
-	// E.2 must be true under the Amendment 3 entry condition (reframed
-	// per §64.1).
 	if !ev.E2AuthorityNFTBan {
 		t.Errorf("E.2 = false on Amendment 3 entry condition; want true (reframed per §64.1)")
 	}
-
-	// AllTrueAmendment3() must be true (E.12 omitted; E.2 reframed-true).
 	if !ev.AllTrueAmendment3() {
 		t.Errorf("AllTrueAmendment3() = false; failed row=%s", ev.FailedRowIDAmendment3())
 	}
-
-	// E.12 (NoConflictExternal) must be FALSE because the entry condition
-	// IS AmbiguityConflictExternal — this is Amendment 3 by construction.
 	if ev.E12NoConflictExternal {
 		t.Errorf("E.12 = true on Amendment 3 entry; want false (entry condition IS AmbiguityConflictExternal)")
 	}
-
-	// Amendment 2's AllTrue() must return false on this fixture because
-	// E.12 is required-true by §54.1 but the Amendment 3 entry condition
-	// makes that impossible. This proves the two predicates are
-	// independently scoped.
 	if ev.AllTrue() {
 		t.Errorf("AllTrue() = true on Amendment 3 entry; want false (Amendment 2 predicate requires E.12=true)")
 	}
 }
 
-// TestAmd3Dispatcher_E2_FalseWhenMisclassified confirms the E.2
-// reframing is conservative: it only fires when the FULL quintuple
-// shape is present in the classifier output. Empty external,
-// non-csf external, and OrphanNFTBan ambiguity all keep E.2 false.
-func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
+// TestGatherOrphanEvidenceAmendment3_E2FalseOnNonQualifying confirms
+// that the Amendment 3 helper's E.2 is conservative: ONLY fires when
+// the full §62 entry condition (AuthorityAmbiguous + ConflictExternal
+// + external=="csf") is present.
+func TestGatherOrphanEvidenceAmendment3_E2FalseOnNonQualifying(t *testing.T) {
 	cases := []struct {
 		name string
 		auth *uninstall.ClassifyResult
 		want bool
 	}{
-		{
-			name: "amd2_path_authority_nftban",
-			auth: &uninstall.ClassifyResult{
-				State:     uninstall.AuthorityNFTBan,
-				Ambiguity: uninstall.AmbiguityNone,
-				External:  "",
-			},
-			want: true, // Amendment 2's classic E.2
-		},
 		{
 			name: "amd3_path_authority_ambiguous_csf",
 			auth: &uninstall.ClassifyResult{
@@ -111,7 +99,16 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				Ambiguity: uninstall.AmbiguityConflictExternal,
 				External:  "csf",
 			},
-			want: true, // Amendment 3 reframed E.2
+			want: true,
+		},
+		{
+			name: "amd2_path_authority_nftban_FAILS_amendment3_helper",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityNFTBan,
+				Ambiguity: uninstall.AmbiguityNone,
+				External:  "",
+			},
+			want: false, // gatherOrphanEvidenceAmendment3 ONLY accepts §62 entry
 		},
 		{
 			name: "external_empty_defensive",
@@ -120,7 +117,7 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				Ambiguity: uninstall.AmbiguityConflictExternal,
 				External:  "",
 			},
-			want: false, // empty external — not a §62 candidate
+			want: false,
 		},
 		{
 			name: "external_ufw_out_of_scope",
@@ -129,7 +126,7 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				Ambiguity: uninstall.AmbiguityConflictExternal,
 				External:  "ufw",
 			},
-			want: false, // non-csf external — not a §62 candidate
+			want: false,
 		},
 		{
 			name: "external_multi_csf_ufw",
@@ -138,7 +135,7 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				Ambiguity: uninstall.AmbiguityConflictExternal,
 				External:  "csf,ufw",
 			},
-			want: false, // multi-external — not a §62 candidate
+			want: false,
 		},
 		{
 			name: "ambiguity_orphan_nftban",
@@ -147,7 +144,7 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				Ambiguity: uninstall.AmbiguityOrphanNFTBan,
 				External:  "csf",
 			},
-			want: false, // wrong sub-classifier — not a §62 candidate
+			want: false,
 		},
 		{
 			name: "authority_external",
@@ -155,10 +152,48 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 				State:    uninstall.AuthorityExternal,
 				External: "csf",
 			},
-			want: false, // AuthorityExternal — locked-REFUSE, not §62
+			want: false,
 		},
 	}
 
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			log := logging.New("/dev/null", false)
+			ev := gatherOrphanEvidenceAmendment3(happyExec(), log, detect.PanelDirectAdmin, c.auth, happyProbe(), happyCfg())
+			if ev.E2AuthorityNFTBan != c.want {
+				t.Errorf("E.2 = %v; want %v", ev.E2AuthorityNFTBan, c.want)
+			}
+		})
+	}
+}
+
+// TestGatherOrphanEvidence_Amendment2Unchanged confirms the Amendment 2
+// helper's E.2 still evaluates strictly AuthorityNFTBan. This is the
+// regression check for §66.2 — Amendment 2 path stays passing.
+func TestGatherOrphanEvidence_Amendment2Unchanged(t *testing.T) {
+	cases := []struct {
+		name string
+		auth *uninstall.ClassifyResult
+		want bool
+	}{
+		{
+			name: "amd2_authority_nftban_true",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityNFTBan,
+				Ambiguity: uninstall.AmbiguityNone,
+			},
+			want: true,
+		},
+		{
+			name: "amd3_classifier_does_NOT_qualify_amendment2_E2",
+			auth: &uninstall.ClassifyResult{
+				State:     uninstall.AuthorityAmbiguous,
+				Ambiguity: uninstall.AmbiguityConflictExternal,
+				External:  "csf",
+			},
+			want: false, // Amendment 2 helper rejects Amendment 3 entry
+		},
+	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			log := logging.New("/dev/null", false)
@@ -170,24 +205,62 @@ func TestAmd3Dispatcher_E2_FalseWhenMisclassified(t *testing.T) {
 	}
 }
 
-// TestAmd3Dispatcher_FailedRow_Amendment3 confirms FailedRowIDAmendment3()
-// returns AMD3-E.{N} on per-row failures from the Amendment 3 path.
-// E.12 is omitted from the Amendment 3 walk so its falseness must not
-// trigger a failed-row return.
-func TestAmd3Dispatcher_FailedRow_Amendment3(t *testing.T) {
+// TestGatherOrphanEvidenceAmendment3_FailedRow confirms
+// FailedRowIDAmendment3() returns AMD3-E.{N} on per-row failures and
+// "" on the happy path. E.12 is omitted from the Amendment 3 walk so
+// its falseness must not trigger a failed-row return.
+func TestGatherOrphanEvidenceAmendment3_FailedRow(t *testing.T) {
 	log := logging.New("/dev/null", false)
 
-	// Happy path: AllTrueAmendment3 holds, FailedRowIDAmendment3 is empty.
-	ev := gatherOrphanEvidence(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+	ev := gatherOrphanEvidenceAmendment3(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
 	if id := ev.FailedRowIDAmendment3(); id != "" {
 		t.Errorf("FailedRowIDAmendment3 on happy path = %q; want \"\"", id)
 	}
 
-	// Failure path: kill E.7 (csf.disabled absent).
 	exec := happyExec()
 	delete(exec.Files, "/usr/sbin/csf.disabled")
-	ev = gatherOrphanEvidence(exec, log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+	ev = gatherOrphanEvidenceAmendment3(exec, log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
 	if id := ev.FailedRowIDAmendment3(); id != "AMD3-E.7" {
 		t.Errorf("FailedRowIDAmendment3 with E.7 absent = %q; want %q", id, "AMD3-E.7")
+	}
+}
+
+// TestGatherOrphanEvidenceAmendment3_E2_FalseOnNonCSFExternal pins
+// the AMD3-7-equivalent gating: external != "csf" → E.2 = false →
+// AllTrueAmendment3 false → FailedRowIDAmendment3 == AMD3-E.2.
+func TestGatherOrphanEvidenceAmendment3_E2_FalseOnNonCSFExternal(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	auth := &uninstall.ClassifyResult{
+		State:     uninstall.AuthorityAmbiguous,
+		Ambiguity: uninstall.AmbiguityConflictExternal,
+		External:  "ufw",
+	}
+	ev := gatherOrphanEvidenceAmendment3(happyExec(), log, detect.PanelDirectAdmin, auth, happyProbe(), happyCfg())
+	if ev.E2AuthorityNFTBan {
+		t.Errorf("E.2 = true on external=ufw; want false")
+	}
+	if ev.AllTrueAmendment3() {
+		t.Errorf("AllTrueAmendment3 = true on external=ufw; want false")
+	}
+	if id := ev.FailedRowIDAmendment3(); id != "AMD3-E.2" {
+		t.Errorf("FailedRowIDAmendment3 on external=ufw = %q; want %q", id, "AMD3-E.2")
+	}
+}
+
+// TestGatherOrphanEvidenceAmendment3_OmitsE12 carries the §66.2
+// invariant from the engine_amendment3_test.go suite into the
+// dispatcher integration: AllTrueAmendment3() must NOT consider
+// E.12 even when it is false.
+func TestGatherOrphanEvidenceAmendment3_OmitsE12(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	ev := gatherOrphanEvidenceAmendment3(happyExec(), log, detect.PanelDirectAdmin, amd3HappyAuth(), happyProbe(), happyCfg())
+
+	// On Amendment 3 entry, E.12 is false (entry IS ConflictExternal).
+	if ev.E12NoConflictExternal {
+		t.Fatalf("invariant: E.12 must be false on Amendment 3 entry; got true")
+	}
+	// AllTrueAmendment3 must still pass — E.12 omitted from predicate.
+	if !ev.AllTrueAmendment3() {
+		t.Errorf("AllTrueAmendment3 = false despite E.12 omission; failed row=%s", ev.FailedRowIDAmendment3())
 	}
 }

--- a/cmd/nftban-installer/restore_decide_evidence.go
+++ b/cmd/nftban-installer/restore_decide_evidence.go
@@ -72,8 +72,27 @@ func gatherOrphanEvidence(
 	// E.1 panel = DirectAdmin
 	ev.E1PanelDirectAdmin = panel == detect.PanelDirectAdmin
 
-	// E.2 authority = AuthorityNFTBan
-	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityNFTBan
+	// E.2 entry-condition row.
+	//
+	// Amendment 2 §54.1: E.2 = (Authority == AuthorityNFTBan).
+	// Amendment 3 §64.1: E.2 reframed to
+	//   (Authority == AuthorityAmbiguous AND
+	//    Ambiguity == AmbiguityConflictExternal AND
+	//    external == "csf").
+	//
+	// The dispatcher sets E.2=true when EITHER entry condition
+	// holds, so the same OrphanEvidence struct serves both
+	// AllTrue() (Amendment 2 path) and AllTrueAmendment3()
+	// (Amendment 3 path). The engine selects which predicate to
+	// evaluate based on the lattice entry it took
+	// (decideAuthorityNFTBan vs decideAmbiguityConflictExternal);
+	// E.2's reframed semantic is upheld in both because the
+	// dispatcher only enters this gathering function when EITHER
+	// candidate quintuple holds.
+	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityNFTBan ||
+		(auth.State == uninstall.AuthorityAmbiguous &&
+			auth.Ambiguity == uninstall.AmbiguityConflictExternal &&
+			auth.External == "csf")
 
 	// E.3 prior = NoRecord
 	ev.E3PriorNoRecord = probe.State == uninstall.PriorNoRecord
@@ -111,8 +130,28 @@ func gatherOrphanEvidence(
 	ev.E12NoConflictExternal = auth.State != uninstall.AuthorityExternal &&
 		auth.Ambiguity != uninstall.AmbiguityConflictExternal
 
-	// E.13 no Ambiguous classification
-	ev.E13NoAmbiguous = auth.State != uninstall.AuthorityAmbiguous
+	// E.13 no AmbiguityOrphanNFTBan.
+	//
+	// Amendment 2 §54.1 wording: "no AmbiguityOrphanNFTBan". The
+	// original implementation used the stricter
+	// `auth.State != AuthorityAmbiguous` because under Amendment 2's
+	// entry condition (AuthorityNFTBan) the two are equivalent —
+	// AuthorityNFTBan implies Ambiguity==None which implies
+	// !OrphanNFTBan. Under Amendment 3's entry condition
+	// (AuthorityAmbiguous + AmbiguityConflictExternal + external=csf),
+	// the strict form returns false even though the contract
+	// requires E.13=true; the operator-intent override does NOT
+	// extend to orphan-nftban-with-conflict cases (§66 forbidden
+	// bullet) but DOES extend to orphan-CSF-with-csf-residue
+	// (§63 lattice extension).
+	//
+	// Match the §64.1 wording exactly: E.13 = (Ambiguity !=
+	// AmbiguityOrphanNFTBan). Both Amendment 2 and Amendment 3
+	// entry conditions satisfy this; only the AmbiguityOrphanNFTBan
+	// path itself fails E.13. Test rows AMD2-E.13 (Amendment 2
+	// fixture) and AMD3-E.13 (Amendment 3 fixture, equivalent
+	// to AMD3-10's classifier shape) both pin this.
+	ev.E13NoAmbiguous = auth.Ambiguity != uninstall.AmbiguityOrphanNFTBan
 
 	return ev
 }

--- a/cmd/nftban-installer/restore_decide_evidence.go
+++ b/cmd/nftban-installer/restore_decide_evidence.go
@@ -51,9 +51,21 @@ const (
 )
 
 // gatherOrphanEvidence reads the 13 §54.1 rows from the live host
-// using only read-only executor surfaces. Returns a populated
-// restore.OrphanEvidence struct; AllTrue() reports whether every row
-// holds.
+// for the Amendment 2 G1/AuthorityNFTBan/orphan-intent-candidate path.
+// Returns a populated restore.OrphanEvidence struct; AllTrue() reports
+// whether every row holds.
+//
+// Caller MUST verify the §54 candidate triple before invoking this
+// helper:
+//
+//   Authority == AuthorityNFTBan
+//   Prior == NoRecord
+//   Panel == DirectAdmin
+//   --panel-auto-takeover
+//   --accept-orphan-nftban
+//
+// Calling this helper outside the §54 candidate path is an upstream
+// invariant violation; the result is undefined.
 //
 // Rows E.1, E.2, E.3, E.4, E.5 are derived from inputs the dispatcher
 // already gathered (`detect.DetectPanel`, `uninstall.Classify`,
@@ -67,32 +79,98 @@ func gatherOrphanEvidence(
 	probe *uninstall.ProbeResult,
 	cfg *config,
 ) restore.OrphanEvidence {
+	ev := populateSharedOrphanEvidenceRows(exec, log, panel, auth, probe, cfg)
+
+	// E.2 (Amendment 2 §54.1): authority = AuthorityNFTBan.
+	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityNFTBan
+
+	return ev
+}
+
+// gatherOrphanEvidenceAmendment3 reads the §64.1 rows from the live
+// host for the Amendment 3 G1/AmbiguityConflictExternal/
+// orphan-intent-candidate-csf path. Returns a populated
+// restore.OrphanEvidence struct; AllTrueAmendment3() reports whether
+// every row holds.
+//
+// Caller MUST verify the §62 candidate quintuple before invoking this
+// helper:
+//
+//   Authority == AuthorityAmbiguous
+//   Ambiguity == AmbiguityConflictExternal
+//   External == "csf"
+//   Prior == NoRecord
+//   Panel == DirectAdmin
+//   --panel-auto-takeover
+//   --accept-orphan-nftban
+//
+// Calling this helper outside the §62 candidate path is an upstream
+// invariant violation; the result is undefined.
+//
+// Identical to gatherOrphanEvidence except E.2 is reframed per §64.1
+// to assert (AuthorityAmbiguous + AmbiguityConflictExternal +
+// external == "csf") rather than (AuthorityNFTBan). Rows E.1, E.3–E.11,
+// E.13 are byte-identical to the Amendment 2 helper. Row E.12
+// (NoConflictExternal) is populated truthfully (false on the §62
+// entry, since AmbiguityConflictExternal IS the entry condition);
+// AllTrueAmendment3() omits E.12 from its predicate per the §64.1
+// reframing, so the false value does not invalidate the predicate.
+func gatherOrphanEvidenceAmendment3(
+	exec executor.Executor,
+	log *logging.Logger,
+	panel detect.PanelType,
+	auth *uninstall.ClassifyResult,
+	probe *uninstall.ProbeResult,
+	cfg *config,
+) restore.OrphanEvidence {
+	ev := populateSharedOrphanEvidenceRows(exec, log, panel, auth, probe, cfg)
+
+	// E.2 (Amendment 3 §64.1): reframed entry condition.
+	//   AuthorityAmbiguous + AmbiguityConflictExternal + external == "csf".
+	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityAmbiguous &&
+		auth.Ambiguity == uninstall.AmbiguityConflictExternal &&
+		auth.External == "csf"
+
+	return ev
+}
+
+// populateSharedOrphanEvidenceRows reads every §54.1/§64.1 evidence
+// row EXCEPT E.2 and returns a partially-populated OrphanEvidence
+// struct. The caller is responsible for setting E.2 per the
+// amendment-specific entry condition (Amendment 2: AuthorityNFTBan;
+// Amendment 3: AuthorityAmbiguous + AmbiguityConflictExternal +
+// external == "csf").
+//
+// The shared rows are:
+//   E.1  panel == DirectAdmin
+//   E.3  prior-record == NoRecord
+//   E.4  --panel-auto-takeover present
+//   E.5  --accept-orphan-nftban present
+//   E.6  csf.service masked or disabled (not active)
+//   E.7  /usr/sbin/csf.disabled exists
+//   E.8  /usr/sbin/csf absent
+//   E.9  ip:nftban table present
+//   E.10 ip6:nftban table present
+//   E.11 nftband.service active
+//   E.12 no AuthorityExternal AND no AmbiguityConflictExternal
+//        (recorded truthfully; AllTrueAmendment3 omits this row)
+//   E.13 no AmbiguityOrphanNFTBan
+//
+// All evaluations are read-only.
+func populateSharedOrphanEvidenceRows(
+	exec executor.Executor,
+	log *logging.Logger,
+	panel detect.PanelType,
+	auth *uninstall.ClassifyResult,
+	probe *uninstall.ProbeResult,
+	cfg *config,
+) restore.OrphanEvidence {
 	ev := restore.OrphanEvidence{}
 
 	// E.1 panel = DirectAdmin
 	ev.E1PanelDirectAdmin = panel == detect.PanelDirectAdmin
 
-	// E.2 entry-condition row.
-	//
-	// Amendment 2 §54.1: E.2 = (Authority == AuthorityNFTBan).
-	// Amendment 3 §64.1: E.2 reframed to
-	//   (Authority == AuthorityAmbiguous AND
-	//    Ambiguity == AmbiguityConflictExternal AND
-	//    external == "csf").
-	//
-	// The dispatcher sets E.2=true when EITHER entry condition
-	// holds, so the same OrphanEvidence struct serves both
-	// AllTrue() (Amendment 2 path) and AllTrueAmendment3()
-	// (Amendment 3 path). The engine selects which predicate to
-	// evaluate based on the lattice entry it took
-	// (decideAuthorityNFTBan vs decideAmbiguityConflictExternal);
-	// E.2's reframed semantic is upheld in both because the
-	// dispatcher only enters this gathering function when EITHER
-	// candidate quintuple holds.
-	ev.E2AuthorityNFTBan = auth.State == uninstall.AuthorityNFTBan ||
-		(auth.State == uninstall.AuthorityAmbiguous &&
-			auth.Ambiguity == uninstall.AmbiguityConflictExternal &&
-			auth.External == "csf")
+	// E.2 — caller fills.
 
 	// E.3 prior = NoRecord
 	ev.E3PriorNoRecord = probe.State == uninstall.PriorNoRecord
@@ -124,33 +202,28 @@ func gatherOrphanEvidence(
 	ev.E11NftbandActive = exec.ServiceActive(nftbandServiceUnit)
 
 	// E.12 no AuthorityExternal / no AmbiguityConflictExternal.
-	// Classifier output already established AuthorityNFTBan (caller),
-	// so this is implicit; recorded explicitly per §54.1 to avoid
-	// inferential gaps.
+	// Recorded truthfully per the live classifier state. Under the
+	// Amendment 2 entry, this is true (caller invariant); under the
+	// Amendment 3 entry, this is false because the entry condition
+	// IS AmbiguityConflictExternal. AllTrueAmendment3() omits E.12
+	// from its predicate per §64.1.
 	ev.E12NoConflictExternal = auth.State != uninstall.AuthorityExternal &&
 		auth.Ambiguity != uninstall.AmbiguityConflictExternal
 
 	// E.13 no AmbiguityOrphanNFTBan.
 	//
-	// Amendment 2 §54.1 wording: "no AmbiguityOrphanNFTBan". The
-	// original implementation used the stricter
-	// `auth.State != AuthorityAmbiguous` because under Amendment 2's
-	// entry condition (AuthorityNFTBan) the two are equivalent —
-	// AuthorityNFTBan implies Ambiguity==None which implies
-	// !OrphanNFTBan. Under Amendment 3's entry condition
-	// (AuthorityAmbiguous + AmbiguityConflictExternal + external=csf),
-	// the strict form returns false even though the contract
-	// requires E.13=true; the operator-intent override does NOT
-	// extend to orphan-nftban-with-conflict cases (§66 forbidden
-	// bullet) but DOES extend to orphan-CSF-with-csf-residue
-	// (§63 lattice extension).
+	// Match the §54.1 / §64.1 wording exactly: E.13 = (Ambiguity !=
+	// AmbiguityOrphanNFTBan). Under Amendment 2's entry
+	// (AuthorityNFTBan), Ambiguity is None — !OrphanNFTBan. Under
+	// Amendment 3's entry (AmbiguityConflictExternal), Ambiguity is
+	// ConflictExternal — also !OrphanNFTBan. Only the
+	// AmbiguityOrphanNFTBan path itself fails E.13.
 	//
-	// Match the §64.1 wording exactly: E.13 = (Ambiguity !=
-	// AmbiguityOrphanNFTBan). Both Amendment 2 and Amendment 3
-	// entry conditions satisfy this; only the AmbiguityOrphanNFTBan
-	// path itself fails E.13. Test rows AMD2-E.13 (Amendment 2
-	// fixture) and AMD3-E.13 (Amendment 3 fixture, equivalent
-	// to AMD3-10's classifier shape) both pin this.
+	// (The earlier implementation used the stricter
+	// `auth.State != AuthorityAmbiguous`; that conflated the two
+	// AuthorityAmbiguous sub-kinds and returned false on the
+	// Amendment 3 path even though §64.1 requires E.13=true. Replaced
+	// with the contract-wording-exact form.)
 	ev.E13NoAmbiguous = auth.Ambiguity != uninstall.AmbiguityOrphanNFTBan
 
 	return ev


### PR DESCRIPTION
## Summary

Closes the dispatcher-side wiring gap that the auditor flagged in their post-merge ruling on Amendment-3-code-A (PR #523). Without this PR, the engine's `G1/AmbiguityConflictExternal` split cannot be reached on a real host because the dispatcher does not:

1. Plumb `auth.External` into `DecisionInput.ExternalIndicator` (required by §62 entry condition `external == "csf"`)
2. Trigger `gatherOrphanEvidence` on the Amendment 3 quintuple shape (`AuthorityAmbiguous + AmbiguityConflictExternal + external=="csf" + NoRecord + DA + both flags`)
3. Reframe `E.2` per Amendment 3 §64.1 so the dispatcher's entry condition is reflected in the evidence row

**cmd/-side wiring only.** Engine.go untouched. Contract.md untouched. No mutation surfaces. No new state terminals. No new exit codes. No CI change.

## Files changed (3)

| File | Change | Lines |
|---|---|---|
| `cmd/nftban-installer/restore_decide.go` | DecisionInput sets ExternalIndicator + extended OrphanEvidence-gathering trigger | +50/−13 |
| `cmd/nftban-installer/restore_decide_evidence.go` | E.2 reframed per §64.1; E.13 tightened to "no AmbiguityOrphanNFTBan" wording | +47/−3 |
| `cmd/nftban-installer/restore_decide_amendment3_test.go` | 3 new tests, 9 sub-cases (NEW) | +200/0 |

## NOT changed

- `internal/installer/restore/engine.go` — lattice unchanged
- `internal/installer/restore/types.go` — struct unchanged
- `internal/installer/restore/contract.md` — no amendment
- `internal/installer/uninstall/*` — classifier unchanged
- `internal/installer/state/*` — state machine unchanged
- `cmd/nftban-installer/main.go` — history gate unchanged
- `cmd/nftban-installer/flags.go` — flag surface unchanged
- `.github/workflows/*` — CI unchanged
- §32 11-step ordering — unchanged
- Amendment 2 §54 path — preserved (regression-checked via existing tests + E.13 wording match)

## E.13 wording fix (carried in this PR)

The original `gatherOrphanEvidence` evaluated `E.13 = (auth.State != AuthorityAmbiguous)`. Per §54.1 and §64.1, the wording is "no AmbiguityOrphanNFTBan". The two were equivalent under Amendment 2's `AuthorityNFTBan` entry condition (Ambiguity is None, so OrphanNFTBan check is trivially true), but they diverge under Amendment 3's `AuthorityAmbiguous + ConflictExternal` entry. Amendment 3 requires E.13=true; the strict implementation returned false. Fixed to match contract wording exactly: `E.13 = (auth.Ambiguity != AmbiguityOrphanNFTBan)`. Amendment 2 path preserved.

## Test results (lab4)

- `go test ./cmd/nftban-installer/...` → **ok**
- `go test ./internal/installer/restore/...` → **ok**
- `go test ./...` → **64 packages ok, 0 FAIL**

3 new test functions, 9 sub-cases including:
- E.2 = true on Amendment 2 entry (AuthorityNFTBan)
- E.2 = true on Amendment 3 entry (AuthorityAmbiguous + ConflictExternal + external=csf)
- E.2 = false on empty external, ufw external, multi-external (csf,ufw), OrphanNFTBan ambiguity, AuthorityExternal
- AllTrueAmendment3 = true on Amendment 3 happy path
- AllTrue (Amendment 2) = false on Amendment 3 happy path (E.12 cannot be true)
- FailedRowIDAmendment3 returns "" on happy and "AMD3-E.7" on E.7 mutation

## Test plan

- [ ] Auditor on-PR audit: scope verification (cmd/-side only), no engine.go change, no contract change, all 9 sub-cases pass
- [ ] Operator merges
- [ ] Fresh Tier 1 binary built on lab4 from post-merge HEAD (supersedes `153f7abe…`)
- [ ] Distribute to dns2; byte-pin source==host
- [ ] Operator runs `systemctl reset-failed lfd.service` (cosmetic, idempotent if dns2 didn't reboot)
- [ ] Fresh dns2-gate-b H2/H3 populated
- [ ] External reachability monitor activated → reachability-pre.txt captured (HARD-GATE-WITH-NO-EXCEPTIONS)
- [ ] Pre-execution Gate B retry audit returns GO
- [ ] Single Gate B retry invocation on dns2: `--mode=restore --panel-auto-takeover --accept-orphan-nftban`
- [ ] Post-B audit returns GO
- [ ] PR-26 final mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)