### PR TITLE
feat(installer/flags+main): V125 R-4 --force / --allow-recommit safety gate

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -35,7 +35,8 @@ type config struct {
 	rpm         bool   // called from RPM %post
 	deb         bool   // called from DEB postinst
 	repair      bool   // resume from last failed phase
-	force       bool   // re-run all phases ignoring state
+	force         bool // re-run all phases ignoring state (V125 R-4: requires --allow-recommit when state==COMMITTED)
+	allowRecommit bool // V125 R-4: companion to --force; explicit operator confirmation for re-running phases on a COMMITTED state
 	takeover    bool   // approve takeover of conflicting firewalls
 	dryRun      bool   // show what would happen without changes
 	verbose     bool   // full diagnostic logging
@@ -107,6 +108,13 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.deb, "deb", false, "Called from DEB postinst")
 	flag.BoolVar(&cfg.repair, "repair", false, "Resume from last failed phase")
 	flag.BoolVar(&cfg.force, "force", false, "Re-run all phases ignoring state")
+	// V125 R-4: companion safety flag for --force on a healthy host. When
+	// install_state is COMMITTED, --force alone is REFUSED (V125 R-4 gate
+	// in cmd/nftban-installer/main.go::run); the operator must add
+	// --allow-recommit to confirm explicit destructive intent. --force
+	// alone still works for non-COMMITTED states (recovery from
+	// StateFailedRebuild, StateFailedRender, etc.). Default OFF.
+	flag.BoolVar(&cfg.allowRecommit, "allow-recommit", false, "Explicitly authorize re-running phases on a COMMITTED state (V125 R-4 companion to --force on healthy hosts). Required together with --force when install_state is COMMITTED; ignored otherwise.")
 	flag.BoolVar(&cfg.takeover, "takeover", false, "Approve takeover of conflicting firewalls")
 	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Show what would happen without changes")
 	flag.BoolVar(&cfg.verbose, "verbose", false, "Full diagnostic logging")
