### PR TITLE
fix(watchdog): emit nftban_host_* vitals per schema doc 17 §F4 (PR-M2b-w1)

### DIFF
--- a/internal/watchdog/collector_system.go
+++ b/internal/watchdog/collector_system.go
@@ -7,7 +7,7 @@
 // meta:version="1.0.0"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:description="Collects system-level metrics including load, memory, and disk usage"
-// meta:inventory.files="/proc/loadavg,/proc/meminfo,/proc/stat"
+// meta:inventory.files="/proc/loadavg,/proc/meminfo,/proc/stat,/proc/vmstat,/proc/self/mountinfo"
 // meta:inventory.binaries=""
 // meta:inventory.env_vars=""
 // meta:inventory.config_files=""
@@ -75,6 +75,9 @@ func (c *SystemCollector) Collect(ctx context.Context, snapshot *Snapshot) error
 	c.collectMemInfo(snapshot)
 	c.collectDiskUsage(snapshot)
 	c.collectEntropy(snapshot)
+	// PR-M2b-w1: host-vitals additions per schema doc 17 §F4.
+	c.collectMultiMountDisks(snapshot)
+	c.collectOOMEvents(snapshot)
 
 	return nil
 }
@@ -211,4 +214,146 @@ func (c *SystemCollector) collectEntropy(snapshot *Snapshot) {
 		return
 	}
 	snapshot.System.Entropy, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+// =============================================================================
+// PR-M2b-w1 (v1.112) — Host-vitals collection per schema doc 17 §F4
+// =============================================================================
+
+// defaultHostDiskMounts is the default mount-policy allowlist for the
+// host_disk_usage_ratio metric per schema doc 17 §F4.3.1. The first three
+// match the doc default; /var/lib/nftban is added because nftban writes
+// state there per the FHS spec.
+var defaultHostDiskMounts = []string{"/", "/var", "/var/log", "/var/lib/nftban"}
+
+// hostDiskMountAllowlist returns the mount-points to read for
+// nftban_host_disk_usage_ratio. Operator may override via
+// NFTBAN_HOST_DISK_MOUNT_ALLOWLIST (comma-separated). Empty env value
+// falls back to defaultHostDiskMounts.
+func hostDiskMountAllowlist() []string {
+	env := strings.TrimSpace(os.Getenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST"))
+	if env == "" {
+		return defaultHostDiskMounts
+	}
+	parts := strings.Split(env, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return defaultHostDiskMounts
+	}
+	return out
+}
+
+// collectMultiMountDisks populates snapshot.System.Disks via per-mount
+// syscall.Statfs() across the allowlist. Mounts that fail to stat are
+// skipped silently (e.g. unmounted, permission denied). Device + fstype
+// are resolved from /proc/self/mountinfo; on parse failure they default
+// to "unknown" so the ratio still emits keyed on the mount path.
+func (c *SystemCollector) collectMultiMountDisks(snapshot *Snapshot) {
+	mounts := hostDiskMountAllowlist()
+	mountInfo := readMountInfo() // best-effort; may be empty map on parse error
+
+	out := make([]DiskUsageEntry, 0, len(mounts))
+	for _, mp := range mounts {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(mp, &stat); err != nil {
+			continue
+		}
+		blockSize := safeconv.Int64ToUint64OrZero(stat.Bsize)
+		totalBytes := stat.Blocks * blockSize
+		if totalBytes == 0 {
+			continue
+		}
+		freeBytes := stat.Bfree * blockSize
+		usedBytes := totalBytes - freeBytes
+		ratio := float64(usedBytes) / float64(totalBytes)
+
+		device, fstype := "unknown", "unknown"
+		if info, ok := mountInfo[mp]; ok {
+			device = info.device
+			fstype = info.fstype
+		}
+		out = append(out, DiskUsageEntry{
+			Mount:  mp,
+			Device: device,
+			FSType: fstype,
+			Ratio:  ratio,
+		})
+	}
+	snapshot.System.Disks = out
+}
+
+// collectOOMEvents reads /proc/vmstat oom_kill (cumulative kernel counter
+// since kernel 4.7). On older kernels missing the field, the counter stays
+// at zero silently — Prometheus Counter handles delta tracking on the
+// emission side.
+func (c *SystemCollector) collectOOMEvents(snapshot *Snapshot) {
+	f, err := os.Open("/proc/vmstat")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "oom_kill ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			snapshot.System.OOMEvents, _ = strconv.ParseUint(fields[1], 10, 64)
+		}
+		return
+	}
+}
+
+// mountInfoEntry holds device + filesystem-type resolved from
+// /proc/self/mountinfo for a given mount path.
+type mountInfoEntry struct {
+	device string
+	fstype string
+}
+
+// readMountInfo parses /proc/self/mountinfo into a mount-point→entry map.
+// Returns an empty (non-nil) map on read or parse failure so callers can
+// always range over it. Format reference: proc(5) mountinfo —
+// fields[4]=mount-point, fields[N+1]=fstype where N is index of "-"
+// separator, fields[N+2]=mount-source.
+func readMountInfo() map[string]mountInfoEntry {
+	out := make(map[string]mountInfoEntry)
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+		mountPoint := fields[4]
+		// Find the "-" separator between optional fields and fstype/source.
+		sepIdx := -1
+		for i := 5; i < len(fields); i++ {
+			if fields[i] == "-" {
+				sepIdx = i
+				break
+			}
+		}
+		if sepIdx < 0 || sepIdx+2 >= len(fields) {
+			continue
+		}
+		out[mountPoint] = mountInfoEntry{
+			device: fields[sepIdx+2],
+			fstype: fields[sepIdx+1],
+		}
+	}
+	return out
 }

