### PR TITLE
ci(fresh-install-guard): fix container deps for RPM/DEB test scaffold

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -180,12 +180,19 @@ jobs:
               # Install base dependencies needed for systemd-in-container
               # -----------------------------------------------------------
               if [ "${PKG_TYPE}" = "deb" ]; then
+                # adduser package provides addgroup/adduser binaries that
+                # packaging/deb/postinst:82-96 invokes during package install.
+                # Minimal Debian/Ubuntu containers omit it by default.
+                # Fixes D-V114-CI-GUARD-CONTAINER-DEPS-001 sub-class B.
                 export DEBIAN_FRONTEND=noninteractive
                 apt-get update -qq
                 apt-get install -y --no-install-recommends \
-                  systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates
+                  systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
               else
-                dnf install -y -q systemd systemd-resolved curl iproute2 nftables jq tar
+                # On EL9/EL10 the iproute tooling package is named `iproute`
+                # (not `iproute2`, which is Debian/Ubuntu only).
+                # Fixes D-V114-CI-GUARD-CONTAINER-DEPS-001 sub-class A.
+                dnf install -y -q systemd systemd-resolved curl iproute nftables jq tar
               fi
 
               # -----------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes **`D-V114-CI-GUARD-CONTAINER-DEPS-001`** (2 sub-classes) — test-scaffold portability bugs in `.github/workflows/ci-fresh-install-namespace-guard.yml` surfaced post PR #613 merge when the workflow_run-triggered Fresh-Install Guard first executed real systemd-in-container test scaffold (jobs ran 19-44s vs 4-7s early-skip).

- **Sub-class A** (RPM family — alma9 / rocky9 / cs9 / cs10): `dnf install ... iproute2 ...` → `Error: Unable to find a match: iproute2`. On EL9/EL10 the package is named **`iproute`**, not `iproute2` (Debian/Ubuntu name).
- **Sub-class B** (DEB family — debian12 / debian13 / ubuntu22.04 / ubuntu24.04): `nftban-core.postinst:84` calls `addgroup --system ...` → exit 127 `addgroup: command not found`. The `addgroup`/`adduser` binaries are provided by the **`adduser`** package, which is not installed in minimal `debian:*` / `ubuntu:*` base images.

Both fixes are **workflow-only** — nftban packaging and runtime code unchanged. Real-host coverage continues to be exercised by `Test {RPM,DEB} install` jobs in `build-packages.yml` (richer base containers).

## Diffstat
\`\`\`
 .github/workflows/ci-fresh-install-namespace-guard.yml | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)
\`\`\`

- RPM branch: `iproute2` → `iproute` (1 active LOC + 3 comment lines)
- DEB branch: append `adduser` to apt-get install list (1 active LOC + 4 comment lines)

## Forbidden surfaces — verified untouched
- ✅ `packaging/build_nftban.sh` untouched (PR #612 RPM tmpfiles preserved)
- ✅ `packaging/deb/postinst` untouched
- ✅ Installer Go code untouched
- ✅ systemd units untouched
- ✅ `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` untouched (schema 1.83.0 frozen)
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO untouched
- ✅ `.gitignore` untouched
- ✅ tags untouched

## Classification
| Property | Value |
|---|---|
| Self-caused | YES — bug introduced by PR #612 test scaffold; surfaced by PR #613 fix enabling real execution |
| Surface | Workflow YAML only |
| Affects nftban product code | NO |
| Blocks v1.113.0 | NO |
| Release-regression | NO |

## Scope reference
- `AUDIT_190_LIFECYCLE/V114_PR_613_MERGE_CLOSURE.md` §4 — locked sub-class descriptions
- Predecessor closure of cross-workflow fix: PR #613 (`58386ab6`)
- DEB postinst evidence: `packaging/deb/postinst:82-96` uses `addgroup` + `adduser` directly (`adduser` package, not `passwd`)

## Test plan
- [ ] PR-time CI: workflow_run-triggered Fresh-Install Guard does NOT fire (designed: workflow_run runs on default-branch push only); other gating checks succeed; expect 2 baseline-advisory failures (OSV-Scanner + Project Health — 19th consecutive ack).
- [ ] Post-merge main CI: workflow_run-triggered Fresh-Install Guard fires after Build NFTBan Packages; per-distro jobs reach the 4-assertion grid (A1 service active / A2 no 226/NAMESPACE / A3 cache dir exists / A4 no failed deps); expect 8/8 PASS on `58386ab6` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)