### PR TITLE
fix(cli): add v1.127 UX-2 well-known infrastructure ban/search guard

### DIFF
--- a/cli/lib/nftban/cli/cmd_ban.sh
+++ b/cli/lib/nftban/cli/cmd_ban.sh
@@ -152,6 +152,42 @@ nftban_cmd_ban() {
     cmd_require_arg "$ip" "IP address" "$json_mode" nftban_cmd_ban_usage || return 1
     cmd_validate_ip "$ip" "$json_mode" nftban_cmd_ban_usage || return 1
 
+    # V127 UX-2 item 1.7: well-known public infrastructure IP guard.
+    # Banning addresses like 8.8.8.8 / 1.1.1.1 / 9.9.9.9 / 208.67.222.222 produces
+    # no security benefit on a typical host and disrupts legitimate name resolution
+    # for the operator's users. Refuse unless --yes (auto_confirm) is set explicitly.
+    # Dry-run path is allowed unconditionally (no mutation) so operators can preview
+    # what the guard would do. JSON mode emits a structured refusal with success=false.
+    # Helper: cli/lib/nftban/lib/nftban_well_known.sh (inline IP map; no /etc/nftban/
+    # fixture; no package payload registration).
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-2 item 1.7)
+    if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" 2>/dev/null || true
+        if declare -f nftban_is_well_known_infra_ip >/dev/null 2>&1; then
+            local _wk_descr
+            if _wk_descr=$(nftban_is_well_known_infra_ip "$ip"); then
+                if [[ "$auto_confirm" != "true" && "$dry_run" != "true" ]]; then
+                    if [[ "$json_mode" == "true" ]] && declare -f json_output >/dev/null 2>&1; then
+                        json_output "false" '{}' "Refused: ${ip} is well-known public infrastructure (${_wk_descr}). Re-run with --yes to override."
+                    else
+                        nftban_well_known_warn_block "$ip" stderr
+                    fi
+                    return 1
+                fi
+                # Explicit override path: log the override + proceed.
+                if [[ "$auto_confirm" == "true" ]]; then
+                    if [[ "$json_mode" != "true" ]]; then
+                        echo "[!] Well-known infrastructure override accepted: ${ip} (${_wk_descr})" >&2
+                        echo "    Proceeding under explicit --yes confirmation." >&2
+                    fi
+                fi
+                # Dry-run path falls through to the dry-run preview block below;
+                # nothing is mutated either way.
+            fi
+        fi
+    fi
+
     # v1.18.8: Check if IP is whitelisted - warn user before banning
     local whitelist_set
     if [[ "$ip" =~ : ]]; then

