### PR TITLE
fix(packaging-deb): converge /etc/nftban config-file ownership root:nftban 0640 (V115 Cand 6)

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -147,6 +147,45 @@ case "$1" in
         fi
         unset _nftban_attrs
 
+        # --- v1.115 Cand 6: DEB config-file ownership/mode convergence -----------
+        # The directory-convergence loop above intentionally skips files
+        # (line `if [ -d "$_attr_path" ]`). DEB payload ships config files at
+        # mode 0640 root:root because `dpkg-deb --build` records the build-user
+        # numeric IDs. RPM payload ships the same files at mode 0640 root:nftban
+        # via spec %attr(640,root,nftban). This block applies the RPM %attr
+        # parity for files on DEB. Idempotent. Closes D-DEG-1 sub-class B as a
+        # side-effect: nftban-alert@.service runs as user `nftban` and can now
+        # read /etc/nftban/nftban.conf via group-read (nftban user is in the
+        # nftban group; group-read 0640 applies). Scope: V115 Cand 6.
+        # Preserves operator-edited file contents — only ownership/mode change.
+        for _nftban_conf in \
+            /etc/nftban/nftban.conf \
+            /etc/nftban/nftables.conf
+        do
+            if [ -f "$_nftban_conf" ]; then
+                chown root:nftban "$_nftban_conf" 2>/dev/null || true
+                chmod 0640 "$_nftban_conf" 2>/dev/null || true
+                if dpkg-statoverride --list "$_nftban_conf" >/dev/null 2>&1; then
+                    dpkg-statoverride --remove "$_nftban_conf" >/dev/null 2>&1 || true
+                fi
+                dpkg-statoverride --update --add \
+                    root nftban 0640 "$_nftban_conf" \
+                    >/dev/null 2>&1 || true
+            fi
+        done
+        unset _nftban_conf
+
+        if [ -d /etc/nftban/conf.d ]; then
+            find /etc/nftban/conf.d \
+                \( -name '*.conf' -o -name '*.conf.default' \) \
+                -type f 2>/dev/null | while IFS= read -r _nftban_subconf; do
+                chown root:nftban "$_nftban_subconf" 2>/dev/null || true
+                chmod 0640 "$_nftban_subconf" 2>/dev/null || true
+            done
+            unset _nftban_subconf
+        fi
+        log_info "DEB config-file convergence: nftban.conf + nftables.conf + conf.d/**/*.conf -> root:nftban 0640"
+
         # --- NB-5: Canonical ownership for privileged binaries (DEB-PERM-001) ---
         # Must run AFTER nftban group is created. DEB payload ships 0750
         # root:root; postinst converges to root:nftban 0750 so the runtime


### PR DESCRIPTION
## Summary

Closes the long-standing **DEB-vs-RPM config-file packaging asymmetry**. RPM ships `/etc/nftban/nftban.conf` and sibling config files at mode `0640` owned `root:nftban` via `%attr(640,root,nftban) %config(noreplace)`. DEB has shipped the same files at mode `0640` owned `root:root` since the v1.107 PKG-EFFECTIVE-PARITY work landed only directory convergence — the existing convergence loop at `packaging/deb/postinst:113-148` explicitly skips files (`if [ -d "$_attr_path" ]`).

This is the **direct cause of D-DEG-1 sub-class B** (`Permission denied on /etc/nftban/nftban.conf` at `cli/lib/nftban/sbin/nftban-service-alert:47`). The alert script runs as user `nftban` (per `nftban-alert@.service` template `meta:inventory.privileges="nftban"`). With the file's group set to `root` instead of `nftban`, group-read `g=r--` does not apply.

This PR adds a file-level convergence loop after the existing dir loop, applying RPM `%attr` parity for files on DEB.

## Fix shape (V115 Cand 6 Option α — locked in scope)

```diff
+ # --- v1.115 Cand 6: DEB config-file ownership/mode convergence -----------
+ for _nftban_conf in /etc/nftban/nftban.conf /etc/nftban/nftables.conf; do
+     if [ -f "$_nftban_conf" ]; then
+         chown root:nftban "$_nftban_conf" 2>/dev/null || true
+         chmod 0640 "$_nftban_conf" 2>/dev/null || true
+         # dpkg-statoverride remove+add idempotent pattern
+         dpkg-statoverride --update --add root nftban 0640 "$_nftban_conf"
+     fi
+ done
+ # conf.d/**/*.conf recursive pass (matches RPM %attr; no statoverride per RPM precedent)
+ find /etc/nftban/conf.d \( -name '*.conf' -o -name '*.conf.default' \) -type f
+   | while IFS= read -r _conf; do chown ...; chmod 0640 ...; done
```

