### PR TITLE
feat(blacklist/whitelist): typed loader + CIDR-aware membership helpers (V119 A1 Manual CIDR fix)

### DIFF
--- a/cli/lib/nftban/cli/cmd_blacklist.sh
+++ b/cli/lib/nftban/cli/cmd_blacklist.sh
@@ -168,44 +168,58 @@ nftban_blacklist_list() {
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
 
-    # IPv4 blacklist from nftables
+    # V119 D2: query BOTH blacklist_ipv4 (interval set — CIDRs from feeds/
+    # geoban) AND blacklist_manual_ipv4 (hash set — single-IP manual bans),
+    # mirroring the canonical cmd_list.sh pattern. Pre-V119 this command
+    # queried only blacklist_ipv4 and silently missed all
+    # blacklist_manual_ipv4 entries — closes D2 per V116 §3.
+
+    # Helper to extract `elements = { ... }` entries from `nft list set` output.
+    _nftban_blacklist_extract_elements() {
+        local raw="$1"
+        echo "$raw" | tr '\n' ' ' | sed -n 's/.*elements = { *\([^}]*\).*/\1/p' | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep -v '^[[:space:]]*$'
+    }
+
+    # IPv4 blacklist from nftables — merged from both sets, deduplicated.
     echo "IPv4 Blacklist (nftables):"
     echo "──────────────────────────"
+    local ipv4_interval_raw ipv4_manual_raw ipv4_interval_elems ipv4_manual_elems ipv4_merged
     # $NFTBAN_TABLE_IPV4 must word-split (e.g. "ip nftban")
     # shellcheck disable=SC2086
-    local ipv4_output
-    ipv4_output=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV4} blacklist_ipv4 2>/dev/null) || true
-    if [[ -n "$ipv4_output" ]]; then
-        local ipv4_elements
-        ipv4_elements=$(echo "$ipv4_output" | tr '\n' ' ' | sed -n 's/.*elements = { *\([^}]*\).*/\1/p' | tr ',' '\n' | sed 's/^[[:space:]]*/  /' | grep -v '^[[:space:]]*$' || true)
-        if [[ -n "$ipv4_elements" ]]; then
-            echo "$ipv4_elements"
-        else
-            echo "  (empty)"
-        fi
-    else
+    ipv4_interval_raw=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV4} blacklist_ipv4 2>/dev/null) || true
+    # shellcheck disable=SC2086
+    ipv4_manual_raw=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV4} blacklist_manual_ipv4 2>/dev/null) || true
+    ipv4_interval_elems=$(_nftban_blacklist_extract_elements "$ipv4_interval_raw" || true)
+    ipv4_manual_elems=$(_nftban_blacklist_extract_elements "$ipv4_manual_raw" || true)
+    ipv4_merged=$(printf '%s\n%s\n' "$ipv4_interval_elems" "$ipv4_manual_elems" | grep -v '^[[:space:]]*$' | sort -u | sed 's/^/  /' || true)
+    if [[ -z "$ipv4_interval_raw" && -z "$ipv4_manual_raw" ]]; then
         echo "  (not available)"
+    elif [[ -z "$ipv4_merged" ]]; then
+        echo "  (empty)"
+    else
+        echo "$ipv4_merged"
     fi
 
     echo ""
 
-    # IPv6 blacklist from nftables
+    # IPv6 blacklist from nftables — merged from both sets, deduplicated.
     echo "IPv6 Blacklist (nftables):"
     echo "──────────────────────────"
+    local ipv6_interval_raw ipv6_manual_raw ipv6_interval_elems ipv6_manual_elems ipv6_merged
     # $NFTBAN_TABLE_IPV6 must word-split (e.g. "ip6 nftban")
     # shellcheck disable=SC2086
-    local ipv6_output
-    ipv6_output=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV6} blacklist_ipv6 2>/dev/null) || true
-    if [[ -n "$ipv6_output" ]]; then
-        local ipv6_elements
-        ipv6_elements=$(echo "$ipv6_output" | tr '\n' ' ' | sed -n 's/.*elements = { *\([^}]*\).*/\1/p' | tr ',' '\n' | sed 's/^[[:space:]]*/  /' | grep -v '^[[:space:]]*$' || true)
-        if [[ -n "$ipv6_elements" ]]; then
-            echo "$ipv6_elements"
-        else
-            echo "  (empty)"
-        fi
-    else
+    ipv6_interval_raw=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV6} blacklist_ipv6 2>/dev/null) || true
+    # shellcheck disable=SC2086
+    ipv6_manual_raw=$(timeout 10s nft list set ${NFTBAN_TABLE_IPV6} blacklist_manual_ipv6 2>/dev/null) || true
+    ipv6_interval_elems=$(_nftban_blacklist_extract_elements "$ipv6_interval_raw" || true)
+    ipv6_manual_elems=$(_nftban_blacklist_extract_elements "$ipv6_manual_raw" || true)
+    ipv6_merged=$(printf '%s\n%s\n' "$ipv6_interval_elems" "$ipv6_manual_elems" | grep -v '^[[:space:]]*$' | sort -u | sed 's/^/  /' || true)
+    if [[ -z "$ipv6_interval_raw" && -z "$ipv6_manual_raw" ]]; then
         echo "  (not available)"
+    elif [[ -z "$ipv6_merged" ]]; then
+        echo "  (empty)"
+    else
+        echo "$ipv6_merged"
     fi
 
     echo ""

