### PR TITLE
fix(packaging): run systemd-tmpfiles --create before service activation in DEB postinst (v1.112.2 hotfix)

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -186,6 +186,22 @@ case "$1" in
         # --- Reload systemd so new unit files are visible ---
         systemctl daemon-reload 2>/dev/null || true
 
+        # --- v1.112.2 hotfix: create runtime directories before service activation.
+        # nftband.service declares ReadWritePaths=/var/cache/nftban for systemd
+        # mount-namespace isolation. On fresh DEB installs the cache dir does not
+        # exist at the moment the Go installer (below) triggers `systemctl start`,
+        # so systemd refuses the unit with status=226/NAMESPACE
+        # ("Failed to set up mount namespacing: /var/cache/nftban: No such file
+        # or directory") and nftban-unified-exporter.service inherits the same
+        # failure. systemd-tmpfiles --create against the package-shipped
+        # /usr/lib/tmpfiles.d/nftban.conf creates the required runtime tree
+        # (/var/cache/nftban, /run/nftban, /var/log/nftban, etc.) idempotently.
+        # Reproduced on 4/4 DEB VMs in the V112.2 lane (Debian 12/13 + Ubuntu
+        # 22.04/24.04); RPM scriptlet ordering was already correct.
+        if [ -f /usr/lib/tmpfiles.d/nftban.conf ]; then
+            systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf 2>/dev/null || true
+        fi
+
         # =================================================================
         # GO INSTALLER
         # =================================================================


### PR DESCRIPTION
## Summary

- DEB postinst was triggering the Go installer (which activates services) before the package-shipped runtime tree was created. `nftband.service` declares `ReadWritePaths=/var/cache/nftban` for systemd mount-namespace isolation; with the directory missing, systemd refuses the unit with `status=226/NAMESPACE` (`"Failed to set up mount namespacing: /var/cache/nftban: No such file or directory"`). The exporter unit inherits the same failure path, surfacing as the v1.112 unified-exporter `exit=2` regression observed on every DEB host.
- Insert `systemd-tmpfiles --create /usr/lib/tmpfiles.d/nftban.conf` between `daemon-reload` and the Go installer. Idempotent, guarded with `[ -f ]` and `|| true`. RPM scriptlet ordering was already correct and needs no change.

## Defect characterization

The v1.112.1 line-805 Shape A arithmetic fix (PR #606) was correct as a local defensive improvement but **was not** the cause of the v1.112 exporter regression. The actual cause is this DEB postinst ordering gap, identified during the V112.2 investigation lane.

| Family | Reproduces? | Why |
|---|---|---|
| RPM (el9, el10) | ❌ NO | RPM `%post` scriptlet ordering creates runtime dirs before service activation |
| DEB (debian12+, ubuntu22.04+) | ✅ YES | DEB `postinst` triggers Go installer before tmpfiles runs |

## Reproduction evidence (V112.2 lane)

11-host parallel matrix on lab2 + lab4 (production-class) + 9 lab VMs on `hyperv-itcms`:

| Host | Pkg | Reproduced exit=2? |
|---|---|---|
| lab4 (AlmaLinux 9) | RPM | ❌ |
| lab2 (Ubuntu 24.04) | DEB | ✅ (postinst preinst-blocked first install) |
| tgt-a9 (AlmaLinux 9) | RPM | ❌ |
| tgt-r9 (Rocky 9) | RPM | ❌ |
| tgt-cs9 (CentOS Stream 9) | RPM | ❌ |
| tgt-a8 (AlmaLinux 8, cross-major el9) | RPM | ❌ |
| **tgt-d11 (Debian 11)** | **DEB** | ✅ |
| **tgt-d12 (Debian 12)** | **DEB** | ✅ (r1-r3 exit=2, then 7/10 SUCCESS) |
| **tgt-d13 (Debian 13)** | **DEB** | ✅ (r1-r4+ exit=2, then SUCCESS) |
| **tgt-u2204 (Ubuntu 22.04)** | **DEB** | ✅ (r1-r3 exit=2, then 7/10 SUCCESS) |
| **tgt-u2404 (Ubuntu 24.04)** | **DEB** | ✅ (r1-r4 exit=2, then SUCCESS) |

5/5 RPM hosts: clean. 4/4 fresh DEB VMs: reproduced. Defect localized to DEB postinst exclusively. Per-VM before/after evidence preserved at `AUDIT_190_LIFECYCLE/V112_HOST_VITALS_EVIDENCE/v112_2_vm_fleet/` (22 files).

## Envelope

- Files changed: 1 (`packaging/deb/postinst`)
- Lines: +16 / -0
- No Go source changes, no schema changes, no systemd unit changes, no FHS spec changes, no metric/registration changes
- Schema 1.83.0 frozen

## Test plan

- [x] `bash -n packaging/deb/postinst` — syntax OK
- [x] `shellcheck packaging/deb/postinst` — only one pre-existing SC2043 warning at line 157 (unchanged from baseline)
- [x] Pre-commit hooks: header validations + shell-files check passed
- [ ] CI: 4 RPM install workflows (alma9 / rocky9 / centos-stream9 / centos-stream10) — expected PASS (no RPM change)
- [ ] CI: 4 DEB install workflows (debian12 / debian13 / ubuntu22.04 / ubuntu24.04) — expected PASS (postinst now runs tmpfiles)
- [ ] CI: standard build / lint / test jobs
- [ ] CI: baseline-advisory triplet (OSV-Scanner + Project Health × 2) acknowledged per V108-V112 precedent

End-to-end acceptance on a fresh DEB host (post-merge) deferred to `EXECUTE_V112_2_VALIDATE_DEB_FAMILY` gate.

## Non-goals (explicitly out of scope for this PR)

- RPM `%post` defensive-in-depth tmpfiles call (optional secondary; separately gated as `OPEN_V112_2_RPM_POST_DEFENSIVE_HOTFIX_PR` if pursued)
- Resume V112.2 exporter-invocation bash-wrapped-vs-bare-path investigation (separately gated)
- `D-DNS-1` dns2 host migration — strictly NOT mixed into this PR
- Production rollout to srv3 / srv2 / srv1 — separately gated post-v1.112.2-release
- v1.112.2 release-prep (VERSION / STATUS / CHANGELOG / FHS regen) — separately gated as `OPEN_V112_2_RELEASE_PREP` after this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)