### PR TITLE
PR26.2: panel-survival framework + FakePanelAdapter

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -78,6 +78,16 @@ type config struct {
 	// any regression that reintroduces an auto-elevate path while the
 	// mutation code is present.
 	confirmMutation bool // --confirm-mutation: authorize uninstall authority release (PR-23)
+	// v1.100 PR26.2: --no-panel — operator opt-out of panel-survival
+	// enforcement (PANEL-SURVIVAL-001). Default off. When set, the
+	// panel-survival assertion still runs registered adapters for
+	// diagnostic logging but never reports Fatal=true. The flag
+	// exists so an operator on a host that legitimately runs without
+	// nftban-panel integration (e.g., panel managed externally) can
+	// proceed past install without an assertion failure they cannot
+	// resolve. PR26.2 ships with an empty adapter registry — the
+	// flag is a no-op until PR26.3 lands the first real adapter.
+	noPanel bool // --no-panel: opt out of panel-survival enforcement
 }
 
 func parseFlags() *config {
@@ -113,6 +123,8 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.acceptOrphanNFTBan, "accept-orphan-nftban", false, "Explicit-intent CSF restore on a DirectAdmin host where NFTBan is the current authority and no prior-authority record exists. Requires --mode=restore AND --panel-auto-takeover AND DirectAdmin AND on-disk evidence that NFTBan previously took over from CSF. Without all preconditions the restore refuses (Amendment 2).")
 	// v1.100 PR-23: --confirm-mutation — explicit uninstall mutation entry.
 	flag.BoolVar(&cfg.confirmMutation, "confirm-mutation", false, "Authorize uninstall authority release (real kernel + service mutation). Required for --mode=uninstall without --dry-run. Mutually exclusive with --dry-run.")
