### PR TITLE
cleanup(packaging): V122 B-10a — quarantine /etc/nftban config sidecars (*.rpmnew + *.dpkg-dist/.dpkg-new)

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1010,6 +1010,41 @@ fi
 find /var/cache/nftban -type f -exec chown nftban:nftban {} \; 2>/dev/null || true
 find /var/cache/nftban -type d -exec chown nftban:nftban {} \; 2>/dev/null || true
 
+# v1.122 B-10a: quarantine RPM-generated config sidecars.
+# RPM writes /etc/nftban/<path>.rpmnew when an operator-edited file marked
+# %config(noreplace) is shipped with a newer default in a package upgrade.
+# Active operator config is never touched. This sweep moves each *.rpmnew
+# under /etc/nftban/ into /var/lib/nftban/state/rpmnew-archive/<UTC-ts>/
+# preserving the relative path so operators can diff at leisure. Idempotent
+# (no-op when nothing matches); non-fatal (never breaks install/upgrade).
+_nftban_rpmnew_quarantine() (
+    ts=\$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)
+    arch="/var/lib/nftban/state/rpmnew-archive/\${ts}"
+    count=0
+    # shellcheck disable=SC2044
+    for sidecar in \$(find /etc/nftban -type f -name '*.rpmnew' 2>/dev/null); do
+        if [ ! -f "\$sidecar" ]; then continue; fi
+        rel="\${sidecar#/etc/nftban/}"
+        reldir=\$(dirname -- "\$rel")
+        dst="\${arch}/\${reldir}"
+        if ! mkdir -p "\$dst" 2>/dev/null; then
+            echo "[NFTBan] WARN: rpmnew-quarantine cannot create \$dst -- skipping \$sidecar"
+            continue
+        fi
+        if mv -- "\$sidecar" "\${dst}/" 2>/dev/null; then
+            echo "[NFTBan] Quarantined RPM config sidecar: \$sidecar -> \${dst}/"
+            count=\$((count + 1))
+        else
+            echo "[NFTBan] WARN: rpmnew-quarantine cannot move \$sidecar"
+        fi
+    done
+    if [ "\$count" -gt 0 ]; then
+        echo "[NFTBan] B-10a: \$count RPM config sidecar(s) quarantined under \${arch}/"
+        echo "[NFTBan] B-10a: review with: diff -u /etc/nftban/<path> \${arch}/<path>"
+    fi
+)
+_nftban_rpmnew_quarantine || true
+
 # Send minimal anonymous install result (fire-and-forget, one-time)
 # Reuses nftban_pro.sh infrastructure. Failure is silent.
 # INVARIANT: this is a MINIMAL signal, NOT enrollment. See state-separation invariant.

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -297,6 +297,43 @@ case "$1" in
         find /var/cache/nftban -type f -exec chown nftban:nftban {} \; 2>/dev/null || true
         find /var/cache/nftban -type d -exec chown nftban:nftban {} \; 2>/dev/null || true
 
+        # --- v1.122 B-10a: quarantine DEB-generated config sidecars ---
+        # dpkg writes /etc/nftban/<path>.dpkg-dist (or .dpkg-new) when an
+        # operator-edited conffile is shipped with a newer default in a
+        # package upgrade. Active operator config is never touched. This
+        # sweep moves each sidecar under /etc/nftban/ into
+        # /var/lib/nftban/state/rpmnew-archive/<UTC-ts>/ preserving the
+        # relative path so operators can diff at leisure. Archive root
+        # shared with the RPM path for symmetry. Idempotent (no-op when
+        # nothing matches); non-fatal (never breaks install/upgrade).
+        _nftban_dpkg_quarantine() (
+            _ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)
+            _arch="/var/lib/nftban/state/rpmnew-archive/${_ts}"
+            _count=0
+            while IFS= read -r _sidecar; do
+                if [ -z "$_sidecar" ]; then continue; fi
+                if [ ! -f "$_sidecar" ]; then continue; fi
+                _rel="${_sidecar#/etc/nftban/}"
+                _reldir=$(dirname -- "$_rel")
+                _dst="${_arch}/${_reldir}"
+                if ! mkdir -p "$_dst" 2>/dev/null; then
+                    log_warn "B-10a: dpkg-quarantine cannot create $_dst -- skipping $_sidecar"
+                    continue
+                fi
+                if mv -- "$_sidecar" "${_dst}/" 2>/dev/null; then
+                    log_info "Quarantined DEB config sidecar: $_sidecar -> ${_dst}/"
+                    _count=$((_count + 1))
+                else
+                    log_warn "B-10a: dpkg-quarantine cannot move $_sidecar"
+                fi
+            done < <(find /etc/nftban -type f \( -name '*.dpkg-dist' -o -name '*.dpkg-new' \) 2>/dev/null || true)
+            if [ "$_count" -gt 0 ]; then
+                log_info "B-10a: $_count DEB config sidecar(s) quarantined under ${_arch}/"
+                log_info "B-10a: review with: diff -u /etc/nftban/<path> ${_arch}/<path>"
+            fi
+        )
+        _nftban_dpkg_quarantine || true
+
         ;;
 esac
 


