### PR TITLE
v1.107 AUTH harden FHS ownership parity

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -814,6 +814,7 @@ directories:
       group: nftban
       description: "Cache files"
       created_by: tmpfiles
+      note: "0755 intentional: public-cache traversal — non-sensitive cache contents (timestamps, last-check status) readable by unprivileged tooling. Sensitive subdirs (e.g. /health) are tightened to 0750 individually."
 
     - path: /var/cache/nftban/health
       mode: "0750"
@@ -828,7 +829,7 @@ directories:
       group: nftban
       description: "Runtime data (PID files, sockets)"
       created_by: tmpfiles
-      note: "Managed by tmpfiles only - do not use RuntimeDirectory= in units to avoid conflict"
+      note: "Managed by tmpfiles only - do not use RuntimeDirectory= in units to avoid conflict. 0755 intentional: socket-discovery — non-nftban-group processes (panel adapters, monitoring tools) must stat() the daemon socket; the socket file itself uses unit-level SocketMode=0660 + group ownership for access control. Tightening the parent dir would break socket-discovery for anything outside the nftban group."
 
   # ---------------------------------------------------------------------------
   # Shared Data (root:root, 755) - Read-only application data

--- a/build/generate-fhs-outputs.sh
+++ b/build/generate-fhs-outputs.sh
@@ -55,6 +55,7 @@ FHS_SPEC="${SCRIPT_DIR}/fhs-spec.yaml"
 TMPFILES_OUT="${PROJECT_ROOT}/install/systemd/tmpfiles.d/nftban.conf"
 SYSUSERS_OUT="${PROJECT_ROOT}/install/systemd/sysusers.d/nftban.conf"
 DEB_DIRS_OUT="${PROJECT_ROOT}/install/packaging/deb/nftban.dirs"
+DEB_ATTRS_OUT="${PROJECT_ROOT}/install/packaging/deb/nftban-dir-attrs.list"
 RPM_FILES_OUT="${PROJECT_ROOT}/install/packaging/rpm/nftban-files.inc"
 JSON_OUT="${PROJECT_ROOT}/cli/lib/nftban/data/fhs_directories.json"
 SHELL_OUT="${PROJECT_ROOT}/cli/lib/nftban/core/nftban_fhs_spec.sh"
@@ -259,6 +260,48 @@ EOF
     yq -r '.directories.shared[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
 
     print_status "Generated $DEB_DIRS_OUT"
