### PR TITLE
v1.107 PKG parity include package data dirs

### DIFF
--- a/build/generate-fhs-outputs.sh
+++ b/build/generate-fhs-outputs.sh
@@ -256,6 +256,12 @@ EOF
     # Config directories
     yq -r '.directories.config[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
 
+    # Data directories (package-territory only; tmpfiles-managed are runtime-created).
+    # PKG-EFFECTIVE-PARITY precondition fix: closes Layer-3 gap where data-tier
+    # dirs declared `created_by:package` (e.g. /var/lib/nftban/community) were
+    # in paths.go::RequiredDirs but missing from package payload.
+    yq -r '.directories.data[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
+
     # Shared directories
     yq -r '.directories.shared[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
 
@@ -301,6 +307,13 @@ EOF
     yq -r '.directories.config[] | select(.created_by == "package") | "\(.path)|\(.mode)|\(.owner)|\(.group)"' \
         "$FHS_SPEC" >> "$DEB_ATTRS_OUT"
 
+    # Data directories (package-territory only). PKG-EFFECTIVE-PARITY precondition
+    # fix: dirs like /var/lib/nftban/community declared `created_by:package` need
+    # ownership/mode metadata recorded in dpkg DB so dpkg-verify is clean and
+    # dpkg --reinstall does not reset to root:root.
+    yq -r '.directories.data[] | select(.created_by == "package") | "\(.path)|\(.mode)|\(.owner)|\(.group)"' \
+        "$FHS_SPEC" >> "$DEB_ATTRS_OUT"
+
     print_status "Generated $DEB_ATTRS_OUT"
 }
 
@@ -335,6 +348,16 @@ EOF
     echo "# ---------------------------------------------------------------------------" >> "$RPM_FILES_OUT"
 
     yq -r '.directories.config[] | select(.created_by == "package") | "%dir %attr(\(.mode),\(.owner),\(.group)) \(.path)"' "$FHS_SPEC" >> "$RPM_FILES_OUT"
+
+    echo "" >> "$RPM_FILES_OUT"
+    echo "# ---------------------------------------------------------------------------" >> "$RPM_FILES_OUT"
+    echo "# DATA DIRECTORIES (package-territory only; tmpfiles-managed runtime dirs excluded)" >> "$RPM_FILES_OUT"
+    echo "# ---------------------------------------------------------------------------" >> "$RPM_FILES_OUT"
+
+    # PKG-EFFECTIVE-PARITY precondition fix: closes Layer-3 gap where data-tier
+    # dirs declared `created_by:package` (e.g. /var/lib/nftban/community) were
+    # in paths.go::RequiredDirs but missing from RPM %files payload.
+    yq -r '.directories.data[] | select(.created_by == "package") | "%dir %attr(\(.mode),\(.owner),\(.group)) \(.path)"' "$FHS_SPEC" >> "$RPM_FILES_OUT"
 
     echo "" >> "$RPM_FILES_OUT"
     echo "# ---------------------------------------------------------------------------" >> "$RPM_FILES_OUT"

--- a/install/packaging/deb/nftban-dir-attrs.list
+++ b/install/packaging/deb/nftban-dir-attrs.list
@@ -51,3 +51,4 @@
 /etc/nftban/suricata/state/last-good|0750|root|nftban
 /etc/nftban/connectors|0750|root|nftban
 /etc/nftban/distros|0750|root|nftban
+/var/lib/nftban/community|0750|nftban|nftban

--- a/install/packaging/deb/nftban.dirs
+++ b/install/packaging/deb/nftban.dirs
@@ -69,6 +69,7 @@
 /etc/nftban/suricata/state/last-good
 /etc/nftban/connectors
 /etc/nftban/distros
+/var/lib/nftban/community
 /usr/share/nftban
 /usr/share/nftban/templates
 /usr/share/nftban/templates/mail

--- a/install/packaging/rpm/nftban-files.inc
+++ b/install/packaging/rpm/nftban-files.inc
@@ -77,6 +77,11 @@
 %dir %attr(0750,root,nftban) /etc/nftban/distros
 
 # ---------------------------------------------------------------------------
+# DATA DIRECTORIES (package-territory only; tmpfiles-managed runtime dirs excluded)
+# ---------------------------------------------------------------------------
+%dir %attr(0750,nftban,nftban) /var/lib/nftban/community
+
+# ---------------------------------------------------------------------------
 # SHARED DATA DIRECTORIES (root:root)
 # ---------------------------------------------------------------------------
 %dir %attr(0755,root,root) /usr/share/nftban


### PR DESCRIPTION
## Summary