--- a/internal/watchdog/collector_system_test.go
+++ b/internal/watchdog/collector_system_test.go
@@ -1,0 +1,239 @@
+// =============================================================================
+// NFTBan - Tests for SystemCollector host-vitals extensions
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="watchdog_collector_system_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-12"
+// meta:description="Tests for PR-M2b-w1 host-vitals collection (collectOOMEvents, collectMultiMountDisks, hostDiskMountAllowlist)"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_HOST_DISK_MOUNT_ALLOWLIST"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Covers schema doc 17 §F4 host-vitals additions: mount allowlist policy
+// (§F4.3.1), OOM events from /proc/vmstat (§F4.2). The collectMultiMountDisks
+// fixture tests use real /proc/self/mountinfo + syscall.Statfs against
+// standard mounts (/ always exists), since stubbing the syscall layer would
+// add abstraction beyond what this fix warrants.
+// =============================================================================
+
+package watchdog
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// =============================================================================
+// hostDiskMountAllowlist — env policy
+// =============================================================================
+
+func TestHostDiskMountAllowlist_DefaultWhenEnvUnset(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "")
+	got := hostDiskMountAllowlist()
+	want := defaultHostDiskMounts
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d len(want)=%d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestHostDiskMountAllowlist_DefaultWhenEnvAllWhitespace(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "  ,  ,  ")
+	got := hostDiskMountAllowlist()
+	if len(got) != len(defaultHostDiskMounts) {
+		t.Errorf("expected default fallback on all-whitespace env, got %v", got)
+	}
+}
+
+func TestHostDiskMountAllowlist_EnvOverride(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "/, /data , /mnt/storage")
+	got := hostDiskMountAllowlist()
+	want := []string{"/", "/data", "/mnt/storage"}
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d len(want)=%d (got=%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestHostDiskMountAllowlist_DefaultDocPolicyPlusNftbanStateDir(t *testing.T) {
+	// Schema doc 17 §F4.3.1 defaults: /, /var, /var/log.
+	// Plus /var/lib/nftban (nftban-specific FHS addition).
+	expected := map[string]bool{
+		"/":               true,
+		"/var":            true,
+		"/var/log":        true,
+		"/var/lib/nftban": true,
+	}
+	for _, m := range defaultHostDiskMounts {
+		if !expected[m] {
+			t.Errorf("unexpected default mount: %q", m)
+		}
+		delete(expected, m)
+	}
+	if len(expected) > 0 {
+		t.Errorf("missing default mounts: %v", expected)
+	}
+}
+
+// =============================================================================
+// collectMultiMountDisks — populates snapshot.System.Disks
+// =============================================================================
+
+func TestCollectMultiMountDisks_RootMountAlwaysPresent(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "/")
+	c := NewSystemCollector("/")
+	snapshot := &Snapshot{}
+	c.collectMultiMountDisks(snapshot)
+
+	if len(snapshot.System.Disks) != 1 {
+		t.Fatalf("expected 1 disk entry for root mount, got %d (disks=%+v)", len(snapshot.System.Disks), snapshot.System.Disks)
+	}
+	d := snapshot.System.Disks[0]
+	if d.Mount != "/" {
+		t.Errorf("Mount = %q, want %q", d.Mount, "/")
+	}
+	if d.Ratio < 0 || d.Ratio > 1 {
+		t.Errorf("Ratio = %v, want 0..1", d.Ratio)
+	}
+	// Device + FSType come from /proc/self/mountinfo on Linux; should resolve
+	// to non-"unknown" on a working test host, but we accept "unknown" as
+	// the documented fallback for parse failure.
+	if d.Device == "" {
+		t.Error("Device should be non-empty")
+	}
+	if d.FSType == "" {
+		t.Error("FSType should be non-empty")
+	}
+}
+
+func TestCollectMultiMountDisks_NonexistentMountSkipped(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "/this/path/does/not/exist/anywhere,/")
+	c := NewSystemCollector("/")
+	snapshot := &Snapshot{}
+	c.collectMultiMountDisks(snapshot)
+
+	// The bogus mount must be silently skipped; "/" should still appear.
+	rootSeen := false
+	for _, d := range snapshot.System.Disks {
+		if d.Mount == "/this/path/does/not/exist/anywhere" {
+			t.Error("nonexistent mount should be skipped, but appeared in snapshot")
+		}
+		if d.Mount == "/" {
+			rootSeen = true
+		}
+	}
+	if !rootSeen {
+		t.Error("expected root mount in snapshot after skipping bogus mount")
+	}
+}
+
+func TestCollectMultiMountDisks_CardinalityBoundDefault(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "")
+	c := NewSystemCollector("/")
+	snapshot := &Snapshot{}
+	c.collectMultiMountDisks(snapshot)
+
+	// Default policy is 4 mounts; not all may exist on the test host.
+	if len(snapshot.System.Disks) > len(defaultHostDiskMounts) {
+		t.Errorf("default-policy emission produced %d series, want ≤ %d", len(snapshot.System.Disks), len(defaultHostDiskMounts))
+	}
+}
+
+// =============================================================================
+// collectOOMEvents — reads /proc/vmstat oom_kill
+// =============================================================================
+
+func TestCollectOOMEvents_LinuxHost(t *testing.T) {
+	if _, err := os.Stat("/proc/vmstat"); err != nil {
+		t.Skip("/proc/vmstat not available (non-Linux test host)")
+	}
+	c := NewSystemCollector("/")
+	snapshot := &Snapshot{}
+	c.collectOOMEvents(snapshot)
+
+	// Modern kernels (≥4.7) have oom_kill; the value is a counter,
+	// usually 0 on healthy hosts but may be > 0 if OOM events occurred.
+	// Either way, the field must be set (or unchanged from zero) without
+	// panic. We just verify the field is reachable.
+	_ = snapshot.System.OOMEvents
+}
+
+// =============================================================================
+// SystemCollector.Collect — integration: host-vitals collectors wired into Collect()
+// =============================================================================
+
+func TestSystemCollector_CollectIncludesHostVitals(t *testing.T) {
+	t.Setenv("NFTBAN_HOST_DISK_MOUNT_ALLOWLIST", "/")
+	c := NewSystemCollector("/var/log")
+	snapshot := &Snapshot{}
+	if err := c.Collect(context.Background(), snapshot); err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	// Pre-existing fields populated.
+	if snapshot.System.NumCPU == 0 {
+		t.Error("NumCPU should be populated")
+	}
+	if snapshot.System.MemTotal == 0 {
+		t.Skip("MemTotal not populated — likely non-Linux test host without /proc/meminfo")
+	}
+
+	// PR-M2b-w1 additions populated.
+	if len(snapshot.System.Disks) == 0 {
+		t.Error("Disks should contain at least the root mount")
+	}
+	// OOMEvents is a cumulative counter (≥0); just verify field reachable.
+	_ = snapshot.System.OOMEvents
+}
+
+// =============================================================================
+// readMountInfo — best-effort /proc/self/mountinfo parser
+// =============================================================================
+
+func TestReadMountInfo_LinuxHostFindsRoot(t *testing.T) {
+	if _, err := os.Stat("/proc/self/mountinfo"); err != nil {
+		t.Skip("/proc/self/mountinfo not available (non-Linux test host)")
+	}
+	info := readMountInfo()
+	if info == nil {
+		t.Fatal("readMountInfo returned nil map (contract is non-nil)")
+	}
+	root, ok := info["/"]
+	if !ok {
+		t.Skip("/ not in mountinfo on this host — unusual but acceptable")
+	}
+	if root.device == "" {
+		t.Error("root device should be non-empty")
+	}
+	if root.fstype == "" {
+		t.Error("root fstype should be non-empty")
+	}
+}
+
+func TestReadMountInfo_NeverReturnsNilMap(t *testing.T) {
+	// Even if /proc/self/mountinfo is unreadable, readMountInfo() must
+	// return a non-nil (empty) map so callers can range without nil check.
+	info := readMountInfo()
+	if info == nil {
+		t.Fatal("readMountInfo must never return nil map")
+	}
+}