### PR DESCRIPTION
## Summary

v1.122 small backlog-burn release, item **B-10a** — the final functional cleanup PR before v1.122 release-prep. Adds symmetric RPM + DEB post-install hygiene so config sidecars written next to operator-edited `%config(noreplace)` / `dpkg conffile` paths under `/etc/nftban/` no longer accumulate silently after package upgrades.

- **RPM `.rpmnew`**: written when an operator-edited file marked `%config(noreplace)` is shipped with a newer default during a package upgrade.
- **DEB `.dpkg-dist` / `.dpkg-new`**: dpkg conffile equivalent.
- **Active operator config**: never touched. This PR only moves the sidecar written next to it.

## Surfaces touched

| File | Surface | Lines added | Insertion point |
|------|---------|-------------|-----------------|
| `packaging/build_nftban.sh` | `create_rpm_spec_nftban_core()` generated `%post` block | +35 | After cache-ownership fix, before install-result telemetry |
| `packaging/deb/postinst` | `configure` case | +37 | After cache-ownership find loop, before closing `;;` |

**Total diff**: +72 / -0 across 2 files.

## Implementation shape

A small `()` subshell helper function on each side. Subshell form:

1. Auto-scopes the locals (no leak into surrounding scriptlet).
2. Captures any internal failure cleanly via the outer `|| true`.
3. Idempotent — no-op when no sidecar exists.

Shared archive root: `/var/lib/nftban/state/rpmnew-archive/<UTC-timestamp>/`, preserving the relative path under `/etc/nftban/`. Both packagers feed the same review path so operator workflows are symmetric across RHEL/Rocky/Alma and Debian/Ubuntu.

### Generated %post helper (RPM, post-heredoc)

```sh
_nftban_rpmnew_quarantine() (
    ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)
    arch="/var/lib/nftban/state/rpmnew-archive/${ts}"
    count=0
    # shellcheck disable=SC2044
    for sidecar in $(find /etc/nftban -type f -name '*.rpmnew' 2>/dev/null); do
        ...
    done
    if [ "$count" -gt 0 ]; then
        echo "[NFTBan] B-10a: $count RPM config sidecar(s) quarantined under ${arch}/"
        echo "[NFTBan] B-10a: review with: diff -u /etc/nftban/<path> ${arch}/<path>"
    fi
)
_nftban_rpmnew_quarantine || true
```

### DEB postinst helper (raw, no heredoc)

```sh
_nftban_dpkg_quarantine() (
    _ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)
    _arch="/var/lib/nftban/state/rpmnew-archive/${_ts}"
    _count=0
    while IFS= read -r _sidecar; do
        ...
    done < <(find /etc/nftban -type f \( -name '*.dpkg-dist' -o -name '*.dpkg-new' \) 2>/dev/null || true)
    ...
)
_nftban_dpkg_quarantine || true
```

`while IFS= read -r ... < <(find ...)` chosen on the DEB side for whitespace safety; outer `|| true` keeps `set -Eeuo pipefail` from killing the postinst on a quarantine failure.

## Invariants

- ✅ **Active config never touched.** RPM `%config(noreplace)` + dpkg conffile handling already preserve the active file; this PR only relocates the sidecar.
- ✅ **Idempotent** — no-op when nothing matches the suffix list.
- ✅ **Non-fatal** — `mkdir` / `mv` failures emit `WARN` and continue; the function is wrapped in `|| true`.
- ✅ **Audit trail** — each move logged to `%post` / `postinst` stdout (visible in `dnf` / `apt-get` output and journald via the installer log), with a summary block listing the archive directory + a `diff -u` review command.
- ✅ **Per-install timestamp directory** so repeated upgrades do not overwrite earlier sidecars.

## V122 scope disposition recorded by this PR

