### PR TITLE
v1.106 MFST-C1: Layer 1 systemd install-list generator

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -133,6 +133,16 @@ jobs:
           fi
           echo "✓ FHS spec: PASS (generated files match YAML spec)"
 
+      - name: Systemd install-list generated file check
+        run: |
+          echo "=== Verifying systemd install-list is up to date ==="
+          if ! ./build/generate-systemd-install-list.sh --check; then
+            echo ""
+            echo "::error::install/packaging/systemd/nftban-systemd-install.list is stale — run: ./build/generate-systemd-install-list.sh"
+            exit 1
+          fi
+          echo "✓ Systemd install-list: PASS (matches install/systemd source)"
+
       # =====================================================================
       # NEW CHECKS (v1.50.1 — Distribution Compatibility Audit)
       # =====================================================================

--- a/build/generate-systemd-install-list.sh
+++ b/build/generate-systemd-install-list.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Systemd Install-List Generator (MFST-C1 / Layer 1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="generate-systemd-install-list"
+# meta:type="build"
+# meta:header="Systemd Install-List Generator"
+# meta:version="1.106.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Generate canonical systemd unit install list consumed by RPM and DEB build paths"
+# meta:inventory.files="install/systemd/*.{service,timer,socket}"
+# meta:inventory.binaries="find,sort,diff,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="user"
+#
+# meta:created_date="2026-05-06"
+# meta:updated_date="2026-05-06"
+#
+# Source of truth: install/systemd/*.{service,timer,socket}
+# Output:          install/packaging/systemd/nftban-systemd-install.list
+#
+# Consumed at package-build time by both packagers
+# (packaging/build_nftban.sh::build_rpm + ::build_deb) to ensure the RPM and
+# DEB install layers ship the same systemd unit set as filesystem truth
+# (D1 closure).
+#
+# Usage:
+#   ./build/generate-systemd-install-list.sh           # regenerate
+#   ./build/generate-systemd-install-list.sh --check   # CI parity check
+#
+# Options:
+#   --check   Verify generated file matches committed version (for CI)
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+readonly SOURCE_DIR="${PROJECT_ROOT}/install/systemd"
+readonly OUTPUT_FILE="${PROJECT_ROOT}/install/packaging/systemd/nftban-systemd-install.list"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+print_info()    { echo -e "${YELLOW}[INFO]${NC} $*"; }
+print_ok()      { echo -e "${GREEN}[OK]${NC} $*"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+generate() {
+    local target="${1:-$OUTPUT_FILE}"
+
+    if [[ ! -d "$SOURCE_DIR" ]]; then
+        print_error "Source directory not found: $SOURCE_DIR"
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$target")"
+
+    local units
+    units=$(find "$SOURCE_DIR" -maxdepth 1 -type f \
+        \( -name '*.service' -o -name '*.timer' -o -name '*.socket' \) \
+        -printf '%f\n' | LC_ALL=C sort -u)
+
+    if [[ -z "$units" ]]; then
+        print_error "No systemd units found in $SOURCE_DIR"
+        return 1
+    fi
+
+    local count
+    count=$(printf '%s\n' "$units" | wc -l)
+
+    {
+        cat <<'EOF'
+# =============================================================================
+# NFTBan systemd unit install list
+# =============================================================================
+# Generated from install/systemd/*.{service,timer,socket} - DO NOT EDIT
+# Generator: build/generate-systemd-install-list.sh
+#
+# Consumers:
+#   - packaging/build_nftban.sh::build_rpm() spec heredoc %install loop
+#   - packaging/build_nftban.sh::build_deb() install-loop
+#
+# Note: filesystem glob; all units in install/systemd are listed.
+# Runtime-controlled enablement is owned by /usr/lib/nftban/bin/nftban-installer
+# (PR-22B safety contract); file presence in /usr/lib/systemd/system/ does NOT
+# imply enable. See V106_LANE_MFST_C1_SCOPE.md §7 for safety analysis.
+# =============================================================================
+EOF
+        printf '%s\n' "$units"
+    } > "$target"
+
+    print_ok "Wrote $count units to $target"
+}
+
+check_mode() {
+    print_info "Running in check mode - verifying generated file..."
+
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    trap 'rm -rf "${temp_dir:-}"' EXIT
+
+    local temp_out="${temp_dir}/nftban-systemd-install.list"
+    generate "$temp_out" >/dev/null
+
+    if [[ ! -f "$OUTPUT_FILE" ]]; then
+        print_error "Committed output missing: $OUTPUT_FILE"
+        return 1
+    fi
+
+    if diff -q "$OUTPUT_FILE" "$temp_out" >/dev/null 2>&1; then
+        print_ok "OK: nftban-systemd-install.list matches install/systemd source"
+        return 0
+    fi
+
+    print_error "DRIFT: $OUTPUT_FILE is stale vs install/systemd"
+    diff -u "$OUTPUT_FILE" "$temp_out" || true
+    print_error "Run 'bash build/generate-systemd-install-list.sh' to regenerate"
+    return 1
+}
+
+main() {
+    case "${1:-}" in
+        --check)
+            check_mode
+            return $?
+            ;;
+        ""|--write)
+            generate
+            return $?
+            ;;
+        -h|--help)
+            sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            return 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            return 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/install/packaging/systemd/nftban-systemd-install.list
+++ b/install/packaging/systemd/nftban-systemd-install.list
@@ -1,0 +1,64 @@
+# =============================================================================
+# NFTBan systemd unit install list
+# =============================================================================
+# Generated from install/systemd/*.{service,timer,socket} - DO NOT EDIT
+# Generator: build/generate-systemd-install-list.sh
+#
+# Consumers:
+#   - packaging/build_nftban.sh::build_rpm() spec heredoc %install loop
+#   - packaging/build_nftban.sh::build_deb() install-loop
+#
+# Note: filesystem glob; all units in install/systemd are listed.
+# Runtime-controlled enablement is owned by /usr/lib/nftban/bin/nftban-installer
+# (PR-22B safety contract); file presence in /usr/lib/systemd/system/ does NOT
+# imply enable. See V106_LANE_MFST_C1_SCOPE.md §7 for safety analysis.
+# =============================================================================
+nftban-alert@.service
+nftban-botscan.service
+nftban-botscan.timer
+nftban-community-stats.service
+nftban-community-stats.timer
+nftban-core-feeds.service
+nftban-core-feeds.timer
+nftban-core-geoip.service
+nftban-core-geoip.timer
+nftban-firewall-init.service
+nftban-health-fix.service
+nftban-health.service
+nftban-health.timer
+nftban-maintenance.service
+nftban-maintenance.timer
+nftban-pro-inventory.service
+nftban-pro-inventory.timer
+nftban-pro-license.service
+nftban-pro-license.timer
+nftban-queue.service
+nftban-queue.timer
+nftban-rbl-check.service
+nftban-rbl-check.timer
+nftban-rebuild-recovery.service
+nftban-rebuild-recovery.timer
+nftban-report-daily.service
+nftban-report-daily.timer
+nftban-rollback.service
+nftban-rollback.timer
+nftban-snapshot.service
+nftban-snapshot.timer
+nftban-soak.service
+nftban-soak.timer
+nftban-suricata-stats.service
+nftban-suricata-update.service
+nftban-suricata-update.timer
+nftban-suricata.service
+nftban-tunnel.service
+nftban-tunnel.timer
+nftban-unified-exporter.service
+nftban-unified-exporter.timer
+nftban-update-apply.service
+nftban-update-apply.timer
+nftban-update-check.service
+nftban-update-check.timer
+nftban-watchdog.service
+nftban-watchdog.timer
+nftband.service
+nftband.socket

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -277,6 +277,7 @@ License:        GPL-3.0-or-later
 URL:            https://nftban.com
 Source0:        %{name}-%{version}.tar.gz
 Source1:        nftban-files.inc