--- a/internal/watchdog/metrics.go
+++ b/internal/watchdog/metrics.go
@@ -261,6 +261,46 @@ var (
 		Name:      "cidr_filter_kept",
 		Help:      "CIDRs that passed filtering in last sync",
 	})
+
+	// ==========================================================================
+	// Host-Vitals Metrics (PR-M2b-w1 — schema doc 17 §F4)
+	// ==========================================================================
+
+	hostLoadAverage = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "host_load_average",
+		Help:      "System load average per window (per /proc/loadavg)",
+	}, []string{"window"})
+
+	hostMemoryTotalBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "host_memory_total_bytes",
+		Help:      "Total system memory in bytes (per /proc/meminfo MemTotal)",
+	})
+
+	hostMemoryAvailableBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "host_memory_available_bytes",
+		Help:      "Available system memory in bytes (per /proc/meminfo MemAvailable)",
+	})
+
+	hostMemoryUsedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "host_memory_used_bytes",
+		Help:      "Used system memory in bytes (derived as MemTotal - MemAvailable)",
+	})
+
+	hostDiskUsageRatio = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "host_disk_usage_ratio",
+		Help:      "Disk usage as ratio (used/total, 0..1) per filesystem (per statvfs)",
+	}, []string{"mount", "device", "fstype"})
+
+	hostOOMEventsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "nftban",
+		Name:      "host_oom_events_total",
+		Help:      "Cumulative OOM-kill events (per /proc/vmstat oom_kill)",
+	})
 )
 
 // MetricsExporter updates Prometheus metrics from watchdog data
