### PR TITLE
fix(installer): V126.2 — operator-friendly FAILED_AUTHORITY_ABORT message

### DIFF
--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -393,10 +393,27 @@ func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile
 
 		log.Phase(p.name)
 		if err := p.fn(ctx, exec, sf, log); err != nil {
-			log.Error("phase %s failed: %v", p.name, err)
+			// V126.2 UX hotfix: for FAILED_AUTHORITY_ABORT only, suppress the cryptic
+			// "[NFTBan ERROR] phase X failed: ..." stdout line because report() emits
+			// the operator-friendly block. The internal log file still gets the error
+			// via ErrorLogOnly so audit trail and diagnostic bundles are unchanged.
+			// Non-ABORT failures preserve existing behavior (ERROR to stdout+log).
+			// Scope: AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4).
+			if sf.State == state.StateFailedAbort {
+				log.ErrorLogOnly("phase %s failed: %v", p.name, err)
+			} else {
+				log.Error("phase %s failed: %v", p.name, err)
+			}
 			log.PhaseEnd(p.name)
 
-			if lb != nil {
+			// V126.2: for FAILED_AUTHORITY_ABORT, skip the lifecycle bridge JSON
+			// event emission to stderr (operator-noise). install_state and the
+			// internal log file still capture the same outcome data, and the
+			// friendly block in report() communicates the action path to the
+			// operator. Lifecycle observers for non-ABORT failures are unchanged
+			// so downstream consumers (CI dashboards, monitoring) continue to
+			// receive their structured events.
+			if lb != nil && sf.State != state.StateFailedAbort {
 				if p.phase == state.PhaseDetect {
 					lb.observeDetect(&globalPhaseData, sf)
 					lb.observePlan(&globalPhaseData)
@@ -479,7 +496,17 @@ func runRepair(ctx context.Context, exec executor.Executor, sf *state.StateFile,
 
 		log.Phase(p.name)
 		if err := p.fn(ctx, exec, sf, log); err != nil {
-			log.Error("repair phase %s failed: %v", p.name, err)
+			// V126.2 UX hotfix: same FAILED_AUTHORITY_ABORT stdout suppression as
+			// the normal-mode handler above. Repair mode CAN also produce
+			// StateFailedAbort if conflicts reappear before takeover is approved
+			// (the second --repair run on an unchanged-state host). Internal log
+			// file unchanged via ErrorLogOnly.
+			// Scope: AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4).
+			if sf.State == state.StateFailedAbort {
+				log.ErrorLogOnly("repair phase %s failed: %v", p.name, err)
+			} else {
+				log.Error("repair phase %s failed: %v", p.name, err)
+			}
 			log.PhaseEnd(p.name)
 			return report(sf, log)
 		}
@@ -514,6 +541,129 @@ func report(sf *state.StateFile, log *logging.Logger) int {
 		log.Result("[NFTBan] to generate a diagnostic bundle and optionally submit it for review.")
 		log.Result("")
 		log.Result("[NFTBan] To fix: nftban-installer --repair")
+	case state.StateFailedAbort:
+		// V126.2 UX hotfix: FAILED_AUTHORITY_ABORT gets a dedicated operator-friendly
+		// block. Replaces the generic FAILED block (default case) which offered
+		// `--repair` and `nftban firewall rebuild` as retry hints — both wrong for the
+		// ABORT case (those apply to FAILED_RENDER / FAILED_REBUILD recovery).
+		//
+		// Also replaces the duplicate ABORTED block previously emitted by RPM/DEB
+		// postinst scripts; the Go installer is now the single source of truth for
+		// this message (postinst scripts shall not duplicate it).
+		//
+		// Critical correctness fixes from dns1 evidence + Gemini/ChatGPT review:
+		//   - PRIOR DEB message instructed `NFTBAN_TAKEOVER=1 dpkg --configure nftban-core`
+		//     which fails with "package already installed and configured" because dpkg
+		//     considers the package configured after postinst returned (even with exit 3).
+		//     The verified-working recovery path is `nftban-installer --repair`, which
+		//     handles the FAILED_AUTHORITY_ABORT state-machine resume.
+		//   - PRIOR two-line `export NFTBAN_TAKEOVER=1 / sudo command` form was silently
+		//     stripped by `sudoers env_reset` defaults. The inline `sudo VAR=value command`
+		//     form survives env_reset.
+		//
+		// Scope: AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4)
+		log.Result("")
+		log.Result("════════════════════════════════════════════════════════════════════════════════")
+		log.Result("[!] NFTBan Installation Paused: Existing Firewalls Detected")
+		log.Result("════════════════════════════════════════════════════════════════════════════════")
+		log.Result("")
+		log.Result("NFTBan found other firewall management software on this server:")
+		log.Result("")
+		if sf.Conflicts != "" {
+			for _, c := range strings.Split(sf.Conflicts, ",") {
+				c = strings.TrimSpace(c)
+				if c != "" {
+					log.Result("  • %s", c)
+				}
+			}
+		} else {
+			log.Result("  (detected conflicts could not be enumerated — check /var/log/nftban/installer.log)")
+		}
+		log.Result("")
+		log.Result("For safety, NFTBan did not activate automatically.")
+		log.Result("")
+		log.Result("Running multiple firewall managers at the same time can cause rules to")
+		log.Result("conflict or overwrite each other. In some cases, this can lock you out of")
+		log.Result("the server.")
+		log.Result("")
+		log.Result("NFTBan is installed, but its firewall is NOT active yet.")
+		log.Result("")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("OPTION 1: Let NFTBan Take Control")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("")
+		log.Result("Use this option only if you want NFTBan to become the main firewall manager")
+		log.Result("for this server.")
+		log.Result("")
+		log.Result("Run ONE of these single-line commands as root:")
+		log.Result("")
+		log.Result("   If you normally use sudo (most operators):")
+		log.Result("       sudo NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair")
+		log.Result("")
+		log.Result("   If you are already logged in as root (a # prompt):")
+		log.Result("       NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair")
+		log.Result("")
+		log.Result("This tells NFTBan:")
+		log.Result("    \"I approve firewall takeover. Continue from where the install stopped.\"")
+		log.Result("")
+		log.Result("NFTBan will then disable or clean up the conflicting firewall setup and")
+		log.Result("activate its own nftables firewall.")
+		log.Result("")
+		log.Result("The same command works on Debian/Ubuntu AND on RHEL/CentOS/AlmaLinux/Rocky —")
+		log.Result("the installer binary is the same on every supported distribution.")
+		log.Result("")
+		log.Result("IMPORTANT — do not press Ctrl+C while it is running.")
+		log.Result("    The takeover happens in phases (Detect → Prepare → Switch → Configure →")
+		log.Result("    Validate). Interrupting it can leave the install in an intermediate state")
+		log.Result("    requiring another --repair run.")
+		log.Result("")
+		log.Result("IMPORTANT — do not run dpkg --configure or rpm --reinstall again.")
+		log.Result("    If a package-manager command says \"package nftban-core is already installed")
+		log.Result("    and configured\", that is normal. The package manager has nothing left to do.")
+		log.Result("    Use the --repair command above instead.")
+		log.Result("")
+		log.Result("If this server is managed by a control panel such as DirectAdmin, cPanel,")
+		log.Result("Plesk, or Webmin, make sure you understand which firewall currently protects")
+		log.Result("the server before continuing.")
+		log.Result("")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("OPTION 2: Stop Here")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("")
+		log.Result("If you are not sure, stop here.")
+		log.Result("")
+		log.Result("No firewall takeover has been performed.")
+		log.Result("Your existing firewall setup remains in control.")
+		log.Result("NFTBan will remain installed but inactive until you approve takeover.")
+		log.Result("")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("After Running Option 1: Verify Status")
+		log.Result("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		log.Result("")
+		log.Result("NFTBan health (works on any Linux):")
+		log.Result("    nftban version")
+		log.Result("    systemctl is-active nftband")
+		log.Result("    cat /var/lib/nftban/state/install_state")
+		log.Result("")
+		log.Result("Kernel-firewall actually applied (trust-but-verify):")
+		log.Result("    nft list tables")
+		log.Result("    nft list ruleset | grep -i nftban")
+		log.Result("")
+		log.Result("Optional package-state sanity (if you want extra reassurance):")
+		log.Result("    Debian/Ubuntu:")
+		log.Result("        dpkg -s nftban-core | grep -E \"Status|Version\"")
+		log.Result("        apt-get check")
+		log.Result("    RHEL/CentOS/AlmaLinux/Rocky:")
+		log.Result("        rpm -q nftban-core")
+		log.Result("        dnf check 2>&1 | head -5")
+		log.Result("")
+		log.Result("A healthy install should show:")
+		log.Result("    nftband is active")
+		log.Result("    INSTALL_STATE=COMMITTED")
+		log.Result("    nft tables include: ip nftban, ip6 nftban")
+		log.Result("    nft ruleset includes \"nftban\" rules")
+		log.Result("")
+		log.Result("════════════════════════════════════════════════════════════════════════════════")
 	default:
 		log.Result("[NFTBan] Install/upgrade FAILED.")
 		log.Result("[NFTBan] State: %s", sf.State)

--- a/cmd/nftban-installer/report_failed_abort_test.go
+++ b/cmd/nftban-installer/report_failed_abort_test.go
@@ -1,0 +1,294 @@
+// =============================================================================
+// V126.2 UX hotfix snapshot test — FAILED_AUTHORITY_ABORT report() output
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-report-failed-abort-test"
+// meta:type="test"
+// meta:version="1.126.2"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-23"
+// meta:description="V126.2 regression guard for the FAILED_AUTHORITY_ABORT operator-friendly message: asserts report() emits the unified sudo-safe --repair recovery block (sudo + root-shell variants), Ctrl-C warning, dpkg-already-configured warning, kernel-verification commands, package-state observe-only commands, and conflict-list dynamic population. Asserts the broken legacy command forms are NOT emitted (NFTBAN_TAKEOVER=1 dpkg --configure nftban-core; generic FAILED block with --repair/firewall rebuild retry hints). Includes empty-Conflicts fallback case + ErrorLogOnly primitive unit test."
+// meta:input="state.StateFile{State=StateFailedAbort, Conflicts=...} via in-memory construction; stdout+stderr+log file captured via os.Pipe redirection"
+// meta:output="t.Errorf on missing INCLUDE strings, present EXCLUDE strings, or missing log-file audit trail"
+// meta:depends="testing,bytes,io,os,strings,internal/installer/logging,internal/installer/state"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Scope: AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4)
+// =============================================================================
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+)
+
+// TestReportFailedAbortV126_2HotfixMessage verifies the FAILED_AUTHORITY_ABORT
+// operator-facing message emitted by report() conforms to the V126.2 UX hotfix
+// scope (AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md REV 4).
+//
+// Acceptance criteria mapped from scope §4:
+//   - Includes the new operator-friendly block (header, options, verification)
+//   - Includes the sudo-safe command form (Gemini REV 4 finding)
+//   - Includes the root-shell command form
+//   - Includes Ctrl-C warning + dpkg-configure warning (operator dns1 evidence)
+//   - Excludes the BROKEN command `NFTBAN_TAKEOVER=1 dpkg --configure nftban-core`
+//   - Excludes the wrong-for-ABORT retry hints `--repair` (generic FAILED form)
+//     and `nftban firewall rebuild` (generic FAILED form)
+//   - Excludes the generic `Install/upgrade FAILED.` block
+//   - Dynamically populates conflict list from sf.Conflicts
+//
+// Snapshot scope: report() output ONLY. The [NFTBan ERROR] phase Detect failed
+// line + JSON detect/plan/result event dumps are emitted by separate code paths
+// (main.go:396 + lifecycle bridge) and out of V126.2 scope per §6.
+func TestReportFailedAbortV126_2HotfixMessage(t *testing.T) {
+	// Redirect os.Stdout AND os.Stderr BEFORE constructing the logger so the
+	// new logger's internal console writer (set at logger.New() time) captures
+	// the pipe instead of the real stdout. Stderr capture is defensive — it
+	// proves report() does NOT emit lifecycle JSON event dumps (those come
+	// from the lifecycle bridge in main.go phase-runner, not from report()).
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe (stdout): %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe (stderr): %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	// Temp log file so writeFile() doesn't touch /var/log on the test host.
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/installer.log"
+	log := logging.New(logPath, false)
+	defer log.Close()
+
+	// Construct a StateFile matching the dns1 FAILED_AUTHORITY_ABORT case
+	// from 2026-05-23: Ubuntu 24.04 DEB install with 4 detected conflicts.
+	sf := state.NewStateFile(tmpDir)
+	sf.State = state.StateFailedAbort
+	sf.Mode = "install"
+	sf.Conflicts = "UFW,iptables-nft,iptables,CSF"
+	sf.Panel = "directadmin"
+	sf.FailureReason = "conflicts detected, takeover not approved: UFW,iptables-nft,iptables,CSF"
+
+	// Run report() — this emits the V126.2 friendly block to stdout.
+	// (Discard the returned exit code; the test asserts on output content.)
+	_ = report(sf, log)
+
+	// Capture both stdout and stderr.
+	if err := wOut.Close(); err != nil {
+		t.Fatalf("stdout pipe writer close: %v", err)
+	}
+	if err := wErr.Close(); err != nil {
+		t.Fatalf("stderr pipe writer close: %v", err)
+	}
+	var bufOut, bufErr bytes.Buffer
+	if _, err := io.Copy(&bufOut, rOut); err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	if _, err := io.Copy(&bufErr, rErr); err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	os.Stdout = origStdout
+	os.Stderr = origStderr
+	output := bufOut.String()
+	stderrOutput := bufErr.String()
+
+	// ====== Required INCLUDES (V126.2 §4 acceptance criteria 1-22) ======
+	mustInclude := []string{
+		// Header
+		"NFTBan Installation Paused",
+		"Existing Firewalls Detected",
+		// OPTION 1 block
+		"OPTION 1: Let NFTBan Take Control",
+		// REV 4 sudo-safe inline form
+		"sudo NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair",
+		// Root-shell alternative
+		"NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair",
+		// OPTION 2 block (the "stop here" exit path)
+		"OPTION 2: Stop Here",
+		// REV 4 kernel-verification additions (Gemini #2)
+		"nft list tables",
+		"nft list ruleset | grep -i nftban",
+		// REV 4 package-state CHECK commands (ChatGPT refinement)
+		"dpkg -s nftban-core",
+		"apt-get check",
+		"rpm -q nftban-core",
+		"dnf check",
+		// REV 4 Ctrl-C warning (operator dns1 evidence)
+		"do not press Ctrl+C",
+		// REV 4 dpkg-already-configured warning
+		"do not run dpkg --configure",
+		// Conflict list dynamically populated from sf.Conflicts
+		"• UFW",
+		"• iptables-nft",
+		"• iptables",
+		"• CSF",
+		// Health verification commands
+		"nftban version",
+		"systemctl is-active nftband",
+		"INSTALL_STATE=COMMITTED",
+	}
+	for _, want := range mustInclude {
+		if !strings.Contains(output, want) {
+			t.Errorf("V126.2 report() FAILED_AUTHORITY_ABORT output is MISSING required string:\n  want: %q", want)
+		}
+	}
+
+	// ====== Required EXCLUDES (V126.2 §4 acceptance criteria 10-22) ======
+	// All excludes are scoped to report() output. The [NFTBan ERROR] phase
+	// Detect failed line + JSON dumps come from separate code paths and are
+	// not part of this test scope per V126.2 §6.
+	mustExclude := []string{
+		// BROKEN command from old DEB postinst (dns1 evidence: dpkg refuses)
+		"NFTBAN_TAKEOVER=1 dpkg --configure nftban-core",
+		// REV 3-era too-detailed RPM command (operator shouldn't need --rpm flag)
+		"nftban-installer --rpm --mode=",
+		// Generic FAILED block retry hints — wrong for the ABORT case
+		// (those apply to FAILED_RENDER / FAILED_REBUILD recovery)
+		"[NFTBan] To retry: /usr/lib/nftban/bin/nftban-installer --repair",
+		"[NFTBan] Or: nftban firewall rebuild",
+		// Generic FAILED block header — replaced by the friendly block
+		"[NFTBan] Install/upgrade FAILED.",
+	}
+	for _, unwanted := range mustExclude {
+		if strings.Contains(output, unwanted) {
+			t.Errorf("V126.2 report() FAILED_AUTHORITY_ABORT output contains FORBIDDEN string:\n  unwanted: %q\n  scope: this string belongs to a pre-V126.2 message form or to a different state's output", unwanted)
+		}
+	}
+
+	// Note: this test does NOT assert absence of "--repair" globally, because
+	// the new (correct) recovery command intentionally contains
+	// "/usr/lib/nftban/bin/nftban-installer --repair". Only specific OLD
+	// command forms are forbidden — see mustExclude list.
+
+	// ====== V126.2 REV 4 stderr cleanliness assertion ======
+	// report() itself must NOT emit lifecycle JSON events to stderr. The
+	// JSON dumps come from the lifecycle bridge (cmd/nftban-installer/
+	// lifecycle_bridge.go), which is invoked from the phase-runner loop in
+	// main.go run(). For FAILED_AUTHORITY_ABORT the phase-runner SKIPS the
+	// lifecycle bridge observer calls (see main.go phase-failure handler),
+	// so JSON dumps never reach stderr. This test asserts report() in
+	// isolation does not produce stderr noise.
+	stderrForbidden := []string{
+		`{"timestamp":`,
+		`"event":"detect"`,
+		`"event":"plan"`,
+		`"event":"result"`,
+	}
+	for _, unwanted := range stderrForbidden {
+		if strings.Contains(stderrOutput, unwanted) {
+			t.Errorf("V126.2 report() FAILED_AUTHORITY_ABORT stderr contains FORBIDDEN string: %q\nstderr:\n%s", unwanted, stderrOutput)
+		}
+	}
+}
+
+// TestErrorLogOnly_DoesNotEmitToStdout verifies the V126.2 logging primitive
+// used by main.go phase-failure handler to suppress the cryptic
+// "[NFTBan ERROR] phase Detect failed:" stdout line for FAILED_AUTHORITY_ABORT
+// while preserving the same line in the log file.
+//
+// Acceptance criterion REV 4 §4 #10: ERROR line REMOVED from stdout for
+// FAILED_AUTHORITY_ABORT case (kept in log file for audit).
+func TestErrorLogOnly_DoesNotEmitToStdout(t *testing.T) {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/installer.log"
+	log := logging.New(logPath, false)
+	defer log.Close()
+
+	// Call the new primitive
+	log.ErrorLogOnly("phase Detect failed: FAILED_AUTHORITY_ABORT: conflicts detected")
+
+	// Close stdout pipe and read
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = origStdout
+
+	// Assertion: stdout MUST be empty (no ERROR line)
+	stdout := buf.String()
+	if strings.Contains(stdout, "[NFTBan ERROR]") {
+		t.Errorf("ErrorLogOnly leaked to stdout — expected log-file-only:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "phase Detect failed") {
+		t.Errorf("ErrorLogOnly leaked to stdout — expected log-file-only:\n%s", stdout)
+	}
+
+	// Assertion: log file SHOULD contain the message (audit trail preserved)
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	logContent := string(logBytes)
+	if !strings.Contains(logContent, "phase Detect failed: FAILED_AUTHORITY_ABORT: conflicts detected") {
+		t.Errorf("ErrorLogOnly did NOT write to log file (audit trail broken):\n%s", logContent)
+	}
+	if !strings.Contains(logContent, "[ERROR]") {
+		t.Errorf("ErrorLogOnly did not include [ERROR] level marker in log file:\n%s", logContent)
+	}
+}
+
+// TestReportFailedAbortV126_2_EmptyConflicts verifies graceful fallback when
+// install_state.CONFLICTS is empty (per D_DETECTOR_OPTION_A_CSF_CONF_GAP_SCOPE.md —
+// the detector can leave CONFLICTS empty even when conflicts are detected).
+func TestReportFailedAbortV126_2_EmptyConflicts(t *testing.T) {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	tmpDir := t.TempDir()
+	log := logging.New(tmpDir+"/installer.log", false)
+	defer log.Close()
+
+	sf := state.NewStateFile(tmpDir)
+	sf.State = state.StateFailedAbort
+	sf.Conflicts = "" // empty — detector-gap case
+
+	_ = report(sf, log)
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = origStdout
+	output := buf.String()
+
+	// Should fall back to a clear message, not crash or emit garbage bullets.
+	if !strings.Contains(output, "detected conflicts could not be enumerated") {
+		t.Errorf("V126.2 report() FAILED_AUTHORITY_ABORT with empty Conflicts: expected fallback message, got:\n%s", output)
+	}
+	// Should still emit the main friendly block.
+	if !strings.Contains(output, "OPTION 1: Let NFTBan Take Control") {
+		t.Errorf("V126.2 report() FAILED_AUTHORITY_ABORT with empty Conflicts: friendly block missing OPTION 1 header")
+	}
+}

--- a/internal/installer/logging/logger.go
+++ b/internal/installer/logging/logger.go
@@ -118,6 +118,19 @@ func (l *Logger) Warn(format string, args ...interface{}) {
 	l.writeFile("WARN", msg)
 }
 
+// ErrorLogOnly writes an error to the log file ONLY, NOT to console.
+// Use when the operator-facing console output is handled by a different code
+// path (e.g., V126.2 FAILED_AUTHORITY_ABORT operator-friendly block emitted
+// by main.go report()) but the log file should still preserve the error for
+// audit/diagnosis. This keeps the machine-readable log unchanged while letting
+// the console show a calmer message.
+//
+// Scope: AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4)
+func (l *Logger) ErrorLogOnly(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	l.writeFile("ERROR", msg)
+}
+
 // Error logs an error to both console and file.
 func (l *Logger) Error(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -989,11 +989,15 @@ if [ -x "\$NFTBAN_INSTALLER" ]; then
         echo ""
         echo "[NFTBan] To fix: nftban-installer --repair"
     elif [ \$INSTALLER_EXIT -eq 3 ]; then
-        echo "[NFTBan] ========================================"
-        echo "[NFTBan]  NFTBan v\${NFTBAN_VERSION} — ABORTED"
-        echo "[NFTBan] ========================================"
-        echo "[NFTBan] Conflicting firewalls detected, takeover not approved."
-        echo "[NFTBan] To takeover: NFTBAN_TAKEOVER=1 nftban-installer --rpm --mode=\$INSTALL_MODE"
+        # V126.2 UX hotfix: FAILED_AUTHORITY_ABORT block is now emitted by the Go
+        # installer (cmd/nftban-installer/main.go report() StateFailedAbort case)
+        # as the single source of truth. Postinst MUST NOT duplicate the message.
+        # Prior message advised "NFTBAN_TAKEOVER=1 nftban-installer --rpm --mode=\$INSTALL_MODE"
+        # which required operator to know \$INSTALL_MODE value and the --rpm flag.
+        # New canonical command is sudo-safe and unified across DEB/RPM:
+        #   sudo NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair
+        # See AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4).
+        :
     else
         echo "[NFTBan] ========================================"
         echo "[NFTBan]  NFTBan v\${NFTBAN_VERSION} — FAILED"

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -274,11 +274,17 @@ case "$1" in
                 log_info "Some post-install checks failed."
                 log_info "To fix: nftban-installer --repair"
             elif [ $INSTALLER_EXIT -eq 3 ]; then
-                log_info "========================================"
-                log_info " NFTBan — ABORTED"
-                log_info "========================================"
-                log_info "Conflicting firewalls detected, takeover not approved."
-                log_info "To takeover: NFTBAN_TAKEOVER=1 dpkg --configure nftban-core"
+                # V126.2 UX hotfix: FAILED_AUTHORITY_ABORT block is now emitted by the Go
+                # installer (cmd/nftban-installer/main.go report() StateFailedAbort case)
+                # as the single source of truth. Postinst MUST NOT duplicate the message.
+                #
+                # Prior message advised "NFTBAN_TAKEOVER=1 dpkg --configure nftban-core"
+                # which BROKE (dns1 2026-05-23 evidence): dpkg reports "package already
+                # installed and configured" and refuses to re-run postinst. The verified-
+                # working canonical recovery path is sudo-safe and unified across DEB/RPM:
+                #   sudo NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair
+                # See AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md (REV 4).
+                :
             else
                 log_error "========================================"
                 log_error " NFTBan — FAILED"


### PR DESCRIPTION
## Summary

Message-only **P2 correctness hotfix**. The prior FAILED_AUTHORITY_ABORT recovery instruction was broken: `NFTBAN_TAKEOVER=1 dpkg --configure nftban-core` returns "package already installed and configured" because dpkg considers postinst complete (even with exit 3). Operators hit an infinite loop until they discover `--repair` on their own.

**Live evidence:** dns1 2026-05-23 13:35:53Z install + 13:50:07Z manual recovery.

## Scope

- ✅ Message-only P2 correctness hotfix
- ✅ Go installer is single source of truth for ABORT guidance
- ✅ DEB/RPM postinst become thin shims (no duplicate ABORTED block)
- ✅ Sudo-safe recovery command (inline `sudo VAR=value command` form survives env_reset)
- ✅ No `dpkg --configure` retry advice (verified broken on dns1)
- ✅ No firewall / planner / detector / takeover logic change
- ✅ Schema 1.83.0 unchanged
- ✅ Daemon binary byte-identical to v1.126.1

## What the operator sees now (replaces 3 prior emit sites)

**Before:**
```
[NFTBan ERROR] phase Detect failed: FAILED_AUTHORITY_ABORT: conflicts detected, takeover not approved: UFW,iptables-nft,iptables,CSF
{"timestamp":"2026-05-23T13:35:53Z","event":"detect",...}
{"timestamp":"2026-05-23T13:35:53Z","event":"plan","actions":["ABORT"]...}
{"timestamp":"2026-05-23T13:35:53Z","event":"result",...}
[NFTBan] Install/upgrade FAILED.
[NFTBan] State: FAILED_AUTHORITY_ABORT
[NFTBan] To retry: /usr/lib/nftban/bin/nftban-installer --repair     ← wrong for ABORT
[NFTBan] Or: nftban firewall rebuild                                  ← wrong for ABORT
[NFTBan] ========================================
[NFTBan]  NFTBan — ABORTED
[NFTBan] ========================================
[NFTBan] Conflicting firewalls detected, takeover not approved.
[NFTBan] To takeover: NFTBAN_TAKEOVER=1 dpkg --configure nftban-core   ← BROKEN
```

**After:**
```
════════════════════════════════════════════════════════════════════════════════
[!] NFTBan Installation Paused: Existing Firewalls Detected
════════════════════════════════════════════════════════════════════════════════

NFTBan found other firewall management software on this server:

  • UFW
  • iptables-nft
  • iptables
  • CSF

[plain-English explanation of the situation]

━━━ OPTION 1: Let NFTBan Take Control ━━━

Run ONE of these single-line commands as root:

   If you normally use sudo (most operators):
       sudo NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair

   If you are already logged in as root (a # prompt):
       NFTBAN_TAKEOVER=1 /usr/lib/nftban/bin/nftban-installer --repair

IMPORTANT — do not press Ctrl+C while it is running.
IMPORTANT — do not run dpkg --configure or rpm --reinstall again.

━━━ OPTION 2: Stop Here ━━━
[exit path explanation]

━━━ After Running Option 1: Verify Status ━━━
[nft list tables, nft list ruleset, dpkg/rpm checks, expected COMMITTED state]
```

## Architecture

| Layer | Role |
|---|---|
| `cmd/nftban-installer/main.go report()` | NEW `case state.StateFailedAbort:` — single source of truth for ABORT block |
| `internal/installer/logging/logger.go` | NEW `ErrorLogOnly()` — writes ERROR to log file but NOT stdout (preserves audit trail without operator-noise) |
| `main.go` phase-failure handlers (normal + repair) | Conditional on `sf.State == StateFailedAbort`: use `ErrorLogOnly` for cryptic ERROR line + skip lifecycle bridge JSON observers |
| `packaging/build_nftban.sh` + `packaging/deb/postinst` | INSTALLER_EXIT=3 branch now a no-op shim; Go installer emits the full block |

## Test plan

- [x] **Unit test:** `TestErrorLogOnly_DoesNotEmitToStdout` — proves the new logging primitive writes to log file only
- [x] **Snapshot test:** `TestReportFailedAbortV126_2HotfixMessage` — full REV 4 INCLUDE/EXCLUDE assertions on report() output (stdout + stderr capture)
- [x] **Edge case test:** `TestReportFailedAbortV126_2_EmptyConflicts` — empty-CONFLICTS fallback (detector-Option-A-gap case)
- [ ] **CI green** — Go build + vet + test on all matrix combos
- [ ] **dns1 spot-check** (separate gate `OPEN_V126_2_DNS1_SPOT_CHECK = GO`) — re-install v1.126.2 on dns1 in same conflicting-firewall state; verify operator-visible output matches the snapshot

## What's still preserved (defensive declaration)

- `internal/installer/state/file.go` (StateFile struct, Transition method) — unchanged
- `internal/installer/state/machine.go` (StateFailedAbort enum) — unchanged
- `cmd/nftban-installer/phases.go` (phaseDetect, authority classification) — unchanged
- `internal/installer/switchop/takeover.go` (DisableConflicts) — unchanged
- `internal/installer/detect/conflicts.go` — unchanged
- Non-ABORT failure handling — unchanged (FAILED_RENDER, FAILED_REBUILD, FAILED_SWITCH still emit Error to stdout+log and lifecycle observers fire normally)

## Breaking-change note

String-match consumers of the old DEB/RPM message lines must migrate to reading `install_state.INSTALL_STATE=FAILED_AUTHORITY_ABORT` or installer exit code `3`. Canonical machine-readable surfaces unchanged.

## References

- Scope doc: `AUDIT_190_LIFECYCLE/V126_2_INSTALL_ABORT_UX_HOTFIX_SCOPE.md` (REV 4 + REV 4 IMPLEMENTATION AMENDMENT)
- Related design lanes (filed earlier today): `D_TAKEOVER_PATH_RETROACTIVE_DISARM_GAP_SCOPE.md`, `D_DETECTOR_OPTION_A_CSF_CONF_GAP_SCOPE.md`, `D_CLI_FIREWALL_CONFLICTS_UNBOUND_VAR_REENTRY_SCOPE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)