### PR TITLE
feat(safety/whitelist/cli): V120 operator temp whitelist guard (D-UPDATE-OPERATOR-SELF-BAN-GAP-001)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -270,12 +270,477 @@ nftban_cmd_firewall() {
             shift
             firewall_takeover "$@"
             ;;
+        whitelist-session)
+            shift
+            firewall_whitelist_session "$@"
+            ;;
         *)
             echo "ERROR: Unknown firewall subcommand: $subcommand" >&2
             echo "Try 'nftban firewall help' for more information." >&2
             return 1
             ;;
     esac
+}
+
+# =============================================================================
+# SUBCOMMAND: WHITELIST-SESSION (v1.120 — D-UPDATE-OPERATOR-SELF-BAN-GAP-001)
+# =============================================================================
+# Manage time-bounded operator-session whitelist entries in
+# /etc/nftban/whitelist.d/00-session.conf. Each entry carries an inline
+# `# EXPIRES_AT=<RFC3339>` marker; the whitelist loader (v1.119 CIDR-aware,
+# extended in v1.120) skips expired entries at load time.
+#
+# v1.120 ships text-mode only. The `--json` flag is REJECTED with an
+# operator-actionable error message per V120_OPERATOR_TEMP_WHITELIST_
+# SCHEMA_IMPACT_DECISION.md §4 amendment (deferred to v1.121 pending the
+# Q2 schema-envelope question).
+firewall_whitelist_session() {
+    local action="${1:-}"
+    [[ -n "$action" ]] && shift
+
+    # V120 §4 amendment: reject --json early at every entry point.
+    # The loop below checks ALL remaining args for --json or -j and refuses.
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --json|-j)
+                cat >&2 <<'JSON_REFUSE_EOF'
+ERROR: --json output for `nftban firewall whitelist-session` is NOT supported in v1.120.
+
+Per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md, JSON output for
+this new subcommand was deferred from v1.120 pending an operator decision
+on whether new top-level CLI subcommand JSON falls under the M81-6 Status
+JSON wire-format freeze envelope. v1.120 supports TEXT MODE only.
+
+If you need machine-readable output, parse the text-mode `list` output OR
+read /etc/nftban/whitelist.d/00-session.conf directly (one entry per line,
+inline `# EXPIRES_AT=<RFC3339>  REASON=<...>  ADDED_BY=<...>` markers).
+
+JSON support is planned for v1.121 if/when the schema decision is locked.
+JSON_REFUSE_EOF
+                return 2
+                ;;
+        esac
+    done
+
+    case "$action" in
+        add)        _whitelist_session_add "$@" ;;
+        list)       _whitelist_session_list "$@" ;;
+        remove|rm)  _whitelist_session_remove "$@" ;;
+        cleanup)    _whitelist_session_cleanup "$@" ;;
+        -h|--help|help|"")
+            cat <<'HELP_EOF'
+Usage: nftban firewall whitelist-session <action> [args]
+
+Manage time-bounded operator-session whitelist entries.
+
+Actions:
+  add <ip-or-cidr> --ttl <duration> [--reason <text>]
+      Add a temporary whitelist entry with EXPIRES_AT = now + ttl.
+      Duration format: 30m, 1h, 1h30m, 24h, etc. (Go's time.ParseDuration).
+      Re-adding the same IP REFRESHES the entry (does not duplicate).
+      Calls `nftban firewall reload` to make the entry effective immediately.
+
+  list
+      Show all non-expired session entries: IP | TTL remaining | Reason | Added-By.
+      Text-mode only; --json deferred to v1.121 (see V120 schema decision).
+
+  remove <ip-or-cidr>
+      Delete the entry for the given IP from 00-session.conf and reload.
+
+  cleanup
+      Manually remove all expired entries from 00-session.conf.
+      (The loader skips expired entries at load time regardless; this is
+      file-hygiene only.)
+
+Notes:
+  - This file is machine-managed: do NOT hand-edit /etc/nftban/whitelist.d/00-session.conf.
+  - Permanent operator entries belong in 99-manual.conf (NOT this file).
+  - Static host-interface entries belong in 00-system.conf (NOT this file).
+  - Requires root (writes /etc/nftban/whitelist.d/).
+
+V120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): closes the operator self-ban gap by
+ensuring `nftban update` / `firewall takeover` / validation workflows
+auto-seed the operator's SSH peer IP into this file with a bounded TTL.
+This subcommand is the explicit operator-override for cases where
+auto-seed cannot detect the right IP (multi-hop SSH, sudo chains, etc.).
+
+HELP_EOF
+            return 0
+            ;;
+        *)
+            echo "ERROR: Unknown whitelist-session action: $action" >&2
+            echo "Try 'nftban firewall whitelist-session help' for usage." >&2
+            return 1
+            ;;
+    esac
+}
+
+# Internal helper: 00-session.conf path
+_NFTBAN_SESSION_WHITELIST_PATH="/etc/nftban/whitelist.d/00-session.conf"
+
+# Internal helper: validate IP or CIDR. Returns 0 if valid, 1 otherwise.
+# Uses basic bash regex; not as strict as Go's net.ParseIP but catches
+# obvious garbage. Real validation happens at whitelist-load time.
+_whitelist_session_validate_ip() {
+    local v="$1"
+    # IPv4: a.b.c.d optionally /N
+    [[ "$v" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?$ ]] && return 0
+    # IPv6: very loose pattern (full validation is the loader's job)
+    [[ "$v" =~ ^[0-9a-fA-F:]+(/[0-9]{1,3})?$ && "$v" == *:* ]] && return 0
+    return 1
+}
+
+# Internal helper: convert TTL like "30m" / "1h" / "1h30m" to seconds.
+# Returns the integer count of seconds on stdout, or 1 on parse error.
+_whitelist_session_ttl_seconds() {
+    local ttl="$1"
+    if [[ -z "$ttl" ]]; then
+        echo "0"; return 1
+    fi
+    local total=0
+    local rest="$ttl"
+    while [[ -n "$rest" ]]; do
+        if [[ "$rest" =~ ^([0-9]+)h(.*)$ ]]; then
+            total=$(( total + ${BASH_REMATCH[1]} * 3600 ))
+            rest="${BASH_REMATCH[2]}"
+        elif [[ "$rest" =~ ^([0-9]+)m(.*)$ ]]; then
+            total=$(( total + ${BASH_REMATCH[1]} * 60 ))
+            rest="${BASH_REMATCH[2]}"
+        elif [[ "$rest" =~ ^([0-9]+)s(.*)$ ]]; then
+            total=$(( total + ${BASH_REMATCH[1]} ))
+            rest="${BASH_REMATCH[2]}"
+        elif [[ "$rest" =~ ^([0-9]+)$ ]]; then
+            # bare integer = seconds
+            total=$(( total + ${BASH_REMATCH[1]} ))
+            rest=""
+        else
+            echo "0"; return 1
+        fi
+    done
+    echo "$total"
+    return 0
+}
+
+# Internal: ensure 00-session.conf has the canonical header on first write.
+_whitelist_session_ensure_header() {
+    [[ -f "$_NFTBAN_SESSION_WHITELIST_PATH" ]] && return 0
+    mkdir -p "$(dirname "$_NFTBAN_SESSION_WHITELIST_PATH")"
+    cat > "$_NFTBAN_SESSION_WHITELIST_PATH" <<'SESSION_HEADER_EOF'
+# =============================================================================
+# NFTBan Session Whitelist (managed by nftban; do not hand-edit)
+# =============================================================================
+#
+# Time-bounded operator-session entries with inline EXPIRES_AT TTL.
+# Expired entries are skipped at whitelist-load time. Use:
+#   nftban firewall whitelist-session add <ip> --ttl 30m
+#   nftban firewall whitelist-session list
+#   nftban firewall whitelist-session remove <ip>
+#   nftban firewall whitelist-session cleanup
+#
+# Permanent operator entries: 99-manual.conf  (NOT this file)
+# Static host-interface entries: 00-system.conf  (NOT this file)
+#
+# =============================================================================
+
+SESSION_HEADER_EOF
+    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+}
+
+_whitelist_session_add() {
+    local ip=""
+    local ttl=""
+    local reason="operator-explicit"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --ttl)     ttl="$2"; shift 2 ;;
+            --reason)  reason="$2"; shift 2 ;;
+            -h|--help) _whitelist_session_add_help; return 0 ;;
+            -*)        echo "ERROR: Unknown flag: $1" >&2; return 1 ;;
+            *)
+                if [[ -z "$ip" ]]; then
+                    ip="$1"; shift
+                else
+                    echo "ERROR: Unexpected argument: $1" >&2
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$ip" || -z "$ttl" ]]; then
+        echo "ERROR: <ip> and --ttl are required" >&2
+        _whitelist_session_add_help
+        return 1
+    fi
+
+    if ! _whitelist_session_validate_ip "$ip"; then
+        echo "ERROR: Invalid IP or CIDR: $ip" >&2
+        return 1
+    fi
+
+    local ttl_sec
+    ttl_sec=$(_whitelist_session_ttl_seconds "$ttl") || {
+        echo "ERROR: Invalid --ttl value: $ttl (use formats like 30m, 1h, 1h30m)" >&2
+        return 1
+    }
+    if [[ "$ttl_sec" -le 0 ]]; then
+        echo "ERROR: --ttl must be > 0" >&2
+        return 1
+    fi
+
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        return 1
+    fi
+
+    _whitelist_session_ensure_header
+
+    local expires_at
+    expires_at=$(date -u -d "@$(( $(date -u +%s) + ttl_sec ))" '+%Y-%m-%dT%H:%M:%SZ')
+
+    # Remove any prior entry for the same IP (refresh semantics).
+    local tmp
+    tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+    # shellcheck disable=SC2016
+    awk -v ip="$ip" '
+        # Drop entry lines whose first token equals ip
+        {
+            t = $0
+            # Strip leading whitespace
+            gsub(/^[ \t]+/, "", t)
+            # If line starts with # or is empty, keep as-is
+            if (t == "" || substr(t, 1, 1) == "#") { print; next }
+            # Take first whitespace-delimited token; strip trailing comment
+            split(t, a, "#")
+            n = split(a[1], b, /[ \t]+/)
+            if (n >= 1 && b[1] == ip) next   # drop
+            print
+        }
+    ' "$_NFTBAN_SESSION_WHITELIST_PATH" > "$tmp"
+
+    # Append the new entry.
+    printf '%s  # EXPIRES_AT=%s  REASON=%s  ADDED_BY=nftban-firewall-whitelist-session\n' \
+        "$ip" "$expires_at" "$reason" >> "$tmp"
+
+    # Atomic rename.
+    mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
+    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+
+    echo "Added: $ip  (expires $expires_at, reason=$reason)"
+
+    # Trigger reload so the daemon picks up the new entry immediately.
+    if command -v nftban >/dev/null 2>&1; then
+        nftban firewall reload >/dev/null 2>&1 || true
+    fi
+    return 0
+}
+
+_whitelist_session_add_help() {
+    cat <<'HELP_EOF'
+Usage: nftban firewall whitelist-session add <ip-or-cidr> --ttl <duration> [--reason <text>]
+
+Add a time-bounded whitelist entry for the operator-session.
+
+Required:
+  <ip-or-cidr>           IPv4 or IPv6 address, optionally with CIDR suffix.
+  --ttl <duration>       Time-to-live: 30m, 1h, 1h30m, 24h, 3600s, etc.
+
+Optional:
+  --reason <text>        Short description (default: "operator-explicit").
+
+Examples:
+  nftban firewall whitelist-session add 62.38.150.122 --ttl 30m
+  nftban firewall whitelist-session add 192.168.1.0/24 --ttl 1h --reason "office VPN"
+HELP_EOF
+}
+
+_whitelist_session_list() {
+    if [[ ! -f "$_NFTBAN_SESSION_WHITELIST_PATH" ]]; then
+        echo "(no session whitelist entries — file absent)"
+        return 0
+    fi
+
+    local now_unix
+    now_unix=$(date -u +%s)
+
+    local count=0
+    printf '%-22s %-12s %-30s %s\n' "IP/CIDR" "TTL-LEFT" "REASON" "ADDED-BY"
+    printf '%-22s %-12s %-30s %s\n' "----------------------" "------------" "------------------------------" "--------"
+
+    local line
+    while IFS= read -r line; do
+        # Skip blank and comment lines (header)
+        local trimmed="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$trimmed" ]] && continue
+        [[ "$trimmed" =~ ^# ]] && continue
+
+        # Extract IP token (first whitespace-delimited field before #)
+        local before_hash="${line%%#*}"
+        local ip
+        # shellcheck disable=SC2086
+        ip=$(echo $before_hash | awk '{print $1}')
+        [[ -z "$ip" ]] && continue
+
+        # Extract EXPIRES_AT, REASON, ADDED_BY from the comment portion
+        local expires_at="" reason="-" added_by="-"
+        if [[ "$line" == *EXPIRES_AT=* ]]; then
+            expires_at=$(echo "$line" | grep -oE 'EXPIRES_AT=[^ ]+' | head -1 | cut -d= -f2)
+        fi
+        if [[ "$line" == *REASON=* ]]; then
+            reason=$(echo "$line" | grep -oE 'REASON=[^ ]+' | head -1 | cut -d= -f2)
+        fi
+        if [[ "$line" == *ADDED_BY=* ]]; then
+            added_by=$(echo "$line" | grep -oE 'ADDED_BY=[^ ]+' | head -1 | cut -d= -f2)
+        fi
+
+        if [[ -z "$expires_at" ]]; then
+            continue
+        fi
+
+        # Compute TTL remaining
+        local expires_unix
+        expires_unix=$(date -u -d "$expires_at" +%s 2>/dev/null) || continue
+        local ttl_left=$(( expires_unix - now_unix ))
+        if [[ "$ttl_left" -le 0 ]]; then
+            continue  # skip expired
+        fi
+
+        local ttl_pretty
+        if [[ "$ttl_left" -ge 3600 ]]; then
+            ttl_pretty="$(( ttl_left / 3600 ))h$(( (ttl_left % 3600) / 60 ))m"
+        elif [[ "$ttl_left" -ge 60 ]]; then
+            ttl_pretty="$(( ttl_left / 60 ))m$(( ttl_left % 60 ))s"
+        else
+            ttl_pretty="${ttl_left}s"
+        fi
+
+        printf '%-22s %-12s %-30s %s\n' "$ip" "$ttl_pretty" "$reason" "$added_by"
+        count=$(( count + 1 ))
+    done < "$_NFTBAN_SESSION_WHITELIST_PATH"
+
+    echo ""
+    echo "($count active session whitelist entries)"
+}
+
+_whitelist_session_remove() {
+    local ip="${1:-}"
+    if [[ -z "$ip" ]]; then
+        echo "ERROR: <ip-or-cidr> is required" >&2
+        echo "Usage: nftban firewall whitelist-session remove <ip-or-cidr>" >&2
+        return 1
+    fi
+
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        return 1
+    fi
+
+    if [[ ! -f "$_NFTBAN_SESSION_WHITELIST_PATH" ]]; then
+        echo "(no session whitelist file — nothing to remove)"
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+    local removed=0
+    # shellcheck disable=SC2016
+    removed=$(awk -v ip="$ip" '
+        {
+            t = $0
+            gsub(/^[ \t]+/, "", t)
+            if (t == "" || substr(t, 1, 1) == "#") { print; next }
+            split(t, a, "#")
+            n = split(a[1], b, /[ \t]+/)
+            if (n >= 1 && b[1] == ip) { count++; next }
+            print
+        }
+        END { print count > "/dev/stderr" }
+    ' "$_NFTBAN_SESSION_WHITELIST_PATH" 2> >(tail -1) > "$tmp")
+
+    if [[ ! -s "$tmp" ]]; then
+        # awk produced no output (file was effectively empty)
+        : > "$tmp"
+    fi
+
+    mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
+    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+
+    # Re-count removed by diffing against the original (simpler & reliable)
+    # We approximate count by re-checking presence of the IP.
+    if grep -qE "^[[:space:]]*${ip//./\\.}[[:space:]]" "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null; then
+        echo "(no entries removed — $ip not found)"
+    else
+        echo "Removed: $ip"
+    fi
+
+    if command -v nftban >/dev/null 2>&1; then
+        nftban firewall reload >/dev/null 2>&1 || true
+    fi
+    return 0
+}
+
+_whitelist_session_cleanup() {
+    if [[ ! -f "$_NFTBAN_SESSION_WHITELIST_PATH" ]]; then
+        echo "(no session whitelist file — nothing to clean up)"
+        return 0
+    fi
+
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        return 1
+    fi
+
+    local now_unix
+    now_unix=$(date -u +%s)
+    local tmp
+    tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+
+    local removed=0
+    local line
+    while IFS= read -r line; do
+        local trimmed="${line#"${line%%[![:space:]]*}"}"
+        if [[ -z "$trimmed" || "${trimmed:0:1}" == "#" ]]; then
+            printf '%s\n' "$line" >> "$tmp"
+            continue
+        fi
+
+        # Entry line — check EXPIRES_AT
+        if [[ "$line" == *EXPIRES_AT=* ]]; then
+            local expires_at
+            expires_at=$(echo "$line" | grep -oE 'EXPIRES_AT=[^ ]+' | head -1 | cut -d= -f2)
+            local expires_unix
+            expires_unix=$(date -u -d "$expires_at" +%s 2>/dev/null)
+            if [[ -z "$expires_unix" ]]; then
+                # Unparseable — drop conservatively
+                removed=$(( removed + 1 ))
+                continue
+            fi
+            if [[ "$expires_unix" -le "$now_unix" ]]; then
+                # Expired — drop
+                removed=$(( removed + 1 ))
+                continue
+            fi
+        fi
+        # No EXPIRES_AT marker OR not expired — keep
+        printf '%s\n' "$line" >> "$tmp"
+    done < "$_NFTBAN_SESSION_WHITELIST_PATH"
+
+    mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
+    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+
+    if [[ "$removed" -gt 0 ]]; then
+        echo "Removed $removed expired entries"
+        if command -v nftban >/dev/null 2>&1; then
+            nftban firewall reload >/dev/null 2>&1 || true
+        fi
+    else
+        echo "(no expired entries — nothing to remove)"
+    fi
+    return 0
 }
 
 # =============================================================================

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -2104,6 +2104,19 @@ nftban_cmd_update() {
         fi
     done
 
+    # v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): capture the operator's
+    # SSH peer IP from $SSH_CLIENT and propagate it to the installer via
+    # the env mirror NFTBAN_OPERATOR_SESSION_IP. The installer's
+    # phaseConfigure auto-seeds /etc/nftban/whitelist.d/00-session.conf
+    # with a bounded TTL so the operator does not self-ban during update.
+    # The capture is best-effort and skipped silently for non-SSH invocations
+    # (cron, systemd, local console). install.sh exec's the installer and
+    # inherits env, so this works across all update paths.
+    if [[ -z "${NFTBAN_OPERATOR_SESSION_IP:-}" && -n "${SSH_CLIENT:-}" ]]; then
+        # SSH_CLIENT format: "<peer-ip> <peer-port> <local-port>"
+        export NFTBAN_OPERATOR_SESSION_IP="${SSH_CLIENT%% *}"
+    fi
+
     # v1.117 (registry option update.options.--panel-auto-takeover):
     # parse-and-forward to the installer via the env mirror that
     # cmd/nftban-installer/flags.go:141 already honors. install.sh

--- a/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.120 firewall whitelist-session subcommand
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_firewall_whitelist_session_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-18"
+# meta:description="Tests for v1.120 nftban firewall whitelist-session add/list/remove/cleanup CLI surface. Asserts --json is REJECTED (text-mode only in v1.120; deferred to v1.121 pending schema decision), add creates file with header + inline EXPIRES_AT/REASON/ADDED_BY markers, re-adding the same IP refreshes (no duplicate), list shows TTL-remaining for active entries, remove takes IP, cleanup drops only expired entries, help works."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,date,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,date,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Purpose: Cover the v1.120 whitelist-session CLI surface introduced in
+# cli/lib/nftban/cli/cmd_firewall.sh:
+#   - firewall_whitelist_session dispatcher (add/list/remove/cleanup/help)
+#   - --json early refusal at the dispatcher (v1.121 deferral)
+#   - file-based mechanism: writes /etc/nftban/whitelist.d/00-session.conf
+#     with inline `# EXPIRES_AT=<RFC3339>  REASON=<...>  ADDED_BY=<...>`
+#   - dedup-by-IP / refresh semantics on re-add
+# Self-contained sandbox; no host contact; no root required.
+# We override $_NFTBAN_SESSION_WHITELIST_PATH after sourcing to point at
+# a tempfile so the test runs as a normal user.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+SESSION_FILE="$SANDBOX/00-session.conf"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n" "$name"
+        printf "         expected to contain: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n" "$name"
+        printf "         did NOT expect: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+reset_session_file() {
+    rm -f "$SESSION_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Wrapper: invoke firewall_whitelist_session in a subshell with a redirected
+# session whitelist path. We extract the function + helpers from
+# cmd_firewall.sh by name pattern. The function uses EUID checks for root;
+# we bypass by overriding EUID via a temporary shell variable trick — bash
+# treats EUID as readonly so we instead set the file path to the sandbox
+# and rely on `mkdir -p $(dirname ...)` creating in the sandbox, but the
+# EUID guard would still fire. Workaround: stub the EUID check by
+# pre-defining the function with the guard line stripped.
+# ---------------------------------------------------------------------------
+call_firewall_whitelist_session() {
+    (
+        set +e
+        # Extract everything from `firewall_whitelist_session()` definition
+        # to end of file (the helpers are below it in cmd_firewall.sh).
+        # Then patch out the `[[ $EUID -ne 0 ]]` root guards because the
+        # test runs as a normal user but writes to a sandbox path.
+        local extracted
+        extracted=$(awk '
+            /^firewall_whitelist_session\(\)/  { capture=1 }
+            /^_whitelist_session_/             { capture=1 }
+            capture                            { print }
+        ' "$NFTBAN_LIB_DIR/cli/cmd_firewall.sh")
+        # Replace the root-required guards (they reference $EUID).
+        # The shape is `if [[ $EUID -ne 0 ]]; then ... return 1; fi` — we
+        # patch the bracket-test to always be false so the gate never fires
+        # while leaving the `; then` / `fi` structure intact.
+        extracted=$(printf '%s' "$extracted" | sed -E 's@\[\[ \$EUID -ne 0 \]\]@[[ 1 -eq 0 ]]@g')
+        eval "$extracted"
+        # Redirect the file path to the sandbox.
+        _NFTBAN_SESSION_WHITELIST_PATH="$SESSION_FILE"
+        # Suppress chmod/chown failures (sandbox path likely fails ownership).
+        firewall_whitelist_session "$@"
+    )
+}
+
+echo "================================================="
+echo "v1.120 firewall whitelist-session test suite"
+echo "================================================="
+
+# ---------------------------------------------------------------------------
+# T1: --help / help / no-args shows usage with v1.120 deferral note
+# ---------------------------------------------------------------------------
+echo
+echo "[T1] firewall whitelist-session --help"
+reset_session_file
+T1_OUT=$(call_firewall_whitelist_session --help 2>&1)
+assert_contains "$T1_OUT" "Usage: nftban firewall whitelist-session" "T1.1 Usage line"
+assert_contains "$T1_OUT" "add"                                      "T1.2 add subcommand mentioned"
+assert_contains "$T1_OUT" "list"                                     "T1.3 list subcommand mentioned"
+assert_contains "$T1_OUT" "remove"                                   "T1.4 remove subcommand mentioned"
+assert_contains "$T1_OUT" "cleanup"                                  "T1.5 cleanup subcommand mentioned"
+assert_contains "$T1_OUT" "EXPIRES_AT"                               "T1.6 EXPIRES_AT mentioned in help"
+assert_contains "$T1_OUT" "v1.121"                                   "T1.7 v1.121 --json deferral noted"
+
+# ---------------------------------------------------------------------------
+# T2: --json is REJECTED at dispatcher with operator-actionable error
+# ---------------------------------------------------------------------------
+echo
+echo "[T2] --json is REJECTED at dispatcher (v1.120 text-mode only)"
+reset_session_file
+T2_OUT=$(call_firewall_whitelist_session list --json 2>&1 || true)
+assert_contains "$T2_OUT" "--json output for"                        "T2.1 explicit rejection text"
+assert_contains "$T2_OUT" "NOT supported in v1.120"                  "T2.2 version-explicit"
+assert_contains "$T2_OUT" "v1.121"                                   "T2.3 deferral target named"
+T2B_OUT=$(call_firewall_whitelist_session add 10.0.0.1 --ttl 30m --json 2>&1 || true)
+assert_contains "$T2B_OUT" "NOT supported in v1.120"                 "T2.4 --json refused on add too"
+T2C_OUT=$(call_firewall_whitelist_session list -j 2>&1 || true)
+assert_contains "$T2C_OUT" "NOT supported in v1.120"                 "T2.5 -j short form also refused"
+
+# ---------------------------------------------------------------------------
+# T3: add creates file with header + entry on first call
+# ---------------------------------------------------------------------------
+echo
+echo "[T3] add creates file with header on first call"
+reset_session_file
+T3_OUT=$(call_firewall_whitelist_session add 62.38.150.122 --ttl 30m --reason test-reason 2>&1)
+assert_contains "$T3_OUT" "Added: 62.38.150.122"                     "T3.1 stdout confirms add"
+if [[ -f "$SESSION_FILE" ]]; then
+    printf "  [PASS] %s\n" "T3.2 session file created"
+    PASS=$((PASS + 1))
+else
+    printf "  [FAIL] %s\n" "T3.2 session file created"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("T3.2")
+fi
+T3_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
+assert_contains "$T3_CONTENT" "Session Whitelist (managed by nftban" "T3.3 header present"
+assert_contains "$T3_CONTENT" "62.38.150.122"                        "T3.4 IP present"
+assert_contains "$T3_CONTENT" "EXPIRES_AT="                          "T3.5 EXPIRES_AT marker"
+assert_contains "$T3_CONTENT" "REASON=test-reason"                   "T3.6 REASON propagated"
+assert_contains "$T3_CONTENT" "ADDED_BY=nftban-firewall-whitelist-session" "T3.7 ADDED_BY tag"
+
+# ---------------------------------------------------------------------------
+# T4: re-adding the same IP REFRESHES (no duplicate)
+# ---------------------------------------------------------------------------
+echo
+echo "[T4] re-add same IP → refresh (no duplicate)"
+# (T3 already added 62.38.150.122; re-add with different reason)
+call_firewall_whitelist_session add 62.38.150.122 --ttl 1h --reason refreshed >/dev/null 2>&1 || true
+T4_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
+T4_COUNT=$(printf '%s\n' "$T4_CONTENT" | grep -c "^62\.38\.150\.122" || true)
+assert_eq "$T4_COUNT" "1"                                            "T4.1 exactly one entry for IP"
+assert_contains "$T4_CONTENT" "REASON=refreshed"                     "T4.2 newer REASON present"
+assert_not_contains "$T4_CONTENT" "REASON=test-reason"               "T4.3 older REASON dropped"
+
+# ---------------------------------------------------------------------------
+# T5: add with invalid IP rejects
+# ---------------------------------------------------------------------------
+echo
+echo "[T5] add with invalid IP rejects"
+T5_OUT=$(call_firewall_whitelist_session add not-an-ip --ttl 30m 2>&1 || true)
+assert_contains "$T5_OUT" "Invalid IP or CIDR"                       "T5.1 invalid IP rejected"
+
+# ---------------------------------------------------------------------------
+# T6: add with missing --ttl rejects
+# ---------------------------------------------------------------------------
+echo
+echo "[T6] add with missing --ttl rejects"
+T6_OUT=$(call_firewall_whitelist_session add 10.0.0.99 2>&1 || true)
+assert_contains "$T6_OUT" "required"                                 "T6.1 missing --ttl explained"
+
+# ---------------------------------------------------------------------------
+# T7: list shows active entries with TTL-remaining
+# ---------------------------------------------------------------------------
+echo
+echo "[T7] list shows active entries with TTL-remaining"
+T7_OUT=$(call_firewall_whitelist_session list 2>&1)
+assert_contains "$T7_OUT" "62.38.150.122"                            "T7.1 active IP listed"
+assert_contains "$T7_OUT" "REASON"                                   "T7.2 REASON column header"
+assert_contains "$T7_OUT" "active session whitelist entries"         "T7.3 footer count"
+
+# ---------------------------------------------------------------------------
+# T8: remove drops the entry
+# ---------------------------------------------------------------------------
+echo
+echo "[T8] remove drops the entry"
+T8_OUT=$(call_firewall_whitelist_session remove 62.38.150.122 2>&1)
+assert_contains "$T8_OUT" "Removed: 62.38.150.122"                   "T8.1 stdout confirms remove"
+T8_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
+assert_not_contains "$T8_CONTENT" "^62\.38\.150\.122"                "T8.2 entry gone from file"
+
+# ---------------------------------------------------------------------------
+# T9: cleanup drops expired but keeps active
+# ---------------------------------------------------------------------------
+echo
+echo "[T9] cleanup drops only expired entries"
+reset_session_file
+# Write a file with one expired + one active entry, header skipped.
+cat > "$SESSION_FILE" <<EOF
+# header
+10.0.0.1  # EXPIRES_AT=2000-01-01T00:00:00Z  REASON=stale  ADDED_BY=test
+10.0.0.2  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=fresh  ADDED_BY=test
+EOF
+T9_OUT=$(call_firewall_whitelist_session cleanup 2>&1)
+assert_contains "$T9_OUT" "Removed 1 expired"                        "T9.1 cleanup reports 1 removed"
+T9_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
+assert_not_contains "$T9_CONTENT" "10.0.0.1"                         "T9.2 expired entry removed"
+assert_contains "$T9_CONTENT" "10.0.0.2"                             "T9.3 active entry kept"
+
+# ---------------------------------------------------------------------------
+# T10: unknown action returns operator-actionable error
+# ---------------------------------------------------------------------------
+echo
+echo "[T10] unknown action surfaces operator-actionable error"
+T10_OUT=$(call_firewall_whitelist_session bogus-action 2>&1 || true)
+assert_contains "$T10_OUT" "Unknown whitelist-session action"        "T10.1 unknown action explained"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "================================================="
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/safety"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 )
 
@@ -88,6 +90,13 @@ type config struct {
 	// resolve. PR26.2 ships with an empty adapter registry — the
 	// flag is a no-op until PR26.3 lands the first real adapter.
 	noPanel bool // --no-panel: opt out of panel-survival enforcement
+	// v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): --session-whitelist-ttl.
+	// Bounds the lifetime of the auto-seeded operator SSH peer IP in
+	// /etc/nftban/whitelist.d/00-session.conf. Default 30m via
+	// safety.DefaultSessionWhitelistTTL. Set to 0 to disable the
+	// auto-seed for the current run (operator can still use
+	// `nftban firewall whitelist-session add` explicitly).
+	sessionWhitelistTTL time.Duration // --session-whitelist-ttl: TTL for auto-seeded operator session entries
 }
 
 func parseFlags() *config {

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -134,6 +134,22 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.confirmMutation, "confirm-mutation", false, "Authorize uninstall authority release (real kernel + service mutation). Required for --mode=uninstall without --dry-run. Mutually exclusive with --dry-run.")
 	// v1.100 PR26.2: PANEL-SURVIVAL-001 opt-out.
 	flag.BoolVar(&cfg.noPanel, "no-panel", false, "Opt out of PANEL-SURVIVAL-001 enforcement. Adapters still run for diagnostic logging but a detected-panel integration failure will NOT block StateCommitted on this run. Default OFF.")
+	// v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): --session-whitelist-ttl.
+	// Bounds the lifetime of the auto-seeded operator SSH peer IP in
+	// /etc/nftban/whitelist.d/00-session.conf. Default is
+	// safety.DefaultSessionWhitelistTTL (30m). Setting to 0 disables the
+	// auto-seed for this run — the operator can still use
+	// `nftban firewall whitelist-session add` explicitly.
+	//
+	// REMEDIATION NOTE (V120_PR_637_ORPHAN_AND_DEAD_CODE_AUDIT B-2):
+	// the registration was missing in the initial V120 commit; absent
+	// this line the field defaulted to zero, causing every auto-seeded
+	// entry to be born expired (ExpiresAt = time.Now() + 0) and the
+	// loader's shouldSkipDueToExpiresAt to drop it on first reload —
+	// silently no-opping the D-UPDATE-OPERATOR-SELF-BAN-GAP-001 fix.
+	flag.DurationVar(&cfg.sessionWhitelistTTL, "session-whitelist-ttl", safety.DefaultSessionWhitelistTTL,
+		"TTL for auto-seeded operator session whitelist entries in /etc/nftban/whitelist.d/00-session.conf. "+
+			"Default 30m (safety.DefaultSessionWhitelistTTL). Set to 0 to disable auto-seed for this run.")
 
 	flag.Parse()
 

--- a/cmd/nftban-installer/flags_test.go
+++ b/cmd/nftban-installer/flags_test.go
@@ -1,0 +1,96 @@
+// =============================================================================
+// NFTBan v1.120 - flags.go regression test for --session-whitelist-ttl default
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-flags-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="V120 regression test for V120_PR_637_ORPHAN_AND_DEAD_CODE_AUDIT B-2: asserts parseFlags() registers --session-whitelist-ttl and defaults it to safety.DefaultSessionWhitelistTTL when the operator does not pass the flag. If this test fails, the auto-seed feature silently no-ops on every host (TTL=0 → ExpiresAt=now → loader skips on first reload → D-UPDATE-OPERATOR-SELF-BAN-GAP-001 fix defeated)."
+// meta:input="None (manipulates os.Args and flag.CommandLine in isolation; restored via t.Cleanup)"
+// meta:output="t.Fatal on TTL drift"
+// meta:depends="testing,flag,os,internal/installer/safety"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/safety"
+)
+
+// TestParseFlags_SessionWhitelistTTLDefault is the v1.120 regression guard
+// for V120_PR_637_ORPHAN_AND_DEAD_CODE_AUDIT B-2. The audit caught that
+// `--session-whitelist-ttl` was declared in the config struct and consumed
+// in main.go + phases.go, but was never registered via flag.DurationVar
+// in parseFlags(). The silent net effect was: every auto-seeded session
+// whitelist entry got ExpiresAt = time.Now() + 0 (the zero-value default
+// of time.Duration), which the v1.120 loader skips on the first reload,
+// silently defeating the D-UPDATE-OPERATOR-SELF-BAN-GAP-001 P1 safety fix.
+//
+// This test asserts that absent the flag on the command line, parseFlags
+// returns cfg.sessionWhitelistTTL == safety.DefaultSessionWhitelistTTL.
+// If a future change removes the flag.DurationVar registration again,
+// this test must catch it BEFORE the silent no-op reaches production.
+//
+// Uses --mode=upgrade (the lightest-validation install mode) so that
+// parseFlags reaches the return path without hitting any os.Exit branch.
+func TestParseFlags_SessionWhitelistTTLDefault(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet("nftban-installer-flagstest", flag.ContinueOnError)
+	os.Args = []string{"nftban-installer", "--mode=upgrade"}
+
+	cfg := parseFlags()
+	if cfg == nil {
+		t.Fatal("parseFlags() returned nil cfg for --mode=upgrade")
+	}
+	if cfg.sessionWhitelistTTL != safety.DefaultSessionWhitelistTTL {
+		t.Fatalf("cfg.sessionWhitelistTTL = %v, want %v (safety.DefaultSessionWhitelistTTL); "+
+			"--session-whitelist-ttl flag.DurationVar registration is missing from parseFlags(); "+
+			"silently defeats D-UPDATE-OPERATOR-SELF-BAN-GAP-001 by giving every auto-seeded "+
+			"entry a zero TTL (born expired).",
+			cfg.sessionWhitelistTTL, safety.DefaultSessionWhitelistTTL)
+	}
+}
+
+// TestParseFlags_SessionWhitelistTTLExplicit asserts that an explicit
+// --session-whitelist-ttl=<value> CLI override is honoured. This protects
+// against a future regression where the registration is present but
+// bound to the wrong variable.
+func TestParseFlags_SessionWhitelistTTLExplicit(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet("nftban-installer-flagstest", flag.ContinueOnError)
+	os.Args = []string{"nftban-installer", "--mode=upgrade", "--session-whitelist-ttl=1h30m"}
+
+	cfg := parseFlags()
+	if cfg == nil {
+		t.Fatal("parseFlags() returned nil cfg")
+	}
+	const want = 90 * 60 * 1_000_000_000 // 1h30m in nanoseconds (time.Duration)
+	if int64(cfg.sessionWhitelistTTL) != int64(want) {
+		t.Fatalf("cfg.sessionWhitelistTTL = %v, want 1h30m", cfg.sessionWhitelistTTL)
+	}
+}

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -118,6 +118,10 @@ func main() {
 	// PR26.2: propagate --no-panel so the panel-survival assertion's
 	// policy can opt out when the operator explicitly disables it.
 	globalPhaseData.noPanel = cfg.noPanel
+	// v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): propagate the operator-
+	// session whitelist TTL. Default safety.DefaultSessionWhitelistTTL (30m)
+	// already applied in parseFlags when --session-whitelist-ttl is unset.
+	globalPhaseData.sessionWhitelistTTL = cfg.sessionWhitelistTTL
 
 	exitCode := run(ctx, exec, sf, cfg, log)
 

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -65,6 +65,12 @@ type phaseData struct {
 	// returns Fatal=false even on adapter failure (operator has
 	// explicitly accepted the risk).
 	noPanel bool
+	// v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): operator-session
+	// whitelist TTL. Propagated from cfg.sessionWhitelistTTL in main().
+	// Default 30m (safety.DefaultSessionWhitelistTTL). Used by
+	// phaseConfigure's AddSessionWhitelist call to bound the auto-seeded
+	// operator SSH peer entry.
+	sessionWhitelistTTL time.Duration
 }
 
 // globalPhaseData is set by phaseDetect and consumed by later phases.
@@ -319,6 +325,29 @@ func phaseConfigure(_ context.Context, exec executor.Executor, sf *state.StateFi
 		if err := safety.SeedManualWhitelist(exec, log); err != nil {
 			log.Warn("safety whitelist seed failed (non-fatal): %v", err)
 		}
+	}
+
+	// v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): operator-session whitelist
+	// auto-seed. UNGATED (runs for both --source AND package installs/upgrades)
+	// to close the gap proven by the 2026-05-18 lab2 self-ban incident. If
+	// SSH_CLIENT is empty (non-SSH invocation: cron, systemd timer, RPM/DEB
+	// scriptlet without inherited env), CaptureSSHPeerIP returns "" and we
+	// skip without seeding. TTL is bounded so stale entries auto-expire even
+	// if cleanup never runs. Non-fatal: failure to seed does NOT block the
+	// install/upgrade — the operator can still recover via the V119 runbook
+	// (manual whitelist edit + reload via OOB console).
+	if peerIP := safety.CaptureSSHPeerIP(); peerIP != "" {
+		entry := safety.SessionWhitelistEntry{
+			IP:        peerIP,
+			ExpiresAt: time.Now().UTC().Add(pd.sessionWhitelistTTL),
+			Reason:    "v120-update-session",
+			AddedBy:   "nftban-installer",
+		}
+		if err := safety.AddSessionWhitelist(exec, log, entry); err != nil {
+			log.Warn("session whitelist seed failed (non-fatal): %v", err)
+		}
+	} else {
+		log.Debug("session whitelist seed skipped: SSH_CLIENT empty (non-SSH invocation)")
 	}
 
 	// 5. Whitelist sync (loads whitelists and feeds)

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1544,6 +1544,46 @@ firewall:
         - "Disarm is REVERSIBLE: external firewall binary renamed to .disabled (sha256-equal), config trees preserved, cron-backup manifest written before any rm"
         - "To reverse: nftban firewall restore csf  (or  /usr/lib/nftban/bin/nftban-installer --mode=restore)"
         - "Env mirror: NFTBAN_PANEL_AUTO_TAKEOVER=1 (useful for cloud-init / Ansible / package %post)"
+    whitelist-session:
+      mutates: true
+      requires_root: true
+      description: "Manage time-bounded operator-session whitelist entries (D-UPDATE-OPERATOR-SELF-BAN-GAP-001; v1.120)"
+      examples:
+        - "nftban firewall whitelist-session add 62.38.150.122 --ttl 30m"
+        - "nftban firewall whitelist-session list"
+        - "nftban firewall whitelist-session remove 62.38.150.122"
+        - "nftban firewall whitelist-session cleanup"
+      subcommands:
+        add:
+          mutates: true
+          requires_root: true
+          description: "Add a time-bounded whitelist entry with EXPIRES_AT marker"
+          options:
+            --ttl:
+              type: string
+              description: "Time-to-live: 30m, 1h, 1h30m, 24h, 3600s (required)"
+            --reason:
+              type: string
+              default: "operator-explicit"
+              description: "Short description of why the entry was added"
+        list:
+          mutates: false
+          description: "Show all non-expired session whitelist entries (text-mode only; --json deferred to v1.121)"
+        remove:
+          mutates: true
+          requires_root: true
+          description: "Remove a session whitelist entry by IP or CIDR"
+        cleanup:
+          mutates: true
+          requires_root: true
+          description: "Manually remove all expired entries from 00-session.conf"
+      notes:
+        - "File-based mechanism (Shape E.0): writes /etc/nftban/whitelist.d/00-session.conf with inline EXPIRES_AT=<RFC3339> markers"
+        - "The whitelist loader skips expired entries at load time (no kernel set, no systemd timer)"
+        - "Auto-seeded during nftban update / firewall takeover with --session-whitelist-ttl (default 30m); this subcommand is the explicit operator override"
+        - "Permanent operator entries belong in 99-manual.conf, NOT this file"
+        - "v1.120 ships text-mode only; --json is REJECTED with operator-actionable error (deferred to v1.121 pending schema-envelope decision)"
+        - "Schema 1.83.0 unchanged (per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md verdict SCHEMA_STAYS_FROZEN)"
     logs:
       mutates: conditional
       requires_root: conditional

--- a/internal/installer/safety/session_whitelist.go
+++ b/internal/installer/safety/session_whitelist.go
@@ -1,0 +1,431 @@
+// =============================================================================
+// NFTBan v1.120 - Installer Safety Session Whitelist (D-UPDATE-OPERATOR-SELF-BAN-GAP-001)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-safety-session"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="Manage time-bounded operator-session whitelist entries with inline EXPIRES_AT TTL"
+// meta:inventory.files="internal/installer/safety/session_whitelist.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="SSH_CLIENT,NFTBAN_OPERATOR_SESSION_IP"
+// meta:inventory.config_files="/etc/nftban/whitelist.d/00-session.conf"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Why this package exists (Shape E.0 — V120 design):
+//
+// On 2026-05-18 a real upgrade-window incident proved the gap:
+// `D-UPDATE-OPERATOR-SELF-BAN-GAP-001`. The operator/dev egress IP was
+// banned by lab2's own nftban LoginMon for 3 ssh_invalid_user events
+// during an attempted V119 validation. The pre-existing SeedManualWhitelist
+// captures SSH_CLIENT but is gated to `--source` install only and is a
+// no-op on subsequent runs. There was no concept of a time-bounded
+// "operator session" whitelist for `nftban update`, `firewall takeover`,
+// or validation workflows.
+//
+// This package adds that concept WITHOUT a new nft set, WITHOUT a new
+// systemd timer, WITHOUT metrics, and WITHOUT a schema bump — per
+// `V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md` verdict
+// SCHEMA_STAYS_FROZEN (conditional on --json deferral).
+//
+// Design (Shape E.0):
+//   - Time-bounded entries live in /etc/nftban/whitelist.d/00-session.conf
+//     with inline `# EXPIRES_AT=<RFC3339>  REASON=<text>  ADDED_BY=<source>`
+//     comments.
+//   - The whitelist loader (internal/whitelist/loader.go, v1.119 CIDR-aware)
+//     is extended to parse the EXPIRES_AT marker and SKIP expired entries
+//     at load time. No separate cleanup daemon required.
+//   - This package provides Add / Cleanup / Read helpers consumed by the
+//     installer (auto-seed during nftban update / firewall takeover) and
+//     by the CLI (operator-explicit `nftban firewall whitelist-session`).
+//
+// Operator content is authoritative: 00-session.conf is managed by nftban
+// (header + footer comments mark it as machine-managed); the operator's
+// 99-manual.conf and 00-system.conf are NEVER touched by this package.
+//
+// =============================================================================
+
+package safety
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// sessionWhitelistPath is the canonical path for time-bounded operator-session
+// whitelist entries. Distinct from manualWhitelistPath (99-manual.conf) which
+// holds permanent operator-owned content.
+const sessionWhitelistPath = "/etc/nftban/whitelist.d/00-session.conf"
+
+// DefaultSessionWhitelistTTL is the default time-to-live for auto-seeded
+// operator SSH peer entries during `nftban update` / `firewall takeover`.
+// Chosen at 30 minutes to comfortably cover a normal upgrade + validation
+// window without leaving long-lived stale allow entries.
+const DefaultSessionWhitelistTTL = 30 * time.Minute
+
+// sessionWhitelistHeader is written when 00-session.conf is created. The
+// header explicitly marks the file as machine-managed so operators don't
+// hand-edit it (use 99-manual.conf for permanent entries instead).
+const sessionWhitelistHeader = `# =============================================================================
+# NFTBan Session Whitelist (managed by nftban; do not hand-edit)
+# =============================================================================
+#
+# This file holds time-bounded operator-session whitelist entries with
+# inline EXPIRES_AT timestamps. Entries past EXPIRES_AT are skipped at
+# whitelist-load time and never enter the runtime CIDR-aware membership
+# check. Cleanup happens passively on every whitelist reload; explicit
+# cleanup is available via ` + "`nftban firewall whitelist-session cleanup`" + `.
+#
+# FORMAT (one entry per line):
+#   <ip-or-cidr>  # EXPIRES_AT=<RFC3339>  REASON=<short-text>  ADDED_BY=<source>
+#
+# Example:
+#   62.38.150.122  # EXPIRES_AT=2026-05-18T10:13:32Z  REASON=v120-update-session  ADDED_BY=nftban-update
+#
+# Permanent operator entries belong in 99-manual.conf (NOT this file).
+# Static host-interface entries belong in 00-system.conf (NOT this file).
+#
+# =============================================================================
+
+`
+
+// SessionWhitelistEntry captures a time-bounded whitelist entry.
+type SessionWhitelistEntry struct {
+	IP        string    // exact IP or CIDR (already validated by caller)
+	ExpiresAt time.Time // UTC, RFC3339-serialized in the file
+	Reason    string    // short human-readable purpose (e.g. "v120-update-session")
+	AddedBy   string    // source identifier (e.g. "nftban-update", "nftban-firewall-whitelist-session")
+}
+
+// AddSessionWhitelist appends an entry to /etc/nftban/whitelist.d/00-session.conf.
+// File is created with seed header on first add. Entries are deduplicated
+// by IP (a new add for the same IP REFRESHES the EXPIRES_AT/REASON/ADDED_BY
+// fields rather than creating a duplicate line).
+//
+// Caller responsibility: validate `entry.IP` is a routable IP or CIDR.
+// This function does NOT re-validate (mirrors SeedManualWhitelist's contract).
+//
+// Atomic write semantics: the function reads the current file (if any),
+// removes any prior entry for the same IP, appends the new entry, and
+// writes the result via exec.WriteFileAtomic (which uses temp-file + rename
+// to guarantee race-free updates).
+func AddSessionWhitelist(exec executor.Executor, log *logging.Logger, entry SessionWhitelistEntry) error {
+	if entry.IP == "" {
+		return fmt.Errorf("AddSessionWhitelist: empty IP")
+	}
+	if entry.ExpiresAt.IsZero() {
+		return fmt.Errorf("AddSessionWhitelist: zero ExpiresAt for %s", entry.IP)
+	}
+	if entry.AddedBy == "" {
+		entry.AddedBy = "unknown"
+	}
+	if entry.Reason == "" {
+		entry.Reason = "session"
+	}
+
+	// Read existing content if file exists.
+	var existing []byte
+	if exec.FileExists(sessionWhitelistPath) {
+		data, err := exec.ReadFile(sessionWhitelistPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", sessionWhitelistPath, err)
+		}
+		existing = data
+	}
+
+	// Build new content: preserve header + lines that are NOT for this IP,
+	// then append the new entry.
+	var b bytes.Buffer
+	hasHeader := bytes.Contains(existing, []byte("# NFTBan Session Whitelist"))
+	if !hasHeader {
+		b.WriteString(sessionWhitelistHeader)
+	}
+
+	// Carry forward all existing lines except a prior entry for this IP.
+	// Lines are matched by the first whitespace-delimited token before the
+	// first '#' (the IP/CIDR field).
+	for _, line := range strings.Split(string(existing), "\n") {
+		if extractIPField(line) == entry.IP {
+			// drop — will be re-appended fresh below
+			continue
+		}
+		// Preserve everything else (header lines, other entries, blanks).
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	// Ensure there's a single trailing newline before the new entry block.
+	trimmed := strings.TrimRight(b.String(), "\n") + "\n"
+	b.Reset()
+	b.WriteString(trimmed)
+
+	// Append the new entry. RFC3339 in UTC.
+	expiresStr := entry.ExpiresAt.UTC().Format(time.RFC3339)
+	fmt.Fprintf(&b, "%s  # EXPIRES_AT=%s  REASON=%s  ADDED_BY=%s\n",
+		entry.IP, expiresStr, entry.Reason, entry.AddedBy)
+
+	if err := exec.WriteFileAtomic(sessionWhitelistPath, b.Bytes(), 0640); err != nil {
+		return fmt.Errorf("write %s: %w", sessionWhitelistPath, err)
+	}
+
+	log.Info("session-whitelist add: %s (expires %s, reason=%s, added_by=%s)",
+		entry.IP, expiresStr, entry.Reason, entry.AddedBy)
+	return nil
+}
+
+// CleanupExpiredSessionWhitelist removes entries past EXPIRES_AT from
+// 00-session.conf. Returns (removed_count, error). Idempotent: safe to
+// call when the file is absent (returns 0, nil) or has no expired entries.
+//
+// The whitelist loader already skips expired entries at runtime, so this
+// function is OPTIONAL for correctness — it is provided as a file-hygiene
+// helper so the on-disk file doesn't accumulate stale entries indefinitely.
+func CleanupExpiredSessionWhitelist(exec executor.Executor, log *logging.Logger) (int, error) {
+	if !exec.FileExists(sessionWhitelistPath) {
+		return 0, nil
+	}
+	data, err := exec.ReadFile(sessionWhitelistPath)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", sessionWhitelistPath, err)
+	}
+
+	now := time.Now().UTC()
+	var b bytes.Buffer
+	removed := 0
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			// Preserve blank/comment lines (incl. header)
+			b.WriteString(line)
+			b.WriteString("\n")
+			continue
+		}
+		// Entry line — check EXPIRES_AT marker
+		if expired, _ := lineIsExpired(line, now); expired {
+			removed++
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan %s: %w", sessionWhitelistPath, err)
+	}
+
+	if removed == 0 {
+		return 0, nil
+	}
+
+	if err := exec.WriteFileAtomic(sessionWhitelistPath, b.Bytes(), 0640); err != nil {
+		return 0, fmt.Errorf("write %s: %w", sessionWhitelistPath, err)
+	}
+
+	log.Info("session-whitelist cleanup: removed %d expired entries", removed)
+	return removed, nil
+}
+
+// ReadSessionWhitelist returns all non-expired entries from 00-session.conf.
+// Used by the CLI list subcommand. Returns an empty slice (not an error)
+// when the file is absent.
+func ReadSessionWhitelist(exec executor.Executor, log *logging.Logger) ([]SessionWhitelistEntry, error) {
+	if !exec.FileExists(sessionWhitelistPath) {
+		return nil, nil
+	}
+	data, err := exec.ReadFile(sessionWhitelistPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", sessionWhitelistPath, err)
+	}
+
+	now := time.Now().UTC()
+	var out []SessionWhitelistEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		entry, ok := parseSessionLine(line)
+		if !ok {
+			continue
+		}
+		if now.After(entry.ExpiresAt) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// RemoveSessionWhitelist deletes any entry for the given IP from 00-session.conf.
+// Returns (removed_count, error). 0 removed is not an error.
+func RemoveSessionWhitelist(exec executor.Executor, log *logging.Logger, ip string) (int, error) {
+	if ip == "" {
+		return 0, fmt.Errorf("RemoveSessionWhitelist: empty IP")
+	}
+	if !exec.FileExists(sessionWhitelistPath) {
+		return 0, nil
+	}
+	data, err := exec.ReadFile(sessionWhitelistPath)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", sessionWhitelistPath, err)
+	}
+
+	var b bytes.Buffer
+	removed := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if extractIPField(line) == ip {
+			removed++
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	// Strip the trailing extra "\n" we added.
+	trimmed := strings.TrimRight(b.String(), "\n") + "\n"
+
+	if removed == 0 {
+		return 0, nil
+	}
+
+	if err := exec.WriteFileAtomic(sessionWhitelistPath, []byte(trimmed), 0640); err != nil {
+		return 0, fmt.Errorf("write %s: %w", sessionWhitelistPath, err)
+	}
+
+	log.Info("session-whitelist remove: %s (%d entries)", ip, removed)
+	return removed, nil
+}
+
+// CaptureSSHPeerIP returns the active SSH peer IP, preferring the explicit
+// NFTBAN_OPERATOR_SESSION_IP env-mirror (set by `nftban update` wrapper in
+// cli/lib/nftban/cli/cmd_update.sh) and falling back to the first
+// whitespace-delimited field of $SSH_CLIENT. Returns empty string if both
+// sources are absent or the resulting token is not a routable IP.
+//
+// The explicit env-mirror takes precedence because the update wrapper
+// captures SSH_CLIENT before any sudo / package-scriptlet hop that might
+// scrub it. Direct invocations of nftban-installer (without the wrapper)
+// still get SSH_CLIENT fallback if the SSH session env is intact.
+//
+// SSH_CLIENT format set by sshd: "client_ip client_port server_port".
+// In non-SSH contexts (cron, systemd timer, etc.) both sources are empty —
+// callers must treat empty return as "no SSH session; skip seeding."
+func CaptureSSHPeerIP() string {
+	// Explicit env-mirror first (set by `nftban update` wrapper; survives
+	// sudo / package-scriptlet hops that scrub SSH_CLIENT).
+	if explicit := strings.TrimSpace(os.Getenv("NFTBAN_OPERATOR_SESSION_IP")); explicit != "" {
+		if isRoutableIP(explicit) {
+			return explicit
+		}
+	}
+	sshClient := os.Getenv("SSH_CLIENT")
+	if sshClient == "" {
+		return ""
+	}
+	fields := strings.Fields(sshClient)
+	if len(fields) == 0 {
+		return ""
+	}
+	if !isRoutableIP(fields[0]) {
+		return ""
+	}
+	return fields[0]
+}
+
+// extractIPField returns the first whitespace-delimited token from a line,
+// stopping at any '#' comment. Returns empty string for blank/comment-only
+// lines. Used for IP-keyed deduplication and removal.
+func extractIPField(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	// Trim at first '#'
+	if idx := strings.Index(trimmed, "#"); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:idx])
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// lineIsExpired returns (true, expiresAt) if the line carries an EXPIRES_AT
+// marker that has already passed `now`, OR is malformed (conservative skip).
+// Returns (false, zeroTime) if no marker or marker is parseable and still
+// in the future.
+func lineIsExpired(line string, now time.Time) (bool, time.Time) {
+	const marker = "EXPIRES_AT="
+	idx := strings.Index(line, marker)
+	if idx < 0 {
+		return false, time.Time{}
+	}
+	rest := line[idx+len(marker):]
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		// Marker present but no value — malformed; conservative skip.
+		return true, time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339, fields[0])
+	if err != nil {
+		// Unparseable; conservative skip.
+		return true, time.Time{}
+	}
+	if now.After(ts) {
+		return true, ts
+	}
+	return false, ts
+}
+
+// parseSessionLine parses a session-whitelist file line into a
+// SessionWhitelistEntry. Returns (entry, true) on success; (zero, false) for
+// blank/comment-only lines, missing EXPIRES_AT, or unparseable timestamps.
+//
+// Unlike lineIsExpired, this requires a parseable EXPIRES_AT — used by
+// ReadSessionWhitelist which needs structured data, not just expiry status.
+func parseSessionLine(line string) (SessionWhitelistEntry, bool) {
+	ip := extractIPField(line)
+	if ip == "" {
+		return SessionWhitelistEntry{}, false
+	}
+	commentIdx := strings.Index(line, "#")
+	if commentIdx < 0 {
+		return SessionWhitelistEntry{}, false
+	}
+	comment := line[commentIdx+1:]
+
+	entry := SessionWhitelistEntry{IP: ip}
+
+	// Token-by-token parse: EXPIRES_AT=<val>, REASON=<val>, ADDED_BY=<val>.
+	// Tokens are whitespace-delimited; values are single-token (no spaces).
+	for _, tok := range strings.Fields(comment) {
+		switch {
+		case strings.HasPrefix(tok, "EXPIRES_AT="):
+			ts, err := time.Parse(time.RFC3339, strings.TrimPrefix(tok, "EXPIRES_AT="))
+			if err != nil {
+				return SessionWhitelistEntry{}, false
+			}
+			entry.ExpiresAt = ts
+		case strings.HasPrefix(tok, "REASON="):
+			entry.Reason = strings.TrimPrefix(tok, "REASON=")
+		case strings.HasPrefix(tok, "ADDED_BY="):
+			entry.AddedBy = strings.TrimPrefix(tok, "ADDED_BY=")
+		}
+	}
+
+	if entry.ExpiresAt.IsZero() {
+		return SessionWhitelistEntry{}, false
+	}
+	return entry, true
+}
+
+// (isRoutableIP is defined in this package's whitelist.go and reused here.)

--- a/internal/installer/safety/session_whitelist_test.go
+++ b/internal/installer/safety/session_whitelist_test.go
@@ -111,9 +111,15 @@ func TestAddSessionWhitelist_RefreshesExistingEntry(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 	content := string(data)
-	occurrences := strings.Count(content, "62.38.150.122")
+	// T-1 fix (V120_PR_637_CI_AND_DIFF_VERIFICATION §3): count only DATA
+	// lines whose first whitespace-delimited token equals the IP. A naive
+	// strings.Count over the raw content double-counts the example
+	// occurrence inside the file header (`# 62.38.150.122 # EXPIRES_AT=...
+	// REASON=v120-update-session ADDED_BY=nftban-update`). Skip blank and
+	// `#`-prefixed comment lines so the header example is not counted.
+	occurrences := countDataLinesForIP(content, "62.38.150.122")
 	if occurrences != 1 {
-		t.Errorf("expected exactly 1 occurrence of 62.38.150.122 after refresh, got %d:\n%s",
+		t.Errorf("expected exactly 1 data-line occurrence of 62.38.150.122 after refresh, got %d:\n%s",
 			occurrences, content)
 	}
 	if !strings.Contains(content, "REASON=second-add") {
@@ -122,6 +128,34 @@ func TestAddSessionWhitelist_RefreshesExistingEntry(t *testing.T) {
 	if strings.Contains(content, "REASON=first-add") {
 		t.Errorf("expected refresh to drop older REASON; still present:\n%s", content)
 	}
+}
+
+// countDataLinesForIP returns the number of non-blank, non-comment lines
+// in `content` whose first whitespace-delimited token equals `ip`. Used by
+// V120 dedup/refresh assertions where a naive substring count would also
+// match the IP appearing inside file-header example/documentation lines.
+//
+// Lines whose trimmed-leading-whitespace form starts with `#` are treated
+// as comments and skipped. Blank lines are skipped. For non-skipped lines,
+// the IP is matched only against the first token before any inline `#`.
+func countDataLinesForIP(content, ip string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Strip inline `# ...` trailing comment, then take the first token.
+		beforeHash := trimmed
+		if idx := strings.IndexByte(beforeHash, '#'); idx >= 0 {
+			beforeHash = beforeHash[:idx]
+		}
+		fields := strings.Fields(beforeHash)
+		if len(fields) > 0 && fields[0] == ip {
+			count++
+		}
+	}
+	return count
 }
 
 // TestCleanupExpiredSessionWhitelist_RemovesOnlyExpired asserts cleanup
@@ -179,8 +213,14 @@ func TestReadSessionWhitelist_ParsesInlineMarkers(t *testing.T) {
 	log := newSessionTestLogger(t)
 	defer log.Close()
 
-	t1 := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)
-	t2 := time.Date(2026, 5, 18, 11, 0, 0, 0, time.UTC)
+	// T-2 fix (V120_PR_637_CI_AND_DIFF_VERIFICATION §3): use relative
+	// timestamps so neither entry can be "born expired" when the test
+	// runs near a calendar boundary. The original hard-coded 2026-05-18
+	// fixtures became stale relative to "now" when CI ran on the same
+	// day, causing the v1.120 loader's EXPIRES_AT skip to drop the first
+	// entry and surface a false-negative read assertion.
+	t1 := time.Now().UTC().Add(time.Hour)
+	t2 := time.Now().UTC().Add(2 * time.Hour)
 	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{
 		IP: "10.0.0.1", ExpiresAt: t1, Reason: "one", AddedBy: "test",
 	})

--- a/internal/installer/safety/session_whitelist_test.go
+++ b/internal/installer/safety/session_whitelist_test.go
@@ -1,0 +1,326 @@
+// =============================================================================
+// NFTBan v1.120 - Session Whitelist Unit Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="session_whitelist_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="V120 unit tests for internal/installer/safety/session_whitelist.go covering AddSessionWhitelist (create-with-header / refresh-dedup), CleanupExpiredSessionWhitelist (mixed expired/active), ReadSessionWhitelist (parses inline markers), RemoveSessionWhitelist, CaptureSSHPeerIP (env-mirror precedence, SSH_CLIENT fallback, non-routable rejection, empty-env), and lineIsExpired / parseSessionLine helpers."
+// meta:input="MockExecutor in-memory files, env vars NFTBAN_OPERATOR_SESSION_IP/SSH_CLIENT"
+// meta:output="t.Fatal/t.Errorf on assertion failure"
+// meta:depends="testing,time,strings,internal/installer/executor,internal/installer/logging"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="SSH_CLIENT,NFTBAN_OPERATOR_SESSION_IP"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package safety
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// newTestLogger returns a Logger writing to /dev/null. The test never
+// asserts on log output; we just need a non-nil Logger.
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	return logging.New("/dev/null", false)
+}
+
+// TestAddSessionWhitelist_CreatesFileWithHeaderOnFirstAdd asserts that the
+// first AddSessionWhitelist call creates 00-session.conf with the
+// machine-managed header AND the new entry.
+func TestAddSessionWhitelist_CreatesFileWithHeaderOnFirstAdd(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	log := newTestLogger(t)
+	defer log.Close()
+
+	entry := SessionWhitelistEntry{
+		IP:        "62.38.150.122",
+		ExpiresAt: time.Date(2026, 5, 18, 10, 13, 32, 0, time.UTC),
+		Reason:    "v120-update-session",
+		AddedBy:   "nftban-update",
+	}
+	if err := AddSessionWhitelist(mock, log, entry); err != nil {
+		t.Fatalf("AddSessionWhitelist: %v", err)
+	}
+
+	data, err := mock.ReadFile(sessionWhitelistPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", sessionWhitelistPath, err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "NFTBan Session Whitelist (managed by nftban; do not hand-edit)") {
+		t.Errorf("header missing from new file:\n%s", content)
+	}
+	if !strings.Contains(content, "62.38.150.122") {
+		t.Errorf("entry IP missing:\n%s", content)
+	}
+	if !strings.Contains(content, "EXPIRES_AT=2026-05-18T10:13:32Z") {
+		t.Errorf("EXPIRES_AT marker missing or wrong format:\n%s", content)
+	}
+	if !strings.Contains(content, "REASON=v120-update-session") {
+		t.Errorf("REASON marker missing:\n%s", content)
+	}
+	if !strings.Contains(content, "ADDED_BY=nftban-update") {
+		t.Errorf("ADDED_BY marker missing:\n%s", content)
+	}
+}
+
+// TestAddSessionWhitelist_RefreshesExistingEntry asserts that re-adding the
+// same IP REPLACES rather than DUPLICATES the prior entry (refresh semantics).
+func TestAddSessionWhitelist_RefreshesExistingEntry(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	log := newTestLogger(t)
+	defer log.Close()
+
+	first := SessionWhitelistEntry{
+		IP:        "62.38.150.122",
+		ExpiresAt: time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC),
+		Reason:    "first-add",
+		AddedBy:   "nftban-update",
+	}
+	if err := AddSessionWhitelist(mock, log, first); err != nil {
+		t.Fatalf("first AddSessionWhitelist: %v", err)
+	}
+
+	second := SessionWhitelistEntry{
+		IP:        "62.38.150.122",
+		ExpiresAt: time.Date(2026, 5, 18, 11, 0, 0, 0, time.UTC),
+		Reason:    "second-add",
+		AddedBy:   "nftban-firewall-whitelist-session",
+	}
+	if err := AddSessionWhitelist(mock, log, second); err != nil {
+		t.Fatalf("second AddSessionWhitelist: %v", err)
+	}
+
+	data, err := mock.ReadFile(sessionWhitelistPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	occurrences := strings.Count(content, "62.38.150.122")
+	if occurrences != 1 {
+		t.Errorf("expected exactly 1 occurrence of 62.38.150.122 after refresh, got %d:\n%s",
+			occurrences, content)
+	}
+	if !strings.Contains(content, "REASON=second-add") {
+		t.Errorf("expected refresh to keep newer REASON; not found:\n%s", content)
+	}
+	if strings.Contains(content, "REASON=first-add") {
+		t.Errorf("expected refresh to drop older REASON; still present:\n%s", content)
+	}
+}
+
+// TestCleanupExpiredSessionWhitelist_RemovesOnlyExpired asserts cleanup
+// drops expired entries and preserves active entries + header lines.
+func TestCleanupExpiredSessionWhitelist_RemovesOnlyExpired(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	log := newTestLogger(t)
+	defer log.Close()
+
+	now := time.Now().UTC()
+	expired := SessionWhitelistEntry{
+		IP:        "10.0.0.1",
+		ExpiresAt: now.Add(-1 * time.Hour),
+		Reason:    "stale",
+		AddedBy:   "test",
+	}
+	active := SessionWhitelistEntry{
+		IP:        "10.0.0.2",
+		ExpiresAt: now.Add(1 * time.Hour),
+		Reason:    "fresh",
+		AddedBy:   "test",
+	}
+	if err := AddSessionWhitelist(mock, log, expired); err != nil {
+		t.Fatalf("seed expired: %v", err)
+	}
+	if err := AddSessionWhitelist(mock, log, active); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+
+	removed, err := CleanupExpiredSessionWhitelist(mock, log)
+	if err != nil {
+		t.Fatalf("CleanupExpiredSessionWhitelist: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed, got %d", removed)
+	}
+
+	data, _ := mock.ReadFile(sessionWhitelistPath)
+	content := string(data)
+	if strings.Contains(content, "10.0.0.1") {
+		t.Errorf("expired entry not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "10.0.0.2") {
+		t.Errorf("active entry was incorrectly removed:\n%s", content)
+	}
+	if !strings.Contains(content, "NFTBan Session Whitelist") {
+		t.Errorf("header was clobbered:\n%s", content)
+	}
+}
+
+// TestReadSessionWhitelist_ParsesInlineMarkers asserts the reader returns
+// structured entries (IP + ExpiresAt + Reason + AddedBy) from the file.
+func TestReadSessionWhitelist_ParsesInlineMarkers(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	log := newTestLogger(t)
+	defer log.Close()
+
+	t1 := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 18, 11, 0, 0, 0, time.UTC)
+	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{
+		IP: "10.0.0.1", ExpiresAt: t1, Reason: "one", AddedBy: "test",
+	})
+	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{
+		IP: "10.0.0.2", ExpiresAt: t2, Reason: "two", AddedBy: "test",
+	})
+
+	entries, err := ReadSessionWhitelist(mock, log)
+	if err != nil {
+		t.Fatalf("ReadSessionWhitelist: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	// Order: insertion order preserved in the file.
+	if entries[0].IP != "10.0.0.1" {
+		t.Errorf("entry[0].IP = %q, want 10.0.0.1", entries[0].IP)
+	}
+	if !entries[0].ExpiresAt.Equal(t1) {
+		t.Errorf("entry[0].ExpiresAt = %v, want %v", entries[0].ExpiresAt, t1)
+	}
+	if entries[0].Reason != "one" {
+		t.Errorf("entry[0].Reason = %q, want one", entries[0].Reason)
+	}
+}
+
+// TestRemoveSessionWhitelist_RemovesByIP asserts removal of one IP keeps
+// other entries intact.
+func TestRemoveSessionWhitelist_RemovesByIP(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	log := newTestLogger(t)
+	defer log.Close()
+
+	now := time.Now().UTC().Add(1 * time.Hour)
+	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{IP: "10.0.0.1", ExpiresAt: now, Reason: "a", AddedBy: "t"})
+	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{IP: "10.0.0.2", ExpiresAt: now, Reason: "b", AddedBy: "t"})
+
+	removed, err := RemoveSessionWhitelist(mock, log, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("RemoveSessionWhitelist: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected removed=1, got %d", removed)
+	}
+
+	entries, _ := ReadSessionWhitelist(mock, log)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 surviving entry, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].IP != "10.0.0.2" {
+		t.Errorf("survivor IP = %q, want 10.0.0.2", entries[0].IP)
+	}
+}
+
+// TestCaptureSSHPeerIP_PrefersExplicitEnvMirror asserts that
+// NFTBAN_OPERATOR_SESSION_IP wins over SSH_CLIENT.
+func TestCaptureSSHPeerIP_PrefersExplicitEnvMirror(t *testing.T) {
+	t.Setenv("NFTBAN_OPERATOR_SESSION_IP", "8.8.8.8")
+	t.Setenv("SSH_CLIENT", "1.1.1.1 22 22")
+
+	if got := CaptureSSHPeerIP(); got != "8.8.8.8" {
+		t.Errorf("CaptureSSHPeerIP = %q, want 8.8.8.8 (explicit env-mirror wins)", got)
+	}
+}
+
+// TestCaptureSSHPeerIP_FallsBackToSSHClient asserts SSH_CLIENT is used when
+// the explicit env-mirror is empty.
+func TestCaptureSSHPeerIP_FallsBackToSSHClient(t *testing.T) {
+	t.Setenv("NFTBAN_OPERATOR_SESSION_IP", "")
+	t.Setenv("SSH_CLIENT", "62.38.150.122 51234 22")
+
+	if got := CaptureSSHPeerIP(); got != "62.38.150.122" {
+		t.Errorf("CaptureSSHPeerIP = %q, want 62.38.150.122", got)
+	}
+}
+
+// TestCaptureSSHPeerIP_EmptyOnBothMissing asserts non-SSH invocations
+// (cron, systemd timer, package scriptlet without env-mirror) return "".
+func TestCaptureSSHPeerIP_EmptyOnBothMissing(t *testing.T) {
+	t.Setenv("NFTBAN_OPERATOR_SESSION_IP", "")
+	t.Setenv("SSH_CLIENT", "")
+
+	if got := CaptureSSHPeerIP(); got != "" {
+		t.Errorf("CaptureSSHPeerIP = %q, want \"\" (non-SSH invocation)", got)
+	}
+}
+
+// TestCaptureSSHPeerIP_RejectsNonRoutable asserts loopback / RFC5735
+// non-routable addresses are filtered (matches v1.98.x SeedManualWhitelist
+// contract via shared isRoutableIP).
+func TestCaptureSSHPeerIP_RejectsNonRoutable(t *testing.T) {
+	t.Setenv("NFTBAN_OPERATOR_SESSION_IP", "127.0.0.1")
+	t.Setenv("SSH_CLIENT", "")
+
+	if got := CaptureSSHPeerIP(); got != "" {
+		t.Errorf("CaptureSSHPeerIP = %q, want \"\" (loopback rejected)", got)
+	}
+}
+
+// TestLineIsExpired_ParsesEXPIRES_AT covers the helper directly.
+func TestLineIsExpired_ParsesEXPIRES_AT(t *testing.T) {
+	now := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		line        string
+		wantExpired bool
+	}{
+		{"expired", "10.0.0.1  # EXPIRES_AT=2026-05-18T09:00:00Z  REASON=x  ADDED_BY=t", true},
+		{"active", "10.0.0.1  # EXPIRES_AT=2026-05-18T11:00:00Z  REASON=x  ADDED_BY=t", false},
+		{"no_marker", "10.0.0.1  # REASON=x  ADDED_BY=t", false},
+		{"comment_only", "# header line", false},
+		{"blank", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := lineIsExpired(c.line, now)
+			if got != c.wantExpired {
+				t.Errorf("lineIsExpired(%q) = %v, want %v", c.line, got, c.wantExpired)
+			}
+		})
+	}
+}
+
+// TestExtractIPField_Basics covers the IP-token extractor used by
+// dedup/remove paths.
+func TestExtractIPField_Basics(t *testing.T) {
+	cases := []struct {
+		line string
+		want string
+	}{
+		{"10.0.0.1  # EXPIRES_AT=2026-05-18T11:00:00Z", "10.0.0.1"},
+		{"  192.168.1.0/24   # comment", "192.168.1.0/24"},
+		{"# just a comment", ""},
+		{"", ""},
+		{"  ", ""},
+	}
+	for _, c := range cases {
+		if got := extractIPField(c.line); got != c.want {
+			t.Errorf("extractIPField(%q) = %q, want %q", c.line, got, c.want)
+		}
+	}
+}

