### PR TITLE
v1.107 SYSUSERS-GECOS-G-LINES one-shot — drop invalid GECOS from g-lines + add Runtime Truth G10 parse-validation

### DIFF
--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -590,6 +590,56 @@ jobs:
           # not "successful download."
           echo "G9 PASS: no Go runtime fatal trace in geoip startup output (exit=$rc)"
 
+      # ------------------------------------------------------------------
+      # G10: install/systemd/sysusers.d/nftban.conf parse-validation
+      # ------------------------------------------------------------------
+      # Row 16 ONE-SHOT regression guard. Closes the SYSUSERS-GECOS-G-LINES
+      # dormant defect: prior generator emitted `g name - "comment"` which
+      # systemd-sysusers rejects ("Lines of type 'g' don't take a GECOS
+      # field") on systemd 252 (AlmaLinux 9), 255 (Ubuntu 24.04), and 259
+      # (verified locally during the fix). Production never noticed
+      # because postinst uses groupadd directly, not systemd-sysusers —
+      # but the shipped file was syntactically invalid and any future
+      # operator running `systemd-sysusers --replace=…` would have hit it.
+      #
+      # Contract: `systemd-sysusers --dry-run` MUST exit 0 on the shipped
+      # file. --dry-run parses + would-create messages without touching
+      # /etc/{passwd,group,shadow}. Runs on both systemd-252-class
+      # (AlmaLinux 9 container) and systemd-255-class (ubuntu-24.04
+      # runner) legs.
+      - name: G10 — sysusers.d/nftban.conf parse-validation (row 16 one-shot guard)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "=== G10: systemd-sysusers parse-validation ==="
+
+          which systemd-sysusers
+          systemd-sysusers --version 2>&1 | head -1
+
+          file=install/systemd/sysusers.d/nftban.conf
+          test -f "$file" || { echo "::error::G10: $file not found"; exit 1; }
+
+          rc=0
+          out=$(sudo systemd-sysusers --dry-run "$file" 2>&1) || rc=$?
+          echo "--- systemd-sysusers --dry-run output ---"
+          echo "$out"
+          echo "--- end (exit=$rc) ---"
+
+          if [ "$rc" != "0" ]; then
+            echo "::error::G10 FAIL: systemd-sysusers rejected $file (exit=$rc)"
+            exit 1
+          fi
+
+          # Belt-and-braces: even if exit=0, fail if the diagnostic message
+          # for malformed g-lines appears in output (in case a future
+          # systemd version downgrades the rejection from error to warning).
+          if echo "$out" | grep -qE "Lines of type 'g' don't take a GECOS field"; then
+            echo "::error::G10 FAIL: malformed g-line GECOS detected in $file"
+            exit 1
+          fi
+
+          echo "G10 PASS: $file parses cleanly under systemd-sysusers"
+
   summary:
     name: Runtime Truth summary
     needs: runtime-truth

--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -616,8 +616,18 @@ jobs:
           which systemd-sysusers
           systemd-sysusers --version 2>&1 | head -1
 
-          file=install/systemd/sysusers.d/nftban.conf
-          test -f "$file" || { echo "::error::G10: $file not found"; exit 1; }
+          # Resolve the sysusers file to an absolute path. `sudo` runs
+          # systemd-sysusers with a sanitized environment, so a relative
+          # path is resolved against root's CWD (or simply not found),
+          # not the runner's CWD — observed on both ubuntu-24.04 (systemd
+          # 255) and almalinux-9 container (systemd 252) as
+          # "Failed to open 'install/systemd/sysusers.d/nftban.conf',
+          #  ignoring: No such file or directory" with exit=1. Using
+          # $GITHUB_WORKSPACE keeps this a source-tree parse-validation;
+          # we deliberately do NOT install the file into /usr/lib/sysusers.d
+          # for this check.
+          file="${GITHUB_WORKSPACE:-$(pwd)}/install/systemd/sysusers.d/nftban.conf"
+          sudo test -f "$file" || { echo "::error::G10: $file not found"; exit 1; }
 
           rc=0
           out=$(sudo systemd-sysusers --dry-run "$file" 2>&1) || rc=$?

