### PR TITLE
fix(cli+core+test): v1.131 PR-A — close CB-1..CB-4 long-tail code bugs from V130 PR-C

### DIFF
--- a/cli/lib/nftban/cli/cmd_blacklist.sh
+++ b/cli/lib/nftban/cli/cmd_blacklist.sh
@@ -260,7 +260,17 @@ nftban_blacklist_files() {
         local basename
         basename=$(basename "$conf_file")
         local count
-        count=$(grep -cvE '^\s*(#|$)' "$conf_file" 2>/dev/null || echo "0")
+        # V131 PR-A CB-1 fix: `grep -c ... 2>/dev/null || echo "0"` produced
+        # "0\n0" when grep matched zero lines — grep -c prints "0" + exits 1,
+        # then `|| echo "0"` ALSO fires concatenating its "0" to grep's
+        # output. The newline then broke `$((total_ips + count))` with a
+        # syntax error. The OLD pattern was also serving as errexit
+        # suppression for `set -e` (sourced from cli/sbin/nftban). Correct
+        # fix: replace `|| echo "0"` with `|| true` — suppresses errexit
+        # without producing concat output; grep -c's own "0" output is
+        # preserved; parameter-default handles file-vanished edge case.
+        count=$(grep -cvE '^\s*(#|$)' "$conf_file" 2>/dev/null || true)
+        count=${count:-0}
         total_ips=$((total_ips + count))
 
         echo "──────────────────────────────────────────────────────────────"

--- a/cli/lib/nftban/cli/cmd_selftest.sh
+++ b/cli/lib/nftban/cli/cmd_selftest.sh
@@ -513,7 +513,12 @@ _verify_feeds() {
         local feed_name
         feed_name=$(basename "$feed_file" | sed 's/\.\(txt\|list\)$//')
         local file_count
-        file_count=$(grep -cE '^[0-9]' "$feed_file" 2>/dev/null || echo "0")
+        # V131 PR-A CB-3 fix (sibling of line 572): same double-zero pattern.
+        # grep -c on no-match prints "0" + exits 1 → `|| echo "0"` fires
+        # producing "0\n0" → arithmetic crash at line below. Use `|| true`
+        # for errexit suppression (file under set -e) without concat output.
+        file_count=$(grep -cE '^[0-9]' "$feed_file" 2>/dev/null || true)
+        file_count=${file_count:-0}
         total_file_ips=$((total_file_ips + file_count))
         # v1.19.20 FIX
         ((feeds_checked++)) || true
@@ -569,7 +574,14 @@ _verify_geoban() {
 
     if [[ $blocked_countries -eq 0 ]]; then
         # Alternative: check geoban list command
-        blocked_countries=$(nftban geoban list 2>/dev/null | grep -c "BLOCKED" 2>/dev/null || echo "0")
+        # V131 PR-A CB-3 fix: same `grep -c ... || echo "0"` double-zero
+        # pattern as CB-1 — grep -c on no-match prints "0" + exits 1, then
+        # `|| echo "0"` fires and concatenates to "0\n0", which printf %d
+        # below cannot parse ("printf: 0" error). Use `|| true` to suppress
+        # errexit without producing concat output (file is under set -e via
+        # cmd_selftest.sh:1 + cli/sbin/nftban:29). grep -c's "0" is preserved.
+        blocked_countries=$(nftban geoban list 2>/dev/null | grep -c "BLOCKED" 2>/dev/null || true)
+        blocked_countries=${blocked_countries:-0}
     fi
 
     printf "     Countries blocked: %d\n" "$blocked_countries"

--- a/cli/lib/nftban/core/nftban_report_fhs.sh
+++ b/cli/lib/nftban/core/nftban_report_fhs.sh
@@ -42,6 +42,16 @@ umask 027
 
 declare -g -A NFTBAN_FHS_DIRECTORIES=()  # key: path -> "expected_perms|expected_owner|expected_group|purpose"
 declare -g -A NFTBAN_FHS_STATUS=()       # key: path -> "OK|ERROR|WARNING"
+# V131 PR-A CB-2 fix: NFTBAN_FHS_ACTUAL was referenced at lines :379 and :564
+# (HTML + JSON reports) via `${NFTBAN_FHS_ACTUAL[$path]:-...}` BUT was never
+# declared. Without `declare -A`, bash treats `[$path]` as arithmetic
+# evaluation; when $path is e.g. "/etc/nftban", arithmetic fails with
+# "syntax error: operand expected (error token is '/etc/nftban')" and crashes
+# the report. The `:-` fallback never fires because the crash is at the array
+# subscript step, not the value lookup. Adding the declaration makes the
+# subscript an associative key (string), and the existing fallback handles
+# the "not populated yet" case.
+declare -g -A NFTBAN_FHS_ACTUAL=()       # key: path -> actual filesystem state ("perms|owner|group") or empty
 declare -g NFTBAN_FHS_TIMESTAMP
 NFTBAN_FHS_TIMESTAMP="$(date --iso-8601=seconds)"
 declare -g NFTBAN_FHS_OUTPUT_FORMAT="${NFTBAN_FHS_OUTPUT_FORMAT:-table}"

--- a/cli/lib/nftban/tests/selftest.sh
+++ b/cli/lib/nftban/tests/selftest.sh
@@ -44,7 +44,25 @@ readonly SCRIPT_VERSION="1.0.0"
 DEFAULT_TIMEOUT=30            # seconds per command (default)
 QUICK_TIMEOUT=15              # seconds for quick tests
 CURRENT_TIMEOUT=$DEFAULT_TIMEOUT  # actual timeout to use
-readonly TRACE_LOG="${NFTBAN_LOG_DIR:-/var/log/nftban}/debug_trace.log"
+# V131 PR-A CB-4 fix: the v1.130 PR-C long-tail battery surfaced that
+# running selftest.sh as a non-root operator (e.g. an nftban-group user)
+# leaks `/var/log/nftban/debug_trace.log: Permission denied` on the trace
+# append at line 154 below — the default log dir is root-owned. Compute
+# a writable trace path BEFORE the readonly so the test stays usable for
+# nftban-group operators without a stderr leak. Order of preference:
+#   1) NFTBAN_LOG_DIR (operator-overridden; respected as-is even if not
+#      writable — operator knows what they want)
+#   2) /var/log/nftban (default; used if writable OR creatable)
+#   3) $TMPDIR/nftban-selftest-$EUID/ (writable per-user fallback)
+_st_trace_dir="${NFTBAN_LOG_DIR:-/var/log/nftban}"
+if [[ -z "${NFTBAN_LOG_DIR:-}" ]] \
+   && [[ ! -w "$_st_trace_dir" ]] \
+   && ! mkdir -p "$_st_trace_dir" 2>/dev/null; then
+    _st_trace_dir="${TMPDIR:-/tmp}/nftban-selftest-${EUID}"
+    mkdir -p "$_st_trace_dir" 2>/dev/null || _st_trace_dir="${TMPDIR:-/tmp}"
+fi
+readonly TRACE_LOG="${_st_trace_dir}/debug_trace.log"
+unset _st_trace_dir
 SMOKE_LOG="$(mktemp /tmp/nftban_smoke_XXXXXX.log)"
 readonly SMOKE_LOG
 # shellcheck disable=SC2034  # Reserved for future trace tracking

--- a/cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh
+++ b/cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V131 PR-A — long-tail code bug fix regression test (CB-1..CB-4)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v131_pr_a_long_tail_code_bug_fix_test"
+# meta:type="test"
+# meta:version="1.131.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-25"
+# meta:description="Deterministic assertions locking the 4 long-tail code bugs that V130 PR-C surfaced on lab2: CB-1 (cmd_blacklist.sh:264 grep-||-echo double-zero arithmetic crash), CB-2 (nftban_report_fhs.sh missing NFTBAN_FHS_ACTUAL associative array declaration → bash arithmetic eval of /etc/nftban path), CB-3 (cmd_selftest.sh:572 same grep-||-echo pattern → printf %d crash on '0\n0'), CB-4 (tests/selftest.sh:47 TRACE_LOG hardcoded to root-only path → permission denied leak when non-root). Tests are a mix of pattern grep (locks the structural shape) and behavioral subshell execution (proves CB-1 + CB-3 + CB-4 actually work post-fix; CB-2 is structural-grep only because exercising it requires populating the array which needs the full FHS validator pipeline)."
+# meta:input="self-contained; sources only the files under test in subshells"
+# meta:output="[PASS]/[FAIL] per assertion; exit 1 on first failure; exit 0 if all pass"
+# meta:depends="bash 4+,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: AUDIT_190_LIFECYCLE/V130_PR_C_LONG_TAIL_BATTERY_REPORT_DEB.md §3
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+_t_assert() {
+    local name="$1"
+    local ok="$2"
+    local detail="${3:-}"
+    if [[ "$ok" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+_blacklist="${_repo_root}/cli/lib/nftban/cli/cmd_blacklist.sh"
+_selftest_cmd="${_repo_root}/cli/lib/nftban/cli/cmd_selftest.sh"
+_fhs_report="${_repo_root}/cli/lib/nftban/core/nftban_report_fhs.sh"
+_selftest_test="${_repo_root}/cli/lib/nftban/tests/selftest.sh"
+
+echo "==============================================================================="
+echo "V131 PR-A — long-tail code bug fix regression test (CB-1..CB-4)"
+echo "==============================================================================="
+echo "  Repo root:    $_repo_root"
+echo
+
+# ----------------------------------------------------------------------------
+# CB-1: cmd_blacklist.sh:264 — grep-||-echo double-zero arithmetic crash
+# ----------------------------------------------------------------------------
+echo "--- CB-1: cmd_blacklist.sh blacklist files command ---"
+
+# Structural: forbidden pattern must NOT reappear in EXECUTABLE code (strip
+# shell comments before grepping so the explanatory comments here don't
+# trip the test).
+if sed -e 's,#.*$,,' "$_blacklist" | grep -qE 'grep -c[^|]*\|\|[[:space:]]*echo "0"'; then
+    _t_assert "CB-1 (struct): cmd_blacklist.sh has no 'grep -c ... || echo \"0\"' double-zero pattern in executable code" 1 \
+        "double-zero pattern present in non-comment line — V130 PR-C CB-1 regression"
+else
+    _t_assert "CB-1 (struct): cmd_blacklist.sh has no 'grep -c ... || echo \"0\"' double-zero pattern in executable code" 0
+fi
+
+# Structural: the V131 PR-A fix shape must be present (|| true for errexit
+# suppression + parameter-default fallback for file-vanished edge case)
+if grep -qE 'count=\$\(grep -cvE.*\|\|[[:space:]]*true[[:space:]]*\)' "$_blacklist" && \
+   grep -qE 'count=\$\{count:-0\}' "$_blacklist"; then
+    _t_assert "CB-1 (struct): cmd_blacklist.sh uses '|| true' errexit-suppression + \${count:-0} fallback" 0
+else
+    _t_assert "CB-1 (struct): cmd_blacklist.sh uses '|| true' errexit-suppression + \${count:-0} fallback" 1
+fi
+
+# Behavioral: simulate the exact failure context — grep on a no-match file
+# and verify the arithmetic succeeds (was the crash site). Use a heredoc so
+# the nested $() / $var / regex special-chars don't get triple-escaped.
+_tmp_empty=$(mktemp)
+trap 'rm -f "$_tmp_empty"' EXIT
+printf '# only comments\n\n' > "$_tmp_empty"
+
+_cb1_rc=$(TMP_FILE="$_tmp_empty" bash <<'BASH' 2>&1
+set -Eeuo pipefail
+total_ips=0
+count=$(grep -cvE '^\s*(#|$)' "$TMP_FILE" 2>/dev/null || true)
+count=${count:-0}
+total_ips=$((total_ips + count))
+echo "$total_ips"
+BASH
+)
+if [[ "$_cb1_rc" == "0" ]]; then
+    _t_assert "CB-1 (behavioral): fixed pattern handles grep -c no-match without arithmetic crash" 0
+else
+    _t_assert "CB-1 (behavioral): fixed pattern handles grep -c no-match without arithmetic crash" 1 \
+        "expected '0', got: $_cb1_rc"
+fi
+
+# Behavioral: prove the OLD pattern would have crashed (sanity check the test
+# is exercising the right thing). This MUST fail with the syntax error.
+_cb1_old=$(TMP_FILE="$_tmp_empty" bash <<'BASH' 2>&1 || true
+set -Eeuo pipefail
+total_ips=0
+count=$(grep -cvE '^\s*(#|$)' "$TMP_FILE" 2>/dev/null || echo "0")
+total_ips=$((total_ips + count))
+echo "$total_ips"
+BASH
+)
+if echo "$_cb1_old" | grep -qE 'syntax error|operand'; then
+    _t_assert "CB-1 (regression-witness): the OLD pattern still produces the arithmetic bug" 0
+else
+    _t_assert "CB-1 (regression-witness): the OLD pattern still produces the arithmetic bug" 1 \
+        "old pattern unexpectedly succeeded — test may not exercise the bug class; got: $_cb1_old"
+fi
+
+# ----------------------------------------------------------------------------
+# CB-2: nftban_report_fhs.sh — missing NFTBAN_FHS_ACTUAL declaration
+# ----------------------------------------------------------------------------
+echo "--- CB-2: nftban_report_fhs.sh NFTBAN_FHS_ACTUAL declaration ---"
+
+if grep -qE '^declare -g -A NFTBAN_FHS_ACTUAL=\(\)' "$_fhs_report"; then
+    _t_assert "CB-2 (struct): NFTBAN_FHS_ACTUAL declared as -g -A associative array" 0
+else
+    _t_assert "CB-2 (struct): NFTBAN_FHS_ACTUAL declared as -g -A associative array" 1 \
+        "missing 'declare -g -A NFTBAN_FHS_ACTUAL=()' — bash will evaluate [\$path] as arithmetic and crash on /etc/nftban"
+fi
+
+# Behavioral: simulate the failure context — undeclared assoc array indexed
+# by a path-like string. Must NOT throw "operand expected" after fix.
+_cb2_rc=$(bash <<'BASH' 2>&1
+set -Eeuo pipefail
+declare -A NFTBAN_FHS_ACTUAL=()
+path="/etc/nftban"
+actual="${NFTBAN_FHS_ACTUAL[$path]:-N/A}"
+echo "$actual"
+BASH
+)
+if [[ "$_cb2_rc" == "N/A" ]]; then
+    _t_assert "CB-2 (behavioral): with -A declaration, path-keyed lookup yields the fallback string" 0
+else
+    _t_assert "CB-2 (behavioral): with -A declaration, path-keyed lookup yields the fallback string" 1 \
+        "got: $_cb2_rc"
+fi
+
+# Behavioral negative: the OLD undeclared-array path must produce the
+# documented arithmetic crash (proves the test exercises the bug class).
+_cb2_old=$(bash <<'BASH' 2>&1 || true
+set -Eeuo pipefail
+path="/etc/nftban"
+actual="${NFTBAN_FHS_ACTUAL[$path]:-N/A}"
+echo "$actual"
+BASH
+)
+if echo "$_cb2_old" | grep -qE 'operand expected|syntax error'; then
+    _t_assert "CB-2 (regression-witness): undeclared-array path produces 'operand expected' on '/etc/nftban'" 0
+else
+    _t_assert "CB-2 (regression-witness): undeclared-array path produces 'operand expected' on '/etc/nftban'" 1 \
+        "old pattern unexpectedly succeeded — got: $_cb2_old"
+fi
+
+# ----------------------------------------------------------------------------
+# CB-3: cmd_selftest.sh:572 — same grep-||-echo pattern → printf %d crash
+# ----------------------------------------------------------------------------
+echo "--- CB-3: cmd_selftest.sh blocked_countries printf ---"
+
+# Structural: the forbidden pattern must NOT reappear in cmd_selftest.sh
+# (same comment-stripping technique to avoid self-matching).
+if sed -e 's,#.*$,,' "$_selftest_cmd" | grep -qE 'grep -c[^|]*\|\|[[:space:]]*echo "0"'; then
+    _t_assert "CB-3 (struct): cmd_selftest.sh has no 'grep -c ... || echo \"0\"' double-zero pattern in executable code" 1
+else
+    _t_assert "CB-3 (struct): cmd_selftest.sh has no 'grep -c ... || echo \"0\"' double-zero pattern in executable code" 0
+fi
+
+# Structural: the fix must use '|| true' errexit-suppression + ${var:-0}
+if grep -qE '\| grep -c[^|]*\|\|[[:space:]]*true[[:space:]]*\)' "$_selftest_cmd" && \
+   grep -qE 'blocked_countries=\$\{blocked_countries:-0\}' "$_selftest_cmd" && \
+   grep -qE 'file_count=\$\{file_count:-0\}' "$_selftest_cmd"; then
+    _t_assert "CB-3 (struct): cmd_selftest.sh uses '|| true' + \${var:-0} fallback in both occurrences" 0
+else
+    _t_assert "CB-3 (struct): cmd_selftest.sh uses '|| true' + \${var:-0} fallback in both occurrences" 1
+fi
+
+# Behavioral: pipe a no-match grep into the fixed pattern + run the printf;
+# must NOT emit "printf: 0" error.
+_cb3_out=$(bash <<'BASH' 2>&1
+set -Eeuo pipefail
+# Input string that produces ZERO matches for the literal word we grep for —
+# the original test data ("NO BLOCKED LINES HERE") contained "BLOCKED" so
+# grep -c returned 1, not 0. Pick a string with no overlap.
+blocked_countries=$(echo "this line will not match" | grep -c "FORBIDDEN_PATTERN_XYZ" 2>/dev/null || true)
+blocked_countries=${blocked_countries:-0}
+printf "     Countries blocked: %d\n" "$blocked_countries"
+BASH
+)
+if [[ "$_cb3_out" == "     Countries blocked: 0" ]]; then
+    _t_assert "CB-3 (behavioral): printf %d emits zero cleanly with fixed pattern" 0
+else
+    _t_assert "CB-3 (behavioral): printf %d emits zero cleanly with fixed pattern" 1 \
+        "got: $_cb3_out"
+fi
+
+# ----------------------------------------------------------------------------
+# CB-4: tests/selftest.sh:47 — TRACE_LOG fallback when default not writable
+# ----------------------------------------------------------------------------
+echo "--- CB-4: tests/selftest.sh TRACE_LOG fallback ---"
+
+# Structural: the fallback init logic must exist
+if grep -qE '_st_trace_dir' "$_selftest_test"; then
+    _t_assert "CB-4 (struct): selftest.sh has _st_trace_dir fallback init" 0
+else
+    _t_assert "CB-4 (struct): selftest.sh has _st_trace_dir fallback init" 1 \
+        "missing fallback logic — selftest will leak Permission denied for non-root"
+fi
+
+# Structural: the fallback must end with TMPDIR path containing $EUID for
+# per-user isolation
+if grep -qE 'TMPDIR:-/tmp.*nftban-selftest-\$\{?EUID' "$_selftest_test"; then
+    _t_assert "CB-4 (struct): TRACE_LOG fallback path is per-user (\$EUID-scoped)" 0
+else
+    _t_assert "CB-4 (struct): TRACE_LOG fallback path is per-user (\$EUID-scoped)" 1
+fi
+
+# Structural: NFTBAN_LOG_DIR operator override must still be honored as-is
+# (operator knows what they want; we do NOT redirect their explicit override)
+if grep -qE '_st_trace_dir="\$\{NFTBAN_LOG_DIR:-/var/log/nftban\}"' "$_selftest_test" && \
+   grep -qE 'if \[\[ -z "\$\{NFTBAN_LOG_DIR:-\}" \]\]' "$_selftest_test"; then
+    _t_assert "CB-4 (struct): NFTBAN_LOG_DIR operator override path is honored as-is (not redirected)" 0
+else
+    _t_assert "CB-4 (struct): NFTBAN_LOG_DIR operator override path is honored as-is (not redirected)" 1
+fi
+
+# Behavioral: simulate the failure context — non-writable default + no
+# NFTBAN_LOG_DIR override. The fallback must pick a writable path.
+_cb4_rc=$(unset NFTBAN_LOG_DIR; bash <<'BASH' 2>&1
+set -Eeuo pipefail
+_st_trace_dir="/nonexistent/cannot/write/here"
+if [[ -z "${NFTBAN_LOG_DIR:-}" ]] \
+   && [[ ! -w "$_st_trace_dir" ]] \
+   && ! mkdir -p "$_st_trace_dir" 2>/dev/null; then
+    _st_trace_dir="${TMPDIR:-/tmp}/nftban-selftest-${EUID}"
+    mkdir -p "$_st_trace_dir" 2>/dev/null || _st_trace_dir="${TMPDIR:-/tmp}"
+fi
+TRACE_LOG="${_st_trace_dir}/debug_trace.log"
+# Try to write to it
+echo "test trace line" >> "$TRACE_LOG" 2>&1 && echo "WROTE: $TRACE_LOG"
+rm -f "$TRACE_LOG"
+BASH
+)
+if echo "$_cb4_rc" | grep -qE 'WROTE: /tmp/nftban-selftest-|WROTE: /tmp/debug_trace'; then
+    _t_assert "CB-4 (behavioral): fallback path is writable; trace append succeeds" 0
+else
+    _t_assert "CB-4 (behavioral): fallback path is writable; trace append succeeds" 1 \
+        "got: $_cb4_rc"
+fi
+
+# ----------------------------------------------------------------------------
+# Cross-cutting: spot-check the rest of the codebase for the SAME grep-||-echo
+# pattern (CB-1+CB-3 shape) and warn but do NOT fail (out of scope to fix
+# others in this PR; operator-only decision whether to widen scope).
+# ----------------------------------------------------------------------------
+echo "--- cross-cutting scan (informational only) ---"
+_other_hits=$(grep -rlE 'grep -c[^|]*\|\|[[:space:]]*echo "0"' \
+    "${_repo_root}/cli/lib/nftban/" 2>/dev/null \
+    | grep -vE '/tests/v131_pr_a_long_tail_code_bug_fix_test\.sh$' \
+    | grep -vE '/cli/cmd_blacklist\.sh$|/cli/cmd_selftest\.sh$' || true)
+if [[ -z "$_other_hits" ]]; then
+    _t_assert "Z1 (informational): no other 'grep -c ... || echo \"0\"' instances in cli/lib/nftban/" 0
+else
+    # Don't fail the suite — out of PR-A scope per operator. Just log.
+    echo "  [INFO] other files still have the pattern (out of PR-A scope to fix):"
+    echo "$_other_hits" | sed 's|^|         - |'
+    _t_assert "Z1 (informational): no other 'grep -c ... || echo \"0\"' instances in cli/lib/nftban/" 0
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "==============================================================================="
+echo "V131 PR-A regression test summary"
+echo "==============================================================================="
+echo "  Passed:  $TESTS_PASSED"
+echo "  Failed:  $TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "  Failed assertions:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "    - $n"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Tight follow-up to V130 PR-C long-tail battery (lab2 DEB, 269 cases, 171 PASS) closing the 4 production CODE_BUG defects surfaced — all confined to the 4 operator-authorized files.

| # | Sev | File | Fix |
|---|---|---|---|
| **CB-1** | P2 | `cli/lib/nftban/cli/cmd_blacklist.sh:264` | `grep -c ... \|\| echo "0"` → `grep -c ... \|\| true` (preserves errexit suppression without concat output; `${count:-0}` handles file-vanished edge case) |
| **CB-2** | P2 | `cli/lib/nftban/core/nftban_report_fhs.sh:43-46` | Add missing `declare -g -A NFTBAN_FHS_ACTUAL=()` (the `[$path]` subscript with undeclared array forced arithmetic eval → crashed on `/etc/nftban`) |
| **CB-3** | P3 | `cli/lib/nftban/cli/cmd_selftest.sh:516, :572` | **Two** occurrences of the CB-1 pattern fixed (line 516 was missed by the original V130 PR-C report; surfaced by this PR's structural test) |
| **CB-4** | P3 | `cli/lib/nftban/tests/selftest.sh:47` | TRACE_LOG fallback to `${TMPDIR:-/tmp}/nftban-selftest-${EUID}/` when default `/var/log/nftban` isn't writable; NFTBAN_LOG_DIR operator override honored as-is |

## Test plan

- [x] **NEW** `cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh` — **15/15 PASS** locally
  - 4 structural (with comment-stripping so the explanatory comments don't self-match)
  - 4 fix-shape (asserts `|| true`, `${var:-0}`, `declare -A`, `$EUID`-scoped fallback are in place)
  - 6 behavioral (heredoc subshells exercising each fix + 2 regression-witness tests proving the OLD pattern still produces the documented bug class)
  - 1 informational cross-cutting scan
- [x] V130 PR-A + PR-A.1 — 28/28 PASS (no regression)
- [x] V129 PR-C — 17/17 PASS
- [x] V128 PR-A — 23/23 PASS
- [x] V128 PR-D — 5/5 PASS
- [x] V127 UX-2 — 40/40 PASS
- [ ] CI: full matrix (Build & Test, Build Go binaries, CodeQL, all DEB/RPM build+install, Runtime Truth, ShellCheck) on PR open

## Cross-cutting observation (not fixed in this PR)

The PR-A regression test includes an **informational cross-cutting scan** that found **22 other files** in `cli/lib/nftban/` with the same `grep -c ... || echo "0"` double-zero pattern (cmd_snapshot/report/zabbix/botguard/status/firewall_logs/flush/suricata/portscan/feeds/ddos_*/geoban/login_alert/health_checks_*/config_doctor/autoheal/nft_schema/panel_directadmin/nft_crosscheck/selftest itself in other spots). They are listed by the test's `[INFO]` output but do NOT fail the suite — fixing them is **out of PR-A scope** per operator directive. Whether to open a separate "double-zero pattern sweep" lane is operator-only.

## Out of scope (operator-explicit; all honored)

- ❌ No UX_DRIFT wording sweep (the 12 V130 PR-C UX_DRIFT cases remain pending a separate v1.131 PR-B lane)
- ❌ No PR-D help/code correlation edits
- ❌ No PR-E docs/wiki/README edits
- ❌ No RPM battery run
- ❌ No production host contact
- ❌ No broad polkit/service expansion
- ❌ No `commands.registry.yml` or `generate-help.sh` change
- ❌ PR-D draft test file `v130_subcommand_flag_help_code_test.sh` remains untracked (separate future PR-D commit)

## Related

- Closes CB-1..CB-4 from `AUDIT_190_LIFECYCLE/V130_PR_C_LONG_TAIL_BATTERY_REPORT_DEB.md` §3
- Per `OPEN_V1_131_PR_A_LONG_TAIL_CODE_BUG_FIX = GO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)