PR-A of v1.107 **PKG-EFFECTIVE-PARITY** (Slot 5; scope path α). **Precondition fix only** — does NOT add the full effective-parity CI gate yet. PR-B will add the gate on top of this clean baseline.

Authoritative scope: `AUDIT_190_LIFECYCLE/V107_PKG_EFFECTIVE_PARITY_SCOPE.md` (verdict GO_IMPLEMENT, scope §3.1 path α).

## Finding

A Layer-3 (package-metadata) gap surfaced during the PKG-EFFECTIVE-PARITY scope:

- `/var/lib/nftban/community` is declared in `build/fhs-spec.yaml` as `created_by:package` (mode 0750, owner `nftban`, group `nftban`)
- It was added to `internal/installer/fhs/paths.go::RequiredDirs` in PR #573 (Slot 3 / AUTH-HARDENING)
- BUT **neither RPM nor DEB packagers shipped it** because the existing emitters in `build/generate-fhs-outputs.sh` only read `directories.{system,config,shared}[]` — never `directories.data[]`

Net effect at HEAD: `dnf reinstall` / `apt-get install --reinstall` would NOT create the directory; only the Go installer (paths.go::EnsureDirectories) was creating it. `dpkg --verify` would silently miss it.

## Fix shape — scope §3.1 path α

Extend three emitters in `build/generate-fhs-outputs.sh` to also read `.directories.data[] | select(.created_by == "package")`:

| Emitter | Insertion point |
|---|---|
| `generate_deb_dirs()` | between config and shared tiers |
| `generate_deb_dir_attrs()` | after config tier |
| `generate_rpm_files()` | new "DATA DIRECTORIES" `%dir` block between config and shared sections |

The yq selectors are deterministic; currently `/var/lib/nftban/community` is the only data-tier dir with `created_by:package`, so each output gains exactly one new entry.

## Changes (4 files, +30/−0)

- `build/generate-fhs-outputs.sh` (+23) — three emitter extensions
- `install/packaging/rpm/nftban-files.inc` (+5; regenerated):
  - new section header + `%dir %attr(0750,nftban,nftban) /var/lib/nftban/community`
- `install/packaging/deb/nftban.dirs` (+1; regenerated):
  - `/var/lib/nftban/community`
- `install/packaging/deb/nftban-dir-attrs.list` (+1; regenerated):
  - `/var/lib/nftban/community|0750|nftban|nftban`

`cli/lib/nftban/data/fhs_directories.json` is **unchanged** — the JSON mirror already enumerates the full data tier; the emitter selector change doesn't affect its output.

## Local validation

- `bash -n build/generate-fhs-outputs.sh` ✅
- `bash build/generate-fhs-outputs.sh --check` ✅ — all 7 outputs match committed versions (regen idempotent)
- Per-output verification: community present in all 3 expected outputs (RPM `%dir`, DEB dirs, DEB attrs)
- Diff scope: 4 files / +30/−0 / zero forbidden surfaces touched

## Forbidden surfaces (all untouched)

`build/fhs-spec.yaml`, `internal/installer/fhs/{paths.go,permissions.go,paths_yaml_parity_test.go}`, `packaging/build_nftban.sh`, all workflows, `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION`, polkit, geoip, portal, schema, tag/release/GHCR.

Per-file `git diff --quiet` verification: 5/5 forbidden surfaces clean.

## Worklog rows

- Row 14 **PKG-EFFECTIVE-PARITY** remains **OPEN** after this PR-A
- PR-A is a precondition for PR-B, NOT row closure by itself
- PR-B (full L3+L4+L5+L6 gate via `scripts/test-package-effective-parity.sh` + `build-packages.yml` + `ci-runtime-truth.yml` + `ci-update-canonization.yml` extensions) will land after PR-A merges and close row 14

## Test plan

- [ ] `Architecture Policy / Policy Gates` green incl. FHS `--check`
- [ ] `Build & Test` (Go) green (no Go changes; parity tests still pass)
- [ ] All 4 `Build DEB` matrix jobs green (new dir gets created in `${deb_root}` via existing while-read of `nftban.dirs`; new attrs entry applied via existing while-read of `nftban-dir-attrs.list`)
- [ ] All 4 `Test DEB install` matrix jobs green (new dir present at `/var/lib/nftban/community` post-install)
- [ ] Both `Build RPM` matrix jobs green (`%dir %attr` ships dir at correct ownership/mode)
- [ ] All 4 `Test RPM install` matrix jobs green
- [ ] `Validate binary consistency (RPM vs DEB)` green
- [ ] `Runtime Truth (almalinux-9, ubuntu-24.04)` green
- [ ] `Update Canonization (almalinux-9, ubuntu-24.04)` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)