@@ -228,6 +236,14 @@ func parseFlags() *config {
 			}
 			if cfg.force {
 				fmt.Fprintln(os.Stderr, "error: --force is not valid with --mode=restore")
+				os.Exit(state.ExitFatal)
+			}
+			// V125 R-4: --allow-recommit is a companion to --force. It has
+			// no meaning on its own and definitely no meaning for restore
+			// mode (which doesn't accept --force in the first place).
+			if cfg.allowRecommit {
+				fmt.Fprintln(os.Stderr, "error: --allow-recommit is not valid with --mode=restore")
+				fmt.Fprintln(os.Stderr, "       --allow-recommit is the V125 R-4 companion to --force; restore mode rejects --force.")
 				os.Exit(state.ExitFatal)
 			}
 			if cfg.rpm || cfg.deb || cfg.source {

--- a/cmd/nftban-installer/force_recommit_gate_test.go
+++ b/cmd/nftban-installer/force_recommit_gate_test.go
@@ -1,0 +1,190 @@
+// =============================================================================
+// NFTBan v1.125 R-4 — --force / --allow-recommit gate regression test
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-force-recommit-gate-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-22"
+// meta:description="V125 R-4 regression test: shouldRefuseForceRecommit predicate truth table + parseFlags --allow-recommit registration"
+// meta:input="None (predicate is pure; flag test manipulates os.Args + flag.CommandLine in isolation)"
+// meta:output="t.Fatal on predicate drift or flag-registration regression"
+// meta:depends="testing,flag,os,internal/installer/state"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/state"
+)
+
+// TestShouldRefuseForceRecommit covers the V125 R-4 gate predicate truth
+// table. The predicate is a pure function over (currentState, force,
+// allowRecommit). Extracted from run() so the gate is testable without
+// constructing a full executor + state file + logger.
+//
+// Refusal MUST fire only when all three conditions hold simultaneously:
+//   1. --force was passed
+//   2. install_state is COMMITTED
+//   3. --allow-recommit was NOT passed
+//
+// All other combinations MUST allow the run (return false).
+func TestShouldRefuseForceRecommit(t *testing.T) {
+	cases := []struct {
+		name          string
+		currentState  state.InstallState
+		force         bool
+		allowRecommit bool
+		wantRefuse    bool
+	}{
+		{
+			name:          "force on COMMITTED without allow-recommit REFUSES",
+			currentState:  state.StateCommitted,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    true,
+		},
+		{
+			name:          "force on COMMITTED with allow-recommit ALLOWS (explicit operator intent)",
+			currentState:  state.StateCommitted,
+			force:         true,
+			allowRecommit: true,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on StateFailedRebuild without allow-recommit ALLOWS (recovery path)",
+			currentState:  state.StateFailedRebuild,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on StateFailedRender without allow-recommit ALLOWS (recovery path)",
+			currentState:  state.StateFailedRender,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on StateFailedNoFirewall without allow-recommit ALLOWS (recovery path)",
+			currentState:  state.StateFailedNoFirewall,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on StateFailedTakeover without allow-recommit ALLOWS (recovery path)",
+			currentState:  state.StateFailedTakeover,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on StateDegraded without allow-recommit ALLOWS (recovery path)",
+			currentState:  state.StateDegraded,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "force on empty state (fresh install) ALLOWS (no install present)",
+			currentState:  state.InstallState(""),
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "NO force on COMMITTED ALLOWS (e.g., package-manager postinst with --rpm/--deb)",
+			currentState:  state.StateCommitted,
+			force:         false,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			name:          "NO force with allow-recommit on COMMITTED ALLOWS (allowRecommit alone is harmless)",
+			currentState:  state.StateCommitted,
+			force:         false,
+			allowRecommit: true,
+			wantRefuse:    false,
+		},
+		{
+			name:          "NO force on StateFailedRebuild ALLOWS",
+			currentState:  state.StateFailedRebuild,
+			force:         false,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldRefuseForceRecommit(tc.currentState, tc.force, tc.allowRecommit)
+			if got != tc.wantRefuse {
+				t.Fatalf("shouldRefuseForceRecommit(state=%q, force=%v, allowRecommit=%v) = %v; want %v",
+					tc.currentState, tc.force, tc.allowRecommit, got, tc.wantRefuse)
+			}
+		})
+	}
+}
+
+// TestParseFlags_AllowRecommitDefault asserts that parseFlags registers
+// --allow-recommit and defaults it to false when the operator does not
+// pass the flag. Mirrors the V120 TestParseFlags_SessionWhitelistTTLDefault
+// pattern (V120_PR_637_ORPHAN_AND_DEAD_CODE_AUDIT B-2 — a flag declared in
+// the config struct but never registered via flag.BoolVar silently no-ops
+// in production).
+//
+// Uses --mode=upgrade (the lightest-validation install mode) so that
+// parseFlags reaches the return path without hitting any os.Exit branch.
+func TestParseFlags_AllowRecommitDefault(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet("nftban-installer-allowrecommittest", flag.ContinueOnError)
+	os.Args = []string{"nftban-installer", "--mode=upgrade"}
+
+	cfg := parseFlags()
+
+	if cfg.allowRecommit != false {
+		t.Fatalf("parseFlags() with no --allow-recommit returned cfg.allowRecommit=%v; want false (default)", cfg.allowRecommit)
+	}
+}
+
+// TestParseFlags_AllowRecommitExplicit asserts that --allow-recommit is
+// honored when explicitly passed on the command line.
+func TestParseFlags_AllowRecommitExplicit(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet("nftban-installer-allowrecommitexplicit", flag.ContinueOnError)
+	os.Args = []string{"nftban-installer", "--mode=upgrade", "--force", "--allow-recommit"}
+
+	cfg := parseFlags()
+
+	if !cfg.allowRecommit {
+		t.Fatal("parseFlags() with --allow-recommit returned cfg.allowRecommit=false; want true")
+	}
+	if !cfg.force {
+		t.Fatal("parseFlags() with --force returned cfg.force=false; want true (sanity check that --allow-recommit didn't shadow --force)")
+	}
+}

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -253,6 +253,40 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 	if cfg.mode == "upgrade" && cfg.dryRun {
 		return runUpdateDryRun(ctx, exec, sf, cfg, log)
 	}