--- a/build/generate-fhs-outputs.sh
+++ b/build/generate-fhs-outputs.sh
@@ -213,8 +213,15 @@ generate_sysusers() {
 EOF
 
     # Groups
+    # Per sysusers.d(5): g-lines have the form `g name [id]` — GECOS/comment
+    # fields are not permitted on g-lines (only on u-lines). Earlier output
+    # included `"\(.comment)"` here, which systemd-sysusers rejects across
+    # systemd 252/255/259+ with "Lines of type 'g' don't take a GECOS field".
+    # Comment metadata is preserved in build/fhs-spec.yaml under
+    # `.sysusers.groups[].comment` for documentation purposes; it is not
+    # consumed by sysusers.d output.
     echo "# Groups" >> "$SYSUSERS_OUT"
-    yq -r '.sysusers.groups[] | "g \(.name) - \"\(.comment)\""' "$FHS_SPEC" >> "$SYSUSERS_OUT"
+    yq -r '.sysusers.groups[] | "g \(.name) -"' "$FHS_SPEC" >> "$SYSUSERS_OUT"
     echo "" >> "$SYSUSERS_OUT"
 
     # Users

--- a/install/systemd/sysusers.d/nftban.conf
+++ b/install/systemd/sysusers.d/nftban.conf
@@ -27,9 +27,9 @@
 # =============================================================================
 
 # Groups
-g nftban - "NFTBan service group"
-g nftban-auditor - "NFTBan auditor group (read-only report access)"
-g nftban-panel - "NFTBan panel group (limited operator actions for hosting panels)"
+g nftban -
+g nftban-auditor -
+g nftban-panel -
 
 # Users
 u nftban - "NFTBan service account" /var/lib/nftban /usr/sbin/nologin


### PR DESCRIPTION
## Summary

Closes **proposed worklog row 16** (SYSUSERS-GECOS-G-LINES) per the operator's `OPEN-SYSUSERS-GECOS-G-LINES-ONE-SHOT` envelope: single bounded PR + single validation + single worklog note. Not a SCOPE→IMPL chain.

The dormant defect: prior generator emitted `g name - "comment"`, which systemd-sysusers rejects with "Lines of type 'g' don't take a GECOS field" on systemd 252 / 255 / 259 (verified locally). Production never noticed because postinst uses `groupadd -r` directly. The shipped file was syntactically invalid; this PR makes it parse cleanly.

## Diff

| File | Δ | Change |
|---|---|---|
| `build/generate-fhs-outputs.sh` | +8 / −1 | g-line emitter: `g \(.name) - "\(.comment)"` → `g \(.name) -` + 7-line mechanism comment |
| `install/systemd/sysusers.d/nftban.conf` | +3 / −3 | regenerated — 3 g-lines now match `g <name> -`; u-line + memberships unchanged |
| `.github/workflows/ci-runtime-truth.yml` | +50 / −0 | new G10 step asserts `systemd-sysusers --dry-run` exits 0 on both matrix legs; belt-and-braces grep on diagnostic message |
| **Total** | **+61 / −4** | **3 files** |

## Before / After

**g-lines (the only entities that changed):**

```
- g nftban - "NFTBan service group"
- g nftban-auditor - "NFTBan auditor group (read-only report access)"
- g nftban-panel - "NFTBan panel group (limited operator actions for hosting panels)"
+ g nftban -
+ g nftban-auditor -
+ g nftban-panel -
```

**u-line (unchanged — GECOS allowed on u-lines per sysusers.d(5)):**

```
u nftban - "NFTBan service account" /var/lib/nftban /usr/sbin/nologin
```

**Group memberships (unchanged):**

```
m nftban nftban-auditor
```

**Comment metadata preserved** in `build/fhs-spec.yaml` under `.sysusers.groups[].comment` for documentation; it is simply no longer emitted to sysusers.d g-lines.

## Validation (local, systemd 259)

| | Result |
|---|---|
| `systemd-sysusers --dry-run` BEFORE (main HEAD) | exit=**1**; 3× `Lines of type 'g' don't take a GECOS field` |
| `systemd-sysusers --dry-run` AFTER (this branch) | exit=**0**; creates 3 groups + 1 user + 1 membership |
| `bash build/generate-fhs-outputs.sh --check` | ✅ All generated files up to date |
| Identity preservation | ✅ groups, user, membership byte-equivalent (only GECOS dropped from g-lines) |
| YAML parse `ci-runtime-truth.yml` | ✅ 16 steps in `runtime-truth` job (was 15) |

## CI expectations (PR build)

G10 will run on:
- **ubuntu-24.04** (systemd-255-class)
- **almalinux-9 container** (systemd-252-class)

Both legs must pass the new parse-validation. No regression to G1–G9 expected.

## Out of scope (forbidden by gate)

- ❌ No postinst migration to systemd-sysusers (postinst still uses `groupadd -r`)
- ❌ No packaging redesign / `packaging/build_nftban.sh` change
- ❌ No Self-Healing / row 17 work
- ❌ No portal / schema / metrics
- ❌ No release docs / `STATUS.md` / `CHANGELOG.md` / `MASTER_TODO.md` / `VERSION`
- ❌ No worklog amendment (row 16 remains proposed/non-counted until a separately-authorized post-merge worklog note)
- ❌ No tag / release
- ❌ No host / lab contact
- ❌ No Slot 8 REGISTRY-HYGIENE work

## References

- Worklog: `V106_POST_MFST_CLOSURE_WORKLOG.md` row 16 (proposed; treatment ONE-SHOT confirmed 2026-05-09 Slot 7 closure amendment)
- Discovered as side-effect of: PR #579 commit `1e4bf69e` (Slot 5b Stage 2 attempt, since reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)