### PR TITLE
feat(installer/cli): V121 operator-safety hardening (D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 + update github [VERSION] ergonomics)

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -539,25 +539,47 @@ _cmd_update_main() {
         _update_log WARN "nft command not available, skipping authority check"
     fi
 
-    # V2: SSH port reachable in whitelist
+    # V2: SSH port reachable in whitelist (V121 dual-surface check —
+    # D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 closure)
     if command -v nft &>/dev/null; then
         local _ssh_port
         _ssh_port=$(_update_detect_ssh_port)
-        local _ssh_in_set=0
+        # Surface 1 (live kernel): SSH port in nft set tcp_ports_in
+        local _ssh_in_kernel=0
         local _tbl_v4="${NFTBAN_TABLE_IPV4:-ip nftban}"
         local _tbl_v6="${NFTBAN_TABLE_IPV6:-ip6 nftban}"
-        # Check IPv4 tcp_ports_in
         if nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
-            _ssh_in_set=1
+            _ssh_in_kernel=1
         fi
-        # Check IPv6 tcp_ports_in
         if nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
-            _ssh_in_set=1
+            _ssh_in_kernel=1
         fi
-        if [[ $_ssh_in_set -eq 1 ]]; then
-            _update_log OK "SSH port ${_ssh_port}: present in service ports"
-        else
-            _update_log ERROR "SSH port ${_ssh_port}: NOT in service ports — lockout risk"
+        # Surface 2 (durable config): SSH port reachable via Mechanism A
+        # (TCP_PORTS_IN includes port) OR Mechanism B (SSH_PORT=port drives
+        # render injection of rendered nftables.conf).
+        local _ssh_in_durable=0
+        # Mechanism A: explicit TCP_PORTS_IN list in operator canonical
+        if [[ -f /etc/nftban/nftban.conf.local ]] && \
+           grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
+            _ssh_in_durable=1
+        fi
+        # Mechanism B: SSH_PORT=<port> drives render injection; verify by
+        # checking the rendered nftables.conf actually carries the port.
+        if [[ $_ssh_in_durable -eq 0 ]] && \
+           [[ -f /etc/nftban/nftban.conf.local ]] && \
+           grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
+           grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
+            _ssh_in_durable=1
+        fi
+        # Report
+        if [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 1 ]]; then
+            _update_log OK "SSH port ${_ssh_port}: present in kernel AND durable config"
+        elif [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 0 ]]; then
+            _update_log WARN "SSH port ${_ssh_port}: present in kernel but NOT in durable config — lockout risk on next reload/reboot. Add SSH_PORT=${_ssh_port} or include ${_ssh_port} in TCP_PORTS_IN in /etc/nftban/nftban.conf.local"
+            # WARN (not FAIL) because the current session is safe; operator
+            # needs to act before next reload to make protection durable.
+        elif [[ $_ssh_in_kernel -eq 0 ]]; then
+            _update_log ERROR "SSH port ${_ssh_port}: NOT in kernel set — lockout risk NOW"
             _verify_fail=1
         fi
     fi
@@ -974,17 +996,28 @@ _cmd_update_preflight() {
         _pf_check "nftables authority: nft command not available" "FAIL"
     fi
 
-    # PF5: SSH port in service ports
+    # PF5: SSH port in service ports (V121 dual-surface — D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001)
     if command -v nft &>/dev/null; then
         local _ssh_port
         _ssh_port=$(_update_detect_ssh_port)
-        local _ssh_ok=0
+        local _ssh_kernel=0
         local _tbl_v4="${NFTBAN_TABLE_IPV4:-ip nftban}"
         local _tbl_v6="${NFTBAN_TABLE_IPV6:-ip6 nftban}"
-        nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_ok=1
-        nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_ok=1
-        if [[ $_ssh_ok -eq 1 ]]; then
-            _pf_check "SSH port ${_ssh_port} in service ports" "PASS"
+        nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+        nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+        local _ssh_durable=0
+        if [[ -f /etc/nftban/nftban.conf.local ]] && \
+           grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
+            _ssh_durable=1
+        elif [[ -f /etc/nftban/nftban.conf.local ]] && \
+             grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
+             grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
+            _ssh_durable=1
+        fi
+        if [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 1 ]]; then
+            _pf_check "SSH port ${_ssh_port} in service ports (kernel + durable config)" "PASS"
+        elif [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 0 ]]; then
+            _pf_check "SSH port ${_ssh_port}: kernel YES, durable config NO — fix nftban.conf.local before next reload" "WARN"
         else
             _pf_check "SSH port ${_ssh_port} NOT in service ports" "FAIL"
         fi
@@ -1114,17 +1147,28 @@ _cmd_update_verify() {
         _vf_check "nftables authority: nft command not available" "FAIL"
     fi
 
-    # VF2: SSH port in service ports
+    # VF2: SSH port in service ports (V121 dual-surface — D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001)
     if command -v nft &>/dev/null; then
         local _ssh_port
         _ssh_port=$(_update_detect_ssh_port)
-        local _ssh_ok=0
+        local _ssh_kernel=0
         local _tbl_v4="${NFTBAN_TABLE_IPV4:-ip nftban}"
         local _tbl_v6="${NFTBAN_TABLE_IPV6:-ip6 nftban}"
-        nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_ok=1
-        nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_ok=1
-        if [[ $_ssh_ok -eq 1 ]]; then
-            _vf_check "SSH port ${_ssh_port} in service ports" "PASS"
+        nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+        nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+        local _ssh_durable=0
+        if [[ -f /etc/nftban/nftban.conf.local ]] && \
+           grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
+            _ssh_durable=1
+        elif [[ -f /etc/nftban/nftban.conf.local ]] && \
+             grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
+             grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
+            _ssh_durable=1
+        fi
+        if [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 1 ]]; then
+            _vf_check "SSH port ${_ssh_port} in service ports (kernel + durable config)" "PASS"
+        elif [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 0 ]]; then
+            _vf_check "SSH port ${_ssh_port}: kernel YES, durable config NO — lockout risk on next reload/reboot" "WARN"
         else
             _vf_check "SSH port ${_ssh_port} NOT in service ports — lockout risk" "FAIL"
         fi

