### PR TITLE
fix(cli+systemd): v1.130 PR-A.1 — close D10 (CLI journalctl race) + D11 (StartLimit wrong section)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1097,8 +1097,21 @@ firewall_validate() {
             local _es
             _es=$(systemctl show -p ExecMainStatus --value nftban-firewall-validate.service 2>/dev/null)
             [[ -n "$_es" ]] && _validator_exit=$_es
-            # Pull the JSON output from this invocation only.
-            journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat 2>/dev/null
+            # V130 PR-A.1 D10 fix: journald is asynchronous to the validator
+            # process exit. A bare journalctl call immediately after `systemctl
+            # start --wait` frequently returns empty output (the JSON hasn't
+            # been flushed to the journal yet). Bounded retry loop: up to 8
+            # tries with 0.1s sleep between = ~800ms wall time worst case.
+            # In practice 1-2 tries succeed once journald flushes. We accept
+            # whatever output we get on the last try (could still be empty
+            # under extreme load — operator can manually run journalctl).
+            local _try _output=""
+            for _try in 1 2 3 4 5 6 7 8; do
+                _output=$(journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat 2>/dev/null)
+                [[ -n "$_output" ]] && break
+                sleep 0.1
+            done
+            printf '%s' "$_output"
         else
             "$_go_validator" --json 2>/dev/null
             _validator_exit=$?

--- a/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
+++ b/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
@@ -93,6 +93,37 @@ if [[ -f "$_unit_file" ]]; then
     grep -qE '^\[Install\]' "$_unit_file" \
         && _t_assert "A9: unit has NO [Install] section (on-demand only)" 1 "unexpected [Install] section" \
         || _t_assert "A9: unit has NO [Install] section (on-demand only)" 0
+
+    # V130 PR-A.1 D11 fix: StartLimitIntervalSec + StartLimitBurst MUST live
+    # in the [Unit] section (systemd 240+ ignores them silently in [Service]).
+    # The check: in the unit file scanned line-by-line, track which section we
+    # are in; record which section StartLimitIntervalSec appears in. Must be
+    # "[Unit]". (PR-B D11 evidence on lab2 systemd 255 confirmed "[Service]"
+    # placement was silently ignored with "Unknown key name" warning.)
+    _sli_section=$(awk '
+        /^\[Unit\]/      { sec="Unit"; next }
+        /^\[Service\]/   { sec="Service"; next }
+        /^\[Install\]/   { sec="Install"; next }
+        /^StartLimitIntervalSec=/ { print sec; exit }
+    ' "$_unit_file")
+    if [[ "$_sli_section" == "Unit" ]]; then
+        _t_assert "A10 (D11): StartLimitIntervalSec is in [Unit] section (systemd 240+ requirement)" 0
+    else
+        _t_assert "A10 (D11): StartLimitIntervalSec is in [Unit] section (systemd 240+ requirement)" 1 \
+            "found in section: [${_sli_section:-NONE}] — systemd 240+ will ignore it silently"
+    fi
+    _slb_section=$(awk '
+        /^\[Unit\]/      { sec="Unit"; next }
+        /^\[Service\]/   { sec="Service"; next }
+        /^\[Install\]/   { sec="Install"; next }
+        /^StartLimitBurst=/ { print sec; exit }
+    ' "$_unit_file")
+    if [[ "$_slb_section" == "Unit" ]]; then
+        _t_assert "A11 (D11): StartLimitBurst is in [Unit] section" 0
+    else
+        _t_assert "A11 (D11): StartLimitBurst is in [Unit] section" 1 \
+            "found in section: [${_slb_section:-NONE}]"
+    fi
 fi
 
 # ----------------------------------------------------------------------------
@@ -170,6 +201,46 @@ grep -qE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli" \
 grep -qE 'systemctl cat nftban-firewall-validate\.service' "$_firewall_cli" \
     && _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 0 \
     || _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 1
+
+# V130 PR-A.1 D10 fix: journalctl read MUST retry with bounded backoff to
+# survive the journald async-write race that PR-B observed on lab2 (operator
+# saw rc=0 with empty stdout because the JSON hadn't flushed to journal when
+# the first journalctl call ran). The retry loop is the contract: a bare
+# single journalctl call would re-introduce the D10 UX bug.
+_journalctl_count=$(grep -cE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli" || echo 0)
+# We expect the journalctl call to appear inside a loop. Two correct patterns:
+#   for _try in ...; do journalctl ...; ...; done
+#   while ...; do journalctl ...; done
+# Negative pattern: a single bare journalctl call with no surrounding loop.
+if grep -B2 -A3 'journalctl -u nftban-firewall-validate\.service --since' "$_firewall_cli" | grep -qE '(for[[:space:]]+[_a-zA-Z]+|while)'; then
+    _t_assert "D6 (D10 fix): journalctl read is inside a retry loop (survives journald async write)" 0
+else
+    _t_assert "D6 (D10 fix): journalctl read is inside a retry loop (survives journald async write)" 1 \
+        "bare journalctl call without retry loop — D10 UX regression"
+fi
+
+# Retry must be bounded (not infinite). Look for a numeric iteration cap.
+if grep -qE 'for _try in 1 2 3' "$_firewall_cli"; then
+    _t_assert "D7 (D10 fix): retry loop has bounded iterations (no infinite wait)" 0
+else
+    _t_assert "D7 (D10 fix): retry loop has bounded iterations (no infinite wait)" 1
+fi
+
+# Each retry iteration must sleep between attempts (otherwise we burn CPU
+# and likely all 8 tries fire within journald's flush window anyway).
+if grep -qE 'sleep 0?\.[0-9]' "$_firewall_cli" && \
+   awk '/for _try in/,/done/' "$_firewall_cli" | grep -q 'sleep'; then
+    _t_assert "D8 (D10 fix): retry loop sleeps between attempts" 0
+else
+    _t_assert "D8 (D10 fix): retry loop sleeps between attempts" 1
+fi
+
+# Loop exits early once output is captured (don't waste 800ms on every call).
+if awk '/for _try in/,/done/' "$_firewall_cli" | grep -qE '\[\[ -n "\$?_output"? \]\] && break'; then
+    _t_assert "D9 (D10 fix): retry loop short-circuits when output appears" 0
+else
+    _t_assert "D9 (D10 fix): retry loop short-circuits when output appears" 1
+fi
 
 # ----------------------------------------------------------------------------
 # E: validator.go D6.B Remediation text is consistent with the now-real unit

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -45,6 +45,13 @@ Documentation=man:nftban(8)
 ConditionPathExists=/usr/lib/nftban/bin/nftban-validate
 # DO NOT add a Requires/After on nftables.service — this unit is meant to be
 # usable even when nftban itself is degraded (operator runs it to diagnose).
+# V130 PR-A.1 D11 fix: StartLimitIntervalSec + StartLimitBurst MUST live in
+# the [Unit] section on systemd 240+. The [Service] placement that v1.130 PR-A
+# shipped was silently ignored (logged "Unknown key name 'StartLimitIntervalSec'
+# in section 'Service', ignoring") which left rate limiting NOT in effect.
+# Cap at 3 starts per 10s to prevent journal flood if an operator script loops.
+StartLimitIntervalSec=10
+StartLimitBurst=3
 
 [Service]
 Type=oneshot
@@ -63,11 +70,6 @@ CapabilityBoundingSet=CAP_NET_ADMIN
 ExecStart=/usr/lib/nftban/bin/nftban-validate --json
 StandardOutput=journal
 StandardError=journal
-
-# Idempotent / DoS protection: cap at 3 starts per 10s to prevent log flood
-# if an operator script loops on this unit.
-StartLimitIntervalSec=10
-StartLimitBurst=3
 
 # =============================================================================
 # Security Hardening (mirrors nftban-firewall-init.service template)


### PR DESCRIPTION
## Summary

Tight follow-up to v1.130 PR-A (PR #682 merged at `090d73b3`) closing **D10** (P1 UX) + **D11** (P3 hardening regression) surfaced by **PR-B's live test on lab2** — both filed in `AUDIT_190_LIFECYCLE/V130_PR_B_LIVE_CONFIRMATION_REPORT.md`.

## D10 — CLI journalctl race (P1 UX)

**Symptom on lab2:** `sudo -u nftban-test nftban firewall validate` returned **rc=0** but stdout showed only the NFTBan banner (no `Validator Status:` line, no findings). The polkit/service path WORKED — service ran, journal eventually had the JSON — but the operator-visible UX claimed silent success.

**Root cause:** `_invoke_validator_json` in `cli/lib/nftban/cli/cmd_firewall.sh` did a bare `journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat` immediately after `systemctl start --wait`. journald is async to validator process exit; the JSON hadn't flushed yet.

**Fix:** bounded retry loop on the journalctl read (8 tries × 0.1s sleep = ~800ms worst case). Short-circuits on first non-empty output. In practice 1-2 tries succeed.

```bash
for _try in 1 2 3 4 5 6 7 8; do
    _output=$(journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat 2>/dev/null)
    [[ -n "$_output" ]] && break
    sleep 0.1
done
printf '%s' "$_output"
```

**Rejected alternatives** (all evaluated, all out of PR-A.1 tight scope):
- `journalctl --flush` — requires root; nftban-test cannot invoke
- `systemd-run --pipe --unit=...` — cleaner but bigger refactor
- `StandardOutput=file:<path>` — synchronous but introduces fd/ownership concerns

## D11 — StartLimit keys in wrong section (P3 hardening regression)

**Symptom on lab2 systemd 255:** `journalctl` showed `/usr/lib/systemd/system/nftban-firewall-validate.service:69: Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.` Rate limiting was **not in effect** — an nftban-group operator could flood `systemctl start` calls without throttling.

**Root cause:** PR-A placed `StartLimitIntervalSec=10` + `StartLimitBurst=3` in `[Service]`. systemd 240+ moved these to `[Unit]` and silently ignores them in `[Service]`.

**Fix:** move both keys to `[Unit]` section. Two-line move; semantics unchanged.

**Note:** `nftban-firewall-init.service` (the template PR-A mirrored) has the same problem with these keys in `[Service]`, but that unit is not polkit-triggerable by operators, so its lack of rate limit is not exercised. **Out of PR-A.1 scope to fix there** — would touch a separate unit not directly involved in D6.A.

## Test plan

- [x] `v130_polkit_validate_service_test.sh` grew **22/22 → 28/28** (added 4 D10 + 2 D11 deterministic assertions)
- [x] V128 PR-A polkit-aware wording sweep — 23/23 PASS (no regression)
- [x] V128 PR-D doc clarity — 5/5 PASS
- [x] V129 PR-C runtime defect fixes — 17/17 PASS
- [x] V127 UX-2 well-known guard — 40/40 PASS
- [ ] CI: full matrix (Build & Test, Build Go binaries, CodeQL, all DEB/RPM build+install, Runtime Truth, ShellCheck) will run on PR open
- [ ] Post-merge: V130 PR-B's lab2 reproduction conditions should now produce non-empty stdout (D10 fix verification — operator decision whether to re-run PR-B subset on lab2)

## Out of scope (per operator directive — `OPEN_V1_130_PR_A_1_OPTION_C_FOLLOWUP = GO` tight-scope)

- ❌ No new polkit mechanism
- ❌ No pkexec
- ❌ No new systemd units
- ❌ No PR-C long-tail changes
- ❌ No PR-D help/code drift fixes
- ❌ No production host contact
- ❌ No `commands.registry.yml` or `generate-help.sh` change
- ❌ No schema/metrics/portal change
- ❌ PR-D draft test file `v130_subcommand_flag_help_code_test.sh` remains untracked (belongs to the separate future PR-D commit)

## Related

- Closes D10 + D11 from `AUDIT_190_LIFECYCLE/V130_PR_B_LIVE_CONFIRMATION_REPORT.md` §5 + §6
- Unblocks `OPEN_V1_130_PR_C_LONG_TAIL_RUNTIME_BATTERY = GO` against a clean Option C baseline
- D12 (lab2 wget stale .deb) is operator network-ops investigation; not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)