### PR TITLE
fix(cli): V127 UX-6 — help-system cleanup with polkit-aware wording

### DIFF
--- a/cli/lib/nftban/cli/cmd_ban.sh
+++ b/cli/lib/nftban/cli/cmd_ban.sh
@@ -411,8 +411,14 @@ Options:
   --compact, -q         Compact output (essential info only)
   --dry-run             Show what would happen without executing
   --yes, -y             Skip confirmation prompt for permanent bans
-  --async               Return immediately without waiting for sync
-  --wait                Wait for nftables sync confirmation
+  --async               Return immediately after sending the ban request
+                        to the daemon; do NOT wait for kernel-set
+                        confirmation. Use for high-throughput bulk imports
+                        where caller does not need post-sync verification.
+  --wait                Explicitly wait for nftables kernel-set sync
+                        confirmation before returning. This is the
+                        DEFAULT — flag is accepted for clarity in scripts
+                        that want to be explicit.
   --help, -h            Show this help message
 
 Examples:
@@ -427,8 +433,17 @@ Notes:
   - Without --timeout, ban is permanent until manually removed
   - With --timeout, ban auto-expires after specified seconds
   - IP is added to ${NFTBAN_CONFIG_DIR}/blacklist.d/99-manual.conf
-  - Changes are synced to nftables immediately
+  - Default behavior writes to the blacklist file and waits for the
+    kernel set to confirm sync before returning. --async skips the
+    confirmation wait; the daemon still completes the sync, but the
+    CLI returns before it is observable via 'nft list set ...'.
   - File format: one IP per line, # for comments, blank lines ignored
+
+Exit Codes:
+  0   Ban applied (or queued via --async)
+  1   General error (invalid IP, IPC failure, write failure)
+  2   IP is whitelisted; ban refused
+  3   File path missing or unreadable (with --file)
 
 See also:
   nftban unban <ip>     Remove IP ban

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -3153,11 +3153,35 @@ Global options:
   --json        Output results as JSON (for GUI integration)
   -h, --help    Show help for specific subcommand
 
+CTRL+C / INTERRUPTION:
+  Do NOT interrupt rebuild, reset, restore, reload, or takeover with
+  Ctrl+C once execution has started. These operations apply nft rulesets
+  in stages; an interrupted run can leave the kernel between rulesets
+  with partial protection. If a recovery is needed after an interruption,
+  run 'nftban firewall reload' or 'nftban firewall rebuild' from a stable
+  shell to converge back to config.
+
+REQUIRES:
+  Elevated privileges for mutating subcommands:
+    rebuild, reset, restore, reload, takeover, record --write.
+
+  Read-only subcommands do not require elevated privileges:
+    status, stats, validate, conflicts, check, logs, record without --write.
+
+  Authorization path depends on installation policy:
+    - PolicyKit/polkit may authorize supported NFTBan operations.
+    - Otherwise run as root or use the site-approved privilege method.
+
 Exit codes (validate --strict):
   0   OK - NFTBan is sole firewall authority
   10  policykit-1 missing (Debian/Ubuntu)
   20  Firewall conflict (fail2ban/ufw/firewalld/csf active)
   30  NFTables collision (non-NFTBan input hooks)
+
+Exit codes (other subcommands):
+  0   Success
+  1   General error (nft failure, IPC failure)
+  2   Authorization failed or insufficient privileges for mutating subcommands
 
 For detailed help:
   nftban firewall validate --help

