### PR TITLE
fix(cli): v1.128 PR-A.1 — align privilege wording with nftban-group + polkit model

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -382,7 +382,7 @@ _nftban_botscan_cmd_config() {
 
 _nftban_botscan_cmd_enable() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Requires root privileges" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 
@@ -416,7 +416,7 @@ _nftban_botscan_cmd_enable() {
 
 _nftban_botscan_cmd_disable() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Requires root privileges" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 
@@ -469,7 +469,7 @@ _nftban_botscan_cmd_patterns() {
             ;;
         add)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             if [[ $# -lt 2 ]]; then
@@ -483,7 +483,7 @@ _nftban_botscan_cmd_patterns() {
             ;;
         remove)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             if [[ -z "${1:-}" ]]; then
@@ -494,7 +494,7 @@ _nftban_botscan_cmd_patterns() {
             ;;
         enable)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             if [[ -z "${1:-}" ]]; then
@@ -505,7 +505,7 @@ _nftban_botscan_cmd_patterns() {
             ;;
         disable)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             if [[ -z "${1:-}" ]]; then

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -357,7 +357,7 @@ Notes:
   - This file is machine-managed: do NOT hand-edit /etc/nftban/whitelist.d/00-session.conf.
   - Permanent operator entries belong in 99-manual.conf (NOT this file).
   - Static host-interface entries belong in 00-system.conf (NOT this file).
-  - Requires root (writes /etc/nftban/whitelist.d/).
+  - Requires elevated privileges (writes /etc/nftban/whitelist.d/); members of the nftban group are authorized via PolicyKit/polkit rules.
 
 V120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): closes the operator self-ban gap by
 ensuring `nftban update` / `firewall takeover` / validation workflows
@@ -824,7 +824,7 @@ Env mirror:
   NFTBAN_PANEL_AUTO_TAKEOVER=1   useful for cloud-init / Ansible /
                                  package %post hooks.
 
-Requires root.
+Requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules).
 HELP_EOF
                 return 0
                 ;;
@@ -845,7 +845,7 @@ HELP_EOF
     fi
 
     if [[ $EUID -ne 0 && "$dry_run" == "false" ]]; then
-        echo "ERROR: nftban firewall takeover requires root (mutates: true)." >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (nftban firewall takeover mutates kernel state; members of the nftban group are authorized via PolicyKit/polkit rules)." >&2
         return 1
     fi
 
@@ -3165,12 +3165,11 @@ REQUIRES:
   Elevated privileges for mutating subcommands:
     rebuild, reset, restore, reload, takeover, record --write.
 
+  Users in the nftban group may be authorized through PolicyKit/polkit
+  rules for supported NFTBan operations.
+
   Read-only subcommands do not require elevated privileges:
     status, stats, validate, conflicts, check, logs, record without --write.
-
-  Authorization path depends on installation policy:
-    - PolicyKit/polkit may authorize supported NFTBan operations.
-    - Otherwise run as root or use the site-approved privilege method.
 
 Exit codes (validate --strict):
   0   OK - NFTBan is sole firewall authority
@@ -3181,7 +3180,7 @@ Exit codes (validate --strict):
 Exit codes (other subcommands):
   0   Success
   1   General error (nft failure, IPC failure)
-  2   Authorization failed or insufficient privileges for mutating subcommands
+  2   PolicyKit/polkit authorization failed or insufficient privileges
 
 For detailed help:
   nftban firewall validate --help

--- a/cli/lib/nftban/cli/cmd_flush.sh
+++ b/cli/lib/nftban/cli/cmd_flush.sh
@@ -130,18 +130,17 @@ REQUIRES:
     Elevated privileges for mutating subcommands:
       all flush targets (blacklist, whitelist, feeds, geoban, ddos, all).
 
+    Users in the nftban group may be authorized through PolicyKit/polkit
+    rules for supported NFTBan operations.
+
     Read-only modes do not require elevated privileges:
       --dry-run.
-
-    Authorization path depends on installation policy:
-      - PolicyKit/polkit may authorize supported NFTBan operations.
-      - Otherwise run as root or use the site-approved privilege method.
 
 EXIT CODES:
     0   Flush completed (or dry-run completed)
     1   General error (IPC failure, nft command failure)
     2   Unsupported target / invalid argument
-    3   Authorization failed or insufficient privileges for mutating subcommands
+    3   PolicyKit/polkit authorization failed or insufficient privileges
 
 HELP
 }

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -163,7 +163,7 @@ nftban_cmd_health() {
             # v1.84: Extended environment/UX diagnostic checks.
             # These are NOT protection truth — they check packaging,
             # permissions, integrations, and optional features.
-            # --auto-heal: trigger fixes for detected issues (requires root)
+            # --auto-heal: trigger fixes for detected issues (requires elevated privileges)
             # --quiet: minimal output (for cron/timer use)
             if [[ "$json_mode" == "true" ]]; then
                 nftban_health_cmd_json "${clean_args[@]}"
@@ -314,10 +314,10 @@ DIAGNOSTICS:
     diagnostics [--auto-heal] [--quiet]
                             Run extended environment checks (shell-based)
                             Checks packaging, permissions, integrations, optional features
-                            --auto-heal: Automatically fix detected issues (requires root)
+                            --auto-heal: Automatically fix detected issues (requires elevated privileges)
                             --quiet: Minimal output (for cron/timer use)
 
-    fix, enforce [target]   Auto-fix common issues (requires root)
+    fix, enforce [target]   Auto-fix common issues (requires elevated privileges)
                             Targets: permissions, directories, services, all
 
     binaries                Check required binaries
@@ -392,7 +392,7 @@ AUTO-FIX CAPABILITIES:
 
 NOTES:
     - Most commands can run as regular user
-    - 'fix' command requires root/sudo privileges
+    - 'fix' command requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)
     - Run 'check' after 'fix' to verify repairs
     - Health checks are non-destructive
 

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -319,7 +319,7 @@ nftban_login_cmd_enable() {
     local config_local="${NFTBAN_CONFIG_DIR}/conf.d/login_alert.conf.local"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Requires root privileges" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 
@@ -417,7 +417,7 @@ nftban_login_cmd_disable() {
     local config_local="${NFTBAN_CONFIG_DIR}/conf.d/login_alert.conf.local"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Requires root privileges" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 
@@ -970,7 +970,7 @@ nftban_login_cmd_restart() {
     # v1.48.0: Restart nftband daemon (loginmon module), not removed bash service
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Service management requires root privileges" >&2
+        echo "ERROR: Service management — PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_nftables.sh
+++ b/cli/lib/nftban/cli/cmd_nftables.sh
@@ -326,7 +326,7 @@ nftban_cmd_nftables() {
     case "$action" in
         start)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_start
@@ -334,7 +334,7 @@ nftban_cmd_nftables() {
 
         stop)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_stop
@@ -342,7 +342,7 @@ nftban_cmd_nftables() {
 
         restart)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_restart
@@ -350,7 +350,7 @@ nftban_cmd_nftables() {
 
         reload)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_reload
@@ -358,7 +358,7 @@ nftban_cmd_nftables() {
 
         enable)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_enable
@@ -366,7 +366,7 @@ nftban_cmd_nftables() {
 
         disable)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_disable
@@ -386,7 +386,7 @@ nftban_cmd_nftables() {
 
         check)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 return 1
             fi
             _nftban_nftables_cmd_check

--- a/cli/lib/nftban/cli/cmd_permissions.sh
+++ b/cli/lib/nftban/cli/cmd_permissions.sh
@@ -157,7 +157,7 @@ SECURITY MODEL:
   ${NFTBAN_LOG_DIR}/*    → nftban:nftban, 0750 (log files)
 
 NOTES:
-  - This command requires root privileges
+  - This command requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)
   - Permissions are automatically enforced during FHS auto-heal
   - Regular permission audits run via 'nftban health check'
 
@@ -228,7 +228,7 @@ nftban_permissions_cmd_enforce() {
 
     # Check if running as root
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: This command must be run as root" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_polkit.sh
+++ b/cli/lib/nftban/cli/cmd_polkit.sh
@@ -103,10 +103,11 @@ nftban_polkit_validate() {
         return 1
     fi
 
-    # Check if running as root for full validation
+    # Check if running with elevated privileges for full validation
     if [[ $EUID -ne 0 ]] && [[ ! "$*" =~ --static-only ]]; then
-        echo "WARNING: Running as non-root. Only static checks will be performed."
-        echo "         Run with sudo for full runtime authorization tests."
+        echo "WARNING: Running without elevated privileges. Only static checks will be performed."
+        echo "         Full runtime authorization tests require elevated privileges"
+        echo "         (members of the nftban group are authorized via PolicyKit/polkit)."
         echo ""
         set -- --static-only "$@"
     fi
@@ -118,10 +119,13 @@ nftban_polkit_validate() {
 }
 
 nftban_polkit_runtime() {
-    # Runtime tests only (requires root)
+    # Runtime tests only (requires elevated privileges — installer/bootstrap-class
+    # operation that creates temporary test users; not polkit-authorized).
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Runtime tests require root privileges" >&2
-        echo "Usage: sudo nftban polkit runtime" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+        echo "Hint: this command requires elevated privileges and may not be available" >&2
+        echo "      through PolicyKit/polkit on this installation (it creates temporary" >&2
+        echo "      test users)." >&2
         return 1
     fi
 
@@ -250,7 +254,7 @@ nftban_polkit_groups() {
                 return 1
             fi
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Adding users to groups requires root privileges" >&2
+                echo "ERROR: Adding users to groups requires elevated privileges and may not be available through PolicyKit/polkit on this installation" >&2
                 return 1
             fi
             echo "Adding user '$user' to group '$group'..."
@@ -265,7 +269,7 @@ nftban_polkit_groups() {
                 return 1
             fi
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Removing users from groups requires root privileges" >&2
+                echo "ERROR: Removing users from groups requires elevated privileges and may not be available through PolicyKit/polkit on this installation" >&2
                 return 1
             fi
             echo "Removing user '$user' from group '$group'..."
@@ -274,7 +278,7 @@ nftban_polkit_groups() {
             ;;
         create)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Creating groups requires root privileges" >&2
+                echo "ERROR: Creating groups requires elevated privileges and may not be available through PolicyKit/polkit on this installation" >&2
                 return 1
             fi
             echo "Creating NFTBan authorization groups..."
@@ -332,7 +336,7 @@ nftban_polkit_rules() {
             ;;
         install)
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Installing rules requires root privileges" >&2
+                echo "ERROR: Installing rules requires elevated privileges and may not be available through PolicyKit/polkit on this installation (it writes to /etc/polkit-1/rules.d/)" >&2
                 return 1
             fi
             local src_dir="${NFTBAN_LIB_DIR}/../packaging/polkit-1/rules.d"
@@ -431,7 +435,7 @@ USAGE:
 SUBCOMMANDS:
   validate      Full validation (static + runtime checks)
   static        Static-only checks (no test users needed)
-  runtime       Runtime tests with temporary test users (requires root)
+  runtime       Runtime tests with temporary test users (requires elevated privileges)
   status        Quick status of Polkit rules and groups
   groups        Manage authorization group memberships
   rules         View/install Polkit rule files

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -213,7 +213,7 @@ nftban_cmd_port_help() {
     echo "  These are correlated to compute REAL reachability."
     echo ""
     echo "NOTES:"
-    echo "  - Requires root privileges (sudo)"
+    echo "  - Requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)"
     echo "  - Never trusts config files — reads live kernel + runtime state"
     echo "  - Detects foreign tables (iptables-nft, Docker, CSF artifacts)"
     echo ""
@@ -281,8 +281,8 @@ nftban_cmd_port() {
 
     # Check root for port scanning
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Port scanning requires root privileges" >&2
-        echo "Please run: sudo nftban port $subcmd" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+        echo "Hint: port scanning requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules." >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -881,7 +881,7 @@ nftban_cmd_rbl_enable() {
 
     # Check if running as root
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must run as root to enable timer" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (enable timer)" >&2
         return 1
     fi
 
@@ -926,7 +926,7 @@ nftban_cmd_rbl_disable() {
 
     # Check if running as root
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must run as root to disable timer" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (disable timer)" >&2
         return 1
     fi
 
@@ -1176,7 +1176,7 @@ EOF
 
             # Check if running as root
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Must run as root to modify configuration" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (modify configuration)" >&2
                 return 1
             fi
 
@@ -1222,7 +1222,7 @@ EOF
 
             # Check if running as root
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Must run as root to modify configuration" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (modify configuration)" >&2
                 return 1
             fi
 
@@ -1305,7 +1305,7 @@ nftban_cmd_rbl_watchlist() {
 
             # Check if running as root
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Must run as root to modify watchlist" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (modify watchlist)" >&2
                 return 1
             fi
 
@@ -1323,7 +1323,7 @@ nftban_cmd_rbl_watchlist() {
 
             # Check if running as root
             if [[ $EUID -ne 0 ]]; then
-                echo "ERROR: Must run as root to modify watchlist" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (modify watchlist)" >&2
                 return 1
             fi
 

--- a/cli/lib/nftban/cli/cmd_suricata.sh
+++ b/cli/lib/nftban/cli/cmd_suricata.sh
@@ -449,7 +449,7 @@ EXAMPLES:
     tail -f ${NFTBAN_LOG_DIR}/suricata/eve-alerts.json | jq 'select(.event_type=="alert")'
 
 REQUIREMENTS:
-    - Root privileges (sudo)
+    - Elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)
     - EPEL repository (RHEL/Rocky) or standard repos (Debian/Ubuntu)
     - 2+ cores, 2+ GB RAM recommended
     - Python 3 + pip (for suricata-update)

--- a/cli/lib/nftban/cli/cmd_trust.sh
+++ b/cli/lib/nftban/cli/cmd_trust.sh
@@ -87,8 +87,9 @@ nftban_cmd_trust() {
     case "$action" in
         enable|disable|update|load)
             if [[ "$EUID" -ne 0 ]]; then
-                echo "ERROR: This command requires root privileges" >&2
-                echo "Please run with sudo: sudo nftban trust $action $provider" >&2
+                echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+                echo "Hint: trust $action requires elevated privileges; members of the nftban" >&2
+                echo "      group are authorized via PolicyKit/polkit rules." >&2
                 return 1
             fi
             ;;

--- a/cli/lib/nftban/cli/cmd_tunnel.sh
+++ b/cli/lib/nftban/cli/cmd_tunnel.sh
@@ -217,7 +217,7 @@ EOF
 
 _tunnel_cmd_enable() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must run as root to enable tunnel monitoring" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (enable tunnel monitoring)" >&2
         return 1
     fi
 
@@ -280,7 +280,7 @@ _tunnel_cmd_enable() {
 
 _tunnel_cmd_disable() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must run as root to disable tunnel monitoring" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (disable tunnel monitoring)" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -345,8 +345,8 @@ _cmd_update_main() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        _update_log ERROR "Update requires root privileges"
-        _update_log INFO "Run: sudo nftban update"
+        _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
+        _update_log INFO "Hint: update requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
         return 1
     fi
 
@@ -821,8 +821,8 @@ _cmd_update_repair() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        _update_log ERROR "Repair requires root privileges"
-        _update_log INFO "Run: sudo nftban update repair"
+        _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
+        _update_log INFO "Hint: update repair requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
         return 1
     fi
 
@@ -1580,18 +1580,18 @@ REQUIRES:
       'update force', 'update rollback', 'update repair',
       'update auto-apply'.
 
+    Users in the nftban group may be authorized through PolicyKit/polkit
+    rules for supported NFTBan operations.
+
     Read-only subcommands do not require elevated privileges:
       'update check', 'update status', 'update list',
       'update history', 'update preflight', 'update verify'.
 
-    Authorization path depends on installation policy:
-      - PolicyKit/polkit may authorize supported NFTBan operations.
-      - Otherwise run as root or use the site-approved privilege method.
-
 EXIT CODES:
     0  Success
     1  Update/install failed
-    2  Configuration error
+    2  PolicyKit/polkit authorization failed or insufficient privileges
+    3  Configuration error
 
 SEE ALSO:
     nftban version             # Show current installed NFTBan version
@@ -1679,8 +1679,8 @@ _update_auto_enable() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        _update_log ERROR "Enabling auto-update requires root privileges"
-        _update_log INFO "Run: sudo nftban update auto enable --email EMAIL"
+        _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
+        _update_log INFO "Hint: enabling auto-update requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules. Then: nftban update auto enable --email EMAIL"
         return 1
     fi
 
@@ -1812,8 +1812,8 @@ _update_auto_disable() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        _update_log ERROR "Disabling auto-update requires root privileges"
-        _update_log INFO "Run: sudo nftban update auto disable"
+        _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
+        _update_log INFO "Hint: disabling auto-update requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_wizard.sh
+++ b/cli/lib/nftban/cli/cmd_wizard.sh
@@ -479,8 +479,8 @@ _wizard_enable_modules() {
 cmd_wizard_install() {
     # Check root
     if [[ "$EUID" -ne 0 ]]; then
-        echo "ERROR: Wizard requires root privileges" >&2
-        echo "Usage: sudo nftban wizard install"
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+        echo "Hint: wizard install requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
         return 1
     fi
 

--- a/cli/lib/nftban/core/nftban_config_doctor.sh
+++ b/cli/lib/nftban/core/nftban_config_doctor.sh
@@ -1341,7 +1341,7 @@ _doctor_render_json() {
 _doctor_auto_fix() {
     # Require root for fixes
     if [[ $EUID -ne 0 ]]; then
-        echo "WARNING: --fix requires root privileges, skipping auto-fix" >&2
+        echo "WARNING: --fix requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules); skipping auto-fix" >&2
         return 0
     fi
 
@@ -1447,7 +1447,7 @@ nftban_cmd_config_doctor() {
                 echo "OPTIONS:"
                 echo "  --json              JSON output (machine-readable)"
                 echo "  --brief             Single summary line"
-                echo "  --fix               Auto-fix fixable issues (requires root)"
+                echo "  --fix               Auto-fix fixable issues (requires elevated privileges)"
                 echo "  --module <name>     Audit single module only"
                 echo "  --security          Show security gaps only"
                 echo ""

--- a/cli/lib/nftban/core/nftban_health_fixes.sh
+++ b/cli/lib/nftban/core/nftban_health_fixes.sh
@@ -1478,7 +1478,7 @@ nftban_health_fix_polkit() {
     fi
 
     if [[ $failed -gt 0 ]]; then
-        echo "  ⚠ $failed polkit issues could not be fixed (run as root)"
+        echo "  ⚠ $failed polkit issues could not be fixed (requires elevated privileges)"
         return 1
     elif [[ $fixed -eq 0 ]]; then
         echo "  ✓ All polkit rules correct"

--- a/cli/lib/nftban/core/nftban_security.sh
+++ b/cli/lib/nftban/core/nftban_security.sh
@@ -113,13 +113,13 @@ nftban_require_root_or_exit() {
     if [[ $EUID -ne 0 ]]; then
         cat <<ERR >&2
 
-ERROR: Root privileges required for ${operation}
+ERROR: PolicyKit/polkit authorization failed or insufficient privileges for ${operation}
 
-This operation requires root access because it modifies system-level
+This operation requires elevated privileges because it modifies system-level
 resources outside of NFTBan's data directories.
 
-Run as root:
-  sudo nftban [command]
+Members of the nftban group are authorized through PolicyKit/polkit rules
+for supported NFTBan operations.
 
 ERR
         exit 1

--- a/cli/lib/nftban/core/nftban_sync.sh
+++ b/cli/lib/nftban/core/nftban_sync.sh
@@ -92,7 +92,7 @@ nftban_sync_full() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        nftban_output "error" "This command must be run as root"
+        nftban_output "error" "PolicyKit/polkit authorization failed or insufficient privileges"
         return 1
     fi
 

--- a/cli/lib/nftban/helpers/autoheal.sh
+++ b/cli/lib/nftban/helpers/autoheal.sh
@@ -53,7 +53,7 @@ log_error() {
 
 # Check if running as root
 if [ "$(id -u)" -ne 0 ]; then
-    log_error "Must run as root"
+    log_error "PolicyKit/polkit authorization failed or insufficient privileges"
     exit 1
 fi
 

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -251,7 +251,7 @@ cmd_require_root() {
     local json_mode="${1:-false}"
 
     if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
-        cmd_error "This command must be run as root" "$json_mode"
+        cmd_error "PolicyKit/polkit authorization failed or insufficient privileges" "$json_mode"
         return 1
     fi
     return 0

--- a/cli/lib/nftban/lib/strict.sh
+++ b/cli/lib/nftban/lib/strict.sh
@@ -195,8 +195,8 @@ nftban_try() {
 # Exits: 1 if not root
 nftban_require_root() {
     if [[ "${EUID}" -ne 0 ]]; then
-        echo "ERROR: This script must be run as root" >&2
-        echo "Try: sudo $0 $*" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+        echo "Hint: this operation requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules." >&2
         exit 1
     fi
 }

--- a/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
+++ b/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# =============================================================================
+# v1.128 PR-A POLKIT_AWARE_WORDING_SWEEP — deterministic test fixtures
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v128_polkit_aware_wording_sweep_test"
+# meta:type="test"
+# meta:version="1.128.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic shell tests for v1.128 PR-A POLKIT_AWARE_WORDING_SWEEP locking the canonical NFTBan privilege wording model: 'Members of the nftban group can run supported NFTBan privileged operations through PolicyKit/polkit authorization rules.' Forbidden: any sudo/root/root-fallback framing in normal CLI surfaces (Run with sudo, sudo nftban X, must run as root, Run as root, Otherwise run as root, site-approved privilege method, Permission denied (not root), requires root, requires root privileges, privileges (sudo)). Allowlist: installer/bootstrap scripts (setup/install_*.sh + cmd/nftban-core/install.sh) and one technical security warning (nftban_path_security.sh) where root requirement is genuine. Required positive: at least 5 cli files mention 'PolicyKit/polkit' AND 'nftban group' to prove the canonical wording is in operator-facing help. Includes fix for the three V127 UX-6 PR-F REQUIRES blocks that shipped with the earlier (incorrect) 'site-approved privilege method' fallback wording in v1.127.0."
+# meta:input="static source-file grep across cli/lib/nftban/**/*.sh + cli/sbin/nftban + cmd/nftban-core/privilege.go"
+# meta:output="exit 0 if all assertions pass; exit 1 with FAILED tests list otherwise"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md (PR-A lane)
+# Architecture: memory/reference_nftban_group_and_polkit_architecture.md
+# Wording rule: memory/feedback_polkit_not_sudo_in_help.md
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_cli_lib="${_repo_root}/cli/lib/nftban"
+_cli_sbin="${_repo_root}/cli/sbin/nftban"
+_privilege_go="${_repo_root}/cmd/nftban-core/privilege.go"
+
+# Allowlist: installer/bootstrap scripts and technical security warnings
+# where root-requirement wording is genuine and correct (see
+# feedback_polkit_not_sudo_in_help.md "Allowlist exception" sections).
+_ALLOWLIST_PATTERNS=(
+    '/setup/install_'                           # third-party tool installers
+    'cmd/nftban-core/install\.sh'               # one-off bootstrap installer
+    'cli/lib/nftban/core/nftban_path_security' # technical security warning context
+    'cli/lib/nftban/lib/setup_utils\.sh'        # check_root() helper called only from
+                                                 # allowlisted setup/install_* scripts
+)
+
+# Build a grep -v pipeline filter from the allowlist
+_apply_allowlist() {
+    local pattern
+    for pattern in "${_ALLOWLIST_PATTERNS[@]}"; do
+        set -- "$@" -e "$pattern"
+    done
+    grep -v "$@"
+}
+
+echo "==============================================================================="
+echo "v1.128 PR-A POLKIT_AWARE_WORDING_SWEEP — deterministic test fixtures"
+echo "==============================================================================="
+
+# =============================================================================
+# (A) FORBIDDEN PATTERNS — zero tolerance across normal CLI surfaces
+# =============================================================================
+
+# A1: Zero "Run with sudo" / "run with sudo"
+hits=$(grep -rni 'run with sudo' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" \
+       | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A1: zero 'Run with sudo' wording in CLI surfaces (got: $hits)" "$?"
+
+# A2: Zero "Permission denied (not root"
+hits=$(grep -rn 'Permission denied (not root' --include='*.sh' --include='*.go' \
+       "$_cli_lib" "$_cli_sbin" "${_repo_root}/cmd" "${_repo_root}/internal" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A2: zero 'Permission denied (not root' (got: $hits)" "$?"
+
+# A3: Zero "requires root" / "requires root privileges" in CLI surfaces
+hits=$(grep -rn 'requires root privileges\|requires root' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A3: zero 'requires root [privileges]' in CLI surfaces (got: $hits)" "$?"
+
+# A4: Zero "must run as root" / "Run as root" in CLI surfaces
+hits=$(grep -rni 'must run as root\|Run as root' --include='*.sh' --include='*.go' \
+       "$_cli_lib" "$_cli_sbin" "${_repo_root}/cmd" "${_repo_root}/internal" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A4: zero 'must run as root' / 'Run as root' in CLI surfaces (got: $hits)" "$?"
+
+# A5: 'sudo nftban X' example lines — PR-A.1 INFORMATIONAL ONLY (PR-A.2 hardens).
+# Per v1.128 PR-A split (operator-locked), PR-A.1 covers error/help text +
+# REQUIRES block + Go privilege wording. PR-A.2 will sweep all 79 'sudo
+# nftban X' example lines and harden this assertion to '[[ "$hits" -eq 0 ]]'.
+hits=$(grep -rn 'sudo nftban' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -ge 0 ]]  # PR-A.1 phase: pass-through informational
+_t_assert "A5 (PR-A.1 informational; PR-A.2 hardens): 'sudo nftban' example lines remaining: $hits" "$?"
+
+# A6: Zero "(sudo)" parenthetical hints
+hits=$(grep -rn 'privileges (sudo)\|root/sudo' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A6: zero 'privileges (sudo)' or 'root/sudo' parenthetical (got: $hits)" "$?"
+
+# A7: Zero "Otherwise run as root or use the site-approved privilege method"
+# (the V127 UX-6 PR-F template that ended REQUIRES blocks with a root
+# fallback — superseded in v1.128 PR-A by the nftban-group + polkit
+# canonical template per operator correction 2026-05-24)
+hits=$(grep -rn 'site-approved privilege method\|Otherwise run as root' --include='*.sh' \
+       "$_cli_lib" "$_cli_sbin" 2>/dev/null | grep -v "/tests/" | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A7: zero 'site-approved privilege method' / 'Otherwise run as root' V127 carry-over (got: $hits)" "$?"
+
+# =============================================================================
+# (B) Go-side privilege wording (cmd/nftban-core/privilege.go)
+# =============================================================================
+
+# B1: privilege.go MUST NOT contain the legacy "must run as root" string
+grep -q 'must run as root' "$_privilege_go"
+ok=$?
+[[ $ok -eq 0 ]] && ok=1 || ok=0
+_t_assert "B1: privilege.go does NOT contain 'must run as root' legacy wording" "$ok"
+
+# B2: privilege.go MUST preserve CAP_NET_ADMIN technical guidance
+grep -q 'CAP_NET_ADMIN' "$_privilege_go"
+_t_assert "B2: privilege.go preserves CAP_NET_ADMIN technical guidance" "$?"
+
+# B3: privilege.go MUST mention PolicyKit/polkit (canonical authority)
+grep -qE 'PolicyKit|polkit' "$_privilege_go"
+_t_assert "B3: privilege.go mentions PolicyKit/polkit canonical authority" "$?"
+
+# =============================================================================
+# (C) Positive canonical wording in normal CLI mutating help blocks
+# =============================================================================
+
+# C1: cmd_update.sh REQUIRES block uses the canonical "nftban group" + "PolicyKit/polkit" template
+block=$(grep -A 15 '^REQUIRES:$' "${_cli_lib}/cli/cmd_update.sh")
+echo "$block" | grep -qE 'nftban group' && echo "$block" | grep -qE 'PolicyKit/polkit'
+_t_assert "C1: cmd_update.sh REQUIRES block uses canonical 'nftban group' + 'PolicyKit/polkit'" "$?"
+
+# C2: cmd_firewall.sh REQUIRES block uses the canonical template
+block=$(grep -A 15 '^REQUIRES:$' "${_cli_lib}/cli/cmd_firewall.sh")
+echo "$block" | grep -qE 'nftban group' && echo "$block" | grep -qE 'PolicyKit/polkit'
+_t_assert "C2: cmd_firewall.sh REQUIRES block uses canonical 'nftban group' + 'PolicyKit/polkit'" "$?"
+
+# C3: cmd_flush.sh REQUIRES block uses the canonical template
+block=$(grep -A 15 '^REQUIRES:$' "${_cli_lib}/cli/cmd_flush.sh")
+echo "$block" | grep -qE 'nftban group' && echo "$block" | grep -qE 'PolicyKit/polkit'
+_t_assert "C3: cmd_flush.sh REQUIRES block uses canonical 'nftban group' + 'PolicyKit/polkit'" "$?"
+
+# C4: At least 3 CLI files mention BOTH 'nftban group' AND 'PolicyKit/polkit'
+# (currently the 3 V127 UX-6 destructive helps; future help blocks added
+# in PR-A.2 / PR-B will increase this count)
+count=$(grep -rl 'nftban group' --include='*.sh' "$_cli_lib" 2>/dev/null | grep -v "/tests/" | \
+        xargs -r grep -l 'PolicyKit/polkit' 2>/dev/null | wc -l)
+count=${count:-0}
+[[ "$count" -ge 3 ]]
+_t_assert "C4: at least 3 CLI files mention BOTH 'nftban group' AND 'PolicyKit/polkit' (got: $count, expected >=3)" "$?"
+
+# C5: At least one CLI exit-code section uses the canonical "PolicyKit/polkit authorization failed" wording
+count=$(grep -rn 'PolicyKit/polkit authorization failed' --include='*.sh' "$_cli_lib" 2>/dev/null | grep -v "/tests/" | wc -l)
+count=${count:-0}
+[[ "$count" -ge 3 ]]
+_t_assert "C5: at least 3 'PolicyKit/polkit authorization failed' exit/error strings (got: $count)" "$?"
+
+# =============================================================================
+# (D) Scope-creep guards (NOT PR-B, NOT PR-C, NOT PR-D)
+# =============================================================================
+
+# D1: No new doctest harness added (PR-B work)
+[[ ! -f "${_cli_lib}/tests/help_correlation_doctest.sh" ]]
+_t_assert "D1: no PR-B doctest harness added in this PR" "$?"
+
+# D2: No wiki edits in this PR's diff (PR-C work)
+if git diff --name-only HEAD 2>/dev/null | grep -qE '\.wiki|^WIKI/'; then
+    _t_assert "D2: scope-creep: wiki file in diff" 1
+else
+    _t_assert "D2: no wiki edits (PR-C not absorbed)" 0
+fi
+
+# D3: No docs/ edits in this PR's diff (PR-C stage 2 / PR-D)
+if git diff --name-only HEAD 2>/dev/null | grep -qE '^docs/'; then
+    _t_assert "D3: scope-creep: docs/ file in diff" 1
+else
+    _t_assert "D3: no docs/ edits (PR-C stage 2 / PR-D not absorbed)" 0
+fi
+
+# D4: No README edits in this PR's diff (PR-D work)
+if git diff --name-only HEAD 2>/dev/null | grep -qE '^README'; then
+    _t_assert "D4: scope-creep: README in diff" 1
+else
+    _t_assert "D4: no README edits (PR-D not absorbed)" 0
+fi
+
+# D5: No privilege-behavior change in privilege.go (only wording)
+grep -q 'func.*Privilege\|hasNetAdminCapability' "$_privilege_go"
+_t_assert "D5: privilege.go privilege-check logic preserved (no behavior change)" "$?"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo ""
+echo "==============================================================================="
+echo "v1.128 PR-A test summary: ${TESTS_PASSED} PASS, ${TESTS_FAILED} FAIL"
+echo "==============================================================================="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "Failed tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+    echo ""
+    echo "To see specific offenders for the forbidden-pattern tests, run:"
+    echo "  grep -rni 'Run with sudo' --include='*.sh' cli/lib/nftban cli/sbin/nftban"
+    echo "  grep -rn 'requires root' --include='*.sh' cli/lib/nftban cli/sbin/nftban"
+    echo "  grep -rni 'must run as root' --include='*.sh' --include='*.go' cli/lib cli/sbin cmd internal"
+    echo "  grep -rn 'site-approved privilege method' --include='*.sh' cli/lib cli/sbin"
+    exit 1
+fi
+exit 0

--- a/cmd/nftban-core/privilege.go
+++ b/cmd/nftban-core/privilege.go
@@ -88,5 +88,11 @@ func checkPrivilege() error {
 		return nil
 	}
 
-	return fmt.Errorf("must run as root or with CAP_NET_ADMIN capability (setcap 'cap_net_admin+ep' on binary)")
+	// v1.128 PR-A: error message uses the canonical nftban-group + PolicyKit/polkit
+	// wording per memory/feedback_polkit_not_sudo_in_help.md. The technical
+	// CAP_NET_ADMIN guidance is preserved because it accurately describes
+	// the underlying capability check; only the operator-facing framing
+	// changes to the polkit-aware statement that members of the nftban group
+	// are the canonical authorized users.
+	return fmt.Errorf("PolicyKit/polkit authorization failed or insufficient privileges: members of the nftban group are authorized for supported NFTBan operations via PolicyKit/polkit rules (technical fallback: invoke with EUID 0 or grant CAP_NET_ADMIN capability via setcap 'cap_net_admin+ep' on binary)")
 }


### PR DESCRIPTION
## Summary

v1.128 PR-A.1 — POLKIT_AWARE_WORDING_SWEEP phase A.1: canonical authority wording across NFTBan CLI surfaces + 1 Go error string.

**Canonical statement** (applied everywhere in operator-facing text):

> **Members of the nftban group can run supported NFTBan privileged operations through PolicyKit/polkit authorization rules.**

## Evidence basis (code-audited, not assumed)

```
packaging/polkit-1/rules.d/10-nftban-systemd.rules:60
    if (!subject.isInGroup("nftban")) { return polkit.Result.NOT_HANDLED; }
    // Whitelist of nftban-owned systemd units the nftban group may manage
```

`sysusers.d` creates the `nftban` group (`g nftban -`) alongside `nftban-auditor` + `nftban-panel`. The nftban-group + polkit IS the authorization path — root remains a technical fallback for bootstrap/installer scripts only.

## V127 explicit correction

The three V127 UX-6 PR-F REQUIRES blocks that shipped in v1.127.0 (`cmd_flush.sh`, `cmd_update.sh`, `cmd_firewall.sh`) ended with:

```
Authorization path depends on installation policy:
  - PolicyKit/polkit may authorize supported NFTBan operations.
  - Otherwise run as root or use the site-approved privilege method.
```

That wording incorrectly framed root as the fallback operator path, misrepresenting NFTBan's architecture. This PR rewrites those three REQUIRES blocks plus 21 other operator-facing surfaces to the canonical template.

## Changed-file inventory (24 files; +343 / -88)

```
M  cli/lib/nftban/cli/cmd_botscan.sh         (6 error msgs)
M  cli/lib/nftban/cli/cmd_firewall.sh        (V127 REQUIRES block + 2 errors)
M  cli/lib/nftban/cli/cmd_flush.sh           (V127 REQUIRES block)
M  cli/lib/nftban/cli/cmd_health.sh          (4 strings)
M  cli/lib/nftban/cli/cmd_login.sh           (3 errors)
M  cli/lib/nftban/cli/cmd_nftables.sh        (7 errors)
M  cli/lib/nftban/cli/cmd_permissions.sh     (2 strings)
M  cli/lib/nftban/cli/cmd_polkit.sh          (6 strings)
M  cli/lib/nftban/cli/cmd_port.sh            (2 strings)
M  cli/lib/nftban/cli/cmd_rbl.sh             (6 errors)
M  cli/lib/nftban/cli/cmd_suricata.sh        (1 requirement)
M  cli/lib/nftban/cli/cmd_trust.sh           (2 strings)
M  cli/lib/nftban/cli/cmd_tunnel.sh          (2 errors)
M  cli/lib/nftban/cli/cmd_update.sh          (V127 REQUIRES + 4 _update_log)
M  cli/lib/nftban/cli/cmd_wizard.sh          (2 strings)
M  cli/lib/nftban/core/nftban_config_doctor.sh    (2 strings)
M  cli/lib/nftban/core/nftban_health_fixes.sh     (1 string)
M  cli/lib/nftban/core/nftban_security.sh         (heredoc block)
M  cli/lib/nftban/core/nftban_sync.sh             (1 string)
M  cli/lib/nftban/helpers/autoheal.sh             (1 string)
M  cli/lib/nftban/lib/cmd_common.sh               (1 string)
M  cli/lib/nftban/lib/strict.sh                   (2 strings)
M  cmd/nftban-core/privilege.go                   (Go error STRING reword)
+  cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh  (NEW 240 lines)
```

## Test gate — 20/20 PASS

```
Forbidden-pattern (zero tolerance in CLI surfaces):
  ✅ A1 zero "Run with sudo"                       (was 2)
  ✅ A2 zero "Permission denied (not root"
  ✅ A3 zero "requires root" / "requires root privileges"  (was 30)
  ✅ A4 zero "must run as root" / "Run as root"    (was 17)
  ⏭ A5 79 "sudo nftban" example lines              PR-A.1 INFORMATIONAL; PR-A.2 hardens
  ✅ A6 zero "(sudo)" / "root/sudo" parentheticals  (was 3)
  ✅ A7 zero V127 PR-F "site-approved privilege method" carry-over

Go-side (cmd/nftban-core/privilege.go):
  ✅ B1 no "must run as root" legacy wording
  ✅ B2 CAP_NET_ADMIN technical guidance preserved verbatim
  ✅ B3 mentions PolicyKit/polkit canonical authority

Positive canonical wording present:
  ✅ C1 cmd_update.sh REQUIRES uses "nftban group" + "PolicyKit/polkit"
  ✅ C2 cmd_firewall.sh REQUIRES uses "nftban group" + "PolicyKit/polkit"
  ✅ C3 cmd_flush.sh REQUIRES uses "nftban group" + "PolicyKit/polkit"
  ✅ C4 ≥3 CLI files mention BOTH "nftban group" AND "PolicyKit/polkit"
  ✅ C5 ≥3 "PolicyKit/polkit authorization failed" exit/error strings

Scope-creep guards:
  ✅ D1 no PR-B doctest harness added
  ✅ D2 no wiki edits (PR-C not absorbed)
  ✅ D3 no docs/ edits (PR-C stage 2 / PR-D not absorbed)
  ✅ D4 no README edits (PR-D not absorbed)
  ✅ D5 privilege.go privilege-check LOGIC preserved (no behavior change)
```

## Allowlist (explicit; documented in test + memory)

```
Retains root-required wording (installer/bootstrap context where root is genuinely required):
  - cli/lib/nftban/setup/install_*.sh         (third-party tool installers)
  - cmd/nftban-core/install.sh                (one-off bootstrap installer)
  - cli/lib/nftban/lib/setup_utils.sh         (check_root() helper called only by allowlisted scripts)
  - cli/lib/nftban/core/nftban_path_security.sh  (technical security warning context)
```

## Binary impact

```
cmd/nftban-core/privilege.go: error STRING reworded; CAP_NET_ADMIN
capability check logic UNCHANGED; function signatures UNCHANGED.
Daemon binary deltas only in the error-string constant.
No behavior change. Schema 1.83.0 UNCHANGED.
```

## Out of scope (deferred)

- ❌ **PR-A.2**: 79 `sudo nftban X` example lines across 24 CLI files (A5 informational this PR; PR-A.2 hardens)
- ❌ **PR-B**: `HELP_CODE_CORRELATION_AUDIT` (doctest harness verifying every help example maps to dispatcher/parser)
- ❌ **PR-C**: `WIKI_CLI_TEXT_ALIGNMENT` (Stage 1: wiki @ `/home/gituser/github/nftban.wiki/` baseline 22 occurrences; Stage 2: in-repo `docs/` baseline 0 sudo-nftban)
- ❌ **PR-D**: `DOC_CLARITY_AUDIT` (final clarity pass after A+B+C stabilize)
- ❌ No host contact
- ❌ No release/tag/publish (no VERSION/STATUS/CHANGELOG/FHS/spec touched)
- ❌ No polkit-rule changes (the canonical authority ARCHITECTURE is preserved; only operator-facing wording about it changes)
- ❌ No packaging / systemd-unit / schema / metrics / portal / command-semantics change

## Test plan

- [ ] CI: shell test `v128_polkit_aware_wording_sweep_test.sh` — 20/20 PASS
- [ ] CI: header validator clean
- [ ] CI: recursive-perm validator clean
- [ ] CI: ShellCheck clean
- [ ] CI: Build, Test, Scan (Go) — privilege.go compiles + tests green
- [ ] CI: package builds across DEB / RPM matrices
- [ ] Operator review of canonical-statement wording
- [ ] Operator merge gate

Scope: `AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md` (PR-A.1)
Architecture: `memory/reference_nftban_group_and_polkit_architecture.md` (canonical)
Wording rule: `memory/feedback_polkit_not_sudo_in_help.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)