### PR TITLE
refactor(module): typed Status().Extra per module (V110 R-12)

### DIFF
--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -228,28 +228,77 @@ func (m *Module) Stop() error {
 	return nil
 }
 
+// BotGuardStatusExtra is the typed status payload for the BotGuard
+// module's Status().Extra field. Field names map to legacy
+// map[string]any keys via JSON tags byte-for-byte; R-12 introduces
+// type-safety without an API change.
+type BotGuardStatusExtra struct {
+	LoopInterval          string `json:"loop_interval"`
+	PressureMode          bool   `json:"pressure_mode"`
+	TrackedIPs            int64  `json:"tracked_ips"`
+	TotalTicks            int64  `json:"total_ticks"`
+	SuspectsFound         int64  `json:"suspects_found"`
+	Classified            int64  `json:"classified"`
+	AllowCount            int64  `json:"allow_count"`
+	GreyCount             int64  `json:"grey_count"`
+	BanCount              int64  `json:"ban_count"`
+	EmergencyCount        int64  `json:"emergency_count"`
+	LastTickDuration      string `json:"last_tick_duration"`
+	VerifyEnqueued        int64  `json:"verify_enqueued"`
+	VerifyCompleted       int64  `json:"verify_completed"`
+	VerifyVerified        int64  `json:"verify_verified"`
+	VerifyFailed          int64  `json:"verify_failed"`
+	BatchSignalsProcessed int64  `json:"batch_signals_processed"`
+}
+
+// ToExtraInfo serializes the typed struct into the module.ExtraInfo
+// map[string]any contract expected by module.Status.Extra.
+func (e BotGuardStatusExtra) ToExtraInfo() module.ExtraInfo {
+	return module.ExtraInfo{
+		"loop_interval":           e.LoopInterval,
+		"pressure_mode":           e.PressureMode,
+		"tracked_ips":             e.TrackedIPs,
+		"total_ticks":             e.TotalTicks,
+		"suspects_found":          e.SuspectsFound,
+		"classified":              e.Classified,
+		"allow_count":             e.AllowCount,
+		"grey_count":              e.GreyCount,
+		"ban_count":               e.BanCount,
+		"emergency_count":         e.EmergencyCount,
+		"last_tick_duration":      e.LastTickDuration,
+		"verify_enqueued":         e.VerifyEnqueued,
+		"verify_completed":        e.VerifyCompleted,
+		"verify_verified":         e.VerifyVerified,
+		"verify_failed":           e.VerifyFailed,
+		"batch_signals_processed": e.BatchSignalsProcessed,
+	}
+}
+
 // Status returns the current module status.
 func (m *Module) Status() module.Status {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	m.status.UpdateUptime()
-	m.status.Extra["loop_interval"] = m.config.LoopInterval.String()
-	m.status.Extra["pressure_mode"] = m.stats.PressureMode
-	m.status.Extra["tracked_ips"] = m.stats.TrackedIPs
-	m.status.Extra["total_ticks"] = m.stats.TickCount
-	m.status.Extra["suspects_found"] = m.stats.SuspectsFound
-	m.status.Extra["classified"] = m.stats.Classified
-	m.status.Extra["allow_count"] = m.stats.AllowCount
-	m.status.Extra["grey_count"] = m.stats.GreyCount
-	m.status.Extra["ban_count"] = m.stats.BanCount
-	m.status.Extra["emergency_count"] = m.stats.EmergencyCount
-	m.status.Extra["last_tick_duration"] = m.stats.LastTickDuration.String()
-	m.status.Extra["verify_enqueued"] = m.stats.VerifyEnqueued
-	m.status.Extra["verify_completed"] = m.stats.VerifyCompleted
-	m.status.Extra["verify_verified"] = m.stats.VerifyVerified
-	m.status.Extra["verify_failed"] = m.stats.VerifyFailed
-	m.status.Extra["batch_signals_processed"] = m.stats.BatchSignalsProcessed
+	extra := BotGuardStatusExtra{
+		LoopInterval:          m.config.LoopInterval.String(),
+		PressureMode:          m.stats.PressureMode,
+		TrackedIPs:            m.stats.TrackedIPs,
+		TotalTicks:            m.stats.TickCount,
+		SuspectsFound:         m.stats.SuspectsFound,
+		Classified:            m.stats.Classified,
+		AllowCount:            m.stats.AllowCount,
+		GreyCount:             m.stats.GreyCount,
+		BanCount:              m.stats.BanCount,
+		EmergencyCount:        m.stats.EmergencyCount,
+		LastTickDuration:      m.stats.LastTickDuration.String(),
+		VerifyEnqueued:        m.stats.VerifyEnqueued,
+		VerifyCompleted:       m.stats.VerifyCompleted,
+		VerifyVerified:        m.stats.VerifyVerified,
+		VerifyFailed:          m.stats.VerifyFailed,
+		BatchSignalsProcessed: m.stats.BatchSignalsProcessed,
+	}
+	m.status.Extra = extra.ToExtraInfo()
 
 	return m.status
 }

