### PR TITLE
v1.101 C2: make report data read merged config

### DIFF
--- a/cli/lib/nftban/lib/nftban_report_data.sh
+++ b/cli/lib/nftban/lib/nftban_report_data.sh
@@ -25,6 +25,41 @@ readonly REPORT_CACHE_FILE="${REPORT_CACHE_DIR}/report_data.json"
 readonly REPORT_CACHE_TTL=5  # seconds
 
 # =============================================================================
+# CONFIG MERGED-READ HELPER
+# =============================================================================
+
+# Read a single KEY from a base .conf and its sibling .conf.local.
+# Base is read first, then .conf.local override. .conf.local wins if it
+# defines the key, even if the value is empty. Pure shell; does not source
+# either file (so malformed .local cannot crash the report layer); does not
+# require jq.
+# Args: $1 = base .conf path; $2 = key name (e.g. DDOS_ENABLED)
+# Output: the value (without surrounding quotes), or empty if undefined.
+_read_conf_key() {
+    local base="$1"
+    local key="$2"
+    local local_file="${base%.conf}.conf.local"
+    local line=""
+    local val=""
+
+    if [[ -f "$base" ]]; then
+        line=$(grep -E "^${key}=" "$base" 2>/dev/null | tail -1 || true)
+        if [[ -n "$line" ]]; then
+            val=$(printf '%s\n' "$line" | cut -d'"' -f2)
+        fi
+    fi
+
+    if [[ -f "$local_file" ]]; then
+        line=$(grep -E "^${key}=" "$local_file" 2>/dev/null | tail -1 || true)
+        if [[ -n "$line" ]]; then
+            val=$(printf '%s\n' "$line" | cut -d'"' -f2)
+        fi
+    fi
+
+    printf '%s' "$val"
+}
+
+# =============================================================================
 # CORE DATA COLLECTION (uses nft_schema.sh SSOT)
 # =============================================================================
 
