### PR TITLE
fix(installer/gate): V126 Lane A — extend R-4 --force gate to DEGRADED state

### DIFF
--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -35,8 +35,8 @@ type config struct {
 	rpm         bool   // called from RPM %post
 	deb         bool   // called from DEB postinst
 	repair      bool   // resume from last failed phase
-	force         bool // re-run all phases ignoring state (V125 R-4: requires --allow-recommit when state==COMMITTED)
-	allowRecommit bool // V125 R-4: companion to --force; explicit operator confirmation for re-running phases on a COMMITTED state
+	force         bool // re-run all phases ignoring state (V125 R-4 + V126 Lane A: requires --allow-recommit when state IN {COMMITTED, DEGRADED})
+	allowRecommit bool // V125 R-4 + V126 Lane A: companion to --force; explicit operator confirmation for re-running phases on a completed install state (COMMITTED or DEGRADED)
 	takeover    bool   // approve takeover of conflicting firewalls
 	dryRun      bool   // show what would happen without changes
 	verbose     bool   // full diagnostic logging
@@ -108,13 +108,17 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.deb, "deb", false, "Called from DEB postinst")
 	flag.BoolVar(&cfg.repair, "repair", false, "Resume from last failed phase")
 	flag.BoolVar(&cfg.force, "force", false, "Re-run all phases ignoring state")
-	// V125 R-4: companion safety flag for --force on a healthy host. When
-	// install_state is COMMITTED, --force alone is REFUSED (V125 R-4 gate
-	// in cmd/nftban-installer/main.go::run); the operator must add
-	// --allow-recommit to confirm explicit destructive intent. --force
-	// alone still works for non-COMMITTED states (recovery from
-	// StateFailedRebuild, StateFailedRender, etc.). Default OFF.
-	flag.BoolVar(&cfg.allowRecommit, "allow-recommit", false, "Explicitly authorize re-running phases on a COMMITTED state (V125 R-4 companion to --force on healthy hosts). Required together with --force when install_state is COMMITTED; ignored otherwise.")
+	// V125 R-4 + V126 Lane A: companion safety flag for --force on a completed
+	// install. When install_state is COMMITTED or DEGRADED, --force alone is
+	// REFUSED (gate in cmd/nftban-installer/main.go::run); the operator must
+	// add --allow-recommit to confirm explicit destructive intent. --force
+	// alone still works for genuine failed-install states (StateFailedSwitch,
+	// StateFailedRebuild, StateFailedRender, etc.) — re-running phases is the
+	// supported recovery path there. V126 added DEGRADED to the gate-fire set
+	// because a DEGRADED install completed all phases with non-fatal
+	// assertion failures and is semantically "completed-with-warnings", not
+	// a failed-install recovery scenario. Default OFF.
+	flag.BoolVar(&cfg.allowRecommit, "allow-recommit", false, "Explicitly authorize re-running phases on a completed install state (V125 R-4 + V126 Lane A companion to --force). Required together with --force when install_state is COMMITTED or DEGRADED. DEGRADED state means the install completed with non-fatal assertion failures — it is still a completed install for safety-gate purposes. For genuine failed installs (StateFailedSwitch/Rebuild/Render/etc.) use --force without --allow-recommit (recovery flow) or use --repair to resume from last failed phase.")
 	flag.BoolVar(&cfg.takeover, "takeover", false, "Approve takeover of conflicting firewalls")
 	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Show what would happen without changes")
 	flag.BoolVar(&cfg.verbose, "verbose", false, "Full diagnostic logging")

--- a/cmd/nftban-installer/force_recommit_gate_test.go
+++ b/cmd/nftban-installer/force_recommit_gate_test.go
@@ -1,13 +1,13 @@
 // =============================================================================
-// NFTBan v1.125 R-4 — --force / --allow-recommit gate regression test
+// NFTBan v1.125 R-4 / v1.126 Lane A — --force / --allow-recommit gate test
 // =============================================================================
 // SPDX-License-Identifier: MPL-2.0
 // meta:name="nftban-installer-force-recommit-gate-test"
 // meta:type="test"
