### PR TITLE
fix(watchdog): wire MetricsExporter.RecordAction via SetOnAction (D-METR-2)

### DIFF
--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -414,6 +414,13 @@ func (d *Daemon) initWatchdog() error {
 		}
 	})
 
+	// Wire up action callback so nftban_watchdog_action_total and
+	// nftban_watchdog_last_action_timestamp_seconds actually emit in production
+	// (fixes D-METR-2 — registered-but-unwired emission).
+	wd.SetOnAction(func(action watchdog.Action) {
+		d.wdMetrics.RecordAction(action)
+	})
+
 	d.watchdog = wd
 	return nil
 }

--- a/internal/watchdog/executor_test.go
+++ b/internal/watchdog/executor_test.go
@@ -585,3 +585,52 @@ func TestExecutorConcurrency(t *testing.T) {
 
 	wg.Wait()
 }
+
+// =============================================================================
+// PR-M2 (D-METR-2) end-to-end emission wiring
+// =============================================================================
+
+// TestActionExecutor_FiresWatchdogOnAction verifies the production callback
+// chain: ActionExecutor.recordAction → Watchdog.handleAction (wired in
+// New() via SetOnAction) → Watchdog.onAction. Before PR-M2 the third hop
+// did not exist; this test guards against regression in the chain that
+// makes nftban_watchdog_action_total actually increment in production.
+func TestActionExecutor_FiresWatchdogOnAction(t *testing.T) {
+	w, err := New(testConfig(), NewRuntimeControls())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	var mu sync.Mutex
+	var fired int
+	var got Action
+	w.SetOnAction(func(a Action) {
+		mu.Lock()
+		defer mu.Unlock()
+		fired++
+		got = a
+	})
+
+	action := Action{
+		Type:      ActionThrottle,
+		Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		Reason:    "executor_chain_regression",
+		Success:   true,
+	}
+	w.executor.recordAction(action)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if fired != 1 {
+		t.Fatalf("watchdog onAction fired %d times through executor chain, want 1", fired)
+	}
+	if got.Type != action.Type {
+		t.Errorf("Action.Type = %q, want %q", got.Type, action.Type)
+	}
+	if got.Reason != action.Reason {
+		t.Errorf("Action.Reason = %q, want %q", got.Reason, action.Reason)
+	}
+	if !got.Timestamp.Equal(action.Timestamp) {
+		t.Errorf("Action.Timestamp = %v, want %v", got.Timestamp, action.Timestamp)
+	}
+}

