### PR TITLE
docs: remove nftban-ui / GOTH GUI references from active docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,7 @@ nftban/
 │       └── setup/         # Installation helpers
 ├── cmd/                    # Go binaries
 │   ├── nftban-core/       # Main Go binary
-│   ├── nftban-api-server/ # REST API
-│   └── nftban-ui/         # Web interface
+│   └── nftban-api-server/ # REST API
 ├── internal/              # Go internal packages
 ├── pkg/                    # Go public packages (ipc, version)
 ├── install/               # Installation scripts

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,7 +124,6 @@ NFTBan implements a **capability-based privilege model** following the principle
 | `nftband` (daemon) | `root` | `CAP_NET_ADMIN`, `CAP_DAC_OVERRIDE` | nftables rule management, stats writing |
 | `nftban-health` | `nftban` | `CAP_NET_ADMIN` | Health monitoring |
 | `nftban-unified-exporter` | `nftban` | `CAP_NET_ADMIN` | Metrics collection |
-| `nftban-ui` | `nftban` | `CAP_NET_ADMIN` | Web interface |
 
 **Key Points:**
 - **Root required for nftables:** `CAP_NET_ADMIN` capability is essential for firewall rule management
@@ -211,7 +210,7 @@ ReadWritePaths=/var/lib/nftban /var/log/nftban /var/cache/nftban /run/nftban
 
 **Status:** Intentionally DISABLED for Go-based services
 
-**Affected Services:** `nftban-ui`, `nftban-ui-auth`
+**Affected Services:** current Go-based services (`nftband`, `nftban-core`)
 
 **Reason:** Go runtime requires writable-executable memory for JIT compilation, which conflicts with `MemoryDenyWriteExecute=true` on Ubuntu 24.04+ (AppArmor + Landlock LSM interaction).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,18 +44,13 @@ Key Principle: Single Writer Architecture
 |  BINARIES (Go)                                                               |
 |  +-------------------------------------------------------------------------+ |
 |  |                                                                         | |
-|  |  +----------------+  +----------------+  +----------------+             | |
-|  |  |    nftband     |  |  nftban-core   |  |   nftban-ui    |             | |
-|  |  |    (daemon)    |  | (fast CLI ops) |  |  (web portal)  |             | |
-|  |  +----------------+  +----------------+  +----------------+             | |
-|  |         |                   |                    |                      | |
-|  |         | Runs as root      | CAP_NET_ADMIN      | CAP_NET_ADMIN        | |
-|  |         | (nftables ops)    | (geoip, feeds)     | (status views)       | |
-|  |                                                                         | |
-|  |  +----------------+                                                     | |
-|  |  | nftban-ui-auth |                                                     | |
-|  |  | (auth service) |                                                     | |
-|  |  +----------------+                                                     | |
+|  |  +----------------+  +----------------+                                 | |
+|  |  |    nftband     |  |  nftban-core   |                                 | |
+|  |  |    (daemon)    |  | (fast CLI ops) |                                 | |
+|  |  +----------------+  +----------------+                                 | |
+|  |         |                   |                                           | |
+|  |         | Runs as root      | CAP_NET_ADMIN                             | |
+|  |         | (nftables ops)    | (geoip, feeds)                            | |
 |  |                                                                         | |
 |  +-------------------------------------------------------------------------+ |
 |                                                                              |
@@ -241,7 +236,7 @@ Exporters (cli/lib/nftban/exporters/):
  |           |                                                                |
  |   +-------+--------+    +----------------+    +------------------+         |
  |   |   nftban CLI   |    |  nftban-core   |    |  nftban-health   |         |
- |   | (bash scripts) |    |  (Go binary)   |    |  nftban-ui       |         |
+ |   | (bash scripts) |    |  (Go binary)   |    |                  |         |
  |   +----------------+    +----------------+    +------------------+         |
  |                                                                            |
  |   Capabilities: CAP_NET_ADMIN (ambient)                                    |
