### PR TITLE
fix(cli): V127 UX-3 — converge stats + banlog output (Option A)

### DIFF
--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -80,8 +80,16 @@ nftban_stats_generate_dashboard() {
     printf "  %-20s %s\n" "Hostname............" "$(hostname)"
     printf "  %-20s %s → %s\n" "Period.............." "$since" "$until"
     printf "  %-20s %s\n" "Generated..........." "$(date '+%Y-%m-%d %H:%M:%S')"
+    # V127 UX-3 item 2.3: always print a Data source label so operators know which
+    # provenance produced the dashboard. Pre-V127 this line was emitted ONLY when
+    # use_unified_cache=true; the fallback path ran silently, so operators reading
+    # `nftban stats` could not tell whether they were seeing canonical aggregated
+    # values or derived live-aggregation values from the awk fallback.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.3)
     if [[ "$use_unified_cache" == "true" ]]; then
         printf "  %-20s %s\n" "Data source........." "unified cache"
+    else
+        printf "  %-20s %s\n" "Data source........." "DERIVED (cache miss; live aggregation from nftables + bans.log)"
     fi
     echo ""
 
@@ -131,10 +139,15 @@ nftban_stats_generate_dashboard() {
 
     # ─────────────────────────────────────────────────────────────────────
     # FIREWALL (CURRENT)
+    # V127 UX-3 items 2.1/3.1: explicitly label the line item as live-kernel
+    # so it cannot be confused with the BANS BY MODULE (cumulative cache) block
+    # below. Pre-V127 the section header alone was the only disambiguation;
+    # operators reading the line in isolation could not tell the semantic.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 items 2.1/3.1)
     # ─────────────────────────────────────────────────────────────────────
     echo "FIREWALL (CURRENT)"
     echo "───────────────────────────────────────────────────────────"
-    printf "  %-20s %s\n" "Blocked IPs........." "$total_black"
+    printf "  %-20s %s\n" "Blocked IPs (live).." "$total_black"
     printf "  %-20s %s\n" "Whitelisted........." "$whitelist_count"
     echo ""
 
@@ -342,8 +355,20 @@ nftban_stats_generate_dashboard() {
 
     # ─────────────────────────────────────────────────────────────────────
     # BANS BY MODULE (SINGLE SOURCE OF TRUTH from unified cache)
+    # V127 UX-3 items 2.1/3.1: explicit "(cumulative)" header disambiguation
+    # so the operator reading this section cannot confuse the cumulative
+    # ban-counts-per-module values with the live-kernel "Blocked IPs (live)"
+    # value in the FIREWALL (CURRENT) section above. The two are semantically
+    # distinct: live-kernel = "what's actively blocking traffic right now"
+    # vs cumulative = "how many ban events did each module produce since
+    # the cache window started".
+    # V127 UX-3 item 2.2: module-label standardization is already in compliance
+    # via the canonical 5-key set used below (login / portscan / ddos / manual /
+    # feeds). The awk fallback at lines ~375-379 also normalizes variants
+    # (loginmon→login, cli→manual, feed→feeds) before display.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 items 2.1/3.1 + 2.2)
     # ─────────────────────────────────────────────────────────────────────
-    echo "BANS BY MODULE"
+    echo "BANS BY MODULE (cumulative)"
     echo "───────────────────────────────────────────────────────────"
 
     local feeds_total=0 login_count=0 portscan_count=0 ddos_count=0 manual_count=0 suricata_count=0

--- a/cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh
+++ b/cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V127 UX-3 stats + banlog — deterministic test fixtures
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v127_ux3_stats_banlog_test"
+# meta:type="test"
+# meta:version="1.127.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic shell tests for V127 UX-3 lane (PR-C). Covers items 2.1/3.1 (stats label disambiguation: Blocked IPs (live) vs BANS BY MODULE (cumulative)), 2.2 (canonical 5-label module set in awk normalizer), 2.3 (Data source: DERIVED fallback label when unified cache missing), 2.5 (RESYNC marker via banlog.LogResync and STATUS=RESYNC + CLASS=resync constants in banlog.go), 2.6 (ban success footer source/set/total breakdown in cmd_ban.go). Go-side BLC-1 convergence regression guard for item 2.4 is in internal/escalation/tracker_blc1_test.go (Go test; runs via go test ./internal/escalation/...). Full runtime behavior of stats commands deferred to V127 final consolidated lab validation per V127_UX_VALIDATION_POLICY_AMENDED.md."
+# meta:input="static source-file inspection via grep code-pattern assertions"
+# meta:output="exit 0 if all assertions pass; exit 1 with FAILED tests list otherwise"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-3 lane)
+# =============================================================================
+
+set -Eeuo pipefail
+# Continue past individual assertion failures
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_stats_format="${_repo_root}/cli/lib/nftban/core/nftban_stats_format.sh"
+_banlog_go="${_repo_root}/internal/banlog/banlog.go"
+_tracker_go="${_repo_root}/internal/escalation/tracker.go"
+_cmd_ban_go="${_repo_root}/cmd/nftban-core/cmd_ban.go"
+
+echo "==============================================================================="
+echo "V127 UX-3 stats + banlog — deterministic test fixtures"
+echo "==============================================================================="
+echo "  Repo root:  $_repo_root"
+echo
+
+# =============================================================================
+# ITEMS 2.1 / 3.1 — stats label disambiguation
+# =============================================================================
+echo "[2.1/3.1] stats label disambiguation (live vs cumulative)"
+
+# Blocked IPs line: must say "(live)" so the value cannot be confused with
+# the BANS BY MODULE cumulative values
+if grep -q 'Blocked IPs (live)' "$_stats_format"; then
+    _t_assert "2.1/3.1 Blocked IPs row labeled '(live)'" 0
+else
+    _t_assert "2.1/3.1 Blocked IPs row labeled '(live)'" 1 "missing '(live)' qualifier"
+fi
+
+# BANS BY MODULE header: must say "(cumulative)"
+if grep -q 'echo "BANS BY MODULE (cumulative)"' "$_stats_format"; then
+    _t_assert "2.1/3.1 BANS BY MODULE header labeled '(cumulative)'" 0
+else
+    _t_assert "2.1/3.1 BANS BY MODULE header labeled '(cumulative)'" 1 "missing '(cumulative)' qualifier"
+fi
+
+# The V127 anchor comment must be present
+if grep -q 'V127 UX-3 items 2.1/3.1' "$_stats_format"; then
+    _t_assert "2.1/3.1 scope-anchor comment present" 0
+else
+    _t_assert "2.1/3.1 scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 2.2 — canonical module labels (login/portscan/ddos/manual/feeds)
+# =============================================================================
+echo "[2.2] canonical 5-label module set in awk fallback normalizer"
+
+# The awk normalizer at the fallback path must produce the canonical 5 labels.
+# Pre-V127 the labels were already mostly correct (per audit §2.2: "needs
+# standardization to login, portscan, ddos, manual, feeds"). The test verifies
+# all 5 are present in the source AND the normalizer reduces variants to them.
+for canonical in 'sources\[ip\]="login"' 'sources\[ip\]="portscan"' 'sources\[ip\]="ddos"' 'sources\[ip\]="manual"' 'sources\[ip\]="feeds"'; do
+    if grep -q "$canonical" "$_stats_format"; then
+        _t_assert "2.2 awk normalizer emits canonical label: $canonical" 0
+    else
+        _t_assert "2.2 awk normalizer emits canonical label: $canonical" 1 "missing"
+    fi
+done
+
+# Verify the V127 comment notes label compliance
+if grep -q 'V127 UX-3 item 2.2' "$_stats_format"; then
+    _t_assert "2.2 scope-anchor comment present" 0
+else
+    _t_assert "2.2 scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 2.3 — Data source: DERIVED fallback label
+# =============================================================================
+echo "[2.3] Data source: DERIVED label on cache-miss fallback"
+
+# The else branch of the use_unified_cache check must emit a DERIVED label
+if grep -qE 'Data source\.\.\.\.\.\.\.\.\." "DERIVED' "$_stats_format"; then
+    _t_assert "2.3 fallback path emits 'Data source: DERIVED'" 0
+else
+    _t_assert "2.3 fallback path emits 'Data source: DERIVED'" 1 "DERIVED label missing"
+fi
+
+# Must explain the reason briefly
+if grep -q 'cache miss' "$_stats_format"; then
+    _t_assert "2.3 DERIVED label includes 'cache miss' explanation" 0
+else
+    _t_assert "2.3 DERIVED label includes 'cache miss' explanation" 1 "explanation missing"
+fi
+
+# V127 anchor
+if grep -q 'V127 UX-3 item 2.3' "$_stats_format"; then
+    _t_assert "2.3 scope-anchor comment present" 0
+else
+    _t_assert "2.3 scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 2.4 — banlog dual-writer convergence (Go side; main check in Go test)
+# =============================================================================
+echo "[2.4] LogTempBan A1 facade convergence (shell-side verification)"
+
+# Shell-side verification that the Go file no longer contains the legacy
+# space-delimited format string. Full assertion battery is in
+# internal/escalation/tracker_blc1_test.go (Go test).
+
+if grep -q '"%s %s %s %s\\\\n"' "$_tracker_go"; then
+    _t_assert "2.4 legacy space-delimited format pattern absent from tracker.go" 1 "legacy pattern still present"
+else
+    _t_assert "2.4 legacy space-delimited format pattern absent from tracker.go" 0
+fi
+
+if grep -q 'banlog.LogBanFull' "$_tracker_go"; then
+    _t_assert "2.4 tracker.go delegates to banlog.LogBanFull" 0
+else
+    _t_assert "2.4 tracker.go delegates to banlog.LogBanFull" 1 "delegation missing"
+fi
+
+if grep -q 'V127 UX-3 item 2.4' "$_tracker_go"; then
+    _t_assert "2.4 scope-anchor comment present" 0
+else
+    _t_assert "2.4 scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 2.5 — RESYNC marker (banlog constants + cmd_ban.go emission)
+# =============================================================================
+echo "[2.5] RESYNC marker (STATUS=RESYNC + CLASS=resync + emission)"
+
+# banlog.go: must define StatusResync constant
+if grep -q 'StatusResync   = "RESYNC"' "$_banlog_go" || grep -q 'StatusResync = "RESYNC"' "$_banlog_go"; then
+    _t_assert "2.5 banlog.go defines StatusResync = \"RESYNC\"" 0
+else
+    _t_assert "2.5 banlog.go defines StatusResync = \"RESYNC\"" 1 "constant missing or named differently"
+fi
+
+# banlog.go: must define ClassResync constant
+if grep -q 'ClassResync = "resync"' "$_banlog_go"; then
+    _t_assert "2.5 banlog.go defines ClassResync = \"resync\"" 0
+else
+    _t_assert "2.5 banlog.go defines ClassResync = \"resync\"" 1 "constant missing"
+fi
+
+# banlog.go: must expose LogResync function
+if grep -q '^func LogResync' "$_banlog_go"; then
+    _t_assert "2.5 banlog.go exposes LogResync function" 0
+else
+    _t_assert "2.5 banlog.go exposes LogResync function" 1 "function missing"
+fi
+
+# cmd_ban.go: must call banlog.LogResync in already-banned path
+if grep -q 'banlog.LogResync' "$_cmd_ban_go"; then
+    _t_assert "2.5 cmd_ban.go invokes banlog.LogResync on already-banned path" 0
+else
+    _t_assert "2.5 cmd_ban.go invokes banlog.LogResync on already-banned path" 1 "RESYNC emission missing"
+fi
+
+# cmd_ban.go: V127 anchor
+if grep -q 'V127 UX-3 item 2.5' "$_cmd_ban_go"; then
+    _t_assert "2.5 cmd_ban.go scope-anchor comment present" 0
+else
+    _t_assert "2.5 cmd_ban.go scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# ITEM 2.6 — ban success footer source/set/total breakdown
+# =============================================================================
+echo "[2.6] ban success footer with source/set/total breakdown"
+
+# cmd_ban.go: must emit labeled lines for Source / Set / Total
+if grep -q 'Source:' "$_cmd_ban_go" && grep -q 'Set:' "$_cmd_ban_go" && grep -q 'Total bans:' "$_cmd_ban_go"; then
+    _t_assert "2.6 footer emits Source / Set / Total labeled lines" 0
+else
+    _t_assert "2.6 footer emits Source / Set / Total labeled lines" 1 "one or more label missing"
+fi
+
+# Must distinguish resync vs new ban via Event type field
+if grep -q 'Event type:' "$_cmd_ban_go"; then
+    _t_assert "2.6 footer emits 'Event type:' distinguishing resync vs new ban" 0
+else
+    _t_assert "2.6 footer emits 'Event type:' distinguishing resync vs new ban" 1 "Event type label missing"
+fi
+
+# Resync footer text
+if grep -q 'resync (idempotent' "$_cmd_ban_go"; then
+    _t_assert "2.6 footer resync event text present" 0
+else
+    _t_assert "2.6 footer resync event text present" 1 "resync footer text missing"
+fi
+
+# V127 anchor for item 2.6
+if grep -q 'V127 UX-3 item 2.6' "$_cmd_ban_go"; then
+    _t_assert "2.6 scope-anchor comment present" 0
+else
+    _t_assert "2.6 scope-anchor comment present" 1 "comment anchor missing"
+fi
+echo
+
+# =============================================================================
+# SCOPE-CREEP GUARD
+# =============================================================================
+echo "[scope-creep guard] UX-4..UX-6 keywords absent from UX-3 diff"
+
+# Verify the UX-3 changes don't accidentally include other lanes' surfaces
+for unwanted in 'suricata.*desurface' 'levenshtein' 'edit_distance' 'banner.*pollut' '"--async"' 'Ctrl\+C'; do
+    if grep -iE "$unwanted" "$_stats_format" "$_banlog_go" "$_tracker_go" "$_cmd_ban_go" 2>/dev/null | grep -v "test\|comment\|//\|#" | head -1 > /dev/null; then
+        _t_assert "scope-creep: '$unwanted' absent from UX-3 surfaces" 1 "found scope-creep keyword in diff"
+    else
+        _t_assert "scope-creep: '$unwanted' absent from UX-3 surfaces" 0
+    fi
+done
+echo
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo "==============================================================================="
+echo "V127 UX-3 test summary: ${TESTS_PASSED} PASS, ${TESTS_FAILED} FAIL"
+echo "==============================================================================="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "FAILED tests:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "  - $n"
+    done
+    exit 1
+fi
+exit 0

--- a/cmd/nftban-core/cmd_ban.go
+++ b/cmd/nftban-core/cmd_ban.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/analytics"
+	"github.com/itcmsgr/nftban/internal/banlog"
 	"github.com/itcmsgr/nftban/internal/blacklist"
 	"github.com/itcmsgr/nftban/internal/geoip"
 	"github.com/itcmsgr/nftban/pkg/ipc"
@@ -152,6 +153,27 @@ func cmdBan(ipStr string, reason string, source string, timeoutSeconds int, cfg 
 			fmt.Printf("  ⚠️  IP %s is already banned\n", normalizedIP)
 			fmt.Println()
 			fmt.Println("Re-syncing to ensure nftables is up to date...")
+			// V127 UX-3 item 2.5: emit a STATUS=RESYNC banlog entry so operators
+			// can distinguish this idempotent re-push from a real new ban when
+			// grep'ing or aggregating bans.log. Pre-V127 this path was silent
+			// in the log AND the kernel re-push (Step 6 below) emitted STATUS=
+			// BANNED via the daemon, so the log was indistinguishable from a
+			// fresh ban — hiding whether the operator-visible "Re-syncing..."
+			// message reflected a no-op or a real mutation.
+			// (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.5)
+			rsSource := source
+			if rsSource == "" {
+				rsSource = "manual"
+			}
+			rsReason := reason
+			if rsReason == "" {
+				rsReason = "idempotent operator re-sync"
+			}
+			if err := banlog.LogResync(normalizedIP, rsSource, "", rsReason); err != nil {
+				// Don't fail the operator command on banlog write error;
+				// surface as a non-fatal warning. The actual re-sync still proceeds.
+				fmt.Printf("  ⚠️  Note: failed to write RESYNC marker to bans.log: %v\n", err)
+			}
 		} else {
 			// Determine source for file mapping
 			banSource := source
@@ -310,7 +332,31 @@ func cmdBan(ipStr string, reason string, source string, timeoutSeconds int, cfg 
 	if !alreadyBanned {
 		totalBans++ // Count the one we just added
 	}
-	fmt.Printf("The IP is now blocked by the firewall. (Total bans: %d)\n", totalBans)
+
+	// V127 UX-3 item 2.6: source/set/total breakdown footer.
+	// Pre-V127 the footer was a single inline line: "The IP is now blocked by
+	// the firewall. (Total bans: %d)" — operators could not tell from the
+	// output which named set the entry landed in, or what the per-set count
+	// was, or whether this was a resync vs new entry. The audit (§2.6) flagged
+	// this as a Persona B scriptability blocker. The new footer breaks out
+	// Source, Set, and Total into individual labeled lines that grep/awk
+	// pipelines can parse field-by-field.
+	// (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.6)
+	footerSource := source
+	if footerSource == "" {
+		footerSource = "manual"
+	}
+	footerEventType := "new ban"
+	if alreadyBanned {
+		footerEventType = "resync (idempotent; no new entry)"
+	}
+	fmt.Println("Ban summary:")
+	fmt.Printf("  Source:        %s\n", footerSource)
+	fmt.Printf("  Set:           %s (%s)\n", targetSet, setType)
+	fmt.Printf("  Event type:    %s\n", footerEventType)
+	fmt.Printf("  Total bans:    %d (across all blacklist sets)\n", totalBans)
+	fmt.Println()
+	fmt.Println("The IP is now blocked by the firewall.")
 	if !alreadyBanned && timeoutSeconds == 0 {
 		// Show correct file based on source
 		savedFile := "99-manual.conf"

--- a/internal/banlog/banlog.go
+++ b/internal/banlog/banlog.go
@@ -61,6 +61,17 @@ const (
 const (
 	StatusBanned   = "BANNED"
 	StatusUnbanned = "UNBANNED"
+
+	// V127 UX-3 item 2.5: idempotent-ban marker.
+	// Emitted when `nftban ban <ip>` is invoked against an IP that is ALREADY
+	// in the relevant blacklist file AND the kernel set is just being
+	// re-synced (no real mutation; no new permanent record being added).
+	// Distinguishes operator-visible "re-sync of existing state" from real
+	// "new ban mutation" — pre-V127 both emitted STATUS=BANNED and operators
+	// could not tell from the log whether a row represented a new ban or
+	// an idempotent re-push to the kernel.
+	// (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.5)
+	StatusResync = "RESYNC"
 )
 
 // BanClass identifies the type of ban for lifecycle tracking (BLC-2).
@@ -73,6 +84,11 @@ const (
 	ClassEscalated = "escalated" // auto-ban with extended TTL (repeat offender)
 	ClassPermanent = "permanent" // auto-ban promoted to permanent (score≥100 or persistent)
 	ClassManual    = "manual"    // operator-issued via nftban ban CLI
+
+	// V127 UX-3 item 2.5: marks an idempotent re-sync as a separate class
+	// so it can be filtered out of "real ban count" aggregations while still
+	// being audited as an event.
+	ClassResync = "resync"
 )
 
 var (
@@ -233,6 +249,17 @@ func LogBanWithID(ip, source, country, reason, banID string) error {
 // Format: DATE|TIME|SOURCE|IP|COUNTRY|UNBANNED|REASON|BAN_ID
 func LogUnbanWithID(ip, source, country, reason, banID string) error {
 	return writeEntryWithReasonAndID(ip, source, country, StatusUnbanned, reason, banID)
+}
+
+// LogResync writes an idempotent-resync entry to bans.log (V127 UX-3 item 2.5).
+// Use when an operator-initiated ban command targets an IP that is ALREADY
+// in the relevant blacklist file AND no real mutation is happening — the
+// kernel set is just being re-pushed in case it drifted from config. The
+// resulting row has STATUS=RESYNC and CLASS=resync so operators (and any
+// downstream consumer) can distinguish re-sync events from real ban events
+// when grep'ing or aggregating bans.log.
+func LogResync(ip, source, country, reason string) error {
+	return writeEntryFull(ip, source, country, StatusResync, reason, "", 0, ClassResync)
 }
 
 // GenerateBanID creates a unique 16-char hex ban correlation ID

--- a/internal/escalation/tracker.go
+++ b/internal/escalation/tracker.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/itcmsgr/nftban/internal/banlog"
 	"github.com/itcmsgr/nftban/internal/safety"
 )
 
@@ -36,24 +37,47 @@ type BanEntry struct {
 	Reason    string
 }
 
-// LogTempBan logs a temporary ban to the tracking file for escalation tracking
-// This tracks temp bans to detect persistent offenders who should be escalated
+// LogTempBan logs a temporary ban to the tracking file for escalation tracking.
+//
+// V127 UX-3 item 2.4 (A1 facade convergence):
+// Pre-V127 this function wrote a SPACE-DELIMITED legacy format
+// ("2025-11-27T10:00:00Z 1.2.3.4 nftban-sshd SSH brute force") to logPath.
+// Callers passed cfg.BanLog (= /var/log/nftban/bans.log), which is the SAME
+// file internal/banlog/banlog.go::writeEntryFull writes in BLC-1 pipe format
+// to — producing interleaved mixed-format rows that broke nftban stats recent
+// (audit item 2.4).
+//
+// LogTempBan is RETAINED as a backward-compatibility facade so existing
+// call sites (cmd/nftban-core/cmd_ban.go, cmd/nftband/daemon_handlers_ban.go,
+// and any future callers) keep their unchanged signature, but the body now
+// delegates to banlog.LogBanFull so bans.log has ONE writer path and ONE
+// canonical 10-field BLC-1 pipe format.
+//
+// Any future caller of LogTempBan automatically gets BLC-1 — the legacy
+// space-delimited format CANNOT reappear unless this function is rewritten
+// or a new direct-write code path is added (regression test guards against
+// that). For new code, prefer calling banlog.LogBanFull directly with an
+// explicit BanClass; reach for LogTempBan only when wrapping an existing
+// jail/reason-pair shape from legacy escalation callers.
+//
+// The logPath parameter is preserved in the signature for backward
+// compatibility but is NOT used — banlog routes to the canonical path via
+// nftbanconf.MustLoadPaths(). If a legacy caller passes a non-canonical
+// path, the entry STILL lands in /var/log/nftban/bans.log (intentional —
+// the convergence is the whole point).
+//
+// (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.4)
 func LogTempBan(logPath, ip, jail, reason string) error {
-	// TOCTOU-safe file open with O_NOFOLLOW
-	f, err := safety.SafeOpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open ban log: %w", err)
-	}
-	defer f.Close()
-
-	timestamp := time.Now().Format(time.RFC3339)
-	logLine := fmt.Sprintf("%s %s %s %s\n", timestamp, ip, jail, reason)
-
-	if _, err := f.WriteString(logLine); err != nil {
-		return fmt.Errorf("failed to write to ban log: %w", err)
-	}
-
-	return nil
+	_ = logPath // intentionally unused; banlog.LogBanFull routes to canonical path
+	// Map jail -> banlog source via banlog.normalizeSource (called inside
+	// writeEntryFull). "jail" was the fail2ban-era field name; for modern
+	// callers it carries the source string (login/portscan/ddos/etc.) directly.
+	// The escalation-relevant temp-ban shape: country unknown (caller doesn't
+	// have it; banlog defaults to "UNK"), banID empty (LogTempBan callers
+	// don't generate a correlation ID), timeoutSec=0 (we don't know the TTL
+	// at this layer; the kernel set TTL is the source of truth), class=temp
+	// (this function exists specifically for temp bans by name).
+	return banlog.LogBanFull(ip, jail, "", reason, "", 0, banlog.ClassTemp)
 }
 
 // CountRecentBans counts how many times an IP was banned in the given period

--- a/internal/escalation/tracker_blc1_behavioral_test.go
+++ b/internal/escalation/tracker_blc1_behavioral_test.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MPL-2.0
+// =============================================================================
+// V127 UX-3 item 2.4 — LogTempBan BLC-1 BEHAVIORAL (runtime) regression test
+// =============================================================================
+// meta:name="tracker-blc1-behavioral-test"
+// meta:type="test"
+// meta:version="1.127.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-24"
+// meta:description="V127 UX-3 item 2.4 RUNTIME regression guard. Complements tracker_blc1_test.go (static source-file inspection) by actually invoking escalation.LogTempBan and banlog.LogResync at runtime, redirecting banlog output to a temp file via nftbanconf.DefaultConfigFile override, then asserting the emitted row is canonical 10-field BLC-1 pipe format (DATE|TIME|SOURCE|IP|COUNTRY|STATUS|REASON|BAN_ID|TIMEOUT|CLASS). Proves the A1 facade convergence holds end-to-end and that the pre-V127 space-delimited writer cannot reappear via runtime divergence. Test seam: nftbanconf.DefaultConfigFile is a pre-existing exported package var; we set it to a temp nftban.conf containing NFTBAN_LOG_DIR=<t.TempDir()> BEFORE any Load() call triggers, so banlog.getBanLogPath() routes writes to <temp>/bans.log."
+// meta:input="temp config file + temp log dir"
+// meta:output="t.Fatal on regression; written bans.log lines parsed and asserted"
+// meta:depends="testing,os,path/filepath,strings,nftbanconf,banlog"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-3 lane)
+// =============================================================================
+package escalation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/banlog"
+	"github.com/itcmsgr/nftban/internal/nftbanconf"
+)
+
+// blc1TestState carries the temp dir + bans.log path set up by TestMain so
+// the behavioral tests below can read the file banlog actually wrote to.
+var (
+	blc1TestBansLog string
+	blc1TestTempDir string
+)
+
+// TestMain configures nftbanconf to read a temp config that points
+// NFTBAN_LOG_DIR at a t.TempDir-style temp directory, BEFORE any banlog
+// call triggers nftbanconf.Load() (singleton sync.Once). This is the
+// least-invasive runtime seam — it uses the existing exported
+// nftbanconf.DefaultConfigFile package variable; no production code is
+// changed.
+//
+// Without this TestMain, the first banlog write in this package would
+// resolve bans.log under /var/log/nftban/ which is (a) not writable in
+// CI/dev and (b) not isolated from real host state.
+//
+// This TestMain applies to ALL tests in internal/escalation. The other
+// tests in this package (config_test.go) do not call nftbanconf.Load()
+// so the override is benign for them.
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "nftban-v127-ux3-blc1-*")
+	if err != nil {
+		panic("v127 ux-3 behavioral test: failed to create temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confPath := filepath.Join(tmpDir, "nftban.conf")
+	confBody := "NFTBAN_LOG_DIR=" + tmpDir + "\n"
+	if err := os.WriteFile(confPath, []byte(confBody), 0644); err != nil {
+		panic("v127 ux-3 behavioral test: failed to write temp nftban.conf: " + err.Error())
+	}
+
+	nftbanconf.DefaultConfigFile = confPath
+	blc1TestTempDir = tmpDir
+	blc1TestBansLog = filepath.Join(tmpDir, "bans.log")
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+// TestLogTempBan_EmitsBLC1 invokes LogTempBan at runtime and asserts the
+// row actually appended to bans.log is canonical BLC-1 (10 pipe fields)
+// with STATUS=BANNED, normalized SOURCE, preserved IP, and class=temp.
+// This is the load-bearing regression check: a future caller-side or
+// internals-side rewrite that re-introduces the legacy "%s %s %s %s\n"
+// writer would fail this test even if the static guard somehow missed it.
+func TestLogTempBan_EmitsBLC1(t *testing.T) {
+	// Reset bans.log so this test sees only its own emission.
+	_ = os.Remove(blc1TestBansLog)
+
+	const (
+		testIP     = "203.0.113.42"
+		testJail   = "nftban-sshd" // normalized -> "login" by banlog.normalizeSource
+		testReason = "SSH brute force"
+	)
+	// LogTempBan's logPath parameter is intentionally unused post-V127;
+	// the canonical path comes from nftbanconf paths. Pass a sentinel
+	// to make sure that ignoring it is intentional and survives refactors.
+	if err := LogTempBan("/dev/null/IGNORED-BY-FACADE", testIP, testJail, testReason); err != nil {
+		t.Fatalf("LogTempBan returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(blc1TestBansLog)
+	if err != nil {
+		t.Fatalf("could not read bans.log written by LogTempBan: %v (path=%s)", err, blc1TestBansLog)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line in bans.log after one LogTempBan call, got %d: %q", len(lines), string(data))
+	}
+	line := lines[0]
+
+	// (1) Must be 10 pipe-delimited BLC-1 fields.
+	fields := strings.Split(line, "|")
+	if len(fields) != 10 {
+		t.Fatalf("BLC-1 violation: expected 10 pipe-delimited fields, got %d in line %q", len(fields), line)
+	}
+
+	// (2) Field 3 (SOURCE) must be normalized from "nftban-sshd" -> banlog.SourceLogin.
+	if fields[2] != banlog.SourceLogin {
+		t.Errorf("SOURCE field = %q, want %q (banlog.normalizeSource(\"nftban-sshd\") -> SourceLogin)", fields[2], banlog.SourceLogin)
+	}
+
+	// (3) Field 4 (IP) must be preserved verbatim.
+	if fields[3] != testIP {
+		t.Errorf("IP field = %q, want %q", fields[3], testIP)
+	}
+
+	// (4) Field 6 (STATUS) must be BANNED — LogTempBan is a real-ban-emit facade.
+	if fields[5] != banlog.StatusBanned {
+		t.Errorf("STATUS field = %q, want %q", fields[5], banlog.StatusBanned)
+	}
+
+	// (5) Field 7 (REASON) must be preserved.
+	if fields[6] != testReason {
+		t.Errorf("REASON field = %q, want %q", fields[6], testReason)
+	}
+
+	// (6) Field 10 (CLASS) must be "temp" — LogTempBan is named for the temp class.
+	if fields[9] != banlog.ClassTemp {
+		t.Errorf("CLASS field = %q, want %q", fields[9], banlog.ClassTemp)
+	}
+
+	// (7) Legacy space-delimited pattern absent. The pre-V127 writer
+	// produced "<RFC3339> <ip> <jail> <reason>" with NO pipes and a 'T'
+	// in the first timestamp token. BLC-1 splits date and time across
+	// two pipe fields, so field 1 must NEVER contain 'T'.
+	if strings.Contains(fields[0], "T") {
+		t.Errorf("LEGACY FORMAT REGRESSION: first field looks like RFC3339 (contains 'T') — BLC-1 uses date|time split: %q", fields[0])
+	}
+}
+
+// TestLogResync_EmitsBLC1 verifies the V127 UX-3 item 2.5 RESYNC marker
+// reaches bans.log as a 10-field BLC-1 row with STATUS=RESYNC and
+// CLASS=resync — proving operators can grep RESYNC events out of bans.log
+// to distinguish idempotent re-syncs from real new bans.
+func TestLogResync_EmitsBLC1(t *testing.T) {
+	// Reset bans.log so this test sees only its own emission.
+	_ = os.Remove(blc1TestBansLog)
+
+	const (
+		testIP      = "198.51.100.7"
+		testSource  = "manual"
+		testCountry = "GR"
+		testReason  = "already-banned re-sync"
+	)
+	if err := banlog.LogResync(testIP, testSource, testCountry, testReason); err != nil {
+		t.Fatalf("banlog.LogResync returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(blc1TestBansLog)
+	if err != nil {
+		t.Fatalf("could not read bans.log written by LogResync: %v (path=%s)", err, blc1TestBansLog)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line in bans.log after one LogResync call, got %d: %q", len(lines), string(data))
+	}
+	line := lines[0]
+
+	fields := strings.Split(line, "|")
+	if len(fields) != 10 {
+		t.Fatalf("BLC-1 violation: expected 10 pipe-delimited fields, got %d in line %q", len(fields), line)
+	}
+
+	if fields[2] != banlog.SourceManual {
+		t.Errorf("SOURCE field = %q, want %q (normalized from \"manual\")", fields[2], banlog.SourceManual)
+	}
+	if fields[3] != testIP {
+		t.Errorf("IP field = %q, want %q", fields[3], testIP)
+	}
+	if fields[4] != testCountry {
+		t.Errorf("COUNTRY field = %q, want %q", fields[4], testCountry)
+	}
+	if fields[5] != banlog.StatusResync {
+		t.Errorf("STATUS field = %q, want %q (V127 UX-3 item 2.5 RESYNC marker missing at runtime)", fields[5], banlog.StatusResync)
+	}
+	if fields[6] != testReason {
+		t.Errorf("REASON field = %q, want %q", fields[6], testReason)
+	}
+	if fields[9] != banlog.ClassResync {
+		t.Errorf("CLASS field = %q, want %q (V127 UX-3 item 2.5 resync class missing at runtime)", fields[9], banlog.ClassResync)
+	}
+}
+
+// TestLogTempBan_TwoCallsAppendTwoBLC1Rows asserts repeated invocations
+// produce two clean BLC-1 rows (no interleaved formats, no truncation,
+// no missing newlines between rows) — the exact regression mode of the
+// pre-V127 bug where space-delimited and pipe-delimited rows coexisted
+// in bans.log and broke `nftban stats recent`.
+func TestLogTempBan_TwoCallsAppendTwoBLC1Rows(t *testing.T) {
+	_ = os.Remove(blc1TestBansLog)
+
+	if err := LogTempBan("/ignored", "192.0.2.1", "nftban-sshd", "first"); err != nil {
+		t.Fatalf("first LogTempBan: %v", err)
+	}
+	if err := LogTempBan("/ignored", "192.0.2.2", "portscan", "second"); err != nil {
+		t.Fatalf("second LogTempBan: %v", err)
+	}
+
+	data, err := os.ReadFile(blc1TestBansLog)
+	if err != nil {
+		t.Fatalf("could not read bans.log: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 BLC-1 rows after two LogTempBan calls, got %d: %q", len(lines), string(data))
+	}
+	for i, line := range lines {
+		fields := strings.Split(line, "|")
+		if len(fields) != 10 {
+			t.Errorf("row %d: expected 10 pipe-delimited fields, got %d in %q", i+1, len(fields), line)
+		}
+		if fields[5] != banlog.StatusBanned {
+			t.Errorf("row %d: STATUS field = %q, want %q", i+1, fields[5], banlog.StatusBanned)
+		}
+		if fields[9] != banlog.ClassTemp {
+			t.Errorf("row %d: CLASS field = %q, want %q", i+1, fields[9], banlog.ClassTemp)
+		}
+	}
+	// Cross-row sanity: sources differ across the two calls
+	r1 := strings.Split(lines[0], "|")
+	r2 := strings.Split(lines[1], "|")
+	if r1[2] != banlog.SourceLogin {
+		t.Errorf("row 1 SOURCE = %q, want %q", r1[2], banlog.SourceLogin)
+	}
+	if r2[2] != banlog.SourcePortscan {
+		t.Errorf("row 2 SOURCE = %q, want %q", r2[2], banlog.SourcePortscan)
+	}
+}

--- a/internal/escalation/tracker_blc1_test.go
+++ b/internal/escalation/tracker_blc1_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+// =============================================================================
+// V127 UX-3 item 2.4 — LogTempBan BLC-1 convergence regression test
+// =============================================================================
+// meta:name="tracker-blc1-test"
+// meta:type="test"
+// meta:version="1.127.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-24"
+// meta:description="V127 UX-3 item 2.4 regression guard. Pre-V127 internal/escalation/tracker.go::LogTempBan wrote a space-delimited legacy format to its logPath argument (typically /var/log/nftban/bans.log via cfg.BanLog), which is the SAME file internal/banlog/banlog.go::writeEntryFull writes BLC-1 pipe format to — producing interleaved mixed-format rows that broke nftban stats recent. V127 fix (A1 facade convergence): LogTempBan keeps its signature but its body delegates to banlog.LogBanFull so bans.log has ONE canonical 10-field BLC-1 pipe writer. This test asserts (a) the source code no longer contains the legacy fmt.Sprintf(\"%s %s %s %s\\n\", ...) writer pattern, (b) LogTempBan source code references banlog.LogBanFull, (c) the escalation package now imports banlog. Full runtime behavior (actual BLC-1 line written to a temp file) is covered indirectly by Go integration tests of banlog.writeEntryFull elsewhere in the suite; here we focus on the regression-guard property that the legacy format CANNOT reappear via this function unless someone rewrites the body."
+// meta:input="static source-file read"
+// meta:output="t.Fatal on regression"
+// meta:depends="testing,bytes,os"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-3 lane)
+// =============================================================================
+package escalation
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLogTempBanBLC1Convergence is the V127 UX-3 item 2.4 regression guard.
+// Asserts the source code of tracker.go shape such that the legacy space-
+// delimited writer cannot reappear without a deliberate source rewrite.
+func TestLogTempBanBLC1Convergence(t *testing.T) {
+	src, err := os.ReadFile("tracker.go")
+	if err != nil {
+		t.Fatalf("could not read tracker.go for regression-guard inspection: %v", err)
+	}
+
+	// (a) The pre-V127 legacy space-delimited writer pattern MUST be absent.
+	// Specifically the format string with 4 %s separated by spaces + newline,
+	// which produced "2025-11-27T10:00:00Z 1.2.3.4 nftban-sshd SSH brute force\n".
+	legacyPatterns := []string{
+		`fmt.Sprintf("%s %s %s %s\n", timestamp`,
+		`fmt.Sprintf("%s %s %s %s\n", time.Now().Format(time.RFC3339)`,
+		// Catch any other "%s %s %s %s\n" Sprintf form regardless of var name
+		`"%s %s %s %s\n"`,
+	}
+	for _, p := range legacyPatterns {
+		if bytes.Contains(src, []byte(p)) {
+			t.Errorf("V127 UX-3 item 2.4 REGRESSION: legacy space-delimited writer pattern %q found in tracker.go — LogTempBan MUST delegate to banlog.LogBanFull (BLC-1 pipe format); see V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.4", p)
+		}
+	}
+
+	// (b) LogTempBan source code MUST reference banlog.LogBanFull
+	if !bytes.Contains(src, []byte("banlog.LogBanFull")) {
+		t.Errorf("V127 UX-3 item 2.4: tracker.go does NOT call banlog.LogBanFull — A1 facade convergence is broken; LogTempBan must delegate to the canonical BLC-1 writer")
+	}
+
+	// (c) Escalation package must import banlog
+	if !bytes.Contains(src, []byte(`"github.com/itcmsgr/nftban/internal/banlog"`)) {
+		t.Errorf("V127 UX-3 item 2.4: tracker.go does not import internal/banlog — A1 facade convergence cannot work")
+	}
+
+	// (d) LogTempBan signature must be preserved (backward-compat facade contract)
+	if !bytes.Contains(src, []byte("func LogTempBan(logPath, ip, jail, reason string) error {")) {
+		t.Errorf("V127 UX-3 item 2.4: LogTempBan signature changed — A1 contract requires signature preservation for zero call-site churn (cmd/nftban-core/cmd_ban.go:369 and cmd/nftband/daemon_handlers_ban.go:96 must not need changes)")
+	}
+
+	// (e) The V127 scope comment anchor must be present in the source
+	if !bytes.Contains(src, []byte("V127 UX-3 item 2.4")) {
+		t.Errorf("V127 UX-3 item 2.4: scope-anchor comment missing from tracker.go — required for traceability")
+	}
+}
+
+// TestLogTempBanFunctionShape asserts the rewritten function body is the
+// minimal A1 facade and not an in-place rewrite that still does its own
+// fmt.Sprintf string-building (which could regress to space-delimited).
+func TestLogTempBanFunctionShape(t *testing.T) {
+	src, err := os.ReadFile("tracker.go")
+	if err != nil {
+		t.Fatalf("could not read tracker.go: %v", err)
+	}
+	srcStr := string(src)
+
+	// Locate LogTempBan function
+	idx := strings.Index(srcStr, "func LogTempBan(logPath, ip, jail, reason string) error {")
+	if idx < 0 {
+		t.Fatalf("LogTempBan function not found")
+	}
+	// Find the closing brace of this function (next standalone "}" line after idx)
+	tail := srcStr[idx:]
+	endIdx := strings.Index(tail, "\n}\n")
+	if endIdx < 0 {
+		t.Fatalf("could not locate end of LogTempBan function body")
+	}
+	body := tail[:endIdx]
+
+	// Body MUST contain the delegation call
+	if !strings.Contains(body, "banlog.LogBanFull(") {
+		t.Errorf("LogTempBan body does not contain banlog.LogBanFull call — A1 facade contract violated")
+	}
+
+	// Body must NOT contain any os.OpenFile / safety.SafeOpenFile / WriteString
+	// pattern (any direct write would be a separate writer path = regression)
+	forbiddenInBody := []string{
+		"safety.SafeOpenFile",
+		"os.OpenFile",
+		"WriteString",
+		"f.Write",
+	}
+	for _, p := range forbiddenInBody {
+		if strings.Contains(body, p) {
+			t.Errorf("LogTempBan body contains forbidden direct-write pattern %q — must delegate to banlog.LogBanFull only", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

V127 UX-3 Option A (operator-authorized): full Go-side fix that converges the bans.log writer onto the canonical BLC-1 pipe format and replaces the ambiguous stats labels + bare ban footer with operator-parseable equivalents.

**Operator authorization:** `OPEN_V127_UX_STATS_AND_BANLOG_IMPLEMENTATION_OPTION_A = GO`
+ explicit Option A acceptance: *"this PR may end the identical daemon/core binary streak at v1.127.0"*.

## Item coverage

| # | Item | Where |
|---|---|---|
| 2.1/3.1 | Stats live-vs-cumulative labels (`Blocked IPs (live)..` + `BANS BY MODULE (cumulative)`) | `cli/lib/nftban/core/nftban_stats_format.sh` |
| 2.2 | Canonical module labels — anchor comment on pre-existing awk normalizer | same file |
| 2.3 | `Data source: DERIVED` fallback on cache-miss path | same file |
| 2.4 | LogTempBan **A1 facade convergence** to `banlog.LogBanFull` (BLC-1) | `internal/escalation/tracker.go` |
| 2.5 | `RESYNC` marker (`StatusResync`, `ClassResync`, `LogResync`) + emission on already-banned path | `internal/banlog/banlog.go` + `cmd/nftban-core/cmd_ban.go` |
| 2.6 | Ban success footer: labeled `Source / Set / Event type / Total bans` | `cmd/nftban-core/cmd_ban.go` |

## Tests

- **Shell** — `cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh`: **30/30 PASS** locally.
- **Static Go regression guards** — `internal/escalation/tracker_blc1_test.go`: asserts legacy `"%s %s %s %s\n"` writer pattern absent, `banlog.LogBanFull` delegation present, banlog import present, signature preserved.
- **Behavioral Go runtime tests** — `internal/escalation/tracker_blc1_behavioral_test.go`: redirects banlog writes to a `t.TempDir()` via the pre-existing exported `nftbanconf.DefaultConfigFile` package var (no production-code seam added), then invokes `escalation.LogTempBan` and `banlog.LogResync` and asserts the emitted rows are canonical 10-field BLC-1 with the correct STATUS / CLASS values.
- **CI** — Go tests expected to run in the existing **Build, Test, Scan (Go)** workflow (no Go toolchain on the dev host).

## Binary impact

```
IDENTICAL_DAEMON_BINARY_STREAK_ENDED_BY_DESIGN_IN_UX_3
```

The 16-release identical-daemon-binary streak (v1.114.0 → v1.126.2), extended to 18 by the shell-only PR-A (UX-1) and PR-B (UX-2), **ends at v1.127.0 by design**. The three production Go files in `internal/banlog`, `internal/escalation`, and `cmd/nftban-core` are the cost of single-writer canonical-format convergence — which was the explicit Option A trade-off.

## Validation policy

Per `AUDIT_190_LIFECYCLE/V127_UX_VALIDATION_POLICY_AMENDED.md`: per-lane lab/runtime validation is **waived** for UX-3. Final consolidated runtime validation deferred to `EXECUTE_V127_FINAL_CONSOLIDATED_LAB_VALIDATION = GO` after all UX lanes (UX-4/5/6) land.

## Out of scope (confirmed)

- ❌ UX-4 Suricata de-surfacing
- ❌ UX-5 typo handler / Levenshtein
- ❌ UX-6 broad help cleanup
- ❌ Schema, metrics, portal, polkit, systemd, packaging behavior change
- ❌ Host contact / lab validation (waived for this lane)
- ❌ Release / tag / publish / VERSION / STATUS / CHANGELOG / FHS

## Test plan

- [ ] CI: header validator clean
- [ ] CI: recursive-perm validator clean
- [ ] CI: shell test `v127_ux3_stats_banlog_test.sh` — 30/30 PASS
- [ ] CI: `Build, Test, Scan (Go)` — `tracker_blc1_test.go` static guards PASS
- [ ] CI: `Build, Test, Scan (Go)` — `tracker_blc1_behavioral_test.go` runtime tests PASS
- [ ] CI: Go build for all targets succeeds
- [ ] Operator review of binary-streak-end decision
- [ ] Operator merge gate

Scope: `AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md` (UX-3 lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)