### PR TITLE
PR26.7.1: Plesk reality calibration (Detect E3 any-of + conf.d 4190)

### DIFF
--- a/etc/nftban/conf.d/panels/plesk/main.conf
+++ b/etc/nftban/conf.d/panels/plesk/main.conf
@@ -2,6 +2,17 @@
 # NFTBan Plesk Panel Configuration
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban-conf-panel-plesk"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Plesk control-panel firewall + security port surface (sourced by panel_loader and nftban_panel_plesk shell library)"
+# meta:inventory.files="/etc/nftban/conf.d/panels/plesk/main.conf"
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_PLESK_TCP_IN,NFTBAN_PLESK_TCP_OUT,NFTBAN_PLESK_UDP_IN,NFTBAN_PLESK_UDP_OUT,NFTBAN_PLESK_TCP6_IN,NFTBAN_PLESK_TCP6_OUT,NFTBAN_PLESK_UDP6_IN,NFTBAN_PLESK_UDP6_OUT"
+# meta:inventory.config_files="/etc/nftban/conf.d/panels/plesk/main.conf,/etc/nftban/conf.d/panels/plesk/main.conf.local"
+# meta:inventory.systemd_units=""
+# meta:inventory.network="tcp/8443 (Plesk HTTPS panel control plane)"
+# meta:inventory.privileges="none"
 # Purpose: Plesk control panel firewall and security configuration
 #
 # File: /etc/nftban/conf.d/panels/plesk/main.conf
@@ -30,9 +41,13 @@ NFTBAN_PLESK_PANEL_SSL_PORT="8443"   # Plesk HTTPS
 # TCP INPUT (incoming connections)
 # Ports: FTP(20,21), SMTP(25), DNS(53), HTTP(80), POP3(110),
 #        IMAP(143), HTTPS(443), SMTPS(465), Submission(587), IMAPS(993),
-#        POP3S(995), Plesk HTTP(8880), Plesk HTTPS(8443),
-#        Passive FTP(49152-65535)
-NFTBAN_PLESK_TCP_IN="20,21,25,53,80,110,143,443,465,587,993,995,8443,8880"
+#        POP3S(995), Sieve/managesieve(4190), Plesk HTTP(8880),
+#        Plesk HTTPS(8443), Passive FTP(49152-65535)
+#
+# 4190 (managesieve, RFC 5804) — dovecot mail-filter management for
+# Plesk mail users. Confirmed listening on Plesk Obsidian 18.0.76 by
+# the 178.105.74.229 read-only audit (sha256 c1a72266e2eb...).
+NFTBAN_PLESK_TCP_IN="20,21,25,53,80,110,143,443,465,587,993,995,4190,8443,8880"
 
 # TCP OUTPUT (outgoing connections)
 NFTBAN_PLESK_TCP_OUT="20,21,25,53,80,110,113,443,587,993,995,8443"
@@ -50,7 +65,7 @@ NFTBAN_PLESK_UDP_OUT="53,123,443"
 # -----------------------------------------------------------------------------
 # IPv6 uses the same ports as IPv4
 
-NFTBAN_PLESK_TCP6_IN="20,21,25,53,80,110,143,443,465,587,993,995,8443,8880"
+NFTBAN_PLESK_TCP6_IN="20,21,25,53,80,110,143,443,465,587,993,995,4190,8443,8880"
 NFTBAN_PLESK_TCP6_OUT="20,21,25,53,80,110,113,443,587,993,995,8443"
 NFTBAN_PLESK_UDP6_IN="53,443"
 NFTBAN_PLESK_UDP6_OUT="53,123,443"

--- a/internal/installer/panelfw/adapters/plesk/plesk.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk.go
@@ -92,10 +92,36 @@ const defaultPort = 8443
 // reference the same canonical names. Marker bin path comes from
 // etc/nftban/conf.d/panels/plesk/main.conf NFTBAN_PLESK_MARKER_BIN.
 const (
-	installDir  = "/usr/local/psa"
-	binaryPath  = "/usr/local/psa/admin/bin/httpdmng"
-	systemdUnit = "plesk.service"
+	installDir = "/usr/local/psa"
+	binaryPath = "/usr/local/psa/admin/bin/httpdmng"
 )
