### PR TITLE
feat(systemd+cli+validator): v1.130 PR-A Option C — polkit-authorized firewall-validate service closes D6.A

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1059,17 +1059,67 @@ firewall_validate() {
         return $VALIDATE_ENV_ERROR
     fi
 
+    # V130 PR-A Option C closure for D6.A: when running as a non-root operator,
+    # route the validator through the polkit-authorized
+    # nftban-firewall-validate.service (oneshot, root+CAP_NET_ADMIN). The
+    # nftban-group members get authorized via the allowedUnits[] whitelist in
+    # 10-nftban-systemd.rules. This preserves the v1.0.19 "no pkexec / no nft
+    # polkit" boundary while making `nftban firewall validate` JustWork without
+    # sudo. If the unit is missing (e.g. partially-upgraded host pre-v1.130),
+    # fall through to direct invocation (which will surface the permission
+    # error with the v1.129 PR-C D6.B polkit-aware Remediation).
+    local _route_via_systemd=false
+    if [[ $EUID -ne 0 ]] \
+       && command -v systemctl >/dev/null 2>&1 \
+       && systemctl cat nftban-firewall-validate.service &>/dev/null; then
+        _route_via_systemd=true
+    fi
+
+    # Helper: emit validator JSON to stdout, set _validator_exit to the
+    # validator's exit code. Uses direct invocation if root; uses
+    # systemctl-then-journal if non-root with the service installed.
+    _invoke_validator_json() {
+        _validator_exit=0
+        if [[ "$_route_via_systemd" == "true" ]]; then
+            local _ts_start
+            _ts_start=$(date +%s)
+            # --wait makes systemctl block until the oneshot finishes; the
+            # exit code reflects whether the unit could be started, not the
+            # ExecMainStatus. Fetch the validator's true rc separately.
+            if ! systemctl start --wait nftban-firewall-validate.service 2>/dev/null; then
+                # Service couldn't even start (e.g. polkit denial on a host
+                # where the user is not in the nftban group). Fall back to
+                # direct invocation so the v1.129 D6.B Remediation surfaces.
+                "$_go_validator" --json 2>/dev/null
+                _validator_exit=$?
+                return $_validator_exit
+            fi
+            local _es
+            _es=$(systemctl show -p ExecMainStatus --value nftban-firewall-validate.service 2>/dev/null)
+            [[ -n "$_es" ]] && _validator_exit=$_es
+            # Pull the JSON output from this invocation only.
+            journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat 2>/dev/null
+        else
+            "$_go_validator" --json 2>/dev/null
+            _validator_exit=$?
+        fi
+    }
+
     local validation_result=$VALIDATE_OK
+    local _validator_exit=0
     local go_exit=0
 
     if [[ "$quiet_mode" == "true" ]]; then
-        "$_go_validator" --json >/dev/null 2>&1 || go_exit=$?
+        _invoke_validator_json >/dev/null
+        go_exit=$_validator_exit
     elif [[ "$output_json" == "true" ]]; then
-        "$_go_validator" --json || go_exit=$?
+        _invoke_validator_json
+        go_exit=$_validator_exit
     else
-        # Human-readable: render Go validator JSON as text
+        # Human-readable: render validator JSON as text
         local _val_json
-        _val_json=$("$_go_validator" --json 2>/dev/null) || go_exit=$?
+        _val_json=$(_invoke_validator_json)
+        go_exit=$_validator_exit
         if [[ -n "$_val_json" ]] && command -v jq >/dev/null 2>&1; then
             local _val_status
             _val_status=$(echo "$_val_json" | jq -r '.status' 2>/dev/null)

--- a/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
+++ b/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V130 PR-A Option C — polkit-authorized validate service regression test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v130_polkit_validate_service_test"
+# meta:type="test"
+# meta:version="1.130.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-25"
+# meta:description="Deterministic shell assertions locking the V130 PR-A Option C closure for D6.A: nftban-firewall-validate.service exists with the expected oneshot+root+CAP_NET_ADMIN shape, is in the 10-nftban-systemd.rules allowedUnits[] polkit whitelist, is picked up by the systemd-install-list generator, the cmd_firewall.sh CLI routes non-root callers through systemctl start --wait, and the v1.129 PR-C D6.B Remediation in validator.go is consistent with the now-real service unit. The intent of this test is to prevent regression: if any of these files drift apart (e.g. someone renames the service file but forgets the polkit whitelist), CI fails."
+# meta:input="self-contained; pattern-greps on the source files"
+# meta:output="[PASS]/[FAIL] per assertion; exit 1 on first failure; exit 0 if all pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DESIGN_ANALYSIS.md (Option C)
+#        + AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DECISION.md
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+export NFTBAN_LIB_DIR="${_repo_root}/cli/lib/nftban"
+
+_unit_file="${_repo_root}/install/systemd/nftban-firewall-validate.service"
+_polkit_file="${_repo_root}/packaging/polkit-1/rules.d/10-nftban-systemd.rules"
+_install_list="${_repo_root}/install/packaging/systemd/nftban-systemd-install.list"
+_firewall_cli="${NFTBAN_LIB_DIR}/cli/cmd_firewall.sh"
+_validator_go="${_repo_root}/internal/validator/validator.go"
+
+echo "==============================================================================="
+echo "V130 PR-A Option C — polkit-authorized validate service regression test"
+echo "==============================================================================="
+echo "  Repo root:    $_repo_root"
+echo
+
+# ----------------------------------------------------------------------------
+# A: systemd unit file shape
+# ----------------------------------------------------------------------------
+echo "--- A: nftban-firewall-validate.service unit shape ---"
+
+[[ -f "$_unit_file" ]] && _t_assert "A1: unit file exists at install/systemd/nftban-firewall-validate.service" 0 \
+    || _t_assert "A1: unit file exists at install/systemd/nftban-firewall-validate.service" 1 "$_unit_file missing"
+
+if [[ -f "$_unit_file" ]]; then
+    grep -qE '^Type=oneshot' "$_unit_file" \
+        && _t_assert "A2: unit is Type=oneshot" 0 \
+        || _t_assert "A2: unit is Type=oneshot" 1
+    grep -qE '^User=root' "$_unit_file" && grep -qE '^Group=root' "$_unit_file" \
+        && _t_assert "A3: unit runs as root:root" 0 \
+        || _t_assert "A3: unit runs as root:root" 1
+    grep -qE '^AmbientCapabilities=CAP_NET_ADMIN' "$_unit_file" \
+        && _t_assert "A4: unit holds CAP_NET_ADMIN ambient capability" 0 \
+        || _t_assert "A4: unit holds CAP_NET_ADMIN ambient capability" 1
+    grep -qE '^CapabilityBoundingSet=CAP_NET_ADMIN' "$_unit_file" \
+        && _t_assert "A5: unit's CapabilityBoundingSet is CAP_NET_ADMIN" 0 \
+        || _t_assert "A5: unit's CapabilityBoundingSet is CAP_NET_ADMIN" 1
+    grep -qE '^ExecStart=/usr/lib/nftban/bin/nftban-validate --json' "$_unit_file" \
+        && _t_assert "A6: ExecStart invokes nftban-validate --json" 0 \
+        || _t_assert "A6: ExecStart invokes nftban-validate --json" 1
+    grep -qE '^StandardOutput=journal' "$_unit_file" \
+        && _t_assert "A7: stdout goes to journal" 0 \
+        || _t_assert "A7: stdout goes to journal" 1
+    grep -qE '^ProtectSystem=strict' "$_unit_file" \
+        && _t_assert "A8: ProtectSystem=strict hardening present" 0 \
+        || _t_assert "A8: ProtectSystem=strict hardening present" 1
+    grep -qE '^\[Install\]' "$_unit_file" \
+        && _t_assert "A9: unit has NO [Install] section (on-demand only)" 1 "unexpected [Install] section" \
+        || _t_assert "A9: unit has NO [Install] section (on-demand only)" 0
+fi
+
+# ----------------------------------------------------------------------------
+# B: polkit whitelist
+# ----------------------------------------------------------------------------
+echo "--- B: 10-nftban-systemd.rules allowedUnits[] whitelist ---"
+
+grep -qE '"nftban-firewall-validate\.service"' "$_polkit_file" \
+    && _t_assert "B1: nftban-firewall-validate.service is in allowedUnits[]" 0 \
+    || _t_assert "B1: nftban-firewall-validate.service is in allowedUnits[]" 1 \
+        "polkit whitelist missing entry — operators will see polkit denial"
+
+# Negative: no new pkexec rule added (the v1.0.19 philosophy must be preserved).
+# Strip comment lines (// ... or /* ... */ blocks) before grepping so the
+# security philosophy comments in 10-nftban-systemd.rules don't trip the test.
+_pkexec_real=$(
+  for f in "${_repo_root}/packaging/polkit-1/rules.d/"*.rules; do
+    [[ -f "$f" ]] || continue
+    # Remove single-line // comments + lines inside /* */ blocks
+    sed -e 's,//.*$,,' -e '/\/\*/,/\*\//d' "$f" | grep -E 'pkexec' || true
+  done
+)
+if [[ -z "$_pkexec_real" ]]; then
+    _t_assert "B2: no polkit rule grants pkexec privileges (v1.0.19 philosophy)" 0
+else
+    _t_assert "B2: no polkit rule grants pkexec privileges (v1.0.19 philosophy)" 1 \
+        "new pkexec authorization found in non-comment code — violates 'NO pkexec privileges': $_pkexec_real"
+fi
+
+# Negative: no new direct nft polkit action authorization
+if grep -rE 'action\.id\s*==\s*"[^"]*nft[^"]*"' "${_repo_root}/packaging/polkit-1/rules.d/" 2>/dev/null | grep -v "systemd1\|locale1\|hostname1\|timedate1" >/dev/null 2>&1; then
+    _t_assert "B3: no polkit rule authorizes nft action ids directly" 1 \
+        "new nft polkit action found — violates 'NO polkit authorization for nft commands'"
+else
+    _t_assert "B3: no polkit rule authorizes nft action ids directly" 0
+fi
+
+# ----------------------------------------------------------------------------
+# C: systemd-install-list generator output includes the unit
+# ----------------------------------------------------------------------------
+echo "--- C: install list generator picks up the unit ---"
+
+if [[ -f "$_install_list" ]]; then
+    grep -qE '^nftban-firewall-validate\.service$' "$_install_list" \
+        && _t_assert "C1: nftban-firewall-validate.service is in nftban-systemd-install.list" 0 \
+        || _t_assert "C1: nftban-firewall-validate.service is in nftban-systemd-install.list" 1 \
+            "run 'bash build/generate-systemd-install-list.sh' to regenerate"
+else
+    _t_assert "C1: install list exists" 1 "$_install_list missing — run generator"
+fi
+
+# ----------------------------------------------------------------------------
+# D: CLI wrapper routes non-root via systemctl
+# ----------------------------------------------------------------------------
+echo "--- D: cmd_firewall.sh routing ---"
+
+grep -qE '_route_via_systemd' "$_firewall_cli" \
+    && _t_assert "D1: cmd_firewall.sh has _route_via_systemd branch" 0 \
+    || _t_assert "D1: cmd_firewall.sh has _route_via_systemd branch" 1
+
+grep -qE 'systemctl start --wait nftban-firewall-validate\.service' "$_firewall_cli" \
+    && _t_assert "D2: cmd_firewall.sh calls 'systemctl start --wait nftban-firewall-validate.service'" 0 \
+    || _t_assert "D2: cmd_firewall.sh calls 'systemctl start --wait nftban-firewall-validate.service'" 1
+
+grep -qE 'EUID -ne 0' "$_firewall_cli" \
+    && _t_assert "D3: cmd_firewall.sh gates the systemd route on \$EUID -ne 0" 0 \
+    || _t_assert "D3: cmd_firewall.sh gates the systemd route on \$EUID -ne 0" 1
+
+grep -qE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli" \
+    && _t_assert "D4: cmd_firewall.sh reads the validator JSON from journalctl" 0 \
+    || _t_assert "D4: cmd_firewall.sh reads the validator JSON from journalctl" 1
+
+# Fallback path: if the unit isn't installed (pre-v1.130 host), the CLI still
+# falls through to direct invocation (which surfaces the D6.B Remediation).
+grep -qE 'systemctl cat nftban-firewall-validate\.service' "$_firewall_cli" \
+    && _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 0 \
+    || _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 1
+
+# ----------------------------------------------------------------------------
+# E: validator.go D6.B Remediation text is consistent with the now-real unit
+# ----------------------------------------------------------------------------
+echo "--- E: validator.go D6.B Remediation consistency ---"
+
+grep -qE 'nftban-firewall-validate\.service' "$_validator_go" \
+    && _t_assert "E1: validator.go Remediation references nftban-firewall-validate.service" 0 \
+    || _t_assert "E1: validator.go Remediation references nftban-firewall-validate.service" 1
+
+grep -qE 'CAP_NET_ADMIN' "$_validator_go" \
+    && _t_assert "E2: validator.go Remediation mentions CAP_NET_ADMIN" 0 \
+    || _t_assert "E2: validator.go Remediation mentions CAP_NET_ADMIN" 1
+
+grep -qE '\(you must be root\)' "$_validator_go" \
+    && _t_assert "E3: validator.go strips upstream '(you must be root)' wording" 0 \
+    || _t_assert "E3: validator.go strips upstream '(you must be root)' wording" 1
+
+# Negative wording: validator.go must not regress to root-first instruction.
+# The only allowed occurrence of "you must be root" in EXECUTABLE Go is the
+# strip call strings.ReplaceAll(errText, "(you must be root)", ""). Any other
+# occurrence inside a Remediation/Message string literal would be a regression.
+# Strip Go comments before grepping so explanatory comments don't trip the test.
+_yumbr_lines=$(sed -e 's,//.*$,,' "$_validator_go" | grep -nE '"\(you must be root\)"' 2>/dev/null | grep -vE 'ReplaceAll' || true)
+if [[ -z "$_yumbr_lines" ]]; then
+    _t_assert "E4: validator.go's only executable 'you must be root' occurrence is the ReplaceAll strip pattern" 0
+else
+    _t_assert "E4: validator.go's only executable 'you must be root' occurrence is the ReplaceAll strip pattern" 1 \
+        "non-strip occurrence found: $_yumbr_lines"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "==============================================================================="
+echo "V130 PR-A Option C test summary"
+echo "==============================================================================="
+echo "  Passed:  $TESTS_PASSED"
+echo "  Failed:  $TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "  Failed assertions:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "    - $n"
+    done
+    exit 1
+fi
+exit 0

--- a/docs/systemd/UNITS.md
+++ b/docs/systemd/UNITS.md
@@ -40,12 +40,13 @@ package inventory projection: `install/packaging/systemd/nftban-systemd-install.
 | `nftban-soak.timer` | Every 2h at HH:17 (staggered off cron storm) | Soak validation (read-only checks + bounded rebuild) |
 | `nftban-tunnel.timer` | Every 5min | DNS tunnel suspicion scan |
 
-## Services (27)
+## Services (28)
 
 | Service | Category | Purpose |
 |---------|----------|---------|
 | `nftband.service` | daemon | Main IPC daemon |
 | `nftban-firewall-init.service` | oneshot | Firewall initialization |
+| `nftban-firewall-validate.service` | oneshot | On-demand read-only nftables validation (polkit-authorized for nftban group; closes V130 D6.A) |
 | `nftban-maintenance.service` | oneshot | Maintenance tasks |
 | `nftban-health.service` | oneshot | Health check |
 | `nftban-health-fix.service` | oneshot | Health auto-fix |

--- a/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
+++ b/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
@@ -44,6 +44,7 @@ for unit in \
     nftban-core-geoip.service \
     nftban-core-geoip.timer \
     nftban-firewall-init.service \
+    nftban-firewall-validate.service \
     nftban-health-fix.service \
     nftban-health.service \
     nftban-health.timer \

--- a/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
+++ b/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
@@ -46,6 +46,7 @@ for unit in \
     nftban-core-geoip.service \
     nftban-core-geoip.timer \
     nftban-firewall-init.service \
+    nftban-firewall-validate.service \
     nftban-health-fix.service \
     nftban-health.service \
     nftban-health.timer \

--- a/install/packaging/systemd/nftban-systemd-install.list
+++ b/install/packaging/systemd/nftban-systemd-install.list
@@ -23,6 +23,7 @@ nftban-core-feeds.timer
 nftban-core-geoip.service
 nftban-core-geoip.timer
 nftban-firewall-init.service
+nftban-firewall-validate.service
 nftban-health-fix.service
 nftban-health.service
 nftban-health.timer

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -1,0 +1,120 @@
+# =============================================================================
+# NFTBan - Firewall Validation Service (read-only, on-demand)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban-firewall-validate.service"
+# meta:type="systemd"
+# meta:tier="STANDARD"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-25"
+# meta:description="On-demand read-only nftables ruleset validation. Triggered by nftban-group operators via systemctl start (polkit-authorized through 10-nftban-systemd.rules whitelist) so the nftban CLI 'firewall validate' works without sudo while preserving the v1.0.19 'no pkexec / no nft polkit' security boundary."
+# meta:input="None (reads kernel nft state)"
+# meta:output="Systemd journal (use: journalctl -u nftban-firewall-validate.service -n 0 -o cat)"
+# meta:depends="/usr/lib/nftban/bin/nftban-validate"
+# meta:inventory.files=""
+# meta:inventory.binaries="/usr/lib/nftban/bin/nftban-validate"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+#
+# V130 PR-A Option C closure for D6.A: this unit is the polkit-authorized
+# privileged path that nftban-group operators use to read nftables state
+# without holding CAP_NET_ADMIN themselves. The CLI wraps `systemctl start
+# --wait` around this unit and reads the journal output.
+#
+# Architecture invariants (preserved from v1.0.19 security philosophy):
+#   - NO pkexec (this is a systemd unit, polkit-authorized via the existing
+#     allowedUnits whitelist in 10-nftban-systemd.rules)
+#   - NO new polkit authorization for `nft` commands directly
+#   - nftables ONLY accessible via nftban-validate (audited Go binary,
+#     contract: ZERO-SIDE-EFFECT, NEVER writes files, NEVER modifies nft)
+#   - Single whitelist entry; no wildcard
+#
+# Related files:
+#   - cli/lib/nftban/cli/cmd_firewall.sh::firewall_validate (wraps systemctl)
+#   - packaging/polkit-1/rules.d/10-nftban-systemd.rules    (allowedUnits[] += this)
+#   - internal/validator/validator.go::ValidateKernel       (the Go code)
+# =============================================================================
+
+[Unit]
+Description=NFTBan Firewall Validation (read-only, on-demand)
+Documentation=man:nftban(8)
+ConditionPathExists=/usr/lib/nftban/bin/nftban-validate
+# DO NOT add a Requires/After on nftables.service — this unit is meant to be
+# usable even when nftban itself is degraded (operator runs it to diagnose).
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+
+# Run as root because nftban-validate needs CAP_NET_ADMIN to read nft state.
+# This is the same model as nftban-firewall-init.service (which already runs
+# root+CAP_NET_ADMIN under the same hardening template).
+User=root
+Group=root
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+
+# JSON output goes to the journal. Operators (or the nftban firewall validate
+# CLI wrapper) read it with: journalctl -u nftban-firewall-validate.service
+ExecStart=/usr/lib/nftban/bin/nftban-validate --json
+StandardOutput=journal
+StandardError=journal
+
+# Idempotent / DoS protection: cap at 3 starts per 10s to prevent log flood
+# if an operator script loops on this unit.
+StartLimitIntervalSec=10
+StartLimitBurst=3
+
+# =============================================================================
+# Security Hardening (mirrors nftban-firewall-init.service template)
+# =============================================================================
+
+# Filesystem Protection — validator is read-only by Go contract, so the
+# stricter ProtectSystem=strict + no ReadWritePaths is safe.
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+
+# Kernel Protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+
+# Namespace Restrictions
+PrivateDevices=yes
+RestrictNamespaces=true
+RestrictRealtime=true
+
+# Privilege Restrictions
+# CAP_NET_ADMIN is required for netlink/nftables read; NoNewPrivileges=no
+# because cap acquisition needs it. Other hardening compensates.
+NoNewPrivileges=no
+
+# Misc Hardening
+LockPersonality=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+
+# Network Access — netlink for nftables read; no AF_PACKET, no DCCP etc.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+
+# System Call Filtering — read-only validator does not need
+# @debug @mount @module @raw-io @reboot @swap @privileged @resources
+SystemCallFilter=@system-service @network-io
+SystemCallFilter=~@debug @mount @module @raw-io @reboot @swap @privileged @resources
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# Don't restart — this is oneshot. If it fails, operator sees the failure
+# directly through systemctl's exit code (via --wait).
+Restart=no
+
+# NOTE: no [Install] section — this unit is not enabled at boot; it is only
+# started on demand by nftban-group operators via polkit-authorized systemctl
+# (or directly by root). Adding it to a target would auto-run validation on
+# boot, which is not the intent (nftban-firewall-init.service handles boot).

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -127,13 +127,17 @@ func ValidateKernel(ctx context.Context) (*ValidationResult, error) {
 		errText := err.Error()
 		message := "Failed to load nftables ruleset: " + errText
 		remediation := "Check nft command availability and permissions"
-		// V129 PR-C D6.B: polkit-aware capability wording when nft fails on
-		// permission. The upstream nft binary emits "(you must be root)" which
-		// contradicts NFTBan's polkit/group-based authorization framing.
+		// V129 PR-C D6.B + V130 PR-A Option C: polkit-aware capability wording
+		// when nft fails on permission. The upstream nft binary emits
+		// "(you must be root)" which contradicts NFTBan's polkit/group-based
+		// authorization framing. V130 PR-A Option C made the
+		// nftban-firewall-validate.service unit real, so the remediation
+		// reference is now truthful — nftban-group operators trigger the
+		// polkit-authorized oneshot unit which holds CAP_NET_ADMIN.
 		if strings.Contains(errText, "Operation not permitted") || strings.Contains(errText, "permission denied") {
 			cleaned := strings.TrimSpace(strings.ReplaceAll(errText, "(you must be root)", ""))
 			message = "Failed to load nftables ruleset: " + cleaned
-			remediation = "Direct nft access requires CAP_NET_ADMIN (root or nftban systemd-service context). The nftban group does not currently grant direct nft access through polkit; run via 'systemctl start nftban-firewall-validate' or equivalent privileged path."
+			remediation = "Direct nft access requires CAP_NET_ADMIN. The nftban CLI normally routes through nftban-firewall-validate.service for operators in the nftban group (polkit-authorized via /etc/polkit-1/rules.d/10-nftban-systemd.rules); if you reached this message you are either invoking nftban-validate directly OR the v1.130+ service is not installed. Fix: run 'systemctl start --wait nftban-firewall-validate.service' (nftban group polkit-authorized) or invoke nftban-validate from a context that holds CAP_NET_ADMIN."
 		}
 		result.Findings = append(result.Findings, Finding{
 			Code:        CodeNftFailed,

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -58,6 +58,7 @@ case "$1" in
             nftban-core-geoip.service \
             nftban-core-geoip.timer \
             nftban-firewall-init.service \
+            nftban-firewall-validate.service \
             nftban-health-fix.service \
             nftban-health.service \
             nftban-health.timer \

--- a/packaging/polkit-1/rules.d/10-nftban-systemd.rules
+++ b/packaging/polkit-1/rules.d/10-nftban-systemd.rules
@@ -115,6 +115,15 @@ polkit.addRule(function (action, subject) {
             "nftban-rebuild-recovery.service",
             "nftban-rebuild-recovery.timer",
 
+            // NFTBan Firewall Validation (v1.130 PR-A Option C closure for D6.A)
+            // Read-only on-demand validator wrapper. Lets nftban-group operators
+            // run `nftban firewall validate` without sudo by routing through this
+            // polkit-authorized oneshot unit (which holds CAP_NET_ADMIN). Preserves
+            // the v1.0.19 "no pkexec / no nft polkit" boundary — operators do NOT
+            // get direct nft access, only the right to trigger this audited service.
+            // See V130_D6A_POLKIT_DESIGN_ANALYSIS.md for the design rationale.
+            "nftban-firewall-validate.service",
+
             // NFTBan Suricata Integration (wrapper units)
             "nftban-suricata.service",
             "nftban-suricata-update.service",


### PR DESCRIPTION
## Summary

Closes **D6.A** — the v1.129 PR-B/PR-D cross-family finding that nftban-group members could not run `nftban firewall validate` because direct nft access requires CAP_NET_ADMIN and the existing polkit rules only cover systemd unit management.

Closes the **dangling D6.B systemctl reference** shipped in v1.129.0: the validator.go Remediation text pointed operators at `systemctl start nftban-firewall-validate` but the unit did not exist. This PR makes it exist.

**Design lane:** `AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DESIGN_ANALYSIS.md` (Options A/B/C analyzed; Option C recommended).
**Operator decision:** `AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DECISION.md` signed Option C 2026-05-25.

## Architecture invariants preserved (v1.0.19 security philosophy)

- ✓ **NO new pkexec authorization** (v1.0.19 explicitly removed the prior `nftban-auth-helper` pkexec rule; this PR does NOT re-introduce it)
- ✓ **NO direct nft polkit action authorization** (the polkit boundary is preserved; operators do NOT gain `nft` action access; they gain the right to trigger ONE new whitelisted systemd unit)
- ✓ nftables remains accessible ONLY via audited Go binary (`nftban-validate`, contract: ZERO-SIDE-EFFECT)
- ✓ Whitelist-only unit access (single entry added; no wildcard)
- ✓ Principle of least privilege (Type=oneshot; read-only; CAP_NET_ADMIN only; full hardening template)

## What this PR changes

| File | Change |
|---|---|
| `install/systemd/nftban-firewall-validate.service` | **NEW** — oneshot unit, root + CAP_NET_ADMIN, journal output, full hardening template mirroring `nftban-firewall-init.service` |
| `packaging/polkit-1/rules.d/10-nftban-systemd.rules` | **+1 entry** in `allowedUnits[]` whitelist |
| `install/packaging/systemd/nftban-systemd-install.list` | Auto-regen via `build/generate-systemd-install-list.sh` (64 → 65 units) |
| `cli/lib/nftban/cli/cmd_firewall.sh::firewall_validate` | New `_route_via_systemd` branch — when EUID != 0 AND systemctl available AND unit installed, route validator via `systemctl start --wait nftban-firewall-validate.service` and read JSON from journalctl. Fallback to direct invocation if not (pre-v1.130 hosts surface v1.129 D6.B Remediation). |
| `internal/validator/validator.go::ValidateKernel` | D6.B Remediation polished — `systemctl start nftban-firewall-validate.service` reference is now truthful. NO "must run as root" / "Run as root" wording (V128 PR-A.1 policy preserved); "(you must be root)" still stripped from upstream nft stderr. |
| `cli/lib/nftban/tests/v130_polkit_validate_service_test.sh` | **NEW** — 22 deterministic assertions locking cross-file invariants + negative guards (no new pkexec, no direct-nft polkit action, no V128 wording regression). |

## Test plan

- [x] `v130_polkit_validate_service_test.sh` — 22/22 PASS locally
- [x] `v128_polkit_aware_wording_sweep_test.sh` — 23/23 PASS (no V128 wording regression)
- [x] `v128_doc_clarity_audit_test.sh` — 5/5 PASS
- [x] `v129_pr_c_runtime_defect_fixes_test.sh` — 17/17 PASS (no V129 PR-C regression)
- [x] `v127_ux2_well_known_test.sh` — 40/40 PASS
- [ ] CI: Build & Test, Build Go binaries, CodeQL Go, Build RPM/DEB matrices, Test RPM/DEB install (will run on PR open)
- [ ] V130 PR-B (D7 live + Option C end-to-end on lab2) will exercise `systemctl start --wait` on a real host post-merge — that's the separate next gate (`OPEN_V1_130_PR_B_D7_LIVE_CONFIRMATION = GO`)

## Out of scope (will be addressed separately)

- No wiki/docs/README updates (V130 PR-E handles, after PR-C and PR-D settle)
- No CI workflow changes (a future test could exercise `systemctl start --wait` in the Runtime Truth Gate; not gated here)
- No D6.A-implementation-tested-end-to-end-against-real-package — the deterministic test suite locks the cross-file invariants but does NOT exercise `systemctl start --wait` on a real host. V130 PR-B will provide that.

## Forbidden in V130 PR-A scope (honored)

- No host contact
- No release/tag/publish
- No `commands.registry.yml` change
- No new commands or aliases
- No schema/metrics/portal change
- No other package/systemd behavior change beyond the one new unit + one whitelist entry

## Related

- Closes the V130 PR-A lane per `OPEN_V1_130_D6A_POLKIT_IMPLEMENTATION_OPTION_C = GO`
- Unblocks V130 PR-E (wiki/docs/README runtime alignment) — docs can now reflect the final Option C behavior
- Per `AUDIT_190_LIFECYCLE/V130_POLKIT_AND_LONG_TAIL_CLI_VALIDATION_SCOPE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)