--- a/internal/watchdog/metrics_test.go
+++ b/internal/watchdog/metrics_test.go
@@ -1,0 +1,194 @@
+// =============================================================================
+// NFTBan - Tests for watchdog Prometheus metrics emission wiring
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="watchdog_metrics_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-12"
+// meta:description="Tests for D-METR-2 fix — action emission wiring via SetOnAction"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Regression coverage for v1.111 PR-M2: nftban_watchdog_action_total and
+// nftban_watchdog_last_action_timestamp_seconds were registered via promauto
+// in metrics.go but the MetricsExporter.RecordAction emission method was
+// orphaned (never called from production code). The fix mirrors the existing
+// onMetrics/SetOnMetrics callback pattern with onAction/SetOnAction and
+// wires it in cmd/nftband/daemon_init.go.
+//
+// These tests verify the callback contract, not the Prometheus counter values
+// directly, since prometheus/client_golang.NewCounterVec semantics are
+// already covered by the upstream library and adding a test dependency on
+// prometheus/testutil is not necessary for the wiring fix.
+// =============================================================================
+
+package watchdog
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// SetOnAction wiring (D-METR-2 fix)
+// =============================================================================
+
+// TestSetOnAction_NilSafe verifies handleAction does not panic when no
+// onAction callback has been set — the default state for any Watchdog that
+// has not been wired (e.g., short-lived tests or future callers).
+func TestSetOnAction_NilSafe(t *testing.T) {
+	w, err := New(testConfig(), NewRuntimeControls())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	// No SetOnAction call — onAction is nil
+	action := Action{
+		Type:      ActionThrottle,
+		Timestamp: time.Now(),
+		Reason:    "test_nil_safe",
+		Success:   true,
+	}
+
+	// Should not panic even with nil callback
+	w.handleAction(action)
+}
+
+// TestSetOnAction_Fires verifies that setting a callback then invoking
+// handleAction dispatches the action to the callback. This is the contract
+// that D-METR-2 relies on: production wiring in daemon_init.go does
+// SetOnAction(func(a) { d.wdMetrics.RecordAction(a) }), so the counter
+// emission depends on this callback firing.
+func TestSetOnAction_Fires(t *testing.T) {
+	w, err := New(testConfig(), NewRuntimeControls())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	var got Action
+	var fired int32
+	w.SetOnAction(func(a Action) {
+		atomic.AddInt32(&fired, 1)
+		got = a
+	})
+
+	want := Action{
+		Type:      ActionDisableOptional,
+		Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		Reason:    "test_fires",
+		Success:   true,
+	}
+
+	w.handleAction(want)
+
+	if n := atomic.LoadInt32(&fired); n != 1 {
+		t.Fatalf("onAction callback fired %d times, want 1", n)
+	}
+	if got.Type != want.Type {
+		t.Errorf("Action.Type = %q, want %q", got.Type, want.Type)
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Errorf("Action.Timestamp = %v, want %v", got.Timestamp, want.Timestamp)
+	}
+	if got.Reason != want.Reason {
+		t.Errorf("Action.Reason = %q, want %q", got.Reason, want.Reason)
+	}
+}
+
+// TestSetOnAction_Replace verifies SetOnAction replaces a previously-set
+// callback so reconfiguration is supported (mirrors SetOnMetrics behavior).
+func TestSetOnAction_Replace(t *testing.T) {
+	w, err := New(testConfig(), NewRuntimeControls())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	var firstFired, secondFired int32
+	w.SetOnAction(func(_ Action) { atomic.AddInt32(&firstFired, 1) })
+	w.SetOnAction(func(_ Action) { atomic.AddInt32(&secondFired, 1) })
+
+	w.handleAction(Action{Type: ActionFreeOSMemory, Timestamp: time.Now(), Reason: "test_replace"})
+
+	if n := atomic.LoadInt32(&firstFired); n != 0 {
+		t.Errorf("first callback fired %d times after replacement, want 0", n)
+	}
+	if n := atomic.LoadInt32(&secondFired); n != 1 {
+		t.Errorf("second callback fired %d times, want 1", n)
+	}
+}
+
+// TestSetOnAction_ConcurrentSetAndDispatch verifies the mu.Lock pattern in
+// SetOnAction/handleAction is race-free under concurrent reconfiguration
+// and dispatch. Mirrors the existing onMetrics callback synchronization.
+func TestSetOnAction_ConcurrentSetAndDispatch(t *testing.T) {
+	w, err := New(testConfig(), NewRuntimeControls())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	var fired int32
+	cb := func(_ Action) { atomic.AddInt32(&fired, 1) }
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			w.SetOnAction(cb)
+		}()
+		go func() {
+			defer wg.Done()
+			w.handleAction(Action{Type: ActionThrottle, Timestamp: time.Now(), Reason: "race"})
+		}()
+	}
+	wg.Wait()
+
+	// At least one dispatch should have observed a non-nil callback. We do
+	// not assert a specific count because dispatch and set are racing; the
+	// test's primary value is exercising the lock under -race.
+	if atomic.LoadInt32(&fired) == 0 {
+		t.Logf("note: zero callbacks fired under heavy race (acceptable; primary check is -race detector)")
+	}
+}
+
+// =============================================================================
+// MetricsExporter.RecordAction smoke
+// =============================================================================
+
+// TestMetricsExporter_RecordAction_Smoke verifies the previously-orphaned
+// RecordAction emission method is callable end-to-end. Pre-PR-M2 this method
+// was defined but never called from production code; after the wiring fix
+// daemon_init.go invokes it from the SetOnAction callback.
+func TestMetricsExporter_RecordAction_Smoke(t *testing.T) {
+	m := NewMetricsExporter()
+	if m == nil {
+		t.Fatal("NewMetricsExporter() returned nil")
+	}
+
+	// Should complete without panic for every documented ActionType.
+	types := []ActionType{
+		ActionThrottle,
+		ActionDisableOptional,
+		ActionFreeOSMemory,
+		ActionDegradeMode,
+		ActionProfileCPU,
+		ActionProfileHeap,
+		ActionProfileGoroutine,
+	}
+	now := time.Now()
+	for _, at := range types {
+		m.RecordAction(Action{Type: at, Timestamp: now, Reason: "smoke", Success: true})
+	}
+}

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -63,6 +63,7 @@ type Watchdog struct {
 
 	// Metrics callbacks
 	onMetrics func(*Snapshot, *PressureState)
+	onAction  func(Action)
 }
 
 // New creates a new watchdog
