### PR TITLE
fix(cli+core+test): v1.132 PR-C — CLI behavior-truth alignment (C1/C2/C3/C5/C7/C8)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -3266,6 +3266,8 @@ Exit codes (validate --strict):
   10  policykit-1 missing (Debian/Ubuntu)
   20  Firewall conflict (fail2ban/ufw/firewalld/csf active)
   30  NFTables collision (non-NFTBan input hooks)
+  1   Structural validation failed (Go validator reported errors)
+  40  Validator binary missing or environment error
 
 Exit codes (other subcommands):
   0   Success

--- a/cli/lib/nftban/cli/cmd_flush.sh
+++ b/cli/lib/nftban/cli/cmd_flush.sh
@@ -90,7 +90,6 @@ TARGETS:
 OPTIONS:
     --yes               Skip confirmation prompt
     --dry-run           Show what would be flushed without executing
-    --json              Output in JSON format
 
 EXAMPLES:
     nftban flush blacklist              # Flush all blacklist IPs (with prompt)
@@ -140,7 +139,6 @@ EXIT CODES:
     0   Flush completed (or dry-run completed)
     1   General error (IPC failure, nft command failure)
     2   Unsupported target / invalid argument
-    3   PolicyKit/polkit authorization failed or insufficient privileges
 
 HELP
 }
@@ -854,8 +852,6 @@ nftban_cmd_flush() {
     # Parse options
     local skip_confirm=false
     local dry_run=false
-    # shellcheck disable=SC2034  # Reserved for future JSON output support
-    local json_mode=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -865,10 +861,6 @@ nftban_cmd_flush() {
             --dry-run|-n)
                 dry_run=true
                 ;;
-            --json)
-                # shellcheck disable=SC2034  # Reserved for future JSON output
-                json_mode=true
-                ;;
             --help|-h)
                 _nftban_flush_help
                 return 0
@@ -876,7 +868,7 @@ nftban_cmd_flush() {
             *)
                 echo "Unknown option: $1"
                 _nftban_flush_help
-                return 1
+                return 2
                 ;;
         esac
         shift
@@ -909,7 +901,7 @@ nftban_cmd_flush() {
             echo "Unknown target: $target"
             echo ""
             echo "Valid targets: blacklist, whitelist, feeds, geoban, ddos, all"
-            return 1
+            return 2
             ;;
     esac
 }

--- a/cli/lib/nftban/cli/cmd_services.sh
+++ b/cli/lib/nftban/cli/cmd_services.sh
@@ -270,7 +270,7 @@ nftban_services_show_help() {
     echo "    • curl             Feed downloads (required)"
     echo "    • jq               JSON processing (optional)"
     echo ""
-    echo "NOTE: fail2ban removed in v2.1 - use native login monitoring instead"
+    echo "NOTE: NFTBan does not use fail2ban — it provides native login monitoring instead"
     echo ""
 }
 

