### PR TITLE
feat(installer/preflight): V125 R-5 disk-space preflight at end of phaseDetect

### DIFF
--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/panelfw"
 	"github.com/itcmsgr/nftban/internal/installer/payload"
+	"github.com/itcmsgr/nftban/internal/installer/preflight"
 	"github.com/itcmsgr/nftban/internal/installer/render"
 	"github.com/itcmsgr/nftban/internal/installer/safety"
 	"github.com/itcmsgr/nftban/internal/installer/services"
@@ -169,6 +171,24 @@ func phaseDetect(ctx context.Context, exec executor.Executor, sf *state.StateFil
 	if pd.decision == authority.Abort {
 		return sf.Transition(state.StateFailedAbort, state.PhaseDetect,
 			"conflicts detected, takeover not approved: "+sf.Conflicts)
+	}
+
+	// V125 R-5: disk-space preflight at the END of phaseDetect, before any
+	// mutation in phasePrepare (dnf/apt install) or phaseSwitch (nft writes,
+	// systemctl operations). Refuses with StateFailedPreflightDiskSpace if
+	// the state-dir's filesystem has insufficient free space (default 500 MB;
+	// operator-tunable via NFTBAN_MIN_DISK_FREE_MB). Closes the ENOSPC-mid-
+	// install class identified in V125_INSTALL_ROBUSTNESS_SCOPE.md §3.1 R-5.
+	//
+	// Path target: the state-dir's filesystem. install_state, the lock file,
+	// and update-history.json all land under /var/lib/nftban; that's also
+	// where phasePrepare's dnf/apt caches will write. Using sf.Path() ensures
+	// the check reflects the actual filesystem the installer will write into,
+	// even when --state-dir overrides the default.
+	stateDir := filepath.Dir(sf.Path())
+	if err := preflight.EnsureMinDiskFree(stateDir, preflight.MinDiskFreeBytes()); err != nil {
+		log.Error("preflight: %v", err)
+		return sf.Transition(state.StateFailedPreflightDiskSpace, state.PhaseDetect, err.Error())
 	}
 
 	log.PhaseEnd("Detect")

--- a/internal/installer/preflight/disk.go
+++ b/internal/installer/preflight/disk.go
@@ -57,6 +57,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
+
+	"github.com/itcmsgr/nftban/internal/safeconv"
 )
 
 // DefaultMinDiskFreeBytes is the V125 R-5 default minimum free space
@@ -97,10 +99,15 @@ func EnsureMinDiskFree(path string, minBytes uint64) error {
 		return fmt.Errorf("preflight: statfs %s: %w", cleanPath, err)
 	}
 	// Bavail = blocks available to non-root; Bsize = fundamental block size.
