### PR TITLE
v1.106 MFST-C5: distroconf loader parity test (Go-side fixture coverage)

### DIFF
--- a/internal/loginmon/distroconf/distroconf_loader_parity_test.go
+++ b/internal/loginmon/distroconf/distroconf_loader_parity_test.go
@@ -1,0 +1,123 @@
+// =============================================================================
+// NFTBan v1.106 - distroconf shell↔Go loader parity test (MFST-C5)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="distroconf-loader-parity-test"
+// meta:type="test"
+// meta:header="distroconf shell↔Go loader parity test"
+// meta:version="1.106.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:homepage="https://nftban.com"
+//
+// meta:description="Iterate all etc/nftban/distros/*.conf fixtures and assert each parses cleanly via Go LoadFromFile() with the 7 shell-recognized sections present"
+// meta:inventory.files="etc/nftban/distros/*.conf"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="user"
+//
+// meta:created_date="2026-05-06"
+// meta:updated_date="2026-05-06"
+//
+// Closes drift D5 (shell distro loader ↔ Go distro loader equivalence). Today's
+// Go-side test coverage exercises only 2 of 18 fixtures (TestLoadFromFile_Almalinux9
+// + TestLoadFromFile_Debian12). This test extends Go-side fixture coverage to
+// all 18, symmetric to the shell-side coverage already provided in CI by
+// .github/workflows/ci-architecture.yml:201 (which runs
+// cli/lib/nftban/tests/validate_distro_configs.sh against the same fixtures).
+//
+// Acceptable design asymmetries (NOT enforced by this test, documented for
+// future readers):
+//
+//  1. Shell parse_config()'s switch-case at nftban_distro_config.sh:158-180
+//     silently drops sections not in {distro, package_manager, packages,
+//     services, paths, repository, features}. All 18 current fixtures include
+//     a [tier] section that the shell loader ignores by design; the Go loader
+//     captures it. The required-sections check below verifies the 7 shell-
+//     recognized sections only; extra sections are tolerated.
+//
+//  2. Shell's ${DISTRO_PATHS[$key]:-} collapses absent / empty / "n/a" to "".
+//     Go's Resolve() distinguishes 4 outcomes (Resolved, NotApplicable,
+//     Absent, LoaderUnavailable). This is a coarse-vs-fine asymmetry by
+//     design; not enforced here.
+//
+//  3. Shell find_config 3-tier waterfall (id-version → id-major → id) vs Go
+//     loadByID exact + family forward-fit. Generic fallbacks centos.conf and
+//     fedora.conf are reachable only via shell's third tier; Go's loadByID
+//     never reaches them at runtime. This test still calls LoadFromFile on
+//     them defensively to verify Go's parser handles their content.
+// =============================================================================
+
+package distroconf
+
+import (
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+)
+
+// shellRecognizedSections lists the section names the shell loader's
+// nftban_distro_parse_config() switch-case stores into named associative
+// arrays. Sections outside this set (e.g., [tier]) are silently dropped by
+// the shell loader; the Go loader captures them. The parity test asserts
+// these 7 are PRESENT in every fixture; extra sections are tolerated.
+var shellRecognizedSections = []string{
+	"distro",
+	"package_manager",
+	"packages",
+	"services",
+	"paths",
+	"repository",
+	"features",
+}
+
+// TestAllDistroConfsLoad iterates every committed fixture in
+// etc/nftban/distros/*.conf and asserts:
+//
+//  1. Go's LoadFromFile(path) succeeds (no parse error).
+//  2. The resulting Loader's parsed INI contains each of the 7
+//     shell-recognized sections from shellRecognizedSections.
+//
+// On failure the error message names the offending fixture and the missing
+// section, so future regressions are diagnosed without further investigation.
+func TestAllDistroConfsLoad(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(filename), "..", "..", "..")
+	fixtureDir := filepath.Join(repoRoot, "etc", "nftban", "distros")
+
+	matches, err := filepath.Glob(filepath.Join(fixtureDir, "*.conf"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", fixtureDir, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no fixtures in %s (expected at least one *.conf)", fixtureDir)
+	}
+
+	sort.Strings(matches)
+	t.Logf("parity-iterating %d fixture(s) under %s", len(matches), fixtureDir)
+
+	for _, path := range matches {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			l, err := LoadFromFile(path)
+			if err != nil {
+				t.Fatalf("LoadFromFile(%s): %v", filepath.Base(path), err)
+			}
+			if l == nil || l.ini == nil {
+				t.Fatalf("LoadFromFile(%s): nil loader or nil ini", filepath.Base(path))
+			}
+
+			for _, sec := range shellRecognizedSections {
+				if _, ok := l.ini[sec]; !ok {
+					t.Errorf("fixture %s missing required shell-recognized section [%s]\n"+
+						"(shell parse_config switch-case in cli/lib/nftban/lib/nftban_distro_config.sh\n"+
+						"requires this section; the Go loader sees the same set plus any extras)",
+						filepath.Base(path), sec)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **MFST-C5 — distroconf loader parity test.** Seventh code lane of v1.106 MANIFEST-AUTHORITY (after #563 RPM C0a, #564 DEB C0b, #565 systemd install-list C1, #566 UNITS.md C2, #567 systemd cleanup C3, #568 paths.go ↔ FHS parity C4). Closes drift **D5**: shell distro loader ↔ Go distro loader equivalence.
- **Test-only PR.** No fixture or loader changes. No runtime behavior change. No workflow edit.
- Extends Go-side fixture coverage from **2 of 18** (`TestLoadFromFile_Almalinux9` + `TestLoadFromFile_Debian12` only) to **all 18**, symmetric to the shell-side coverage already in CI via `validate_distro_configs.sh`.

## Files changed (1)

- `internal/loginmon/distroconf/distroconf_loader_parity_test.go` (+123 LOC, new file)

## Fixture iteration (18 fixtures)

```
almalinux-10.conf   almalinux-9.conf
centos-10.conf      centos-9.conf       centos.conf  ← shell-only generic fallback
centos-stream-10.conf  centos-stream-9.conf
debian-11.conf  debian-12.conf  debian-13.conf  debian-14.conf
fedora-43.conf  fedora.conf  ← shell-only generic fallback
rocky-10.conf  rocky-8.conf  rocky-9.conf
ubuntu-22.conf  ubuntu-24.conf
```

## Test summary

```go
func TestAllDistroConfsLoad(t *testing.T) {
    // Glob etc/nftban/distros/*.conf relative to repo root via runtime.Caller.
    // For each fixture: LoadFromFile() must succeed; Loader.ini must contain
    // each of the 7 shell-recognized sections.
}
```

`shellRecognizedSections` = `{distro, package_manager, packages, services, paths, repository, features}` — exactly the 7 names the shell loader's `parse_config()` switch-case stores into named associative arrays.

## Acceptable design asymmetries (documented inline; NOT enforced)

1. Shell `parse_config()` silently drops `[tier]` and any future unknown section. Go captures all sections. Test tolerates extras.
2. Shell `${DISTRO_PATHS[$key]:-}` collapses absent / empty / `"n/a"` to `""`. Go has 4-state `Resolve()`. Coarse vs fine, by design.
3. `centos.conf` and `fedora.conf` are shell 3rd-tier fallbacks; Go's `loadByID` uses forward-fit family scan and never reaches them at runtime. Test still calls `LoadFromFile` defensively on them to verify Go's parser handles their content.

## Local validation

- Python simulation across all 18 fixtures: **18/18 PASS** — every fixture has the 7 shell-recognized sections plus one extra (`[tier]`).
- Structural checks: braces 12/12 balanced, parens 43/43 balanced; required tokens present.
- Generators regression-free: FHS + systemd-install-list + systemd-maintainer-scripts `--check` all pass.
- `gofmt`/`go vet`/`go test` will run in CI (Go not installed on dev workstation).

## Out of scope (carried forward)

- Shell loader (`cli/lib/nftban/lib/nftban_distro_config.sh`) — untouched.
- Go loader (`internal/loginmon/distroconf/{distroconf.go,ini.go}`) — untouched.
- Existing Go tests (`distroconf_test.go`) — untouched (11 tests preserved).
- Existing shell tests (`test_distro_config.sh`, `validate_distro_configs.sh`) — untouched.
- Distro fixtures — unchanged.
- All C0a/C0b/C1/C2/C3/C4 artifacts — unchanged.
- Mode/owner alignment in `[paths]` values — AUTH-HARDENING territory.
- AUTH-HARDENING / POLKIT-AUTHORITY / Lane G / Shape A / F14 — not touched.

## Test plan

- [ ] CI green — new test runs as part of `go test ./...` inside existing `Build & Test` step. 18 subtests expected to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)