+Source2:        nftban-systemd-install.list
 
 BuildRequires:  systemd-rpm-macros
 
@@ -439,54 +440,14 @@ mkdir -p %{buildroot}/etc/nftban/blacklist.d
 install -m 0640 etc/nftban/whitelist.d/99-manual.conf %{buildroot}/etc/nftban/whitelist.d/99-manual.conf
 install -m 0640 etc/nftban/blacklist.d/99-manual.conf %{buildroot}/etc/nftban/blacklist.d/99-manual.conf
 
-# Systemd units (actual files that exist)
-install -D -m 0644 install/systemd/nftban-maintenance.service %{buildroot}/usr/lib/systemd/system/nftban-maintenance.service
-install -D -m 0644 install/systemd/nftban-maintenance.timer %{buildroot}/usr/lib/systemd/system/nftban-maintenance.timer
-install -D -m 0644 install/systemd/nftban-health.service %{buildroot}/usr/lib/systemd/system/nftban-health.service
-install -D -m 0644 install/systemd/nftban-health.timer %{buildroot}/usr/lib/systemd/system/nftban-health.timer
-# v1.23.0 (EVAL-3): nftban-login-monitor.service REMOVED from package
-# Deprecated since v1.21.3, replaced by Go daemon loginmon module (internal/loginmon)
-install -D -m 0644 install/systemd/nftban-core-geoip.service %{buildroot}/usr/lib/systemd/system/nftban-core-geoip.service
-install -D -m 0644 install/systemd/nftban-core-geoip.timer %{buildroot}/usr/lib/systemd/system/nftban-core-geoip.timer
-install -D -m 0644 install/systemd/nftban-core-feeds.service %{buildroot}/usr/lib/systemd/system/nftban-core-feeds.service
-install -D -m 0644 install/systemd/nftban-core-feeds.timer %{buildroot}/usr/lib/systemd/system/nftban-core-feeds.timer
-install -D -m 0644 install/systemd/nftban-unified-exporter.service %{buildroot}/usr/lib/systemd/system/nftban-unified-exporter.service
-install -D -m 0644 install/systemd/nftban-unified-exporter.timer %{buildroot}/usr/lib/systemd/system/nftban-unified-exporter.timer
-install -D -m 0644 install/systemd/nftban-watchdog.service %{buildroot}/usr/lib/systemd/system/nftban-watchdog.service
-install -D -m 0644 install/systemd/nftban-watchdog.timer %{buildroot}/usr/lib/systemd/system/nftban-watchdog.timer
-install -D -m 0644 install/systemd/nftban-snapshot.service %{buildroot}/usr/lib/systemd/system/nftban-snapshot.service
-install -D -m 0644 install/systemd/nftban-snapshot.timer %{buildroot}/usr/lib/systemd/system/nftban-snapshot.timer
-install -D -m 0644 install/systemd/nftban-rollback.service %{buildroot}/usr/lib/systemd/system/nftban-rollback.service
-install -D -m 0644 install/systemd/nftban-rollback.timer %{buildroot}/usr/lib/systemd/system/nftban-rollback.timer
-install -D -m 0644 install/systemd/nftban-suricata-update.service %{buildroot}/usr/lib/systemd/system/nftban-suricata-update.service
-install -D -m 0644 install/systemd/nftban-suricata-update.timer %{buildroot}/usr/lib/systemd/system/nftban-suricata-update.timer
-install -D -m 0644 install/systemd/nftban-suricata.service %{buildroot}/usr/lib/systemd/system/nftban-suricata.service
-install -D -m 0644 install/systemd/nftban-suricata-stats.service %{buildroot}/usr/lib/systemd/system/nftban-suricata-stats.service
-# v1.100.1b.A: nftban-ui + nftban-ui-auth service/socket files no longer installed.
-install -D -m 0644 install/systemd/nftban-queue.service %{buildroot}/usr/lib/systemd/system/nftban-queue.service
-install -D -m 0644 install/systemd/nftban-queue.timer %{buildroot}/usr/lib/systemd/system/nftban-queue.timer
-install -D -m 0644 install/systemd/nftban-botscan.service %{buildroot}/usr/lib/systemd/system/nftban-botscan.service
-install -D -m 0644 install/systemd/nftban-botscan.timer %{buildroot}/usr/lib/systemd/system/nftban-botscan.timer
-install -D -m 0644 install/systemd/nftban-health-fix.service %{buildroot}/usr/lib/systemd/system/nftban-health-fix.service
-install -D -m 0644 install/systemd/nftban-rbl-check.service %{buildroot}/usr/lib/systemd/system/nftban-rbl-check.service
-install -D -m 0644 install/systemd/nftban-rbl-check.timer %{buildroot}/usr/lib/systemd/system/nftban-rbl-check.timer
-install -D -m 0644 install/systemd/nftban-tunnel.service %{buildroot}/usr/lib/systemd/system/nftban-tunnel.service
-install -D -m 0644 install/systemd/nftban-tunnel.timer %{buildroot}/usr/lib/systemd/system/nftban-tunnel.timer
-install -D -m 0644 install/systemd/nftband.service %{buildroot}/usr/lib/systemd/system/nftband.service
-install -D -m 0644 install/systemd/nftband.socket %{buildroot}/usr/lib/systemd/system/nftband.socket
-# v1.41.0: Report timer + community stats
-install -D -m 0644 install/systemd/nftban-report-daily.service %{buildroot}/usr/lib/systemd/system/nftban-report-daily.service
-install -D -m 0644 install/systemd/nftban-report-daily.timer %{buildroot}/usr/lib/systemd/system/nftban-report-daily.timer
-install -D -m 0644 install/systemd/nftban-community-stats.service %{buildroot}/usr/lib/systemd/system/nftban-community-stats.service
-install -D -m 0644 install/systemd/nftban-community-stats.timer %{buildroot}/usr/lib/systemd/system/nftban-community-stats.timer
-# v1.71.0: Split update units (check=unprivileged, apply=gated)
-install -D -m 0644 install/systemd/nftban-update-check.service %{buildroot}/usr/lib/systemd/system/nftban-update-check.service
-install -D -m 0644 install/systemd/nftban-update-check.timer %{buildroot}/usr/lib/systemd/system/nftban-update-check.timer
-install -D -m 0644 install/systemd/nftban-update-apply.service %{buildroot}/usr/lib/systemd/system/nftban-update-apply.service
-install -D -m 0644 install/systemd/nftban-update-apply.timer %{buildroot}/usr/lib/systemd/system/nftban-update-apply.timer
-# v1.98.1: Soak validation timer (opt-in, staggered off HH:00)
-install -D -m 0644 install/systemd/nftban-soak.service %{buildroot}/usr/lib/systemd/system/nftban-soak.service
-install -D -m 0644 install/systemd/nftban-soak.timer %{buildroot}/usr/lib/systemd/system/nftban-soak.timer
+# MFST-C1: systemd units come from generator (install/systemd glob -> nftban-systemd-install.list).
+# Closes D1 install-list drift. File presence does NOT auto-enable units; the Go installer
+# (/usr/lib/nftban/bin/nftban-installer) owns enablement per PR-22B safety contract.
+while IFS= read -r unit; do
+    [ -z "\$unit" ] && continue
+    case "\$unit" in '#'*) continue ;; esac
+    install -D -m 0644 "install/systemd/\$unit" "%{buildroot}/usr/lib/systemd/system/\$unit"
+done < %{_sourcedir}/nftban-systemd-install.list
 
 # Sysctl tuning profile (v1.38.0)
 install -D -m 0644 install/sysctl/90-nftban.conf %{buildroot}/etc/sysctl.d/90-nftban.conf
