### PR TITLE
feat(cli): registry-backed firewall takeover discoverability (V117)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -266,12 +266,98 @@ nftban_cmd_firewall() {
             shift
             firewall_record "$@"
             ;;
+        takeover)
+            shift
+            firewall_takeover "$@"
+            ;;
         *)
             echo "ERROR: Unknown firewall subcommand: $subcommand" >&2
             echo "Try 'nftban firewall help' for more information." >&2
             return 1
             ;;
     esac
+}
+
+# =============================================================================
+# SUBCOMMAND: TAKEOVER (v1.117 — registry-backed discoverability)
+# =============================================================================
+# Forwards to the installer's panel-auto-takeover flow. The mechanism is
+# unchanged from PR-22B; this is a discoverability surface only. The actual
+# disarm logic lives in cmd/nftban-installer + internal/installer/switchop.
+firewall_takeover() {
+    local panel_auto=false
+    local dry_run=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --panel-auto-takeover) panel_auto=true; shift ;;
+            --dry-run|-n) dry_run=true; shift ;;
+            -h|--help|help)
+                cat <<'HELP_EOF'
+Usage: nftban firewall takeover [--panel-auto-takeover] [--dry-run]
+
+Disarm conflicting external firewalls (CSF/iptables/firewalld) so nftban
+can become the sole authority on this host. REVERSIBLE.
+
+Options:
+  --panel-auto-takeover   Allow detected control-panel presence
+                          (cPanel/Plesk/DirectAdmin) to auto-approve
+                          takeover. Default OFF (PR-22B gate).
+  --dry-run, -n           Preview takeover actions without changes.
+
+What disarm does (reversible):
+  - External firewall binary renamed to <name>.disabled (sha256-equal)
+  - Service masked (systemctl mask)
+  - Config trees preserved verbatim
+  - Cron-backup manifest written before any rm
+
+To reverse:
+  nftban firewall restore csf
+  # or equivalently:
+  /usr/lib/nftban/bin/nftban-installer --mode=restore
+
+Env mirror:
+  NFTBAN_PANEL_AUTO_TAKEOVER=1   useful for cloud-init / Ansible /
+                                 package %post hooks.
+
+Requires root.
+HELP_EOF
+                return 0
+                ;;
+            *)
+                echo "ERROR: Unknown takeover argument: $1" >&2
+                echo "Try 'nftban firewall takeover --help' for more information." >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [[ "$panel_auto" == "false" && "$dry_run" == "false" ]]; then
+        echo "ERROR: nftban firewall takeover requires --panel-auto-takeover or --dry-run." >&2
+        echo "  --panel-auto-takeover : opt into auto-approve on detected panel hosts (PR-22B gate)" >&2
+        echo "  --dry-run             : preview without changes" >&2
+        echo "Reference: nftban firewall takeover --help" >&2
+        return 2
+    fi
+
+    if [[ $EUID -ne 0 && "$dry_run" == "false" ]]; then
+        echo "ERROR: nftban firewall takeover requires root (mutates: true)." >&2
+        return 1
+    fi
+
+    local installer="${NFTBAN_INSTALLER_BIN:-/usr/lib/nftban/bin/nftban-installer}"
+    if [[ ! -x "$installer" ]]; then
+        echo "ERROR: nftban-installer not found at $installer" >&2
+        echo "       Set NFTBAN_INSTALLER_BIN to override path." >&2
+        return 1
+    fi
+
+    local args=(--mode=upgrade)
+    [[ "$panel_auto" == "true" ]] && args+=(--panel-auto-takeover)
+    [[ "$dry_run" == "true" ]] && args+=(--dry-run)
+
+    echo "Invoking installer: $installer ${args[*]}"
+    exec "$installer" "${args[@]}"
 }
 
 # =============================================================================
@@ -2479,6 +2565,7 @@ Operations:
   rebuild       Rebuild schema (fix corruption, keeps IPs)
   reset         Complete reset (flush all, rebuild clean)
   restore       Enterprise rollback (restore previous state)
