### PR TITLE
test(loginmon): rename Lane M boundary guard to permanent regression guard

### DIFF
--- a/internal/nftbanconf/loader_alias_test.go
+++ b/internal/nftbanconf/loader_alias_test.go
@@ -256,20 +256,40 @@ func TestOverlayFromFile_DDoSAlias_PreservesIndependentInvocationState(t *testin
 }
 
 // -----------------------------------------------------------------------------
-// Login is intentionally NOT aliased here — DEFER to Lane M / v1.104.
-// This negative assertion documents the intent.
+// Login: permanent semantic guard (Lane M / v1.104 Decision B).
+//
+// Per Lane M finding (recorded in
+// AUDIT_190_CONFIGS_ECOSYSTEM/06_REPORTS/PR_M_A_LANE_M_LOGIN_OWNERSHIP_AUDIT.md):
+// LOGIN_ENABLED is the Go loginmon module's per-module self-enable flag
+// (owned by internal/loginmon, declared in conf.d/login/main.conf).
+// NFTBAN_LOGIN_MONITOR_ENABLED is the central nftban infra's
+// observability/monitor-gate flag (owned by internal/nftbanconf, declared
+// in nftban.conf). They are DISTINCT FACTS and must never be aliased.
+// These tests are permanent regression guards against future re-attempts
+// to collapse the two keys into one struct field. Drift row C0A-D-07
+// closed by Lane M Decision B (no runtime behavior change).
 // -----------------------------------------------------------------------------
 
-func TestLoadFromFile_LoginNotAliasedInC3C(t *testing.T) {
-	// Bare LOGIN_ENABLED is NOT recognized by the central nftbanconf loader
-	// in v1.103 (Login is structurally deferred to Lane M / v1.104).
-	// Only NFTBAN_LOGIN_MONITOR_ENABLED still drives cfg.LoginMonitorEnabled.
+func TestLoadFromFile_LoginKeysAreDistinctFacts(t *testing.T) {
+	// LOGIN_ENABLED must NOT alias into cfg.LoginMonitorEnabled via loadFromFile.
+	// Only NFTBAN_LOGIN_MONITOR_ENABLED drives cfg.LoginMonitorEnabled.
 	p := writeConf(t, "LOGIN_ENABLED=\"true\"\n")
 	cfg, err := loadFromFile(p)
 	if err != nil {
 		t.Fatalf("loadFromFile: %v", err)
 	}
 	if cfg.LoginMonitorEnabled {
-		t.Errorf("LoginMonitorEnabled = true, want false (LOGIN_ENABLED must NOT alias to LoginMonitorEnabled in v1.103; deferred to Lane M)")
+		t.Errorf("LoginMonitorEnabled = true, want false (LOGIN_ENABLED must NOT alias to LoginMonitorEnabled per Lane M Decision B; distinct facts)")
+	}
+}
+
+func TestOverlayFromFile_LoginKeysAreDistinctFacts(t *testing.T) {
+	// Symmetric guard against the overlay path: LOGIN_ENABLED in a .conf.local
+	// must NOT flip cfg.LoginMonitorEnabled either.
+	cfg := &Config{LoginMonitorEnabled: false}
+	p := writeConf(t, "LOGIN_ENABLED=\"true\"\n")
+	overlayFromFile(cfg, p)
+	if cfg.LoginMonitorEnabled {
+		t.Errorf("LoginMonitorEnabled = true, want false (LOGIN_ENABLED in overlay must NOT alias to LoginMonitorEnabled per Lane M Decision B; distinct facts)")
 	}
 }


### PR DESCRIPTION
## Summary

- Lane M / v1.104 Decision B (recorded in workspace closure `AUDIT_190_CONFIGS_ECOSYSTEM/06_REPORTS/PR_M_LANE_M_CLOSURE_NOTE.md`) formalized that `LOGIN_ENABLED` and `NFTBAN_LOGIN_MONITOR_ENABLED` are **distinct configuration facts**, owned by different packages, and must never be aliased.
- This PR converts the temporary v1.103 boundary-guard test `TestLoadFromFile_LoginNotAliasedInC3C` into a **permanent regression guard** named `TestLoadFromFile_LoginKeysAreDistinctFacts`, with a comment block citing Lane M Decision B.
- Adds symmetric guard `TestOverlayFromFile_LoginKeysAreDistinctFacts` covering the `.conf.local` overlay path (the v1.103 test only covered the base `loadFromFile` path).
- Drift row **C0A-D-07** is already CLOSED by PR-M-B (workspace doc lane); this is the optional code-side counterpart.

## What does NOT change

- No alias added.
- No struct fields added or removed.
- No production code path modified.
- Schema remains frozen at `1.83.0`.
- No metrics, portal, lifecycle, install, packaging, or panel-adapter changes.
- Issue #525 (geoip startup panic, P1) remains deferred to Lane G.

## Files changed (1)

| File | + | − |
|---|---|---|
| `internal/nftbanconf/loader_alias_test.go` | 27 | 7 |

Single-file scope, allowlist-locked; pre-commit guard verified `git diff --name-only` matched exactly `internal/nftbanconf/loader_alias_test.go`.

## Test plan

- [ ] PR CI Go Build & Test green (this is the primary gate; gofmt/vet/test)
- [ ] New tests pass: `go test -run 'TestLoadFromFile_LoginKeysAreDistinctFacts|TestOverlayFromFile_LoginKeysAreDistinctFacts' -v ./internal/nftbanconf/...`
- [ ] Full alias-test suite green: `go test -run 'TestLoadFromFile_|TestOverlayFromFile_' -v ./internal/nftbanconf/...`
- [ ] Full package green: `go test -v ./internal/nftbanconf/...`
- [ ] PR CI all-green (expect ~24/24 success matching HEAD `bb1524c9` baseline; expect 51/0/2 PR-CI shape matching v1.103 release-prep PR #560)
- [ ] Operator merge-readiness audit returns GO_MERGE before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)