@@ -319,9 +320,14 @@ func (w *Watchdog) handleAction(action Action) {
 
 	w.mu.RLock()
 	snapshot := w.lastSnapshot
+	cb := w.onAction
 	w.mu.RUnlock()
 
 	w.recorder.RecordAction(action, snapshot)
+
+	if cb != nil {
+		cb(action)
+	}
 }
 
 // getLevelEntryTime returns when a dimension entered its current level
@@ -377,6 +383,17 @@ func (w *Watchdog) SetOnMetrics(cb func(*Snapshot, *PressureState)) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.onMetrics = cb
+}
+
+// SetOnAction sets a callback fired when the watchdog executes an action.
+// The callback runs on the watchdog's action-dispatch goroutine; it must not
+// block. Wires action events into the Prometheus metrics exporter so that
+// nftban_watchdog_action_total and nftban_watchdog_last_action_timestamp_seconds
+// are emitted in production (companion to SetOnMetrics for tick-based metrics).
+func (w *Watchdog) SetOnAction(cb func(Action)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.onAction = cb
 }
 
 // GetRecorderStats returns flight recorder statistics


### PR DESCRIPTION
## Summary

Closes the D-METR-2 watchdog metric emission gap. `nftban_watchdog_action_total` and `nftban_watchdog_last_action_timestamp_seconds` were registered in `internal/watchdog/metrics.go` via `promauto.NewCounterVec` / `promauto.NewGaugeVec` (so they appear in `/metrics`), but their `MetricsExporter.RecordAction` emission method was orphaned — never called from production code. `Watchdog.handleAction` dispatched only to the in-memory flight recorder, not to the Prometheus exporter.

Fix mirrors the existing `onMetrics`/`SetOnMetrics` callback pattern with a parallel `onAction`/`SetOnAction` hook, then wires it in `cmd/nftband/daemon_init.go` after the `SetOnMetrics` block:

```go
wd.SetOnAction(func(action watchdog.Action) {
    d.wdMetrics.RecordAction(action)
})
```

## Scope

- ✅ `internal/watchdog/watchdog.go` — `onAction` field + `SetOnAction` setter (mirrors `SetOnMetrics`); `handleAction` reads callback under RLock and dispatches after releasing the lock
- ✅ `cmd/nftband/daemon_init.go` — wires `SetOnAction` callback to `d.wdMetrics.RecordAction(action)` after the `SetOnMetrics` block
- ✅ `internal/watchdog/metrics_test.go` (new) — nil-safe, fires, replace, race coverage; smoke test for the previously-orphaned `MetricsExporter.RecordAction`
- ✅ `internal/watchdog/executor_test.go` — end-to-end chain regression test (executor → handleAction → onAction)

**Schema impact: ZERO.** Both metric names were already registered with the default Prometheus registry at v1.110.0; this change only makes their counter values actually advance in production when watchdog actions fire.

## Out of scope (per PR-A scope artifact)

- `internal/metrics/*`, `internal/module/*`
- Schema contracts (`internal/contracts/`, `17_SCHEMA_AND_CONTRACT_FINAL.md`)
- `scripts/lint-module-isolation.sh` (R-10 lint)
- CI workflows
- `VERSION` / `STATUS.md` / `CHANGELOG.md` (release-prep is a separate gate)
- `go.mod` / `go.sum`
- Host vitals registration (PR-M2b-w1 — deferred to v1.112 schema-fulfill gate per PR-A scope §4 friction point 1)

## Reference artifacts

- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V111_METRICS_PORTAL_SCOPE_PREFLIGHT.md` — parent preflight (frozen subset confirmed via receiver-v2 inspection)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V111_METRICS_PORTAL_PR_A_SCOPE.md` — PR-A daemon-source scope; 10 locked questions answered with file:line evidence
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V111_PR_A_PREREQUISITE_CHECK.md` — 7 verification axes cleared (R-10 / R-12 / configs / contracts / CI / master worklog / struct wiring)

## Test plan

- [ ] CI Architecture Policy workflow green (R-10 lint unaffected — watchdog is not a Module)
- [ ] `go build ./...` clean (build runs on lab2/monitor per build-host policy)
- [ ] `gofmt -l ./internal/watchdog/ ./cmd/nftband/` empty diff
- [ ] `go test ./internal/watchdog/...` green; new `TestSetOnAction_*` + `TestActionExecutor_FiresWatchdogOnAction` pass
- [ ] `go test -race ./internal/watchdog/...` green (race coverage on the mu.Lock pattern)
- [ ] Release Packages workflow green
- [ ] Docker workflow green
- [ ] Baseline-advisory failures permitted (OSV Vulnerability Scan + Project Health) per V108/V109/V110 precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)