+	// V125 R-4: --force safety gate on a COMMITTED state. The dispatch
+	// paths below (runUpdateApply, runInstall) re-run all phases without
+	// consulting install_state. On a healthy COMMITTED host, an accidental
+	// `nftban-installer --mode=install --takeover --force` would re-trigger
+	// Switch — re-flushing iptables, re-masking CSF if the operator
+	// unmasked manually, re-rendering config — without operator intent
+	// for that destruction.
+	//
+	// Gate placement is intentional:
+	//   - AFTER repair (repair has its own COMMITTED no-op at line 344).
+	//   - AFTER uninstall (operator IS intending to remove a COMMITTED install).
+	//   - AFTER restore (decision-only, no mutation; flags.go also rejects
+	//     --force with --mode=restore at line 237).
+	//   - AFTER upgrade --dry-run (no mutation by design).
+	//   - BEFORE runUpdateApply / runInstall, which ARE the mutating paths.
+	//
+	// Package-manager postinst paths (--rpm / --deb) do NOT pass --force
+	// (verified: packaging/deb/postinst and packaging/build_nftban.sh RPM
+	// spec invoke nftban-installer without --force), so legitimate package
+	// upgrades on COMMITTED hosts are unaffected by this gate.
+	//
+	// --force alone still works for non-COMMITTED states (the typical
+	// recovery path from StateFailedRebuild / StateFailedRender / etc.):
+	// the helper shouldRefuseForceRecommit only refuses when ALL THREE
+	// conditions hold (force=true AND state==COMMITTED AND allowRecommit=false).
+	if shouldRefuseForceRecommit(sf.State, cfg.force, cfg.allowRecommit) {
+		fmt.Fprintln(os.Stderr, "error: --force on a COMMITTED install requires --allow-recommit confirmation.")
+		fmt.Fprintln(os.Stderr, "       this gate exists to prevent accidental destructive re-runs of a healthy install.")
+		fmt.Fprintln(os.Stderr, "       if you really want to re-run all phases on this COMMITTED host, add --allow-recommit.")
+		fmt.Fprintln(os.Stderr, "       if you intended to resume a failed install, use --repair instead of --force.")
+		log.Error("V125 R-4: --force refused on COMMITTED state without --allow-recommit (use --repair to resume failed installs, or add --allow-recommit to confirm destructive re-run)")
+		return state.ExitRefused
+	}
+
 	// v1.99 PR-18 (G3-U5..U10): update apply orchestration. Thin sequencer
 	// over rebuild + validator (see apply_contract.md). INV-U-001/002/003
 	// enforced; no custom apply/recovery/authority logic introduced.
@@ -266,6 +300,29 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 		return runUpdateApply(ctx, exec, sf, cfg, log)
 	}
 	return runInstall(ctx, exec, sf, cfg, log)
