### PR TITLE
docs(v1.100.4): add H4 schema/metrics disclosure notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,21 @@ decommission is gated on per-function `MIGRATION_COVERAGE.md` (H3.1+).
 ### Release-hygiene PRs
 
 - **H1.1** version truth + build metadata (`c8ede6d7`) — `/VERSION` 1.98.2 → 1.100.4-dev; `pkg/version` centralizes `GitCommit` + `BuildDate` ldflag-injectable vars + `Line(component)` helper; all 4 binaries (`nftband`, `nftban-core`, `nftban-installer`, `nftban-validate`) print canonical line via `--version`; `nftban-validate --version` is zero-side-effect; sentinel `dev`/`unknown` defaults flag uninjected builds; FHS spec regenerated and Policy Gates clean
-- **H2** docs/wiki/status sync (this PR) — STATUS.md + CHANGELOG.md + V1.90 staging refreshed against current main
+- **H2** docs/wiki/status sync — STATUS.md + CHANGELOG.md + V1.90 staging refreshed against current main
+- **H3.1** migration coverage doc (CLOSED INTERNAL) — classification rules inlined into CI gates; spec lives in private audit/wiki workspace, not shipped in repo (PR #546)
+- **H3.2** migration-coverage CI gate (`50ab2532`) — 8-check gate enforcing panelfw adapter coverage, payload-destinations sole truth, nftban-table classifier parity, G3-UN-NO-MUTATION whitelist, deprecated UI unit refusal, port-list bounds, validator-authority pin
+- **H3.3** shell-delete CI gate (`09325e87`) — 5-check gate refusing protected shell deletions without `[MIGRATION-LANE-AUTHORIZED]` or `[DEPRECATED-REMOVAL]` PR markers; 7/7 self-test scenarios green
+- **H4** schema + metrics — closed as **GO-NO-CODE** for v1.100.4. No metric names, labels, or health JSON schema changed. Schema remains frozen at `1.83.0`. Deeper attribution / effective-state work routed to v1.101+ (R-01-impl source label split, R-02-impl `EffectiveUnverifiable`, R-12-impl typed `Status().Extra`, MET-01..05). See "H4 schema/metrics disclosures" below.
+
+### H4 schema/metrics disclosures (read carefully)
+
+These are **disclosure only.** No metric, label, or schema changed in v1.100.4. They describe behaviors operators should be aware of when interpreting v1.100.4 output. The deeper work that resolves each item is deferred to v1.101+.
+
+1. **Ban attribution disclosure.** Current per-source ban metrics may aggregate some module-originated bans under `source=manual`. Forensic correlation remains available through evidence/source-index data (`evidence_correlate.go` + `source_index.jsonl`). Per-source label expansion is deferred to v1.101.
+
+2. **Effective-state disclosure.** Portscan and LoginMon currently report `EffectiveIdle` when no kernel-observable per-module enforcement signal exists. This should be read as *"not independently kernel-verifiable,"* not proof that the modules are inactive. `EffectiveUnverifiable` / per-module counters are deferred to v1.101.
+
+3. **Shared counter disclosure.** `input_syn_rate_exceeded` is a shared DDoS / Portscan signal in v1.100.4. Per-module counter split is deferred to v1.101.
 
 ### Invariants codified during the lane
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,6 +5,7 @@
 
 **Version (this commit):** v1.100.4-dev — sourced from [`/VERSION`](VERSION); static per commit, not auto-updated. For the current released tag see [GitHub releases](https://github.com/itcmsgr/nftban/releases) or the README badge.
 **Release lane:** v1.100.4 (in flight). Panel-adapter coverage under `panelfw`: **DirectAdmin** (live destructive evidence) + **Plesk** (live + read-only reality audits) + **cPanel** (read-only reality audit). CyberPanel / CWP / InterWorx / Vesta / Generic deferred to v1.101+ pending licensed clean evidence hosts.
+**H4 status:** schema + metrics closed as **GO-NO-CODE** for v1.100.4. No metric names, labels, or health JSON schema changed. Schema remains `1.83.0`. See [CHANGELOG.md](CHANGELOG.md) "H4 schema/metrics disclosures" for three behavior notes operators should be aware of (ban attribution, effective-state, shared counter); resolution deferred to v1.101+.
 **Truth model:** Kernel → Validator → CLI
 **Enforcement:** [Design Principles](docs/DESIGN_PRINCIPLES.md)
 


### PR DESCRIPTION
## Summary

- Closes the H4 schema/metrics lane for v1.100.4 as **GO-NO-CODE** per H4.0 briefing verdict A (operator ACK 2026-05-02)
- Adds three operator-facing release-note disclosures (ban attribution / effective-state / shared counter)
- Pure docs change — `CHANGELOG.md` + `STATUS.md` only; zero code, metrics, labels, schema, or registry touched

## Scope

**CHANGELOG.md** — under `[Unreleased] - v1.100.4-dev`:
- Append H3.1 / H3.2 / H3.3 / H4 to the release-hygiene PRs list
- New "H4 schema/metrics disclosures" subsection with three operator-facing notes:

  1. **Ban attribution** — `source=manual` may aggregate some module-originated bans; forensic correlation via `evidence_correlate.go` + `source_index.jsonl`. R-01-impl deferred to v1.101.
  2. **Effective-state** — Portscan/LoginMon report `EffectiveIdle` when no kernel-observable per-module enforcement signal exists. Read as "not independently kernel-verifiable," not proof of inactivity. R-02-impl / `EffectiveUnverifiable` deferred to v1.101.
  3. **Shared counter** — `input_syn_rate_exceeded` is a shared DDoS/Portscan signal in v1.100.4. Per-module counter split deferred to v1.101.

**STATUS.md** — header gains a single H4-status line pointing at the CHANGELOG block; schema 1.83.0 lock restated.

## Locks honored

Per H4.0 verdict A (ACK'd 2026-05-02):

- ✅ No metric names change
- ✅ No metric labels change
- ✅ No health JSON schema change
- ✅ Schema remains frozen at `1.83.0` (`internal/validator/types.go:67`)
- ✅ Zero nftban-core code changes for H4
- ✅ No portal receiver / allow-list / M-T9 cutover trigger
- ✅ No reopening of H4

## Acceptance criteria

- [x] Disclosure-only diff (2 files, 16 insertions, 1 deletion)
- [x] CHANGELOG and STATUS agree on H4 closure + schema 1.83.0
- [x] No repo code touched
- [x] No metrics registry touched
- [x] No schema files touched
- [ ] CI green

## After this merges

1. Confirm post-merge main CI green
2. Decide final tag mechanics (`/VERSION` flip `1.100.4-dev` → `1.100.4` + tag)
3. Cut **v1.100.4** final tag

Portal M-T9 cutover is independent and remains blocked on portal-bot Step B (62-metric allow-list reconciliation) — does NOT block this tag.

## Test plan

- [ ] CI green (Header Validation, Bash Validation, ShellCheck, Go Build & Test, Policy Gates, Migration Coverage Gate, Shell-Delete Guard)
- [ ] No code/test/spec changes; docs-only diff verified via `git diff --stat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)