### PR TITLE
fix(systemd): set NFTBAN_DATA_DIR/RUN_DIR/LOG_DIR env on nftban-queue.service (V115 Cand 2 sub-A / D-DEG-1)

### DIFF
--- a/install/systemd/nftban-queue.service
+++ b/install/systemd/nftban-queue.service
@@ -31,6 +31,18 @@ OnFailure=nftban-alert@%n.service
 
 [Service]
 Type=oneshot
+
+# v1.115 Cand 2 sub-A: D-DEG-1 NFTBAN_DATA_DIR unbound-variable fix.
+# The helper at cli/lib/nftban/helpers/nftban_task_queue.sh runs under
+# `set -u` and references NFTBAN_DATA_DIR, NFTBAN_RUN_DIR, and
+# NFTBAN_LOG_DIR without per-var fallbacks. systemd does not inherit
+# shell environment by default — these literal directives keep the
+# queue processor deterministic across distros without depending on
+# an external EnvironmentFile.
+Environment=NFTBAN_DATA_DIR=/var/lib/nftban
+Environment=NFTBAN_RUN_DIR=/run/nftban
+Environment=NFTBAN_LOG_DIR=/var/log/nftban
+
 ExecStart=/usr/lib/nftban/sbin/nftban-queue-processor
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary

Closes **D-DEG-1 sub-class A**. `cli/lib/nftban/helpers/nftban_task_queue.sh:64-65` runs under `set -u` and references `NFTBAN_DATA_DIR`, `NFTBAN_RUN_DIR`, `NFTBAN_LOG_DIR` in fallback-substitution chains without per-var fallbacks. systemd does not inherit shell environment by default — the queue service unit had no `Environment=` directives, producing `NFTBAN_DATA_DIR: unbound variable` runtime failures on lab2 (confirmed reproduction host) and any other host where the system environment does not pre-set these vars.

Cand 6 (PR #622, merged `00e73a78`) already closed D-DEG-1 sub-class B as a permission-theoretical side-effect. **Cand 2 in v1.115 is therefore complete after this PR lands** with sub-class A only.

## Fix shape (Option 1b + Option 2a — operator-locked)

After `Type=oneshot` in the `[Service]` section, add 3 literal Environment directives:

```ini
Environment=NFTBAN_DATA_DIR=/var/lib/nftban
Environment=NFTBAN_RUN_DIR=/run/nftban
Environment=NFTBAN_LOG_DIR=/var/log/nftban
```

Values match the FHS spec at `build/fhs-spec.yaml`. **All three vars set defensively** (defense-in-depth Option 1b) so any future helper that references RUN_DIR/LOG_DIR through the same fallback pattern is also protected.

**Literal `Environment=` (Option 2a)** chosen over `EnvironmentFile=-` to avoid introducing an external packaging surface in this narrow lane.

## Diffstat

```
 install/systemd/nftban-queue.service | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

**Single-file systemd unit change.** 3 active directive lines + 7 comment lines + 2 surrounding blank lines.

## Pre-merge verification

- ✅ `git diff` confirms only `install/systemd/nftban-queue.service` changed
- ✅ Header validations passed (pre-commit hook)
- ✅ `systemd-analyze verify` returns only expected dev-host warnings (`ExecStart` binary path not executable on dev host; manpage absent) — **NOT syntax errors**. The new `Environment=` directives are syntactically valid systemd unit syntax (key=value pairs with `Environment=` prefix; matches systemd.exec(5) specification)

## Schema 1.83.0 frozen

- ✅ No nftban-core / nftband Go change
- ✅ No `internal/` / `cmd/` change
- ✅ No FHS spec change (`build/fhs-spec.yaml` `diff_lines=0`)
- ✅ No metric / label / cardinality change
- ✅ No JSON event schema change

## Forbidden surfaces — all 20 verified untouched

`packaging/deb/postinst` (Cand 6 preserved at HEAD `00e73a78`) / `packaging/build_nftban.sh` / `cli/lib/nftban/helpers/nftban_task_queue.sh` (the *helper* that consumes these env vars stays unchanged — only the unit that *launches* it gets the directives) / `cli/lib/nftban/sbin/nftban-service-alert` / `install/systemd/{nftban-alert@.service.in,nftband.service}` / `.github/workflows/ci-fresh-install-namespace-guard.yml` / `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` / `cli/lib/nftban/core/nftban_fhs_spec.sh` / `.gitignore` / `packaging/deb/{conffiles,preinst,prerm,postrm,control,changelog}` / `install/packaging/deb/nftban-dir-attrs.list` — all `diff_lines=0`.

## Scope reference

- `AUDIT_190_LIFECYCLE/V115_SCOPE_TRIAGE.md` §3 P2 (Cand 2 sub-A locked fix shape)
- `AUDIT_190_LIFECYCLE/V115_CAND6_DEB_CONFIG_PERM_SCOPE.md` §13 (Cand 6 narrowed Cand 2 to sub-A only)
- `AUDIT_190_LIFECYCLE/V113_D_DEG_1_LAB2_REPRO_AND_NEXT_GATES.md` (lab2 reproduction evidence)
- v1.114.0 published baseline; Cand 6 merged at `00e73a78`

## Expected effect

- D-DEG-1 sub-class A closed: `nftban-queue.service` gets deterministic runtime path variables from systemd; `nftban_task_queue.sh` fallback-substitution chains resolve without `unbound variable` error
- D-DEG-1 sub-class B remains closed by Cand 6 side-effect (PR #622 at `00e73a78`)
- v1.115 continues as narrow cleanup/stabilization; schema frozen
- nftban-queue.service runtime behavior remains unchanged on hosts where the env was already set (literal `Environment=` overrides any inherited value deterministically)

## Test plan

- [ ] PR-time CI: expect ~42-46 pass / 3 baseline-advisory fail (OSV + Project Health × 2 = 27th consecutive ack) / 4 designed skip
- [ ] Post-merge main CI: workflow_run-triggered Fresh-Install Guard 8/8 A1-A4 must remain PASS (32/32 assertion baseline preserved)
- [ ] Fleet revalidation (release-prep time): lab2 — confirm `journalctl -u nftban-queue.service` no longer shows `NFTBAN_DATA_DIR: unbound variable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)