### PR TITLE
feat(cli): nftban login stats consumes LoginMon module status (V116 Cand1)

### DIFF
--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -581,8 +581,126 @@ nftban_login_cmd_run() {
     fi
 }
 
+# v1.116 Cand1: Fetch raw `modules` IPC response from nftband daemon.
+# Emits the JSON response on stdout, returns non-zero if daemon/socket/socat
+# unavailable. Mirrors the proven pattern in cmd_watchdog.sh:_watchdog_ipc_call
+# (read-only IPC call to an already-existing daemon method; no new method).
+_loginmon_ipc_call() {
+    local socket_path="${NFTBAN_RUN_DIR:-/run/nftban}/nftband.sock"
+    [[ -S "$socket_path" ]] || return 1
+    command -v socat >/dev/null 2>&1 || return 1
+    local resp=""
+    resp=$(echo '{"method":"modules","params":{}}' | \
+        timeout 5 socat - "UNIX-CONNECT:$socket_path" 2>/dev/null) || return 1
+    [[ -n "$resp" ]] || return 1
+    printf '%s' "$resp"
+}
+
+# v1.116 Cand1: Extract the LoginMon module's `.extra` object from the raw
+# `modules` IPC response. Emits the extra object (JSON) on stdout, empty
+# string on miss. jq required; absent jq → empty (caller falls back).
+_loginmon_extract_extra() {
+    command -v jq >/dev/null 2>&1 || return 1
+    local extra=""
+    extra=$(jq -c '.data[]? | select(.name=="loginmon") | .extra // empty' 2>/dev/null) || return 1
+    [[ -n "$extra" ]] || return 1
+    printf '%s' "$extra"
+}
+
 nftban_login_cmd_stats() {
-    # Show login statistics for Prometheus/metrics
+    # v1.116 Cand1: daemon-first formatter consuming LoginMon Module Status Extra.
+    # Falls back to file-log-only behavior if daemon/socket/socat/jq absent.
+    local module_extra=""
+    local ipc_raw=""
+    if ipc_raw=$(_loginmon_ipc_call 2>/dev/null); then
+        module_extra=$(printf '%s' "$ipc_raw" | _loginmon_extract_extra 2>/dev/null) || module_extra=""
+    fi
+
+    echo "NFTBan Login Statistics"
+    echo "======================="
+    echo ""
+
+    if [[ -n "$module_extra" ]] && command -v jq >/dev/null 2>&1; then
+        # Tier 1 — module status header
+        local mode suricata tracked
+        mode=$(printf '%s' "$module_extra" | jq -r '.mode // "unknown"' 2>/dev/null || echo "unknown")
+        suricata=$(printf '%s' "$module_extra" | jq -r '.suricata_available // false' 2>/dev/null || echo "false")
+        tracked=$(printf '%s' "$module_extra" | jq -r '.tracked_ips // 0' 2>/dev/null || echo "0")
+        echo "Module Status (from daemon):"
+        printf "  %-20s %s\n" "Mode:" "$mode"
+        if [[ "$suricata" == "true" ]]; then
+            printf "  %-20s %s\n" "Suricata:" "available"
+        else
+            printf "  %-20s %s\n" "Suricata:" "unavailable"
+        fi
+        printf "  %-20s %s\n" "Tracked IPs:" "$tracked"
+        echo ""
+
+        # Tier 1 + 2 — totals
+        local d_total d_v4 d_v6 b_total b_v4 b_v6 esc perm uniq
+        d_total=$(printf '%s' "$module_extra" | jq -r '.total_detections // 0' 2>/dev/null || echo "0")
+        d_v4=$(printf '%s' "$module_extra" | jq -r '.detections_ipv4 // 0' 2>/dev/null || echo "0")
+        d_v6=$(printf '%s' "$module_extra" | jq -r '.detections_ipv6 // 0' 2>/dev/null || echo "0")
+        b_total=$(printf '%s' "$module_extra" | jq -r '.total_bans // 0' 2>/dev/null || echo "0")
+        b_v4=$(printf '%s' "$module_extra" | jq -r '.bans_ipv4 // 0' 2>/dev/null || echo "0")
+        b_v6=$(printf '%s' "$module_extra" | jq -r '.bans_ipv6 // 0' 2>/dev/null || echo "0")
+        esc=$(printf '%s' "$module_extra" | jq -r '.total_escalations // 0' 2>/dev/null || echo "0")
+        perm=$(printf '%s' "$module_extra" | jq -r '.total_permanent // 0' 2>/dev/null || echo "0")
+        uniq=$(printf '%s' "$module_extra" | jq -r '.unique_ips // 0' 2>/dev/null || echo "0")
+        echo "Totals:"
+        printf "  %-20s %s (IPv4: %s / IPv6: %s)\n" "Detections:" "$d_total" "$d_v4" "$d_v6"
+        printf "  %-20s %s (IPv4: %s / IPv6: %s)\n" "Bans:" "$b_total" "$b_v4" "$b_v6"
+        printf "  %-20s %s\n" "Escalations:" "$esc"
+        printf "  %-20s %s\n" "Permanent Bans:" "$perm"
+        printf "  %-20s %s\n" "Unique Offenders:" "$uniq"
+        echo ""
+
+        # Tier 3 — Top services by detections
+        local top_dbs
+        top_dbs=$(printf '%s' "$module_extra" | jq -r '
+            (.detections_by_service // {}) | to_entries
+            | sort_by(-.value) | .[:5]
+            | map("  \(.key)\t\(.value)") | .[]' 2>/dev/null || true)
+        if [[ -n "$top_dbs" ]]; then
+            echo "Top Services (by detections):"
+            printf '%s\n' "$top_dbs"
+            echo ""
+        fi
+
+        # Tier 3 — Top reasons by bans
+        local top_rbs
+        top_rbs=$(printf '%s' "$module_extra" | jq -r '
+            (.bans_by_reason // {}) | to_entries
+            | sort_by(-.value) | .[:5]
+            | map("  \(.key)\t\(.value)") | .[]' 2>/dev/null || true)
+        if [[ -n "$top_rbs" ]]; then
+            echo "Top Reasons (by bans):"
+            printf '%s\n' "$top_rbs"
+            echo ""
+        fi
+
+        # Tier 4 — Subnet aggregation (v1.113). Section omitted when all zero.
+        local sub_p sub_b sub_w sub_nonzero
+        sub_p=$(printf '%s' "$module_extra" | jq -r '.subnet_pressure_count // 0' 2>/dev/null || echo "0")
+        sub_b=$(printf '%s' "$module_extra" | jq -r '.subnet_bans_total // 0' 2>/dev/null || echo "0")
+        sub_w=$(printf '%s' "$module_extra" | jq -r '.subnet_watch_active // 0' 2>/dev/null || echo "0")
+        sub_nonzero="false"
+        if [[ "$sub_p" != "0" || "$sub_b" != "0" || "$sub_w" != "0" ]]; then
+            sub_nonzero="true"
+        fi
+        if [[ "$sub_nonzero" == "true" ]]; then
+            echo "Subnet Aggregation (v1.113):"
+            printf "  %-20s %s (observe-mode counter)\n" "Pressure events:" "$sub_p"
+            printf "  %-20s %s (enforce-mode counter)\n" "CIDR bans:" "$sub_b"
+            printf "  %-20s %s (gauge)\n" "Watched prefixes:" "$sub_w"
+            echo ""
+        fi
+    else
+        echo "Module Status: (daemon unreachable — file-log fallback only)"
+        echo ""
+    fi
+
+    # File-log section (preserved from pre-v1.116 behavior).
     local log_file="$NFTBAN_LOGIN_ALERT_LOG"
     local total_events=0
     local success_events=0
@@ -599,13 +717,11 @@ nftban_login_cmd_stats() {
         today_events=$(grep -c "\[$today" "$log_file" 2>/dev/null) || today_events=0
     fi
 
-    echo "NFTBan Login Statistics"
-    echo "======================="
-    echo ""
-    echo "Total Events: $total_events"
-    echo "  Successful: $success_events"
-    echo "  Failed:     $failed_events"
-    echo "  Today:      $today_events"
+    echo "Today's logged events (file: $log_file):"
+    echo "  Total:                $total_events"
+    echo "  Successful:           $success_events"
+    echo "  Failed:               $failed_events"
+    echo "  Today:                $today_events"
     echo ""
 
     # Daemon uptime (v1.48.0: use nftband, not removed service)
@@ -645,27 +761,59 @@ _nftban_login_cmd_stats_json() {
             service_uptime=$(systemctl show nftband.service --property=ActiveEnterTimestamp --value 2>/dev/null) || service_uptime=""
         fi
 
+        # v1.116 Cand1: fetch module status from daemon. Omit .module key
+        # entirely when unavailable to keep wire format compatible.
+        local module_extra=""
+        local ipc_raw=""
+        if ipc_raw=$(_loginmon_ipc_call 2>/dev/null); then
+            module_extra=$(printf '%s' "$ipc_raw" | _loginmon_extract_extra 2>/dev/null) || module_extra=""
+        fi
+
         local data
         if command -v jq &>/dev/null; then
-            data=$(jq -n \
-                --arg total "$total_events" \
-                --arg success "$success_events" \
-                --arg failed "$failed_events" \
-                --arg today "$today_events" \
-                --arg running "$service_running" \
-                --arg uptime "$service_uptime" \
-                '{
-                    events: {
-                        total: ($total | tonumber),
-                        success: ($success | tonumber),
-                        failed: ($failed | tonumber),
-                        today: ($today | tonumber)
-                    },
-                    service: {
-                        running: ($running == "true"),
-                        uptime: $uptime
-                    }
-                }')
+            if [[ -n "$module_extra" ]]; then
+                data=$(jq -n \
+                    --arg total "$total_events" \
+                    --arg success "$success_events" \
+                    --arg failed "$failed_events" \
+                    --arg today "$today_events" \
+                    --arg running "$service_running" \
+                    --arg uptime "$service_uptime" \
+                    --argjson module "$module_extra" \
+                    '{
+                        events: {
+                            total: ($total | tonumber),
+                            success: ($success | tonumber),
+                            failed: ($failed | tonumber),
+                            today: ($today | tonumber)
+                        },
+                        service: {
+                            running: ($running == "true"),
+                            uptime: $uptime
+                        },
+                        module: $module
+                    }')
+            else
+                data=$(jq -n \
+                    --arg total "$total_events" \
+                    --arg success "$success_events" \
+                    --arg failed "$failed_events" \
+                    --arg today "$today_events" \
+                    --arg running "$service_running" \
+                    --arg uptime "$service_uptime" \
+                    '{
+                        events: {
+                            total: ($total | tonumber),
+                            success: ($success | tonumber),
+                            failed: ($failed | tonumber),
+                            today: ($today | tonumber)
+                        },
+                        service: {
+                            running: ($running == "true"),
+                            uptime: $uptime
+                        }
+                    }')
+            fi
         else
             data="{\"total\":$total_events,\"success\":$success_events,\"failed\":$failed_events,\"today\":$today_events,\"service_running\":$service_running}"
         fi
@@ -1257,6 +1405,8 @@ export -f nftban_login_cmd_status
 export -f _nftban_login_cmd_status_json
 export -f nftban_login_cmd_stats
 export -f _nftban_login_cmd_stats_json
+export -f _loginmon_ipc_call
+export -f _loginmon_extract_extra
 export -f nftban_login_cmd_config
 export -f nftban_login_cmd_install
 export -f nftban_login_cmd_enable

--- a/cli/lib/nftban/tests/cmd_login_stats_test.sh
+++ b/cli/lib/nftban/tests/cmd_login_stats_test.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.116 Cand1 cmd_login stats CLI formatter
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_login_stats_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-16"
+# meta:description="Tests for v1.116 Cand1 cmd_login stats CLI formatter consuming LoginMonStatusExtra"
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,python3,grep,timeout"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq,python3"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_RUN_DIR,NFTBAN_LOG_DIR,NFTBAN_CACHE_DIR,NFTBAN_CONFIG_DIR,NFTBAN_DATA_DIR,NFTBAN_LOGIN_ALERT_LOG,NFTBAN_DISTRO_CONFIG_LOADED,NFTBAN_LOGIN_ALERT_LOADED,NFTBAN_LOGIN_LOADED"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Purpose: Cover the LoginMon source-state CLI surface introduced by the
+#          v1.116 Cand1 PR — daemon-first formatter that consumes the
+#          already-existing LoginMonStatusExtra via the IPC `modules` method.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# Test harness — load the cmd_login.sh helpers from the repo without
+# requiring an installed nftban.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+# Sandbox for synthetic socket + log file so the suite doesn't touch
+# /run/nftban or /var/log/nftban.
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+export NFTBAN_RUN_DIR="$SANDBOX/run"
+export NFTBAN_LOG_DIR="$SANDBOX/log"
+export NFTBAN_CACHE_DIR="$SANDBOX/cache"
+export NFTBAN_CONFIG_DIR="$SANDBOX/etc"
+export NFTBAN_DATA_DIR="$SANDBOX/data"
+mkdir -p "$NFTBAN_RUN_DIR" "$NFTBAN_LOG_DIR" "$NFTBAN_CACHE_DIR" "$NFTBAN_CONFIG_DIR" "$NFTBAN_DATA_DIR"
+export NFTBAN_LOGIN_ALERT_LOG="$NFTBAN_LOG_DIR/login_alert.log"
+
+# Bypass the dependency-laden bootstrap of cmd_login.sh. The sandbox does
+# not have /etc/nftban/distros/* or a populated lib tree; setting these two
+# flags short-circuits the optional `source` calls at the top of cmd_login.sh.
+export NFTBAN_DISTRO_CONFIG_LOADED=1
+export NFTBAN_LOGIN_ALERT_LOADED=1
+export NFTBAN_LOGIN_LOADED=1
+
+# Make json_output a no-op passthrough so the JSON-mode tests can capture
+# the raw payload by simply echoing it on stdout.
+json_output() {
+    # $1 = success bool (unused); $2 = data payload
+    printf '%s\n' "$2"
+}
+export -f json_output
+
+# systemctl stub — never claims daemon is running, to keep tests host-agnostic.
+# The CLI uses systemctl only for the "Daemon Started:" suffix line; tests do
+# not assert on that line.
+systemctl() {
+    return 1
+}
+export -f systemctl
+
+# Source the cmd_login.sh under test.
+NFTBAN_TEST_MODE=1 source "${REPO_ROOT}/cli/lib/nftban/cli/cmd_login.sh" >/dev/null 2>&1 || true
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n" "$name"
+        printf "         expected to contain: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n" "$name"
+        printf "         did NOT expect: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# install_socat_stub <fixture-path>
+# Places a real shell script named `socat` in $SANDBOX/bin and prepends
+# that dir to PATH. The CLI's `timeout 5 socat -` invocation goes through
+# execv, so a bash function will not be visible — only a script on PATH
+# works. The wrapper ignores all arguments and emits the fixture JSON.
+install_socat_stub() {
+    local fixture="$1"
+    mkdir -p "$SANDBOX/bin"
+    cat > "$SANDBOX/bin/socat" <<EOF
+#!/usr/bin/env bash
+cat "$fixture"
+EOF
+    chmod +x "$SANDBOX/bin/socat"
+    case ":$PATH:" in
+        *":$SANDBOX/bin:"*) ;;
+        *) export PATH="$SANDBOX/bin:$PATH" ;;
+    esac
+}
+
+# remove_socket_marker — ensures _loginmon_ipc_call returns failure.
+remove_socket_marker() {
+    rm -f "$NFTBAN_RUN_DIR/nftband.sock"
+    # Also remove the socat wrapper so the helper would short-circuit
+    # on either path (socket absent OR socat absent).
+    rm -f "$SANDBOX/bin/socat"
+}
+
+# create_socket_marker — creates the unix-socket placeholder so the
+# `[[ -S "$socket_path" ]]` test in _loginmon_ipc_call passes.
+create_socket_marker() {
+    # bash test `-S` requires a real socket. Use python's socket module.
+    python3 - <<PY
+import socket, os
+p = os.environ["NFTBAN_RUN_DIR"] + "/nftband.sock"
+try: os.unlink(p)
+except FileNotFoundError: pass
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(p)
+s.close()
+PY
+}
+
+# Fixture A: daemon-up with non-zero subnet aggregation fields.
+FIXTURE_DAEMON_UP_SUBNET_NONZERO=$(cat <<'EOF'
+{
+  "success": true,
+  "data": [
+    {
+      "name": "loginmon",
+      "state": "running",
+      "extra": {
+        "mode": "observe",
+        "suricata_available": true,
+        "services": "ssh,exim,dovecot",
+        "detectors": ["ssh", "exim"],
+        "total_detections": 1284,
+        "total_bans": 312,
+        "total_escalations": 22,
+        "total_permanent": 9,
+        "unique_ips": 199,
+        "detections_ipv4": 1201,
+        "detections_ipv6": 83,
+        "bans_ipv4": 298,
+        "bans_ipv6": 14,
+        "tracked_ips": 47,
+        "detections_by_service": {"ssh": 742, "dovecot": 213, "exim": 189, "postfix": 93, "ftp": 47},
+        "bans_by_service": {"ssh": 198, "exim": 89, "dovecot": 25},
+        "detections_by_reason": {"brute_force": 800, "rate_limit": 484},
+        "bans_by_reason": {"brute_force_auth_fail": 219, "rate_limit_exceeded": 71, "exim_smtp_auth_fail": 22},
+        "subnet_pressure_count": 18,
+        "subnet_bans_total": 3,
+        "subnet_watch_active": 2
+      }
+    }
+  ]
+}
+EOF
+)
+
+# Fixture B: daemon-up with subnet aggregation fields all zero.
+FIXTURE_DAEMON_UP_SUBNET_ZERO=$(cat <<'EOF'
+{
+  "success": true,
+  "data": [
+    {
+      "name": "loginmon",
+      "state": "running",
+      "extra": {
+        "mode": "enforce",
+        "suricata_available": false,
+        "services": "ssh",
+        "detectors": ["ssh"],
+        "total_detections": 100,
+        "total_bans": 10,
+        "total_escalations": 0,
+        "total_permanent": 0,
+        "unique_ips": 9,
+        "detections_ipv4": 100,
+        "detections_ipv6": 0,
+        "bans_ipv4": 10,
+        "bans_ipv6": 0,
+        "tracked_ips": 9,
+        "detections_by_service": {"ssh": 100},
+        "bans_by_service": {"ssh": 10},
+        "detections_by_reason": {},
+        "bans_by_reason": {"brute_force": 10},
+        "subnet_pressure_count": 0,
+        "subnet_bans_total": 0,
+        "subnet_watch_active": 0
+      }
+    }
+  ]
+}
+EOF
+)
+
+# Write fixtures to disk for the socat stub.
+FIXTURE_A_PATH="$SANDBOX/fixture_subnet_nonzero.json"
+FIXTURE_B_PATH="$SANDBOX/fixture_subnet_zero.json"
+printf '%s\n' "$FIXTURE_DAEMON_UP_SUBNET_NONZERO" > "$FIXTURE_A_PATH"
+printf '%s\n' "$FIXTURE_DAEMON_UP_SUBNET_ZERO" > "$FIXTURE_B_PATH"
+
+# Seed a small login_alert.log so the file-log section has non-zero numbers.
+{
+    echo "[$(date '+%Y-%m-%d') 10:00:00] SUCCESS user=root ip=1.2.3.4"
+    echo "[$(date '+%Y-%m-%d') 10:01:00] FAILED user=root ip=5.6.7.8"
+    echo "[$(date '+%Y-%m-%d') 10:02:00] FAILED user=admin ip=9.8.7.6"
+} > "$NFTBAN_LOGIN_ALERT_LOG"
+
+echo "============================================"
+echo "v1.116 Cand1 — cmd_login stats test suite"
+echo "============================================"
+
+# --- Test 1: daemon-up text mode contains Mode + Tracked IPs + Detections + Top Services row ---
+echo
+echo "[T1] daemon-up text mode core fields"
+create_socket_marker
+install_socat_stub "$FIXTURE_A_PATH"
+T1_OUT=$(nftban_login_cmd_stats 2>&1)
+assert_contains "$T1_OUT" "Mode:"                                "T1.1 Mode label present"
+assert_contains "$T1_OUT" "observe"                              "T1.2 Mode value 'observe'"
+assert_contains "$T1_OUT" "Tracked IPs:"                         "T1.3 Tracked IPs label"
+assert_contains "$T1_OUT" "Detections:"                          "T1.4 Detections label"
+assert_contains "$T1_OUT" "1284"                                 "T1.5 Detections total"
+assert_contains "$T1_OUT" "Top Services (by detections):"        "T1.6 Top Services header"
+assert_contains "$T1_OUT" "ssh"                                  "T1.7 Top Services row contains ssh"
+
+# --- Test 2: daemon-up with non-zero subnet aggregation shows section ---
+echo
+echo "[T2] daemon-up text mode with subnet non-zero"
+assert_contains "$T1_OUT" "Subnet Aggregation (v1.113):"         "T2.1 Subnet Aggregation header present"
+assert_contains "$T1_OUT" "Pressure events:"                     "T2.2 Pressure events label"
+assert_contains "$T1_OUT" "CIDR bans:"                           "T2.3 CIDR bans label"
+assert_contains "$T1_OUT" "Watched prefixes:"                    "T2.4 Watched prefixes label"
+
+# --- Test 3: daemon-up with all-zero subnet aggregation omits section ---
+echo
+echo "[T3] daemon-up text mode with subnet all-zero"
+install_socat_stub "$FIXTURE_B_PATH"
+T3_OUT=$(nftban_login_cmd_stats 2>&1)
+assert_contains "$T3_OUT" "Mode:"                                "T3.1 Module status still present"
+assert_contains "$T3_OUT" "enforce"                              "T3.2 Mode 'enforce' shown"
+assert_not_contains "$T3_OUT" "Subnet Aggregation"               "T3.3 Subnet section omitted (all-zero)"
+
+# --- Test 4: daemon-down text mode falls back to file-log-only ---
+echo
+echo "[T4] daemon-down text mode fallback"
+remove_socket_marker
+T4_OUT=$(nftban_login_cmd_stats 2>&1)
+T4_RC=$?
+assert_contains "$T4_OUT" "daemon unreachable"                   "T4.1 Fallback notice present"
+assert_contains "$T4_OUT" "Today's logged events"                "T4.2 File-log section present"
+if [[ "$T4_RC" -eq 0 ]]; then
+    printf "  [PASS] T4.3 Exit code 0 on daemon-down fallback\n"
+    PASS=$((PASS + 1))
+else
+    printf "  [FAIL] T4.3 Exit code 0 on daemon-down fallback (got rc=%s)\n" "$T4_RC"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("T4.3")
+fi
+assert_not_contains "$T4_OUT" "Module Status (from daemon):"     "T4.4 No module section in fallback"
+
+# --- Test 5: JSON daemon-up includes .module.mode and .module.total_detections ---
+echo
+echo "[T5] daemon-up JSON includes .module"
+create_socket_marker
+install_socat_stub "$FIXTURE_A_PATH"
+T5_OUT=$(_nftban_login_cmd_stats_json "true" 2>&1)
+assert_contains "$T5_OUT" '"module"'                             "T5.1 .module key present"
+assert_contains "$T5_OUT" '"mode": "observe"'                    "T5.2 .module.mode value"
+assert_contains "$T5_OUT" '"total_detections": 1284'             "T5.3 .module.total_detections value"
+assert_contains "$T5_OUT" '"events"'                             "T5.4 .events still present"
+assert_contains "$T5_OUT" '"service"'                            "T5.5 .service still present"
+
+# --- Test 6: JSON daemon-down omits .module but preserves .events + .service ---
+echo
+echo "[T6] daemon-down JSON omits .module"
+remove_socket_marker
+T6_OUT=$(_nftban_login_cmd_stats_json "true" 2>&1)
+assert_not_contains "$T6_OUT" '"module"'                         "T6.1 .module key absent"
+assert_contains "$T6_OUT" '"events"'                             "T6.2 .events preserved"
+assert_contains "$T6_OUT" '"service"'                            "T6.3 .service preserved"
+assert_contains "$T6_OUT" '"running": false'                     "T6.4 .service.running present (stub systemctl=fail)"
+
+echo
+echo "============================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "============================================"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    printf 'Failed tests:\n'
+    for t in "${FAILED_TESTS[@]}"; do
+        printf '  - %s\n' "$t"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds shell-side helpers `_loginmon_ipc_call` + `_loginmon_extract_extra` that fetch the daemon's existing `modules` IPC response (no new IPC method, no new HTTP route, no new struct).
- Rewrites `nftban_login_cmd_stats` to render Tier 1..3 fields from `LoginMonStatusExtra` (mode, suricata availability, tracked IPs, detection/ban totals + IPv4/v6 split, top services, top reasons) plus zero-omittable v1.113 subnet aggregation section.
- Rewrites `_nftban_login_cmd_stats_json` to merge a `.module` key into the existing JSON payload; key is omitted entirely when daemon unreachable.
- Adds bats-free test fixture covering daemon-up text/JSON, daemon-down fallback, and subnet-zero/non-zero paths.

## Scope

Bounded by `AUDIT_190_LIFECYCLE/V116_CAND1_LOGINMON_SOURCE_STATE_API_SCOPE.md` (verdict `INCLUDE_READY`). Allowed files:

- `cli/lib/nftban/cli/cmd_login.sh` (production)
- `cli/lib/nftban/tests/cmd_login_stats_test.sh` (new test)

Forbidden surfaces — **untouched**:
- `internal/loginmon/**`, `cmd/nftband/**`, `pkg/ipc/**`, `internal/module/**`
- `internal/metrics/**`, `install/**`, `packaging/**`
- `internal/contracts/schema/**`, `internal/validator/schema_generated.go`
- `cli/lib/nftban/lib/nft_schema.sh`, `cli/lib/nftban/helpers/json_output.sh`
- `cli/lib/nftban/cli/cmd_watchdog.sh`, `cli/lib/nftban/cli/cmd_stats.sh`
- `VERSION`, `STATUS.md`, `CHANGELOG.md`, `build/fhs-spec.yaml`
- `dns2/`, `nftbanpro_cms/`, `MASTER_TODO*`

Diffstat: `2 files changed, 500 insertions(+), 27 deletions(-)`. Net production Go: **0 lines**. Schema unchanged (1.83.0 frozen).

## Behavior before/after

**Before:** `nftban login stats` reads `NFTBAN_LOGIN_ALERT_LOG` and counts SUCCESS/FAILED/today via `grep -c`. The typed `LoginMonStatusExtra` exposed at `internal/loginmon/module.go:454-484` is invisible at the CLI without portal/receiver.

**After:** `nftban login stats` first queries the daemon (existing IPC `modules` method, mirroring the `_watchdog_ipc_call` pattern from `cmd_watchdog.sh:632`). On success, displays module status header, totals, top services, top reasons, and (when non-zero) v1.113 subnet aggregation gauges/counters. The original file-log section is preserved as "Today's logged events". On daemon-down, prints `(daemon unreachable — file-log fallback only)` and falls through to the file-log section (pre-v1.116 behavior).

JSON mode: adds `module` key when daemon data available; omits it otherwise. `events` and `service` keys remain byte-stable for existing JSON consumers.

## Test plan

- [x] `cli/lib/nftban/tests/cmd_login_stats_test.sh` — 27 sub-assertions across 6 scenarios; all passing locally in a `mktemp -d` sandbox (no host contact, no SSH).
  - T1 daemon-up text mode shows Mode + Tracked IPs + Detections + Top Services row
  - T2 daemon-up with non-zero subnet fields shows Subnet Aggregation section
  - T3 daemon-up with all-zero subnet fields omits the section
  - T4 daemon-down text mode falls back to file-log-only, exit 0
  - T5 daemon-up JSON includes `.module.mode` and `.module.total_detections`
  - T6 daemon-down JSON omits `.module` but preserves `.events` and `.service`
- [x] Shellcheck: zero new warnings on `cmd_login.sh` (27→27 lines, all pre-existing SC1091); zero warnings on the new test file
- [x] `bash -n` syntax check passes on both files
- [ ] CI: workflows on PR open
- [ ] Existing LoginMon Go tests (`internal/loginmon/module_test.go::TestLoginMonStatusExtra_*`) unchanged byte-for-byte → expected to pass unchanged

## Schema frozen

- Schema version stays at **1.83.0** (no `internal/contracts/schema/`, `internal/validator/schema_generated.go`, `install/nftables/*`, or `cli/lib/nftban/lib/nft_schema.sh` touched)
- No Prometheus metric added/renamed
- No new IPC method or HTTP route

🤖 Generated with [Claude Code](https://claude.com/claude-code)