### PR TITLE
v1.106 hotfix: %install mkdir-p loop + build-packages.yml strict mode

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -166,6 +166,10 @@ jobs:
         run: |
           chmod +x bin/*
           docker run --rm -v "$(pwd):/workspace" -w /workspace ${{ matrix.container }} bash -c "
+            # MFST-HOTFIX-B2: strict mode — surface rpmbuild failures to CI
+            # instead of swallowing them. Mirror release.yml's pattern.
+            set -euo pipefail
+
             # Install build dependencies (curl required for yq download)
             # Note: --allowerasing handles curl-minimal vs curl conflict on Rocky/Alma
             dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl
@@ -173,7 +177,14 @@ jobs:
             # Build RPM
             chmod +x packaging/build_nftban.sh
             cd packaging
-            ./build_nftban.sh rpm
+            ./build_nftban.sh rpm || { echo '❌ RPM build failed!'; exit 1; }
+
+            # Verify at least one RPM was created (catches silent rpmbuild failures)
+            if ! ls /workspace/build/packages/RPMS/*/*.rpm 2>/dev/null; then
+              echo '❌ No RPM files created!'
+              ls -laR /workspace/build/ || true
+              exit 1
+            fi
 
             # Fix permissions
             chmod -R a+rX /workspace/build/

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -348,6 +348,24 @@ echo "Using pre-built nftban-core binary"
 ls -la bin/
 
 %install
+# MFST-HOTFIX-B1: pre-create all package-owned directories declared in
+# install/packaging/rpm/nftban-files.inc (staged as Source1 by build_rpm()).
+# Symmetric to DEB build_deb()'s nftban.dirs while-read loop. Idempotent —
+# mkdir -p on an already-existing dir is a no-op, so this does not conflict
+# with subsequent install/cp -r operations. Without this, dirs declared as
+# %dir in nftban-files.inc but having no source content (e.g. /usr/lib/nftban/
+# modules, /etc/nftban/connectors, /usr/share/nftban/dashboards) cause
+# rpmbuild to fail at "Processing files" with "Directory not found".
+while IFS= read -r dir_line; do
+    case "\$dir_line" in
+        ''|\#*) continue ;;
+        '%dir '*)
+            dir_path=\$(echo "\$dir_line" | sed -E 's|^%dir[[:space:]]+%attr\([^)]+\)[[:space:]]+||')
+            mkdir -p "%{buildroot}\${dir_path}"
+            ;;
+    esac
+done < %{_sourcedir}/nftban-files.inc
+
 # Download yq at BUILD time (supply-chain safe - not at install time)
 # SHA256 verified before bundling in package
 YQ_VERSION="4.44.1"


### PR DESCRIPTION
## Summary

Closes the **v1.106.0 release blocker**: rpmbuild fails at "Processing files" with "Directory not found" for 10 directories declared as `%dir` in `install/packaging/rpm/nftban-files.inc` but never created in `%install`. C0a wired `%include` for `%files` but did not add corresponding `mkdir -p` lines in `%install`. C0b inadvertently fixed DEB via the `nftban.dirs` loop; RPM was left incomplete and the failure was silently swallowed by `build-packages.yml` (no `set -e`, no artifact-existence assertion).

This PR fixes both bugs.

## B-1 — `%install` mkdir-p loop (`packaging/build_nftban.sh`, +18 LOC)

Yaml-driven loop at the top of `%install` reads `%{_sourcedir}/nftban-files.inc` (Source1, already staged by `build_rpm()`) and pre-creates every `%dir` path under `%{buildroot}`. **Symmetric to DEB `build_deb()`'s `nftban.dirs` while-read loop.** Idempotent. Future-proof.

10 dirs that previously failed:

| Path | Classification |
|---|---|
| `/usr/lib/nftban/modules` | Package-owned, empty placeholder for runtime-loaded modules |
| `/usr/lib/nftban/tools` | Package-owned, empty placeholder |
| `/etc/nftban/nftables.d` | Package-owned, empty placeholder |
| `/etc/nftban/ssl` | Package-owned, empty placeholder for TLS certs |
| `/etc/nftban/suricata/state` | Package-owned (runtime state lives here) |
| `/etc/nftban/suricata/state/last-good` | Package-owned (.gitkeep only) |
| `/etc/nftban/connectors` | Package-owned, empty placeholder |
| `/usr/share/nftban/templates/zabbix` | Package-owned, empty placeholder |
| `/usr/share/nftban/dashboards` | Package-owned, empty placeholder |
| `/usr/share/nftban/dashboards/grafana` | Package-owned, empty placeholder |

All 10 ship empty (no source content) — same behavior as DEB.

## B-2 — `build-packages.yml` strict-mode hardening (+13 LOC)

Build RPM step's docker `bash -c` now uses `set -euo pipefail`, fails explicitly on `./build_nftban.sh rpm` failure (`|| { echo failed; exit 1 }`), and asserts at least one RPM exists (`ls /workspace/build/packages/RPMS/*/*.rpm`). **Mirrors `release.yml`'s strict pattern.** Without this, rpmbuild failures were swallowed and six MFST PRs (#563–#569) merged with the latent B-1 failure hidden until tag push.

## Local validation

- `bash -n packaging/build_nftban.sh` — OK
- YAML parse on `build-packages.yml` — OK
- 3 generators `--check` — all pass (FHS, systemd-install-list, systemd-maintainer-scripts)
- Spec heredoc renders cleanly with new `%install` loop visible
- **Loop simulation: 71 dirs created in test buildroot (10/10 originally-failing dirs + 61 others; idempotent)**

## Out of scope (explicitly preserved)

- `v1.106.0` tag — NOT mutated. Recovery (R-A or R-B) is a separate `TAG-RECOVERY-MFST-v1.106.0` audit after this merges.
- `release.yml` — already strict; unchanged.
- DEB build path, `build_deb()` — unchanged.
- All C0a/C0b/C1/C2/C3/C4/C5 artifacts — unchanged.
- `build/fhs-spec.yaml` + 5 generated FHS outputs — unchanged.
- AUTH-HARDENING / POLKIT-AUTHORITY / Lane G / portal — not touched.

## Test plan

- [ ] Build RPM (el9, el10) — both pass with new strict mode (proves B-2 hardening works AND B-1 fix succeeds, by transitive logic: workflow strict → would fail on rpmbuild error → workflow green proves rpmbuild succeeded).
- [ ] Build DEB (×4) — regression-free.
- [ ] Test {RPM,DEB} install (×8) — regression-free.
- [ ] All 4 generator `--check` steps — regression-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)