+  takeover      Disarm conflicting external firewalls (CSF/iptables/firewalld); reversible
 
 Examples:
   # Validate with strict mode (recommended before enabling)

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -2104,6 +2104,25 @@ nftban_cmd_update() {
         fi
     done
 
+    # v1.117 (registry option update.options.--panel-auto-takeover):
+    # parse-and-forward to the installer via the env mirror that
+    # cmd/nftban-installer/flags.go:141 already honors. install.sh
+    # exec's the installer (install.sh:67) and inherits env, so this
+    # works for every update path (github / git / local / package).
+    # The flag is stripped from argv before the case dispatch so it
+    # doesn't pollute version/branch/path subcommand parsers.
+    local _filtered_args=()
+    for arg in "$@"; do
+        if [[ "$arg" == "--panel-auto-takeover" ]]; then
+            export NFTBAN_PANEL_AUTO_TAKEOVER=1
+        else
+            _filtered_args+=("$arg")
+        fi
+    done
+    if [[ ${#_filtered_args[@]} -lt $# ]]; then
+        set -- "${_filtered_args[@]}"
+    fi
+
     case "$cmd" in
         check|--check|-c)
             _cmd_update_check "$@"

--- a/cli/lib/nftban/tests/cmd_firewall_takeover_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_takeover_test.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.117 firewall takeover discoverability
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_firewall_takeover_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-16"
+# meta:description="Tests for v1.117 firewall takeover + update --panel-auto-takeover CLI surfaces"
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,python3"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_INSTALLER_BIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Purpose: Cover the v1.117 firewall-takeover discoverability surface:
+#   - nftban firewall takeover dispatcher (cmd_firewall.sh)
+#   - nftban update --panel-auto-takeover env-mirror forwarding (cmd_update.sh)
+#   - help output, root/dry-run gating, argv forwarding to installer stub.
+# Self-contained sandbox; no host contact; no real installer invocation.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Installer stub: a real script on PATH that records its argv + env and
+# exits 0. The cmd_firewall.sh `exec` of the installer would normally
+# replace the test shell; we override via NFTBAN_INSTALLER_BIN to point
+# at this stub. The stub's argv/env trace is written to a file the test
+# reads after each invocation.
+INSTALLER_STUB="$SANDBOX/bin/nftban-installer"
+INSTALLER_LOG="$SANDBOX/installer.log"
+mkdir -p "$SANDBOX/bin"
+cat > "$INSTALLER_STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+{
+    echo "argv: $*"
+    echo "NFTBAN_PANEL_AUTO_TAKEOVER=${NFTBAN_PANEL_AUTO_TAKEOVER:-unset}"
+    echo "NFTBAN_JSON=${NFTBAN_JSON:-unset}"
+} >> "${INSTALLER_LOG:-/dev/null}"
+exit 0
+STUB_EOF
+chmod +x "$INSTALLER_STUB"
+export NFTBAN_INSTALLER_BIN="$INSTALLER_STUB"
+export INSTALLER_LOG
+
+# Bypass dependency-laden bootstrap of cmd_firewall.sh / cmd_update.sh.
+export NFTBAN_RUN_DIR="$SANDBOX/run"
+export NFTBAN_LOG_DIR="$SANDBOX/log"
+export NFTBAN_CACHE_DIR="$SANDBOX/cache"
+export NFTBAN_CONFIG_DIR="$SANDBOX/etc"
+export NFTBAN_DATA_DIR="$SANDBOX/data"
+mkdir -p "$NFTBAN_RUN_DIR" "$NFTBAN_LOG_DIR" "$NFTBAN_CACHE_DIR" "$NFTBAN_CONFIG_DIR" "$NFTBAN_DATA_DIR"
+export NFTBAN_DISTRO_CONFIG_LOADED=1
+export NFTBAN_FIREWALL_LOADED=1   # speculative guard; harmless if absent
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n" "$name"
+        printf "         expected to contain: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n" "$name"
+        printf "         did NOT expect: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+reset_installer_log() {
+    : > "$INSTALLER_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Wrapper: invoke firewall_takeover in a subshell so its `exec` doesn't
+# replace the test runner. The subshell exec's the stub installer, which
+# writes to INSTALLER_LOG and exits, ending the subshell.
+# ---------------------------------------------------------------------------
+call_firewall_takeover() {
+    # shellcheck disable=SC2317  # function is called below via subshell
+    (
+        set +e
+        # Re-source minimum: cmd_firewall.sh requires its own bootstrap.
+        # To keep this test self-contained without dragging the whole
+        # NFTBAN_LIB_DIR runtime, we extract firewall_takeover from the
+        # source file and re-source ONLY that function plus the dispatcher.
+        # The function is self-contained — no external helper required.
+        eval "$(awk '
+            /^# SUBCOMMAND: TAKEOVER/,/^# =========.*$/ { print }
+            /^firewall_takeover\(\)/,/^}$/ { print }
+        ' "$NFTBAN_LIB_DIR/cli/cmd_firewall.sh")"
+        firewall_takeover "$@"
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Wrapper: invoke the update dispatcher's argv-stripping logic without
+# running the full update pipeline. We extract just the nftban_cmd_update
+# preamble (the new v1.117 filter) and verify env-mirror is set.
+# ---------------------------------------------------------------------------
+call_update_with_panel_flag() {
+    (
+        set +e
+        # Source only the dispatcher header (preamble + flag-strip).
+        # cmd_update.sh's full body has dependencies we don't need here;
+        # this test focuses on the flag-strip side-effect.
+        local _stub_dispatcher
+        _stub_dispatcher=$(awk '
+            /^nftban_cmd_update\(\)/ { capture=1 }
+            capture { print }
+            capture && /^    case "\$cmd" in/ { print "        *) return 0 ;;"; print "    esac"; print "}"; exit }
+        ' "$NFTBAN_LIB_DIR/cli/cmd_update.sh")
+        eval "$_stub_dispatcher"
+        unset NFTBAN_PANEL_AUTO_TAKEOVER
+        nftban_cmd_update "$@" >/dev/null 2>&1 || true
+        # Emit the env-mirror value for the test runner to capture.
+        printf 'NFTBAN_PANEL_AUTO_TAKEOVER=%s\n' "${NFTBAN_PANEL_AUTO_TAKEOVER:-unset}"
+    )
+}
+
+echo "================================================="
+echo "v1.117 firewall takeover discoverability test suite"
+echo "================================================="
+
+# ---------------------------------------------------------------------------
+# T1: --help / -h exits 0 with usage text
+# ---------------------------------------------------------------------------
+echo
+echo "[T1] firewall takeover --help"
+reset_installer_log
+T1_OUT=$(call_firewall_takeover --help 2>&1)
+assert_contains "$T1_OUT" "Usage: nftban firewall takeover"          "T1.1 Usage line"
+assert_contains "$T1_OUT" "--panel-auto-takeover"                    "T1.2 flag mentioned"
+assert_contains "$T1_OUT" "--dry-run"                                "T1.3 dry-run mentioned"
+assert_contains "$T1_OUT" "REVERSIBLE"                               "T1.4 reversibility callout"
+assert_contains "$T1_OUT" "NFTBAN_PANEL_AUTO_TAKEOVER=1"             "T1.5 env mirror documented"
+
+# ---------------------------------------------------------------------------
+# T2: bare invocation (no flags) refuses with operator-actionable error
+# ---------------------------------------------------------------------------
+echo
+echo "[T2] firewall takeover (no flags) refuses"
+reset_installer_log
+T2_OUT=$(call_firewall_takeover 2>&1 || true)
+assert_contains "$T2_OUT" "requires --panel-auto-takeover or --dry-run"  "T2.1 refusal explains gate"
+[[ ! -s "$INSTALLER_LOG" ]] && {
+    printf "  [PASS] %s\n" "T2.2 installer not invoked (no flags)"
+    PASS=$((PASS + 1))
+} || {
+    printf "  [FAIL] %s\n" "T2.2 installer not invoked (no flags)"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("T2.2")
+}
+
+# ---------------------------------------------------------------------------
+# T3: --dry-run path invokes installer with correct argv (no root required)
+# ---------------------------------------------------------------------------
+echo
+echo "[T3] firewall takeover --dry-run"
+reset_installer_log
+call_firewall_takeover --dry-run >/dev/null 2>&1 || true
+T3_LOG=$(cat "$INSTALLER_LOG" 2>/dev/null || true)
+assert_contains "$T3_LOG" "argv: --mode=upgrade --dry-run"           "T3.1 installer argv includes mode + dry-run"
+assert_not_contains "$T3_LOG" "--panel-auto-takeover"                "T3.2 dry-run alone does NOT include --panel-auto-takeover"
+
+# ---------------------------------------------------------------------------
+# T4: --panel-auto-takeover path invokes installer with correct argv
+# ---------------------------------------------------------------------------
+echo
+echo "[T4] firewall takeover --panel-auto-takeover (no root path uses dry-run skipped)"
+# Bypass root check by also passing --dry-run so the test runner (non-root)
+# doesn't trip the EUID gate. The argv must still contain --panel-auto-takeover.
+reset_installer_log
+call_firewall_takeover --panel-auto-takeover --dry-run >/dev/null 2>&1 || true
+T4_LOG=$(cat "$INSTALLER_LOG" 2>/dev/null || true)
+assert_contains "$T4_LOG" "--mode=upgrade"                           "T4.1 mode=upgrade present"
+assert_contains "$T4_LOG" "--panel-auto-takeover"                    "T4.2 --panel-auto-takeover forwarded"
+assert_contains "$T4_LOG" "--dry-run"                                "T4.3 --dry-run forwarded"
+
+# ---------------------------------------------------------------------------
+# T5: unknown flag refuses with exit 2
+# ---------------------------------------------------------------------------
+echo
+echo "[T5] firewall takeover --bogus refuses"
+reset_installer_log
+T5_OUT=$(call_firewall_takeover --bogus 2>&1 || true)
+assert_contains "$T5_OUT" "Unknown takeover argument"                "T5.1 unknown arg refusal"
+[[ ! -s "$INSTALLER_LOG" ]] && {
+    printf "  [PASS] %s\n" "T5.2 installer not invoked (bogus arg)"
+    PASS=$((PASS + 1))
+} || {
+    printf "  [FAIL] %s\n" "T5.2 installer not invoked (bogus arg)"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("T5.2")
+}
+
+# ---------------------------------------------------------------------------
+# T6: root gate — non-root + no --dry-run refuses with exit 1
+# (We are non-root in CI; --panel-auto-takeover alone must hit the gate.)
+# ---------------------------------------------------------------------------
+echo
+echo "[T6] root gate"
+if [[ $EUID -ne 0 ]]; then
+    reset_installer_log
+    T6_OUT=$(call_firewall_takeover --panel-auto-takeover 2>&1 || true)
+    assert_contains "$T6_OUT" "requires root"                        "T6.1 non-root refusal"
+    [[ ! -s "$INSTALLER_LOG" ]] && {
+        printf "  [PASS] %s\n" "T6.2 installer not invoked (non-root)"
+        PASS=$((PASS + 1))
+    } || {
+        printf "  [FAIL] %s\n" "T6.2 installer not invoked (non-root)"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("T6.2")
+    }
+else
+    echo "  [SKIP] T6 — running as root; cannot exercise non-root gate"
+fi
+
+# ---------------------------------------------------------------------------
+# T7: update --panel-auto-takeover sets NFTBAN_PANEL_AUTO_TAKEOVER=1 and
+#     strips the flag from the version/branch parser path.
+# ---------------------------------------------------------------------------
+echo
+echo "[T7] update --panel-auto-takeover env-mirror forwarding"
+T7_OUT=$(call_update_with_panel_flag check --panel-auto-takeover 2>&1 || true)
+assert_contains "$T7_OUT" "NFTBAN_PANEL_AUTO_TAKEOVER=1"             "T7.1 env mirror set"
+
+T7B_OUT=$(call_update_with_panel_flag check 2>&1 || true)
+assert_contains "$T7B_OUT" "NFTBAN_PANEL_AUTO_TAKEOVER=unset"        "T7.2 env mirror NOT set when flag absent"
+
+# ---------------------------------------------------------------------------
+# T8: Registry YAML structural validity + new entries present
+# ---------------------------------------------------------------------------
+echo
+echo "[T8] Registry YAML structural validation"
+if command -v python3 >/dev/null 2>&1; then
+    T8_OUT=$(python3 - <<PY 2>&1
+import yaml, sys
+try:
+    d = yaml.safe_load(open("$REPO_ROOT/commands.registry.yml"))
+    assert "takeover" in d["firewall"]["subcommands"], "missing firewall.subcommands.takeover"
+    assert d["firewall"]["subcommands"]["takeover"]["requires_root"] is True, "takeover should require root"
+    assert "--panel-auto-takeover" in d["firewall"]["subcommands"]["takeover"]["options"], "missing takeover.options.--panel-auto-takeover"
+    assert "options" in d["update"] and "--panel-auto-takeover" in d["update"]["options"], "missing update.options.--panel-auto-takeover"
+    print("YAML_OK")
+except Exception as e:
+    print(f"YAML_ERR: {e}")
+PY
+)
+    assert_contains "$T8_OUT" "YAML_OK"                              "T8.1 Registry structurally valid"
+    assert_not_contains "$T8_OUT" "YAML_ERR"                         "T8.2 No YAML errors"
+else
+    echo "  [SKIP] T8 — python3 not available"
+fi
+
+# ---------------------------------------------------------------------------
+# T9: Installer flags.go untouched (regression guard against scope-creep)
+# ---------------------------------------------------------------------------
+echo
+echo "[T9] Installer flags.go regression guard"
+if command -v git >/dev/null 2>&1 && [[ -d "$REPO_ROOT/.git" ]]; then
+    cd "$REPO_ROOT"
+    if git diff --quiet main -- cmd/nftban-installer/flags.go 2>/dev/null; then
+        printf "  [PASS] %s\n" "T9.1 cmd/nftban-installer/flags.go byte-unchanged vs main"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n" "T9.1 cmd/nftban-installer/flags.go modified — SCOPE VIOLATION"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("T9.1")
+    fi
+    cd - >/dev/null
+else
+    echo "  [SKIP] T9 — not in git repo or git unavailable"
+fi
+
+echo
+echo "================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================================="
+
+if [[ "$FAIL" -gt 0 ]]; then
+    printf 'Failed tests:\n'
+    for t in "${FAILED_TESTS[@]}"; do
+        printf '  - %s\n' "$t"
+    done
+    exit 1
+fi
+exit 0

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1524,6 +1524,26 @@ firewall:
       mutates: true
       requires_root: true
       description: "Reload nftables ruleset"
+    takeover:
+      mutates: true
+      requires_root: true
+      description: "Disarm conflicting external firewalls (CSF/iptables/firewalld); reversible; explicit operator approval required"
+      examples:
+        - "nftban firewall takeover --panel-auto-takeover"
+        - "nftban firewall takeover --dry-run"
+      options:
+        --panel-auto-takeover:
+          type: bool
+          default: false
+          description: "Allow detected control-panel presence (cPanel/Plesk/DA) to auto-approve takeover. Default OFF (PR-22B gate)."
+        --dry-run:
+          type: bool
+          default: false
+          description: "Preview takeover actions without changes"
+      notes:
+        - "Disarm is REVERSIBLE: external firewall binary renamed to .disabled (sha256-equal), config trees preserved, cron-backup manifest written before any rm"
+        - "To reverse: nftban firewall restore csf  (or  /usr/lib/nftban/bin/nftban-installer --mode=restore)"
+        - "Env mirror: NFTBAN_PANEL_AUTO_TAKEOVER=1 (useful for cloud-init / Ansible / package %post)"
     logs:
       mutates: conditional
       requires_root: conditional
@@ -3360,6 +3380,11 @@ update:
     methods:
       mutates: false
       description: "Update method implementations (github, git, local)"
+  options:
+    --panel-auto-takeover:
+      type: bool
+      default: false
+      description: "Allow detected control-panel presence to auto-approve takeover of conflicting firewalls during the update. Exported as NFTBAN_PANEL_AUTO_TAKEOVER=1 and forwarded to /usr/lib/nftban/bin/nftban-installer. Default OFF (PR-22B gate)."
   config_file: "/etc/nftban/update.conf"
   config_vars:
     NFTBAN_UPDATE_SOURCE:


### PR DESCRIPTION
## Summary

Closes the V117 firewall-takeover discoverability gap. Registers two new operator-facing surfaces in `commands.registry.yml` so the existing central help/wiki/completion pipeline (generate-help.sh + generate-wiki-operator.sh + generate-wiki-auditor.sh + lint-registry-parity G15) automatically picks them up:

- `nftban firewall takeover` — explicit reversible-disarm entry, requires `--panel-auto-takeover` OR `--dry-run`, requires root for mutation, forwards to `/usr/lib/nftban/bin/nftban-installer --mode=upgrade ...`.
- `nftban update --panel-auto-takeover` — parses + strips the flag from argv and exports `NFTBAN_PANEL_AUTO_TAKEOVER=1` for the duration of the update.

## Scope

Bounded by `AUDIT_190_LIFECYCLE/V117_FIREWALL_TAKEOVER_DISCOVERABILITY_SCOPE.md` (verdict `V117_FIREWALL_TAKEOVER_DISCOVERABILITY_SCOPE_FILED`).

**Allowed envelope (4 files, +463/-0):**

| File | Change |
|------|--------|
| `commands.registry.yml` | +25 lines — `firewall.subcommands.takeover` + `update.options.--panel-auto-takeover` |
| `cli/lib/nftban/cli/cmd_firewall.sh` | +87 lines — `takeover` dispatch case + `firewall_takeover()` handler |
| `cli/lib/nftban/cli/cmd_update.sh` | +19 lines — argv-strip + env-mirror in `nftban_cmd_update` preamble |
| `cli/lib/nftban/tests/cmd_firewall_takeover_test.sh` | +332 lines — NEW test fixture, 21 sub-assertions |

## Mechanism unchanged

- ✅ `cmd/nftban-installer/flags.go` — **byte-identical** (regression guard test T9.1)
- ✅ `internal/installer/switchop/takeover.go` — byte-identical
- ✅ `internal/installer/restore/contract.md` — byte-identical
- ✅ `cmd/nftban-installer/**` — no Go change
- ✅ Schema 1.83.0 frozen (`internal/validator/types.go:SchemaVersionCurrent = "1.83.0"`)
- ✅ No metric / packaging / systemd / install / .github-workflow / FHS / dns2 / nftbanpro_cms / MASTER_TODO touch

The actual takeover logic is **unchanged from PR-22B** (2026-02). This PR is a discoverability surface only — registers the existing installer entry points in the central CLI registry so operators can find them via `nftban help firewall takeover` instead of needing prior knowledge of `/usr/lib/nftban/bin/nftban-installer --help`.

## How update forwarding works

`nftban update --panel-auto-takeover` flow:

1. `nftban_cmd_update` (cmd_update.sh) preamble strips `--panel-auto-takeover` from argv and exports `NFTBAN_PANEL_AUTO_TAKEOVER=1`.
2. Update dispatcher proceeds normally (github / git / local / package paths).
3. `install.sh:67` `exec`'s `nftban-installer --source --mode=install "$@"` — env is inherited.
4. `cmd/nftban-installer/flags.go:141` honors `NFTBAN_PANEL_AUTO_TAKEOVER=1` env mirror (existing PR-22B code; unchanged).

This pattern works regardless of which update path is taken because all update paths terminate at `install.sh` → `exec` `nftban-installer`.

## Test plan

- [x] `cli/lib/nftban/tests/cmd_firewall_takeover_test.sh` — 21 sub-assertions PASS in `mktemp -d` sandbox with PATH-based installer stub
  - T1 (5 sub) help output: usage, --panel-auto-takeover, --dry-run, REVERSIBLE callout, env mirror documented
  - T2 (2 sub) no-flags refusal explains gate; installer not invoked
  - T3 (2 sub) --dry-run argv includes `--mode=upgrade --dry-run`; no `--panel-auto-takeover`
  - T4 (3 sub) --panel-auto-takeover forwards mode + flag + dry-run
  - T5 (2 sub) unknown-arg refusal; installer not invoked
  - T6 (2 sub) non-root + no-dry-run refusal; installer not invoked
  - T7 (2 sub) update --panel-auto-takeover sets `NFTBAN_PANEL_AUTO_TAKEOVER=1`; absence leaves unset
  - T8 (2 sub) registry YAML structurally valid + entries present
  - T9 (1 sub) installer flags.go byte-unchanged vs main — **scope-violation regression guard**
- [x] `bash -n` syntax check passes on both edited scripts
- [x] Shellcheck delta: zero new warnings (166→166 cmd_firewall.sh, 50→50 cmd_update.sh)
- [x] `python3 -c "import yaml; yaml.safe_load(open('commands.registry.yml'))"` — YAML loads OK
- [ ] CI: 24+ workflows on PR open

## Schema frozen

- ✅ `SchemaVersionCurrent = "1.83.0"` byte-unchanged
- ✅ No `internal/contracts/schema/**` touch
- ✅ No `internal/validator/schema_generated.go` touch
- ✅ No `cli/lib/nftban/lib/nft_schema.sh` touch
- ✅ No new Prometheus metric, no new IPC method, no new HTTP route, no new Go struct

## Out of scope (recorded in scope doc §13)

- Wiki page generation may auto-regenerate from registry; if project policy commits generated artifacts, that's a follow-on. This PR is registry-source-only.
- Optional `nftban status` ambiguous-authority guidance hint (§4.D of scope doc) — deferred for cleaner reviewer surface; the registry/dispatcher path closes the primary gap on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)