## Diffstat

```
 packaging/deb/postinst | 39 +++++++++++++++++++++++++++++++++++++++
 1 file changed, 39 insertions(+)
```

**Single-file change.** Exactly the locked allowed-file from the scope.

## Schema 1.83.0 frozen

- ✅ No nftban-core Go change
- ✅ No `internal/` change
- ✅ No `cmd/` change
- ✅ No systemd unit change
- ✅ No FHS spec change
- ✅ No metric / label / cardinality change
- ✅ No JSON event schema change

## Forbidden surfaces — verified untouched (diff vs main)

- ✅ `packaging/build_nftban.sh` — RPM packaging unchanged (RPM already correct)
- ✅ `packaging/deb/conffiles` — explicitly deferred to v1.116+ per scope
- ✅ `packaging/deb/preinst` / `prerm` / `postrm` / `control` / `changelog` — untouched
- ✅ `install/packaging/deb/nftban-dir-attrs.list` — unchanged (dir-only by design; file handling is in postinst not in the attrs list)
- ✅ `install/systemd/nftban-queue.service` — Cand 2 sub-A territory, not this gate
- ✅ `install/systemd/nftban-alert@.service.in` / `nftband.service` — no systemd change
- ✅ `cli/lib/nftban/sbin/nftban-service-alert` / `cli/lib/nftban/helpers/nftban_task_queue.sh` — unchanged
- ✅ `build/fhs-spec.yaml`, `VERSION`, `STATUS.md`, `CHANGELOG.md`, `cli/lib/nftban/core/nftban_fhs_spec.sh` — release-prep handles those separately
- ✅ `.github/workflows/ci-fresh-install-namespace-guard.yml` — `/bin/kill` VERIFY polish is separate gate
- ✅ `dns2` / `nftbanpro_cms` / Bucket-C / MASTER_TODO — NEVER touched
- ✅ Prior tags (v1.108.0 … v1.114.0) — untouched

## Pre-merge verification

- ✅ `bash -n packaging/deb/postinst` — syntax OK
- ✅ `shellcheck -S error` — clean (the pre-existing SC2043 warning on the binary-perm loop is unchanged; line number shifted 157→196 due to insertion)
- ✅ Header validations passed (pre-commit hook)
- ✅ All chown/chmod guarded with `2>/dev/null || true` matching existing dir-loop precedent
- ✅ Idempotent — preserves operator-edited file contents

## Side-effect: D-DEG-1 sub-class B closed

Post-merge, on any DEB host with v1.115 installed: `/etc/nftban/nftban.conf` is mode `0640` owned `root:nftban`. The `nftban` user is a member of the `nftban` group, so group-read permission `g=r--` applies. `cli/lib/nftban/sbin/nftban-service-alert:47` can now read the file. **D-DEG-1 sub-class B is closed.** Cand 2 in v1.115 reduces to sub-class A only (`Environment=NFTBAN_DATA_DIR=` on `nftban-queue.service`).

## Scope reference

- `AUDIT_190_LIFECYCLE/V115_CAND6_DEB_CONFIG_PERM_SCOPE.md` (Option α, V115_CAND6_DEB_CONFIG_PERM_SCOPE_LOCKED_PLAN_READY)
- `AUDIT_190_LIFECYCLE/V115_SCOPE_TRIAGE.md` (P1 priority; first implementation gate)
- `AUDIT_190_LIFECYCLE/V113_BACKLOG.md` §E Cand 6 row + §C D-DEG-1 sub-B
- v1.114.0 baseline `ce6eb94b` / tag `d23a65867f88`

## Test plan

- [ ] PR-time CI: expect 42-45 pass / 3 baseline-advisory fail (OSV + Project Health × 2 = 26th consecutive ack) / 4 designed skip
- [ ] Post-merge main CI: workflow_run-triggered Fresh-Install Guard 8/8 A1-A4 must remain PASS (32/32 assertion baseline preserved)
- [ ] Post-merge DEB-family A4 dependent-unit check: nftban-alert@ should no longer fail at nftban-service-alert:47 EACCES
- [ ] Post-merge `Test DEB install ×4` jobs: verify `stat /etc/nftban/nftban.conf` returns `0640 root:nftban` post-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)