### PR TITLE
ci(docker): emit deterministic 8-char short-SHA tag (V117 CAND-A)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # v1.117 D-DOCKER-SHA-LENGTH-OBSERVATION fix:
+      # docker/metadata-action@v5 does NOT honor `length=N` on `type=sha`
+      # (the attribute is parsed but ignored — v1.116.0 release evidence:
+      # `length=8` was specified yet `sha-3ea0488` 7-char was published).
+      # `type=sha,format=short` uses git's `core.abbrev` (typically 7 chars,
+      # hard-coded `context.sha.substr(0, 7)` in the action source). The
+      # documented escape hatch is `type=raw,value=...` with a pre-computed
+      # value, which is what this step + raw rule below provide.
+      - name: Compute 8-char short SHA for Docker tag
+        id: short_sha
+        run: |
+          short_sha=$(printf '%s' "${GITHUB_SHA}" | cut -c1-8)
+          printf 'SHA_SHORT=%s\n' "$short_sha" >> "$GITHUB_ENV"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
@@ -66,9 +80,12 @@ jobs:
             type=semver,pattern=v{{version}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # 8-char short SHA — restores v1.108.0-era format. Default of
-            # `type=sha` is 7-char; explicit length=8 matches git short-form.
-            type=sha,format=short,length=8
+            # 8-char short SHA via raw template — closes V117
+            # D-DOCKER-SHA-LENGTH-OBSERVATION (v1.116.0 closure §6).
+            # See the `Compute 8-char short SHA` step above for the
+            # workaround rationale (length= is silently ignored on type=sha
+            # in metadata-action@v5).
+            type=raw,value=sha-${{ env.SHA_SHORT }},enable=true,priority=100
 
       - name: Build and push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0


### PR DESCRIPTION
## Summary

Closes `D-DOCKER-SHA-LENGTH-OBSERVATION` recorded in `V1_116_0_RELEASE_CLOSURE.md` §6. Makes the Docker workflow emit the intended 8-character short-SHA tag (`sha-<8>`) instead of the 7-character default `docker/metadata-action@v5` produces for `type=sha,format=short`.

## Root cause

`docker/metadata-action@v5` **silently ignores** the `length=N` attribute on `type=sha`. The action source hard-codes `context.sha.substr(0, 7)` when `format=short` is set. v1.116.0 evidence: the workflow declared `type=sha,format=short,length=8` but the published Docker tag was `ghcr.io/itcmsgr/nftban:sha-3ea0488` (7-char, HTTP 200) — the intended `sha-3ea0488b` (8-char) returns HTTP 404 because the action did not emit that tag.

## Fix

1. Add a pre-step `Compute 8-char short SHA for Docker tag` that computes `${GITHUB_SHA:0:8}` and exports it via `$GITHUB_ENV` as `SHA_SHORT`.
2. Replace the broken `type=sha,format=short,length=8` rule with the documented `type=raw,value=sha-${{ env.SHA_SHORT }},enable=true,priority=100` escape hatch.

This is the canonical metadata-action workaround when built-in extractors don't fit. The v-prefix + non-v + major.minor semver tags from PR #626 remain unchanged.

## Scope

Bounded by `AUDIT_190_LIFECYCLE/V117_SCOPE_TRIAGE.md` (Option B). Allowed envelope: `.github/workflows/docker.yml` only.

**Diffstat:** +20 / −3 (1 file).

**Forbidden surfaces — untouched:**
- ✅ No Go change (`cmd/**`, `internal/**`, `pkg/**`)
- ✅ No shell CLI change (`cli/lib/nftban/**`)
- ✅ No registry change (`commands.registry.yml`)
- ✅ No schema / metric (`internal/contracts/schema/**`, `internal/validator/schema_generated.go`, `cli/lib/nftban/lib/nft_schema.sh`)
- ✅ No installer / takeover internals (`cmd/nftban-installer/**`, `internal/installer/**`)
- ✅ No packaging / systemd / install (`install/**`, `packaging/**`)
- ✅ No release files (`VERSION`, `STATUS.md`, `CHANGELOG.md`, `build/fhs-spec.yaml`, `cli/lib/nftban/core/nftban_fhs_spec.sh`)
- ✅ No `dns2/`, `nftbanpro_cms/`, `MASTER_TODO*`, `README.md`, `Dockerfile`, `Makefile`

## Schema frozen

- ✅ `internal/validator/types.go:SchemaVersionCurrent = "1.83.0"` byte-unchanged
- ✅ `VERSION` remains `1.116.0` (release-prep is a separate gate)
- ✅ v1.117.0 tag absent
- ✅ Prior tags untouched

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"` — YAML loads OK, 7 steps
- [x] `git diff --name-only main` → exactly `.github/workflows/docker.yml`
- [x] PR #630 takeover discoverability changes preserved on main (verified by grep)
- [ ] CI: Docker workflow runs; published image tag verified post-merge to be `sha-<8>` (8-char)
- [ ] Existing baseline-advisory triplet (OSV + health PR + health push) remains the only acceptable failures

## Expected post-merge verification (separate gate)

Once v1.117.0 publishes, the closure doc §6 observation will reflect:

```
ghcr.io/itcmsgr/nftban:sha-<8>   HTTP 200   ✅ 8-char restored
```

instead of the v1.116.0 state where only the 7-char `sha-<7>` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)