### PR TITLE
v1.107 Slot 6 POLKIT-AUTHORITY — document auditor exception + panel keep-decision

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -27,6 +27,27 @@ sysusers:
     - name: nftban-panel
       system: true
       comment: "NFTBan panel group (limited operator actions for hosting panels)"
+      note: |
+        D-NEW-11 closure (Slot 6 / 2026-05-09): KEEP, do NOT decommission.
+        Live consumer: cli/sbin/nftban-panelctl wrapper (PANEL_GROUP="nftban-panel"
+        auth gate at line 55, membership check at lines 154-155).
+        Tier-3 of three-tier polkit model:
+          - 10-nftban-systemd.rules → nftban (operator, full systemd)
+          - 20-nftban-auditor.rules → nftban-auditor (read-only)
+          - 30-nftban-panel.rules  → nftban-panel (read + reload-only)
+        Cascading dependent surfaces verified at v1.107:
+          - cli/sbin/nftban-panelctl (auth gate)
+          - internal/installer/users/ensure.go:66 (identity-ensure)
+          - internal/installer/payload/payload.go:383 (ships nftban-panelctl)
+          - internal/installer/validate/assertions.go:407 (install-validation)
+          - cli/lib/nftban/tests/polkit_validator.sh (rule + group structural validator)
+          - cli/lib/nftban/cli/cmd_polkit.sh (nftban polkit status diagnostic)
+          - cli/lib/nftban/core/nftban_health_checks_security.sh:536 (rule presence check)
+          - cli/lib/nftban/core/nftban_health_fixes.sh:1409 (repair surface)
+        Decommission would force panels into operator tier (over-privileged: gains
+        start/stop/restart) or auditor tier (under-privileged: loses reload).
+        Neither acceptable. See packaging/polkit-1/rules.d/30-nftban-panel.rules
+        header CONSUMERS block for verified-live consumer list.
 
   users:
     - name: nftban
@@ -539,6 +560,25 @@ directories:
       group: nftban-auditor
       description: "Auditor reports (nftban-auditor group access)"
       created_by: tmpfiles
+      note: |
+        D-NEW-10 closure (Slot 6 / 2026-05-09): AUTHORITY EXCEPTION — intentional, NOT drift.
+        This is the ONLY directory in the /var/lib/nftban tree owned by `nftban-auditor`
+        instead of `nftban`. It exists to give the auditor tier filesystem-write access
+        to a daemon-managed parent without granting daemon-group privileges. Mode 0770
+        + group nftban-auditor is intentional.
+        DO NOT "normalize" this entry to the 0750 root:nftban / 0750 nftban:nftban defaults
+        seen elsewhere in this section — that would break the auditor write-channel.
+        Structural assertion (CI hard-fails on drift):
+          - .github/workflows/ci-runtime-truth.yml G8 step (sudo-wrapped post-Slot-5b)
+          - scripts/test-package-effective-parity.sh EXPECTED_TABLE entry (line 77)
+          - cli/lib/nftban/setup/fhs-permissions.sh:65-69 (excludes from default chown)
+          - internal/installer/fhs/paths.go:237 (RequiredDirs entry)
+        Architecture: see V106_LANE_MFST_AUTHORITY_MODEL_ADDENDUM.md §2.4 for the
+        full authority-model rationale (workspace artifact). The auditor tier writes
+        JSON reports as a non-`nftban` group; the daemon-managed parent of this dir
+        is `nftban:nftban` (line 515 above), so this leaf `0770 root:nftban-auditor`
+        is the precise minimum-privilege exception that lets the auditor process
+        write without joining the daemon group.
 
     - path: /var/lib/nftban/metrics
       mode: "0750"

--- a/packaging/polkit-1/rules.d/30-nftban-panel.rules
+++ b/packaging/polkit-1/rules.d/30-nftban-panel.rules
@@ -63,10 +63,43 @@
 //   - Plesk "Security Advisor" extension
 //   - Webmin "NFTBan" module
 //