--- a/internal/botguard/guard_test.go
+++ b/internal/botguard/guard_test.go
@@ -1,0 +1,80 @@
+// =============================================================================
+// NFTBan v1.0 - BotGuard Module Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="guard_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-12"
+// meta:description="Unit tests for BotGuard typed Status.Extra (V110 R-12)"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing,reflect"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package botguard
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/module"
+)
+
+// TestBotGuardStatusExtra_ToExtraInfo asserts the typed-status struct
+// marshals to the byte-exact module.ExtraInfo map[string]any contract,
+// covering all 16 keys. Backstops the V110 R-12 invariant that
+// Module.Status() API and JSON wire keys remain unchanged.
+func TestBotGuardStatusExtra_ToExtraInfo(t *testing.T) {
+	extra := BotGuardStatusExtra{
+		LoopInterval:          "30s",
+		PressureMode:          false,
+		TrackedIPs:            128,
+		TotalTicks:            1000,
+		SuspectsFound:         42,
+		Classified:            40,
+		AllowCount:            30,
+		GreyCount:             5,
+		BanCount:              5,
+		EmergencyCount:        0,
+		LastTickDuration:      "120ms",
+		VerifyEnqueued:        12,
+		VerifyCompleted:       10,
+		VerifyVerified:        8,
+		VerifyFailed:          2,
+		BatchSignalsProcessed: 250,
+	}
+	want := module.ExtraInfo{
+		"loop_interval":           "30s",
+		"pressure_mode":           false,
+		"tracked_ips":             int64(128),
+		"total_ticks":             int64(1000),
+		"suspects_found":          int64(42),
+		"classified":              int64(40),
+		"allow_count":             int64(30),
+		"grey_count":              int64(5),
+		"ban_count":               int64(5),
+		"emergency_count":         int64(0),
+		"last_tick_duration":      "120ms",
+		"verify_enqueued":         int64(12),
+		"verify_completed":        int64(10),
+		"verify_verified":         int64(8),
+		"verify_failed":           int64(2),
+		"batch_signals_processed": int64(250),
+	}
+	got := extra.ToExtraInfo()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToExtraInfo() = %v, want %v", got, want)
+	}
+	if len(got) != 16 {
+		t.Errorf("ToExtraInfo() key count = %d, want 16", len(got))
+	}
+}

--- a/internal/ddos/module.go
+++ b/internal/ddos/module.go
@@ -296,14 +296,35 @@ func (m *Module) Stop() error {
 	return nil
 }
 