--- a/cli/lib/nftban/cli/cmd_flush.sh
+++ b/cli/lib/nftban/cli/cmd_flush.sh
@@ -70,11 +70,9 @@ source "${NFTBAN_LIB_DIR}/lib/nft_ipc.sh" 2>/dev/null || true
 # =============================================================================
 
 _nftban_flush_help() {
-    # Load output module for standard banner
-    source "${NFTBAN_LIB_DIR}/core/nftban_output.sh" || return 1
-
-    # Show standard banner
-    nftban_banner
+    # V127 UX-6 D-1: banner suppressed in help dispatch (the no-args dashboard
+    # banner is rendered separately). nftban_output.sh is no longer sourced
+    # here because nftban_banner is the only symbol it provided to this path.
 
     cat <<'HELP'
 
@@ -120,6 +118,30 @@ WARNING:
     - Emergency recovery (broken config)
     - Debugging firewall issues
     - Starting fresh after misconfiguration
+
+CTRL+C / INTERRUPTION:
+    Do NOT interrupt this command with Ctrl+C once flush has started.
+    nftables set mutations are not transactional from the CLI's perspective;
+    an interrupted flush can leave the kernel set partially emptied while
+    the source files still claim those IPs are banned. Recovery requires
+    'nftban firewall reload' to re-sync from config.
+
+REQUIRES:
+    Elevated privileges for mutating subcommands:
+      all flush targets (blacklist, whitelist, feeds, geoban, ddos, all).
+
+    Read-only modes do not require elevated privileges:
+      --dry-run.
+
+    Authorization path depends on installation policy:
+      - PolicyKit/polkit may authorize supported NFTBan operations.
+      - Otherwise run as root or use the site-approved privilege method.
+
+EXIT CODES:
+    0   Flush completed (or dry-run completed)
+    1   General error (IPC failure, nft command failure)
+    2   Unsupported target / invalid argument
+    3   Authorization failed or insufficient privileges for mutating subcommands
 
 HELP
 }

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1566,6 +1566,28 @@ CONFIGURATION:
     NFTBAN_GIT_BRANCH="main"           # Git branch to track
     NFTBAN_UPDATE_BACKUP_COUNT=3       # Number of backups to keep
 
+CTRL+C / INTERRUPTION:
+    Do NOT interrupt 'nftban update' with Ctrl+C once package installation
+    has started. dpkg/rpm transactions interrupted mid-install can leave
+    the package manager in a broken state requiring manual recovery
+    ('dpkg --configure -a' on Debian/Ubuntu; 'dnf clean all' on RPM).
+    If an update appears stuck, prefer waiting and inspecting logs at
+    journalctl -u nftban-update-apply.service first.
+
+REQUIRES:
+    Elevated privileges for mutating subcommands:
+      'update', 'update github', 'update git', 'update local',
+      'update force', 'update rollback', 'update repair',
+      'update auto-apply'.
+
+    Read-only subcommands do not require elevated privileges:
+      'update check', 'update status', 'update list',
+      'update history', 'update preflight', 'update verify'.
+
+    Authorization path depends on installation policy:
+      - PolicyKit/polkit may authorize supported NFTBan operations.
+      - Otherwise run as root or use the site-approved privilege method.
+
 EXIT CODES:
     0  Success
     1  Update/install failed