@@ -277,7 +272,6 @@ Socket Access Control:
 | `nftband` | root | CAP_NET_ADMIN, CAP_DAC_OVERRIDE | nftables rule management |
 | `nftban-health` | nftban | CAP_NET_ADMIN | Health monitoring |
 | `nftban-unified-exporter` | nftban | CAP_NET_ADMIN | Metrics collection |
-| `nftban-ui` | nftban | CAP_NET_ADMIN | Web interface |
 | `nftban CLI` | varies | via IPC | User commands |
 
 ---
@@ -386,8 +380,6 @@ SYSTEMD UNITS (/etc/systemd/system/ or /lib/systemd/system/)
 |  +-- nftban-watchdog.timer    # Self-monitoring                              |
 |                                                                              |
 |  Optional Services:                                                          |
-|  +-- nftban-ui.service        # Web interface                                |
-|  +-- nftban-ui-auth.service   # Authentication service                       |
 |  +-- nftban-api.service       # REST API                                     |
 +-----------------------------------------------------------------------------+
 ```
@@ -535,8 +527,6 @@ nftban/
 +-- cmd/                    # Go main packages (binaries)
 |   +-- nftband/            # Main daemon
 |   +-- nftban-core/        # Fast CLI operations (Go)
-|   +-- nftban-ui/          # Web portal
-|   +-- nftban-ui-auth/     # Auth service
 |   +-- nftban-loginmon/    # Login monitor (placeholder)
 +-- pkg/                    # Go packages (libraries)
 +-- cli/                    # Bash CLI components
@@ -559,7 +549,6 @@ nftban/
 |--------|--------------|
 | `cmd/nftband/` | `/usr/lib/nftban/bin/nftband` |
 | `cmd/nftban-core/` | `/usr/lib/nftban/bin/nftban-core` |
-| `cmd/nftban-ui/` | `/usr/lib/nftban/bin/nftban-ui` |
 | `cli/sbin/nftban` | `/usr/sbin/nftban` |
 | `cli/lib/nftban/` | `/usr/lib/nftban/` |
 | `etc/nftban/` | `/etc/nftban/` |

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -16,29 +16,28 @@ go version
 
 ### Required System Packages
 
-**For CGO-disabled builds (nftban-core, nftban-ui):**
+**For CGO-disabled builds (nftban-core):**
 - Go 1.23+
 - No additional system dependencies
 
-**For CGO-enabled builds (nftban-ui-auth, nftband):**
+**For CGO-enabled builds (nftband):**
 - Go 1.23+
 - GCC compiler (build-essential on Debian/Ubuntu)
-- PAM development headers (for nftban-ui-auth only)
 
 ```bash
 # Debian/Ubuntu
-sudo apt-get install -y build-essential libpam0g-dev
+sudo apt-get install -y build-essential
 
 # RHEL/Fedora/Rocky
-sudo dnf install -y gcc pam-devel
+sudo dnf install -y gcc
 ```
 
 ### Environment Variables
 
 | Variable | Value | Description |
 |----------|-------|-------------|
-| `CGO_ENABLED` | `0` | For SLSA builds (nftban-core, nftban-ui) |
-| `CGO_ENABLED` | `1` | For PAM builds (nftban-ui-auth) |
+| `CGO_ENABLED` | `0` | For SLSA builds (nftban-core) |
+| `CGO_ENABLED` | `1` | For CGO builds (nftband) |
 | `GOOS` | `linux` | Target operating system |
 | `GOARCH` | `amd64` | Target architecture |
 
@@ -46,7 +45,7 @@ sudo dnf install -y gcc pam-devel
 
 ### SLSA-Verified Binaries (Recommended)
 
-The official release binaries for `nftban-core` and `nftban-ui` are built using the [SLSA Go Builder](https://github.com/slsa-framework/slsa-github-generator) which provides SLSA Level 3 compliance. These builds are:
+The official release binary for `nftban-core` is built using the [SLSA Go Builder](https://github.com/slsa-framework/slsa-github-generator) which provides SLSA Level 3 compliance. These builds are:
 
 - Hermetic (isolated build environment)
 - Reproducible (deterministic output)
@@ -60,12 +59,6 @@ CGO_ENABLED=0 go build -trimpath \
   -ldflags="-s -w -X github.com/itcmsgr/nftban/pkg/version.FullVersion=vX.Y.Z" \
   -o nftban-core-linux-amd64 \
   ./cmd/nftban-core
-
-# nftban-ui
-CGO_ENABLED=0 go build -trimpath \
-  -ldflags="-s -w -X main.Version=vX.Y.Z" \
-  -o nftban-ui-linux-amd64 \
-  ./cmd/nftban-ui
 ```
 
 Replace `vX.Y.Z` with the actual version tag (e.g., `v1.18.0`).