--- a/cli/lib/nftban/cli/cmd_setup.sh
+++ b/cli/lib/nftban/cli/cmd_setup.sh
@@ -314,7 +314,7 @@ nftban_cmd_setup() {
         echo "  🛡️  Unauthorized access attempts"
         echo ""
         echo "What I protected for you automatically:"
-        echo "  ✅ SSH (port 22) - Protected with fail2ban (brute force protection)"
+        echo "  ✅ SSH (port 22) - Protected by NFTBan login monitoring (brute force protection)"
         echo "  ✅ Basic firewall - Only allows what you need"
         echo ""
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -462,7 +462,7 @@ nftban_stats_cmd_dashboard() {
         # Get top data
         local top_ips="[]"
         local top_countries="[]"
-        local top_jails="[]"
+        local top_filters="[]"
 
         if declare -f nftban_stats_top_ips >/dev/null 2>&1; then
             top_ips=$(nftban_stats_top_ips 10 "$since" "$until" 2>/dev/null || echo "[]")
@@ -473,8 +473,10 @@ nftban_stats_cmd_dashboard() {
             total_countries=$(echo "$top_countries" | jq '. | length' 2>/dev/null) || total_countries=0
         fi
 
-        if declare -f nftban_stats_top_jails >/dev/null 2>&1; then
-            top_jails=$(nftban_stats_top_jails 10 "$since" "$until" 2>/dev/null || echo "[]")
+        # C5: "filters" (ban-source breakdown) replaces the old fail2ban-era
+        # "jails" concept; backed by the real nftban_stats_top_sources.
+        if declare -f nftban_stats_top_sources >/dev/null 2>&1; then
+            top_filters=$(nftban_stats_top_sources 10 "$since" "$until" 2>/dev/null || echo "[]")
         fi
 
         # Get portscan statistics from nftban-actions.log
@@ -602,7 +604,7 @@ nftban_stats_cmd_dashboard() {
                 --arg rules_total "$rules_total" \
                 --argjson top_ips "$top_ips" \
                 --argjson top_countries "$top_countries" \
-                --argjson top_jails "$top_jails" \
+                --argjson top_filters "$top_filters" \
                 '{
                     period: {since: $since, until: $until},
                     summary: {
@@ -657,8 +659,7 @@ nftban_stats_cmd_dashboard() {
                     },
                     top_ips: $top_ips,
                     top_countries: $top_countries,
-                    top_jails: $top_jails,
-                    top_filters: $top_jails
+                    top_filters: $top_filters
                 }')
         else
             # Fallback without jq
@@ -666,7 +667,7 @@ nftban_stats_cmd_dashboard() {
             [[ "$portscan_enabled" == "true" ]] && portscan_enabled_json="true"
             local ddos_enabled_json="false"
             [[ "$ddos_enabled" == "true" ]] && ddos_enabled_json="true"
-            data="{\"period\":{\"since\":\"$since\",\"until\":\"$until\"},\"summary\":{\"total_bans\":$total_bans,\"active_bans\":$active_bans,\"total_countries\":$total_countries},\"breakdown\":{\"temporary\":{\"total\":$total_temp,\"ipv4\":$temp_v4,\"ipv6\":$temp_v6},\"blacklist\":{\"total\":$total_black,\"ipv4\":$black_v4,\"ipv6\":$black_v6},\"feeds\":{\"total\":$total_feed,\"ipv4\":$feed_v4,\"ipv6\":$feed_v6},\"whitelist\":{\"total\":$total_whitelist,\"ipv4\":$whitelist_v4,\"ipv6\":$whitelist_v6}},\"portscan\":{\"monitored_ports\":$portscan_monitored_ports,\"blocked_24h\":$portscan_blocked_24h,\"blocked_total\":$portscan_blocked_total,\"enabled\":$portscan_enabled_json},\"ddos\":{\"packets_dropped\":$ddos_packets_dropped,\"bytes_dropped\":$ddos_bytes_dropped,\"blocked_24h\":$ddos_blocked_24h,\"blocked_total\":$ddos_blocked_total,\"enabled\":$ddos_enabled_json},\"shared_state\":{\"feeds_active\":$feeds_active,\"feeds_ips\":$feeds_ips,\"rules_total\":$rules_total},\"top_ips\":$top_ips,\"top_countries\":$top_countries,\"top_jails\":$top_jails,\"top_filters\":$top_jails}"
+            data="{\"period\":{\"since\":\"$since\",\"until\":\"$until\"},\"summary\":{\"total_bans\":$total_bans,\"active_bans\":$active_bans,\"total_countries\":$total_countries},\"breakdown\":{\"temporary\":{\"total\":$total_temp,\"ipv4\":$temp_v4,\"ipv6\":$temp_v6},\"blacklist\":{\"total\":$total_black,\"ipv4\":$black_v4,\"ipv6\":$black_v6},\"feeds\":{\"total\":$total_feed,\"ipv4\":$feed_v4,\"ipv6\":$feed_v6},\"whitelist\":{\"total\":$total_whitelist,\"ipv4\":$whitelist_v4,\"ipv6\":$whitelist_v6}},\"portscan\":{\"monitored_ports\":$portscan_monitored_ports,\"blocked_24h\":$portscan_blocked_24h,\"blocked_total\":$portscan_blocked_total,\"enabled\":$portscan_enabled_json},\"ddos\":{\"packets_dropped\":$ddos_packets_dropped,\"bytes_dropped\":$ddos_bytes_dropped,\"blocked_24h\":$ddos_blocked_24h,\"blocked_total\":$ddos_blocked_total,\"enabled\":$ddos_enabled_json},\"shared_state\":{\"feeds_active\":$feeds_active,\"feeds_ips\":$feeds_ips,\"rules_total\":$rules_total},\"top_ips\":$top_ips,\"top_countries\":$top_countries,\"top_filters\":$top_filters}"
         fi
 
         json_output "true" "$data"
@@ -698,8 +699,8 @@ nftban_stats_cmd_dashboard() {
 # =============================================================================
 
 nftban_stats_cmd_top() {
-    # Show top lists (IPs, countries, jails)
-    # Usage: nftban stats top [ips|countries|jails] [LIMIT] [--json]
+    # Show top lists (IPs, countries, filters)
+    # Usage: nftban stats top [ips|countries|filters] [LIMIT] [--json]
 
     local type="${1:-ips}"
     local limit="${2:-${STATS_TOP_N:-10}}"
@@ -758,13 +759,13 @@ nftban_stats_cmd_top() {
                     result_data=$(nftban_stats_top_countries "$limit" "$since" "$until" 2>/dev/null || echo "[]")
                 fi
                 ;;
-            jails|jail)
-                if declare -f nftban_stats_top_jails >/dev/null 2>&1; then
-                    result_data=$(nftban_stats_top_jails "$limit" "$since" "$until" 2>/dev/null || echo "[]")
+            filters|filter)
+                if declare -f nftban_stats_top_sources >/dev/null 2>&1; then
+                    result_data=$(nftban_stats_top_sources "$limit" "$since" "$until" 2>/dev/null || echo "[]")
                 fi
                 ;;
             *)
-                json_output "false" '{}' "Unknown top type: $type. Valid types: ips, countries, jails"
+                json_output "false" '{}' "Unknown top type: $type. Valid types: ips, countries, filters"
                 return 1
                 ;;
         esac
@@ -836,8 +837,8 @@ nftban_stats_cmd_top() {
                 return 1
             fi
             ;;
-        jails|jail)
-            echo "Top ${limit} Jails (${since} to ${until})"
+        filters|filter)
+            echo "Top ${limit} Filters (${since} to ${until})"
             if type -t nftban_render_separator >/dev/null 2>&1; then
                 nftban_render_separator "─"
             else
@@ -845,7 +846,7 @@ nftban_stats_cmd_top() {
             fi
             echo ""
             if command -v jq &>/dev/null; then
-                nftban_stats_top_jails "$limit" "$since" "$until" | \
+                nftban_stats_top_sources "$limit" "$since" "$until" | \
                     jq -r '.[] | "\(.name): \(.count) bans"'
             else
                 echo "ERROR: jq is required for formatted output" >&2
@@ -854,7 +855,7 @@ nftban_stats_cmd_top() {
             ;;
         *)
             echo "ERROR: Unknown top type: $type" >&2
-            echo "Valid types: ips, countries, jails" >&2
+            echo "Valid types: ips, countries, filters" >&2
             return 1
             ;;
     esac
@@ -964,7 +965,7 @@ nftban_stats_cmd_ip() {
         echo ""
 
         # Display events
-        echo "$history" | jq -r '.[] | "[\(.action)] \(.timestamp)\n  Jail: \(.jail)\n  Reason: \(.reason)\n"'
+        echo "$history" | jq -r '.[] | "[\(.action)] \(.timestamp)\n  Source: \(.jail)\n  Reason: \(.reason)\n"'
     else
         echo "ERROR: jq is required for formatted output" >&2
         return 1
@@ -1331,7 +1332,7 @@ USAGE:
 COMMANDS:
     dashboard | summary    Show comprehensive statistics dashboard (default)
     trend                  Show 7-day trend analysis with averages
-    top <type> [N]         Show top lists (ips, countries, jails)
+    top <type> [N]         Show top lists (ips, countries, filters)
     ip <IP>                Show ban history for specific IP
     recent [N]             Show recent ban activity
     monitor                Real-time monitoring with auto-refresh
@@ -1351,7 +1352,7 @@ DASHBOARD OPTIONS:
 TOP COMMAND:
     nftban stats top ips 20            Top 20 banned IPs
     nftban stats top countries 10      Top 10 countries
-    nftban stats top jails 5           Top 5 jails
+    nftban stats top filters 5         Top 5 ban filters (sources)
 
 EXPORT OPTIONS:
     --format FORMAT        Export format (json, csv)

--- a/cli/lib/nftban/cli/cmd_test.sh
+++ b/cli/lib/nftban/cli/cmd_test.sh
@@ -240,7 +240,7 @@ DESCRIPTION:
 
   Tests performed:
     • Core commands (status, health, check)
-    • Module commands (ddos, portscan, fail2ban, feeds)
+    • Module commands (ddos, portscan, login, feeds)
     • Management commands (firewall, whitelist, geoip, ports)
     • Security commands (permissions)
 

--- a/cli/lib/nftban/cli/cmd_version.sh
+++ b/cli/lib/nftban/cli/cmd_version.sh
@@ -240,8 +240,9 @@ EOF
         nftban_version_info
     fi
 
-    # Completion marker for test validation (only on success path)
-    echo "# NFTBAN_CMD_EXIT: version"
+    # Completion marker (debug-gated canonical helper — silent unless NFTBAN_DEBUG=true;
+    # the raw echo here previously corrupted `version --json` output. PR-C C1.)
+    command -v nftban_cmd_exit >/dev/null 2>&1 && nftban_cmd_exit "version"
     return 0
 }
 

--- a/cli/lib/nftban/core/nftban_firewall_conflicts.sh
+++ b/cli/lib/nftban/core/nftban_firewall_conflicts.sh
@@ -118,10 +118,8 @@ nftban_detect_fail2ban() {
         if [[ $status -eq 3 ]]; then
             NFTBAN_FIREWALL_CONFLICTS+=("  CRITICAL: fail2ban creates conflicting nftables rules")
             NFTBAN_FIREWALL_CONFLICTS+=("  └─ Creates 'ip filter' table that conflicts with nftban")
-            NFTBAN_FIREWALL_FIXES+=("Option 1: Disable fail2ban (recommended)")
+            NFTBAN_FIREWALL_FIXES+=("Disable fail2ban — NFTBan's native login monitoring replaces it:")
             NFTBAN_FIREWALL_FIXES+=("  systemctl stop fail2ban && systemctl disable fail2ban")
-            NFTBAN_FIREWALL_FIXES+=("Option 2: Migrate fail2ban jails to nftban")
-            NFTBAN_FIREWALL_FIXES+=("  nftban migrate fail2ban")
             [[ $NFTBAN_FIREWALL_SEVERITY -lt $CONFLICT_CRITICAL ]] && NFTBAN_FIREWALL_SEVERITY=$CONFLICT_CRITICAL
         else
             NFTBAN_FIREWALL_FIXES+=("Consider disabling fail2ban in favor of nftban:")

--- a/cli/lib/nftban/core/nftban_ip_and_stats.sh
+++ b/cli/lib/nftban/core/nftban_ip_and_stats.sh
@@ -54,9 +54,10 @@ validate_structure() {
     # NOTE (v1.80, B80-1 — truth consolidation):
     # This function is now a THIN SHIM over the Go validator (nftban-validate).
     # It exists ONLY for backward compatibility with existing CLI callers:
-    #   - cli/lib/nftban/cli/cmd_validate.sh:103  (nftban validate)
-    #   - cli/lib/nftban/cli/cmd_firewall.sh:453+ (firewall reload/rebuild/reset
-    #                                             validation fallback paths)
+    #   - cli/lib/nftban/cli/cmd_validate.sh:104  (nftban validate) — the SOLE
+    #     runtime caller. cmd_firewall.sh no longer calls this shim (its
+    #     validate path is self-contained — see cmd_firewall.sh:1061), so the
+    #     PR-C C8 exit-code remap below has no cross-command impact.
     #
     # It MUST NOT contain independent validation logic (no jq on nftables JSON,
     # no nft list ruleset, no spec loading). The single source of truth is the
@@ -66,23 +67,26 @@ validate_structure() {
     # Output contract (MUST match legacy shell format byte-for-byte for callers):
     #   JSON: {status:"OK"|"WARNING"|"ERROR", errors:[], warnings:[], info:[]}
     #   Text: "NFTBan Structure Validation" header + status + error/warning lists
-    #   Exit: 0 if status=="OK" or "WARNING", 1 if status=="ERROR"
+    #   Exit (documented `nftban validate` contract — see cmd_validate.sh):
+    #     0 OK/WARNING (PROTECTED/IDLE) · 1 ERROR or Go status degraded (DEGRADED)
+    #     2 Go status down (DOWN) · 3 validator binary missing/empty/crashed
     #
     # Full removal of this shell file (including the still-independent
     # check_ip_or_port and get_firewall_stats below) is v1.81 scope (B80-1).
     # =========================================================================
     #
     # Args: $1 = output_json (true/false)
-    # Returns: 0 if OK/WARNING, 1 if ERROR
+    # Returns: 0 OK/WARNING · 1 ERROR/degraded · 2 down · 3 validator missing/crashed
 
     local output_json="${1:-false}"
     local validator_bin="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-validate"
 
     # Guardrail: the Go validator binary MUST exist. If it doesn't, we fail
-    # closed with exit code 2 (distinct from generic validation failure so
-    # callers can distinguish "tool missing" from "tool ran but validation
-    # failed"). No independent fallback validation logic — that would
-    # re-create the exact drift risk B80-1 is closing.
+    # closed with exit code 3 ("validator binary crashed or was unreachable"
+    # per the documented `nftban validate` contract) — distinct from 2 (DOWN,
+    # a real protection state) so a missing tool never masquerades as DOWN.
+    # No independent fallback validation logic — that would re-create the exact
+    # drift risk B80-1 is closing. (PR-C C8: was rc=2, collided with DOWN.)
     #
     # NOTE: this fail-closed path must work WITHOUT jq. We use printf with
     # hand-escaped JSON because jq itself may be missing (the jq-missing
@@ -104,7 +108,7 @@ validate_structure() {
             echo "❌ ERRORS (1):"
             echo "  $missing_msg"
         fi
-        return 2
+        return 3
     fi
 
     # Call the Go validator. Capture its exit code — we derive shell exit
@@ -139,7 +143,9 @@ validate_structure() {
             echo "❌ ERRORS (1):"
             echo "  $empty_msg"
         fi
-        return 1
+        # C8: validator ran but produced no output → unreachable/crashed (3),
+        # not DEGRADED (1) — a tool failure, not a protection state.
+        return 3
     fi
 
     # --- jq-missing fallback ---
@@ -281,7 +287,14 @@ validate_structure() {
         return 1
     fi
     if (( go_rc != 0 )); then
-        return "$go_rc"
+        # C8: only documented validator exits pass through — 1 (DEGRADED),
+        # 2 (DOWN). Any other nonzero exit is an unexpected tool failure →
+        # normalize to 3 (crashed/unreachable); never leak an undocumented
+        # code or collide with the 0/1/2 status contract.
+        case "$go_rc" in
+            1|2) return "$go_rc" ;;
+            *)   return 3 ;;
+        esac
     fi
     case "$go_status" in
         down)     return 2 ;;

--- a/cli/lib/nftban/tests/test_validate_structure_is_shim.sh
+++ b/cli/lib/nftban/tests/test_validate_structure_is_shim.sh
@@ -222,11 +222,13 @@ else
     assert "body checks 'command -v jq' for jq-missing fallback (Amend-2)" "no"
 fi
 
-# N9: body must use 'return 2' for missing-binary path — Amend-1 contract
-if printf '%s' "$body" | grep -qE '^\s*return 2\b'; then
-    assert "body uses 'return 2' for missing-binary fail (Amend-1)" "yes"
+# N9: missing/unreachable validator must return 3 (PR-C C8 — supersedes the
+#     Amend-1 'return 2'; rc=2 is now reserved for Go status DOWN only, so a
+#     missing/empty/crashed validator can never masquerade as a real DOWN state).
+if printf '%s' "$body" | grep -qE '^\s*return 3\b'; then
+    assert "body uses 'return 3' for missing/unreachable validator (C8)" "yes"
 else
-    assert "body uses 'return 2' for missing-binary fail (Amend-1)" "no"
+    assert "body uses 'return 3' for missing/unreachable validator (C8)" "no"
 fi
 
 echo ""

--- a/cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh
+++ b/cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V132 PR-C — behavior-truth regression guard (C1/C2/C3/C5/C7/C8)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v132_pr_c_behavior_truth_test"
+# meta:type="test"
+# meta:version="1.132.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:description="V132 PR-C behavior-truth regression guard. Static assertions that the displayed CLI text matches actual code behavior after the PR-C truth-alignment fixes: C1 (version --json emits no raw sentinel line), C2 (flush no longer advertises an unimplemented --json), C3 (flush returns rc=2 for invalid target/option and help no longer documents a non-existent rc=3 polkit branch), C5 (stale fail2ban-era 'jails' top-type replaced by 'filters' backed by the real nftban_stats_top_sources; no dead top_jails key; no bogus 'nftban migrate fail2ban' command; no 'Protected with fail2ban' claim), C7 (firewall validate --strict help documents the reachable exit codes 1 and 40), C8 (validate shim returns 3 — not 2 — for a missing/unreachable validator so rc=2 means DOWN only). Pure static + bash -n; no host contact, no build, no privileges."
+# =============================================================================
+set -Eeuo pipefail
+
+_repo_root=$(cd "${BASH_SOURCE[0]%/*}/../../../.." && pwd)
+_cli="$_repo_root/cli/lib/nftban/cli"
+_core="$_repo_root/cli/lib/nftban/core"
+_scan="$_repo_root/cli/lib/nftban"
+
+_pass=0
+_fail=0
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then
+        echo "  [PASS] $name"; _pass=$((_pass+1))
+    else
+        echo "  [FAIL] $name${detail:+ — $detail}"; _fail=$((_fail+1))
+    fi
+}
+# _match PATH PATTERN — grep -E; recurses over *.sh when PATH is a directory
+_match() { if [[ -d "$1" ]]; then grep -rqE --include='*.sh' --exclude-dir=tests "$2" "$1"; else grep -qE "$2" "$1"; fi; }
+# pass when pattern IS present
+_has()   { if _match "$1" "$2"; then _t_assert "$3" 0; else _t_assert "$3" 1 "missing /$2/ in ${1##*/}"; fi; }
+# pass when pattern is ABSENT
+_lacks() { if _match "$1" "$2"; then _t_assert "$3" 1 "unexpected /$2/ in ${1##*/}"; else _t_assert "$3" 0; fi; }
+
+echo "==============================================================================="
+echo "V132 PR-C — behavior-truth regression guard"
+echo "  Scan root: $_scan"
+echo "==============================================================================="
+
+echo "[C1] version --json emits valid JSON (no raw completion sentinel)"
+_lacks "$_cli/cmd_version.sh" 'echo "# NFTBAN_CMD_EXIT: version"' "C1: raw sentinel echo removed"
+_has  "$_cli/cmd_version.sh" 'nftban_cmd_exit "version"'          "C1: uses debug-gated nftban_cmd_exit helper"
+
+echo "[C2] flush no longer advertises an unimplemented --json"
+_lacks "$_cli/cmd_flush.sh" '[-][-]json' "C2: --json advertisement removed from flush"
+_lacks "$_cli/cmd_flush.sh" 'json_mode=' "C2: dead json_mode variable removed"
+
+echo "[C3] flush exit-code truth (rc=2 for invalid input; no false rc=3)"
+_has  "$_cli/cmd_flush.sh" 'Unknown target: \$target'            "C3: unknown-target path present"
+_has  "$_cli/cmd_flush.sh" 'return 2'                            "C3: returns rc=2 for invalid target/option"
+_has  "$_cli/cmd_flush.sh" 'Unsupported target / invalid argument' "C3: help retains rc=2 documentation"
+_lacks "$_cli/cmd_flush.sh" 'PolicyKit/polkit authorization failed' "C3: false rc=3 polkit line removed (flush has no polkit branch)"
+
+echo "[C5] stale fail2ban 'jails' replaced by working 'filters'"
+_lacks "$_cli/cmd_stats.sh" 'nftban_stats_top_jails' "C5: undefined nftban_stats_top_jails reference gone"
+_has  "$_cli/cmd_stats.sh" 'nftban_stats_top_sources' "C5: filters backed by real nftban_stats_top_sources"
+_has  "$_cli/cmd_stats.sh" 'filters\|filter\)'        "C5: 'filters' top-type dispatch present"
+_lacks "$_cli/cmd_stats.sh" 'top_jails'               "C5: dead top_jails JSON key removed"
+_lacks "$_cli/cmd_stats.sh" 'Valid types: ips, countries, jails' "C5: help/errors no longer advertise jails"
+_lacks "$_scan" 'nftban migrate fail2ban'            "C5: bogus 'nftban migrate fail2ban' remediation removed (tree-wide)"
+_lacks "$_scan" 'Protected with fail2ban'            "C5: false 'Protected with fail2ban' claim removed (tree-wide)"
+
+echo "[C7] firewall validate --strict documents reachable exit codes 1 and 40"
+_has "$_cli/cmd_firewall.sh" 'Structural validation failed'              "C7: strict help documents rc=1 (structural)"
+_has "$_cli/cmd_firewall.sh" 'Validator binary missing or environment error' "C7: strict help documents rc=40 (env)"
+
+echo "[C8] validate shim: missing/unreachable validator returns 3 (not 2=DOWN)"
+_has "$_core/nftban_ip_and_stats.sh" 'return 3'        "C8: shim returns 3 for missing/empty validator"
+_has "$_core/nftban_ip_and_stats.sh" 'case "\$go_rc" in' "C8: passthrough clamp normalizes unexpected validator rc"
+_has "$_cli/cmd_validate.sh" 'Validator binary crashed or was unreachable' "C8: help documents rc=3 contract"
+
+echo "[SYNTAX] touched files parse with bash -n"
+for f in cmd_version.sh cmd_flush.sh cmd_stats.sh cmd_firewall.sh cmd_validate.sh cmd_test.sh cmd_services.sh; do
+    if bash -n "$_cli/$f" 2>/dev/null; then _t_assert "bash -n cli/$f" 0; else _t_assert "bash -n cli/$f" 1; fi
+done
+for f in nftban_ip_and_stats.sh nftban_firewall_conflicts.sh; do
+    if bash -n "$_core/$f" 2>/dev/null; then _t_assert "bash -n core/$f" 0; else _t_assert "bash -n core/$f" 1; fi
+done
+
+echo "==============================================================================="
+echo "Results: $_pass passed, $_fail failed"
+echo "==============================================================================="
+[[ "$_fail" -eq 0 ]]


### PR DESCRIPTION
## v1.132.0 PR-C — behavior-truth lane

Aligns displayed CLI text & exit codes with actual code behavior (the deferred V129 Layer-B / V130 PR-C long-tail). **Truth-alignment only — no feature change.** Decisions recorded in `AUDIT_190_LIFECYCLE/V129_TILL_V131_TEXT_CODE_DEBT_LEDGER_AND_PLAN.md`.

| Item | Fix |
|------|-----|
| **C1** | `version --json` emits valid JSON — raw `# NFTBAN_CMD_EXIT` sentinel → debug-gated `nftban_cmd_exit` |
| **C2** | `flush` drops the advertised-but-unimplemented `--json` (+ dead `json_mode`) |
| **C3** | `flush` returns rc=2 for invalid target/option (matches help); false rc=3 polkit line removed |
| **C5** | fail2ban-era `jails` top-type (undefined fn, empty key) → `filters` backed by real `nftban_stats_top_sources`; dead `top_jails`/`top_filters` double-feed removed; + stale fail2ban cleanup (bogus `nftban migrate fail2ban`, "Protected with fail2ban", false "v2.1" note, removed test-module entry, "Jail:" label) |
| **C7** | `firewall validate --strict` documents reachable exit codes 1 & 40 |
| **C8** | `validate` shim returns 3 (not 2) for missing/empty/unexpected validator so rc=2 = DOWN only; N9 contract test flipped. Sole caller is `nftban validate` — zero cross-command impact |

### Verification
- New `v132_pr_c_behavior_truth_test.sh`: **29/0**
- `test_validate_structure_is_shim.sh`: **17/0** (N9 → `return 3`)
- v129 PR-C / v130 polkit / v131 PR-A / PR-A.2: green; `bash -n` clean

### Scope notes
- **Docs/wiki verified clean** — no `stats top jails`, no stale fail2ban claims; staleness was code-only.
- Backlog (not this PR): ban-log `jail` schema field rename (compat); D-01..D-30 help drift (PR-D); the rest of the 61-item ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)