--- a/cli/lib/nftban/cli/cmd_search.sh
+++ b/cli/lib/nftban/cli/cmd_search.sh
@@ -626,7 +626,34 @@ _suggest_actions() {
     local ip="$1"
     local is_banned="$2"
 
+    # V127 UX-2 item 3.2: if the searched IP is well-known public infrastructure
+    # (Cloudflare/Google/Quad9/OpenDNS DNS resolver), prepend an advisory note to
+    # the Quick Actions block so the operator sees the same warning here as they
+    # would on `nftban ban` (cmd_ban.sh UX-2 item 1.7). The advisory is purely
+    # informational on this surface — `nftban search` does not mutate anything.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-2 item 3.2)
+    local _wk_search_descr=""
+    if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" 2>/dev/null || true
+        if declare -f nftban_is_well_known_infra_ip >/dev/null 2>&1; then
+            _wk_search_descr=$(nftban_is_well_known_infra_ip "$ip" 2>/dev/null) || _wk_search_descr=""
+        fi
+    fi
+
     echo ""
+    if [[ -n "$_wk_search_descr" ]]; then
+        echo "⚠️  Advisory: ${ip} is well-known public infrastructure"
+        echo "───────────────────────────────────────────────────────────────"
+        echo "  ${_wk_search_descr}"
+        echo ""
+        echo "  Banning this address typically disrupts legitimate traffic for"
+        echo "  the protected network without providing a security benefit."
+        echo "  If you intend to ban it anyway, nftban ban will require an"
+        echo "  explicit --yes override:"
+        echo "    nftban ban ${ip} --yes"
+        echo ""
+    fi
     echo "💡 Quick Actions:"
     echo "───────────────────────────────────────────────────────────────"
 

--- a/cli/lib/nftban/lib/nftban_well_known.sh
+++ b/cli/lib/nftban/lib/nftban_well_known.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.127 - Well-known infrastructure IP advisory library
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_well_known"
+# meta:type="lib"
+# meta:version="1.127.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="V127 UX-2 lane: shared helper that identifies well-known public infrastructure IPs (major DNS resolvers from Cloudflare/Google/Quad9/OpenDNS). Used by cmd_ban.sh and cmd_search.sh to surface an advisory + require explicit --yes override before mutating such addresses. Inline list (NO /etc/nftban/ fixture and NO package payload registration) to honor operator constraint that UX-2 must not change packaging behavior. Categories covered: IPv4 + IPv6 anycast resolvers from the 4 most-recognized providers. Out of scope for this initial cut: CIDR matching (treats inputs as exact-match keys), Quad9-secondary unicast, regional anycast variants, CDN edge prefixes (Cloudflare/Akamai/CloudFront IP ranges — those belong to the trust-provider pipeline, not this advisory)."
+# meta:input="IP address (string) via nftban_is_well_known_infra_ip <ip>"
+# meta:output="rc=0 if well-known (provider name to stdout); rc=1 if not well-known (no output)"
+# meta:depends="bash"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-2 lane)
+# =============================================================================
+
+set -Eeuo pipefail
+
+# Prevent double-loading
+[[ -n "${NFTBAN_WELL_KNOWN_LOADED:-}" ]] && return 0
+
+# =============================================================================
+# WELL-KNOWN INFRASTRUCTURE IP MAP
+# =============================================================================
+# Inline associative map: IP -> "provider | description".
+# Exact-match only (no CIDR expansion in v1.127.0 — see meta:description
+# above for rationale). Future lanes can add CIDR matching if operator scope
+# changes.
+#
+# Curation principle: include ONLY addresses where banning would
+# (a) likely produce no security benefit on a typical end-user host AND
+# (b) have a high probability of disrupting legitimate name-resolution or
+# similar critical infrastructure-class traffic for the operator's users.
+# This list is INTENTIONALLY conservative — it is NOT a substitute for the
+# trust-provider whitelist mechanism (CDN edge prefixes etc.).
+declare -gA _NFTBAN_WELL_KNOWN_IPS=(
+    # Cloudflare 1.1.1.1 family (https://1.1.1.1)
+    ["1.1.1.1"]="Cloudflare | public DNS resolver (1.1.1.1)"
+    ["1.0.0.1"]="Cloudflare | public DNS resolver (1.0.0.1, secondary)"
+    ["2606:4700:4700::1111"]="Cloudflare | public DNS resolver (IPv6 primary)"
+    ["2606:4700:4700::1001"]="Cloudflare | public DNS resolver (IPv6 secondary)"
+
+    # Google Public DNS (https://developers.google.com/speed/public-dns)
+    ["8.8.8.8"]="Google | public DNS resolver (8.8.8.8)"
+    ["8.8.4.4"]="Google | public DNS resolver (8.8.4.4, secondary)"
+    ["2001:4860:4860::8888"]="Google | public DNS resolver (IPv6 primary)"
+    ["2001:4860:4860::8844"]="Google | public DNS resolver (IPv6 secondary)"
+
+    # Quad9 (https://www.quad9.net)
+    ["9.9.9.9"]="Quad9 | public DNS resolver with malware filtering (primary)"
+    ["149.112.112.112"]="Quad9 | public DNS resolver (secondary)"
+    ["2620:fe::fe"]="Quad9 | public DNS resolver (IPv6 primary)"
+    ["2620:fe::9"]="Quad9 | public DNS resolver (IPv6 secondary)"
+
+    # Cisco/OpenDNS (https://www.opendns.com)
+    ["208.67.222.222"]="Cisco/OpenDNS | public DNS resolver (primary)"
+    ["208.67.220.220"]="Cisco/OpenDNS | public DNS resolver (secondary)"
+    ["2620:119:35::35"]="Cisco/OpenDNS | public DNS resolver (IPv6 primary)"
+    ["2620:119:53::53"]="Cisco/OpenDNS | public DNS resolver (IPv6 secondary)"
+)
+readonly _NFTBAN_WELL_KNOWN_IPS
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+# nftban_is_well_known_infra_ip <ip>
+# Returns 0 if the given IP is in the well-known infrastructure map and prints
+# "provider | description" to stdout. Returns 1 otherwise (no output).
+# Exact match only; no CIDR expansion.
+nftban_is_well_known_infra_ip() {
+    local ip="${1:-}"
+    [[ -z "$ip" ]] && return 1
+
+    # Strip any IPv4-in-IPv6 prefix for matching (operator might pass ::ffff:8.8.8.8)
+    local lookup_ip="$ip"
+    lookup_ip="${lookup_ip#::ffff:}"
+
+    if [[ -n "${_NFTBAN_WELL_KNOWN_IPS[$lookup_ip]:-}" ]]; then
+        printf '%s\n' "${_NFTBAN_WELL_KNOWN_IPS[$lookup_ip]}"
+        return 0
+    fi
+    return 1
+}
+
+# nftban_well_known_provider <ip>
+# Returns just the provider name (e.g., "Cloudflare") for a well-known IP.
+# Returns 1 if not well-known (no output).
+nftban_well_known_provider() {
+    local ip="${1:-}"
+    local descr
+    if descr=$(nftban_is_well_known_infra_ip "$ip"); then
+        printf '%s\n' "${descr%% |*}"
+        return 0
+    fi
+    return 1
+}
+
+# nftban_well_known_warn_block <ip> [stream]
+# Emits the standard operator-facing advisory block for a well-known IP.
+# Default stream is stderr (intended for cmd_ban.sh refusal path); pass "stdout"
+# to send to stdout (intended for cmd_search.sh Quick Actions advisory).
+# Caller is responsible for the surrounding context (header, action items).
+nftban_well_known_warn_block() {
+    local ip="${1:-}"
+    local stream="${2:-stderr}"
+    local descr provider
+    descr=$(nftban_is_well_known_infra_ip "$ip") || return 1
+    provider="${descr%% |*}"
+
+    local lines=(
+        "[!] Well-known public infrastructure detected: ${ip}"
+        "    ${descr}"
+        ""
+        "    Banning this address would not stop attacker traffic — the IP belongs"
+        "    to a public service operating millions of legitimate queries. Banning"
+        "    it on this host typically disrupts name-resolution or similar critical"
+        "    infrastructure for users on the protected network without providing"
+        "    a meaningful security benefit."
+        ""
+        "    If you genuinely want to proceed (e.g., for a controlled lab test or"
+        "    a documented compliance scenario), re-run the command with --yes:"
+        ""
+        "        nftban ban ${ip} --yes [--timeout SECONDS]"
+        ""
+        "    Provider docs:  consult ${provider} public-resolver documentation"
+        "                    for the canonical IP list before overriding."
+    )
+
+    if [[ "$stream" == "stdout" ]]; then
+        printf '%s\n' "${lines[@]}"
+    else
+        printf '%s\n' "${lines[@]}" >&2
+    fi
+}
+
+# =============================================================================
+# EXPORTS
+# =============================================================================
+
+export -f nftban_is_well_known_infra_ip
+export -f nftban_well_known_provider
+export -f nftban_well_known_warn_block
+
+# =============================================================================
+# MARK AS LOADED
+# =============================================================================
+
+readonly NFTBAN_WELL_KNOWN_LOADED=1
+export NFTBAN_WELL_KNOWN_LOADED

--- a/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
+++ b/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V127 UX-2 well-known infrastructure guard — deterministic test fixtures
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v127_ux2_well_known_test"
+# meta:type="test"
+# meta:version="1.127.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic shell tests for V127 UX-2 lane (PR-B). Covers item 1.7 (nftban ban well-known IP guard with --yes override) and item 3.2 (nftban search advisory). Helper-library tests verify the inline well-known IP map: positive cases for Cloudflare 1.1.1.1, Google 8.8.8.8, Quad9 9.9.9.9, OpenDNS 208.67.222.222 + IPv6 variants 2606:4700:4700::1111 and 2001:4860:4860::8888; negative cases for TEST-NET 192.0.2.1 and 198.51.100.1 + documentation-prefix 2001:db8::1. cmd_ban.sh + cmd_search.sh integration assertions are code-pattern grep (full runtime behavior validation deferred to lab2/lab4 per umbrella scope §6)."
+# meta:input="self-contained; sources nftban_well_known.sh in a subshell with strict mode tolerated"
+# meta:output="t.Fatal-style stderr + exit 1 on first failed assertion; exit 0 if all UX-2 items pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-2 lane)
+# =============================================================================
+
+set -Eeuo pipefail
+# Test harness intentionally continues past individual assertion failures.
+set +e
+
+# Test harness ----------------------------------------------------------------
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+# Locate the repo root (the test may be run from various working directories)
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+export NFTBAN_LIB_DIR="${_repo_root}/cli/lib/nftban"
+
+_helper_lib="${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh"
+_ban_cli="${NFTBAN_LIB_DIR}/cli/cmd_ban.sh"
+_search_cli="${NFTBAN_LIB_DIR}/cli/cmd_search.sh"
+
+echo "==============================================================================="
+echo "V127 UX-2 well-known infrastructure guard — deterministic test fixtures"
+echo "==============================================================================="
+echo "  Repo root:    $_repo_root"
+echo "  Helper:       $_helper_lib"
+echo
+
+# =============================================================================
+# HELPER LIBRARY — IP map correctness
+# =============================================================================
+echo "[helper] nftban_well_known.sh — IP map + helper function"
+
+if [[ ! -f "$_helper_lib" ]]; then
+    _t_assert "helper lib exists" 1 "$_helper_lib not found"
+else
+    _t_assert "helper lib exists" 0
+fi
+
+# Positive cases (well-known IPs — must match)
+for ip in 1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 9.9.9.9 149.112.112.112 208.67.222.222 208.67.220.220; do
+    rc=0
+    out=$(bash -c "source '$_helper_lib' && nftban_is_well_known_infra_ip '$ip'") || rc=$?
+    if [[ "$rc" == "0" && -n "$out" ]]; then
+        _t_assert "helper recognizes IPv4 $ip" 0
+    else
+        _t_assert "helper recognizes IPv4 $ip" 1 "rc=$rc out=[$out]"
+    fi
+done
+
+# Positive cases — IPv6
+for ip in '2606:4700:4700::1111' '2001:4860:4860::8888' '2620:fe::fe' '2620:119:35::35'; do
+    rc=0
+    out=$(bash -c "source '$_helper_lib' && nftban_is_well_known_infra_ip '$ip'") || rc=$?
+    if [[ "$rc" == "0" && -n "$out" ]]; then
+        _t_assert "helper recognizes IPv6 $ip" 0
+    else
+        _t_assert "helper recognizes IPv6 $ip" 1 "rc=$rc out=[$out]"
+    fi
+done
+
+# Negative cases (TEST-NET + documentation prefix — must NOT match)
+for ip in 192.0.2.1 198.51.100.1 203.0.113.1 '2001:db8::1' 10.0.0.1 192.168.1.1; do
+    rc=0
+    out=$(bash -c "source '$_helper_lib' && nftban_is_well_known_infra_ip '$ip'") || rc=$?
+    if [[ "$rc" != "0" && -z "$out" ]]; then
+        _t_assert "helper rejects non-well-known $ip" 0
+    else
+        _t_assert "helper rejects non-well-known $ip" 1 "rc=$rc out=[$out] (should be rc=1 + empty)"
+    fi
+done
+
+# Provider name extraction
+prov=$(bash -c "source '$_helper_lib' && nftban_well_known_provider '1.1.1.1'" 2>/dev/null || echo "")
+if [[ "$prov" == "Cloudflare" ]]; then
+    _t_assert "provider extraction for 1.1.1.1 returns 'Cloudflare'" 0
+else
+    _t_assert "provider extraction for 1.1.1.1 returns 'Cloudflare'" 1 "got [$prov]"
+fi
+
+prov=$(bash -c "source '$_helper_lib' && nftban_well_known_provider '8.8.8.8'" 2>/dev/null || echo "")
+if [[ "$prov" == "Google" ]]; then
+    _t_assert "provider extraction for 8.8.8.8 returns 'Google'" 0
+else
+    _t_assert "provider extraction for 8.8.8.8 returns 'Google'" 1 "got [$prov]"
+fi
+
+# Empty input + nonsense input must not match
+rc=0
+bash -c "source '$_helper_lib' && nftban_is_well_known_infra_ip ''" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" != "0" ]]; then
+    _t_assert "helper rejects empty input" 0
+else
+    _t_assert "helper rejects empty input" 1 "rc=0 means empty matched"
+fi
+
+rc=0
+bash -c "source '$_helper_lib' && nftban_is_well_known_infra_ip 'not-an-ip'" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" != "0" ]]; then
+    _t_assert "helper rejects 'not-an-ip' string" 0
+else
+    _t_assert "helper rejects 'not-an-ip' string" 1 "rc=0 means garbage matched"
+fi
+
+# Warn-block output goes to stderr by default; switches to stdout on demand
+out_stderr=$(bash -c "source '$_helper_lib' && nftban_well_known_warn_block '8.8.8.8' 2>&1 >/dev/null")
+if grep -q "Well-known public infrastructure detected: 8.8.8.8" <<< "$out_stderr"; then
+    _t_assert "warn_block default goes to stderr" 0
+else
+    _t_assert "warn_block default goes to stderr" 1 "expected stderr line not found"
+fi
+
+out_stdout=$(bash -c "source '$_helper_lib' && nftban_well_known_warn_block '8.8.8.8' stdout 2>/dev/null")
+if grep -q "Well-known public infrastructure detected: 8.8.8.8" <<< "$out_stdout"; then
+    _t_assert "warn_block stdout-mode goes to stdout" 0
+else
+    _t_assert "warn_block stdout-mode goes to stdout" 1 "expected stdout line not found"
+fi
+echo
+
+# =============================================================================
+# ITEM 1.7 — cmd_ban.sh well-known guard (code-pattern assertions)
+# =============================================================================
+echo "[1.7] cmd_ban.sh well-known infrastructure guard"
+
+if grep -q 'V127 UX-2 item 1.7' "$_ban_cli"; then
+    _t_assert "1.7 cmd_ban.sh contains UX-2 guard block" 0
+else
+    _t_assert "1.7 cmd_ban.sh contains UX-2 guard block" 1 "comment anchor missing"
+fi
+
+if grep -q 'nftban_is_well_known_infra_ip' "$_ban_cli"; then
+    _t_assert "1.7 cmd_ban.sh calls helper function" 0
+else
+    _t_assert "1.7 cmd_ban.sh calls helper function" 1 "helper call missing"
+fi
+
+if grep -q '"\$auto_confirm" != "true" && "\$dry_run" != "true"' "$_ban_cli"; then
+    _t_assert "1.7 guard refuses unless --yes (auto_confirm) OR --dry-run" 0
+else
+    _t_assert "1.7 guard refuses unless --yes (auto_confirm) OR --dry-run" 1 "conditional pattern missing"
+fi
+
+if grep -q 'override accepted' "$_ban_cli"; then
+    _t_assert "1.7 explicit --yes path logs override acknowledgement" 0
+else
+    _t_assert "1.7 explicit --yes path logs override acknowledgement" 1 "override-acknowledgement missing"
+fi
+
+# JSON mode emits structured refusal
+if grep -q 'json_output "false".*Refused.*well-known' "$_ban_cli"; then
+    _t_assert "1.7 JSON mode emits structured refusal" 0
+else
+    _t_assert "1.7 JSON mode emits structured refusal" 1 "json refusal pattern missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 3.2 — cmd_search.sh Quick Actions advisory
+# =============================================================================
+echo "[3.2] cmd_search.sh Quick Actions advisory"
+
+if grep -q 'V127 UX-2 item 3.2' "$_search_cli"; then
+    _t_assert "3.2 cmd_search.sh contains UX-2 advisory block" 0
+else
+    _t_assert "3.2 cmd_search.sh contains UX-2 advisory block" 1 "comment anchor missing"
+fi
+
+if grep -q 'nftban_is_well_known_infra_ip' "$_search_cli"; then
+    _t_assert "3.2 cmd_search.sh calls helper function" 0
+else
+    _t_assert "3.2 cmd_search.sh calls helper function" 1 "helper call missing"
+fi
+
+if grep -q 'well-known public infrastructure' "$_search_cli"; then
+    _t_assert "3.2 advisory text present in cmd_search.sh" 0
+else
+    _t_assert "3.2 advisory text present in cmd_search.sh" 1 "advisory phrase missing"
+fi
+
+# Advisory appears BEFORE the Quick Actions header
+# (so the operator reads warning context first, then the ban suggestion)
+if awk '/V127 UX-2 item 3\.2/{found_advisory=1} /💡 Quick Actions:/{if(found_advisory){print "OK"; exit 0}}' "$_search_cli" | grep -q OK; then
+    _t_assert "3.2 advisory positioned BEFORE Quick Actions header" 0
+else
+    _t_assert "3.2 advisory positioned BEFORE Quick Actions header" 1 "ordering wrong"
+fi
+echo
+
+# =============================================================================
+# OUT-OF-SCOPE GUARD — no UX-3..UX-6 surfaces touched
+# =============================================================================
+echo "[scope-creep guard] UX-3..UX-6 keywords absent from UX-2 diff"
+
+# Verify the new helper does NOT contain anything that would belong to other lanes
+for unwanted_pattern in "stats.*BLC" "RESYNC" "suricata.*desurface" "levenshtein" "Ctrl+C" "edit_distance"; do
+    if grep -qiE "$unwanted_pattern" "$_helper_lib" 2>/dev/null; then
+        _t_assert "scope-creep: '$unwanted_pattern' absent from helper" 1 "found scope-creep keyword"
+    else
+        _t_assert "scope-creep: '$unwanted_pattern' absent from helper" 0
+    fi
+done
+echo
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo "==============================================================================="
+echo "V127 UX-2 test summary: ${TESTS_PASSED} PASS, ${TESTS_FAILED} FAIL"
+echo "==============================================================================="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "FAILED tests:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "  - $n"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

**PR-B of the V127 full UX correction release train.** Adds an operator-safety guard that requires explicit `--yes` override when banning well-known public DNS resolver IPs, plus an informational advisory on `nftban search`. Closes 2 audit defects:

- **1.7** `nftban ban <well-known-IP>` exits nonzero with warning unless `--yes`
- **3.2** `nftban search <well-known-IP>` Quick Actions includes advisory

Scope reference: `AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md` (UX-2 lane)

## Changed-file inventory

```
+  cli/lib/nftban/lib/nftban_well_known.sh           NEW    ~140 lines  helper library
M  cli/lib/nftban/cli/cmd_ban.sh                     +36/-0             item 1.7 guard
M  cli/lib/nftban/cli/cmd_search.sh                  +27/-0             item 3.2 advisory
+  cli/lib/nftban/tests/v127_ux2_well_known_test.sh  NEW    ~270 lines  40 deterministic assertions
```

Total: **4 files / +475 / -0**. Each anchor includes `V127 UX-2 item X.Y` + scope reference.

## Behavior

| Command | Behavior |
|---|---|
| `nftban search 8.8.8.8` | Advisory block ("⚠️ Advisory: ... well-known public infrastructure") prepended BEFORE Quick Actions header. Action items still shown. |
| `nftban ban 8.8.8.8` (no `--yes`) | Exits 1; multi-line stderr warning. No mutation. JSON: `{"success":false,"message":"Refused: 8.8.8.8 is well-known ..."}` |
| `nftban ban 8.8.8.8 --yes` | Proceeds. Stderr ack: `[!] Well-known infrastructure override accepted: 8.8.8.8 (Google | ...)`. Normal ban flow. |
| `nftban ban 8.8.8.8 --dry-run` | Dry-run preview unconditional (no mutation). Guard does NOT refuse dry-run. |
| `nftban ban 8.8.8.8 --yes --dry-run` | Dry-run preview + override-accepted message visible. Still no mutation. |
| `nftban ban 1.1.1.1` | Same refusal pattern (Cloudflare). |
| `nftban ban 192.0.2.1` | Normal flow (TEST-NET not in well-known list). |

## Well-known IP map (inline; 16 addresses, 4 providers)

| Provider | IPv4 | IPv6 |
|---|---|---|
| **Cloudflare** | 1.1.1.1, 1.0.0.1 | 2606:4700:4700::1111, 2606:4700:4700::1001 |
| **Google** | 8.8.8.8, 8.8.4.4 | 2001:4860:4860::8888, 2001:4860:4860::8844 |
| **Quad9** | 9.9.9.9, 149.112.112.112 | 2620:fe::fe, 2620:fe::9 |
| **Cisco/OpenDNS** | 208.67.222.222, 208.67.220.220 | 2620:119:35::35, 2620:119:53::53 |

Exact-match only (no CIDR expansion in v1.127.0). Curation principle: conservative — only addresses where banning would (a) produce no security benefit on a typical end-user host AND (b) have a high probability of disrupting legitimate name-resolution for users on the protected network. **Not a substitute for the trust-provider whitelist mechanism** (CDN edge prefixes etc. — those remain in the trust-provider lane).

**No `/etc/nftban/` fixture file** — inline IP map avoids any package payload registration (per operator UX-2 constraint).

## Tests run

```
V127 UX-2 test summary: 40 PASS, 0 FAIL ✅
```

Breakdown:
- Helper IP map: 12 positive (8 IPv4 + 4 IPv6) + 6 negative (TEST-NET, docs prefix, RFC1918, empty, garbage) + 2 provider extraction + 2 warn_block stream-routing
- Item 1.7 (cmd_ban): 5 code-pattern assertions
- Item 3.2 (cmd_search): 4 code-pattern assertions
- Scope-creep guard: 6 keyword absence checks

Local run: `bash cli/lib/nftban/tests/v127_ux2_well_known_test.sh`

## Binary-impact statement

**Daemon binary streak: 17 → 18 PRESERVED** ✅

```
Forbidden surfaces touched: 0
  cmd/nftban-core/      → 0  ✅
  cmd/nftband/          → 0  ✅
  internal/             → 0  ✅
  cmd/nftban-installer/ → 0  ✅
  packaging/            → 0  ✅  (inline IP map; no payload registration)
  install/systemd/      → 0  ✅
```

UX-2 lane is shell-only. The 18-release identical-daemon-binary streak (v1.114.0 → v1.127.0-pre-UX-2) is preserved through this lane.

## Out-of-scope confirmation

```
✅ NO UX-3 stats / banlog changes
✅ NO UX-4 Suricata de-surfacing
✅ NO UX-5 typo handler rewrite
✅ NO UX-6 broad help-system cleanup
✅ NO detector / planner / takeover semantic changes
✅ NO schema/metrics/portal/polkit/systemd/package behavior changes
✅ NO new /etc/nftban/ fixture (inline map satisfies operator constraint)
✅ NO host contact during implementation
✅ NO release/tag/publish
```

## Validation policy (operator-amended 2026-05-24)

Per `AUDIT_190_LIFECYCLE/V127_UX_VALIDATION_POLICY_AMENDED.md` (gate `AMEND_V127_UX_VALIDATION_POLICY = GO`):

- ✅ Per-lane lab2/lab4 runtime validation **WAIVED** for UX-1 through UX-6
- ✅ Recorded: `VALIDATION_SKIPPED_PER_UX_LANE_OPERATOR_ACCEPTED_RISK`
- ✅ Replaced by: per-PR CI green + deterministic tests + diff/scope/forbidden checks
- ⏳ Final consolidated lab validation deferred to `EXECUTE_V127_FINAL_CONSOLIDATED_LAB_VALIDATION = GO` after all UX lanes land

This PR satisfies the new policy fully (40/40 tests + clean diff/scope/forbidden). Awaiting CI green for merge.

## Test plan

- [x] Helper library tests (40 assertions, IPv4 + IPv6 + edge cases + provider extraction + stream routing)
- [x] `git diff --check` — clean
- [x] Forbidden-path guard — 0 surfaces touched
- [x] Scope-creep guard — 0 UX-3..UX-6 keywords (helper file)
- [x] Header validation passed (4 files)
- [ ] CI green on push (populated automatically on PR open)

## Sequencing note

Per umbrella scope §8.2 + operator validation policy: **PR-A (UX-1) merged first** ✅ at `5d14ba6e`. PR-B (this PR) is the second of six UX lanes. PR-C (UX-3 stats+banlog) may follow but requires explicit operator decision because it's the candidate streak-breaker per umbrella §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)