### PR TITLE
test(docs): v1.128 PR-D — lockable doc clarity audit invariant

### DIFF
--- a/cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh
+++ b/cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# =============================================================================
+# v1.128 PR-D DOC_CLARITY_AUDIT — deterministic test fixtures
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v128_doc_clarity_audit_test"
+# meta:type="test"
+# meta:version="1.128.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic clarity-lint across operator-facing repo markdown (README.md + docs/**/*.md). Locks the v1.128 invariant after PR-A.1/.2 (polkit wording sweep), PR-B (help/code correlation), and PR-C (wiki + docs alignment): operator-facing markdown must not contain TODO/XXX/FIXME placeholders, vague qualifier phrases ('for various reasons', 'usually works', 'should work', 'in general'), double-negative constructions (heuristic check excluding technical double-negatives), or any residual sudo/root drift that escaped PR-A.2. The clarity-lint is conservative and additive: it locks a small set of high-signal patterns rather than attempting subjective prose review. Wiki (/home/gituser/github/nftban.wiki/) is a separate sibling git repo not available to CI — that surface was aligned in PR-C wiki commit 312fdb3 on the nftban.wiki master branch and lives outside this test's reach. The 1 known technical double-negative in docs/THREAT_MODEL.md ('over-blocking but not under-blocking') is explicitly allowlisted as legitimate technical contrast wording."
+# meta:input="static scan of README.md + docs/**/*.md"
+# meta:output="exit 0 if clarity invariants hold; exit 1 with offender list otherwise"
+# meta:depends="bash,grep,find"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md (PR-D lane)
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_readme="${_repo_root}/README.md"
+_docs_dir="${_repo_root}/docs"
+
+# Allowlist: technical contexts where a "lint" hit is actually correct content
+_ALLOWLIST=(
+    'docs/THREAT_MODEL.md.*over-blocking.*but not under-blocking'  # legitimate technical contrast
+)
+
+_apply_allowlist() {
+    local pattern
+    for pattern in "${_ALLOWLIST[@]}"; do
+        set -- "$@" -e "$pattern"
+    done
+    grep -v "$@"
+}
+
+echo "==============================================================================="
+echo "v1.128 PR-D DOC_CLARITY_AUDIT — deterministic test fixtures"
+echo "==============================================================================="
+
+# =============================================================================
+# (A) Placeholder markers — operator-facing markdown must not ship with these
+# =============================================================================
+hits=$(grep -rnE 'TODO:|XXX:|FIXME:' --include='*.md' "$_readme" "$_docs_dir" 2>/dev/null | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A1: zero TODO/XXX/FIXME placeholder markers in README + docs/ (got: $hits)" "$?"
+
+# =============================================================================
+# (B) Vague qualifier phrases — undermine operator confidence
+# =============================================================================
+hits=$(grep -rniE 'for various reasons|should work|usually works|in general,' --include='*.md' "$_readme" "$_docs_dir" 2>/dev/null | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "B1: zero vague qualifier phrases ('for various reasons' / 'should work' / 'usually works' / 'in general,') in README + docs/ (got: $hits)" "$?"
+
+# =============================================================================
+# (C) Double-negative constructions — heuristic with explicit allowlist
+# =============================================================================
+hits=$(grep -rniE "don'?t not|not un[a-z]+|cannot not" --include='*.md' "$_readme" "$_docs_dir" 2>/dev/null \
+       | _apply_allowlist | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "C1: zero double-negative constructions (allowlist: legitimate technical contrast in THREAT_MODEL.md) (got: $hits)" "$?"
+
+# =============================================================================
+# (D) Residual sudo/root drift in operator-facing markdown
+# (cross-check that PR-A.2 + PR-C polkit wording didn't regress here)
+# =============================================================================
+hits=$(grep -rnE 'sudo nftban |must run as root|requires root|Run with sudo|Permission denied \(not root|root privileges' \
+       --include='*.md' "$_readme" "$_docs_dir" 2>/dev/null | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "D1: zero residual sudo/root drift in README + docs/ markdown (got: $hits)" "$?"
+
+# =============================================================================
+# (E) Scope/sanity sample counts
+# =============================================================================
+md_count=$(find "$_docs_dir" -name '*.md' 2>/dev/null | wc -l)
+md_count=${md_count:-0}
+[[ "$md_count" -ge 10 ]]
+_t_assert "E1: docs/ contains at least 10 .md files audited (got: $md_count)" "$?"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==============================================================================="
+echo "v1.128 PR-D test summary: ${TESTS_PASSED} PASS, ${TESTS_FAILED} FAIL"
+echo "==============================================================================="
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "Failed tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

v1.128 PR-D DOC_CLARITY_AUDIT — final lockable clarity-lint invariant for operator-facing repo markdown (README.md + docs/**/*.md).

**Recon at branch open: ZERO actionable clarity issues found** in README.md (349 lines) or docs/ (16 .md files). The V128 arc (PR-A.1 + PR-A.2 + PR-B + PR-C) already brought operator-facing markdown to the canonical state. PR-D ships as the lockable test that prevents future regression.

## Test gate: 5/5 PASS

```
A1: zero TODO/XXX/FIXME placeholder markers in README + docs/
B1: zero vague qualifier phrases ('for various reasons', 'should work', etc.)
C1: zero double-negative constructions (allowlist: one legitimate technical contrast in THREAT_MODEL.md)
D1: zero residual sudo/root drift (cross-check that PR-A.2 + PR-C didn't regress)
E1: scope/sanity — docs/ contains at least 10 .md files audited
```

## Changes

- **1 file added** (the test). **Zero source-content changes.**

## V128 arc complete

| Lane | SHA | Description |
|---|---|---|
| ✅ PR-A.1 | `b3b28121` | POLKIT_AWARE_WORDING_SWEEP authority text |
| ✅ PR-A.2 | `53ec9b61` | sudo-example line sweep across 24 files |
| ✅ PR-B | `44420367` | HELP_CODE_CORRELATION_AUDIT + 11 canonical list fixes |
| ✅ PR-C | wiki `312fdb3` | WIKI_CLI_TEXT_ALIGNMENT (separate `nftban.wiki:master` push) |
| 🔁 PR-D | THIS PR | DOC_CLARITY_AUDIT lockable lint |

## Wiki scope note

The nftban.wiki sibling repo at `/home/gituser/github/nftban.wiki/` (separate git repo, `master` branch, remote `itcmsgr/nftban.wiki`) was aligned in PR-C wiki commit `312fdb3` — that surface lives outside this main-repo test's CI reach because wikis are separate repos with no integrated CI pipeline.

## Binary impact

ZERO. Test file only; no source touched. Schema 1.83.0 UNCHANGED.

## Out of scope

- ❌ No host contact
- ❌ No release/tag/publish (v1.128.0 release-prep is a separate follow-on gate)
- ❌ No polkit-rule / packaging / systemd / schema / metrics / portal / command-semantics change

🤖 Generated with [Claude Code](https://claude.com/claude-code)