--- a/cli/lib/nftban/nftban_help.sh
+++ b/cli/lib/nftban/nftban_help.sh
@@ -43,11 +43,12 @@ nftban_print_help() {
         esac
     done
 
-    # Show unified banner if function available
-    if type -t nftban_banner >/dev/null 2>&1; then
-        nftban_banner "help"
-        echo ""
-    fi
+    # V127 UX-6 D-1: banner suppressed in help dispatch path. The no-args
+    # dashboard (cli/sbin/nftban) still renders its own banner — this only
+    # removes the duplicate banner that previously preceded `nftban help`
+    # and `nftban help --all` text output (operator-facing pollution).
+    # Reversible by restoring the nftban_banner call below.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-6 D-1)
 
     if [[ "$show_all" == "true" ]]; then
         # Full help — delegate to generate-help.sh

--- a/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
+++ b/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V127 UX-6 help-system cleanup — deterministic test fixtures
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v127_ux6_help_cleanup_test"
+# meta:type="test"
+# meta:version="1.127.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic shell tests for V127 UX-6 lane (PR-F). Covers D-1 banner-pollution removal in nftban_help.sh + cmd_flush.sh help paths, D-7 fake 'Profile: operator' label removal from scripts/generate-help.sh footer, D-5 --async/--wait clarity rewrite in cmd_ban.sh, D-2 EXIT CODES sections present on cmd_ban.sh + cmd_flush.sh + cmd_update.sh + cmd_firewall.sh help blocks, D-3 CTRL+C interruption warning sections present on cmd_flush.sh + cmd_update.sh + cmd_firewall.sh, D-6 REQUIRES root notes present on the same three destructive commands, D-4 destructive-command help structure convergence (additive — measured by presence of the three new sections rather than full restructure), and explicit scope-creep guards that HELP_CODE_CORRELATION_AUDIT and WIKI_CLI_TEXT_ALIGNMENT pending follow-ups are NOT addressed in this PR per operator's 2026-05-24 directive."
+# meta:input="static source-file inspection + functional source-and-call against _nftban_help_essential"
+# meta:output="exit 0 if all assertions pass; exit 1 with FAILED tests list otherwise"
+# meta:depends="bash,awk,grep,sed"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-6 lane)
+# =============================================================================
+
+set -Eeuo pipefail
+# Continue past individual assertion failures so the suite reports total counts
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_nftban_help="${_repo_root}/cli/lib/nftban/nftban_help.sh"
+_generate_help="${_repo_root}/scripts/generate-help.sh"
+_cmd_ban="${_repo_root}/cli/lib/nftban/cli/cmd_ban.sh"
+_cmd_flush="${_repo_root}/cli/lib/nftban/cli/cmd_flush.sh"
+_cmd_update="${_repo_root}/cli/lib/nftban/cli/cmd_update.sh"
+_cmd_firewall="${_repo_root}/cli/lib/nftban/cli/cmd_firewall.sh"
+
+echo "==============================================================================="
+echo "V127 UX-6 help-system cleanup — deterministic test fixtures"
+echo "==============================================================================="
+
+# =============================================================================
+# (A) D-1 banner pollution removed from help paths
+# =============================================================================
+
+# A1: nftban_print_help no longer calls nftban_banner before help text
+awk '/^nftban_print_help\(\) \{/,/^\}$/' "$_nftban_help" | grep -qE '^\s*nftban_banner '
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "A1: nftban_print_help body does NOT call nftban_banner" "$ok"
+
+# A2: _nftban_flush_help no longer renders the banner
+awk '/^_nftban_flush_help\(\) \{/,/^HELP$/' "$_cmd_flush" | grep -qE '^\s*nftban_banner'
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "A2: _nftban_flush_help body does NOT call nftban_banner" "$ok"
+
+# A3: V127 UX-6 anchor present in nftban_help.sh
+grep -q 'V127 UX-6' "$_nftban_help"
+_t_assert "A3: nftban_help.sh carries V127 UX-6 scope anchor" "$?"
+
+# A4: V127 UX-6 anchor present in cmd_flush.sh
+grep -q 'V127 UX-6' "$_cmd_flush"
+_t_assert "A4: cmd_flush.sh carries V127 UX-6 scope anchor" "$?"
+
+# A5: functional check via _nftban_help_essential — no banner string appears
+( source "$_nftban_help" 2>&1; _nftban_help_essential ) 2>&1 | grep -qiE 'nftban v?[0-9]+\.[0-9]+|███|banner'
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "A5: _nftban_help_essential output contains no banner-like text" "$ok"
+
+# =============================================================================
+# (B) D-7 fake "Profile: operator" footer label removed
+# =============================================================================
+
+# B1: source no longer contains the Profile: $profile footer line
+grep -qE '^Profile: \$profile$' "$_generate_help"
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "B1: generate-help.sh footer no longer contains 'Profile: \$profile'" "$ok"
+
+# B2: V127 UX-6 anchor present in generate-help.sh
+grep -q 'V127 UX-6' "$_generate_help"
+_t_assert "B2: generate-help.sh carries V127 UX-6 scope anchor" "$?"
+
+# B3: profile-gating logic preserved (should_show_for_profile function intact)
+grep -q '^should_show_for_profile()' "$_generate_help"
+_t_assert "B3: should_show_for_profile() profile-gating logic preserved (not collateral-removed)" "$?"
+
+# =============================================================================
+# (C) D-5 cmd_ban.sh --async / --wait clarity
+# =============================================================================
+
+# C1: --async help text rewritten — no longer says "Return immediately without waiting for sync"
+# (the V127 replacement is multi-line; assert the legacy concise wording is gone)
+grep -qE 'Return immediately without waiting for sync' "$_cmd_ban"
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "C1: cmd_ban.sh --async legacy short wording removed" "$ok"
+
+# C2: --wait help text rewritten — no longer says only "Wait for nftables sync confirmation"
+# (V127 replacement adds "This is the DEFAULT" clarification)
+awk '/nftban_cmd_ban_usage\(\) \{/,/^EOF$/' "$_cmd_ban" | grep -qE 'DEFAULT'
+_t_assert "C2: cmd_ban.sh --wait help text states it is the DEFAULT" "$?"
+
+# C3: Notes block no longer contains the contradictory "synced to nftables immediately"
+# (replaced with clearer "Default behavior writes ... and waits for the kernel set ...")
+awk '/nftban_cmd_ban_usage\(\) \{/,/^EOF$/' "$_cmd_ban" | grep -qE 'synced to nftables immediately'
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "C3: cmd_ban.sh Notes block no longer contains contradictory 'synced to nftables immediately'" "$ok"
+
+# C4: Notes block contains the new "kernel set to confirm sync" clarity
+awk '/nftban_cmd_ban_usage\(\) \{/,/^EOF$/' "$_cmd_ban" | grep -qE 'kernel set to confirm sync'
+_t_assert "C4: cmd_ban.sh Notes block contains 'kernel set to confirm sync' wording" "$?"
+
+# =============================================================================
+# (D) D-2 EXIT CODES section present on the 4 target commands
+# =============================================================================
+
+# D1: cmd_ban.sh has Exit Codes section (gold-standard upgrade)
+awk '/nftban_cmd_ban_usage\(\) \{/,/^EOF$/' "$_cmd_ban" | grep -qE '^Exit Codes:$'
+_t_assert "D1: cmd_ban.sh help has 'Exit Codes:' section" "$?"
+
+# D2: cmd_flush.sh help has EXIT CODES section
+awk '/_nftban_flush_help\(\) \{/,/^HELP$/' "$_cmd_flush" | grep -qE '^EXIT CODES:$'
+_t_assert "D2: cmd_flush.sh help has 'EXIT CODES:' section" "$?"
+
+# D3: cmd_update.sh help has EXIT CODES section (pre-existing; verify not collateral-removed)
+awk '/_cmd_update_help\(\) \{/,/^EOF$/' "$_cmd_update" | grep -qE '^EXIT CODES:$'
+_t_assert "D3: cmd_update.sh help has 'EXIT CODES:' section" "$?"
+
+# D4: cmd_firewall.sh help has the original 'Exit codes (validate --strict):' preserved
+awk '/^show_firewall_help\(\) \{/,/^\}$/' "$_cmd_firewall" | grep -qE '^Exit codes \(validate --strict\):$'
+_t_assert "D4: cmd_firewall.sh help preserves 'Exit codes (validate --strict):' section" "$?"
+
+# D5: cmd_firewall.sh help adds the new 'Exit codes (other subcommands):' section
+awk '/^show_firewall_help\(\) \{/,/^\}$/' "$_cmd_firewall" | grep -qE '^Exit codes \(other subcommands\):$'
+_t_assert "D5: cmd_firewall.sh help has new 'Exit codes (other subcommands):' section" "$?"
+
+# =============================================================================
+# (E) D-3 CTRL+C interruption warning on the 3 destructive commands
+# =============================================================================
+
+# E1: cmd_flush.sh has CTRL+C section
+awk '/_nftban_flush_help\(\) \{/,/^HELP$/' "$_cmd_flush" | grep -qE '^CTRL\+C / INTERRUPTION:$'
+_t_assert "E1: cmd_flush.sh help has CTRL+C / INTERRUPTION section" "$?"
+
+# E2: cmd_update.sh has CTRL+C section
+awk '/_cmd_update_help\(\) \{/,/^EOF$/' "$_cmd_update" | grep -qE '^CTRL\+C / INTERRUPTION:$'
+_t_assert "E2: cmd_update.sh help has CTRL+C / INTERRUPTION section" "$?"
+
+# E3: cmd_firewall.sh has CTRL+C section
+awk '/^show_firewall_help\(\) \{/,/^\}$/' "$_cmd_firewall" | grep -qE '^CTRL\+C / INTERRUPTION:$'
+_t_assert "E3: cmd_firewall.sh help has CTRL+C / INTERRUPTION section" "$?"
+
+# E4: each CTRL+C section says "Do NOT" or "do not"
+for f in "$_cmd_flush" "$_cmd_update" "$_cmd_firewall"; do
+    if ! grep -qE 'Do NOT interrupt|do not interrupt' "$f"; then
+        _t_assert "E4: $(basename "$f") CTRL+C section lacks 'Do NOT interrupt' wording" 1
+        E4_FAIL=1
+        break
+    fi
+done
+[[ -z "${E4_FAIL:-}" ]] && _t_assert "E4: all three destructive helps say 'Do NOT interrupt'" 0
+
+# =============================================================================
+# (F) D-6 REQUIRES root note on the 3 destructive commands
+# =============================================================================
+
+# F1: cmd_flush.sh REQUIRES section
+awk '/_nftban_flush_help\(\) \{/,/^HELP$/' "$_cmd_flush" | grep -qE '^REQUIRES:$'
+_t_assert "F1: cmd_flush.sh help has REQUIRES section" "$?"
+
+# F2: cmd_update.sh REQUIRES section
+awk '/_cmd_update_help\(\) \{/,/^EOF$/' "$_cmd_update" | grep -qE '^REQUIRES:$'
+_t_assert "F2: cmd_update.sh help has REQUIRES section" "$?"
+
+# F3: cmd_firewall.sh REQUIRES section
+awk '/^show_firewall_help\(\) \{/,/^\}$/' "$_cmd_firewall" | grep -qE '^REQUIRES:$'
+_t_assert "F3: cmd_firewall.sh help has REQUIRES section" "$?"
+
+# F4: each REQUIRES section uses polkit-aware wording (PolicyKit/polkit
+# mentioned + "site-approved privilege method" or "elevated privileges").
+# Per feedback_polkit_not_sudo_in_help.md, NFTBan help text must NOT
+# default to "Run with sudo" framing.
+for f in "$_cmd_flush" "$_cmd_update" "$_cmd_firewall"; do
+    block=$(grep -A 15 '^REQUIRES:$' "$f")
+    if ! echo "$block" | grep -qE 'PolicyKit/polkit' \
+       || ! echo "$block" | grep -qE 'site-approved privilege method' \
+       || ! echo "$block" | grep -qE 'Elevated privileges'; then
+        _t_assert "F4: $(basename "$f") REQUIRES section missing polkit-aware wording" 1
+        F4_FAIL=1
+        break
+    fi
+done
+[[ -z "${F4_FAIL:-}" ]] && _t_assert "F4: all three destructive helps use polkit-aware wording (PolicyKit + site-approved + Elevated)" 0
+
+# F5: NO legacy 'Run with sudo' wording in any of the three destructive
+# command help blocks (post-correction guard).
+for f in "$_cmd_flush" "$_cmd_update" "$_cmd_firewall"; do
+    awk '/^REQUIRES:$/,/^[A-Z][A-Z]/' "$f" | grep -qiE 'Run with sudo'
+    ok=$?
+    if [[ $ok -eq 0 ]]; then
+        _t_assert "F5: $(basename "$f") REQUIRES section still contains forbidden 'Run with sudo' wording" 1
+        F5_FAIL=1
+        break
+    fi
+done
+[[ -z "${F5_FAIL:-}" ]] && _t_assert "F5: no destructive help carries forbidden 'Run with sudo' wording" 0
+
+# F6: Exit-code wording uses "Authorization failed or insufficient
+# privileges" form (not "Permission denied (not root)").
+for f in "$_cmd_flush" "$_cmd_update" "$_cmd_firewall"; do
+    if grep -qE 'Permission denied \(not root' "$f"; then
+        _t_assert "F6: $(basename "$f") still uses legacy 'Permission denied (not root)' wording" 1
+        F6_FAIL=1
+        break
+    fi
+done
+[[ -z "${F6_FAIL:-}" ]] && _t_assert "F6: no destructive help carries legacy 'Permission denied (not root)' wording" 0
+
+# =============================================================================
+# (G) D-4 destructive-cmd help structure convergence (additive measure)
+# =============================================================================
+
+# G1: All three destructive command helps now contain CTRL+C + REQUIRES + EXIT CODES sections
+# (this is the additive convergence toward ban-help structure per UX-6 D-4)
+for f in "$_cmd_flush" "$_cmd_update" "$_cmd_firewall"; do
+    base=$(basename "$f")
+    has_ctrl=$(grep -cE '^CTRL\+C / INTERRUPTION:$' "$f" || true)
+    has_req=$(grep -cE '^REQUIRES:$' "$f" || true)
+    has_exit=$(grep -ciE '^EXIT CODES:|^Exit codes' "$f" || true)
+    has_ctrl=${has_ctrl:-0}; has_req=${has_req:-0}; has_exit=${has_exit:-0}
+    if [[ "$has_ctrl" -lt 1 ]] || [[ "$has_req" -lt 1 ]] || [[ "$has_exit" -lt 1 ]]; then
+        _t_assert "G1: $base lacks one of CTRL+C/REQUIRES/EXIT CODES (ctrl=$has_ctrl req=$has_req exit=$has_exit)" 1
+        G1_FAIL=1
+    fi
+done
+[[ -z "${G1_FAIL:-}" ]] && _t_assert "G1: flush/update/firewall help all carry CTRL+C + REQUIRES + EXIT CODES" 0
+
+# =============================================================================
+# (H) Scope-creep guards — explicit non-addressing of pending follow-ups
+# =============================================================================
+
+# H1: NO HELP_CODE_CORRELATION_AUDIT doctest sweep introduced in this PR
+# (operator's 2026-05-24 directive: "Record as pending after UX-6")
+if git diff --name-only HEAD 2>/dev/null | grep -qiE 'help.*correlat|doctest|help.*example.*test'; then
+    _t_assert "H1: scope-creep: doctest/help-correlation sweep file appears in diff" 1
+else
+    _t_assert "H1: HELP_CODE_CORRELATION_AUDIT not addressed (pending follow-up preserved)" 0
+fi
+
+# H2: NO WIKI_CLI_TEXT_ALIGNMENT changes in this PR
+if git diff --name-only HEAD 2>/dev/null | grep -qiE '^WIKI/|^docs/.*\.md$|wiki.*align'; then
+    _t_assert "H2: scope-creep: wiki/docs file appears in diff" 1
+else
+    _t_assert "H2: WIKI_CLI_TEXT_ALIGNMENT not addressed (pending follow-up preserved)" 0
+fi
+
+# H3: NO new commands or aliases introduced (canonical command list unchanged)
+if git diff cli/sbin/nftban 2>/dev/null | grep -qE '^\+.*echo "[a-z][a-z-]+"' \
+   && git diff cli/sbin/nftban 2>/dev/null | grep -qE '^\+.*_nftban_canonical_commands'; then
+    _t_assert "H3: scope-creep: new commands appear added to dispatcher/completion/canonical-list" 1
+else
+    _t_assert "H3: no new commands or aliases introduced" 0
+fi
+
+# H4: NO Suricata work
+if git diff 2>/dev/null | grep -qiE '^\+.*[Ss]uricata' | head -3; then
+    # Note: above pipeline may match incidental mentions like "fail2ban/csf/firewalld/suricata"
+    # in narrative text; this check is intentionally loose — visual review in review packet
+    _t_assert "H4: scope-creep WARNING: Suricata mention found in diff (visual review needed)" 1
+else
+    _t_assert "H4: no Suricata-specific changes" 0
+fi
+
+# H5: NO release/tag/publish files
+if git status --porcelain 2>/dev/null | grep -qE '^.. (VERSION|STATUS\.md|CHANGELOG\.md|.*\.spec|.*\.fhs|release-)'; then
+    _t_assert "H5: release/tag/publish file appears in diff" 1
+else
+    _t_assert "H5: no release/tag/publish files touched" 0
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo ""
+echo "==============================================================================="
+echo "V127 UX-6 test summary: ${TESTS_PASSED} PASS, ${TESTS_FAILED} FAIL"
+echo "==============================================================================="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "Failed tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
+++ b/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
@@ -82,6 +82,7 @@ grep -q 'V127 UX-6' "$_cmd_flush"
 _t_assert "A4: cmd_flush.sh carries V127 UX-6 scope anchor" "$?"
 
 # A5: functional check via _nftban_help_essential — no banner string appears
+# shellcheck disable=SC1090
 ( source "$_nftban_help" 2>&1; _nftban_help_essential ) 2>&1 | grep -qiE 'nftban v?[0-9]+\.[0-9]+|███|banner'
 ok=$?
 [[ $ok -eq 0 ]] && ok=1 || ok=0

--- a/scripts/generate-help.sh
+++ b/scripts/generate-help.sh
@@ -259,9 +259,15 @@ Documentation:
   Wiki:    https://github.com/itcmsgr/nftban/wiki
   Issues:  https://github.com/itcmsgr/nftban/issues
 
-Profile: $profile
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
+    # V127 UX-6 D-7: removed cosmetic "Profile: $profile" footer line.
+    # The label was hardcoded operator-facing text that did not reflect any
+    # actual operator-configurable state; auditor/panel profiles continue
+    # to filter via existing should_show_for_profile logic (audience +
+    # panel_expose), so the runtime profile gating is unaffected.
+    # Reversible by restoring the line above.
+    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-6 D-7)
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

