### PR TITLE
fix(cli/update-detection): V126 Lane B — unblock cleanly-migrated hosts in _detect_install_type

### DIFF
--- a/cli/lib/nftban/cli/cmd_update_detection.sh
+++ b/cli/lib/nftban/cli/cmd_update_detection.sh
@@ -63,6 +63,109 @@ _read_history_first_type() {
 }
 
 # -----------------------------------------------------------------------------
+# V126 Lane B: Read the MOST-RECENT successful entry's "type" field from
+# update-history.json. Skips entries with status != "success" (install_fail,
+# verify_fail, etc.). Returns the type string ("rpm" / "deb" / "source") or
+# empty if no successful entry exists.
+#
+# Why: _read_history_first_type returns the OLDEST entry, which catches
+# packaging-family migrations (e.g., source→RPM) but treats them as permanent
+# "mixed" drift even after a clean migration completes. This helper provides
+# the complementary "latest-successful-known-good-state" signal so the
+# detector can distinguish "host is cleanly RPM-migrated" from "host has
+# genuine source/rpm mix".
+#
+# Closes part of D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK
+# (V126_UPDATE_HISTORY_MIXED_INSTALL_DETECTOR_SCOPE.md §3.1).
+#
+# Test-overrides:
+#   NFTBAN_TEST_HISTORY_FILE     - override path to history JSON (for fixtures)
+# -----------------------------------------------------------------------------
+_read_history_last_successful_type() {
+    local f="${NFTBAN_TEST_HISTORY_FILE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/update-history.json}"
+    [[ -r "$f" ]] || { echo ""; return 0; }
+
+    # Prefer jq if available — pick the type of the first object (newest-first
+    # ordering) whose status == "success". Returns empty if no success entry.
+    if command -v jq &>/dev/null; then
+        jq -r '[.[] | select(.status == "success")][0].type // empty' "$f" 2>/dev/null
+        return 0
+    fi
+
+    # Bash fallback: scan newest-first; track each line's type, emit the type
+    # of the first object whose status field is "success". History entries
+    # are flat JSON objects one-per-array-element; awk-style state machine.
+    # Use a Python one-liner if available (more robust than awk for JSON);
+    # else fall through to a best-effort grep that handles the common shape.
+    if command -v python3 &>/dev/null; then
+        python3 -c "
+import json, sys
+try:
+    with open('$f') as fh:
+        arr = json.load(fh)
+    for ent in arr:
+        if ent.get('status') == 'success':
+            t = ent.get('type', '')
+            if t:
+                print(t)
+            sys.exit(0)
+except Exception:
+    pass
+" 2>/dev/null
+        return 0
+    fi
+
+    # Last-resort grep fallback: limited but covers the canonical formatter
+    # output (one entry per array element with status before type, or vice
+    # versa, on adjacent lines within one record). We walk the file once,
+    # buffering the type-seen-so-far within the current record (record
+    # boundaries are blank-comma-brace transitions) and emit when status
+    # == "success" is hit. Imperfect but works for the formatter
+    # internal/installer/history/history.go currently uses.
+    local current_type="" success_type=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ \"type\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+            current_type="${BASH_REMATCH[1]}"
+        fi
+        if [[ "$line" =~ \"status\"[[:space:]]*:[[:space:]]*\"success\" ]]; then
+            if [[ -n "$current_type" ]]; then
+                success_type="$current_type"
+                break
+            fi
+        fi
+        # Reset current_type at object boundaries (closing brace on its own)
+        if [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*,?[[:space:]]*$ ]]; then
+            current_type=""
+        fi
+    done < "$f"
+    echo "$success_type"
+}
+
+# -----------------------------------------------------------------------------
+# V126 Lane B: Returns 0 if install_state shows the host as a completed
+# wrapper-managed install (INSTALL_STATE=COMMITTED AND AUTHORITY=UPDATE).
+# Non-zero otherwise (including unreadable file).
+#
+# Why: cleanly-migrated source→RPM hosts have install_state COMMITTED +
+# AUTHORITY=UPDATE (the migration ran the wrapper installer to a successful
+# completion). Genuinely broken hosts (mid-failed install, takeover-only,
+# uninitialized) lack this signal. This helper is the third positive-evidence
+# requirement for the migration-clean unblock path (alongside current
+# package-db ownership + latest-successful history type).
+#
+# Test-overrides:
+#   NFTBAN_TEST_INSTALL_STATE_FILE - override path to install_state (for fixtures)
+# -----------------------------------------------------------------------------
+_probe_install_state_committed_update_authority() {
+    local f="${NFTBAN_TEST_INSTALL_STATE_FILE:-${NFTBAN_LIB_DIR_STATE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/state}/install_state}"
+    [[ -r "$f" ]] || return 1
+    local state authority
+    state=$(grep -E '^INSTALL_STATE=' "$f" 2>/dev/null | head -1 | cut -d= -f2-)
+    authority=$(grep -E '^AUTHORITY='   "$f" 2>/dev/null | head -1 | cut -d= -f2-)
+    [[ "$state" == "COMMITTED" && "$authority" == "UPDATE" ]]
+}
+
+# -----------------------------------------------------------------------------
 # Override-aware probes for test fixtures.
 # Real production paths use rpm/dpkg/etc; fixtures inject mocked outputs via
 # the NFTBAN_TEST_* env vars without polluting the rpm/dpkg databases.
@@ -98,9 +201,22 @@ _detect_install_type() {
     # Returns one of: rpm, deb, source, mixed, unknown
     #
     # V108 Item 6 (dns2-derived): adds history.json probe + mixed/source classes.
+    # V126 Lane B (D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK): adds the
+    # migration-clean positive-evidence path so cleanly source→RPM (or DEB)
+    # migrated hosts no longer classify as "mixed" permanently. The v1.108
+    # strict-detection reads the OLDEST history entry; if that's non-rpm and
+    # rpm-db owns the package, the host is flagged "mixed". v1.126 extends:
+    # check the MOST-RECENT successful history type AND install_state
+    # COMMITTED+AUTHORITY=UPDATE — if both confirm the current family, the
+    # host is treated as cleanly migrated to that family rather than mixed.
+    # All existing v1.125 refusals are preserved (any missing positive
+    # signal falls back to "mixed").
+    #
     # Probe order (deterministic, first-match):
-    #   1. RPM db ownership (with drift check vs history "rpm")
-    #   2. DEB db ownership (with drift check vs history "deb")
+    #   1. RPM db ownership (with drift check vs history "rpm";
+    #      v1.126 migration-clean unblock when last-successful=rpm AND
+    #      install_state=COMMITTED+AUTHORITY=UPDATE)
+    #   2. DEB db ownership (symmetric to RPM)
     #   3. History first-entry "type":"source"          → source
     #   4. History first-entry "type":"rpm" no rpm db   → mixed
     #   5. History first-entry "type":"deb" no dpkg db  → mixed
@@ -115,6 +231,17 @@ _detect_install_type() {
     if _probe_rpm_owns_nftban; then
         # Drift check: rpm db says yes but history says non-rpm
         if [[ -n "$history_type" && "$history_type" != "rpm" ]]; then
+            # V126: migration-clean unblock — was this host cleanly migrated
+            # to RPM? Both signals must confirm:
+            #   a) latest SUCCESS history entry is "rpm"
+            #   b) install_state shows COMMITTED + AUTHORITY=UPDATE
+            local last_successful_type
+            last_successful_type=$(_read_history_last_successful_type)
+            if [[ "$last_successful_type" == "rpm" ]] && \
+               _probe_install_state_committed_update_authority; then
+                echo "rpm"
+                return 0
+            fi
             echo "mixed"
             return 0
         fi
@@ -126,6 +253,14 @@ _detect_install_type() {
     if _probe_dpkg_owns_nftban; then
         # Drift check: dpkg db says yes but history says non-deb
         if [[ -n "$history_type" && "$history_type" != "deb" ]]; then
+            # V126: migration-clean unblock (symmetric to RPM branch above)
+            local last_successful_type
+            last_successful_type=$(_read_history_last_successful_type)
+            if [[ "$last_successful_type" == "deb" ]] && \
+               _probe_install_state_committed_update_authority; then
+                echo "deb"
+                return 0
+            fi
             echo "mixed"
             return 0
         fi

--- a/cli/lib/nftban/tests/cmd_update_detection_v126_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_detection_v126_test.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.126 update-history mixed-install detector fix
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_update_detection_v126_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-22"
+# meta:description="Tests for the v1.126 fix that adds a migration-clean unblock path to _detect_install_type. Closes D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK (cleanly source→RPM/DEB migrated hosts previously classified as 'mixed' permanently because the v1.108 strict-detection reads OLDEST history entry). Tests cover: (a) 3 regression-guard cases preserving all existing v1.125 verdicts (clean RPM / clean DEB / pure source), (b) 2 new positive paths for cleanly-migrated hosts (rpm-side dns2-shape + symmetric deb-side), (c) 5 preserved-refusal cases ensuring the new positive path is gated correctly (genuinely broken / failed install / takeover authority / empty history / failed-only history). Uses existing NFTBAN_TEST_* env-var overrides plus the new NFTBAN_TEST_INSTALL_STATE_FILE override. No host contact; no root required."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq-optional,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_detection.sh"
+# meta:inventory.binaries="bash,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_TEST_HISTORY_FILE,NFTBAN_TEST_INSTALL_STATE_FILE,NFTBAN_TEST_RPM_OWNS,NFTBAN_TEST_DPKG_OWNS,NFTBAN_TEST_GIT_REPO_PRESENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Defect closed:  D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK
+# Scope file:     AUDIT_190_LIFECYCLE/V126_UPDATE_HISTORY_MIXED_INSTALL_DETECTOR_SCOPE.md
+# Reproduction:   AUDIT_190_LIFECYCLE/V125_VALIDATE_DNS2_CLOSURE.md §3
+# Fix mechanism:  cmd_update_detection.sh::_detect_install_type adds a
+#                 migration-clean unblock path. When rpm-db (or dpkg-db)
+#                 owns nftban AND the oldest history entry is non-matching
+#                 (legacy v1.108 "mixed" trigger), v1.126 now ALSO checks:
+#                   a) last successful history entry matches current family
+#                   b) install_state shows COMMITTED + AUTHORITY=UPDATE
+#                 If both confirm, the host is treated as cleanly migrated
+#                 to the current family. All existing v1.125 refusals are
+#                 preserved when any positive signal is missing.
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Source the detection script. Its double-load guard means we must not
+# re-source within this process. Each test case sets its env vars BEFORE
+# calling _detect_install_type via a subshell to keep state isolated.
+# ---------------------------------------------------------------------------
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/cli/cmd_update_detection.sh"
+
+# Reset cross-test env vars at the start of each case.
+clean_env() {
+    unset NFTBAN_TEST_HISTORY_FILE NFTBAN_TEST_INSTALL_STATE_FILE
+    unset NFTBAN_TEST_RPM_OWNS NFTBAN_TEST_DPKG_OWNS
+    unset NFTBAN_TEST_GIT_REPO_PRESENT
+}
+
+# Write a history.json fixture. Pass entries newest-first via args; each
+# arg is a colon-separated "type:status" pair. Output is canonical
+# newest-first array shape matching internal/installer/history/history.go.
+write_history() {
+    local file="$1"; shift
+    {
+        echo "["
+        local first=1
+        local entry
+        for entry in "$@"; do
+            local etype estatus
+            etype="${entry%%:*}"
+            estatus="${entry#*:}"
+            if (( first )); then
+                first=0
+            else
+                echo ","
+            fi
+            printf '  {\n'
+            printf '    "timestamp": "2026-05-22T00:00:00Z",\n'
+            printf '    "from": "1.0.0",\n'
+            printf '    "to": "1.0.0",\n'
+            printf '    "status": "%s",\n' "$estatus"
+            printf '    "type": "%s",\n' "$etype"
+            printf '    "duration_s": 1,\n'
+            printf '    "host": "test"\n'
+            printf '  }'
+        done
+        echo ""
+        echo "]"
+    } > "$file"
+}
+
+# Write an install_state fixture. Args: state, authority.
+write_install_state() {
+    local file="$1" state="$2" authority="$3"
+    cat > "$file" <<EOF
+INSTALL_STATE=${state}
+INSTALL_MODE=install
+INSTALL_VERSION=1.0.0
+INSTALL_TIMESTAMP=2026-05-22T00:00:00Z
+SSH_PORT=22
+AUTHORITY=${authority}
+PANEL=
+CONFLICTS=
+PREFLIGHT_PASSED=1
+EOF
+}
+
+echo "=========================================================="
+echo "V126 Lane B — _detect_install_type migration-clean test"
+echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# CASE 1: Clean RPM host — no source history, current rpm-db ownership
+# Expected: rpm (preserves existing v1.125 behavior — REGRESSION GUARD)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case1.json"
+write_history "$HISTORY" "rpm:success" "rpm:success" "rpm:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no _detect_install_type)
+assert_eq "$result" "rpm" "regression_1_clean_rpm_no_source_history_returns_rpm"
+
+# ---------------------------------------------------------------------------
+# CASE 2: Clean DEB host — no source history, current dpkg-db ownership
+# Expected: deb (REGRESSION GUARD)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case2.json"
+write_history "$HISTORY" "deb:success" "deb:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_RPM_OWNS=no NFTBAN_TEST_DPKG_OWNS=yes NFTBAN_TEST_GIT_REPO_PRESENT=no _detect_install_type)
+assert_eq "$result" "deb" "regression_2_clean_deb_no_source_history_returns_deb"
+
+# ---------------------------------------------------------------------------
+# CASE 3: Pure source install — only source entries, no pkg-db ownership
+# Expected: source (REGRESSION GUARD)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case3.json"
+write_history "$HISTORY" "source:success" "source:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_RPM_OWNS=no NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no _detect_install_type)
+assert_eq "$result" "source" "regression_3_pure_source_install_returns_source"
+
+# ---------------------------------------------------------------------------
+# CASE 4: dns2-shape — rpm-db owns + oldest=source + last-successful=rpm
+#         + install_state=COMMITTED+UPDATE
+# Expected: rpm (V126 NEW POSITIVE PATH — was "mixed" pre-v1.126)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case4.json"
+# newest-first: most recent success is rpm; oldest is source (the dns2 shape)
+# install_fail entry in between (proves the new helper skips non-success entries)
+write_history "$HISTORY" \
+    "mixed:install_fail" \
+    "rpm:success" \
+    "rpm:success" \
+    "rpm:success" \
+    "source:success"
+STATE="$SANDBOX/case4.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "rpm" "new_4_dns2_shape_rpm_db_plus_migrated_returns_rpm_unblocked"
+
+# ---------------------------------------------------------------------------
+# CASE 5: Symmetric DEB — dpkg-db owns + oldest=source + last-successful=deb
+#         + install_state=COMMITTED+UPDATE
+# Expected: deb (V126 NEW POSITIVE PATH — symmetric to case 4)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case5.json"
+write_history "$HISTORY" \
+    "deb:success" \
+    "deb:success" \
+    "source:success"
+STATE="$SANDBOX/case5.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=no NFTBAN_TEST_DPKG_OWNS=yes NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "deb" "new_5_symmetric_deb_migrated_returns_deb_unblocked"
+
+# ---------------------------------------------------------------------------
+# CASE 6: Genuinely broken — rpm-db owns + oldest=source + last-successful=source
+#         (rpm package somehow added on top of a source install; latest success
+#         predates rpm-db ownership). Operator review required.
+# Expected: mixed (PRESERVED REFUSAL — new positive path must NOT fire)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case6.json"
+write_history "$HISTORY" \
+    "source:success" \
+    "source:success"
+STATE="$SANDBOX/case6.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "mixed" "preserve_6_genuinely_broken_rpm_over_source_returns_mixed"
+
+# ---------------------------------------------------------------------------
+# CASE 7: Failed install — rpm-db owns + oldest=source + last-successful=rpm
+#         + install_state=FAILED_REBUILD (install never committed cleanly)
+# Expected: mixed (PRESERVED REFUSAL — state gate must NOT fire)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case7.json"
+write_history "$HISTORY" \
+    "rpm:success" \
+    "source:success"
+STATE="$SANDBOX/case7.state"
+write_install_state "$STATE" "FAILED_REBUILD" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "mixed" "preserve_7_failed_rebuild_state_returns_mixed"
+
+# ---------------------------------------------------------------------------
+# CASE 8: Takeover authority — rpm-db owns + oldest=source + last-successful=rpm
+#         + install_state=COMMITTED+TAKEOVER (committed but different mode)
+# Expected: mixed (PRESERVED REFUSAL — conservative; TAKEOVER ≠ clean UPDATE
+#                  migration; operator review required)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case8.json"
+write_history "$HISTORY" \
+    "rpm:success" \
+    "source:success"
+STATE="$SANDBOX/case8.state"
+write_install_state "$STATE" "COMMITTED" "TAKEOVER"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "mixed" "preserve_8_committed_takeover_authority_returns_mixed"
+
+# ---------------------------------------------------------------------------
+# CASE 9: Empty history + rpm-db ownership
+# Expected: rpm (no drift trigger — preserves existing behavior)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case9.json"
+echo "[]" > "$HISTORY"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "rpm" "case_9_empty_history_returns_rpm"
+
+# ---------------------------------------------------------------------------
+# CASE 10: Only failed entries — rpm-db owns + history has source-old + only
+#          failure-status newer entries. _read_history_last_successful_type
+#          returns empty; positive path must NOT fire.
+# Expected: mixed (PRESERVED REFUSAL — no positive evidence of clean install)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case10.json"
+write_history "$HISTORY" \
+    "mixed:install_fail" \
+    "rpm:verify_fail" \
+    "rpm:install_fail" \
+    "source:success"
+STATE="$SANDBOX/case10.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+# Latest success in this fixture is the oldest source entry, NOT rpm. Positive
+# path predicate requires last_successful == "rpm" which is false here.
+assert_eq "$result" "mixed" "preserve_10_only_failures_above_old_source_returns_mixed"
+
+# ---------------------------------------------------------------------------
+# CASE 11: Bonus — install_state file missing entirely
+# Expected: mixed (positive path requires readable install_state; missing
+#                  file → _probe_install_state_committed_update_authority
+#                  returns non-zero → fallback to mixed)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case11.json"
+write_history "$HISTORY" "rpm:success" "source:success"
+# Point at a non-existent file
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" \
+    NFTBAN_TEST_INSTALL_STATE_FILE="$SANDBOX/does-not-exist" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "mixed" "preserve_11_missing_install_state_file_returns_mixed"
+
+# ---------------------------------------------------------------------------
+# Sub-test: _read_history_last_successful_type helper behavior
+# ---------------------------------------------------------------------------
+echo
+echo "----- helper: _read_history_last_successful_type direct probes -----"
+
+# h1: empty array → empty
+echo "[]" > "$SANDBOX/h1.json"
+result=$(NFTBAN_TEST_HISTORY_FILE="$SANDBOX/h1.json" _read_history_last_successful_type)
+assert_eq "$result" "" "helper_h1_empty_array_returns_empty"
+
+# h2: only failed entries → empty
+write_history "$SANDBOX/h2.json" "rpm:install_fail" "rpm:verify_fail"
+result=$(NFTBAN_TEST_HISTORY_FILE="$SANDBOX/h2.json" _read_history_last_successful_type)
+assert_eq "$result" "" "helper_h2_only_failures_returns_empty"
+
+# h3: newest success is rpm (mid-array), oldest is source-success
+write_history "$SANDBOX/h3.json" \
+    "rpm:install_fail" \
+    "rpm:success" \
+    "source:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$SANDBOX/h3.json" _read_history_last_successful_type)
+assert_eq "$result" "rpm" "helper_h3_newest_success_rpm_returns_rpm"
+
+# h4: latest success is source (no later success)
+write_history "$SANDBOX/h4.json" \
+    "rpm:install_fail" \
+    "source:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$SANDBOX/h4.json" _read_history_last_successful_type)
+assert_eq "$result" "source" "helper_h4_only_source_success_returns_source"
+
+# h5: unreadable file
+result=$(NFTBAN_TEST_HISTORY_FILE="$SANDBOX/does-not-exist" _read_history_last_successful_type)
+assert_eq "$result" "" "helper_h5_unreadable_returns_empty"
+
+# ---------------------------------------------------------------------------
+# Sub-test: _probe_install_state_committed_update_authority helper behavior
+# ---------------------------------------------------------------------------
+echo
+echo "----- helper: _probe_install_state_committed_update_authority direct -----"
+
+# p1: COMMITTED + UPDATE → 0 (success)
+write_install_state "$SANDBOX/p1.state" "COMMITTED" "UPDATE"
+NFTBAN_TEST_INSTALL_STATE_FILE="$SANDBOX/p1.state" _probe_install_state_committed_update_authority && p1_rc=0 || p1_rc=$?
+assert_eq "$p1_rc" "0" "helper_p1_committed_update_returns_0"
+
+# p2: COMMITTED + TAKEOVER → non-zero
+write_install_state "$SANDBOX/p2.state" "COMMITTED" "TAKEOVER"
+NFTBAN_TEST_INSTALL_STATE_FILE="$SANDBOX/p2.state" _probe_install_state_committed_update_authority && p2_rc=0 || p2_rc=$?
+assert_eq "$p2_rc" "1" "helper_p2_committed_takeover_returns_1"
+
+# p3: FAILED_REBUILD + UPDATE → non-zero
+write_install_state "$SANDBOX/p3.state" "FAILED_REBUILD" "UPDATE"
+NFTBAN_TEST_INSTALL_STATE_FILE="$SANDBOX/p3.state" _probe_install_state_committed_update_authority && p3_rc=0 || p3_rc=$?
+assert_eq "$p3_rc" "1" "helper_p3_failed_rebuild_returns_1"
+
+# p4: missing file
+NFTBAN_TEST_INSTALL_STATE_FILE="$SANDBOX/does-not-exist-p4" _probe_install_state_committed_update_authority && p4_rc=0 || p4_rc=$?
+assert_eq "$p4_rc" "1" "helper_p4_missing_file_returns_1"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "=========================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=========================================================="
+if (( FAIL > 0 )); then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All v1.126 Lane B mixed-install detector tests passed."
+exit 0


### PR DESCRIPTION
## Summary

- **Defect closed:** \`D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK\` (P2)
- **Root cause:** \`_detect_install_type\` at \`cli/lib/nftban/cli/cmd_update_detection.sh:96+\` reads the OLDEST history entry via \`jq '.[-1].type'\`. This deliberately catches packaging-family migrations (source→RPM) — but the v1.108 author landed the protection without the corresponding unblock-after-clean-migration story. Any host that ever underwent a source→RPM (or DEB) migration permanently classifies as \`mixed\`, blocking \`nftban update\` / \`nftban update github\` with exit 13 regardless of how clean its current state is.
- **Fix:** extend the rpm-db and dpkg-db drift-check predicates with a migration-clean unblock path requiring ALL THREE positive signals: (a) package-db ownership, (b) most-recent SUCCESSFUL history entry matches current family, (c) \`install_state\` shows \`INSTALL_STATE=COMMITTED + AUTHORITY=UPDATE\`. All existing v1.125 refusals preserved when any positive signal is missing.
- **Second of three v1.126 lanes** per the locked C → B → A order in \`V126_IMPLEMENTATION_ORDER_PLAN.md\`. Lane C merged at \`af904f43\` (PR #660).

## Empirical reproduction (dns2, v1.123.0, 2026-05-22T19:39Z post-crash recheck)

| Surface | State |
|---|---|
| \`rpm -q nftban-core\` | \`nftban-core-1.123.0-1.el9.x86_64\` (Install Date 2026-05-20) |
| \`install_state\` | \`INSTALL_STATE=COMMITTED\` / \`AUTHORITY=UPDATE\` / \`PANEL=directadmin\` / \`PREFLIGHT_PASSED=1\` |
| \`update-history.json\` (newest-first) | \`[install_fail/mixed/2026-05-22, success/rpm/2026-05-20×3, success/source/2026-04-30]\` |
| \`_read_history_first_type\` (existing) | \`"source"\` (the 2026-04-30 entry — 23 days old, superseded) |
| \`_read_history_last_successful_type\` (NEW v1.126) | \`"rpm"\` (the most-recent success on 2026-05-20) |
| \`_probe_install_state_committed_update_authority\` (NEW v1.126) | 0 (COMMITTED + UPDATE confirmed) |
| \`_detect_install_type\` verdict (v1.125) | \`"mixed"\` ✗ — refuses with exit 13 |
| \`_detect_install_type\` verdict (v1.126 with this PR) | \`"rpm"\` ✓ — proceeds normally |

## New helpers (additive; existing functions unchanged)

\`\`\`
_read_history_last_successful_type     ← sibling to _read_history_first_type
   jq '[.[] | select(.status == \"success\")][0].type // empty'
   Falls back to python3 json parsing → awk-style bash state machine

_probe_install_state_committed_update_authority
   Returns 0 iff install_state file readable AND INSTALL_STATE=COMMITTED
   AND AUTHORITY=UPDATE. TAKEOVER mode and FAILED_REBUILD etc. → non-zero.

   Test override: NFTBAN_TEST_INSTALL_STATE_FILE (new; matches existing
   NFTBAN_TEST_HISTORY_FILE convention)
\`\`\`

## Decision matrix (the 8 fixture cases from V126 scope §4)

| State | rpm-db | oldest history | last-success | install_state | v1.125 | v1.126 |
|---|---|---|---|---|---|---|
| Clean RPM | yes | rpm | rpm | COMMITTED/UPDATE | rpm | rpm (unchanged) |
| Clean DEB | dpkg | deb | deb | COMMITTED/UPDATE | deb | deb (unchanged) |
| Pure source | no | source | source | COMMITTED/INSTALL | source | source (unchanged) |
| **dns2 migrated** | **yes** | **source** | **rpm** | **COMMITTED/UPDATE** | **mixed ✗** | **rpm ✓ NEW** |
| Genuinely broken | yes | source | source | COMMITTED/UPDATE | mixed | mixed (preserved) |
| Failed install | yes | source | rpm | FAILED_REBUILD | mixed | mixed (preserved) |
| Empty history | yes | (empty) | (empty) | COMMITTED/UPDATE | rpm | rpm (unchanged) |
| Only failed entries | yes | source | (empty) | any | mixed | mixed (preserved) |

## Invariants preserved

- ✅ Schema 1.83.0 stays frozen (no schema surface touched; verified by \`test_schema_version_guard.sh\`)
- ✅ \`update-history.json\` format unchanged (new helper READS the existing JSON shape only)
- ✅ \`install_state\` schema unchanged (new helper reads existing AUTHORITY/INSTALL_STATE fields)
- ✅ Daemon binary unchanged (shell-only fix; identical-binary streak continues)
- ✅ \`cmd/nftban-installer\` unchanged
- ✅ \`_read_history_first_type\` behavior unchanged (new helper is additive)
- ✅ \`_classify_for_pkg_mgr_update\` exit-code semantics unchanged (\`cmd_update_detection.sh:179\`)

## Test plan

- [x] **New test:** \`cli/lib/nftban/tests/cmd_update_detection_v126_test.sh\` — 20 assertions:
  - 3 regression guards (clean RPM / clean DEB / pure source)
  - 2 NEW positive-path cases (dns2 shape + symmetric DEB)
  - 6 preserved-refusal cases (genuinely broken / FAILED_REBUILD / TAKEOVER authority / empty history / failure-only-above-old-source / missing install_state)
  - 9 direct helper tests (5 for \`_read_history_last_successful_type\` + 4 for \`_probe_install_state_committed_update_authority\`)
- [x] **Sibling regression:** \`test_update_ssh_port_durability.sh\` 8/0; \`test_update_version_normalization.sh\` 21/0; \`test_schema_version_guard.sh\` 2/0
- [x] **Shellcheck:** zero new warnings on \`cmd_update_detection.sh\` vs main baseline (delta = 0 — file was 0 warnings before and after); zero warnings on the new test file

## Acceptance gate (per V126 scope §5 + V126_IMPLEMENTATION_ORDER_PLAN §7)

After this PR + Lane A ship in v1.126.0:

- [ ] dns2 V125 re-validation (\`EXECUTE_V126_VALIDATE_DNS2\`): \`nftban update\` succeeds via standard auto-detect path on dns2's existing update-history.json (no normalization, no operator-history-edit)
- [ ] \`nftban update status\` on dns2 reports \`Install Type: rpm\` instead of \`mixed\`
- [ ] Flipping \`INSTALL_STATE=FAILED_REBUILD\` (artificially) on a test VM with dns2-shaped history still reports \`Install Type: mixed\` (preserved refusal)

## Workspace references

- Scope: \`AUDIT_190_LIFECYCLE/V126_UPDATE_HISTORY_MIXED_INSTALL_DETECTOR_SCOPE.md\`
- Reproduction: \`AUDIT_190_LIFECYCLE/V125_VALIDATE_DNS2_CLOSURE.md\` §3.4 (live recheck attestation)
- Order plan: \`AUDIT_190_LIFECYCLE/V126_IMPLEMENTATION_ORDER_PLAN.md\` (Lane B, #2 of 3)
- Sibling v1.126 lanes: Lane C merged in #660 (trust re-merge); Lane A pending (\`V126_R4_DEGRADED_GATE_EXTENSION_SCOPE.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)