+// CONSUMERS (verified live as of v1.107):
+//   - cli/sbin/nftban-panelctl:55       PANEL_GROUP="nftban-panel" auth gate
+//   - cli/sbin/nftban-panelctl:154-155  id -nG | grep -qw "$PANEL_GROUP"
+//   - internal/installer/users/ensure.go:66       identity-ensure step
+//   - internal/installer/payload/payload.go:383   ships nftban-panelctl binary
+//   - internal/installer/validate/assertions.go:407 install-validation required-files
+//   - cli/lib/nftban/tests/polkit_validator.sh    rule + group structural validator
+//   - cli/lib/nftban/cli/cmd_polkit.sh            nftban polkit status diagnostic
+//   - cli/lib/nftban/core/nftban_health_checks_security.sh:536  rule presence check
+//   - cli/lib/nftban/core/nftban_health_fixes.sh:1409           repair surface
+//
+//   Adapter-level consumers (NOT FOUND, intentional — adapters route through wrapper):
+//     etc/nftban/conf.d/panels/{cpanel,cwp,cyberpanel,directadmin,
+//                               generic,interworx,plesk,vesta}/main.conf  -> empty grep
+//     cli/lib/nftban/lib/nftban_panel_*.sh + cli/lib/nftban/cli/cmd_panel.sh -> empty grep
+//
+//   D-NEW-11 closure (Slot 6 / 2026-05-09):
+//     Decommission rejected. The wrapper auth gate IS the live consumer.
+//     Removing the nftban-panel group + 30-nftban-panel.rules would force panels
+//     into either:
+//       (a) operator tier (10-nftban-systemd.rules) - over-privileged: panels
+//           would gain start/stop/restart on all whitelisted units; security
+//           regression.
+//       (b) auditor tier (20-nftban-auditor.rules) - under-privileged: panels
+//           would lose `reload` (cannot apply config changes); functional
+//           regression.
+//     Neither is acceptable. The three-tier model (operator/auditor/panel) is
+//     intentional and load-bearing. See build/fhs-spec.yaml `nftban-panel`
+//     group entry `note:` field for the cross-reference.
+//
 // Version History:
 //   v1.0.19: Created for panel integration Phase 1
 //            Provides minimal privileges needed for panel UIs
 //            Complements nftban-panelctl wrapper security
