### PR TITLE
fix(systemd): v1.131.3 D13 — setgid handoff dir (2750) so last.json inherits group nftban without CAP_CHOWN

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -872,10 +872,10 @@ directories:
       note: "Managed by tmpfiles only - do not use RuntimeDirectory= in units to avoid conflict. 0755 intentional: socket-discovery — non-nftban-group processes (panel adapters, monitoring tools) must stat() the daemon socket; the socket file itself uses unit-level SocketMode=0660 + group ownership for access control. Tightening the parent dir would break socket-discovery for anything outside the nftban group."
 
     - path: /run/nftban/firewall-validate
-      mode: "0750"
+      mode: "2750"
       owner: root
       group: nftban
-      description: "V131.2 D13 — group-readable handoff dir for nftban-firewall-validate.service output (last.json)"
+      description: "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
       created_by: tmpfiles
 
   # ---------------------------------------------------------------------------

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -160,7 +160,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/cache/nftban"]="0755|nftban|nftban|Cache files"
     NFTBAN_FHS_DIRECTORIES["/var/cache/nftban/health"]="0750|nftban|nftban|Health check status cache"
     NFTBAN_FHS_DIRECTORIES["/run/nftban"]="0755|nftban|nftban|Runtime data (PID files, sockets)"
-    NFTBAN_FHS_DIRECTORIES["/run/nftban/firewall-validate"]="0750|root|nftban|V131.2 D13 — group-readable handoff dir for nftban-firewall-validate.service output (last.json)"
+    NFTBAN_FHS_DIRECTORIES["/run/nftban/firewall-validate"]="2750|root|nftban|V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
 
     # Shared Directories
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban"]="0755|root|root|Shared application data"

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -861,10 +861,10 @@
       },
       {
         "path": "/run/nftban/firewall-validate",
-        "mode": "0750",
+        "mode": "2750",
         "owner": "root",
         "group": "nftban",
-        "description": "V131.2 D13 — group-readable handoff dir for nftban-firewall-validate.service output (last.json)",
+        "description": "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN",
         "created_by": "tmpfiles"
       }
     ],

--- a/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
+++ b/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
@@ -111,10 +111,10 @@ fi
 # ----------------------------------------------------------------------------
 echo "--- B: tmpfiles ---"
 
-if grep -qE '^d /run/nftban/firewall-validate 0750 root nftban -$' "$_tmpfiles"; then
-    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 0750 root nftban -'" 0
+if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
+    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -'" 0
 else
-    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 0750 root nftban -'" 1
+    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -'" 1
 fi
 
 # ----------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
