### PR TITLE
fix(exporter): nftban_nft_sets_total arithmetic syntax error (v1.112.1 hotfix)

### DIFF
--- a/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
@@ -802,7 +802,20 @@ collect_all_metrics() {
             # Count sets per family (nft list sets FAMILY, not "nft list sets FAMILY TABLE")
             local ipv4_family="${NFTBAN_TABLE_IPV4%% *}"  # "ip" from "ip nftban"
             local ipv6_family="${NFTBAN_TABLE_IPV6%% *}"  # "ip6" from "ip6 nftban"
-            sets_count=$(( $(nft list sets "$ipv4_family" 2>/dev/null | grep -c "set " || echo 0) + $(nft list sets "$ipv6_family" 2>/dev/null | grep -c "set " || echo 0) ))
+            # v1.112.1 hotfix: split the compound arithmetic into separate steps to avoid
+            # bash arithmetic syntax error when `grep -c` exits 1 on zero matches AND
+            # `|| echo 0` then concatenates a second "0" into the captured stdout. The
+            # captured `0\n0` is invalid inside `$(( ))` and exits the script with code 2
+            # under `set -Eeuo pipefail`, breaking the entire extended-mode pipeline under
+            # systemd. Discovered in lab4 (EL9) bash -x trace; EL10 (newer toolchain) does
+            # not reproduce reliably. Per-step assignment + numeric validation makes the
+            # arithmetic safe regardless of whether `nft list sets` finds 0 or N sets.
+            local _v4_sets _v6_sets
+            _v4_sets=$(nft list sets "$ipv4_family" 2>/dev/null | grep -c "set " 2>/dev/null) || _v4_sets=0
+            _v6_sets=$(nft list sets "$ipv6_family" 2>/dev/null | grep -c "set " 2>/dev/null) || _v6_sets=0
+            [[ "$_v4_sets" =~ ^[0-9]+$ ]] || _v4_sets=0
+            [[ "$_v6_sets" =~ ^[0-9]+$ ]] || _v6_sets=0
+            sets_count=$((_v4_sets + _v6_sets))
             # Total elements across all standard sets (use function-level whitelist_v4/v6 from LIVE)
             elements_total=$((${active_v4:-0} + ${active_v6:-0} + ${whitelist_v4:-0} + ${whitelist_v6:-0}))
             metrics+="nftban_nft_sets_total $sets_count $timestamp\n"


### PR DESCRIPTION
## Summary

Closes the v1.112.0 unified-exporter regression where `extended`-mode collection fails under `systemd User=nftban + ProtectSystem=strict` with `exit-code 2/INVALIDARGUMENT` on EL9 + Ubuntu hosts. EL10 unaffected.

## Root cause (line 805)

```bash
sets_count=$(( $(nft list sets "$ipv4_family" 2>/dev/null \
                  | grep -c "set " || echo 0) + ... ))
```

When `nft list sets` returns no `"set "` matches:
- `grep -c "set "` outputs `"0"` AND exits **1** (no matches)
- `|| echo 0` then outputs **another** `"0"`
- Combined captured stdout = `"0\n0"`
- `$(( "0\n0" + ... ))` → **arithmetic syntax error → bash exits 2** → systemd reports `INVALIDARGUMENT`

Manifests reliably under `live extended` group invocation in restricted systemd context. EL10 (newer toolchain/timing) does not reproduce because nft tables are usually populated by the time `extended` fires.

## Fix

Split the compound arithmetic into separate command-substitutions + numeric-validation guards so the dual-output pattern cannot occur:

```bash
local _v4_sets _v6_sets
_v4_sets=$(nft list sets "$ipv4_family" 2>/dev/null | grep -c "set " 2>/dev/null) || _v4_sets=0
_v6_sets=$(nft list sets "$ipv6_family" 2>/dev/null | grep -c "set " 2>/dev/null) || _v6_sets=0
[[ "$_v4_sets" =~ ^[0-9]+$ ]] || _v4_sets=0
[[ "$_v6_sets" =~ ^[0-9]+$ ]] || _v6_sets=0
sets_count=$((_v4_sets + _v6_sets))
```

## Verification

- Local bash reproduction: empty input → `result=0` (no syntax error); with-matches input → `result=N` (correct sum)
- `bash -n` syntax check: PASS
- shellcheck: no NEW warnings (2 pre-existing INFOs on unchanged lines 448 + 597)
- Full end-to-end validation on lab4 (EL9 reproducible host) deferred to `EXECUTE_V112_1_VALIDATE_LAB4` post-release gate

## Envelope

**1 file / +14 / -1** — `cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh` only.

## NO IMPACT on

- v1.112.0 host-vitals release content (Go daemon `/metrics` emits all 6 `nftban_host_*` metrics correctly on all 4 validated hosts; not touched by this fix)
- Schema 1.83.0 (frozen)
- Receiver-v2 ingest contract (allow-list unchanged)
- systemd unit file (verified not the issue via systemd-run isolation test)
- All other exporter scripts (loader / helpers / export — unchanged)

## Cross-distro defect characterization (from validation gates)

| Host | OS | unified-exporter v1.112.0 |
|---|---|---|
| lab2 | Ubuntu 24.04 (DEB) | ❌ extended-fail; basic intermittent |
| lab4 | AlmaLinux 9 (RPM) | ❌ extended-fail; `bash -x` trace captured the moment before exit 2 |
| srv4 | AlmaLinux 10.1 (RPM) | ✅ ALL runs succeed (incl. `live extended`) |
| monitor | (receiver-side; n/a) | n/a |

## Reference artifacts

- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_1_UNIFIED_EXPORTER_HOTFIX_SCOPE.md` (parent scope)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_1_HOTFIX_PR_B_SCOPE.md` (investigation findings + Shape A confirmed)
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_HOST_VITALS_EVIDENCE/lab2/exporter-defect-investigation.txt`
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_HOST_VITALS_EVIDENCE/lab4/bashx-trace-investigation.txt`
- `V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/V112_HOST_VITALS_EVIDENCE/srv4/unified-exporter-el10-check.txt`

## Test plan

- [ ] CI Architecture Policy workflow green
- [ ] `go build ./...` clean (no Go source changes in this PR)
- [ ] shellcheck pass
- [ ] All RPM + DEB build matrix green
- [ ] Runtime Truth × 2 distros green
- [ ] Baseline-advisory failures permitted (OSV + Project Health × 2)
- [ ] Post-release: `EXECUTE_V112_1_VALIDATE_LAB4 = GO` — lab4 unified-exporter 5 consecutive runs SUCCESS including ≥2 `live extended`

🤖 Generated with [Claude Code](https://claude.com/claude-code)