### PR TITLE
docs: decommission stale nftban-api / nftban-api.service references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 # Triggers: Push to v* tags (e.g., v1.0.0, v1.0.1)
 #
 # What this does:
-#   1. Builds Go binaries (nftban-core, nftban-api-server) for x86_64
+#   1. Builds Go binaries (nftban-core) for x86_64
 #   2. Creates RPM packages for EL9, EL10
 #   3. Creates DEB packages for Ubuntu 22.04/24.04, Debian 12/13
 #   4. Generates SHA256SUMS.build (local ground truth checksums)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,7 @@ nftban/
 │       ├── helpers/       # Utility functions
 │       └── setup/         # Installation helpers
 ├── cmd/                    # Go binaries
-│   ├── nftban-core/       # Main Go binary
-│   └── nftban-api-server/ # REST API
+│   └── nftban-core/       # Main Go binary
 ├── internal/              # Go internal packages
 ├── pkg/                    # Go public packages (ipc, version)
 ├── install/               # Installation scripts

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -378,9 +378,6 @@ SYSTEMD UNITS (/etc/systemd/system/ or /lib/systemd/system/)
 |  +-- nftban-snapshot.timer    # Periodic snapshots                           |
 |  +-- nftban-unified-exporter  # Metrics export                               |
 |  +-- nftban-watchdog.timer    # Self-monitoring                              |
-|                                                                              |
-|  Optional Services:                                                          |
-|  +-- nftban-api.service       # REST API                                     |
 +-----------------------------------------------------------------------------+
 ```
 

--- a/docs/systemd/TIMERS.md
+++ b/docs/systemd/TIMERS.md
@@ -115,7 +115,7 @@ the daemon is active.
 
 | Service | Tier | Purpose |
 |---------|------|---------|
-| `nftban-api.service` | PRO | REST API server |
+| ~~`nftban-api.service`~~ | ~~PRO~~ | ~~REST API server~~ (deprecated; never shipped passively; cleaned at upgrade by packaging — see `docs/systemd/UNITS.md`) |
 | `nftban-firewall-init.service` | EXPERIMENTAL | Boot delay initialization |
 
 ## Configuration


### PR DESCRIPTION
## Purpose

Complete **documentation-side** decommissioning of the legacy `nftban-api-server` / `nftban-api.service` surface.

This is **residue cleanup only**. The `cmd/nftban-api-server` source tree is already absent at v1.108.0; this PR does **not** remove live code and does **not** alter runtime behavior. It only removes or marks historical references that incorrectly imply `nftban-api-server` / `nftban-api.service` is still an active optional service.

## Scope (V109 narrow-governance lane, PR B only)

Authorized under `OPEN_V109_NARROW_GOVERNANCE_PR_B_ONLY = GO_IMPLEMENTATION_ONLY` (CF-13 + CF-14 from `V109_NARROW_GOVERNANCE_SCOPE.md`).

## Summary

| File | Change | Lines |
|---|---|---|
| `CONTRIBUTING.md` | Removed stale `cmd/nftban-api-server/` tree entry; tree connector adjusted | -1 -1 +1 |
| `.github/workflows/release.yml` | Comment-only — dropped `nftban-api-server` from Go-binary build list | -1 +1 |
| `docs/systemd/TIMERS.md` | HISTORICAL_KEEP strikethrough on `nftban-api.service` row with deprecation annotation pointing to `UNITS.md` | -1 +1 |
| `docs/ARCHITECTURE.md` | Removed deprecated "Optional Services" block from ASCII art (strikethrough does not render inside code blocks; historical record preserved at `docs/systemd/UNITS.md:103`) | -3 |

**Total:** 4 files, +3 / -7.

## Preserved (intentionally NOT touched)

- `install/packaging/deb/nftban-preinst-deprecated-cleanup.inc`
- `install/packaging/deb/nftban-prerm-systemd-cleanup.inc`
- `install/packaging/rpm/nftban-pre-deprecated-cleanup.inc`
- `install/packaging/rpm/nftban-preun-systemd-cleanup.inc`

These reference `nftban-api.service` as part of the **deprecated-service cleanup loop**. They are the runtime mechanism that removes stale `nftban-api.service` from systems upgrading from older versions and **must remain**.

Also preserved:
- `docs/systemd/UNITS.md:103` — already follows HISTORICAL_KEEP discipline (strikethrough + "never shipped passively" annotation); unchanged.
- All runtime services, IPC, portal/receiver/metrics transport — untouched.
- Schema — frozen at 1.83.0.
- `cli/lib/nftban/data/metrics-registry.json` — contains a single metric-name reference; not live code, not in scope.

## HISTORICAL_KEEP discipline (per V108 Item 7 precedent)

- `docs/systemd/UNITS.md` already preserves the deprecation record at line 103: `~~`nftban-api.service`~~ - never shipped passively; only referenced in defensive %preun/prerm mask lists for upgrade-from-prior-installs`.
- `docs/systemd/TIMERS.md` — strikethrough row matches the UNITS.md pattern.
- `docs/ARCHITECTURE.md` — removal accepted because strikethrough does not render inside fenced code blocks; the canonical history record lives in `UNITS.md`.

## Test plan

- [x] Pre-commit hooks: header validation + shell/packaging check passed locally
- [ ] `Project Health` — green or classified-advisory
- [ ] `Architecture Policy` — pass
- [ ] `Architecture / FHS structure` — pass
- [ ] `validate-package-effective-parity` — pass (V108 invariant)
- [ ] `validate-package-immutable-file-coverage` — pass (V108 invariant)
- [ ] No `go.mod` / `go.sum` change
- [ ] No `internal/contracts/schema/` change (schema frozen at 1.83.0)
- [ ] Diff is comment/docs-only; `release.yml` edit verified comment-only

## Out of scope (explicit non-goals for THIS PR)

- CF-12 `internal/config/` delete (separate PR A)
- CF-04 README PR #586 (separate inherited PR)
- CF-05 Dependabot PRs (per-PR independent triage)
- CF-07 MASTER_TODO refresh (workspace-only)
- Any FHS / sysusers / polkit / dns2 / DEGRADED / security / transport / portal work
- Any release-prep (`VERSION`, `STATUS.md`, `CHANGELOG.md`)
- Any tag / release / issue mutation
- Any host / lab contact
- Any Bucket C v0.x tag action

## References

- Scope artifact: `V109_NARROW_GOVERNANCE_SCOPE.md`
- Debt inventory: `V109_DEBT_INVENTORY_AND_ALIGNMENT.md` (D-RES-2 + D-RES-3)
- Base commit: `d49e7427` (v1.108.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)