### PR TITLE
ci(fresh-install-guard): restore curl in DEB systemd_install entries

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -106,22 +106,22 @@ jobs:
             image: debian:12
             pkg_type: deb
             artifact: deb-debian12
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
           - distro: debian13
             image: debian:13
             pkg_type: deb
             artifact: deb-debian13
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
           - distro: ubuntu22.04
             image: ubuntu:22.04
             pkg_type: deb
             artifact: deb-ubuntu22.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
           - distro: ubuntu24.04
             image: ubuntu:24.04
             pkg_type: deb
             artifact: deb-ubuntu24.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Closes **`D-V114-CI-GUARD-DEB-DEPS-REGRESSION-001`** — self-caused regression from PR #617 surfaced post-merge when workflow_run guard `25906377742` on `50c6170b` ran the assertion grid for the first time. RPM family fully passed A1-A4 (16/16) but DEB family failed identically at nftban-core preinst with `[✗] MISSING: curl (CRITICAL)`.

## Root cause
PR #617 over-generalized PR #615's RPM curl-minimal fix to the DEB matrix `systemd_install` entries. PR #615 correctly dropped `curl` from the RPM dnf install list because EL9/10 minimal base images ship `curl-minimal` (provides `/usr/bin/curl`). Debian/Ubuntu minimal images do **not** ship curl, and the nftban-core DEB preinst declares curl as a CRITICAL prerequisite (real hosts use it for threat-feed fetching and repository discovery — product-correct enforcement).

## Fix
Add `curl` back to each of 4 DEB matrix `systemd_install` entries (debian12 / debian13 / ubuntu22.04 / ubuntu24.04). RPM entries (alma9 / rocky9 / centos-stream9 / centos-stream10) unchanged — they still omit curl to preserve the curl-minimal-safe shape from PR #615.

\`\`\`diff
- systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv iproute2 nftables jq tar ca-certificates adduser
+ systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
\`\`\`

## Diffstat
\`\`\`
 .github/workflows/ci-fresh-install-namespace-guard.yml | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
\`\`\`

Exactly 4 LOC: one `curl` insertion per DEB matrix entry.

## Forbidden surfaces — verified untouched
- ✅ `packaging/build_nftban.sh` untouched (PR #612 RPM tmpfiles preserved)
- ✅ `packaging/deb/postinst` untouched
- ✅ Installer Go code untouched
- ✅ systemd units untouched
- ✅ `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` / `install/scripts/nftban_fhs_spec.sh` untouched (schema 1.83.0 frozen)
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO untouched
- ✅ `.gitignore` untouched

## Acceptance after merge
- RPM 4/4 distros remain A1-A4 PASS (curl entries unchanged)
- DEB 4/4 distros now also reach A1-A4 (preinst curl prerequisite check passes)
- Target final Candidate 5 verdict: `V114_CI_FRESH_INSTALL_GUARD_A1_A4_PASSED_8_OF_8`

## Scope reference
- `AUDIT_190_LIFECYCLE/V114_PR_617_MERGE_CLOSURE.md` §5 — locked fix description
- CI-guard arc: PRs #612 → #613 → #614 → #615 → #616 → #617 → (this PR #618)

## Test plan
- [ ] PR-time CI: workflow_run-triggered guard does NOT fire (designed); other gating checks succeed; expect 2 baseline-advisory failures (OSV-Scanner + Project Health — 23rd consecutive ack).
- [ ] Post-merge main CI: workflow_run-triggered guard fires after Build NFTBan Packages; per-distro jobs reach A1-A4 grid; expected 8/8 PASS (32/32 assertions PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)