+}
+
+// shouldRefuseForceRecommit is the V125 R-4 gate predicate. Returns true if
+// the installer should refuse this run with ExitRefused because the operator
+// passed --force on a COMMITTED state without the --allow-recommit companion.
+//
+// Pure function over the three inputs; no I/O, no side effects. Extracted so
+// the gate is testable without constructing a full run() context (executor,
+// state file, logger, etc.).
+//
+// Refusal rule (all three must be true):
+//   1. --force was passed
+//   2. install_state is COMMITTED (healthy install)
+//   3. --allow-recommit was NOT passed
+//
+// All other combinations return false (no refusal):
+//   - --force alone on StateFailedRebuild / StateFailedRender / etc.: allowed
+//     (legitimate recovery path)
+//   - No --force on COMMITTED: allowed (e.g., package-manager postinst with
+//     --rpm/--deb passes no --force; routine package upgrades unaffected)
+//   - --force + --allow-recommit on COMMITTED: allowed (explicit operator intent)
+func shouldRefuseForceRecommit(currentState state.InstallState, force, allowRecommit bool) bool {
+	return force && currentState == state.StateCommitted && !allowRecommit
 }
 
 // runInstall runs all phases in order for a fresh install or upgrade.


### PR DESCRIPTION
## Summary

V125 R-4 — fourth narrow installer-robustness PR. Closes the safety gap in `cmd/nftban-installer/flags.go:109` / `main.go` where `--force` re-runs ALL phases on a healthy COMMITTED host without any confirmation, re-triggering Switch (re-flushing iptables, re-masking CSF, re-rendering config) without explicit operator intent for that destruction.

Per `AUDIT_190_LIFECYCLE/V125_INSTALL_ROBUSTNESS_SCOPE.md` §3.1 Lane R-4 (LOC budget ~30 code + tests; risk LOW). Actual: +264/-1 across 3 files (code stayed at ~21 LOC; the test file is intentionally thorough — 11-case truth table to lock the predicate behavior).

## Changes

1. **`cmd/nftban-installer/flags.go`** (+18/-1):
   - New `allowRecommit bool` config field.
   - New `--allow-recommit` flag (default OFF).
   - Restore-mode rejection: `--allow-recommit` rejected with `--mode=restore` (same pattern as existing `--force` rejection at line 237).

2. **`cmd/nftban-installer/main.go`** (+57/-0):
   - New `shouldRefuseForceRecommit` pure predicate function — returns true iff `(force && state==COMMITTED && !allowRecommit)`. Extracted from `run()` so the gate is testable without constructing full executor + state file + logger.
   - V125 R-4 gate added at the top of `run()`'s install/upgrade dispatch path (AFTER repair/uninstall/restore/upgrade-dry-run early returns; BEFORE the mutating `runUpdateApply` / `runInstall` paths).
   - Refusal message points to two remediations: `--allow-recommit` (if destruction is really intended) or `--repair` (if the intent was to resume a failed install).
   - Uses `state.ExitRefused` (=5) rather than the generic `ExitFatal`.