@@ -268,6 +308,11 @@ type MetricsExporter struct {
 	// For cost calculation
 	lastRSS    uint64
 	lastBlocks int
+
+	// PR-M2b-w1 (v1.112): tracks the last cumulative oom_kill counter so
+	// the Prometheus Counter advances by the per-tick delta rather than
+	// being set to the absolute kernel value (Counter only supports Add).
+	lastOOMEvents uint64
 }
 
 // NewMetricsExporter creates a new metrics exporter
@@ -356,6 +401,26 @@ func (m *MetricsExporter) Update(snapshot *Snapshot, state *PressureState) {
 	}
 
 	// Cost per block calculation
+	// Host-vitals metrics (PR-M2b-w1 — schema doc 17 §F4).
+	// SystemMetrics has been populated this tick by SystemCollector.Collect().
+	hostLoadAverage.WithLabelValues("1m").Set(snapshot.System.LoadAvg1)
+	hostLoadAverage.WithLabelValues("5m").Set(snapshot.System.LoadAvg5)
+	hostLoadAverage.WithLabelValues("15m").Set(snapshot.System.LoadAvg15)
+	hostMemoryTotalBytes.Set(float64(snapshot.System.MemTotal))
+	hostMemoryAvailableBytes.Set(float64(snapshot.System.MemAvail))
+	if snapshot.System.MemTotal >= snapshot.System.MemAvail {
+		hostMemoryUsedBytes.Set(float64(snapshot.System.MemTotal - snapshot.System.MemAvail))
+	}
+	for _, d := range snapshot.System.Disks {
+		hostDiskUsageRatio.WithLabelValues(d.Mount, d.Device, d.FSType).Set(d.Ratio)
+	}
+	// Counter semantics: oom_kill is a cumulative kernel counter; emit the
+	// per-tick delta so the Prometheus Counter monotonically advances.
+	if snapshot.System.OOMEvents > m.lastOOMEvents {
+		hostOOMEventsTotal.Add(float64(snapshot.System.OOMEvents - m.lastOOMEvents))
+	}
+	m.lastOOMEvents = snapshot.System.OOMEvents
+
 	m.updateCostMetrics(snapshot)
 
 	// CIDR filter metrics (read from state file)

