### PR TITLE
fix(cli): v1.128 PR-A.2 — drop sudo from nftban examples; finish polkit wording sweep

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -160,13 +160,13 @@ WHITELIST:
 
 EXAMPLES:
     # Enable bot scanner detection
-    sudo nftban botscan enable
+    nftban botscan enable
 
     # Check status
     nftban botscan status
 
     # Run manual check (parse recent logs)
-    sudo nftban botscan check
+    nftban botscan check
 
     # List all patterns
     nftban botscan patterns list
@@ -175,7 +175,7 @@ EXAMPLES:
     nftban botscan patterns list enabled
 
     # Add custom pattern
-    sudo nftban botscan patterns add MY_PATTERN "malicious\.php" url-404 3 60 3600 "My pattern"
+    nftban botscan patterns add MY_PATTERN "malicious\.php" url-404 3 60 3600 "My pattern"
 
     # Show detection history
     nftban botscan history

--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -111,8 +111,8 @@ EXAMPLES:
   nftban config diff                  # Base vs local overrides
   nftban config diff --kernel         # Config vs kernel state
   nftban config get portscan --json   # Module config in JSON
-  sudo nftban config set portscan PORTSCAN_BAN_THRESHOLD=15
-  sudo nftban config apply portscan   # Apply to running service
+  nftban config set portscan PORTSCAN_BAN_THRESHOLD=15
+  nftban config apply portscan   # Apply to running service
 
 EOF
 }

--- a/cli/lib/nftban/cli/cmd_ddos.sh
+++ b/cli/lib/nftban/cli/cmd_ddos.sh
@@ -133,10 +133,10 @@ PROFILE SELECTION:
 
 EXAMPLES:
     # Enable all DDoS protections (based on config)
-    sudo nftban ddos enable
+    nftban ddos enable
 
     # Disable all DDoS protections
-    sudo nftban ddos disable
+    nftban ddos disable
 
     # Show status of all protections
     nftban ddos status
@@ -151,14 +151,14 @@ EXAMPLES:
     nftban ddos mode show
 
     # Set mode to classic
-    sudo nftban ddos mode set classic
+    nftban ddos mode set classic
 
 LOG FILES:
     DDoS protection logs: ${NFTBAN_LOG_DIR}/ddos.log
     Statistics: /var/lib/nftban/ddos/stats.json
 
 REQUIREMENTS:
-    • Root privileges (for enable/disable commands)
+    • Elevated privileges (members of the nftban group are authorized via PolicyKit/polkit for enable/disable commands)
     • nftables >= 0.9.0
     • Linux kernel >= 3.13 (for connection tracking)
 