@@ -94,12 +87,6 @@ ls -la bin/
 ```bash
 # nftban-core only
 ./build.sh core
-
-# nftban-ui only (requires templ code generation)
-./build.sh gui
-
-# nftban-ui-auth only (requires CGO + PAM)
-./build.sh ui-auth
 
 # nftband (IPC daemon)
 ./build.sh daemon
@@ -154,7 +141,7 @@ For cryptographic verification, use SLSA provenance instead.
 
 ## 4. SLSA Provenance Verification
 
-NFTBan releases include [SLSA Level 3](https://slsa.dev/spec/v1.0/levels) provenance for `nftban-core` and `nftban-ui`. This cryptographically proves the binary was built from the claimed source code.
+NFTBan releases include [SLSA Level 3](https://slsa.dev/spec/v1.0/levels) provenance for `nftban-core`. This cryptographically proves the binary was built from the claimed source code.
 
 ### Install slsa-verifier
 
@@ -173,14 +160,6 @@ sudo mv slsa-verifier-linux-amd64 /usr/local/bin/slsa-verifier
 ```bash
 slsa-verifier verify-artifact nftban-core-linux-amd64 \
   --provenance-path nftban-core-linux-amd64.intoto.jsonl \
-  --source-uri github.com/itcmsgr/nftban
-```
-
-### Verify nftban-ui
-
-```bash
-slsa-verifier verify-artifact nftban-ui-linux-amd64 \
-  --provenance-path nftban-ui-linux-amd64.intoto.jsonl \
   --source-uri github.com/itcmsgr/nftban
 ```
 
@@ -217,7 +196,7 @@ The `SHA256SUMS` file contains checksums for:
 
 - **RPM packages:** `nftban-el9-x86_64.rpm`, `nftban-el10-x86_64.rpm`
 - **DEB packages:** `nftban-ubuntu22.04-amd64.deb`, `nftban-ubuntu24.04-amd64.deb`, `nftban-debian12-amd64.deb`, `nftban-debian13-amd64.deb`
-- **Binaries:** `nftban-core-linux-amd64`, `nftban-ui-linux-amd64`, `nftband-linux-amd64`, `nftban-ui-auth-linux-amd64`
+- **Binaries:** `nftban-core-linux-amd64`, `nftband-linux-amd64`
 
 ### Verification Commands
 
@@ -244,31 +223,6 @@ sha256sum nftban-core-linux-amd64
 
 ## 6. Known Limitations
 
-### CGO and PAM Dependencies
-
-**`nftban-ui-auth` cannot be built with SLSA provenance** because it requires:
-- CGO enabled (`CGO_ENABLED=1`)
-- PAM development headers (`libpam0g-dev` / `pam-devel`)
-
-The SLSA hermetic build environment does not support external C dependencies. This binary is built via the standard release workflow instead and verified via SHA256 checksums only.
-
-### Templ Code Generation
-
-**`nftban-ui` requires templ code generation** before building:
-
-```bash
-# Install templ
-go install github.com/a-h/templ/cmd/templ@latest
-
-# Generate Go code from .templ files
-templ generate
-
-# Then build
-CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" ./cmd/nftban-ui
-```
-
-The SLSA workflow handles this automatically, but local builds must run `templ generate` first.
-
 ### Factors Affecting Reproducibility
 
 | Factor | Impact | Mitigation |
@@ -278,7 +232,6 @@ The SLSA workflow handles this automatically, but local builds must run `templ g
 | `-s -w` ldflags | Strips debug info | Always use both flags |
 | Build timestamp | May be embedded | Stripped by `-s -w` |
 | Module cache | Different downloads | Use `go mod download` first |