| Item | Disposition | Where |
|---|---|---|
| **B-9** CLI residue cleanup | **ALREADY-CLOSED** / no deletable surface | confirmed during B-5 investigation; `nftban-api-server` only in CHANGELOG/STATUS; `nftban-ui` references all in active cleanup logic, historical docs, or CI guards |
| **B-10a** config sidecar quarantine | **implemented here** | this PR |
| **B-10b** CSF preservation docs | **ALREADY-CLOSED** by PR #641 (squash `a66449d8`) | all three acceptance criteria met: <br>• `docs/operator/CSF_REMOVAL_AND_TAKEOVER.md:139-144` (over-removal anti-pattern + cross-ref) <br>• `docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md:97-100` (explicit deletion warning) <br>• `docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md:101-108` (backup `cp -p` block + non-recreation note) <br>• `docs/operator/UPGRADING_FROM_V1_120_AND_EARLIER.md:114-116` (codified takeover preferred) |

This makes the final v1.122 effective scope: B-1, B-2, B-3 (PR #641), B-4 (PR #642), B-5 (PR #643), B-10a (this PR). B-9 and B-10b carried into the release-prep closure as ALREADY-CLOSED.

## Forbidden surfaces — verified clean

| Surface | Status |
|---|---|
| `CHANGELOG.md` / `VERSION` / `STATUS.md` / FHS regen | not touched |
| Schema (`internal/validator/types.go`, schema 1.83.0 frozen) | not touched |
| Metrics | not touched |
| Go source (`cmd/`, `internal/`, `pkg/`) | not touched |
| systemd units (`install/systemd/*`) | not touched |
| `nftban-ui` / `nftban-api-server` | not touched |
| B-9 implementation | not touched (ALREADY-CLOSED) |
| B-10b docs | not touched (ALREADY-CLOSED) |
| MASTER_TODO / dns2 / portal / nftbanpro_cms / Bucket-C | not touched |
| Host contact | none |

Diff confirmed limited to `packaging/build_nftban.sh` + `packaging/deb/postinst` (`git diff --shortstat`: 2 files changed, 72 insertions(+)).

## Validation

```
$ bash -n packaging/build_nftban.sh        # OK
$ bash -n packaging/deb/postinst           # OK
$ shellcheck packaging/build_nftban.sh
    # only pre-existing findings at lines 1440/1728/1810 (SC1091, SC2295, SC2016)
    # — unchanged by this PR.
$ shellcheck packaging/deb/postinst
    # zero findings.
$ # generator simulation:
$ awk '/cat > .*spec.*<<EOF/,/^EOF$/' packaging/build_nftban.sh \
    | eval "cat <<EOF $(cat /dev/stdin) EOF" > /tmp/spec.simulated
    # → generated %post body shows the helper de-escaped correctly:
    #   \$(date ...) → $(date ...) ✓
    #   \${ts}, \${arch}, \${reldir}, \${dst} → ${ts}, ${arch}, ... ✓
    #   \$count, \$sidecar → $count, $sidecar ✓
$ bash -n /tmp/post-body.sh
    # OK (166 lines)
$ shellcheck /tmp/post-body.sh | grep B-10a
    # (empty — zero findings in the B-10a range)
```

## Test plan

- [ ] CI green: Build & Test, Build Test Scan (Go), Go Security Analysis, CodeQL, Shell Quality, Detailed ShellCheck — Core scripts
- [ ] CI green: Build RPM (el9, el10), Build DEB (debian12/13, ubuntu22.04/24.04), Test RPM install, Test DEB install
- [ ] CI green: P0/P1 license + SPDX + lychee + libyear, Policy Gates, Semgrep, gosec, govulncheck, Trivy, CodeQL Analysis (Go)
- [ ] Runtime Truth almalinux-9 + ubuntu-24.04 + summary
- [ ] Validate systemd ExecStart payload resolution + Validate package effective parity (RPM vs DEB) + Validate binary consistency
- [ ] Baseline-advisory failures expected unchanged: OSV Vulnerability Scan + Project Health ×2 (matches V120/V121/V122 PR #641 + #642 + #643 pattern)
- [ ] Diff scope: exactly 2 files (`packaging/build_nftban.sh` + `packaging/deb/postinst`), +72 / -0
- [ ] No schema/version/CHANGELOG/STATUS/FHS surfaces in diff

Recommended next gate: `VERIFY_V122_HYGIENE_B10A_PR_CI = GO_READ_ONLY`.