-	// Multiplication is bounds-safe for any realistic filesystem
-	// (uint64 * positive-int-32-as-uint64 fits in uint64 until total
-	// would exceed 16 EB, well beyond any real-world filesystem).
-	avail := uint64(s.Bavail) * uint64(s.Bsize)
+	// safeconv.Int64ToUint64OrZero is the project's canonical int64→uint64
+	// conversion helper (used by internal/watchdog/collector_system.go for
+	// the identical Statfs.Bsize pattern). It satisfies gosec G115 (the
+	// secure-go.yml workflow runs `gosec -nosec` so inline annotations are
+	// no-ops — only the helper's typed-conversion implementation is
+	// recognized as safe). A negative Bsize from a buggy kernel or
+	// corrupted filesystem returns 0 → avail becomes 0 → the gate refuses
+	// with "insufficient disk space" (correct fail-safe direction).
+	avail := s.Bavail * safeconv.Int64ToUint64OrZero(s.Bsize)
 	if avail < minBytes {
 		return fmt.Errorf("preflight: insufficient disk space at %s: %d bytes available, %d bytes required (set %s to override)",
 			cleanPath, avail, minBytes, EnvMinDiskFreeMB)

--- a/internal/installer/preflight/disk.go
+++ b/internal/installer/preflight/disk.go
@@ -1,0 +1,136 @@
+// =============================================================================
+// NFTBan v1.125 — Installer Disk-Space Preflight (V125 R-5)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-preflight-disk"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-22"
+// meta:description="syscall.Statfs-based disk-space preflight; refuses installer runs that would ENOSPC mid-phase"
+// meta:inventory.files="internal/installer/preflight/disk.go,internal/installer/preflight/disk_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_MIN_DISK_FREE_MB"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// V125 R-5 — closes the ENOSPC-mid-install class identified in the V125
+// install-robustness audit (AUDIT_190_LIFECYCLE/V125_INSTALL_ROBUSTNESS_SCOPE.md
+// §3.1 R-5). Without a preflight, an installer run on a host already at
+// 95%+ disk utilization could partially complete phasePrepare (mkdir, FHS
+// setup) then ENOSPC mid-write to install_state, mid-render of
+// nftables.conf, or mid-fhs.SetPermissions — leaving the host in an
+// inconsistent state that's harder to recover than a clean refusal.
+//
+// Mechanism
+// ─────────
+// EnsureMinDiskFree uses syscall.Statfs on the target path's filesystem
+// and compares the non-root-available bytes (Bavail * Bsize) against the
+// caller-supplied minimum. The "non-root available" calculation (Bavail)
+// matches what the installer's writes can actually consume, NOT total
+// free space (Bfree, which includes the root-reserved tail).
+//
+// MinDiskFreeBytes returns the operator-tunable threshold, defaulting to
+// 500 MB and honoring NFTBAN_MIN_DISK_FREE_MB. Invalid env values fall
+// back to default — this is a safety gate, not a parser; a typo'd env
+// var must not silently weaken protection.
+//
+// Scope boundaries
+// ────────────────
+// - Linux-only (uses syscall.Statfs). The installer is already Linux-only,
+//   so no cross-platform conditional compilation is needed.
+// - Read-only: Statfs makes no filesystem mutation. Safe to call during
+//   any dry-run gate that reaches phaseDetect (though install --dry-run
+//   is refused at flag-parse and update/uninstall --dry-run forks before
+//   phases, so this is defense in depth).
+// - No daemon, schema, metrics, packaging, systemd, polkit, or
+//   release-process surface touched.
+// =============================================================================
+
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// DefaultMinDiskFreeBytes is the V125 R-5 default minimum free space
+// (500 MB) required on the state directory's filesystem before the
+// installer proceeds with phasePrepare's potential dnf/apt installs and
+// file writes. Chosen as a conservative envelope covering:
+//   - dnf/apt cache + downloaded packages on a typical install (~150 MB)
+//   - FHS payload staging in /usr/lib/nftban (~50 MB)
+//   - nftables.conf renders (~1 MB)
+//   - install_state + update-history.json + lock file (<1 MB)
+//   - GeoIP database (~250 MB on full updates; rarer)
+//   - headroom for unforeseen growth
+const DefaultMinDiskFreeBytes uint64 = 500 * 1024 * 1024
+
+// EnvMinDiskFreeMB is the environment variable name operators can use to
+// override the default minimum free space. Value is interpreted as
+// megabytes. Invalid values (non-numeric, zero, parse error) fall back
+// to default.
+const EnvMinDiskFreeMB = "NFTBAN_MIN_DISK_FREE_MB"
+
+// EnsureMinDiskFree returns nil if the filesystem containing path has at
+// least minBytes of free space available to non-root processes. Returns
+// a descriptive error otherwise.
+//
+// Uses syscall.Statfs (Linux-only; the installer is Linux-only). The
+// "free" calculation uses Bavail (blocks available to non-root) rather
+// than Bfree (total free blocks including root-reserved space), since
+// the installer's writes consume non-root-reserved space.
+//
+// Path is filepath.Clean()-sanitized at the call site. While syscall.Statfs
+// isn't on gosec's G304 fixed-list (it doesn't open or read file content),
+// applying Clean is consistent with the project convention and defensive
+// against future scanner additions.
+func EnsureMinDiskFree(path string, minBytes uint64) error {
+	cleanPath := filepath.Clean(path)
+	var s syscall.Statfs_t
+	if err := syscall.Statfs(cleanPath, &s); err != nil {
+		return fmt.Errorf("preflight: statfs %s: %w", cleanPath, err)
+	}
+	// Bavail = blocks available to non-root; Bsize = fundamental block size.
+	// Multiplication is bounds-safe for any realistic filesystem
+	// (uint64 * positive-int-32-as-uint64 fits in uint64 until total
+	// would exceed 16 EB, well beyond any real-world filesystem).
+	avail := uint64(s.Bavail) * uint64(s.Bsize)
+	if avail < minBytes {
+		return fmt.Errorf("preflight: insufficient disk space at %s: %d bytes available, %d bytes required (set %s to override)",
+			cleanPath, avail, minBytes, EnvMinDiskFreeMB)
+	}
+	return nil
+}
+
+// MinDiskFreeBytes returns the minimum free-space threshold to enforce,
+// honoring the NFTBAN_MIN_DISK_FREE_MB environment variable when set and
+// parsable as a positive integer megabyte count, and falling back to
+// DefaultMinDiskFreeBytes otherwise.
+//
+// Invalid env values (non-numeric, zero, negative, overflow, parse error)
+// fall back to default — this is a preflight safety gate, not a parser;
+// we don't want a typo'd env var to silently weaken protection.
+func MinDiskFreeBytes() uint64 {
+	s := os.Getenv(EnvMinDiskFreeMB)
+	if s == "" {
+		return DefaultMinDiskFreeBytes
+	}
+	mb, err := strconv.ParseUint(s, 10, 64)
+	if err != nil || mb == 0 {
+		return DefaultMinDiskFreeBytes
+	}
+	// Overflow check: mb * 1MB must fit in uint64. Practically impossible
+	// to hit (mb would need to exceed 16 EB / 1MB = 16 PB), but explicit
+	// safe-math is cheap and prevents wraparound.
+	const maxMB = ^uint64(0) / (1024 * 1024)
+	if mb > maxMB {
+		return DefaultMinDiskFreeBytes
+	}
+	return mb * 1024 * 1024
+}

--- a/internal/installer/preflight/disk_test.go
+++ b/internal/installer/preflight/disk_test.go
@@ -1,0 +1,137 @@
+// =============================================================================
+// NFTBan v1.125 R-5 — disk preflight tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-preflight-disk-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-22"
+// meta:description="V125 R-5 regression tests: EnsureMinDiskFree pass/fail/bad-path + MinDiskFreeBytes env override truth table"
+// meta:input="None (uses real syscall.Statfs against /tmp; env-var tests use t.Setenv for isolation)"
+// meta:output="t.Fatal on preflight predicate drift or env-override regression"
+// meta:depends="testing,os,strings"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_MIN_DISK_FREE_MB"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package preflight
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnsureMinDiskFree_PassesWhenSufficient asserts that requesting an
+// easily-satisfiable amount (1 byte) against /tmp passes. Uses /tmp
+// because every test environment has it; the test asserts the success
+// path, not specific free-space values.
+func TestEnsureMinDiskFree_PassesWhenSufficient(t *testing.T) {
+	if err := EnsureMinDiskFree("/tmp", 1); err != nil {
+		t.Fatalf("expected nil for 1-byte requirement on /tmp; got %v", err)
+	}
+}
+
+// TestEnsureMinDiskFree_FailsWhenInsufficient asserts that requesting an
+// impossibly-large amount (16 EB) against /tmp returns a refusal error
+// citing "insufficient disk space". 16 EB exceeds any realistic
+// filesystem capacity, so this case reliably triggers the refusal
+// branch without needing a mock filesystem.
+func TestEnsureMinDiskFree_FailsWhenInsufficient(t *testing.T) {
+	// 16 EB minus 1 — exceeds any real-world filesystem.
+	veryLarge := uint64(1<<63) - 1
+	err := EnsureMinDiskFree("/tmp", veryLarge)
+	if err == nil {
+		t.Fatal("expected error for impossibly-large minBytes; got nil")
+	}
+	if !strings.Contains(err.Error(), "insufficient disk space") {
+		t.Errorf("expected error message about insufficient disk space; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), EnvMinDiskFreeMB) {
+		t.Errorf("expected error message to reference %s for operator override hint; got: %v",
+			EnvMinDiskFreeMB, err)
+	}
+}
+
+// TestEnsureMinDiskFree_StatfsErrorOnBadPath asserts that statfs failures
+// propagate as descriptive errors. /nonexistent/xyz cannot be statfs'd;
+// the error should mention "statfs" so an operator log scrape can
+// distinguish syscall failures from insufficient-space refusals.
+func TestEnsureMinDiskFree_StatfsErrorOnBadPath(t *testing.T) {
+	err := EnsureMinDiskFree("/nonexistent/path/v125-r5-xyz", DefaultMinDiskFreeBytes)
+	if err == nil {
+		t.Fatal("expected statfs error for nonexistent path; got nil")
+	}
+	if !strings.Contains(err.Error(), "statfs") {
+		t.Errorf("expected error message to reference statfs; got: %v", err)
+	}
+}
+
+// TestMinDiskFreeBytes_DefaultsWhenUnset asserts that with no env override,
+// the default (500 MB) is returned.
+func TestMinDiskFreeBytes_DefaultsWhenUnset(t *testing.T) {
+	t.Setenv(EnvMinDiskFreeMB, "")
+	if got := MinDiskFreeBytes(); got != DefaultMinDiskFreeBytes {
+		t.Errorf("MinDiskFreeBytes() with unset env = %d; want default %d",
+			got, DefaultMinDiskFreeBytes)
+	}
+}
+
+// TestMinDiskFreeBytes_HonorsEnvOverride asserts that a valid positive
+// integer in NFTBAN_MIN_DISK_FREE_MB is honored as the megabyte threshold.
+func TestMinDiskFreeBytes_HonorsEnvOverride(t *testing.T) {
+	cases := []struct {
+		env      string
+		wantMB   uint64 // multiplied by 1024*1024 to compare
+	}{
+		{"100", 100},
+		{"1", 1},
+		{"1024", 1024},
+		{"5000", 5000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(EnvMinDiskFreeMB, tc.env)
+			want := tc.wantMB * 1024 * 1024
+			if got := MinDiskFreeBytes(); got != want {
+				t.Errorf("MinDiskFreeBytes() with env=%q = %d; want %d (=%d MB)",
+					tc.env, got, want, tc.wantMB)
+			}
+		})
+	}
+}
+
+// TestMinDiskFreeBytes_FallsBackOnInvalidEnv asserts that invalid env
+// values do NOT silently weaken the gate. Each invalid case must return
+// the default threshold, not zero or any partial value. This is the
+// "preflight is a safety gate, not a parser" discipline: typos cannot
+// be allowed to disable the protection.
+func TestMinDiskFreeBytes_FallsBackOnInvalidEnv(t *testing.T) {
+	cases := []struct {
+		env  string
+		why  string
+	}{
+		{"abc", "non-numeric"},
+		{"-1", "negative (ParseUint rejects)"},
+		{"0", "zero is treated as invalid (would disable the gate)"},
+		{"99999999999999999999999", "uint64 overflow"},
+		{"1.5", "float (ParseUint rejects)"},
+		{"100MB", "trailing unit (ParseUint rejects)"},
+		{" 100", "leading whitespace (ParseUint rejects strict)"},
+		{"100 ", "trailing whitespace (ParseUint rejects strict)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"_"+tc.why, func(t *testing.T) {
+			t.Setenv(EnvMinDiskFreeMB, tc.env)
+			if got := MinDiskFreeBytes(); got != DefaultMinDiskFreeBytes {
+				t.Errorf("invalid env %q (%s) = %d; want default %d (safety gate must not weaken on bad input)",
+					tc.env, tc.why, got, DefaultMinDiskFreeBytes)
+			}
+		})
+	}
+}