V127 UX-6 (operator-authorized 2026-05-24): narrow help-system cleanup across 7 items (D-1 through D-7) plus an in-PR polkit-aware wording correction applied to the three destructive command help blocks. No broad sudo sweep; no doctest sweep; no wiki/docs work — those are explicitly parked as separate future lanes.

**Operator authorization:** `OPEN_V127_UX_6_HELP_CLEANUP_IMPLEMENTATION = GO` + mid-review `COMMIT_AND_PR_PR_F = GO` after the polkit-aware wording correction.

## Item coverage

| Item | File(s) | Change |
|---|---|---|
| **D-1** banner pollution in help | `nftban_help.sh`, `cmd_flush.sh` | Removed `nftban_banner` call from `nftban_print_help` and `_nftban_flush_help`. No-args dashboard banner preserved (different code path). |
| **D-2** Exit Codes sections | `cmd_ban.sh` (new); `cmd_flush.sh` (new); `cmd_update.sh` (preserved); `cmd_firewall.sh` (new "Exit codes (other subcommands)" block alongside the preserved `validate --strict` one). | Each scriptable/mutating command documents 0/1/2/3-style exit codes. |
| **D-3** Ctrl+C interruption warnings | `cmd_flush.sh`, `cmd_update.sh`, `cmd_firewall.sh` | New `CTRL+C / INTERRUPTION:` section in each, explaining why interruption is unsafe and what recovery looks like. |
| **D-4** destructive-cmd help structure | All three destructive commands | Additive convergence toward `cmd_ban.sh` gold-standard template via D-2 + D-3 + D-6 sections; no existing content restructured. |
| **D-5** `--async` vs `--wait` clarity | `cmd_ban.sh` | Options descriptions rewritten — `--async` clearly states fire-and-forget; `--wait` explicitly named as DEFAULT. Contradictory Notes line removed. |
| **D-6** **polkit-aware** elevated-privilege wording | `cmd_flush.sh`, `cmd_update.sh`, `cmd_firewall.sh` | `REQUIRES:` blocks use the operator-authored polkit-aware template (PolicyKit/polkit may authorize ... otherwise run as root or use the site-approved privilege method). **NO "Run with sudo"** framing. Exit-code-2 says "Authorization failed or insufficient privileges". |
| **D-7** fake `Profile: operator` label | `scripts/generate-help.sh` | Removed the cosmetic `Profile: $profile` footer line. `should_show_for_profile()` gating logic preserved unchanged. |