+}
+
+# =============================================================================
+# DEB DIR ATTRIBUTES (D-NEW-12 fix; AUTH-HARDENING)
+# =============================================================================
+# Emits ownership/mode metadata for package-territory directories so the DEB
+# build (build_deb() in packaging/build_nftban.sh) can record correct owner/
+# group/mode in the dpkg DB — bringing DEB to RPM %attr parity for /etc/nftban.
+#
+# Format (deterministic, easy to parse):
+#   path|mode|owner|group
+# RPM uses %attr() inside nftban-files.inc for the same purpose; DEB needs
+# this externalised list because dpkg-deb has no equivalent in-tree directive.
+#
+# Scope: ONLY config-tier directories (/etc/nftban + subdirs). System dirs
+# (/usr/lib/nftban, /usr/share/nftban) are correctly root:root 0755 by
+# default and need no override. Tmpfiles-managed dirs are runtime-created
+# and not in the package payload.
+generate_deb_dir_attrs() {
+    print_info "Generating deb/nftban-dir-attrs.list..."
+
+    mkdir -p "$(dirname "$DEB_ATTRS_OUT")"
+
+    cat > "$DEB_ATTRS_OUT" << 'EOF'
+# =============================================================================
+# NFTBan Debian package directory attributes (ownership + mode)
+# =============================================================================
+# Generated from build/fhs-spec.yaml - DO NOT EDIT
+#
+# Consumer: packaging/build_nftban.sh build_deb() — applies chown/chmod
+# inside ${deb_root} before dpkg-deb --build so dpkg DB records correct
+# ownership/mode. Brings DEB to RPM %attr parity (closes D-NEW-12).
+#
+# Format: path|mode|owner|group
+# =============================================================================
+
+EOF
+
+    yq -r '.directories.config[] | select(.created_by == "package") | "\(.path)|\(.mode)|\(.owner)|\(.group)"' \
+        "$FHS_SPEC" >> "$DEB_ATTRS_OUT"
+
+    print_status "Generated $DEB_ATTRS_OUT"
 }
 
 generate_rpm_files() {
@@ -544,6 +587,7 @@ check_mode() {
     local orig_tmpfiles="$TMPFILES_OUT"
     local orig_sysusers="$SYSUSERS_OUT"
     local orig_deb="$DEB_DIRS_OUT"
+    local orig_deb_attrs="$DEB_ATTRS_OUT"
     local orig_rpm="$RPM_FILES_OUT"
     local orig_json="$JSON_OUT"
     local orig_shell="$SHELL_OUT"
@@ -552,6 +596,7 @@ check_mode() {
     TMPFILES_OUT="${temp_dir}/tmpfiles.conf"
     SYSUSERS_OUT="${temp_dir}/sysusers.conf"
     DEB_DIRS_OUT="${temp_dir}/nftban.dirs"
+    DEB_ATTRS_OUT="${temp_dir}/nftban-dir-attrs.list"
     RPM_FILES_OUT="${temp_dir}/nftban-files.inc"
     JSON_OUT="${temp_dir}/fhs_directories.json"
     SHELL_OUT="${temp_dir}/nftban_fhs_spec.sh"
@@ -560,6 +605,7 @@ check_mode() {
     generate_tmpfiles
     generate_sysusers
     generate_deb_dirs
+    generate_deb_dir_attrs
     generate_rpm_files
     generate_json
     generate_shell_helper
@@ -569,6 +615,7 @@ check_mode() {
         "${temp_dir}/tmpfiles.conf:${orig_tmpfiles}" \
         "${temp_dir}/sysusers.conf:${orig_sysusers}" \
         "${temp_dir}/nftban.dirs:${orig_deb}" \
+        "${temp_dir}/nftban-dir-attrs.list:${orig_deb_attrs}" \
         "${temp_dir}/nftban-files.inc:${orig_rpm}" \
         "${temp_dir}/fhs_directories.json:${orig_json}" \
         "${temp_dir}/nftban_fhs_spec.sh:${orig_shell}"; do
@@ -705,6 +752,7 @@ main() {
     generate_tmpfiles
     generate_sysusers
     generate_deb_dirs
+    generate_deb_dir_attrs
     generate_rpm_files
     generate_json
     generate_shell_helper
@@ -719,6 +767,7 @@ main() {
     echo "  - $TMPFILES_OUT"
     echo "  - $SYSUSERS_OUT"
     echo "  - $DEB_DIRS_OUT"
+    echo "  - $DEB_ATTRS_OUT"
     echo "  - $RPM_FILES_OUT"
     echo "  - $JSON_OUT"
     echo "  - $SHELL_OUT"

--- a/install/packaging/deb/nftban-dir-attrs.list
+++ b/install/packaging/deb/nftban-dir-attrs.list
@@ -1,0 +1,53 @@
+# =============================================================================
+# NFTBan Debian package directory attributes (ownership + mode)
+# =============================================================================
+# Generated from build/fhs-spec.yaml - DO NOT EDIT
+#
+# Consumer: packaging/build_nftban.sh build_deb() — applies chown/chmod
+# inside ${deb_root} before dpkg-deb --build so dpkg DB records correct
+# ownership/mode. Brings DEB to RPM %attr parity (closes D-NEW-12).
+#
+# Format: path|mode|owner|group
+# =============================================================================
+
+/etc/nftban|0750|root|nftban
+/etc/nftban/conf.d|0750|root|nftban
+/etc/nftban/conf.d/ddos|0750|root|nftban
+/etc/nftban/conf.d/portscan|0750|root|nftban
+/etc/nftban/conf.d/login|0750|root|nftban
+/etc/nftban/conf.d/panels|0750|root|nftban
+/etc/nftban/conf.d/panels/cpanel|0750|root|nftban
+/etc/nftban/conf.d/panels/cwp|0750|root|nftban
+/etc/nftban/conf.d/panels/cyberpanel|0750|root|nftban
+/etc/nftban/conf.d/panels/directadmin|0750|root|nftban
+/etc/nftban/conf.d/panels/generic|0750|root|nftban
+/etc/nftban/conf.d/panels/interworx|0750|root|nftban
+/etc/nftban/conf.d/panels/plesk|0750|root|nftban
+/etc/nftban/conf.d/panels/vesta|0750|root|nftban
+/etc/nftban/conf.d/botscan|0750|root|nftban
+/etc/nftban/conf.d/botguard|0750|root|nftban
+/etc/nftban/conf.d/botguard/profiles|0750|root|nftban
+/etc/nftban/conf.d/suricata|0750|root|nftban
+/etc/nftban/conf.d/tunnel|0750|root|nftban
+/etc/nftban/templates|0750|root|nftban
+/etc/nftban/patterns.d|0750|root|nftban
+/etc/nftban/patterns.d/botscan|0750|root|nftban
+/etc/nftban/whitelist.d|0750|root|nftban
+/etc/nftban/blacklist.d|0750|root|nftban
+/etc/nftban/ports.d|0750|root|nftban
+/etc/nftban/rules.d|0750|root|nftban
+/etc/nftban/access.d|0750|root|nftban
+/etc/nftban/conf.d/rbl|0750|root|nftban
+/etc/nftban/conf.d/geoban|0750|root|nftban
+/etc/nftban/conf.d/geoip|0750|root|nftban
+/etc/nftban/nftables.d|0750|root|nftban
+/etc/nftban/ssl|0750|root|nftban
+/etc/nftban/suricata|0750|root|nftban
+/etc/nftban/suricata/profiles|0750|root|nftban
+/etc/nftban/suricata/config|0750|root|nftban
+/etc/nftban/suricata/rules|0750|root|nftban
+/etc/nftban/suricata/cache|0750|root|nftban
+/etc/nftban/suricata/state|0750|root|nftban
+/etc/nftban/suricata/state/last-good|0750|root|nftban
+/etc/nftban/connectors|0750|root|nftban
+/etc/nftban/distros|0750|root|nftban

--- a/internal/installer/fhs/paths.go
+++ b/internal/installer/fhs/paths.go
@@ -222,8 +222,10 @@ var RequiredDirs = []DirSpec{
 	{EtcDir + "/suricata/cache", 0750, "root:nftban"},
 	{EtcDir + "/suricata/state", 0750, "root:nftban"},
 	{EtcDir + "/suricata/state/last-good", 0750, "root:nftban"},
-	// /var/lib/nftban/ — nftban:nftban (synced with install/systemd/tmpfiles.d/nftban.conf)
-	{DataDir, 0750, "nftban:nftban"},
+	// /var/lib/nftban/ — synced with install/systemd/tmpfiles.d/nftban.conf
+	// Top dir + integrity-sensitive subdirs are root:nftban (security boundary).
+	// Writable subdirs are nftban:nftban.
+	{DataDir, 0750, "root:nftban"},
 	{StateDir, 0750, "nftban:nftban"},
 	{FeedsDir, 0750, "nftban:nftban"},
 	{PanelsDir, 0750, "nftban:nftban"},
@@ -232,9 +234,10 @@ var RequiredDirs = []DirSpec{
 	{DataDir + "/geoip", 0750, "nftban:nftban"},
 	{DataDir + "/reports", 0750, "nftban:nftban"},
 	{DataDir + "/reports/baseline", 0750, "nftban:nftban"},
-	{DataDir + "/reports/auditors", 0770, "nftban:nftban"},
+	{DataDir + "/reports/auditors", 0770, "root:nftban-auditor"},
 	{DataDir + "/reports/watchdog", 0750, "nftban:nftban"},
 	{DataDir + "/reports/archive", 0750, "nftban:nftban"},
+	{DataDir + "/community", 0750, "nftban:nftban"},
 	{DataDir + "/config", 0750, "nftban:nftban"},
 	{DataDir + "/metrics", 0750, "nftban:nftban"},
 	{DataDir + "/snapshots", 0750, "nftban:nftban"},
@@ -250,26 +253,29 @@ var RequiredDirs = []DirSpec{
 	{DataDir + "/botguard", 0750, "nftban:nftban"},
 	{DataDir + "/tunnel", 0750, "nftban:nftban"},
 	{DataDir + "/analytics", 0750, "nftban:nftban"},
-	{DataDir + "/backup", 0750, "nftban:nftban"},
+	{DataDir + "/backup", 0750, "root:nftban"},
 	{DataDir + "/login", 0750, "nftban:nftban"},
 	{DataDir + "/portscan", 0750, "nftban:nftban"},
 	{DataDir + "/recorder", 0750, "nftban:nftban"},
 	{DataDir + "/staging", 0750, "nftban:nftban"},
 	{DataDir + "/suricata", 0750, "nftban:nftban"},
-	{DataDir + "/update-backups", 0750, "nftban:nftban"},
+	{DataDir + "/update-backups", 0750, "root:nftban"},
 	{DataDir + "/watchdog", 0750, "nftban:nftban"},
-	{DataDir + "/pro", 0750, "nftban:nftban"},
+	{DataDir + "/pro", 0750, "root:nftban"},
 	// /var/log/nftban/ — nftban:nftban (synced with install/systemd/tmpfiles.d/nftban.conf)
+	// Note: /var/log/nftban/suricata is feature_enable per fhs-spec.yaml
+	// (created by `nftban suricata enable` as suricata:nftban 0770) and
+	// intentionally NOT eagerly created here.
 	{LogDir, 0750, "nftban:nftban"},
 	{LogDir + "/reports", 0750, "nftban:nftban"},
 	{LogDir + "/watchdog", 0750, "nftban:nftban"},
 	{LogDir + "/rbl", 0750, "nftban:nftban"},
 	{LogDir + "/botguard", 0750, "nftban:nftban"},
-	{LogDir + "/suricata", 0750, "nftban:nftban"},
 	{LogDir + "/metrics", 0750, "nftban:nftban"},
 	{LogDir + "/soak", 0750, "nftban:nftban"},
-	// /var/cache/nftban/ — nftban:nftban
-	{CacheDir, 0750, "nftban:nftban"},
+	// /var/cache/nftban/ — nftban:nftban; top is 0755 (public-cache traversal),
+	// /health subdir tightened to 0750 (per fhs-spec.yaml).
+	{CacheDir, 0755, "nftban:nftban"},
 	{CacheDir + "/health", 0750, "nftban:nftban"},
 	// /run/nftban/ — nftban:nftban
 	{RunDir, 0755, "nftban:nftban"},

--- a/internal/installer/fhs/paths_yaml_parity_test.go
+++ b/internal/installer/fhs/paths_yaml_parity_test.go
@@ -34,11 +34,14 @@
 package fhs
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -137,5 +140,136 @@ Remediation (pick one):
       one-line rationale describing why the path is runtime-only and not
       part of package-territory.`,
 			len(missing), strings.Join(missing, "\n"))
+	}
+}
+
+// =============================================================================
+// AUTH-HARDENING (v1.107): paths.go ↔ tmpfiles.d mode/owner parity (D-NEW-8)
+// =============================================================================
+// Closes drift class D-NEW-8 (rows 1-7 in V107_AUTH_HARDENING_SCOPE.md §3).
+// Asserts that for every shared path, paths.go RequiredDirs mode + owner
+// matches install/systemd/tmpfiles.d/nftban.conf (which is generated from
+// build/fhs-spec.yaml — verified by FHS --check).
+//
+// Drift here means a future paths.go edit re-introduced an authority-surface
+// disagreement; the test names the path + the divergent value pair so the
+// remediation is obvious.
+
+// tmpfilesEntry captures one parsed tmpfiles.d directive.
+type tmpfilesEntry struct {
+	path  string
+	mode  uint32
+	owner string
+	group string
+}
+
+// loadTmpfilesEntries parses install/systemd/tmpfiles.d/nftban.conf and
+// returns a path -> entry map for `d` (directory) directives only.
+func loadTmpfilesEntries(t *testing.T) map[string]tmpfilesEntry {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(filename), "..", "..", "..")
+	tmpfilesPath := filepath.Join(repoRoot, "install", "systemd", "tmpfiles.d", "nftban.conf")
+
+	f, err := os.Open(tmpfilesPath) // #nosec G304 — fixed test-time path under repo root
+	if err != nil {
+		t.Fatalf("read %s: %v\n(generator output missing or stale; run: bash build/generate-fhs-outputs.sh)", tmpfilesPath, err)
+	}
+	defer f.Close()
+
+	out := make(map[string]tmpfilesEntry)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Format: <type> <path> <mode> <owner> <group> <age> <argument>
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		if fields[0] != "d" {
+			continue
+		}
+		mode, err := strconv.ParseUint(fields[2], 8, 32)
+		if err != nil {
+			t.Fatalf("parse mode %q on line %q in %s: %v", fields[2], line, tmpfilesPath, err)
+		}
+		out[fields[1]] = tmpfilesEntry{
+			path:  fields[1],
+			mode:  uint32(mode),
+			owner: fields[3],
+			group: fields[4],
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", tmpfilesPath, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s contained zero `d` directives (likely generator regression)", tmpfilesPath)
+	}
+	return out
+}
+
+// TestRequiredDirsModesAndOwnersMatchTmpfiles asserts mode/owner parity
+// between paths.go::RequiredDirs and tmpfiles.d/nftban.conf for every
+// path that appears in both surfaces. Paths only in one surface are
+// ignored (covered by TestRequiredDirsYamlParity above + the FHS --check
+// gate); this test catches *value* drift, not *presence* drift.
+func TestRequiredDirsModesAndOwnersMatchTmpfiles(t *testing.T) {
+	tmpfiles := loadTmpfilesEntries(t)
+
+	type mismatch struct {
+		path     string
+		paths_go string
+		tmpfiles string
+	}
+	var mismatches []mismatch
+
+	for _, dir := range RequiredDirs {
+		entry, ok := tmpfiles[dir.Path]
+		if !ok {
+			continue // path is package-territory or feature-gated; not in tmpfiles
+		}
+		expected := fmt.Sprintf("%s:%s", entry.owner, entry.group)
+		if dir.Owner != expected || dir.Mode != entry.mode {
+			mismatches = append(mismatches, mismatch{
+				path:     dir.Path,
+				paths_go: fmt.Sprintf("%04o %s", dir.Mode, dir.Owner),
+				tmpfiles: fmt.Sprintf("%04o %s", entry.mode, expected),
+			})
+		}
+	}
+
+	if len(mismatches) > 0 {
+		sort.Slice(mismatches, func(i, j int) bool { return mismatches[i].path < mismatches[j].path })
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "RequiredDirs ↔ tmpfiles.d mode/owner parity failed (%d mismatches)\n\n", len(mismatches))
+		fmt.Fprintf(&msg, "%-50s  %-22s  %-22s\n", "PATH", "paths.go", "tmpfiles.d (SoT)")
+		fmt.Fprintf(&msg, "%-50s  %-22s  %-22s\n", strings.Repeat("-", 50), strings.Repeat("-", 22), strings.Repeat("-", 22))
+		for _, m := range mismatches {
+			fmt.Fprintf(&msg, "%-50s  %-22s  %-22s\n", m.path, m.paths_go, m.tmpfiles)
+		}
+		fmt.Fprintf(&msg, "\nRemediation: align paths.go::RequiredDirs to tmpfiles.d (which is generated from build/fhs-spec.yaml).\n")
+		fmt.Fprintf(&msg, "Do NOT edit tmpfiles.d directly — edit fhs-spec.yaml + regen.\n")
+		t.Errorf("%s", msg.String())
+	}
+}
+
+// TestSuricataLogIsFeatureGated asserts paths.go does NOT eagerly create
+// /var/log/nftban/suricata. Per build/fhs-spec.yaml the directory is
+// `created_by: feature_enable` (via `nftban suricata enable`) with owner
+// suricata:nftban. Eager creation by paths.go conflicts with the
+// feature-gate contract (D8.7 in V107 scope §3).
+func TestSuricataLogIsFeatureGated(t *testing.T) {
+	const suricataLog = "/var/log/nftban/suricata"
+	for _, dir := range RequiredDirs {
+		if dir.Path == suricataLog {
+			t.Errorf(`paths.go RequiredDirs eagerly creates %s.
+This conflicts with the feature_enable contract in build/fhs-spec.yaml
+(directory is created by 'nftban suricata enable' as suricata:nftban 0770).
+Remove the entry from RequiredDirs.`, suricataLog)
+		}
 	}
 }

--- a/internal/installer/fhs/permissions.go
+++ b/internal/installer/fhs/permissions.go
@@ -89,9 +89,9 @@ func applyPermissions(exec executor.Executor, log *logging.Logger) {
 	exec.Run("chown", "-R", "nftban:nftban", LogDir)
 	exec.Run("chmod", "0750", LogDir)
 
-	// /var/cache/nftban — nftban:nftban 0750
+	// /var/cache/nftban — nftban:nftban 0755 (public-cache traversal; /health subdir is 0750)
 	exec.Run("chown", "-R", "nftban:nftban", CacheDir)
-	exec.Run("chmod", "0750", CacheDir)
+	exec.Run("chmod", "0755", CacheDir)
 
 	// /run/nftban — nftban:nftban 0755
 	exec.Run("chown", "-R", "nftban:nftban", RunDir)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1959,6 +1959,30 @@ build_deb() {
     fakeroot find "${deb_root}/etc" -type f -exec chown root:root {} \;
     fakeroot find "${deb_root}/etc" -type d -exec chown root:root {} \;
 
+    # AUTH-HARDENING (D-NEW-12): apply config-tier directory ownership/mode
+    # from generator output (build/fhs-spec.yaml -> nftban-dir-attrs.list).
+    # Brings DEB to RPM %attr parity for /etc/nftban + subdirs (root:nftban 0750)
+    # so dpkg-verify is clean and `dpkg --reinstall` does not reset to root:root.
+    # RPM uses %attr() inside nftban-files.inc for the same purpose.
+    local nftban_dir_attrs="${PROJECT_ROOT}/install/packaging/deb/nftban-dir-attrs.list"
+    if [[ ! -f "$nftban_dir_attrs" ]]; then
+        log_error "nftban-dir-attrs.list not found at $nftban_dir_attrs; run 'bash build/generate-fhs-outputs.sh' first"
+        return 1
+    fi
+    log_info "Applying config-tier directory attributes from $(basename "$nftban_dir_attrs")..."
+    local attrs_count=0
+    while IFS='|' read -r dir_path dir_mode dir_owner dir_group; do
+        [[ -z "$dir_path" || "$dir_path" =~ ^[[:space:]]*# ]] && continue
+        if [[ -d "${deb_root}${dir_path}" ]]; then
+            fakeroot chown "${dir_owner}:${dir_group}" "${deb_root}${dir_path}"
+            fakeroot chmod "${dir_mode}" "${deb_root}${dir_path}"
+            ((attrs_count++))
+        else
+            log_warn "Skipping attrs for missing dir: ${deb_root}${dir_path}"
+        fi
+    done < "$nftban_dir_attrs"
+    log_success "Applied attrs to ${attrs_count} config-tier directories"
+
     # Build DEB
     fakeroot dpkg-deb --build "${deb_root}" "${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
 


### PR DESCRIPTION
## Summary

Slot 3 of v1.106 post-MFST controlled-execution worklog. Closes:
- **D-NEW-8** — paths.go ↔ tmpfiles owner/mode drift
- **D-NEW-9** — `/run/nftban` + `/var/cache/nftban` 0755 hardening decision (Option A: keep, document)
- **D-NEW-12** — DEB `/etc/nftban/*` ownership parity with RPM `%attr`

Authoritative scope: `AUDIT_190_LIFECYCLE/V107_AUTH_HARDENING_SCOPE.md` (verdict GO_IMPLEMENT, 7-file allowlist).

## Changes (7 files, +279/−12)

### `internal/installer/fhs/paths.go` — D-NEW-8 RequiredDirs convergence
8 drift fixes + 1 omission fix + 1 deletion (suricata feature-gate restored):
| Path | Before | After |
|---|---|---|
| `/var/lib/nftban` | `nftban:nftban` | `root:nftban` |
| `/var/lib/nftban/reports/auditors` | `0770 nftban:nftban` | `0770 root:nftban-auditor` |
| `/var/lib/nftban/backup` | `nftban:nftban` | `root:nftban` |
| `/var/lib/nftban/update-backups` | `nftban:nftban` | `root:nftban` |
| `/var/lib/nftban/pro` | `nftban:nftban` | `root:nftban` |
| `/var/cache/nftban` | `0750` | `0755` |
| `/var/log/nftban/suricata` | eager-created `0750 nftban:nftban` | **REMOVED** (feature_enable) |
| `/var/lib/nftban/community` | missing | added `0750 nftban:nftban` |

### `internal/installer/fhs/permissions.go` — fallback alignment
- `applyPermissions` `/var/cache/nftban` chmod `0750 → 0755` to match spec.

### `build/fhs-spec.yaml` — D-NEW-9 rationale notes
- `/run/nftban`: append socket-discovery rationale to existing note.
- `/var/cache/nftban`: add public-cache traversal note.

### `build/generate-fhs-outputs.sh` — new emitter
- `generate_deb_dir_attrs()` reads `.directories.config[]` (`created_by:package`) and emits `install/packaging/deb/nftban-dir-attrs.list` with format `path|mode|owner|group`.
- Registered in `main()` and `check_mode()` so `--check` verifies the new artifact alongside existing 6.

### `install/packaging/deb/nftban-dir-attrs.list` — NEW generated artifact
- 41 entries, all `root:nftban 0750`. Generated; do not edit.

### `packaging/build_nftban.sh` — `build_deb()` ONLY
- New while-read attrs loop after the existing `fakeroot find ... chown root:root` pass and BEFORE `dpkg-deb --build`. Reads `nftban-dir-attrs.list` and applies `chown $owner:$group` + `chmod $mode` per entry. Closes the dpkg DB ownership gap so `dpkg-verify` is clean and `dpkg --reinstall` does not reset to `root:root`.
- **RPM section unchanged.** RPM already records correct ownership via `%attr()` in `install/packaging/rpm/nftban-files.inc`.

### `internal/installer/fhs/paths_yaml_parity_test.go` — extended
- **TestRequiredDirsModesAndOwnersMatchTmpfiles**: parses `install/systemd/tmpfiles.d/nftban.conf` and asserts every shared path's mode+owner matches `paths.go`. Catches future D-NEW-8 regression.
- **TestSuricataLogIsFeatureGated**: asserts `paths.go` does NOT eagerly create `/var/log/nftban/suricata`. Catches future D8.7 regression.
- Existing **TestRequiredDirsYamlParity** unchanged.

## Local validation

- `bash -n packaging/build_nftban.sh` ✅
- `bash -n build/generate-fhs-outputs.sh` ✅
- YAML parse `build/fhs-spec.yaml` ✅
- `bash build/generate-fhs-outputs.sh --check` ✅ — all 7 outputs (now including `nftban-dir-attrs.list`) match committed versions
- Generated `nftban-dir-attrs.list` content verified: 41 data lines, uniform `0750|root|nftban`
- `git diff` scope: 7 files, no forbidden surfaces touched
- Go tests will run in CI (no local Go toolchain)

## Forbidden-surface verification

```
$ git diff --name-only main..HEAD
build/fhs-spec.yaml
build/generate-fhs-outputs.sh
install/packaging/deb/nftban-dir-attrs.list
internal/installer/fhs/paths.go
internal/installer/fhs/paths_yaml_parity_test.go
internal/installer/fhs/permissions.go
packaging/build_nftban.sh
```

✅ No edits to: `packaging/build_nftban.sh` RPM section (single hunk inside `build_deb()` only), `install/packaging/rpm/nftban-files.inc`, `packaging/deb/{postrm,prerm}`, `release.yml`, Docker workflow, `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION`, polkit/*, internal/loginmon/geoip*, orphan files, schema, portal, metrics, tag/release/GHCR ops.

## DEB ownership/mode evidence

After this PR, DEB `/etc/nftban` and 41 subdirs ship as `root:nftban 0750` in dpkg DB metadata, matching RPM's `%attr(0750,root,nftban)` declarations in `nftban-files.inc`. CI `Test DEB install` matrix will exercise this; lab verification on tgt-u24 will confirm `dpkg --verify nftban-core` is clean.

## RPM unchanged evidence

- `install/packaging/rpm/nftban-files.inc`: not modified (verified by generator `--check` showing identical output).
- `packaging/build_nftban.sh` RPM section (lines 1-1747): single diff hunk is at line 1959, inside `build_deb()`. RPM `%pre`, `%post`, `%preun`, `%install`, `%files` all untouched.

## AM-5 CI gate

Per scope §8 row 9 + operator instructions ("If not simple, omit and rely on generator/check + package verification"): **omitted.** The generator `--check` already verifies the new attrs list shape; the new Go parity tests verify paths.go ↔ tmpfiles convergence. AM-5 would be redundant.

## Worklog rows targeted for closure (after merge)

- Row 3: **D-NEW-8** — paths.go vs tmpfiles owner/mode drift
- Row 4: **D-NEW-9** — /run/nftban + /var/cache/nftban 0755 hardening
- Row 5: **D-NEW-12** — DEB postinst/package ownership parity for /etc/nftban/*

## Worklog rows that REMAIN open

- Row 6 (F-4) + Row 7 (F-5): route per scope §11 Option α — close at separate v1.107.0 release-prep PR.
- Rows 8-13 (F-2, F-3, D-NEW-10, D-NEW-11, #525, F-6): unchanged, routed to subsequent slots.

## Test plan

- [ ] `Policy Gates` (architecture-policy) green incl. existing AM-4 + E6 + FHS `--check`
- [ ] `Go Build & Test` green incl. new `TestRequiredDirsModesAndOwnersMatchTmpfiles` and `TestSuricataLogIsFeatureGated`
- [ ] All 4 `Build DEB` matrix jobs green; new attrs while-read loop applies cleanly under fakeroot
- [ ] All 4 `Test DEB install` matrix jobs green; install assertions pass
- [ ] Both `Build RPM` matrix jobs green (no regression — RPM untouched)
- [ ] All 4 `Test RPM install` matrix jobs green
- [ ] `Validate binary consistency (RPM vs DEB)` green
- [ ] No forbidden surfaces touched (verified via diff scope)
- [ ] Lab verification (post-merge): fresh DEB install on tgt-u24 → `stat -c '%U:%G %a' /etc/nftban` returns `root:nftban 750`; `dpkg --verify nftban-core` clean for `/etc/nftban/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)