@@ -1309,6 +1270,15 @@ build_rpm() {
     cp "$files_inc_src" "${BUILD_DIR}/SOURCES/nftban-files.inc"
     log_success "Staged nftban-files.inc ($(wc -l < "${BUILD_DIR}/SOURCES/nftban-files.inc") lines)"
 
+    # MFST-C1: stage Layer-1 generated systemd install list into SOURCES/ for spec %install loop.
+    local systemd_list_src="${PROJECT_ROOT}/install/packaging/systemd/nftban-systemd-install.list"
+    if [[ ! -f "$systemd_list_src" ]]; then
+        log_error "nftban-systemd-install.list not found at $systemd_list_src; run 'bash build/generate-systemd-install-list.sh' first"
+        return 1
+    fi
+    cp "$systemd_list_src" "${BUILD_DIR}/SOURCES/nftban-systemd-install.list"
+    log_success "Staged nftban-systemd-install.list ($(grep -cvE '^#|^$' "${BUILD_DIR}/SOURCES/nftban-systemd-install.list") units)"
+
     # Build RPM (version from VERSION file)
     if rpmbuild --define "_topdir ${BUILD_DIR}" \
         --define "pkg_version ${PKG_VERSION}" \
@@ -1917,57 +1887,19 @@ build_deb() {
     install -m 0640 "${PROJECT_ROOT}/etc/nftban/whitelist.d/99-manual.conf" "${deb_root}/etc/nftban/whitelist.d/"
     install -m 0640 "${PROJECT_ROOT}/etc/nftban/blacklist.d/99-manual.conf" "${deb_root}/etc/nftban/blacklist.d/"
 
-    # Copy all systemd units
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-maintenance.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-maintenance.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-health.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-health.timer" "${deb_root}/usr/lib/systemd/system/"
-    # v1.23.0 (EVAL-3): nftban-login-monitor.service REMOVED from package
-    # Deprecated since v1.21.3, replaced by Go daemon loginmon module (internal/loginmon)
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-core-geoip.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-core-geoip.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-core-feeds.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-core-feeds.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-unified-exporter.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-unified-exporter.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-watchdog.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-watchdog.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-snapshot.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-snapshot.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-rollback.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-rollback.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-suricata-update.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-suricata-update.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-suricata.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-suricata-stats.service" "${deb_root}/usr/lib/systemd/system/"
-    # v1.100.1b.A: nftban-ui.service + nftban-ui-auth.service + nftban-ui-auth.socket
-    # no longer installed in DEB payload (GOTH PR-D4 stage 1). Transitional postinst
-    # cleans up any prior install via deb_root postinst handlers.
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-queue.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-queue.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-botscan.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-botscan.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-health-fix.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-rbl-check.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-rbl-check.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-tunnel.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-tunnel.timer" "${deb_root}/usr/lib/systemd/system/"
-    # v1.100.1b.A: nftban-ui-auth.socket no longer installed.
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftband.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftband.socket" "${deb_root}/usr/lib/systemd/system/"
-    # v1.41.0: Report timer + community stats
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-report-daily.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-report-daily.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-community-stats.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-community-stats.timer" "${deb_root}/usr/lib/systemd/system/"
-    # v1.71.0: Split update units (check=unprivileged, apply=gated)
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-check.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-check.timer" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-apply.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-update-apply.timer" "${deb_root}/usr/lib/systemd/system/"
-    # v1.98.1: Soak validation timer (opt-in, staggered off HH:00)
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-soak.service" "${deb_root}/usr/lib/systemd/system/"
-    install -m 0644 "${PROJECT_ROOT}/install/systemd/nftban-soak.timer" "${deb_root}/usr/lib/systemd/system/"
+    # MFST-C1: systemd units come from generator (install/systemd glob -> nftban-systemd-install.list).
+    # Closes D1 install-list drift; the list is canonical and re-checked by CI --check.
+    # File presence here does NOT auto-enable any unit; enablement is owned by
+    # /usr/lib/nftban/bin/nftban-installer (PR-22B safety contract).
+    local systemd_install_list="${PROJECT_ROOT}/install/packaging/systemd/nftban-systemd-install.list"
+    if [[ ! -f "$systemd_install_list" ]]; then
+        log_error "nftban-systemd-install.list not found at $systemd_install_list; run 'bash build/generate-systemd-install-list.sh' first"
+        return 1
+    fi
+    while IFS= read -r unit; do
+        [[ -z "$unit" || "$unit" =~ ^[[:space:]]*# ]] && continue
+        install -m 0644 "${PROJECT_ROOT}/install/systemd/${unit}" "${deb_root}/usr/lib/systemd/system/"
+    done < "$systemd_install_list"
     # v1.41.0: Community stats config default
     install -m 0644 "${PROJECT_ROOT}/install/config/conf.d/community_stats.conf.default" "${deb_root}/etc/nftban/conf.d/"
 


### PR DESCRIPTION
## Summary

- **MFST-C1 — Layer 1 systemd install-list generator.** Third code lane of v1.106 MANIFEST-AUTHORITY (after #563 RPM C0a + #564 DEB C0b). Closes drift **D1**: the RPM `%install` heredoc and DEB `build_deb()` systemd block hand-rolled identical 41-unit install lists, while `install/systemd/` carries 49 units. The 8-unit gap (`nftban-alert@.service`, `nftban-firewall-init.service`, `nftban-pro-{inventory,license}.{service,timer}`, `nftban-rebuild-recovery.{service,timer}`) was previously placed only at runtime by `internal/installer/payload/payload.go:467-469` under `--panel-auto-takeover`.
- **New generator** `build/generate-systemd-install-list.sh` reads `install/systemd/*.{service,timer,socket}` and emits `install/packaging/systemd/nftban-systemd-install.list` (49 unit basenames, deterministic `LC_ALL=C sort`). `--check` mode for CI parity.
- **Both packagers consume the shared list** via while-read loops (RPM `%install` heredoc using `Source2: nftban-systemd-install.list` from `%{_sourcedir}`; DEB `build_deb()` reading from `${PROJECT_ROOT}/install/packaging/systemd/nftban-systemd-install.list`).
- **CI** gets a parallel `--check` step in `ci-architecture.yml` next to the existing FHS `--check`.

## Behavior change

Passive install will ship **49 unit files** (was 41). The 8 net-new units are **file presence only** — no auto-enable:
- No `%systemd_post` / `%systemd_preset` macros in the spec.
- No preset files shipped.
- `%post` / `postinst` delegate enablement to the Go installer (`internal/installer/services/daemon.go`).
- `payload.go:467-469` runtime stage becomes an idempotent no-op for the 8 units when `--panel-auto-takeover` runs.

PR-22B safety contract preserved.

## Files changed

- `build/generate-systemd-install-list.sh` (new, +133 lines)
- `install/packaging/systemd/nftban-systemd-install.list` (new, 49 units + 14-line header)
- `packaging/build_nftban.sh` (`build_rpm()` Source2 + spec heredoc loop replaces 47-line install block; `build_deb()` while-loop replaces 50-line install block; net `−99/+27`)
- `.github/workflows/ci-architecture.yml` (+10 lines, parallel `--check` step)

## Local validation

- `bash -n build/generate-systemd-install-list.sh` — OK
- `bash -n packaging/build_nftban.sh` — OK
- `bash build/generate-systemd-install-list.sh --check` — exit 0 (matches)
- `bash build/generate-fhs-outputs.sh --check` — OK (regression-free)
- Drift simulation (delete one unit, run `--check`) — exit 1 as expected
- `rpmbuild -bs` — OK; SRPM contains Source0+1+2 (tarball + nftban-files.inc + nftban-systemd-install.list)
- generated-list count = `install/systemd` truth = **49**

## Out of scope (carried forward)

- `docs/systemd/UNITS.md` — D3; reserved for **MFST-C2**.
- `%preun` / `prerm` mask logic — D6; reserved for **MFST-C3**.
- `internal/installer/payload/payload.go` — runtime stage unchanged.
- `packaging/deb/{postinst,prerm,postrm,control,changelog,conffiles}` — maintainer scripts unchanged.
- `build/fhs-spec.yaml` + FHS generator + 5 FHS regen outputs — unchanged (different SoT).
- `internal/validator/types.go` — schema frozen 1.83.0.
- AUTH-HARDENING / POLKIT-AUTHORITY / Lane G / Shape A / F14 — not touched.

## Test plan

- [ ] CI green (Architecture: FHS + Systemd `--check` both pass; Build RPM ×2; Test RPM install ×4; Build DEB ×4; Test DEB install ×4; Validate binary consistency; Runtime Truth ×2).
- [ ] Lab: `rpm -qpl` shows 49 unit paths under `/usr/lib/systemd/system/` (was 41); `dpkg-deb -c` shows 49.
- [ ] Lab: on alma9 / debian13 fresh install, `systemctl is-enabled` for the 8 net-new units returns `disabled` (NOT auto-enabled).
- [ ] Lab: `nftban status` runs cleanly post-install, no behavior delta from v1.106 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)