+++ b/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V131.3 D13 — setgid handoff-dir group-ownership regression test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v131_3_d13_setgid_group_ownership_test"
+# meta:type="test"
+# meta:version="1.131.3"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:description="Deterministic assertions locking the V131.3 D13 setgid group-ownership fix (Option C). v1.131.2 fixed the sandbox WRITE (last.json is now created under ProtectSystem=strict) but the file landed root:root 0640 instead of root:nftban: the unit's CapabilityBoundingSet=CAP_NET_ADMIN drops CAP_CHOWN so the wrapper's best-effort chgrp nftban silently failed, and the 0750 handoff dir was not setgid so a file created in it inherited the process egid (root). The fix makes the handoff dir setgid (2750 root nftban) in BOTH the generated tmpfiles entry and the unit's +-prefixed ExecStartPre install -d, so a file created there inherits group nftban automatically — no chgrp / no CAP_CHOWN — and the wrapper's owner-side chmod 0640 still works → final root:nftban 0640 → nftban-group operators read it → '^Validator Status:' renders. The KEY behavioral assertion (the class that would have caught the v1.131.2 miss) proves setgid group inheritance does NOT depend on chgrp: it creates a real setgid dir, writes a file as a stub, and asserts the file's group == the dir's group; and IF root + systemd-run are available it runs the wrapper under the real unit caps (CapabilityBoundingSet=CAP_NET_ADMIN, no CAP_CHOWN) into a pre-created setgid dir and asserts last.json group == the dir's group and mode 0640 even though the process cannot chown — SKIPPED with a clear note (real proof = lab package validation) when not root / no systemd-run / cannot chgrp the temp dir."
+# meta:input="self-contained; pattern-greps the source files + exercises setgid inheritance, optionally runs the wrapper under systemd-run"
+# meta:output="[PASS]/[FAIL]/[SKIP] per assertion; exit 0 iff no failures"
+# meta:depends="bash,grep,install,stat"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_RUN_DIR,NFTBAN_VALIDATE_BIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
+# Scope: gate OPEN_V1_131_3_D13_SETGID_GROUP_OWNERSHIP_FIX (D13 only).
+# =============================================================================
+
+set -Eeuo pipefail
+set +e
+
+_pass=0
+_fail=0
+_skip=0
+_failed_names=()
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then
+        printf "  [PASS] %s\n" "$name"; _pass=$((_pass+1))
+    else
+        printf "  [FAIL] %s%s\n" "$name" "${detail:+ — $detail}"; _fail=$((_fail+1))
+        _failed_names+=("$name")
+    fi
+}
+_t_skip() {
+    local name="$1" detail="${2:-}"
+    printf "  [SKIP] %s%s\n" "$name" "${detail:+ — $detail}"; _skip=$((_skip+1))
+}
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+_unit_file="${_repo_root}/install/systemd/nftban-firewall-validate.service"
+_wrapper="${_repo_root}/cli/lib/nftban/helpers/firewall_validate_run.sh"
+_tmpfiles="${_repo_root}/install/systemd/tmpfiles.d/nftban.conf"
+
+echo "==============================================================================="
+echo "V131.3 D13 — setgid handoff-dir group-ownership regression test"
+echo "  Repo root: $_repo_root"
+echo "==============================================================================="
+
+# ----------------------------------------------------------------------------
+# A: generated tmpfiles — setgid (2750) handoff dir, exact line.
+# ----------------------------------------------------------------------------
+echo "--- A: tmpfiles (generated) ---"
+
+# A1: exact setgid line (must match exactly; mode 2750, owner root, group nftban).
+if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
+    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -'" 0
+else
+    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -'" 1 \
+        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
+fi
+
+# A2: the old non-setgid 0750 form is GONE (no stale mode left behind).
+if grep -qE '^d /run/nftban/firewall-validate 0750 ' "$_tmpfiles"; then
+    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 1 \
+        "0750 entry still present — generator did not pick up the 2750 mode"
+else
+    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 0
+fi
+
+# ----------------------------------------------------------------------------
+# B: unit — setgid ExecStartPre + preserved hardening, NO CAP_CHOWN.
+# ----------------------------------------------------------------------------
+echo "--- B: unit ExecStartPre + hardening ---"
+
+# B1: ExecStartPre install -d uses -m 2750 AND -o root AND -g nftban AND the dir.
+_espre=$(grep -E '^ExecStartPre=\+/usr/bin/install -d ' "$_unit_file" | head -1)
+if [[ -n "$_espre" ]] \
+    && grep -qE '\-m 2750' <<<"$_espre" \
+    && grep -qE '\-o root' <<<"$_espre" \
+    && grep -qE '\-g nftban' <<<"$_espre" \
+    && grep -qE '/run/nftban/firewall-validate' <<<"$_espre"; then
+    _t_assert "B1: ExecStartPre install -d has -m 2750 -o root -g nftban + the dir path" 0
+else
+    _t_assert "B1: ExecStartPre install -d has -m 2750 -o root -g nftban + the dir path" 1 \
+        "line: [$_espre]"
+fi
+
+# B2: unit keeps CapabilityBoundingSet=CAP_NET_ADMIN (exact, only).
+if grep -qE '^CapabilityBoundingSet=CAP_NET_ADMIN$' "$_unit_file"; then
+    _t_assert "B2: unit keeps CapabilityBoundingSet=CAP_NET_ADMIN (only)" 0
+else
+    _t_assert "B2: unit keeps CapabilityBoundingSet=CAP_NET_ADMIN (only)" 1
+fi
+
+# B3: CAP_CHOWN appears in NO active unit directive (no capability widening; the
+#     whole point is that setgid removes the need for chown). Scan ACTIVE
+#     directive lines only (strip comment lines first) so the explanatory
+#     comment that legitimately names CAP_CHOWN does not trip the guard.
+_b3_active=$(grep -vE '^[[:space:]]*#' "$_unit_file")
+if grep -qE 'CAP_CHOWN' <<<"$_b3_active"; then
+    _t_assert "B3: unit has NO CAP_CHOWN in any active directive" 1 \
+        "found CAP_CHOWN in an active directive — capability widening is forbidden for this fix"
+else
+    _t_assert "B3: unit has NO CAP_CHOWN in any active directive" 0
+fi
+
+# B4: ProtectSystem=strict preserved.
+if grep -qE '^ProtectSystem=strict' "$_unit_file"; then
+    _t_assert "B4: unit keeps ProtectSystem=strict" 0
+else
+    _t_assert "B4: unit keeps ProtectSystem=strict" 1
+fi
+
+# B5: narrow ReadWritePaths preserved (the v1.131.2 subdir grant stays).
+if grep -qE '^ReadWritePaths=/run/nftban/firewall-validate' "$_unit_file"; then
+    _t_assert "B5: unit keeps ReadWritePaths=/run/nftban/firewall-validate" 0
+else
+    _t_assert "B5: unit keeps ReadWritePaths=/run/nftban/firewall-validate" 1
+fi
+
+# ----------------------------------------------------------------------------
+# C: BEHAVIORAL, capability-faithful — prove setgid inheritance does NOT rely on
+#    chgrp. The assertion class that would have caught the v1.131.2 miss.
+# ----------------------------------------------------------------------------
+echo "--- C: setgid group-inheritance (no chgrp) ---"
+
+_tmp="$(mktemp -d)"
+trap 'rm -rf "$_tmp"' EXIT
+
+# Pick a secondary group we are a member of (other than our primary egid) so a
+# setgid dir owned by THAT group demonstrably changes the inherited group of a
+# file created inside it. If no usable secondary group exists, SKIP — the proof
+# then lives in lab package validation.
+_test_grp=""
+if command -v id >/dev/null 2>&1; then
+    _primary_gid="$(id -g)"
+    for _g in $(id -G 2>/dev/null); do
+        if [[ "$_g" != "$_primary_gid" ]]; then _test_grp="$_g"; break; fi
+    done
+fi
+
+if [[ -n "$_test_grp" ]]; then
+    _sg_dir="$_tmp/setgid-dir"
+    mkdir -p "$_sg_dir"
+    # chgrp to the secondary group, then set setgid (2750). We are an owner-side
+    # member, so this needs no special capability.
+    if chgrp "$_test_grp" "$_sg_dir" 2>/dev/null && chmod 2750 "$_sg_dir" 2>/dev/null; then
+        # Write a file in the setgid dir as a stub — WITHOUT any chgrp on the file.
+        _sg_file="$_sg_dir/last.json"
+        printf '%s\n' '{"status":"OK"}' > "$_sg_file"
+        _dir_grp="$(stat -c '%g' "$_sg_dir" 2>/dev/null)"
+        _file_grp="$(stat -c '%g' "$_sg_file" 2>/dev/null)"
+        if [[ -n "$_file_grp" && "$_file_grp" == "$_dir_grp" ]]; then
+            _t_assert "C1: file created in setgid dir inherits the dir's GROUP without chgrp" 0
+        else
+            _t_assert "C1: file created in setgid dir inherits the dir's GROUP without chgrp" 1 \
+                "dir gid=$_dir_grp file gid=$_file_grp (setgid inheritance did not happen)"
+        fi
+        # The owner-side chmod 0640 (what the wrapper does) needs no capability.
+        if chmod 0640 "$_sg_file" 2>/dev/null && [[ "$(stat -c '%a' "$_sg_file" 2>/dev/null)" == "640" ]]; then
+            _t_assert "C2: owner chmod 0640 on the inherited-group file succeeds (no capability)" 0
+        else
+            _t_assert "C2: owner chmod 0640 on the inherited-group file succeeds (no capability)" 1 \
+                "mode=$(stat -c '%a' "$_sg_file" 2>/dev/null)"
+        fi
+    else
+        _t_skip "C1/C2: setgid group-inheritance behavioral" \
+            "could not chgrp/chmod a temp dir to a secondary group in this env; real proof = lab package validation"
+    fi
+else
+    _t_skip "C1/C2: setgid group-inheritance behavioral" \
+        "no usable secondary group for this user; real proof = lab package validation"
+fi
+
+# ----------------------------------------------------------------------------
+# D: CAPABILITY-FAITHFUL end-to-end — run the wrapper under the REAL unit caps
+#    (CapabilityBoundingSet=CAP_NET_ADMIN, no CAP_CHOWN) into a PRE-CREATED
+#    setgid dir; assert last.json inherits the dir's group + mode 0640 EVEN
+#    THOUGH the process cannot chown. Proves chgrp is not required. Needs root +
+#    systemd-run + a chgrp-able temp dir; otherwise SKIP.
+# ----------------------------------------------------------------------------
+echo "--- D: capability-faithful wrapper run (systemd-run, no CAP_CHOWN) ---"
+
+_d_grp=""
+if command -v id >/dev/null 2>&1; then
+    _d_primary_gid="$(id -g)"
+    for _g in $(id -G 2>/dev/null); do
+        if [[ "$_g" != "$_d_primary_gid" ]]; then _d_grp="$_g"; break; fi
+    done
+fi
+
+if command -v systemd-run >/dev/null 2>&1 && [[ $EUID -eq 0 ]] && [[ -n "$_d_grp" ]]; then
+    _drun="$(mktemp -d)"
+    _drun_sub="$_drun/firewall-validate"
+    _drun_file="$_drun_sub/last.json"
+    _drun_stub="$_drun/stub-validate"
+    cat > "$_drun_stub" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' '{"status":"OK","findings":[]}'
+exit 0
+STUB
+    chmod +x "$_drun_stub"
+
+    # Pre-create the setgid handoff dir owned by the test group (production:
+    # tmpfiles + +ExecStartPre create it 2750 root nftban). chmod 2750 AFTER
+    # chgrp so the setgid bit is not stripped by the ownership change.
+    mkdir -p "$_drun_sub"
+    if chgrp "$_d_grp" "$_drun_sub" 2>/dev/null && chmod 2750 "$_drun_sub" 2>/dev/null; then
+        rm -f "$_drun_file"
+        systemd-run --quiet --pipe \
+            --property=CapabilityBoundingSet=CAP_NET_ADMIN \
+            --property=AmbientCapabilities=CAP_NET_ADMIN \
+            --property=ProtectSystem=strict \
+            --property=ReadWritePaths="$_drun_sub" \
+            --setenv=NFTBAN_RUN_DIR="$_drun" \
+            --setenv=NFTBAN_VALIDATE_BIN="$_drun_stub" \
+            bash "$_wrapper" >/dev/null 2>&1
+        if [[ -f "$_drun_file" ]]; then
+            _d_dir_grp="$(stat -c '%g' "$_drun_sub" 2>/dev/null)"
+            _d_file_grp="$(stat -c '%g' "$_drun_file" 2>/dev/null)"
+            if [[ "$_d_file_grp" == "$_d_dir_grp" ]]; then
+                _t_assert "D1: last.json inherits the setgid dir's group under CAP_NET_ADMIN-only (no CAP_CHOWN)" 0
+            else
+                _t_assert "D1: last.json inherits the setgid dir's group under CAP_NET_ADMIN-only (no CAP_CHOWN)" 1 \
+                    "dir gid=$_d_dir_grp file gid=$_d_file_grp — group did not inherit (chgrp would have been needed)"
+            fi
+            if [[ "$(stat -c '%a' "$_drun_file" 2>/dev/null)" == "640" ]]; then
+                _t_assert "D2: last.json mode is 0640 (owner chmod works without capability)" 0
+            else
+                _t_assert "D2: last.json mode is 0640 (owner chmod works without capability)" 1 \
+                    "mode=$(stat -c '%a' "$_drun_file" 2>/dev/null)"
+            fi
+        else
+            _t_assert "D1/D2: capability-faithful wrapper run produced last.json" 1 \
+                "last.json not created under the sandboxed run"
+        fi
+    else
+        _t_skip "D1/D2: capability-faithful wrapper run (systemd-run, no CAP_CHOWN)" \
+            "could not chgrp/chmod-setgid the temp handoff dir; real proof = lab package validation"
+    fi
+    rm -rf "$_drun"
+else
+    _t_skip "D1/D2: capability-faithful wrapper run (systemd-run, no CAP_CHOWN)" \
+        "not root / systemd-run unavailable / no usable secondary group; real proof = lab package validation"
+fi
+
+# ----------------------------------------------------------------------------
+# E: operator-visibility label uses the exact anchored 'Validator Status:'
+#    report line (NEVER a loose IDLE|PROTECTED case-insensitive match).
+# ----------------------------------------------------------------------------
+echo "--- E: operator-visibility label ---"
+
+if grep -q '^Validator Status:' <(echo "Validator Status: OK"); then
+    _t_assert "E1: operator-visibility check uses exact '^Validator Status:'" 0
+else
+    _t_assert "E1: operator-visibility check uses exact '^Validator Status:'" 1
+fi
+
+# ----------------------------------------------------------------------------
+# F: changed files still parse.
+# ----------------------------------------------------------------------------
+echo "--- F: parse ---"
+_broken=""
+for f in "$_wrapper" "${BASH_SOURCE[0]}"; do
+    bash -n "$f" 2>/dev/null || _broken+="$f"$'\n'
+done
+if [[ -z "$_broken" ]]; then
+    _t_assert "F1: wrapper and this test parse (bash -n)" 0
+else
+    _t_assert "F1: wrapper and this test parse (bash -n)" 1 "broken:"$'\n'"$_broken"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo "-------------------------------------------------------------------------------"
+echo "V131.3 D13 setgid group-ownership test summary"
+echo "  Passed:  $_pass"
+echo "  Failed:  $_fail"
+echo "  Skipped: $_skip"
+if [[ "$_fail" -gt 0 ]]; then
+    echo "  Failed assertions:"
+    for n in "${_failed_names[@]}"; do echo "    - $n"; done
+fi
+echo "-------------------------------------------------------------------------------"
+[[ "$_fail" -eq 0 ]]

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -79,10 +79,21 @@ CapabilityBoundingSet=CAP_NET_ADMIN
 # read-only for the (sandboxed) main process. The `+` exemption is required:
 # ReadWritePaths=<subdir> only binds an EXISTING path writable, so the subdir
 # must exist before the sandboxed ExecStart runs. tmpfiles creates it at boot