3. **`cmd/nftban-installer/force_recommit_gate_test.go`** (NEW, +180):
   - `TestShouldRefuseForceRecommit` — 11-case truth table:
     - REFUSAL: force + COMMITTED + no allow-recommit
     - 7 ALLOW cases for `--force` on non-COMMITTED failure states (FailedRebuild/Render/NoFirewall/Takeover/Degraded) + fresh install + the harmless no-force-on-COMMITTED case (package-manager postinst path)
     - Plus the no-force + allow-recommit harmless case
   - `TestParseFlags_AllowRecommitDefault` — asserts flag registers, defaults to false. Mirrors the V120 TestParseFlags_SessionWhitelistTTLDefault pattern (pre-applies the V120 PR #637 B-2 lesson: a config-struct field without `flag.BoolVar` registration silently no-ops in production).
   - `TestParseFlags_AllowRecommitExplicit` — asserts `--allow-recommit` is honored when explicitly passed alongside `--force`.

## Critical design choices

**Package-manager postinst paths UNAFFECTED.** Verified `packaging/deb/postinst` and `packaging/build_nftban.sh` RPM spec invoke `nftban-installer --rpm` or `--deb` WITHOUT `--force`. The R-4 gate only fires when `--force` is set, so legitimate package upgrades on COMMITTED hosts continue to work normally.

**Recovery paths UNAFFECTED.** `nftban-installer --force` on `StateFailedRebuild` / `StateFailedRender` / `StateFailedNoFirewall` / `StateFailedTakeover` / `StateDegraded` continues to work without `--allow-recommit` (the typical recovery flow). Only the COMMITTED state gates `--force` behind the explicit confirmation.

**Helper extraction enables narrow testing.** The 11-case truth-table test asserts predicate behavior without mocking `executor.Executor`, constructing `state.StateFile`, creating `logging.Logger`, or wiring `context.Context`. The gate's invocation in `run()` is a 6-line block.

## 7-question precheck (passed before first line of code)

Per `AUDIT_190_LIFECYCLE/V125_INSTALLER_ENTRYPOINT_PRECHECK.md` with the V125 R-3 Q4 sub-rule (`gosec -nosec` workflow-first) applied:

- **Q1 dry-run mutation:** NO — refusal-class gate exits before phases run.
- **Q2 canonization:** NO — no `/var/lib/nftban` or `/etc/nftban` writes.
- **Q3 test-binary/container:** NO — pure flag parsing + state comparison.
- **Q4 security-lint:** Confirmed `.github/workflows/secure-go.yml:89` still runs `gosec -nosec`; R-4 introduces no variable file paths, no `#nosec`, no new I/O.
- **Q5 mode matrix:** R-4 affects only install + upgrade modes on COMMITTED state. Uninstall/restore/repair flows unchanged. Package-manager postinst paths (`--rpm`/`--deb` without `--force`) unaffected.
- **Q6 failure-state:** Refusal is SAFER than current behavior — refuses before mutation; state-file untouched.
- **Q7 rollback/repair:** Refusal doesn't leave host degraded; operator re-runs with `--allow-recommit` if intent was real.

## Audit pre-clearance

`V125_CROSS_CUTTING_CONTRACT_AUDIT_COMPLETE` (run 2026-05-21) verified zero `BLOCK_R3` findings; R-4 falls into the same clean cluster.

## Forbidden surfaces (untouched — lane-wide invariant)

- daemon (`cmd/nftband/`, `cmd/nftban-core/`)
- schema (`internal/validator/`) — 1.83.0 frozen
- metrics
- packaging (verified does NOT pass `--force`)
- `install/systemd/`, `install/polkit/`
- VERSION, STATUS.md, CHANGELOG.md

## Pre-PR verification on monitor

Ran on monitor.example.test (Ubuntu 24.04, Go 1.22 system + auto-fetched Go 1.25 toolchain) at branch HEAD `6ebdbfb`:

| Command | Result |
|---|---|
| `go vet ./...` | ✅ clean |
| `go build ./...` | ✅ clean |
| `go test -v -run "Force\|Recommit\|AllowRecommit" ./cmd/nftban-installer/...` | ✅ 11/11 truth-table PASS + 2/2 parseFlags PASS |
| `go test ./cmd/nftban-installer/...` (full regression) | ✅ ok |

## Test plan

- [ ] CI `Build & Test` green
- [ ] CI `Build, Test, Scan (Go)` green
- [ ] CI `CodeQL Analysis (Go)` green
- [ ] CI `gosec` green (no new findings)
- [ ] CI `govulncheck` green
- [ ] CI `staticcheck` green
- [ ] CI `Update Canonization (almalinux-9)` green
- [ ] CI `Update Canonization (ubuntu-24.04)` green
- [ ] CI `Uninstall Canonization (almalinux-9)` green
- [ ] CI `Uninstall Canonization (ubuntu-24.04)` green
- [ ] CI `Install Canonization (almalinux-9)` green (validates that `--mode=install --dry-run` refusal path still fires; R-4 gate operates on `--force` only)
- [ ] CI `Install Canonization (ubuntu-24.04)` green
- [ ] CI `Project Health` (check-name `health`) green
- [ ] CI `ShellCheck - Find bash errors` green
- [ ] CI `Shell Quality` green
- [ ] CI `Docs Quality` green
- [ ] CI `Policy Gates` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
