### PR TITLE
v1.103 C3-C: add DDoS/Portscan enabled-key alias reads

### DIFF
--- a/cli/lib/nftban/core/nftban_config_doctor.sh
+++ b/cli/lib/nftban/core/nftban_config_doctor.sh
@@ -55,11 +55,13 @@ fi
 # =============================================================================
 
 # Canonical security-sensitive key list — shared definition to prevent drift
+# v1.103 PR-C3-C: bare canonical and prefixed alias both listed for DDoS and
+# Portscan so the effective-config snapshot picks up either form (Strategy C).
 readonly -a _DOCTOR_SECURITY_KEYS=(
     TCP_PORTS_IN UDP_PORTS_IN SSH_PORT
-    NFTBAN_DDOS_ENABLED NFTBAN_DDOS_SYNPROXY_ENABLED
+    DDOS_ENABLED NFTBAN_DDOS_ENABLED NFTBAN_DDOS_SYNPROXY_ENABLED
     DDOS_SYN_RATE DDOS_CONN_LIMIT_SSH DDOS_CONN_LIMIT_HTTP DDOS_CONN_LIMIT_MAIL
-    NFTBAN_PORTSCAN_ENABLED PORTSCAN_BAN_THRESHOLD
+    PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED PORTSCAN_BAN_THRESHOLD
     NFTBAN_LOGIN_MONITOR_ENABLED LOGIN_BAN_THRESHOLD LOGIN_BAN_DURATION
     HTTP_BOTGUARD_ENABLED
     NFTBAN_FEEDS_ENABLED
@@ -70,9 +72,12 @@ readonly -a _DOCTOR_SECURITY_KEYS=(
 )
 
 # Module definitions: name -> enable_key|chain_artifacts|set_artifacts
+# v1.103 PR-C3-C: enable_key is the CANONICAL key per Strategy C.
+# Compatibility aliases are mapped via _DOCTOR_MODULE_ALIASES below;
+# consumers call _doctor_config_bool_aliased() when an alias is mapped.
 declare -g -A _DOCTOR_MODULES=(
-    ["portscan"]="NFTBAN_PORTSCAN_ENABLED|portscan_detection|"
-    ["ddos"]="NFTBAN_DDOS_ENABLED|ddos_protection|"
+    ["portscan"]="PORTSCAN_ENABLED|portscan_detection|"
+    ["ddos"]="DDOS_ENABLED|ddos_protection|"
     ["botguard"]="HTTP_BOTGUARD_ENABLED|http_bot_guard|http_bot_suspect"
     ["login"]="NFTBAN_LOGIN_MONITOR_ENABLED||"
     ["feeds"]="NFTBAN_FEEDS_ENABLED||blacklist_ipv4"
@@ -80,6 +85,14 @@ declare -g -A _DOCTOR_MODULES=(
     ["geoban"]="GEOBAN_ENABLED||"
     ["suricata"]="NFTBAN_SURICATA_ENABLED||"
     ["synproxy"]="NFTBAN_DDOS_SYNPROXY_ENABLED||"
+)
+
+# v1.103 PR-C3-C: canonical-key -> compatibility-alias-key map.
+# Only DDoS and Portscan are in scope for v1.103; Login and BotGuard are
+# explicitly out of scope (DEFER / SKIP per PR_C3_INTERNAL_DECISION_MEMO §2).
+declare -g -A _DOCTOR_MODULE_ALIASES=(
+    ["DDOS_ENABLED"]="NFTBAN_DDOS_ENABLED"
+    ["PORTSCAN_ENABLED"]="NFTBAN_PORTSCAN_ENABLED"
 )
 
 # Severity constants
@@ -123,6 +136,37 @@ _doctor_config_bool() {
     local val
     val=$(_doctor_config_val "$1")
     case "${val,,}" in
+        true|1|yes|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# v1.103 PR-C3-C: aliased boolean read for Strategy-C canonical/alias pairs.
+# Doctor-local wrapper around the doctor's effective-config snapshot.
+# Args: $1 = canonical key (e.g. DDOS_ENABLED)
+#       $2 = alias key     (e.g. NFTBAN_DDOS_ENABLED)
+# Returns 0 (true) iff the resolved value is true|1|yes|on.
+# Canonical wins on conflict; emits one-line WARN to stderr when both are
+# set in the effective config with different values. Never fatal.
+_doctor_config_bool_aliased() {
+    local canonical_key="$1"
+    local alias_key="$2"
+    local canonical_val alias_val resolved
+    canonical_val=$(_doctor_config_val "$canonical_key")
+    alias_val=$(_doctor_config_val "$alias_key")
+
+    if [[ -n "$canonical_val" && -n "$alias_val" && "$canonical_val" != "$alias_val" ]]; then
+        printf 'WARN _doctor_config_bool_aliased: both %s=%q and %s=%q set with conflicting values; using %s (canonical)\n' \
+            "$canonical_key" "$canonical_val" "$alias_key" "$alias_val" "$canonical_key" >&2
+    fi
+
+    if [[ -n "$canonical_val" ]]; then
+        resolved="$canonical_val"
+    else
+        resolved="$alias_val"
+    fi
+
+    case "${resolved,,}" in
         true|1|yes|on) return 0 ;;
         *) return 1 ;;
     esac
@@ -568,7 +612,12 @@ _doctor_global_drift() {
         [[ -z "$chain_artifact" ]] && continue
 
         local config_enabled=false
-        _doctor_config_bool "$enable_key" && config_enabled=true
+        local _alias_key="${_DOCTOR_MODULE_ALIASES[$enable_key]:-}"
+        if [[ -n "$_alias_key" ]]; then
+            _doctor_config_bool_aliased "$enable_key" "$_alias_key" && config_enabled=true
+        else
+            _doctor_config_bool "$enable_key" && config_enabled=true
+        fi
 
         local kernel_present=false
         # Check both families — chain should exist in at least ip
@@ -611,7 +660,12 @@ _doctor_module_audit() {
 
     # --- L1: Enabled in config? ---
     if [[ -n "$enable_key" ]]; then
-        _doctor_config_bool "$enable_key" && l1_enabled=true
+        local _alias_key="${_DOCTOR_MODULE_ALIASES[$enable_key]:-}"
+        if [[ -n "$_alias_key" ]]; then
+            _doctor_config_bool_aliased "$enable_key" "$_alias_key" && l1_enabled=true
+        else
+            _doctor_config_bool "$enable_key" && l1_enabled=true
+        fi
     fi
 
     # --- L2: Kernel artifacts exist? ---
@@ -916,8 +970,9 @@ _doctor_security_gaps() {
     fi
 
     # CT limit check for SSH
+    # v1.103 PR-C3-C: read both DDOS_ENABLED (canonical) and NFTBAN_DDOS_ENABLED (alias)
     local ddos_enabled=false
-    _doctor_config_bool "NFTBAN_DDOS_ENABLED" && ddos_enabled=true
+    _doctor_config_bool_aliased "DDOS_ENABLED" "NFTBAN_DDOS_ENABLED" && ddos_enabled=true
     if [[ "$ddos_enabled" == "false" ]]; then
         # Check if SSH is in allowed ports — warning if no DDoS protection
         local kernel_tcp
@@ -1013,7 +1068,12 @@ _doctor_diff_kernel() {
         [[ -z "$enable_key" || -z "$chain_artifact" ]] && continue
 
         local config_val="false"
-        _doctor_config_bool "$enable_key" && config_val="true"
+        local _alias_key="${_DOCTOR_MODULE_ALIASES[$enable_key]:-}"
+        if [[ -n "$_alias_key" ]]; then
+            _doctor_config_bool_aliased "$enable_key" "$_alias_key" && config_val="true"
+        else
+            _doctor_config_bool "$enable_key" && config_val="true"
+        fi
 
         local kernel_val="absent"
         _doctor_nft_chain_exists "$chain_artifact" "ip" && kernel_val="present"

--- a/cli/lib/nftban/helpers/suricata_effective_config.sh
+++ b/cli/lib/nftban/helpers/suricata_effective_config.sh
@@ -29,6 +29,12 @@ _NFTBAN_SURICATA_EFFECTIVE_CONFIG_LOADED=1
 : "${SURICATA_CONFIG_DIR:=/etc/suricata}"
 : "${SURICATA_RULES_DIR:=/var/lib/suricata/rules}"
 
+# v1.103 PR-C3-C: load canonical/alias resolver for DDoS + Portscan enabled keys.
+# Resolves to a no-op if the helper is missing (e.g. partial install during
+# upgrade); falls back to the prior alias-only behavior in that case.
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban/lib}/nftban_config_alias.sh" 2>/dev/null || true
+
 # =============================================================================
 # DISTRO DETECTION
 # =============================================================================
@@ -226,9 +232,16 @@ _suricata_generate_module_overlap_disables() {
     login_enabled="${NFTBAN_LOGIN_ENABLED:-$login_enabled}"
     login_ssh_enabled="${NFTBAN_LOGIN_SSH_ENABLED:-$login_ssh_enabled}"
     login_mail_enabled="${NFTBAN_LOGIN_MAIL_ENABLED:-$login_mail_enabled}"
-    portscan_enabled="${NFTBAN_PORTSCAN_ENABLED:-$portscan_enabled}"
+    # v1.103 PR-C3-C: accept canonical (bare) OR compatibility (NFTBAN_*) form;
+    # canonical wins on conflict; warn on conflict (one stderr line, never fatal).
+    if declare -F nftban_config_alias_env >/dev/null 2>&1; then
+        portscan_enabled="$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "$portscan_enabled")"
+        ddos_enabled="$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "$ddos_enabled")"
+    else
+        portscan_enabled="${PORTSCAN_ENABLED:-${NFTBAN_PORTSCAN_ENABLED:-$portscan_enabled}}"
+        ddos_enabled="${DDOS_ENABLED:-${NFTBAN_DDOS_ENABLED:-$ddos_enabled}}"
+    fi
     portscan_mode="${NFTBAN_PORTSCAN_MODE:-$portscan_mode}"
-    ddos_enabled="${NFTBAN_DDOS_ENABLED:-$ddos_enabled}"
     ddos_mode="${NFTBAN_DDOS_MODE:-$ddos_mode}"
 
     cat > "$output" << 'EOF'

--- a/cli/lib/nftban/lib/nftban_config_alias.sh
+++ b/cli/lib/nftban/lib/nftban_config_alias.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_config_alias" meta:type="lib" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Generic canonical/alias key resolver for already-sourced shell variables (Strategy C; canonical wins on conflict; warn-only)"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+
+set -Eeuo pipefail
+
+# Module guard
+[[ -n "${NFTBAN_CONFIG_ALIAS_LOADED:-}" ]] && return 0
+readonly NFTBAN_CONFIG_ALIAS_LOADED=1
+
+# =============================================================================
+# nftban_config_alias_env — read canonical OR alias from already-sourced env
+# =============================================================================
+# Resolves a canonical/alias key pair against the current shell environment
+# (variables previously sourced via `source <conf>`). Implements Strategy C
+# from PR-C3: canonical wins on conflict, alias is read when canonical is
+# unset, warning emitted to stderr (one line) when both are set with
+# conflicting values.
+#
+# Args:
+#   $1 = canonical variable name (e.g. DDOS_ENABLED)
+#   $2 = alias variable name     (e.g. NFTBAN_DDOS_ENABLED)
+#   $3 = optional fallback value when neither is set (default: empty)
+#
+# Output (stdout):
+#   - canonical value if set and non-empty
+#   - else alias value if set and non-empty
+#   - else $3 fallback
+#
+# Side effects:
+#   - one-line WARN to stderr when both are non-empty and differ
+#   - never fatal; never mutates either variable; never writes to disk
+nftban_config_alias_env() {
+    local canonical_name="$1"
+    local alias_name="$2"
+    local fallback="${3-}"
+
+    local canonical_val="${!canonical_name-}"
+    local alias_val="${!alias_name-}"
+
+    if [[ -n "$canonical_val" && -n "$alias_val" && "$canonical_val" != "$alias_val" ]]; then
+        printf 'WARN nftban_config_alias: both %s=%q and %s=%q set with conflicting values; using %s (canonical)\n' \
+            "$canonical_name" "$canonical_val" "$alias_name" "$alias_val" "$canonical_name" >&2
+    fi
+
+    if [[ -n "$canonical_val" ]]; then
+        printf '%s' "$canonical_val"
+    elif [[ -n "$alias_val" ]]; then
+        printf '%s' "$alias_val"
+    else
+        printf '%s' "$fallback"
+    fi
+}

--- a/cli/lib/nftban/tests/test_config_alias_ddos_portscan.sh
+++ b/cli/lib/nftban/tests/test_config_alias_ddos_portscan.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="test_config_alias_ddos_portscan"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-05"
+# meta:description="PR-C3-C: verify nftban_config_alias_env handles canonical/alias for DDoS + Portscan; static-grep guard against compatibility-key writes in production."
+# meta:input="None"
+# meta:output="Test pass/fail to stdout"
+# meta:depends="cli/lib/nftban/lib/nftban_config_alias.sh"
+# meta:inventory.files=""
+# meta:inventory.binaries="grep,bash,find"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+
+set -Eeuo pipefail
+
+# DDOS_ENABLED / NFTBAN_DDOS_ENABLED / PORTSCAN_ENABLED / NFTBAN_PORTSCAN_ENABLED
+# are read indirectly by the helper via ${!canonical_name-} / ${!alias_name-}.
+# Tell shellcheck not to flag them as unused.
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/lib/nftban/lib/nftban_config_alias.sh"
+
+PASS=0
+FAIL=0
+
+_assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf "  PASS %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL %s — expected=%q actual=%q\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+_assert_warn_emitted() {
+    local name="$1" stderr_capture="$2"
+    if grep -q '^WARN nftban_config_alias' <<< "$stderr_capture"; then
+        printf "  PASS %s (warn emitted)\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL %s — expected WARN line in stderr; got=%q\n" "$name" "$stderr_capture"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+_assert_no_warn() {
+    local name="$1" stderr_capture="$2"
+    if grep -q '^WARN nftban_config_alias' <<< "$stderr_capture"; then
+        printf "  FAIL %s — unexpected WARN line: %q\n" "$name" "$stderr_capture"
+        FAIL=$((FAIL + 1))
+    else
+        printf "  PASS %s (no warn)\n" "$name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Reset env for each scenario; sub-shells keep the helper isolated from the
+# parent shell's variable state.
+_reset_env() {
+    unset DDOS_ENABLED NFTBAN_DDOS_ENABLED PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED
+}
+
+# -----------------------------------------------------------------------------
+# DDoS scenarios
+# -----------------------------------------------------------------------------
+echo "[1/12] DDoS — canonical only set"
+_reset_env
+DDOS_ENABLED="true"
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false")
+_assert_eq "ddos canonical-only returns canonical value" "true" "$out_stdout"
+_assert_no_warn "ddos canonical-only no warn" "$out_stderr"
+
+echo "[2/12] DDoS — alias only set"
+_reset_env
+NFTBAN_DDOS_ENABLED="true"
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false")
+_assert_eq "ddos alias-only returns alias value" "true" "$out_stdout"
+_assert_no_warn "ddos alias-only no warn" "$out_stderr"
+
+echo "[3/12] DDoS — both set, same value"
+_reset_env
+DDOS_ENABLED="true"
+NFTBAN_DDOS_ENABLED="true"
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false")
+_assert_eq "ddos both-same returns canonical" "true" "$out_stdout"
+_assert_no_warn "ddos both-same no warn" "$out_stderr"
+
+echo "[4/12] DDoS — both set, conflict canonical=true"
+_reset_env
+# shellcheck disable=SC2034  # read indirectly by nftban_config_alias_env via ${!name}
+DDOS_ENABLED="true"
+# shellcheck disable=SC2034
+NFTBAN_DDOS_ENABLED="false"
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "false")
+_assert_eq "ddos conflict canonical-true returns canonical (true)" "true" "$out_stdout"
+_assert_warn_emitted "ddos conflict canonical-true emits warn" "$out_stderr"
+
+echo "[5/12] DDoS — both set, conflict canonical=false"
+_reset_env
+# shellcheck disable=SC2034  # read indirectly by nftban_config_alias_env via ${!name}
+DDOS_ENABLED="false"
+# shellcheck disable=SC2034
+NFTBAN_DDOS_ENABLED="true"
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "true" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "true")
+_assert_eq "ddos conflict canonical-false returns canonical (false)" "false" "$out_stdout"
+_assert_warn_emitted "ddos conflict canonical-false emits warn" "$out_stderr"
+
+echo "[6/12] DDoS — neither set, fallback honoured"
+_reset_env
+out_stderr=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "fallback-default" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env DDOS_ENABLED NFTBAN_DDOS_ENABLED "fallback-default")
+_assert_eq "ddos neither-set returns fallback" "fallback-default" "$out_stdout"
+_assert_no_warn "ddos neither-set no warn" "$out_stderr"
+
+# -----------------------------------------------------------------------------
+# Portscan scenarios
+# -----------------------------------------------------------------------------
+echo "[7/12] Portscan — canonical only set"
+_reset_env
+PORTSCAN_ENABLED="true"
+out_stderr=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false")
+_assert_eq "portscan canonical-only returns canonical value" "true" "$out_stdout"
+_assert_no_warn "portscan canonical-only no warn" "$out_stderr"
+
+echo "[8/12] Portscan — alias only set"
+_reset_env
+NFTBAN_PORTSCAN_ENABLED="true"
+out_stderr=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false")
+_assert_eq "portscan alias-only returns alias value" "true" "$out_stdout"
+_assert_no_warn "portscan alias-only no warn" "$out_stderr"
+
+echo "[9/12] Portscan — both set, same value"
+_reset_env
+PORTSCAN_ENABLED="false"
+NFTBAN_PORTSCAN_ENABLED="false"
+out_stderr=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "true" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "true")
+_assert_eq "portscan both-same returns canonical" "false" "$out_stdout"
+_assert_no_warn "portscan both-same no warn" "$out_stderr"
+
+echo "[10/12] Portscan — both set, conflict canonical=true"
+_reset_env
+# shellcheck disable=SC2034  # read indirectly by nftban_config_alias_env via ${!name}
+PORTSCAN_ENABLED="true"
+# shellcheck disable=SC2034
+NFTBAN_PORTSCAN_ENABLED="false"
+out_stderr=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "false")
+_assert_eq "portscan conflict canonical-true returns canonical (true)" "true" "$out_stdout"
+_assert_warn_emitted "portscan conflict canonical-true emits warn" "$out_stderr"
+
+echo "[11/12] Portscan — both set, conflict canonical=false"
+_reset_env
+# shellcheck disable=SC2034  # read indirectly by nftban_config_alias_env via ${!name}
+PORTSCAN_ENABLED="false"
+# shellcheck disable=SC2034
+NFTBAN_PORTSCAN_ENABLED="true"
+out_stderr=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "true" 2>&1 >/dev/null)
+out_stdout=$(nftban_config_alias_env PORTSCAN_ENABLED NFTBAN_PORTSCAN_ENABLED "true")
+_assert_eq "portscan conflict canonical-false returns canonical (false)" "false" "$out_stdout"
+_assert_warn_emitted "portscan conflict canonical-false emits warn" "$out_stderr"
+
+# -----------------------------------------------------------------------------
+# Static-grep guard: no production code path may write the compatibility key.
+# Allowed sites: schema declarations (data/config-schema.json), base config
+# alias declaration (install/config/nftban.conf), CHANGELOG/history,
+# packaging/deb/changelog, .md docs, this very file, and tests.
+# -----------------------------------------------------------------------------
+echo "[12/12] Negative guard — no production writes of NFTBAN_{DDOS,PORTSCAN}_ENABLED="
+_reset_env
+HITS=$(grep -rnE '(sed -i|echo).*NFTBAN_(DDOS|PORTSCAN)_ENABLED=' \
+        "$REPO_ROOT" 2>/dev/null \
+    | grep -v -E '/(tests|test_|CHANGELOG|\.git/|packaging/deb/changelog|data/config-schema\.json|install/config/(nftban\.conf|schema/config-schema\.json)|\.md:)' \
+    || true)
+if [[ -z "$HITS" ]]; then
+    printf "  PASS no production writes of compatibility key\n"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL compatibility-key writes found in production code:\n%s\n" "$HITS"
+    FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+printf "Total: %d PASS, %d FAIL\n" "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+    exit 1
+fi
+exit 0

--- a/internal/nftbanconf/loader.go
+++ b/internal/nftbanconf/loader.go
@@ -52,8 +52,8 @@ type Config struct {
 	ConfigVersion string
 
 	// Binary paths (from nftban.conf PATHS section)
-	Bin      string // NFTBAN_BIN - main CLI
-	CoreBin  string // NFTBAN_CORE_BIN - Go core binary
+	Bin     string // NFTBAN_BIN - main CLI
+	CoreBin string // NFTBAN_CORE_BIN - Go core binary
 
 	// Directory paths
 	LibDir    string // NFTBAN_LIB_DIR
@@ -64,32 +64,32 @@ type Config struct {
 	RunDir    string // NFTBAN_RUN_DIR
 
 	// Feature flags
-	MetricsEnabled      bool   // NFTBAN_METRICS_ENABLED
-	MetricsBackend      string // NFTBAN_METRICS_BACKEND
-	MetricsSamplingInterval int // NFTBAN_METRICS_SAMPLING_INTERVAL (seconds)
-	MetricsMaxSamples   int    // NFTBAN_METRICS_MAX_SAMPLES
-	PrometheusDir       string // NFTBAN_PROMETHEUS_DIR (node_exporter textfile dir)
+	MetricsEnabled          bool   // NFTBAN_METRICS_ENABLED
+	MetricsBackend          string // NFTBAN_METRICS_BACKEND
+	MetricsSamplingInterval int    // NFTBAN_METRICS_SAMPLING_INTERVAL (seconds)
+	MetricsMaxSamples       int    // NFTBAN_METRICS_MAX_SAMPLES
+	PrometheusDir           string // NFTBAN_PROMETHEUS_DIR (node_exporter textfile dir)
 	MetricsPrometheusAddr   string // NFTBAN_METRICS_PROMETHEUS_ADDR
 	MetricsNodeExporterAddr string // NFTBAN_METRICS_NODE_EXPORTER_ADDR
 	MetricsVictoriaAddr     string // NFTBAN_METRICS_VICTORIA_ADDR
-	GeoIPEnabled        bool   // NFTBAN_GEOIP_ENABLED
-	GeoIPLicenseKey     string // NFTBAN_GEOIP_LICENSE_KEY
-	FeedsEnabled        bool   // NFTBAN_FEEDS_ENABLED
-	FeedsAutoUpdate     bool   // NFTBAN_FEEDS_AUTO_UPDATE
-	SuricataEnabled     bool   // NFTBAN_SURICATA_ENABLED
-	GUIEnabled          bool   // NFTBAN_GUI_ENABLED
-	GUIAddr             string // NFTBAN_GUI_ADDR
-	APIAddr             string // NFTBAN_API_ADDR (daemon HTTP API address)
-	PortscanEnabled     bool   // NFTBAN_PORTSCAN_ENABLED
-	DDoSEnabled         bool   // NFTBAN_DDOS_ENABLED
-	LoginMonitorEnabled bool   // NFTBAN_LOGIN_MONITOR_ENABLED
+	GeoIPEnabled            bool   // NFTBAN_GEOIP_ENABLED
+	GeoIPLicenseKey         string // NFTBAN_GEOIP_LICENSE_KEY
+	FeedsEnabled            bool   // NFTBAN_FEEDS_ENABLED
+	FeedsAutoUpdate         bool   // NFTBAN_FEEDS_AUTO_UPDATE
+	SuricataEnabled         bool   // NFTBAN_SURICATA_ENABLED
+	GUIEnabled              bool   // NFTBAN_GUI_ENABLED
+	GUIAddr                 string // NFTBAN_GUI_ADDR
+	APIAddr                 string // NFTBAN_API_ADDR (daemon HTTP API address)
+	PortscanEnabled         bool   // PORTSCAN_ENABLED (canonical; v1.103 PR-C3-C) / NFTBAN_PORTSCAN_ENABLED (compatibility alias)
+	DDoSEnabled             bool   // DDOS_ENABLED (canonical; v1.103 PR-C3-C) / NFTBAN_DDOS_ENABLED (compatibility alias)
+	LoginMonitorEnabled     bool   // NFTBAN_LOGIN_MONITOR_ENABLED
 
 	// Suricata settings
-	SuricataEveLog            string // NFTBAN_SURICATA_EVE_LOG
-	SuricataLogDir            string // NFTBAN_SURICATA_LOG_DIR
-	SuricataBanThreshold      int    // NFTBAN_SURICATA_BAN_THRESHOLD
-	SuricataScoreDecay        int    // NFTBAN_SURICATA_SCORE_DECAY
-	SuricataCloudflareWhitelist bool // NFTBAN_SURICATA_CLOUDFLARE_WHITELIST
+	SuricataEveLog              string // NFTBAN_SURICATA_EVE_LOG
+	SuricataLogDir              string // NFTBAN_SURICATA_LOG_DIR
+	SuricataBanThreshold        int    // NFTBAN_SURICATA_BAN_THRESHOLD
+	SuricataScoreDecay          int    // NFTBAN_SURICATA_SCORE_DECAY
+	SuricataCloudflareWhitelist bool   // NFTBAN_SURICATA_CLOUDFLARE_WHITELIST
 
 	// Grafana settings
 	GrafanaEnabled bool   // NFTBAN_GRAFANA_ENABLED
@@ -97,9 +97,9 @@ type Config struct {
 	GrafanaAPIKey  string // NFTBAN_GRAFANA_API_KEY
 
 	// Logging
-	LogLevel    string // NFTBAN_LOG_LEVEL
-	ColorOutput bool   // NFTBAN_COLOR_OUTPUT
-	DebugTrace  bool   // NFTBAN_DEBUG_TRACE
+	LogLevel      string // NFTBAN_LOG_LEVEL
+	ColorOutput   bool   // NFTBAN_COLOR_OUTPUT
+	DebugTrace    bool   // NFTBAN_DEBUG_TRACE
 	DebugTraceLog string // NFTBAN_DEBUG_TRACE_LOG
 
 	// Distro config
@@ -117,25 +117,25 @@ type Paths struct {
 	ExportsDir   string
 
 	// Config subdirectories
-	ConfD        string
-	WhitelistD   string
-	BlacklistD   string
-	PortsD       string
-	GeobanD      string
-	DistrosD     string
+	ConfD      string
+	WhitelistD string
+	BlacklistD string
+	PortsD     string
+	GeobanD    string
+	DistrosD   string
 
 	// Log files
-	MainLog      string
-	AuditLog     string
-	BansLog      string
-	PortscanLog  string
-	DDoSLog      string
-	LoginAlertLog string
-	FeedsLog     string
-	GeobanLog    string
-	CronLog      string
+	MainLog        string
+	AuditLog       string
+	BansLog        string
+	PortscanLog    string
+	DDoSLog        string
+	LoginAlertLog  string
+	FeedsLog       string
+	GeobanLog      string
+	CronLog        string
 	MaintenanceLog string
-	CLIErrorsLog string
+	CLIErrorsLog   string
 
 	// Botguard log files
 	BotguardLog          string
@@ -148,8 +148,8 @@ type Paths struct {
 	SuricataMainLog  string
 
 	// Runtime files
-	PIDFile      string
-	SocketFile   string
+	PIDFile    string
+	SocketFile string
 
 	// Metrics files
 	PrometheusFile          string // nftban.prom
@@ -166,24 +166,24 @@ type Timeouts struct {
 
 // NFTables references (table/chain/set names)
 type NFTables struct {
-	TableIPv4       string
-	TableIPv6       string
-	BlacklistIPv4   string
-	BlacklistIPv6   string
-	WhitelistIPv4   string
-	WhitelistIPv6   string
+	TableIPv4     string
+	TableIPv6     string
+	BlacklistIPv4 string
+	BlacklistIPv6 string
+	WhitelistIPv4 string
+	WhitelistIPv6 string
 	// v2.1: All ban sources (feeds, geoban, auto, manual) go to blacklist
 	// Source tracking done in daemon database, not separate nft sets
 }
 
 var (
 	// Global singleton
-	globalConfig *Config
-	globalPaths  *Paths
+	globalConfig   *Config
+	globalPaths    *Paths
 	globalTimeouts *Timeouts
-	globalNFT    *NFTables
-	loadOnce     sync.Once
-	loadErr      error
+	globalNFT      *NFTables
+	loadOnce       sync.Once
+	loadErr        error
 
 	// Default config file path
 	DefaultConfigFile = "/etc/nftban/nftban.conf"
@@ -276,6 +276,53 @@ func GetNFT() *NFTables {
 }
 
 // loadFromFile reads and parses the config file
+// aliasState tracks per-(canonical,alias) pair occurrences inside a single
+// parser invocation. It implements Strategy C from PR-C3 (v1.103 PR-C3-C):
+// canonical wins on conflict, alias is accepted when canonical is absent,
+// and a single warning is emitted to the loader's logger when both keys are
+// present in the same file with conflicting values. Never fatal.
+type aliasState struct {
+	sawCanonical bool
+	sawAlias     bool
+	canonicalVal string
+	aliasVal     string
+}
+
+// setBoolAlias resolves a canonical/alias bool key pair seen on a single line
+// of the parsed config. The CALLER passes the matching switch case ("canonical"
+// or "alias"). Canonical assignments always overwrite the target. Alias
+// assignments only overwrite the target when no canonical assignment has been
+// seen yet on this parser invocation. Conflicts (both keys present with
+// different values) emit one log line and proceed.
+func setBoolAlias(target *bool, state *aliasState, isCanonical bool, value, path, canonical, alias string) {
+	parsed := util.ParseBool(value, false)
+	if isCanonical {
+		*target = parsed
+		state.canonicalVal = value
+		if state.sawAlias && state.aliasVal != value {
+			warnAliasConflict(path, canonical, alias, value, state.aliasVal)
+		}
+		state.sawCanonical = true
+		return
+	}
+	// alias case
+	if !state.sawCanonical {
+		*target = parsed
+	} else if state.canonicalVal != value {
+		warnAliasConflict(path, canonical, alias, state.canonicalVal, value)
+	}
+	state.aliasVal = value
+	state.sawAlias = true
+}
+
+// warnAliasConflict logs a single warning when both canonical and alias keys
+// appear in the same parsed file with conflicting values. Canonical always
+// wins; this is informational only.
+func warnAliasConflict(path, canonical, alias, canonicalVal, aliasVal string) {
+	log.Printf("nftbanconf: %s: both %s=%q and %s=%q set with conflicting values; using %s (canonical)",
+		path, canonical, canonicalVal, alias, aliasVal, canonical)
+}
+
 func loadFromFile(path string) (*Config, error) {
 	// Start with defaults
 	cfg := defaultConfig()
@@ -289,6 +336,11 @@ func loadFromFile(path string) (*Config, error) {
 		return nil, err
 	}
 	defer file.Close()
+
+	// v1.103 PR-C3-C: per-parser-invocation alias tracking for DDoS + Portscan.
+	// Login (NFTBAN_LOGIN_MONITOR_ENABLED) is intentionally NOT aliased here —
+	// deferred to Lane M / v1.104.
+	var ddosAlias, portscanAlias aliasState
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -375,10 +427,16 @@ func loadFromFile(path string) (*Config, error) {
 			cfg.GUIAddr = value
 		case "NFTBAN_API_ADDR":
 			cfg.APIAddr = value
+		// v1.103 PR-C3-C: Strategy C — accept canonical bare key OR prefixed
+		// alias for DDoS + Portscan. Canonical always wins on conflict.
+		case "PORTSCAN_ENABLED":
+			setBoolAlias(&cfg.PortscanEnabled, &portscanAlias, true, value, path, "PORTSCAN_ENABLED", "NFTBAN_PORTSCAN_ENABLED")
 		case "NFTBAN_PORTSCAN_ENABLED":
-			cfg.PortscanEnabled = util.ParseBool(value, false)
+			setBoolAlias(&cfg.PortscanEnabled, &portscanAlias, false, value, path, "PORTSCAN_ENABLED", "NFTBAN_PORTSCAN_ENABLED")
+		case "DDOS_ENABLED":
+			setBoolAlias(&cfg.DDoSEnabled, &ddosAlias, true, value, path, "DDOS_ENABLED", "NFTBAN_DDOS_ENABLED")
 		case "NFTBAN_DDOS_ENABLED":
-			cfg.DDoSEnabled = util.ParseBool(value, false)
+			setBoolAlias(&cfg.DDoSEnabled, &ddosAlias, false, value, path, "DDOS_ENABLED", "NFTBAN_DDOS_ENABLED")
 		case "NFTBAN_LOGIN_MONITOR_ENABLED":
 			cfg.LoginMonitorEnabled = util.ParseBool(value, false)
 
@@ -430,6 +488,11 @@ func overlayFromFile(cfg *Config, path string) {
 		return
 	}
 	defer file.Close()
+
+	// v1.103 PR-C3-C: alias tracking is per-invocation. Overlays from
+	// nftban.conf.local maintain their own alias state independent from the
+	// base file's.
+	var ddosAlias, portscanAlias aliasState
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -499,10 +562,15 @@ func overlayFromFile(cfg *Config, path string) {
 			cfg.GUIAddr = value
 		case "NFTBAN_API_ADDR":
 			cfg.APIAddr = value
+		// v1.103 PR-C3-C: Strategy C — accept canonical OR prefixed alias.
+		case "PORTSCAN_ENABLED":
+			setBoolAlias(&cfg.PortscanEnabled, &portscanAlias, true, value, path, "PORTSCAN_ENABLED", "NFTBAN_PORTSCAN_ENABLED")
 		case "NFTBAN_PORTSCAN_ENABLED":
-			cfg.PortscanEnabled = util.ParseBool(value, false)
+			setBoolAlias(&cfg.PortscanEnabled, &portscanAlias, false, value, path, "PORTSCAN_ENABLED", "NFTBAN_PORTSCAN_ENABLED")
+		case "DDOS_ENABLED":
+			setBoolAlias(&cfg.DDoSEnabled, &ddosAlias, true, value, path, "DDOS_ENABLED", "NFTBAN_DDOS_ENABLED")
 		case "NFTBAN_DDOS_ENABLED":
-			cfg.DDoSEnabled = util.ParseBool(value, false)
+			setBoolAlias(&cfg.DDoSEnabled, &ddosAlias, false, value, path, "DDOS_ENABLED", "NFTBAN_DDOS_ENABLED")
 		case "NFTBAN_LOGIN_MONITOR_ENABLED":
 			cfg.LoginMonitorEnabled = util.ParseBool(value, false)
 		case "NFTBAN_SURICATA_EVE_LOG":
@@ -563,15 +631,15 @@ func defaultConfig() *Config {
 		MetricsNodeExporterAddr: "localhost:9100",
 		MetricsVictoriaAddr:     "localhost:8428",
 		GeoIPEnabled:            false,
-		FeedsEnabled:        false,
-		FeedsAutoUpdate:     true,
-		SuricataEnabled:     false,
-		GUIEnabled:          false,
-		GUIAddr:             "127.0.0.1:3940",
-		APIAddr:             ":9580",
-		PortscanEnabled:     false,
-		DDoSEnabled:         false,
-		LoginMonitorEnabled: false,
+		FeedsEnabled:            false,
+		FeedsAutoUpdate:         true,
+		SuricataEnabled:         false,
+		GUIEnabled:              false,
+		GUIAddr:                 "127.0.0.1:3940",
+		APIAddr:                 ":9580",
+		PortscanEnabled:         false,
+		DDoSEnabled:             false,
+		LoginMonitorEnabled:     false,
 
 		// Suricata
 		SuricataEveLog:       "/var/log/nftban/suricata/eve-alerts.json",
@@ -652,8 +720,8 @@ func derivePaths(cfg *Config) *Paths {
 func defaultTimeouts() *Timeouts {
 	return &Timeouts{
 		Fast:   constants.IPCFastTimeout,   // status, simple queries
-		Medium: constants.IPCMediumTimeout,  // ban, unban, search
-		Slow:   constants.IPCSlowTimeout,    // sync, health, feed updates
+		Medium: constants.IPCMediumTimeout, // ban, unban, search
+		Slow:   constants.IPCSlowTimeout,   // sync, health, feed updates
 	}
 }
 
@@ -669,7 +737,6 @@ func defaultNFTables() *NFTables {
 		// v2.1: All bans go to blacklist (source tracked in DB)
 	}
 }
-
 
 // Reload forces config reload (for testing or config changes)
 func Reload() error {

--- a/internal/nftbanconf/loader_alias_test.go
+++ b/internal/nftbanconf/loader_alias_test.go
@@ -1,0 +1,275 @@
+// =============================================================================
+// NFTBan - Tests for v1.103 PR-C3-C canonical/alias DDoS+Portscan handling
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftbanconf_loader_alias_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-05"
+// meta:description="PR-C3-C: aliasState + setBoolAlias coverage for DDoS + Portscan in loadFromFile and overlayFromFile"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing,bytes,log,os,path/filepath,strings"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package nftbanconf
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLog redirects the standard logger output for the duration of fn and
+// returns the captured bytes. Used to assert warnAliasConflict() behavior.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+	fn()
+	return buf.String()
+}
+
+func writeConf(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nftban.conf")
+	if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	return p
+}
+
+// -----------------------------------------------------------------------------
+// loadFromFile — DDoS
+// -----------------------------------------------------------------------------
+
+func TestLoadFromFile_DDoSAlias_CanonicalOnly(t *testing.T) {
+	p := writeConf(t, "DDOS_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.DDoSEnabled {
+			t.Errorf("DDoSEnabled = false, want true (canonical only)")
+		}
+	})
+	if strings.Contains(out, "WARN") || strings.Contains(out, "conflicting") {
+		t.Errorf("unexpected warn captured: %q", out)
+	}
+}
+
+func TestLoadFromFile_DDoSAlias_PrefixedOnly(t *testing.T) {
+	p := writeConf(t, "NFTBAN_DDOS_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.DDoSEnabled {
+			t.Errorf("DDoSEnabled = false, want true (alias only)")
+		}
+	})
+	if strings.Contains(out, "conflicting") {
+		t.Errorf("unexpected conflict warn: %q", out)
+	}
+}
+
+func TestLoadFromFile_DDoSAlias_BothSame(t *testing.T) {
+	p := writeConf(t, "NFTBAN_DDOS_ENABLED=\"true\"\nDDOS_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.DDoSEnabled {
+			t.Errorf("DDoSEnabled = false, want true")
+		}
+	})
+	if strings.Contains(out, "conflicting") {
+		t.Errorf("unexpected conflict warn for matching values: %q", out)
+	}
+}
+
+func TestLoadFromFile_DDoSAlias_BothConflict_AliasFirst_CanonicalWins(t *testing.T) {
+	// Alias appears before canonical; canonical must win.
+	p := writeConf(t, "NFTBAN_DDOS_ENABLED=\"false\"\nDDOS_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.DDoSEnabled {
+			t.Errorf("DDoSEnabled = false, want true (canonical wins)")
+		}
+	})
+	if !strings.Contains(out, "conflicting") {
+		t.Errorf("expected conflict warn, got: %q", out)
+	}
+	if !strings.Contains(out, "DDOS_ENABLED") || !strings.Contains(out, "NFTBAN_DDOS_ENABLED") {
+		t.Errorf("warn missing key names: %q", out)
+	}
+}
+
+func TestLoadFromFile_DDoSAlias_BothConflict_CanonicalFirst_AliasIgnored(t *testing.T) {
+	// Canonical appears before alias; alias must NOT overwrite, but conflict warn emitted.
+	p := writeConf(t, "DDOS_ENABLED=\"true\"\nNFTBAN_DDOS_ENABLED=\"false\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.DDoSEnabled {
+			t.Errorf("DDoSEnabled = false, want true (canonical wins; alias must not overwrite)")
+		}
+	})
+	if !strings.Contains(out, "conflicting") {
+		t.Errorf("expected conflict warn, got: %q", out)
+	}
+}
+
+func TestLoadFromFile_DDoSAlias_Neither_DefaultsFalse(t *testing.T) {
+	// Neither key present — DDoSEnabled stays at default (false).
+	p := writeConf(t, "NFTBAN_VERSION=\"1.0.0\"\n")
+	cfg, err := loadFromFile(p)
+	if err != nil {
+		t.Fatalf("loadFromFile: %v", err)
+	}
+	if cfg.DDoSEnabled {
+		t.Errorf("DDoSEnabled = true, want false (neither key set)")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// loadFromFile — Portscan
+// -----------------------------------------------------------------------------
+
+func TestLoadFromFile_PortscanAlias_CanonicalOnly(t *testing.T) {
+	p := writeConf(t, "PORTSCAN_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if !cfg.PortscanEnabled {
+			t.Errorf("PortscanEnabled = false, want true (canonical only)")
+		}
+	})
+	if strings.Contains(out, "conflicting") {
+		t.Errorf("unexpected warn: %q", out)
+	}
+}
+
+func TestLoadFromFile_PortscanAlias_PrefixedOnly(t *testing.T) {
+	p := writeConf(t, "NFTBAN_PORTSCAN_ENABLED=\"true\"\n")
+	cfg, err := loadFromFile(p)
+	if err != nil {
+		t.Fatalf("loadFromFile: %v", err)
+	}
+	if !cfg.PortscanEnabled {
+		t.Errorf("PortscanEnabled = false, want true (alias only)")
+	}
+}
+
+func TestLoadFromFile_PortscanAlias_BothConflict_CanonicalWins(t *testing.T) {
+	p := writeConf(t, "PORTSCAN_ENABLED=\"false\"\nNFTBAN_PORTSCAN_ENABLED=\"true\"\n")
+	out := captureLog(t, func() {
+		cfg, err := loadFromFile(p)
+		if err != nil {
+			t.Fatalf("loadFromFile: %v", err)
+		}
+		if cfg.PortscanEnabled {
+			t.Errorf("PortscanEnabled = true, want false (canonical wins)")
+		}
+	})
+	if !strings.Contains(out, "conflicting") {
+		t.Errorf("expected conflict warn, got: %q", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// overlayFromFile — DDoS + Portscan
+// -----------------------------------------------------------------------------
+
+func TestOverlayFromFile_DDoSAlias_CanonicalWins(t *testing.T) {
+	p := writeConf(t, "NFTBAN_DDOS_ENABLED=\"false\"\nDDOS_ENABLED=\"true\"\n")
+	cfg := defaultConfig()
+	cfg.DDoSEnabled = false
+	out := captureLog(t, func() {
+		overlayFromFile(cfg, p)
+	})
+	if !cfg.DDoSEnabled {
+		t.Errorf("DDoSEnabled = false, want true (canonical wins on overlay)")
+	}
+	if !strings.Contains(out, "conflicting") {
+		t.Errorf("expected conflict warn on overlay, got: %q", out)
+	}
+}
+
+func TestOverlayFromFile_PortscanAlias_AliasOnly(t *testing.T) {
+	p := writeConf(t, "NFTBAN_PORTSCAN_ENABLED=\"true\"\n")
+	cfg := defaultConfig()
+	cfg.PortscanEnabled = false
+	overlayFromFile(cfg, p)
+	if !cfg.PortscanEnabled {
+		t.Errorf("PortscanEnabled = false, want true (alias-only overlay)")
+	}
+}
+
+func TestOverlayFromFile_DDoSAlias_PreservesIndependentInvocationState(t *testing.T) {
+	// Alias state must be per-invocation. A first overlay with a conflict must
+	// not bleed into a second overlay against the same Config.
+	cfg := defaultConfig()
+
+	p1 := writeConf(t, "DDOS_ENABLED=\"true\"\nNFTBAN_DDOS_ENABLED=\"false\"\n")
+	out1 := captureLog(t, func() { overlayFromFile(cfg, p1) })
+	if !cfg.DDoSEnabled {
+		t.Errorf("after overlay-1: DDoSEnabled = false, want true")
+	}
+	if !strings.Contains(out1, "conflicting") {
+		t.Errorf("overlay-1: expected conflict warn, got: %q", out1)
+	}
+
+	// Second file: only canonical; should not emit conflict warn (state reset).
+	p2 := writeConf(t, "DDOS_ENABLED=\"false\"\n")
+	out2 := captureLog(t, func() { overlayFromFile(cfg, p2) })
+	if cfg.DDoSEnabled {
+		t.Errorf("after overlay-2: DDoSEnabled = true, want false")
+	}
+	if strings.Contains(out2, "conflicting") {
+		t.Errorf("overlay-2: unexpected conflict warn (state should be per-invocation): %q", out2)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Login is intentionally NOT aliased here — DEFER to Lane M / v1.104.
+// This negative assertion documents the intent.
+// -----------------------------------------------------------------------------
+
+func TestLoadFromFile_LoginNotAliasedInC3C(t *testing.T) {
+	// Bare LOGIN_ENABLED is NOT recognized by the central nftbanconf loader
+	// in v1.103 (Login is structurally deferred to Lane M / v1.104).
+	// Only NFTBAN_LOGIN_MONITOR_ENABLED still drives cfg.LoginMonitorEnabled.
+	p := writeConf(t, "LOGIN_ENABLED=\"true\"\n")
+	cfg, err := loadFromFile(p)
+	if err != nil {
+		t.Fatalf("loadFromFile: %v", err)
+	}
+	if cfg.LoginMonitorEnabled {
+		t.Errorf("LoginMonitorEnabled = true, want false (LOGIN_ENABLED must NOT alias to LoginMonitorEnabled in v1.103; deferred to Lane M)")
+	}
+}


### PR DESCRIPTION
## Summary

Adds compatibility alias reads for DDoS and Portscan only. Closes drift rows **C0A-D-05** and **C0A-D-06** only.

Implements operator-decided **Strategy C (accept divergence + alias)** per `PR_C3_INTERNAL_DECISION_MEMO.md` §2 + `PR_C3_CLEAN_AUDITOR_PRECHECK.md` verdict GO_WITH_AMENDMENTS (A1–A7 applied). Branched from `main` @ `7edef9b738a898e2fc723fc6ce4363a79999958b` (post v1.102.0 release).

## Behavior

- **DDoS canonical key:** `DDOS_ENABLED`
- **DDoS compatibility alias:** `NFTBAN_DDOS_ENABLED`
- **Portscan canonical key:** `PORTSCAN_ENABLED`
- **Portscan compatibility alias:** `NFTBAN_PORTSCAN_ENABLED`
- **Canonical key wins on conflict** (canonical value used; alias value ignored when both set with conflicting values).
- **Conflict is warning-only / non-fatal.** Logged WARN; loader/helpers continue.
- **Alias-only configs continue to work** (read returns alias value when canonical absent).
- **Canonical-only configs continue to work** (no change to current canonical-only deployments).
- **Write paths remain canonical-only.** No module/CLI code writes the alias key.
- **No base-config mutation.** `install/config/nftban.conf:197` and `:200` declarations of `NFTBAN_PORTSCAN_ENABLED` / `NFTBAN_DDOS_ENABLED` are retained as alias declarations; Strategy C accepts the divergence.

## Out of scope (explicitly NOT touched)

- **Login:** **DEFER** per C3-A finding A3 (related-but-not-duplicate; separate ownership domains: `LOGIN_ENABLED` consumed by Go-daemon/loginmon module + shell login paths; `NFTBAN_LOGIN_MONITOR_ENABLED` consumed by central nftban infra including `internal/nftbanconf/loader.go`); routed to Lane M / v1.104. Asserted by `TestLoadFromFile_LoginNotAliasedInC3C`.
- **BotGuard:** **SKIP** — production already on canonical `HTTP_BOTGUARD_ENABLED` (17 files); 0 production consumers of legacy `BOTGUARD_ENABLED`; legacy key surviving only as regression-guard fixture in `cli/lib/nftban/tests/test_botguard_rebuild_sequencing.sh:34, 145-146, 151-160` (asserting legacy key is ignored). Fixture retained.
- **GeoBan:** tracked separately as **GEO-CLEANUP-001** (NOT C3-C). Phantom prefixed read at `cli/lib/nftban/core/nftban_report_services.sh:53` (`${NFTBAN_GEOBAN_ENABLED:-false}`) is a separate cleanup item.
- **No schema changes.** `SchemaVersionCurrent` remains `1.83.0`.
- **No metrics changes.**
- **No portal contract changes.**

## Drift closure

| Drift row | Status |
|---|---|
| C0A-D-05 (DDoS DUPLICATE) | **CLOSED by this PR** |
| C0A-D-06 (Portscan DUPLICATE) | **CLOSED by this PR** |
| C0A-D-07 (Login DUPLICATE + DIVERGENT-NAME) | NOT closed; routed to Lane M / v1.104 |
| C0A-D-08 (BotGuard PARTIAL DUPLICATE) | NOT closed; production already canonical; regression-guard fixture retained |
| GEO-CLEANUP-001 (GeoBan phantom prefixed read) | NOT closed; separate workspace track |

## Files changed (exactly 6)

| File | Type | Purpose |
|---|---|---|
| `internal/nftbanconf/loader.go` | modified | `Load()` and `ApplyOverlay()` read both canonical + alias for DDoS + Portscan; canonical-wins-on-conflict; warn-only |
| `internal/nftbanconf/loader_alias_test.go` | new | Go test suite for alias-read semantics including `TestLoadFromFile_LoginNotAliasedInC3C` boundary guard |
| `cli/lib/nftban/lib/nftban_config_alias.sh` | new | Private shell helper implementing the same canonical/alias read semantics for shell-side consumers |
| `cli/lib/nftban/core/nftban_config_doctor.sh` | modified | Use alias helper for DDoS + Portscan read paths |
| `cli/lib/nftban/helpers/suricata_effective_config.sh` | modified | Use alias helper for DDoS + Portscan read paths |
| `cli/lib/nftban/tests/test_config_alias_ddos_portscan.sh` | new | Shell test (23 alias scenarios) |

Diff envelope: `6 files changed, 763 insertions(+), 81 deletions(-)`.

## Validation evidence

| Check | Result |
|---|---|
| `bash -n` on changed shell files | OK |
| `shellcheck` on new shell helper + test | OK |
| Shell test `test_config_alias_ddos_portscan.sh` | **23 / 23 PASS** |
| Go verification VM | Hyper-V `tgt-a9` (AlmaLinux 9.7, `go1.25.9 (Red Hat 1.25.9-1.el9_7) linux/amd64`) |
| `gofmt -l internal/nftbanconf/loader.go internal/nftbanconf/loader_alias_test.go` | OK (clean after `gofmt -w` struct-field column re-alignment caused by new fields; column-spacing only, no logic change) |
| `go vet ./internal/nftbanconf/...` | OK (`VET_RC=0`) |
| `go test ./internal/nftbanconf/... -count=1 -v` | OK — all alias tests + existing tests PASS (`TestLoadFromFile_PortscanAlias_PrefixedOnly`, `TestLoadFromFile_PortscanAlias_BothConflict_CanonicalWins`, `TestOverlayFromFile_DDoSAlias_CanonicalWins`, `TestOverlayFromFile_PortscanAlias_AliasOnly`, `TestOverlayFromFile_DDoSAlias_PreservesIndependentInvocationState`, `TestLoadFromFile_LoginNotAliasedInC3C`) |
| `go test ./internal/... -count=1` (broader sanity) | OK — 50+ internal packages PASS in 3m22s |

Local Go toolchain unavailable on dev workstation by project policy (`memory/feedback_no_local_go.md`). CI is authoritative for gofmt + go test.

## Test plan

- [ ] CI green on this PR (Bash Validation, ShellCheck, Architecture Policy, Go Build & Test, Policy Gates incl. FHS spec, package builds + install tests).
- [ ] Operator ACK after CI green.
- [ ] Operator authorization to merge.
- [ ] Main CI green for ≥1 post-merge cycle.
- [ ] No auto-chain to Login (Lane M / v1.104), BotGuard (SKIP), GeoBan (GEO-CLEANUP-001 separate), Lane S, portal, or TRANSPORT-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)