--- a/internal/watchdog/metrics_test.go
+++ b/internal/watchdog/metrics_test.go
@@ -192,3 +192,128 @@ func TestMetricsExporter_RecordAction_Smoke(t *testing.T) {
 		m.RecordAction(Action{Type: at, Timestamp: now, Reason: "smoke", Success: true})
 	}
 }
+
+// =============================================================================
+// Host-vitals emission (PR-M2b-w1 — schema doc 17 §F4)
+// =============================================================================
+
+// TestMetricsExporter_HostVitalsEmission verifies Update() does not panic
+// when called with a synthetic Snapshot populated with host-vitals fields.
+// The Prometheus library handles the actual counter/gauge mechanics; this
+// test confirms the wiring is reachable for every code path in the new
+// emission block (3 load-average windows + 3 memory gauges + multi-mount
+// loop + OOM counter delta).
+func TestMetricsExporter_HostVitalsEmission(t *testing.T) {
+	m := NewMetricsExporter()
+	snapshot := &Snapshot{
+		System: SystemMetrics{
+			LoadAvg1:  0.5,
+			LoadAvg5:  0.75,
+			LoadAvg15: 1.25,
+			MemTotal:  16 * 1024 * 1024 * 1024,
+			MemAvail:  8 * 1024 * 1024 * 1024,
+			Disks: []DiskUsageEntry{
+				{Mount: "/", Device: "/dev/sda1", FSType: "ext4", Ratio: 0.42},
+				{Mount: "/var", Device: "/dev/sda2", FSType: "xfs", Ratio: 0.18},
+			},
+			OOMEvents: 0,
+		},
+	}
+	state := NewPressureState()
+
+	// Should not panic with valid host-vitals fields populated.
+	m.Update(snapshot, state)
+}
+
+// TestMetricsExporter_OOMEventsCounterDelta verifies the per-tick delta
+// pattern for the cumulative kernel oom_kill counter. The Prometheus
+// Counter only supports Add(); the kernel counter is cumulative; the
+// emission code must Add the delta and remember the last cumulative
+// value.
+func TestMetricsExporter_OOMEventsCounterDelta(t *testing.T) {
+	m := NewMetricsExporter()
+	state := NewPressureState()
+
+	// First tick: kernel counter at 5; lastOOMEvents = 0; delta = 5.
+	s1 := &Snapshot{System: SystemMetrics{OOMEvents: 5}}
+	m.Update(s1, state)
+	if m.lastOOMEvents != 5 {
+		t.Errorf("after first tick, lastOOMEvents = %d, want 5", m.lastOOMEvents)
+	}
+
+	// Second tick: kernel counter at 5 (no OOM since last tick); delta = 0.
+	s2 := &Snapshot{System: SystemMetrics{OOMEvents: 5}}
+	m.Update(s2, state)
+	if m.lastOOMEvents != 5 {
+		t.Errorf("after stable tick, lastOOMEvents = %d, want 5", m.lastOOMEvents)
+	}
+
+	// Third tick: kernel counter at 8 (3 new OOM events); delta = 3.
+	s3 := &Snapshot{System: SystemMetrics{OOMEvents: 8}}
+	m.Update(s3, state)
+	if m.lastOOMEvents != 8 {
+		t.Errorf("after delta tick, lastOOMEvents = %d, want 8", m.lastOOMEvents)
+	}
+}
+
+// TestMetricsExporter_OOMEventsCounterMonotonicDownIgnored verifies the
+// counter does not regress if the kernel value somehow decreases (e.g.
+// counter reset on kernel/host change). The emission code must NOT
+// attempt to Add a negative delta — Prometheus Counter would panic.
+func TestMetricsExporter_OOMEventsCounterMonotonicDownIgnored(t *testing.T) {
+	m := NewMetricsExporter()
+	state := NewPressureState()
+
+	// Establish lastOOMEvents = 10.
+	m.Update(&Snapshot{System: SystemMetrics{OOMEvents: 10}}, state)
+	if m.lastOOMEvents != 10 {
+		t.Fatalf("setup: lastOOMEvents = %d, want 10", m.lastOOMEvents)
+	}
+
+	// Kernel value regresses to 3 (e.g. counter reset). The emission code
+	// must not Add(-7); the Counter would panic. Implementation guards
+	// with `if snapshot > lastOOMEvents`. We update lastOOMEvents to the
+	// new (lower) value so a future advance from 3 → 4 emits delta=1.
+	m.Update(&Snapshot{System: SystemMetrics{OOMEvents: 3}}, state)
+	if m.lastOOMEvents != 3 {
+		t.Errorf("after regression, lastOOMEvents = %d, want 3 (resync to new baseline)", m.lastOOMEvents)
+	}
+}
+
+// TestMetricsExporter_HostDiskMultiMount verifies the per-disk loop in
+// Update() emits one series per DiskUsageEntry without per-entry side
+// effects on the exporter state.
+func TestMetricsExporter_HostDiskMultiMount(t *testing.T) {
+	m := NewMetricsExporter()
+	state := NewPressureState()
+
+	// Empty Disks slice: loop body never executes; no panic.
+	m.Update(&Snapshot{System: SystemMetrics{Disks: nil}}, state)
+
+	// Multiple entries: each emitted via WithLabelValues.
+	m.Update(&Snapshot{
+		System: SystemMetrics{
+			Disks: []DiskUsageEntry{
+				{Mount: "/", Device: "/dev/sda1", FSType: "ext4", Ratio: 0.10},
+				{Mount: "/var", Device: "/dev/sda2", FSType: "xfs", Ratio: 0.20},
+				{Mount: "/var/log", Device: "/dev/sda3", FSType: "ext4", Ratio: 0.30},
+				{Mount: "/var/lib/nftban", Device: "/dev/sda4", FSType: "ext4", Ratio: 0.40},
+			},
+		},
+	}, state)
+}
+
+// TestMetricsExporter_HostMemoryUsedGuardedAgainstUnderflow verifies the
+// hostMemoryUsedBytes derivation (MemTotal - MemAvailable) is guarded
+// against the rare race where a snapshot is captured mid-update and
+// MemAvail > MemTotal. The emission code must NOT subtract uint64s
+// in a way that underflows.
+func TestMetricsExporter_HostMemoryUsedGuardedAgainstUnderflow(t *testing.T) {
+	m := NewMetricsExporter()
+	state := NewPressureState()
+
+	// Pathological case: MemAvail somehow > MemTotal (impossible normally,
+	// but the guard ensures we don't crash). Emission code must skip the
+	// derivation rather than wrap around uint64.
+	m.Update(&Snapshot{System: SystemMetrics{MemTotal: 100, MemAvail: 200}}, state)
+}

