### PR TITLE
v1.101 P4: run apt-get update before Debian dependency install

### DIFF
--- a/internal/installer/deps/deps.go
+++ b/internal/installer/deps/deps.go
@@ -143,10 +143,34 @@ func installRPM(exec executor.Executor, pkgs []string, log *logging.Logger) erro
 	return nil
 }
 
+// aptGetUpdate refreshes the apt package index. Called as a preflight
+// before apt-get install so a stale index does not cause a misleading
+// "Unable to locate package" failure on fresh VMs (issue #467).
+//
+// Operator policy: deterministic correctness — if the index refresh
+// itself fails, surface a clear preflight error rather than continuing
+// into the install command (which would fail less readably).
+func aptGetUpdate(exec executor.Executor, log *logging.Logger) error {
+	log.Debug("running: apt-get update (preflight)")
+	res := exec.RunTimeout(60*time.Second, "apt-get", "update")
+	if res.ExitCode != 0 {
+		return fmt.Errorf("apt-get update preflight failed (exit %d): %s", res.ExitCode, res.Stderr)
+	}
+	return nil
+}
+
 // installDEB uses apt-get to install packages.
 func installDEB(exec executor.Executor, pkgs []string, log *logging.Logger) error {
 	if !exec.CommandExists("apt-get") {
 		return fmt.Errorf("apt-get not available")
+	}
+
+	// Preflight: refresh apt index before install. Required on fresh VMs
+	// with stale apt cache; otherwise apt-get install fails with
+	// "Unable to locate package". Fail-fast on update error so the
+	// operator sees the real cause (issue #467).
+	if err := aptGetUpdate(exec, log); err != nil {
+		return err
 	}
 
 	args := append([]string{"install", "-y", "--no-install-recommends"}, pkgs...)

--- a/internal/installer/deps/deps_test.go
+++ b/internal/installer/deps/deps_test.go
@@ -216,3 +216,130 @@ func TestIsRPMFamily(t *testing.T) {
 		}
 	}
 }