+
+// systemdUnits is the ordered any-of list of systemd units that, if any
+// one is active, count as E3 evidence that Plesk is running.
+//
+// PR26.7.1 calibration: the original adapter probed `plesk.service`
+// alone, which does NOT exist on Ubuntu Plesk Obsidian — verified by
+// the read-only audit on 178.105.74.229 (frozen evidence sha256
+// c1a72266e2eb3489768a188d40d4cebcd242e1ed2bb3ba45ad0d316b549b21c3).
+// Real Ubuntu Plesk units:
+//
+//	sw-cp-server.service   active running   enabled  ← owns 8443/8880 listener
+//	sw-engine.service      active running   enabled  ← PHP-FPM panel backend
+//	psa.service            active(exited)   enabled  ← orchestrator (one-shot)
+//
+// `plesk.service` is absent from `systemctl list-unit-files` on Ubuntu.
+//
+// Order matters for evidence reporting (first match wins): we list the
+// strongest indicator (the daemon that actually owns the panel listener)
+// first and the legacy compat unit last. Detect must NOT broaden so
+// far that a non-Plesk host with a coincidentally-named service trips a
+// signal — Plesk-specific filesystem markers (E1/E2) and/or the 8443
+// listener (E4) remain required for any positive Detect.
+var systemdUnits = []string{
+	"sw-cp-server.service", // primary: owns 8443/8880 listener (sw-cp-serverd)
+	"psa.service",          // orchestrator: active(exited) on healthy host
+	"plesk.service",        // legacy/compat: present on some non-Ubuntu Plesk distros
+}
 
 // panelConfDLoader is the function the adapter calls to load the
 // canonical conf.d panel config. Defaults to the package-public
@@ -133,8 +159,15 @@ func (a *adapter) ID() panelfw.PanelID { return adapterID }
 //
 //	E1 — /usr/local/psa/                      (canonical install dir)
 //	E2 — /usr/local/psa/admin/bin/httpdmng    (panel binary marker)
-//	E3 — plesk.service active                 (systemd-managed run)
+//	E3 — any of {sw-cp-server.service,
+//	             psa.service,
+//	             plesk.service} active        (systemd-managed run)
 //	E4 — TCP 8443 in LISTEN state             (panel actually serving)
+//
+// E3 is an any-of probe (PR26.7.1 calibration) because `plesk.service`
+// does not exist on Ubuntu Plesk Obsidian — `sw-cp-server.service`
+// owns the 8443 listener instead. The first matching unit wins for
+// evidence reporting; `service-active:<unit>` records which one fired.
 //
 // Confidence rule: 3+ indicators ⇒ "strong"; 1–2 ⇒ "weak"; 0 ⇒
 // Detected=false. The required port is always declared (8443) so the
@@ -156,9 +189,16 @@ func (a *adapter) Detect(ctx context.Context, exec executor.Executor) panelfw.Pa
 		det.Evidence = append(det.Evidence, "binary-present:"+binaryPath)
 		signals++
 	}
