### PR TITLE
v1.107 PKG add effective-parity invariant gate

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -970,35 +970,49 @@ jobs:
       - name: L3 — assert DEB package metadata matches expected table
         run: |
           set -euo pipefail
+          # PKG-EFFECTIVE-PARITY Slot 5a: DEB archive ships postinst-converged
+          # paths as root:root (per V107_PKG_EFFECTIVE_PARITY_DEB_POSTINST_OWNERSHIP_SCOPE.md
+          # Option α). Pass the exception list so the L3 assert expects
+          # root:root for the 6 converged paths instead of root:nftban etc.
+          # L4 (installed-fs stat) and L6 (dpkg --verify) are NOT affected by
+          # this exception list — they continue to require by-name parity.
+          DEB_L3_EXCEPTIONS="scripts/test-package-deb-l3-exceptions.list"
+          [[ -r "$DEB_L3_EXCEPTIONS" ]] || { echo "::error::Missing $DEB_L3_EXCEPTIONS"; exit 1; }
           fail=0
           for f in parity/parity-deb-debian12/*.txt parity/parity-deb-debian13/*.txt parity/parity-deb-ubuntu22.04/*.txt parity/parity-deb-ubuntu24.04/*.txt; do
             [[ -f "$f" ]] || continue
-            echo "=== Asserting expected against $f ==="
+            echo "=== Asserting expected against $f (with DEB L3 postinst-converged exceptions) ==="
             cat "$f"
-            if ! bash scripts/test-package-effective-parity.sh assert-expected "$f" package; then
+            if ! bash scripts/test-package-effective-parity.sh assert-expected "$f" package "--deb-l3-exceptions=$DEB_L3_EXCEPTIONS"; then
               echo "::error::L3 DEB metadata mismatch in $f"
               fail=1
             fi
           done
           [ "$fail" = "0" ] || exit 1
-          echo "✓ L3 DEB metadata matches expected for all matrix variants"
+          echo "✓ L3 DEB metadata matches expected for all matrix variants (postinst-converged paths verified as root:root in archive)"
 
       - name: L3 — cross-packager parity diff (RPM vs DEB)
         run: |
           set -euo pipefail
-          # Pick representative variants (Tier 0): el9 + ubuntu24.04
+          # Pick representative variants (Tier 0): el9 + ubuntu24.04.
+          # PKG-EFFECTIVE-PARITY Slot 5a: pass the exception list so the diff
+          # tolerates the documented postinst-converged divergence (RPM ships
+          # root:nftban via %attr; DEB ships root:root in archive and converges
+          # at postinst). All non-exception paths must still match exactly.
+          DEB_L3_EXCEPTIONS="scripts/test-package-deb-l3-exceptions.list"
+          [[ -r "$DEB_L3_EXCEPTIONS" ]] || { echo "::error::Missing $DEB_L3_EXCEPTIONS"; exit 1; }
           rpm_meta=$(ls parity/parity-rpm-el9/*.txt 2>/dev/null | head -1)
           deb_meta=$(ls parity/parity-deb-ubuntu24.04/*.txt 2>/dev/null | head -1)
           if [[ -z "$rpm_meta" || -z "$deb_meta" ]]; then
             echo "::error::Missing parity metadata artifacts (rpm=$rpm_meta deb=$deb_meta)"
             exit 1
           fi
-          echo "=== L3 cross-packager diff: $rpm_meta vs $deb_meta ==="
-          if ! bash scripts/test-package-effective-parity.sh diff "$rpm_meta" "$deb_meta"; then
-            echo "::error::L3 RPM vs DEB metadata divergence (no AUTHORITY_EXCEPTION channel honored at HEAD)"
+          echo "=== L3 cross-packager diff: $rpm_meta vs $deb_meta (with $DEB_L3_EXCEPTIONS) ==="
+          if ! bash scripts/test-package-effective-parity.sh diff "$rpm_meta" "$deb_meta" "--exceptions=$DEB_L3_EXCEPTIONS"; then
+            echo "::error::L3 RPM vs DEB metadata divergence on non-exception paths (postinst-converged paths are tolerated; non-exception divergence is a real packaging bug)"
             exit 1
           fi
-          echo "✓ L3 cross-packager metadata parity: RPM == DEB for critical paths"
+          echo "✓ L3 cross-packager metadata parity: RPM == DEB for non-exception critical paths (6 paths converged at postinst)"
 
       - name: L4+L5 — cross-packager fresh-install stat parity (Tier 0)
         run: |

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -432,6 +432,12 @@ jobs:
             tier: 0
 
     steps:
+      # Checkout required so docker mount of $(pwd)/scripts/ resolves to a real
+      # path containing test-package-effective-parity.sh + verify-exceptions.list
+      # (PKG-EFFECTIVE-PARITY Phase 4/5/6).
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Download RPM packages (with retry)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -591,6 +597,12 @@ jobs:
             tier: 1
 
     steps:
+      # Checkout required so docker mount of $(pwd)/scripts/ resolves to a real
+      # path containing test-package-effective-parity.sh + verify-exceptions.list
+      # (PKG-EFFECTIVE-PARITY Phase 4/5/6).
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Download DEB packages (with retry)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -240,6 +240,27 @@ jobs:
           path: dist/packages/*.rpm
           retention-days: 30
 
+      # PKG-EFFECTIVE-PARITY (Slot 5 / row 14): extract L3 package metadata
+      # from the built RPM artifact. Output is consumed by the
+      # validate-package-effective-parity aggregation job for cross-packager diff.
+      - name: Extract RPM package metadata (PKG-EFFECTIVE-PARITY L3)
+        run: |
+          mkdir -p dist/parity
+          for rpm in dist/packages/*.rpm; do
+            [[ -f "$rpm" ]] || continue
+            bash scripts/test-package-effective-parity.sh rpm-meta "$rpm" \
+              > "dist/parity/rpm-${{ matrix.distro }}-meta.txt"
+            echo "=== RPM metadata table (${{ matrix.distro }}) ==="
+            cat "dist/parity/rpm-${{ matrix.distro }}-meta.txt"
+          done
+
+      - name: Upload RPM parity metadata (${{ matrix.distro }})
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: parity-rpm-${{ matrix.distro }}
+          path: dist/parity/rpm-${{ matrix.distro }}-meta.txt
+          retention-days: 30
+
   # ==========================================================================
   # BUILD DEB PACKAGES
   # ==========================================================================
@@ -359,6 +380,27 @@ jobs:
           path: dist/packages/*.deb
           retention-days: 30
 
+      # PKG-EFFECTIVE-PARITY (Slot 5 / row 14): extract L3 package metadata
+      # from the built DEB artifact. Output is consumed by the
+      # validate-package-effective-parity aggregation job for cross-packager diff.
+      - name: Extract DEB package metadata (PKG-EFFECTIVE-PARITY L3)
+        run: |
+          mkdir -p dist/parity
+          for deb in dist/packages/*.deb; do
+            [[ -f "$deb" ]] || continue
+            bash scripts/test-package-effective-parity.sh deb-meta "$deb" \
+              > "dist/parity/deb-${{ matrix.distro }}-meta.txt"
+            echo "=== DEB metadata table (${{ matrix.distro }}) ==="
+            cat "dist/parity/deb-${{ matrix.distro }}-meta.txt"
+          done
+
+      - name: Upload DEB parity metadata (${{ matrix.distro }})
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: parity-deb-${{ matrix.distro }}
+          path: dist/parity/deb-${{ matrix.distro }}-meta.txt
+          retention-days: 30
+
   # ==========================================================================
   # TEST INSTALLATION (RPM - CentOS Stream)
   # ==========================================================================
@@ -409,7 +451,12 @@ jobs:
       - name: Test installation on ${{ matrix.distro }}
         if: steps.download.outcome == 'success'
         run: |
-          docker run --rm -v $(pwd)/packages:/packages ${{ matrix.container }} bash -c '
+          mkdir -p parity-out
+          docker run --rm \
+            -v $(pwd)/packages:/packages \
+            -v $(pwd)/scripts:/scripts:ro \
+            -v $(pwd)/parity-out:/parity-out \
+            ${{ matrix.container }} bash -c '
             set -euo pipefail
             INSTALL_LOG=$(mktemp)
 
@@ -469,9 +516,49 @@ jobs:
               echo "[EXPECTED] No installer.log (Docker has no systemd/nftables)"
             fi
 
+            # PKG-EFFECTIVE-PARITY Phase 4: fresh-install stat (L4)
+            # Best-effort tmpfiles-managed dir creation (vanilla Docker has no
+            # systemd PID 1 but systemd-tmpfiles binary works without dbus)
+            echo "=== Phase 4: Fresh-install stat (PKG-EFFECTIVE-PARITY L4) ==="
+            systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf 2>/dev/null || true
+            bash /scripts/test-package-effective-parity.sh fresh-stat \
+              > /parity-out/rpm-${{ matrix.distro }}-fresh-stat.txt
+            cat /parity-out/rpm-${{ matrix.distro }}-fresh-stat.txt
+            # Assert package-shipped paths match expected (HARD FAIL on mismatch)
+            bash /scripts/test-package-effective-parity.sh assert-expected \
+              /parity-out/rpm-${{ matrix.distro }}-fresh-stat.txt package
+
+            # PKG-EFFECTIVE-PARITY Phase 5: reinstall preservation (L5)
+            echo "=== Phase 5: Reinstall preservation (PKG-EFFECTIVE-PARITY L5) ==="
+            dnf reinstall -y nftban-core > /dev/null 2>&1 || dnf install -y --allowerasing /packages/*.rpm > /dev/null 2>&1
+            systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf 2>/dev/null || true
+            bash /scripts/test-package-effective-parity.sh reinstall-stat \
+              > /parity-out/rpm-${{ matrix.distro }}-reinstall-stat.txt
+            bash /scripts/test-package-effective-parity.sh diff \
+              /parity-out/rpm-${{ matrix.distro }}-fresh-stat.txt \
+              /parity-out/rpm-${{ matrix.distro }}-reinstall-stat.txt
+
+            # PKG-EFFECTIVE-PARITY Phase 6: verify-tool (L6)
+            echo "=== Phase 6: rpm -V verify-tool (PKG-EFFECTIVE-PARITY L6) ==="
+            bash /scripts/test-package-effective-parity.sh verify-tool rpm \
+              > /parity-out/rpm-${{ matrix.distro }}-verify.txt 2>&1 || {
+                echo "[FAIL] rpm -V flagged unexpected entries:"
+                cat /parity-out/rpm-${{ matrix.distro }}-verify.txt
+                exit 1
+              }
+            cat /parity-out/rpm-${{ matrix.distro }}-verify.txt
+
             rm -f "$INSTALL_LOG"
             echo "=== Install test PASSED ==="
           '
+
+      - name: Upload RPM parity install artifacts (${{ matrix.distro }})
+        if: always() && steps.download.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: parity-rpm-install-${{ matrix.distro }}
+          path: parity-out/rpm-${{ matrix.distro }}-*.txt
+          retention-days: 30
 
   # ==========================================================================
   # TEST INSTALLATION (DEB)
@@ -523,7 +610,12 @@ jobs:
       - name: Test installation on ${{ matrix.distro }}
         if: steps.download.outcome == 'success'
         run: |
-          docker run --rm -v $(pwd)/packages:/packages ${{ matrix.container }} bash -c '
+          mkdir -p parity-out
+          docker run --rm \
+            -v $(pwd)/packages:/packages \
+            -v $(pwd)/scripts:/scripts:ro \
+            -v $(pwd)/parity-out:/parity-out \
+            ${{ matrix.container }} bash -c '
             set -euo pipefail
             INSTALL_LOG=$(mktemp)
 
@@ -585,9 +677,49 @@ jobs:
               echo "[EXPECTED] No installer.log (Docker has no systemd/nftables)"
             fi
 
+            # PKG-EFFECTIVE-PARITY Phase 4: fresh-install stat (L4)
+            echo "=== Phase 4: Fresh-install stat (PKG-EFFECTIVE-PARITY L4) ==="
+            systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf 2>/dev/null || true
+            bash /scripts/test-package-effective-parity.sh fresh-stat \
+              > /parity-out/deb-${{ matrix.distro }}-fresh-stat.txt
+            cat /parity-out/deb-${{ matrix.distro }}-fresh-stat.txt
+            # Assert package-shipped paths match expected (HARD FAIL on mismatch)
+            # This is THE D-NEW-12 regression guard: DEB regressing /etc/nftban
+            # to root:root 0755 will fail here.
+            bash /scripts/test-package-effective-parity.sh assert-expected \
+              /parity-out/deb-${{ matrix.distro }}-fresh-stat.txt package
+
+            # PKG-EFFECTIVE-PARITY Phase 5: reinstall preservation (L5)
+            echo "=== Phase 5: Reinstall preservation (PKG-EFFECTIVE-PARITY L5) ==="
+            apt-get install --reinstall -y nftban-core > /dev/null 2>&1 || apt-get install -y /packages/*.deb > /dev/null 2>&1
+            systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf 2>/dev/null || true
+            bash /scripts/test-package-effective-parity.sh reinstall-stat \
+              > /parity-out/deb-${{ matrix.distro }}-reinstall-stat.txt
+            bash /scripts/test-package-effective-parity.sh diff \
+              /parity-out/deb-${{ matrix.distro }}-fresh-stat.txt \
+              /parity-out/deb-${{ matrix.distro }}-reinstall-stat.txt
+
+            # PKG-EFFECTIVE-PARITY Phase 6: verify-tool (L6)
+            echo "=== Phase 6: dpkg --verify verify-tool (PKG-EFFECTIVE-PARITY L6) ==="
+            bash /scripts/test-package-effective-parity.sh verify-tool deb \
+              > /parity-out/deb-${{ matrix.distro }}-verify.txt 2>&1 || {
+                echo "[FAIL] dpkg --verify flagged unexpected entries:"
+                cat /parity-out/deb-${{ matrix.distro }}-verify.txt
+                exit 1
+              }
+            cat /parity-out/deb-${{ matrix.distro }}-verify.txt
+
             rm -f "$INSTALL_LOG"
             echo "=== Install test PASSED ==="
           '
+
+      - name: Upload DEB parity install artifacts (${{ matrix.distro }})
+        if: always() && steps.download.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: parity-deb-install-${{ matrix.distro }}
+          path: parity-out/deb-${{ matrix.distro }}-*.txt
+          retention-days: 30
 
   # ==========================================================================
   # CONSOLIDATE ALL PACKAGES
@@ -777,6 +909,112 @@ jobs:
             name=$(basename "$binary")
             hash=$(sha256sum "$binary" | cut -c1-16)
             echo "| $name | \`$hash...\` |" >> $GITHUB_STEP_SUMMARY
+          done
+
+  # ==========================================================================
+  # PKG-EFFECTIVE-PARITY: cross-packager aggregation (Slot 5 / row 14)
+  # ==========================================================================
+  # Closes the L3 escape class that lived ~13 releases pre-AUTH-HARDENING:
+  # both packages could "ship the same dirs" while recording different
+  # ownership/mode in their package DBs. Now we extract metadata from each
+  # built artifact + diff cross-packager + assert against expected table.
+  # ==========================================================================
+  validate-package-effective-parity:
+    name: Validate package effective parity (RPM vs DEB)
+    needs: [build-rpm, build-deb, test-rpm-install, test-deb-install]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download all parity artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: parity/
+          pattern: parity-*
+
+      - name: Inspect parity artifact tree
+        run: |
+          echo "=== Parity artifact tree ==="
+          find parity -type f | sort
+          echo ""
+
+      - name: L3 — assert RPM package metadata matches expected table
+        run: |
+          set -euo pipefail
+          fail=0
+          for f in parity/parity-rpm-el9/*.txt parity/parity-rpm-el10/*.txt; do
+            [[ -f "$f" ]] || continue
+            echo "=== Asserting expected against $f ==="
+            cat "$f"
+            if ! bash scripts/test-package-effective-parity.sh assert-expected "$f" package; then
+              echo "::error::L3 RPM metadata mismatch in $f"
+              fail=1
+            fi
+          done
+          [ "$fail" = "0" ] || exit 1
+          echo "✓ L3 RPM metadata matches expected for all matrix variants"
+
+      - name: L3 — assert DEB package metadata matches expected table
+        run: |
+          set -euo pipefail
+          fail=0
+          for f in parity/parity-deb-debian12/*.txt parity/parity-deb-debian13/*.txt parity/parity-deb-ubuntu22.04/*.txt parity/parity-deb-ubuntu24.04/*.txt; do
+            [[ -f "$f" ]] || continue
+            echo "=== Asserting expected against $f ==="
+            cat "$f"
+            if ! bash scripts/test-package-effective-parity.sh assert-expected "$f" package; then
+              echo "::error::L3 DEB metadata mismatch in $f"
+              fail=1
+            fi
+          done
+          [ "$fail" = "0" ] || exit 1
+          echo "✓ L3 DEB metadata matches expected for all matrix variants"
+
+      - name: L3 — cross-packager parity diff (RPM vs DEB)
+        run: |
+          set -euo pipefail
+          # Pick representative variants (Tier 0): el9 + ubuntu24.04
+          rpm_meta=$(ls parity/parity-rpm-el9/*.txt 2>/dev/null | head -1)
+          deb_meta=$(ls parity/parity-deb-ubuntu24.04/*.txt 2>/dev/null | head -1)
+          if [[ -z "$rpm_meta" || -z "$deb_meta" ]]; then
+            echo "::error::Missing parity metadata artifacts (rpm=$rpm_meta deb=$deb_meta)"
+            exit 1
+          fi
+          echo "=== L3 cross-packager diff: $rpm_meta vs $deb_meta ==="
+          if ! bash scripts/test-package-effective-parity.sh diff "$rpm_meta" "$deb_meta"; then
+            echo "::error::L3 RPM vs DEB metadata divergence (no AUTHORITY_EXCEPTION channel honored at HEAD)"
+            exit 1
+          fi
+          echo "✓ L3 cross-packager metadata parity: RPM == DEB for critical paths"
+
+      - name: L4+L5 — cross-packager fresh-install stat parity (Tier 0)
+        run: |
+          set -euo pipefail
+          # Pick Tier 0 representatives
+          rpm_stat=$(ls parity/parity-rpm-install-rocky9/*-fresh-stat.txt 2>/dev/null | head -1)
+          deb_stat=$(ls parity/parity-deb-install-ubuntu24.04/*-fresh-stat.txt 2>/dev/null | head -1)
+          if [[ -z "$rpm_stat" || -z "$deb_stat" ]]; then
+            echo "::warning::Missing install-stat artifacts (rpm=$rpm_stat deb=$deb_stat) — Tier 0 install jobs may have skipped"
+            exit 0
+          fi
+          echo "=== L4 cross-packager fresh-install stat diff: $rpm_stat vs $deb_stat ==="
+          if ! bash scripts/test-package-effective-parity.sh diff "$rpm_stat" "$deb_stat"; then
+            echo "::error::L4 RPM vs DEB installed-fs divergence (no AUTHORITY_EXCEPTION)"
+            exit 1
+          fi
+          echo "✓ L4 cross-packager installed-fs parity"
+
+      - name: Generate parity report
+        if: always()
+        run: |
+          echo "## PKG-EFFECTIVE-PARITY Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Layers asserted: L3 (package metadata) + L4 (installed-fs) + L5 (reinstall preservation) + L6 (verify-tool)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Critical paths (11)" >> $GITHUB_STEP_SUMMARY
+          bash scripts/test-package-effective-parity.sh list-expected | while IFS='|' read -r path type mode owner group pkg; do
+            echo "- \`$path\` → $type $mode $owner:$group (pkg-shipped=$pkg)" >> $GITHUB_STEP_SUMMARY
           done
 
   # ==========================================================================

--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -269,6 +269,76 @@ jobs:
           echo "G7 enforcement lives in .github/workflows/build-packages.yml"
           echo "(RPM + DEB build + install matrix must also stay green for merge)"
 
+      # ------------------------------------------------------------------
+      # G8: PKG-EFFECTIVE-PARITY L4 tmpfiles-managed coverage (Slot 5 / row 14)
+      # ------------------------------------------------------------------
+      # Runtime Truth runs on real OS images with full systemd. This step
+      # verifies the 6 tmpfiles-managed critical paths (which Test RPM/DEB
+      # install jobs in build-packages.yml cannot reliably exercise inside
+      # vanilla Docker without systemd PID 1).
+      #
+      # Path-set coverage:
+      #   - /run/nftban (0755 nftban:nftban)
+      #   - /var/cache/nftban (0755 nftban:nftban)
+      #   - /var/lib/nftban (0750 root:nftban)
+      #   - /var/lib/nftban/reports/auditors (0770 root:nftban-auditor)
+      #   - /var/log/nftban (0750 nftban:nftban)
+      #   (Note: /var/lib/nftban/community is package-shipped, NOT tmpfiles —
+      #   asserted in build-packages.yml Test * install jobs)
+      - name: G8 — PKG-EFFECTIVE-PARITY L4 tmpfiles parity (real-systemd)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "=== G8: tmpfiles-managed path parity ==="
+
+          # 1. Create system users/groups (matches install/systemd/sysusers.d/nftban.conf)
+          sudo getent group nftban >/dev/null 2>&1 || sudo groupadd --system nftban
+          sudo getent group nftban-auditor >/dev/null 2>&1 || sudo groupadd --system nftban-auditor
+          sudo getent group suricata >/dev/null 2>&1 || sudo groupadd --system suricata
+          sudo getent passwd nftban >/dev/null 2>&1 || \
+            sudo useradd --system --gid nftban --groups nftban-auditor \
+              --home-dir /var/lib/nftban --no-create-home --shell /usr/sbin/nologin nftban
+
+          # 2. Stage tmpfiles config (single source of truth)
+          sudo install -m 0644 install/systemd/tmpfiles.d/nftban.conf /usr/lib/tmpfiles.d/nftban.conf
+
+          # 3. Run systemd-tmpfiles --create (full systemd available here)
+          if ! sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf; then
+            echo "::warning::G8 systemd-tmpfiles --create reported issues; will check anyway"
+          fi
+
+          # 4. Assert each of the 6 tmpfiles-managed critical paths
+          fail=0
+          # Format: path|expected_mode|expected_owner|expected_group
+          for entry in \
+              "/run/nftban|0755|nftban|nftban" \
+              "/var/cache/nftban|0755|nftban|nftban" \
+              "/var/lib/nftban|0750|root|nftban" \
+              "/var/lib/nftban/reports/auditors|0770|root|nftban-auditor" \
+              "/var/log/nftban|0750|nftban|nftban" \
+          ; do
+            IFS='|' read -r p exp_mode exp_owner exp_group <<< "$entry"
+            if [[ ! -d "$p" ]]; then
+              echo "::error::G8 missing dir: $p"
+              fail=1
+              continue
+            fi
+            actual_mode=$(stat -c '%a' "$p")
+            [[ ${#actual_mode} -eq 3 ]] && actual_mode="0$actual_mode"
+            actual_owner=$(stat -c '%U' "$p")
+            actual_group=$(stat -c '%G' "$p")
+            if [[ "$actual_mode" != "$exp_mode" || "$actual_owner" != "$exp_owner" || "$actual_group" != "$exp_group" ]]; then
+              echo "::error::G8 mismatch on $p"
+              echo "::error::  expected: $exp_mode $exp_owner:$exp_group"
+              echo "::error::  observed: $actual_mode $actual_owner:$actual_group"
+              fail=1
+            else
+              echo "[PASS] $p: $actual_mode $actual_owner:$actual_group"
+            fi
+          done
+          [ "$fail" = "0" ] || exit 1
+          echo "G8 PASS: tmpfiles-managed path parity verified on real systemd"
+
   summary:
     name: Runtime Truth summary
     needs: runtime-truth

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -476,6 +476,117 @@ jobs:
           fi
           echo "G3-U13 PASS — source case present in historyInstallType"
 
+      # ------------------------------------------------------------------
+      # G4: PKG-EFFECTIVE-PARITY L5 upgrade transition (Slot 5 / row 14)
+      # ------------------------------------------------------------------
+      # Honest test of v1.106.0 → current upgrade ownership transition.
+      # v1.106.0 DEB shipped /etc/nftban as root:root 0755 (D-NEW-12 origin);
+      # current DEB ships it as root:nftban 0750 (post-AUTH-HARDENING / PR #573).
+      # The upgrade path must converge to the current state regardless of
+      # pre-upgrade state. If the upgrade does NOT transition ownership,
+      # this gate reports failure honestly — masking is forbidden.
+      #
+      # Scope: ubuntu-24.04 matrix entry only (DEB; full systemd available).
+      # RPM upgrade transition can be added in a follow-up; v1.106.0 RPM
+      # already shipped /etc/nftban correctly via %attr() so it has no
+      # ownership-transition gap to test.
+      - name: G4 — v1.106.0 → current upgrade transition (DEB only)
+        if: matrix.label == 'ubuntu-24.04'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "=== G4: PKG-EFFECTIVE-PARITY L5 upgrade transition ==="
+
+          # Install build dependencies for inline DEB build
+          sudo apt-get install -y dpkg-dev fakeroot build-essential file curl
+
+          # Build current DEB inline (uses packaging/build_nftban.sh deb path
+          # — same as build-packages.yml). Binaries are already in bin/ from
+          # the earlier "Build nftban-installer + nftban-validate" step; we
+          # need the missing nftban-core + nftband binaries too.
+          go build -trimpath -o bin/nftban-core ./cmd/nftban-core/ 2>/dev/null || \
+            sudo install -m 0755 /bin/true bin/nftban-core
+          go build -trimpath -o bin/nftband ./cmd/nftband/ 2>/dev/null || \
+            sudo install -m 0755 /bin/true bin/nftband
+
+          # Build the current DEB
+          chmod +x packaging/build_nftban.sh
+          ( cd packaging && ./build_nftban.sh deb ) || {
+            echo "::warning::G4: current DEB inline build failed — upgrade test cannot run"
+            echo "::warning::G4: this is acceptable for PR-B introduction; follow-up to extract DEB from build-packages.yml"
+            exit 0
+          }
+          CURRENT_DEB=$(ls /home/runner/work/*/*/build/packages/*.deb 2>/dev/null | head -1 || ls build/packages/*.deb 2>/dev/null | head -1 || true)
+          if [[ -z "$CURRENT_DEB" || ! -f "$CURRENT_DEB" ]]; then
+            echo "::warning::G4: current DEB not found post-build — skipping upgrade test"
+            exit 0
+          fi
+          echo "G4: current DEB built at $CURRENT_DEB"
+
+          # Download v1.106.0 release DEB (Ubuntu 24.04 variant)
+          V106_URL="https://github.com/itcmsgr/nftban/releases/download/v1.106.0/nftban-ubuntu24.04-amd64.deb"
+          mkdir -p /tmp/v106
+          if ! curl -fsSL -o /tmp/v106/nftban-v1.106.0.deb "$V106_URL"; then
+            echo "::warning::G4: v1.106.0 release DEB download failed — skipping upgrade test (network/release availability)"
+            exit 0
+          fi
+
+          # Install v1.106.0 (best-effort; may fail postinst due to missing
+          # kernel state but the package payload + ownership land regardless)
+          sudo apt-get install -y /tmp/v106/nftban-v1.106.0.deb || \
+            sudo dpkg -i /tmp/v106/nftban-v1.106.0.deb || \
+            echo "::warning::G4: v1.106.0 install reported errors (postinst); proceeding to stat snapshot"
+
+          # PRE-UPGRADE: snapshot the v1.106.0-installed state
+          echo "=== G4 PRE-UPGRADE STATE (v1.106.0 installed) ==="
+          PRE_MODE=$(stat -c '%a' /etc/nftban 2>/dev/null || echo "MISSING")
+          PRE_OWNER=$(stat -c '%U:%G' /etc/nftban 2>/dev/null || echo "MISSING")
+          echo "pre-upgrade /etc/nftban: $PRE_MODE $PRE_OWNER"
+          # HONEST: log the pre-upgrade state to GITHUB_STEP_SUMMARY for visibility
+          {
+            echo "## G4 v1.106.0 → current upgrade transition"
+            echo ""
+            echo "**Pre-upgrade** (v1.106.0 installed): \`/etc/nftban\` = $PRE_MODE $PRE_OWNER"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # UPGRADE to current
+          echo "=== G4 UPGRADE to current ==="
+          sudo apt-get install -y "$CURRENT_DEB" || \
+            sudo dpkg -i "$CURRENT_DEB" || \
+            echo "::warning::G4: current install reported errors (postinst); proceeding to stat snapshot"
+
+          # POST-UPGRADE: snapshot transitioned state
+          echo "=== G4 POST-UPGRADE STATE (current installed) ==="
+          POST_MODE=$(stat -c '%a' /etc/nftban 2>/dev/null || echo "MISSING")
+          POST_OWNER=$(stat -c '%U:%G' /etc/nftban 2>/dev/null || echo "MISSING")
+          echo "post-upgrade /etc/nftban: $POST_MODE $POST_OWNER"
+          {
+            echo "**Post-upgrade** (current installed): \`/etc/nftban\` = $POST_MODE $POST_OWNER"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # ASSERT: post-upgrade /etc/nftban must be root:nftban 0750
+          [[ ${#POST_MODE} -eq 3 ]] && POST_MODE="0$POST_MODE"
+          if [[ "$POST_MODE" != "0750" || "$POST_OWNER" != "root:nftban" ]]; then
+            echo "::error::G4 FAIL: v1.106.0 → current upgrade did NOT transition /etc/nftban ownership"
+            echo "::error::  expected post-upgrade: 0750 root:nftban"
+            echo "::error::  observed post-upgrade: $POST_MODE $POST_OWNER"
+            echo "::error::  pre-upgrade was:       $PRE_MODE $PRE_OWNER"
+            echo "::error::  Operator decision needed: add postinst chown loop, OR document"
+            echo "::error::  v1.106.0 → vN as one-time ownership-transition gap in release notes."
+            {
+              echo ":x: **G4 FAILED**: upgrade did NOT transition ownership."
+              echo ""
+              echo "Pre-upgrade was \`$PRE_MODE $PRE_OWNER\`; post-upgrade is \`$POST_MODE $POST_OWNER\`."
+              echo "Expected: \`0750 root:nftban\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "G4 PASS: v1.106.0 → current upgrade transitions /etc/nftban → 0750 root:nftban"
+          {
+            echo ":white_check_mark: **G4 PASSED**: upgrade transitioned ownership correctly."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   summary:
     name: Update Canonization summary
     needs: update-canonization

--- a/build/generate-fhs-outputs.sh
+++ b/build/generate-fhs-outputs.sh
@@ -262,6 +262,16 @@ EOF
     # in paths.go::RequiredDirs but missing from package payload.
     yq -r '.directories.data[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
 
+    # PKG-EFFECTIVE-PARITY Slot 5a: explicit parent emission. /var/lib/nftban
+    # is `created_by:tmpfiles` in fhs-spec.yaml (runtime authority via
+    # tmpfiles.d), but DEB build's `mkdir -p /var/lib/nftban/community`
+    # incidentally creates the parent in the staged tree, and the L3 cross-
+    # packager parity gate sees it diverge from RPM (which doesn't ship it).
+    # Make /var/lib/nftban explicit in package payload to keep the L3 diff
+    # symmetric. The runtime authority remains tmpfiles + postinst chown
+    # (DEB ships root:root, postinst converges to root:nftban).
+    echo "/var/lib/nftban" >> "$DEB_DIRS_OUT"
+
     # Shared directories
     yq -r '.directories.shared[] | select(.created_by == "package") | .path' "$FHS_SPEC" >> "$DEB_DIRS_OUT"
 
@@ -314,6 +324,17 @@ EOF
     yq -r '.directories.data[] | select(.created_by == "package") | "\(.path)|\(.mode)|\(.owner)|\(.group)"' \
         "$FHS_SPEC" >> "$DEB_ATTRS_OUT"
 
+    # PKG-EFFECTIVE-PARITY Slot 5a: explicit parent emission for /var/lib/nftban.
+    # See generate_deb_dirs() for rationale. Emit using the metadata from
+    # fhs-spec.yaml (which still says created_by:tmpfiles — that is the runtime
+    # authority — but the package archive layer also needs to ship it so cross-
+    # packager L3 parity is symmetric). The chmod loop in build_deb() reads
+    # this attrs.list and applies mode 0750 to /var/lib/nftban at build time;
+    # ownership is left as root:root in the archive (postinst converges to
+    # root:nftban via the same attrs.list).
+    yq -r '.directories.data[] | select(.path == "/var/lib/nftban") | "\(.path)|\(.mode)|\(.owner)|\(.group)"' \
+        "$FHS_SPEC" >> "$DEB_ATTRS_OUT"
+
     print_status "Generated $DEB_ATTRS_OUT"
 }
 
@@ -358,6 +379,15 @@ EOF
     # dirs declared `created_by:package` (e.g. /var/lib/nftban/community) were
     # in paths.go::RequiredDirs but missing from RPM %files payload.
     yq -r '.directories.data[] | select(.created_by == "package") | "%dir %attr(\(.mode),\(.owner),\(.group)) \(.path)"' "$FHS_SPEC" >> "$RPM_FILES_OUT"
+
+    # PKG-EFFECTIVE-PARITY Slot 5a: explicit parent emission for /var/lib/nftban.
+    # See generate_deb_dirs() for rationale. RPM uses %attr() which is name-
+    # based and re-applied at install time, so RPM ships /var/lib/nftban at
+    # 0750 root:nftban (matching fhs-spec.yaml + tmpfiles.d). Cross-packager
+    # L3 parity is preserved via test-package-deb-l3-exceptions.list which
+    # filters /var/lib/nftban from both sides (DEB ships postinst-converged
+    # root:root in archive; RPM ships root:nftban directly).
+    yq -r '.directories.data[] | select(.path == "/var/lib/nftban") | "%dir %attr(\(.mode),\(.owner),\(.group)) \(.path)"' "$FHS_SPEC" >> "$RPM_FILES_OUT"
 
     echo "" >> "$RPM_FILES_OUT"
     echo "# ---------------------------------------------------------------------------" >> "$RPM_FILES_OUT"

--- a/install/packaging/deb/nftban-dir-attrs.list
+++ b/install/packaging/deb/nftban-dir-attrs.list
@@ -52,3 +52,4 @@
 /etc/nftban/connectors|0750|root|nftban
 /etc/nftban/distros|0750|root|nftban
 /var/lib/nftban/community|0750|nftban|nftban
+/var/lib/nftban|0750|root|nftban

--- a/install/packaging/deb/nftban.dirs
+++ b/install/packaging/deb/nftban.dirs
@@ -70,6 +70,7 @@
 /etc/nftban/connectors
 /etc/nftban/distros
 /var/lib/nftban/community
+/var/lib/nftban
 /usr/share/nftban
 /usr/share/nftban/templates
 /usr/share/nftban/templates/mail

--- a/install/packaging/rpm/nftban-files.inc
+++ b/install/packaging/rpm/nftban-files.inc
@@ -80,6 +80,7 @@
 # DATA DIRECTORIES (package-territory only; tmpfiles-managed runtime dirs excluded)
 # ---------------------------------------------------------------------------
 %dir %attr(0750,nftban,nftban) /var/lib/nftban/community
+%dir %attr(0750,root,nftban) /var/lib/nftban
 
 # ---------------------------------------------------------------------------
 # SHARED DATA DIRECTORIES (root:root)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1926,8 +1926,17 @@ build_deb() {
         install -D -m 0644 "$tmpl" "${deb_root}/usr/share/nftban/templates/$rel_path"
     done
 
-    # Copy man page
+    # Copy man page (Debian convention: ship gzipped to match dpkg DB after
+    # mandb auto-compresses on Ubuntu). PKG-EFFECTIVE-PARITY Slot 5a Phase 6
+    # exposed this: Ubuntu mandb auto-compresses /usr/share/man/man8/nftban.8
+    # → nftban.8.gz post-install, but dpkg DB still recorded the uncompressed
+    # name, causing dpkg --verify to flag the path as missing on ubuntu22.04
+    # and ubuntu24.04 while debian12/13 happened to pass. RPM has the
+    # equivalent behavior via rpmbuild's brp-compress (the %files glob
+    # `nftban.8*` accommodates both forms). Gzip with -9n for deterministic
+    # compression (no timestamp/name in header → reproducible builds).
     install -m 0644 "${PROJECT_ROOT}/install/man/man8/nftban.8" "${deb_root}/usr/share/man/man8/"
+    gzip -9n "${deb_root}/usr/share/man/man8/nftban.8"
 
     # Copy bash completion
     install -m 0644 "${PROJECT_ROOT}/install/bash-completion/nftban" "${deb_root}/usr/share/bash-completion/completions/"

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1966,8 +1966,39 @@ build_deb() {
         return 1
     fi
 
+    # PKG-EFFECTIVE-PARITY (Slot 5 / row 14): build-host identity preconditions.
+    # libfakeroot intercepts chown/lchown/fchown SYSCALLS but does NOT fake
+    # getpwnam()/getgrnam() name resolution. coreutils chown resolves owner/
+    # group names BEFORE the syscall, so 'chown nftban:nftban target' aborts
+    # with "invalid group" inside the fakeroot session when the nftban identity
+    # is absent on the build host. Create the identities idempotently here so
+    # the per-directory chown loop below can resolve "nftban" (and the
+    # "nftban-auditor" group, kept symmetric with the runtime identity model).
+    # Build-host-only: the package's own postinst/sysusers still creates these
+    # identities on the target host at install time.
+    PATH="/usr/sbin:/sbin:${PATH}"
+    if ! command -v groupadd >/dev/null 2>&1; then
+        log_error "groupadd not available on build host; cannot ensure DEB build-time identities"
+        return 1
+    fi
+    if ! command -v useradd >/dev/null 2>&1; then
+        log_error "useradd not available on build host; cannot ensure DEB build-time identities"
+        return 1
+    fi
+    if ! getent group nftban >/dev/null 2>&1; then
+        groupadd -r nftban || { log_error "groupadd -r nftban failed on build host"; return 1; }
+    fi
+    if ! getent group nftban-auditor >/dev/null 2>&1; then
+        groupadd -r nftban-auditor || { log_error "groupadd -r nftban-auditor failed on build host"; return 1; }
+    fi
+    if ! id -u nftban >/dev/null 2>&1; then
+        useradd -r -g nftban -s /usr/sbin/nologin -d /var/lib/nftban nftban \
+            || { log_error "useradd -r nftban failed on build host"; return 1; }
+    fi
+
     log_info "Setting DEB ownership/attrs and building package in single fakeroot session..."
-    fakeroot -- bash -ec '
+    local deb_out="${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
+    if ! fakeroot -- bash -ec '
         deb_root="$1"; attrs_file="$2"; deb_out="$3"
 
         # Baseline: own everything as root:root (FHS: /usr/lib/nftban = root:root)
@@ -1994,9 +2025,23 @@ build_deb() {
         # Build DEB inside same fakeroot context so chown/chmod values are
         # recorded in the package control DB (root:nftban 0750 for /etc/nftban*).
         dpkg-deb --build "$deb_root" "$deb_out"
-    ' _ "$deb_root" "$nftban_dir_attrs" "${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
+    ' _ "$deb_root" "$nftban_dir_attrs" "$deb_out"; then
+        log_error "DEB build failed inside fakeroot session (see output above)"
+        return 1
+    fi
 
-    log_success "DEB built: ${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
+    # Verify the artifact actually exists. build_deb is invoked as
+    # `build_deb || { ... }` in main(), which disables errexit inside the
+    # function (Bash gotcha) — without this explicit check, a fakeroot
+    # session that printed errors but exited 0 anyway would still reach
+    # log_success and produce the misleading "DEB built" log line that
+    # PKG-EFFECTIVE-PARITY caught in CI.
+    if [[ ! -s "$deb_out" ]]; then
+        log_error "DEB build did not produce ${deb_out}"
+        return 1
+    fi
+
+    log_success "DEB built: ${deb_out}"
 }
 
 main() {

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1951,40 +1951,50 @@ build_deb() {
     # Create control file
     create_deb_control
 
-    # Fix ownership before building (FHS: /usr/lib/nftban = root:root)
-    # Without this, files keep the builder's UID which breaks systemd services
-    log_info "Setting package file ownership to root:root..."
-    fakeroot find "${deb_root}/usr" -type f -exec chown root:root {} \;
-    fakeroot find "${deb_root}/usr" -type d -exec chown root:root {} \;
-    fakeroot find "${deb_root}/etc" -type f -exec chown root:root {} \;
-    fakeroot find "${deb_root}/etc" -type d -exec chown root:root {} \;
-
-    # AUTH-HARDENING (D-NEW-12): apply config-tier directory ownership/mode
-    # from generator output (build/fhs-spec.yaml -> nftban-dir-attrs.list).
-    # Brings DEB to RPM %attr parity for /etc/nftban + subdirs (root:nftban 0750)
-    # so dpkg-verify is clean and `dpkg --reinstall` does not reset to root:root.
-    # RPM uses %attr() inside nftban-files.inc for the same purpose.
+    # AUTH-HARDENING (D-NEW-12) + PKG-EFFECTIVE-PARITY (Slot 5 / row 14):
+    # baseline chown, per-directory attrs from nftban-dir-attrs.list, and
+    # `dpkg-deb --build` MUST share ONE fakeroot session. Each `fakeroot <cmd>`
+    # invocation is an independent in-memory state — chown/chmod values from
+    # one session are NOT visible to the next, so a separate `fakeroot dpkg-deb`
+    # records the real on-disk owner (root from the baseline pass), losing the
+    # AUTH-HARDENING root:nftban metadata for /etc/nftban/*. PKG-EFFECTIVE-PARITY
+    # L4 stat assertions on Test DEB install caught this. RPM uses %attr() in
+    # nftban-files.inc for the equivalent metadata channel.
     local nftban_dir_attrs="${PROJECT_ROOT}/install/packaging/deb/nftban-dir-attrs.list"
     if [[ ! -f "$nftban_dir_attrs" ]]; then
         log_error "nftban-dir-attrs.list not found at $nftban_dir_attrs; run 'bash build/generate-fhs-outputs.sh' first"
         return 1
     fi
-    log_info "Applying config-tier directory attributes from $(basename "$nftban_dir_attrs")..."
-    local attrs_count=0
-    while IFS='|' read -r dir_path dir_mode dir_owner dir_group; do
-        [[ -z "$dir_path" || "$dir_path" =~ ^[[:space:]]*# ]] && continue
-        if [[ -d "${deb_root}${dir_path}" ]]; then
-            fakeroot chown "${dir_owner}:${dir_group}" "${deb_root}${dir_path}"
-            fakeroot chmod "${dir_mode}" "${deb_root}${dir_path}"
-            ((attrs_count++))
-        else
-            log_warn "Skipping attrs for missing dir: ${deb_root}${dir_path}"
-        fi
-    done < "$nftban_dir_attrs"
-    log_success "Applied attrs to ${attrs_count} config-tier directories"
 
-    # Build DEB
-    fakeroot dpkg-deb --build "${deb_root}" "${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
+    log_info "Setting DEB ownership/attrs and building package in single fakeroot session..."
+    fakeroot -- bash -ec '
+        deb_root="$1"; attrs_file="$2"; deb_out="$3"
+
+        # Baseline: own everything as root:root (FHS: /usr/lib/nftban = root:root)
+        find "$deb_root/usr" -type f -exec chown root:root {} +
+        find "$deb_root/usr" -type d -exec chown root:root {} +
+        find "$deb_root/etc" -type f -exec chown root:root {} +
+        find "$deb_root/etc" -type d -exec chown root:root {} +
+
+        # Apply per-directory attrs from generator output (D-NEW-12)
+        attrs_count=0
+        while IFS="|" read -r dir_path dir_mode dir_owner dir_group; do
+            [[ -z "$dir_path" || "$dir_path" =~ ^[[:space:]]*# ]] && continue
+            target="${deb_root}${dir_path}"
+            if [[ -d "$target" ]]; then
+                chown "${dir_owner}:${dir_group}" "$target"
+                chmod "$dir_mode" "$target"
+                attrs_count=$((attrs_count + 1))
+            else
+                echo "WARN: skipping attrs for missing dir: $target" >&2
+            fi
+        done < "$attrs_file"
+        echo "Applied attrs to $attrs_count config-tier directories"
+
+        # Build DEB inside same fakeroot context so chown/chmod values are
+        # recorded in the package control DB (root:nftban 0750 for /etc/nftban*).
+        dpkg-deb --build "$deb_root" "$deb_out"
+    ' _ "$deb_root" "$nftban_dir_attrs" "${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
 
     log_success "DEB built: ${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
 }

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1951,81 +1951,42 @@ build_deb() {
     # Create control file
     create_deb_control
 
-    # AUTH-HARDENING (D-NEW-12) + PKG-EFFECTIVE-PARITY (Slot 5 / row 14):
-    # baseline chown, per-directory attrs from nftban-dir-attrs.list, and
-    # `dpkg-deb --build` MUST share ONE fakeroot session. Each `fakeroot <cmd>`
-    # invocation is an independent in-memory state — chown/chmod values from
-    # one session are NOT visible to the next, so a separate `fakeroot dpkg-deb`
-    # records the real on-disk owner (root from the baseline pass), losing the
-    # AUTH-HARDENING root:nftban metadata for /etc/nftban/*. PKG-EFFECTIVE-PARITY
-    # L4 stat assertions on Test DEB install caught this. RPM uses %attr() in
-    # nftban-files.inc for the equivalent metadata channel.
+    # PKG-EFFECTIVE-PARITY Slot 5a (row 14) — DEB ownership authority moved to postinst.
+    # Per V107_PKG_EFFECTIVE_PARITY_DEB_POSTINST_OWNERSHIP_SCOPE.md (Option α + Option A):
+    # the .deb archive ships with root:root metadata only; postinst chown + chmod +
+    # dpkg-statoverride converge ownership to root:nftban / nftban:nftban after the
+    # nftban identities exist on the target host. Build-time fakeroot per-directory
+    # ownership baking was structurally wrong for DEB because dpkg archives store
+    # numeric UID/GID, not portable names — on a target host without matching numeric
+    # IDs, /etc/nftban resolved to root:systemd-journal (or root:UNKNOWN). RPM is
+    # unaffected because %attr() in nftban-files.inc is a name-based directive
+    # re-applied at install time. The attrs list is shipped inside the DEB at
+    # /usr/share/nftban/packaging/nftban-dir-attrs.list so postinst can consume it.
     local nftban_dir_attrs="${PROJECT_ROOT}/install/packaging/deb/nftban-dir-attrs.list"
     if [[ ! -f "$nftban_dir_attrs" ]]; then
         log_error "nftban-dir-attrs.list not found at $nftban_dir_attrs; run 'bash build/generate-fhs-outputs.sh' first"
         return 1
     fi
+    install -D -m 0644 "$nftban_dir_attrs" \
+        "${deb_root}/usr/share/nftban/packaging/nftban-dir-attrs.list"
 
-    # PKG-EFFECTIVE-PARITY (Slot 5 / row 14): build-host identity preconditions.
-    # libfakeroot intercepts chown/lchown/fchown SYSCALLS but does NOT fake
-    # getpwnam()/getgrnam() name resolution. coreutils chown resolves owner/
-    # group names BEFORE the syscall, so 'chown nftban:nftban target' aborts
-    # with "invalid group" inside the fakeroot session when the nftban identity
-    # is absent on the build host. Create the identities idempotently here so
-    # the per-directory chown loop below can resolve "nftban" (and the
-    # "nftban-auditor" group, kept symmetric with the runtime identity model).
-    # Build-host-only: the package's own postinst/sysusers still creates these
-    # identities on the target host at install time.
-    PATH="/usr/sbin:/sbin:${PATH}"
-    if ! command -v groupadd >/dev/null 2>&1; then
-        log_error "groupadd not available on build host; cannot ensure DEB build-time identities"
-        return 1
-    fi
-    if ! command -v useradd >/dev/null 2>&1; then
-        log_error "useradd not available on build host; cannot ensure DEB build-time identities"
-        return 1
-    fi
-    if ! getent group nftban >/dev/null 2>&1; then
-        groupadd -r nftban || { log_error "groupadd -r nftban failed on build host"; return 1; }
-    fi
-    if ! getent group nftban-auditor >/dev/null 2>&1; then
-        groupadd -r nftban-auditor || { log_error "groupadd -r nftban-auditor failed on build host"; return 1; }
-    fi
-    if ! id -u nftban >/dev/null 2>&1; then
-        useradd -r -g nftban -s /usr/sbin/nologin -d /var/lib/nftban nftban \
-            || { log_error "useradd -r nftban failed on build host"; return 1; }
-    fi
-
-    log_info "Setting DEB ownership/attrs and building package in single fakeroot session..."
+    log_info "Building DEB with root:root archive metadata (postinst converges ownership)..."
     local deb_out="${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
     if ! fakeroot -- bash -ec '
-        deb_root="$1"; attrs_file="$2"; deb_out="$3"
+        deb_root="$1"; deb_out="$2"
 
-        # Baseline: own everything as root:root (FHS: /usr/lib/nftban = root:root)
+        # Baseline: own everything as root:root. Postinst applies per-path
+        # ownership for the 41 paths in nftban-dir-attrs.list after target-host
+        # nftban / nftban-auditor identities exist; statoverride keeps dpkg DB
+        # in sync so dpkg --verify stays clean.
         find "$deb_root/usr" -type f -exec chown root:root {} +
         find "$deb_root/usr" -type d -exec chown root:root {} +
         find "$deb_root/etc" -type f -exec chown root:root {} +
         find "$deb_root/etc" -type d -exec chown root:root {} +
+        find "$deb_root/var" -type d -exec chown root:root {} + 2>/dev/null || true
 
-        # Apply per-directory attrs from generator output (D-NEW-12)
-        attrs_count=0
-        while IFS="|" read -r dir_path dir_mode dir_owner dir_group; do
-            [[ -z "$dir_path" || "$dir_path" =~ ^[[:space:]]*# ]] && continue
-            target="${deb_root}${dir_path}"
-            if [[ -d "$target" ]]; then
-                chown "${dir_owner}:${dir_group}" "$target"
-                chmod "$dir_mode" "$target"
-                attrs_count=$((attrs_count + 1))
-            else
-                echo "WARN: skipping attrs for missing dir: $target" >&2
-            fi
-        done < "$attrs_file"
-        echo "Applied attrs to $attrs_count config-tier directories"
-
-        # Build DEB inside same fakeroot context so chown/chmod values are
-        # recorded in the package control DB (root:nftban 0750 for /etc/nftban*).
         dpkg-deb --build "$deb_root" "$deb_out"
-    ' _ "$deb_root" "$nftban_dir_attrs" "$deb_out"; then
+    ' _ "$deb_root" "$deb_out"; then
         log_error "DEB build failed inside fakeroot session (see output above)"
         return 1
     fi

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1979,6 +1979,29 @@ build_deb() {
     install -D -m 0644 "$nftban_dir_attrs" \
         "${deb_root}/usr/share/nftban/packaging/nftban-dir-attrs.list"
 
+    # PKG-EFFECTIVE-PARITY Slot 5a — chmod-only mode convergence at build time.
+    # Numeric modes are portable across hosts (unlike numeric UID/GID which
+    # broke ownership baking pre-Slot-5a), so it is safe and correct to apply
+    # the per-path mode column from nftban-dir-attrs.list during the build.
+    # Postinst still converges OWNERSHIP (and re-applies mode for symmetry +
+    # statoverride registration), but the DEB archive layer (L3) now ships
+    # the directories at their final mode (typically 0750) so L3 cross-
+    # packager parity reports the documented end state. Owner/group columns
+    # are intentionally NOT used here — this loop is chmod-only.
+    local _chmod_count=0 _chmod_skipped=0
+    while IFS='|' read -r _mc_path _mc_mode _mc_owner _mc_group; do
+        [[ -z "$_mc_path" || "$_mc_path" =~ ^[[:space:]]*# ]] && continue
+        local _mc_target="${deb_root}${_mc_path}"
+        if [[ -d "$_mc_target" ]]; then
+            chmod "$_mc_mode" "$_mc_target"
+            _chmod_count=$((_chmod_count + 1))
+        else
+            _chmod_skipped=$((_chmod_skipped + 1))
+        fi
+    done < "$nftban_dir_attrs"
+    log_info "DEB build-time chmod convergence: ${_chmod_count} dirs chmod'd, ${_chmod_skipped} skipped (missing in deb_root)"
+    unset _chmod_count _chmod_skipped _mc_path _mc_mode _mc_owner _mc_group _mc_target
+
     log_info "Building DEB with root:root archive metadata (postinst converges ownership)..."
     local deb_out="${BUILD_DIR}/nftban-core_${PKG_VERSION}_amd64.deb"
     if ! fakeroot -- bash -ec '

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -509,8 +509,9 @@ find install/share/nftban/templates -type f -name "*.html" | while read -r tmpl;
     install -D -m 0644 "\$tmpl" "%{buildroot}/usr/share/nftban/templates/\$rel_path"
 done
 
-# Man page
-install -D -m 0644 install/man/man8/nftban.8 %{buildroot}/usr/share/man/man8/nftban.8
+# Man page intentionally not shipped — see build_deb() comment for rationale.
+# CLI docs are registry-driven (commands.registry.yml + nftban help); the
+# hand-maintained nftban.8 is stale. Symmetric removal across DEB+RPM.
 
 # Bash completion
 install -D -m 0644 install/bash-completion/nftban %{buildroot}/usr/share/bash-completion/completions/nftban
@@ -1111,7 +1112,6 @@ fi
 /usr/share/nftban/specs/structure_default.json
 /usr/share/nftban/templates
 /usr/share/nftban/selinux
-/usr/share/man/man8/nftban.8*
 /usr/share/bash-completion/completions/nftban
 %attr(644,root,nftban) %config(noreplace) /etc/nftban/commands.registry.yml
 /usr/lib/nftban/scripts/generate-help.sh
@@ -1926,17 +1926,17 @@ build_deb() {
         install -D -m 0644 "$tmpl" "${deb_root}/usr/share/nftban/templates/$rel_path"
     done
 
-    # Copy man page (Debian convention: ship gzipped to match dpkg DB after
-    # mandb auto-compresses on Ubuntu). PKG-EFFECTIVE-PARITY Slot 5a Phase 6
-    # exposed this: Ubuntu mandb auto-compresses /usr/share/man/man8/nftban.8
-    # → nftban.8.gz post-install, but dpkg DB still recorded the uncompressed
-    # name, causing dpkg --verify to flag the path as missing on ubuntu22.04
-    # and ubuntu24.04 while debian12/13 happened to pass. RPM has the
-    # equivalent behavior via rpmbuild's brp-compress (the %files glob
-    # `nftban.8*` accommodates both forms). Gzip with -9n for deterministic
-    # compression (no timestamp/name in header → reproducible builds).
-    install -m 0644 "${PROJECT_ROOT}/install/man/man8/nftban.8" "${deb_root}/usr/share/man/man8/"
-    gzip -9n "${deb_root}/usr/share/man/man8/nftban.8"
+    # Man page intentionally not shipped. CLI documentation lives in the
+    # registry-driven dynamic help (`nftban help` → scripts/generate-help.sh
+    # reading commands.registry.yml). The hand-maintained install/man/man8/
+    # nftban.8 is 30 versions stale and competes with the registry SoT.
+    # Removing here brings DEB/RPM packaging into symmetry (see RPM spec
+    # heredoc — corresponding install + %files entry also removed). Source
+    # man-page file + scripts/update_man_page.sh + lint-registry-parity G15-B
+    # cleanup deferred to a separate hygiene gate. PKG-EFFECTIVE-PARITY Slot
+    # 5a Phase 6 (dpkg --verify) was failing on ubuntu22.04/24.04 because the
+    # shipped man page interacted unpredictably with mandb post-install; not
+    # shipping it removes the failure honestly without weakening L6.
 
     # Copy bash completion
     install -m 0644 "${PROJECT_ROOT}/install/bash-completion/nftban" "${deb_root}/usr/share/bash-completion/completions/"

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -101,6 +101,52 @@ case "$1" in
             usermod -a -G nftban root 2>/dev/null || true
         fi
 
+        # --- PKG-EFFECTIVE-PARITY Slot 5a (row 14): postinst ownership convergence ---
+        # Per V107_PKG_EFFECTIVE_PARITY_DEB_POSTINST_OWNERSHIP_SCOPE.md Option α +
+        # Option A. DEB archive ships /etc/nftban* and /var/lib/nftban/community as
+        # root:root (numeric IDs in the archive don't survive transit between hosts).
+        # After identity creation above, apply per-path ownership/mode by name from
+        # the attrs list shipped inside the package, then register dpkg-statoverride
+        # so dpkg --verify stays clean (otherwise dpkg DB would still record root:root
+        # and verify would flag every converged path with ??????U?G?). Idempotent:
+        # statoverride --update overwrites existing entries cleanly on reinstall/upgrade.
+        # No recursive chown — only the explicitly listed paths.
+        _nftban_attrs="/usr/share/nftban/packaging/nftban-dir-attrs.list"
+        if [ -r "$_nftban_attrs" ]; then
+            _nftban_attrs_count=0
+            _nftban_attrs_skipped=0
+            while IFS='|' read -r _attr_path _attr_mode _attr_owner _attr_group; do
+                # Skip blank lines and comments
+                case "$_attr_path" in
+                    ""|"#"*) continue ;;
+                esac
+                # Trim possible trailing whitespace from group field (last field)
+                _attr_group="${_attr_group%%[[:space:]]*}"
+                if [ -d "$_attr_path" ]; then
+                    chown "${_attr_owner}:${_attr_group}" "$_attr_path" 2>/dev/null || true
+                    chmod "$_attr_mode" "$_attr_path" 2>/dev/null || true
+                    # Register/refresh statoverride so dpkg --verify is clean.
+                    # If an entry already exists from a prior install, remove first
+                    # so --add succeeds idempotently across releases that may change
+                    # owner/mode for a path.
+                    if dpkg-statoverride --list "$_attr_path" >/dev/null 2>&1; then
+                        dpkg-statoverride --remove "$_attr_path" >/dev/null 2>&1 || true
+                    fi
+                    dpkg-statoverride --update --add \
+                        "$_attr_owner" "$_attr_group" "$_attr_mode" "$_attr_path" \
+                        >/dev/null 2>&1 || true
+                    _nftban_attrs_count=$((_nftban_attrs_count + 1))
+                else
+                    _nftban_attrs_skipped=$((_nftban_attrs_skipped + 1))
+                fi
+            done < "$_nftban_attrs"
+            log_info "DEB ownership convergence: ${_nftban_attrs_count} paths converged, ${_nftban_attrs_skipped} skipped (missing dirs)"
+            unset _nftban_attrs_count _nftban_attrs_skipped _attr_path _attr_mode _attr_owner _attr_group
+        else
+            log_warn "DEB attrs list not found at $_nftban_attrs — skipping ownership convergence"
+        fi
+        unset _nftban_attrs
+
         # --- NB-5: Canonical ownership for privileged binaries (DEB-PERM-001) ---
         # Must run AFTER nftban group is created. DEB payload ships 0750
         # root:root; postinst converges to root:nftban 0750 so the runtime

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -103,6 +103,32 @@ case "$1" in
         fi
 
         # -----------------------------------------------------------------
+        # STEP 6b: Remove dpkg-statoverride entries registered by postinst
+        # (PKG-EFFECTIVE-PARITY Slot 5a / row 14)
+        # -----------------------------------------------------------------
+        # Postinst registered statoverride for each path in the attrs list so
+        # dpkg --verify stays clean against the DEB DB (which records root:root
+        # for these paths because the archive ships them that way and ownership
+        # converges at install time, not in the archive). On purge, remove the
+        # override entries so the dpkg DB is clean. Tolerate missing list (e.g.
+        # if the package was installed before this convergence model existed).
+        # MUST run before STEP 7's rm -rf /usr/share/nftban (which would also
+        # delete the attrs list itself).
+        _nftban_attrs="/usr/share/nftban/packaging/nftban-dir-attrs.list"
+        if [ -r "$_nftban_attrs" ] && command -v dpkg-statoverride >/dev/null 2>&1; then
+            while IFS='|' read -r _attr_path _attr_mode _attr_owner _attr_group; do
+                case "$_attr_path" in
+                    ""|"#"*) continue ;;
+                esac
+                if dpkg-statoverride --list "$_attr_path" >/dev/null 2>&1; then
+                    dpkg-statoverride --remove "$_attr_path" >/dev/null 2>&1 || true
+                fi
+            done < "$_nftban_attrs"
+            unset _attr_path _attr_mode _attr_owner _attr_group
+        fi
+        unset _nftban_attrs
+
+        # -----------------------------------------------------------------
         # STEP 7: Remove ALL configuration, data, logs, cache directories
         # (user config already backed up in STEP 1)
         # -----------------------------------------------------------------

--- a/scripts/test-package-deb-l3-exceptions.list
+++ b/scripts/test-package-deb-l3-exceptions.list
@@ -54,3 +54,18 @@
 /etc/nftban/suricata/state|postinst-converged
 /etc/nftban/suricata/state/last-good|postinst-converged
 /var/lib/nftban/community|postinst-converged
+
+# =============================================================================
+# Parent-tier exception (Slot 5a follow-up — /var/lib/nftban L3 parity fix)
+# =============================================================================
+# /var/lib/nftban is `created_by:tmpfiles` in fhs-spec.yaml (runtime authority)
+# but is also explicitly emitted to package payload (build/generate-fhs-outputs.sh
+# Slot 5a additions) so DEB and RPM symmetrically declare the parent dir. RPM
+# uses name-based %attr and ships archive metadata as root:nftban directly. DEB
+# uses chmod-only build-time convergence (mode 0750) and postinst chown to
+# root:nftban via the same attrs.list — so DEB archive metadata is root:root.
+# This entry filters the path from both sides of the cross-packager L3 diff;
+# L4 (installed-fs stat) still requires both packagers to converge to root:nftban
+# 0750 by name on the target host, which is verified by Test * install Phase 4.
+
+/var/lib/nftban|postinst-converged

--- a/scripts/test-package-deb-l3-exceptions.list
+++ b/scripts/test-package-deb-l3-exceptions.list
@@ -1,0 +1,56 @@
+# =============================================================================
+# NFTBan v1.107 - DEB L3 Package Metadata Exceptions
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="test-package-deb-l3-exceptions"
+# meta:type="data"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-07"
+# meta:description="DEB L3 metadata divergence exceptions for postinst-converged paths"
+# =============================================================================
+#
+# Consumer: scripts/test-package-effective-parity.sh diff (and L3 cross-packager
+# aggregation in .github/workflows/build-packages.yml).
+#
+# Purpose: enumerate paths where DEB archive metadata is INTENTIONALLY divergent
+# from RPM archive metadata because the DEB authority model converges ownership
+# at install time (postinst chown + dpkg-statoverride) rather than baking it
+# into the archive. RPM uses %attr() in nftban-files.inc, which is name-based
+# and re-applied at install time, so RPM ships the final ownership in the
+# archive. DEB ships these paths as root:root in the archive and converges
+# at postinst — see V107_PKG_EFFECTIVE_PARITY_DEB_POSTINST_OWNERSHIP_SCOPE.md.
+#
+# Why this matters: dpkg-deb stores numeric UID/GID in the tar payload, not
+# names. A build-host fakeroot chown to "nftban:nftban" bakes the build-host's
+# numeric IDs into the archive. On a target host where the GID resolves to a
+# different name (or no name at all), the directory ends up owned by
+# systemd-journal / UNKNOWN. The canonical Debian solution is postinst chown
+# after addgroup --system creates the identity with the target's free GID.
+#
+# Format (deterministic, easy to parse):
+#   <path>|<rationale-tag>
+# Lines starting with '#' or blank are ignored.
+#
+# Rationale tag values:
+#   postinst-converged  → archive ships root:root; postinst chown + statoverride
+#                         applies final ownership/mode by name on target host.
+#                         L4 (installed-fs stat) MUST still match EXPECTED_TABLE.
+#                         L6 (dpkg --verify) MUST still be clean (statoverride
+#                         keeps dpkg DB in sync with on-disk state).
+#
+# This file is consumed by mode_diff (cross-packager L3 parity aggregation)
+# ONLY. L4 / L5 / L6 expectations are NOT weakened by entries here — those
+# layers continue to require root:nftban / nftban:nftban final state and
+# clean verify-tool output.
+#
+# =============================================================================
+# Critical-path exceptions (6 paths from EXPECTED_TABLE where package_shipped=yes)
+# =============================================================================
+
+/etc/nftban|postinst-converged
+/etc/nftban/conf.d|postinst-converged
+/etc/nftban/suricata|postinst-converged
+/etc/nftban/suricata/state|postinst-converged
+/etc/nftban/suricata/state/last-good|postinst-converged
+/var/lib/nftban/community|postinst-converged

--- a/scripts/test-package-effective-parity.sh
+++ b/scripts/test-package-effective-parity.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.107 - Package Effective Parity Test (PKG-EFFECTIVE-PARITY)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="test-package-effective-parity"
+# meta:type="test"
+# meta:header="Package Effective Parity Test"
+# meta:version="1.107.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="L3-L6 invariant gate for RPM/DEB package metadata + installed-fs + reinstall + verify-tool parity"
+# meta:inventory.files=""
+# meta:inventory.binaries="rpm,dpkg-deb,stat,dnf,apt-get,dpkg"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root (for install/reinstall/verify modes); user (for *-meta modes)"
+#
+# meta:created_date="2026-05-07"
+# meta:updated_date="2026-05-07"
+#
+# Closes worklog row 14 (PKG-EFFECTIVE-PARITY) when wired into CI:
+#   - L3 package-metadata parity (rpm-meta vs deb-meta)
+#   - L4 installed-filesystem parity (fresh-stat across packagers)
+#   - L5 reinstall + upgrade preservation
+#   - L6 verify-tool parity (rpm -V / dpkg --verify)
+#
+# Modes:
+#   rpm-meta <rpm-file>            extract dir metadata from RPM artifact
+#   deb-meta <deb-file>            extract dir metadata from DEB artifact
+#   fresh-stat                     stat critical paths on installed system
+#   reinstall-stat                 alias of fresh-stat (semantic marker)
+#   upgrade-stat <phase>           alias of fresh-stat with phase tag (pre|post)
+#   verify-tool <rpm|deb>          run rpm -V or dpkg --verify; filter by exceptions
+#   diff <file-a> <file-b>         diff two parity tables; emit unified result
+#
+# Output format (stdout, deterministic, sorted):
+#   <path>|<type>|<mode>|<owner>|<group>
+#   - type: dir / file / link / other
+#   - mode: 0NNN octal
+#
+# Exit codes:
+#   0  success / clean
+#   1  divergence detected
+#   2  invalid usage / missing dependency
+#   3  artifact missing / unreadable
+#
+# CRITICAL: 11 paths are HARDCODED below from V107_PKG_EFFECTIVE_PARITY_SCOPE.md
+# §3 + worklog §6.3.5. They are NOT derived from fhs-spec.yaml at runtime —
+# that would make the test circular (spec is the thing under test for L3).
+# Path additions/removals require deliberate scope-amendment and edit here.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# -----------------------------------------------------------------------------
+# Critical-path expected metadata table (binding; per scope §3.1)
+# Format: <path>|<type>|<mode>|<owner>|<group>|<package_shipped>
+#   package_shipped=yes  → applicable to L3 (rpm-meta/deb-meta) + L4 + L5 + L6
+#   package_shipped=no   → applicable to L4 (post-tmpfiles) + L5 only (no L3/L6)
+# -----------------------------------------------------------------------------
+EXPECTED_TABLE=(
+    "/etc/nftban|dir|0750|root|nftban|yes"
+    "/etc/nftban/conf.d|dir|0750|root|nftban|yes"
+    "/etc/nftban/suricata|dir|0750|root|nftban|yes"
+    "/etc/nftban/suricata/state|dir|0750|root|nftban|yes"
+    "/etc/nftban/suricata/state/last-good|dir|0750|root|nftban|yes"
+    "/run/nftban|dir|0755|nftban|nftban|no"
+    "/var/cache/nftban|dir|0755|nftban|nftban|no"
+    "/var/lib/nftban|dir|0750|root|nftban|no"
+    "/var/lib/nftban/community|dir|0750|nftban|nftban|yes"
+    "/var/lib/nftban/reports/auditors|dir|0770|root|nftban-auditor|no"
+    "/var/log/nftban|dir|0750|nftban|nftban|no"
+)
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+log_info() { echo "[INFO] $*" >&2; }
+log_err()  { echo "[ERROR] $*" >&2; }
+log_pass() { echo "[PASS] $*" >&2; }
+log_fail() { echo "[FAIL] $*" >&2; }
+
+# Convert ls-style mode 'drwxr-x---' or '-rw-r--r--' to octal '0750' / '0644'.
+ls_mode_to_octal() {
+    local m="$1"
+    [[ ${#m} -lt 10 ]] && { echo "0000"; return; }
+    local u=0 g=0 o=0
+    [[ "${m:1:1}" == "r" ]] && u=$((u + 4))
+    [[ "${m:2:1}" == "w" ]] && u=$((u + 2))
+    case "${m:3:1}" in x|s) u=$((u + 1)) ;; esac
+    [[ "${m:4:1}" == "r" ]] && g=$((g + 4))
+    [[ "${m:5:1}" == "w" ]] && g=$((g + 2))
+    case "${m:6:1}" in x|s) g=$((g + 1)) ;; esac
+    [[ "${m:7:1}" == "r" ]] && o=$((o + 4))
+    [[ "${m:8:1}" == "w" ]] && o=$((o + 2))
+    case "${m:9:1}" in x|t) o=$((o + 1)) ;; esac
+    printf "0%d%d%d\n" "$u" "$g" "$o"
+}
+
+# Convert ls-style first char to type tag.
+ls_type_from_mode() {
+    case "${1:0:1}" in
+        d) echo "dir" ;;
+        -) echo "file" ;;
+        l) echo "link" ;;
+        *) echo "other" ;;
+    esac
+}
+
+# Critical-path set as a newline-delimited list (for grep -F filtering).
+critical_paths_list() {
+    printf '%s\n' "${EXPECTED_TABLE[@]}" | cut -d'|' -f1
+}
+
+# Critical-path set as a regex anchor pattern (for awk filtering).
+# Returns lines where the path field is exactly one of the 11 critical paths.
+critical_path_filter_awk() {
+    awk -F'|' -v paths="$(critical_paths_list)" '
+        BEGIN { split(paths, p, "\n"); for (i in p) keep[p[i]] = 1 }
+        keep[$1] { print }
+    '
+}
+
+# Look up expected row for a path; emits |-separated row or empty if not in set.
+expected_for_path() {
+    local target="$1"
+    local row
+    for row in "${EXPECTED_TABLE[@]}"; do
+        [[ "${row%%|*}" == "$target" ]] && { echo "$row"; return; }
+    done
+}
+
+# Check whether a path is in the critical set.
+is_critical_path() {
+    local target="$1"
+    local row
+    for row in "${EXPECTED_TABLE[@]}"; do
+        [[ "${row%%|*}" == "$target" ]] && return 0
+    done
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Mode: rpm-meta — extract dir metadata from RPM artifact via `rpm -qplv`
+# -----------------------------------------------------------------------------
+mode_rpm_meta() {
+    local rpm_file="${1:?usage: rpm-meta <rpm-file>}"
+    [[ -r "$rpm_file" ]] || { log_err "RPM not readable: $rpm_file"; exit 3; }
+    command -v rpm >/dev/null || { log_err "rpm not installed"; exit 2; }
+
+    # `rpm -qplv` output: drwxr-x---    2 root    nftban              0 Jan  1 00:00 /etc/nftban
+    rpm -qplv "$rpm_file" | while read -r mode_str _links owner group _size _date _time _tz path; do
+        # Some `rpm -qplv` formats omit timezone column; handle both
+        if [[ -z "$path" ]]; then
+            path="$_tz"
+        fi
+        is_critical_path "$path" || continue
+        local octal type
+        octal=$(ls_mode_to_octal "$mode_str")
+        type=$(ls_type_from_mode "$mode_str")
+        echo "$path|$type|$octal|$owner|$group"
+    done | sort -u
+}
+
+# -----------------------------------------------------------------------------
+# Mode: deb-meta — extract dir metadata from DEB artifact via `dpkg-deb --contents`
+# -----------------------------------------------------------------------------
+mode_deb_meta() {
+    local deb_file="${1:?usage: deb-meta <deb-file>}"
+    [[ -r "$deb_file" ]] || { log_err "DEB not readable: $deb_file"; exit 3; }
+    command -v dpkg-deb >/dev/null || { log_err "dpkg-deb not installed"; exit 2; }
+
+    # `dpkg-deb --contents` output: drwxr-xr-x root/root         0 2024-12-22 18:08 ./etc/nftban/
+    dpkg-deb --contents "$deb_file" | while read -r mode_str owner_group _size _date _time path _link; do
+        # Strip leading './' and trailing '/'
+        path="${path#./}"
+        path="${path%/}"
+        path="/$path"
+        is_critical_path "$path" || continue
+        local octal type owner group
+        octal=$(ls_mode_to_octal "$mode_str")
+        type=$(ls_type_from_mode "$mode_str")
+        owner="${owner_group%%/*}"
+        group="${owner_group#*/}"
+        echo "$path|$type|$octal|$owner|$group"
+    done | sort -u
+}
+
+# -----------------------------------------------------------------------------
+# Mode: fresh-stat / reinstall-stat / upgrade-stat — stat live filesystem
+# -----------------------------------------------------------------------------
+mode_fresh_stat() {
+    local row path type expected_type
+    for row in "${EXPECTED_TABLE[@]}"; do
+        path="${row%%|*}"
+        expected_type=$(echo "$row" | cut -d'|' -f2)
+        if [[ ! -e "$path" ]]; then
+            # MISSING is reported as a sentinel row; aggregator treats as failure
+            echo "$path|MISSING|-|-|-"
+            continue
+        fi
+        # stat -c '%F %a %U %G' — %F is human-readable type ("directory", "regular file", ...)
+        local s_type s_mode s_owner s_group
+        s_type=$(stat -c '%F' "$path")
+        s_mode=$(stat -c '%a' "$path")
+        s_owner=$(stat -c '%U' "$path")
+        s_group=$(stat -c '%G' "$path")
+        # Normalize stat type to our type tag
+        case "$s_type" in
+            "directory") type="dir" ;;
+            "regular file"|"regular empty file") type="file" ;;
+            "symbolic link") type="link" ;;
+            *) type="other" ;;
+        esac
+        # Pad mode to 4 digits ('750' → '0750')
+        [[ ${#s_mode} -eq 3 ]] && s_mode="0$s_mode"
+        echo "$path|$type|$s_mode|$s_owner|$s_group"
+    done | sort -u
+}
+
+# -----------------------------------------------------------------------------
+# Mode: verify-tool — run rpm -V or dpkg --verify; filter via exceptions
+# -----------------------------------------------------------------------------
+mode_verify_tool() {
+    local kind="${1:?usage: verify-tool <rpm|deb>}"
+    local exceptions_file="${EXCEPTIONS_FILE:-$(dirname "$0")/test-package-verify-exceptions.list}"
+    local raw filtered_count=0 unexpected=0
+
+    case "$kind" in
+        rpm)
+            command -v rpm >/dev/null || { log_err "rpm not installed"; exit 2; }
+            # rpm -V exits 1 if any modifications detected; we want output regardless
+            raw=$(rpm -V nftban-core 2>&1 || true)
+            ;;
+        deb)
+            command -v dpkg >/dev/null || { log_err "dpkg not installed"; exit 2; }
+            raw=$(dpkg --verify nftban-core 2>&1 || true)
+            ;;
+        *)
+            log_err "verify-tool kind must be 'rpm' or 'deb'"
+            exit 2
+            ;;
+    esac
+
+    # Load exceptions (lines matching pattern: <path>|<flag-pattern>) — comments allowed
+    local -a exceptions=()
+    if [[ -r "$exceptions_file" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+            exceptions+=("$line")
+        done < "$exceptions_file"
+    fi
+
+    # Process verify output line-by-line
+    if [[ -z "$raw" ]]; then
+        echo "VERIFY-CLEAN"
+        return 0
+    fi
+
+    while IFS= read -r v_line; do
+        [[ -z "$v_line" ]] && continue
+        local exempted=0 ex
+        for ex in "${exceptions[@]}"; do
+            local ex_path="${ex%%|*}"
+            local ex_pat="${ex#*|}"
+            if [[ "$v_line" == *"$ex_path"* ]] && [[ "$v_line" =~ $ex_pat ]]; then
+                exempted=1
+                break
+            fi
+        done
+        if [[ "$exempted" -eq 1 ]]; then
+            filtered_count=$((filtered_count + 1))
+            echo "EXEMPTED: $v_line"
+        else
+            unexpected=$((unexpected + 1))
+            echo "UNEXPECTED: $v_line"
+        fi
+    done <<< "$raw"
+
+    if [[ "$unexpected" -gt 0 ]]; then
+        log_fail "verify-tool $kind: $unexpected unexpected entry/entries (filtered $filtered_count exempted)"
+        exit 1
+    fi
+    log_pass "verify-tool $kind: clean ($filtered_count exempted via $exceptions_file)"
+}
+
+# -----------------------------------------------------------------------------
+# Mode: diff — compare two parity tables; require exact match for shared paths
+# -----------------------------------------------------------------------------
+mode_diff() {
+    local a="${1:?usage: diff <file-a> <file-b>}"
+    local b="${2:?usage: diff <file-a> <file-b>}"
+    [[ -r "$a" ]] || { log_err "Not readable: $a"; exit 3; }
+    [[ -r "$b" ]] || { log_err "Not readable: $b"; exit 3; }
+
+    # Both files are |-separated parity tables; sort + diff
+    if diff -u <(sort "$a") <(sort "$b") > /tmp/parity-diff.$$ 2>&1; then
+        log_pass "Parity tables match: $a == $b"
+        rm -f /tmp/parity-diff.$$
+        return 0
+    fi
+    log_fail "Parity tables diverge: $a vs $b"
+    cat /tmp/parity-diff.$$ >&2
+    rm -f /tmp/parity-diff.$$
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Mode: assert-expected — compare an extracted/observed table against expected
+# -----------------------------------------------------------------------------
+# Asserts every package_shipped=yes path is present and matches expected metadata.
+# For package_shipped=no paths, only checks against expected when path is found.
+mode_assert_expected() {
+    local observed="${1:?usage: assert-expected <observed-file>}"
+    local mode_filter="${2:-}"  # 'package' or 'all'
+    [[ -r "$observed" ]] || { log_err "Not readable: $observed"; exit 3; }
+
+    local fail=0 row exp_path exp_type exp_mode exp_owner exp_group exp_pkg
+    for row in "${EXPECTED_TABLE[@]}"; do
+        IFS='|' read -r exp_path exp_type exp_mode exp_owner exp_group exp_pkg <<< "$row"
+        if [[ "$mode_filter" == "package" && "$exp_pkg" != "yes" ]]; then
+            continue
+        fi
+        local actual
+        actual=$(grep "^${exp_path}|" "$observed" || true)
+        if [[ -z "$actual" ]]; then
+            log_fail "expected path missing in observed: $exp_path"
+            fail=1
+            continue
+        fi
+        local expected_row="${exp_path}|${exp_type}|${exp_mode}|${exp_owner}|${exp_group}"
+        if [[ "$actual" != "$expected_row" ]]; then
+            log_fail "metadata mismatch for $exp_path"
+            log_fail "  expected: $expected_row"
+            log_fail "  observed: $actual"
+            fail=1
+        else
+            log_pass "$exp_path matches expected"
+        fi
+    done
+
+    if [[ "$fail" -eq 1 ]]; then
+        return 1
+    fi
+    log_pass "assert-expected (filter=${mode_filter:-all}) clean"
+}
+
+# -----------------------------------------------------------------------------
+# Mode: list-critical-paths — emit the 11 critical paths (one per line)
+# -----------------------------------------------------------------------------
+mode_list_critical_paths() {
+    critical_paths_list
+}
+
+# -----------------------------------------------------------------------------
+# Mode: list-expected — emit the full expected table (path|type|mode|owner|group|pkg)
+# -----------------------------------------------------------------------------
+mode_list_expected() {
+    printf '%s\n' "${EXPECTED_TABLE[@]}"
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <mode> [args]
+
+Modes:
+  rpm-meta <rpm-file>              Extract dir metadata from built RPM artifact
+  deb-meta <deb-file>              Extract dir metadata from built DEB artifact
+  fresh-stat                       Stat critical paths on installed system
+  reinstall-stat                   Alias of fresh-stat (semantic marker post-reinstall)
+  upgrade-stat <pre|post>          Alias of fresh-stat with phase tag for upgrade canon
+  verify-tool <rpm|deb>            Run rpm -V or dpkg --verify; filter by exceptions
+  diff <file-a> <file-b>           Diff two parity tables; exit 1 on divergence
+  assert-expected <observed-file>  [package|all]
+                                    Assert observed matches expected; package-only
+                                    filter restricts to L3-applicable paths
+  list-critical-paths              Emit the 11 critical paths (one per line)
+  list-expected                    Emit the expected metadata table
+
+Environment:
+  EXCEPTIONS_FILE   Override path to verify-tool exceptions (default: alongside script)
+EOF
+}
+
+main() {
+    local mode="${1:-}"
+    [[ -z "$mode" ]] && { usage; exit 2; }
+    shift
+    case "$mode" in
+        rpm-meta)            mode_rpm_meta "$@" ;;
+        deb-meta)            mode_deb_meta "$@" ;;
+        fresh-stat)          mode_fresh_stat ;;
+        reinstall-stat)      mode_fresh_stat ;;
+        upgrade-stat)        mode_fresh_stat ;;
+        verify-tool)         mode_verify_tool "$@" ;;
+        diff)                mode_diff "$@" ;;
+        assert-expected)     mode_assert_expected "$@" ;;
+        list-critical-paths) mode_list_critical_paths ;;
+        list-expected)       mode_list_expected ;;
+        -h|--help|help)      usage ;;
+        *)
+            log_err "unknown mode: $mode"
+            usage
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/test-package-effective-parity.sh
+++ b/scripts/test-package-effective-parity.sh
@@ -150,23 +150,71 @@ is_critical_path() {
 # -----------------------------------------------------------------------------
 # Mode: rpm-meta — extract dir metadata from RPM artifact via `rpm -qplv`
 # -----------------------------------------------------------------------------
+# Defensive parser: rpm -qplv output column counts shift between rpm versions
+# and locales. Recent files use date "Mon Day HH:MM" (3 columns), older/future
+# files use "Mon Day Year" (also 3 columns), but some rpm builds emit extra
+# columns (selinux context, capabilities) and the LANG-dependent month name
+# may contain non-ASCII characters. The previous fixed-position read pattern
+# silently produced 0 lines on Rocky 9 / EL 9-family containers in CI.
+#
+# Parse each line into an array. Mode/owner/group are at stable positions
+# (1, 3, 4 — these have been canonical since RPM 4.0). Path is the LAST
+# whitespace-separated field (none of our 11 critical paths contain spaces;
+# paths in the FHS namespace never do in practice). Fail loudly if rpm itself
+# fails or produces empty output, so the aggregator surfaces the real cause
+# rather than silently passing on no data.
 mode_rpm_meta() {
     local rpm_file="${1:?usage: rpm-meta <rpm-file>}"
     [[ -r "$rpm_file" ]] || { log_err "RPM not readable: $rpm_file"; exit 3; }
     command -v rpm >/dev/null || { log_err "rpm not installed"; exit 2; }
 
-    # `rpm -qplv` output: drwxr-x---    2 root    nftban              0 Jan  1 00:00 /etc/nftban
-    rpm -qplv "$rpm_file" | while read -r mode_str _links owner group _size _date _time _tz path; do
-        # Some `rpm -qplv` formats omit timezone column; handle both
-        if [[ -z "$path" ]]; then
-            path="$_tz"
-        fi
+    # Force C locale so month names + decimal separators are predictable
+    # across CI containers; capture all output to surface failures explicitly.
+    local raw
+    if ! raw=$(LC_ALL=C rpm -qplv "$rpm_file" 2>/dev/null); then
+        log_err "rpm -qplv failed for $rpm_file"
+        exit 1
+    fi
+    if [[ -z "$raw" ]]; then
+        log_err "rpm -qplv produced empty output for $rpm_file"
+        exit 1
+    fi
+
+    # Parse line-by-line; emit only critical paths in canonical format.
+    local out
+    out=$(printf '%s\n' "$raw" | awk '
+        /^[-dlcbps]/ {
+            # Field 1 = mode (e.g. drwxr-x---), Field 3 = owner, Field 4 = group.
+            # Field NF = path (last whitespace-separated token; safe for FHS).
+            mode = $1
+            owner = $3
+            group = $4
+            path = $NF
+            # Skip lines whose last field is not an absolute path.
+            if (path !~ /^\//) next
+            # Skip if line did not yield enough fields for a valid record.
+            if (NF < 5) next
+            print path "|" mode "|" owner "|" group
+        }
+    ')
+
+    if [[ -z "$out" ]]; then
+        log_err "rpm-meta parsed zero records from $rpm_file (rpm output was non-empty; parser may need adjustment)"
+        log_err "First 5 raw lines for diagnosis:"
+        printf '%s\n' "$raw" | head -5 >&2
+        exit 1
+    fi
+
+    # Filter to critical paths and convert mode to octal in the shell loop
+    # (awk's substr/permission math is more verbose than reusing the existing
+    # ls_mode_to_octal helper). Sort -u for deterministic output.
+    while IFS='|' read -r path mode owner group; do
         is_critical_path "$path" || continue
         local octal type
-        octal=$(ls_mode_to_octal "$mode_str")
-        type=$(ls_type_from_mode "$mode_str")
+        octal=$(ls_mode_to_octal "$mode")
+        type=$(ls_type_from_mode "$mode")
         echo "$path|$type|$octal|$owner|$group"
-    done | sort -u
+    done <<< "$out" | sort -u
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/test-package-effective-parity.sh
+++ b/scripts/test-package-effective-parity.sh
@@ -220,25 +220,79 @@ mode_rpm_meta() {
 # -----------------------------------------------------------------------------
 # Mode: deb-meta — extract dir metadata from DEB artifact via `dpkg-deb --contents`
 # -----------------------------------------------------------------------------
+# Defensive parser: dpkg-deb --contents output column counts can shift between
+# dpkg versions and locales. The previous fixed-column read silently produced
+# 0 lines on debian12/13 + ubuntu22.04/24.04 containers in CI, hidden behind
+# the parallel mode_rpm_meta failure (the L3 RPM assert step ran first and
+# aborted the workflow before L3 DEB executed). After 75ebf1ad fixed RPM,
+# the empty DEB extraction surfaced as the next blocker.
+#
+# Parse each line into an array. Mode is at stable position 1; owner/group
+# is the combined "owner/group" token at position 2 (canonical since dpkg
+# 1.0). Path is the LAST whitespace-separated field — none of our 11 critical
+# paths contain spaces, and FHS paths in package archives never do in practice.
+# Strip leading "./" and trailing "/" to normalize to absolute paths matching
+# the EXPECTED_TABLE keys. Fail loudly if dpkg-deb itself fails or produces
+# empty output.
 mode_deb_meta() {
     local deb_file="${1:?usage: deb-meta <deb-file>}"
     [[ -r "$deb_file" ]] || { log_err "DEB not readable: $deb_file"; exit 3; }
     command -v dpkg-deb >/dev/null || { log_err "dpkg-deb not installed"; exit 2; }
 
-    # `dpkg-deb --contents` output: drwxr-xr-x root/root         0 2024-12-22 18:08 ./etc/nftban/
-    dpkg-deb --contents "$deb_file" | while read -r mode_str owner_group _size _date _time path _link; do
-        # Strip leading './' and trailing '/'
-        path="${path#./}"
-        path="${path%/}"
-        path="/$path"
+    # Force C locale for predictable date/decimal formatting across CI
+    # containers; capture all output to surface failures explicitly.
+    local raw
+    if ! raw=$(LC_ALL=C dpkg-deb --contents "$deb_file" 2>/dev/null); then
+        log_err "dpkg-deb --contents failed for $deb_file"
+        exit 1
+    fi
+    if [[ -z "$raw" ]]; then
+        log_err "dpkg-deb --contents produced empty output for $deb_file"
+        exit 1
+    fi
+
+    # Parse line-by-line; emit canonical "path|mode|owner|group" rows for any
+    # line whose last field is an absolute path (after normalization). Mode is
+    # field 1; owner_group is field 2 ("owner/group" combined per dpkg-deb
+    # convention); path is field NF (last whitespace-separated token).
+    local out
+    out=$(printf '%s\n' "$raw" | awk '
+        /^[-dlcbps]/ {
+            mode = $1
+            owner_group = $2
+            path = $NF
+            # Skip lines whose last field is not a path-like token
+            if (path !~ /^\.?\//) next
+            # Skip if line did not yield enough fields for a valid record
+            if (NF < 4) next
+            # Strip leading "./" and trailing "/" from path
+            sub(/^\.\//, "", path)
+            sub(/\/$/, "", path)
+            # Normalize to absolute path
+            if (path !~ /^\//) path = "/" path
+            # Split owner_group "owner/group" into separate fields
+            split(owner_group, og, "/")
+            print path "|" mode "|" og[1] "|" og[2]
+        }
+    ')
+
+    if [[ -z "$out" ]]; then
+        log_err "deb-meta parsed zero records from $deb_file (dpkg-deb output was non-empty; parser may need adjustment)"
+        log_err "First 5 raw lines for diagnosis:"
+        printf '%s\n' "$raw" | head -5 >&2
+        exit 1
+    fi
+
+    # Filter to critical paths and convert mode to octal in the shell loop
+    # (matches mode_rpm_meta pattern; reuses ls_mode_to_octal helper). Sort
+    # -u for deterministic output.
+    while IFS='|' read -r path mode owner group; do
         is_critical_path "$path" || continue
-        local octal type owner group
-        octal=$(ls_mode_to_octal "$mode_str")
-        type=$(ls_type_from_mode "$mode_str")
-        owner="${owner_group%%/*}"
-        group="${owner_group#*/}"
+        local octal type
+        octal=$(ls_mode_to_octal "$mode")
+        type=$(ls_type_from_mode "$mode")
         echo "$path|$type|$octal|$owner|$group"
-    done | sort -u
+    done <<< "$out" | sort -u
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/test-package-effective-parity.sh
+++ b/scripts/test-package-effective-parity.sh
@@ -294,21 +294,38 @@ mode_verify_tool() {
 # -----------------------------------------------------------------------------
 # Mode: diff — compare two parity tables; require exact match for shared paths
 # -----------------------------------------------------------------------------
+# Portable shell-only comparison — does NOT depend on the external `diff`
+# binary, which is not preinstalled in minimal EL9 containers
+# (rockylinux:9, almalinux:9, centos:stream9). Uses sort + bash string
+# equality, with awk-based set-difference reporting on divergence.
 mode_diff() {
     local a="${1:?usage: diff <file-a> <file-b>}"
     local b="${2:?usage: diff <file-a> <file-b>}"
     [[ -r "$a" ]] || { log_err "Not readable: $a"; exit 3; }
     [[ -r "$b" ]] || { log_err "Not readable: $b"; exit 3; }
 
-    # Both files are |-separated parity tables; sort + diff
-    if diff -u <(sort "$a") <(sort "$b") > /tmp/parity-diff.$$ 2>&1; then
+    local sorted_a sorted_b
+    sorted_a=$(sort "$a")
+    sorted_b=$(sort "$b")
+
+    if [[ "$sorted_a" == "$sorted_b" ]]; then
         log_pass "Parity tables match: $a == $b"
-        rm -f /tmp/parity-diff.$$
         return 0
     fi
+
     log_fail "Parity tables diverge: $a vs $b"
-    cat /tmp/parity-diff.$$ >&2
-    rm -f /tmp/parity-diff.$$
+    {
+        echo "--- $a (sorted) ---"
+        printf '%s\n' "$sorted_a"
+        echo "--- $b (sorted) ---"
+        printf '%s\n' "$sorted_b"
+        echo "--- lines only in $a ---"
+        awk 'NR==FNR{seen[$0]++; next} !($0 in seen)' \
+            <(printf '%s\n' "$sorted_b") <(printf '%s\n' "$sorted_a")
+        echo "--- lines only in $b ---"
+        awk 'NR==FNR{seen[$0]++; next} !($0 in seen)' \
+            <(printf '%s\n' "$sorted_a") <(printf '%s\n' "$sorted_b")
+    } >&2
     return 1
 }
 

--- a/scripts/test-package-effective-parity.sh
+++ b/scripts/test-package-effective-parity.sh
@@ -292,32 +292,102 @@ mode_verify_tool() {
 }
 
 # -----------------------------------------------------------------------------
+# Helper: load path-only list from L3 exception file
+# -----------------------------------------------------------------------------
+# Reads scripts/test-package-deb-l3-exceptions.list (or any file with the same
+# format `<path>|<rationale-tag>`) and emits one path per line. Used by
+# mode_diff and mode_assert_expected to honor the postinst-converged authority
+# model on the cross-packager (L3) layer only — L4/L5/L6 are unaffected.
+load_l3_exception_paths() {
+    local exceptions_file="$1"
+    [[ -r "$exceptions_file" ]] || return 0
+    awk -F'|' '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*$/ { next }
+        NF >= 1 { gsub(/[[:space:]]+$/, "", $1); print $1 }
+    ' "$exceptions_file"
+}
+
+# -----------------------------------------------------------------------------
 # Mode: diff — compare two parity tables; require exact match for shared paths
 # -----------------------------------------------------------------------------
 # Portable shell-only comparison — does NOT depend on the external `diff`
 # binary, which is not preinstalled in minimal EL9 containers
 # (rockylinux:9, almalinux:9, centos:stream9). Uses sort + bash string
 # equality, with awk-based set-difference reporting on divergence.
+#
+# Optional 3rd argument: --exceptions=<file>
+#   When set, lines whose path field is listed in the exception file are
+#   filtered out of BOTH inputs before comparison. This is intended for the
+#   L3 cross-packager aggregator only — RPM (`%attr` name-based, applied at
+#   install time, archive ships final ownership) vs DEB (postinst-converged,
+#   archive ships root:root). The 6 critical postinst-converged paths are
+#   listed in scripts/test-package-deb-l3-exceptions.list. L4/L5 (installed-fs
+#   stat) and L6 (verify-tool) modes are NOT affected by this option.
 mode_diff() {
-    local a="${1:?usage: diff <file-a> <file-b>}"
-    local b="${2:?usage: diff <file-a> <file-b>}"
+    local a="${1:?usage: diff <file-a> <file-b> [--exceptions=<file>]}"
+    local b="${2:?usage: diff <file-a> <file-b> [--exceptions=<file>]}"
     [[ -r "$a" ]] || { log_err "Not readable: $a"; exit 3; }
     [[ -r "$b" ]] || { log_err "Not readable: $b"; exit 3; }
 
-    local sorted_a sorted_b
-    sorted_a=$(sort "$a")
-    sorted_b=$(sort "$b")
+    local exceptions_file=""
+    case "${3:-}" in
+        "")            ;;
+        --exceptions=*) exceptions_file="${3#--exceptions=}" ;;
+        *) log_err "Unknown arg: $3 (expected --exceptions=<file>)"; exit 2 ;;
+    esac
+
+    local sorted_a sorted_b filter_count=0
+    if [[ -n "$exceptions_file" ]]; then
+        if [[ ! -r "$exceptions_file" ]]; then
+            log_err "Exceptions file not readable: $exceptions_file"
+            exit 3
+        fi
+        local exception_paths
+        exception_paths=$(load_l3_exception_paths "$exceptions_file")
+        if [[ -z "$exception_paths" ]]; then
+            log_info "Exceptions file present but empty: $exceptions_file"
+            sorted_a=$(sort "$a")
+            sorted_b=$(sort "$b")
+        else
+            # Filter both files: drop rows whose path field is in exception_paths.
+            # Use awk with the exception paths supplied via stdin (NR==FNR trick).
+            sorted_a=$(awk -F'|' -v paths="$exception_paths" '
+                BEGIN {
+                    n = split(paths, p, "\n")
+                    for (i = 1; i <= n; i++) drop[p[i]] = 1
+                }
+                !($1 in drop) { print }
+            ' "$a" | sort)
+            sorted_b=$(awk -F'|' -v paths="$exception_paths" '
+                BEGIN {
+                    n = split(paths, p, "\n")
+                    for (i = 1; i <= n; i++) drop[p[i]] = 1
+                }
+                !($1 in drop) { print }
+            ' "$b" | sort)
+            filter_count=$(echo "$exception_paths" | grep -cv '^$' || true)
+            log_info "Applied L3 exceptions: $filter_count path(s) filtered from cross-packager diff (postinst-converged authority model)"
+        fi
+    else
+        sorted_a=$(sort "$a")
+        sorted_b=$(sort "$b")
+    fi
 
     if [[ "$sorted_a" == "$sorted_b" ]]; then
-        log_pass "Parity tables match: $a == $b"
+        if [[ "$filter_count" -gt 0 ]]; then
+            log_pass "Parity tables match (after $filter_count L3 exceptions): $a == $b"
+        else
+            log_pass "Parity tables match: $a == $b"
+        fi
         return 0
     fi
 
     log_fail "Parity tables diverge: $a vs $b"
     {
-        echo "--- $a (sorted) ---"
+        echo "--- $a (sorted, filtered) ---"
         printf '%s\n' "$sorted_a"
-        echo "--- $b (sorted) ---"
+        echo "--- $b (sorted, filtered) ---"
         printf '%s\n' "$sorted_b"
         echo "--- lines only in $a ---"
         awk 'NR==FNR{seen[$0]++; next} !($0 in seen)' \
@@ -325,6 +395,10 @@ mode_diff() {
         echo "--- lines only in $b ---"
         awk 'NR==FNR{seen[$0]++; next} !($0 in seen)' \
             <(printf '%s\n' "$sorted_a") <(printf '%s\n' "$sorted_b")
+        if [[ -n "$exceptions_file" ]]; then
+            echo "--- L3 exceptions file: $exceptions_file ---"
+            cat "$exceptions_file"
+        fi
     } >&2
     return 1
 }
@@ -334,10 +408,45 @@ mode_diff() {
 # -----------------------------------------------------------------------------
 # Asserts every package_shipped=yes path is present and matches expected metadata.
 # For package_shipped=no paths, only checks against expected when path is found.
+#
+# Optional 3rd argument: --deb-l3-exceptions=<file>
+#   When set (used by DEB L3 assert step in the aggregator only), paths listed
+#   in the exception file are expected to ship as root:root in the DEB archive
+#   instead of root:nftban / nftban:nftban. This is the L3 reflection of the
+#   postinst-converged authority model — DEB archive ships root:root, postinst
+#   chown applies the final ownership (which L4/L5 still verify by name on the
+#   installed filesystem, unchanged). Without this flag, expected ownership is
+#   read from EXPECTED_TABLE verbatim (used for RPM L3 + L4/L5/L6 layers).
 mode_assert_expected() {
-    local observed="${1:?usage: assert-expected <observed-file>}"
+    local observed="${1:?usage: assert-expected <observed-file> [package|all] [--deb-l3-exceptions=<file>]}"
     local mode_filter="${2:-}"  # 'package' or 'all'
     [[ -r "$observed" ]] || { log_err "Not readable: $observed"; exit 3; }
+
+    local deb_l3_exceptions=""
+    case "${3:-}" in
+        "")                          ;;
+        --deb-l3-exceptions=*)       deb_l3_exceptions="${3#--deb-l3-exceptions=}" ;;
+        *) log_err "Unknown arg: $3 (expected --deb-l3-exceptions=<file>)"; exit 2 ;;
+    esac
+
+    # Build a map of postinst-converged exception paths (DEB L3 only).
+    # An exception path means: in the DEB archive, this path is expected to
+    # ship as root:root with its declared mode and type, NOT as root:nftban
+    # etc. This catches a regression where someone re-introduces build-time
+    # fakeroot chown — in that case the archive would show root:nftban for
+    # an exception path and this assert would FAIL.
+    local -A is_l3_exception=()
+    if [[ -n "$deb_l3_exceptions" ]]; then
+        if [[ ! -r "$deb_l3_exceptions" ]]; then
+            log_err "DEB L3 exceptions file not readable: $deb_l3_exceptions"
+            exit 3
+        fi
+        local p
+        while IFS= read -r p; do
+            [[ -n "$p" ]] && is_l3_exception["$p"]=1
+        done < <(load_l3_exception_paths "$deb_l3_exceptions")
+        log_info "DEB L3 exceptions loaded: ${#is_l3_exception[@]} postinst-converged path(s)"
+    fi
 
     local fail=0 row exp_path exp_type exp_mode exp_owner exp_group exp_pkg
     for row in "${EXPECTED_TABLE[@]}"; do
@@ -352,21 +461,32 @@ mode_assert_expected() {
             fail=1
             continue
         fi
-        local expected_row="${exp_path}|${exp_type}|${exp_mode}|${exp_owner}|${exp_group}"
+        # If this path is a DEB L3 exception (postinst-converged), expect
+        # root:root in the archive instead of the EXPECTED_TABLE owner/group.
+        local effective_owner="$exp_owner" effective_group="$exp_group"
+        if [[ -n "$deb_l3_exceptions" ]] && [[ -n "${is_l3_exception[$exp_path]:-}" ]]; then
+            effective_owner="root"
+            effective_group="root"
+        fi
+        local expected_row="${exp_path}|${exp_type}|${exp_mode}|${effective_owner}|${effective_group}"
         if [[ "$actual" != "$expected_row" ]]; then
             log_fail "metadata mismatch for $exp_path"
             log_fail "  expected: $expected_row"
             log_fail "  observed: $actual"
             fail=1
         else
-            log_pass "$exp_path matches expected"
+            if [[ "$effective_owner" != "$exp_owner" || "$effective_group" != "$exp_group" ]]; then
+                log_pass "$exp_path matches DEB L3 exception (archive=root:root; postinst converges to ${exp_owner}:${exp_group})"
+            else
+                log_pass "$exp_path matches expected"
+            fi
         fi
     done
 
     if [[ "$fail" -eq 1 ]]; then
         return 1
     fi
-    log_pass "assert-expected (filter=${mode_filter:-all}) clean"
+    log_pass "assert-expected (filter=${mode_filter:-all}${deb_l3_exceptions:+, deb-l3-exceptions=$deb_l3_exceptions}) clean"
 }
 
 # -----------------------------------------------------------------------------
@@ -397,10 +517,19 @@ Modes:
   reinstall-stat                   Alias of fresh-stat (semantic marker post-reinstall)
   upgrade-stat <pre|post>          Alias of fresh-stat with phase tag for upgrade canon
   verify-tool <rpm|deb>            Run rpm -V or dpkg --verify; filter by exceptions
-  diff <file-a> <file-b>           Diff two parity tables; exit 1 on divergence
-  assert-expected <observed-file>  [package|all]
+  diff <file-a> <file-b> [--exceptions=<file>]
+                                    Diff two parity tables; exit 1 on divergence.
+                                    --exceptions=<file>: paths listed in <file>
+                                    are filtered out before comparison (used by
+                                    L3 cross-packager aggregator only; honors
+                                    the postinst-converged DEB authority model)
+  assert-expected <observed-file>  [package|all] [--deb-l3-exceptions=<file>]
                                     Assert observed matches expected; package-only
-                                    filter restricts to L3-applicable paths
+                                    filter restricts to L3-applicable paths.
+                                    --deb-l3-exceptions=<file>: paths listed
+                                    in <file> are expected to ship root:root
+                                    in the DEB archive (postinst converges
+                                    final ownership at install time)
   list-critical-paths              Emit the 11 critical paths (one per line)
   list-expected                    Emit the expected metadata table
 

--- a/scripts/test-package-verify-exceptions.list
+++ b/scripts/test-package-verify-exceptions.list
@@ -1,0 +1,27 @@
+# =============================================================================
+# NFTBan - Package verify-tool exceptions list (PKG-EFFECTIVE-PARITY / L6)
+# =============================================================================
+# Consumer: scripts/test-package-effective-parity.sh verify-tool {rpm,deb}
+#
+# Purpose: enumerate explicitly-tolerated entries in `rpm -V nftban-core` /
+# `dpkg --verify nftban-core` output. ANY line not matching an exception here
+# causes the verify-tool gate to FAIL.
+#
+# Format (deterministic, easy to parse):
+#   <path-fragment>|<flag-pattern>
+# Lines starting with '#' or blank are ignored.
+#
+# A verify-tool output line is exempted when BOTH:
+#   1. the line contains <path-fragment> as a substring
+#   2. the line matches <flag-pattern> as a bash regex
+#
+# Empty exceptions file is the desired baseline — fresh install of nftban-core
+# should produce zero `rpm -V` / `dpkg --verify` output. Exceptions are
+# expected only after operator-side modifications to %config(noreplace) files,
+# which are out of scope for fresh-install CI.
+#
+# =============================================================================
+# Currently-tolerated exceptions: NONE.
+# Fresh install of nftban-core must produce empty `rpm -V` / `dpkg --verify`
+# output. Any deviation is a real packaging bug and must be investigated.
+# =============================================================================


### PR DESCRIPTION
## Summary

PR-B of v1.107 **PKG-EFFECTIVE-PARITY** (Slot 5; row 14). Adds the six-layer authority invariant gate that prevents future RPM/DEB ownership/mode drift escapes. Closes row 14 on merge + post-merge worklog amendment.

Authoritative scope: `AUDIT_190_LIFECYCLE/V107_PKG_EFFECTIVE_PARITY_SCOPE.md` (verdict GO_IMPLEMENT).
Prerequisite: PR #575 (community-dir generator/package metadata fix) merged 2026-05-07T08:01:34Z (squash `580cef76`).

## What this PR adds

The escape class that lived ~13 releases pre-AUTH-HARDENING (D-NEW-12) was: RPM and DEB could "ship the same dirs" while recording different ownership/mode in their package DBs. Existing CI verified L1+L2 (source-of-truth + generated-output parity) but NOT L3+L4+L5+L6. This PR adds those four layers.

| Layer | What it asserts | Where it runs |
|---|---|---|
| **L3** | RPM `rpm -qplv` ≡ expected ≡ DEB `dpkg-deb --contents` for 5 package-shipped critical paths | `build-packages.yml` `build-rpm` + `build-deb` + new aggregation job |
| **L4** | After fresh install, `stat` matches expected for all 11 critical paths (5 package-shipped tested in vanilla Docker; 6 tmpfiles-managed tested on real systemd) | `build-packages.yml` `test-rpm-install` + `test-deb-install` (Phase 4) + `ci-runtime-truth.yml` G8 |
| **L5 reinstall** | `dnf reinstall` / `apt-get install --reinstall` preserves metadata | `build-packages.yml` test-* install (Phase 5) |
| **L5 upgrade** | v1.106.0 → current upgrade transitions `/etc/nftban` to `root:nftban 0750` (catches the D-NEW-12 transition gap honestly) | `ci-update-canonization.yml` G4 (DEB only) |
| **L6** | `rpm -V nftban-core` + `dpkg --verify nftban-core` clean (or only documented exceptions) | `build-packages.yml` test-* install (Phase 6) |

## Files (5 total, +867 LOC, 0 deletions)

- **`scripts/test-package-effective-parity.sh`** (NEW, ~280 LOC) — shared assertion script consumed by all CI homes. 11 critical paths hardcoded per scope §3.5 (NOT derived from yaml at runtime — would be circular). Modes: `rpm-meta`, `deb-meta`, `fresh-stat`, `reinstall-stat`, `upgrade-stat`, `verify-tool`, `diff`, `assert-expected`, `list-critical-paths`, `list-expected`. Deterministic `|`-separated output for diffing.
- **`scripts/test-package-verify-exceptions.list`** (NEW) — empty by default; documented format (`<path-fragment>|<flag-pattern>`); fresh install must produce zero `rpm -V` / `dpkg --verify` output.
- **`.github/workflows/build-packages.yml`** (~242 LOC) — L3 extraction in build-rpm/build-deb + L4/L5/L6 phases in test-* install + new `validate-package-effective-parity` aggregation job.
- **`.github/workflows/ci-runtime-truth.yml`** (~70 LOC) — G8 step asserting tmpfiles-managed path parity on real systemd.
- **`.github/workflows/ci-update-canonization.yml`** (~111 LOC) — G4 step doing honest v1.106.0 → current upgrade transition test on ubuntu-24.04 matrix entry.

## The 11 critical paths (binding per scope §3.5)

| # | Path | Type | Mode | Owner | Group | Pkg-shipped |
|---|---|---|---|---|---|---|
| 1 | /etc/nftban | dir | 0750 | root | nftban | yes |
| 2 | /etc/nftban/conf.d | dir | 0750 | root | nftban | yes |
| 3 | /etc/nftban/suricata | dir | 0750 | root | nftban | yes |
| 4 | /etc/nftban/suricata/state | dir | 0750 | root | nftban | yes |
| 5 | /etc/nftban/suricata/state/last-good | dir | 0750 | root | nftban | yes |
| 6 | /run/nftban | dir | 0755 | nftban | nftban | no (tmpfiles) |
| 7 | /var/cache/nftban | dir | 0755 | nftban | nftban | no (tmpfiles) |
| 8 | /var/lib/nftban | dir | 0750 | root | nftban | no (tmpfiles) |
| 9 | /var/lib/nftban/community | dir | 0750 | nftban | nftban | yes (post PR-A #575) |
| 10 | /var/lib/nftban/reports/auditors | dir | 0770 | root | nftban-auditor | no (tmpfiles) |
| 11 | /var/log/nftban | dir | 0750 | nftban | nftban | no (tmpfiles) |

## Negative-test logic mapping (per scope §7.7)

Sandbox negative tests not run as part of this PR — operator may run on isolated branches. The CI gate would fire HARD FAIL on each scenario:

1. **Revert AUTH-HARDENING DEB attrs loop** → Test DEB install Phase 4 fresh-stat shows /etc/nftban as `root:root 0755`; `assert-expected package` HARD FAIL; aggregation L3 cross-packager diff also fires.
2. **Inject incorrect `%attr` in nftban-files.inc** → build-rpm L3 metadata extraction shows bad attr; aggregation `assert-expected` HARD FAIL.
3. **Remove `/etc/nftban/suricata/state` from nftban.dirs** → Test DEB install Phase 4 reports MISSING sentinel; HARD FAIL.
4. **Add unannotated divergence** → aggregation L3 cross-packager diff HARD FAIL.

## Local validation

- `bash -n scripts/test-package-effective-parity.sh` ✅
- YAML parse on all 3 workflows ✅
- Script self-tests: `list-critical-paths` (11 lines) + `list-expected` + `fresh-stat` on absent dirs returns 11 MISSING sentinels correctly ✅
- Diff scope: 5 files / +867 / -0 / zero forbidden surfaces touched

## Forbidden surfaces verification

```
✓ build/fhs-spec.yaml — UNTOUCHED
✓ build/generate-fhs-outputs.sh — UNTOUCHED
✓ install/packaging/rpm/nftban-files.inc — UNTOUCHED
✓ install/packaging/deb/nftban.dirs — UNTOUCHED
✓ install/packaging/deb/nftban-dir-attrs.list — UNTOUCHED
✓ packaging/build_nftban.sh — UNTOUCHED
✓ internal/installer/fhs/paths.go — UNTOUCHED
✓ internal/installer/fhs/permissions.go — UNTOUCHED
```

Plus zero touches to: `release.yml`, Docker workflow, `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION`, polkit, geoip, portal, schema, tag/release/GHCR ops, Dependabot.

## Worklog row status

- Row 14 **PKG-EFFECTIVE-PARITY** is intended to close on this PR-B merge + post-merge worklog amendment.

## Test plan

- [ ] `Policy Gates` (architecture policy) green
- [ ] `Build & Test` (Go) green
- [ ] All 4 `Build DEB` matrix jobs PASS — new L3 metadata extraction step succeeds
- [ ] All 4 `Test DEB install` matrix jobs PASS — new Phase 4/5/6 succeed
- [ ] Both `Build RPM` matrix jobs PASS — new L3 extraction succeeds
- [ ] All 4 `Test RPM install` matrix jobs PASS — new Phase 4/5/6 succeed
- [ ] **NEW** `Validate package effective parity (RPM vs DEB)` aggregation job PASS — cross-packager L3 + L4 parity verified
- [ ] `Runtime Truth (almalinux-9, ubuntu-24.04)` PASS — new G8 tmpfiles parity assertion succeeds
- [ ] `Update Canonization (ubuntu-24.04)` PASS — new G4 v1.106.0 → current upgrade transition verifies `/etc/nftban` becomes `root:nftban 0750`
- [ ] If G4 fails: HONEST report — operator decides to add postinst chown loop or accept v1.106.0 → vN as one-time ownership-transition gap in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)