### PR TITLE
feat(systemd): V122 B-4 — exporter transient hardening (Wants= → Requires=)

### DIFF
--- a/install/systemd/nftban-unified-exporter.service
+++ b/install/systemd/nftban-unified-exporter.service
@@ -24,7 +24,16 @@
 Description=NFTBan Unified Metrics Exporter
 Documentation=https://nftban.com/docs/metrics
 After=network.target nftband.service
-Wants=nftband.service
+# V122 B-4: upgraded from Wants= to Requires= to eliminate the recurrent
+# post-upgrade exit-code-2 transient observed on lab2, monitor, srv3, srv4
+# during the nftband-restart window. With nftband.service Type=notify,
+# systemd considers nftband "active" only after the daemon signals READY=1;
+# Requires= now refuses to start the exporter when nftband is not in the
+# active state, preventing the timer-fire-during-restart race. Combined
+# with the existing After= ordering, this guarantees the exporter runs only
+# against a ready daemon. Telemetry-only failure mode — no impact on
+# bans/enforcement.
+Requires=nftband.service
 
 # MUTUAL EXCLUSION: Prevent running alongside legacy exporters
 Conflicts=nftban-metrics-exporter.service


### PR DESCRIPTION
## Summary

V1.122 small backlog-burn release, 2 of 7 items (B-4 alone).

Upgrade `nftban-unified-exporter.service` unit's dependency on `nftband.service` from `Wants=` (weak) to `Requires=` (strong). Single file change to `install/systemd/nftban-unified-exporter.service`. 1 line removed, 1 line added + 9-line comment block.

## Symptom (4 production hosts)

During post-upgrade `nftband.service` restart windows, the unified-exporter timer fires (per `OnUnitActiveSec=60s` / `OnBootSec=45s`) and the triggered service attempts to run while nftband is still in the transitional state. The exporter shell invokes `nft` commands and Zabbix-export pipelines; during the brief restart window these encounter inconsistent state and exit code 2 (INVALIDARGUMENT). systemd records this as `Failed with result 'exit-code'` and retains the failure status until manual `systemctl reset-failed`.

| Host | Date / event | Note |
|------|--------------|------|
| lab2 | earlier session (V115 upgrade) | self-recovered within 1 timer cycle |
| monitor | earlier session (V115 upgrade) | same |
| srv3 | 2026-05-19T08:18:30Z (V121 upgrade) | F-5 in `SRV3_V121_VALIDATION_CLOSURE.md` |
| srv4 | 2026-05-19T09:43:47Z (V121 upgrade) | F-6 in `SRV4_V121_VALIDATION_CLOSURE.md` |

All 4 self-recovered within 60-90s. Functional impact: zero (telemetry-only). Cosmetic impact: `systemctl --failed` retains the entry until manual `reset-failed`.

## Root cause

Existing unit:
```
After=network.target nftband.service
Wants=nftband.service
```

`After=` provides ordering but doesn't block when nftband transitions `active → activating → active` during a restart. `Wants=` is weak: doesn't prevent the exporter from running when nftband is inactive/transitioning. Result: timer can fire and service can start before nftband has signaled `READY=1` again.

## Fix

Change `Wants=nftband.service` to `Requires=nftband.service`.

nftband.service is `Type=notify` — systemd considers it active only after `sd_notify(READY=1)` from the daemon. With `Requires=`:
- If nftband is not in active state, the exporter REFUSES to start (rather than starting and failing exit-2)
- During nftband restart window, timer-fired exporter requests are held until READY=1 again, or refused on TimeoutStartSec
- Combined with `After=nftband.service`, this guarantees the exporter runs only against a fully-ready daemon

9-line block comment added inline so future operators understand the intent without git-archaeology.

## Why not `BindsTo=`?

`BindsTo=` would stop the exporter if nftband stops mid-execution. For oneshot timer-triggered services with ~60s execution windows, that's overkill — the oneshot either completes or fails naturally. `Requires=` is idiomatic per `systemd.unit(5)`.

## Why not `ConditionPathExists=` readiness marker?

nftband.service is `Type=notify`, which is stricter than a PathExists marker (notify requires active READY=1 signal). The existing `After=` already leverages this. `Requires=` is additive, not a substitute.

## Scope

| Item | Status |
|------|--------|
| Single file edited: `install/systemd/nftban-unified-exporter.service` | ✅ |
| Diff: 1 line removed (`Wants=`), 1 added (`Requires=`), 9-line comment block | ✅ |
| No source code changes | ✅ |
| No schema mutation (schema 1.83.0 frozen) | ✅ |
| No CHANGELOG.md / VERSION / STATUS.md / FHS changes (release-prep PR territory) | ✅ |
| No new tests (existing CI validates unit-file syntax via systemd-analyze) | ✅ |
| No new dependencies | ✅ |

## Refs

- `AUDIT_190_LIFECYCLE/V122_SCOPE_TRIAGE.md` §2 (Bucket B-4: nftban-unified-exporter transient hardening; preferred α design)
- `AUDIT_190_LIFECYCLE/V121_PRODUCTION_ROLLOUT_FINAL_ATTESTATION.md` §6 (P2 engineering hardening)
- `AUDIT_190_LIFECYCLE/SRV3_V121_VALIDATION_CLOSURE.md` F-5 (exporter transient on srv3)
- `AUDIT_190_LIFECYCLE/SRV4_V121_VALIDATION_CLOSURE.md` F-6 (exporter transient on srv4)

## Test plan

- [ ] CI: `Validate systemd ExecStart payload resolution` workflow — verifies unit syntax
- [ ] CI: standard product gates (Go build, ShellCheck, CodeQL, etc.) — should match V121 PR #640 baseline shape (3 baseline-advisory failures + ~40 SUCCESS)
- [ ] No CHANGELOG.md changes — release-prep PR territory
- [ ] No source-code changes — Go test suite unaffected
- [ ] Manual sniff-check after merge + fleet rollout: verify `systemctl --failed` stays empty on next upgrade cycle (post-v1.122) — but this is operational verification, not CI-level

## v1.122 release scope (this PR is 2 of 4 v1.122 code PRs)

- ✅ `OPEN_V122_DOCS_PR` (B-1 + B-2 + B-3) — merged as PR #641 squash `a66449d8`
- ⏸ **This PR**: `OPEN_V122_EXPORTER_TRANSIENT_PR` (B-4) — pending CI verify + merge
- ⏸ `OPEN_V122_DEAD_CODE_CLEANUP_PR` (B-5 + B-9 paired)
- ⏸ `OPEN_V122_HYGIENE_PR` (B-10a + B-10b)
- ⏸ `OPEN_V122_RELEASE_PREP_PR` (VERSION + STATUS.md + CHANGELOG.md + FHS regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)