### PR TITLE
v1.106 MFST-C0b: DEB Layer-0 wire-in (consume nftban.dirs)

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -179,6 +179,13 @@ directories:
       description: "Utility tools and scripts"
       created_by: package
 
+    - path: /usr/lib/nftban/scripts
+      mode: "0755"
+      owner: root
+      group: root
+      description: "Helper scripts (generate-help, generate-wiki, soak-check)"
+      created_by: package
+
   # ---------------------------------------------------------------------------
   # Configuration (root:nftban, 750) - Daemon needs read access via group
   # Note: /etc stays root-owned, nftban user has read-only via group

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -62,6 +62,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/usr/lib/nftban/data"]="0755|root|root|Static data files (registries, schemas)"
     NFTBAN_FHS_DIRECTORIES["/usr/lib/nftban/templates"]="0755|root|root|Config templates with placeholders (rendered at install/rebuild)"
     NFTBAN_FHS_DIRECTORIES["/usr/lib/nftban/tools"]="0755|root|root|Utility tools and scripts"
+    NFTBAN_FHS_DIRECTORIES["/usr/lib/nftban/scripts"]="0755|root|root|Helper scripts (generate-help, generate-wiki, soak-check)"
 
     # Configuration Directories (root:nftban)
     NFTBAN_FHS_DIRECTORIES["/etc/nftban"]="0750|root|nftban|Configuration files (daemon readable via group)"

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -130,6 +130,14 @@
         "group": "root",
         "description": "Utility tools and scripts",
         "created_by": "package"
