### PR TITLE
v1.107 MFST-C6 harden package workflow gates

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -281,6 +281,10 @@ jobs:
         run: |
           chmod +x bin/*
           docker run --rm -v "$(pwd):/workspace" -w /workspace ${{ matrix.container }} bash -c "
+            # MFST-C6 / F-1: strict mode — surface dpkg-deb failures to CI
+            # instead of swallowing them. Mirror RPM step pattern (post-#571).
+            set -euo pipefail
+
             # Install build dependencies (curl required for yq download)
             for i in 1 2 3; do
               apt-get update && apt-get install -y dpkg-dev build-essential file curl && break
@@ -291,7 +295,14 @@ jobs:
             # Build DEB
             chmod +x packaging/build_nftban.sh
             cd packaging
-            ./build_nftban.sh deb
+            ./build_nftban.sh deb || { echo '❌ DEB build failed!'; exit 1; }
+
+            # Verify at least one DEB was created (catches silent dpkg-deb failures)
+            if ! ls /workspace/build/packages/*.deb 2>/dev/null; then
+              echo '❌ No DEB files created!'
+              ls -laR /workspace/build/ || true
+              exit 1
+            fi
 
             # Fix permissions
             chmod -R a+rX /workspace/build/

--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -192,6 +192,83 @@ jobs:
           echo "✓ C3 structural assertions: PASS (mask_if_exists + /dev/null boundary + no unconditional mask)"
 
       # =====================================================================
+      # MFST-C6 (v1.107): packaging-wire structural assertions (AM-4)
+      # =====================================================================
+      # Proves both packagers consume generated manifest authority artifacts.
+      # If a future edit silently replaces a generator-driven %include / while-read
+      # loop with hardcoded content, these greps fail before the build runs.
+      #   AM-4.1: RPM Source1 + %include of nftban-files.inc
+      #   AM-4.2: DEB build_deb() while-read of nftban.dirs
+      #   AM-4.3: RPM/DEB consume nftban-systemd-install.list
+      - name: MFST-C6 packaging-wire structural assertions (AM-4)
+        run: |
+          echo "=== MFST-C6 / AM-4: packaging-wire structural assertions ==="
+          spec=packaging/build_nftban.sh
+          fail=0
+
+          # AM-4.1 — RPM consumes generated nftban-files.inc
+          grep -qE '^Source1:[[:space:]]+nftban-files\.inc' "$spec" \
+            || { echo "::error::AM-4.1: RPM Source1: nftban-files.inc missing in $spec"; fail=1; }
+          grep -qE '^%include[[:space:]]+%\{_sourcedir\}/nftban-files\.inc' "$spec" \
+            || { echo "::error::AM-4.1: %include %{_sourcedir}/nftban-files.inc missing in $spec"; fail=1; }
+
+          # AM-4.2 — DEB build_deb() consumes generated nftban.dirs via while-read
+          if ! awk '/^build_deb\(\)/,/^\}/' "$spec" \
+               | grep -qE 'install/packaging/deb/nftban\.dirs'; then
+            echo "::error::AM-4.2: build_deb() does not reference install/packaging/deb/nftban.dirs in $spec"
+            fail=1
+          fi
+          if ! awk '/^build_deb\(\)/,/^\}/' "$spec" \
+               | grep -qE 'while[[:space:]]+(IFS=.*[[:space:]]+)?read'; then
+            echo "::error::AM-4.2: build_deb() lacks while-read loop consuming nftban.dirs in $spec"
+            fail=1
+          fi
+
+          # AM-4.3 — RPM and DEB both consume generated nftban-systemd-install.list
+          grep -qE '^Source2:[[:space:]]+nftban-systemd-install\.list' "$spec" \
+            || { echo "::error::AM-4.3: RPM Source2: nftban-systemd-install.list missing in $spec"; fail=1; }
+          # %install RPM body must reference the generated install list
+          grep -qE '%\{_sourcedir\}/nftban-systemd-install\.list' "$spec" \
+            || { echo "::error::AM-4.3: RPM %install does not reference %{_sourcedir}/nftban-systemd-install.list in $spec"; fail=1; }
+          # build_deb() must reference the generated install list
+          if ! awk '/^build_deb\(\)/,/^\}/' "$spec" \
+               | grep -qE 'install/packaging/systemd/nftban-systemd-install\.list'; then
+            echo "::error::AM-4.3: build_deb() does not reference install/packaging/systemd/nftban-systemd-install.list in $spec"
+            fail=1
+          fi
+
+          [ "$fail" = "0" ] || exit 1
+          echo "✓ MFST-C6 / AM-4: PASS (RPM Source1+%include + DEB while-read + RPM/DEB systemd-install-list)"
+
+      # =====================================================================
+      # MFST-C6 (v1.107): UNITS.md per-row parity (E6)
+      # =====================================================================
+      # Closes content-gap left by the existing count-only check above.
+      # Asserts every active unit listed in nftban-systemd-install.list (the C1
+      # source-of-truth) appears as a backticked table row in UNITS.md.
+      - name: MFST-C6 docs/systemd/UNITS.md table-row parity (E6)
+        run: |
+          echo "=== MFST-C6 / E6: UNITS.md per-row parity vs systemd install list ==="
+          list=install/packaging/systemd/nftban-systemd-install.list
+          doc=docs/systemd/UNITS.md
+          fail=0
+          missing=0
+          while IFS= read -r unit; do
+            # Skip blank lines and comments
+            case "$unit" in
+              ''|\#*) continue ;;
+            esac
+            # Each unit must appear as a backticked token somewhere in UNITS.md
+            if ! grep -qF "\`${unit}\`" "$doc"; then
+              echo "::error::E6: docs/systemd/UNITS.md missing row for unit: ${unit}"
+              missing=$((missing + 1))
+              fail=1
+            fi
+          done < "$list"
+          [ "$fail" = "0" ] || { echo "::error::E6: ${missing} unit(s) missing from $doc"; exit 1; }
+          echo "✓ MFST-C6 / E6: PASS (every unit in $list has a backticked row in $doc)"
+
+      # =====================================================================
       # NEW CHECKS (v1.50.1 — Distribution Compatibility Audit)
       # =====================================================================
 


### PR DESCRIPTION
## Summary

Slot 1 of the v1.106 post-MFST controlled-execution worklog. Closes:
- **MFST-C6** — structural CI hardening
- **F-1** — DEB strict-mode parity gap

Scope authority: `AUDIT_190_LIFECYCLE/V107_MFST_C6_HARDENING_SCOPE.md` (verdict GO_IMPLEMENT, 2-file allowlist).

## Changes

### `.github/workflows/build-packages.yml` — Build DEB step (F-1)
Mirrors the RPM step pattern landed in PR #571 hotfix:
- `set -euo pipefail` inside docker `bash -c` body
- `./build_nftban.sh deb || { echo '❌ DEB build failed!'; exit 1; }`
- assert at least one `.deb` exists under `/workspace/build/packages/`
- on missing artifacts, dump build tree (`ls -laR`) and exit 1

### `.github/workflows/ci-architecture.yml` — two new steps (AM-4 + E6)
Appended after the existing C3 A5 maintainer-script structural-assertion step.

**MFST-C6 packaging-wire structural assertions (AM-4)** — proves both packagers consume generated manifest authority artifacts:
- AM-4.1: RPM `Source1: nftban-files.inc` + `%include %{_sourcedir}/nftban-files.inc`
- AM-4.2: DEB `build_deb()` while-read loop consuming `install/packaging/deb/nftban.dirs`
- AM-4.3: RPM `Source2: nftban-systemd-install.list` + `%install` reference + DEB `build_deb()` reference to the same generated install-list

**MFST-C6 docs/systemd/UNITS.md table-row parity (E6)** — closes the content-gap left by the existing count-only check by asserting every unit listed in `nftban-systemd-install.list` (the C1 source-of-truth) appears as a backticked row in `docs/systemd/UNITS.md`.

## Local validation

- YAML parse OK on both workflows
- AM-4: all 7 sub-gates pass against current `packaging/build_nftban.sh`
- E6: 49/49 active units in install list have backticked rows in `UNITS.md`
- Forbidden surfaces clean — only the 2 allowlist files modified

## Forbidden surfaces (untouched)

`packaging/build_nftban.sh`, `packaging/deb/*`, `install/packaging/*` artifacts, `build/generate-*.sh`, `build/fhs-spec.yaml`, `build/deprecated-units.yaml`, `internal/installer/fhs/{paths.go,permissions.go}`, `internal/loginmon`, `internal/geoip`, validator schema, `release.yml`, Docker workflow, `docs/systemd/{UNITS,TIMERS}.md`, `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION`. No tag/release/GHCR ops. No F-2/F-3/F-4/F-5/F-6, no D-NEW-8/9/10/11/12, no #525, no portal, no metrics/schema, no Dependabot.

## Test plan

- [ ] Architecture Policy workflow runs the 2 new steps on this PR
- [ ] AM-4 fires green (RPM Source1 + %include + DEB while-read + systemd-install-list consumed by both)
- [ ] E6 fires green (every unit in install-list has UNITS.md row)
- [ ] Build NFTBan Packages runs end-to-end on this PR; DEB matrix completes under new strict mode without regression
- [ ] All other architecture-policy gates remain green
- [ ] No release-asset / tag / GHCR side-effects

## Worklog rows

Will close on merge (per scope §9.1):
- MFST-C6
- F-1

Remaining worklog rows stay OPEN, routed to subsequent slots:
- F-2, F-3 → Slot 4 (ORPHAN-CLEANUP)
- F-4, F-5 → Slot 2 (AUTH-HARDENING-SCOPE doc fold)
- F-6 → Slot 7 (REGISTRY-HYGIENE)
- D-NEW-8/9/12 → Slot 2-3 (AUTH-HARDENING)
- D-NEW-10/11 → Slot 5 (POLKIT-AUTHORITY)
- #525 → Slot 6 (LANE-G)

🤖 Generated with [Claude Code](https://claude.com/claude-code)