+
+// PR-P4 (issue #467): apt-get update preflight before apt-get install.
+
+// TestInstallMissing_DEB_RunsAptGetUpdateBeforeInstall verifies that the
+// DEB path issues `apt-get update` BEFORE `apt-get install` so a stale
+// apt index does not cause a misleading "Unable to locate package".
+func TestInstallMissing_DEB_RunsAptGetUpdateBeforeInstall(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	for _, d := range requiredDeps {
+		if d.cmd != "jq" {
+			mock.ExistingCommands[d.cmd] = true
+		}
+	}
+	mock.ExistingCommands["apt-get"] = true
+
+	distro := &detect.DistroInfo{ID: "ubuntu", VersionID: "22.04"}
+	// jq remains "missing" so the post-install check returns critical-still-missing,
+	// but that's fine — we only assert the call ordering.
+	_ = InstallMissing(mock, distro, newTestLogger())
+
+	updateIdx := -1
+	installIdx := -1
+	for i, cmd := range mock.Commands {
+		if cmd.Name != "apt-get" {
+			continue
+		}
+		if len(cmd.Args) > 0 && cmd.Args[0] == "update" && updateIdx == -1 {
+			updateIdx = i
+		}
+		if len(cmd.Args) > 0 && cmd.Args[0] == "install" && installIdx == -1 {
+			installIdx = i
+		}
+	}
+	if updateIdx == -1 {
+		t.Fatal("expected apt-get update to be called as preflight")
+	}
+	if installIdx == -1 {
+		t.Fatal("expected apt-get install to be called")
+	}
+	if updateIdx >= installIdx {
+		t.Errorf("apt-get update must precede apt-get install (updateIdx=%d, installIdx=%d)", updateIdx, installIdx)
+	}
+}
+
+// TestInstallMissing_DEB_AptGetUpdateFailureIsFatal verifies that when the
+// apt-get update preflight fails, InstallMissing returns a clear preflight
+// error AND apt-get install is NOT attempted.
+func TestInstallMissing_DEB_AptGetUpdateFailureIsFatal(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	for _, d := range requiredDeps {
+		if d.cmd != "jq" {
+			mock.ExistingCommands[d.cmd] = true
+		}
+	}
+	mock.ExistingCommands["apt-get"] = true
+
+	// Seed apt-get update to fail (simulates network-down / repo unreachable).
+	mock.RunResults["apt-get:update"] = executor.Result{
+		ExitCode: 100,
+		Stderr:   "E: Could not resolve 'archive.ubuntu.com'",
+	}
+
+	distro := &detect.DistroInfo{ID: "debian", VersionID: "12"}
+	err := InstallMissing(mock, distro, newTestLogger())
+	if err == nil {
+		t.Fatal("expected error when apt-get update preflight fails (critical dep missing path)")
+	}
+
+	// Find apt-get update + assert apt-get install was NOT attempted.
+	sawUpdate := false
+	sawInstall := false
+	for _, cmd := range mock.Commands {
+		if cmd.Name != "apt-get" {
+			continue
+		}
+		if len(cmd.Args) > 0 && cmd.Args[0] == "update" {
+			sawUpdate = true
+		}
+		if len(cmd.Args) > 0 && cmd.Args[0] == "install" {
+			sawInstall = true
+		}
+	}
+	if !sawUpdate {
+		t.Fatal("expected apt-get update to be attempted")
+	}
+	if sawInstall {
+		t.Error("apt-get install must NOT run after apt-get update preflight failure")
+	}
+
+	// Direct helper check: aptGetUpdate must surface a clear preflight error.
+	directErr := aptGetUpdate(mock, newTestLogger())
+	if directErr == nil {
+		t.Fatal("expected aptGetUpdate to return an error when apt-get exits non-zero")
+	}
+	msg := directErr.Error()
+	if !strings.Contains(msg, "apt-get update preflight failed") {
+		t.Errorf("expected error to contain 'apt-get update preflight failed', got: %v", directErr)
+	}
+	if !strings.Contains(msg, "100") {
+		t.Errorf("expected error to contain exit code 100, got: %v", directErr)
+	}
+	if !strings.Contains(msg, "archive.ubuntu.com") {
+		t.Errorf("expected error to contain stderr text, got: %v", directErr)
+	}
+}
+
+// TestInstallMissing_RPM_DoesNotRunAptGetUpdate verifies that the RPM/DNF
+// path is unaffected by the PR-P4 preflight (apt-get update only applies
+// to the DEB family).
+func TestInstallMissing_RPM_DoesNotRunAptGetUpdate(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	for _, d := range requiredDeps {
+		if d.cmd != "socat" {
+			mock.ExistingCommands[d.cmd] = true
+		}
+	}
+	mock.ExistingCommands["dnf"] = true
+
+	distro := &detect.DistroInfo{ID: "almalinux", VersionID: "9"}
+	_ = InstallMissing(mock, distro, newTestLogger())
+
+	for _, cmd := range mock.Commands {
+		if cmd.Name == "apt-get" {
+			t.Errorf("RPM path must not call apt-get (got: %s %v)", cmd.Name, cmd.Args)
+		}
+	}
+}


### PR DESCRIPTION
## 1. Issue

Fixes #467 — `installer: deps.InstallMissing should run 'apt-get update' before install on Debian/Ubuntu`.

PR-P0 (Lane P reproduction, recorded at `V101_EXECUTION_ALIGNMENT_LOCK.md` §8.10) confirmed this issue STILL_REPRODUCES at HEAD `28e114b6` by code truth: `internal/installer/deps/deps.go:155` calls `apt-get install` with no preceding `apt-get update`. On fresh VMs (cloud-init, minimal images, old snapshots) this fails with a misleading `E: Unable to locate package` because the apt index is stale or empty — the install command can't find any package.

Branched from `main` @ `28e114b6505bd05430c6e499b413ff4e462bdf43` (post v1.101 PR-C2).

## 2. Implementation summary

