### PR TITLE
docs(operator+internals): v1.122 docs PR — codified takeover rule + bare-version upgrade syntax + V119 manual CIDR dual-API

### DIFF
--- a/docs/internals/V119_MANUAL_CIDR_DUAL_API.md
+++ b/docs/internals/V119_MANUAL_CIDR_DUAL_API.md
@@ -1,0 +1,167 @@
+# V119 Manual CIDR Dual-API — Operational Semantics
+
+## Purpose
+
+V119 (released 2026-05-18 as v1.119.0) changed how CIDR entries in
+`/etc/nftban/blacklist.d/99-manual.conf` and
+`/etc/nftban/whitelist.d/99-manual.conf` are loaded and enforced. The
+change is operationally significant when upgrading from v1.118.0 or
+earlier: CIDR entries that were silently inert pre-V119 become
+effective post-V119, **without any file mutation**.
+
+This document explains the mechanism so operators understand why some
+bans "started working" after upgrade.
+
+## Pre-V119 behavior (silent inert)
+
+Versions through v1.118.0 used an untyped flat-list loader for
+manual files. The loader read each non-comment line as a string and
+attempted to insert into the kernel nft set:
+
+- For `blacklist_manual_ipv4` the kernel set type is `ipv4_addr` with
+  `flags timeout`. The `timeout` flag is incompatible with `interval`
+  in nft kernel-set semantics — meaning the set can only hold single
+  IPs, not CIDR prefixes.
+- A `/27` line like `81.30.98.32/27` would attempt insertion, fail
+  silently (or get treated as the bare address `81.30.98.32`, losing
+  the prefix), and **the /27 range as a whole was not enforced**.
+
+The result: operator entries like `81.30.98.32/27` (a 32-address
+exim-bruteforce block) were durably present in the file but
+operationally inert. Connections from the other 31 addresses in the
+/27 were not blocked by the manual-blacklist code path.
+
+## Post-V119 behavior (file-based CIDR containment)
+
+V119 (PR #633, commit `2632141b`) introduced a **typed loader**:
+
+- `BlacklistEntry{Value string, IsCIDR bool}` and corresponding
+  `WhitelistEntry{Value string, IsCIDR bool}` carry per-entry type
+  information through the loader.
+- `LoadAllBlacklistTyped()` and `LoadAllWhitelistTyped()` parse the
+  file once and classify each line as either a bare IP or a CIDR
+  prefix (`netip.Prefix`).
+- A new containment-check helper, `IsIPInBlacklistFile()` (and
+  whitelist equivalent), uses `netip.Prefix.Contains(addr)` to decide
+  membership at decision time. CIDRs do not need to be expanded into
+  kernel sets.
+
+The dual-API split: kernel sets still hold runtime-banned IPs
+(loginmon emissions, threat-feed entries, etc. — `flags timeout`
+elements that came in through the daemon's runtime path). File-based
+CIDRs are checked at userspace inside the Go daemon when a packet
+hits a decision point that needs to consult the manual file. This is
+why the kernel `blacklist_manual_ipv4` set still has `flags timeout`
+only on V119+ hosts that have CIDR entries in `99-manual.conf` — the
+CIDRs are not expanded into the kernel, they are file-based.
+
+## Behavior delta on upgrade
+
+When a host upgrades from pre-V119 to V119+ (a v1.113.0 → v1.121.0
+jump, for example), the operator observes:
+
+| Surface | Pre-upgrade | Post-upgrade |
+|---------|-------------|--------------|
+| `/etc/nftban/blacklist.d/99-manual.conf` content | unchanged | byte-identical (same md5) |
+| Kernel `blacklist_manual_ipv4` set | 0 elements (CIDRs silently rejected) | 0 elements (CIDRs not expanded) |
+| Kernel `blacklist_manual_ipv4` set flags | `timeout` only | `timeout` only |
+| Userspace daemon containment check | not present | active via `IsIPInBlacklistFile()` |
+| Connection from inside a /27 range in the file | not blocked by manual-blacklist | **blocked** by manual-blacklist (via file-based containment) |
+
+In words: the operator file is byte-identical pre vs post. The kernel
+set looks identical pre vs post. The behavior change is at the Go
+daemon's decision-point layer — and it is in the operator's favor (the
+intent of the /27 ban is now realized).
+
+Empirical observation from V121 fleet rollout: srv1 had 5 `/27`
+CIDR entries in `99-manual.conf` (exim-bruteforce blocks). Pre-V121
+the kernel `blacklist_manual_ipv4` set had 0 elements; post-V121 the
+set still has 0 elements and the same `flags timeout`, but the daemon
+now correctly classifies all 160 addresses across the five /27 ranges
+as "in manual blacklist file" via the typed loader.
+
+## `nftban firewall check` does NOT surface this
+
+The `nftban firewall check <ip>` CLI inspects the kernel nft ruleset
+directly. It does not exercise the Go daemon's `IsIPInBlacklistFile()`
+helper. Consequently:
+
+```
+$ nftban firewall check 81.30.98.35
+...
+Status: ❌ BLOCKED
+Matched Rule:
+  Rule:     default policy
+  Verdict:  drop
+```
+
+The reason given is `default policy: drop` (not "matched manual
+blacklist file"). This is **NOT** a contradiction — the kernel
+default-input policy is `drop`, and the IP isn't in any kernel
+accept-set, so it gets dropped. The fact that it's ALSO in the
+manual-blacklist-file CIDR is irrelevant to the kernel check.
+
+Operators looking for evidence that a manual CIDR is active should
+look at the Go daemon logs and runtime decisions (loginmon /
+portscan / botguard hits that reference the file), not at
+`nftban firewall check` output.
+
+## Why this design (dual-API, not kernel expansion)
+
+Three considerations led to V119's dual-API choice:
+
+1. **Kernel-set semantics.** `flags timeout` and `flags interval` are
+   mutually exclusive in nft. Manual blacklist needs `timeout` to
+   support automatic-ban entries that age out. Splitting into two
+   sets (one timeout-flagged, one interval-flagged) would have
+   doubled the surface and required dual-set lookups for every
+   decision.
+
+2. **Efficiency.** A /16 CIDR contains 65,536 addresses. Expanding it
+   into kernel-set elements is wasteful and slow. File-based
+   containment via `netip.Prefix.Contains` is O(1) per CIDR check
+   regardless of prefix length.
+
+3. **Operator transparency.** The file remains the source of truth.
+   Operators reading `99-manual.conf` see exactly what they wrote.
+   No kernel-side expansion that could drift from the file.
+
+The trade-off: CIDR entries are not enforced by the kernel's
+fast-path `set lookup` — they are enforced by the daemon's
+decision-point logic. Net effect on operations: CIDRs work; they just
+don't show up in `nft list set ip nftban blacklist_manual_ipv4`.
+
+## What did NOT change in V119
+
+- Kernel set type and flags
+- File format (existing `99-manual.conf` entries remain valid)
+- Bare-IP behavior (single IPs still go through the kernel-set path
+  when added at runtime by the daemon)
+- `nftban whitelist add` / `nftban blacklist add` CLI commands
+- Schema (M81-6 remains frozen at 1.83.0)
+
+## Related cycle artifacts
+
+- `AUDIT_190_LIFECYCLE/V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md`
+  (verdict: `SCHEMA_STAYS_FROZEN`)
+- `AUDIT_190_LIFECYCLE/V119_MANUAL_CIDR_PREFLIGHT_PROFILE_SYNC_AUDIT.md`
+  (verdict: `SCOPE_CONSTRAINT_CONFIRMED_NON_BLOCKING_WITH_DUAL_API`)
+- `AUDIT_190_LIFECYCLE/V119_A1_WHITELIST_BLACKLIST_CORRECTNESS_AND_ORPHAN_AUDIT.md`
+- v1.119.0 CHANGELOG entry (PR #633 squash `2632141b`)
+
+## Code references
+
+| Component | File | Line / function |
+|-----------|------|-----------------|
+| Typed `BlacklistEntry` struct | `internal/blacklist/` | `BlacklistEntry{Value, IsCIDR}` |
+| Typed `WhitelistEntry` struct | `internal/whitelist/` | `WhitelistEntry{Value, IsCIDR}` |
+| `LoadAllBlacklistTyped()` | `internal/blacklist/` | typed loader |
+| `LoadAllWhitelistTyped()` | `internal/whitelist/` | typed loader |
+| `IsIPInBlacklistFile()` | `internal/blacklist/` | `netip.Prefix.Contains` containment check |
+| `IsIPInWhitelistFile()` | `internal/whitelist/` | mirror of the above |
+| Daemon-side CIDR safety predicate | `cmd/nftband/` (D3 daemon guard) | runtime decision-point integration |
+| In-PR schema-freeze guard | `internal/blacklist/` test file | `TestSchemaVersionUnchangedByManualCIDRFix` |
+
+(Exact line numbers may drift as the codebase evolves; use `grep
+'BlacklistEntry\|WhitelistEntry\|IsCIDR\|IsIPInBlacklistFile' internal/`
+to locate current definitions.)

--- a/docs/operator/CSF_REMOVAL_AND_TAKEOVER.md
+++ b/docs/operator/CSF_REMOVAL_AND_TAKEOVER.md
@@ -1,0 +1,185 @@
+# CSF / lfd Removal and Takeover (DirectAdmin Hosts)
+
+## Purpose
+
+This document is the canonical operator procedure for disarming or removing
+CSF/lfd on DirectAdmin hosts before installing or upgrading NFTBan. It
+exists because manual sequences (`systemctl stop csf` + `csf -x` +
+`da build remove_csf`) duplicate logic that NFTBan already encodes — and
+those manual sequences omit refinements that the codified path applies
+(structured cron-backup manifest, DirectAdmin `services.status` watchdog
+flip, stale `systemctl --failed` marker reset).
+
+**Rule:** Use the codified takeover command. Do not run manual disarm
+sequences unless you have an explicit reason that doesn't fit the
+codified path.
+
+## The codified command
+
+Two steps. The first is a dry-run preview. The second is the actual
+disarm. Both require root.
+
+```
+nftban firewall takeover --dry-run
+nftban firewall takeover --panel-auto-takeover
+```
+
+The `--panel-auto-takeover` flag is the PR-22B opt-in for control-panel
+hosts (cPanel / Plesk / DirectAdmin). Without it the codified path
+refuses to act, which is by design.
+
+## What the codified path does
+
+`nftban firewall takeover` is a discoverability surface — the actual
+work happens inside the installer when called as
+`nftban-installer --mode=upgrade --panel-auto-takeover`. The disarm
+logic is `DisableConflicts()` at
+`internal/installer/switchop/takeover.go:32`.
+
+For each conflicting service (CSF emits two entries — `csf.service`
+and `lfd.service` — so each is handled independently):
+
+- `systemctl stop` the service
+- `systemctl disable` the service
+- `systemctl mask` the service
+- `systemctl reset-failed` the service (PR-P1, closes #524) — clears
+  the stale `failed (Result: signal)` marker so `systemctl --failed`
+  does not show units NFTBan just intentionally tore down
+
+Then a legacy-firewall flush:
+
+- For both `iptables` and `ip6tables` (if present):
+  - Reset INPUT/FORWARD/OUTPUT to ACCEPT (prevents DROP-policy lockout
+    during the flush)
+  - Flush + delete chains in `filter`, `nat`, `mangle`
+
+Then CSF-artifact disarm (`disarmCSFArtifacts()`):
+
+- **Write a structured cron-backup manifest** (PR-26-code-C) under
+  `/var/lib/nftban/state/csf-cron-backup/` BEFORE removing the cron
+  files. The manifest records per-file `sha256 + mode + uid + gid +
+  size` so the restore path (`internal/installer/restore/`) can later
+  reverse the removal with fidelity. Hosts that took the manual route
+  ship without a manifest; A.4 restore stays soft-skip on those hosts.
+- `rm -f /etc/cron.d/lfd-cron /etc/cron.d/csf-cron`
+- `mv /usr/sbin/csf /usr/sbin/csf.disabled` (sha256 byte-identical;
+  no content change)
+
+DirectAdmin-specific disarm (`disarmPanelCSF()`):
+
+- **Flip `lfd=ON` → `lfd=OFF`** in `/usr/local/directadmin/data/admin/services.status`
+  (PR26.6.1, PANEL-WATCHDOG-COHERENCE-001). Without this, `dataskq`
+  emits `error=service "lfd": Unit lfd.service is masked.` every 60
+  seconds. The dns2 host evidence (2026-04-30 → 2026-05-01) showed 14+
+  hours of that noise on a host where the codified path was not used.
+- Run `custombuild/build set csf no` to flip `csf=yes` → `csf=no` in
+  `/usr/local/directadmin/custombuild/options.conf` so that
+  `./build update` does not re-enable CSF.
+- Audit `/usr/local/directadmin/scripts/custom/` for `csf|lfd|iptables`
+  references and emit one informational `WARN` per match. This is
+  informational only — operator review is recommended but not
+  required.
+
+Ghost-table cleanup (`CleanGhostTables()`, runs in `phaseSwitch` after
+`DisableConflicts`):
+
+- Removes 10 documented ghost-table candidates:
+  `{ip,ip6} × {filter, nat, mangle, security}` + `inet firewalld` +
+  `inet filter`. Only present-and-empty tables are deleted.
+- **Does NOT clean `inet nftban_install_emergency`** — that table's
+  lifecycle is managed by `InjectEmergencySSH` / `RemoveEmergencySSH`
+  in `internal/installer/switchop/sshguard.go`. The codified comment
+  at `ghost.go:55–58` documents this exclusion.
+
+## What the codified path does NOT do
+
+It does not run `da build remove_csf`. The DirectAdmin "remove" command
+deletes `/etc/csf/` entirely, removes `/usr/sbin/lfd`, removes
+`/usr/local/csf/`, and removes the CSF plugin from
+`/usr/local/directadmin/plugins/csf`. This is more aggressive than
+`DisableConflicts()` and sacrifices reversibility. The codified path
+keeps `/etc/csf/` intact and only renames binaries — full reversal is
+possible with `nftban firewall restore csf` or
+`nftban-installer --mode=restore`.
+
+If the operator's intent is to permanently remove CSF (not just disarm
+it), `da build remove_csf` is the DirectAdmin canonical command for
+that — but it is a separate decision and should be made deliberately,
+not as a default disarm step.
+
+## Reversibility
+
+The codified disarm is reversible:
+
+```
+nftban firewall restore csf
+```
+
+Or equivalently:
+
+```
+/usr/lib/nftban/bin/nftban-installer --mode=restore
+```
+
+This relies on the cron-backup manifest (`/var/lib/nftban/state/csf-cron-backup/`).
+Hosts disarmed via the manual route — where the manifest may be
+absent or non-conformant — will see the restore path soft-skip
+gracefully.
+
+## Anti-patterns
+
+These sequences are duplicate-logic and miss codified refinements:
+
+- `systemctl stop csf lfd` + `systemctl disable csf lfd` + `csf -x`
+  alone — misses PR-P1 reset-failed, misses PR26.6.1 DA watchdog
+  flip, misses structured cron-backup manifest
+- `csf -x` alone — flushes CSF rules but does not stop the
+  `csf.service` / `lfd.service` units, does not touch DirectAdmin
+  `services.status`, does not preserve cron files
+- `da build remove_csf` alone — over-removes (deletes `/etc/csf/`
+  including operator-curated `csf.allow` + `csf.deny`); sacrifices
+  reversibility. See the companion document
+  `docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md` for the
+  byte-equivalent backup recommendation if you must use this path
+
+## When to use the codified path
+
+Any time you need to disarm CSF/lfd to install or upgrade NFTBan on a
+DirectAdmin host. This includes:
+
+- Initial installation of NFTBan on a host that previously ran CSF
+- Upgrading from a version of NFTBan that coexisted with active CSF
+- Operator-decided shift from CSF to NFTBan as primary firewall
+  authority
+
+## Environment-variable equivalent
+
+For cloud-init, Ansible, or package `%post` hooks where you need
+non-interactive automation:
+
+```
+NFTBAN_PANEL_AUTO_TAKEOVER=1 nftban-installer --mode=upgrade
+```
+
+This sets the equivalent of `--panel-auto-takeover` at the
+environment-variable level. The PR-22B gate semantics are unchanged.
+
+## Code references
+
+| Component | File | Line |
+|-----------|------|------|
+| CLI wrapper | `cli/lib/nftban/cli/cmd_firewall.sh` | 752 (`firewall_takeover()`) |
+| Installer dispatch | `cmd/nftban-installer/main.go` | `--mode=upgrade --panel-auto-takeover` |
+| Core disarm | `internal/installer/switchop/takeover.go` | 32 (`DisableConflicts()`) |
+| Per-service stop+mask+reset-failed | `internal/installer/switchop/takeover.go` | 38–66 |
+| iptables flush | `internal/installer/switchop/takeover.go` | 69–82 |
+| `WriteCronBackupManifest()` | `internal/installer/switchop/cron_manifest.go` | 158 |
+| CSF binary rename | `internal/installer/switchop/takeover.go` | 133 |
+| DA watchdog flip | `internal/installer/switchop/takeover.go` | 251 (`disarmDAWatchdog()`) |
+| `flipLfdWatchdogOff()` (pure function, unit-testable) | `internal/installer/switchop/takeover.go` | 285 |
+| CustomBuild `set csf no` | `internal/installer/switchop/takeover.go` | 172 |
+| DA custom-scripts audit | `internal/installer/switchop/takeover.go` | 199–210 |
+| Ghost-table cleanup | `internal/installer/switchop/ghost.go` | 44 (`CleanGhostTables()`) |
+| Ghost-table list (10 candidates) | `internal/installer/switchop/ghost.go` | 25–37 |
+| Emergency-table exclusion | `internal/installer/switchop/ghost.go` | 55–58 (comment) |
+| Conflict detection | `internal/installer/detect/conflicts.go` | 65 (`DetectConflicts()`) |

--- a/docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md
+++ b/docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md
@@ -1,0 +1,131 @@
+# Upgrading from v1.120.0 or Earlier to v1.121.0+
+
+## TL;DR
+
+Use bare version syntax when upgrading from v1.120.0 or earlier:
+
+```
+nftban update github 1.121.0
+```
+
+Not:
+
+```
+nftban update github v1.121.0
+```
+
+The leading-v form is rejected by the updater on v1.120.0 and earlier.
+After the upgrade to v1.121.0+ lands, both forms (`1.X.Y` and `v1.X.Y`
+and `V1.X.Y`) are accepted.
+
+## Why
+
+`nftban update github [VERSION]` validates the version argument against
+a strict regex before doing anything else. Prior to v1.121.0 the regex
+was `^[0-9]+\.[0-9]+\.[0-9]+$` — that rejects a leading `v` or `V`.
+
+v1.121.0 (PR #639) added a normalization step in
+`cli/lib/nftban/cli/cmd_update_methods.sh` that strips an optional
+leading `v` or `V` before the regex runs, so post-V121 the user-facing
+input is more forgiving.
+
+The self-bootstrapping aspect: the fix lives in v1.121.0 itself, so a
+host at v1.113.0 (or any version through v1.120.0) does not yet have
+the leading-v strip. The bare-format invocation is the only path that
+works for the first jump.
+
+## What happens if you use the leading-v form anyway
+
+The updater fails fast — before any package transition:
+
+```
+$ nftban update github v1.121.0
+  Acquiring update lock...
+  Lock acquired
+  === Update started on <host> ===
+  ...
+  Creating backup...
+  ✓ Backup: nftban-1.113.0-<timestamp>
+  ✗ Invalid version format: 'v1.121.0' (expected: N.N.N)
+  ✗ === Update failed: <version> (4s) ===
+```
+
+Exit code 1. No RPM/DEB transition happens. The pre-upgrade backup is
+created and retained. Re-invoke with the bare form and the upgrade
+proceeds.
+
+## Gate-authorized fallback (operator-only)
+
+If the pre-package-transition failure is recorded as a finding under
+an operator-authorized fleet rollout gate, direct dnf/apt install of
+the release asset is the documented escape hatch:
+
+```
+# RPM hosts
+dnf install -y https://github.com/itcmsgr/nftban/releases/download/v1.121.0/nftban-el9-x86_64.rpm
+
+# DEB hosts
+NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive \
+  apt-get install -y ./nftban-ubuntu22.04-amd64.deb
+```
+
+Bypasses the `nftban update` lifecycle (no automatic
+firewall-rebuild scheduling, no update-hook scripts). Should only be
+used under explicit gate authorization with the pre-transition
+failure recorded.
+
+## Post-V121 behavior
+
+Once a host is at v1.121.0+, all four input forms work:
+
+```
+nftban update github 1.122.0
+nftban update github v1.122.0
+nftban update github V1.122.0
+nftban update github 1.122.0      # also works
+```
+
+The downstream strict regex is preserved (just runs after the
+optional leading-letter strip). Inputs like `not-a-version`,
+`latest`, or `1.122` (two-part) remain rejected.
+
+## Companion: operator-curated CSF config preservation
+
+The companion document
+[`docs/operator/CSF_REMOVAL_AND_TAKEOVER.md`](CSF_REMOVAL_AND_TAKEOVER.md)
+recommends the codified `nftban firewall takeover --panel-auto-takeover`
+path for disarming CSF before upgrade. If your local operator
+sequence diverges and reaches `da build remove_csf`, note that the
+DirectAdmin command **deletes `/etc/csf/csf.allow` and
+`/etc/csf/csf.deny`** as part of its full removal pass. If you have
+operator-curated entries in those files you may want to re-arm CSF
+later, back them up first:
+
+```
+mkdir -p /var/lib/nftban/state/operator-csf-backup-$(date -u +%Y%m%dT%H%M%SZ)
+cp -p /etc/csf/csf.allow /etc/csf/csf.deny \
+   /var/lib/nftban/state/operator-csf-backup-$(date -u +%Y%m%dT%H%M%SZ)/
+```
+
+These files are NOT recreated by `da build set csf yes && da build csf`
+— that command re-fetches CSF from upstream and writes default
+configurations. Operator entries must be restored from your backup.
+
+The codified takeover path (`nftban firewall takeover`) preserves
+`/etc/csf/` byte-equivalent and avoids this issue entirely, but is a
+disarm (reversible) rather than a remove (over-removal).
+
+## Code references
+
+| Component | File | Note |
+|-----------|------|------|
+| Version-string normalization (PR #639) | `cli/lib/nftban/cli/cmd_update_methods.sh` | strips leading `v` / `V` |
+| Strict regex (preserved post-strip) | `cli/lib/nftban/cli/cmd_update_methods.sh` | `^[0-9]+\.[0-9]+\.[0-9]+$` |
+| Registry doc | `commands.registry.yml` | `update.subcommands.github` `arguments: VERSION` block |
+| Auto-rendered wiki coverage | (output of registry → wiki build) | covers all four input forms |
+
+## Related cycle artifacts
+
+- `AUDIT_190_LIFECYCLE/V121_UPDATE_GITHUB_VERSION_ARG_DOC_SCOPE.md`
+- `AUDIT_190_LIFECYCLE/V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md`
+- v1.121.0 CHANGELOG entry (V121 Part B normalization)


### PR DESCRIPTION
## Summary

V1.122 small backlog-burn release, docs-only PR (3 of 7 v1.122 items). No source code changes. No CHANGELOG.md update (release-prep PR territory). No schema mutation. No version bump.

## Items

### B-1 — `docs/operator/CSF_REMOVAL_AND_TAKEOVER.md` (7,979 B)

Codified-takeover process rule. Documents `nftban firewall takeover --panel-auto-takeover` as the canonical operator procedure for disarming CSF/lfd on DirectAdmin hosts, with full code-trace into `internal/installer/switchop/takeover.go` + `ghost.go` + `cron_manifest.go`. Documents the 4 PR-tagged refinements the codified path integrates:

- PR-22B `--panel-auto-takeover` opt-in
- PR-26-code-C `WriteCronBackupManifest()` structured cron-backup manifest
- PR26.6.1 `disarmDAWatchdog()` flips `lfd=ON` → `lfd=OFF` in `services.status` (PANEL-WATCHDOG-COHERENCE-001)
- PR-P1 `ServiceResetFailed()` clears stale `systemctl --failed` markers (closes #524)

Lists anti-patterns (manual `systemctl` sequences, `csf -x` alone, over-removal via `da build remove_csf`).

Closes the process-debt finding from V121 srv4 lane (`V121_SRV4_CSF_REMOVE_CODE_DISCOVERY.md`): manual sequences are ~10x wall vs codified single-call.

### B-2 — `docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md` (4,591 B)

Bare-version upgrade-syntax callout. Documents the constraint that hosts at v1.120.0 or earlier MUST use bare `1.121.0` format (not `v1.121.0`) because the v/V leading-letter strip landed in v1.121.0 itself (PR #639). Post-V121 all four input forms (`1.X.Y`, `v1.X.Y`, `V1.X.Y`, post-strip) accepted.

Includes gate-authorized `dnf`/`apt` direct-install fallback for operators who hit the pre-package-transition rejection. Cross-references the CSF takeover doc with a warning about `da build remove_csf` over-removing operator-curated `/etc/csf/csf.allow` + `csf.deny`.

### B-3 — `docs/internals/V119_MANUAL_CIDR_DUAL_API.md` (7,773 B)

V119 Manual CIDR dual-API operational semantics. Explains the pre-V119 silent-inert vs post-V119 file-based-containment behavior for CIDR entries in `blacklist.d/99-manual.conf` and `whitelist.d/99-manual.conf`.

Documents the design rationale:
- Kernel `flags timeout` vs `flags interval` mutual exclusion
- Efficiency of `netip.Prefix.Contains` over kernel-set expansion (O(1) per check vs /16 = 65,536 elements)
- Operator-file source-of-truth invariant

Explains why `nftban firewall check <ip>` doesn't surface file-based CIDR matches (kernel-ruleset inspection only; daemon decision-point uses `IsIPInBlacklistFile()` separately).

Empirical evidence: srv1 had 5 `/27` CIDR exim-bruteforce blocks that transitioned from silently-inert (pre-V119) to operationally-effective (post-V121, via V119 dual-API). File md5 byte-identical; kernel set unchanged; only userspace daemon behavior changed.

## Refs

- `AUDIT_190_LIFECYCLE/V122_SCOPE_TRIAGE.md` §2 (Bucket B small-safe items B-1..B-3)
- `AUDIT_190_LIFECYCLE/V121_PRODUCTION_ROLLOUT_FINAL_ATTESTATION.md` §6 (P0 process rule + P1 docs)
- `AUDIT_190_LIFECYCLE/V121_SRV4_CSF_REMOVE_CODE_DISCOVERY.md` (codified takeover finding — origin of B-1)

## Test plan

- [ ] CI: standard docs-PR checks (header validation, link validation if any)
- [ ] No source code changes — Go tests N/A
- [ ] No CHANGELOG.md changes — release-prep PR territory
- [ ] No schema changes — frozen at 1.83.0
- [ ] Manual review: docs render correctly on GitHub markdown viewer
- [ ] Verify cross-references between B-1 (CSF_REMOVAL_AND_TAKEOVER.md) and B-2 (UPGRADING_FROM_V1_120_AND_EARLIER.md) resolve correctly
- [ ] Verify all code-trace file/line references in B-1 still exist on `main` HEAD `ed6429bb` (snapshot taken from v1.121.0 source)

## v1.122 release scope (this PR is 1 of 4 v1.122 code PRs)

This PR (`OPEN_V122_DOCS_PR`) lands 3 of the 7 v1.122 items. The remaining 4 items will arrive in:
- `OPEN_V122_EXPORTER_TRANSIENT_PR` (B-4 systemd guard)
- `OPEN_V122_DEAD_CODE_CLEANUP_PR` (B-5 + B-9 paired dead-code cleanup)
- `OPEN_V122_HYGIENE_PR` (B-10a + B-10b)
- `OPEN_V122_RELEASE_PREP_PR` (VERSION + STATUS.md + CHANGELOG.md + FHS regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)