+//   v1.107  (2026-05-09): D-NEW-11 closure - decommission rejected, live
+//            consumers documented above. Rule body unchanged. Header-only
+//            documentation amendment via Slot 6 POLKIT-AUTHORITY.
 // =============================================================================
 
 polkit.addRule(function (action, subject) {


### PR DESCRIPTION
## Summary

Slot 6 POLKIT-AUTHORITY closure — documentation-only PR per `V107_POLKIT_AUTHORITY_SCOPE.md` verdict `GO_IMPLEMENT_POLKIT_AUTHORITY` (2026-05-09). No behavioral change. Closes worklog rows **10** (D-NEW-10) and **11** (D-NEW-11) after merge + a separate worklog amendment gate.

## What changed

**2 files, +73 LOC, documentation-only:**

| File | Change |
|---|---|
| `build/fhs-spec.yaml` | Two `note:` fields added: (1) on the `nftban-panel` group entry recording D-NEW-11 keep-decision + verified-live consumer list; (2) on the `/var/lib/nftban/reports/auditors` data entry flagging it as an intentional AUTHORITY EXCEPTION (the only `nftban-auditor`-owned dir in the `/var/lib/nftban` tree) |
| `packaging/polkit-1/rules.d/30-nftban-panel.rules` | Header comment block additions (between existing `// Use Cases` and `// Version History` sections): `// CONSUMERS` block listing 9 verified-live consumers + adapter-level NOT-FOUND block + `D-NEW-11 closure` decommission-rejected rationale + `v1.107` Version History entry. **`polkit.addRule(...)` body unchanged.** |

## Why this is correct

### D-NEW-11 (`nftban-panel` decommission?)

Empirical live-consumer audit (per scope §4.1):
- Adapter-level grep across all 8 panel adapters (`cpanel/cwp/cyberpanel/directadmin/generic/interworx/plesk/vesta`) and 5 panel lib shells: **zero direct references** to `nftban-panel` group
- But `cli/sbin/nftban-panelctl` wrapper IS a live consumer (`PANEL_GROUP="nftban-panel"` auth gate at line 55, membership check at lines 154-155)
- 8 cascading dependent surfaces would break if removed (installer ensure.go, payload.go, validate/assertions.go, polkit_validator.sh, cmd_polkit.sh, health_checks_security.sh, health_fixes.sh)
- Three-tier polkit model (`10-systemd` operator, `20-auditor` read-only, `30-panel` read+reload-only) is intentional and load-bearing
- **Decision: KEEP** (option (b) per worklog row closure offer)

### D-NEW-10 (auditor write-channel undocumented)

The structural-test requirement was **already delivered by Slot 5** (G8 step in `.github/workflows/ci-runtime-truth.yml:450` + EXPECTED_TABLE entry in `scripts/test-package-effective-parity.sh:77`). Both gates hard-fail CI on any drift from `0770 root:nftban-auditor`. The repo-level documentation gap (only workspace `V106_LANE_MFST_AUTHORITY_MODEL_ADDENDUM.md §2.4` documents the exception) is closed by adding the explicit `note:` field flagging this entry as intentional, NOT drift.

## Generator verification

```
$ bash build/generate-fhs-outputs.sh --check
[OK] All generated files are up to date
```

The `note:` field is **NOT consumed by yq queries** in `build/generate-fhs-outputs.sh` (verified by inspection: emitters select `.path`, `.mode`, `.owner`, `.group`, `.description`, `.created_by` only). Adding `note:` fields produces zero generated-artifact drift.

## Three findings stay separate (preserved discipline)

| Stream | Status | Notes |
|---|---|---|
| Slot 5 PKG-EFFECTIVE-PARITY (rows 14, 15) | CLOSED | PR #576 `15bb9f44` + PR #579 `0daeb38e` |
| **Slot 6 POLKIT-AUTHORITY (rows 10, 11)** | **THIS PR** | Documentation-only |
| SYSUSERS-GECOS-G-LINES dormant defect | OPEN, not in scope | Separate `OPEN-SYSUSERS-GECOS-G-LINES-SCOPE` gate later |
| Slot 7 LANE-G (#525) | blocked-until Slot 6 closes | Will unblock after this merge |

## Forbidden surfaces (verified untouched)

- `install/systemd/sysusers.d/nftban.conf` (SYSUSERS-GECOS-G-LINES territory)
- `install/systemd/tmpfiles.d/nftban.conf` (generated)
- `build/generate-fhs-outputs.sh` (generator)
- All generated packaging artifacts (`install/packaging/{rpm,deb}/*`)
- `packaging/build_nftban.sh`, `packaging/deb/{postinst,postrm,prerm}`
- `packaging/polkit-1/rules.d/{10-nftban-systemd,20-nftban-auditor}.rules` (other tiers)
- `polkit.addRule(...)` body in `30-nftban-panel.rules` (only header touched)
- `cli/sbin/nftban-panelctl` (wrapper code)
- All `internal/*`, `cli/lib/nftban/{lib,cli,core,tests}/*`, `scripts/*`
- All `.github/workflows/*.yml`
- `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION`, all worklog files
- Lane G, GHCR, Dependabot

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('build/fhs-spec.yaml'))"` — passed
- [x] `bash build/generate-fhs-outputs.sh --check` — passed (no generated drift)
- [x] Diff scoped to 2 files — confirmed
- [x] `polkit.addRule(...)` body byte-identical — confirmed by grep
- [ ] CI Build × 6, Test × 8, parity aggregator, Runtime Truth × 2, Update Canonization × 2, Policy Gates — to be confirmed by CI on this PR
- [ ] polkit_validator (CLI test harness) — to be confirmed by CI on this PR

## Closes (after merge + separate worklog amendment)

- Row 10 (D-NEW-10) — auditor write-channel exception now repo-documented
- Row 11 (D-NEW-11) — decommission rejected, live consumers documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)