--- a/internal/installer/safety/session_whitelist_test.go
+++ b/internal/installer/safety/session_whitelist_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
-// newTestLogger returns a Logger writing to /dev/null. The test never
+// newSessionTestLogger returns a Logger writing to /dev/null. The test never
 // asserts on log output; we just need a non-nil Logger.
-func newTestLogger(t *testing.T) *logging.Logger {
+func newSessionTestLogger(t *testing.T) *logging.Logger {
 	t.Helper()
 	return logging.New("/dev/null", false)
 }
@@ -43,7 +43,7 @@ func newTestLogger(t *testing.T) *logging.Logger {
 // machine-managed header AND the new entry.
 func TestAddSessionWhitelist_CreatesFileWithHeaderOnFirstAdd(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	log := newTestLogger(t)
+	log := newSessionTestLogger(t)
 	defer log.Close()
 
 	entry := SessionWhitelistEntry{
@@ -83,7 +83,7 @@ func TestAddSessionWhitelist_CreatesFileWithHeaderOnFirstAdd(t *testing.T) {
 // same IP REPLACES rather than DUPLICATES the prior entry (refresh semantics).
 func TestAddSessionWhitelist_RefreshesExistingEntry(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	log := newTestLogger(t)
+	log := newSessionTestLogger(t)
 	defer log.Close()
 
 	first := SessionWhitelistEntry{
@@ -128,7 +128,7 @@ func TestAddSessionWhitelist_RefreshesExistingEntry(t *testing.T) {
 // drops expired entries and preserves active entries + header lines.
 func TestCleanupExpiredSessionWhitelist_RemovesOnlyExpired(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	log := newTestLogger(t)
+	log := newSessionTestLogger(t)
 	defer log.Close()
 
 	now := time.Now().UTC()
@@ -176,7 +176,7 @@ func TestCleanupExpiredSessionWhitelist_RemovesOnlyExpired(t *testing.T) {
 // structured entries (IP + ExpiresAt + Reason + AddedBy) from the file.
 func TestReadSessionWhitelist_ParsesInlineMarkers(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	log := newTestLogger(t)
+	log := newSessionTestLogger(t)
 	defer log.Close()
 
 	t1 := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)
@@ -211,7 +211,7 @@ func TestReadSessionWhitelist_ParsesInlineMarkers(t *testing.T) {
 // other entries intact.
 func TestRemoveSessionWhitelist_RemovesByIP(t *testing.T) {
 	mock := executor.NewMockExecutor()
-	log := newTestLogger(t)
+	log := newSessionTestLogger(t)
 	defer log.Close()
 
 	now := time.Now().UTC().Add(1 * time.Hour)

--- a/internal/installer/safety/session_whitelist_test.go
+++ b/internal/installer/safety/session_whitelist_test.go
@@ -219,8 +219,17 @@ func TestReadSessionWhitelist_ParsesInlineMarkers(t *testing.T) {
 	// fixtures became stale relative to "now" when CI ran on the same
 	// day, causing the v1.120 loader's EXPIRES_AT skip to drop the first
 	// entry and surface a false-negative read assertion.
-	t1 := time.Now().UTC().Add(time.Hour)
-	t2 := time.Now().UTC().Add(2 * time.Hour)
+	//
+	// T-2 follow-on fix (V120_PR_637_CI_AND_DIFF_VERIFICATION_RERUN §3):
+	// truncate to second precision so the in-memory value matches the
+	// RFC3339 round-trip the implementation performs at write/read.
+	// time.Now() returns nanosecond precision; AddSessionWhitelist
+	// serializes via RFC3339 ("2026-05-18T12:08:59Z") which drops sub-
+	// second digits; ReadSessionWhitelist parses back at 0 ns. Without
+	// the Truncate, entries[0].ExpiresAt.Equal(t1) returns false for
+	// any non-zero-nanosecond t1 even when the implementation is correct.
+	t1 := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	t2 := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
 	_ = AddSessionWhitelist(mock, log, SessionWhitelistEntry{
 		IP: "10.0.0.1", ExpiresAt: t1, Reason: "one", AddedBy: "test",
 	})

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/itcmsgr/nftban/internal/feeds"
 	"github.com/itcmsgr/nftban/internal/netutil"
@@ -157,10 +158,25 @@ func IsIPInWhitelistFile(ip string, entries map[string]WhitelistEntry) bool {
 
 // loadWhitelistFileTyped loads IPs from a single whitelist file into typed
 // maps, preserving IsCIDR semantics from feeds.ParsedEntry.
+//
+// V120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): if the line carries an inline
+// `# EXPIRES_AT=<RFC3339>` marker, the entry is loaded only when the
+// timestamp is in the future. Expired entries are skipped at load time so
+// the runtime CIDR-aware membership check never sees them. Lines without an
+// EXPIRES_AT marker continue to be loaded unchanged (backward compatibility
+// with 00-system.conf, 99-manual.conf, and any pre-V120 whitelist files).
+// Malformed EXPIRES_AT markers (no value, unparseable RFC3339) cause the
+// entry to be skipped conservatively — operator-intent ambiguity is treated
+// as "do not honor as whitelist."
 func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntry) error {
 	return util.LoadLines(filePath, func(line string) error {
 		entry := feeds.ParseFeedLineSilent(line)
 		if entry == nil {
+			return nil
+		}
+		// V120: skip if the entry carries an EXPIRES_AT marker that is past
+		// or unparseable. No marker → load normally (backward compat).
+		if shouldSkipDueToExpiresAt(line) {
 			return nil
 		}
 		we := WhitelistEntry{
@@ -174,6 +190,38 @@ func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntr
 		}
 		return nil
 	})
+}
+
+// shouldSkipDueToExpiresAt inspects the raw whitelist line for an inline
+// `EXPIRES_AT=<RFC3339>` marker (V120 session-whitelist convention) and
+// returns true if the entry should be SKIPPED — either because the marker
+// is present-but-malformed, or because the timestamp has already passed.
+// Returns false when there is no marker (the entry is non-expiring and
+// loads normally) or when the marker is parseable and the timestamp is
+// still in the future.
+//
+// V120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): keeps the EXPIRES_AT contract
+// in one place so AddSessionWhitelist (writer) and the loader (reader)
+// stay byte-compatible. See internal/installer/safety/session_whitelist.go.
+func shouldSkipDueToExpiresAt(line string) bool {
+	const marker = "EXPIRES_AT="
+	idx := strings.Index(line, marker)
+	if idx < 0 {
+		// No marker — entry is non-expiring; load normally.
+		return false
+	}
+	rest := line[idx+len(marker):]
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		// Marker present but no value — malformed; skip conservatively.
+		return true
+	}
+	ts, err := time.Parse(time.RFC3339, fields[0])
+	if err != nil {
+		// Unparseable timestamp — skip conservatively.
+		return true
+	}
+	return time.Now().UTC().After(ts)
 }
 
 // AddIP adds an IP to the appropriate whitelist file

--- a/internal/whitelist/loader_test.go
+++ b/internal/whitelist/loader_test.go
@@ -624,6 +624,101 @@ func TestIsIPInWhitelistFile_InvalidIPInput(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// V120 EXPIRES_AT matrix tests (D-UPDATE-OPERATOR-SELF-BAN-GAP-001)
+// =============================================================================
+// Asserts the v1.120 loader extension `shouldSkipDueToExpiresAt`:
+//   * loads entries with EXPIRES_AT in the future
+//   * skips entries with EXPIRES_AT in the past (expired)
+//   * conservatively skips entries with malformed EXPIRES_AT timestamps
+//   * preserves backward compatibility (no marker → always load)
+// =============================================================================
+
+func TestLoadAllWhitelists_EXPIRES_AT_FutureEntryLoaded(t *testing.T) {
+	dir := setupTestConfig(t)
+	// EXPIRES_AT in the year 2100 — comfortably future.
+	writeWhitelistFile(t, dir, "00-session.conf", `10.0.0.1  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=test  ADDED_BY=test
+`)
+
+	ipv4, _, err := LoadAllWhitelists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ipv4["10.0.0.1/32"] && !ipv4["10.0.0.1"] {
+		t.Errorf("expected 10.0.0.1 to be loaded (EXPIRES_AT future), ipv4=%v", ipv4)
+	}
+}
+
+func TestLoadAllWhitelists_EXPIRES_AT_PastEntrySkipped(t *testing.T) {
+	dir := setupTestConfig(t)
+	// EXPIRES_AT in the year 2000 — comfortably past.
+	writeWhitelistFile(t, dir, "00-session.conf", `10.0.0.2  # EXPIRES_AT=2000-01-01T00:00:00Z  REASON=stale  ADDED_BY=test
+`)
+
+	ipv4, _, err := LoadAllWhitelists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ipv4["10.0.0.2/32"] || ipv4["10.0.0.2"] {
+		t.Errorf("expected 10.0.0.2 to be SKIPPED (EXPIRES_AT past), ipv4=%v", ipv4)
+	}
+}
+
+func TestLoadAllWhitelists_EXPIRES_AT_MalformedSkippedConservatively(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "00-session.conf", `10.0.0.3  # EXPIRES_AT=not-a-timestamp  REASON=garbage  ADDED_BY=test
+`)
+
+	ipv4, _, err := LoadAllWhitelists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Malformed marker → conservative skip (the marker's PRESENCE signals
+	// "this is a TTL'd entry"; failure to parse must not be treated as
+	// "no marker" because that would default to permanent load).
+	if ipv4["10.0.0.3/32"] || ipv4["10.0.0.3"] {
+		t.Errorf("expected 10.0.0.3 to be SKIPPED (malformed EXPIRES_AT), ipv4=%v", ipv4)
+	}
+}
+
+func TestLoadAllWhitelists_EXPIRES_AT_NoMarkerLoaded(t *testing.T) {
+	dir := setupTestConfig(t)
+	// Plain entry without any EXPIRES_AT marker — backward-compat path.
+	writeWhitelistFile(t, dir, "99-manual.conf", `10.0.0.4
+`)
+
+	ipv4, _, err := LoadAllWhitelists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ipv4["10.0.0.4/32"] && !ipv4["10.0.0.4"] {
+		t.Errorf("expected 10.0.0.4 to be loaded (no EXPIRES_AT = permanent), ipv4=%v", ipv4)
+	}
+}
+
+func TestLoadAllWhitelists_EXPIRES_AT_MixedFileFutureAndPast(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "00-session.conf", `# header
+10.0.0.5  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=keep  ADDED_BY=test
+10.0.0.6  # EXPIRES_AT=2000-01-01T00:00:00Z  REASON=drop  ADDED_BY=test
+10.0.0.7
+`)
+
+	ipv4, _, err := LoadAllWhitelists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ipv4["10.0.0.5/32"] && !ipv4["10.0.0.5"] {
+		t.Errorf("expected 10.0.0.5 loaded (future), ipv4=%v", ipv4)
+	}
+	if ipv4["10.0.0.6/32"] || ipv4["10.0.0.6"] {
+		t.Errorf("expected 10.0.0.6 SKIPPED (past), ipv4=%v", ipv4)
+	}
+	if !ipv4["10.0.0.7/32"] && !ipv4["10.0.0.7"] {
+		t.Errorf("expected 10.0.0.7 loaded (no marker), ipv4=%v", ipv4)
+	}
+}
+
 // Dual-API parity guard: legacy LoadAllWhitelists key set must match
 // LoadAllWhitelistsTyped (guards profile_sync.go callers against drift).
 func TestLoadAllWhitelists_DualAPIParity(t *testing.T) {

--- a/internal/whitelist/schema_freeze_test.go
+++ b/internal/whitelist/schema_freeze_test.go
@@ -1,0 +1,61 @@
+// =============================================================================
+// NFTBan v1.120 - Schema-freeze regression guard for V120 Operator Temp Whitelist Guard
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="whitelist_schema_freeze_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-18"
+// meta:description="V120 schema-freeze regression guard — asserts SchemaVersionCurrent stays 1.83.0 throughout the V120 Operator Temp Whitelist Guard implementation. Per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md verdict SCHEMA_STAYS_FROZEN (conditional on --json deferral). Mirrors internal/blacklist/schema_freeze_test.go from v1.119."
+// meta:input="None"
+// meta:output="t.Fatal on schema drift"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package whitelist
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/validator"
+)
+
+// TestSchemaVersionUnchangedByV120OperatorSessionWhitelist is the v1.120
+// equivalent of v1.119's TestSchemaVersionUnchangedByManualCIDRFix
+// (located in internal/blacklist/schema_freeze_test.go). It asserts that
+// the V120 Operator Temp Whitelist Guard implementation does NOT bump the
+// frozen schema version. Per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md
+// verdict SCHEMA_STAYS_FROZEN (conditional on --json deferral), all seven
+// surface analyses (Q1 text CLI, Q2 list --json [DEFERRED], Q3 file format
+// EXPIRES_AT, Q4 status output, Q5 metrics, Q6 validator/schema, Q7 nftables
+// kernel set) returned NO schema impact.
+//
+// If this test fails, the V120 implementation has accidentally introduced
+// a schema-impacting change. Stop, re-read V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md,
+// and either revert the change OR open a separate
+// OPEN_V12x_SCHEMA_UNFREEZE_GATE for the new schema version BEFORE
+// merging the implementation PR.
+//
+// Co-located in internal/whitelist/ because this package is the load-bearing
+// site of the V120 EXPIRES_AT loader extension; placing the guard adjacent
+// to the typed-loader changes makes drift-detection blast radius local
+// (mirrors v1.119's adjacency at internal/blacklist/schema_freeze_test.go).
+func TestSchemaVersionUnchangedByV120OperatorSessionWhitelist(t *testing.T) {
+	const expectedSchema = "1.83.0"
+	if validator.SchemaVersionCurrent != expectedSchema {
+		t.Fatalf("SchemaVersionCurrent = %q, want %q — V120 Operator Temp Whitelist Guard MUST NOT "+
+			"bump schema (per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md verdict "+
+			"SCHEMA_STAYS_FROZEN). If a schema bump is genuinely needed (e.g. for --json "+
+			"support on the new whitelist-session subcommand), request "+
+			"OPEN_V12x_SCHEMA_UNFREEZE_GATE separately.",
+			validator.SchemaVersionCurrent, expectedSchema)
+	}
+}


### PR DESCRIPTION
## Summary

Closes operator self-ban gap **D-UPDATE-OPERATOR-SELF-BAN-GAP-001** (verdict
`OPERATOR_SELF_BAN_GAP_CONFIRMED_CODE_FIX_REQUIRED`, per
`V119_OPERATOR_SELF_BAN_INCIDENT_AUDIT.md`).

When the operator runs `nftban update` or `firewall takeover` from an SSH
session whose peer IP is not in the permanent whitelist, the LoginMon
brute-force scorer can ban that IP during the brief reload window and lock
the operator out for the full timeout (typ. 900s).

V120 ships **Shape E.0 (file-based)** — no new nft set, no systemd timer,
schema 1.83.0 unchanged:

- `internal/installer/safety/session_whitelist.go` (new) writes
  `/etc/nftban/whitelist.d/00-session.conf` with inline
  `# EXPIRES_AT=<RFC3339>` markers and refresh-by-IP dedup.
- `internal/whitelist/loader.go` skips expired entries at load time
  (backward compatible; no marker = permanent, unchanged).
- `cmd/nftban-installer/{flags,main,phases}.go` auto-seed the SSH peer IP
  every update path (ungated, unlike `SeedManualWhitelist --source` gate).
  New `--session-whitelist-ttl` flag (default 30m; 0 disables).
- `cli/lib/nftban/cli/cmd_update.sh` captures `$SSH_CLIENT` pre-invoke
  and exports `NFTBAN_OPERATOR_SESSION_IP` so the env mirror survives
  sudo / package-scriptlet hops that scrub SSH_CLIENT.
- `cli/lib/nftban/cli/cmd_firewall.sh` adds explicit operator override:
  `nftban firewall whitelist-session {add,list,remove,cleanup}`.

## Schema impact

**SCHEMA_STAYS_FROZEN at 1.83.0** per
`V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md` — conditional on
**`--json` deferral**. The new `whitelist-session` subcommand REJECTS
`--json` (and `-j`) at the dispatcher with an operator-actionable error
message; JSON output is deferred to v1.121 pending the Q2 schema-envelope
decision (whether new top-level CLI subcommand JSON falls under the
M81-6 Status JSON wire-format freeze).

A regression guard `TestSchemaVersionUnchangedByV120OperatorSessionWhitelist`
co-located in `internal/whitelist/` asserts `SchemaVersionCurrent == "1.83.0"`.

## Forbidden-surface zero-touch (per scope locks)

- schema 1.83.0 unchanged
- `internal/profile/profile_sync.go` byte-unchanged
- `internal/runtime/state.go` byte-unchanged
- no new nft set / no nftables ruleset change
- no `install/systemd/*` change
- no metrics / Prometheus surface change
- no validator change
- no panel adapter change
- no MASTER_TODO file edits
- no v0.x tag mutation

## Test plan

- [x] Go unit tests added: `internal/installer/safety/session_whitelist_test.go` (11 cases)
- [x] Go loader matrix added: `internal/whitelist/loader_test.go` (+5 EXPIRES_AT cases)
- [x] Schema-freeze regression guard added: `internal/whitelist/schema_freeze_test.go`
- [x] Shell test suite added: `cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh` (33/33 PASS locally)
- [x] `bash -n` syntax checks pass for both edited shell files + new test
- [ ] CI green (await GitHub Actions)
- [ ] Post-merge: `EXECUTE_V119_VALIDATE_LAB2_CORE = GO` resumed with v1.120 binaries — operator pre-seeds SSH peer IP via `nftban firewall whitelist-session add <ip> --ttl 30m` before invoking the update path on a real host

## References

- `AUDIT_190_LIFECYCLE/V119_OPERATOR_SELF_BAN_INCIDENT_AUDIT.md` (incident root cause)
- `AUDIT_190_LIFECYCLE/V119_VALIDATE_RUNBOOK_SELF_BAN_GUARD_AMENDMENT.md` (operational mitigation)
- `AUDIT_190_LIFECYCLE/V120_OPERATOR_TEMP_WHITELIST_GUARD_SCOPE.md` (Shape E.0 design)
- `AUDIT_190_LIFECYCLE/V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md` (verdict SCHEMA_STAYS_FROZEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)