### PR TITLE
v1.101 H3: remove stale HEADER_SPEC Makefile references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ fuzz-long:
 lint: lint-headers lint-shell lint-go
 	@echo "All linting passed."
 
-# Validate HEADER_SPEC compliance
+# Validate file-header compliance
 lint-headers:
-	@echo "Validating headers (HEADER_SPEC.md)..."
+	@echo "Validating headers (per CONTRIBUTING.md File Headers)..."
 	@./tools/validate-headers.sh
 
 # ShellCheck for Bash scripts
@@ -108,7 +108,7 @@ help:
 	@echo "  make fuzz          - Run fuzz tests (30 seconds each)"
 	@echo "  make fuzz-long     - Run extended fuzz tests (5 minutes each)"
 	@echo "  make lint          - Run all linters (headers, shell, go)"
-	@echo "  make lint-headers  - Validate HEADER_SPEC.md compliance"
+	@echo "  make lint-headers  - Validate file-header compliance (per CONTRIBUTING.md)"
 	@echo "  make lint-shell    - Run ShellCheck on Bash scripts"
 	@echo "  make lint-go       - Run Go formatters and linters"
 	@echo "  make install-hooks - Install pre-commit hooks"


### PR DESCRIPTION
## Summary

Closes the residual surface of audit finding **H-10** by removing the last 3 live references to the non-existent `HEADER_SPEC.md` from the `Makefile`. Pure-cosmetic operator-facing echo / comment / help text. No behavior change. Branched from `main` @ `58b6b231` (post-PR-H2).

Per `V101_EXECUTION_ALIGNMENT_LOCK.md` §5 Phase H / PR-H3 + §4 row 6, this PR was scoped only after a fresh re-verification of the H-10 finding at current HEAD.

## 1. H-10 was partially resolved before this PR

The original H-10 audit cited two sites: `CONTRIBUTING.md` and `tools/validate-headers.sh`. Both were correctly closed in v1.100.3a slice 1a (`CHANGELOG.md:242–252`). At that time, three sister references in `Makefile` were missed. Lock §4 row 6 explicitly predicted this ("the H-10 audit reference may have been **partially cleaned** by an earlier hygiene PR"); the re-verification confirmed it.

## 2. CONTRIBUTING.md is the current inline authority

`CONTRIBUTING.md` carries the authoritative `File Headers` section (heading at line 226: `### 1. File Headers`). It enumerates SPDX-License-Identifier, file-id, classification, etc., as the live single source of truth for header rules. **Not edited by this PR.**

## 3. tools/validate-headers.sh already points to CONTRIBUTING.md and remains unchanged

Already cleaned in v1.100.3a:
- Header comment at line 24: `defined in CONTRIBUTING.md section 'File Headers'.`
- Error pointer at line 178: `CONTRIBUTING.md, section 'File Headers' (authoritative spec)`

The validator is healthy and self-contained. **Not edited by this PR.**

## 4. Makefile had the final live operator-facing `HEADER_SPEC.md` references

| Line | Before | After |
|---|---|---|
| 71 (comment) | `# Validate HEADER_SPEC compliance` | `# Validate file-header compliance` |
| 73 (`make lint-headers` echo) | `@echo "Validating headers (HEADER_SPEC.md)..."` | `@echo "Validating headers (per CONTRIBUTING.md File Headers)..."` |
| 111 (`make help` text) | `@echo "  make lint-headers  - Validate HEADER_SPEC.md compliance"` | `@echo "  make lint-headers  - Validate file-header compliance (per CONTRIBUTING.md)"` |

Echo wording mirrors the pointer text already used by `tools/validate-headers.sh:178`. The `lint-headers` target still invokes `./tools/validate-headers.sh` — validator command unchanged.

`HEADER_SPEC.md` is **not** created. Re-creating it would re-introduce the duplicate-source-of-truth problem v1.100.3a deliberately removed.

## 5. `CHANGELOG.md` HEADER_SPEC mentions preserved as historical v1.100.3a records

Three entries at `CHANGELOG.md:245`, `:249`, `:250` accurately record what slice 1a fixed. They are not stale; they are history. **Not edited by this PR.**

## 6. Verification

- `git grep -nE "HEADER_SPEC" -- ':(exclude).claude/*' ':(exclude)CHANGELOG.md'` — **0 hits** (live references outside CHANGELOG.md historical block are gone).
- `git grep -nE "HEADER_SPEC" -- 'CHANGELOG.md'` — 3 hits at lines 245/249/250 (historical, intentionally preserved).
- `make lint-headers` on the branch:
  ```
  Validating headers (per CONTRIBUTING.md File Headers)...
  Validating headers for 0 files...
  All header validations passed.
  ```
  Exit 0. Validator command unchanged.
- `git status --short` before commit:
  ```
   M Makefile
  ```
  Only `Makefile` modified. CONTRIBUTING.md, tools/validate-headers.sh, CHANGELOG.md untouched. No new files.
- Diff stat: `1 file changed, 3 insertions(+), 3 deletions(-)`.

## Test plan

- [ ] CI green on this PR.
- [ ] Operator ACK after merge.
- [ ] Main CI green for ≥1 post-merge cycle.
- [ ] PR-H4 will **not** auto-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)