### PR TITLE
fix(cli+validator): v1.129 PR-C — runtime defect fixes from PR-B cross-family evidence

### DIFF
--- a/cli/lib/nftban/cli/cmd_ban.sh
+++ b/cli/lib/nftban/cli/cmd_ban.sh
@@ -152,22 +152,22 @@ nftban_cmd_ban() {
     cmd_require_arg "$ip" "IP address" "$json_mode" nftban_cmd_ban_usage || return 1
     cmd_validate_ip "$ip" "$json_mode" nftban_cmd_ban_usage || return 1
 
-    # V127 UX-2 item 1.7: well-known public infrastructure IP guard.
-    # Banning addresses like 8.8.8.8 / 1.1.1.1 / 9.9.9.9 / 208.67.222.222 produces
-    # no security benefit on a typical host and disrupts legitimate name resolution
-    # for the operator's users. Refuse unless --yes (auto_confirm) is set explicitly.
-    # Dry-run path is allowed unconditionally (no mutation) so operators can preview
-    # what the guard would do. JSON mode emits a structured refusal with success=false.
-    # Helper: cli/lib/nftban/lib/nftban_well_known.sh (inline IP map; no /etc/nftban/
-    # fixture; no package payload registration).
-    # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-2 item 1.7)
+    # V127 UX-2 item 1.7 (V129 PR-C D7 corrected): well-known public infrastructure
+    # IP guard. Banning addresses like 8.8.8.8 / 1.1.1.1 / 9.9.9.9 / 208.67.222.222
+    # produces no security benefit on a typical host and disrupts legitimate name
+    # resolution for the operator's users. Refuse unless --yes (auto_confirm) is set
+    # explicitly. V129 PR-C D7 fix: the guard now fires for BOTH live AND --dry-run
+    # paths. A dry-run preview showing "would ban 8.8.8.8" misleads operators into
+    # thinking the subsequent live command will succeed; instead dry-run must
+    # reflect what the guard would actually do (refuse). --yes still overrides for
+    # both live and dry-run paths.
     if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" ]]; then
         # shellcheck source=/dev/null
         source "${NFTBAN_LIB_DIR}/lib/nftban_well_known.sh" 2>/dev/null || true
         if declare -f nftban_is_well_known_infra_ip >/dev/null 2>&1; then
             local _wk_descr
             if _wk_descr=$(nftban_is_well_known_infra_ip "$ip"); then
-                if [[ "$auto_confirm" != "true" && "$dry_run" != "true" ]]; then
+                if [[ "$auto_confirm" != "true" ]]; then
                     if [[ "$json_mode" == "true" ]] && declare -f json_output >/dev/null 2>&1; then
                         json_output "false" '{}' "Refused: ${ip} is well-known public infrastructure (${_wk_descr}). Re-run with --yes to override."
                     else
@@ -176,14 +176,11 @@ nftban_cmd_ban() {
                     return 1
                 fi
                 # Explicit override path: log the override + proceed.
-                if [[ "$auto_confirm" == "true" ]]; then
-                    if [[ "$json_mode" != "true" ]]; then
-                        echo "[!] Well-known infrastructure override accepted: ${ip} (${_wk_descr})" >&2
-                        echo "    Proceeding under explicit --yes confirmation." >&2
-                    fi
+                # Both dry-run and live fall through after this block when --yes is set.
+                if [[ "$json_mode" != "true" ]]; then
+                    echo "[!] Well-known infrastructure override accepted: ${ip} (${_wk_descr})" >&2
+                    echo "    Proceeding under explicit --yes confirmation." >&2
                 fi
-                # Dry-run path falls through to the dry-run preview block below;
-                # nothing is mutated either way.
             fi
         fi
     fi

--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -114,6 +114,10 @@ EXAMPLES:
   nftban config set portscan PORTSCAN_BAN_THRESHOLD=15
   nftban config apply portscan   # Apply to running service
 
+EXIT CODES:
+  0   Success — command completed and (if applicable) data emitted
+  1   Generic failure — module/config not found, parse error, missing arg
+
 EOF
 }
 

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1087,10 +1087,14 @@ firewall_validate() {
     # If strict mode, run additional checks
     if [[ "$strict_mode" == "true" ]]; then
         local strict_exit=$VALIDATE_OK
+        # V129 PR-C D8: tell strict mode whether the structural validator passed
+        # so its footer label matches the exit code we'll return.
+        local _struct_ok="true"
+        [[ $validation_result -ne $VALIDATE_OK ]] && _struct_ok="false"
         if [[ "$quiet_mode" == "true" ]]; then
-            _firewall_validate_strict "$output_json" >/dev/null 2>&1 || strict_exit=$?
+            _firewall_validate_strict "$output_json" "$_struct_ok" >/dev/null 2>&1 || strict_exit=$?
         else
-            _firewall_validate_strict "$output_json" || strict_exit=$?
+            _firewall_validate_strict "$output_json" "$_struct_ok" || strict_exit=$?
         fi
 
         # Return the more severe exit code
@@ -1109,7 +1113,12 @@ firewall_validate() {
 _firewall_validate_strict() {
     # Enforce Single Firewall Authority
     # Returns: 0=OK, 10=policykit, 20=conflict, 30=collision, 40=env
+    # V129 PR-C D8: 2nd arg `structural_ok` ("true"/"false") tells strict mode
+    # whether the structural validator passed. When false, the strict-mode
+    # footer MUST NOT say PASSED — the operator must see a UX-consistent
+    # report that matches the nonzero exit code from the caller.
     local json_mode="${1:-false}"
+    local structural_ok="${2:-true}"
 
     [[ "$json_mode" == "false" ]] && echo ""
     [[ "$json_mode" == "false" ]] && echo "STRICT MODE: Single Firewall Authority Check"
@@ -1131,8 +1140,17 @@ _firewall_validate_strict() {
     fi
 
     [[ "$json_mode" == "false" ]] && echo ""
-    [[ "$json_mode" == "false" ]] && echo "STRICT PREFLIGHT: PASSED"
-    [[ "$json_mode" == "false" ]] && echo "NFTBan is sole firewall authority - enforce mode OK"
+    if [[ "$structural_ok" == "true" ]]; then
+        [[ "$json_mode" == "false" ]] && echo "STRICT PREFLIGHT: PASSED"
+        [[ "$json_mode" == "false" ]] && echo "NFTBan is sole firewall authority - enforce mode OK"
+    else
+        # V129 PR-C D8: structural validator did NOT pass. Strict-mode conflict
+        # checks all passed, but we can NOT say PASSED because the caller will
+        # return a nonzero rc reflecting the structural failure. Operator must
+        # see a label that matches the exit code.
+        [[ "$json_mode" == "false" ]] && echo "STRICT PREFLIGHT: NOT VERIFIED (see Validator Status above)"
+        [[ "$json_mode" == "false" ]] && echo "Conflict checks passed, but the structural validator could not confirm ruleset truth."
+    fi
 
     return $VALIDATE_OK
 }

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -107,8 +107,20 @@ nftban_cmd_health() {
     # Main health command handler
     # Args: subcommand [options]
 
-    local subcommand="${1:-check}"
-    shift || true
+    # V129 PR-C D4: if the first argument is a global flag (not a subcommand),
+    # default subcommand to "check" and leave the flag in $@ so the args loop
+    # below can parse it. Without this, `nftban health --verbose` mis-sets
+    # subcommand="--verbose" and the case below emits "Unknown health command".
+    local subcommand
+    case "${1:-}" in
+        --verbose|-v|--json)
+            subcommand="check"
+            ;;
+        *)
+            subcommand="${1:-check}"
+            shift || true
+            ;;
+    esac
 
     # v1.83 F2 fix: scan for --json AFTER shift, so subcommand position
     # is excluded. Then build a clean args array without --json so it

--- a/cli/lib/nftban/cli/cmd_version.sh
+++ b/cli/lib/nftban/cli/cmd_version.sh
@@ -212,9 +212,7 @@ nftban_cmd_version() {
   "build_date": "${NFTBAN_BUILD_DATE}",
   "components": {
     "cli": "${NFTBAN_CLI_VERSION}",
-    "core": "${NFTBAN_CORE_VERSION}",
-    "gui": "${NFTBAN_GUI_VERSION}",
-    "api": "${NFTBAN_API_VERSION}"
+    "core": "${NFTBAN_CORE_VERSION}"
   },
   "requirements": {
     "bash_min": "${NFTBAN_MIN_BASH_VERSION}",

--- a/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
+++ b/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
@@ -170,10 +170,15 @@ else
     _t_assert "1.7 cmd_ban.sh calls helper function" 1 "helper call missing"
 fi
 
-if grep -q '"\$auto_confirm" != "true" && "\$dry_run" != "true"' "$_ban_cli"; then
-    _t_assert "1.7 guard refuses unless --yes (auto_confirm) OR --dry-run" 0
+# V129 PR-C D7: the pre-fix condition `[[ "$auto_confirm" != "true" && "$dry_run" != "true" ]]`
+# bypassed the guard in --dry-run mode (silently mis-confirming "would ban 8.8.8.8" on
+# dry-run preview). The v1.129 corrected condition is auto_confirm-only — dry-run is
+# ALSO refused unless --yes is set. See AUDIT_190_LIFECYCLE/V129_PR_B_LAB2_EXECUTION_REPORT.md
+# §3 D7 + cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh.
+if grep -q 'if \[\[ "\$auto_confirm" != "true" \]\]; then' "$_ban_cli"; then
+    _t_assert "1.7 guard refuses on dry-run AND live unless --yes (V129 PR-C D7 corrected)" 0
 else
-    _t_assert "1.7 guard refuses unless --yes (auto_confirm) OR --dry-run" 1 "conditional pattern missing"
+    _t_assert "1.7 guard refuses on dry-run AND live unless --yes (V129 PR-C D7 corrected)" 1 "post-V129-PR-C auto_confirm-only condition missing"
 fi
 
 if grep -q 'override accepted' "$_ban_cli"; then

--- a/cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh
+++ b/cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V129 PR-C — runtime defect fixes regression test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v129_pr_c_runtime_defect_fixes_test"
+# meta:type="test"
+# meta:version="1.129.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-24"
+# meta:description="Deterministic regression tests for the six runtime defects classified cross-family in V129 PR-B and fixed in V129 PR-C: D1 (version --json broken by NFTBAN_GUI_VERSION unbound), D4 (health --verbose unknown as first arg), D5 (config get exit-code contract documented), D6.B (validator polkit-aware wording on permission denied), D7 (well-known IP guard bypassed in --dry-run), D8 (strict-validate prints PASSED when structural validator failed). Tests are pattern-based (grep) for shell paths and execution-based for D1 JSON validity. Full lab2/RPM runtime verification is the PR-C exit gate; this file is the deterministic CI-side guard."
+# meta:input="self-contained; sources only the files under test in subshells"
+# meta:output="[PASS]/[FAIL] per assertion; exit 1 on first failure; exit 0 if all pass"
+# meta:depends="bash,grep,jq (for D1 JSON parse only)"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V129_PR_B_LAB2_EXECUTION_REPORT.md
+#        + AUDIT_190_LIFECYCLE/V129_PR_B_RPM_EXECUTION_REPORT.md
+#        + AUDIT_190_LIFECYCLE/V129_DEB_RPM_COMPARISON_MATRIX.md
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+export NFTBAN_LIB_DIR="${_repo_root}/cli/lib/nftban"
+
+_version_cli="${NFTBAN_LIB_DIR}/cli/cmd_version.sh"
+_health_cli="${NFTBAN_LIB_DIR}/cli/cmd_health.sh"
+_config_cli="${NFTBAN_LIB_DIR}/cli/cmd_config.sh"
+_ban_cli="${NFTBAN_LIB_DIR}/cli/cmd_ban.sh"
+_firewall_cli="${NFTBAN_LIB_DIR}/cli/cmd_firewall.sh"
+_validator_go="${_repo_root}/internal/validator/validator.go"
+
+echo "==============================================================================="
+echo "V129 PR-C — runtime defect fixes regression test"
+echo "==============================================================================="
+echo "  Repo root:    $_repo_root"
+echo
+
+# ----------------------------------------------------------------------------
+# D1: nftban version --json emits valid JSON; no NFTBAN_GUI_VERSION reference
+# ----------------------------------------------------------------------------
+echo "--- D1: nftban version --json ---"
+
+# Source check: the JSON heredoc MUST NOT reference NFTBAN_GUI_VERSION or
+# NFTBAN_API_VERSION (V127 UX-1 1.3 removed them; v1.129 PR-C removes the
+# residual heredoc references).
+if grep -qE 'NFTBAN_(GUI|API)_VERSION' "$_version_cli"; then
+    _t_assert "D1: cmd_version.sh has no NFTBAN_GUI_VERSION/API_VERSION references" 1 \
+        "grep still finds NFTBAN_(GUI|API)_VERSION"
+else
+    _t_assert "D1: cmd_version.sh has no NFTBAN_GUI_VERSION/API_VERSION references" 0
+fi
+
+# Runtime check: when run with strict mode + --json, output parses as valid JSON
+# and contains a version key. Skip jq-based parse if jq missing.
+if command -v jq >/dev/null 2>&1; then
+    _json_out=$(bash -Eeuo pipefail -c '
+        export NFTBAN_VERSION="1.129.0-test"
+        export NFTBAN_VERSION_NAME="PR-C-test"
+        export NFTBAN_VERSION_DATE="2026-05-24"
+        export NFTBAN_BUILD_DATE="2026-05-24"
+        export NFTBAN_CLI_VERSION="1.129.0-test"
+        export NFTBAN_CORE_VERSION="1.129.0-test"
+        export NFTBAN_MIN_BASH_VERSION="4.4"
+        export NFTBAN_MIN_NFT_VERSION="0.9.0"
+        export NFTBAN_LIB_DIR="'"$NFTBAN_LIB_DIR"'"
+        # shellcheck source=/dev/null
+        source "'"$_version_cli"'" 2>/dev/null || true
+        if declare -f nftban_cmd_version >/dev/null; then
+            nftban_cmd_version --json 2>/dev/null
+        fi
+    ' 2>/dev/null)
+    # Strip post-JSON sentinel line `# NFTBAN_CMD_EXIT: version` emitted by
+    # cmd_version.sh at the end of every invocation.
+    _json_clean=$(printf '%s\n' "$_json_out" | sed '/^# NFTBAN_CMD_EXIT/,$d')
+    if echo "$_json_clean" | jq -e '.version' >/dev/null 2>&1; then
+        _t_assert "D1: --json output parses as JSON with .version key" 0
+    else
+        _t_assert "D1: --json output parses as JSON with .version key" 1 \
+            "output was: $_json_out"
+    fi
+else
+    echo "  [SKIP] D1 runtime jq check (jq not installed)"
+fi
+
+# ----------------------------------------------------------------------------
+# D4: nftban health --verbose works as first arg (does NOT route to "Unknown")
+# ----------------------------------------------------------------------------
+echo "--- D4: nftban health --verbose ---"
+
+# The cmd_health.sh dispatcher MUST handle --verbose / -v / --json as first arg
+# by routing to default "check" subcommand without consuming them as subcommand.
+if grep -qE '^\s*--verbose\|-v\|--json\)' "$_health_cli"; then
+    _t_assert "D4: cmd_health.sh routes --verbose/-v/--json first-arg to default subcommand" 0
+else
+    _t_assert "D4: cmd_health.sh routes --verbose/-v/--json first-arg to default subcommand" 1 \
+        "expected case branch '--verbose|-v|--json)' near subcommand parser"
+fi
+
+# Negative pattern: there must NOT be an executable assignment that sets
+# subcommand="--verbose" (ignoring comments). The pre-fix bug was the literal
+# "local subcommand=\"${1:-check}\"" line being the sole subcommand setter
+# without flag detection.
+if grep -vE '^\s*#' "$_health_cli" | grep -qE 'subcommand="--verbose"'; then
+    _t_assert "D4: no executable code assigns subcommand=\"--verbose\"" 1 \
+        "found explicit subcommand=\"--verbose\" assignment outside comments"
+else
+    _t_assert "D4: no executable code assigns subcommand=\"--verbose\"" 0
+fi
+
+# ----------------------------------------------------------------------------
+# D5: cmd_config.sh help has EXIT CODES block documenting rc=1 for not-found
+# ----------------------------------------------------------------------------
+echo "--- D5: nftban config exit-code documentation ---"
+
+if grep -qE '^EXIT CODES:' "$_config_cli"; then
+    _t_assert "D5: cmd_config.sh usage block contains EXIT CODES section" 0
+else
+    _t_assert "D5: cmd_config.sh usage block contains EXIT CODES section" 1 \
+        "missing 'EXIT CODES:' header in show_usage heredoc"
+fi
+
+if grep -qE '^\s+1\s+Generic failure' "$_config_cli"; then
+    _t_assert "D5: cmd_config.sh EXIT CODES documents '1 Generic failure'" 0
+else
+    _t_assert "D5: cmd_config.sh EXIT CODES documents '1 Generic failure'" 1
+fi
+
+# Verify the not-found path actually returns 1 (the intended v1.127 UX-1 1.9 contract)
+if grep -A 3 'Configuration file not found for module' "${NFTBAN_LIB_DIR}/core/nftban_config.sh" | grep -qE '^\s*return 1$'; then
+    _t_assert "D5: nftban_config.sh not-found path returns 1 (per UX-1 1.9 contract)" 0
+else
+    _t_assert "D5: nftban_config.sh not-found path returns 1 (per UX-1 1.9 contract)" 1 \
+        "expected 'return 1' immediately after not-found stderr block"
+fi
+
+# ----------------------------------------------------------------------------
+# D6.B: no "you must be root" wording in NFTBan-emitted text; polkit-aware
+# remediation in validator
+# ----------------------------------------------------------------------------
+echo "--- D6.B: polkit-aware wording on permission denied ---"
+
+# CLI shell tree must never contain the forbidden V128 PR-A.1 wording.
+_root_hits=$(grep -rln "you must be root" "${NFTBAN_LIB_DIR}" 2>/dev/null | grep -v -E '/tests/|/V129_' || true)
+if [[ -z "$_root_hits" ]]; then
+    _t_assert "D6.B: no 'you must be root' wording in cli/lib/nftban/ (non-test)" 0
+else
+    _t_assert "D6.B: no 'you must be root' wording in cli/lib/nftban/ (non-test)" 1 \
+        "hits in: $_root_hits"
+fi
+
+# Validator must scrub the upstream nft "(you must be root)" pattern when wrapping.
+if grep -qE '\(you must be root\)' "$_validator_go"; then
+    _t_assert "D6.B: validator.go strips/handles '(you must be root)' upstream wording" 0
+else
+    _t_assert "D6.B: validator.go strips/handles '(you must be root)' upstream wording" 1 \
+        "expected explicit (you must be root) handling — fix dropped or pattern changed"
+fi
+
+# Validator remediation must be polkit/capability-aware, not legacy "permissions" wording.
+if grep -qE 'CAP_NET_ADMIN' "$_validator_go"; then
+    _t_assert "D6.B: validator.go remediation mentions CAP_NET_ADMIN" 0
+else
+    _t_assert "D6.B: validator.go remediation mentions CAP_NET_ADMIN" 1
+fi
+
+# ----------------------------------------------------------------------------
+# D7: nftban ban --dry-run on well-known IP must be rejected
+# ----------------------------------------------------------------------------
+echo "--- D7: well-known guard fires in --dry-run ---"
+
+# The guard condition must NOT include `&& "$dry_run" != "true"` (the original bug)
+if grep -qE 'auto_confirm.*!=.*"true".*&&.*dry_run.*!=.*"true"' "$_ban_cli"; then
+    _t_assert "D7: cmd_ban.sh guard condition does NOT exclude dry-run" 1 \
+        "found pre-fix condition that excluded dry-run from the refusal branch"
+else
+    _t_assert "D7: cmd_ban.sh guard condition does NOT exclude dry-run" 0
+fi
+
+# Positive: the new condition checks only auto_confirm
+if grep -qE 'if \[\[ "\$auto_confirm" != "true" \]\]; then' "$_ban_cli"; then
+    _t_assert "D7: cmd_ban.sh guard uses auto_confirm-only condition" 0
+else
+    _t_assert "D7: cmd_ban.sh guard uses auto_confirm-only condition" 1 \
+        "expected the refusal branch to be gated on auto_confirm only"
+fi
+
+# Documentation comment must be updated to reflect that dry-run is also refused
+if grep -qE '(dry.run|dry_run)' "$_ban_cli" | head -1 >/dev/null && \
+   grep -qE 'V129 PR-C D7' "$_ban_cli"; then
+    _t_assert "D7: cmd_ban.sh comments reference V129 PR-C D7 fix" 0
+else
+    _t_assert "D7: cmd_ban.sh comments reference V129 PR-C D7 fix" 1
+fi
+
+# ----------------------------------------------------------------------------
+# D8: strict-validate must NOT say PASSED when structural validator failed
+# ----------------------------------------------------------------------------
+echo "--- D8: strict-validate PASSED only when structural_ok ---"
+
+# The strict-mode function must accept a structural_ok parameter
+if grep -qE 'structural_ok="?\$\{2:-true\}"?' "$_firewall_cli"; then
+    _t_assert "D8: _firewall_validate_strict accepts structural_ok 2nd arg" 0
+else
+    _t_assert "D8: _firewall_validate_strict accepts structural_ok 2nd arg" 1
+fi
+
+# The function must emit "NOT VERIFIED" label when structural_ok != "true"
+if grep -qE 'STRICT PREFLIGHT: NOT VERIFIED' "$_firewall_cli"; then
+    _t_assert "D8: 'STRICT PREFLIGHT: NOT VERIFIED' label exists" 0
+else
+    _t_assert "D8: 'STRICT PREFLIGHT: NOT VERIFIED' label exists" 1
+fi
+
+# The PASSED label must be gated on structural_ok=="true"
+_passed_branch=$(awk '/structural_ok.*==.*"true"/,/else/' "$_firewall_cli" 2>/dev/null | grep -c 'STRICT PREFLIGHT: PASSED' || true)
+if [[ "$_passed_branch" -ge 1 ]]; then
+    _t_assert "D8: 'STRICT PREFLIGHT: PASSED' is inside structural_ok==true branch" 0
+else
+    _t_assert "D8: 'STRICT PREFLIGHT: PASSED' is inside structural_ok==true branch" 1 \
+        "PASSED not found inside structural_ok==\"true\" branch"
+fi
+
+# Caller must pass structural_ok based on validation_result
+if grep -qE '_struct_ok="false"' "$_firewall_cli" && \
+   grep -qE '_firewall_validate_strict.*"\$_struct_ok"' "$_firewall_cli"; then
+    _t_assert "D8: firewall_validate caller passes structural_ok to strict mode" 0
+else
+    _t_assert "D8: firewall_validate caller passes structural_ok to strict mode" 1
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "==============================================================================="
+echo "V129 PR-C regression test summary"
+echo "==============================================================================="
+echo "  Passed:  $TESTS_PASSED"
+echo "  Failed:  $TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "  Failed assertions:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "    - $n"
+    done
+    exit 1
+fi
+exit 0

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -124,12 +124,23 @@ func ValidateKernel(ctx context.Context) (*ValidationResult, error) {
 	ruleset, err := LoadRulesetJSON(ctx)
 	if err != nil {
 		result.Status = StatusDown
+		errText := err.Error()
+		message := "Failed to load nftables ruleset: " + errText
+		remediation := "Check nft command availability and permissions"
+		// V129 PR-C D6.B: polkit-aware capability wording when nft fails on
+		// permission. The upstream nft binary emits "(you must be root)" which
+		// contradicts NFTBan's polkit/group-based authorization framing.
+		if strings.Contains(errText, "Operation not permitted") || strings.Contains(errText, "permission denied") {
+			cleaned := strings.TrimSpace(strings.ReplaceAll(errText, "(you must be root)", ""))
+			message = "Failed to load nftables ruleset: " + cleaned
+			remediation = "Direct nft access requires CAP_NET_ADMIN (root or nftban systemd-service context). The nftban group does not currently grant direct nft access through polkit; run via 'systemctl start nftban-firewall-validate' or equivalent privileged path."
+		}
 		result.Findings = append(result.Findings, Finding{
 			Code:        CodeNftFailed,
 			Severity:    SeverityCritical,
 			Component:   "kernel",
-			Message:     "Failed to load nftables ruleset: " + err.Error(),
-			Remediation: "Check nft command availability and permissions",
+			Message:     message,
+			Remediation: remediation,
 		})
 		result.Summary = computeSummary(result)
 		return result, nil // Return result, not error - DOWN is a valid state


### PR DESCRIPTION
## Summary

Closes 6 defects classified **cross-family** by V129 PR-B lab2 (DEB) + dns2 (RPM-el9) + srv1 (RPM-el10) §9 battery.

| Defect | Severity | File | Fix |
|---|---|---|---|
| **D1** | P1 | `cli/lib/nftban/cli/cmd_version.sh` | Drop `gui`/`api` keys from JSON heredoc (V127 UX-1 1.3 removed those vars from `lib/version.sh` but the heredoc still referenced them → `NFTBAN_GUI_VERSION: unbound` + empty JSON + misleading rc=0) |
| **D4** | P1 | `cli/lib/nftban/cli/cmd_health.sh` | Route `--verbose` / `-v` / `--json` as first arg to default `check` subcommand (was consumed as subcommand → `Unknown health command: --verbose`) |
| **D5** | matrix-correction | `cli/lib/nftban/cli/cmd_config.sh` | Code is at the intended `rc=1` per V127 UX-1 1.9 ("Returns 1 (unchanged) for nonzero rc"); static matrix prediction was wrong. PR-C adds an `EXIT CODES` block to `show_usage` to surface the contract to operators |
| **D6.B** | P1 | `internal/validator/validator.go` | Strip upstream nft `(you must be root)` substring on permission-denied; substitute polkit/capability-aware `Remediation` mentioning CAP_NET_ADMIN; restores V128 PR-A.1 wording policy on the validator surface |
| **D7** | **P0 CRITICAL** | `cli/lib/nftban/cli/cmd_ban.sh` | Well-known infrastructure guard now fires for BOTH `--dry-run` and live paths (was: condition `&& "$dry_run" != "true"` silently bypassed dry-run, so `nftban ban 8.8.8.8 --dry-run` lied with rc=0). New behavior: `--yes` is the sole override |
| **D8** | P2 (RPM-revealed) | `cli/lib/nftban/cli/cmd_firewall.sh` | `_firewall_validate_strict` accepts new `structural_ok` 2nd arg + emits `STRICT PREFLIGHT: NOT VERIFIED` when structural validator failed (was: text said `PASSED` while rc=1 — operator-confusing) |

**Out of PR-C scope (per operator directive):** D6.A polkit-architecture expansion — deferred to v1.130+ design decision.

## Evidence base

- `AUDIT_190_LIFECYCLE/V129_PR_B_LAB2_EXECUTION_REPORT.md`
- `AUDIT_190_LIFECYCLE/V129_PR_B_RPM_EXECUTION_REPORT.md`
- `AUDIT_190_LIFECYCLE/V129_DEB_RPM_COMPARISON_MATRIX.md`
- `AUDIT_190_LIFECYCLE/V129_TEXT_FORMAT_FINDINGS.md`

All 7 confirmed defects + D8 are CROSS_FAMILY-verified: byte-identical broken behavior on DEB + RPM-el9 + RPM-el10. Single CLI fix in this PR closes all platforms simultaneously (binaries are byte-equivalent across families).

## Test plan

- [x] new test file `cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh` — 17 deterministic assertions covering all 6 defects (17/17 PASS locally)
- [x] V127 UX-2 well-known guard test updated (assertion 1.7 previously encoded the D7 bug as a feature; now reflects PR-C corrected condition) — 40/40 PASS
- [x] V128 PR-A polkit-aware wording sweep — 23/23 PASS unchanged
- [x] V128 PR-D doc clarity audit — 5/5 PASS unchanged
- [ ] Go tests for `internal/validator/...` (CI will run; no Go on local dev host per build policy)
- [ ] **Post-merge runtime verification (PR-D gate):** rerun §9 battery on lab2 + dns2 + srv1 for changed cases (D1/D4/D5/D6.B/D7/D8) — defect-class records in PR-B reports will flip from `PR-C-FIXED-PENDING-RUNTIME` to `RUNTIME-VERIFIED`

## Scope boundaries (operator-explicit)

- No release/tag/publish (release-prep is a separate cycle)
- No v1.128.1 hotfix branch (operator may open separately if D7 declared urgent)
- No D6.A polkit-architecture expansion (deferred to v1.130+)
- No long-tail command sweep beyond §9 representative battery
- No live mutation testing
- No packaging/systemd/schema/metrics/portal changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)