### PR TITLE
fix(cli+systemd): v1.131.1 D13 — Option C validator output via /run/nftban file (cross-family DEB+RPM)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1103,20 +1103,23 @@ firewall_validate() {
             local _es
             _es=$(systemctl show -p ExecMainStatus --value nftban-firewall-validate.service 2>/dev/null)
             [[ -n "$_es" ]] && _validator_exit=$_es
-            # V130 PR-A.1 D10 fix: journald is asynchronous to the validator
-            # process exit. A bare journalctl call immediately after `systemctl
-            # start --wait` frequently returns empty output (the JSON hasn't
-            # been flushed to the journal yet). Bounded retry loop: up to 8
-            # tries with 0.1s sleep between = ~800ms wall time worst case.
-            # In practice 1-2 tries succeed once journald flushes. We accept
-            # whatever output we get on the last try (could still be empty
-            # under extreme load — operator can manually run journalctl).
-            local _try _output=""
-            for _try in 1 2 3 4 5 6 7 8; do
+            # V131.1 D13 fix: read the validator JSON from the group-readable
+            # file the ExecStart wrapper (firewall_validate_run.sh) writes,
+            # NOT from the unit journal. A non-root nftban-group operator (the
+            # whole point of Option C) cannot read this unit's journal without
+            # systemd-journal/adm membership, so the old journalctl read (D10)
+            # returned empty for exactly the users this service exists to serve.
+            # The wrapper writes /run/nftban/firewall-validate/last.json with
+            # chgrp nftban + chmod 0640 — that file is the PRIMARY source now.
+            local _runfile="${NFTBAN_RUN_DIR:-/run/nftban}/firewall-validate/last.json"
+            local _output=""
+            _output=$(cat "$_runfile" 2>/dev/null)
+            # Last-resort fallback ONLY if the file is empty/unreadable (e.g. an
+            # unusual /run on a root invocation): try the journal once so root
+            # still works. Non-root operators rely on the file above.
+            if [[ -z "$_output" ]]; then
                 _output=$(journalctl -u nftban-firewall-validate.service --since "@${_ts_start}" -o cat 2>/dev/null)
-                [[ -n "$_output" ]] && break
-                sleep 0.1
-            done
+            fi
             printf '%s' "$_output"
         else
             "$_go_validator" --json 2>/dev/null

--- a/cli/lib/nftban/helpers/firewall_validate_run.sh
+++ b/cli/lib/nftban/helpers/firewall_validate_run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Firewall Validate Run Wrapper (Option C output capture)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="firewall_validate_run"
+# meta:type="helper"
+# meta:version="1.131.1"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:description="V131.1 D13 Option C output-capture wrapper. ExecStart target of nftban-firewall-validate.service: runs the audited read-only nftban-validate --json as root+CAP_NET_ADMIN, then writes the validator JSON to a group-readable file under /run/nftban/firewall-validate/last.json (chgrp nftban, chmod 0640) so nftban-group operators can read the result WITHOUT root and WITHOUT systemd-journal/adm membership. The journal-read path (D10) failed cross-family for non-root operators because the unit journal is not readable by an unprivileged nftban-group member; this file hand-off fixes that. Also echoes the JSON to stdout so the root/audit journal copy is preserved, and PRESERVES the validator exit code (DEGRADED states return non-zero and must propagate)."
+# meta:input="None (delegates to nftban-validate which reads kernel nft state)"
+# meta:output="/run/nftban/firewall-validate/last.json (group nftban, 0640) + stdout copy"
+# meta:depends="/usr/lib/nftban/bin/nftban-validate"
+# meta:inventory.files="/run/nftban/firewall-validate/last.json"
+# meta:inventory.binaries="/usr/lib/nftban/bin/nftban-validate"
+# meta:inventory.env_vars="NFTBAN_RUN_DIR,NFTBAN_VALIDATE_BIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-firewall-validate.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+#
+# Runtime contract:
+#   - Runs ONLY as the ExecStart of nftban-firewall-validate.service (root).
+#   - Writes a group-readable JSON snapshot the CLI reads back (see
+#     cli/lib/nftban/cli/cmd_firewall.sh::_invoke_validator_json).
+#   - The NFTBAN_RUN_DIR / NFTBAN_VALIDATE_BIN overrides exist ONLY so the
+#     deterministic test can exercise this on a dev host without root or the
+#     nftban group. Production uses /run/nftban and the installed validator.
+#   - chgrp/chmod are best-effort (|| true): a non-nftban-group dev host must
+#     not fail. The file-write + chmod happen REGARDLESS of validator rc.
+# =============================================================================
+
+set -Eeuo pipefail
+
+# Runtime dir + output file (NFTBAN_RUN_DIR override is test-only).
+_dir="${NFTBAN_RUN_DIR:-/run/nftban}/firewall-validate"
+_file="$_dir/last.json"
+
+# Validator binary (NFTBAN_VALIDATE_BIN override is test-only).
+_bin="${NFTBAN_VALIDATE_BIN:-/usr/lib/nftban/bin/nftban-validate}"
+
+# Pre-run stale-output guard: never let the CLI read a previous run's JSON if
+# this run produces nothing (e.g. validator crashes before printing).
+rm -f "$_file" 2>/dev/null || true
+
+# Ensure the runtime dir exists and is group-readable by the nftban group.
+mkdir -p "$_dir"
+chgrp nftban "$_dir" 2>/dev/null || true
+chmod 0750 "$_dir" 2>/dev/null || true
+
+# Run the validator, capturing stdout and PRESERVING its exit code. The
+# `|| rc=$?` form is required under `set -e`: a bare `out=$(...)` assignment
+# from a non-zero command substitution would trigger errexit and abort before
+# we could write the file or read $? (DEGRADED states return non-zero).
+rc=0
+out=$("$_bin" --json 2>/dev/null) || rc=$?
+
+# Write the group-readable snapshot the non-root CLI reads back. This MUST
+# happen regardless of validator rc (DEGRADED states still emit JSON we want).
+printf '%s\n' "$out" > "$_file"
+chgrp nftban "$_file" 2>/dev/null || true
+chmod 0640 "$_file" 2>/dev/null || true
+
+# Keep the journal/audit copy for root (StandardOutput=journal).
+printf '%s\n' "$out"
+
+# Propagate the validator's true exit code (non-zero DEGRADED must surface).
+exit "$rc"

--- a/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
+++ b/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
@@ -81,9 +81,13 @@ if [[ -f "$_unit_file" ]]; then
     grep -qE '^CapabilityBoundingSet=CAP_NET_ADMIN' "$_unit_file" \
         && _t_assert "A5: unit's CapabilityBoundingSet is CAP_NET_ADMIN" 0 \
         || _t_assert "A5: unit's CapabilityBoundingSet is CAP_NET_ADMIN" 1
-    grep -qE '^ExecStart=/usr/lib/nftban/bin/nftban-validate --json' "$_unit_file" \
-        && _t_assert "A6: ExecStart invokes nftban-validate --json" 0 \
-        || _t_assert "A6: ExecStart invokes nftban-validate --json" 1
+    # V131.1 D13: ExecStart now points to the firewall_validate_run.sh wrapper
+    # (which runs nftban-validate --json and writes a group-readable file). The
+    # bare `nftban-validate --json` ExecStart was superseded so non-root
+    # nftban-group operators can read the result without journal access.
+    grep -qE '^ExecStart=/usr/lib/nftban/helpers/firewall_validate_run\.sh' "$_unit_file" \
+        && _t_assert "A6 (D13): ExecStart invokes the firewall_validate_run.sh wrapper" 0 \
+        || _t_assert "A6 (D13): ExecStart invokes the firewall_validate_run.sh wrapper" 1
     grep -qE '^StandardOutput=journal' "$_unit_file" \
         && _t_assert "A7: stdout goes to journal" 0 \
         || _t_assert "A7: stdout goes to journal" 1
@@ -192,9 +196,15 @@ grep -qE 'EUID -ne 0' "$_firewall_cli" \
     && _t_assert "D3: cmd_firewall.sh gates the systemd route on \$EUID -ne 0" 0 \
     || _t_assert "D3: cmd_firewall.sh gates the systemd route on \$EUID -ne 0" 1
 
-grep -qE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli" \
-    && _t_assert "D4: cmd_firewall.sh reads the validator JSON from journalctl" 0 \
-    || _t_assert "D4: cmd_firewall.sh reads the validator JSON from journalctl" 1
+# V131.1 D13: the PRIMARY validator-output source is now the group-readable
+# /run/nftban/firewall-validate/last.json file the ExecStart wrapper writes,
+# NOT the unit journal (a non-root nftban-group operator cannot read the unit
+# journal without systemd-journal/adm membership). A single best-effort
+# journalctl call remains ONLY as a last-resort root fallback if the file is
+# empty.
+grep -qE 'firewall-validate/last\.json' "$_firewall_cli" \
+    && _t_assert "D4 (D13): cmd_firewall.sh reads the validator JSON from the /run/nftban last.json file" 0 \
+    || _t_assert "D4 (D13): cmd_firewall.sh reads the validator JSON from the /run/nftban last.json file" 1
 
 # Fallback path: if the unit isn't installed (pre-v1.130 host), the CLI still
 # falls through to direct invocation (which surfaces the D6.B Remediation).
@@ -202,45 +212,54 @@ grep -qE 'systemctl cat nftban-firewall-validate\.service' "$_firewall_cli" \
     && _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 0 \
     || _t_assert "D5: cmd_firewall.sh checks unit existence (systemctl cat) before routing" 1
 
-# V130 PR-A.1 D10 fix: journalctl read MUST retry with bounded backoff to
-# survive the journald async-write race that PR-B observed on lab2 (operator
-# saw rc=0 with empty stdout because the JSON hadn't flushed to journal when
-# the first journalctl call ran). The retry loop is the contract: a bare
-# single journalctl call would re-introduce the D10 UX bug.
-_journalctl_count=$(grep -cE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli" || true)
-_journalctl_count=${_journalctl_count:-0}
-# We expect the journalctl call to appear inside a loop. Two correct patterns:
-#   for _try in ...; do journalctl ...; ...; done
-#   while ...; do journalctl ...; done
-# Negative pattern: a single bare journalctl call with no surrounding loop.
-if grep -B2 -A3 'journalctl -u nftban-firewall-validate\.service --since' "$_firewall_cli" | grep -qE '(for[[:space:]]+[_a-zA-Z]+|while)'; then
-    _t_assert "D6 (D10 fix): journalctl read is inside a retry loop (survives journald async write)" 0
+# V131.1 D13: the D10 journalctl retry loop was superseded. journald read is
+# unreadable for the non-root nftban-group operators Option C exists to serve
+# (no systemd-journal/adm membership), so the CLI now reads the group-readable
+# file the ExecStart wrapper writes. The file read is the contract; the journal
+# call is demoted to a single best-effort root-only fallback.
+
+# D6: the CLI honors the NFTBAN_RUN_DIR override when resolving the run file
+# (so the read path is the same one the wrapper writes, and tests can redirect
+# it on a dev host).
+if grep -qE 'NFTBAN_RUN_DIR' "$_firewall_cli"; then
+    _t_assert "D6 (D13): cmd_firewall.sh resolves the run file under \${NFTBAN_RUN_DIR:-/run/nftban}" 0
 else
-    _t_assert "D6 (D10 fix): journalctl read is inside a retry loop (survives journald async write)" 1 \
-        "bare journalctl call without retry loop — D10 UX regression"
+    _t_assert "D6 (D13): cmd_firewall.sh resolves the run file under \${NFTBAN_RUN_DIR:-/run/nftban}" 1
 fi
 
-# Retry must be bounded (not infinite). Look for a numeric iteration cap.
+# D7: the run file is read AFTER the systemctl start --wait (the wrapper writes
+# it during that run). Verify the file-read appears after the start line.
+_start_ln=$(grep -nE 'systemctl start --wait nftban-firewall-validate\.service' "$_firewall_cli" | head -1 | cut -d: -f1)
+_read_ln=$(grep -nE 'firewall-validate/last\.json' "$_firewall_cli" | head -1 | cut -d: -f1)
+if [[ -n "$_start_ln" && -n "$_read_ln" && "$_read_ln" -gt "$_start_ln" ]]; then
+    _t_assert "D7 (D13): the last.json read happens after 'systemctl start --wait'" 0
+else
+    _t_assert "D7 (D13): the last.json read happens after 'systemctl start --wait'" 1 \
+        "start line=$_start_ln read line=$_read_ln"
+fi
+
+# D8: a single best-effort journalctl call may remain ONLY as a last-resort
+# fallback (root, unusual /run). It must NOT be inside a multi-try retry loop
+# anymore — that was the D10 shape that returned empty for non-root operators.
 if grep -qE 'for _try in 1 2 3' "$_firewall_cli"; then
-    _t_assert "D7 (D10 fix): retry loop has bounded iterations (no infinite wait)" 0
+    _t_assert "D8 (D13): the D10 multi-try journalctl retry loop is gone (file read replaces it)" 1 \
+        "found the old 'for _try in 1 2 3' journalctl retry loop"
 else
-    _t_assert "D7 (D10 fix): retry loop has bounded iterations (no infinite wait)" 1
+    _t_assert "D8 (D13): the D10 multi-try journalctl retry loop is gone (file read replaces it)" 0
 fi
 
-# Each retry iteration must sleep between attempts (otherwise we burn CPU
-# and likely all 8 tries fire within journald's flush window anyway).
-if grep -qE 'sleep 0?\.[0-9]' "$_firewall_cli" && \
-   awk '/for _try in/,/done/' "$_firewall_cli" | grep -q 'sleep'; then
-    _t_assert "D8 (D10 fix): retry loop sleeps between attempts" 0
+# D9: the fallback journalctl read (if present) is gated on an empty file read,
+# i.e. it is a fallback, not the primary source.
+if awk '/firewall-validate\/last\.json/{seen=1} seen && /journalctl -u nftban-firewall-validate/{print; exit}' "$_firewall_cli" | grep -q 'journalctl'; then
+    _t_assert "D9 (D13): the journalctl read (if any) is a fallback AFTER the file read" 0
 else
-    _t_assert "D8 (D10 fix): retry loop sleeps between attempts" 1
-fi
-
-# Loop exits early once output is captured (don't waste 800ms on every call).
-if awk '/for _try in/,/done/' "$_firewall_cli" | grep -qE '\[\[ -n "\$?_output"? \]\] && break'; then
-    _t_assert "D9 (D10 fix): retry loop short-circuits when output appears" 0
-else
-    _t_assert "D9 (D10 fix): retry loop short-circuits when output appears" 1
+    # No journalctl fallback at all is also acceptable (file is the only source).
+    if grep -qE 'journalctl -u nftban-firewall-validate\.service' "$_firewall_cli"; then
+        _t_assert "D9 (D13): the journalctl read (if any) is a fallback AFTER the file read" 1 \
+            "journalctl appears before the file read — file must be primary"
+    else
+        _t_assert "D9 (D13): the journalctl read (if any) is a fallback AFTER the file read" 0
+    fi
 fi
 
 # ----------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh
+++ b/cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V131.1 D13 — Option C validator output-capture regression test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v131_1_d13_option_c_output_capture_test"
+# meta:type="test"
+# meta:version="1.131.1"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:description="Deterministic assertions locking the V131.1 D13 fix: nftban firewall validate Option C output is captured via a group-readable /run/nftban/firewall-validate/last.json file written by the firewall_validate_run.sh ExecStart wrapper, NOT via a non-root-unreadable journalctl read. Structural asserts: the unit ExecStart points to the wrapper (not bare nftban-validate --json); the wrapper exists, is executable, contains the run-dir/last.json path, chgrp nftban, chmod 0640, a pre-run rm -f stale-cleanup, and exit-code preservation; cmd_firewall.sh reads the last.json file. Behavioral asserts (dev-host runnable, no root/nftban group): a stub validator exercises the wrapper through NFTBAN_RUN_DIR + NFTBAN_VALIDATE_BIN overrides and proves the file is written with the validator JSON, the wrapper preserves the validator exit code (rc=0 and rc=3), and the pre-run rm -f removes stale prior output when a run produces nothing."
+# meta:input="self-contained; pattern-greps the source files + runs the wrapper against a stub validator in a temp dir"
+# meta:output="[PASS]/[FAIL] per assertion; exit 0 iff all pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_RUN_DIR,NFTBAN_VALIDATE_BIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: gate OPEN_V1_131_1_D13_OPTION_C_OUTPUT_CAPTURE_FIX (D13 only).
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+_pass=0
+_fail=0
+_failed_names=()
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"; _pass=$((_pass+1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"; _fail=$((_fail+1))
+        _failed_names+=("$name")
+    fi
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_unit_file="${_repo_root}/install/systemd/nftban-firewall-validate.service"
+_wrapper="${_repo_root}/cli/lib/nftban/helpers/firewall_validate_run.sh"
+_firewall_cli="${_repo_root}/cli/lib/nftban/cli/cmd_firewall.sh"
+
+echo "==============================================================================="
+echo "V131.1 D13 — Option C validator output-capture regression test"
+echo "  Repo root: $_repo_root"
+echo "==============================================================================="
+
+# ----------------------------------------------------------------------------
+# A: structural — unit ExecStart, wrapper presence/content, CLI file read
+# ----------------------------------------------------------------------------
+echo "--- A: structural ---"
+
+# A1: unit ExecStart points to the wrapper, NOT bare nftban-validate --json.
+if grep -qE '^ExecStart=/usr/lib/nftban/helpers/firewall_validate_run\.sh' "$_unit_file"; then
+    _t_assert "A1: unit ExecStart points to firewall_validate_run.sh wrapper" 0
+else
+    _t_assert "A1: unit ExecStart points to firewall_validate_run.sh wrapper" 1
+fi
+
+# A2: the old bare ExecStart is gone (no `ExecStart=...nftban-validate --json`).
+if grep -qE '^ExecStart=/usr/lib/nftban/bin/nftban-validate --json' "$_unit_file"; then
+    _t_assert "A2: bare 'nftban-validate --json' ExecStart no longer present" 1 \
+        "unit still has the bare validator ExecStart"
+else
+    _t_assert "A2: bare 'nftban-validate --json' ExecStart no longer present" 0
+fi
+
+# A3: wrapper exists and is executable.
+if [[ -f "$_wrapper" && -x "$_wrapper" ]]; then
+    _t_assert "A3: wrapper exists and is executable" 0
+else
+    _t_assert "A3: wrapper exists and is executable" 1 "$_wrapper missing or not +x"
+fi
+
+# A4: wrapper resolves the /run/nftban .../firewall-validate/last.json path.
+if grep -qE '/run/nftban' "$_wrapper" && grep -qE 'firewall-validate' "$_wrapper" && grep -qE 'last\.json' "$_wrapper"; then
+    _t_assert "A4: wrapper references /run/nftban .../firewall-validate/last.json" 0
+else
+    _t_assert "A4: wrapper references /run/nftban .../firewall-validate/last.json" 1
+fi
+
+# A5: wrapper chgrps the file to the nftban group.
+if grep -qE 'chgrp nftban' "$_wrapper"; then
+    _t_assert "A5: wrapper chgrp nftban (group-readable hand-off)" 0
+else
+    _t_assert "A5: wrapper chgrp nftban (group-readable hand-off)" 1
+fi
+
+# A6: wrapper chmods the file 0640 (group read, no group write).
+if grep -qE 'chmod 0640' "$_wrapper"; then
+    _t_assert "A6: wrapper chmod 0640 on the output file" 0
+else
+    _t_assert "A6: wrapper chmod 0640 on the output file" 1
+fi
+
+# A7: wrapper has a pre-run rm -f stale-output guard.
+if grep -qE 'rm -f .*_file' "$_wrapper" || grep -qE 'rm -f "\$_file"' "$_wrapper"; then
+    _t_assert "A7: wrapper has a pre-run 'rm -f' stale-output guard" 0
+else
+    _t_assert "A7: wrapper has a pre-run 'rm -f' stale-output guard" 1
+fi
+
+# A8: wrapper preserves the validator exit code (exit "$rc" / exit $rc).
+if grep -qE '^exit "?\$rc"?' "$_wrapper"; then
+    _t_assert "A8: wrapper preserves validator exit code (exit \$rc)" 0
+else
+    _t_assert "A8: wrapper preserves validator exit code (exit \$rc)" 1
+fi
+
+# A9: cmd_firewall.sh service branch reads the last.json file (no longer SOLELY
+#     dependent on journalctl).
+if grep -qE 'firewall-validate/last\.json' "$_firewall_cli"; then
+    _t_assert "A9: cmd_firewall.sh reads the last.json file" 0
+else
+    _t_assert "A9: cmd_firewall.sh reads the last.json file" 1
+fi
+
+# ----------------------------------------------------------------------------
+# B: behavioral — run the wrapper against a stub validator in a temp dir.
+#    No root / nftban group required (chgrp/chmod are || true on a dev host).
+# ----------------------------------------------------------------------------
+echo "--- B: behavioral (stub validator, temp dir) ---"
+
+_tmp="$(mktemp -d)"
+trap 'rm -rf "$_tmp"' EXIT
+
+# Stub validator: prints a known JSON, exits with the rc passed via env STUB_RC.
+_stub="$_tmp/stub-validate"
+cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' '{"status":"OK","findings":[]}'
+exit "${STUB_RC:-0}"
+STUB
+chmod +x "$_stub"
+
+_runfile="$_tmp/firewall-validate/last.json"
+
+# B1: rc=0 path → file written with the JSON, wrapper exit code 0.
+STUB_RC=0 NFTBAN_RUN_DIR="$_tmp" NFTBAN_VALIDATE_BIN="$_stub" bash "$_wrapper" >/dev/null 2>&1
+_w_rc=$?
+if [[ "$_w_rc" == "0" ]]; then
+    _t_assert "B1a: wrapper preserves rc=0 from the validator" 0
+else
+    _t_assert "B1a: wrapper preserves rc=0 from the validator" 1 "wrapper rc=$_w_rc"
+fi
+if [[ -f "$_runfile" ]] && grep -q '"status":"OK"' "$_runfile"; then
+    _t_assert "B1b: last.json exists and contains the validator JSON" 0
+else
+    _t_assert "B1b: last.json exists and contains the validator JSON" 1 \
+        "runfile=$_runfile contents=[$(cat "$_runfile" 2>/dev/null)]"
+fi
+
+# B2: rc=3 path (DEGRADED) → wrapper exit code 3 (rc preserved), file still written.
+STUB_RC=3 NFTBAN_RUN_DIR="$_tmp" NFTBAN_VALIDATE_BIN="$_stub" bash "$_wrapper" >/dev/null 2>&1
+_w_rc=$?
+if [[ "$_w_rc" == "3" ]]; then
+    _t_assert "B2a: wrapper preserves non-zero rc=3 from the validator (DEGRADED propagates)" 0
+else
+    _t_assert "B2a: wrapper preserves non-zero rc=3 from the validator (DEGRADED propagates)" 1 "wrapper rc=$_w_rc"
+fi
+if [[ -f "$_runfile" ]] && grep -q '"status":"OK"' "$_runfile"; then
+    _t_assert "B2b: last.json is written even when the validator exits non-zero" 0
+else
+    _t_assert "B2b: last.json is written even when the validator exits non-zero" 1
+fi
+
+# B3: stale-cleanup — pre-seed last.json with old content, then run a stub that
+#     exits non-zero WITHOUT printing. The pre-run rm -f must remove the old
+#     content (file is rewritten empty, not left stale).
+_silent_stub="$_tmp/stub-silent"
+cat > "$_silent_stub" <<'STUB'
+#!/usr/bin/env bash
+exit "${STUB_RC:-1}"
+STUB
+chmod +x "$_silent_stub"
+
+mkdir -p "$_tmp/firewall-validate"
+printf '%s\n' '{"status":"STALE_OLD_RUN"}' > "$_runfile"
+
+STUB_RC=1 NFTBAN_RUN_DIR="$_tmp" NFTBAN_VALIDATE_BIN="$_silent_stub" bash "$_wrapper" >/dev/null 2>&1
+_w_rc=$?
+if ! grep -q 'STALE_OLD_RUN' "$_runfile" 2>/dev/null; then
+    _t_assert "B3a: pre-run rm -f removes stale prior last.json content" 0
+else
+    _t_assert "B3a: pre-run rm -f removes stale prior last.json content" 1 \
+        "stale content survived: [$(cat "$_runfile" 2>/dev/null)]"
+fi
+if [[ "$_w_rc" == "1" ]]; then
+    _t_assert "B3b: wrapper preserves rc=1 from the silent (no-output) validator" 0
+else
+    _t_assert "B3b: wrapper preserves rc=1 from the silent (no-output) validator" 1 "wrapper rc=$_w_rc"
+fi
+
+# ----------------------------------------------------------------------------
+# C: every changed shell file still parses.
+# ----------------------------------------------------------------------------
+echo "--- C: parse ---"
+_broken=""
+for f in "$_wrapper" "$_firewall_cli" "${BASH_SOURCE[0]}"; do
+    bash -n "$f" 2>/dev/null || _broken+="$f"$'\n'
+done
+if [[ -z "$_broken" ]]; then
+    _t_assert "C1: wrapper, cmd_firewall.sh, and this test all parse (bash -n)" 0
+else
+    _t_assert "C1: wrapper, cmd_firewall.sh, and this test all parse (bash -n)" 1 \
+        "broken:"$'\n'"$_broken"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo "-------------------------------------------------------------------------------"
+echo "V131.1 D13 Option C output-capture test summary"
+echo "  Passed:  $_pass"
+echo "  Failed:  $_fail"
+if [[ "$_fail" -gt 0 ]]; then
+    echo "  Failed assertions:"
+    for n in "${_failed_names[@]}"; do echo "    - $n"; done
+fi
+echo "-------------------------------------------------------------------------------"
+[[ "$_fail" -eq 0 ]]

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -65,9 +65,15 @@ Group=root
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
 
-# JSON output goes to the journal. Operators (or the nftban firewall validate
-# CLI wrapper) read it with: journalctl -u nftban-firewall-validate.service
-ExecStart=/usr/lib/nftban/bin/nftban-validate --json
+# V131.1 D13 fix: ExecStart is a thin wrapper (firewall_validate_run.sh) that
+# runs nftban-validate --json and writes the JSON to a GROUP-READABLE file at
+# /run/nftban/firewall-validate/last.json (chgrp nftban, 0640). The CLI reads
+# that file. Previously the CLI read this unit's JSON via journalctl, but a
+# non-root nftban-group operator (the whole point of Option C) cannot read the
+# unit journal without systemd-journal/adm membership, so they saw no result.
+# The wrapper still echoes the JSON to stdout, so StandardOutput=journal keeps
+# the root/audit journal copy, and it PRESERVES the validator exit code.
+ExecStart=/usr/lib/nftban/helpers/firewall_validate_run.sh
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Problem (D13, confirmed cross-family DEB+RPM)
`nftban firewall validate` for a non-root **nftban-group** operator returned `rc=0` and `nftban-firewall-validate.service` ran correctly, but the CLI read the validator JSON via `journalctl -u nftban-firewall-validate.service`. An unprivileged operator **not** in `systemd-journal`/`adm` cannot read that unit journal, so they saw only the banner and no validator status — defeating the whole point of Option C (let nftban-group operators validate **without** root). Root was unaffected, which is why it slipped past V130/V131.

## Fix
Stop using the non-root-unreadable unit journal as the Option C output source.

- **New wrapper** `cli/lib/nftban/helpers/firewall_validate_run.sh` (ExecStart target): runs `nftban-validate --json`, writes the JSON to a **group-readable** file `/run/nftban/firewall-validate/last.json` (`chgrp nftban`, `chmod 0640`) with a **pre-run `rm -f` stale-output guard**, echoes to stdout (keeps the root/audit journal copy), and **preserves the validator exit code** (DEGRADED returns non-zero and must propagate). `NFTBAN_RUN_DIR`/`NFTBAN_VALIDATE_BIN` overrides are test-only.
- **Unit** `install/systemd/nftban-firewall-validate.service`: `ExecStart` now points to the wrapper. `[Unit]` StartLimit keys, User/Group, Type, hardening, polkit — all untouched. `StandardOutput=journal` kept.
- **CLI** `cli/lib/nftban/cli/cmd_firewall.sh` (`_invoke_validator_json`): after `systemctl start --wait` succeeds, reads `${NFTBAN_RUN_DIR:-/run/nftban}/firewall-validate/last.json` as the **primary** source; a single best-effort `journalctl` call remains only as a last-resort root fallback when the file is empty. `_validator_exit` via `ExecMainStatus` unchanged; the direct-validator fallback branch unchanged.

No packaging/payload edits needed: `cli/lib/nftban/helpers/*.sh` is already auto-staged to `/usr/lib/nftban/helpers/` by the Go installer payload glob (`payload.go:394`) and the RPM/DEB `cp -r cli/lib/nftban/*` (`build_nftban.sh:425`/`:1644`).

## Tests
- **New** `cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh` — 16/16 PASS. Structural (ExecStart→wrapper, wrapper content: path/chgrp/chmod/`rm -f`/`exit $rc`, CLI file read) + behavioral against a stub validator (file written with JSON; rc preserved for rc=0/rc=3; stale-cleanup verified with a silent non-zero stub).
- Updated `v130_polkit_validate_service_test.sh` A6/D4/D6–D9: those assertions hard-coded the now-**superseded** bare ExecStart + journalctl retry-loop shape, so they were re-pointed to lock the D13 file-handoff behavior. Now 28/28 PASS.
- Adjacent suites green: `v131_pr_a_2_double_zero_sweep` 6/6, `v131_pr_a_long_tail_code_bug_fix` 15/15, `v129_pr_c_runtime_defect_fixes` 17/17.
- `shellcheck -S warning` clean on all changed shell files; `bash -n` clean; header validator passes.

## Scope-lock
D13 only. No pkexec; no `systemd-journal`/`adm` group changes; no broader polkit/UX/docs work; no production hosts. Do **not** merge, do **not** tag.