+// DDoSStatusExtra is the typed status payload for the DDoS module's
+// Status().Extra field. Field names map to legacy map[string]any keys
+// via JSON tags byte-for-byte; R-12 introduces type-safety without an
+// API change. Module.Status() / Status.Extra / ExtraInfo all unchanged.
+type DDoSStatusExtra struct {
+	Mode              string `json:"mode"`
+	SuricataAvailable bool   `json:"suricata_available"`
+}
+
+// ToExtraInfo serializes the typed struct into the module.ExtraInfo
+// map[string]any contract expected by module.Status.Extra.
+func (e DDoSStatusExtra) ToExtraInfo() module.ExtraInfo {
+	return module.ExtraInfo{
+		"mode":               e.Mode,
+		"suricata_available": e.SuricataAvailable,
+	}
+}
+
 // Status returns the current module status
 func (m *Module) Status() module.Status {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	m.status.UpdateUptime()
-	m.status.Extra["mode"] = m.mode
-	m.status.Extra["suricata_available"] = m.suricataAvail
+	extra := DDoSStatusExtra{
+		Mode:              m.mode,
+		SuricataAvailable: m.suricataAvail,
+	}
+	m.status.Extra = extra.ToExtraInfo()
 
 	return m.status
 }

--- a/internal/ddos/module_test.go
+++ b/internal/ddos/module_test.go
@@ -1,0 +1,52 @@
+// =============================================================================
+// NFTBan v1.0 - DDoS Module Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="module_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-12"
+// meta:description="Unit tests for DDoS module typed Status.Extra (V110 R-12)"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing,reflect"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package ddos
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/module"
+)
+
+// TestDDoSStatusExtra_ToExtraInfo asserts the typed-status struct marshals
+// to the byte-exact module.ExtraInfo map[string]any contract. Backstops
+// the V110 R-12 invariant that Module.Status() API and JSON wire keys
+// remain unchanged after the typed-struct refactor.
+func TestDDoSStatusExtra_ToExtraInfo(t *testing.T) {
+	extra := DDoSStatusExtra{
+		Mode:              "hybrid",
+		SuricataAvailable: false,
+	}
+	want := module.ExtraInfo{
+		"mode":               "hybrid",
+		"suricata_available": false,
+	}
+	got := extra.ToExtraInfo()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToExtraInfo() = %v, want %v", got, want)
+	}
+	if len(got) != 2 {
+		t.Errorf("ToExtraInfo() key count = %d, want 2", len(got))
+	}
+}

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -458,7 +458,7 @@ func (m *Module) Stop() error {
 type LoginMonStatusExtra struct {
 	Mode                string           `json:"mode"`
 	SuricataAvailable   bool             `json:"suricata_available"`
-	Services            []string         `json:"services"`
+	Services            string           `json:"services"`
 	Detectors           []string         `json:"detectors"`
 	TotalDetections     int64            `json:"total_detections"`
 	TotalBans           int64            `json:"total_bans"`
@@ -469,7 +469,7 @@ type LoginMonStatusExtra struct {
 	DetectionsIPv6      int64            `json:"detections_ipv6"`
 	BansIPv4            int64            `json:"bans_ipv4"`
 	BansIPv6            int64            `json:"bans_ipv6"`
-	TrackedIPs          int64            `json:"tracked_ips"`
+	TrackedIPs          int              `json:"tracked_ips"`
 	DetectionsByService map[string]int64 `json:"detections_by_service"`
 	BansByService       map[string]int64 `json:"bans_by_service"`
 	DetectionsByReason  map[string]int64 `json:"detections_by_reason"`

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -451,33 +451,84 @@ func (m *Module) Stop() error {
 	return nil
 }
 
+// LoginMonStatusExtra is the typed status payload for the LoginMon
+// module's Status().Extra field. Field names map to legacy
+// map[string]any keys via JSON tags byte-for-byte; R-12 introduces
+// type-safety without an API change.
+type LoginMonStatusExtra struct {
+	Mode                string           `json:"mode"`
+	SuricataAvailable   bool             `json:"suricata_available"`
+	Services            []string         `json:"services"`
+	Detectors           []string         `json:"detectors"`
+	TotalDetections     int64            `json:"total_detections"`
+	TotalBans           int64            `json:"total_bans"`
+	TotalEscalations    int64            `json:"total_escalations"`
+	TotalPermanent      int64            `json:"total_permanent"`
+	UniqueIPs           int64            `json:"unique_ips"`
+	DetectionsIPv4      int64            `json:"detections_ipv4"`
+	DetectionsIPv6      int64            `json:"detections_ipv6"`
+	BansIPv4            int64            `json:"bans_ipv4"`
+	BansIPv6            int64            `json:"bans_ipv6"`
+	TrackedIPs          int64            `json:"tracked_ips"`
+	DetectionsByService map[string]int64 `json:"detections_by_service"`
+	BansByService       map[string]int64 `json:"bans_by_service"`
+	DetectionsByReason  map[string]int64 `json:"detections_by_reason"`
+	BansByReason        map[string]int64 `json:"bans_by_reason"`
+}
+
+// ToExtraInfo serializes the typed struct into the module.ExtraInfo
+// map[string]any contract expected by module.Status.Extra.
+func (e LoginMonStatusExtra) ToExtraInfo() module.ExtraInfo {
+	return module.ExtraInfo{
+		"mode":                  e.Mode,
+		"suricata_available":    e.SuricataAvailable,
+		"services":              e.Services,
+		"detectors":             e.Detectors,
+		"total_detections":      e.TotalDetections,
+		"total_bans":            e.TotalBans,
+		"total_escalations":     e.TotalEscalations,
+		"total_permanent":       e.TotalPermanent,
+		"unique_ips":            e.UniqueIPs,
+		"detections_ipv4":       e.DetectionsIPv4,
+		"detections_ipv6":       e.DetectionsIPv6,
+		"bans_ipv4":             e.BansIPv4,
+		"bans_ipv6":             e.BansIPv6,
+		"tracked_ips":           e.TrackedIPs,
+		"detections_by_service": e.DetectionsByService,
+		"bans_by_service":       e.BansByService,
+		"detections_by_reason":  e.DetectionsByReason,
+		"bans_by_reason":        e.BansByReason,
+	}
+}
+
 // Status returns the current module status
 func (m *Module) Status() module.Status {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	m.status.UpdateUptime()
-	m.status.Extra["mode"] = string(m.mode)
-	m.status.Extra["suricata_available"] = m.suricataAvail
-	m.status.Extra["services"] = m.getServiceList()
-	m.status.Extra["detectors"] = m.registry.Detectors()
-
-	// Add scorer statistics
 	stats := m.scorer.GetStats()
-	m.status.Extra["total_detections"] = stats.TotalDetections
-	m.status.Extra["total_bans"] = stats.TotalBans
-	m.status.Extra["total_escalations"] = stats.TotalEscalations
-	m.status.Extra["total_permanent"] = stats.TotalPermanent
-	m.status.Extra["unique_ips"] = stats.UniqueIPs
-	m.status.Extra["detections_ipv4"] = stats.DetectionsIPv4
-	m.status.Extra["detections_ipv6"] = stats.DetectionsIPv6
-	m.status.Extra["bans_ipv4"] = stats.BansIPv4
-	m.status.Extra["bans_ipv6"] = stats.BansIPv6
-	m.status.Extra["tracked_ips"] = m.scorer.TrackedIPs()
-	m.status.Extra["detections_by_service"] = stats.DetectionsByService
-	m.status.Extra["bans_by_service"] = stats.BansByService
-	m.status.Extra["detections_by_reason"] = stats.DetectionsByReason
-	m.status.Extra["bans_by_reason"] = stats.BansByReason
+	extra := LoginMonStatusExtra{
+		Mode:                string(m.mode),
+		SuricataAvailable:   m.suricataAvail,
+		Services:            m.getServiceList(),
+		Detectors:           m.registry.Detectors(),
+		TotalDetections:     stats.TotalDetections,
+		TotalBans:           stats.TotalBans,
+		TotalEscalations:    stats.TotalEscalations,
+		TotalPermanent:      stats.TotalPermanent,
+		UniqueIPs:           stats.UniqueIPs,
+		DetectionsIPv4:      stats.DetectionsIPv4,
+		DetectionsIPv6:      stats.DetectionsIPv6,
+		BansIPv4:            stats.BansIPv4,
+		BansIPv6:            stats.BansIPv6,
+		TrackedIPs:          m.scorer.TrackedIPs(),
+		DetectionsByService: stats.DetectionsByService,
+		BansByService:       stats.BansByService,
+		DetectionsByReason:  stats.DetectionsByReason,
+		BansByReason:        stats.BansByReason,
+	}
+	m.status.Extra = extra.ToExtraInfo()
 
 	return m.status
 }

--- a/internal/loginmon/module_test.go
+++ b/internal/loginmon/module_test.go
@@ -1,0 +1,85 @@
+// =============================================================================
+// NFTBan v1.0 - LoginMon Module Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="module_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-12"
+// meta:description="Unit tests for LoginMon typed Status.Extra (V110 R-12)"
+// meta:input="Test cases"
+// meta:output="Test results"
+// meta:depends="testing,reflect"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package loginmon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/module"
+)
+
+// TestLoginMonStatusExtra_ToExtraInfo asserts the typed-status struct
+// marshals to the byte-exact module.ExtraInfo map[string]any contract,
+// covering all 18 keys (including string, bool, int64, []string, and
+// map[string]int64 value types). Backstops the V110 R-12 invariant that
+// Module.Status() API and JSON wire keys remain unchanged.
+func TestLoginMonStatusExtra_ToExtraInfo(t *testing.T) {
+	extra := LoginMonStatusExtra{
+		Mode:                "auto",
+		SuricataAvailable:   true,
+		Services:            []string{"ssh", "ftp"},
+		Detectors:           []string{"SSHDetector", "FTPDetector"},
+		TotalDetections:     100,
+		TotalBans:           20,
+		TotalEscalations:    3,
+		TotalPermanent:      1,
+		UniqueIPs:           17,
+		DetectionsIPv4:      90,
+		DetectionsIPv6:      10,
+		BansIPv4:            18,
+		BansIPv6:            2,
+		TrackedIPs:          5,
+		DetectionsByService: map[string]int64{"ssh": 80, "ftp": 20},
+		BansByService:       map[string]int64{"ssh": 18, "ftp": 2},
+		DetectionsByReason:  map[string]int64{"bruteforce": 95, "scan": 5},
+		BansByReason:        map[string]int64{"bruteforce": 19, "scan": 1},
+	}
+	want := module.ExtraInfo{
+		"mode":                  "auto",
+		"suricata_available":    true,
+		"services":              []string{"ssh", "ftp"},
+		"detectors":             []string{"SSHDetector", "FTPDetector"},
+		"total_detections":      int64(100),
+		"total_bans":            int64(20),
+		"total_escalations":     int64(3),
+		"total_permanent":       int64(1),
+		"unique_ips":            int64(17),
+		"detections_ipv4":       int64(90),
+		"detections_ipv6":       int64(10),
+		"bans_ipv4":             int64(18),
+		"bans_ipv6":             int64(2),
+		"tracked_ips":           int64(5),
+		"detections_by_service": map[string]int64{"ssh": 80, "ftp": 20},
+		"bans_by_service":       map[string]int64{"ssh": 18, "ftp": 2},
+		"detections_by_reason":  map[string]int64{"bruteforce": 95, "scan": 5},
+		"bans_by_reason":        map[string]int64{"bruteforce": 19, "scan": 1},
+	}
+	got := extra.ToExtraInfo()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToExtraInfo() = %v, want %v", got, want)
+	}
+	if len(got) != 18 {
+		t.Errorf("ToExtraInfo() key count = %d, want 18", len(got))
+	}
+}

--- a/internal/loginmon/module_test.go
+++ b/internal/loginmon/module_test.go
@@ -38,7 +38,7 @@ func TestLoginMonStatusExtra_ToExtraInfo(t *testing.T) {
 	extra := LoginMonStatusExtra{
 		Mode:                "auto",
 		SuricataAvailable:   true,
-		Services:            []string{"ssh", "ftp"},
+		Services:            "ssh,ftp",
 		Detectors:           []string{"SSHDetector", "FTPDetector"},
 		TotalDetections:     100,
 		TotalBans:           20,
@@ -58,7 +58,7 @@ func TestLoginMonStatusExtra_ToExtraInfo(t *testing.T) {
 	want := module.ExtraInfo{
 		"mode":                  "auto",
 		"suricata_available":    true,
-		"services":              []string{"ssh", "ftp"},
+		"services":              "ssh,ftp",
 		"detectors":             []string{"SSHDetector", "FTPDetector"},
 		"total_detections":      int64(100),
 		"total_bans":            int64(20),
@@ -69,7 +69,7 @@ func TestLoginMonStatusExtra_ToExtraInfo(t *testing.T) {
 		"detections_ipv6":       int64(10),
 		"bans_ipv4":             int64(18),
 		"bans_ipv6":             int64(2),
-		"tracked_ips":           int64(5),
+		"tracked_ips":           5,
 		"detections_by_service": map[string]int64{"ssh": 80, "ftp": 20},
 		"bans_by_service":       map[string]int64{"ssh": 18, "ftp": 2},
 		"detections_by_reason":  map[string]int64{"bruteforce": 95, "scan": 5},

--- a/internal/portscan/module.go
+++ b/internal/portscan/module.go
@@ -285,15 +285,38 @@ func (m *Module) Stop() error {
 	return nil
 }
 
+// PortscanStatusExtra is the typed status payload for the Portscan
+// module's Status().Extra field. Field names map to legacy
+// map[string]any keys via JSON tags byte-for-byte; R-12 introduces
+// type-safety without an API change.
+type PortscanStatusExtra struct {
+	Mode              string `json:"mode"`
+	SuricataAvailable bool   `json:"suricata_available"`
+	ScansDetected     int64  `json:"scans_detected"`
+}
+
+// ToExtraInfo serializes the typed struct into the module.ExtraInfo
+// map[string]any contract expected by module.Status.Extra.
+func (e PortscanStatusExtra) ToExtraInfo() module.ExtraInfo {
+	return module.ExtraInfo{
+		"mode":               e.Mode,
+		"suricata_available": e.SuricataAvailable,
+		"scans_detected":     e.ScansDetected,
+	}
+}
+
 // Status returns the current module status
 func (m *Module) Status() module.Status {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	m.status.UpdateUptime()
-	m.status.Extra["mode"] = m.mode
-	m.status.Extra["suricata_available"] = m.suricataAvail
-	m.status.Extra["scans_detected"] = m.scansDetected
+	extra := PortscanStatusExtra{
+		Mode:              m.mode,
+		SuricataAvailable: m.suricataAvail,
+		ScansDetected:     m.scansDetected,
+	}
+	m.status.Extra = extra.ToExtraInfo()
 
 	return m.status
 }

--- a/internal/portscan/module_test.go
+++ b/internal/portscan/module_test.go
@@ -23,8 +23,11 @@
 package portscan
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/module"
 )
 
 // newTestModule creates a Module without calling nftbanconf.MustLoad() so
@@ -242,5 +245,33 @@ func TestModule_Name(t *testing.T) {
 	m := newTestModule()
 	if m.Name() != "portscan" {
 		t.Errorf("Name() = %q, want %q", m.Name(), "portscan")
+	}
+}
+
+// =============================================================================
+// PortscanStatusExtra.ToExtraInfo() Tests (V110 R-12)
+// =============================================================================
+
+// TestPortscanStatusExtra_ToExtraInfo asserts the typed-status struct
+// marshals to the byte-exact module.ExtraInfo map[string]any contract.
+// Backstops the V110 R-12 invariant that Module.Status() API and
+// JSON wire keys remain unchanged after the typed-struct refactor.
+func TestPortscanStatusExtra_ToExtraInfo(t *testing.T) {
+	extra := PortscanStatusExtra{
+		Mode:              "classic",
+		SuricataAvailable: true,
+		ScansDetected:     42,
+	}
+	want := module.ExtraInfo{
+		"mode":               "classic",
+		"suricata_available": true,
+		"scans_detected":     int64(42),
+	}
+	got := extra.ToExtraInfo()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToExtraInfo() = %v, want %v", got, want)
+	}
+	if len(got) != 3 {
+		t.Errorf("ToExtraInfo() key count = %d, want 3", len(got))
 	}
 }


### PR DESCRIPTION
## Purpose

V110 narrow-lane PR B — implements R-12 (typed `Status().Extra` per module) per `V110_MOD_ISOLATION_DELTA_AUDIT.md` §5 and `V110_R12_SURFACE_PREFLIGHT.md`.

Introduces typed `<Module>StatusExtra` structs for each registered Module implementer. **API impact: NONE.** The Module interface, Status struct, and ExtraInfo type are all unchanged. JSON wire keys preserved byte-for-byte. **Schema remains frozen at 1.83.0.**

## Gate

Authorized under `OPEN_V110_MOD_ISOLATION_PR_B_ONLY = GO_IMPLEMENTATION_R12_ONLY` (sequential moderate cut; PR A R-10 merged as `c8050d9e`).

## Diff (8 files, +433 / -41)

### Production (4 files)

| File | Struct added | Fields |
|---|---|---|
| `internal/ddos/module.go` | `DDoSStatusExtra` | 2 |
| `internal/portscan/module.go` | `PortscanStatusExtra` | 3 |
| `internal/loginmon/module.go` | `LoginMonStatusExtra` | 18 (incl. `[]string` + `map[string]int64` value types) |
| `internal/botguard/guard.go` | `BotGuardStatusExtra` | 16 |

### Tests (4 files — 3 new + 1 extended)

| File | Coverage |
|---|---|
| `internal/ddos/module_test.go` (new) | 2-field `ToExtraInfo()` round-trip |
| `internal/portscan/module_test.go` (extended) | 3-field round-trip + existing config-parse tests preserved |
| `internal/loginmon/module_test.go` (new) | 18-field round-trip including slice + map value types |
| `internal/botguard/guard_test.go` (new) | 16-field round-trip |

## Refactor pattern (uniform across all 4 modules)

**Before:**
```go
m.status.Extra["mode"] = m.mode
m.status.Extra["suricata_available"] = m.suricataAvail
```

**After:**
```go
extra := DDoSStatusExtra{
    Mode:              m.mode,
    SuricataAvailable: m.suricataAvail,
}
m.status.Extra = extra.ToExtraInfo()
```

The `ToExtraInfo()` method on each typed struct builds the `module.ExtraInfo` (`map[string]any`) manually — no reflection, no JSON marshal roundtrip. Key literals are checked into source visibly for git-grep / code-search.

## API invariants preserved (unchanged byte-for-byte)

| Surface | State |
|---|---|
| `module.Module.Status() Status` | UNCHANGED |
| `module.Status.Extra` field type | UNCHANGED (`ExtraInfo`) |
| `module.ExtraInfo` | UNCHANGED (`map[string]any`) |
| JSON wire keys (lowercase snake_case) | UNCHANGED byte-for-byte via struct tags |
| Mutex semantics (`RLock` + `defer RUnlock` in `Status()`) | UNCHANGED |

External consumers reading the JSON-marshaled `Status` (HTTP API, CLI status output, evidence collectors) see byte-identical output.

## R-10 lint interaction (post-merge state)

After R-12 lands, no module file contains direct `Extra["KEY"] = ` writes — all Extra population flows through typed struct → `ToExtraInfo()` map literal. R-10's A3 cross-module check finds:
- 0 direct Extra writes in module dirs
- 0 baseline-allowed keys actively present in lint scope
- A3 still PASSES by construction (no violations)

R-10 A1 (distinct ModuleName) and A2 (EventBan source label) remain active and enforce their invariants. **No R-10 lint script changes needed.** Verified locally: `bash scripts/lint-module-isolation.sh` → exit 0.

## What this PR does NOT change

| Surface | Status |
|---|---|
| `internal/module/module.go` interface (Status / ExtraInfo types) | ✅ UNCHANGED |
| `internal/contracts/schema/**` | ✅ UNCHANGED (schema frozen at 1.83.0) |
| `internal/metrics/**` metric registration / emission | ✅ UNCHANGED |
| `internal/eventbus/bus.go` (R-11 SafetyPressure deferred) | ✅ UNCHANGED |
| `scripts/lint-module-isolation.sh` (R-10) | ✅ UNCHANGED |
| `.github/workflows/**` | ✅ UNCHANGED |
| `install/packaging/**`, `install/systemd/**`, `cli/lib/nftban/**` runtime | ✅ UNCHANGED |
| `go.mod` / `go.sum` (no new deps) | ✅ UNCHANGED |
| `VERSION` / `STATUS.md` / `CHANGELOG.md` (release-prep is separate gate) | ✅ UNCHANGED |
| Portal / receiver / pro.nftban.com | ✅ UNCHANGED |
| dns2 host / Bucket C tags | ✅ UNCHANGED |

## Test plan

- [x] Pre-commit hooks (header validation + recursive permission check) PASSED locally
- [x] `bash scripts/lint-module-isolation.sh` PASSED locally (A1 + A2 + A3 all green; A3 now vacuous as expected)
- [x] Direct `Extra["KEY"] =` writes in module dirs: 0 (verified via grep)
- [ ] CI: `Build & Test (Go Build & Test)` — validates `go build ./...` + `go test ./...`
- [ ] CI: `Build NFTBan Packages` matrix (RPM EL9/EL10 + DEB Debian 12/13 + Ubuntu 22.04/24.04) + 8 install tests
- [ ] CI: `CodeQL Analysis (Go)` — Go-side semantic check
- [ ] CI: `Runtime Truth (ubuntu-24.04)` + `Runtime Truth (almalinux-9)`
- [ ] CI: `CLI Smoke Test`
- [ ] CI: `Policy Gates` (Architecture Policy) — including R-10 lint step
- [ ] CI: `Validate package effective parity (RPM vs DEB)` (V108 invariant)
- [ ] CI: `Validate systemd ExecStart payload resolution` (V108 invariant)

**Local Go validation not run on this host** per build policy (`feedback_build_host_policy.md`: builds run on lab2 / monitor server only; no Go toolchain installed locally). CI matrix is authoritative.

Expected baseline-advisory failures (same pattern across all V109/V110 PRs): `OSV Vulnerability Scan` + `Project Health` ×2 — classified baseline-pre-existing.

## Out of scope (explicit non-goals)

- R-11 (Watchdog → BotGuard SafetyPressure topic) — ambitious-cut only; not in this PR
- R-04 / R-05 — CHANGED_SCOPE per delta-audit; separate re-derivation gates
- R-06 — already resolved via Lane M Decision B (v1.104.0)
- R-01 / R-02 / R-03 — metrics/schema-touching → D-MET-1 / v1.111+
- R-07 / R-08 — wiki docs → D-WIK-2
- R-09 — Suricata formal module → too big; v1.112+

## References

- Workspace preflight: `V110_R12_SURFACE_PREFLIGHT.md` (407 lines; answers 8 design questions)
- Delta-audit anchor: `V110_MOD_ISOLATION_DELTA_AUDIT.md` §5 PR B
- Audit anchor: `AUDIT_190_MODULE_ISOLATION/REMEDIATION_PLAN.md` §B R-12 (FM-H, STM-07)
- Prior PR in V110 lane: #599 (R-10 lint; merged as `c8050d9e`)
- Base: `c8050d9e` (post-PR-#599 main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)