### PR TITLE
fix(cli/firewall): V126 Lane C — re-apply trust providers in firewall_reload

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1522,6 +1522,35 @@ firewall_reload() {
         }
     fi
 
+    # Step 4d (v1.126): Re-apply trust providers if any enabled — reload destroys
+    # whitelist_ipv4/6 elements added by `nftban trust enable <PROVIDER>`.
+    # Without this step, any reload (incl. via V120 whitelist-session add/remove
+    # which calls firewall_reload internally) erases trust ranges from the kernel
+    # sets and they don't auto-re-apply — they stay gone until the operator
+    # manually runs `nftban trust enable <PROVIDER>` or `nftban trust update --all`.
+    # Closes D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS (fleet-wide latent;
+    # surfaced by V125 srv3 validation 2026-05-22; scope at
+    # AUDIT_190_LIFECYCLE/V126_TRUST_WHITELIST_RELOAD_MERGE_SCOPE.md).
+    # Uses `nftban trust load` CLI subprocess (idempotent over enabled providers;
+    # reads from on-disk /var/lib/nftban/trust/*.txt cache; no network re-fetch).
+    local _any_trust_enabled="false"
+    local _trust_packaged="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/trust.conf"
+    local _trust_local="${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
+    local _trust_file
+    for _trust_file in "$_trust_packaged" "$_trust_local"; do
+        if [[ -f "$_trust_file" ]] && \
+           grep -qE '^TRUST_[A-Z]+_ENABLED="true"' "$_trust_file" 2>/dev/null; then
+            _any_trust_enabled="true"
+            break
+        fi
+    done
+    if [[ "$_any_trust_enabled" == "true" ]]; then
+        [[ "$quiet" == "false" ]] && echo "Re-applying trust provider rules..."
+        nftban trust load >/dev/null 2>&1 || {
+            [[ "$quiet" == "false" ]] && echo "Warning: Failed to re-apply trust providers. Run: nftban trust load" || true
+        }
+    fi
+
     # Step 5 (v1.50.1): Re-sync feeds — reload destroys sets (delete table + recreate)
     [[ "$quiet" == "false" ]] && echo "Re-syncing threat feeds..."
     if declare -f nftban_feeds_sync_to_nftables &>/dev/null; then

