### PR TITLE
ci(fresh-install-guard): seed sshd_config + drop curl from RPM deps

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -192,7 +192,11 @@ jobs:
                 # On EL9/EL10 the iproute tooling package is named `iproute`
                 # (not `iproute2`, which is Debian/Ubuntu only).
                 # Fixes D-V114-CI-GUARD-CONTAINER-DEPS-001 sub-class A.
-                dnf install -y -q systemd systemd-resolved curl iproute nftables jq tar
+                # curl intentionally omitted: EL9/EL10 minimal base images
+                # ship curl-minimal which provides /usr/bin/curl; installing
+                # the full curl package triggers a baseos package conflict.
+                # Fixes D-V114-CI-GUARD-CONTAINER-DEPS-002 sub-class C.
+                dnf install -y -q systemd systemd-resolved iproute nftables jq tar
               fi
 
               # -----------------------------------------------------------
@@ -206,6 +210,18 @@ jobs:
                 /lib/systemd/systemd --system --unit=multi-user.target &
                 sleep 5
               fi
+
+              # -----------------------------------------------------------
+              # Seed a minimal sshd_config so nftban-installer's Detect phase
+              # can resolve an SSH port. On real hosts this comes from the
+              # OS image + a running sshd; minimal CI base images carry
+              # neither, and the installer correctly refuses to proceed with
+              # FAILED_SSH_UNKNOWN (lockout-prevention defense-in-depth).
+              # Fixes D-V114-CI-GUARD-CONTAINER-DEPS-002 sub-class D.
+              # Scaffold-only: no nftban product code change.
+              # -----------------------------------------------------------
+              mkdir -p /etc/ssh
+              echo "Port 22" > /etc/ssh/sshd_config
 
               # -----------------------------------------------------------
               # Install the package under test (fresh install path)


### PR DESCRIPTION
## Summary
Closes **`D-V114-CI-GUARD-CONTAINER-DEPS-002`** (2 sub-classes) — next scaffold layer surfaced post PR #614 when the workflow_run-triggered Fresh-Install Guard reached past the dep-install layer on 8/8 distros and onto the next failures.

- **Sub-class C** (RPM family — alma9 / rocky9 / cs9 / cs10): `dnf install ... curl ...` fails with `curl-minimal ... conflicts with curl provided by curl ... from baseos`. EL9/EL10 minimal base images ship `curl-minimal` (already provides `/usr/bin/curl`); installing full `curl` triggers a baseos conflict. Drop `curl` from the RPM dep list — `curl-minimal` is sufficient for scaffold network needs.
- **Sub-class D** (DEB family — debian12 / debian13 / ubuntu22.04 / ubuntu24.04): `nftban-installer` Detect phase correctly exits `FAILED_SSH_UNKNOWN` in a clean container (no sshd_config, no running sshd, no installer state). This is product-correct defense-in-depth that prevents real-host operator lockout. Seed a minimal `/etc/ssh/sshd_config` with `Port 22` before package install so installer Detect finds an SSH port.

Both fixes are **workflow-only**. sshd_config seeding runs unconditionally for both families so RPM is forward-protected once sub-class C clears curl.

## Diffstat
\`\`\`
 .github/workflows/ci-fresh-install-namespace-guard.yml | 18 +++++++++++++++++-
 1 file changed, 17 insertions(+), 1 deletion(-)
\`\`\`

- Sub-class C (RPM dep list): drop `curl` (-1 active LOC) + 4 comment lines
- Sub-class D (sshd_config seed): `mkdir -p /etc/ssh` + `echo "Port 22" > /etc/ssh/sshd_config` (+2 active LOC) + 9 comment lines + 1 blank

## Forbidden surfaces — verified untouched
- ✅ `packaging/build_nftban.sh` untouched (PR #612 RPM tmpfiles preserved)
- ✅ `packaging/deb/postinst` untouched
- ✅ Installer Go code untouched
- ✅ systemd units untouched
- ✅ `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` untouched (schema 1.83.0 frozen)
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO untouched
- ✅ `.gitignore` untouched

## Classification
| Property | Value |
|---|---|
| Self-caused C | YES — scaffold `curl` entry incompatible with EL9/10 minimal base |
| Self-caused D | NO — surfaces correct product-side defense-in-depth that scaffold doesn't accommodate |
| Surface | Workflow YAML only |
| Affects nftban product code | NO |
| Blocks v1.113.0 | NO |
| Release-regression | NO |

## Scope reference
- `AUDIT_190_LIFECYCLE/V114_PR_614_MERGE_CLOSURE.md` §4 — locked sub-class C/D descriptions
- Predecessor: PR #614 (`5214cff8`) closed `D-V114-CI-GUARD-CONTAINER-DEPS-001` sub-classes A + B

## Test plan
- [ ] PR-time CI: workflow_run-triggered guard does NOT fire (designed); other gating checks succeed; expect 2 baseline-advisory failures (OSV-Scanner + Project Health — 20th consecutive ack).
- [ ] Post-merge main CI: workflow_run-triggered guard fires after Build NFTBan Packages; per-distro jobs reach the 4-assertion grid (A1 service active / A2 no 226/NAMESPACE / A3 cache dir exists / A4 no failed deps); expected 8/8 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)