--- a/internal/watchdog/types.go
+++ b/internal/watchdog/types.go
@@ -176,8 +176,24 @@ type SystemMetrics struct {
 	MemAvail   uint64  `json:"mem_available_bytes"`
 	SwapTotal  uint64  `json:"swap_total_bytes"`
 	SwapFree   uint64  `json:"swap_free_bytes"`
-	DiskUsePct float64 `json:"disk_use_percent"`  // Log partition
+	DiskUsePct float64 `json:"disk_use_percent"`  // Log partition (single-mount; preserved for backwards compat)
 	Entropy    int     `json:"entropy_available"` // /proc/sys/kernel/random/entropy_avail
+
+	// PR-M2b-w1 (v1.112): host-vitals additions per schema doc 17 §F4.
+	// `omitempty` preserves byte-identical JSON output for zero-value cases.
+	Disks     []DiskUsageEntry `json:"disks,omitempty"`      // multi-mount disk usage per NFTBAN_HOST_DISK_MOUNT_ALLOWLIST
+	OOMEvents uint64           `json:"oom_events,omitempty"` // cumulative /proc/vmstat oom_kill counter
+}
+
+// DiskUsageEntry holds per-mount disk usage data emitted as the
+// nftban_host_disk_usage_ratio{mount,device,fstype} metric per schema doc 17
+// §F4.3. Populated by SystemCollector.collectMultiMountDisks against the
+// NFTBAN_HOST_DISK_MOUNT_ALLOWLIST policy.
+type DiskUsageEntry struct {
+	Mount  string  `json:"mount"`
+	Device string  `json:"device"`
+	FSType string  `json:"fstype"`
+	Ratio  float64 `json:"ratio"` // used / total, 0..1
 }
 
 // KernelMetrics contains kernel/netfilter metrics