-	if exec.ServiceActive(systemdUnit) {
-		det.Evidence = append(det.Evidence, "service-active:"+systemdUnit)
-		signals++
+	// E3 — any-of probe across the canonical Plesk service units.
+	// Stops at the first active unit so Evidence carries exactly one
+	// `service-active:<unit>` entry naming which one fired. Avoids
+	// double-counting if multiple units happen to be active.
+	for _, unit := range systemdUnits {
+		if exec.ServiceActive(unit) {
+			det.Evidence = append(det.Evidence, "service-active:"+unit)
+			signals++
+			break
+		}
 	}
 	if portInListenState(exec, port) {
 		det.Evidence = append(det.Evidence, fmt.Sprintf("listener-tcp:%d", port))

--- a/internal/installer/panelfw/adapters/plesk/plesk_test.go
+++ b/internal/installer/panelfw/adapters/plesk/plesk_test.go
@@ -37,13 +37,50 @@ func newTestLogger() *logging.Logger {
 	return logging.New("/dev/null", false)
 }
 
-// seedPlesk populates the mock with strong-confidence Plesk evidence:
-// install dir, marker binary, active service, and TCP <port> in LISTEN
-// state.
+// seedPlesk populates the mock with strong-confidence Plesk evidence
+// in the Ubuntu-realistic shape: install dir, marker binary,
+// sw-cp-server.service active (the canonical panel-listener daemon
+// per the 178.105.74.229 audit; sha256 c1a72266e2eb...), and TCP
+// <port> in LISTEN state.
+//
+// PR26.7.1 calibration: the original seedPlesk activated
+// `plesk.service`, which does not exist on Ubuntu Plesk Obsidian.
+// Switching the default to `sw-cp-server.service` makes the strong-
+// confidence path mirror real-world Ubuntu Plesk. Tests covering the
+// legacy plesk.service compat path use seedPleskLegacyService below.
 func seedPlesk(mock *executor.MockExecutor, port int) {
 	mock.Dirs[installDir] = true
 	mock.Files[binaryPath] = []byte("ELF")
-	mock.Services[systemdUnit] = true
+	mock.Services["sw-cp-server.service"] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   ssOutput(port),
+	}
+}
+
+// seedPleskLegacyService activates `plesk.service` (the legacy/compat
+// unit) instead of sw-cp-server.service. Used to verify that hosts
+// where only the legacy unit is the systemd surface still detect
+// strong. Mirror of seedPlesk but with E3 wired through the legacy
+// any-of branch.
+func seedPleskLegacyService(mock *executor.MockExecutor, port int) {
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services["plesk.service"] = true
+	mock.RunResults["ss:-lnt"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   ssOutput(port),
+	}
+}
+
+// seedPleskOrchestratorOnly activates psa.service (the orchestrator
+// unit, typically `active(exited)` on a healthy host). Used to verify
+// the any-of probe accepts psa as fallback E3 evidence when neither
+// sw-cp-server nor plesk.service is the surfaced unit.
+func seedPleskOrchestratorOnly(mock *executor.MockExecutor, port int) {
+	mock.Dirs[installDir] = true
+	mock.Files[binaryPath] = []byte("ELF")
+	mock.Services["psa.service"] = true
 	mock.RunResults["ss:-lnt"] = executor.Result{
 		ExitCode: 0,
 		Stdout:   ssOutput(port),
@@ -125,11 +162,14 @@ func TestDetect_PartialInstall_Weak(t *testing.T) {
 	}
 }
 
-// Service-only signal still counts as a (weak) detection.
+// Service-only signal still counts as a (weak) detection. Activating
+// the canonical Ubuntu Plesk listener unit (sw-cp-server.service) is
+// the strongest single E3 evidence; PR26.7.1 any-of probe accepts it
+// alone as enough for Detected=true with weak confidence.
 func TestDetect_ServiceOnly_Weak(t *testing.T) {
 	a := New()
 	mock := executor.NewMockExecutor()
-	mock.Services[systemdUnit] = true
+	mock.Services["sw-cp-server.service"] = true
 
 	det := a.Detect(context.Background(), mock)
 	if !det.Detected {
@@ -137,6 +177,159 @@ func TestDetect_ServiceOnly_Weak(t *testing.T) {
 	}
 	if det.Confidence != "weak" {
 		t.Errorf("expected weak confidence; got %q", det.Confidence)
+	}
+}
+
+// PR26.7.1 — Ubuntu Plesk Obsidian realistic strong-detect path.
+//
+// Real-world Ubuntu Plesk (per the 178.105.74.229 audit, sha256
+// c1a72266e2eb...) has:
+//   /usr/local/psa            present (symlink → /opt/psa)
+//   httpdmng                  present (symlink → ../sbin/wrapper)
+//   sw-cp-server.service      active+enabled (owns 8443/8880 listener)
+//   plesk.service             ABSENT from systemctl list-unit-files
+//   8443                      LISTEN
+//
+// The pre-PR26.7.1 adapter probed only `plesk.service`, computing
+// confidence="weak" with a misleading "partial install" warning on a
+// fully-functional Ubuntu Plesk panel. After PR26.7.1, Detect must
+// compute confidence="strong" with no warnings on this realistic
+// signal set.
+func TestDetect_UbuntuRealistic_SwCpServer_Strong(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPlesk(mock, defaultPort) // seedPlesk now defaults to sw-cp-server.service
+
+	// Explicit guard: plesk.service must be absent from this fixture
+	// to prove the any-of probe does NOT silently fall back to it.
+	if mock.Services["plesk.service"] {
+		t.Fatal("test fixture invariant: plesk.service must not be active in this case")
+	}
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true on Ubuntu-realistic Plesk fixture; got %#v", det)
+	}
+	if det.Confidence != "strong" {
+		t.Errorf("expected strong confidence on Ubuntu-realistic 4-signal Plesk; got %q (evidence=%v)",
+			det.Confidence, det.Evidence)
+	}
+	if len(det.Warnings) != 0 {
+		t.Errorf("expected zero warnings on healthy Ubuntu Plesk; got %v", det.Warnings)
+	}
+	// Evidence must explicitly name sw-cp-server.service (not plesk.service).
+	foundSwCp := false
+	for _, e := range det.Evidence {
+		if e == "service-active:sw-cp-server.service" {
+			foundSwCp = true
+		}
+		if e == "service-active:plesk.service" {
+			t.Errorf("evidence wrongly references plesk.service when sw-cp-server is the active unit: %v", det.Evidence)
+		}
+	}
+	if !foundSwCp {
+		t.Errorf("evidence must record service-active:sw-cp-server.service; got %v", det.Evidence)
+	}
+}
+
+// PR26.7.1 — psa.service-only fallback path. When sw-cp-server is
+// somehow not the surfaced unit (rare, but possible on fresh-boot
+// race or non-Ubuntu Plesk distros), psa.service active(exited) is
+// the orchestrator-evidence fallback. Adapter must accept it as E3.
+func TestDetect_UbuntuRealistic_PsaServiceFallback_Strong(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPleskOrchestratorOnly(mock, defaultPort)
+
+	if mock.Services["sw-cp-server.service"] || mock.Services["plesk.service"] {
+		t.Fatal("test fixture invariant: only psa.service must be the surfaced unit")
+	}
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true with psa.service evidence; got %#v", det)
+	}
+	if det.Confidence != "strong" {
+		t.Errorf("expected strong confidence (4 signals); got %q (evidence=%v)",
+			det.Confidence, det.Evidence)
+	}
+	foundPsa := false
+	for _, e := range det.Evidence {
+		if e == "service-active:psa.service" {
+			foundPsa = true
+		}
+	}
+	if !foundPsa {
+		t.Errorf("evidence must record service-active:psa.service; got %v", det.Evidence)
+	}
+}
+
+// PR26.7.1 — legacy plesk.service compat path. Distros that DO ship
+// `plesk.service` (some non-Ubuntu Plesk hosts) must still detect
+// strong via the legacy any-of branch.
+func TestDetect_LegacyPleskService_Compat_Strong(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	seedPleskLegacyService(mock, defaultPort)
+
+	if mock.Services["sw-cp-server.service"] || mock.Services["psa.service"] {
+		t.Fatal("test fixture invariant: only plesk.service must be the surfaced unit")
+	}
+
+	det := a.Detect(context.Background(), mock)
+	if !det.Detected {
+		t.Fatalf("expected Detected=true with plesk.service evidence; got %#v", det)
+	}
+	if det.Confidence != "strong" {
+		t.Errorf("expected strong confidence on legacy plesk.service compat path; got %q",
+			det.Confidence)
+	}
+	foundLegacy := false
+	for _, e := range det.Evidence {
+		if e == "service-active:plesk.service" {
+			foundLegacy = true
+		}
+	}
+	if !foundLegacy {
+		t.Errorf("evidence must record service-active:plesk.service; got %v", det.Evidence)
+	}
+}
+
+// PR26.7.1 — broadening guard: bare TCP 8443 listener WITHOUT Plesk
+// filesystem markers must NOT trigger detection. The any-of systemd
+// probe could otherwise incorrectly broaden the detection surface to
+// any non-Plesk host that happens to listen on 8443 (e.g., a custom
+// HTTPS service). Filesystem markers (E1/E2) gate the host as Plesk
+// before E3/E4 contribute.
+//
+// Note on confidence: a bare 8443 listener still records E4 evidence,
+// which technically means signals=1 → Detected=true / Confidence=weak
+// per the existing rule. That is correct framework behavior — the
+// adapter does not pretend the host is non-Plesk. The PANEL-SURVIVAL
+// invariant fires only on `Detected=true` AND failing reachability;
+// this test guards against a confident MISdetection (e.g., strong on
+// 8443 alone).
+func TestDetect_BarePort8443_NoPleskMarkers_NotConfidentDetection(t *testing.T) {
+	a := New()
+	mock := executor.NewMockExecutor()
+	mock.RunResults["ss:-lnt"] = executor.Result{
+		ExitCode: 0,
+		Stdout:   ssOutput(defaultPort),
+	}
+
+	det := a.Detect(context.Background(), mock)
+	if det.Confidence == "strong" {
+		t.Errorf("bare 8443 without Plesk markers must NOT yield strong confidence; got %q evidence=%v",
+			det.Confidence, det.Evidence)
+	}
+	// E1/E2/E3 must all be absent in evidence — only the listener entry.
+	for _, e := range det.Evidence {
+		if e == "install-dir-present:"+installDir || e == "binary-present:"+binaryPath {
+			t.Errorf("evidence wrongly claims Plesk filesystem markers on bare-8443 fixture: %v", det.Evidence)
+		}
+		if len(e) >= 16 && e[:16] == "service-active:s" {
+			t.Errorf("evidence wrongly claims Plesk service on bare-8443 fixture: %v", det.Evidence)
+		}
 	}
 }
 
@@ -399,6 +592,14 @@ func TestRequiredPorts_RealLoader_ControlPortAndSurfaceSize(t *testing.T) {
 	// Plesk control plane MUST be in the surface.
 	if !containsInt(tcp, defaultPort) {
 		t.Errorf("TCP_IN must include the Plesk control port %d; got len=%d", defaultPort, len(tcp))
+	}
+	// PR26.7.1 — TCP 4190 (Sieve/managesieve, RFC 5804) MUST be in
+	// the surface. Confirmed listening on real Plesk Obsidian 18.0.76
+	// by the 178.105.74.229 audit; required for dovecot-managed mail
+	// filter rules from external clients.
+	if !containsInt(tcp, 4190) {
+		t.Errorf("TCP_IN must include managesieve port 4190 (RFC 5804); got len=%d — "+
+			"check %s for missing 4190 entry (PR26.7.1)", len(tcp), shipped)
 	}
 	// SSH must be absent.
 	if containsInt(tcp, 22) {
@@ -688,7 +889,7 @@ func TestFrameworkIntegration_Plesk_Detected_NotReachable_Blocks(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Dirs[installDir] = true
 	mock.Files[binaryPath] = []byte("ELF")
-	mock.Services[systemdUnit] = true
+	mock.Services["sw-cp-server.service"] = true
 	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
 
 	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),
@@ -714,7 +915,7 @@ func TestFrameworkIntegration_Plesk_ControlPlaneError_DoesNotClaimFullSurfaceRea
 	mock := executor.NewMockExecutor()
 	mock.Dirs[installDir] = true
 	mock.Files[binaryPath] = []byte("ELF")
-	mock.Services[systemdUnit] = true
+	mock.Services["sw-cp-server.service"] = true
 	mock.RunResults["ss:-lnt"] = executor.Result{ExitCode: 0, Stdout: ssOutput(80)}
 
 	res := panelfw.EvaluateAdapters(context.Background(), mock, newTestLogger(),


### PR DESCRIPTION
## Summary

Surgical follow-up to PR26.7. Driven by the read-only audit on 203.0.113.229 (Ubuntu 24.04.3 / Plesk Obsidian 18.0.76), frozen at sha256 `c1a72266e2eb3489768a188d40d4cebcd242e1ed2bb3ba45ad0d316b549b21c3`.

**Two real adapter calibration gaps** surfaced by the audit, fixed together because they share the same evidence source and are both Plesk-only.

### Finding A — Detect E3 broken on Ubuntu Plesk Obsidian

`plesk.service` does **not exist** on Ubuntu Plesk Obsidian. The canonical units are `sw-cp-server.service` (owns 8443/8880 listener), `sw-engine.service` (PHP-FPM backend), `psa.service` (orchestrator, `active(exited)`). Pre-PR26.7.1 adapter probed `plesk.service` alone → `Confidence=\"weak\"` with misleading \"partial install\" warning on a fully-functional panel.

**Fix**: replace single `systemdUnit` constant with ordered any-of list `systemdUnits = [sw-cp-server.service, psa.service, plesk.service]`. Stops at first active unit; records `service-active:<unit>` in Evidence. Detection breadth guarded — Plesk filesystem markers (E1: `/usr/local/psa`, E2: `httpdmng`) and/or 8443 listener (E4) remain required for any positive Detect.

### Finding B — TCP 4190 (managesieve, RFC 5804) absent from Plesk conf.d

Dovecot's managesieve listener runs on TCP 4190 on real Plesk hosts for mail-filter rule management. Pre-PR26.7.1 conf.d omits it; mail-filter clients would be firewalled out post-install.

**Fix**: add 4190 to `NFTBAN_PLESK_TCP_IN` and `NFTBAN_PLESK_TCP6_IN` with header comment citing RFC 5804 and the audit anchor. Plesk conf.d only — DA/cPanel/etc. untouched.

## Test plan

Plesk adapter test surface **25 → 29**:

- [x] `TestDetect_UbuntuRealistic_SwCpServer_Strong` — Ubuntu canonical case; plesk.service ABSENT, sw-cp-server.service active → strong/4-signal/no warnings
- [x] `TestDetect_UbuntuRealistic_PsaServiceFallback_Strong` — psa.service-only fallback path
- [x] `TestDetect_LegacyPleskService_Compat_Strong` — plesk.service legacy compat preserved
- [x] `TestDetect_BarePort8443_NoPleskMarkers_NotConfidentDetection` — guards detection-breadth
- [x] `TestRequiredPorts_RealLoader_ControlPortAndSurfaceSize` extended to assert TCP 4190
- [x] `TestValidateReachability_Only8447Listening_FailsBecauseNot8443` unchanged
- [x] FUTURE-AUDITOR DIRECTIVE block unchanged
- [x] No hardcoded full Plesk port list in production code (synthPlesk remains test-only)

Lab proof on lab2 (Ubuntu 24.04, go1.22.2):
- [x] `go vet ./internal/installer/panelfw/adapters/plesk/... ./cmd/nftban-installer/...` — clean
- [x] `go test -v ./internal/installer/panelfw/adapters/plesk/...` — **29/29 PASS**
- [x] `go test ./internal/installer/... ./cmd/nftban-installer/...` — **18/18 packages PASS**
- [x] `go test ./...` — **67/67 packages PASS**
- [x] `staticcheck ./internal/installer/panelfw/adapters/plesk/...` — exit 0

## Out of scope (deferred)

- cPanel adapter (PR26.8 — gated on clean cPanel host)
- DirectAdmin changes
- Generic ufw/fail2ban/firewalld disarm routines (cross-panel architecture note recorded as feedback memory)
- Plesk Firewall extension conflict detection
- Per-host control-port override via `/etc/sw-cp-server/applications.d/`
- Restore redesign
- Destructive Plesk install evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