+      },
+      {
+        "path": "/usr/lib/nftban/scripts",
+        "mode": "0755",
+        "owner": "root",
+        "group": "root",
+        "description": "Helper scripts (generate-help, generate-wiki, soak-check)",
+        "created_by": "package"
       }
     ],
     "config": [

--- a/install/packaging/deb/nftban.dirs
+++ b/install/packaging/deb/nftban.dirs
@@ -27,6 +27,7 @@
 /usr/lib/nftban/data
 /usr/lib/nftban/templates
 /usr/lib/nftban/tools
+/usr/lib/nftban/scripts
 /etc/nftban
 /etc/nftban/conf.d
 /etc/nftban/conf.d/ddos

--- a/install/packaging/rpm/nftban-files.inc
+++ b/install/packaging/rpm/nftban-files.inc
@@ -29,6 +29,7 @@
 %dir %attr(0755,root,root) /usr/lib/nftban/data
 %dir %attr(0755,root,root) /usr/lib/nftban/templates
 %dir %attr(0755,root,root) /usr/lib/nftban/tools
+%dir %attr(0755,root,root) /usr/lib/nftban/scripts
 
 # ---------------------------------------------------------------------------
 # CONFIGURATION DIRECTORIES (root:nftban)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1779,9 +1779,36 @@ build_deb() {
     local deb_root="${BUILD_DIR}/deb"
     rm -rf "${deb_root}"
 
-    # Create directory structure
-    # Bug #18: Debian/Ubuntu use /usr/share/polkit-1/rules.d/ for polkit rules
-    mkdir -p "${deb_root}"/{DEBIAN,usr/bin,usr/sbin,usr/libexec,usr/lib/nftban/bin,usr/lib/systemd/system,etc/{nftables,nftban/{conf.d/{botguard/profiles,tunnel},distros,whitelist.d,blacklist.d,ports.d,rules.d,access.d}},usr/share/polkit-1/rules.d,var/{lib/nftban/{feeds,geoip,staging,reports,botguard,tunnel,community},log/nftban/botguard,cache/nftban},run/nftban}
+    # MFST-C0b: directory creation comes from generator (build/fhs-spec.yaml -> nftban.dirs).
+    # Tmpfiles-managed runtime dirs (/var/lib/nftban, /var/log/nftban, /var/cache/nftban,
+    # /run/nftban) are intentionally NOT listed in nftban.dirs and NOT created here
+    # (Option 4a — owned by /usr/lib/tmpfiles.d/nftban.conf at boot).
+    local nftban_dirs="${PROJECT_ROOT}/install/packaging/deb/nftban.dirs"
+    if [[ ! -f "$nftban_dirs" ]]; then
+        log_error "nftban.dirs not found at $nftban_dirs; run 'bash build/generate-fhs-outputs.sh' first"
+        return 1
+    fi
+
+    # Bucket 2 — DEB metadata + FHS system dirs (NOT package-territory; not in generator).
+    # Bug #18: Debian/Ubuntu use /usr/share/polkit-1/rules.d/ for polkit rules.
+    mkdir -p "${deb_root}/DEBIAN" \
+             "${deb_root}/etc/logrotate.d" \
+             "${deb_root}/etc/nftables" \
+             "${deb_root}/etc/sysctl.d" \
+             "${deb_root}/usr/bin" \
+             "${deb_root}/usr/sbin" \
+             "${deb_root}/usr/libexec" \
+             "${deb_root}/usr/lib/systemd/system" \
+             "${deb_root}/usr/lib/tmpfiles.d" \
+             "${deb_root}/usr/share/bash-completion/completions" \
+             "${deb_root}/usr/share/man/man8" \
+             "${deb_root}/usr/share/polkit-1/rules.d"
+
+    # Package-territory dirs — consume generator output (closes D-NEW-1 DEB-side).
+    while IFS= read -r path; do
+        [[ -z "$path" || "$path" =~ ^[[:space:]]*# ]] && continue
+        mkdir -p "${deb_root}${path}"
+    done < "$nftban_dirs"
 
     # Copy binaries
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-core" "${deb_root}/usr/lib/nftban/bin/"
@@ -1807,7 +1834,6 @@ build_deb() {
     # Copy helper scripts to /usr/lib/nftban/sbin/
     # CRITICAL: These scripts are executed by systemd services and MUST have 755 permissions
     # Bug fix v1.9.4: Ensure sbin scripts are always installed with correct permissions
-    mkdir -p "${deb_root}/usr/lib/nftban/sbin"
     local sbin_count=0
     for script in nftban-apply nftban-confirm nftban-panelctl nftban-queue-processor \
                   nftban-botscan-processor nftban-rollback nftban-service-alert; do
@@ -1847,19 +1873,16 @@ build_deb() {
     find "${deb_root}/usr/lib/nftban" -name "*.sh" -exec chmod 755 {} \;
 
     # Copy main configuration file
-    mkdir -p "${deb_root}/etc/nftban"
     install -m 0640 "${PROJECT_ROOT}/install/config/nftban.conf" "${deb_root}/etc/nftban/nftban.conf"
 
     # Copy nftables config (pre-rendered with safe defaults, boot-safe)
     install -m 0644 "${PROJECT_ROOT}/install/nftables/nftables.conf" "${deb_root}/etc/nftban/nftables.conf"
 
     # v1.50.0: Template with placeholders (always overwritten on upgrade)
-    mkdir -p "${deb_root}/usr/lib/nftban/templates"
     install -m 0644 "${PROJECT_ROOT}/install/nftables/nftables.conf.tpl" "${deb_root}/usr/lib/nftban/templates/nftables.conf.tpl"
 
     # Copy conf.d directory with subdirectories
     # NOTE: Central whitelist moved to whitelist.d/ - per-module whitelist.txt files removed
-    mkdir -p "${deb_root}/etc/nftban/conf.d"
     cp -r "${PROJECT_ROOT}/etc/nftban/conf.d"/* "${deb_root}/etc/nftban/conf.d/"
     # Remove any stale whitelist.txt files (consolidated to whitelist.d/)
     find "${deb_root}/etc/nftban/conf.d" -name 'whitelist.txt' -delete 2>/dev/null || true
@@ -1870,21 +1893,14 @@ build_deb() {
     install -m 0640 "${PROJECT_ROOT}/install/config/conf.d/persistent.conf" "${deb_root}/etc/nftban/conf.d/persistent.conf"
 
     # Copy patterns.d directory (botscan patterns)
-    mkdir -p "${deb_root}/etc/nftban/patterns.d/botscan"
     cp "${PROJECT_ROOT}/etc/nftban/patterns.d/botscan"/*.patterns "${deb_root}/etc/nftban/patterns.d/botscan/"
 
     # Install logrotate configuration
-    mkdir -p "${deb_root}/etc/logrotate.d"
     install -m 0644 "${PROJECT_ROOT}/install/config/nftban.logrotate" "${deb_root}/etc/logrotate.d/nftban"
-    mkdir -p "${deb_root}/etc/nftban/templates"
     install -m 0644 "${PROJECT_ROOT}/install/config/nftban.logrotate" "${deb_root}/etc/nftban/templates/nftban.logrotate"
     install -m 0644 "${PROJECT_ROOT}/install/config/nftban-suricata.logrotate" "${deb_root}/etc/nftban/templates/nftban-suricata.logrotate"
 
-    # Copy Suricata profile templates and create config directories
-    mkdir -p "${deb_root}/etc/nftban/suricata/profiles"
-    mkdir -p "${deb_root}/etc/nftban/suricata/config"
-    mkdir -p "${deb_root}/etc/nftban/suricata/rules"
-    mkdir -p "${deb_root}/etc/nftban/suricata/cache"
+    # Copy Suricata profile templates
     install -m 0644 "${PROJECT_ROOT}/etc/nftban/suricata/profiles/minimal.yaml" "${deb_root}/etc/nftban/suricata/profiles/"
     install -m 0644 "${PROJECT_ROOT}/etc/nftban/suricata/profiles/standard.yaml" "${deb_root}/etc/nftban/suricata/profiles/"
     install -m 0644 "${PROJECT_ROOT}/etc/nftban/suricata/profiles/maximum.yaml" "${deb_root}/etc/nftban/suricata/profiles/"
@@ -1895,12 +1911,9 @@ build_deb() {
     install -m 0644 "${PROJECT_ROOT}/etc/nftban/conf.d/botguard/profiles/wordpress.yaml" "${deb_root}/etc/nftban/conf.d/botguard/profiles/"
 
     # Copy distro configuration files (CRITICAL for distro-aware paths)
-    mkdir -p "${deb_root}/etc/nftban/distros"
     cp "${PROJECT_ROOT}/etc/nftban/distros"/*.conf "${deb_root}/etc/nftban/distros/"
 
     # Manual whitelist/blacklist files (user-managed, preserved on upgrade)
-    mkdir -p "${deb_root}/etc/nftban/whitelist.d"
-    mkdir -p "${deb_root}/etc/nftban/blacklist.d"
     install -m 0640 "${PROJECT_ROOT}/etc/nftban/whitelist.d/99-manual.conf" "${deb_root}/etc/nftban/whitelist.d/"
     install -m 0640 "${PROJECT_ROOT}/etc/nftban/blacklist.d/99-manual.conf" "${deb_root}/etc/nftban/blacklist.d/"
 
@@ -1959,11 +1972,9 @@ build_deb() {
     install -m 0644 "${PROJECT_ROOT}/install/config/conf.d/community_stats.conf.default" "${deb_root}/etc/nftban/conf.d/"
 
     # Sysctl tuning profile (v1.38.0)
-    mkdir -p "${deb_root}/etc/sysctl.d"
     install -m 0644 "${PROJECT_ROOT}/install/sysctl/90-nftban.conf" "${deb_root}/etc/sysctl.d/"
 
     # v1.47.0 DEPLOY-006: tmpfiles.d for /run/nftban ownership
-    mkdir -p "${deb_root}/usr/lib/tmpfiles.d"
     install -m 0644 "${PROJECT_ROOT}/install/systemd/tmpfiles.d/nftban.conf" "${deb_root}/usr/lib/tmpfiles.d/"
 
     # Copy PolicyKit rules (v1.0.19: Consolidated 6 files → 3 files)
@@ -1973,29 +1984,24 @@ build_deb() {
     install -m 0644 "${PROJECT_ROOT}/packaging/polkit-1/rules.d/30-nftban-panel.rules" "${deb_root}/usr/share/polkit-1/rules.d/"
 
     # Copy validator spec
-    mkdir -p "${deb_root}/usr/share/nftban/specs"
     install -m 0644 "${PROJECT_ROOT}/install/share/nftban/specs/structure_default.json" "${deb_root}/usr/share/nftban/specs/"
 
     # Copy templates (mail, reports, email, partials)
-    mkdir -p "${deb_root}/usr/share/nftban/templates"
     find "${PROJECT_ROOT}/install/share/nftban/templates" -type f -name "*.html" | while read -r tmpl; do
         rel_path="${tmpl#${PROJECT_ROOT}/install/share/nftban/templates/}"
         install -D -m 0644 "$tmpl" "${deb_root}/usr/share/nftban/templates/$rel_path"
     done
 
     # Copy man page
-    mkdir -p "${deb_root}/usr/share/man/man8"
     install -m 0644 "${PROJECT_ROOT}/install/man/man8/nftban.8" "${deb_root}/usr/share/man/man8/"
 
     # Copy bash completion
-    mkdir -p "${deb_root}/usr/share/bash-completion/completions"
     install -m 0644 "${PROJECT_ROOT}/install/bash-completion/nftban" "${deb_root}/usr/share/bash-completion/completions/"
 
     # Copy commands registry (v1.0.16 - single source of truth)
     install -m 0644 "${PROJECT_ROOT}/commands.registry.yml" "${deb_root}/etc/nftban/"
 
     # Copy documentation generators (v1.0.16)
-    mkdir -p "${deb_root}/usr/lib/nftban/scripts"
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-help.sh" "${deb_root}/usr/lib/nftban/scripts/"
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-wiki-operator.sh" "${deb_root}/usr/lib/nftban/scripts/"
     install -m 0755 "${PROJECT_ROOT}/scripts/generate-wiki-auditor.sh" "${deb_root}/usr/lib/nftban/scripts/"
@@ -2006,7 +2012,6 @@ build_deb() {
     # See: https://github.com/itcmsgr/nftban/wiki
 
     # Copy test scripts
-    mkdir -p "${deb_root}/usr/lib/nftban/tests"
     find "${PROJECT_ROOT}/cli/lib/nftban/tests" -type f -name "*.sh" -exec install -m 0755 {} "${deb_root}/usr/lib/nftban/tests/" \;
 
     # Create control file


### PR DESCRIPTION
## Summary

- **MFST-C0b — DEB Layer-0 wire-in.** Second code lane of v1.106 MANIFEST-AUTHORITY (after #563 RPM C0a). Closes drift **D-NEW-1** on the DEB side: the generator has emitted `install/packaging/deb/nftban.dirs` since v1.50.0, but `build_deb()` hand-rolled a 26-entry brace expansion + 17 inline `mkdir -p` calls that duplicated and drifted from the generator.
- **Net `build_deb()` shape:** 12 Bucket-2 explicit mkdirs at the top of the function (DEB metadata + FHS system dirs), plus a `while … read` loop that consumes `nftban.dirs`. 22 inline dedup mkdirs deleted. 10 tmpfiles-managed runtime dirs (`/run/nftban`, `/var/cache/nftban`, 7×`/var/lib/nftban/*`, `/var/log/nftban/botguard`) no longer created at build time (Option 4a mirror of C0a — tmpfiles owns them at boot).
- **Generator extension:** `/usr/lib/nftban/scripts` added to `build/fhs-spec.yaml` (0755 root:root, `created_by: package`). Closes a small gap that benefits both packagers — DEB gains the dir via the loop, RPM gains a `%dir` line in `nftban-files.inc`.

## Changes

- `build/fhs-spec.yaml` (+7 lines): one new `/usr/lib/nftban/scripts` entry.
- 4 regenerated outputs (`nftban.dirs` +1, `nftban-files.inc` +1, `fhs_directories.json` +1, `nftban_fhs_spec.sh` +1). `tmpfiles.d` and `sysusers.d` unchanged (entry is package-territory).
- `packaging/build_nftban.sh::build_deb()` only:
  - 26-entry brace at `:1784` → 12 Bucket-2 explicit mkdirs + while-loop reading `${PROJECT_ROOT}/install/packaging/deb/nftban.dirs`.
  - 17 inline dedup `mkdir -p` calls deleted.
  - File payload installs (`install -m`, `cp -r`, `find … -exec install`) preserved verbatim.
  - `fakeroot find … -exec chown root:root` and `dpkg-deb --build` pipeline unchanged.

## Local validation

- `bash build/generate-fhs-outputs.sh --check` — OK.
- `bash -n packaging/build_nftban.sh` — OK.
- Payload-parent coverage check — 22 unique parent dirs extracted from `install/cp` lines; **zero uncovered** (all in `nftban.dirs` or the 12 Bucket-2 set).
- Loop dry-simulation — creates 78 explicit dirs (66 from `nftban.dirs` + 12 Bucket-2), zero `/var/*` or `/run/*` (Option 4a verified).
- `rpmbuild -bs` and runtime DEB build deferred to CI runners (no `dpkg-deb` on dev workstation).

## Out of scope (carried forward)

- `packaging/deb/postinst` (D-NEW-12 — DEB ships `/etc/nftban/*` as `root:root` because of the blanket `fakeroot find … chown root:root`; postinst doesn't chown to `root:nftban`. Pre-existing drift; routed to AUTH-HARDENING).
- `build_rpm()` (C0a already wired). The only RPM-side delta in this PR is the +1 line regen in `nftban-files.inc`.
- F14 / Shape A / D4 / D5 / MFST-C1+ — reserved for later MFST-Cn / v1.107+.
- Schema frozen at 1.83.0; no metrics/portal/lifecycle/install API changes.

## Test plan

- [ ] CI green (Build DEB ×4 distros, Test DEB install ×4 distros, Build RPM ×2, Test RPM install ×4, FHS `--check`, runtime truth).
- [ ] Lab: `dpkg-deb -c` on built DEB — net `+43 dirs` (A\B from generator), `−10 dirs` (Option 4a tmpfiles), `+1 dir` (`/usr/lib/nftban/scripts`); zero file-payload changes.
- [ ] Lab: clean install on Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)