### PR TITLE
ci(fresh-install-guard): add netbase to DEB systemd_install entries

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -106,22 +106,22 @@ jobs:
             image: debian:12
             pkg_type: deb
             artifact: deb-debian12
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
           - distro: debian13
             image: debian:13
             pkg_type: deb
             artifact: deb-debian13
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
           - distro: ubuntu22.04
             image: ubuntu:22.04
             pkg_type: deb
             artifact: deb-ubuntu22.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
           - distro: ubuntu24.04
             image: ubuntu:24.04
             pkg_type: deb
             artifact: deb-ubuntu24.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Closes (pending workflow_run verification) **`D-V114-CI-GUARD-DEB-NETBASE-MISSING-001`** — surfaced post-PR-#618 in workflow_run guard `25913253615` on main `d02642e9`. The DEB family advanced ~5 layers vs PR #617 but `systemctl start nftables` fails at installer Phase Switch:

\`\`\`
nft[1150]: /etc/nftban/nftables.conf:743:22-30: Error: Could not resolve protocol name
nftables.service: Main process exited, code=exited, status=1/FAILURE
[NFTBan ERROR] phase Switch failed: FAILED_NO_FIREWALL
\`\`\`

## Root cause
Minimal `debian:*` / `ubuntu:*` base images do not include `/etc/protocols`. `nft` resolves protocol names (`tcp`/`udp`/`icmp`/`esp`/`ah`/`gre`) by consulting that file, which on Debian/Ubuntu is provided by the **`netbase`** package — essential-priority on standard installs, NOT in minimal containers. RPM family does not hit this because EL9/10 base images include `setup` (which ships `/etc/protocols`).

## Fix
Append `netbase` to each of the 4 DEB matrix `systemd_install` entries. RPM entries remain unchanged.

\`\`\`diff
- systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser
+ systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
\`\`\`

## Diffstat
\`\`\`
 .github/workflows/ci-fresh-install-namespace-guard.yml | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
\`\`\`

## Confidence calibration (per operator instruction — do not overclaim)
- **HIGH**: `netbase` fixes the immediate `Could not resolve protocol name` failure. `/etc/protocols` presence is a well-understood prerequisite for nft's protocol-name resolution.
- **MEDIUM**: this is the final DEB scaffold layer. The V114 CI-guard arc has consistently surfaced one layer per fix. A 9th layer may still appear (e.g. `/etc/services` / `iana-etc`, kernel-module loading, service-restart timing race).

**Do not declare Candidate 5 complete until the post-merge workflow_run proves 8/8 A1-A4 PASS.** If a new layer appears, record it honestly and decide whether to continue iterating or freeze the guard at RPM-full / DEB-partial coverage.

## Forbidden surfaces — verified untouched
- ✅ `packaging/build_nftban.sh` untouched (PR #612 RPM tmpfiles preserved)
- ✅ `packaging/deb/postinst` untouched
- ✅ Installer Go code untouched
- ✅ systemd units untouched
- ✅ `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` / `install/scripts/nftban_fhs_spec.sh` untouched (schema 1.83.0 frozen)
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO untouched
- ✅ `.gitignore` untouched

## Acceptance after merge (decisive, not predictive)
- RPM 4/4 must remain A1-A4 PASS (no regression from this DEB-only change)
- DEB 4/4 nftables.service must start successfully
- If 8/8 reach A1-A4: target verdict `V114_CI_FRESH_INSTALL_GUARD_A1_A4_PASSED_8_OF_8`
- If a 9th layer surfaces: honest verdict + recorded follow-up decision

## Scope reference
- `AUDIT_190_LIFECYCLE/V114_PR_618_MERGE_CLOSURE.md` §5 — locked finding + fix description

## Test plan
- [ ] PR-time CI: 42 pass / 3 baseline-advisory fail (24th consecutive ack) / 4 designed skip
- [ ] Post-merge main CI: Build NFTBan Packages SUCCESS; workflow_run guard fires; 8 distros reach A1-A4 OR new layer surfaces (record honestly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)