### PR TITLE
PR26.6.1: DirectAdmin watchdog coherence after CSF/LFD takeover

### DIFF
--- a/internal/installer/switchop/takeover.go
+++ b/internal/installer/switchop/takeover.go
@@ -132,6 +132,9 @@ func disarmCSFArtifacts(exec executor.Executor, log *logging.Logger) {
 //
 // DirectAdmin: runs `custombuild/build set csf no` to set csf=no in options.conf.
 // Also audits DA custom scripts for CSF/iptables references (informational WARN).
+// PR26.6.1 addition: also flips DirectAdmin's runtime services.status watchdog
+// `lfd=ON` → `lfd=OFF` so dataskq stops trying to restart the masked lfd unit
+// (PANEL-WATCHDOG-COHERENCE-001). See disarmDAWatchdog for details.
 //
 // cPanel/Plesk: CSF is standalone — service masking is sufficient.
 func disarmPanelCSF(exec executor.Executor, panel detect.PanelType, log *logging.Logger) {
@@ -139,6 +142,10 @@ func disarmPanelCSF(exec executor.Executor, panel detect.PanelType, log *logging
 		log.Debug("panel %s — CSF masking is sufficient, no custombuild disarm needed", panel)
 		return
 	}
+	// PR26.6.1: clear the DA runtime watchdog so dataskq no longer
+	// emits perpetual "Unit lfd.service is masked." failures every
+	// minute. Best-effort — failure here does not break takeover.
+	disarmDAWatchdog(exec, log)
 
 	buildCmd := filepath.Join(detect.PathDirectAdmin, "custombuild", "build")
 	if !exec.FileExists(buildCmd) {
@@ -187,4 +194,96 @@ func disarmPanelCSF(exec executor.Executor, panel detect.PanelType, log *logging
 			}
 		}
 	}
+}
+
+// daServicesStatusPath is the canonical DirectAdmin runtime
+// service-monitor configuration. dataskq reads this file every minute
+// and runs service-watchdog for each `<svc>=ON` line.
+const daServicesStatusPath = "/usr/local/directadmin/data/admin/services.status"
+
+// disarmDAWatchdog flips DirectAdmin's runtime watchdog setting for
+// lfd from ON to OFF after takeover masks lfd.service.
+//
+// PR26.6.1 invariant — PANEL-WATCHDOG-COHERENCE-001:
+//
+//	When takeover intentionally disarms an external firewall service
+//	that a panel monitors, takeover must also update the panel's
+//	runtime service-monitor configuration so the panel does not
+//	continuously attempt to restart the disarmed service.
+//
+// Without this, dns2 evidence (2026-04-30 → 2026-05-01) showed
+// dataskq emitting `error=service "lfd": Unit lfd.service is masked.`
+// every 60 seconds for 14+ hours. The lfd binary is preserved on
+// disk and the systemd mask is intact — the loop is purely a
+// false-failure-noise issue, but it is high-volume and obscures
+// real failures in the journal.
+//
+// Behavior:
+//   - Idempotent: re-running on a host where lfd=OFF already is a no-op.
+//   - Best-effort: file absent → no-op + debug log; read/write failure
+//     → warn + continue. Takeover does not abort on watchdog disarm.
+//   - Surgical: only the `^lfd=ON` line is edited; all other watchdog
+//     entries (dovecot, exim, named, mysqld, etc.) are preserved
+//     byte-for-byte. The match is anchored to the line start to avoid
+//     accidentally matching an inline comment or substring.
+//   - DA-only: this helper runs only when panel == DirectAdmin (caller
+//     gates it). cPanel/Plesk have separate service-monitor mechanisms
+//     handled in their own future PRs.
+//
+// Out of scope (deferred to restore-coherence work): re-enabling the
+// watchdog (`lfd=OFF` → `lfd=ON`) on full §32 CSF restore. The forward
+// direction is the immediate operational fix; the reverse is part of
+// the broader restore-coherence track.
+func disarmDAWatchdog(exec executor.Executor, log *logging.Logger) {
+	if !exec.FileExists(daServicesStatusPath) {
+		log.Debug("DA services.status not present at %s — watchdog disarm skipped", daServicesStatusPath)
+		return
+	}
+	data, err := exec.ReadFile(daServicesStatusPath)
+	if err != nil {
+		log.Warn("DA watchdog: read %s: %v", daServicesStatusPath, err)
+		return
+	}
+
+	original := string(data)
+	updated, changed := flipLfdWatchdogOff(original)
+	if !changed {
+		log.Debug("DA watchdog: lfd already OFF (or absent) in %s — no change", daServicesStatusPath)
+		return
+	}
+
+	if err := exec.WriteFileAtomic(daServicesStatusPath, []byte(updated), 0644); err != nil {
+		log.Warn("DA watchdog: write %s: %v (dataskq may continue emitting masked-lfd noise)", daServicesStatusPath, err)
+		return
+	}
+	log.Info("DA services.status: lfd watchdog disabled (PANEL-WATCHDOG-COHERENCE-001)")
+}
+
+// flipLfdWatchdogOff replaces every `^lfd=ON` line with `lfd=OFF`,
+// preserving line endings and all other content byte-for-byte.
+// Returns (newContent, didChange). Pure function — no I/O — so the
+// edit logic is unit-testable independently of executor mocking.
+//
+// Match anchors to start-of-line on purpose: a substring match would
+// risk hitting comment lines like `# lfd=ON disabled in 2024-12 ...`
+// that should not be rewritten. Only the canonical setting line at
+// column zero is flipped.
+func flipLfdWatchdogOff(content string) (string, bool) {
+	const target = "lfd=ON"
+	const replacement = "lfd=OFF"
+	if !strings.Contains(content, target) {
+		return content, false
+	}
+	changed := false
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if line == target {
+			lines[i] = replacement
+			changed = true
+		}
+	}
+	if !changed {
+		return content, false
+	}
+	return strings.Join(lines, "\n"), true
 }