-// meta:version="1.0.0"
+// meta:version="1.1.0"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-05-22"
-// meta:description="V125 R-4 regression test: shouldRefuseForceRecommit predicate truth table + parseFlags --allow-recommit registration"
+// meta:description="V125 R-4 + V126 Lane A regression test: shouldRefuseForceRecommit predicate truth table + parseFlags --allow-recommit registration. V126 Lane A extends the gate-fire state set from {COMMITTED} to {COMMITTED, DEGRADED} — chronic-DEGRADED hosts (e.g., lab2 with D-DEG-1) need the same destructive-re-run protection as COMMITTED hosts. Genuine failure-recovery states (StateFailedSwitch/Rebuild/Render/etc.) remain unguarded by R-4 by design."
 // meta:input="None (predicate is pure; flag test manipulates os.Args + flag.CommandLine in isolation)"
 // meta:output="t.Fatal on predicate drift or flag-registration regression"
 // meta:depends="testing,flag,os,internal/installer/state"
@@ -30,17 +30,21 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/state"
 )
 
-// TestShouldRefuseForceRecommit covers the V125 R-4 gate predicate truth
-// table. The predicate is a pure function over (currentState, force,
-// allowRecommit). Extracted from run() so the gate is testable without
-// constructing a full executor + state file + logger.
+// TestShouldRefuseForceRecommit covers the V125 R-4 + V126 Lane A gate
+// predicate truth table. The predicate is a pure function over
+// (currentState, force, allowRecommit). Extracted from run() so the gate
+// is testable without constructing a full executor + state file + logger.
 //
 // Refusal MUST fire only when all three conditions hold simultaneously:
 //   1. --force was passed
-//   2. install_state is COMMITTED
+//   2. install_state is one of {COMMITTED, DEGRADED} (the "completed
+//      install" states; V126 Lane A extended this set from {COMMITTED})
 //   3. --allow-recommit was NOT passed
 //
