### PR TITLE
PR26.7: Plesk adapter via conf.d/panel_loader (panelfw)

### DIFF
--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -37,6 +37,8 @@ import (
 	// before phaseValidate runs. Future panel adapters land alongside
 	// this import.
 	_ "github.com/itcmsgr/nftban/internal/installer/panelfw/adapters/directadmin"
+	// PR26.7: Plesk adapter — same registration shape as DirectAdmin.
+	_ "github.com/itcmsgr/nftban/internal/installer/panelfw/adapters/plesk"
 )
 
 // globalTimeout is the maximum wall-clock time for the entire installer run.

--- a/internal/installer/panelfw/adapters/plesk/plesk.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk.go
@@ -200,15 +200,15 @@ func (a *adapter) Detect(ctx context.Context, exec executor.Executor) panelfw.Pa
 func (a *adapter) RequiredPorts(ctx context.Context, exec executor.Executor) ([]int, []int, error) {
 	cfg, err := panelConfDLoader(panelConfDDir, string(adapterID))
 	if err != nil {
-		return nil, nil, fmt.Errorf("Plesk conf.d load failed: %w (path: %s/conf.d/panels/%s/main.conf)",
+		return nil, nil, fmt.Errorf("conf.d load failed for Plesk panel: %w (path: %s/conf.d/panels/%s/main.conf)",
 			err, panelConfDDir, string(adapterID))
 	}
 	if cfg == nil {
-		return nil, nil, fmt.Errorf("Plesk conf.d load returned nil PanelConfig")
+		return nil, nil, fmt.Errorf("conf.d load returned nil PanelConfig for Plesk panel")
 	}
 	if len(cfg.TCPIn) == 0 {
 		return nil, nil, fmt.Errorf(
-			"Plesk conf.d declares no TCP_IN ports (malformed: %s) — "+
+			"conf.d for Plesk panel declares no TCP_IN ports (malformed: %s) — "+
 				"a real Plesk host must declare its inbound port surface",
 			cfg.ConfigFile)
 	}
@@ -241,7 +241,7 @@ func (a *adapter) ValidateReachability(ctx context.Context, exec executor.Execut
 		return nil
 	}
 	return fmt.Errorf(
-		"Plesk control-plane port %d not in LISTEN state — control-plane unreachable "+
+		"control-plane port %d (Plesk) not in LISTEN state — control-plane unreachable "+
 			"(this assertion probes the control plane only; the full Plesk port surface is loaded "+
 			"from conf.d via RequiredPorts but not probed here)",
 		port)

--- a/internal/installer/panelfw/adapters/plesk/plesk.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk.go
@@ -1,0 +1,286 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.7 - Plesk Panel Adapter
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw-plesk"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-30"
+// meta:description="Plesk adapter for the panelfw framework — control-plane reachability + canonical conf.d port surface"
+// meta:inventory.files="internal/installer/panelfw/adapters/plesk/plesk.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="/etc/nftban/conf.d/panels/plesk/main.conf"
+// meta:inventory.systemd_units="plesk.service"
+// meta:inventory.network="tcp/8443 (Plesk control plane HTTPS, fixed)"
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// PR26.7 — Plesk adapter under the PR26.2 panelfw contract. Second
+// adapter shipped (after PR26.3+PR26.4 DirectAdmin). cPanel is PR26.8;
+// CyberPanel/CWP/InterWorx/Vesta land later under the same framework.
+//
+// SCOPE
+// -----
+// CONTROL PLANE — ValidateReachability tests the Plesk control port
+// only (TCP 8443, HTTPS). Failure ⇒ PANEL-SURVIVAL-001 fires unless
+// --no-panel.
+//
+// FULL PORT SURFACE — RequiredPorts consults the canonical
+// /etc/nftban/conf.d/panels/plesk/main.conf via
+// internal/ports/panel_loader.LoadPanelConfig("plesk") and returns the
+// conf.d-declared TCP_IN / UDP_IN port set. The adapter does NOT
+// invent a port list. Conf.d is the single source of truth.
+//
+// Differences from DirectAdmin (PR26.3+26.4):
+//
+//  1. No per-host control-port override. DirectAdmin reads `port=N`
+//     from /usr/local/directadmin/conf/directadmin.conf to support
+//     non-default panel ports. Plesk ships TCP 8443 fixed at install
+//     time and does not expose a comparable per-host override path.
+//     The adapter therefore returns the constant default 8443; if a
+//     future Plesk version exposes an override, this is the place to
+//     add it (mirroring DA's readConfiguredPort path).
+//
+//  2. TCP 8447 (Plesk Updater) is intentionally NOT control-plane.
+//     8443 is the panel surface; 8447 is the auto-installer/repository
+//     channel and may be absent on a panel that has been updated and
+//     since stopped serving 8447. Conf.d declares 8447 as part of the
+//     full TCP_IN surface; the adapter probes 8443 only.
+//
+// Fail-closed contract (matches DA):
+//   - Missing conf.d main.conf → RequiredPorts returns error →
+//     PanelResult.Fatal=true via panelfw.finalizeDetected.
+//   - Loaded conf.d with empty TCP_IN → returns error (a Plesk panel
+//     host with zero declared inbound ports is malformed).
+//
+// Read-only by interface contract:
+//   - Detect:               filesystem stat + service-active query + ss listener parse
+//   - RequiredPorts:        canonical conf.d load via panel_loader (read-only)
+//   - ValidateReachability: ss -lnt output parse for the control port
+//
+// =============================================================================
+
+package plesk
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/fhs"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+	"github.com/itcmsgr/nftban/internal/ports"
+)
+
+// adapterID is the canonical PanelID for this adapter. Matches the
+// detect.PanelPlesk / nftban panel-name convention and the conf.d
+// directory name (etc/nftban/conf.d/panels/plesk/).
+const adapterID panelfw.PanelID = "plesk"
+
+// defaultPort is Plesk's control-panel HTTPS port. Plesk ships 8443
+// fixed at install time. Unlike DirectAdmin (which exposes a per-host
+// override at /usr/local/directadmin/conf/directadmin.conf `port=N`),
+// Plesk has no canonical per-host override path. Operators who retune
+// Plesk's panel port do so via Plesk-internal admin actions that this
+// adapter does not parse; the adapter probes 8443 only.
+const defaultPort = 8443
+
+// Filesystem evidence paths. Constants kept here so test fixtures
+// reference the same canonical names. Marker bin path comes from
+// etc/nftban/conf.d/panels/plesk/main.conf NFTBAN_PLESK_MARKER_BIN.
+const (
+	installDir  = "/usr/local/psa"
+	binaryPath  = "/usr/local/psa/admin/bin/httpdmng"
+	systemdUnit = "plesk.service"
+)
+
+// panelConfDLoader is the function the adapter calls to load the
+// canonical conf.d panel config. Defaults to the package-public
+// internal/ports/panel_loader.LoadPanelConfig at process startup.
+//
+// Tests inject a fixture loader by writing to this var; production
+// code never reassigns it. The seam is here (rather than passing the
+// loader down through every call site) because PanelAdapter's
+// interface is fixed by panelfw.
+var panelConfDLoader func(configDir, panelName string) (*ports.PanelConfig, error) = ports.LoadPanelConfig
+
+// panelConfDDir is the configDir argument supplied to the loader.
+// Default: fhs.EtcDir ("/etc/nftban"). Tests override to a tempdir
+// containing fixture conf.d/panels/plesk/main.conf.
+var panelConfDDir = fhs.EtcDir
+
+// adapter is the package-private Plesk adapter type. The framework
+// receives it via Register(); callers should not construct or reach
+// into it directly.
+type adapter struct{}
+
+// New returns a fresh adapter instance.
+func New() panelfw.PanelAdapter { return &adapter{} }
+
+func init() {
+	panelfw.Register(New())
+}
+
+// ID implements panelfw.PanelAdapter.
+func (a *adapter) ID() panelfw.PanelID { return adapterID }
+
+// Detect implements panelfw.PanelAdapter. Read-only.
+//
+// Evidence collected (in order):
+//
+//	E1 — /usr/local/psa/                      (canonical install dir)
+//	E2 — /usr/local/psa/admin/bin/httpdmng    (panel binary marker)
+//	E3 — plesk.service active                 (systemd-managed run)
+//	E4 — TCP 8443 in LISTEN state             (panel actually serving)
+//
+// Confidence rule: 3+ indicators ⇒ "strong"; 1–2 ⇒ "weak"; 0 ⇒
+// Detected=false. The required port is always declared (8443) so the
+// framework's downstream consumers have a port to reason about even
+// when the panel is not yet running.
+func (a *adapter) Detect(ctx context.Context, exec executor.Executor) panelfw.PanelDetection {
+	det := panelfw.PanelDetection{ID: adapterID}
+
+	port := defaultPort
+	det.RequiredTCP = []int{port}
+
+	signals := 0
+
+	if exec.FileExists(installDir) {
+		det.Evidence = append(det.Evidence, "install-dir-present:"+installDir)
+		signals++
+	}
+	if exec.FileExists(binaryPath) {
+		det.Evidence = append(det.Evidence, "binary-present:"+binaryPath)
+		signals++
+	}
+	if exec.ServiceActive(systemdUnit) {
+		det.Evidence = append(det.Evidence, "service-active:"+systemdUnit)
+		signals++
+	}
+	if portInListenState(exec, port) {
+		det.Evidence = append(det.Evidence, fmt.Sprintf("listener-tcp:%d", port))
+		signals++
+	}
+
+	if signals == 0 {
+		det.Detected = false
+		return det
+	}
+	det.Detected = true
+	if signals >= 3 {
+		det.Confidence = "strong"
+	} else {
+		det.Confidence = "weak"
+		det.Warnings = append(det.Warnings,
+			fmt.Sprintf("only %d of 4 indicators present; partial install or stopped panel", signals))
+	}
+	return det
+}
+
+// RequiredPorts implements panelfw.PanelAdapter. Read-only.
+//
+// Returns the canonical conf.d-declared Plesk TCP_IN / UDP_IN port
+// surface, loaded via internal/ports/panel_loader.LoadPanelConfig.
+//
+// The adapter does NOT invent a port list — it reports exactly what
+// /etc/nftban/conf.d/panels/plesk/main.conf declares. Conf.d wins
+// over the legacy shell library; SSH port 22 is intentionally absent
+// because /etc/nftban/ports.d/00-ssh.conf manages it separately.
+//
+// Fail-closed contract:
+//   - Missing main.conf → returns error.
+//   - Loaded with empty TCP_IN → returns error (malformed for a real
+//     Plesk host; an empty inbound list cannot serve the panel).
+//
+// On error, panelfw.finalizeDetected sets PanelResult.Fatal=true per
+// PANEL-SURVIVAL-001 unless --no-panel.
+func (a *adapter) RequiredPorts(ctx context.Context, exec executor.Executor) ([]int, []int, error) {
+	cfg, err := panelConfDLoader(panelConfDDir, string(adapterID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("Plesk conf.d load failed: %w (path: %s/conf.d/panels/%s/main.conf)",
+			err, panelConfDDir, string(adapterID))
+	}
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("Plesk conf.d load returned nil PanelConfig")
+	}
+	if len(cfg.TCPIn) == 0 {
+		return nil, nil, fmt.Errorf(
+			"Plesk conf.d declares no TCP_IN ports (malformed: %s) — "+
+				"a real Plesk host must declare its inbound port surface",
+			cfg.ConfigFile)
+	}
+	// Conf.d is the authoritative source; copy slices defensively so
+	// the caller cannot mutate the loader's cached values.
+	tcp := append([]int(nil), cfg.TCPIn...)
+	udp := append([]int(nil), cfg.UDPIn...)
+	return tcp, udp, nil
+}
+
+// ValidateReachability implements panelfw.PanelAdapter. Read-only.
+//
+// Confirms the Plesk **control-plane** TCP port (8443 HTTPS) is in
+// LISTEN state. Returns nil on success; a structured error otherwise.
+// Does NOT mutate ports, services, or rules.
+//
+// Scope is the control plane only. RequiredPorts loads the full Plesk
+// service-port surface from the canonical conf.d via panel_loader, but
+// this method deliberately does NOT probe each conf.d-declared port —
+// full-surface reachability probing is intentionally out of scope here
+// and remains the broader rebuild/validate path's responsibility.
+//
+// Note: TCP 8447 (Plesk Updater / auto-installer) is part of the
+// conf.d-declared full surface but is NOT the control plane; a
+// well-functioning Plesk host may have 8447 closed without affecting
+// panel reachability. Probing 8443 only is the correct scope.
+func (a *adapter) ValidateReachability(ctx context.Context, exec executor.Executor) error {
+	port := defaultPort
+	if portInListenState(exec, port) {
+		return nil
+	}
+	return fmt.Errorf(
+		"Plesk control-plane port %d not in LISTEN state — control-plane unreachable "+
+			"(this assertion probes the control plane only; the full Plesk port surface is loaded "+
+			"from conf.d via RequiredPorts but not probed here)",
+		port)
+}
+
+// portInListenState reports whether tcpPort is in LISTEN state on the
+// host. Uses `ss -lnt` (no name resolution, no remote info, TCP
+// listeners only). Read-only.
+//
+// Identical to the DA adapter's helper — kept package-local rather
+// than refactored into a shared util because the panelfw contract is
+// per-adapter and a future Plesk-specific tweak (e.g., probe the
+// HTTPS handshake instead of just LISTEN state) belongs here, not in
+// a shared file edited from multiple adapters.
+func portInListenState(exec executor.Executor, tcpPort int) bool {
+	res := exec.Run("ss", "-lnt")
+	if res.ExitCode != 0 {
+		return false
+	}
+	want := ":" + strconv.Itoa(tcpPort)
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "LISTEN") {
+			continue
+		}
+		local := fields[3]
+		if !strings.HasSuffix(local, want) {
+			continue
+		}
+		idx := strings.LastIndexByte(local, ':')
+		if idx < 0 {
+			continue
+		}
+		if local[idx:] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/installer/panelfw/adapters/plesk/plesk_test.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk_test.go
@@ -308,8 +308,8 @@ func TestRequiredPorts_MissingConfD_FailsClosed(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error on missing conf.d; got tcp=%v udp=%v", tcp, udp)
 	}
-	if !strings.Contains(err.Error(), "Plesk conf.d") {
-		t.Errorf("error must reference Plesk conf.d; got %v", err)
+	if !strings.Contains(err.Error(), "Plesk") || !strings.Contains(err.Error(), "conf.d") {
+		t.Errorf("error must reference Plesk and conf.d; got %v", err)
 	}
 	assertNoControlPlaneFallback(t, tcp, udp)
 }

--- a/internal/installer/panelfw/adapters/plesk/plesk_test.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk_test.go
@@ -1,0 +1,819 @@
+// =============================================================================
+// NFTBan v1.100.x PR26.7 - Plesk Adapter Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-panelfw-plesk-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-04-30"
+// meta:description="Detect / RequiredPorts / ValidateReachability + framework integration for Plesk"
+// meta:inventory.files="internal/installer/panelfw/adapters/plesk/plesk_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package plesk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+	"github.com/itcmsgr/nftban/internal/ports"
+)
+
+func newTestLogger() *logging.Logger {
+	return logging.New("/dev/null", false)
+}
+
+// seedPlesk populates the mock with strong-confidence Plesk evidence:
+// install dir, marker binary, active service, and TCP <port> in LISTEN
+// state.
+func seedPlesk(mock *executor.MockExecutor, port int) {
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   ssOutput(port),
+	}
+}
+
+func ssOutput(listenPorts ...int) string {
+	header := "State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n"
+	rows := []string{header}
+	for _, p := range listenPorts {
+		rows = append(rows, "LISTEN 0 128 0.0.0.0:"+itoa(p)+" 0.0.0.0:* users:((\"sw-cp-server\",pid=1,fd=3))")
+	}
+	return strings.Join(rows, "\n")
+}
+
+func itoa(n int) string { return formatInt(n) }
+
+func formatInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// ----------------------------------------------------------------------------
+// Detect
+// ----------------------------------------------------------------------------
+
+func TestDetect_AllSignals_Strong(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPlesk(mock, defaultPort)
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true; got %#v", det)
+	}
+	if det.Confidence != "strong" {
+		t.Errorf("expected strong confidence with 4 indicators; got %q", det.Confidence)
+	}
+	if len(det.Evidence) != 4 {
+		t.Errorf("expected 4 evidence entries; got %d (%v)", len(det.Evidence), det.Evidence)
+	}
+	if len(det.RequiredTCP) != 1 || det.RequiredTCP[0] != defaultPort {
+		t.Errorf("expected RequiredTCP=[%d]; got %v", defaultPort, det.RequiredTCP)
+	}
+}
+
+func TestDetect_Absent_NotDetected(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	det := a.Detect(context.Background(), mock)
+	if det.Detected {
+		t.Fatalf("expected Detected=false on bare host; got %#v", det)
+	}
+}
+
+func TestDetect_PartialInstall_Weak(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	// Only the install dir + marker binary; service stopped, no listener.
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true on 2 indicators; got %#v", det)
+	}
+	if det.Confidence != "weak" {
+		t.Errorf("expected weak confidence; got %q", det.Confidence)
+	}
+	if len(det.Warnings) == 0 {
+		t.Errorf("expected at least one warning for partial install")
+	}
+}
+
+// Service-only signal still counts as a (weak) detection.
+func TestDetect_ServiceOnly_Weak(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Services[systemdUnit] = true
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true on service-active alone")
+	}
+	if det.Confidence != "weak" {
+		t.Errorf("expected weak confidence; got %q", det.Confidence)
+	}
+}
+
+// Negative-coupling guard: a DirectAdmin-shape mock (binary at
+// /usr/local/directadmin/...) must NOT trigger Plesk detection. Catches
+// future regressions where a path constant gets fat-fingered.
+func TestDetect_DirectAdminEvidence_NotPlesk(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs["/usr/local/directadmin"] = true
+	mock.Files["/usr/local/directadmin/directadmin"] = []byte("ELF")
+	mock.Services["directadmin.service"] = true
+
+	det := a.Detect(context.Background(), mock)
+	if det.Detected {
+		t.Fatalf("Plesk adapter must not detect on a DA-only host: %#v", det)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// RequiredPorts
+// ----------------------------------------------------------------------------
+
+// withStubLoader temporarily replaces panelConfDLoader with a
+// deterministic fixture provider. Restores the original on cleanup.
+func withStubLoader(t *testing.T, fn func(configDir, panelName string) (*ports.PanelConfig, error)) {
+	t.Helper()
+	saved := panelConfDLoader
+	panelConfDLoader = fn
+	t.Cleanup(func() { panelConfDLoader = saved })
+}
+
+// withFixtureConfD writes a real conf.d/panels/plesk/main.conf under a
+// tempdir and points panelConfDDir at it for the duration of the test.
+// Used by integration tests that exercise the real LoadPanelConfig
+// (which shells to bash to source the file).
+func withFixtureConfD(t *testing.T, mainConf string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	confDir := filepath.Join(tmp, "conf.d", "panels", "plesk")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "main.conf"), []byte(mainConf), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	saved := panelConfDDir
+	panelConfDDir = tmp
+	t.Cleanup(func() { panelConfDDir = saved })
+	return tmp
+}
+
+// =============================================================================
+// FUTURE-AUDITOR DIRECTIVE — port content lives in CONF.D, not in Go.
+// =============================================================================
+// The Plesk port surface (TCP/UDP × IN/OUT × IPv4/IPv6 + CUSTOM) lives
+// ONLY in the shipped conf.d file:
+//
+//	etc/nftban/conf.d/panels/plesk/main.conf
+//
+// That file is the single source of truth. Operators edit conf.d, not
+// Go. Reproducing any port list in Go (this test file or production
+// code) recreates the four-truth drift PR26.4 was created to close.
+//
+// RULES FOR FUTURE EDITS TO THIS TEST FILE:
+//   1. Stub-loader tests use the small `synthPlesk` synthetic fixture
+//      below — clearly marked synthetic, not authoritative. Its only
+//      job is to give the adapter SOMETHING to pass through so we can
+//      test the contract (errors, defensive copies, fail-closed
+//      branches). Its specific port values are arbitrary.
+//   2. Tests that verify ACTUAL Plesk port content read the shipped
+//      conf.d via the real loader. Use
+//      `locateRepoFile(t, "etc/nftban/conf.d/panels/plesk/main.conf")`.
+//   3. Do NOT add hardcoded port lists to Go. If you find yourself
+//      typing a list of Plesk ports in this file, stop and put them
+//      in conf.d instead.
+// =============================================================================
+
+// synthPlesk is a tiny synthetic PanelConfig used only by stub-loader
+// tests that test the adapter contract (pass-through, defensive copy,
+// non-trivial surface size). Its port values are arbitrary fixtures —
+// NOT the canonical Plesk port surface. The canonical surface lives
+// in etc/nftban/conf.d/panels/plesk/main.conf and is verified by
+// real-loader tests.
+var synthPlesk = struct {
+	tcpIn []int
+	udpIn []int
+}{
+	tcpIn: []int{8443, 8880, 25, 80, 443, 587},
+	udpIn: []int{53, 443},
+}
+
+// adapter passes through the loader's PanelConfig verbatim.
+func TestRequiredPorts_ConfDLoaded_FullSurface(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		if panelName != "plesk" {
+			t.Fatalf("loader called with panelName=%q; want plesk", panelName)
+		}
+		return &ports.PanelConfig{
+			Name:       "plesk",
+			Enabled:    true,
+			ConfigFile: configDir + "/conf.d/panels/plesk/main.conf",
+			TCPIn:      synthPlesk.tcpIn,
+			UDPIn:      synthPlesk.udpIn,
+		}, nil
+	})
+
+	a := New()
+	tcp, udp, err := a.RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("RequiredPorts must not error on stub fixture: %v", err)
+	}
+	if !equalIntSlices(tcp, synthPlesk.tcpIn) {
+		t.Errorf("TCP pass-through mismatch:\n  got  %v\n  want %v", tcp, synthPlesk.tcpIn)
+	}
+	if !equalIntSlices(udp, synthPlesk.udpIn) {
+		t.Errorf("UDP pass-through mismatch:\n  got  %v\n  want %v", udp, synthPlesk.udpIn)
+	}
+}
+
+// RequiredPorts is NOT [8443]-only. Structural regression guard.
+func TestRequiredPorts_ConfDLoaded_NotJust8443(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return &ports.PanelConfig{
+			Name:  "plesk",
+			TCPIn: synthPlesk.tcpIn,
+			UDPIn: synthPlesk.udpIn,
+		}, nil
+	})
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tcp) <= 1 {
+		t.Fatalf("expected full Plesk TCP surface; got only %v", tcp)
+	}
+	hasNon8443 := false
+	for _, p := range tcp {
+		if p != defaultPort {
+			hasNon8443 = true
+			break
+		}
+	}
+	if !hasNon8443 {
+		t.Errorf("RequiredPorts must include ports beyond control-plane %d; got %v", defaultPort, tcp)
+	}
+	if len(udp) == 0 {
+		t.Errorf("RequiredPorts must declare UDP surface for Plesk; got empty")
+	}
+	for _, p := range []int{25, 443} {
+		if !containsInt(tcp, p) {
+			t.Errorf("TCP surface missing canonical port %d; got %v", p, tcp)
+		}
+	}
+	if !containsInt(udp, 53) {
+		t.Errorf("UDP surface missing canonical port 53; got %v", udp)
+	}
+}
+
+// Missing conf.d main.conf must fail closed.
+func TestRequiredPorts_MissingConfD_FailsClosed(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return nil, fmt.Errorf("panel config not found: %s/conf.d/panels/%s/main.conf",
+			configDir, panelName)
+	})
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err == nil {
+		t.Fatalf("expected error on missing conf.d; got tcp=%v udp=%v", tcp, udp)
+	}
+	if !strings.Contains(err.Error(), "Plesk conf.d") {
+		t.Errorf("error must reference Plesk conf.d; got %v", err)
+	}
+	assertNoControlPlaneFallback(t, tcp, udp)
+}
+
+// Malformed conf.d (loaded but empty TCP_IN) must fail closed.
+func TestRequiredPorts_EmptyTCPIn_FailsClosed(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return &ports.PanelConfig{
+			Name:       "plesk",
+			ConfigFile: "/tmp/test/main.conf",
+			TCPIn:      nil,
+			UDPIn:      []int{53},
+		}, nil
+	})
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err == nil {
+		t.Fatalf("expected error on empty TCP_IN")
+	}
+	if !strings.Contains(err.Error(), "no TCP_IN") {
+		t.Errorf("error must explain malformed TCP_IN; got %v", err)
+	}
+	assertNoControlPlaneFallback(t, tcp, udp)
+}
+
+// Loader returning nil PanelConfig must fail closed.
+func TestRequiredPorts_NilPanelConfig_FailsClosed(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return nil, nil
+	})
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err == nil {
+		t.Fatalf("expected error when loader returns nil cfg")
+	}
+	assertNoControlPlaneFallback(t, tcp, udp)
+}
+
+// Real-loader assertion against the SHIPPED conf.d: SSH port 22 must
+// not appear in Plesk TCP_IN/UDP_IN. SSH is managed separately via
+// /etc/nftban/ports.d/00-ssh.conf.
+func TestRequiredPorts_ConfDDoesNotIncludeSSHPort22(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skipf("/bin/bash unavailable on this host: %v", err)
+	}
+	shipped := locateRepoFile(t, "etc/nftban/conf.d/panels/plesk/main.conf")
+	data, err := os.ReadFile(shipped) // #nosec G304 -- fixed path under repo
+	if err != nil {
+		t.Fatalf("read shipped main.conf at %s: %v", shipped, err)
+	}
+	withFixtureConfD(t, string(data))
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("unexpected error loading shipped conf.d: %v", err)
+	}
+	if containsInt(tcp, 22) {
+		t.Errorf("shipped Plesk conf.d declares port 22 in TCP_IN — "+
+			"SSH is managed by /etc/nftban/ports.d/00-ssh.conf; check %s", shipped)
+	}
+	if containsInt(udp, 22) {
+		t.Errorf("shipped Plesk conf.d declares port 22 in UDP_IN; check %s", shipped)
+	}
+}
+
+// Real-loader assertion: the shipped conf.d must include the Plesk
+// control plane port (8443). Without it the panel itself is unreachable.
+// Structural assertions only — never enumerates the full port list.
+//
+// FUTURE-AUDITOR DIRECTIVE — DO NOT INVENT PORT LISTS HERE.
+// Source of truth for Plesk ports is etc/nftban/conf.d/panels/plesk/main.conf.
+func TestRequiredPorts_RealLoader_ControlPortAndSurfaceSize(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skipf("/bin/bash unavailable on this host: %v", err)
+	}
+	shipped := locateRepoFile(t, "etc/nftban/conf.d/panels/plesk/main.conf")
+	data, err := os.ReadFile(shipped) // #nosec G304 -- fixed path under repo
+	if err != nil {
+		t.Fatalf("read shipped main.conf at %s: %v", shipped, err)
+	}
+	withFixtureConfD(t, string(data))
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("real-loader RequiredPorts: %v", err)
+	}
+
+	// Plesk control plane MUST be in the surface.
+	if !containsInt(tcp, defaultPort) {
+		t.Errorf("TCP_IN must include the Plesk control port %d; got len=%d", defaultPort, len(tcp))
+	}
+	// SSH must be absent.
+	if containsInt(tcp, 22) {
+		t.Errorf("real loader produced TCP_IN containing port 22 — conf.d four-truth violation; check %s", shipped)
+	}
+	if containsInt(udp, 22) {
+		t.Errorf("real loader produced UDP_IN containing port 22; check %s", shipped)
+	}
+	// UDP must be non-empty (Plesk needs DNS at minimum).
+	if len(udp) == 0 {
+		t.Errorf("UDP_IN empty — conf.d should declare Plesk's UDP surface (DNS, etc.)")
+	}
+	// Sanity floor on TCP surface — bigger than just the control port.
+	// Avoid an exact count so future operator-edits to conf.d don't
+	// churn this test.
+	if len(tcp) < 5 {
+		t.Errorf("TCP_IN length = %d; expected larger Plesk surface (HTTPS, mail, etc.); "+
+			"loader may be dropping declarations", len(tcp))
+	}
+}
+
+// locateRepoFile climbs from the test file's directory until it finds
+// the repo's go.mod, then resolves relPath against that root.
+func locateRepoFile(t *testing.T, relPath string) string {
+	t.Helper()
+	_, this, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	dir := filepath.Dir(this)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, relPath)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod above %s", filepath.Dir(this))
+		}
+		dir = parent
+	}
+}
+
+// assertNoControlPlaneFallback is a fail-closed assertion helper: when
+// RequiredPorts errors, the returned slices must be nil/empty — never
+// the legacy [8443] fallback.
+func assertNoControlPlaneFallback(t *testing.T, tcp, udp []int) {
+	t.Helper()
+	if len(tcp) != 0 {
+		t.Errorf("fail-closed: tcp must be nil/empty on error — must NOT fall back to [%d]; got %v", defaultPort, tcp)
+	}
+	if len(udp) != 0 {
+		t.Errorf("fail-closed: udp must be nil/empty on error; got %v", udp)
+	}
+}
+
+// Returned slices must not alias internal loader state.
+func TestRequiredPorts_DefensiveCopy(t *testing.T) {
+	internalTCP := []int{20, 21, 25, 8443}
+	internalUDP := []int{53, 443}
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return &ports.PanelConfig{Name: "plesk", TCPIn: internalTCP, UDPIn: internalUDP}, nil
+	})
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tcp[0] = 99999
+	udp[0] = 99999
+	if internalTCP[0] == 99999 || internalUDP[0] == 99999 {
+		t.Errorf("RequiredPorts must return defensive copies; caller mutation leaked into loader cache")
+	}
+}
+
+// Real internal/ports.LoadPanelConfig against a tempdir-stamped
+// fixture main.conf. Exercises the actual bash-subshell parser path.
+func TestRequiredPorts_ConfDLoaded_RealLoader_FixtureFile(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skipf("/bin/bash unavailable on this host: %v", err)
+	}
+	const fixtureMain = `# fixture main.conf for PR26.7 integration test
+NFTBAN_PLESK_PATH="/usr/local/psa"
+NFTBAN_PLESK_PANEL_PORT="8880"
+NFTBAN_PLESK_PANEL_SSL_PORT="8443"
+NFTBAN_PLESK_TCP_IN="20,21,25,8443,8880"
+NFTBAN_PLESK_UDP_IN="53,443"
+NFTBAN_PLESK_TCP_OUT="20,21,25,8443"
+NFTBAN_PLESK_UDP_OUT="53,123"
+`
+	withFixtureConfD(t, fixtureMain)
+
+	tcp, udp, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor())
+	if err != nil {
+		t.Fatalf("real-loader RequiredPorts: %v", err)
+	}
+	wantTCP := []int{20, 21, 25, 8443, 8880}
+	wantUDP := []int{53, 443}
+	if !equalIntSlices(tcp, wantTCP) {
+		t.Errorf("TCP mismatch:\n  got  %v\n  want %v", tcp, wantTCP)
+	}
+	if !equalIntSlices(udp, wantUDP) {
+		t.Errorf("UDP mismatch:\n  got  %v\n  want %v", udp, wantUDP)
+	}
+}
+
+// Missing fixture main.conf must surface as a fail-closed error.
+func TestRequiredPorts_RealLoader_MissingConfD_FailsClosed(t *testing.T) {
+	saved := panelConfDDir
+	panelConfDDir = t.TempDir()
+	t.Cleanup(func() { panelConfDDir = saved })
+
+	if _, _, err := New().RequiredPorts(context.Background(), executor.NewMockExecutor()); err == nil {
+		t.Fatalf("expected error from real loader when main.conf is absent")
+	}
+}
+
+func equalIntSlices(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsInt(slice []int, v int) bool {
+	for _, p := range slice {
+		if p == v {
+			return true
+		}
+	}
+	return false
+}
+
+// ----------------------------------------------------------------------------
+// ValidateReachability
+// ----------------------------------------------------------------------------
+
+func TestValidateReachability_Listening_OK(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(defaultPort)}
+
+	if err := a.ValidateReachability(context.Background(), mock); err != nil {
+		t.Errorf("expected nil; got %v", err)
+	}
+}
+
+func TestValidateReachability_NotListening_ReturnsError(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	err := a.ValidateReachability(context.Background(), mock)
+	if err == nil {
+		t.Fatalf("expected error when port %d not listening", defaultPort)
+	}
+	if !strings.Contains(err.Error(), "8443") {
+		t.Errorf("error should mention the port: %v", err)
+	}
+}
+
+// Error must explicitly identify the scope as control-plane.
+func TestValidateReachability_NotListening_ErrorMentionsControlPlane(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	err := a.ValidateReachability(context.Background(), mock)
+	if err == nil {
+		t.Fatalf("expected error when control port not listening")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "control-plane") {
+		t.Errorf("error must explicitly say 'control-plane'; got %q", msg)
+	}
+	for _, forbidden := range []string{
+		"full panel survival validated",
+		"full panel survived",
+		"all Plesk ports validated",
+		"all Plesk ports listening",
+		"all panel ports listening",
+		"all panel ports validated",
+	} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("error must NOT claim %q (overstates scope); got %q", forbidden, msg)
+		}
+	}
+}
+
+// Defensive: ":84443" must not match expected ":8443".
+func TestValidateReachability_PortPrefixCollision(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(84443)}
+	if err := a.ValidateReachability(context.Background(), mock); err == nil {
+		t.Errorf("expected error — :84443 must not collide with :8443")
+	}
+}
+
+// ss exit-code non-zero → treated as not-reachable.
+func TestValidateReachability_SsErrorsOut_NotListening(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 1, Stdout: "", Stderr: "ss: command not found"}
+	if err := a.ValidateReachability(context.Background(), mock); err == nil {
+		t.Errorf("expected error when ss fails — must NOT silently report reachable")
+	}
+}
+
+// 8447 (Plesk Updater) listening but 8443 not — must FAIL.
+// 8447 is part of the conf.d full surface but is NOT the control plane.
+// This guard ensures the adapter probes 8443 specifically, not "any
+// Plesk-shaped port".
+func TestValidateReachability_Only8447Listening_FailsBecauseNot8443(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(8447)}
+	if err := a.ValidateReachability(context.Background(), mock); err == nil {
+		t.Errorf("expected error — Plesk Updater 8447 must not satisfy control-plane probe")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// ID + adapter contract identity
+// ----------------------------------------------------------------------------
+
+func TestID(t *testing.T) {
+	a := New()
+	if a.ID() != adapterID {
+		t.Errorf("ID() = %q; want %q", a.ID(), adapterID)
+	}
+	if string(a.ID()) != "plesk" {
+		t.Errorf("string ID drift: %q", string(a.ID()))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Framework integration: registered adapter detected → policy fires
+// ----------------------------------------------------------------------------
+
+func stubCanonicalPlesk(t *testing.T) {
+	withStubLoader(t, func(configDir, panelName string) (*ports.PanelConfig, error) {
+		return &ports.PanelConfig{
+			Name:    "plesk",
+			Enabled: true,
+			TCPIn:   synthPlesk.tcpIn,
+			UDPIn:   synthPlesk.udpIn,
+		}, nil
+	})
+}
+
+func TestFrameworkIntegration_Plesk_Detected_Reachable_Passes(t *testing.T) {
+	stubCanonicalPlesk(t)
+
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPlesk(mock, defaultPort)
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on healthy Plesk host; got %#v", res)
+	}
+	if string(res.Detection.ID) != "plesk" {
+		t.Errorf("expected detection ID=plesk; got %q", res.Detection.ID)
+	}
+	if !res.PortsApplied || !res.ReachableAfter {
+		t.Errorf("expected PortsApplied+ReachableAfter true; got %#v", res)
+	}
+	if !equalIntSlices(res.PortsTCP, synthPlesk.tcpIn) {
+		t.Errorf("PortsTCP pass-through mismatch; got %v want %v", res.PortsTCP, synthPlesk.tcpIn)
+	}
+	if !equalIntSlices(res.PortsUDP, synthPlesk.udpIn) {
+		t.Errorf("PortsUDP pass-through mismatch; got %v want %v", res.PortsUDP, synthPlesk.udpIn)
+	}
+}
+
+func TestFrameworkIntegration_Plesk_Detected_NotReachable_Blocks(t *testing.T) {
+	stubCanonicalPlesk(t)
+
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true when Plesk detected but unreachable; got %#v", res)
+	}
+	if !strings.Contains(res.Reason, "plesk") && !strings.Contains(res.Reason, "Plesk") {
+		t.Errorf("Reason should mention plesk: %q", res.Reason)
+	}
+	if !strings.Contains(res.Reason, "control-plane") {
+		t.Errorf("Reason must say 'control-plane'; got %q", res.Reason)
+	}
+}
+
+// Surfaced Reason on control-plane miss must NOT claim full-surface
+// reachability has been probed.
+func TestFrameworkIntegration_Plesk_ControlPlaneError_DoesNotClaimFullSurfaceReachability(t *testing.T) {
+	stubCanonicalPlesk(t)
+
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services[systemdUnit] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true; got %#v", res)
+	}
+	for _, forbidden := range []string{
+		"full panel survival validated",
+		"full panel survived",
+		"all Plesk ports validated",
+		"all Plesk ports listening",
+		"all panel ports listening",
+		"all panel ports validated",
+	} {
+		if strings.Contains(res.Reason, forbidden) {
+			t.Errorf("Reason must NOT claim %q (control-plane probe only); got %q", forbidden, res.Reason)
+		}
+	}
+}
+
+func TestFrameworkIntegration_Plesk_Absent_Passes(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, panelfw.DefaultPolicy())
+	if res.Fatal {
+		t.Fatalf("expected Fatal=false on bare host; got %#v", res)
+	}
+	if res.Detection.Detected {
+		t.Errorf("expected Detection.Detected=false")
+	}
+}
+
+// OperatorDisabled (--no-panel) flips a failing Plesk host to non-fatal.
+func TestFrameworkIntegration_Plesk_NotReachable_OperatorDisabled_Passes(t *testing.T) {
+	stubCanonicalPlesk(t)
+
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
+
+	policy := panelfw.DefaultPolicy()
+	policy.OperatorDisabled = true
+	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
+		[]panelfw.PanelAdapter{a}, policy)
+
+	if res.Fatal {
+		t.Fatalf("OperatorDisabled=true must convert failure to non-fatal: %#v", res)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// init() registration
+// ----------------------------------------------------------------------------
+
+func TestInitRegistration_AdapterPresent(t *testing.T) {
+	got := panelfw.RegisteredAdapters()
+	var found bool
+	for _, a := range got {
+		if a.ID() == adapterID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Plesk adapter not registered via init(); registry=%v", got)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Read-only discipline
+// ----------------------------------------------------------------------------
+
+func TestReadOnly_NoWrites_NoMutationCommands(t *testing.T) {
+	stubCanonicalPlesk(t)
+
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPlesk(mock, defaultPort)
+
+	_ = a.Detect(context.Background(), mock)
+	_, _, _ = a.RequiredPorts(context.Background(), mock)
+	_ = a.ValidateReachability(context.Background(), mock)
+
+	if len(mock.WrittenFiles) != 0 {
+		t.Errorf("adapter wrote %d files via executor (want 0)", len(mock.WrittenFiles))
+	}
+	for _, c := range mock.Commands {
+		switch c.Name {
+		case "ss":
+			// expected — read-only socket query
+		case "systemctl":
+			// is-active only — ServiceActive is read-only on the mock
+		default:
+			t.Errorf("unexpected command %q (mutation suspected)", c.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Second adapter under the PR26.2 panelfw contract, mirroring the PR26.3+PR26.4 DirectAdmin shape. **Plesk-first** sequence (cPanel deferred to PR26.8 because the cPanel host is currently down/incident-tied; clean Plesk path is available).

- **Adapter** (\`internal/installer/panelfw/adapters/plesk/plesk.go\`): Detect via 4 signals (\`/usr/local/psa\`, \`httpdmng\` marker, \`plesk.service\`, TCP 8443 listener). RequiredPorts loads canonical \`etc/nftban/conf.d/panels/plesk/main.conf\` via \`internal/ports/panel_loader.LoadPanelConfig(\"plesk\")\`. ValidateReachability probes **TCP 8443 only** (the HTTPS control plane).
- **Tests** (\`plesk_test.go\`): 25 tests covering Detect, RequiredPorts (incl. real-loader against shipped conf.d, fail-closed, defensive copy, FUTURE-AUDITOR DIRECTIVE block), ValidateReachability (incl. 8447-not-8443 guard), framework integration, init registration, read-only discipline.
- **Wiring** (\`cmd/nftban-installer/main.go\`): blank-import alongside DirectAdmin.

## Differences from DirectAdmin

1. **No per-host control-port override.** Plesk has no canonical config file analogous to \`directadmin.conf\` \`port=N\`. The adapter returns the constant default 8443. Seam for future override is at the same place as DA's \`readConfiguredPort\`.
2. **TCP 8447 is not control-plane.** It's part of the conf.d full surface (Plesk Updater) but may be closed on a healthy panel host. Dedicated test guards against the adapter \"passing\" a Plesk host where only 8447 listens.

## Test plan

- [x] \`go vet ./internal/installer/panelfw/... ./cmd/nftban-installer/...\` — clean
- [x] \`go test -v ./internal/installer/panelfw/adapters/plesk/...\` — **25/25 PASS** on lab2
- [x] \`go test ./internal/installer/... ./cmd/nftban-installer/...\` — **18/18 packages PASS** on lab2 (no DA regression)
- [x] \`go build ./cmd/nftban-installer\` — builds clean with both adapters
- [ ] CI green
- [ ] Auditor review
- [ ] Real-host Plesk evidence — **deferred** until PR26.7 merged + Tier 1 rebuilt + clean non-build Plesk host authorized (lab2 is the build host; using it destructively would weaken isolation)

## Out of scope

- cPanel adapter (PR26.8 — gated on Plesk evidence + clean cPanel host)
- DirectAdmin changes
- Shell decommission of \`nftban_panel_plesk.sh\`
- Plesk Firewall extension conflict detection (informational warn — future PR)
- Plesk takeover lifecycle (no equivalent of \`da build set csf no\`)
- Restore redesign
- Destructive lab2/dns2/Plesk install

🤖 Generated with [Claude Code](https://claude.com/claude-code)