-| Templ version | Different generated code | Pin templ version |
 
 ### What SLSA Provenance Proves
 

--- a/docs/systemd/TIMERS.md
+++ b/docs/systemd/TIMERS.md
@@ -116,9 +116,6 @@ the daemon is active.
 | Service | Tier | Purpose |
 |---------|------|---------|
 | `nftban-api.service` | PRO | REST API server |
-| `nftban-ui.service` | PRO | Web UI |
-| `nftban-ui-auth.service` | PRO | UI authentication |
-| `nftban-ui-auth.socket` | PRO | UI auth socket activation |
 | `nftban-firewall-init.service` | EXPERIMENTAL | Boot delay initialization |
 
 ## Configuration


### PR DESCRIPTION
## Summary

V108 Item 7A — completes Stage 4 of the v1.100.1b.A→.D GOTH/`nftban-ui` decommissioning at the **documentation** level. After this PR merges, V108 Item 7 (the full four-stage decommissioning) is functionally complete.

Implements exactly the perimeter scoped in `AUDIT_190_LIFECYCLE/V108_ITEM7A_GOTH_DOCS_CLEANUP_SCOPE.md` (verdict `GO_SCOPE_7A_GOTH_DOCS_CLEANUP`).

`HISTORICAL_KEEP` discipline applied: `CHANGELOG.md` (39 historical entries) and `docs/systemd/UNITS.md` (3 strikethrough-marked entries) are deliberately untouched.

## Changes (5 files, all docs-only)

| File | Edit | Lines |
|---|---|---|
| `CONTRIBUTING.md` | Remove `cmd/nftban-ui/` from source-tree map | 1 |
| `SECURITY.md` | Remove `nftban-ui` row from Privilege Model table; update MDWE Affected-Services line | 2 |
| `docs/ARCHITECTURE.md` | Remove `nftban-ui` from 2 architecture diagrams, Privilege Model table, Optional Services list, directory-structure tree, Installation Mapping table | 9 (5 sub-edits) |
| `docs/REPRODUCIBLE_BUILDS.md` | Drop nftban-ui from CGO-disabled list, nftban-ui-auth from CGO-enabled list, PAM dev headers; update env-var table; delete nftban-ui build commands; delete nftban-ui sub-build branches; delete nftban-ui SLSA-verify section; drop binaries from asset list; delete CGO/PAM + Templ callouts | ~19 (8 sub-edits) |
| `docs/systemd/TIMERS.md` | Delete 3 PRO-tier rows (nftban-ui.service, nftban-ui-auth.service, nftban-ui-auth.socket) | 3 |

**Diff stat:** 5 files changed, 19 insertions(+), 82 deletions(-).

## Preserved unchanged (HISTORICAL_KEEP)

| File | Reason |
|---|---|
| `CHANGELOG.md` | 39 occurrences, all inside `## [vX.Y.Z]` historical version sections (Lane MFST closure v1.106.0; GOTH PR-D4 stages 1/2/3 under v1.100.1b.A/B/C; v1.98.1 follow-ups). Debian-changelog convention applies — never edit history. |
| `docs/systemd/UNITS.md` | 3 occurrences, lines 104-106, all already-correctly marked with `~~strikethrough~~` + `removed v1.100.1b.A` annotation. Parent §8.1 explicitly directs to preserve. |