--- a/cli/lib/nftban/cli/cmd_egress.sh
+++ b/cli/lib/nftban/cli/cmd_egress.sh
@@ -528,7 +528,7 @@ nftban_cmd_egress() {
 
     # Check root
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Egress commands require root privileges" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_feeds.sh
+++ b/cli/lib/nftban/cli/cmd_feeds.sh
@@ -1001,19 +1001,19 @@ CATEGORIES:
 
 EXAMPLES:
     # Interactive selection menu (RECOMMENDED!)
-    sudo nftban feeds select
+    nftban feeds select
 
     # List all available feeds
     nftban feeds list
 
     # Enable specific feed
-    sudo nftban feeds enable SPAMHAUS_DROP
+    nftban feeds enable SPAMHAUS_DROP
 
     # Enable all SSH protection feeds
-    sudo nftban feeds enable-category ssh
+    nftban feeds enable-category ssh
 
     # Update all enabled feeds
-    sudo nftban feeds update
+    nftban feeds update
 
     # Check status
     nftban feeds status

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -492,7 +492,7 @@ _whitelist_session_add() {
     fi
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
         return 1
     fi
 
@@ -635,7 +635,7 @@ _whitelist_session_remove() {
     fi
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
         return 1
     fi
 
@@ -698,7 +698,7 @@ _whitelist_session_cleanup() {
     fi
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: root privileges required to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges to write $_NFTBAN_SESSION_WHITELIST_PATH" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -356,16 +356,16 @@ EXAMPLES:
     nftban health pro          # Pro subscription status
 
     # Auto-heal during check (combines check + fix)
-    sudo nftban health check --auto-heal
+    nftban health check --auto-heal
 
     # Quiet mode for cron/timer
     nftban health check --auto-heal --quiet
 
     # Manual fix (traditional approach)
-    sudo nftban health fix all
+    nftban health fix all
 
     # Or use 'enforce' (alias for 'fix')
-    sudo nftban health enforce all
+    nftban health enforce all
 
     # Verify installation completeness
     nftban health install

--- a/cli/lib/nftban/cli/cmd_health_core.sh
+++ b/cli/lib/nftban/cli/cmd_health_core.sh
@@ -335,7 +335,7 @@ nftban_health_cmd_fix() {
     if [[ $EUID -eq 0 ]]; then
         echo "Running as: root (can fix everything)"
     else
-        echo "Running as: $(whoami) (can fix owned files, will report what needs root)"
+        echo "Running as: $(whoami) (can fix owned files, will report what requires elevated privileges)"
     fi
     echo ""
 

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -956,7 +956,7 @@ CONF
 
     if [[ $issues_found -gt $issues_fixed ]]; then
         echo ""
-        echo "Some issues require manual attention or root privileges."
+        echo "Some issues require manual attention or elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)."
         return 1
     elif [[ $issues_found -eq 0 ]]; then
         echo ""
@@ -1270,16 +1270,16 @@ TARGETS:
 
 EXAMPLES:
     # Quick setup (one command - enables all monitoring)
-    sudo nftban login enable
+    nftban login enable
 
     # Check status (shows detected services)
     nftban login status
 
     # Enable all monitoring types
-    sudo nftban login enable all
+    nftban login enable all
 
     # Disable login monitoring
-    sudo nftban login disable
+    nftban login disable
 
     # Send test alert
     nftban login test

--- a/cli/lib/nftban/cli/cmd_menu.sh
+++ b/cli/lib/nftban/cli/cmd_menu.sh
@@ -143,7 +143,7 @@ ui_input() {
 require_root() {
     # Check root permissions and show error if not root
     if [[ $EUID -ne 0 ]]; then
-        ui_msg "Permission required" "This action needs root. Re-run: sudo nftban menu"
+        ui_msg "Permission required" "This action requires elevated privileges (members of the nftban group are authorized via PolicyKit/polkit). Re-run: nftban menu"
         return 1
     fi
 }

--- a/cli/lib/nftban/cli/cmd_nftables.sh
+++ b/cli/lib/nftban/cli/cmd_nftables.sh
@@ -106,19 +106,19 @@ EXAMPLES:
     nftban nftables status
 
     # Restart nftables service
-    sudo nftban nftables restart
+    nftban nftables restart
 
     # Enable nftables at boot
-    sudo nftban nftables enable
+    nftban nftables enable
 
     # View current ruleset
     nftban nftables list
 
     # Check configuration
-    sudo nftban nftables check
+    nftban nftables check
 
 NOTES:
-    - Most commands require root privileges
+    - Most commands require elevated privileges (members of the nftban group are authorized via PolicyKit/polkit rules)
     - NFTBan manages nftables rules automatically
     - Manual changes to nftables rules may be overwritten by NFTBan
 

--- a/cli/lib/nftban/cli/cmd_permissions.sh
+++ b/cli/lib/nftban/cli/cmd_permissions.sh
@@ -142,13 +142,13 @@ OPTIONS:
 
 EXAMPLES:
   # Check current permissions
-  sudo nftban permissions check
+  nftban permissions check
 
   # Enforce secure permissions
-  sudo nftban permissions enforce
+  nftban permissions enforce
 
   # Preview changes without applying
-  sudo nftban permissions enforce --dry-run
+  nftban permissions enforce --dry-run
 
 SECURITY MODEL:
   /etc/nftban/*        → root:root, 0750/0640 (configs are code-sensitive!)

--- a/cli/lib/nftban/cli/cmd_polkit.sh
+++ b/cli/lib/nftban/cli/cmd_polkit.sh
@@ -446,10 +446,10 @@ EXAMPLES:
   nftban polkit status                    # Quick status check
   nftban polkit validate                  # Full validation (sudo for runtime)
   nftban polkit static                    # Static checks only
-  sudo nftban polkit runtime              # Full runtime tests with test users
+  nftban polkit runtime              # Full runtime tests with test users
   nftban polkit groups list               # List groups and members
-  sudo nftban polkit groups add john      # Add user to operator group
-  sudo nftban polkit groups create        # Create NFTBan groups
+  nftban polkit groups add john      # Add user to operator group
+  nftban polkit groups create        # Create NFTBan groups
   nftban polkit rules list                # List installed rules
   nftban polkit rules view 10-nftban-systemd.rules  # View rule file
   nftban polkit test                      # Test your authorization

--- a/cli/lib/nftban/cli/cmd_portscan.sh
+++ b/cli/lib/nftban/cli/cmd_portscan.sh
@@ -163,16 +163,16 @@ PROFILE SELECTION:
 
 EXAMPLES:
     # Enable port scan detection
-    sudo nftban portscan enable
+    nftban portscan enable
 
     # Disable port scan detection
-    sudo nftban portscan disable
+    nftban portscan disable
 
     # Show detection status
     nftban portscan status
 
     # Run manual check (parse logs)
-    sudo nftban portscan check
+    nftban portscan check
 
     # Show detected scans
     nftban portscan history
@@ -196,7 +196,7 @@ LOG FILES:
     Tracking database: /var/lib/nftban/portscan/tracker.db
 
 REQUIREMENTS:
-    • Root privileges (for enable/disable commands)
+    • Elevated privileges (members of the nftban group are authorized via PolicyKit/polkit for enable/disable commands)
     • nftables >= 0.9.0
     • Kernel logging enabled
 
@@ -535,7 +535,7 @@ nftban_cmd_portscan() {
                 echo "     Rules: $rule_count logging rules"
             else
                 echo "  ❌ Port scan detection chain not found (IPv4)"
-                echo "     Run 'sudo nftban portscan enable' to create"
+                echo "     Run 'nftban portscan enable' to create"
             fi
 
             if nft list chain "${NFTBAN_TABLE_IPV6}" portscan_detection &>/dev/null; then

--- a/cli/lib/nftban/cli/cmd_profile.sh
+++ b/cli/lib/nftban/cli/cmd_profile.sh
@@ -83,7 +83,7 @@ _nftban_profile_deprecated_notice() {
     echo "    • Configures optimal settings for your server"
     echo ""
     echo "  Run the wizard:"
-    echo "    sudo nftban wizard"
+    echo "    nftban wizard"
     echo ""
 }
 
@@ -210,13 +210,13 @@ _nftban_profile_show() {
         echo "No configuration file found at: $NFTBAN_CONFIG_LOCAL"
         echo ""
         echo "Run the wizard to configure NFTBan:"
-        echo "  sudo nftban wizard"
+        echo "  nftban wizard"
     fi
 
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-    echo "To reconfigure, run: sudo nftban wizard"
+    echo "To reconfigure, run: nftban wizard"
     echo ""
 
     return 0
@@ -242,8 +242,8 @@ OPTIONS:
     --json, -j          Output in JSON format (machine-readable)
 
 DEPRECATED (use wizard instead):
-    select              → Use: sudo nftban wizard
-    apply <name>        → Use: sudo nftban wizard
+    select              → Use: nftban wizard
+    apply <name>        → Use: nftban wizard
     list                → Static profiles removed
 
 MIGRATION TO WIZARD:
@@ -267,7 +267,7 @@ MIGRATION TO WIZARD:
 
 RUN THE WIZARD:
 
-    sudo nftban wizard
+    nftban wizard
 
 SEE ALSO:
     nftban wizard help       - Wizard help
@@ -344,7 +344,7 @@ nftban_cmd_profile() {
             echo "Available commands: show, help"
             echo ""
             echo "For configuration, use the wizard:"
-            echo "  sudo nftban wizard"
+            echo "  nftban wizard"
             return 1
             ;;
     esac

--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -1829,7 +1829,7 @@ EXAMPLES:
   nftban support --email               # Email to default recipient
 
 WHEN REPORTING ISSUES:
-  1. Run: sudo nftban support
+  1. Run: nftban support
   2. Review the bundle for sensitive data
   3. Transfer/email the bundle:
      - Use --email to send directly

--- a/cli/lib/nftban/cli/cmd_system.sh
+++ b/cli/lib/nftban/cli/cmd_system.sh
@@ -678,13 +678,13 @@ TARGETS:
 
 EXAMPLES:
     # Enable everything
-    sudo nftban enable
+    nftban enable
 
     # Disable Suricata only
-    sudo nftban disable suricata
+    nftban disable suricata
 
     # Restart all services
-    sudo nftban restart
+    nftban restart
 
     # Check status
     nftban services status
@@ -693,7 +693,7 @@ EXAMPLES:
     nftban services status --json
 
     # EMERGENCY: Disable all NFTBan
-    sudo nftban disable all
+    nftban disable all
 
 CONFIGURATION:
     ${NFTBAN_CONFIG_DIR}/conf.d/services.conf        - Service settings

--- a/cli/lib/nftban/cli/cmd_trust.sh
+++ b/cli/lib/nftban/cli/cmd_trust.sh
@@ -409,22 +409,22 @@ EXAMPLES:
     nftban trust list
 
     # Enable Cloudflare
-    sudo nftban trust enable CLOUDFLARE
+    nftban trust enable CLOUDFLARE
 
     # Enable AWS
-    sudo nftban trust enable AWS
+    nftban trust enable AWS
 
     # Check status
     nftban trust status
 
     # Update all enabled providers
-    sudo nftban trust update
+    nftban trust update
 
     # Update only Cloudflare
-    sudo nftban trust update CLOUDFLARE
+    nftban trust update CLOUDFLARE
 
     # Disable Google Cloud
-    sudo nftban trust disable GOOGLE
+    nftban trust disable GOOGLE
 
 CONFIGURATION:
     Config file: /etc/nftban/conf.d/trust.conf

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -778,7 +778,7 @@ _cmd_update_main() {
             echo "  See the installer output above for the canonical recovery path."
             echo "  Common recovery commands:"
             echo "      sudo nftban-installer --repair       # resume from failed phase"
-            echo "      sudo nftban update rollback          # restore previous version"
+            echo "      nftban update rollback          # restore previous version"
             echo "      nftban support                       # diagnostic bundle"
             echo ""
             echo "  Log: $UPDATE_LOG_FILE"
@@ -945,7 +945,7 @@ _cmd_update_repair() {
             _update_log INFO "No backups found"
             if [[ $repair_status -ne 0 ]]; then
                 _update_log WARN "No backup to restore from"
-                _update_log INFO "Try: sudo nftban update force"
+                _update_log INFO "Try: nftban update force"
             fi
         fi
     else
@@ -959,7 +959,7 @@ _cmd_update_repair() {
         echo "  Repair completed successfully"
     else
         echo "  Repair completed with warnings"
-        echo "  If issues persist, try: sudo nftban update force"
+        echo "  If issues persist, try: nftban update force"
         echo "  Or reinstall: sudo dpkg -i --force-all <package.deb>"
     fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -2215,10 +2215,10 @@ Please check the server and review the logs:
   journalctl -u nftban-update-apply.service
 
 To manually update:
-  sudo nftban update
+  nftban update
 
 To rollback:
-  sudo nftban update rollback"
+  nftban update rollback"
     fi
 
     # Load mail module if available

--- a/cli/lib/nftban/cli/cmd_whitelist_system.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist_system.sh
@@ -86,19 +86,19 @@ OPTIONS:
 
 EXAMPLES:
   # Auto-detect and protect all system IPs
-  sudo nftban whitelist-system sync
+  nftban whitelist-system sync
 
   # Quick sync (skip public IP HTTP lookups)
-  sudo nftban whitelist-system sync --quick
+  nftban whitelist-system sync --quick
 
   # Package upgrade: protect admin SSH session + quick sync
-  sudo nftban whitelist-system sync --quick --protect-session
+  nftban whitelist-system sync --quick --protect-session
 
   # Show protected system IPs
   nftban whitelist-system show
 
   # Protect your current IP from being banned
-  sudo nftban whitelist-system whitelistme
+  nftban whitelist-system whitelistme
 
 WHAT IS AUTO-DETECTED:
   • Localhost (127.0.0.1, ::1)

--- a/cli/lib/nftban/cli/cmd_wizard.sh
+++ b/cli/lib/nftban/cli/cmd_wizard.sh
@@ -580,7 +580,7 @@ DEFAULTS:
     - IDS: OFF on small environments
 
 EXAMPLES:
-    sudo nftban wizard install    # Run full wizard
+    nftban wizard install    # Run full wizard
     nftban wizard env             # Just show environment
 
 EOF

--- a/cli/lib/nftban/core/nftban_geoip_download.sh
+++ b/cli/lib/nftban/core/nftban_geoip_download.sh
@@ -338,13 +338,13 @@ CONFIGURATION:
 
 EXAMPLES:
     # Initial setup
-    sudo nftban geoip download
+    nftban geoip download
 
     # Check status
     nftban geoip status
 
     # Update database
-    sudo nftban geoip update
+    nftban geoip update
 
     # Test lookup
     nftban geoip lookup 8.8.8.8

--- a/cli/lib/nftban/core/nftban_health_checks_core.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_core.sh
@@ -330,10 +330,10 @@ nftban_health_check_auditor_acls() {
                     }
                 fi
             else
-                acl_issues+=("NEEDS ROOT: Run 'sudo nftban health fix permissions' to set ACLs")
+                acl_issues+=("NEEDS ELEVATED PRIVILEGES: Run 'nftban health fix permissions' to set ACLs")
             fi
         else
-            acl_issues+=("FIX: Run 'sudo nftban health fix permissions' or 'sudo nftban permissions enforce'")
+            acl_issues+=("FIX: Run 'nftban health fix permissions' or 'nftban permissions enforce'")
         fi
     fi
 

--- a/cli/lib/nftban/core/nftban_health_fixes.sh
+++ b/cli/lib/nftban/core/nftban_health_fixes.sh
@@ -448,13 +448,13 @@ nftban_health_fix_permissions() {
     # Report what needs root
     if [[ $need_root_count -gt 0 ]]; then
         echo ""
-        echo "  ⚠️  Cannot fix $need_root_count permission/ownership issues (need root privileges):"
+        echo "  ⚠️  Cannot fix $need_root_count permission/ownership issues (require elevated privileges; members of the nftban group are authorized via PolicyKit/polkit):"
         for item in "${need_root_fixes[@]}"; do
             echo "     - $item"
         done
         echo ""
-        echo "  💡 Run with root privileges to fix:"
-        echo "     sudo nftban health fix permissions"
+        echo "  💡 Run with elevated privileges to fix (members of the nftban group are authorized via PolicyKit/polkit):"
+        echo "     nftban health fix permissions"
     fi
 
     # Also fix auditor ACLs if running as root
@@ -549,13 +549,13 @@ nftban_health_fix_directories() {
     # Report what needs root
     if [[ $need_root_count -gt 0 ]]; then
         echo ""
-        echo "  ⚠️  Cannot create $need_root_count directories (need root privileges):"
+        echo "  ⚠️  Cannot create $need_root_count directories (require elevated privileges; members of the nftban group are authorized via PolicyKit/polkit):"
         for item in "${need_root_dirs[@]}"; do
             echo "     - $item"
         done
         echo ""
-        echo "  💡 Run with root privileges to fix:"
-        echo "     sudo nftban health fix directories"
+        echo "  💡 Run with elevated privileges to fix (members of the nftban group are authorized via PolicyKit/polkit):"
+        echo "     nftban health fix directories"
     fi
     return 0
 }
@@ -823,7 +823,7 @@ nftban_health_fix_system_config() {
 # Editing manually will cause health check failures.
 #
 # If UID/GID changes (user deleted/recreated), run:
-#   sudo nftban health fix all
+#   nftban health fix all
 #
 # This file is auto-maintained by:
 #   - install.sh (during installation)

--- a/cli/lib/nftban/core/nftban_security.sh
+++ b/cli/lib/nftban/core/nftban_security.sh
@@ -88,7 +88,7 @@ RECOMMENDED SOLUTION (service-scoped capability):
 TEMPORARY WORKAROUND (not recommended):
   Run the command as root:
 
-  sudo nftban [command]
+  nftban [command]
 
 DOCUMENTATION:
   See /usr/share/nftban/docs/README.capabilities for details

--- a/cli/lib/nftban/core/nftban_trust.sh
+++ b/cli/lib/nftban/core/nftban_trust.sh
@@ -765,7 +765,7 @@ nftban_trust_update() {
 
     if ! _trust_is_enabled "$provider"; then
         echo "ERROR: $provider is not enabled" >&2
-        echo "Enable first: sudo nftban trust enable $provider" >&2
+        echo "Enable first: nftban trust enable $provider" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/helpers/nftban_mode.sh
+++ b/cli/lib/nftban/helpers/nftban_mode.sh
@@ -297,7 +297,7 @@ _nftban_mode_set() {
     # Check root privileges
     if [[ $EUID -ne 0 ]]; then
         if [[ "$json_mode" == "true" ]] && declare -f json_error &>/dev/null; then
-            json_error "Root privileges required to change mode"
+            json_error "PolicyKit/polkit authorization failed or insufficient privileges to change mode"
         else
             echo "ERROR: Root privileges required to change mode" >&2
         fi

--- a/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
+++ b/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
@@ -110,15 +110,42 @@ hits=${hits:-0}
 [[ "$hits" -eq 0 ]]
 _t_assert "A4: zero 'must run as root' / 'Run as root' in CLI surfaces (got: $hits)" "$?"
 
-# A5: 'sudo nftban X' example lines — PR-A.1 INFORMATIONAL ONLY (PR-A.2 hardens).
-# Per v1.128 PR-A split (operator-locked), PR-A.1 covers error/help text +
-# REQUIRES block + Go privilege wording. PR-A.2 will sweep all 79 'sudo
-# nftban X' example lines and harden this assertion to '[[ "$hits" -eq 0 ]]'.
-hits=$(grep -rn 'sudo nftban' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+# A5: 'sudo nftban X' example lines — HARDENED in PR-A.2.
+# Allowed (allowlist via grep -E): 'sudo nftban-installer' (installer/bootstrap
+# binary; not the main CLI and not polkit-covered the same way; documented
+# in feedback_polkit_not_sudo_in_help.md "Allowlist exception").
+hits=$(grep -rn 'sudo nftban ' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
        | grep -v "/tests/" | _apply_allowlist | wc -l)
 hits=${hits:-0}
-[[ "$hits" -ge 0 ]]  # PR-A.1 phase: pass-through informational
-_t_assert "A5 (PR-A.1 informational; PR-A.2 hardens): 'sudo nftban' example lines remaining: $hits" "$?"
+[[ "$hits" -eq 0 ]]
+_t_assert "A5: zero 'sudo nftban X' example lines in main-CLI examples (got: $hits; 'sudo nftban-installer' allowlisted separately)" "$?"
+
+# A5b: 'sudo nftban-installer' (installer/bootstrap) — informational count
+# (allowlisted; reported for visibility but not asserted to zero)
+hits=$(grep -rn 'sudo nftban-installer' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null | grep -v "/tests/" | wc -l)
+hits=${hits:-0}
+[[ "$hits" -ge 0 ]]  # informational
+_t_assert "A5b (informational; allowlisted): 'sudo nftban-installer' installer/bootstrap references: $hits" "$?"
+
+# A8: PR-A.2 residual sweeps — 'root privileges' / 'NEEDS ROOT' / 'needs root'
+# in operator-facing strings (echo statements + ui_msg calls; internal
+# # comments excluded by the grep filter).
+hits=$(grep -rnE 'root privileges|NEEDS ROOT' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist \
+       | grep -v ':\s*#' \
+       | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A8: zero 'root privileges' / 'NEEDS ROOT' in operator-facing strings (got: $hits; internal # comments OK)" "$?"
+
+# A9: PR-A.2 ui_msg / echo "needs root" residuals
+hits=$(grep -rnE 'needs root|need root privileges' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist \
+       | grep -v ':\s*#' \
+       | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A9: zero 'needs root' / 'need root privileges' in operator-facing strings (got: $hits)" "$?"
 
 # A6: Zero "(sudo)" parenthetical hints
 hits=$(grep -rn 'privileges (sudo)\|root/sudo' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \


### PR DESCRIPTION
## Summary

v1.128 PR-A.2 — sweeps the 68 main-CLI `sudo nftban X` example lines + 14 residual operator-facing `root privileges` / `NEEDS ROOT` strings that PR-A.1's narrower test patterns missed.

Completes the POLKIT_AWARE_WORDING_SWEEP arc started in [PR #675](https://github.com/itcmsgr/nftban/pull/675).

## Canonical model (unchanged from PR-A.1)

> **Members of the nftban group can run supported NFTBan privileged operations through PolicyKit/polkit authorization rules.**

## Changes

- **68 `sudo nftban X` example lines** across 23 CLI shell files → `nftban X` (drop sudo prefix; privilege requirement is documented once in REQUIRES block, not repeated in every example)
- **2 `sudo nftban-installer` references preserved** (`cmd_update.sh:746/780`) per installer/bootstrap allowlist
- **14 residual operator-facing strings** rewritten to canonical: `cmd_egress.sh`, `cmd_ddos.sh`, `cmd_nftables.sh`, `cmd_firewall.sh` (×3), `cmd_portscan.sh`, `cmd_login.sh`, `cmd_menu.sh`, `cmd_health_core.sh`, `cmd_health_checks_core.sh`, `nftban_mode.sh`, `nftban_health_fixes.sh` (×4)
- **Internal code comments preserved** (`# Smart about privileges: ... reports what needs root` in `nftban_health_fixes.sh`) — not operator-facing

## Test hardening (23/23 PASS, up from PR-A.1's 20/20)

```
A5  HARDENED: zero 'sudo nftban X' main-CLI example lines  (was informational)
A5b NEW (informational): 'sudo nftban-installer' allowlist count = 2 (preserved)
A8  NEW: zero 'root privileges' / 'NEEDS ROOT' operator-facing strings
A9  NEW: zero 'needs root' / 'need root privileges' operator-facing strings
```

## Binary impact

```
ZERO. PR-A.2 is shell-only; no Go file touched.
cmd/nftband + cmd/nftban-core byte-identical to PR-A.1's main HEAD b3b28121.
Schema 1.83.0 UNCHANGED.
```

## Out of scope (deferred to PR-B/C/D)

- ❌ PR-B: HELP_CODE_CORRELATION_AUDIT (doctest harness)
- ❌ PR-C: WIKI_CLI_TEXT_ALIGNMENT
- ❌ PR-D: DOC_CLARITY_AUDIT
- ❌ No host contact / release / tag / publish
- ❌ No polkit-rule / packaging / systemd / schema / metrics / portal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)