### PR TITLE
PR26.3: DirectAdmin adapter under panelfw

### DIFF
--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -31,6 +31,12 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 	"github.com/itcmsgr/nftban/pkg/version"
+
+	// PR26.3: panel adapter registration via blank import. The package
+	// init() calls panelfw.Register so the adapter is in the registry
+	// before phaseValidate runs. Future panel adapters land alongside
+	// this import.
+	_ "github.com/itcmsgr/nftban/internal/installer/panelfw/adapters/directadmin"
 )
 
 // globalTimeout is the maximum wall-clock time for the entire installer run.

--- a/internal/installer/panelfw/adapters/directadmin/directadmin.go
+++ b/internal/installer/panelfw/adapters/directadmin/directadmin.go
@@ -1,0 +1,251 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.3 - DirectAdmin Panel Adapter
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw-directadmin"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="DirectAdmin adapter for the panelfw framework — first specimen under PR26.2 contract"
+// meta:inventory.files="internal/installer/panelfw/adapters/directadmin/directadmin.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="/usr/local/directadmin/conf/directadmin.conf"
+// meta:inventory.systemd_units="directadmin.service"
+// meta:inventory.network="tcp/2222 (or override per directadmin.conf)"
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// PR26.3 — DirectAdmin adapter under the PR26.2 panelfw contract.
+// First and only adapter shipped in this PR. cPanel/Plesk/etc. live in
+// future PRs under the same framework.
+//
+// Read-only by interface contract:
+//   - Detect:               filesystem stat + service-active query + ss listener parse
+//   - RequiredPorts:        config-file read (best-effort); falls back to default 2222
+//   - ValidateReachability: ss -lnt output parse for the required port
+//
+// No mutation surface: no nft, no service writes, no file writes, no
+// shell out beyond the read-only `systemctl is-active` and `ss -lnt`
+// invocations the framework's existing executor already supports.
+//
+// =============================================================================
+
+package directadmin
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+)
+
+// adapterID is the canonical PanelID for this adapter. Matches the
+// detect.PanelDirectAdmin / nftban panel-name convention.
+const adapterID panelfw.PanelID = "directadmin"
+
+// Default control-panel port. DirectAdmin's installer ships TCP 2222
+// as the default and operators rarely change it; the override lives
+// in /usr/local/directadmin/conf/directadmin.conf as `port=N`.
+const defaultPort = 2222
+
+// Filesystem evidence paths. Constants kept here so test fixtures
+// reference the same canonical names.
+const (
+	installDir    = "/usr/local/directadmin"
+	binaryPath    = "/usr/local/directadmin/directadmin"
+	configPath    = "/usr/local/directadmin/conf/directadmin.conf"
+	systemdUnit   = "directadmin.service"
+	confidenceKey = "port"
+)
+
+// adapter is the package-private DirectAdmin adapter type. The
+// framework receives it via Register(); callers should not construct
+// or reach into it directly.
+type adapter struct{}
+
+// New returns a fresh adapter instance. Exposed for tests that need
+// to call EvaluateAdapters with an explicit slice; production code
+// uses init()/panelfw.Register and never sees the constructor.
+func New() panelfw.PanelAdapter { return &adapter{} }
+
+func init() {
+	panelfw.Register(New())
+}
+
+// ID implements panelfw.PanelAdapter.
+func (a *adapter) ID() panelfw.PanelID { return adapterID }
+
+// Detect implements panelfw.PanelAdapter. Read-only.
+//
+// Evidence collected (in order):
+//
+//	E1 — /usr/local/directadmin/             (canonical install dir)
+//	E2 — /usr/local/directadmin/directadmin  (panel binary)
+//	E3 — directadmin.service active          (systemd-managed run)
+//	E4 — TCP <port> in LISTEN state          (panel actually serving)
+//
+// Confidence rule: 3+ indicators ⇒ "strong"; 1–2 ⇒ "weak"; 0 ⇒
+// Detected=false. The required port is always declared (default 2222
+// or per-config override) so the framework's downstream consumers
+// have a port to reason about even when the panel is not yet running.
+func (a *adapter) Detect(ctx context.Context, exec executor.Executor) panelfw.PanelDetection {
+	det := panelfw.PanelDetection{ID: adapterID}
+
+	port := readConfiguredPort(exec)
+	det.RequiredTCP = []int{port}
+
+	signals := 0
+
+	if exec.FileExists(installDir) {
+		det.Evidence = append(det.Evidence, "install-dir-present:"+installDir)
+		signals++
+	}
+	if exec.FileExists(binaryPath) {
+		det.Evidence = append(det.Evidence, "binary-present:"+binaryPath)
+		signals++
+	}
+	if exec.ServiceActive(systemdUnit) {
+		det.Evidence = append(det.Evidence, "service-active:"+systemdUnit)
+		signals++
+	}
+	if portInListenState(exec, port) {
+		det.Evidence = append(det.Evidence, fmt.Sprintf("listener-tcp:%d", port))
+		signals++
+	}
+
+	if signals == 0 {
+		det.Detected = false
+		return det
+	}
+	det.Detected = true
+	if signals >= 3 {
+		det.Confidence = "strong"
+	} else {
+		det.Confidence = "weak"
+		det.Warnings = append(det.Warnings,
+			fmt.Sprintf("only %d of 4 indicators present; partial install or stopped panel", signals))
+	}
+	return det
+}
+
+// RequiredPorts implements panelfw.PanelAdapter. Read-only.
+//
+// Returns DirectAdmin's required TCP control port (default 2222 or
+// per-config override). UDP list is always empty — DirectAdmin's
+// surface is HTTP/HTTPS only.
+//
+// Adapter does NOT error on a missing config file: if directadmin.conf
+// cannot be read the default port is returned with no error. Detect()
+// already records the partial-install signal via Confidence=weak.
+func (a *adapter) RequiredPorts(ctx context.Context, exec executor.Executor) ([]int, []int, error) {
+	port := readConfiguredPort(exec)
+	return []int{port}, nil, nil
+}
+
+// ValidateReachability implements panelfw.PanelAdapter. Read-only.
+//
+// Confirms the required TCP port is in LISTEN state. Returns nil on
+// success; a structured error otherwise. Does NOT mutate ports,
+// services, or rules.
+func (a *adapter) ValidateReachability(ctx context.Context, exec executor.Executor) error {
+	port := readConfiguredPort(exec)
+	if portInListenState(exec, port) {
+		return nil
+	}
+	return fmt.Errorf("DirectAdmin TCP port %d not in LISTEN state — panel control surface unreachable", port)
+}
+
+// readConfiguredPort returns the configured control port from
+// /usr/local/directadmin/conf/directadmin.conf, falling back to the
+// default 2222 when the file is unreadable or has no `port=` line.
+//
+// The directadmin.conf format is `key=value` per line; we look for
+// the first `port=N` entry and parse N. Whitespace/comments are
+// tolerated.
+func readConfiguredPort(exec executor.Executor) int {
+	if !exec.FileExists(configPath) {
+		return defaultPort
+	}
+	data, err := exec.ReadFile(configPath)
+	if err != nil {
+		return defaultPort
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(line[:eq])
+		v := strings.TrimSpace(line[eq+1:])
+		if k != confidenceKey {
+			continue
+		}
+		// Strip an inline comment on the value side, if present.
+		if hash := strings.IndexByte(v, '#'); hash >= 0 {
+			v = strings.TrimSpace(v[:hash])
+		}
+		n, perr := strconv.Atoi(v)
+		if perr != nil {
+			return defaultPort
+		}
+		if n <= 0 || n > 65535 {
+			return defaultPort
+		}
+		return n
+	}
+	return defaultPort
+}
+
+// portInListenState reports whether tcpPort is in LISTEN state on the
+// host. Uses `ss -lnt` (no name resolution, no remote info, TCP
+// listeners only). Read-only.
+//
+// Output line shape (after header):
+//
+//	State Recv-Q Send-Q  Local Address:Port  Peer Address:Port  Process
+//	LISTEN 0     128     0.0.0.0:22          0.0.0.0:*
+//	LISTEN 0     128     [::]:2222           [::]:*
+//
+// We split each line on whitespace and look for the local-address
+// field's :port suffix matching tcpPort.
+func portInListenState(exec executor.Executor, tcpPort int) bool {
+	res := exec.Run("ss", "-lnt")
+	if res.ExitCode != 0 {
+		return false
+	}
+	want := ":" + strconv.Itoa(tcpPort)
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		// First field is "State" (LISTEN). The 4th column is local
+		// address:port. ss prints headers; skip a non-LISTEN row.
+		if !strings.EqualFold(fields[0], "LISTEN") {
+			continue
+		}
+		local := fields[3]
+		if !strings.HasSuffix(local, want) {
+			continue
+		}
+		// Guard against false matches like ":22222" matching ":2222"
+		// when a non-:port-aligned suffix happens to share digits.
+		// Re-extract the colon-separated tail.
+		idx := strings.LastIndexByte(local, ':')
+		if idx < 0 {
+			continue
+		}
+		if local[idx:] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/installer/panelfw/adapters/directadmin/directadmin.go
+++ b/internal/installer/panelfw/adapters/directadmin/directadmin.go
@@ -20,10 +20,33 @@
 // First and only adapter shipped in this PR. cPanel/Plesk/etc. live in
 // future PRs under the same framework.
 //
+// SCOPE — CONTROL PLANE ONLY (PR26.3)
+// -----------------------------------
+// This adapter validates DirectAdmin **control-plane reachability**
+// only. It detects DirectAdmin and validates the DirectAdmin control
+// port (TCP 2222 by default, per-config override via directadmin.conf
+// `port=N`).
+//
+// It does NOT yet validate the full DirectAdmin service-port surface
+// (the 16+ public-facing ports DirectAdmin manages on behalf of
+// hosted accounts: SMTP/SMTPS, IMAP/IMAPS, POP3/POP3S, FTP/FTPS, SSH,
+// HTTP/HTTPS, DNS, etc.). Those are tracked separately by the
+// canonical /etc/nftban/conf.d/panels/directadmin/main.conf and are
+// loaded by internal/ports/panel_loader.LoadPanelConfig — neither of
+// which this adapter consumes.
+//
+// PR26.4 follow-up:
+//   Full port-surface validation MUST reuse
+//   internal/ports/panel_loader.LoadPanelConfig("directadmin") and the
+//   canonical conf.d panel config. PR26.3 deliberately does not import
+//   internal/ports — that import lands in PR26.4 so the control-plane
+//   assertion ships narrowly first and full-surface validation is a
+//   separate, separately-reviewed change.
+//
 // Read-only by interface contract:
 //   - Detect:               filesystem stat + service-active query + ss listener parse
 //   - RequiredPorts:        config-file read (best-effort); falls back to default 2222
-//   - ValidateReachability: ss -lnt output parse for the required port
+//   - ValidateReachability: ss -lnt output parse for the control port
 //
 // No mutation surface: no nft, no service writes, no file writes, no
 // shell out beyond the read-only `systemctl is-active` and `ss -lnt`
@@ -148,15 +171,22 @@ func (a *adapter) RequiredPorts(ctx context.Context, exec executor.Executor) ([]
 
 // ValidateReachability implements panelfw.PanelAdapter. Read-only.
 //
-// Confirms the required TCP port is in LISTEN state. Returns nil on
-// success; a structured error otherwise. Does NOT mutate ports,
-// services, or rules.
+// Confirms the DirectAdmin **control-plane** TCP port is in LISTEN
+// state. Returns nil on success; a structured error otherwise. Does
+// NOT mutate ports, services, or rules.
+//
+// Scope is the control plane (default 2222) only. The full DirectAdmin
+// service-port surface (mail/web/SSH/etc.) is NOT validated here —
+// see the file-level "PR26.4 follow-up" comment.
 func (a *adapter) ValidateReachability(ctx context.Context, exec executor.Executor) error {
 	port := readConfiguredPort(exec)
 	if portInListenState(exec, port) {
 		return nil
 	}
-	return fmt.Errorf("DirectAdmin TCP port %d not in LISTEN state — panel control surface unreachable", port)
+	return fmt.Errorf(
+		"DirectAdmin control-plane port %d not in LISTEN state — control-plane unreachable "+
+			"(note: this assertion validates the control plane only; full DirectAdmin port surface validated in PR26.4)",
+		port)
 }
 
 // readConfiguredPort returns the configured control port from

--- a/internal/installer/panelfw/adapters/directadmin/directadmin_test.go
+++ b/internal/installer/panelfw/adapters/directadmin/directadmin_test.go
@@ -1,0 +1,414 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.3 - DirectAdmin Adapter Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw-directadmin-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-29"
+// meta:description="Detect / RequiredPorts / ValidateReachability + framework integration"
+// meta:inventory.files="internal/installer/panelfw/adapters/directadmin/directadmin_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package directadmin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("/dev/null", false)
+}
+
+// seedDirectAdmin populates the mock with strong-confidence DA evidence:
+// install dir, binary, active service, and TCP <port> in LISTEN state.
+func seedDirectAdmin(mock *executor.MockExecutor, port int) {
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	// Mock the `ss -lnt` output containing a LISTEN row for the port.
+	mock.RunResults["ss:-lnt"] = executor.Result{
+		ExitCode: 0,
+		Stdout: ssOutput(port),
+	}
+}
+
+func ssOutput(listenPorts ...int) string {
+	header := "State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n"
+	rows := []string{header}
+	for _, p := range listenPorts {
+		rows = append(rows, "LISTEN 0 128 0.0.0.0:"+itoa(p)+" 0.0.0.0:* users:((\"directadmin\",pid=1,fd=3))")
+	}
+	return strings.Join(rows, "\n")
+}
+
+func itoa(n int) string {
+	// Avoid pulling strconv into the test fixture preamble; the
+	// adapter uses strconv.Itoa internally.
+	return formatInt(n)
+}
+
+// formatInt renders a non-negative int as decimal. Sufficient for the
+// 1–65535 port range used in tests.
+func formatInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// ----------------------------------------------------------------------------
+// Detect
+// ----------------------------------------------------------------------------
+
+func TestDetect_AllSignals_Strong(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedDirectAdmin(mock, 2222)
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true; got %#v", det)
+	}
+	if det.Confidence != "strong" {
+		t.Errorf("expected strong confidence with 4 indicators; got %q", det.Confidence)
+	}
+	if len(det.Evidence) != 4 {
+		t.Errorf("expected 4 evidence entries; got %d (%v)", len(det.Evidence), det.Evidence)
+	}
+	if len(det.RequiredTCP) != 1 || det.RequiredTCP[0] != 2222 {
+		t.Errorf("expected RequiredTCP=[2222]; got %v", det.RequiredTCP)
+	}
+}
+
+func TestDetect_Absent_NotDetected(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	// no install dir, no binary, no service, no listener
+	det := a.Detect(context.Background(), mock)
+	if det.Detected {
+		t.Fatalf("expected Detected=false on bare host; got %#v", det)
+	}
+}
+
+func TestDetect_PartialInstall_Weak(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	// Only the install dir + binary; service stopped, no listener.
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true on 2 indicators; got %#v", det)
+	}
+	if det.Confidence != "weak" {
+		t.Errorf("expected weak confidence; got %q", det.Confidence)
+	}
+	if len(det.Warnings) == 0 {
+		t.Errorf("expected at least one warning for partial install")
+	}
+}
+
+// Service-only signal still counts as a (weak) detection — DirectAdmin
+// with no install dir present is unusual, but the signal matters.
+func TestDetect_ServiceOnly_Weak(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Services[systemdUnit] = true
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true on service-active alone")
+	}
+	if det.Confidence != "weak" {
+		t.Errorf("expected weak confidence; got %q", det.Confidence)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// RequiredPorts
+// ----------------------------------------------------------------------------
+
+func TestRequiredPorts_Default(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	tcp, udp, err := a.RequiredPorts(context.Background(), mock)
+	if err != nil {
+		t.Fatalf("RequiredPorts must not error on default-port path: %v", err)
+	}
+	if len(tcp) != 1 || tcp[0] != 2222 {
+		t.Errorf("expected default TCP=[2222]; got %v", tcp)
+	}
+	if len(udp) != 0 {
+		t.Errorf("expected UDP=[]; got %v", udp)
+	}
+}
+
+func TestRequiredPorts_ConfigOverride(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Files[configPath] = []byte("# header\nport=2225\nfoo=bar\n")
+	tcp, _, err := a.RequiredPorts(context.Background(), mock)
+	if err != nil {
+		t.Fatalf("config-override path must not error: %v", err)
+	}
+	if len(tcp) != 1 || tcp[0] != 2225 {
+		t.Errorf("expected TCP=[2225] from config override; got %v", tcp)
+	}
+}
+
+// Malformed override falls back to default (no error — read-only tolerance).
+func TestRequiredPorts_MalformedConfig_FallsBackToDefault(t *testing.T) {
+	cases := []struct {
+		name, conf string
+	}{
+		{"non-numeric", "port=NOT_A_PORT\n"},
+		{"out-of-range-zero", "port=0\n"},
+		{"out-of-range-high", "port=99999\n"},
+		{"missing-port", "foo=bar\n"},
+		{"empty", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := New()
+			mock := executor.NewMockExecutor()
+			mock.Files[configPath] = []byte(c.conf)
+			tcp, _, err := a.RequiredPorts(context.Background(), mock)
+			if err != nil {
+				t.Fatalf("malformed-config path must not error: %v", err)
+			}
+			if tcp[0] != defaultPort {
+				t.Errorf("expected fallback to default port %d; got %v", defaultPort, tcp)
+			}
+		})
+	}
+}
+
+// Inline-comment tolerance: `port=2222 # comment` parses as 2222.
+func TestRequiredPorts_ConfigInlineComment(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Files[configPath] = []byte("port=2225 # operator override\n")
+	tcp, _, err := a.RequiredPorts(context.Background(), mock)
+	if err != nil {
+		t.Fatalf("inline-comment path must not error: %v", err)
+	}
+	if tcp[0] != 2225 {
+		t.Errorf("expected port=2225 with inline comment; got %v", tcp)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// ValidateReachability
+// ----------------------------------------------------------------------------
+
+func TestValidateReachability_Listening_OK(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(2222)}
+
+	if err := a.ValidateReachability(context.Background(), mock); err != nil {
+		t.Errorf("expected nil; got %v", err)
+	}
+}
+
+func TestValidateReachability_NotListening_ReturnsError(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	// Listener present but on a different port — must NOT match.
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	err := a.ValidateReachability(context.Background(), mock)
+	if err == nil {
+		t.Fatalf("expected error when port 2222 not listening")
+	}
+	if !strings.Contains(err.Error(), "2222") {
+		t.Errorf("error should mention the port: %v", err)
+	}
+}
+
+// Defensive: ":22222" must not match expected ":2222".
+func TestValidateReachability_PortPrefixCollision(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(22222)}
+	if err := a.ValidateReachability(context.Background(), mock); err == nil {
+		t.Errorf("expected error — :22222 must not collide with :2222")
+	}
+}
+
+// ss exit-code non-zero → treated as not-reachable. Adapter does not
+// invent reachability when the source of truth is unavailable.
+func TestValidateReachability_SsErrorsOut_NotListening(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 1, Stdout: "", Stderr: "ss: command not found"}
+	if err := a.ValidateReachability(context.Background(), mock); err == nil {
+		t.Errorf("expected error when ss fails — must NOT silently report reachable")
+	}
+}
+
+// Config-override port flows through to ValidateReachability.
+func TestValidateReachability_OverridePortHonored(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Files[configPath] = []byte("port=2225\n")
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(2225)}
+	if err := a.ValidateReachability(context.Background(), mock); err != nil {
+		t.Errorf("expected nil for overridden port 2225; got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// ID + adapter contract identity
+// ----------------------------------------------------------------------------
+
+func TestID(t *testing.T) {
+	a := New()
+	if a.ID() != adapterID {
+		t.Errorf("ID() = %q; want %q", a.ID(), adapterID)
+	}
+	if string(a.ID()) != "directadmin" {
+		t.Errorf("string ID drift: %q", string(a.ID()))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Framework integration: registered adapter detected → policy fires
+// ----------------------------------------------------------------------------
+
+func TestFrameworkIntegration_DA_Detected_Reachable_Passes(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedDirectAdmin(mock, 2222)
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on healthy DA host; got %#v", res)
+	}
+	if string(res.Detection.ID) != "directadmin" {
+		t.Errorf("expected detection ID=directadmin; got %q", res.Detection.ID)
+	}
+	if !res.PortsApplied || !res.ReachableAfter {
+		t.Errorf("expected PortsApplied+ReachableAfter true; got %#v", res)
+	}
+}
+
+func TestFrameworkIntegration_DA_Detected_NotReachable_Blocks(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	// Install dir + binary + service active, but port NOT listening.
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true when DA detected but unreachable; got %#v", res)
+	}
+	if !strings.Contains(res.Reason, "directadmin") {
+		t.Errorf("Reason should mention directadmin: %q", res.Reason)
+	}
+}
+
+func TestFrameworkIntegration_DA_Absent_Passes(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on bare host; got %#v", res)
+	}
+	if res.Detection.Detected {
+		t.Errorf("expected Detection.Detected=false")
+	}
+}
+
+// OperatorDisabled (--no-panel) flips a failing DA host to non-fatal.
+func TestFrameworkIntegration_DA_NotReachable_OperatorDisabled_Passes(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	policy := panelfw.DefaultPolicy()
+	policy.OperatorDisabled = true
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, policy)
+
+	if res.Fatal {
+		t.Fatalf("OperatorDisabled=true must convert failure to non-fatal: %#v", res)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// init() registration: the package adds itself to the global registry
+// ----------------------------------------------------------------------------
+
+func TestInitRegistration_AdapterPresent(t *testing.T) {
+	// The init() runs at package import; the test merely confirms
+	// the registry contains a DirectAdmin adapter.
+	got := panelfw.RegisteredAdapters()
+	var found bool
+	for _, a := range got {
+		if a.ID() == adapterID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("DirectAdmin adapter not registered via init(); registry=%v", got)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Read-only discipline — adapter does not write files or run mutation cmds
+// ----------------------------------------------------------------------------
+
+func TestReadOnly_NoWrites_NoMutationCommands(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedDirectAdmin(mock, 2222)
+
+	_ = a.Detect(context.Background(), mock)
+	_, _, _ = a.RequiredPorts(context.Background(), mock)
+	_ = a.ValidateReachability(context.Background(), mock)
+
+	if len(mock.WrittenFiles) != 0 {
+		t.Errorf("adapter wrote %d files via executor (want 0)", len(mock.WrittenFiles))
+	}
+	for _, c := range mock.Commands {
+		switch c.Name {
+		case "ss":
+			// expected — read-only socket query
+		case "systemctl":
+			// `is-active` only — ServiceActive is read-only on the mock
+		default:
+			t.Errorf("unexpected command %q (mutation suspected)", c.Name)
+		}
+	}
+}

--- a/internal/installer/panelfw/adapters/directadmin/directadmin_test.go
+++ b/internal/installer/panelfw/adapters/directadmin/directadmin_test.go
@@ -245,6 +245,42 @@ func TestValidateReachability_NotListening_ReturnsError(t *testing.T) {
 	}
 }
 
+// PR26.3 Path A: the user-facing error must explicitly identify the
+// scope as control-plane, not "panel survival" or "full panel". This
+// keeps operators from mistakenly believing the assertion has
+// validated the full DirectAdmin port surface.
+func TestValidateReachability_NotListening_ErrorMentionsControlPlane(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	err := a.ValidateReachability(context.Background(), mock)
+	if err == nil {
+		t.Fatalf("expected error when control port not listening")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "control-plane") {
+		t.Errorf("error must explicitly say 'control-plane'; got %q", msg)
+	}
+	// Negative: the message must NOT make affirmative claims of full
+	// survival or full surface validation. We allow the explanatory
+	// negation form ("full DirectAdmin port surface validated in
+	// PR26.4") because it reads as scope clarification, not a claim
+	// the assertion has validated those ports.
+	for _, forbidden := range []string{
+		"full panel survival validated",
+		"full panel survived",
+		"all DirectAdmin ports validated",
+		"all DirectAdmin ports listening",
+		"all panel ports listening",
+		"all panel ports validated",
+	} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("error must NOT claim %q (overstates scope); got %q", forbidden, msg)
+		}
+	}
+}
+
 // Defensive: ":22222" must not match expected ":2222".
 func TestValidateReachability_PortPrefixCollision(t *testing.T) {
 	a := New()
@@ -331,6 +367,46 @@ func TestFrameworkIntegration_DA_Detected_NotReachable_Blocks(t *testing.T) {
 	}
 	if !strings.Contains(res.Reason, "directadmin") {
 		t.Errorf("Reason should mention directadmin: %q", res.Reason)
+	}
+	// PR26.3 Path A: the surfaced Reason must say control-plane.
+	if !strings.Contains(res.Reason, "control-plane") {
+		t.Errorf("Reason must say 'control-plane'; got %q", res.Reason)
+	}
+}
+
+// PR26.3 Path A: the surfaced Reason on a failing DA host must NOT
+// claim that the full panel survival was checked — the assertion
+// covers only the control plane in PR26.3. Full port-surface
+// validation lands in PR26.4.
+func TestFrameworkIntegration_DA_Reason_DoesNotImplyFullPortSurvival(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true; got %#v", res)
+	}
+	// These phrases would imply the assertion validated more than the
+	// control plane. The error MAY mention "full ... port surface" in
+	// a NEGATION (e.g., "...full DirectAdmin port surface validated in
+	// PR26.4"), so we look for affirmative-claim verbs instead.
+	for _, forbidden := range []string{
+		"full panel survival validated",
+		"full panel survived",
+		"all DirectAdmin ports validated",
+		"all DirectAdmin ports listening",
+		"all panel ports listening",
+		"all panel ports validated",
+	} {
+		if strings.Contains(res.Reason, forbidden) {
+			t.Errorf("Reason must NOT claim %q (overstates PR26.3 scope); got %q", forbidden, res.Reason)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

DirectAdmin adapter — the first specimen registered under the PR26.2 `panelfw.PanelAdapter` contract. Read-only adapter implementation. No real-host destructive testing in this PR.

## Scope

**Hard exclusions** preserved:
- No cPanel / Plesk / cyberpanel / hestia adapter
- No authority residue classifier
- No restore semantics change
- No firewall mutation
- No runtime nft surgery
- No destructive host testing

## What landed

| File | Purpose |
|---|---|
| `internal/installer/panelfw/adapters/directadmin/directadmin.go` | Adapter implementation (251 lines) |
| `internal/installer/panelfw/adapters/directadmin/directadmin_test.go` | Detect / RequiredPorts / ValidateReachability + framework integration tests (414 lines) |
| `cmd/nftban-installer/main.go` | Blank import so the adapter's `init()` fires during process startup |

### Detect (4 signals)

| Signal | Source |
|---|---|
| install-dir-present | `/usr/local/directadmin/` |
| binary-present | `/usr/local/directadmin/directadmin` |
| service-active | `directadmin.service` (via `ServiceActive`) |
| listener-tcp | `<port>` in `LISTEN` state via `ss -lnt` parse |

Confidence: 3+ → `strong`; 1–2 → `weak` (with warning); 0 → `Detected=false`.

### RequiredPorts

- Default: TCP `[2222]`
- Override: parses `port=N` from `/usr/local/directadmin/conf/directadmin.conf` (tolerates inline comments, falls back to default on malformed/missing config)
- UDP always empty

### ValidateReachability

- Verifies the required TCP port is in `LISTEN` state via `ss -lnt`
- Returns structured error on miss (port not listening, ss failed, or prefix collision like `:22222` ≠ `:2222`)
- Read-only — no nft, no service writes, no file writes

## Tests

22 tests in `./internal/installer/panelfw/adapters/directadmin/...`, all green on lab4:

- `TestDetect_AllSignals_Strong` / `_Absent_NotDetected` / `_PartialInstall_Weak` / `_ServiceOnly_Weak`
- `TestRequiredPorts_Default` / `_ConfigOverride` / `_MalformedConfig_FallsBackToDefault` (5 sub-tests) / `_ConfigInlineComment`
- `TestValidateReachability_Listening_OK` / `_NotListening_ReturnsError` / `_PortPrefixCollision` / `_SsErrorsOut_NotListening` / `_OverridePortHonored`
- `TestID`
- `TestFrameworkIntegration_DA_Detected_Reachable_Passes` / `_NotReachable_Blocks` / `_Absent_Passes` / `_NotReachable_OperatorDisabled_Passes` (proves `--no-panel` still works for DA)
- `TestInitRegistration_AdapterPresent` (proves `init()` populates the global registry)
- `TestReadOnly_NoWrites_NoMutationCommands` (structural mutation audit)

## Lab proof (lab4, RHEL/cPanel, go1.25.8)

Branch base: `fdbebe8c` (origin/main, post-PR26.2 merge).

```
go vet ./internal/installer/panelfw/... ./internal/installer/validate/... ./cmd/nftban-installer/...
  → VET_EXIT=0 (clean)

go test -v ./internal/installer/panelfw/...
  → PASS — 14 panelfw + 22 directadmin tests, all green

go test ./...
  → 66 packages PASS, 0 FAIL
  (was 65 pre-PR26.3; +1 = new internal/installer/panelfw/adapters/directadmin)
```

`TMPDIR=/root/build-tmp` (lab4: both /tmp and /var/tmp are noexec under cPanel `/usr/tmpDSK`).

## Behavior on a real DirectAdmin host (post-merge)

When the installer runs on a host where `/usr/local/directadmin/` exists, `directadmin` binary is present, `directadmin.service` is active, and TCP 2222 is listening:

1. `panelfw.RegisteredAdapters()` returns `[directadmin]` (init() fires on startup).
2. `phaseValidate` calls `RunAssertionsWithOpts` with the operator-derived policy.
3. `assertPanelSurvival` calls `panelfw.EvaluateAdapters([directadmin], policy)`:
   - Detect → strong, 4 evidence rows, `RequiredTCP=[2222]`
   - RequiredPorts → `[2222], [], nil`
   - ValidateReachability → nil (port 2222 in LISTEN)
   - PanelResult: `Fatal=false`, `PortsApplied=true`, `ReachableAfter=true`
4. Assertion passes; install proceeds to StateCommitted.

If TCP 2222 is NOT listening (DirectAdmin stopped, panel-enable failed, or another bug): `Fatal=true`, the assertion fails, `AllPassed=false`, install drops to `StateDegraded`. **dns2's silent panel-enable failure is now caught at install time** — unless the operator passes `--no-panel`.

## Test plan

- [x] `go test ./internal/installer/panelfw/...` green on lab4
- [x] `go vet ./internal/installer/panelfw/... ./internal/installer/validate/... ./cmd/nftban-installer/...` clean on lab4
- [x] `go test ./...` green on lab4 (66 packages, 0 fail)
- [ ] CI green on this PR
- [ ] Auditor on-PR final review

🤖 Generated with [Claude Code](https://claude.com/claude-code)