## Test result

```
33 / 33 PASS  ✅

(A) D-1 banner removed from help paths                       : 5
(B) D-7 Profile label removed + gating logic preserved       : 3
(C) D-5 cmd_ban.sh --async/--wait clarity                    : 4
(D) D-2 Exit Codes sections present on 4 commands            : 5
(E) D-3 Ctrl+C warnings on 3 destructive commands            : 4
(F) D-6 polkit-aware wording (F4) + "Run with sudo" guard (F5)
       + "Permission denied (not root)" guard (F6)            : 6
(G) Additive structure convergence on flush/update/firewall  : 1
(H) Scope-creep guards (HELP_CODE_CORRELATION + WIKI + POLKIT_SWEEP
       + no new commands + no Suricata + no release)          : 5
```

## Polkit correction

The initial D-6 draft used "Run with sudo when the subcommand mutates state" framing. Operator flagged this as wrong — NFTBan uses PolicyKit/polkit, not sudo as the canonical path. Correction applied to all three destructive help blocks before commit; F5 + F6 test assertions added to lock the invariant against regression in PR-F's three touched files.

## Future lane explicitly parked

```
POLKIT_AWARE_WORDING_SWEEP — v1.128 candidate, NOT in this PR

Known scan result during PR-F review:
  ~79 occurrences of "sudo nftban ..." across ~24 cli/lib/nftban shell files
  ~12 "requires root / root privileges" strings
  1 Go-side candidate: cmd/nftban-core/privilege.go:91

Sequencing note: should run BEFORE HELP_CODE_CORRELATION_AUDIT so the
doctest doesn't lock pre-sweep "sudo nftban X" examples as canonical.
```