-# (d /run/nftban/firewall-validate 0750 root nftban); this guarantees it
+# (d /run/nftban/firewall-validate 2750 root nftban); this guarantees it
 # per-start too (idempotent mkdir+chown+chmod via /usr/bin/install). Absolute
 # path is required by systemd for ExecStartPre.
-ExecStartPre=+/usr/bin/install -d -o root -g nftban -m 0750 /run/nftban/firewall-validate
+#
+# V131.3 D13 fix: the dir mode is now SETGID (2750, not 0750). The setgid bit
+# makes a file created in this dir inherit the dir's GROUP (nftban) regardless
+# of the creating process's egid. The wrapper runs as root:root and drops
+# CAP_CHOWN (CapabilityBoundingSet=CAP_NET_ADMIN only), so its `chgrp nftban`
+# on last.json silently fails ("Operation not permitted") — under 0750 the file
+# stayed root:root and nftban-group operators could not read it (D13 still
+# open after v1.131.2). With setgid, last.json lands group nftban automatically
+# WITHOUT needing CAP_CHOWN; the wrapper's `chmod 0640` still works (owner chmod
+# needs no capability) → final file root:nftban 0640 → nftban-group reads it →
+# `Validator Status:` renders. No capability widening required.
+ExecStartPre=+/usr/bin/install -d -o root -g nftban -m 2750 /run/nftban/firewall-validate
 ExecStart=/usr/lib/nftban/helpers/firewall_validate_run.sh
 StandardOutput=journal
 StandardError=journal