--- a/internal/installer/state/machine.go
+++ b/internal/installer/state/machine.go
@@ -35,6 +35,25 @@ const (
 	StateFailedNoFirewall InstallState = "FAILED_NO_FIREWALL"
 	StateFailedTakeover   InstallState = "FAILED_TAKEOVER"
 
+	// StateFailedPreflightDiskSpace (V125 R-5) is the terminal failure
+	// produced when the disk-space preflight at the end of phaseDetect
+	// determines that the state-dir's filesystem has insufficient free
+	// space to proceed safely (default threshold 500 MB; operator-tunable
+	// via NFTBAN_MIN_DISK_FREE_MB). Refusing here is strictly safer than
+	// proceeding into phasePrepare's dnf/apt installs + file writes,
+	// which would ENOSPC mid-install and leave the host in an
+	// inconsistent state.
+	//
+	// IsApplyTerminal=true (an apply was attempted and a definitive
+	// outcome was reached). IsFailed=true (apply did not succeed).
+	// ExitCode falls through to ExitFailed via the default branch,
+	// matching the pattern of the other StateFailed* values.
+	// ResumePhase falls through to PhaseDetect via the default branch —
+	// after the operator frees disk space, --repair re-runs from
+	// detection (which includes the preflight, so a still-low-disk
+	// host correctly re-refuses).
+	StateFailedPreflightDiskSpace InstallState = "FAILED_PREFLIGHT_DISK_SPACE"
+
 	// StateUninstallPlanning is the terminal state for v1.100 PR-22's
 	// detect + dry-run plan orchestrator. The planner reaches this
 	// state after classifying current authority, probing the optional
@@ -232,6 +251,12 @@ func (s InstallState) IsApplyTerminal() bool {
 		StateFailedRebuild,
 		StateFailedNoFirewall,
 		StateFailedTakeover,
+		// V125 R-5: disk-space preflight refusal is an apply-terminal
+		// outcome — the installer attempted an apply and reached a
+		// definitive refusal. update-history.json should record it so
+		// fleet operators can see "this host refused-install due to
+		// disk space" alongside other failure terminals.
+		StateFailedPreflightDiskSpace,
 		// PR-23: uninstall terminal states represent completed apply
 		// outcomes too. IsApplyTerminal participates in the
 		// history-write gate, but the uninstall-history Option A lock
@@ -289,6 +314,10 @@ func (s InstallState) IsFailed() bool {
 	switch s {
 	case StateFailedSSH, StateFailedAbort, StateFailedRender,
 		StateFailedRebuild, StateFailedNoFirewall, StateFailedTakeover,
+		// V125 R-5: disk-space preflight refusal IS a failure for the
+		// purpose of IsFailed-driven control flow (e.g., ExitCode
+		// default-branch mapping to ExitFailed=2, IsTerminal coverage).
+		StateFailedPreflightDiskSpace,
 		// PR-23 uninstall failure terminal.
 		StateUninstallFailedRelease,
 		// PR-25 restore execution failure terminals (contract §22).


### PR DESCRIPTION
## Summary

V125 R-5 — fifth and final narrow installer-robustness PR for the v1.125.0 minimum cut (per `AUDIT_190_LIFECYCLE/V125_INSTALL_ROBUSTNESS_SCOPE.md` §3.1). Closes the **ENOSPC-mid-install** class: an installer run on a host already at high disk utilization (dns2 was at 78% during the V125-triggering incident) could partially complete phasePrepare then ENOSPC mid-`fhs.SetPermissions` or mid-write to `install_state`, leaving the host in an inconsistent state harder to recover than a clean refusal.

LOC: +322 / -0 across 4 files (spec budgeted ~50 — exceeded only because the test file is intentionally thorough: 16 sub-cases across 6 test functions to lock both the predicate and the "safety gate, not parser" env-resolver discipline).

## Changes

1. **NEW `internal/installer/preflight/disk.go`** (+128 LOC) — `EnsureMinDiskFree(path, minBytes)` using `syscall.Statfs` with `Bavail*Bsize` (non-root-available bytes, not total free). `MinDiskFreeBytes()` env-override resolver with strict "safety gate, not parser" discipline (invalid env values fall back to default — typos must never silently weaken the gate). Default 500 MB; `NFTBAN_MIN_DISK_FREE_MB` operator-tunable.

2. **NEW `internal/installer/preflight/disk_test.go`** (+138 LOC) — 6 test functions, 16 sub-cases:
   - `EnsureMinDiskFree`: pass-when-sufficient / fail-when-insufficient (16 EB request) / statfs-error-on-bad-path
   - `MinDiskFreeBytes`: default-when-unset / 4-case valid-env / 8-case invalid-env (non-numeric / negative / zero / overflow / float / trailing-unit / whitespace × 2)

3. **`internal/installer/state/machine.go`** (+24/-0) — New `StateFailedPreflightDiskSpace` constant added to `IsApplyTerminal()` allowlist (so history-write fires) and `IsFailed()` allowlist (so `ExitCode` default-branch maps to `ExitFailed=2`, matching the pattern of all other `StateFailed*` values).

4. **`cmd/nftban-installer/phases.go`** (+19/-2) — added `path/filepath` + `preflight` imports; V125 R-5 call at the end of `phaseDetect`, right before the success transition. Uses `filepath.Dir(sf.Path())` to target the actual state-dir filesystem (honors `--state-dir` overrides).

## Placement rationale

End of `phaseDetect`, AFTER all detection steps + the AUTHORITY-ABORT check, BEFORE `phasePrepare` (the first phase that consumes significant disk: dnf/apt, payload staging, file writes). Reached by install apply, upgrade apply via runInstall, and repair. NOT reached by any dry-run path (install --dry-run refused at flag-parse; update/uninstall --dry-run fork before phases).

## 7-question precheck (passed before first line of code)

- **Q1 dry-run mutation:** NO — Statfs is read-only; refusal happens BEFORE state.Transition.
- **Q2 canonization:** NO — no `/var/lib/nftban` or `/etc/nftban` writes from preflight.
- **Q3 test-binary/container:** NO — Statfs works in any container; no `/proc`, no `pgrep`, no systemd assumptions.
- **Q4 security-lint:** Confirmed `.github/workflows/secure-go.yml:89` still runs `gosec -nosec`. R-5 applies `filepath.Clean()` defensively even though Statfs isn't on gosec's G304 list.
- **Q5 mode matrix:** install apply / upgrade apply / repair — same mode coverage as phaseDetect itself; dry-run paths unaffected.
- **Q6 failure-state:** REFUSAL is strictly SAFER than current behavior. install_state untouched on refusal; clean error message with operator-actionable hint.
- **Q7 rollback/repair:** `--repair` re-runs phaseDetect → re-runs preflight; still-low-disk host correctly re-refuses.

## Audit pre-clearance

`V125_CROSS_CUTTING_CONTRACT_AUDIT_COMPLETE` (run 2026-05-21) pre-cleared R-3/R-4/R-5 together with zero `BLOCK_R3` findings.

## Forbidden surfaces

Untouched. Verified: daemon, schema (1.83.0 frozen), metrics, packaging (note: --rpm/--deb postinst paths reach phaseDetect via runInstall, so package upgrades on low-disk hosts will now cleanly refuse instead of ENOSPC'ing mid-postinst — same operator-friendly improvement, no packaging file edits), install/systemd, install/polkit, VERSION/STATUS/CHANGELOG.

## Pre-PR verification on monitor

Ran on `monitor.example.test:55000` (Ubuntu 24.04, Go 1.22 + auto-fetched Go 1.25 toolchain) at HEAD `8d692246`:

| Command | Result |
|---|---|
| `go vet ./...` | ✅ clean |
| `go build ./...` | ✅ clean |
| `go test -v ./internal/installer/preflight/...` | ✅ 16/16 sub-cases PASS |
| `go test ./cmd/nftban-installer/...` (regression) | ✅ ok |
| `go test ./internal/installer/state/...` (state machine regression) | ✅ ok |

## V125 v1.125.0 minimum cut — final lane

| R-* | PR | Squash SHA |
|---|---|---|
| R-1 SSH multi-port | #653 | `95c1f119` |
| R-2 installer lock | #654 | `3911ecf5` |
| R-3 phase context | #656 | `3898d8cc` |
| R-4 force-recommit gate | #657 | `c6e71909` |
| **R-5 disk preflight** | **this PR** | — |

All five R-* lanes from V125_INSTALL_ROBUSTNESS_SCOPE §3.1 are now in flight. After R-5 merge, the next gate would be `OPEN_V125_RELEASE_PREP` (operator-discretion stretch lanes R-6/R-7/R-8/R-12/R-14 can fold in first, OR release the minimum cut as v1.125.0).

## Test plan

- [ ] CI `Build & Test` green
- [ ] CI `Build, Test, Scan (Go)` green
- [ ] CI `CodeQL Analysis (Go)` green
- [ ] CI `gosec` green
- [ ] CI `govulncheck` green
- [ ] CI `staticcheck` green
- [ ] CI `Update Canonization (almalinux-9)` green
- [ ] CI `Update Canonization (ubuntu-24.04)` green
- [ ] CI `Uninstall Canonization (almalinux-9)` green
- [ ] CI `Uninstall Canonization (ubuntu-24.04)` green
- [ ] CI `Install Canonization (almalinux-9)` green
- [ ] CI `Install Canonization (ubuntu-24.04)` green
- [ ] CI `Project Health` (health check) green
- [ ] CI `ShellCheck - Find bash errors` green
- [ ] CI `Shell Quality` green
- [ ] CI `Docs Quality` green
- [ ] CI `Policy Gates` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