- New private helper `aptGetUpdate(exec executor.Executor, log *logging.Logger) error` runs `apt-get update` with a 60s timeout.
- `installDEB` now calls `aptGetUpdate` as a **preflight** before `apt-get install`, immediately after the `CommandExists("apt-get")` check.
- **Operator policy: fail-fast.** If `apt-get update` exits non-zero, `installDEB` returns a clear preflight error containing:
  - the literal text `"apt-get update preflight failed"`
  - the exit code
  - the command's stderr
  Operator sees the real cause (network down, mirror outage) instead of chasing a phantom missing package.
- The existing `apt-get install` call and its 120s timeout are preserved unchanged.
- **RPM / DNF / yum path (`installRPM`) is NOT touched.** Only the DEB path is affected.
- `requiredDeps` list, installer phases, and the state machine are NOT touched.

## 3. Test summary

3 new test cases appended to `internal/installer/deps/deps_test.go` (existing 7 tests unmodified):

| Test | Asserts |
|---|---|
| `TestInstallMissing_DEB_RunsAptGetUpdateBeforeInstall` | Walks `mock.Commands[]` and asserts the `apt-get update` index is strictly less than the `apt-get install` index — i.e., update precedes install in the call sequence. |
| `TestInstallMissing_DEB_AptGetUpdateFailureIsFatal` | Seeds `mock.RunResults["apt-get:update"] = Result{ExitCode:100, Stderr:"E: Could not resolve 'archive.ubuntu.com'"}`. Asserts (a) `apt-get update` was attempted, (b) `apt-get install` was **NOT** attempted (preflight short-circuits), (c) the direct `aptGetUpdate` error contains all three required substrings: `"apt-get update preflight failed"`, the exit code (`"100"`), and the stderr text (`"archive.ubuntu.com"`). |
| `TestInstallMissing_RPM_DoesNotRunAptGetUpdate` | distro=`almalinux` with `dnf` available; iterates `mock.Commands[]` and fails if any `apt-get` command is recorded — confirms RPM path is unaffected. |

Existing 7 tests (`TestInstallMissing_AllPresent`, `TestInstallMissing_DEB_CallsAptGet`, `TestInstallMissing_RPM_CallsDnf`, `TestInstallMissing_RPM_FallbackToYum`, `TestInstallMissing_CriticalStillMissing`, `TestInstallMissing_OptionalStillMissing_NoError`, `TestDedup`, `TestIsRPMFamily`) are **unchanged**. Their assertions filter per-command (e.g. `cmd.Args[0] == "install"`) and remain valid with the new `apt-get update` ahead of `apt-get install`.

## 4. Local validation

- `git status` before commit showed only the 2 allowed files changed:
  ```
   M internal/installer/deps/deps.go
   M internal/installer/deps/deps_test.go
  ```
- Local `go test` / `gofmt` could **not** be run because the Go toolchain is intentionally unavailable on the dev workstation per project policy (`memory/feedback_no_local_go.md`: "Local Go builds run on lab2/lab4 only — NEVER on dev workstation. CI builds all packages.").
- **CI is authoritative for Go compile, gofmt, and tests.** Visual review confirmed: identifier resolution (`executor.Result`, `executor.NewMockExecutor`, `mock.Commands`, `mock.RunResults`, `mock.ExistingCommands`, `requiredDeps`, `aptGetUpdate`, `InstallMissing`, `detect.DistroInfo`, `newTestLogger`, `strings.Contains`) — all present at HEAD or added by this PR; required imports (`strings`, `executor`) already present in `deps_test.go`.

## Diff envelope

```
 internal/installer/deps/deps.go      |  24 +++++++
 internal/installer/deps/deps_test.go | 127 +++++++++++++++++++++++++++++++++++
 2 files changed, 151 insertions(+)
```

No deletions. RPM/DNF/yum behavior unchanged. `requiredDeps` unchanged. Installer phases / state machine unchanged. No panel / config / portal / schema / metrics / UI / GOTH changes.

## Test plan

- [ ] CI green on this PR (in particular: `Build & Test` Go workflow, `Build, Test, Scan (Go)`, package builds + install tests across debian12/13, ubuntu22.04/24.04, alma9, rocky9, centos-stream9/10).
- [ ] Operator ACK after merge.
- [ ] Main CI green for ≥1 post-merge cycle.
- [ ] PR-P1 (#524 lfd reset-failed) will **not** auto-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)