## Wiki alignment (per operator request during gate)

Audited `/home/gituser/github/nftban.wiki` at HEAD `b1b6bf93`. All 35 occurrences across 7 files are already correctly historicized:
- Explicit `Historical note (≤ v1.100.0)` disclosures (3 files)
- `archive/` namespace entries (3 files)
- The formal `Deprecations-v190.md` document

Zero stale active claims. Zero broken cross-refs from wiki to repo. **No wiki changes required.**

## Validation

```
✅ git grep -lE 'nftban-ui' file count: 29 → 24 (target hit exactly)
✅ All 5 cleaned files: 0 remaining nftban-ui occurrences
✅ CHANGELOG.md: byte-unchanged
✅ docs/systemd/UNITS.md: byte-unchanged
✅ Remaining 24 files = 22 Tier A non-doc transitional/CI + CHANGELOG.md
                         + docs/systemd/UNITS.md (all legitimate KEEP)
✅ No stale "Web GUI" / "port 3940" / "GOTH" / "templ generate"
   residue in the 5 cleaned files
✅ Pre-commit hook (validate-headers.sh + permission check) passed
```

## V108 Item 7 — completion status after this PR

| Stage | Item | Status |
|---|---|---|
| Stage 1 — v1.100.1b.A — stop shipping binaries/units/SLSA | already-done | ✅ DONE |
| Stage 2 — v1.100.1b.B — source-tree delete | already-done | ✅ DONE |
| Stage 3 — v1.100.1b.C — cross-cutting refs | already-done | ✅ DONE |
| Item 7B — residual source/config (PR #588) | done | ✅ DONE |
| Item 7C — NEW-package transitional cleanup (PR #587) | done | ✅ DONE |
| **Stage 4 — v1.100.1b.D — docs cleanup** | **this PR** | ⏳ pending merge |

After this PR merges, V108 Item 7 is fully complete.

## Out of scope (per scope §4.6)

- ❌ no code/config/packaging/CI changes
- ❌ no CHANGELOG.md edits
- ❌ no docs/systemd/UNITS.md edits
- ❌ no nftban-ui revival
- ❌ no `/etc/nftban/ui.conf` shipping
- ❌ no portal/schema/metrics/FHS-ATG/Self-Healing work
- ❌ no host/lab contact
- ❌ no tag/release/Issue mutation

## Follow-up findings (flagged in commit message; NOT addressed in 7A)

These were observed during the audit but are outside the nftban-ui/GOTH perimeter:

1. `cmd/nftban-api-server/` entry in `CONTRIBUTING.md` source-tree map is also stale (the directory doesn't exist at HEAD). Single line.
2. `nftban-api.service` still appears in active Optional Services list in `docs/ARCHITECTURE.md` and as a PRO-tier row in `docs/systemd/TIMERS.md`. Per `build/deprecated-units.yaml` it's a "never-shipped defensive entry" with `policy: stop_only`.

Both belong to a future separately-gated cleanup PR.

## Test plan (post-merge / next gates)

- [ ] CI: `Docs Quality` gate stays green
- [ ] CI: `markdownlint` (if part of Docs Quality) — no warnings introduced
- [ ] CI: `Lychee URL validation` — no broken internal anchors (deletes are anchor-removing, not anchor-creating)
- [ ] CI: zero non-doc files in the diff — pre-checked locally
- [ ] CI: all PR-relevant package/build gates stay green (this PR doesn't touch packaging, so should be unaffected)
- [ ] After merge: V108 Item 7 closure record can be written; next gate is `OPEN-V108-ITEM-1-EXECSTART-PAYLOAD-RESOLUTION-SCOPE` per operator's locked sequence

## Source scope artifact

`AUDIT_190_LIFECYCLE/V108_ITEM7A_GOTH_DOCS_CLEANUP_SCOPE.md` (7 sections; per-file detailed inventory; HISTORICAL_KEEP vs ACTIVE_DOC_CLEAN classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)