### PR DESCRIPTION
## Summary

Closes PR-M2b-w1 host-vitals schema-fulfillment gap. Emits 6 already-declared metric names from schema doc 17 §F4 that the daemon was not previously implementing despite being accepted by the receiver-v2 181-entry allow-list since v1.111.0.

Per operator contract-fulfill interpretation locked at `V112_CONTRACT_FULFILL_ATTESTATION.md`: implementing already-declared schema names is **schema fulfillment**, not schema mutation. **Schema 1.83.0 frozen invariant remains intact.** No new metric names. No new label cardinality dimensions beyond what schema doc 17 §F4 already declared.

## Metrics emitted

| Metric | Type | Labels | Source |
|---|---|---|---|
| `nftban_host_load_average` | GaugeVec | `window` (1m/5m/15m) | `/proc/loadavg` |
| `nftban_host_memory_total_bytes` | Gauge | — | `/proc/meminfo` MemTotal |
| `nftban_host_memory_available_bytes` | Gauge | — | `/proc/meminfo` MemAvailable |
| `nftban_host_memory_used_bytes` | Gauge | — | derived (MemTotal − MemAvailable) |
| `nftban_host_disk_usage_ratio` | GaugeVec | `mount`, `device`, `fstype` | `syscall.Statfs()` + `/proc/self/mountinfo` |
| `nftban_host_oom_events_total` | Counter | — | `/proc/vmstat oom_kill` (delta) |

Cardinality bound under default mount policy: ~11 series per host (3 load_average + 3 memory + ~4 disk + 1 OOM counter).

## Architecture (key design decision)

This PR is an **EXTENSION of the existing `SystemCollector`** (`internal/watchdog/collector_system.go`), **not a new collector**. The V112 scope artifact initially planned a new `collector_host.go`; the V112 PR-B scope audit (`V112_METRICS_PORTAL_PR_B_SCOPE.md`) found that `SystemCollector` already reads `/proc/loadavg`, `/proc/meminfo`, `/proc/stat`, and uses `syscall.Statfs()` — and `SystemMetrics` already exposes `LoadAvg1/5/15`, `MemTotal`, `MemAvail`, etc. Extending the existing collector is much cleaner.

**Watchdog struct, config.go, and collector_base.go remain UNCHANGED** — no struct/interface churn.

## Scope

5 files in `internal/watchdog/*` only:

- `types.go` (+18/-2): extend `SystemMetrics` with `Disks []DiskUsageEntry` + `OOMEvents uint64` (both `omitempty` for byte-identical zero-value JSON output); NEW `DiskUsageEntry{Mount, Device, FSType string; Ratio float64}`
- `collector_system.go` (+147): NEW `collectOOMEvents()`, `collectMultiMountDisks()`, `hostDiskMountAllowlist()` env helper, `readMountInfo()` parser, `defaultHostDiskMounts` var; wired into existing `Collect()` body
- `metrics.go` (+65): 6 new `promauto.New*` blocks (one Counter, two GaugeVec, three Gauge); new `lastOOMEvents uint64` field on `MetricsExporter` for counter-delta semantics; new emission section in `Update()` pump
- `collector_system_test.go` (NEW, 239 lines): mount-policy tests (default/env/whitespace), multi-mount tests (root-always-present/nonexistent-skipped/cardinality-bound), OOM events test, Collect() integration test, mountinfo parser tests
- `metrics_test.go` (+125): host-vitals emission test, OOM counter delta test, OOM monotonic-down regression guard, multi-mount loop test, memory underflow guard test

## Mount policy

Per schema doc 17 §F4.3.1:
- Default: `/`, `/var`, `/var/log` (doc default) + `/var/lib/nftban` (nftban FHS spec)
- Operator override: `NFTBAN_HOST_DISK_MOUNT_ALLOWLIST=/data,/mnt/storage` (comma-separated)
- Mounts that fail `statfs` are skipped silently (unmounted / permission denied)
- Device + FSType resolved from `/proc/self/mountinfo`; fallback to `"unknown"` if not resolvable

## Counter semantics

`/proc/vmstat oom_kill` is a cumulative kernel counter (kernel ≥4.7). Prometheus Counter only supports `Add()`; emission code tracks `lastOOMEvents` and Adds the per-tick delta. Counter regression (kernel reset / host change) is handled by resyncing baseline without crashing — test `TestMetricsExporter_OOMEventsCounterMonotonicDownIgnored` guards this.

Kernel compatibility: all supported distros (EL9/10, Debian 12/13, Ubuntu 22.04/24.04) ship kernel ≥5.14, well above the 4.7 `oom_kill` threshold and 3.14 `MemAvailable` threshold.

## Out of scope (per V112 scope §6)

- §F4 metrics beyond the 6 PR-M2b-w1 targets (CPU details, swap, inodes, IO wait, SMART, RAID, service health) — defer to future PR-M2b sub-items
- PR-M2b-w2..w7 per-module emission waves (LoginMon, DDoS, BotGuard, Feed, Geoban, Suricata)
- PR-M2c new nft named counters — schema-unfreeze required
- PR-M2d kernel set element annotation cookies — schema-unfreeze + migration plan
- PR-M3 cache v2 producer + PR-M1 CLI formatter
- R-11 Watchdog → BotGuard EventSafetyPressure
- D-LMA-1 W1 governance
- All long-deferred D-* backlog

## Schema status

**Schema frozen at `1.83.0`.** All 6 emitted metric names are pre-declared in `17_SCHEMA_AND_CONTRACT_FINAL.md` §F4 and pre-accepted in `nftbanpro_cms/shared/metrics-allowlist.json` (181-entry allow-list since v1.111.0 publish). No new metric names. No new schema entries. No new label cardinality dimensions.

## Reference artifacts

- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_SCHEMA_FULFILL_HOST_VITALS_SCOPE.md` (parent planning verdict)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_CONTRACT_FULFILL_ATTESTATION.md` (operator interpretation lock)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_METRICS_PORTAL_PR_B_SCOPE.md` (daemon-source scope)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_PR_B_PREREQUISITE_CHECK.md` (7-axis prereq check)
- Schema doc: `V190_METRICS_SYSTEM/17_SCHEMA_AND_CONTRACT_FINAL.md` §F4

## Test plan

- [ ] CI Architecture Policy workflow green (R-10 lint unaffected — watchdog still not a Module)
- [ ] `go build ./...` clean (build runs on lab2/monitor per build-host policy)
- [ ] `gofmt -l ./internal/watchdog/` empty diff
- [ ] `go test ./internal/watchdog/...` green — 13 new tests pass (8 in collector_system_test.go + 5 in metrics_test.go)
- [ ] `go test -race ./internal/watchdog/...` green
- [ ] Release Packages workflow green
- [ ] Docker workflow green
- [ ] Baseline-advisory failures permitted (OSV + Project Health × 2) per V108/V109/V110/V111 precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)