@@ -96,7 +107,7 @@ StandardError=journal
 # firewall_validate_run.sh wrapper, so it needs exactly one writable path.
 # ProtectSystem=strict makes all of /run (and the whole filesystem) read-only;
 # grant write to ONLY the dedicated status subdir, which tmpfiles creates as
-# root:nftban 0750 (d /run/nftban/firewall-validate 0750 root nftban). This
+# setgid root:nftban 2750 (d /run/nftban/firewall-validate 2750 root nftban). This
 # does NOT expose the daemon's /run/nftban (which holds the live socket) and
 # does NOT re-chown /run/nftban — it is the narrowest writable surface that
 # lets the validator drop last.json for nftban-group operators to read.

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -77,4 +77,4 @@ d /var/log/nftban/soak 0750 nftban nftban -
 d /var/cache/nftban 0755 nftban nftban -
 d /var/cache/nftban/health 0750 nftban nftban -
 d /run/nftban 0755 nftban nftban -
-d /run/nftban/firewall-validate 0750 root nftban -
+d /run/nftban/firewall-validate 2750 root nftban -


### PR DESCRIPTION
## Summary
- D13 stayed open after v1.131.2: the sandbox-write fix made `nftban-firewall-validate.service` write `/run/nftban/firewall-validate/last.json`, but it landed `root:root 0640` instead of `root:nftban`, so non-root nftban-group operators still saw banner-only output (no `Validator Status:`).
- Root cause (confirmed live on lab2 DEB): the unit's `CapabilityBoundingSet=CAP_NET_ADMIN` drops `CAP_CHOWN`, so the wrapper's best-effort `chgrp nftban` fails silently; and the `0750` handoff dir was not setgid, so a file created in it inherited the process egid (`root`), not `nftban`.
- Fix (narrow, no capability widening): make the handoff dir **setgid `2750 root nftban`** in BOTH the generated tmpfiles entry (via `build/fhs-spec.yaml` regen) and the unit's `+`-prefixed `ExecStartPre install -d -m 2750`. The setgid bit makes a created file inherit group `nftban` automatically (no chgrp / no CAP_CHOWN); the wrapper's owner-side `chmod 0640` still works → final `root:nftban 0640` → nftban-group reads it → `Validator Status:` renders.

