### PR TITLE
v1.101 T1: document rollback timer manual-trigger model

### DIFF
--- a/docs/systemd/TIMERS.md
+++ b/docs/systemd/TIMERS.md
@@ -73,6 +73,14 @@ Activated by events, not by schedule.
 | `nftban-rollback.timer` | Manual/auto-update failure | Emergency rollback countdown |
 | `nftban-alert@.service` | `OnFailure=` in other units | Service failure alerting |
 
+#### `nftban-rollback.timer` — manual-trigger safety net
+
+`nftban-rollback.timer` is intentionally manual-trigger, not orphaned and not auto-enabled. `nftban-apply` starts the timer after staging a firewall ruleset; `nftban-confirm` stops it after the operator confirms the ruleset is healthy. If it is not stopped, `nftban-rollback.service` runs after `OnActiveSec=5min` and restores the previous ruleset from `backup.rules`.
+
+The timer's `WantedBy=timers.target` line is intentionally commented out. Auto-enabling it at boot would start rollback countdowns on fresh installs where no `backup.rules` exists, causing spurious failures. It should only be active during the `nftban-apply` → `nftban-confirm` window.
+
+> Future doc follow-up: the full update/apply/backup/confirm/rollback flow should be documented in a dedicated operator runbook, because this timer is only one part of the safety mechanism.
+
 ## Services
 
 ### CORE Services

--- a/docs/systemd/UNITS.md
+++ b/docs/systemd/UNITS.md
@@ -20,7 +20,7 @@
 | `nftban-suricata-update.timer` | Weekly Sun 3:40 | Suricata rules update |
 | `nftban-update-check.timer` | Daily 3:30 | Update availability check |
 | `nftban-update-apply.timer` | Weekly Sun 4:00 | Auto-update apply (gated) |
-| `nftban-rollback.timer` | Manual | Emergency rollback |
+| `nftban-rollback.timer` | Manual-trigger (`OnActiveSec=5min`) | Emergency rollback — started by `nftban-apply`, stopped by `nftban-confirm` |
 
 ## Services (25)
 


### PR DESCRIPTION
## 1. Summary

Pure-docs disclosure of the `nftban-rollback.timer` manual-trigger contract in public/operator systemd documentation. Closes Lane T item T-1 per `V101_MASTER_TODO_CLEANUP_RECONCILED.md` §3.2 (re-scoped to doc-only per `V101_EXECUTION_ALIGNMENT_LOCK.md` §4 row 1 — the timer is intentionally manual-trigger, **not** an orphan; code is the source of truth).

This PR documents:
- `nftban-rollback.timer` is **manual-trigger**, not auto-enabled.
- Schedule directive: `OnActiveSec=5min`.
- **Started by** `nftban-apply` after staging a firewall ruleset.
- **Stopped by** `nftban-confirm` once the operator confirms the new ruleset is healthy.
- `WantedBy=timers.target` is intentionally commented out — auto-enabling at boot would start rollback countdowns on fresh installs where no `backup.rules` exists, causing spurious failures.

Branched from `main` @ `57305c76` (post v1.101 PR-H4).

## 2. Scope

- Public/operator-facing systemd documentation only.
- **No unit edits** — `install/systemd/nftban-rollback.timer` unchanged.
- **No schedule edits** — `OnActiveSec=5min` is documented as-is.
- **No behavior change** — pure disclosure of existing code-truth.
- **No** `UNITS.md` timer-count drift fix (out of PR-T1 scope).

Files changed:
- `docs/systemd/UNITS.md` — line 23 rewritten: rollback row now names `OnActiveSec=5min` and the `nftban-apply` / `nftban-confirm` start/stop pair.
- `docs/systemd/TIMERS.md` — new \"manual-trigger safety net\" subsection inserted inside the existing \"ON-DEMAND Units (static)\" section. Covers: `nftban-apply` start, `nftban-confirm` stop, `OnActiveSec=5min` fire, `nftban-rollback.service` restoring from `backup.rules`, and the intentional `WantedBy=` comment-out reason.

Diff envelope: `2 files changed, 9 insertions(+), 1 deletion(-)`.

## 3. Verification

- **`grep -n nftban-rollback.timer docs/systemd/`** — 4 hits across the two files.
- **`grep -n OnActiveSec=5min docs/systemd/`** — 2 hits (`UNITS.md:23`, `TIMERS.md:78`).
- **`grep -n nftban-apply docs/systemd/`** — 3 hits (`UNITS.md:23`, `TIMERS.md:78`, `TIMERS.md:80`).
- **`grep -n nftban-confirm docs/systemd/`** — 3 hits (same locations).
- **`git diff --name-only install/systemd/`** — empty. No systemd unit changes.
- **`git status --short`** before commit:
  ```
   M docs/systemd/TIMERS.md
   M docs/systemd/UNITS.md
  ```
  Only those two files modified.

## 4. Future follow-up (NOT in this PR)

`docs/systemd/TIMERS.md` carries a single-sentence note flagging that the **full `update / apply / backup / confirm / rollback` operator-flow runbook** remains future docs work, tracked separately as `DOC-T-FOLLOWUP-001`. PR-T1 deliberately does not document the full mechanism — that would expand scope into a runbook rewrite. PR-T1's value is the small, focused correction; the runbook is its own future PR.

PR-T2 (cluster spread, conditional on operator alerting independence) does **not** auto-chain from this PR.

## Test plan

- [ ] CI green on this PR (docs validation, link check, hallucination guard).
- [ ] Operator ACK after merge.
- [ ] Main CI green for ≥1 post-merge cycle.
- [ ] PR-T2 will **not** auto-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)