### PR TITLE
fix(installer): clear stale install_state fields on terminal success

### DIFF
--- a/internal/installer/state/file.go
+++ b/internal/installer/state/file.go
@@ -117,6 +117,15 @@ func (sf *StateFile) Transition(newState InstallState, phase Phase, reason strin
 	sf.PhaseReached = string(phase)
 	if newState.IsFailed() {
 		sf.FailureReason = reason
+	} else if newState == StateCommitted || newState == StateDegraded {
+		// V108 Item 5: clear stale pre-failure carry-over fields when reaching
+		// success/soft-success terminals. Without this, a host that experienced
+		// FAILED_AUTHORITY_ABORT earlier and then advanced to COMMITTED/DEGRADED
+		// would carry CONFLICTS=… / FAILURE_REASON="takeover not approved…" /
+		// PREFLIGHT_PASSED=0 verbatim into the terminal state file — visible on
+		// 4 of 6 v1.107.2 rollout hosts (lab2/srv1/srv3/srv4) and confusing for
+		// operator diagnosis. See V108_ITEM5_INSTALL_STATE_HYGIENE_SCOPE.md.
+		sf.applyTerminalHygiene()
 	}
 	sf.Timestamp = time.Now().UTC()
 	if !sf.DryRun {
@@ -129,6 +138,29 @@ func (sf *StateFile) Transition(newState InstallState, phase Phase, reason strin
 		return fmt.Errorf("%s: %s", newState, reason)
 	}
 	return nil
+}
+
+// applyTerminalHygiene clears stale pre-failure carry-over fields when
+// transitioning to COMMITTED or DEGRADED. Per V108 Item 5 scope §4:
+//
+//   - FailureReason: cleared (no current failure on success/soft-success
+//     terminal — the prior reason is no longer current)
+//   - Conflicts: cleared iff Authority == "UPDATE" (takeover approved, so
+//     the prior conflict descriptors no longer reflect current state)
+//   - PreflightPassed: set true (a successful terminal implies preflight
+//     passed; the prior 0 from an aborted phase is stale)
+//
+// All three writes are idempotent on a clean (never-failed) host.
+//
+// Failure terminals (StateFailedAbort etc.) MUST preserve all fields —
+// operator needs the diagnostic — and intermediate states preserve as-is
+// (legitimate carry-over for diagnosis).
+func (sf *StateFile) applyTerminalHygiene() {
+	sf.FailureReason = ""
+	if sf.Authority == "UPDATE" {
+		sf.Conflicts = ""
+	}
+	sf.PreflightPassed = true
 }
 
 // WriteAtomic writes the state file atomically (write to tmp, then rename).

--- a/internal/installer/state/file_test.go
+++ b/internal/installer/state/file_test.go
@@ -1,0 +1,221 @@
+// =============================================================================
+// NFTBan v1.107 - Installer State File I/O — V108 Item 5 hygiene tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-state-file-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-11"
+// meta:description="Unit tests for V108 Item 5 applyTerminalHygiene rule + Transition()"
+// meta:inventory.files="internal/installer/state/file.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package state
+
+import (
+	"testing"
+)
+
+// V108 Item 5 — apply hygiene rule when transitioning to terminal success
+// or soft-success. See V108_ITEM5_INSTALL_STATE_HYGIENE_SCOPE.md.
+
+// newDryStateFile returns a StateFile that does not touch the filesystem.
+// All hygiene-rule tests use DryRun=true so Transition() exercises the
+// in-memory path without needing a real /var/lib/nftban/state.
+func newDryStateFile(t *testing.T) *StateFile {
+	t.Helper()
+	sf := NewStateFile("/tmp/v108-item5-test-not-used")
+	sf.DryRun = true
+	return sf
+}
+
+// TestTransitionToCommittedClearsCarryOverFields covers the canonical
+// hygiene case: an earlier-failed phase left FailureReason+Conflicts+
+// PreflightPassed=false set. Authority is now UPDATE (takeover approved).
+// On Transition(StateCommitted, …) all three fields are cleaned.
+func TestTransitionToCommittedClearsCarryOverFields(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "prior failure: conflicts detected"
+	sf.Conflicts = "UFW"
+	sf.PreflightPassed = false
+	sf.Authority = "UPDATE"
+
+	if err := sf.Transition(StateCommitted, PhaseValidate, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "" {
+		t.Errorf("FailureReason: want \"\", got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "" {
+		t.Errorf("Conflicts: want \"\" (Authority=UPDATE), got %q", sf.Conflicts)
+	}
+	if !sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want true, got false")
+	}
+	if sf.State != StateCommitted {
+		t.Errorf("State: want %s, got %s", StateCommitted, sf.State)
+	}
+}
+
+// TestTransitionToCommittedPreservesConflictsWhenAuthorityAmbiguous
+// covers the lab2 case: AUTHORITY=AMBIGUOUS so CONFLICTS still describes
+// current state. FailureReason is still cleared (no current failure)
+// per §4 rule. Conflicts must be preserved.
+func TestTransitionToCommittedPreservesConflictsWhenAuthorityAmbiguous(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "prior reason"
+	sf.Conflicts = "UFW"
+	sf.PreflightPassed = false
+	sf.Authority = "AMBIGUOUS"
+
+	if err := sf.Transition(StateCommitted, PhaseValidate, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "" {
+		t.Errorf("FailureReason: want \"\" (terminal hygiene clears it), got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "UFW" {
+		t.Errorf("Conflicts: want %q (preserved because Authority=AMBIGUOUS), got %q",
+			"UFW", sf.Conflicts)
+	}
+	if !sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want true, got false")
+	}
+}
+
+// TestTransitionToDegradedSrv4Case reproduces srv4's v1.107.2 rollout
+// row: AUTHORITY=UPDATE (takeover approved) but pre-state CONFLICTS+
+// FAILURE_REASON still describing pre-approval conflicts. After
+// transition to DEGRADED, both should be cleared.
+func TestTransitionToDegradedSrv4Case(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "conflicts detected, takeover not approved: iptables-nft,iptables,CSF"
+	sf.Conflicts = "iptables-nft,iptables,CSF"
+	sf.PreflightPassed = false
+	sf.Authority = "UPDATE"
+
+	if err := sf.Transition(StateDegraded, PhaseValidate, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "" {
+		t.Errorf("FailureReason: want \"\", got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "" {
+		t.Errorf("Conflicts: want \"\" (Authority=UPDATE), got %q", sf.Conflicts)
+	}
+	if !sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want true, got false")
+	}
+	if sf.State != StateDegraded {
+		t.Errorf("State: want %s, got %s", StateDegraded, sf.State)
+	}
+}
+
+// TestTransitionToDegradedLab2Case reproduces lab2's v1.107.2 rollout
+// row: AUTHORITY=AMBIGUOUS, CONFLICTS=UFW, FAILURE_REASON describing
+// the UFW conflict. After DEGRADED transition, Conflicts is preserved
+// (Authority is not UPDATE) but FailureReason is cleared.
+func TestTransitionToDegradedLab2Case(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "conflicts detected, takeover not approved: UFW"
+	sf.Conflicts = "UFW"
+	sf.PreflightPassed = false
+	sf.Authority = "AMBIGUOUS"
+
+	if err := sf.Transition(StateDegraded, PhaseValidate, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "" {
+		t.Errorf("FailureReason: want \"\" (terminal hygiene), got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "UFW" {
+		t.Errorf("Conflicts: want %q (preserved because Authority=AMBIGUOUS), got %q",
+			"UFW", sf.Conflicts)
+	}
+	if !sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want true, got false")
+	}
+}
+
+// TestTransitionToFailedAbortPreservesAllFields ensures failure
+// terminals (StateFailedAbort) keep all diagnostic fields intact.
+// FailureReason is overwritten by the new reason; Conflicts and
+// PreflightPassed are NOT cleared.
+func TestTransitionToFailedAbortPreservesAllFields(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "previous reason"
+	sf.Conflicts = "UFW,iptables-nft"
+	sf.PreflightPassed = false
+	sf.Authority = "AMBIGUOUS"
+
+	const newReason = "fresh failure on this transition"
+	err := sf.Transition(StateFailedAbort, PhaseDetect, newReason)
+	// Failure transition returns an error (per Transition contract)
+	if err == nil {
+		t.Fatalf("Transition to failure state must return an error")
+	}
+	if sf.FailureReason != newReason {
+		t.Errorf("FailureReason: want %q (overwritten), got %q", newReason, sf.FailureReason)
+	}
+	if sf.Conflicts != "UFW,iptables-nft" {
+		t.Errorf("Conflicts: want preserved %q, got %q", "UFW,iptables-nft", sf.Conflicts)
+	}
+	if sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want false (preserved), got true")
+	}
+}
+
+// TestTransitionToIntermediateStatePreservesAllFields ensures the
+// hygiene step does NOT fire on non-terminal transitions. Intermediate
+// states (anything not COMMITTED, DEGRADED, or a failure terminal) keep
+// the prior FailureReason/Conflicts/PreflightPassed verbatim.
+func TestTransitionToIntermediateStatePreservesAllFields(t *testing.T) {
+	sf := newDryStateFile(t)
+	sf.FailureReason = "diagnostic carry-over"
+	sf.Conflicts = "UFW"
+	sf.PreflightPassed = false
+	sf.Authority = "UPDATE"
+
+	// Pick a non-terminal, non-failure intermediate state. The state-machine
+	// has many such states; use StateFilesInstalled which is the default
+	// initial state per NewStateFile.
+	if err := sf.Transition(StateFilesInstalled, PhaseDetect, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "diagnostic carry-over" {
+		t.Errorf("FailureReason: want preserved, got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "UFW" {
+		t.Errorf("Conflicts: want preserved, got %q", sf.Conflicts)
+	}
+	if sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want false (preserved), got true")
+	}
+}
+
+// TestTransitionFromCleanIdleToCommittedIdempotent ensures the hygiene
+// step is a clean no-op on a host that never failed. All fields start
+// at their zero values; the hygiene sets PreflightPassed=true (which
+// it correctly should on COMMITTED success).
+func TestTransitionFromCleanIdleToCommittedIdempotent(t *testing.T) {
+	sf := newDryStateFile(t)
+	// Fields default to zero values; no prior failure.
+
+	if err := sf.Transition(StateCommitted, PhaseValidate, ""); err != nil {
+		t.Fatalf("Transition returned unexpected error: %v", err)
+	}
+	if sf.FailureReason != "" {
+		t.Errorf("FailureReason: want \"\", got %q", sf.FailureReason)
+	}
+	if sf.Conflicts != "" {
+		t.Errorf("Conflicts: want \"\", got %q", sf.Conflicts)
+	}
+	if !sf.PreflightPassed {
+		t.Errorf("PreflightPassed: want true on successful COMMITTED, got false")
+	}
+}


### PR DESCRIPTION
## Summary

V108 Item 5 — adds **terminal-state hygiene** to `internal/installer/state/file.go::Transition` so that successful/soft-success terminals (`COMMITTED` / `DEGRADED`) do not carry stale `FAILURE_REASON` / `CONFLICTS` / `PREFLIGHT_PASSED=0` from earlier failed phases.

Implements exactly the scope `AUDIT_190_LIFECYCLE/V108_ITEM5_INSTALL_STATE_HYGIENE_SCOPE.md` (verdict `GO_SCOPE_ITEM5_INSTALL_STATE_HYGIENE`).

## Why this fix exists

4 of 6 v1.107.2 rollout hosts (lab2/srv1/srv3/srv4) produced final `install_state` files with contradictory carry-over fields. The most striking instance is **srv4**:

```
INSTALL_STATE=DEGRADED
AUTHORITY=UPDATE                                              ← takeover approved
CONFLICTS=iptables-nft,iptables,CSF                          ← but still says conflicts
FAILURE_REASON=conflicts detected, takeover not approved: …  ← directly contradicts AUTHORITY=UPDATE
PREFLIGHT_PASSED=0                                            ← but we reached terminal
```

The contradiction made operator diagnosis confusing. The current `Transition()` only writes `FailureReason` on failure transitions; it never CLEARS pre-failure carry-over when reaching success.

## Changes (2 files, exact §7.1 allowlist)

### EDIT: `internal/installer/state/file.go`

- `Transition()` now invokes a new private helper `applyTerminalHygiene()` when transitioning to `StateCommitted` or `StateDegraded`. Failure transitions still write `FailureReason = reason` (unchanged). Intermediate transitions preserve all fields (unchanged).
- New private method `applyTerminalHygiene()` — clears `FailureReason`; clears `Conflicts` iff `Authority == "UPDATE"` (takeover approved); sets `PreflightPassed = true` (successful terminal implies preflight passed).

### NEW: `internal/installer/state/file_test.go`

7 unit tests covering the rule + edge cases, exactly the operator-authorized list:

| Test | Scenario | Outcome |
|---|---|---|
| `TestTransitionToCommittedClearsCarryOverFields` | Prior failure + Authority=UPDATE → COMMITTED | All 3 fields cleared |
| `TestTransitionToCommittedPreservesConflictsWhenAuthorityAmbiguous` | Authority=AMBIGUOUS → COMMITTED | Conflicts preserved; FailureReason cleared |
| `TestTransitionToDegradedSrv4Case` | srv4 reproduction (UPDATE + DEGRADED) | Cleared |
| `TestTransitionToDegradedLab2Case` | lab2 reproduction (AMBIGUOUS + DEGRADED) | Conflicts preserved |
| `TestTransitionToFailedAbortPreservesAllFields` | Failure terminal | All diagnostic fields preserved |
| `TestTransitionToIntermediateStatePreservesAllFields` | Non-terminal | Preserved as-is |
| `TestTransitionFromCleanIdleToCommittedIdempotent` | Clean host → COMMITTED | No-op except PreflightPassed=true |

## Validation (pre-commit)

```
✅ gofmt -l on both files (clean) — verified via lab2
✅ Structural check: 7 top-level functions in file.go (applyTerminalHygiene
   added at line 158), 1 helper + 7 tests in file_test.go
✅ Test names match operator-authorized list exactly
✅ tools/validate-headers.sh on both files (SPDX + meta + Go header)
🟡 go test ./internal/installer/state/... — NOT runnable locally
   (Fedora workstation has no go; lab2 has go 1.22 < module's 1.25)
   → CI's Build & Test job will validate first run
```

## Backward compatibility

- Read side (`file.go::Read` lines 199-221) already handles empty values gracefully — empty `CONFLICTS` / `FAILURE_REASON` are no-ops on read.
- Existing `Transition()` callers unchanged: same signature, same error contract, same DryRun behavior.
- Existing tests in the package (none in `state/` at HEAD; this PR adds the first state-package test file).
- Schema unchanged: same 15 KEY=VALUE fields written by `WriteAtomic()`.

## Out of scope (per scope §9 — preserved untouched)

- ❌ No state-machine semantic redesign (`machine.go` untouched)
- ❌ No struct field declarations changed
- ❌ No schema / serialization format changed
- ❌ No portal/schema/metrics work
- ❌ No FHS-ATG / Self-Healing / GOTH work
- ❌ No CI workflow edits (existing Build & Test covers new tests)
- ❌ No host/lab contact
- ❌ No tag/release/Issue mutation
- ❌ No v1.107.3 release work
- ❌ No changes outside the 2 allowed files

## V108 hardening lane status after this PR

| Item | Description | Status |
|---|---|---|
| 7 (4 sub-items) | nftban-ui / GOTH GUI decommissioning | ✅ DONE (PRs #587/#588/#589) |
| 1 | systemd ExecStart payload-resolution CI gate | ✅ DONE (PR #590) |
| 3 | heredoc command-substitution safety CI gate | ✅ DONE (PR #591) |
| 6 | source-install package-manager mismatch detection | ✅ DONE (PR #592) |
| **5** | **install_state carry-over hygiene** | ⏳ **this PR** |
| 2 | +i lifecycle matrix CI gate | NEXT |
| 4 | DEGRADED-runtime-pattern investigation | SEPARATE (not bundled v1.108.0) |

After Item 2 closes, v1.108.0 release-prep can be considered.

## Test plan (post-merge)

- [ ] CI: `Build & Test` (Go) — 7 new unit tests pass
- [ ] CI: `Runtime Truth` integration tests — verify cleaner state files post-merge (informational; not required)
- [ ] CI: all sibling V108 gates (Item 1, 3, 6) stay green
- [ ] Future v1.108.0 rollout: post-install `install_state` files should be self-consistent (no AUTHORITY=UPDATE + FAILURE_REASON="takeover not approved" combinations)

## Source scope artifact

`AUDIT_190_LIFECYCLE/V108_ITEM5_INSTALL_STATE_HYGIENE_SCOPE.md` (344 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