No wrapper logic change (its `chgrp` becomes a harmless no-op). No CAP_CHOWN, no systemd-journal/adm, no pkexec, no broadened `ReadWritePaths`; `ProtectSystem=strict`, `CapabilityBoundingSet=CAP_NET_ADMIN`, `AmbientCapabilities=CAP_NET_ADMIN`, `ReadWritePaths=/run/nftban/firewall-validate`, StartLimit, ExecStart, and all other hardening preserved.

### Files changed
- `build/fhs-spec.yaml` — dir mode `0750` → `2750` for `/run/nftban/firewall-validate`.
- Regenerated (generator-touched, `--check` clean): `install/systemd/tmpfiles.d/nftban.conf` (now `d /run/nftban/firewall-validate 2750 root nftban -`), `cli/lib/nftban/core/nftban_fhs_spec.sh`, `cli/lib/nftban/data/fhs_directories.json`.
- `install/systemd/nftban-firewall-validate.service` — `ExecStartPre` mode `0750` → `2750` + explanatory comment (setgid removes the need for CAP_CHOWN).
- `cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh` — new regression test.
- `cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh` — dir-mode expectation `0750` → `2750`.

## Test plan
- [x] `bash build/generate-fhs-outputs.sh --check` clean
- [x] new v131_3 test: 11 PASS / 0 FAIL / 1 SKIP (systemd-run cap-faithful case skips as non-root)
- [x] v131_2 (15/0), v131_1 (17/0), v130_polkit (28/0), v129_pr_c (17/0) all PASS
- [x] `shellcheck -S warning` on changed shell files clean
- [x] `bash -n` clean on changed shell/test files
- [ ] lab package validation on lab2 DEB + lab4 RPM (authoritative proof: nftban-group operator now sees `Validator Status:` with `last.json` = `root:nftban 0640`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)