### PR TITLE
ci(fresh-install-guard): add procps to DEB systemd_install (V115 /bin/kill VERIFY polish)

### DIFF
--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -106,22 +106,22 @@ jobs:
             image: debian:12
             pkg_type: deb
             artifact: deb-debian12
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
           - distro: debian13
             image: debian:13
             pkg_type: deb
             artifact: deb-debian13
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
           - distro: ubuntu22.04
             image: ubuntu:22.04
             pkg_type: deb
             artifact: deb-ubuntu22.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
           - distro: ubuntu24.04
             image: ubuntu:24.04
             pkg_type: deb
             artifact: deb-ubuntu24.04
-            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Closes **`D-V114-CI-GUARD-DEB-BINKILL-VERIFY-001`** — deferred from V114 PR #620 closure as non-blocking workflow-only polish; declared optional P3 in V115 scope triage; authorized as part of v1.115 narrow-cleanup.

The nftban-installer VERIFY phase reports DEGRADED on DEB CI containers because `install/systemd/nftband.service:75 ExecReload=/bin/kill -HUP $MAINPID` cannot be resolved by the `systemd_execstart_paths_ok` validator in a container that lacks `/bin/kill`. On Debian/Ubuntu, `/bin/kill` resolves via the merged-usr `/bin → /usr/bin` symlink to `/usr/bin/kill`, which is provided by the `procps` package. Minimal `debian:*` / `ubuntu:*` base images installed via `apt-get install --no-install-recommends` do NOT include `procps`.

**A1-A4 grid was NOT blocked** by this WARN (assertions check service runtime state, not the installer's internal VERIFY-phase validator), but the DEGRADED health surfaced in installer JSON output and was recorded as deferred technical debt.

RPM family does not hit this because EL9/EL10 base images include procps implicitly via the `setup` and `coreutils-single` base dependency chain.

## Fix shape (mechanical — same pattern as V114 PR #618 curl restore + PR #620 netbase add)

```diff
- systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase
+ systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
```

## Diffstat

```
 .github/workflows/ci-fresh-install-namespace-guard.yml | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

Exactly **4 LOC** — one `procps` insertion per DEB matrix entry (debian12 / debian13 / ubuntu22.04 / ubuntu24.04). **RPM entries unchanged** (alma9 / rocky9 / centos-stream9 / centos-stream10).

## Acceptance after merge

On the next workflow_run-triggered Fresh-Install Guard:
- ✅ DEB containers resolve `/bin/kill` via merged-usr → `/usr/bin/kill` (provided by `procps`)
- ✅ nftban-installer VERIFY phase reports `health=PROTECTED` (not DEGRADED)
- ✅ `[NFTBan WARN] ASSERT systemd_execstart_paths_ok: FAIL — 1 missing: ... /bin/kill` warning disappears from DEB jobs
- ✅ All 8 distros remain 32/32 A1-A4 PASS

## Schema 1.83.0 frozen

- ✅ No nftban product code change
- ✅ No systemd unit change
- ✅ No installer Go change
- ✅ No packaging change
- ✅ No FHS spec change
- ✅ No metric / label / cardinality change

## Forbidden surfaces — all 20 verified untouched (diff vs main)

`packaging/deb/postinst` (Cand 6 preserved) / `install/systemd/nftban-queue.service` (Cand 2 sub-A preserved) / `packaging/build_nftban.sh` / `install/systemd/{nftband.service,nftban-alert@.service.in}` / `cli/lib/nftban/{helpers/nftban_task_queue.sh,sbin/nftban-service-alert}` / `VERSION` / `STATUS.md` / `CHANGELOG.md` / `build/fhs-spec.yaml` / `cli/lib/nftban/core/nftban_fhs_spec.sh` / `.gitignore` / `packaging/deb/{conffiles,preinst,prerm,postrm,control,changelog}` / `install/packaging/deb/nftban-dir-attrs.list` — all `diff_lines=0`.

## Scope reference

- `AUDIT_190_LIFECYCLE/V115_SCOPE_TRIAGE.md` §3 P3 (optional polish, ~4 LOC workflow-only)
- `AUDIT_190_LIFECYCLE/V114_PR_620_MERGE_CLOSURE.md` §5 (locked finding + fix shape)
- Precedent PRs in same workflow YAML: V114 #618 (curl restore), V114 #620 (netbase add)

## Test plan

- [ ] PR-time CI: ~46-47 pass / 3 baseline-advisory fail (28th consecutive ack) / 4 designed skip
- [ ] Post-merge main CI: workflow_run-triggered Fresh-Install Guard 8/8 A1-A4 PASS preserved; DEB-family DEGRADED VERIFY observation disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)