-// All other combinations MUST allow the run (return false).
+// All other combinations MUST allow the run (return false). Genuine
+// failure-recovery states (StateFailedSwitch / StateFailedRebuild /
+// StateFailedRender / StateFailedNoFirewall / StateFailedTakeover) remain
+// unguarded by R-4 by design — --force is the supported retry path.
 func TestShouldRefuseForceRecommit(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -92,8 +96,45 @@ func TestShouldRefuseForceRecommit(t *testing.T) {
 			wantRefuse:    false,
 		},
 		{
-			name:          "force on StateDegraded without allow-recommit ALLOWS (recovery path)",
+			// V126 Lane A behavior change: DEGRADED is now a completed-install
+			// state for gate purposes (lab2 chronic-DEGRADED reproduction).
+			// Pre-v1.126 this asserted ALLOWS; post-v1.126 the gate REFUSES
+			// without --allow-recommit.
+			name:          "V126: force on StateDegraded without allow-recommit REFUSES (completed-with-warnings)",
 			currentState:  state.StateDegraded,
+			force:         true,
+			allowRecommit: false,
+			wantRefuse:    true,
+		},
+		{
+			// V126 Lane A new positive case: companion to the COMMITTED+
+			// allow-recommit case above; explicit operator intent allows
+			// destructive re-run on a DEGRADED host.
+			name:          "V126: force on StateDegraded with allow-recommit ALLOWS (explicit operator intent)",
+			currentState:  state.StateDegraded,
+			force:         true,
+			allowRecommit: true,
+			wantRefuse:    false,
+		},
+		{
+			// V126 Lane A negative case: NO force on DEGRADED never fires the
+			// gate regardless of --allow-recommit (gate requires force=true).
+			// Mirrors the existing COMMITTED parity cases below.
+			name:          "V126: NO force on StateDegraded ALLOWS (gate requires --force)",
+			currentState:  state.StateDegraded,
+			force:         false,
+			allowRecommit: false,
+			wantRefuse:    false,
+		},
+		{
+			// V126 Lane A: StateFailedTakeover (Switch-phase failure mode in
+			// which takeover-of-conflicting-firewalls failed) is a failure-
+			// recovery state and MUST remain unguarded by R-4 (asymmetric
+			// with COMMITTED/DEGRADED). The existing v1.125 test cases above
+			// cover this; this case re-asserts the boundary explicitly so
+			// it can't drift if cases are reordered.
+			name:          "V126 boundary: force on StateFailedTakeover without allow-recommit ALLOWS (failure recovery — unguarded by R-4 by design)",
+			currentState:  state.StateFailedTakeover,
 			force:         true,
 			allowRecommit: false,
 			wantRefuse:    false,

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -274,16 +274,24 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 	// spec invoke nftban-installer without --force), so legitimate package
 	// upgrades on COMMITTED hosts are unaffected by this gate.
 	//
-	// --force alone still works for non-COMMITTED states (the typical
+	// --force alone still works for non-completed states (the typical
 	// recovery path from StateFailedRebuild / StateFailedRender / etc.):
 	// the helper shouldRefuseForceRecommit only refuses when ALL THREE
-	// conditions hold (force=true AND state==COMMITTED AND allowRecommit=false).
+	// conditions hold (force=true AND state IN {COMMITTED, DEGRADED} AND
+	// allowRecommit=false). V126 Lane A extends the gate-fire state set to
+	// also include DEGRADED — chronic-DEGRADED hosts (e.g., lab2 with
+	// D-DEG-1) are "completed-with-warnings" installs and need the same
+	// destructive-re-run protection as COMMITTED hosts. Genuine failed
+	// installs (StateFailedSwitch/Rebuild/Render/etc.) remain unguarded by
+	// R-4 by design — --force is the legitimate recovery path there.
 	if shouldRefuseForceRecommit(sf.State, cfg.force, cfg.allowRecommit) {
-		fmt.Fprintln(os.Stderr, "error: --force on a COMMITTED install requires --allow-recommit confirmation.")
-		fmt.Fprintln(os.Stderr, "       this gate exists to prevent accidental destructive re-runs of a healthy install.")
-		fmt.Fprintln(os.Stderr, "       if you really want to re-run all phases on this COMMITTED host, add --allow-recommit.")
+		fmt.Fprintf(os.Stderr, "error: --force on a %s install requires --allow-recommit confirmation.\n", sf.State)
+		fmt.Fprintln(os.Stderr, "       this gate exists to prevent accidental destructive re-runs of a completed install.")
+		fmt.Fprintln(os.Stderr, "       DEGRADED state means the install completed with non-fatal assertion failures —")
+		fmt.Fprintln(os.Stderr, "       it is NOT a failed-install recovery scenario (use --repair for that).")
+		fmt.Fprintf(os.Stderr, "       if you really want to re-run all phases on this %s host, add --allow-recommit.\n", sf.State)
 		fmt.Fprintln(os.Stderr, "       if you intended to resume a failed install, use --repair instead of --force.")
-		log.Error("V125 R-4: --force refused on COMMITTED state without --allow-recommit (use --repair to resume failed installs, or add --allow-recommit to confirm destructive re-run)")
+		log.Error("V126 R-4: --force refused on %s state without --allow-recommit (use --repair to resume failed installs, or add --allow-recommit to confirm destructive re-run)", sf.State)
 		return state.ExitRefused
 	}
 
@@ -302,27 +310,51 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 	return runInstall(ctx, exec, sf, cfg, log)
 }
 
-// shouldRefuseForceRecommit is the V125 R-4 gate predicate. Returns true if
-// the installer should refuse this run with ExitRefused because the operator
-// passed --force on a COMMITTED state without the --allow-recommit companion.
+// shouldRefuseForceRecommit is the V125 R-4 gate predicate, extended in V126
+// Lane A. Returns true if the installer should refuse this run with
+// ExitRefused because the operator passed --force on a completed-install
+// state ({COMMITTED, DEGRADED}) without the --allow-recommit companion.
 //
 // Pure function over the three inputs; no I/O, no side effects. Extracted so
 // the gate is testable without constructing a full run() context (executor,
 // state file, logger, etc.).
 //
 // Refusal rule (all three must be true):
-//   1. --force was passed
-//   2. install_state is COMMITTED (healthy install)
-//   3. --allow-recommit was NOT passed
+//  1. --force was passed
+//  2. install_state is one of {COMMITTED, DEGRADED} (the "completed install"
+//     states — install reached Validate phase; COMMITTED = clean,
+//     DEGRADED = completed-with-non-fatal-assertion-failures)
+//  3. --allow-recommit was NOT passed
 //
 // All other combinations return false (no refusal):
-//   - --force alone on StateFailedRebuild / StateFailedRender / etc.: allowed
-//     (legitimate recovery path)
-//   - No --force on COMMITTED: allowed (e.g., package-manager postinst with
-//     --rpm/--deb passes no --force; routine package upgrades unaffected)
-//   - --force + --allow-recommit on COMMITTED: allowed (explicit operator intent)
+//   - --force alone on StateFailedSwitch / StateFailedRebuild / StateFailedRender /
+//     StateFailedNoFirewall / StateFailedTakeover: allowed (legitimate recovery
+//     path — the install never reached completion and re-running phases is the
+//     supported way to recover)
+//   - No --force on COMMITTED or DEGRADED: allowed (e.g., package-manager
+//     postinst with --rpm/--deb passes no --force; routine package upgrades
+//     unaffected)
+//   - --force + --allow-recommit on COMMITTED or DEGRADED: allowed (explicit
+//     operator intent)
+//
+// V126 Lane A change: extended the gate-fire set from {COMMITTED} to
+// {COMMITTED, DEGRADED}. Rationale: a DEGRADED install completed all phases
+// (Detect → Plan → Prepare → Switch → Configure → Validate) but ended with
+// non-fatal assertion failures (e.g., chronic D-DEG-1 cascade on lab2). It
+// is semantically closer to COMMITTED than to StateFailedRebuild. Operators
+// running --force on a DEGRADED host without --allow-recommit are not on a
+// legitimate failure-recovery path — they need the same explicit-authorization
+// safety as COMMITTED hosts get. Failure-recovery flows (StateFailed*) are
+// explicitly preserved unguarded; --force is the supported way to retry them.
+//
+// Scope: AUDIT_190_LIFECYCLE/V126_R4_DEGRADED_GATE_EXTENSION_SCOPE.md
+// Reproduction: AUDIT_190_LIFECYCLE/V125_VALIDATE_LAB2_CLOSURE.md (lab2 chronic
+// DEGRADED hit the gap during V125 validation; R-4 active test was
+// inapplicable on DEGRADED state)
 func shouldRefuseForceRecommit(currentState state.InstallState, force, allowRecommit bool) bool {
-	return force && currentState == state.StateCommitted && !allowRecommit
+	return force &&
+		(currentState == state.StateCommitted || currentState == state.StateDegraded) &&
+		!allowRecommit
 }
 
 // runInstall runs all phases in order for a fresh install or upgrade.


### PR DESCRIPTION
## Summary

- **Defect closed:** `D-V125-R4-GAP-DEGRADED-STATE-NOT-GATED` (P2; design-gap surfaced by lab2 V125 validation 2026-05-22)
- **Root cause:** V125 R-4's `shouldRefuseForceRecommit` predicate (`cmd/nftban-installer/main.go:354` pre-PR) refuses `--force` only when `state == StateCommitted`. `StateDegraded` is non-`StateCommitted` but does NOT represent failure-recovery — the install completed all five phases (Detect → Plan → Prepare → Switch → Configure → Validate) but ended with non-fatal assertion failures. Chronic-DEGRADED hosts (lab2 with the D-DEG-1 cascade, hit 2026-05-22T15:16:09Z) had **NO** V125 R-4 protection against accidental `--force` re-runs — the very protection scenario the gate was designed for went unguarded.
- **Fix:** extend the predicate's gate-fire set from `{StateCommitted}` to `{StateCommitted, StateDegraded}`. Failure-recovery states (`StateFailedSwitch` / `StateFailedRebuild` / `StateFailedRender` / `StateFailedNoFirewall` / `StateFailedTakeover`) remain unguarded by R-4 — `--force` is the supported retry path there.
- **Third of three v1.126 lanes** per the locked C → B → A order in `V126_IMPLEMENTATION_ORDER_PLAN.md`. Lane C merged at `af904f43` (PR #660); Lane B merged at `2f8d9487` (PR #661).

## Predicate truth table — before vs after

| `state` | `force` | `allow-recommit` | v1.125 verdict | v1.126 verdict |
|---|---|---|---|---|
| `COMMITTED` | true | false | REFUSE | REFUSE (unchanged) |
| `COMMITTED` | true | true | ALLOW | ALLOW (unchanged) |
| `COMMITTED` | false | * | ALLOW | ALLOW (unchanged) |
| **`DEGRADED`** | **true** | **false** | **ALLOW ✗** | **REFUSE ✓ NEW** |
| **`DEGRADED`** | **true** | **true** | **ALLOW** | **ALLOW (now an explicit-intent path)** |
| **`DEGRADED`** | **false** | * | **ALLOW** | **ALLOW (gate requires --force; mirrors COMMITTED parity)** |
| `FAILED_SWITCH` | true | false | ALLOW | ALLOW (preserved — recovery) |
| `FAILED_REBUILD` | true | false | ALLOW | ALLOW (preserved — recovery) |
| `FAILED_RENDER` | true | false | ALLOW | ALLOW (preserved — recovery) |
| `FAILED_NO_FIREWALL` | true | false | ALLOW | ALLOW (preserved — recovery) |
| `FAILED_TAKEOVER` | true | false | ALLOW | ALLOW (preserved — recovery) |
| `""` (fresh) | true | false | ALLOW | ALLOW (preserved — no install present) |

## How lab2 V125 validation surfaced this gap (2026-05-22)

Per `V125_VALIDATE_LAB2_CLOSURE.md` (V126 scope §1.4):

> "After a successful `nftban update` on lab2 (state==COMMITTED), execute ONCE: `nftban-installer --mode=upgrade --force` … expect ExitRefused, error message naming `--allow-recommit`."

lab2's `nftban update` completed as `StateDegraded` instead of `StateCommitted` (D-DEG-1 cascade triggered the `failed_units_postinstall_ok` non-fatal assertion). The active V125 R-4 test therefore could not be executed safely:

- `--force` on `StateDegraded` does NOT fire the gate
- That means the test would have re-run all 5 phases on a real host
- So the test was correctly held back — but it revealed that the gate gap matches a real fleet shape

Operator impact on chronic-DEGRADED hosts: an accidental `nftban-installer --mode=install --takeover --force` would re-trigger Switch — re-flushing iptables, re-masking CSF if the operator unmasked manually, re-rendering config — with **no** operator intent for that destruction. That is precisely the class of accident V125 R-4 was designed to prevent for COMMITTED hosts.

## Code change shape

### Predicate (`cmd/nftban-installer/main.go`)

```go
// V126 Lane A: gate-fire set extended from {COMMITTED} to {COMMITTED, DEGRADED}.
func shouldRefuseForceRecommit(currentState state.InstallState, force, allowRecommit bool) bool {
	return force &&
		(currentState == state.StateCommitted || currentState == state.StateDegraded) &&
		!allowRecommit
}
```

The call site `run()` updates the error message to print the actual state via `Fprintf %s` so the operator sees which state triggered refusal (`--force on a DEGRADED install requires --allow-recommit confirmation.`) and explicitly names the `--repair` escape hatch for genuine failure recovery.

### Flag help text (`cmd/nftban-installer/flags.go`)

`--allow-recommit` help text expanded to name both `COMMITTED` and `DEGRADED` as gate-fire states, and to clarify that `DEGRADED` means "completed with non-fatal assertion failures — it is still a completed install for safety-gate purposes."

### Tests (`cmd/nftban-installer/force_recommit_gate_test.go`)

- Header banner + `meta:version` bumped 1.0.0 → 1.1.0
- One **changed** case: `DEGRADED + force + no-recommit` now asserts REFUSE (was ALLOW pre-V126)
- Two **new** positive cases:
  - `DEGRADED + force + allow-recommit` ALLOWS (explicit operator intent — companion to the existing COMMITTED+allow case)
  - `NO force on DEGRADED` ALLOWS (gate requires `--force`; mirrors the existing COMMITTED parity case)
- One **new** boundary re-assertion: `StateFailedTakeover + force` ALLOWS (failure recovery — explicit guard against future test-case reorders accidentally regressing the asymmetry)
- Preserved unchanged: `TestParseFlags_AllowRecommitDefault`, `TestParseFlags_AllowRecommitExplicit`

## Invariants preserved

- ✅ Schema 1.83.0 stays frozen (no schema surface touched)
- ✅ Daemon binary NOT modified (this PR touches `cmd/nftban-installer/` only; `cmd/nftband` + `cmd/nftban-core` are untouched — daemon-binary identical-binary streak continues)
- ✅ Failure-recovery flows (`StateFailedSwitch` / `Rebuild` / `Render` / `NoFirewall` / `Takeover`) remain unguarded by R-4 — `--force` is the supported retry path there
- ✅ Package-manager postinst paths unaffected (`packaging/deb/postinst` + RPM `%post` invoke `nftban-installer` without `--force`; verified by grep)
- ✅ `--repair` flow unaffected (separate dispatch path; the R-4 gate sits AFTER the repair check in `run()`)
- ✅ No mutation in `--dry-run` or `--mode=restore` paths (gate is AFTER those branches)
- ✅ `--mode=uninstall` unaffected (gate is AFTER the uninstall dispatch)
- ✅ `cli/lib/nftban/` shell surface unchanged (V126 Lane A is Go-only)

## Test plan

- [x] **Predicate truth table:** `TestShouldRefuseForceRecommit` now covers 14 cases (was 10) — 6 COMMITTED + 4 DEGRADED + 4 failure-recovery + edge cases (empty state, no-force-on-failed)
- [x] **Flag registration:** `TestParseFlags_AllowRecommitDefault` (defaults to false) + `TestParseFlags_AllowRecommitExplicit` (true when passed alongside `--force`) — preserved from V125 R-4
- [x] **Build/test verification:** CI on this PR — `go build ./...` and `go test ./cmd/nftban-installer/... -run 'TestShouldRefuseForceRecommit|TestParseFlags_AllowRecommit'` run inside the `rockylinux:9` builder container (matches the verification path used for #660 and #661 per `memory/feedback_build_host_policy.md`; local `go` is forbidden on the Fedora 44 dev host)
- [x] **Schema-frozen attestation:** `test_schema_version_guard.sh` (1.83.0 across Go validator + CLI)
- [x] **Sibling regression:** `cmd/nftban-installer/` existing tests must remain green (no changes outside the gate predicate + its tests + flag help text)

## Acceptance gate (per V126 scope §3 + `V126_IMPLEMENTATION_ORDER_PLAN.md` §7)

After this PR ships in v1.126.0, the v1.126 acceptance matrix completes:

- [ ] **lab2 V125 re-validation** (`EXECUTE_V126_VALIDATE_LAB2`): with lab2 still in chronic DEGRADED, run `nftban-installer --mode=install --takeover --force` and observe `ExitRefused` (exit 76) plus the error message naming `--allow-recommit` and citing DEGRADED. Then re-run with `--force --allow-recommit` and observe normal phase execution (or the same DEGRADED end-state — gate purpose is *authorization*, not state change).
- [ ] **srv3 V125 re-validation** (per Lane C acceptance): kernel `whitelist_ipv4` contains Cloudflare ranges + operator session entry after `nftban update`
- [ ] **dns2 V125 re-validation** (per Lane B acceptance): `nftban update` succeeds via standard auto-detect path
- [ ] **Daemon binary identical-binary streak** continues (v1.114.0 → v1.126.0; this PR does NOT touch `cmd/nftband` or `cmd/nftban-core`)

## Workspace references

- Scope: `AUDIT_190_LIFECYCLE/V126_R4_DEGRADED_GATE_EXTENSION_SCOPE.md`
- Reproduction: `AUDIT_190_LIFECYCLE/V125_VALIDATE_LAB2_CLOSURE.md` (lab2 chronic DEGRADED 2026-05-22; R-4 active test held back because `--force` did not fire the gate)
- Order plan: `AUDIT_190_LIFECYCLE/V126_IMPLEMENTATION_ORDER_PLAN.md` (Lane A, #3 of 3)
- Sibling v1.126 lanes (now merged): Lane C in #660 (trust re-merge in `firewall_reload`); Lane B in #661 (mixed-install detector unblock-after-clean-migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)