@@ -185,9 +220,9 @@ _collect_module_status() {
     local -n _mdata="$1"
 
     # DDoS Module
-    local ddos_enabled="false"
-    [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/ddos/main.conf" ]] && \
-        ddos_enabled=$(grep -E "^DDOS_ENABLED=" "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/ddos/main.conf" 2>/dev/null | cut -d'"' -f2 || echo "false")
+    local ddos_enabled
+    ddos_enabled=$(_read_conf_key "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/ddos/main.conf" DDOS_ENABLED)
+    [[ -z "$ddos_enabled" ]] && ddos_enabled="false"
 
     if [[ "$ddos_enabled" == "true" ]]; then
         _mdata[MODULE_DDOS_STATUS]="Active"
@@ -202,9 +237,9 @@ _collect_module_status() {
     fi
 
     # Portscan Module
-    local portscan_enabled="false"
-    [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf" ]] && \
-        portscan_enabled=$(grep -E "^PORTSCAN_ENABLED=" "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf" 2>/dev/null | cut -d'"' -f2 || echo "false")
+    local portscan_enabled
+    portscan_enabled=$(_read_conf_key "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf" PORTSCAN_ENABLED)
+    [[ -z "$portscan_enabled" ]] && portscan_enabled="false"
 
     if [[ "$portscan_enabled" == "true" ]]; then
         _mdata[MODULE_PORTSCAN_STATUS]="Active"
@@ -246,9 +281,9 @@ _collect_module_status() {
     _mdata[FEEDS_COUNT]="$feeds_count"
 
     # GeoBan
-    local geoban_enabled="false"
-    [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/geoban/main.conf" ]] && \
-        geoban_enabled=$(grep -E "^GEOBAN_ENABLED=" "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/geoban/main.conf" 2>/dev/null | cut -d'"' -f2 || echo "false")
+    local geoban_enabled
+    geoban_enabled=$(_read_conf_key "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/geoban/main.conf" GEOBAN_ENABLED)
+    [[ -z "$geoban_enabled" ]] && geoban_enabled="false"
 
     if [[ "$geoban_enabled" == "true" ]]; then
         _mdata[MODULE_GEOBAN_STATUS]="Active"
@@ -279,16 +314,20 @@ _get_module_activity() {
 }
 
 _get_geoban_countries() {
-    local geoban_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/geoban/main.conf"
-    if [[ -f "$geoban_conf" ]]; then
-        local countries
-        countries=$(grep -E "^GEOBAN_COUNTRIES=" "$geoban_conf" 2>/dev/null | cut -d'"' -f2 || echo "")
-        local count
-        count=$(echo "$countries" | tr ',' '\n' | grep -c . || echo 0)
-        echo "${count} countries"
-    else
+    local base="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/geoban/main.conf"
+    local local_file="${base%.conf}.conf.local"
+    # Preserve "-" sentinel: only when neither base nor .local exists
+    if [[ ! -f "$base" && ! -f "$local_file" ]]; then
         echo "-"
+        return
     fi
+    local countries
+    countries=$(_read_conf_key "$base" GEOBAN_COUNTRIES)
+    # grep -c . emits "0" + exits 1 on empty input; swallow exit, count is already correct
+    local count
+    count=$(printf '%s' "$countries" | tr ',' '\n' | grep -c . || true)
+    [[ -z "$count" ]] && count=0
+    echo "${count} countries"
 }
 
 # =============================================================================

--- a/cli/lib/nftban/tests/test_report_data_merged_config.sh
+++ b/cli/lib/nftban/tests/test_report_data_merged_config.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="test_report_data_merged_config"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-03"
+# meta:description="PR-C2: verify nftban_report_data.sh reads merged base+.conf.local for module enabled flags and GeoBan countries"
+# meta:input="None"
+# meta:output="Test pass/fail to stdout"
+# meta:depends="cli/lib/nftban/lib/nftban_report_data.sh"
+# meta:inventory.files=""
+# meta:inventory.binaries="grep,cut,tr,bash"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR,NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+
+set -Eeuo pipefail
+
+# Test sandbox
+SANDBOX="$(mktemp -d -t nftban-c2-test.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Load report data lib against sandbox
+export NFTBAN_CONFIG_DIR="$SANDBOX"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/lib/nftban/lib/nftban_report_data.sh"
+
+# Test counters
+PASS=0
+FAIL=0
+
+_assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf "  PASS %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL %s\n    expected: %q\n    actual:   %q\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+_reset() {
+    rm -rf "$SANDBOX/conf.d"
+    mkdir -p "$SANDBOX/conf.d/ddos" "$SANDBOX/conf.d/portscan" "$SANDBOX/conf.d/geoban"
+}
+
+_collect_status() {
+    declare -gA status_data=()
+    _collect_module_status status_data
+}
+
+# =============================================================================
+# DDoS module — base / .local / override semantics
+# =============================================================================
+
+echo "[1/4] DDoS enabled-check (DDOS_ENABLED merged read)"
+
+_reset
+echo 'DDOS_ENABLED="true"'  > "$SANDBOX/conf.d/ddos/main.conf"
+_collect_status
+_assert_eq "DDoS base=true => Active" "Active" "${status_data[MODULE_DDOS_STATUS]}"
+
+_reset
+echo 'DDOS_ENABLED="false"' > "$SANDBOX/conf.d/ddos/main.conf"
+_collect_status
+_assert_eq "DDoS base=false => Disabled" "Disabled" "${status_data[MODULE_DDOS_STATUS]}"
+
+_reset
+echo 'DDOS_ENABLED="false"' > "$SANDBOX/conf.d/ddos/main.conf"
+echo 'DDOS_ENABLED="true"'  > "$SANDBOX/conf.d/ddos/main.conf.local"
+_collect_status
+_assert_eq "DDoS base=false + .local=true => Active (override wins)" "Active" "${status_data[MODULE_DDOS_STATUS]}"
+
+_reset
+echo 'DDOS_ENABLED="true"'  > "$SANDBOX/conf.d/ddos/main.conf"
+echo 'DDOS_ENABLED="false"' > "$SANDBOX/conf.d/ddos/main.conf.local"
+_collect_status
+_assert_eq "DDoS base=true + .local=false => Disabled (override wins)" "Disabled" "${status_data[MODULE_DDOS_STATUS]}"
+
+# =============================================================================
+# Portscan module — base / .local / override semantics
+# =============================================================================
+
+echo "[2/4] Portscan enabled-check (PORTSCAN_ENABLED merged read)"
+
+_reset
+echo 'PORTSCAN_ENABLED="true"'  > "$SANDBOX/conf.d/portscan/main.conf"
+_collect_status
+_assert_eq "Portscan base=true => Active" "Active" "${status_data[MODULE_PORTSCAN_STATUS]}"
+
+_reset
+echo 'PORTSCAN_ENABLED="false"' > "$SANDBOX/conf.d/portscan/main.conf"
+_collect_status
+_assert_eq "Portscan base=false => Disabled" "Disabled" "${status_data[MODULE_PORTSCAN_STATUS]}"
+
+_reset
+echo 'PORTSCAN_ENABLED="false"' > "$SANDBOX/conf.d/portscan/main.conf"
+echo 'PORTSCAN_ENABLED="true"'  > "$SANDBOX/conf.d/portscan/main.conf.local"
+_collect_status
+_assert_eq "Portscan base=false + .local=true => Active (override wins)" "Active" "${status_data[MODULE_PORTSCAN_STATUS]}"
+
+_reset
+echo 'PORTSCAN_ENABLED="true"'  > "$SANDBOX/conf.d/portscan/main.conf"
+echo 'PORTSCAN_ENABLED="false"' > "$SANDBOX/conf.d/portscan/main.conf.local"
+_collect_status
+_assert_eq "Portscan base=true + .local=false => Disabled (override wins)" "Disabled" "${status_data[MODULE_PORTSCAN_STATUS]}"
+
+# =============================================================================
+# GeoBan module — enabled-check
+# =============================================================================
+
+echo "[3/4] GeoBan enabled-check (GEOBAN_ENABLED merged read)"
+
+_reset
+echo 'GEOBAN_ENABLED="true"'  > "$SANDBOX/conf.d/geoban/main.conf"
+_collect_status
+_assert_eq "GeoBan base=true => Active" "Active" "${status_data[MODULE_GEOBAN_STATUS]}"
+
+_reset
+echo 'GEOBAN_ENABLED="false"' > "$SANDBOX/conf.d/geoban/main.conf"
+_collect_status
+_assert_eq "GeoBan base=false => Disabled" "Disabled" "${status_data[MODULE_GEOBAN_STATUS]}"
+
+_reset
+echo 'GEOBAN_ENABLED="false"' > "$SANDBOX/conf.d/geoban/main.conf"
+echo 'GEOBAN_ENABLED="true"'  > "$SANDBOX/conf.d/geoban/main.conf.local"
+_collect_status
+_assert_eq "GeoBan base=false + .local=true => Active (override wins)" "Active" "${status_data[MODULE_GEOBAN_STATUS]}"
+
+_reset
+echo 'GEOBAN_ENABLED="true"'  > "$SANDBOX/conf.d/geoban/main.conf"
+echo 'GEOBAN_ENABLED="false"' > "$SANDBOX/conf.d/geoban/main.conf.local"
+_collect_status
+_assert_eq "GeoBan base=true + .local=false => Disabled (override wins)" "Disabled" "${status_data[MODULE_GEOBAN_STATUS]}"
+
+# =============================================================================
+# GeoBan countries — _get_geoban_countries merged read + sentinels
+# =============================================================================
+
+echo "[4/4] GeoBan countries (GEOBAN_COUNTRIES merged read + sentinel)"
+
+_reset
+echo 'GEOBAN_COUNTRIES="US,CA"' > "$SANDBOX/conf.d/geoban/main.conf"
+_assert_eq "Countries base=US,CA => 2 countries" "2 countries" "$(_get_geoban_countries)"
+
+_reset
+echo 'GEOBAN_COUNTRIES="US,CA"'        > "$SANDBOX/conf.d/geoban/main.conf"
+echo 'GEOBAN_COUNTRIES="DE,FR,IT"'     > "$SANDBOX/conf.d/geoban/main.conf.local"
+_assert_eq "Countries base=US,CA + .local=DE,FR,IT => 3 countries (override wins)" \
+           "3 countries" "$(_get_geoban_countries)"
+
+# Empty .local override MUST win (operator semantics — explicit empty wipes base)
+_reset
+echo 'GEOBAN_COUNTRIES="US,CA"' > "$SANDBOX/conf.d/geoban/main.conf"
+echo 'GEOBAN_COUNTRIES=""'      > "$SANDBOX/conf.d/geoban/main.conf.local"
+_assert_eq "Countries base=US,CA + .local=\"\" => 0 countries (explicit empty override)" \
+           "0 countries" "$(_get_geoban_countries)"
+
+# Missing base + missing .local must preserve "-" sentinel
+_reset
+_assert_eq "Countries no base + no .local => \"-\" sentinel" "-" "$(_get_geoban_countries)"
+
+# .local-only define (no base) — should still report the count
+_reset
+echo 'GEOBAN_COUNTRIES="DE,FR"' > "$SANDBOX/conf.d/geoban/main.conf.local"
+_assert_eq "Countries no base + .local=DE,FR => 2 countries" "2 countries" "$(_get_geoban_countries)"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo
+echo "================================================================"
+echo "  PR-C2 merged-config read: PASS=$PASS  FAIL=$FAIL"
+echo "================================================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 1. Evidence source

Closes the four P1 BASE_VS_LOCAL read-path drift rows confirmed in the PR-C0A internal audit:

| Drift ID | Site | Module / key |
|---|---|---|
| C0A-D-01 | `cli/lib/nftban/lib/nftban_report_data.sh:281-292` (`_get_geoban_countries`) | GeoBan / `GEOBAN_COUNTRIES` |
| C0A-D-02 | `cli/lib/nftban/lib/nftban_report_data.sh:189-190` | DDoS / `DDOS_ENABLED` |
| C0A-D-03 | `cli/lib/nftban/lib/nftban_report_data.sh:206-207` | Portscan / `PORTSCAN_ENABLED` |
| C0A-D-04 | `cli/lib/nftban/lib/nftban_report_data.sh:250-251` | GeoBan / `GEOBAN_ENABLED` |

Authoritative evidence: `AUDIT_190_CONFIGS_ECOSYSTEM/06_REPORTS/PR_C0A_DRIFT_CONFIRMATION.md` §5.1; `AUDIT_190_CONFIGS_ECOSYSTEM/05_DRIFT/CONFIG_DRIFT.md` rows C0A-D-01..04. Operator setting any of `DDOS_ENABLED`, `PORTSCAN_ENABLED`, `GEOBAN_ENABLED`, or `GEOBAN_COUNTRIES` in the `.conf.local` override was not reflected by the report layer.

Branched from `main` @ `535c60ef741a067b8c9ed6067aa2ad91563c50f4` (post v1.101 PR-T1).

## 2. Implementation summary

New private helper `_read_conf_key(base, key)` added at the top of `nftban_report_data.sh`:

- Reads base `.conf` first, then sibling `.conf.local`.
- `.conf.local` wins if it defines the key, **even when value is empty** (assignment-exists semantics, not value-non-empty). Required by operator: an explicit `KEY=""` in `.local` correctly wipes the base value.
- Does **not** source either file. Malformed `.local` cannot crash the report layer or pollute its namespace.
- Pure shell. **No `jq` dependency.**
- **No** dependency on `nftban_config_schema.sh` (avoids transitive jq + heavy load-order coupling).
- `tail -1` ensures last definition wins on duplicate lines.

Four call sites in `_collect_module_status` and `_get_geoban_countries` rewritten to call the helper. The missing-both-files `"-"` sentinel in `_get_geoban_countries` is preserved.

### Same-function correction discovered by PR-C2 tests

While verifying the empty-`.local`-override case (operator-required), the test at `_get_geoban_countries` exposed a pre-existing latent bug in the count pipeline: `grep -c . || echo 0` produced `"0\n0"` on empty input because `grep -c` emits `"0"` AND exits 1, so `|| echo 0` fired and doubled the value. Fixed inline because the new operator-required empty-override case hits the same path; the fix is inside the same target function and directly tied to PR-C2's correctness story.

## 3. Test summary

New file: `cli/lib/nftban/tests/test_report_data_merged_config.sh` — 17 cases organized in 4 sections:

| Section | Cases | Verifies |
|---|---|---|
| [1/4] DDoS | 4 | base=true→Active; base=false→Disabled; base=false+`.local`=true→Active; base=true+`.local`=false→Disabled |
| [2/4] Portscan | 4 | same 4-case override matrix |
| [3/4] GeoBan enabled | 4 | same 4-case override matrix |
| [4/4] GeoBan countries | 5 | base→count; base+`.local`→`.local` count (override wins); **base+empty `.local`→0 countries (explicit empty override)**; no base+no `.local`→`"-"` sentinel; `.local`-only→count |

Test isolates against `$SANDBOX` `NFTBAN_CONFIG_DIR`; no real `/etc` writes. Pattern mirrors existing `cli/lib/nftban/tests/test_botguard_rebuild_sequencing.sh:107-145`.

## 4. Local verification

- **`bash -n cli/lib/nftban/lib/nftban_report_data.sh`** → OK
- **`bash -n cli/lib/nftban/tests/test_report_data_merged_config.sh`** → OK
- **`shellcheck -S error`** on both files → 0 severe findings
- **`bash cli/lib/nftban/tests/test_report_data_merged_config.sh`** → `PASS=17 FAIL=0` (exit 0)
- **`git status --short`** before commit:
  ```
   M cli/lib/nftban/lib/nftban_report_data.sh
  ?? cli/lib/nftban/tests/test_report_data_merged_config.sh
  ```
  Exactly the 2 allowed files. No other repo paths touched.
- Diff stat: `2 files changed, 238 insertions(+), 18 deletions(-)`.

## 5. Scope exclusions

- **No config defaults changed.** Base `.conf` files in `etc/nftban/conf.d/` and `install/config/nftban.conf` untouched.
- **No installer changes.** `internal/installer/payload/payload.go` untouched. Lifecycle policy `policyConfigNoReplace` + `*.conf.default` (PR-C0A finding C0A-D-09 = DESIGN-CORRECT FOR v1.101) untouched.
- **No PR-C3 duplicate-key work.** `DDOS_ENABLED` ↔ `NFTBAN_DDOS_ENABLED` and other `*_ENABLED` duplicate-pair coalescing remains deferred.
- **No PR-C0B full audit.** 1614-key inventory and 10 PENDING module templates remain deferred.
- **No portal / schema / metrics / UI / GOTH changes.**

## Test plan

- [ ] CI green on this PR (Bash Validation, ShellCheck, Architecture Policy, Smoke Test, package builds, install tests).
- [ ] Operator ACK after merge.
- [ ] Main CI green for ≥1 post-merge cycle.
- [ ] PR-C3 will **not** auto-chain.
- [ ] PR-C0B will **not** auto-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)