+	// v1.100 PR26.2: PANEL-SURVIVAL-001 opt-out.
+	flag.BoolVar(&cfg.noPanel, "no-panel", false, "Opt out of PANEL-SURVIVAL-001 enforcement. Adapters still run for diagnostic logging but a detected-panel integration failure will NOT block StateCommitted on this run. Default OFF.")
 
 	flag.Parse()
 

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -105,6 +105,9 @@ func main() {
 	// authority classifier honours the operator's explicit opt-in. Default
 	// false — panel presence alone no longer implicitly approves takeover.
 	globalPhaseData.panelAutoApprove = cfg.panelAutoTakeover
+	// PR26.2: propagate --no-panel so the panel-survival assertion's
+	// policy can opt out when the operator explicitly disables it.
+	globalPhaseData.noPanel = cfg.noPanel
 
 	exitCode := run(ctx, exec, sf, cfg, log)
 

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -29,6 +29,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/fhs"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
 	"github.com/itcmsgr/nftban/internal/installer/payload"
 	"github.com/itcmsgr/nftban/internal/installer/render"
 	"github.com/itcmsgr/nftban/internal/installer/safety"
@@ -59,6 +60,11 @@ type phaseData struct {
 	// cfg.panelAutoTakeover in main() before phases run. Default false —
 	// panel detection alone no longer auto-approves takeover.
 	panelAutoApprove bool
+	// v1.100 PR26.2: PANEL-SURVIVAL-001 opt-out. Propagated from
+	// cfg.noPanel in main(). When true, the panel-survival assertion
+	// returns Fatal=false even on adapter failure (operator has
+	// explicitly accepted the risk).
+	noPanel bool
 }
 
 // globalPhaseData is set by phaseDetect and consumed by later phases.
@@ -345,7 +351,13 @@ func phaseValidate(_ context.Context, exec executor.Executor, sf *state.StateFil
 	validate.RunPermissionsEnforce(exec, log)
 
 	// 3. Run assertions (VALIDATE_1)
-	results := validate.RunAssertions(exec, pd.sshPort, log)
+	// PR26.2: derive panel-survival policy from operator flags. The
+	// adapter registry is consulted by panelfw (empty in PR26.2 —
+	// effectively a no-op until PR26.3 lands the first adapter).
+	policy := panelfw.DefaultPolicy()
+	policy.OperatorDisabled = pd.noPanel
+	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
+	results := validate.RunAssertionsWithOpts(exec, pd.sshPort, log, opts)
 
 	// 4. Set immutable flags on security-critical files (G8)
 	validate.SetImmutableFlags(exec, log)
@@ -373,7 +385,7 @@ func phaseValidate(_ context.Context, exec executor.Executor, sf *state.StateFil
 	}
 
 	// v1.98 INV-I-013: Re-run assertions (VALIDATE_2) — only this result counts
-	results2 := validate.RunAssertions(exec, pd.sshPort, log)
+	results2 := validate.RunAssertionsWithOpts(exec, pd.sshPort, log, opts)
 
 	if validate.AllPassed(results2) {
 		log.Info("VALIDATE_2: all assertions passed after safe auto-fix — COMMITTED")

--- a/internal/installer/panelfw/panelfw.go
+++ b/internal/installer/panelfw/panelfw.go
@@ -1,0 +1,305 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.2 - Reusable Panel Adapter Framework
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="Generic hosting-panel adapter framework — survival policy + registry"
+// meta:inventory.files="internal/installer/panelfw/panelfw.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// PR26.2 — generic panel framework. PANEL-SURVIVAL-001 invariant:
+//
+//	If a hosting panel is detected before lifecycle mutation,
+//	then nftban must either preserve the panel's required service ports
+//	through the canonical ports model and validate integration success,
+//	OR abort before StateCommitted with a clear panel-safety error.
+//	Panel detected + integration failure must never reach StateCommitted,
+//	unless the operator explicitly disables panel integration with a
+//	supported flag.
+//
+// Hard exclusions in this PR (DirectAdmin/cPanel/Plesk live in PR26.3+):
+//   - no real adapter implementations (RegisteredAdapters returns nil)
+//   - no firewall mutation
+//   - no host destructive testing
+//   - no restore semantics
+//
+// Adapters are required to be read-only by interface contract:
+// Detect, RequiredPorts, and ValidateReachability MUST NOT mutate the
+// host. The framework calls each in sequence and converts results into
+// a PanelResult; the caller (validate.assertion) decides whether to
+// block StateCommitted.
+//
+// =============================================================================
+
+package panelfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// PanelID is the canonical identifier for a hosting panel adapter.
+// Matches the lower-case panel-name convention used throughout the
+// installer (e.g., "directadmin", "cpanel", "plesk", "fakepanel").
+type PanelID string
+
+// PanelDetection is the structured outcome of an adapter's Detect()
+// call. Adapters set Detected=true only when their evidence list is
+// non-empty; Confidence is "strong" when the adapter is sure (e.g.,
+// canonical install dir + listening port + active service) and "weak"
+// when only one indicator was found.
+type PanelDetection struct {
+	ID          PanelID
+	Detected    bool
+	Confidence  string
+	Evidence    []string
+	RequiredTCP []int
+	RequiredUDP []int
+	Warnings    []string
+}
+
+// PanelAdapter is the contract every panel plugin implements. All
+// methods MUST be read-only — the framework guarantees that calling
+// Detect, RequiredPorts, or ValidateReachability never mutates host
+// state. Adapters that need to write configuration (e.g., to apply
+// ports to the canonical ports model) do that through a separate
+// host-controlled write path; the framework only consults the adapter
+// for facts and validates outcomes.
+type PanelAdapter interface {
+	// ID returns the canonical adapter identifier.
+	ID() PanelID
+
+	// Detect inspects the host and returns whether this adapter's
+	// panel is present, with evidence and required ports.
+	Detect(ctx context.Context, exec executor.Executor) PanelDetection
+
+	// RequiredPorts returns the TCP and UDP port lists the panel
+	// must keep reachable for its control surface to survive an
+	// nftban lifecycle operation. Returns an error if the adapter
+	// cannot enumerate them (e.g., panel config unreadable).
+	RequiredPorts(ctx context.Context, exec executor.Executor) (tcp []int, udp []int, err error)
+
+	// ValidateReachability confirms the panel's control surface is
+	// reachable in the current ruleset. Read-only: it MUST NOT
+	// mutate ports, services, or rules. Returns nil on success or
+	// a structured error describing the missing-port/timeout/etc.
+	// condition.
+	ValidateReachability(ctx context.Context, exec executor.Executor) error
+}
+
+// PanelPolicy controls how the framework converts adapter outcomes
+// into a Fatal/non-fatal verdict.
+type PanelPolicy struct {
+	// RequirePanelSuccess: when an adapter detects a panel and either
+	// RequiredPorts or ValidateReachability errors, the result is
+	// Fatal. Default true. The "non-fatal warning" path that let
+	// dns2's panel-enable failure slip through StateCommitted is
+	// removed by setting this to true.
+	RequirePanelSuccess bool
+
+	// AllowPanelAbsent: when no adapter detects a panel, treat as
+	// healthy (the common no-panel case). Default true.
+	AllowPanelAbsent bool
+
+	// OperatorDisabled: operator passed --no-panel (or equivalent
+	// supported flag) to opt out of panel-survival enforcement on
+	// this run. The framework still runs adapters for diagnostic
+	// purposes but always returns Fatal=false.
+	OperatorDisabled bool
+}
+
+// DefaultPolicy returns the production-default policy:
+// RequirePanelSuccess=true, AllowPanelAbsent=true, OperatorDisabled=false.
+func DefaultPolicy() PanelPolicy {
+	return PanelPolicy{
+		RequirePanelSuccess: true,
+		AllowPanelAbsent:    true,
+		OperatorDisabled:    false,
+	}
+}
+
+// PanelResult is the structured outcome of Evaluate.
+type PanelResult struct {
+	// Detection is the first adapter's detection record (or a
+	// zero-value detection with ID="" when no adapter detected
+	// anything).
+	Detection PanelDetection
+
+	// PortsTCP / PortsUDP mirror the RequiredPorts result for the
+	// detected panel (nil when no panel detected or RequiredPorts
+	// errored).
+	PortsTCP []int
+	PortsUDP []int
+
+	// PortsApplied indicates whether the adapter's RequiredPorts
+	// call succeeded. It does NOT confirm ports were written to the
+	// canonical ports model — that is a separate framework
+	// responsibility outside PR26.2 scope. The flag exists so the
+	// assertion message can distinguish "couldn't determine ports"
+	// from "ports known and reachability validated".
+	PortsApplied bool
+
+	// ReachableAfter is true when ValidateReachability returned nil.
+	// False on adapter error or when the framework did not reach
+	// the reachability check (e.g., RequiredPorts errored first).
+	ReachableAfter bool
+
+	// Fatal is the policy-derived verdict. When true, the caller
+	// (validate.assertion) MUST block StateCommitted.
+	Fatal bool
+
+	// Reason carries a human-readable summary suitable for the
+	// AssertionResult.Detail field. Empty when not Fatal.
+	Reason string
+}
+
+// registry holds adapters in package-private state. Production code
+// path: filled by adapter packages' init() (PR26.3 onwards). Tests
+// pass an explicit slice to EvaluateAdapters and bypass the registry.
+var registry []PanelAdapter
+
+// Register adds a PanelAdapter to the package registry. Adapter
+// packages call this from init(); the framework iterates the registry
+// in registration order during Evaluate.
+//
+// Duplicate IDs are not enforced — the first detected panel wins
+// regardless. Adapter authors are responsible for non-overlapping
+// detection criteria.
+func Register(a PanelAdapter) {
+	if a == nil {
+		return
+	}
+	registry = append(registry, a)
+}
+
+// RegisteredAdapters returns a copy of the current registry. Stable
+// in registration order. Returns an empty slice when nothing has
+// been registered (the PR26.2 default — no adapters compiled in).
+func RegisteredAdapters() []PanelAdapter {
+	out := make([]PanelAdapter, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// resetRegistryForTest is exported via _test.go helpers to allow
+// per-test isolation. Production code never calls it.
+func resetRegistryForTest() {
+	registry = nil
+}
+
+// Evaluate runs the registered adapters and returns the first detected
+// panel's PanelResult. Pure framework call — relies entirely on the
+// adapter contract; no panel-specific knowledge in this function.
+func Evaluate(ctx context.Context, exec executor.Executor, log *logging.Logger, policy PanelPolicy) PanelResult {
+	return EvaluateAdapters(ctx, exec, log, RegisteredAdapters(), policy)
+}
+
+// EvaluateAdapters is the test-callable variant of Evaluate. Callers
+// pass an explicit adapter slice so they can inject FakePanelAdapter
+// without touching the global registry.
+func EvaluateAdapters(ctx context.Context, exec executor.Executor, log *logging.Logger, adapters []PanelAdapter, policy PanelPolicy) PanelResult {
+	if log == nil {
+		log = logging.New("/dev/null", false)
+	}
+
+	// No adapter detected anything → policy decides. Default
+	// AllowPanelAbsent=true means non-fatal pass.
+	if len(adapters) == 0 {
+		log.Debug("panelfw: no adapters registered — treating as no-panel host")
+		return PanelResult{
+			Detection: PanelDetection{},
+			Fatal:     !policy.AllowPanelAbsent,
+			Reason:    panelAbsentReason(policy),
+		}
+	}
+
+	for _, a := range adapters {
+		det := a.Detect(ctx, exec)
+		if !det.Detected {
+			continue
+		}
+		log.Info("panelfw: detected panel id=%s confidence=%s",
+			string(det.ID), det.Confidence)
+		return finalizeDetected(ctx, exec, log, a, det, policy)
+	}
+
+	log.Debug("panelfw: no adapter reported a detected panel")
+	return PanelResult{
+		Detection: PanelDetection{},
+		Fatal:     !policy.AllowPanelAbsent,
+		Reason:    panelAbsentReason(policy),
+	}
+}
+
+func panelAbsentReason(policy PanelPolicy) string {
+	if policy.AllowPanelAbsent {
+		return ""
+	}
+	return "no hosting panel detected, but policy.AllowPanelAbsent=false requires one"
+}
+
+// finalizeDetected runs RequiredPorts + ValidateReachability and
+// converts the outcomes into a policy-derived PanelResult.
+func finalizeDetected(ctx context.Context, exec executor.Executor, log *logging.Logger, a PanelAdapter, det PanelDetection, policy PanelPolicy) PanelResult {
+	res := PanelResult{Detection: det}
+
+	tcp, udp, err := a.RequiredPorts(ctx, exec)
+	if err != nil {
+		res.PortsApplied = false
+		res.Reason = fmt.Sprintf("panel %s RequiredPorts failed: %v", string(det.ID), err)
+		log.Warn("panelfw: %s", res.Reason)
+		res.Fatal = computeFatal(policy)
+		return res
+	}
+	res.PortsTCP = tcp
+	res.PortsUDP = udp
+	res.PortsApplied = true
+
+	if rerr := a.ValidateReachability(ctx, exec); rerr != nil {
+		res.ReachableAfter = false
+		res.Reason = fmt.Sprintf("panel %s ValidateReachability failed: %v", string(det.ID), rerr)
+		log.Warn("panelfw: %s", res.Reason)
+		res.Fatal = computeFatal(policy)
+		return res
+	}
+	res.ReachableAfter = true
+	log.Info("panelfw: panel %s integration validated tcp=%s udp=%s",
+		string(det.ID), portsToString(tcp), portsToString(udp))
+	return res
+}
+
+// computeFatal applies the policy to a failed integration outcome.
+// The OperatorDisabled override turns any failure non-fatal — the
+// operator has explicitly accepted the risk via --no-panel.
+func computeFatal(policy PanelPolicy) bool {
+	if policy.OperatorDisabled {
+		return false
+	}
+	return policy.RequirePanelSuccess
+}
+
+// portsToString renders a port slice as a stable comma-separated
+// string for log output.
+func portsToString(ps []int) string {
+	if len(ps) == 0 {
+		return "[]"
+	}
+	parts := make([]string, len(ps))
+	for i, p := range ps {
+		parts[i] = fmt.Sprintf("%d", p)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/internal/installer/panelfw/panelfw_test.go
+++ b/internal/installer/panelfw/panelfw_test.go
@@ -1,0 +1,390 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.2 - Panel Framework Tests (FakePanelAdapter)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="FakePanelAdapter + EvaluateAdapters tests; framework read-only invariant"
+// meta:inventory.files="internal/installer/panelfw/panelfw_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package panelfw
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("/dev/null", false)
+}
+
+// FakePanelAdapter is a configurable test double for the PanelAdapter
+// contract. It is defined in _test.go so it never compiles into the
+// production binary.
+//
+// It deliberately does NOT call any executor mutation method — the
+// framework-read-only invariant is enforced structurally by giving
+// the fake no mutation surface to invoke.
+type FakePanelAdapter struct {
+	IDValue          PanelID
+	DetectResult     PanelDetection
+	RequiredTCP      []int
+	RequiredUDP      []int
+	RequiredPortsErr error
+	ReachabilityErr  error
+
+	// Counters for assertions about call discipline.
+	DetectCalls       int
+	RequiredCalls     int
+	ReachabilityCalls int
+}
+
+func (f *FakePanelAdapter) ID() PanelID { return f.IDValue }
+
+func (f *FakePanelAdapter) Detect(_ context.Context, _ executor.Executor) PanelDetection {
+	f.DetectCalls++
+	return f.DetectResult
+}
+
+func (f *FakePanelAdapter) RequiredPorts(_ context.Context, _ executor.Executor) ([]int, []int, error) {
+	f.RequiredCalls++
+	return f.RequiredTCP, f.RequiredUDP, f.RequiredPortsErr
+}
+
+func (f *FakePanelAdapter) ValidateReachability(_ context.Context, _ executor.Executor) error {
+	f.ReachabilityCalls++
+	return f.ReachabilityErr
+}
+
+// ----------------------------------------------------------------------------
+// Spec case 1: fake panel detected + integration failure → StateCommitted blocked
+// ----------------------------------------------------------------------------
+
+func TestFake_Detected_ReachabilityFails_PolicyBlocks(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue: "fakepanel",
+		DetectResult: PanelDetection{
+			ID:          "fakepanel",
+			Detected:    true,
+			Confidence:  "strong",
+			Evidence:    []string{"fake-marker"},
+			RequiredTCP: []int{12345},
+		},
+		RequiredTCP:     []int{12345},
+		ReachabilityErr: errors.New("port 12345 unreachable"),
+	}
+	mock := executor.NewMockExecutor()
+
+	res := EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true; got %#v", res)
+	}
+	if !res.Detection.Detected {
+		t.Errorf("expected Detection.Detected=true")
+	}
+	if !res.PortsApplied {
+		t.Errorf("PortsApplied should be true (RequiredPorts succeeded)")
+	}
+	if res.ReachableAfter {
+		t.Errorf("ReachableAfter should be false")
+	}
+	if fake.ReachabilityCalls != 1 {
+		t.Errorf("expected ValidateReachability called once; got %d", fake.ReachabilityCalls)
+	}
+}
+
+func TestFake_Detected_RequiredPortsFails_PolicyBlocks(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue:          "fakepanel",
+		DetectResult:     PanelDetection{ID: "fakepanel", Detected: true},
+		RequiredPortsErr: errors.New("config unreadable"),
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true on RequiredPorts error")
+	}
+	if res.PortsApplied {
+		t.Errorf("PortsApplied should be false on RequiredPorts error")
+	}
+	if fake.ReachabilityCalls != 0 {
+		t.Errorf("ValidateReachability must NOT be called after RequiredPorts errored; got %d", fake.ReachabilityCalls)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Spec case 2: fake panel absent → pass
+// ----------------------------------------------------------------------------
+
+func TestFake_Absent_PolicyPasses(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue:      "fakepanel",
+		DetectResult: PanelDetection{ID: "fakepanel", Detected: false},
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false when no panel detected; got %#v", res)
+	}
+	if fake.RequiredCalls != 0 || fake.ReachabilityCalls != 0 {
+		t.Errorf("RequiredPorts/Reachability must NOT be called when Detect=false; got Required=%d Reachability=%d",
+			fake.RequiredCalls, fake.ReachabilityCalls)
+	}
+}
+
+// AllowPanelAbsent=false should make absence Fatal.
+func TestAbsent_AllowPanelAbsentFalse_Fatal(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AllowPanelAbsent = false
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		nil, policy)
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true when AllowPanelAbsent=false")
+	}
+	if res.Reason == "" {
+		t.Errorf("expected non-empty Reason for absent + AllowPanelAbsent=false")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Spec case 3: fake panel detected + required ports applied → pass
+// ----------------------------------------------------------------------------
+
+func TestFake_Detected_HappyPath_PolicyPasses(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue: "fakepanel",
+		DetectResult: PanelDetection{
+			ID:          "fakepanel",
+			Detected:    true,
+			Confidence:  "strong",
+			RequiredTCP: []int{12345},
+		},
+		RequiredTCP: []int{12345},
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on happy path; got %#v", res)
+	}
+	if !res.PortsApplied || !res.ReachableAfter {
+		t.Errorf("expected PortsApplied=true ReachableAfter=true; got %#v", res)
+	}
+	if len(res.PortsTCP) != 1 || res.PortsTCP[0] != 12345 {
+		t.Errorf("expected PortsTCP=[12345]; got %v", res.PortsTCP)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Spec case 4: --no-panel / explicit disabled mode → policy decides
+// ----------------------------------------------------------------------------
+
+// OperatorDisabled=true makes a failed integration non-fatal.
+func TestFake_Detected_FailingIntegration_OperatorDisabled_Passes(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue:         "fakepanel",
+		DetectResult:    PanelDetection{ID: "fakepanel", Detected: true},
+		RequiredTCP:     []int{12345},
+		ReachabilityErr: errors.New("port unreachable"),
+	}
+	policy := DefaultPolicy()
+	policy.OperatorDisabled = true
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, policy)
+	if res.Fatal {
+		t.Fatalf("OperatorDisabled=true must convert failure to non-fatal; got Fatal=true (%#v)", res)
+	}
+	if res.ReachableAfter {
+		t.Errorf("ReachableAfter should still reflect actual outcome (false), not policy override")
+	}
+}
+
+// OperatorDisabled=true with happy-path integration still passes.
+func TestFake_Detected_HappyPath_OperatorDisabled_Passes(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue:      "fakepanel",
+		DetectResult: PanelDetection{ID: "fakepanel", Detected: true},
+		RequiredTCP:  []int{12345},
+	}
+	policy := DefaultPolicy()
+	policy.OperatorDisabled = true
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, policy)
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on happy path even with OperatorDisabled; got %#v", res)
+	}
+}
+
+// RequirePanelSuccess=false disables the gate even when OperatorDisabled is
+// false. Mirrors the pre-PR26.2 "warn only" behavior, useful for migration.
+func TestFake_Detected_FailingIntegration_RequirePanelSuccessFalse_Passes(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue:         "fakepanel",
+		DetectResult:    PanelDetection{ID: "fakepanel", Detected: true},
+		RequiredTCP:     []int{12345},
+		ReachabilityErr: errors.New("port unreachable"),
+	}
+	policy := DefaultPolicy()
+	policy.RequirePanelSuccess = false
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, policy)
+	if res.Fatal {
+		t.Fatalf("RequirePanelSuccess=false must convert failure to non-fatal; got Fatal=true")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Spec case 5: framework read-only — no executor mutation
+// ----------------------------------------------------------------------------
+
+// The fake adapter calls only the methods declared on PanelAdapter.
+// We verify the framework never invokes a mutation primitive on the
+// executor by inspecting MockExecutor.Commands and the WrittenFiles
+// map after EvaluateAdapters runs across every shape.
+func TestFramework_NoExecutorMutation(t *testing.T) {
+	cases := []struct {
+		name string
+		fake *FakePanelAdapter
+	}{
+		{"absent", &FakePanelAdapter{IDValue: "fakepanel"}},
+		{"happy", &FakePanelAdapter{
+			IDValue:      "fakepanel",
+			DetectResult: PanelDetection{ID: "fakepanel", Detected: true},
+			RequiredTCP:  []int{12345},
+		}},
+		{"reach-fail", &FakePanelAdapter{
+			IDValue:         "fakepanel",
+			DetectResult:    PanelDetection{ID: "fakepanel", Detected: true},
+			RequiredTCP:     []int{12345},
+			ReachabilityErr: errors.New("x"),
+		}},
+		{"required-fail", &FakePanelAdapter{
+			IDValue:          "fakepanel",
+			DetectResult:     PanelDetection{ID: "fakepanel", Detected: true},
+			RequiredPortsErr: errors.New("x"),
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mock := executor.NewMockExecutor()
+			_ = EvaluateAdapters(context.Background(), mock, newTestLogger(),
+				[]PanelAdapter{c.fake}, DefaultPolicy())
+			if len(mock.WrittenFiles) != 0 {
+				t.Errorf("framework wrote %d files via executor (want 0)", len(mock.WrittenFiles))
+			}
+			if len(mock.Commands) != 0 {
+				t.Errorf("framework executed %d commands via executor (want 0); first=%v",
+					len(mock.Commands), mock.Commands[0])
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// First-detected-wins semantics across multi-adapter registry.
+// ----------------------------------------------------------------------------
+
+func TestEvaluateAdapters_FirstDetectedWins(t *testing.T) {
+	first := &FakePanelAdapter{
+		IDValue:      "first",
+		DetectResult: PanelDetection{ID: "first", Detected: false},
+	}
+	second := &FakePanelAdapter{
+		IDValue:      "second",
+		DetectResult: PanelDetection{ID: "second", Detected: true},
+		RequiredTCP:  []int{2222},
+	}
+	third := &FakePanelAdapter{
+		IDValue:      "third",
+		DetectResult: PanelDetection{ID: "third", Detected: true},
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{first, second, third}, DefaultPolicy())
+	if res.Detection.ID != "second" {
+		t.Errorf("expected detection ID=second; got %q", res.Detection.ID)
+	}
+	if third.DetectCalls != 0 {
+		t.Errorf("third adapter MUST NOT be called after second matched; got DetectCalls=%d", third.DetectCalls)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Registry isolation
+// ----------------------------------------------------------------------------
+
+func TestRegisteredAdapters_EmptyByDefault(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+	got := RegisteredAdapters()
+	if len(got) != 0 {
+		t.Fatalf("expected empty registry in PR26.2; got %d adapters", len(got))
+	}
+}
+
+func TestRegister_AppendsAndCopiesOut(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+	a := &FakePanelAdapter{IDValue: "fakepanel"}
+	Register(a)
+	got := RegisteredAdapters()
+	if len(got) != 1 || got[0].ID() != "fakepanel" {
+		t.Fatalf("Register did not append fakepanel; got %v", got)
+	}
+	// Returned slice must be a copy — mutating it must not affect the
+	// internal registry.
+	got[0] = nil
+	got2 := RegisteredAdapters()
+	if got2[0] == nil {
+		t.Errorf("RegisteredAdapters returned slice aliasing internal state")
+	}
+}
+
+func TestRegister_NilIsNoop(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+	Register(nil)
+	if len(RegisteredAdapters()) != 0 {
+		t.Errorf("Register(nil) must be a no-op")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// DefaultPolicy contract
+// ----------------------------------------------------------------------------
+
+func TestDefaultPolicy_Values(t *testing.T) {
+	p := DefaultPolicy()
+	if !p.RequirePanelSuccess {
+		t.Errorf("DefaultPolicy.RequirePanelSuccess must be true")
+	}
+	if !p.AllowPanelAbsent {
+		t.Errorf("DefaultPolicy.AllowPanelAbsent must be true")
+	}
+	if p.OperatorDisabled {
+		t.Errorf("DefaultPolicy.OperatorDisabled must be false")
+	}
+}
+
+// Logger nil tolerance: production wires a real logger; tests sometimes
+// pass nil. The framework must not panic.
+func TestEvaluateAdapters_NilLoggerTolerated(t *testing.T) {
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), nil,
+		nil, DefaultPolicy())
+	if res.Fatal {
+		t.Errorf("nil logger + empty adapters + default policy should be non-fatal")
+	}
+}

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -18,12 +18,14 @@
 package validate
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/fhs"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
 	"github.com/itcmsgr/nftban/internal/installer/payload"
 )
 
@@ -34,9 +36,58 @@ type AssertionResult struct {
 	Detail string
 }
 
-// RunAssertions performs all post-install assertions and returns the results.
-// None of these are individually fatal — the caller decides based on the aggregate.
+// AssertionOpts carries policy + dependency injections that downstream
+// assertions need. New in PR26.2 to thread the panel-survival policy
+// through without forcing every existing caller to construct one.
+//
+// Zero-value AssertionOpts is safe: PanelPolicy defaults to
+// panelfw.DefaultPolicy() (RequirePanelSuccess=true, AllowPanelAbsent=true,
+// OperatorDisabled=false) when unset, and PanelAdapters defaults to
+// the global registry (currently empty in PR26.2).
+type AssertionOpts struct {
+	// PanelPolicy controls how the panel-survival assertion converts
+	// adapter outcomes into a pass/fail verdict. PR26.3+ wires this
+	// from the operator's --no-panel flag and any future policy
+	// flags through the installer's globalPhaseData.
+	PanelPolicy panelfw.PanelPolicy
+
+	// PanelAdapters is an optional adapter slice override. When nil,
+	// the assertion uses panelfw.RegisteredAdapters(). Tests pass a
+	// fixture-controlled slice (typically containing FakePanelAdapter)
+	// to exercise the framework without touching the global registry.
+	PanelAdapters []panelfw.PanelAdapter
+
+	// panelPolicySet records whether the caller explicitly set
+	// PanelPolicy. Internal — used by RunAssertionsWithOpts to
+	// decide between caller-provided and DefaultPolicy(). Exposed
+	// via WithPanelPolicy.
+	panelPolicySet bool
+}
+
+// WithPanelPolicy returns a copy of opts with PanelPolicy set and the
+// internal "set" flag enabled, so RunAssertionsWithOpts honors the
+// override even when the caller passes a zero-value PanelPolicy.
+func (o AssertionOpts) WithPanelPolicy(p panelfw.PanelPolicy) AssertionOpts {
+	o.PanelPolicy = p
+	o.panelPolicySet = true
+	return o
+}
+
+// RunAssertions performs all post-install assertions with default
+// AssertionOpts (panelfw.DefaultPolicy, empty adapter override).
+// Equivalent to RunAssertionsWithOpts(exec, sshPort, log, AssertionOpts{}).
+//
+// Existing callers stay source-compatible. Production paths that need
+// to feed an operator-derived policy use RunAssertionsWithOpts.
 func RunAssertions(exec executor.Executor, sshPort int, log *logging.Logger) []AssertionResult {
+	return RunAssertionsWithOpts(exec, sshPort, log, AssertionOpts{})
+}
+
+// RunAssertionsWithOpts is the policy-aware entry point. The new
+// panel-survival assertion (PR26.2) consumes opts.PanelPolicy /
+// opts.PanelAdapters; every other assertion is unchanged from the
+// pre-PR26.2 surface.
+func RunAssertionsWithOpts(exec executor.Executor, sshPort int, log *logging.Logger, opts AssertionOpts) []AssertionResult {
 	var results []AssertionResult
 
 	results = append(results, assertNftablesActive(exec, log))
@@ -65,6 +116,11 @@ func RunAssertions(exec executor.Executor, sshPort int, log *logging.Logger) []A
 		assertSystemdPayloadInventory(spr, log),
 		assertFailedUnitsPostInstall(spr, log),
 	)
+
+	// PR26.2: PANEL-SURVIVAL-001. The framework runs registered
+	// adapters and produces a Fatal verdict per policy; failure
+	// blocks StateCommitted via the existing AllPassed gate.
+	results = append(results, assertPanelSurvival(exec, log, opts))
 
 	passed := 0
 	for _, r := range results {
@@ -352,4 +408,44 @@ func defaultInventoryPaths() map[string]bool {
 		"/usr/lib/nftban/sbin/nftban-service-alert":     true,
 		"/usr/lib/nftban/sbin/nftban-botscan-processor": true,
 	}
+}
+
+// PR26.2: PANEL-SURVIVAL-001 -------------------------------------------------
+//
+// assertPanelSurvival evaluates the registered (or test-injected)
+// panel adapters under opts.PanelPolicy and converts the result into
+// an AssertionResult. Failure → AllPassed false → StateCommitted
+// blocked (via the existing gate at cmd/nftban-installer/phases.go).
+//
+// PR26.2 ships with an empty adapter registry. With no adapters and
+// the default policy (AllowPanelAbsent=true), this assertion always
+// passes. PR26.3 wires the first adapter (DirectAdmin) and the
+// production policy gains the operator-flag-derived OperatorDisabled
+// override.
+func assertPanelSurvival(exec executor.Executor, log *logging.Logger, opts AssertionOpts) AssertionResult {
+	policy := opts.PanelPolicy
+	if !opts.panelPolicySet {
+		policy = panelfw.DefaultPolicy()
+	}
+
+	adapters := opts.PanelAdapters
+	if adapters == nil {
+		adapters = panelfw.RegisteredAdapters()
+	}
+
+	result := panelfw.EvaluateAdapters(context.Background(), exec, log, adapters, policy)
+
+	r := AssertionResult{Name: "panel_survival_ok", Passed: !result.Fatal}
+	if result.Fatal {
+		r.Detail = result.Reason
+		log.Warn("ASSERT panel_survival_ok: FAIL — %s", result.Reason)
+		return r
+	}
+	if result.Detection.Detected {
+		log.Debug("ASSERT panel_survival_ok: PASS — panel=%s reachable=%v",
+			string(result.Detection.ID), result.ReachableAfter)
+	} else {
+		log.Debug("ASSERT panel_survival_ok: PASS — no panel detected")
+	}
+	return r
 }

--- a/internal/installer/validate/panel_survival_test.go
+++ b/internal/installer/validate/panel_survival_test.go
@@ -1,0 +1,161 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.2 - panel_survival_ok assertion integration tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-validate-panel-survival-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="End-to-end test that PANEL-SURVIVAL-001 blocks StateCommitted via AllPassed"
+// meta:inventory.files="internal/installer/validate/panel_survival_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+)
+
+// fakeAdapter is a minimal stand-in. We deliberately do NOT import
+// the FakePanelAdapter from panelfw_test.go (which is _test-scoped
+// to that package).
+type fakeAdapter struct {
+	id        panelfw.PanelID
+	detected  bool
+	tcp       []int
+	rpErr     error
+	reachErr  error
+}
+
+func (f fakeAdapter) ID() panelfw.PanelID { return f.id }
+func (f fakeAdapter) Detect(_ context.Context, _ executor.Executor) panelfw.PanelDetection {
+	return panelfw.PanelDetection{ID: f.id, Detected: f.detected, RequiredTCP: f.tcp}
+}
+func (f fakeAdapter) RequiredPorts(_ context.Context, _ executor.Executor) ([]int, []int, error) {
+	return f.tcp, nil, f.rpErr
+}
+func (f fakeAdapter) ValidateReachability(_ context.Context, _ executor.Executor) error {
+	return f.reachErr
+}
+
+// Detected + integration failure must block StateCommitted: the new
+// panel_survival_ok assertion flips Passed=false; AllPassed returns
+// false; the lifecycle gate at phases.go:353/378 falls through to
+// StateDegraded.
+func TestRunAssertions_PanelSurvival_BlocksStateCommitted(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Services["nftables"] = true
+	mock.Services["nftband.service"] = true
+	mock.NftTables["ip:nftban"] = true
+	mock.NftTables["ip6:nftban"] = true
+	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	mock.NftSets["ip:nftban:tcp_ports_in"] = "elements = { 22, 80, 443 }"
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("COMMITTED")
+	seedCompletePayloadInventory(mock)
+
+	failingAdapter := fakeAdapter{
+		id:       "fakepanel",
+		detected: true,
+		tcp:      []int{12345},
+		reachErr: errors.New("port 12345 unreachable"),
+	}
+	opts := AssertionOpts{
+		PanelAdapters: []panelfw.PanelAdapter{failingAdapter},
+	}.WithPanelPolicy(panelfw.DefaultPolicy())
+
+	results := RunAssertionsWithOpts(mock, 22, newTestLogger(), opts)
+
+	if AllPassed(results) {
+		t.Fatalf("AllPassed must be false when panel-survival fails")
+	}
+	var found bool
+	for _, r := range results {
+		if r.Name == "panel_survival_ok" {
+			found = true
+			if r.Passed {
+				t.Errorf("panel_survival_ok must be Passed=false")
+			}
+			if r.Detail == "" {
+				t.Errorf("panel_survival_ok must carry a non-empty Detail message")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("panel_survival_ok assertion missing from results: %v", FailedNames(results))
+	}
+}
+
+// Operator-disabled (--no-panel) flips a failing adapter to non-fatal:
+// the assertion still runs (diagnostic) but does not block StateCommitted.
+func TestRunAssertions_PanelSurvival_OperatorDisabled_DoesNotBlock(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Services["nftables"] = true
+	mock.Services["nftband.service"] = true
+	mock.NftTables["ip:nftban"] = true
+	mock.NftTables["ip6:nftban"] = true
+	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	mock.NftSets["ip:nftban:tcp_ports_in"] = "elements = { 22, 80, 443 }"
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("COMMITTED")
+	seedCompletePayloadInventory(mock)
+
+	failingAdapter := fakeAdapter{
+		id:       "fakepanel",
+		detected: true,
+		tcp:      []int{12345},
+		reachErr: errors.New("port 12345 unreachable"),
+	}
+	policy := panelfw.DefaultPolicy()
+	policy.OperatorDisabled = true
+	opts := AssertionOpts{
+		PanelAdapters: []panelfw.PanelAdapter{failingAdapter},
+	}.WithPanelPolicy(policy)
+
+	results := RunAssertionsWithOpts(mock, 22, newTestLogger(), opts)
+
+	if !AllPassed(results) {
+		t.Fatalf("AllPassed must be true when --no-panel disables the gate; failures: %v", FailedNames(results))
+	}
+}
+
+// Default RunAssertions (no opts) keeps the registry empty + default
+// policy → assertion is a no-op pass. Verifies existing callers stay
+// source-compatible.
+func TestRunAssertions_DefaultPath_PanelSurvivalPasses(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.Services["nftables"] = true
+	mock.Services["nftband.service"] = true
+	mock.NftTables["ip:nftban"] = true
+	mock.NftTables["ip6:nftban"] = true
+	mock.RunResults["nft:list:chain:ip:nftban:input"] = executor.Result{ExitCode: 0}
+	mock.NftSets["ip:nftban:tcp_ports_in"] = "elements = { 22, 80, 443 }"
+	mock.Files["/var/lib/nftban/state/install_state"] = []byte("COMMITTED")
+	seedCompletePayloadInventory(mock)
+
+	results := RunAssertions(mock, 22, newTestLogger())
+
+	if !AllPassed(results) {
+		t.Fatalf("default RunAssertions must pass when registry is empty: failures=%v", FailedNames(results))
+	}
+	var seen bool
+	for _, r := range results {
+		if r.Name == "panel_survival_ok" {
+			seen = true
+			if !r.Passed {
+				t.Errorf("panel_survival_ok must pass with empty registry + default policy")
+			}
+		}
+	}
+	if !seen {
+		t.Errorf("panel_survival_ok must be present in default RunAssertions output")
+	}
+}


### PR DESCRIPTION
## Summary

Generic hosting-panel adapter framework. Adds **PANEL-SURVIVAL-001** as a new post-install assertion so a detected panel with a failing integration cannot reach StateCommitted (unless the operator passes `--no-panel`).

PR26.2 ships the framework + a test-only `FakePanelAdapter`. **No real adapter is registered** — DirectAdmin lands in PR26.3 only after this merges.

## Scope

**Hard exclusions** preserved per the operator authorization:
- No DirectAdmin adapter
- No cPanel/Plesk adapter
- No authority residue classifier
- No restore redesign
- No firewall mutation
- No runtime nft surgery
- No host destructive testing

## Invariant — PANEL-SURVIVAL-001

> If a hosting panel is detected before lifecycle mutation, then nftban must either preserve the panel's required service ports through the canonical ports model and validate integration success, OR abort before StateCommitted with a clear panel-safety error. Panel detected + panel integration failure must never reach StateCommitted, unless the operator explicitly disables panel integration with a supported flag.

Implemented as: assertion `panel_survival_ok` appended to `RunAssertions`. Failure → `AllPassed` returns false → existing gate at `cmd/nftban-installer/phases.go` falls through to `StateDegraded`. No `phases.go` mutation logic added — only an opts-bearing call to the new `RunAssertionsWithOpts`.

## Architecture

```
internal/installer/panelfw/
  panelfw.go         PanelAdapter interface, types, policy, registry, EvaluateAdapters
  panelfw_test.go    FakePanelAdapter + 14 framework tests (test-only — never compiled into prod)
internal/installer/validate/
  assertions.go      +AssertionOpts, +WithPanelPolicy, +panel_survival_ok assertion, +RunAssertionsWithOpts
  panel_survival_test.go   3 integration tests proving the gate via AllPassed
cmd/nftban-installer/
  flags.go           +--no-panel
  main.go            +globalPhaseData.noPanel
  phases.go          phaseValidate calls RunAssertionsWithOpts with operator-derived policy
```

The framework calls only the contract methods on adapters (`Detect`, `RequiredPorts`, `ValidateReachability`). All three are read-only by interface contract. PR26.2's `FakePanelAdapter` has zero mutation surface — verified structurally by the `TestFramework_NoExecutorMutation` table test.

## Test matrix (FakePanelAdapter spec)

| Case | Result |
|---|---|
| Fake panel detected + integration failure (RequiredPorts errors) | StateCommitted blocked |
| Fake panel detected + integration failure (ValidateReachability errors) | StateCommitted blocked |
| Fake panel absent | pass |
| `AllowPanelAbsent=false` + no panel detected | blocked (policy variant) |
| Fake panel detected + happy path | pass |
| Fake panel detected + failing integration + `OperatorDisabled=true` | pass (operator opt-out) |
| Fake panel detected + happy path + `OperatorDisabled=true` | pass |
| Fake panel detected + failing integration + `RequirePanelSuccess=false` | pass (migration variant) |
| Multi-adapter registry: first-detected-wins; later adapters not called | proven |
| Framework executor-mutation audit: 0 commands, 0 written files across 4 shapes | proven |
| Default registry empty | proven |
| Register / RegisteredAdapters returns a copy | proven |
| Register(nil) is a no-op | proven |
| `DefaultPolicy()` values | proven |
| Nil logger tolerated | proven |

Plus 3 `validate`-level integration tests:
- `TestRunAssertions_PanelSurvival_BlocksStateCommitted` — adapter failure → `AllPassed=false`
- `TestRunAssertions_PanelSurvival_OperatorDisabled_DoesNotBlock` — `--no-panel` → `AllPassed=true`
- `TestRunAssertions_DefaultPath_PanelSurvivalPasses` — default `RunAssertions` (empty registry) → pass

## Lab proof (lab4, RHEL/cPanel, go1.25.8)

Branch base: `cdf8f770` (origin/main, post-PR26.1 merge).

```
go vet ./internal/installer/panelfw/... ./internal/installer/validate/... ./cmd/nftban-installer/...
  → VET_EXIT=0 (clean)

go test -v ./internal/installer/panelfw/... ./internal/installer/validate/...
  → PASS — all 14 panelfw tests + all validate tests including the 3 new panel_survival tests

go test ./...
  → FULL_EXIT=0 — 65 packages PASS, 0 FAIL
  (was 64 before PR26.2; +1 = new internal/installer/panelfw)
```

`TMPDIR=/root/build-tmp` (lab4: both /tmp and /var/tmp are noexec under cPanel).

## Test plan

- [x] `go test ./internal/installer/panelfw/...` green on lab4
- [x] `go test ./internal/installer/validate/...` green on lab4 (no regression vs PR26.1 baseline)
- [x] `go vet ./internal/installer/panelfw/... ./internal/installer/validate/... ./cmd/nftban-installer/...` clean on lab4
- [x] `go test ./...` green on lab4 (65 packages, 0 fail)
- [ ] CI green on this PR (incl. staticcheck)
- [ ] Auditor on-PR final review

🤖 Generated with [Claude Code](https://claude.com/claude-code)