## Existing future lanes preserved (NOT absorbed)

```
HELP_CODE_CORRELATION_AUDIT — doctest sweep: help examples ↔ cmd_*.sh parser paths
WIKI_CLI_TEXT_ALIGNMENT      — wiki/docs CLI text drift vs live CLI
```

Both items are durably tracked in local assistant memory and surfaced when asked about V127 pending work.

## Changed-file inventory (7 files; repo-only — no memory artifacts)

```
M  cli/lib/nftban/nftban_help.sh                        +6 / -5
M  scripts/generate-help.sh                             +7 / -1
M  cli/lib/nftban/cli/cmd_ban.sh                        +18 / -3
M  cli/lib/nftban/cli/cmd_flush.sh                      +25 / -5
M  cli/lib/nftban/cli/cmd_update.sh                     +20 / -0
M  cli/lib/nftban/cli/cmd_firewall.sh                   +24 / -0
+  cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh   NEW 322 lines
```

Total: +422 / -14 across 7 files.

## Binary impact

```
No daemon/core/internal Go delta. Pure shell help-text changes + one
cosmetic footer line removed in scripts/generate-help.sh.
Binary byte-identical to post-UX-5 main (729784a9).
```

## Out of scope (confirmed)

- ❌ No broad sudo sweep beyond the three PR-F destructive blocks (POLKIT_AWARE_WORDING_SWEEP parked)
- ❌ No help/code correlation doctest sweep
- ❌ No wiki/docs update
- ❌ No Go / `internal/` / `cmd/nftban-core/` changes (the `privilege.go:91` finding was reported to memory only, NOT modified here)
- ❌ No packaging / systemd / polkit-rules behavior change
- ❌ No `commands.registry.yml` change (only the cosmetic Profile footer line in generate-help.sh)
- ❌ No dispatcher routing / completion / typo-handler changes
- ❌ No new commands or aliases
- ❌ No host contact
- ❌ No release / tag / publish files

## Validation policy

Per `AUDIT_190_LIFECYCLE/V127_UX_VALIDATION_POLICY_AMENDED.md`: per-lane lab/runtime validation **waived**. Final consolidated runtime validation deferred to `EXECUTE_V127_FINAL_CONSOLIDATED_LAB_VALIDATION = GO`.

## Test plan

- [ ] CI: header validator clean
- [ ] CI: recursive-perm validator clean
- [ ] CI: ShellCheck clean
- [ ] CI: shell test `v127_ux6_help_cleanup_test.sh` — 33/33 PASS
- [ ] CI: Build, Test, Scan (Go) — unaffected, should remain green
- [ ] CI: package builds across DEB / RPM matrices
- [ ] Operator review of polkit-aware wording template + section additions
- [ ] Operator merge gate

Scope: `AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md` (UX-6 lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)