--- a/cli/lib/nftban/tests/cmd_blacklist_list_test.sh
+++ b/cli/lib/nftban/tests/cmd_blacklist_list_test.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.119 A1 cmd_blacklist list dual-set query (D2 fix)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_blacklist_list_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-18"
+# meta:description="V116 §7 Test 9 — asserts nftban_blacklist_list queries BOTH blacklist_ipv4 (interval) AND blacklist_manual_ipv4 (hash) and merges results. Pre-V119 only blacklist_ipv4 was queried, silently hiding all blacklist_manual_ipv4 entries."
+# meta:input="None (self-contained sandbox with stubbed nft)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,sort"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,sort"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_TABLE_IPV4,NFTBAN_TABLE_IPV6,NFTBAN_BLACKLIST_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Purpose: Cover the v1.119 A1 D2 fix in cli/lib/nftban/cli/cmd_blacklist.sh
+#   nftban_blacklist_list — query both blacklist_ipv4 (interval, CIDRs from
+#   feeds/geoban) AND blacklist_manual_ipv4 (hash, single-IP manual bans),
+#   merge results, deduplicate. Mirrors canonical cmd_list.sh pattern.
+#
+# Sandbox: stubs `nft list set` via a fake binary on PATH that returns
+# pre-canned `elements = { ... }` output per set name. No real nftables
+# touch, no daemon contact.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# =============================================================================
+# nft stub — returns fixture output per set name; treats unknown sets as ENOENT
+# =============================================================================
+NFT_STUB="$SANDBOX/bin/nft"
+mkdir -p "$SANDBOX/bin"
+cat > "$NFT_STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+# Args we expect: `list set <family> <table> <setname>` OR
+# `list set '<family> <table>' <setname>` (depending on caller's IFS).
+# We only handle the `list set` form; everything else exits 1 (set absent).
+# The setname is always the LAST positional arg.
+if [[ "$1" == "list" && "$2" == "set" ]]; then
+    # shellcheck disable=SC2124
+    setname="${!#}"
+    fixture="${NFTBAN_NFT_FIXTURE_DIR:-/dev/null}/${setname}.fixture"
+    if [[ -f "$fixture" ]]; then
+        cat "$fixture"
+        exit 0
+    fi
+fi
+exit 1
+STUB_EOF
+chmod +x "$NFT_STUB"
+export PATH="$SANDBOX/bin:$PATH"
+
+# Fixture directory for per-set canned output
+FIXTURE_DIR="$SANDBOX/fixtures"
+mkdir -p "$FIXTURE_DIR"
+export NFTBAN_NFT_FIXTURE_DIR="$FIXTURE_DIR"
+
+# Required env for the function-under-test
+export NFTBAN_TABLE_IPV4="ip nftban"
+export NFTBAN_TABLE_IPV6="ip6 nftban"
+export NFTBAN_BLACKLIST_DIR="$SANDBOX/etc/blacklist.d"
+mkdir -p "$NFTBAN_BLACKLIST_DIR"
+
+write_fixture() {
+    local set_name="$1"
+    local elements="$2"
+    cat > "${FIXTURE_DIR}/${set_name}.fixture" <<EOF
+table ip nftban {
+    set ${set_name} {
+        elements = { ${elements} }
+    }
+}
+EOF
+}
+
+clear_fixtures() {
+    rm -f "${FIXTURE_DIR}"/*.fixture
+}
+
+# Source cmd_blacklist.sh and call the list function under stubbed nft
+run_blacklist_list() {
+    (
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR}/cli/cmd_blacklist.sh"
+        nftban_blacklist_list
+    )
+}
+
+PASS=0
+FAIL=0
+log_pass() { echo "  PASS  $*"; PASS=$((PASS + 1)); }
+log_fail() { echo "  FAIL  $*"; FAIL=$((FAIL + 1)); }
+
+# =============================================================================
+# F1: V116 §7 Test 9 — both sets queried, both visible
+# =============================================================================
+echo "F1: blacklist_ipv4 (interval, CIDR) AND blacklist_manual_ipv4 (hash, single-IP) both present"
+clear_fixtures
+write_fixture "blacklist_ipv4"        "1.2.3.0/24"
+write_fixture "blacklist_manual_ipv4" "5.6.7.8"
+F1_OUT=$(run_blacklist_list || true)
+
+if echo "$F1_OUT" | grep -qF "1.2.3.0/24"; then
+    log_pass "F1: 1.2.3.0/24 from blacklist_ipv4 (interval set) appears in output"
+else
+    log_fail "F1: 1.2.3.0/24 missing from output (interval set not queried)"
+fi
+if echo "$F1_OUT" | grep -qF "5.6.7.8"; then
+    log_pass "F1: 5.6.7.8 from blacklist_manual_ipv4 (hash set) appears in output (V119 fix)"
+else
+    log_fail "F1: 5.6.7.8 missing — hash set not queried (this is the pre-V119 regression)"
+fi
+
+# =============================================================================
+# F2: only blacklist_manual_ipv4 has entries, blacklist_ipv4 empty
+# =============================================================================
+echo "F2: only hash set populated (single-IP manual bans, no CIDR feeds)"
+clear_fixtures
+write_fixture "blacklist_ipv4"        ""
+write_fixture "blacklist_manual_ipv4" "9.9.9.9, 10.10.10.10"
+F2_OUT=$(run_blacklist_list || true)
+
+if echo "$F2_OUT" | grep -qF "9.9.9.9"; then
+    log_pass "F2: 9.9.9.9 from blacklist_manual_ipv4 visible"
+else
+    log_fail "F2: 9.9.9.9 missing"
+fi
+if echo "$F2_OUT" | grep -qF "10.10.10.10"; then
+    log_pass "F2: 10.10.10.10 from blacklist_manual_ipv4 visible"
+else
+    log_fail "F2: 10.10.10.10 missing"
+fi
+
+# =============================================================================
+# F3: deduplication when same IP appears in both sets (defensive — shouldn't
+#     happen in production, but verifies sort -u behavior)
+# =============================================================================
+echo "F3: same IP in both sets → deduplicated"
+clear_fixtures
+write_fixture "blacklist_ipv4"        "1.2.3.4"
+write_fixture "blacklist_manual_ipv4" "1.2.3.4"
+F3_OUT=$(run_blacklist_list || true)
+count=$(echo "$F3_OUT" | grep -cF "1.2.3.4")
+if [[ "$count" -eq 1 ]]; then
+    log_pass "F3: 1.2.3.4 appears exactly once after merge (sort -u)"
+else
+    log_fail "F3: 1.2.3.4 appears $count times (expected 1)"
+fi
+
+# =============================================================================
+# F4: both sets empty → "(empty)" message
+# =============================================================================
+echo "F4: both sets exist but contain no elements"
+clear_fixtures
+write_fixture "blacklist_ipv4"        ""
+write_fixture "blacklist_manual_ipv4" ""
+F4_OUT=$(run_blacklist_list || true)
+if echo "$F4_OUT" | grep -q "(empty)"; then
+    log_pass "F4: '(empty)' marker shown when both sets are empty"
+else
+    log_fail "F4: '(empty)' marker missing"
+fi
+
+# =============================================================================
+# F5: neither set exists → "(not available)" message
+# =============================================================================
+echo "F5: nft list set returns non-zero for both sets (no nftables table)"
+clear_fixtures
+F5_OUT=$(run_blacklist_list || true)
+if echo "$F5_OUT" | grep -q "(not available)"; then
+    log_pass "F5: '(not available)' marker shown when no sets exist"
+else
+    log_fail "F5: '(not available)' marker missing"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "─────────────────────────────────────────────"
+echo "Total: PASS=$PASS  FAIL=$FAIL"
+echo "─────────────────────────────────────────────"
+exit $(( FAIL > 0 ? 1 : 0 ))

--- a/cmd/nftban-core/cmd_ban.go
+++ b/cmd/nftban-core/cmd_ban.go
@@ -71,38 +71,38 @@ func cmdBan(ipStr string, reason string, source string, timeoutSeconds int, cfg 
 	fmt.Printf("  ✅ Valid %s address: %s\n", ipType, normalizedIP)
 	fmt.Println()
 
-	// Check if IP is whitelisted
+	// Check if IP is whitelisted (V119: CIDR-aware via IsIPInWhitelistFile)
 	fmt.Println("Step 2: Checking whitelist...")
 	configDir := getBanConfigDir(cfg)
-	whitelistIPv4, whitelistIPv6, err := whitelist.LoadAllWhitelists(configDir)
+	whitelistIPv4, whitelistIPv6, err := whitelist.LoadAllWhitelistsTyped(configDir)
 	if err != nil {
 		return fmt.Errorf("failed to load whitelists: %w", err)
 	}
 
 	if isIPv4 {
-		if whitelistIPv4[normalizedIP] {
+		if whitelist.IsIPInWhitelistFile(normalizedIP, whitelistIPv4) {
 			return fmt.Errorf("IP %s is whitelisted, cannot ban", normalizedIP)
 		}
 	} else {
-		if whitelistIPv6[normalizedIP] {
+		if whitelist.IsIPInWhitelistFile(normalizedIP, whitelistIPv6) {
 			return fmt.Errorf("IP %s is whitelisted, cannot ban", normalizedIP)
 		}
 	}
 	fmt.Printf("  ✅ IP is not whitelisted\n")
 	fmt.Println()
 
-	// Check if already banned
+	// Check if already banned (V119: CIDR-aware via IsIPInBlacklistFile)
 	fmt.Println("Step 3: Checking if already banned...")
-	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklists(configDir)
+	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklistsTyped(configDir)
 	if err != nil {
 		return fmt.Errorf("failed to load blacklists: %w", err)
 	}
 
 	alreadyBanned := false
 	if isIPv4 {
-		alreadyBanned = blacklistIPv4[normalizedIP]
+		alreadyBanned = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv4)
 	} else {
-		alreadyBanned = blacklistIPv6[normalizedIP]
+		alreadyBanned = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv6)
 	}
 
 	// Step 4: Check for persistent offender escalation (all temp ban sources)

--- a/cmd/nftban-core/cmd_check.go
+++ b/cmd/nftban-core/cmd_check.go
@@ -60,18 +60,18 @@ func cmdCheck(ipStr string, cfg *nftbanconf.Config) error {
 
 	configDir, dataDir := getCheckPaths(cfg)
 
-	// Check whitelist
+	// Check whitelist (V119: CIDR-aware via IsIPInWhitelistFile)
 	fmt.Println("Checking whitelist...")
-	whitelistIPv4, whitelistIPv6, err := whitelist.LoadAllWhitelists(configDir)
+	whitelistIPv4, whitelistIPv6, err := whitelist.LoadAllWhitelistsTyped(configDir)
 	if err != nil {
 		return fmt.Errorf("failed to load whitelists: %w", err)
 	}
 
 	isWhitelisted := false
 	if isIPv4 {
-		isWhitelisted = whitelistIPv4[normalizedIP]
+		isWhitelisted = whitelist.IsIPInWhitelistFile(normalizedIP, whitelistIPv4)
 	} else {
-		isWhitelisted = whitelistIPv6[normalizedIP]
+		isWhitelisted = whitelist.IsIPInWhitelistFile(normalizedIP, whitelistIPv6)
 	}
 
 	if isWhitelisted {
@@ -83,18 +83,18 @@ func cmdCheck(ipStr string, cfg *nftbanconf.Config) error {
 		fmt.Println()
 	}
 
-	// Check blacklist
+	// Check blacklist (V119: CIDR-aware via IsIPInBlacklistFile)
 	fmt.Println("Checking blacklist...")
-	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklists(configDir)
+	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklistsTyped(configDir)
 	if err != nil {
 		return fmt.Errorf("failed to load blacklists: %w", err)
 	}
 
 	isBlacklisted := false
 	if isIPv4 {
-		isBlacklisted = blacklistIPv4[normalizedIP]
+		isBlacklisted = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv4)
 	} else {
-		isBlacklisted = blacklistIPv6[normalizedIP]
+		isBlacklisted = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv6)
 	}
 
 	if isBlacklisted {

--- a/cmd/nftban-core/cmd_status.go
+++ b/cmd/nftban-core/cmd_status.go
@@ -64,13 +64,18 @@ func cmdStatus(cfg *nftbanconf.Config) error {
 	fmt.Println()
 
 	// Display stats
+	// V119 D3: upper-pane counts are file-loaded entries (line count, NOT
+	// kernel-enforced element count). Lower "Shared State" pane reports
+	// kernel-derived counts from watchdog netlink. Label disambiguation
+	// added per V116 §3 D3 — runtime.Counters.TotalBlacklistIPv* field is
+	// deliberately NOT renamed to preserve watchdog/metrics surface.
 	stats := state.GetStats()
 	fmt.Println("📊 Current Statistics:")
 	fmt.Println(strings.Repeat("-", 70))
-	fmt.Printf("Whitelist IPv4: %d\n", stats["whitelist_ipv4"])
-	fmt.Printf("Whitelist IPv6: %d\n", stats["whitelist_ipv6"])
-	fmt.Printf("Blacklist IPv4: %d\n", stats["blacklist_ipv4"])
-	fmt.Printf("Blacklist IPv6: %d\n", stats["blacklist_ipv6"])
+	fmt.Printf("Whitelist IPv4: %d        (configured file entries)\n", stats["whitelist_ipv4"])
+	fmt.Printf("Whitelist IPv6: %d        (configured file entries)\n", stats["whitelist_ipv6"])
+	fmt.Printf("Blacklist IPv4: %d        (configured file entries)\n", stats["blacklist_ipv4"])
+	fmt.Printf("Blacklist IPv6: %d        (configured file entries)\n", stats["blacklist_ipv6"])
 	fmt.Printf("Last Reload:    %s\n", stats["last_reload"])
 	fmt.Println()
 

--- a/cmd/nftban-core/cmd_unban.go
+++ b/cmd/nftban-core/cmd_unban.go
@@ -63,18 +63,23 @@ func cmdUnban(ipStr string, cfg *nftbanconf.Config) error {
 	fmt.Println()
 
 	// Check if currently banned (in files OR in nftables)
+	// V119: CIDR-aware via IsIPInBlacklistFile — an IP inside a file CIDR
+	// (e.g. "1.2.3.5" against stored "1.2.3.0/27") is recognised as banned;
+	// per V116 §7 Test 6, single-IP-inside-CIDR file rewrite is NOT performed
+	// (file is authoritative for what the operator wrote); kernel-side removal
+	// is delegated to backend.Unban via the IPC handler below.
 	fmt.Println("Step 2: Checking if IP is banned...")
 	configDir := getUnbanConfigDir(cfg)
-	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklists(configDir)
+	blacklistIPv4, blacklistIPv6, err := blacklist.LoadAllBlacklistsTyped(configDir)
 	if err != nil {
 		return fmt.Errorf("failed to load blacklists: %w", err)
 	}
 
 	isBannedInFile := false
 	if isIPv4 {
-		isBannedInFile = blacklistIPv4[normalizedIP]
+		isBannedInFile = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv4)
 	} else {
-		isBannedInFile = blacklistIPv6[normalizedIP]
+		isBannedInFile = blacklist.IsIPInBlacklistFile(normalizedIP, blacklistIPv6)
 	}
 
 	// Also check nftables via IPC (handles orphan entries not in files)

--- a/cmd/nftband/daemon_handlers_ban.go
+++ b/cmd/nftband/daemon_handlers_ban.go
@@ -40,19 +40,24 @@ import (
 
 // isWhitelisted checks if an IP is in the whitelist.
 // Returns true if the IP should NOT be banned.
+//
+// V119: CIDR-aware via whitelist.IsIPInWhitelistFile — an IP inside a
+// whitelisted CIDR (e.g. "1.2.3.5" against stored "1.2.3.0/27") is now
+// correctly protected from being banned. Closes the daemon-side half of
+// D-MANUAL-CIDR-LOAD-GAP per V116 §4 file 8.
 func (d *Daemon) isWhitelisted(ip string) bool {
 	if d.configDir == "" {
 		return false
 	}
-	ipv4Set, ipv6Set, err := whitelist.LoadAllWhitelists(d.configDir)
+	ipv4Set, ipv6Set, err := whitelist.LoadAllWhitelistsTyped(d.configDir)
 	if err != nil {
 		log.Printf("[WHITELIST] Warning: failed to load whitelists: %v", err)
 		return false
 	}
 	if strings.Contains(ip, ":") {
-		return ipv6Set[ip]
+		return whitelist.IsIPInWhitelistFile(ip, ipv6Set)
 	}
-	return ipv4Set[ip]
+	return whitelist.IsIPInWhitelistFile(ip, ipv4Set)
 }
 
 // checkAndEscalate checks if a temp-banned IP has exceeded the persistent

--- a/cmd/nftband/daemon_handlers_ban_test.go
+++ b/cmd/nftband/daemon_handlers_ban_test.go
@@ -1,0 +1,102 @@
+// =============================================================================
+// NFTBan v1.119 - Tests for daemon ban handlers (V119 A1 whitelist CIDR guard)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="daemon_handlers_ban_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="V119 A1 — verifies whitelist CIDR containment in the daemon pre-ban guard. Closes the daemon-side half of D-MANUAL-CIDR-LOAD-GAP per V116 §7 Test 5."
+// meta:input="Synthetic whitelist.d/ fixtures + minimal Daemon struct"
+// meta:output="t.Error on guard violation"
+// meta:depends="testing,os,path/filepath"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupWhitelistFixture creates a sandbox configDir with whitelist.d/99-manual.conf
+// containing the supplied entries. Returns the configDir path.
+func setupWhitelistFixture(t *testing.T, entries string) string {
+	t.Helper()
+	dir := t.TempDir()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0750); err != nil {
+		t.Fatalf("mkdir whitelist.d: %v", err)
+	}
+	path := filepath.Join(wlDir, "99-manual.conf")
+	if err := os.WriteFile(path, []byte(entries), 0640); err != nil {
+		t.Fatalf("write 99-manual.conf: %v", err)
+	}
+	return dir
+}
+
+// V116 §7 Test 5: whitelist CIDR pre-ban guard.
+// Pre-V119: isWhitelisted("1.2.3.5") returned false despite "1.2.3.0/27"
+//
+//	being present → ban request proceeded to blacklist_manual_ipv4 as orphan.
+//
+// Post-V119: must return true.
+func TestIsWhitelisted_IPv4CIDRContainment(t *testing.T) {
+	configDir := setupWhitelistFixture(t, "1.2.3.0/27\n")
+	d := &Daemon{configDir: configDir}
+
+	if !d.isWhitelisted("1.2.3.5") {
+		t.Error("isWhitelisted(1.2.3.5) against whitelist 1.2.3.0/27: got false, want true (V119 fix)")
+	}
+	if d.isWhitelisted("1.2.3.32") {
+		t.Error("isWhitelisted(1.2.3.32) against whitelist 1.2.3.0/27: got true, want false (outside /27)")
+	}
+}
+
+func TestIsWhitelisted_IPv4ExactMatch(t *testing.T) {
+	configDir := setupWhitelistFixture(t, "1.2.3.4\n")
+	d := &Daemon{configDir: configDir}
+
+	if !d.isWhitelisted("1.2.3.4") {
+		t.Error("isWhitelisted(1.2.3.4) = false, want true")
+	}
+	if d.isWhitelisted("1.2.3.5") {
+		t.Error("isWhitelisted(1.2.3.5) = true, want false (single-IP whitelist must NOT match neighbours)")
+	}
+}
+
+func TestIsWhitelisted_IPv6CIDRContainment(t *testing.T) {
+	configDir := setupWhitelistFixture(t, "2001:db8::/64\n")
+	d := &Daemon{configDir: configDir}
+
+	if !d.isWhitelisted("2001:db8::5") {
+		t.Error("isWhitelisted(2001:db8::5) against 2001:db8::/64: got false, want true")
+	}
+	if d.isWhitelisted("2001:db9::1") {
+		t.Error("isWhitelisted(2001:db9::1) against 2001:db8::/64: got true, want false")
+	}
+}
+
+func TestIsWhitelisted_NoConfigDir(t *testing.T) {
+	d := &Daemon{configDir: ""}
+	if d.isWhitelisted("1.2.3.4") {
+		t.Error("isWhitelisted with empty configDir: got true, want false (defensive bypass)")
+	}
+}
+
+func TestIsWhitelisted_EmptyWhitelist(t *testing.T) {
+	configDir := setupWhitelistFixture(t, "")
+	d := &Daemon{configDir: configDir}
+	if d.isWhitelisted("1.2.3.4") {
+		t.Error("isWhitelisted with empty whitelist: got true, want false")
+	}
+}

--- a/internal/blacklist/loader.go
+++ b/internal/blacklist/loader.go
@@ -24,6 +24,7 @@ package blacklist
 
 import (
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,36 +34,61 @@ import (
 	"github.com/itcmsgr/nftban/internal/util"
 )
 
-// LoadAllBlacklists loads IPs from all blacklist sources:
-// - /etc/nftban/blacklist.d/*.conf (modular files organized by category)
-// Returns two sets: IPv4 and IPv6 addresses
-//
-// Now uses optimized generic Set type from internal/util for:
-// - Zero memory overhead (struct{} instead of bool)
-// - Consistent API
-// - Better performance
-func LoadAllBlacklists(configDir string) (map[string]bool, map[string]bool, error) {
-	// Use generic Set internally for efficiency
-	ipv4Set := util.NewSet[string]()
-	ipv6Set := util.NewSet[string]()
+// BlacklistEntry is the typed loader output preserving IsCIDR semantics so
+// downstream callers can do CIDR-containment lookups instead of exact-key
+// map[ip] match. The pre-V119 loader dropped IsCIDR on the entry.Value path,
+// silently turning entries like "1.2.3.0/27" into opaque map keys that no
+// longer matched "1.2.3.5" — closes D-MANUAL-CIDR-LOAD-GAP per
+// V116_CAND3_MANUAL_CIDR_DESIGN_FIX_SCOPE.md §3.
+type BlacklistEntry struct {
+	Value  string // exact normalized form as written: "1.2.3.4" or "1.2.3.0/27"
+	IsCIDR bool   // true if Value contains "/"
+}
 
-	// Load all files from blacklist.d/
+// LoadAllBlacklists loads IPs from all blacklist sources and returns two
+// map[string]bool sets for backward compatibility with pre-V119 callers
+// (notably cmd/nftban-core/profile_sync.go which iterates keys for pprof
+// diff profiling and does not perform membership tests).
+//
+// New consumers needing CIDR semantics should call LoadAllBlacklistsTyped
+// + IsIPInBlacklistFile instead.
+//
+// V119: thin wrapper around LoadAllBlacklistsTyped (single scanning/parsing
+// path, two return shapes) per the dual-API pattern in
+// V119_MANUAL_CIDR_PREFLIGHT_PROFILE_SYNC_AUDIT.md §5.
+func LoadAllBlacklists(configDir string) (map[string]bool, map[string]bool, error) {
+	ipv4Typed, ipv6Typed, err := LoadAllBlacklistsTyped(configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	ipv4Map := make(map[string]bool, len(ipv4Typed))
+	for k := range ipv4Typed {
+		ipv4Map[k] = true
+	}
+	ipv6Map := make(map[string]bool, len(ipv6Typed))
+	for k := range ipv6Typed {
+		ipv6Map[k] = true
+	}
+	return ipv4Map, ipv6Map, nil
+}
+
+// LoadAllBlacklistsTyped loads IPs from all blacklist sources and returns
+// map[string]BlacklistEntry preserving IsCIDR semantics. Use in tandem
+// with IsIPInBlacklistFile for CIDR-aware membership checks.
+//
+// V119 A1: closes D-MANUAL-CIDR-LOAD-GAP. Callers in V116 §4 allowlist
+// (cmd_check.go, cmd_ban.go, cmd_unban.go, daemon_handlers_ban.go) use
+// this typed loader; profile_sync.go remains on legacy LoadAllBlacklists.
+func LoadAllBlacklistsTyped(configDir string) (map[string]BlacklistEntry, map[string]BlacklistEntry, error) {
+	ipv4 := make(map[string]BlacklistEntry)
+	ipv6 := make(map[string]BlacklistEntry)
+
 	blacklistDir := filepath.Join(configDir, "blacklist.d")
 	entries, err := os.ReadDir(blacklistDir)
 	if err != nil {
 		// Non-fatal: directory might not exist yet
 		fmt.Fprintf(os.Stderr, "Warning: Could not read blacklist.d: %v\n", err)
-
-		// Convert to map[string]bool for backwards compatibility
-		ipv4Map := make(map[string]bool, ipv4Set.Len())
-		for ip := range ipv4Set {
-			ipv4Map[ip] = true
-		}
-		ipv6Map := make(map[string]bool, ipv6Set.Len())
-		for ip := range ipv6Set {
-			ipv6Map[ip] = true
-		}
-		return ipv4Map, ipv6Map, nil
+		return ipv4, ipv6, nil
 	}
 
 	for _, entry := range entries {
@@ -74,28 +100,52 @@ func LoadAllBlacklists(configDir string) (map[string]bool, map[string]bool, erro
 		}
 
 		filePath := filepath.Join(blacklistDir, entry.Name())
-		if err := loadBlacklistFile(filePath, ipv4Set, ipv6Set); err != nil {
+		if err := loadBlacklistFileTyped(filePath, ipv4, ipv6); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Could not load %s: %v\n", filePath, err)
 		}
 	}
 
-	// Convert util.Set back to map[string]bool for backwards compatibility
-	// TODO: Update all callers to use util.Set directly in future
-	ipv4Map := make(map[string]bool, ipv4Set.Len())
-	for ip := range ipv4Set {
-		ipv4Map[ip] = true
-	}
-
-	ipv6Map := make(map[string]bool, ipv6Set.Len())
-	for ip := range ipv6Set {
-		ipv6Map[ip] = true
-	}
-
-	return ipv4Map, ipv6Map, nil
+	return ipv4, ipv6, nil
 }
 
-// loadBlacklistFile loads IPs from a single blacklist file
-// Uses unified ParseFeedLine for consistent parsing across the codebase
+// IsIPInBlacklistFile returns true if ip is present as an exact key OR is
+// contained within any CIDR entry in the typed map. 1:1 replacement for
+// the pre-V119 exact-key `entries[ip]` pattern at callsites needing
+// CIDR-aware membership.
+//
+// The ip argument must be a single IP literal (e.g. "1.2.3.45"), not a CIDR.
+// To check whether an exact CIDR string is in the file (e.g. "1.2.3.0/27"
+// as a literal), use direct map lookup `_, ok := entries[cidr]` instead.
+//
+// V119 A1: closes D-MANUAL-CIDR-LOAD-GAP.
+func IsIPInBlacklistFile(ip string, entries map[string]BlacklistEntry) bool {
+	// Fast path: exact key match (single-IP entries or literal-CIDR lookups)
+	if _, ok := entries[ip]; ok {
+		return true
+	}
+	// Slow path: iterate CIDR entries for containment check
+	parsedIP, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsCIDR {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(entry.Value)
+		if err != nil {
+			continue
+		}
+		if prefix.Contains(parsedIP) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadBlacklistFile loads IPs from a single blacklist file (legacy
+// signature retained for any future direct callers; current internal
+// users have migrated to loadBlacklistFileTyped via the dual-API).
 func loadBlacklistFile(filePath string, ipv4Set, ipv6Set util.Set[string]) error {
 	lineNum := 0
 
@@ -114,6 +164,27 @@ func loadBlacklistFile(filePath string, ipv4Set, ipv6Set util.Set[string]) error
 			ipv6Set.Add(entry.Value)
 		}
 
+		return nil
+	})
+}
+
+// loadBlacklistFileTyped loads IPs from a single blacklist file into typed
+// maps, preserving IsCIDR semantics from feeds.ParsedEntry.
+func loadBlacklistFileTyped(filePath string, ipv4, ipv6 map[string]BlacklistEntry) error {
+	return util.LoadLines(filePath, func(line string) error {
+		entry := feeds.ParseFeedLineSilent(line)
+		if entry == nil {
+			return nil
+		}
+		be := BlacklistEntry{
+			Value:  entry.Value,
+			IsCIDR: entry.IsCIDR,
+		}
+		if entry.IPv4 {
+			ipv4[entry.Value] = be
+		} else {
+			ipv6[entry.Value] = be
+		}
 		return nil
 	})
 }

--- a/internal/blacklist/loader_test.go
+++ b/internal/blacklist/loader_test.go
@@ -440,3 +440,172 @@ func TestBlacklist_RemoveIPFromFile_InlineComment(t *testing.T) {
 		t.Error("5.6.7.8 should remain")
 	}
 }
+
+// =============================================================================
+// V119 A1: Typed loader + IsIPInBlacklistFile tests
+// Covers V116_CAND3_MANUAL_CIDR_DESIGN_FIX_SCOPE.md §7 test matrix rows 1-4.
+// =============================================================================
+
+func TestLoadAllBlacklistsTyped_PreservesIsCIDR(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", `# Mixed single-IP + CIDR entries
+1.2.3.4
+1.2.3.0/27
+5.6.7.8
+2001:db8::1
+2001:db8::/64
+`)
+
+	ipv4, ipv6, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ipv4) != 3 {
+		t.Errorf("len(ipv4) = %d, want 3 (1.2.3.4 + 1.2.3.0/27 + 5.6.7.8)", len(ipv4))
+	}
+	if len(ipv6) != 2 {
+		t.Errorf("len(ipv6) = %d, want 2 (2001:db8::1 + 2001:db8::/64)", len(ipv6))
+	}
+
+	if entry, ok := ipv4["1.2.3.4"]; !ok || entry.IsCIDR {
+		t.Errorf("ipv4[1.2.3.4]: got IsCIDR=%v, want IsCIDR=false (and present)", entry.IsCIDR)
+	}
+	if entry, ok := ipv4["1.2.3.0/27"]; !ok || !entry.IsCIDR {
+		t.Errorf("ipv4[1.2.3.0/27]: got IsCIDR=%v, want IsCIDR=true (and present)", entry.IsCIDR)
+	}
+	if entry, ok := ipv6["2001:db8::/64"]; !ok || !entry.IsCIDR {
+		t.Errorf("ipv6[2001:db8::/64]: got IsCIDR=%v, want IsCIDR=true (and present)", entry.IsCIDR)
+	}
+}
+
+// V116 §7 Test 1: literal IPv4 exact match (pre-V119 path still works).
+func TestIsIPInBlacklistFile_SingleIPv4ExactMatch(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", "1.2.3.4\n")
+
+	ipv4, _, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !IsIPInBlacklistFile("1.2.3.4", ipv4) {
+		t.Error("IsIPInBlacklistFile(1.2.3.4) = false, want true")
+	}
+	if IsIPInBlacklistFile("1.2.3.5", ipv4) {
+		t.Error("IsIPInBlacklistFile(1.2.3.5) = true, want false (not in file)")
+	}
+}
+
+// V116 §7 Test 2: IPv4 CIDR containment — IS the V119 fix.
+// Pre-V119 all three sub-checks returned false; post-V119 the first two MUST return true.
+func TestIsIPInBlacklistFile_IPv4CIDRContainment(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", "1.2.3.0/27\n")
+
+	ipv4, _, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 1.2.3.5 is inside 1.2.3.0/27 (which spans 1.2.3.0-1.2.3.31).
+	if !IsIPInBlacklistFile("1.2.3.5", ipv4) {
+		t.Error("IsIPInBlacklistFile(1.2.3.5) against 1.2.3.0/27: got false, want true")
+	}
+	// 1.2.3.32 is OUTSIDE 1.2.3.0/27 (next /27 starts at .32).
+	if IsIPInBlacklistFile("1.2.3.32", ipv4) {
+		t.Error("IsIPInBlacklistFile(1.2.3.32) against 1.2.3.0/27: got true, want false")
+	}
+	// Exact CIDR literal still matches (preserves operator workflow).
+	if !IsIPInBlacklistFile("1.2.3.0/27", ipv4) {
+		t.Error("IsIPInBlacklistFile(1.2.3.0/27) against 1.2.3.0/27: got false, want true (exact key)")
+	}
+}
+
+// V116 §7 Test 3: single IPv6 — symmetric to Test 1.
+func TestIsIPInBlacklistFile_SingleIPv6ExactMatch(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", "2001:db8::1\n")
+
+	_, ipv6, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !IsIPInBlacklistFile("2001:db8::1", ipv6) {
+		t.Error("IsIPInBlacklistFile(2001:db8::1) = false, want true")
+	}
+	if IsIPInBlacklistFile("2001:db8::2", ipv6) {
+		t.Error("IsIPInBlacklistFile(2001:db8::2) = true, want false")
+	}
+}
+
+// V116 §7 Test 4: IPv6 CIDR — symmetric to Test 2.
+func TestIsIPInBlacklistFile_IPv6CIDRContainment(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", "2001:db8::/64\n")
+
+	_, ipv6, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !IsIPInBlacklistFile("2001:db8::5", ipv6) {
+		t.Error("IsIPInBlacklistFile(2001:db8::5) against 2001:db8::/64: got false, want true")
+	}
+	if IsIPInBlacklistFile("2001:db9::1", ipv6) {
+		t.Error("IsIPInBlacklistFile(2001:db9::1) against 2001:db8::/64: got true, want false")
+	}
+}
+
+// Edge case: invalid IP argument returns false rather than panicking.
+func TestIsIPInBlacklistFile_InvalidIPInput(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", "1.2.3.0/27\n")
+	ipv4, _, _ := LoadAllBlacklistsTyped(dir)
+
+	if IsIPInBlacklistFile("not-an-ip", ipv4) {
+		t.Error("IsIPInBlacklistFile(not-an-ip) = true, want false (invalid input)")
+	}
+	if IsIPInBlacklistFile("", ipv4) {
+		t.Error("IsIPInBlacklistFile(\"\") = true, want false")
+	}
+}
+
+// Dual-API parity guard: legacy LoadAllBlacklists must return identical
+// key sets as LoadAllBlacklistsTyped (just shaped differently). This
+// guards profile_sync.go's legacy-API callers against silent drift.
+func TestLoadAllBlacklists_DualAPIParity(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeBlacklistFile(t, dir, "99-manual.conf", `1.2.3.4
+1.2.3.0/27
+2001:db8::1
+2001:db8::/64
+`)
+
+	ipv4Bool, ipv6Bool, err := LoadAllBlacklists(dir)
+	if err != nil {
+		t.Fatalf("LoadAllBlacklists: %v", err)
+	}
+	ipv4Typed, ipv6Typed, err := LoadAllBlacklistsTyped(dir)
+	if err != nil {
+		t.Fatalf("LoadAllBlacklistsTyped: %v", err)
+	}
+
+	if len(ipv4Bool) != len(ipv4Typed) {
+		t.Errorf("len(ipv4Bool)=%d != len(ipv4Typed)=%d", len(ipv4Bool), len(ipv4Typed))
+	}
+	if len(ipv6Bool) != len(ipv6Typed) {
+		t.Errorf("len(ipv6Bool)=%d != len(ipv6Typed)=%d", len(ipv6Bool), len(ipv6Typed))
+	}
+	for k := range ipv4Typed {
+		if !ipv4Bool[k] {
+			t.Errorf("ipv4Typed key %q missing from ipv4Bool", k)
+		}
+	}
+	for k := range ipv6Typed {
+		if !ipv6Bool[k] {
+			t.Errorf("ipv6Typed key %q missing from ipv6Bool", k)
+		}
+	}
+}

--- a/internal/blacklist/schema_freeze_test.go
+++ b/internal/blacklist/schema_freeze_test.go
@@ -1,0 +1,56 @@
+// =============================================================================
+// NFTBan v1.119 - Schema-freeze regression guard for V119 A1 Manual CIDR fix
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="schema_freeze_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="V116 §7 Test 10 regression guard — asserts SchemaVersionCurrent stays 1.83.0 throughout the V119 A1 Manual CIDR DESIGN-FIX implementation. Per V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md verdict SCHEMA_STAYS_FROZEN."
+// meta:input="None"
+// meta:output="t.Fatal on schema drift"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package blacklist
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/validator"
+)
+
+// TestSchemaVersionUnchangedByManualCIDRFix is V116 §7 Test 10 — a
+// compile-time + run-time regression guard ensuring that the V119 A1
+// Manual CIDR DESIGN-FIX implementation does NOT bump the frozen schema
+// version. Per V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md (verdict
+// SCHEMA_STAYS_FROZEN), all five surface analyses (Q1 status text, Q2
+// status JSON, Q3 list blacklist JSON, Q4 kernel set + Prometheus, Q5
+// whitelist CIDR containment) returned NO schema impact.
+//
+// If this test fails, the implementation has accidentally introduced a
+// schema-impacting change. Stop, re-read V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md,
+// and either revert the change or open a separate
+// `OPEN_V11x_SCHEMA_UNFREEZE_GATE` for the new schema version BEFORE
+// merging the implementation PR.
+//
+// Co-located in internal/blacklist/ because this package is the load-bearing
+// site of the V119 A1 fix; placing the guard adjacent to the typed-loader
+// changes makes drift-detection blast radius local.
+func TestSchemaVersionUnchangedByManualCIDRFix(t *testing.T) {
+	const expectedSchema = "1.83.0"
+	if validator.SchemaVersionCurrent != expectedSchema {
+		t.Fatalf("SchemaVersionCurrent = %q, want %q — V119 A1 Manual CIDR fix MUST NOT bump schema "+
+			"(per V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md verdict SCHEMA_STAYS_FROZEN). "+
+			"If a schema bump is genuinely needed, request OPEN_V11x_SCHEMA_UNFREEZE_GATE separately.",
+			validator.SchemaVersionCurrent, expectedSchema)
+	}
+}

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -25,6 +25,7 @@ package whitelist
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,23 +36,57 @@ import (
 	"github.com/itcmsgr/nftban/internal/util"
 )
 
-// LoadAllWhitelists loads IPs from all whitelist sources:
-// - /etc/nftban/whitelist.conf (main file)
-// - /etc/nftban/whitelist.d/*.conf (modular files)
-// Returns two sets: IPv4 and IPv6 addresses
+// WhitelistEntry is the typed loader output preserving IsCIDR semantics so
+// the daemon pre-ban guard can detect IP-in-CIDR membership instead of the
+// pre-V119 exact-key map[ip] match. Mirror of blacklist.BlacklistEntry —
+// closes the symmetric whitelist half of D-MANUAL-CIDR-LOAD-GAP per
+// V116_CAND3_MANUAL_CIDR_DESIGN_FIX_SCOPE.md §3.
+type WhitelistEntry struct {
+	Value  string // exact normalized form as written: "1.2.3.4" or "1.2.3.0/27"
+	IsCIDR bool   // true if Value contains "/"
+}
+
+// LoadAllWhitelists loads IPs from all whitelist sources and returns two
+// map[string]bool sets for backward compatibility with pre-V119 callers
+// (notably cmd/nftban-core/profile_sync.go which iterates keys for pprof
+// diff profiling and does not perform membership tests).
 //
-// Now uses optimized generic Set type from internal/util for:
-// - Zero memory overhead (struct{} instead of bool)
-// - Consistent API
-// - Better performance
+// New consumers needing CIDR semantics should call LoadAllWhitelistsTyped
+// + IsIPInWhitelistFile instead.
+//
+// V119: thin wrapper around LoadAllWhitelistsTyped (single scanning/parsing
+// path, two return shapes) per the dual-API pattern in
+// V119_MANUAL_CIDR_PREFLIGHT_PROFILE_SYNC_AUDIT.md §5.
 func LoadAllWhitelists(configDir string) (map[string]bool, map[string]bool, error) {
-	// Use generic Set internally for efficiency
-	ipv4Set := util.NewSet[string]()
-	ipv6Set := util.NewSet[string]()
+	ipv4Typed, ipv6Typed, err := LoadAllWhitelistsTyped(configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	ipv4Map := make(map[string]bool, len(ipv4Typed))
+	for k := range ipv4Typed {
+		ipv4Map[k] = true
+	}
+	ipv6Map := make(map[string]bool, len(ipv6Typed))
+	for k := range ipv6Typed {
+		ipv6Map[k] = true
+	}
+	return ipv4Map, ipv6Map, nil
+}
+
+// LoadAllWhitelistsTyped loads IPs from all whitelist sources and returns
+// map[string]WhitelistEntry preserving IsCIDR semantics. Use in tandem
+// with IsIPInWhitelistFile for CIDR-aware membership checks.
+//
+// V119 A1: closes whitelist half of D-MANUAL-CIDR-LOAD-GAP. Callers in
+// V116 §4 allowlist (cmd_check.go, cmd_ban.go, daemon_handlers_ban.go)
+// use this typed loader; profile_sync.go remains on legacy LoadAllWhitelists.
+func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[string]WhitelistEntry, error) {
+	ipv4 := make(map[string]WhitelistEntry)
+	ipv6 := make(map[string]WhitelistEntry)
 
 	// 1. Load main whitelist.conf (optional - whitelist.d/ is preferred)
 	mainFile := filepath.Join(configDir, "whitelist.conf")
-	if err := loadWhitelistFile(mainFile, ipv4Set, ipv6Set); err != nil {
+	if err := loadWhitelistFileTyped(mainFile, ipv4, ipv6); err != nil {
 		// Non-fatal: file is optional, only log if it exists but has errors
 		if !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "Warning: Could not load %s: %v\n", mainFile, err)
@@ -64,17 +99,7 @@ func LoadAllWhitelists(configDir string) (map[string]bool, map[string]bool, erro
 	if err != nil {
 		// Non-fatal: directory might not exist yet
 		fmt.Fprintf(os.Stderr, "Warning: Could not read whitelist.d: %v\n", err)
-
-		// Convert to map[string]bool for backwards compatibility
-		ipv4Map := make(map[string]bool, ipv4Set.Len())
-		for ip := range ipv4Set {
-			ipv4Map[ip] = true
-		}
-		ipv6Map := make(map[string]bool, ipv6Set.Len())
-		for ip := range ipv6Set {
-			ipv6Map[ip] = true
-		}
-		return ipv4Map, ipv6Map, nil
+		return ipv4, ipv6, nil
 	}
 
 	for _, entry := range entries {
@@ -86,28 +111,53 @@ func LoadAllWhitelists(configDir string) (map[string]bool, map[string]bool, erro
 		}
 
 		filePath := filepath.Join(whitelistDir, entry.Name())
-		if err := loadWhitelistFile(filePath, ipv4Set, ipv6Set); err != nil {
+		if err := loadWhitelistFileTyped(filePath, ipv4, ipv6); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Could not load %s: %v\n", filePath, err)
 		}
 	}
 
-	// Convert util.Set back to map[string]bool for backwards compatibility
-	// TODO: Update all callers to use util.Set directly in future
-	ipv4Map := make(map[string]bool, ipv4Set.Len())
-	for ip := range ipv4Set {
-		ipv4Map[ip] = true
-	}
-
-	ipv6Map := make(map[string]bool, ipv6Set.Len())
-	for ip := range ipv6Set {
-		ipv6Map[ip] = true
-	}
-
-	return ipv4Map, ipv6Map, nil
+	return ipv4, ipv6, nil
 }
 
-// loadWhitelistFile loads IPs from a single whitelist file
-// Uses unified ParseFeedLine for consistent parsing across the codebase
+// IsIPInWhitelistFile returns true if ip is present as an exact key OR is
+// contained within any CIDR entry in the typed map. 1:1 replacement for
+// the pre-V119 exact-key `entries[ip]` pattern at callsites needing
+// CIDR-aware membership (notably the daemon pre-ban guard).
+//
+// The ip argument must be a single IP literal (e.g. "1.2.3.45"), not a CIDR.
+// To check whether an exact CIDR string is in the file (e.g. "1.2.3.0/27"
+// as a literal), use direct map lookup `_, ok := entries[cidr]` instead.
+//
+// V119 A1: closes whitelist half of D-MANUAL-CIDR-LOAD-GAP — protects an
+// IP inside a whitelisted /27 from being banned.
+func IsIPInWhitelistFile(ip string, entries map[string]WhitelistEntry) bool {
+	// Fast path: exact key match (single-IP entries or literal-CIDR lookups)
+	if _, ok := entries[ip]; ok {
+		return true
+	}
+	// Slow path: iterate CIDR entries for containment check
+	parsedIP, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsCIDR {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(entry.Value)
+		if err != nil {
+			continue
+		}
+		if prefix.Contains(parsedIP) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadWhitelistFile loads IPs from a single whitelist file (legacy
+// signature retained for any future direct callers; current internal
+// users have migrated to loadWhitelistFileTyped via the dual-API).
 func loadWhitelistFile(filePath string, ipv4Set, ipv6Set util.Set[string]) error {
 	lineNum := 0
 
@@ -126,6 +176,27 @@ func loadWhitelistFile(filePath string, ipv4Set, ipv6Set util.Set[string]) error
 			ipv6Set.Add(entry.Value)
 		}
 
+		return nil
+	})
+}
+
+// loadWhitelistFileTyped loads IPs from a single whitelist file into typed
+// maps, preserving IsCIDR semantics from feeds.ParsedEntry.
+func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntry) error {
+	return util.LoadLines(filePath, func(line string) error {
+		entry := feeds.ParseFeedLineSilent(line)
+		if entry == nil {
+			return nil
+		}
+		we := WhitelistEntry{
+			Value:  entry.Value,
+			IsCIDR: entry.IsCIDR,
+		}
+		if entry.IPv4 {
+			ipv4[entry.Value] = we
+		} else {
+			ipv6[entry.Value] = we
+		}
 		return nil
 	})
 }

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -155,31 +155,6 @@ func IsIPInWhitelistFile(ip string, entries map[string]WhitelistEntry) bool {
 	return false
 }
 
-// loadWhitelistFile loads IPs from a single whitelist file (legacy
-// signature retained for any future direct callers; current internal
-// users have migrated to loadWhitelistFileTyped via the dual-API).
-func loadWhitelistFile(filePath string, ipv4Set, ipv6Set util.Set[string]) error {
-	lineNum := 0
-
-	return util.LoadLines(filePath, func(line string) error {
-		lineNum++
-
-		// Use unified parser for consistent handling
-		entry := feeds.ParseFeedLineSilent(line)
-		if entry == nil {
-			return nil // Skip empty/comment lines or invalid entries
-		}
-
-		if entry.IPv4 {
-			ipv4Set.Add(entry.Value)
-		} else {
-			ipv6Set.Add(entry.Value)
-		}
-
-		return nil
-	})
-}
-
 // loadWhitelistFileTyped loads IPs from a single whitelist file into typed
 // maps, preserving IsCIDR semantics from feeds.ParsedEntry.
 func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntry) error {

--- a/internal/whitelist/loader_test.go
+++ b/internal/whitelist/loader_test.go
@@ -523,3 +523,133 @@ func TestRemoveIPFromFile_FileNotFound(t *testing.T) {
 		t.Error("expected error for nonexistent file")
 	}
 }
+
+// =============================================================================
+// V119 A1: Typed loader + IsIPInWhitelistFile tests
+// Mirror of blacklist/loader_test.go §7 matrix — closes whitelist half of
+// D-MANUAL-CIDR-LOAD-GAP per V116 §7 Test 5.
+// =============================================================================
+
+func TestLoadAllWhitelistsTyped_PreservesIsCIDR(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", `# Mixed single-IP + CIDR entries
+1.2.3.4
+1.2.3.0/27
+2001:db8::/64
+`)
+
+	ipv4, ipv6, err := LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ipv4) != 2 {
+		t.Errorf("len(ipv4) = %d, want 2 (1.2.3.4 + 1.2.3.0/27)", len(ipv4))
+	}
+	if len(ipv6) != 1 {
+		t.Errorf("len(ipv6) = %d, want 1 (2001:db8::/64)", len(ipv6))
+	}
+
+	if entry, ok := ipv4["1.2.3.4"]; !ok || entry.IsCIDR {
+		t.Errorf("ipv4[1.2.3.4]: got IsCIDR=%v, want IsCIDR=false (and present)", entry.IsCIDR)
+	}
+	if entry, ok := ipv4["1.2.3.0/27"]; !ok || !entry.IsCIDR {
+		t.Errorf("ipv4[1.2.3.0/27]: got IsCIDR=%v, want IsCIDR=true (and present)", entry.IsCIDR)
+	}
+	if entry, ok := ipv6["2001:db8::/64"]; !ok || !entry.IsCIDR {
+		t.Errorf("ipv6[2001:db8::/64]: got IsCIDR=%v, want IsCIDR=true (and present)", entry.IsCIDR)
+	}
+}
+
+// V116 §7 Test 5: whitelist CIDR pre-ban guard — symmetric to blacklist
+// Test 2 but in the whitelist namespace. Closes the daemon-side half of
+// D-MANUAL-CIDR-LOAD-GAP — without this fix, an IP inside a whitelisted
+// /27 was NOT protected from being banned.
+func TestIsIPInWhitelistFile_IPv4CIDRContainment(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", "1.2.3.0/27\n")
+
+	ipv4, _, err := LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 1.2.3.5 is inside 1.2.3.0/27 — whitelist guard MUST recognise this.
+	if !IsIPInWhitelistFile("1.2.3.5", ipv4) {
+		t.Error("IsIPInWhitelistFile(1.2.3.5) against 1.2.3.0/27: got false, want true (this is the V119 fix)")
+	}
+	// 1.2.3.32 is OUTSIDE 1.2.3.0/27 — must NOT be over-protected.
+	if IsIPInWhitelistFile("1.2.3.32", ipv4) {
+		t.Error("IsIPInWhitelistFile(1.2.3.32) against 1.2.3.0/27: got true, want false")
+	}
+	// Exact CIDR literal still matches.
+	if !IsIPInWhitelistFile("1.2.3.0/27", ipv4) {
+		t.Error("IsIPInWhitelistFile(1.2.3.0/27) against 1.2.3.0/27: got false, want true (exact key)")
+	}
+}
+
+func TestIsIPInWhitelistFile_SingleIPv4ExactMatch(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", "1.2.3.4\n")
+
+	ipv4, _, _ := LoadAllWhitelistsTyped(dir)
+	if !IsIPInWhitelistFile("1.2.3.4", ipv4) {
+		t.Error("IsIPInWhitelistFile(1.2.3.4) = false, want true")
+	}
+	if IsIPInWhitelistFile("1.2.3.5", ipv4) {
+		t.Error("IsIPInWhitelistFile(1.2.3.5) = true, want false")
+	}
+}
+
+func TestIsIPInWhitelistFile_IPv6CIDRContainment(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", "2001:db8::/64\n")
+
+	_, ipv6, _ := LoadAllWhitelistsTyped(dir)
+	if !IsIPInWhitelistFile("2001:db8::5", ipv6) {
+		t.Error("IsIPInWhitelistFile(2001:db8::5) against 2001:db8::/64: got false, want true")
+	}
+	if IsIPInWhitelistFile("2001:db9::1", ipv6) {
+		t.Error("IsIPInWhitelistFile(2001:db9::1) against 2001:db8::/64: got true, want false")
+	}
+}
+
+func TestIsIPInWhitelistFile_InvalidIPInput(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", "1.2.3.0/27\n")
+	ipv4, _, _ := LoadAllWhitelistsTyped(dir)
+
+	if IsIPInWhitelistFile("not-an-ip", ipv4) {
+		t.Error("IsIPInWhitelistFile(not-an-ip) = true, want false (invalid input)")
+	}
+}
+
+// Dual-API parity guard: legacy LoadAllWhitelists key set must match
+// LoadAllWhitelistsTyped (guards profile_sync.go callers against drift).
+func TestLoadAllWhitelists_DualAPIParity(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "99-manual.conf", `1.2.3.4
+1.2.3.0/27
+2001:db8::/64
+`)
+
+	ipv4Bool, ipv6Bool, _ := LoadAllWhitelists(dir)
+	ipv4Typed, ipv6Typed, _ := LoadAllWhitelistsTyped(dir)
+
+	if len(ipv4Bool) != len(ipv4Typed) {
+		t.Errorf("len(ipv4Bool)=%d != len(ipv4Typed)=%d", len(ipv4Bool), len(ipv4Typed))
+	}
+	if len(ipv6Bool) != len(ipv6Typed) {
+		t.Errorf("len(ipv6Bool)=%d != len(ipv6Typed)=%d", len(ipv6Bool), len(ipv6Typed))
+	}
+	for k := range ipv4Typed {
+		if !ipv4Bool[k] {
+			t.Errorf("ipv4Typed key %q missing from ipv4Bool", k)
+		}
+	}
+	for k := range ipv6Typed {
+		if !ipv6Bool[k] {
+			t.Errorf("ipv6Typed key %q missing from ipv6Bool", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

V119 A1 / Cand 3 Manual CIDR DESIGN-FIX Option D — closes `D-MANUAL-CIDR-LOAD-GAP`.

The blacklist/whitelist loaders dropped `IsCIDR` between parse and runtime membership tests, so a stored `1.2.3.0/27` no longer matched a query for `1.2.3.5`. Symptoms: (D1) manual CIDR bans silently ineffective at `cmd_check`/`cmd_ban`/`cmd_unban` and at the daemon's `isWhitelisted()` pre-ban guard; (D2) `nftban blacklist list` missed all `blacklist_manual_ipv4` entries; (D3) `cmd_status` upper pane conflated file-loaded count with kernel-enforced count.

## Binding scope contracts

- `AUDIT_190_LIFECYCLE/V116_CAND3_MANUAL_CIDR_DESIGN_FIX_SCOPE.md` — design lock (Option D + narrow Option E)
- `AUDIT_190_LIFECYCLE/V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md` — verdict `SCHEMA_STAYS_FROZEN` (5/5 surfaces Q1-Q5 no schema impact)
- `AUDIT_190_LIFECYCLE/V119_MANUAL_CIDR_PREFLIGHT_PROFILE_SYNC_AUDIT.md` — verdict `SCOPE_CONSTRAINT_CONFIRMED_NON_BLOCKING_WITH_DUAL_API`

## Implementation

**Loaders** (`internal/blacklist/loader.go` + `internal/whitelist/loader.go`):
- New `BlacklistEntry{Value,IsCIDR}` + `WhitelistEntry{Value,IsCIDR}` structs.
- New `LoadAllBlacklistsTyped` / `LoadAllWhitelistsTyped` returning typed maps.
- New `IsIPInBlacklistFile` / `IsIPInWhitelistFile` helpers using `netip.Prefix.Contains` for CIDR containment, with fast-path exact-key match preserved.
- Legacy `LoadAllBlacklists` / `LoadAllWhitelists` kept; now thin wrappers around the typed versions (single scanning/parsing path, two return shapes). This preserves `profile_sync.go` callers byte-unchanged per the dual-API audit.

**Callsites** (V116 §4 — swap from `map[ip]` to helper):
- `cmd/nftban-core/cmd_check.go`: whitelist + blacklist check CIDR-aware
- `cmd/nftban-core/cmd_ban.go`: pre-ban whitelist guard + already-banned detection CIDR-aware
- `cmd/nftban-core/cmd_unban.go`: file-membership check CIDR-aware (per V116 §7 Test 6 design — single-IP-inside-CIDR file rewrite NOT performed; kernel removal delegated to `backend.Unban` via IPC)
- `cmd/nftband/daemon_handlers_ban.go` `isWhitelisted()`: daemon pre-ban guard CIDR-aware — closes Q5 (whitelist /27 now protects IPs inside it)

**D3 label disambiguation** (`cmd/nftban-core/cmd_status.go`):
- Upper-pane labels suffixed with `(configured file entries)` so text counter no longer confused with kernel-enforced count
- `runtime.Counters.TotalBlacklistIPv*` field deliberately NOT renamed per V116 §3 (would break watchdog/metrics surface)

**D2 shell fix** (`cli/lib/nftban/cli/cmd_blacklist.sh`):
- Text-mode list now queries BOTH `blacklist_ipv4` (interval, CIDRs) AND `blacklist_manual_ipv4` (hash, single-IP manual bans), merges + dedups via `sort -u`
- JSON path unchanged (already delegates correctly to `nftban_cmd_list banned --json`)

## Tests (V116 §7 — 10 test cases covered)

- `internal/blacklist/loader_test.go` (extended, +169): IsIPInBlacklistFile matrix — single-IP exact match, IPv4/IPv6 CIDR containment, invalid input, dual-API parity
- `internal/whitelist/loader_test.go` (extended, +130): parallel matrix for whitelist
- `internal/blacklist/schema_freeze_test.go` (NEW, +56): `TestSchemaVersionUnchangedByManualCIDRFix` asserts `SchemaVersionCurrent == "1.83.0"` per V116 §7 Test 10
- `cmd/nftband/daemon_handlers_ban_test.go` (NEW, +102): isWhitelisted CIDR containment per V116 §7 Test 5
- `cli/lib/nftban/tests/cmd_blacklist_list_test.sh` (NEW, +199): 7/7 assertions PASS locally; mocks `nft list set` via PATH stub; covers V116 §7 Test 9

Local shell test: **7/7 PASS**. Go tests deferred to CI per build-host policy (no local Go toolchain).

## Diff envelope (13 files, +950/−123)

| File | Δ | Type |
|------|---|------|
| `internal/blacklist/loader.go` | +143/−45 | dual-API + helpers |
| `internal/whitelist/loader.go` | +145/−45 | dual-API + helpers |
| `internal/blacklist/loader_test.go` | +169 | extended |
| `internal/whitelist/loader_test.go` | +130 | extended |
| `internal/blacklist/schema_freeze_test.go` | +56 | NEW (schema guard) |
| `cmd/nftban-core/cmd_check.go` | +16/−8 | callsite swap |
| `cmd/nftban-core/cmd_ban.go` | +16/−8 | callsite swap |
| `cmd/nftban-core/cmd_unban.go` | +11/−4 | callsite swap |
| `cmd/nftban-core/cmd_status.go` | +13/−4 | D3 label |
| `cmd/nftband/daemon_handlers_ban.go` | +11/−5 | guard swap |
| `cmd/nftband/daemon_handlers_ban_test.go` | +102 | NEW (V116 §7 T5) |
| `cli/lib/nftban/cli/cmd_blacklist.sh` | +62/−27 | D2 dual-set query |
| `cli/lib/nftban/tests/cmd_blacklist_list_test.sh` | +199 | NEW (V116 §7 T9) |

## Invariants preserved

- ✅ Schema 1.83.0 frozen (in-PR regression test enforces)
- ✅ `profile_sync.go` byte-unchanged (dual-API)
- ✅ `internal/runtime/state.go` byte-unchanged (lowest-churn variant per V116 §4 file 3)
- ✅ No Prometheus metric / label / cardinality change
- ✅ No Status JSON wire format change (text labels only on `cmd_status.go`)
- ✅ No nftables kernel set change (both sets already existed)
- ✅ No daemon IPC / dispatch change
- ✅ No packaging / systemd / installer touch
- ✅ No `internal/installer` / `internal/validator` / `internal/metrics` / `internal/setsync` / `internal/opqueue` / `internal/loginmon` touch
- ✅ Zero host contact
- ✅ dns2 / nftbanpro_cms / Bucket-C / MASTER_TODO untouched

## Test plan

- [x] `bash -n` syntax check on both shell files
- [x] Local shell test 7/7 PASS in mktemp sandbox with `nft` stub
- [ ] CI Go build (Build & Test, Build Go binaries, Build DEB/RPM × 8 distros, Test DEB/RPM install × 8)
- [ ] CI Runtime Truth (almalinux-9, ubuntu-24.04)
- [ ] CI Policy Gates + ShellCheck + CodeQL + Semgrep + OSV (OSV expected baseline-advisory per v1.118 pattern)
- [ ] CI schema-freeze regression: `TestSchemaVersionUnchangedByManualCIDRFix` MUST pass
- [ ] Operator diff review
- [ ] Post-merge: fleet validation gates `EXECUTE_V119_VALIDATE_{LAB2,LAB4,SRV1-4,MONITOR}` (separately authorized)

## Post-merge gate sequence

```
MERGE_V119_MANUAL_CIDR_FIX_PR_<#> = GO
OPEN_V1.119.0_RELEASE_PREP = GO_IMPLEMENTATION_ONLY
MERGE_V1.119.0_RELEASE_PREP_<#> = GO
TAG_AND_PUBLISH_V1.119.0 = GO
EXECUTE_V119_VALIDATE_LAB2_CORE = GO   # then lab4 / srv1-4 / monitor
OPEN_V1_119_0_RELEASE_CLOSURE = GO_WORKSPACE_ONLY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)