### PR TITLE
v1.107 LANE-G fix nftban-core-geoip TasksMax + add Runtime Truth G9 fatal-trace assertion (#525)

### DIFF
--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -477,6 +477,119 @@ jobs:
           [ "$fail" = "0" ] || exit 1
           echo "G8 PASS: tmpfiles-managed path parity verified on real systemd"
 
+      # ------------------------------------------------------------------
+      # G9: nftban-core-geoip.service runtime-fatal-trace assertion (#525)
+      # ------------------------------------------------------------------
+      # Slot 7 / Lane G regression guard. Closes #525 silent-recurrence:
+      # the geoip service emitted a Go runtime fatal trace
+      # ("runtime.(*cleanupQueue)..." with status=2/INVALIDARGUMENT) at
+      # startup on a canonical install. No CI step previously asserted
+      # geoip startup was crash-free, so the panic class could recur
+      # silently on any change to the unit file, the Go binary, or the
+      # maxminddb-golang dependency.
+      #
+      # Contract: invoking the geoip updater (via real systemd on the
+      # ubuntu-24.04 leg, or directly on the alma9 container leg where
+      # systemd PID 1 is unavailable) MUST NOT emit any of the documented
+      # Go runtime fatal-trace patterns. Normal command failure caused by
+      # network / config / download conditions is tolerated as long as no
+      # fatal trace appears in the captured output.
+      - name: G9 — nftban-core-geoip startup runtime-fatal-trace assertion
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "=== G9: nftban-core-geoip runtime-fatal-trace assertion (#525) ==="
+
+          # Build the real nftban-core binary. Earlier setup (line 111)
+          # stubbed /usr/lib/nftban/bin/nftban-core with /bin/true to keep
+          # G1-G8 CGO-free; G9 needs the real binary. nftban-core +
+          # github.com/oschwald/maxminddb-golang are pure Go (no CGO).
+          go build -trimpath -o bin/nftban-core ./cmd/nftban-core/
+          sudo install -m 0755 bin/nftban-core /usr/lib/nftban/bin/nftban-core
+
+          # Stage the systemd unit so systemctl can resolve it on the
+          # ubuntu-24.04 leg (real systemd PID 1).
+          sudo mkdir -p /etc/systemd/system
+          sudo install -m 0644 install/systemd/nftban-core-geoip.service \
+                                /etc/systemd/system/nftban-core-geoip.service
+
+          # Detect whether systemd PID 1 is available. ubuntu-24.04 runner
+          # has it; almalinux:9 container does not (PID 1 is the runner
+          # agent, not systemd). systemctl daemon-reload returns non-zero
+          # when there is no D-Bus to systemd; we use that as the probe.
+          have_systemd=0
+          if sudo systemctl daemon-reload 2>/dev/null; then
+            have_systemd=1
+          fi
+          echo "systemd PID 1 available: $have_systemd"
+
+          output_file=/tmp/g9-output.log
+          : > "$output_file"
+          rc=0
+
+          if [ "$have_systemd" = "1" ]; then
+            # Path A: real systemd. Apply unit verbatim, capture journal.
+            echo "--- G9 path A: systemctl start nftban-core-geoip.service ---"
+            sudo systemctl start nftban-core-geoip.service 2>&1 \
+              | sudo tee -a "$output_file" \
+              || rc=$?
+            sudo journalctl -u nftban-core-geoip.service --no-pager 2>&1 \
+              | sudo tee -a "$output_file" \
+              || true
+          else
+            # Path B: no systemd PID 1 (alma9 container). Run the binary
+            # directly under prlimit --nproc=64 to mirror TasksMax=64.
+            # The fatal-trace assertion is the contract; the unit's
+            # full sandbox cannot be applied here, but the runtime path
+            # the panic class follows (clone(2) under cgroup pids limit
+            # in #525, runtime cleanup-queue interaction generally) is
+            # still exercised by running the binary through `geoip
+            # update`. Network/download failure is tolerated.
+            echo "--- G9 path B: direct exec under prlimit --nproc=64 ---"
+            sudo prlimit --nproc=64 -- /usr/lib/nftban/bin/nftban-core geoip update 2>&1 \
+              | sudo tee -a "$output_file" \
+              || rc=$?
+          fi
+
+          echo "G9 nftban-core-geoip exit=$rc, output captured at $output_file"
+          echo "--- output (last 80 lines) ---"
+          sudo tail -80 "$output_file" || true
+          echo "--- end ---"
+
+          # Assert NO Go runtime fatal trace patterns. These are the
+          # signatures the #525 reproduction emitted (and adjacent
+          # signatures the runtime emits on related fatal paths).
+          fatal_patterns=(
+            'runtime\.fatalpanic'
+            'runtime\.gopanic'
+            'runtime\.\(\*cleanupQueue\)'
+            'fatal error:'
+            '^panic:'
+            'goroutine 1 \[running\]:'
+          )
+          fail=0
+          for pat in "${fatal_patterns[@]}"; do
+            if sudo grep -E -q "$pat" "$output_file"; then
+              echo "::error::G9 FAIL: Go runtime fatal trace detected: pattern=$pat"
+              echo "::error::  matching lines:"
+              sudo grep -E -n "$pat" "$output_file" | head -5 \
+                | sed 's/^/::error::    /' || true
+              fail=1
+            fi
+          done
+
+          if [ "$fail" = "1" ]; then
+            echo "::error::G9 FAIL — see #525; geoip emitted Go runtime fatal trace"
+            exit 1
+          fi
+
+          # Tolerate non-zero exit codes when no fatal trace was found.
+          # Network/download/config failures produce fmt.Errorf strings
+          # (exit 1) which is acceptable in this CI environment; the
+          # contract this step enforces is "no Go runtime fatal trace,"
+          # not "successful download."
+          echo "G9 PASS: no Go runtime fatal trace in geoip startup output (exit=$rc)"
+
   summary:
     name: Runtime Truth summary
     needs: runtime-truth

--- a/install/systemd/nftban-core-geoip.service
+++ b/install/systemd/nftban-core-geoip.service
@@ -83,7 +83,14 @@ SystemCallErrorNumber=EPERM
 # Resource limits
 CPUQuota=50%
 MemoryMax=256M
-TasksMax=10
+# TasksMax sets the cgroup pids.max limit. The geoip updater is a Go 1.25
+# binary that performs HTTP downloads + maxminddb finalizer cleanup; the
+# Go runtime needs OS-thread headroom for sysmon, GC workers, the
+# finalizer/cleanup goroutine, and net/http I/O. TasksMax=10 is too low —
+# clone(2) returns EAGAIN once the cgroup is exhausted, which surfaces as
+# a Go runtime fatal trace on startup (see #525). 64 matches the upper
+# range of peer Go services in install/systemd (feeds=20, suricata-update=50).
+TasksMax=64
 TimeoutStartSec=10min
 
 [Install]

--- a/install/systemd/nftban-health.service
+++ b/install/systemd/nftban-health.service
@@ -80,7 +80,12 @@ RestrictAddressFamilies=AF_UNIX AF_NETLINK
 
 # Resource limits
 MemoryMax=128M
-TasksMax=10
+# Mirror of the nftban-core-geoip.service TasksMax fix (#525). The health
+# check shells out to nftban-core subcommands, including geoip status,
+# which exercise the same Go 1.25 runtime + finalizer-goroutine surface.
+# Raising the cgroup pids.max limit prevents the same clone(2) EAGAIN
+# class of fatal trace from recurring here.
+TasksMax=64
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Summary

Closes Slot 7 / row 12 / **#525** `nftban-core-geoip.service` Go runtime panic at startup (`status=2/INVALIDARGUMENT`). The reproduction was a `clone(2)` `EAGAIN` class fatal trace (`runtime.(*cleanupQueue)...`) triggered by an anomalously low cgroup `pids.max` setting on the geoip unit.

Per `V107_LANE_G_GEOIP_SCOPE.md` §5.1 conservative scope (~30–60 LOC, 3 files, **no Go code or dependency changes**).

## Diff

| File | Δ | Change |
|---|---|---|
| `install/systemd/nftban-core-geoip.service` | +8 / −1 | `TasksMax=10` → `TasksMax=64` + 6-line mechanism-only comment |
| `install/systemd/nftban-health.service` | +6 / −1 | `TasksMax=10` → `TasksMax=64` + 5-line mirror-risk comment |
| `.github/workflows/ci-runtime-truth.yml` | +113 / −0 | new `G9` step (geoip startup runtime-fatal-trace assertion) on both matrix legs |
| **Total** | **+127 / −2** | **3 files** |

## G9 contract

Asserts **no Go runtime fatal trace** appears in geoip startup output:

- `runtime.fatalpanic`
- `runtime.gopanic`
- `runtime.(*cleanupQueue)`
- `fatal error:`
- `^panic:`
- `goroutine 1 [running]:`

**Path A** (ubuntu-24.04 leg): real systemd PID 1 → `systemctl daemon-reload` + `systemctl start nftban-core-geoip.service` + `journalctl -u`. The unit's full TasksMax=64 + sandbox is applied verbatim.

**Path B** (almalinux-9 container leg): no systemd PID 1 → direct exec of `/usr/lib/nftban/bin/nftban-core geoip update` under `prlimit --nproc=64` (mirrors the new TasksMax). The fatal-trace assertion is identical.

Network / download / config failure is tolerated as long as no fatal-trace pattern appears (the contract is "no Go runtime fatal trace," not "successful download").

## Out of scope (deferred / forbidden by gate)

- `go.mod` / `go.sum` (no maxminddb-golang version bump in this PR)
- `cmd/nftban-core/cmd_geoip.go` / `internal/geoip/lookup.go` (no Go code changes)
- `build/fhs-spec.yaml`, `packaging/build_nftban.sh`, `install/packaging/`
- `install/systemd/sysusers.d/`, `install/systemd/tmpfiles.d/` (Row 16 separate gate)
- `packaging/polkit-1/` (Slot 6 just closed)
- Self-Healing surfaces (Row 17 separate gate)
- `STATUS.md`, `CHANGELOG.md`, `MASTER_TODO.md`, `VERSION` (release-prep — held)
- Worklog amendment (separate gate post-merge)
- Tag / release / Dependabot
- Host / lab contact

## Test plan

- [x] git diff bounded to 3 allowed files
- [x] grep proves `TasksMax=64` in both unit files
- [x] YAML parse `ci-runtime-truth.yml` clean (15 steps in `runtime-truth` job)
- [x] Existing G1–G8 assertions byte-identical (only G9 added)
- [x] G9 contains all 6 fatal-trace patterns
- [ ] Build RPM x2 — pending CI
- [ ] Build DEB x4 — pending CI
- [ ] Test RPM install x4 — pending CI
- [ ] Test DEB install x4 — pending CI
- [ ] Validate package effective parity (Slot 5 invariant) — pending CI
- [ ] Runtime Truth (ubuntu-24.04) — G1–G8 unchanged, G9 PASS expected via Path A
- [ ] Runtime Truth (almalinux-9) — G1–G8 unchanged, G9 PASS expected via Path B
- [ ] Architecture / generators `--check` — pending CI (no fhs-spec.yaml change → no drift expected)

## References

- Issue: #525
- Scope artifact: `V107_LANE_G_GEOIP_SCOPE.md` (workspace, not in repo)
- Worklog: `V106_POST_MFST_CLOSURE_WORKLOG.md` row 12 (workspace)
- Verdict: `GO_IMPLEMENT_LANE_G`

🤖 Generated with [Claude Code](https://claude.com/claude-code)