--- a/cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.126 firewall_reload trust-provider re-merge
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_firewall_trust_remerge_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-22"
+# meta:description="Tests for the v1.126 fix that adds a trust-provider re-apply step to firewall_reload. Closes D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS (fleet-wide latent defect surfaced by V125 srv3 validation; cmd_firewall.sh::firewall_reload re-applied DDoS/portscan/botguard/feeds per v1.50.1+v1.81.0 but missed trust providers; reload invocations erased trust ranges and they did not auto-re-apply). Tests cover: (a) regression guard that the trust-load invocation is present in firewall_reload, (b) the helper logic gates on TRUST_*_ENABLED, (c) precedence between conf.d/trust.conf and nftban.conf.local, (d) preserved sequencing relative to DDoS/portscan/botguard/feeds steps. Static + behavioral; no host contact; no root required."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,grep,awk,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Defect closed:  D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS
+# Scope file:     AUDIT_190_LIFECYCLE/V126_TRUST_WHITELIST_RELOAD_MERGE_SCOPE.md
+# Reproduction:   V125_VALIDATE_SRV3_DEFERRED_WHITELIST_KERNEL_SYNC_ANOMALY.md §3
+# Fix mechanism:  cmd_firewall.sh::firewall_reload now invokes `nftban trust
+#                 load` after the botguard re-apply step (Step 4d), gated on
+#                 grep of TRUST_*_ENABLED="true" across trust.conf +
+#                 nftban.conf.local.
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+CMD_FIREWALL="${NFTBAN_LIB_DIR}/cli/cmd_firewall.sh"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    # In-process bash pattern matching — avoids the printf|grep SIGPIPE race
+    # that fires under `set -o pipefail` when the haystack is large (e.g.,
+    # full cmd_firewall.sh file body ~136KB) and grep -q exits early before
+    # printf finishes writing.
+    local haystack="$1" needle="$2" name="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n" "$name"
+        printf "         expected to contain: %s\n" "$needle"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+echo "=========================================================="
+echo "V126 Lane C — firewall_reload trust-provider re-merge test"
+echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# §1 Static fixture: cmd_firewall.sh contains the v1.126 Step 4d block
+# ---------------------------------------------------------------------------
+if [[ ! -f "$CMD_FIREWALL" ]]; then
+    echo "FATAL: cmd_firewall.sh not found at $CMD_FIREWALL"
+    exit 2
+fi
+
+CMD_BODY=$(cat "$CMD_FIREWALL")
+
+assert_contains "$CMD_BODY" \
+    "Step 4d (v1.126): Re-apply trust providers if any enabled" \
+    "regression_guard_step_4d_comment_present"
+
+assert_contains "$CMD_BODY" \
+    "D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS" \
+    "regression_guard_defect_marker_present"
+
+assert_contains "$CMD_BODY" \
+    "nftban trust load" \
+    "regression_guard_nftban_trust_load_invocation_present"
+
+assert_contains "$CMD_BODY" \
+    'TRUST_[A-Z]+_ENABLED="true"' \
+    "regression_guard_enabled_grep_pattern_present"
+
+assert_contains "$CMD_BODY" \
+    "Re-applying trust provider rules" \
+    "regression_guard_non_quiet_progress_message_present"
+
+assert_contains "$CMD_BODY" \
+    "Warning: Failed to re-apply trust providers. Run: nftban trust load" \
+    "regression_guard_subprocess_failure_warning_present"
+
+# ---------------------------------------------------------------------------
+# §2 Sequencing: Step 4d must appear AFTER Step 4c (botguard) and BEFORE
+# Step 5 (feeds). This preserves the v1.50.1+v1.81.0 ordering invariants.
+# ---------------------------------------------------------------------------
+BOTGUARD_LINE=$(grep -n "Step 4c (v1.50.1, v1.81.0 key fix): Re-apply botguard" "$CMD_FIREWALL" | head -1 | cut -d: -f1)
+TRUST_LINE=$(grep -n "Step 4d (v1.126): Re-apply trust providers" "$CMD_FIREWALL" | head -1 | cut -d: -f1)
+FEEDS_LINE=$(grep -n "Step 5 (v1.50.1): Re-sync feeds" "$CMD_FIREWALL" | head -1 | cut -d: -f1)
+
+if [[ -n "$BOTGUARD_LINE" && -n "$TRUST_LINE" && -n "$FEEDS_LINE" ]]; then
+    if (( BOTGUARD_LINE < TRUST_LINE && TRUST_LINE < FEEDS_LINE )); then
+        printf "  [PASS] sequencing_trust_step_between_botguard_and_feeds (botguard=%d trust=%d feeds=%d)\n" \
+            "$BOTGUARD_LINE" "$TRUST_LINE" "$FEEDS_LINE"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] sequencing_trust_step_between_botguard_and_feeds (botguard=%d trust=%d feeds=%d)\n" \
+            "$BOTGUARD_LINE" "$TRUST_LINE" "$FEEDS_LINE"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("sequencing_trust_step_between_botguard_and_feeds")
+    fi
+else
+    printf "  [FAIL] sequencing markers missing: botguard=%s trust=%s feeds=%s\n" \
+        "${BOTGUARD_LINE:-MISSING}" "${TRUST_LINE:-MISSING}" "${FEEDS_LINE:-MISSING}"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("sequencing_markers_present")
+fi
+
+# ---------------------------------------------------------------------------
+# §3 Behavioral: extract the trust-enabled gating logic and verify it gates
+# correctly under various TRUST_*_ENABLED fixture combinations.
+#
+# Strategy: reproduce the inline gating logic in this test (byte-equivalent
+# to the production block), run it against sandbox config files, assert the
+# resulting _any_trust_enabled value.
+# ---------------------------------------------------------------------------
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Mirror the production gating logic (kept in sync with cmd_firewall.sh
+# Step 4d block; if production changes, this block must change too — the
+# §1 regression-guard tests above will catch comment/marker drift).
+detect_any_trust_enabled() {
+    local cfg_dir="$1"
+    local _any_trust_enabled="false"
+    local _trust_packaged="${cfg_dir}/conf.d/trust.conf"
+    local _trust_local="${cfg_dir}/nftban.conf.local"
+    local _trust_file
+    for _trust_file in "$_trust_packaged" "$_trust_local"; do
+        if [[ -f "$_trust_file" ]] && \
+           grep -qE '^TRUST_[A-Z]+_ENABLED="true"' "$_trust_file" 2>/dev/null; then
+            _any_trust_enabled="true"
+            break
+        fi
+    done
+    echo "$_any_trust_enabled"
+}
+
+# Setup sandbox config directory
+mkdir -p "$SANDBOX/conf.d"
+
+# Case 3.1: no config files at all -> false
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "false" "gating_no_config_files_returns_false"
+
+# Case 3.2: trust.conf with all providers disabled (packaged default shape)
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+TRUST_ENABLED="true"
+TRUST_CLOUDFLARE_ENABLED="false"
+TRUST_AWS_ENABLED="false"
+TRUST_GOOGLE_ENABLED="false"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "false" "gating_all_providers_disabled_returns_false"
+
+# Case 3.3: trust.conf with TRUST_CLOUDFLARE_ENABLED="true" -> true
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+TRUST_ENABLED="true"
+TRUST_CLOUDFLARE_ENABLED="true"
+TRUST_AWS_ENABLED="false"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "true" "gating_cloudflare_enabled_returns_true"
+
+# Case 3.4: trust.conf with TRUST_AWS_ENABLED="true" -> true (cross-provider)
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+TRUST_CLOUDFLARE_ENABLED="false"
+TRUST_AWS_ENABLED="true"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "true" "gating_aws_only_enabled_returns_true"
+
+# Case 3.5: srv3-shaped layout — packaged trust.conf disables CLOUDFLARE,
+# but operator override in nftban.conf.local enables it. The gating must
+# detect the override.
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+TRUST_CLOUDFLARE_ENABLED="false"
+TRUST_AWS_ENABLED="false"
+EOF
+cat >"$SANDBOX/nftban.conf.local" <<'EOF'
+TRUST_CLOUDFLARE_ENABLED="true"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "true" "gating_local_override_enables_returns_true_srv3_shape"
+
+# Case 3.6: multiple providers enabled across both files
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+TRUST_CLOUDFLARE_ENABLED="true"
+EOF
+cat >"$SANDBOX/nftban.conf.local" <<'EOF'
+TRUST_AWS_ENABLED="true"
+TRUST_GOOGLE_ENABLED="true"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "true" "gating_multiple_providers_enabled_returns_true"
+
+# Case 3.7: commented-out lines must NOT trigger the gate (^TRUST anchors
+# the grep to start-of-line; # TRUST_X_ENABLED="true" should be ignored).
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+# TRUST_CLOUDFLARE_ENABLED="true"
+# Example: enable Cloudflare ranges below if you proxy traffic
+TRUST_CLOUDFLARE_ENABLED="false"
+EOF
+rm -f "$SANDBOX/nftban.conf.local"
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "false" "gating_commented_enable_does_not_trigger_returns_false"
+
+# Case 3.8: whitespace-prefixed lines must NOT trigger (^TRUST anchors)
+cat >"$SANDBOX/conf.d/trust.conf" <<'EOF'
+    TRUST_CLOUDFLARE_ENABLED="true"
+TRUST_CLOUDFLARE_ENABLED="false"
+EOF
+result=$(detect_any_trust_enabled "$SANDBOX")
+assert_eq "$result" "false" "gating_indented_enable_does_not_trigger_returns_false"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "=========================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=========================================================="
+if (( FAIL > 0 )); then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All v1.126 Lane C trust-remerge tests passed."
+exit 0


### PR DESCRIPTION
## Summary

- **Defect closed:** \`D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS\` (P2, fleet-wide latent)
- **Root cause:** \`firewall_reload\` re-applies DDoS / portscan / botguard / feeds / geoban (per inline v1.50.1 + v1.81.0 comments) but missed trust providers. Any reload trigger — including via V120 \`whitelist-session add/remove\` which calls \`firewall_reload\` internally at \`cmd_firewall.sh:537,689,746\` — erased trust ranges from the kernel \`whitelist_ipv4/6\` sets, and trust providers did not auto-re-apply.
- **Fix:** add Step 4d to \`firewall_reload\`, between Step 4c (botguard) and Step 5 (feeds). Invokes \`nftban trust load\` as a sibling CLI subprocess (same pattern as the other re-apply steps). Gated on \`grep TRUST_*_ENABLED="true"\` across \`/etc/nftban/conf.d/trust.conf\` and \`/etc/nftban/nftban.conf.local\` — skips the subprocess fork when no trust providers are enabled.
- **First of three v1.126 lanes** per the locked C → B → A order in \`V126_IMPLEMENTATION_ORDER_PLAN.md\`.

## Empirical reproduction (srv3, v1.121.0, 2026-05-22T19:55–20:11Z)

| Surface | Pre-reload | Post-reload |
|---|---|---|
| \`TRUST_CLOUDFLARE_ENABLED\` | \`"true"\` in \`/etc/nftban/nftban.conf.local:5\` | unchanged |
| \`/var/lib/nftban/trust/cloudflare.txt\` | present, 22 CIDR lines | unchanged |
| \`nftban trust status\` ENABLED count | 1/7 | 1/7 |
| \`nftban trust status\` Total IP ranges (CLOUDFLARE) | (presumed >0; not measured pre) | **0** |
| Kernel \`whitelist_ipv4\` element count | 17 (incl. 14 Cloudflare CIDRs) | **3** (interface + localhost + operator IP) |

Reproduction trigger: a single \`nftban firewall whitelist-session add 192.0.2.122 --ttl 30m\` invocation (which calls \`firewall_reload\` internally) erased all 14 Cloudflare CIDR ranges from the kernel set. They had been applied by a past \`nftban trust enable CLOUDFLARE\` invocation, persisted across daemon restarts, and were not auto-re-applied.

## Why v1.125.0 ships the gap unchanged

\`\`\`
$ git log --oneline v1.121.0..v1.125.0 -- \\
    cli/lib/nftban/core/nftban_trust.sh \\
    cli/lib/nftban/cli/cmd_firewall.sh \\
    cli/lib/nftban/cli/cmd_trust.sh
4e782ea3 release(v1.124.1): V124 hotfix — clear Project Health workflow shellcheck baseline (#652)
a0755fe1 fix(cli): V124 takeover CLI guidance + wrapper dispatch + help clarity (#650)
\`\`\`

Only the v1.124.1 cosmetic shellcheck hotfix + v1.124 CLI guidance fix. No commit modified \`firewall_reload\` or the trust loading path between v1.121.0 and v1.125.0.

## Caller graph (repo HEAD before this PR)

\`\`\`
nftban_trust_load()        ← cli/lib/nftban/core/nftban_trust.sh:832
   ↑ called only by:
       cli/lib/nftban/cli/cmd_trust.sh:128  (CLI \`nftban trust load\` subcommand)

firewall_reload()          ← cli/lib/nftban/cli/cmd_firewall.sh:1400
   ↓ re-applies: DDoS / portscan / botguard / feeds / geoban
   ❌ MISSING: trust providers   ← THIS PR adds the step
\`\`\`

## Invariants preserved

- ✅ Schema 1.83.0 frozen (no schema surface touched; verified by \`test_schema_version_guard.sh\`)
- ✅ Daemon binary unchanged (shell-only fix; 14-release identical-binary streak continues)
- ✅ \`cmd/nftban-installer\` unchanged
- ✅ Existing v1.125 reload behavior preserved when no trust providers enabled (gating skips subprocess fork; identical observable output)
- ✅ \`/var/lib/nftban/trust/*.txt\` format unchanged (fix only ADDS a reader call over existing data)

## Test plan

- [x] **New test:** \`cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh\` — 15 assertions
  - 6 regression guards (block presence, defect marker citation, \`nftban trust load\` invocation, grep pattern, non-quiet progress message, subprocess failure warning)
  - 1 sequencing assertion (Step 4c < Step 4d < Step 5)
  - 8 gating fixture cases (no-config / all-disabled / single-enabled / cross-provider / local-override-of-packaged-default = srv3 shape / multi-provider / commented-line negative / indented-line negative)
- [x] **Sibling regression:** \`cmd_firewall_takeover_test.sh\` 39/0; \`cmd_firewall_whitelist_session_test.sh\` 33/0; \`test_botguard_rebuild_sequencing.sh\` 10/0
- [x] **Schema-frozen attestation:** \`test_schema_version_guard.sh\` 2/0 (1.83.0 across Go validator + CLI)
- [x] **Shellcheck:** zero new warnings on \`cmd_firewall.sh\` vs main baseline (delta = 0 lines); zero warnings on the new test file

## Acceptance gate (per operator-locked V126 plan §7)

After this PR + Lane B + Lane A ship in v1.126.0:

- [ ] srv3 V125 re-validation: kernel \`whitelist_ipv4\` post-update contains Cloudflare ranges + operator session entry
- [ ] dns2 V125 re-validation: \`nftban update\` succeeds via standard auto-detect path
- [ ] lab2 V125 re-validation: R-4 gate fires on DEGRADED state
- [ ] Daemon binary 14-release identical-binary streak continues (v1.114.0 → v1.126.0)

## Workspace references

- Scope: \`AUDIT_190_LIFECYCLE/V126_TRUST_WHITELIST_RELOAD_MERGE_SCOPE.md\`
- Reproduction: \`AUDIT_190_LIFECYCLE/V125_VALIDATE_SRV3_DEFERRED_WHITELIST_KERNEL_SYNC_ANOMALY.md\` §3
- Order plan: \`AUDIT_190_LIFECYCLE/V126_IMPLEMENTATION_ORDER_PLAN.md\` (Lane C, #1)
- Sibling v1.126 scopes (not in this PR): \`V126_UPDATE_HISTORY_MIXED_INSTALL_DETECTOR_SCOPE.md\` (Lane B, #2), \`V126_R4_DEGRADED_GATE_EXTENSION_SCOPE.md\` (Lane A, #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