--- a/internal/installer/switchop/takeover_pr26_6_1_test.go
+++ b/internal/installer/switchop/takeover_pr26_6_1_test.go
@@ -1,0 +1,284 @@
+// =============================================================================
+// NFTBan PR26.6.1 - DA Watchdog Coherence Lock-In Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-switchop-takeover-pr26-6-1-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-01"
+// meta:description="Locks PANEL-WATCHDOG-COHERENCE-001 — DA services.status lfd watchdog flipped OFF after takeover; idempotent; surgical; absent-file safe; non-DA panels untouched"
+// meta:inventory.files="internal/installer/switchop/takeover_pr26_6_1_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// PANEL-WATCHDOG-COHERENCE-001 invariant:
+//
+//   When takeover intentionally disarms an external firewall service
+//   that a panel monitors, takeover must also update the panel's
+//   runtime service-monitor configuration so the panel does not
+//   continuously attempt to restart the disarmed service.
+//
+// Source evidence: dns2 evidence (2026-04-30 → 2026-05-01) showed
+// dataskq emitting `error=service "lfd": Unit lfd.service is masked.`
+// every 60 seconds for 14+ hours after PR-26 takeover masked lfd.
+// Operational hotfix on dns2 (sed lfd=ON → OFF + systemctl reset-failed
+// lfd.service) verified the noise stops in <3 minutes; this PR makes
+// the fix automatic for every future DA takeover.
+package switchop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// seedDirectAdminTakeoverPrereqs sets up the minimum mock state for
+// DisableConflicts to reach the DA-takeover branch:
+//   - CSF + LFD services exist (they will be masked)
+//   - DirectAdmin install dir + custombuild/build present
+//   - custombuild set csf no will succeed
+//   - options.conf already shows csf=no (post-disarm verification path)
+//   - csf binary exists (will be renamed to .disabled)
+func seedDirectAdminTakeoverPrereqs(mock *executor.MockExecutor) {
+	mock.Services["csf.service"] = true
+	mock.Services["lfd.service"] = true
+	mock.ExistingCommands["iptables"] = true
+
+	buildCmd := "/usr/local/directadmin/custombuild/build"
+	mock.Files[buildCmd] = []byte("#!/bin/bash")
+	mock.Dirs["/usr/local/directadmin"] = true
+	mock.RunResults[buildCmd+":set:csf:no"] = executor.Result{ExitCode: 0}
+
+	optionsPath := "/usr/local/directadmin/custombuild/options.conf"
+	mock.Files[optionsPath] = []byte("csf=no\nfirewall=no\n")
+
+	mock.Files["/usr/sbin/csf"] = []byte("#!/usr/bin/perl\n")
+}
+
+// daCSFConflicts returns the canonical (CSF + LFD) conflict pair used
+// by the DA-takeover tests below.
+func daCSFConflicts() []detect.Conflict {
+	return []detect.Conflict{
+		{Name: "CSF", Service: "csf.service", Active: true},
+		{Name: "CSF", Service: "lfd.service", Active: true},
+	}
+}
+
+// realisticServicesStatus is a representative DirectAdmin runtime
+// services.status fixture covering common watchdog entries. Used to
+// verify surgical edits do not perturb unrelated lines.
+const realisticServicesStatus = `apache=ON
+crond=ON
+dovecot=ON
+exim=ON
+mysqld=ON
+named=ON
+proftpd=ON
+sshd=ON
+directadmin=ON
+lfd=ON
+`
+
+// TestPR26_6_1_DAServicesStatus_LfdSetToOFF — the operational symptom
+// the fix targets. Pre-takeover services.status has lfd=ON; post-
+// takeover must be lfd=OFF, atomically written.
+func TestPR26_6_1_DAServicesStatus_LfdSetToOFF(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedDirectAdminTakeoverPrereqs(mock)
+	mock.Files[daServicesStatusPath] = []byte(realisticServicesStatus)
+
+	if err := DisableConflicts(mock, daCSFConflicts(), detect.PanelDirectAdmin, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	got, err := mock.ReadFile(daServicesStatusPath)
+	if err != nil {
+		t.Fatalf("read %s after takeover: %v", daServicesStatusPath, err)
+	}
+	if strings.Contains(string(got), "lfd=ON") {
+		t.Errorf("services.status still contains lfd=ON after DA takeover:\n%s", got)
+	}
+	if !strings.Contains(string(got), "lfd=OFF") {
+		t.Errorf("services.status missing lfd=OFF after DA takeover:\n%s", got)
+	}
+	// Confirm the writer ran via WriteFileAtomic (atomic-write pin).
+	if _, ok := mock.WrittenFiles[daServicesStatusPath]; !ok {
+		t.Errorf("services.status was not written via WriteFileAtomic")
+	}
+}
+
+// TestPR26_6_1_DAServicesStatus_PreservesOtherEntries — surgical edit
+// guard. The fix must touch only the lfd= line; every other watchdog
+// entry must survive byte-for-byte. A future regression that does a
+// reckless rewrite (e.g., regenerates the file from a template) would
+// trip this test.
+func TestPR26_6_1_DAServicesStatus_PreservesOtherEntries(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedDirectAdminTakeoverPrereqs(mock)
+	mock.Files[daServicesStatusPath] = []byte(realisticServicesStatus)
+
+	if err := DisableConflicts(mock, daCSFConflicts(), detect.PanelDirectAdmin, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	got, err := mock.ReadFile(daServicesStatusPath)
+	if err != nil {
+		t.Fatalf("read %s after takeover: %v", daServicesStatusPath, err)
+	}
+	for _, mustKeep := range []string{
+		"apache=ON",
+		"crond=ON",
+		"dovecot=ON",
+		"exim=ON",
+		"mysqld=ON",
+		"named=ON",
+		"proftpd=ON",
+		"sshd=ON",
+		"directadmin=ON",
+	} {
+		if !strings.Contains(string(got), mustKeep) {
+			t.Errorf("services.status lost unrelated watchdog entry %q after DA takeover:\n%s", mustKeep, got)
+		}
+	}
+}
+
+// TestPR26_6_1_DAServicesStatus_AbsentFile_NoFail — graceful-skip
+// guard. On hosts where DA is not present at the expected path or the
+// services.status file has not been created, takeover must not abort
+// or warn loudly. The disarm runs only when the file exists.
+func TestPR26_6_1_DAServicesStatus_AbsentFile_NoFail(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedDirectAdminTakeoverPrereqs(mock)
+	// Deliberately do NOT seed daServicesStatusPath.
+
+	if err := DisableConflicts(mock, daCSFConflicts(), detect.PanelDirectAdmin, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts must not error when services.status is absent: %v", err)
+	}
+	// Must not have written it from thin air either.
+	if _, ok := mock.WrittenFiles[daServicesStatusPath]; ok {
+		t.Errorf("services.status wrongly created from absent state: %v", mock.WrittenFiles[daServicesStatusPath])
+	}
+}
+
+// TestPR26_6_1_DAServicesStatus_Idempotent — re-running takeover on a
+// host where lfd=OFF already must be a no-op (no spurious write, no
+// change to the file). Catches a regression where the disarm always
+// rewrites regardless of current state.
+func TestPR26_6_1_DAServicesStatus_Idempotent(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	seedDirectAdminTakeoverPrereqs(mock)
+	already := strings.ReplaceAll(realisticServicesStatus, "lfd=ON", "lfd=OFF")
+	mock.Files[daServicesStatusPath] = []byte(already)
+
+	if err := DisableConflicts(mock, daCSFConflicts(), detect.PanelDirectAdmin, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+	// Either the file is not in WrittenFiles at all (preferred — no
+	// write performed), or — if some other PR wires a write through
+	// the same path — the content must equal the original byte-for-byte.
+	if got, written := mock.WrittenFiles[daServicesStatusPath]; written {
+		if string(got) != already {
+			t.Errorf("idempotent re-takeover should not mutate already-OFF services.status:\nbefore=%q\nafter=%q",
+				already, got)
+		}
+	}
+}
+
+// TestPR26_6_1_DAServicesStatus_NonDirectAdminPanel_Untouched — scope
+// guard. The disarm runs only when the detected panel is DirectAdmin.
+// On a host where takeover is invoked with PanelNone / PanelCpanel /
+// PanelPlesk, services.status (if it happens to exist for some other
+// reason) MUST NOT be touched.
+func TestPR26_6_1_DAServicesStatus_NonDirectAdminPanel_Untouched(t *testing.T) {
+	for _, panel := range []detect.PanelType{detect.PanelNone, detect.PanelCPanel, detect.PanelPlesk} {
+		t.Run(string(panel), func(t *testing.T) {
+			mock := executor.NewMockExecutor()
+			mock.Services["csf.service"] = true
+			mock.Services["lfd.service"] = true
+			mock.ExistingCommands["iptables"] = true
+			mock.Files["/usr/sbin/csf"] = []byte("#!/usr/bin/perl\n")
+			mock.Files[daServicesStatusPath] = []byte(realisticServicesStatus)
+
+			if err := DisableConflicts(mock, daCSFConflicts(), panel, newTestLogger()); err != nil {
+				t.Fatalf("DisableConflicts: %v", err)
+			}
+			if _, written := mock.WrittenFiles[daServicesStatusPath]; written {
+				t.Errorf("services.status wrongly written on non-DA panel %q (must be DA-only)", panel)
+			}
+			got, _ := mock.ReadFile(daServicesStatusPath)
+			if !strings.Contains(string(got), "lfd=ON") {
+				t.Errorf("non-DA panel %q wrongly flipped lfd=ON → OFF: %s", panel, got)
+			}
+		})
+	}
+}
+
+// TestPR26_6_1_FlipLfdWatchdogOff_PureLogic — pure-function regression
+// guard for the line-edit logic. Independent of executor mocking so
+// future refactors that rewire the I/O don't accidentally weaken the
+// edit semantics. Covers: anchored-line-start match (no substring
+// false positive), no-op when input has no target, line-ending
+// preservation, multiple lfd=ON lines (unusual but possible).
+func TestPR26_6_1_FlipLfdWatchdogOff_PureLogic(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantOut   string
+		wantFlip  bool
+	}{
+		{
+			name:     "single canonical line",
+			in:       "lfd=ON\n",
+			wantOut:  "lfd=OFF\n",
+			wantFlip: true,
+		},
+		{
+			name:     "with neighbours",
+			in:       "exim=ON\nlfd=ON\nnamed=ON\n",
+			wantOut:  "exim=ON\nlfd=OFF\nnamed=ON\n",
+			wantFlip: true,
+		},
+		{
+			name:     "already off — no-op",
+			in:       "exim=ON\nlfd=OFF\nnamed=ON\n",
+			wantOut:  "exim=ON\nlfd=OFF\nnamed=ON\n",
+			wantFlip: false,
+		},
+		{
+			name:     "absent — no-op",
+			in:       "exim=ON\nnamed=ON\n",
+			wantOut:  "exim=ON\nnamed=ON\n",
+			wantFlip: false,
+		},
+		{
+			name:     "comment containing target — must not flip (line not equal target)",
+			in:       "exim=ON\n# lfd=ON disabled in 2024-12 by ops\nlfd=ON\n",
+			wantOut:  "exim=ON\n# lfd=ON disabled in 2024-12 by ops\nlfd=OFF\n",
+			wantFlip: true,
+		},
+		{
+			name:     "no trailing newline",
+			in:       "exim=ON\nlfd=ON",
+			wantOut:  "exim=ON\nlfd=OFF",
+			wantFlip: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, flip := flipLfdWatchdogOff(c.in)
+			if flip != c.wantFlip {
+				t.Errorf("flip=%v want %v", flip, c.wantFlip)
+			}
+			if out != c.wantOut {
+				t.Errorf("out mismatch:\n  got  %q\n  want %q", out, c.wantOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the PANEL-WATCHDOG-COHERENCE-001 gap surfaced by 14+ hours of dns2 dataskq journal noise post-PR-26 takeover.

**Operational symptom**: dataskq emitted `error=service "lfd": Unit lfd.service is masked.` every 60 seconds. Cause: `/usr/local/directadmin/data/admin/services.status` retained `lfd=ON` after takeover masked lfd.service. dataskq reads this file every minute and runs service-watchdog on each `=ON` entry; the watchdog attempt fails forever.

**Operational hotfix already applied** on dns2 (`sed lfd=ON → OFF` + `systemctl reset-failed lfd.service`). Verified the noise stops in <3 minutes. Evidence frozen at `/home/commonfolder/LLMAI4NFTBAN/V1.90_AUDIT_WIKI_CODE/PR26_6_1_DA_WATCHDOG_HOTFIX/` sha256 `f9e1cc8f3dbaf90ad38bfd334503fa136c1b04472154dca37fb85adb4604fea7`.

**Permanent fix in this PR**: `disarmDAWatchdog` runs after the existing `disarmPanelCSF` for DA hosts. Idempotent, surgical, atomic, fail-safe.

## Files changed

- `internal/installer/switchop/takeover.go`
  - `+ disarmDAWatchdog(exec, log)` — idempotent flip `^lfd=ON` → `lfd=OFF` via atomic write
  - `+ flipLfdWatchdogOff(content)` — pure-function line-edit logic
  - `+ daServicesStatusPath` constant
  - `~ disarmPanelCSF` calls `disarmDAWatchdog` when panel == DirectAdmin
- `internal/installer/switchop/takeover_pr26_6_1_test.go` (new)
  - 6 tests / 14 sub-cases covering: lfd=ON→OFF, surgical preservation of other watchdog entries, absent-file graceful skip, idempotency, non-DA panel scope guard (PanelNone / PanelCPanel / PanelPlesk untouched), pure-function logic (anchored line match, no-op cases, line-ending preservation)

## Test plan

- [x] `go vet ./internal/installer/switchop/...` — clean
- [x] `go test -v -run TestPR26_6_1_ ./internal/installer/switchop/...` — **6/6 tests PASS** (14 sub-tests)
- [x] `go test ./internal/installer/... ./cmd/nftban-installer/...` — **18/18 packages PASS**
- [x] `staticcheck ./internal/installer/switchop/...` — exit 0
- [x] dns2 operational hotfix verified in real journal (3-min observation window: zero `lfd is masked` lines)
- [ ] CI green
- [ ] Auditor review

## Out of scope (deferred)

- cPanel watchdog coherence (cPHulk + chkservd have separate service-monitor semantics)
- Plesk watchdog coherence (sw-engine task-manager — separate semantics)
- Restore-symmetric re-arm (`lfd=OFF` → `lfd=ON` on §32 CSF restore — tracked as restore-coherence work)
- Generic ufw/fail2ban/firewalld disarm routines (cross-panel architecture note in feedback memory)
- Destructive Plesk install evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)