### PR TITLE
ci(fresh-install-guard): drop apostrophe from in-container bash comment

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -212,7 +212,7 @@ jobs:
               fi
 
               # -----------------------------------------------------------
-              # Seed a minimal sshd_config so nftban-installer's Detect phase
+              # Seed a minimal sshd_config so nftban-installer Detect phase
               # can resolve an SSH port. On real hosts this comes from the
               # OS image + a running sshd; minimal CI base images carry
               # neither, and the installer correctly refuses to proceed with


### PR DESCRIPTION
## Summary
Closes **`D-V114-CI-GUARD-SHELL-QUOTING-001`** — self-caused regression from PR #615 surfaced post-merge when the workflow_run guard (run `25904744100` on main HEAD `15139672`) failed 8/8 distros identically:

\`\`\`
/home/runner/work/_temp/<uuid>.sh: line 77: /etc/ssh/sshd_config: Permission denied
\`\`\`

## Root cause
The apostrophe in PR #615's comment word `installer's` (inside the in-container `/bin/bash -c '...'` block) is parsed by bash as the closing single-quote of the surrounding block. From that point, content is parsed by the GitHub Actions **runner shell**, not the in-container bash. The subsequent `echo "Port 22" > /etc/ssh/sshd_config` then targets the runner host's `/etc/ssh/sshd_config` (root-owned) as user `runner` (unprivileged) → Permission denied, scaffold short-circuited before container could seed sshd_config or install the package.

## Fix
1-character edit: drop the apostrophe from the comment.

\`\`\`diff
-              # Seed a minimal sshd_config so nftban-installer's Detect phase
+              # Seed a minimal sshd_config so nftban-installer Detect phase
\`\`\`

## Diffstat
\`\`\`
 .github/workflows/ci-fresh-install-namespace-guard.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
\`\`\`

## Audit
- ✅ No other apostrophes remain inside the `/bin/bash -c '...'` block (verified by awk scan)
- ✅ The merged PR #615 logic (drop `curl` from RPM dnf, seed `/etc/ssh/sshd_config` with `Port 22`) is syntactically correct and will activate once this hotfix lands

## Forbidden surfaces — verified untouched
- ✅ `packaging/build_nftban.sh` untouched (PR #612 RPM tmpfiles preserved)
- ✅ `packaging/deb/postinst` untouched
- ✅ Installer Go code untouched
- ✅ systemd units untouched
- ✅ `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` untouched (schema 1.83.0 frozen)
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO untouched
- ✅ `.gitignore` untouched

## Classification
| Property | Value |
|---|---|
| Self-caused | YES — apostrophe introduced in PR #615 |
| Surface | Workflow YAML only |
| Affects nftban product code | NO |
| Blocks v1.113.0 | NO |
| Release-regression | NO (CI guard is no-op-but-not-broken; same effective state as pre-PR-#614 for assertion grid) |

## Scope reference
- `AUDIT_190_LIFECYCLE/V114_PR_615_MERGE_CLOSURE.md` §4 — failure analysis + locked hotfix shape
- Predecessor regression: PR #615 (`15139672`)

## Test plan
- [ ] PR-time CI: workflow_run-triggered guard does NOT fire (designed); other gating checks succeed; expect 2 baseline-advisory failures (OSV-Scanner + Project Health — 21st consecutive ack).
- [ ] Post-merge main CI: workflow_run-triggered guard fires after Build NFTBan Packages; per-distro jobs reach A1-A4 grid; expected 8/8 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)