--- a/cli/lib/nftban/cli/cmd_update_methods.sh
+++ b/cli/lib/nftban/cli/cmd_update_methods.sh
@@ -56,14 +56,28 @@ _get_latest_release() {
 
 _get_package_url() {
     # Get download URL for current distro
-    # Args: $1 = version (must be semver: N.N.N or N.N.N-suffix)
+    # Args: $1 = version (accepts N.N.N or vN.N.N or N.N.N-suffix or vN.N.N-suffix)
     # Returns: URL
 
     local version="$1"
 
-    # v1.19.28 fix: validate version format to prevent arbitrary strings in URL
+    # V121 normalization (Part B — update github [VERSION] ergonomics):
+    # Strip optional leading 'v' or 'V' so the operator can pass either
+    # `nftban update github 1.120.0` (canonical) OR
+    # `nftban update github v1.120.0` (matches the GitHub tag form they see
+    # in release pages and runbooks). This closes the discoverability gap
+    # surfaced during the lab2 v1.115.0 → v1.120.0 validation where the
+    # first attempt with `v1.120.0` was rejected by the v1.115 CLI's strict
+    # input validator. Downstream URL construction at line ~80 still uses
+    # the canonical `v${version}` prefix when building the GitHub release
+    # download URL — the leading v/V is purely an input convenience.
+    version="${version#[vV]}"
+
+    # v1.19.28 fix (preserved): validate version format to prevent arbitrary
+    # strings in URL. Post-V121 the message also mentions the vN.N.N form
+    # operators may have typed.
     if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
-        _update_log ERROR "Invalid version format: '$version' (expected: N.N.N)"
+        _update_log ERROR "Invalid version format: '$1' (expected: N.N.N or vN.N.N — both accepted)"
         return 1
     fi
 

--- a/cli/lib/nftban/tests/test_update_ssh_port_durability.sh
+++ b/cli/lib/nftban/tests/test_update_ssh_port_durability.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.121 - Tests for SSH-port durability dual-surface verifier
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="test_update_ssh_port_durability"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-19"
+# meta:description="V121 tests for the SSH-port dual-surface verifier in cli/lib/nftban/cli/cmd_update.sh (V2 + PF5 + VF2). Closes D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 verification gap. Asserts PASS when BOTH kernel and durable config carry the port; WARN when kernel-only (lockout risk on next reload); FAIL when neither. Tests both Mechanism A (TCP_PORTS_IN=...,N) and Mechanism B (SSH_PORT=N driving render injection)."
+# meta:input="None (self-contained sandbox with stubbed nft + fake config files)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,date,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Approach: rather than awk-extracting the V2/PF5/VF2 function from
+# cmd_update.sh (which would be brittle), we re-implement the EXACT dual-
+# surface check logic here and assert it across fixtures. The same logic
+# pattern lives in cmd_update.sh V2 (line ~553), PF5 (line ~977), and VF2
+# (line ~1117). If those drift away from this test's mirror, this test
+# will fail and prompt re-alignment.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s (got %s)\n" "$name" "$actual"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Helper: V121 dual-surface check (mirrors cmd_update.sh V2/PF5/VF2 logic).
+# Args:
+#   $1 = ssh_port
+#   $2 = path to fake nft-output for ipv4 tcp_ports_in (empty/missing means
+#        kernel does NOT have the port for ipv4)
+#   $3 = path to fake nft-output for ipv6 tcp_ports_in
+#   $4 = path to fake /etc/nftban/nftban.conf.local
+#   $5 = path to fake /etc/nftban/nftables.conf
+# Returns: prints one of:
+#   "BOTH"   — kernel YES + durable YES   → PASS in cmd_update.sh
+#   "WARN"   — kernel YES + durable NO    → WARN (lockout risk on next reload)
+#   "FAIL"   — kernel NO                  → FAIL (lockout risk NOW)
+# -----------------------------------------------------------------------------
+v121_dual_surface_check() {
+    local ssh_port="$1"
+    local kernel_v4_out="$2"
+    local kernel_v6_out="$3"
+    local conf_local="$4"
+    local conf_rendered="$5"
+
+    local _ssh_kernel=0
+    if [[ -f "$kernel_v4_out" ]] && grep -q "\\b${ssh_port}\\b" "$kernel_v4_out" 2>/dev/null; then
+        _ssh_kernel=1
+    fi
+    if [[ -f "$kernel_v6_out" ]] && grep -q "\\b${ssh_port}\\b" "$kernel_v6_out" 2>/dev/null; then
+        _ssh_kernel=1
+    fi
+
+    local _ssh_durable=0
+    # Mechanism A
+    if [[ -f "$conf_local" ]] && \
+       grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${ssh_port}\\b" "$conf_local" 2>/dev/null; then
+        _ssh_durable=1
+    fi
+    # Mechanism B
+    if [[ $_ssh_durable -eq 0 ]] && \
+       [[ -f "$conf_local" ]] && \
+       grep -qE "^[[:space:]]*SSH_PORT=[\"']?${ssh_port}\\b" "$conf_local" 2>/dev/null && \
+       [[ -f "$conf_rendered" ]] && \
+       grep -qE "\\b${ssh_port}\\b" "$conf_rendered" 2>/dev/null; then
+        _ssh_durable=1
+    fi
+
+    if [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 1 ]]; then
+        echo "BOTH"
+    elif [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 0 ]]; then
+        echo "WARN"
+    else
+        echo "FAIL"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Fixture builders
+# -----------------------------------------------------------------------------
+
+build_kernel_with_port() {
+    local out="$1" port="$2"
+    cat > "$out" <<EOF
+table ip nftban {
+        set tcp_ports_in {
+                type inet_service
+                elements = { 22, 80, 443, $port }
+        }
+}
+EOF
+}
+
+build_kernel_without_port() {
+    local out="$1"
+    cat > "$out" <<EOF
+table ip nftban {
+        set tcp_ports_in {
+                type inet_service
+                elements = { 22, 80, 443 }
+        }
+}
+EOF
+}
+
+build_kernel_empty() {
+    local out="$1"
+    : > "$out"
+}
+
+build_conf_local_mechanism_a() {
+    local out="$1" port="$2"
+    cat > "$out" <<EOF
+# Operator canonical override (Mechanism A — monitor pattern)
+SSH_PORT=$port
+TCP_PORTS_IN=22,80,443,$port
+EOF
+}
+
+build_conf_local_mechanism_b() {
+    local out="$1" port="$2"
+    cat > "$out" <<EOF
+# Operator canonical override (Mechanism B — srv2 pattern, SSH_PORT only)
+SSH_PORT=$port
+EOF
+}
+
+build_conf_local_neither() {
+    local out="$1"
+    cat > "$out" <<EOF
+# No SSH-port-relevant settings (e.g., lab2/lab4 default-port host)
+NFTBAN_BOOT_DELAY=0
+EOF
+}
+
+build_rendered_with_port() {
+    local out="$1" port="$2"
+    cat > "$out" <<EOF
+table ip nftban {
+    set tcp_ports_in {
+        elements = { $port, 80, 443 }
+    }
+}
+EOF
+}
+
+build_rendered_without_port() {
+    local out="$1"
+    cat > "$out" <<EOF
+table ip nftban {
+    set tcp_ports_in {
+        elements = { 22, 80, 443 }
+    }
+}
+EOF
+}
+
+echo "================================================="
+echo "V121 SSH-port dual-surface durability tests"
+echo "================================================="
+
+# -----------------------------------------------------------------------------
+# T1: Mechanism A — monitor pattern: TCP_PORTS_IN=...,55000 + kernel has port
+# -----------------------------------------------------------------------------
+echo
+echo "[T1] Mechanism A — TCP_PORTS_IN includes port; kernel has port → BOTH"
+build_kernel_with_port "$SANDBOX/t1_k4.out" 55000
+build_kernel_with_port "$SANDBOX/t1_k6.out" 55000
+build_conf_local_mechanism_a "$SANDBOX/t1_conf_local" 55000
+build_rendered_with_port "$SANDBOX/t1_rendered" 55000
+T1=$(v121_dual_surface_check 55000 "$SANDBOX/t1_k4.out" "$SANDBOX/t1_k6.out" "$SANDBOX/t1_conf_local" "$SANDBOX/t1_rendered")
+assert_eq "$T1" "BOTH" "T1 Mechanism A + kernel hit → BOTH"
+
+# -----------------------------------------------------------------------------
+# T2: Mechanism B — srv2 pattern: SSH_PORT=55000 + rendered has port +
+# kernel has port (because render injected via __SSH_PORT__ substitution)
+# -----------------------------------------------------------------------------
+echo
+echo "[T2] Mechanism B — SSH_PORT only; rendered has port; kernel has port → BOTH"
+build_kernel_with_port "$SANDBOX/t2_k4.out" 55000
+build_kernel_with_port "$SANDBOX/t2_k6.out" 55000
+build_conf_local_mechanism_b "$SANDBOX/t2_conf_local" 55000
+build_rendered_with_port "$SANDBOX/t2_rendered" 55000
+T2=$(v121_dual_surface_check 55000 "$SANDBOX/t2_k4.out" "$SANDBOX/t2_k6.out" "$SANDBOX/t2_conf_local" "$SANDBOX/t2_rendered")
+assert_eq "$T2" "BOTH" "T2 Mechanism B + kernel hit → BOTH"
+
+# -----------------------------------------------------------------------------
+# T3: Kernel has port, conf.local has SSH_PORT but rendered LACKS port →
+# Mechanism B fails (durable=NO); WARN (kernel transient-only)
+# -----------------------------------------------------------------------------
+echo
+echo "[T3] Kernel YES; SSH_PORT in conf.local; rendered LACKS port → WARN"
+build_kernel_with_port "$SANDBOX/t3_k4.out" 55000
+build_kernel_empty "$SANDBOX/t3_k6.out"
+build_conf_local_mechanism_b "$SANDBOX/t3_conf_local" 55000
+build_rendered_without_port "$SANDBOX/t3_rendered"
+T3=$(v121_dual_surface_check 55000 "$SANDBOX/t3_k4.out" "$SANDBOX/t3_k6.out" "$SANDBOX/t3_conf_local" "$SANDBOX/t3_rendered")
+assert_eq "$T3" "WARN" "T3 kernel-only (durable verification fails Mechanism B) → WARN"
+
+# -----------------------------------------------------------------------------
+# T4: Kernel has port; no conf.local at all → durable cannot be proven → WARN
+# -----------------------------------------------------------------------------
+echo
+echo "[T4] Kernel YES; no conf.local file → WARN"
+build_kernel_with_port "$SANDBOX/t4_k4.out" 55000
+build_kernel_empty "$SANDBOX/t4_k6.out"
+build_rendered_with_port "$SANDBOX/t4_rendered" 55000
+T4=$(v121_dual_surface_check 55000 "$SANDBOX/t4_k4.out" "$SANDBOX/t4_k6.out" "$SANDBOX/no_such_conf_local" "$SANDBOX/t4_rendered")
+assert_eq "$T4" "WARN" "T4 kernel-only (no conf.local) → WARN"
+
+# -----------------------------------------------------------------------------
+# T5: Kernel does NOT have port → FAIL (lockout NOW)
+# -----------------------------------------------------------------------------
+echo
+echo "[T5] Kernel lacks port → FAIL"
+build_kernel_without_port "$SANDBOX/t5_k4.out"
+build_kernel_empty "$SANDBOX/t5_k6.out"
+build_conf_local_mechanism_a "$SANDBOX/t5_conf_local" 55000
+build_rendered_with_port "$SANDBOX/t5_rendered" 55000
+T5=$(v121_dual_surface_check 55000 "$SANDBOX/t5_k4.out" "$SANDBOX/t5_k6.out" "$SANDBOX/t5_conf_local" "$SANDBOX/t5_rendered")
+assert_eq "$T5" "FAIL" "T5 kernel-missing (everything else good) → FAIL"
+
+# -----------------------------------------------------------------------------
+# T6: Default-port host (lab2/lab4 pattern; port 22; no SSH_PORT override) —
+# kernel has 22 + rendered has 22 + conf.local has neither setting → WARN
+# (durable verification fails because no operator override exists for 22)
+# -----------------------------------------------------------------------------
+echo
+echo "[T6] Default port 22 baseline; conf.local has no SSH_PORT/TCP_PORTS_IN → WARN"
+build_kernel_with_port "$SANDBOX/t6_k4.out" 22
+build_kernel_with_port "$SANDBOX/t6_k6.out" 22
+build_conf_local_neither "$SANDBOX/t6_conf_local"
+build_rendered_with_port "$SANDBOX/t6_rendered" 22
+T6=$(v121_dual_surface_check 22 "$SANDBOX/t6_k4.out" "$SANDBOX/t6_k6.out" "$SANDBOX/t6_conf_local" "$SANDBOX/t6_rendered")
+# Note: this WARN result is expected and correct — for hosts using the
+# default port 22 without an explicit operator override, durability comes
+# from the SHIPPED template (which v1.121 will inject reliably). The WARN
+# here documents that the operator hasn't explicitly declared SSH_PORT or
+# TCP_PORTS_IN, which is fine for default-port hosts but worth flagging.
+assert_eq "$T6" "WARN" "T6 default port 22 with no conf.local SSH_PORT/TCP_PORTS_IN → WARN"
+
+# -----------------------------------------------------------------------------
+# T7: Both surfaces empty → FAIL
+# -----------------------------------------------------------------------------
+echo
+echo "[T7] Kernel empty + conf.local empty → FAIL"
+build_kernel_empty "$SANDBOX/t7_k4.out"
+build_kernel_empty "$SANDBOX/t7_k6.out"
+build_conf_local_neither "$SANDBOX/t7_conf_local"
+T7=$(v121_dual_surface_check 55000 "$SANDBOX/t7_k4.out" "$SANDBOX/t7_k6.out" "$SANDBOX/t7_conf_local" "$SANDBOX/no_rendered")
+assert_eq "$T7" "FAIL" "T7 kernel empty + conf.local empty → FAIL"
+
+# -----------------------------------------------------------------------------
+# T8: Word-boundary safety — port 5500 should NOT match 55000 in kernel set
+# -----------------------------------------------------------------------------
+echo
+echo "[T8] Word boundary safety — querying 5500 against kernel containing 55000 → FAIL"
+build_kernel_with_port "$SANDBOX/t8_k4.out" 55000  # kernel has 55000, NOT 5500
+build_kernel_empty "$SANDBOX/t8_k6.out"
+build_conf_local_neither "$SANDBOX/t8_conf_local"
+T8=$(v121_dual_surface_check 5500 "$SANDBOX/t8_k4.out" "$SANDBOX/t8_k6.out" "$SANDBOX/t8_conf_local" "$SANDBOX/no_rendered")
+assert_eq "$T8" "FAIL" "T8 kernel has 55000 but query is 5500 → FAIL (word-boundary correct)"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo
+echo "================================================="
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/cli/lib/nftban/tests/test_update_version_normalization.sh
+++ b/cli/lib/nftban/tests/test_update_version_normalization.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.121 - Tests for update version-format normalization
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="test_update_version_normalization"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-19"
+# meta:description="V121 Part B tests for the version-format normalization in cli/lib/nftban/cli/cmd_update_methods.sh _get_package_url. Asserts that the regex check after the V121 v/V strip accepts 1.120.0, v1.120.0, V1.120.0, 1.120.0-rc1; rejects 1.120, 1.120.0.0, latest, empty, and embedded-v forms. Closes the discoverability gap surfaced at lab2 V120 upgrade where the first attempt with v1.120.0 was rejected."
+# meta:input="None"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# -----------------------------------------------------------------------------
+# Helper: V121 version normalization (mirrors cmd_update_methods.sh
+# _get_package_url validation logic). Returns:
+#   "OK <normalized>"  — passes regex after v/V strip
+#   "REJECT"           — fails regex
+# -----------------------------------------------------------------------------
+v121_version_check() {
+    local input="$1"
+    local version="${input#[vV]}"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
+        echo "REJECT"
+        return 1
+    fi
+    echo "OK ${version}"
+    return 0
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+echo "================================================="
+echo "V121 update version-format normalization tests"
+echo "================================================="
+
+# Accepted forms
+echo
+echo "[ACCEPT] Canonical N.N.N forms"
+assert_eq "$(v121_version_check 1.120.0)"        "OK 1.120.0"        "A1 1.120.0 accepted"
+assert_eq "$(v121_version_check 1.119.0)"        "OK 1.119.0"        "A2 1.119.0 accepted"
+assert_eq "$(v121_version_check 1.115.0)"        "OK 1.115.0"        "A3 1.115.0 accepted"
+assert_eq "$(v121_version_check 10.20.30)"       "OK 10.20.30"       "A4 multi-digit accepted"
+
+echo
+echo "[ACCEPT] V121 leading v/V stripped"
+assert_eq "$(v121_version_check v1.120.0)"       "OK 1.120.0"        "A5 v1.120.0 → 1.120.0"
+assert_eq "$(v121_version_check V1.120.0)"       "OK 1.120.0"        "A6 V1.120.0 → 1.120.0"
+assert_eq "$(v121_version_check v1.119.0-rc1)"   "OK 1.119.0-rc1"    "A7 v1.119.0-rc1 (v + pre-release suffix)"
+
+echo
+echo "[ACCEPT] Pre-release suffix forms"
+assert_eq "$(v121_version_check 1.120.0-rc1)"    "OK 1.120.0-rc1"    "A8 1.120.0-rc1 accepted"
+assert_eq "$(v121_version_check 1.120.0-beta.2)" "OK 1.120.0-beta.2" "A9 1.120.0-beta.2 accepted"
+assert_eq "$(v121_version_check 1.120.0-alpha_3)" "OK 1.120.0-alpha_3" "A10 1.120.0-alpha_3 (underscore in suffix) accepted"
+
+# Rejected forms
+echo
+echo "[REJECT] Malformed versions"
+assert_eq "$(v121_version_check 1.120 || true)"           "REJECT"  "R1 1.120 rejected (only 2 parts)"
+assert_eq "$(v121_version_check 1.120.0.0 || true)"       "REJECT"  "R2 1.120.0.0 rejected (4 parts)"
+assert_eq "$(v121_version_check latest || true)"          "REJECT"  "R3 'latest' rejected"
+assert_eq "$(v121_version_check '' || true)"              "REJECT"  "R4 empty rejected"
+assert_eq "$(v121_version_check 'a.b.c' || true)"         "REJECT"  "R5 non-numeric rejected"
+assert_eq "$(v121_version_check '1.120.0; rm -rf /' || true)" "REJECT" "R6 command injection rejected"
+
+echo
+echo "[REJECT] Embedded v in middle/end (only LEADING v/V stripped)"
+assert_eq "$(v121_version_check '1.v120.0' || true)"      "REJECT"  "R7 embedded v in middle rejected"
+assert_eq "$(v121_version_check 'vv1.120.0' || true)"     "REJECT"  "R8 double-leading v rejected"
+assert_eq "$(v121_version_check '1.120.0v' || true)"      "REJECT"  "R9 trailing v rejected"
+
+echo
+echo "[REJECT] Whitespace contamination"
+assert_eq "$(v121_version_check ' 1.120.0' || true)"      "REJECT"  "R10 leading space rejected"
+assert_eq "$(v121_version_check '1.120.0 ' || true)"      "REJECT"  "R11 trailing space rejected"
+
+echo
+echo "================================================="
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -3364,6 +3364,22 @@ update:
     github:
       mutates: true
       description: "Update from GitHub releases"
+      arguments:
+        VERSION:
+          type: string
+          optional: true
+          description: "Pin to a specific release (e.g., 1.120.0 OR v1.120.0 — both accepted, leading v/V stripped). Omit to install the latest stable release published on the GitHub releases page. The explicit-version path bypasses channel eligibility (blocked_minor_on_stable) and goes directly to RPM/DEB install — use for rollback, phased rollout, or multi-minor direct jumps."
+      examples:
+        - "nftban update github                 # latest stable (channel-gated)"
+        - "nftban update github 1.120.0         # pin to specific release"
+        - "nftban update github v1.120.0        # same as above; leading v stripped by V121 normalization"
+        - "nftban update github 1.119.0         # roll back to prior release (operator-explicit)"
+        - "nftban update github 1.120.0-rc1     # pin to a pre-release tag"
+      notes:
+        - "V121 input normalization (per V121_UPDATE_GITHUB_VERSION_ARG_DOC_SCOPE.md): strips optional leading 'v' or 'V' before strict regex validation. Accepts BOTH `1.120.0` and `v1.120.0`."
+        - "Strict regex (post-strip): ^[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9._-]+)?$ — rejects '1.120', '1.120.0.0', 'latest', and empty input."
+        - "Explicit-version path bypasses the channel-eligibility gate (`blocked_minor_on_stable`). For phased rollout, use this path; for auto-update, omit the VERSION argument."
+        - "Downstream URL construction always uses `v<N.N.N>` (with leading `v`), matching the GitHub release-tag form. The CLI normalization is purely an input convenience."
     git:
       mutates: true
       description: "Update from git repository"

--- a/internal/installer/render/nftables.go
+++ b/internal/installer/render/nftables.go
@@ -19,6 +19,7 @@ package render
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -36,6 +37,14 @@ var placeholders = []string{
 	"__CT_LIMIT_HTTP__",
 	"__CT_LIMIT_MAIL__",
 }
+
+// tcpPortsInElementsRe matches the `elements = { … }` line inside a
+// `set tcp_ports_in { … }` block. Group 1 is "elements = {", group 2 is the
+// inner comma-separated port list (possibly multi-line), group 3 is "}". Used
+// by ensureSSHPortInTcpPortsIn to inject the detected SSH port when the
+// template doesn't carry it via __SSH_PORT__ substitution. V121 fix for
+// D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001.
+var tcpPortsInElementsRe = regexp.MustCompile(`(?s)(set tcp_ports_in \{[^{}]*elements = \{)([^}]*)(\})`)
 
 // RenderNftablesConf reads the nftables.conf template, substitutes placeholders,
 // validates syntax, and writes back atomically.
@@ -61,10 +70,33 @@ func RenderNftablesConf(exec executor.Executor, sshPort int, ct detect.CTLimits,
 		}
 	}
 
-	// Check SSH port appears in tcp_ports_in set
+	// V121 — D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001:
+	// Ensure the SSH port reaches the rendered nftables.conf tcp_ports_in set.
+	// Templates that lack a __SSH_PORT__ placeholder (older v1.x templates,
+	// custom operator-edited templates) previously left the rendered config
+	// without the SSH port — the kernel set still got the port from
+	// downstream conf.d/ports.d merges, but the durable config drifted from
+	// the kernel state. Hosts using non-default SSH ports could lose SSH
+	// access on the next firewall reload/restart/reboot if the rebuild
+	// ever read only the rendered config.
+	//
+	// Two durable mechanisms produce a correct outcome (per
+	// SRV2_V120_PREFLIGHT_CLOSURE.md §4 and V121 schema-impact decision §4):
+	//   Mechanism A — template has `tcp_ports_in = { 22, … }` with the
+	//                 SSH port explicitly listed (monitor pattern).
+	//   Mechanism B — template uses `__SSH_PORT__` placeholder, substituted
+	//                 above (srv2/lab2/lab4 default pattern).
+	// If neither produces a rendered file containing the SSH port, this
+	// helper INJECTS the port into the tcp_ports_in elements list so the
+	// rendered file is durable on its own.
+	content = ensureSSHPortInTcpPortsIn(content, sshPort, log)
+
+	// Final sanity check (warning only — injection above should have made
+	// this pass, but a malformed template without any tcp_ports_in set
+	// would still log a warning).
 	portStr := strconv.Itoa(sshPort)
 	if !strings.Contains(content, portStr) {
-		log.Warn("SSH port %d not found in rendered nftables.conf — may need manual tcp_ports_in entry", sshPort)
+		log.Warn("SSH port %d still not present in rendered nftables.conf after V121 injection — template may lack a tcp_ports_in set entirely", sshPort)
 	}
 
 	// Skip write if content unchanged
@@ -85,4 +117,59 @@ func RenderNftablesConf(exec executor.Executor, sshPort int, ct detect.CTLimits,
 
 	log.Info("rendered nftables.conf (SSH=%d, CT: ssh=%d http=%d mail=%d)", sshPort, ct.SSH, ct.HTTP, ct.Mail)
 	return nil
+}
+
+// ensureSSHPortInTcpPortsIn guarantees the detected SSH port appears inside
+// every `set tcp_ports_in { … elements = { … } … }` block in the rendered
+// content. If the port is already present anywhere in the content, the
+// function is a no-op (avoids duplicate injection). Otherwise, for each
+// matched `tcp_ports_in` set block, it injects the port at the head of the
+// elements list, preserving existing entries and formatting.
+//
+// V121 fix for D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 — closes the gap where
+// hosts using non-default SSH ports could end up with kernel-only safety
+// (transient) instead of durable-config safety (survives reload/restart/
+// reboot/update).
+//
+// Idempotent: calling on already-correct content returns content unchanged.
+func ensureSSHPortInTcpPortsIn(content string, sshPort int, log *logging.Logger) string {
+	portStr := strconv.Itoa(sshPort)
+
+	// Fast-path exact-substring check — if the port number appears anywhere
+	// in the content, assume it's already in the set(s) and skip injection.
+	// This handles both Mechanism A (template hardcodes the port) and
+	// Mechanism B (template uses __SSH_PORT__ which was substituted above).
+	if strings.Contains(content, portStr) {
+		return content
+	}
+
+	// Slow path: port is missing. Inject into every tcp_ports_in set.
+	injections := 0
+	out := tcpPortsInElementsRe.ReplaceAllStringFunc(content, func(match string) string {
+		groups := tcpPortsInElementsRe.FindStringSubmatch(match)
+		if len(groups) < 4 {
+			return match
+		}
+		prefix, inner, suffix := groups[1], groups[2], groups[3]
+		// Inject port at the head of the elements list.
+		trimmedInner := strings.TrimSpace(inner)
+		var newInner string
+		if trimmedInner == "" {
+			newInner = " " + portStr + " "
+		} else {
+			// Preserve original leading whitespace where possible.
+			leadingWS := inner[:len(inner)-len(strings.TrimLeft(inner, " \t\n\r"))]
+			if leadingWS == "" {
+				leadingWS = " "
+			}
+			newInner = leadingWS + portStr + ", " + strings.TrimLeft(inner, " \t\n\r")
+		}
+		injections++
+		return prefix + newInner + suffix
+	})
+
+	if injections > 0 {
+		log.Info("V121 injected SSH port %d into %d tcp_ports_in set(s) in rendered nftables.conf (template did not carry the port via __SSH_PORT__ or hardcoded list)", sshPort, injections)
+	}
+	return out
 }

--- a/internal/installer/render/nftables_test.go
+++ b/internal/installer/render/nftables_test.go
@@ -1,0 +1,204 @@
+// =============================================================================
+// NFTBan v1.121 - Installer nftables.conf Render Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-render-nftables-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-19"
+// meta:description="V121 unit tests for ensureSSHPortInTcpPortsIn injection helper. Covers Mechanism A (template hardcodes port via __SSH_PORT__ placeholder substitution), Mechanism B (template hardcodes port directly), Mechanism C (template lacks port — V121 injection fires), idempotency, and multi-set injection (ip + ip6 tcp_ports_in)."
+// meta:input="None"
+// meta:output="t.Fatalf/t.Errorf on assertion failure"
+// meta:depends="testing,internal/installer/logging"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func newRenderTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	return logging.New("/dev/null", false)
+}
+
+// TestEnsureSSHPortInTcpPortsIn_Mechanism_A_PortAlreadyPresent asserts
+// that templates already carrying the SSH port (e.g., monitor pattern
+// where the template hardcodes `tcp_ports_in = { 22, 55000, 80, 443 }`)
+// are returned unchanged. V121 injection must be idempotent.
+func TestEnsureSSHPortInTcpPortsIn_Mechanism_A_PortAlreadyPresent(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 22, 55000, 80, 443 }
+	}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	if out != input {
+		t.Errorf("expected no-op for already-present port; got diff:\n--input--\n%s\n--output--\n%s", input, out)
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_Mechanism_B_PortSubstitutedViaPlaceholder
+// asserts that templates where __SSH_PORT__ has already been substituted
+// (srv2/lab2/lab4/monitor default pattern) are detected via the fast-path
+// substring check and returned unchanged.
+func TestEnsureSSHPortInTcpPortsIn_Mechanism_B_PortSubstitutedViaPlaceholder(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	// Simulating post-placeholder-substitution content (55000 was put in place
+	// of __SSH_PORT__ in the line above).
+	input := `table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 55000, 80, 443 }
+	}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	if out != input {
+		t.Errorf("expected no-op when substituted port already present; got diff")
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_Mechanism_C_InjectIntoSingleSet covers the
+// V121 primary fix path: template lacks the SSH port entirely, and the
+// helper must inject it into the tcp_ports_in elements list.
+func TestEnsureSSHPortInTcpPortsIn_Mechanism_C_InjectIntoSingleSet(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 80, 443 }
+	}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	if out == input {
+		t.Fatalf("expected injection but output is unchanged")
+	}
+	if !strings.Contains(out, "55000") {
+		t.Errorf("expected '55000' in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "80, 443") && !strings.Contains(out, "80,  443") {
+		t.Errorf("expected existing entries 80, 443 to be preserved; got:\n%s", out)
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_Mechanism_C_InjectIntoBothSets covers the
+// dual-family case (ip nftban + ip6 nftban each have a tcp_ports_in set).
+// The V121 injection must apply to both sets.
+func TestEnsureSSHPortInTcpPortsIn_Mechanism_C_InjectIntoBothSets(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 80, 443 }
+	}
+}
+table ip6 nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 80, 443 }
+	}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	// Both sets must now carry the port.
+	count := strings.Count(out, "55000")
+	if count < 2 {
+		t.Errorf("expected port to appear in both v4 + v6 sets (count >= 2), got count=%d:\n%s", count, out)
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_Idempotent asserts a second invocation on
+// already-injected content does not duplicate the port.
+func TestEnsureSSHPortInTcpPortsIn_Idempotent(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set tcp_ports_in {
+		elements = { 80, 443 }
+	}
+}`
+	once := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	twice := ensureSSHPortInTcpPortsIn(once, 55000, log)
+	if once != twice {
+		t.Errorf("expected idempotent (second call unchanged); got:\n--once--\n%s\n--twice--\n%s", once, twice)
+	}
+	if strings.Count(twice, "55000") != 1 {
+		t.Errorf("expected exactly 1 occurrence of '55000' after double-call; got %d", strings.Count(twice, "55000"))
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_EmptyElements covers the edge case where
+// the tcp_ports_in set has an empty `elements = { }` block. Injection
+// should produce `elements = { 55000 }`.
+func TestEnsureSSHPortInTcpPortsIn_EmptyElements(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `set tcp_ports_in {
+	elements = {}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	if !strings.Contains(out, "55000") {
+		t.Errorf("expected '55000' to be injected into empty elements list; got:\n%s", out)
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_NoTcpPortsInSet covers the degenerate case
+// where the content has no `tcp_ports_in` set at all. The helper must
+// return content unchanged (the outer caller will log a warning).
+func TestEnsureSSHPortInTcpPortsIn_NoTcpPortsInSet(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set whitelist_v4 {
+		elements = { 127.0.0.1 }
+	}
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	if out != input {
+		t.Errorf("expected unchanged output when no tcp_ports_in set present; got diff")
+	}
+}
+
+// TestEnsureSSHPortInTcpPortsIn_MultilineElements covers the realistic
+// case where elements span multiple lines (large port lists wrapped):
+//
+//   elements = { 20, 21, 25, 53, 80,
+//                110, 143, 443, 465 }
+//
+// The regex uses (?s) for dotall; injection should still place the port
+// at the head and preserve formatting reasonably.
+func TestEnsureSSHPortInTcpPortsIn_MultilineElements(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `set tcp_ports_in {
+	elements = { 20, 21, 25, 53, 80,
+		     110, 143, 443, 465 }
+}`
+	out := ensureSSHPortInTcpPortsIn(input, 22222, log)
+	if !strings.Contains(out, "22222") {
+		t.Errorf("expected '22222' in output; got:\n%s", out)
+	}
+	// Original entries must still be present.
+	for _, p := range []string{"20", "21", "25", "53", "80", "110", "143", "443", "465"} {
+		if !strings.Contains(out, p) {
+			t.Errorf("expected original port %s preserved; got:\n%s", p, out)
+		}
+	}
+}

--- a/internal/installer/render/schema_freeze_test.go
+++ b/internal/installer/render/schema_freeze_test.go
@@ -1,0 +1,67 @@
+// =============================================================================
+// NFTBan v1.121 - Schema-freeze regression guard for V121 operator-safety hardening
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="render_schema_freeze_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-19"
+// meta:description="V121 schema-freeze regression guard — asserts SchemaVersionCurrent stays 1.83.0 throughout the V121 operator-safety hardening implementation (Part A render-path SSH-port injection + verifier dual-surface check + Part B update github [VERSION] doc + CLI normalization). Mirrors V120's TestSchemaVersionUnchangedByV120OperatorSessionWhitelist pattern (internal/whitelist/schema_freeze_test.go) and V119's TestSchemaVersionUnchangedByManualCIDRFix (internal/blacklist/schema_freeze_test.go). Per V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md §5 mandate."
+// meta:input="None"
+// meta:output="t.Fatalf on schema drift"
+// meta:depends="testing,internal/validator"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package render
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/validator"
+)
+
+// TestSchemaVersionUnchangedByV121OperatorSafetyHardening is the V121
+// equivalent of v1.119's TestSchemaVersionUnchangedByManualCIDRFix and
+// v1.120's TestSchemaVersionUnchangedByV120OperatorSessionWhitelist. It
+// asserts that the V121 operator-safety hardening bundle (Part A:
+// render-path SSH-port injection in this package + verifier dual-surface
+// check in cli/lib/nftban/cli/cmd_update.sh; Part B: update version
+// normalization in cli/lib/nftban/cli/cmd_update_methods.sh + registry
+// docs in commands.registry.yml) does NOT bump the frozen schema version.
+//
+// Per V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md verdict
+// SCHEMA_STAYS_FROZEN (unconditional), all seven surface analyses (render
+// injection, verifier dual-surface, version stripping, registry docs,
+// shell tests Part A + B, this guard) returned NO schema impact.
+//
+// If this test fails, the V121 implementation has accidentally introduced
+// a schema-impacting change. Stop, re-read V121_OPERATOR_SAFETY_HARDENING_
+// SCHEMA_IMPACT_DECISION.md, and either revert the change OR open a
+// separate OPEN_V12x_SCHEMA_UNFREEZE_GATE for the new schema version
+// BEFORE merging the implementation PR.
+//
+// Co-located in internal/installer/render/ because Part A's primary
+// code-affecting change is in this package; placing the guard adjacent to
+// the render-path injection makes drift-detection blast radius local
+// (mirrors v1.119's adjacency at internal/blacklist/schema_freeze_test.go
+// and v1.120's adjacency at internal/whitelist/schema_freeze_test.go).
+func TestSchemaVersionUnchangedByV121OperatorSafetyHardening(t *testing.T) {
+	const expectedSchema = "1.83.0"
+	if validator.SchemaVersionCurrent != expectedSchema {
+		t.Fatalf("SchemaVersionCurrent = %q, want %q — V121 operator-safety hardening "+
+			"MUST NOT bump schema (per V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md "+
+			"verdict SCHEMA_STAYS_FROZEN). If a schema bump is genuinely needed "+
+			"(e.g., for a new metric surfacing the dual-surface verifier outcome "+
+			"or for new registry-document-format fields), request "+
+			"OPEN_V12x_SCHEMA_UNFREEZE_GATE separately.",
+			validator.SchemaVersionCurrent, expectedSchema)
+	}
+}


### PR DESCRIPTION
## Summary

Two operator-safety improvements scoped jointly in v1.121 (bundled per `V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md` §7):

**Part A — `D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001` fix (P1 silent self-lockout class)**

Hosts using non-default SSH ports (e.g., monitor + srv2 both on port 55000) could end up with the operator's SSH port reflected in the LIVE kernel `tcp_ports_in` set but NOT in the DURABLE rendered config. A future `nftban firewall reload` / `systemctl restart nftband` / reboot / `nftban update` would re-render the kernel state from the durable config and drop the SSH port — silent operator lockout on next SSH attempt.

The V120 upgrade installer's Prepare-phase warning ("SSH port N not found in rendered nftables.conf …") was correct in observation but misleading as operator signal: the post-update verifier reported PASS by checking only the live kernel state, masking the durable-config drift.

V121 Part A closes the gap with TWO complementary changes:
1. **Render-path injection** (`internal/installer/render/nftables.go`): new `ensureSSHPortInTcpPortsIn` helper injects the detected SSH port into every `set tcp_ports_in { … elements = { … } … }` block if missing after `__SSH_PORT__` substitution. Fast-path no-op when port already present. Multi-set (ip + ip6). Idempotent.
2. **Verifier dual-surface check** (`cli/lib/nftban/cli/cmd_update.sh` V2 + PF5 + VF2): widens from kernel-only check to BOTH kernel AND durable config. Durable check accepts **Mechanism A** (`TCP_PORTS_IN=…,<port>`) OR **Mechanism B** (`SSH_PORT=<port>` + rendered config carries it). Reports PASS / WARN / FAIL based on the two-surface state.

**Part B — `update github [VERSION]` ergonomics**

The v1.x update CLI requires strict `N.N.N` and rejects `v1.120.0` even though GitHub release pages display the `v`-prefixed tag form. The lab2 V120 validation hit this trap; the retry with `1.120.0` succeeded in 26 seconds.

V121 Part B closes the gap with two complementary changes:
1. **Version normalization** (`cli/lib/nftban/cli/cmd_update_methods.sh`): strip optional leading `v` or `V` before existing regex check. Both `1.120.0` and `v1.120.0` accepted. Strict regex preserved post-strip.
2. **Registry doc** (`commands.registry.yml`): add `arguments: VERSION` block under `update.subcommands.github:` with 5 examples + 4 notes covering V121 normalization, strict regex, channel-eligibility bypass, downstream URL form. Auto-renders into operator wiki via `scripts/generate-wiki-operator.sh`.

## Schema impact

**`SCHEMA_STAYS_FROZEN` (unconditional)** per `V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md`. Validated by `internal/installer/render/schema_freeze_test.go` (NEW regression guard mirroring V120 + V119 patterns).

Schema 1.83.0 byte-unchanged in `internal/validator/types.go`. No new metric / Prometheus label / Status JSON key / validator field / install_state field / nftables kernel structure.

## Forbidden-surface zero-touch

- `internal/runtime/state.go` ✓ untouched
- `internal/profile/profile_sync.go` ✓ untouched
- `internal/validator/` ✓ untouched
- `install/systemd/` ✓ untouched
- `install/nftables/` ✓ untouched
- `internal/metrics/`, `internal/health/`, `internal/lifecycle/`, `internal/portal/`, `internal/dns2/`, `internal/panel/` ✓ all untouched
- `packaging/` ✓ untouched
- `MASTER_TODO*` ✓ untouched
- `build/fhs-spec.yaml` ✓ untouched
- Bucket-C v0.x tag paths ✓ untouched

## Test plan

- [x] **Part A Go tests** — `internal/installer/render/nftables_test.go` (NEW, 7 cases covering Mechanism A/B/C, multi-set, idempotency, empty-elements, no-tcp_ports_in degenerate case, multi-line elements)
- [x] **Part A shell tests** — `cli/lib/nftban/tests/test_update_ssh_port_durability.sh` (NEW, 8 cases, **8/8 PASS** locally)
- [x] **Part B shell tests** — `cli/lib/nftban/tests/test_update_version_normalization.sh` (NEW, 21 cases, **21/21 PASS** locally)
- [x] **Schema-freeze regression guard** — `internal/installer/render/schema_freeze_test.go` (NEW)
- [x] `bash -n` syntax checks pass on all 4 shell files (modified + new)
- [ ] CI green (await GitHub Actions)

## Envelope

| File | Change | LOC |
| --- | --- | --- |
| `internal/installer/render/nftables.go` | inject helper + render-path call + refined warning | +91 |
| `internal/installer/render/nftables_test.go` | NEW Go test cases for injection helper | +204 |
| `internal/installer/render/schema_freeze_test.go` | NEW schema-freeze regression guard | +67 |
| `cli/lib/nftban/cli/cmd_update.sh` | V2 + PF5 + VF2 dual-surface check | +88 |
| `cli/lib/nftban/cli/cmd_update_methods.sh` | leading v/V strip + error message refinement | +20 |
| `cli/lib/nftban/tests/test_update_ssh_port_durability.sh` | NEW dual-surface shell tests | +306 |
| `cli/lib/nftban/tests/test_update_version_normalization.sh` | NEW version-format shell tests | +116 |
| `commands.registry.yml` | `arguments: VERSION` block + examples + notes | +16 |
| **Total** | **8 files** | **+881 / −27** |

Slightly over the scope estimate (~480 LOC) due to more thorough test coverage (29 shell + 7 Go test cases combined).

## References

- `AUDIT_190_LIFECYCLE/V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md` (verdict `SCHEMA_STAYS_FROZEN` unconditional)
- `AUDIT_190_LIFECYCLE/V121_SSH_PORT_TEMPLATE_GAP_SCOPE.md` (Part A scope)
- `AUDIT_190_LIFECYCLE/V121_UPDATE_GITHUB_VERSION_ARG_DOC_SCOPE.md` (Part B scope)
- `AUDIT_190_LIFECYCLE/MONITOR_SSH_PORT_DURABILITY_DIAG_AND_FIX.md` (Mechanism A evidence on monitor)
- `AUDIT_190_LIFECYCLE/SRV2_V120_PREFLIGHT_CLOSURE.md` (Mechanism B evidence on srv2; per §8 of that doc, V121 verifier must accept both mechanisms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)