### PR TITLE
fix(cli+lib+core+test): v1.133 PR-B — polkit-aware wording sweep (A1–A15)

### DIFF
--- a/cli/lib/nftban/cli/cmd_snapshot.sh
+++ b/cli/lib/nftban/cli/cmd_snapshot.sh
@@ -78,8 +78,12 @@ nftban_snapshot_create() {
     timestamp=$(date +%Y%m%d-%H%M%S)
     local snapshot_file="${snapshot_dir}/snapshot-${timestamp}.json"
 
-    # Ensure directory exists
-    mkdir -p "$snapshot_dir" || return 1
+    # Ensure directory exists (polkit-aware refusal instead of a raw write leak)
+    mkdir -p "$snapshot_dir" 2>/dev/null || true
+    if [[ $EUID -ne 0 && ! -w "$snapshot_dir" ]]; then
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (create snapshot)" >&2
+        return 1
+    fi
 
     # Collect snapshot data
     {

--- a/cli/lib/nftban/cli/cmd_system.sh
+++ b/cli/lib/nftban/cli/cmd_system.sh
@@ -343,7 +343,7 @@ nftban_system_restart() {
     local target="${1:-all}"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to restart services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (restart services)" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/core/nftban_ip_and_stats.sh
+++ b/cli/lib/nftban/core/nftban_ip_and_stats.sh
@@ -39,7 +39,16 @@ get_live_ruleset() {
     output=$(nft -j list ruleset 2>&1)
     local rc=$?
     if [[ $rc -ne 0 ]]; then
-        echo "{\"error\": \"Failed to get nftables ruleset: $output\"}" >&2
+        # A15: reframe raw kernel permission errors to the polkit-aware contract
+        # (mirror internal/validator/validator.go) — a direct `nft` read needs
+        # CAP_NET_ADMIN; nftban-group operators are authorized via the
+        # nftban-firewall-validate.service. Never leak "(you must be root)".
+        output="${output//" (you must be root)"/}"
+        if printf '%s' "$output" | grep -qiE 'operation not permitted|permission denied'; then
+            echo "{\"error\": \"Failed to get nftables ruleset (direct nft read requires CAP_NET_ADMIN; nftban-group operators are polkit-authorized via nftban-firewall-validate.service): ${output}\"}" >&2
+        else
+            echo "{\"error\": \"Failed to get nftables ruleset: ${output}\"}" >&2
+        fi
         return 1
     fi
     echo "$output"

--- a/cli/lib/nftban/core/nftban_report_module.sh
+++ b/cli/lib/nftban/core/nftban_report_module.sh
@@ -762,8 +762,12 @@ nftban_module_generate_html_report() {
     timestamp=$(date +%Y%m%d_%H%M%S)
     local report_file="${report_dir}/module_report_${timestamp}.html"
 
-    # Ensure report directory exists
+    # Ensure report directory exists (polkit-aware refusal instead of a raw write leak)
     mkdir -p "$report_dir" 2>/dev/null || true
+    if [[ $EUID -ne 0 && ! -w "$report_dir" ]]; then
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (write module report)" >&2
+        return 1
+    fi
 
     # Check if template exists
     if [[ ! -f "$template_path" ]]; then

--- a/cli/lib/nftban/helpers/nftban_mode.sh
+++ b/cli/lib/nftban/helpers/nftban_mode.sh
@@ -299,7 +299,7 @@ _nftban_mode_set() {
         if [[ "$json_mode" == "true" ]] && declare -f json_error &>/dev/null; then
             json_error "PolicyKit/polkit authorization failed or insufficient privileges to change mode"
         else
-            echo "ERROR: Root privileges required to change mode" >&2
+            echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges to change mode" >&2
         fi
         return 1
     fi
@@ -384,7 +384,7 @@ HEADER
     echo "  Config File:      $config_local"
     echo ""
     echo "Note: Restart nftban daemon to apply changes:"
-    echo "  sudo systemctl restart nftban"
+    echo "  systemctl restart nftban    # nftban group members are polkit-authorized"
     echo ""
 }
 

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -274,7 +274,7 @@ ERROR: nftband daemon not running
 The daemon socket was not found at: $socket
 
 Start the daemon with:
-  sudo systemctl start nftband
+  systemctl start nftband    # nftban group members are polkit-authorized
 EOF
         fi
         return 1

--- a/cli/lib/nftban/lib/nftban_pro.sh
+++ b/cli/lib/nftban/lib/nftban_pro.sh
@@ -527,8 +527,12 @@ nftban_pro_disable_remote() {
         fi
     fi
 
-    # Mark Pro as disabled
-    mkdir -p "$NFTBAN_PRO_DATA_DIR" || return 1
+    # Mark Pro as disabled (polkit-aware refusal instead of a raw write leak)
+    mkdir -p "$NFTBAN_PRO_DATA_DIR" 2>/dev/null || true
+    if [[ $EUID -ne 0 && ! -w "$NFTBAN_PRO_DATA_DIR" ]]; then
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (update Pro status)" >&2
+        return 1
+    fi
     printf '{"enabled": false, "reason": "subscription_invalid", "disabled_at": "%s"}\n' \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$NFTBAN_PRO_DATA_DIR/status.json"
 }
@@ -545,8 +549,12 @@ nftban_pro_enable_remote() {
         fi
     fi
 
-    # Mark Pro as enabled
-    mkdir -p "$NFTBAN_PRO_DATA_DIR" || return 1
+    # Mark Pro as enabled (polkit-aware refusal instead of a raw write leak)
+    mkdir -p "$NFTBAN_PRO_DATA_DIR" 2>/dev/null || true
+    if [[ $EUID -ne 0 && ! -w "$NFTBAN_PRO_DATA_DIR" ]]; then
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (update Pro status)" >&2
+        return 1
+    fi
     printf '{"enabled": true, "enabled_at": "%s"}\n' \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$NFTBAN_PRO_DATA_DIR/status.json"
 }

--- a/cli/lib/nftban/lib/nftban_service_control.sh
+++ b/cli/lib/nftban/lib/nftban_service_control.sh
@@ -98,7 +98,7 @@ nftban_systemd_start() {
     local service="$1"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to start services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (start service)" >&2
         return 1
     fi
 
@@ -117,7 +117,7 @@ nftban_systemd_stop() {
     local service="$1"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to stop services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (stop service)" >&2
         return 1
     fi
 
@@ -136,7 +136,7 @@ nftban_systemd_restart() {
     local service="$1"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to restart services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (restart service)" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -255,7 +255,7 @@ nftban_resolve_firewall_conflicts() {
 # Usage: nftban_enable_all
 nftban_enable_all() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to enable services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (enable services)" >&2
         return 1
     fi
 
@@ -722,7 +722,7 @@ nftban_enable_all() {
 #                   Without this flag, nft rules remain active in kernel
 nftban_disable_all() {
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to disable services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (disable services)" >&2
         return 1
     fi
 
@@ -824,7 +824,7 @@ nftban_service_start() {
     local service="$1"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to start services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (start services)" >&2
         return 1
     fi
 
@@ -863,7 +863,7 @@ nftban_service_stop() {
     local service="$1"
 
     if [[ $EUID -ne 0 ]]; then
-        echo "ERROR: Must be root to stop services" >&2
+        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges (stop services)" >&2
         return 1
     fi
 

--- a/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
+++ b/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
@@ -60,6 +60,10 @@ _ALLOWLIST_PATTERNS=(
     'cli/lib/nftban/core/nftban_path_security' # technical security warning context
     'cli/lib/nftban/lib/setup_utils\.sh'        # check_root() helper called only from
                                                  # allowlisted setup/install_* scripts
+    '/setup/deploy_'                            # metrics/infra deploy scripts ($0-run install
+                                                 # tooling) — root is a genuine install
+                                                 # requirement, not an nftban polkit-managed
+                                                 # CLI operation (v1.133 PR-B)
 )
 
 # Build a grep -v pipeline filter from the allowlist
@@ -130,22 +134,34 @@ _t_assert "A5b (informational; allowlisted): 'sudo nftban-installer' installer/b
 # A8: PR-A.2 residual sweeps — 'root privileges' / 'NEEDS ROOT' / 'needs root'
 # in operator-facing strings (echo statements + ui_msg calls; internal
 # # comments excluded by the grep filter).
-hits=$(grep -rnE 'root privileges|NEEDS ROOT' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+hits=$(grep -rniE 'root privileges|NEEDS ROOT' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
        | grep -v "/tests/" | _apply_allowlist \
        | grep -v ':\s*#' \
        | wc -l)
 hits=${hits:-0}
 [[ "$hits" -eq 0 ]]
-_t_assert "A8: zero 'root privileges' / 'NEEDS ROOT' in operator-facing strings (got: $hits; internal # comments OK)" "$?"
+_t_assert "A8: zero 'root privileges' / 'NEEDS ROOT' in operator-facing strings, case-insensitive (got: $hits; internal # comments OK)" "$?"
 
 # A9: PR-A.2 ui_msg / echo "needs root" residuals
-hits=$(grep -rnE 'needs root|need root privileges' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+hits=$(grep -rniE 'needs root|need root privileges' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
        | grep -v "/tests/" | _apply_allowlist \
        | grep -v ':\s*#' \
        | wc -l)
 hits=${hits:-0}
 [[ "$hits" -eq 0 ]]
-_t_assert "A9: zero 'needs root' / 'need root privileges' in operator-facing strings (got: $hits)" "$?"
+_t_assert "A9: zero 'needs root' / 'need root privileges' in operator-facing strings, case-insensitive (got: $hits)" "$?"
+
+# A10 (v1.133 PR-B): zero 'Must be root' framing in operator-facing strings
+# (case-insensitive). Excludes # comments and the get_live_ruleset A15 reframe,
+# which legitimately STRIPS the kernel fragment "(you must be root)".
+hits=$(grep -rniE 'must be root' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \
+       | grep -v "/tests/" | _apply_allowlist \
+       | grep -v ':\s*#' \
+       | grep -v 'you must be root' \
+       | wc -l)
+hits=${hits:-0}
+[[ "$hits" -eq 0 ]]
+_t_assert "A10: zero 'Must be root' in operator-facing strings, case-insensitive (got: $hits; A15 strip + # comments excluded)" "$?"
 
 # A6: Zero "(sudo)" parenthetical hints
 hits=$(grep -rn 'privileges (sudo)\|root/sudo' --include='*.sh' "$_cli_lib" "$_cli_sbin" 2>/dev/null \

--- a/cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh
+++ b/cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V133 PR-B — write-guard / reframe refusal regression guard (A12–A15)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v133_pr_b_write_guard_refusal_test"
+# meta:type="test"
+# meta:version="1.133.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_PRO_DATA_DIR,NFTBAN_DATA_DIR,NFTBAN_REPORT_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:description="V133 PR-B regression guard for A12–A15: operator-facing privileged-write/read paths must emit the canonical polkit-aware refusal instead of leaking a raw OS error. A15 (get_live_ruleset) is deterministic — a stubbed failing nft printing 'Operation not permitted (you must be root)' must be reframed to a polkit/CAP_NET_ADMIN-aware JSON error with NO 'you must be root' substring. A12 (nftban_pro), A13 (cmd_snapshot), A14 (nftban_report_module) get static structural assertions (EUID guard + '! -w' + canonical message present) always, plus a non-root behavioral refusal (rc=1 + polkit stderr + no raw 'Permission denied') that SKIPs under root (CI runners are root; real non-root proof is lab/local)."
+# =============================================================================
+set -Eeuo pipefail
+
+_lib=$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)   # .../cli/lib/nftban
+_msg='PolicyKit/polkit authorization failed or insufficient privileges'
+
+_pass=0; _fail=0; _skip=0
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then echo "  [PASS] $name"; _pass=$((_pass+1))
+    else echo "  [FAIL] $name${detail:+ — $detail}"; _fail=$((_fail+1)); fi
+}
+_t_skip() { echo "  [SKIP] $1"; _skip=$((_skip+1)); }
+
+echo "==============================================================================="
+echo "V133 PR-B — write-guard / reframe refusal guard (A12–A15)"
+echo "  lib root: $_lib"
+echo "==============================================================================="
+
+# ---------------------------------------------------------------------------
+# A15 — get_live_ruleset reframes raw nft permission errors (DETERMINISTIC)
+# ---------------------------------------------------------------------------
+echo "[A15] get_live_ruleset reframes 'Operation not permitted (you must be root)'"
+_a15_out() {
+    local td out
+    td=$(mktemp -d)
+    printf '#!/usr/bin/env bash\necho "Error: Operation not permitted (you must be root)" >&2\nexit 1\n' > "$td/nft"
+    chmod +x "$td/nft"
+    out=$(
+        set +eu
+        export NFTBAN_LIB_DIR="$_lib"
+        PATH="$td:$PATH"
+        # shellcheck disable=SC1090
+        source "$_lib/core/nftban_ip_and_stats.sh" >/dev/null 2>&1
+        get_live_ruleset 2>&1
+    ) || true
+    rm -rf "$td"
+    printf '%s' "$out"
+}
+a15=$(_a15_out)
+if printf '%s' "$a15" | grep -qi 'you must be root'; then
+    _t_assert "A15: reframed error contains NO 'you must be root'" 1 "got: $a15"
+else
+    _t_assert "A15: reframed error contains NO 'you must be root'" 0
+fi
+if printf '%s' "$a15" | grep -qiE 'polkit-authorized|CAP_NET_ADMIN'; then
+    _t_assert "A15: reframed error carries polkit/CAP_NET_ADMIN framing" 0
+else
+    _t_assert "A15: reframed error carries polkit/CAP_NET_ADMIN framing" 1 "got: $a15"
+fi
+
+# ---------------------------------------------------------------------------
+# A12–A14 — STATIC structural: EUID guard + '! -w' + canonical message present
+# ---------------------------------------------------------------------------
+echo "[A12-A14] static structural guards present"
+_static_guard() { # $1=file $2=human-id
+    local f="$_lib/$1"
+    if grep -q '! -w ' "$f" && grep -qF "$_msg" "$f" && grep -qE '\$EUID -ne 0' "$f"; then
+        _t_assert "$2: EUID + '! -w' + canonical polkit message present" 0
+    else
+        _t_assert "$2: EUID + '! -w' + canonical polkit message present" 1 "missing guard in $1"
+    fi
+}
+_static_guard "lib/nftban_pro.sh"            "A12 (pro write)"
+_static_guard "cli/cmd_snapshot.sh"          "A13 (snapshot write)"
+_static_guard "core/nftban_report_module.sh" "A14 (report write)"
+
+# ---------------------------------------------------------------------------
+# A12/A13 — NON-ROOT behavioral refusal (SKIP under root; real proof is non-root)
+# ---------------------------------------------------------------------------
+echo "[A12-A13] non-root behavioral refusal (skips as root)"
+_behavioral_refuse() { # $1=file $2=envvar $3=func $4=human-id
+    if [[ $EUID -eq 0 ]]; then _t_skip "$4: behavioral refusal (running as root — guard is EUID-gated)"; return; fi
+    local f="$_lib/$1" td out rc=0
+    td=$(mktemp -d); chmod 000 "$td"
+    out=$(
+        set +eu
+        export NFTBAN_LIB_DIR="$_lib"
+        export "$2=$td"
+        # shellcheck disable=SC1090
+        source "$f" >/dev/null 2>&1
+        if ! declare -f "$3" >/dev/null 2>&1; then echo "__NOFUNC__"; exit 0; fi
+        "$3" 2>&1
+    ) || rc=$?
+    chmod 700 "$td" 2>/dev/null || true; rm -rf "$td"
+    if printf '%s' "$out" | grep -q '__NOFUNC__'; then
+        _t_skip "$4: behavioral refusal (function $3 not sourceable standalone)"; return
+    fi
+    if [[ "$rc" -ne 0 ]] \
+       && printf '%s' "$out" | grep -qF "$_msg" \
+       && ! printf '%s' "$out" | grep -qiE 'permission denied|you must be root'; then
+        _t_assert "$4: non-root → rc!=0 + polkit refusal + no raw leak" 0
+    else
+        _t_assert "$4: non-root → rc!=0 + polkit refusal + no raw leak" 1 "rc=$rc out=$out"
+    fi
+}
+_behavioral_refuse "lib/nftban_pro.sh"   "NFTBAN_PRO_DATA_DIR" "nftban_pro_enable_remote" "A12 (pro enable)"
+_behavioral_refuse "cli/cmd_snapshot.sh" "NFTBAN_DATA_DIR"     "nftban_snapshot_create"   "A13 (snapshot create)"
+
+echo "==============================================================================="
+echo "Results: $_pass passed, $_fail failed, $_skip skipped"
+echo "==============================================================================="
+[[ "$_fail" -eq 0 ]]


### PR DESCRIPTION
## v1.133.0 PR-B — UX_DRIFT wording sweep (A1–A15)

Replaces sudo/root/"Must be root" framing on operator-facing privileged-management paths with the canonical PolicyKit/polkit refusal. **UX/truth-alignment only — no Go, no schema, no install/systemd/polkit-rule change.** Plan: `AUDIT_190_LIFECYCLE/V133_SCOPE_PR_B_AND_PR_D_P2.md`.

| Items | Change |
|-------|--------|
| **A1–A11** | text-swaps to canonical `PolicyKit/polkit authorization failed or insufficient privileges (<action>)` (service start/stop/restart/enable/disable, mode change, daemon-start hints). `nftban_mode.sh` JSON sibling unchanged (already correct). |
| **A12–A14** | `nftban_pro` / `cmd_snapshot` / `nftban_report_module` emit the polkit refusal (rc=1) when **non-root AND target dir not writable**, instead of leaking raw `Permission denied`. |
| **A15** | `get_live_ruleset` strips `(you must be root)` and reframes to the polkit/CAP_NET_ADMIN contract (mirrors `validator.go`), preserving the `{"error":…}` JSON shape. |

### Tests
- v128 wording sweep: **A8/A9 made case-insensitive** + new **A10 `Must be root` lock** (caught + allowlisted the genuine-root `setup/deploy_metrics.sh` requirement — a `$0`-run deploy script, not a CLI op).
- New `v133_pr_b_write_guard_refusal_test.sh` (**7/0**): A15 deterministic reframe + A12/A13 real non-root behavioral refusal (skips under root CI) + A12–A14 static structural.
- Adjacent suites green (v132 PR-C 29/0, shim 17/0, v130 polkit); `bash -n` clean.

### Scope
- Disjoint from PR-D P2 (privilege paths vs cli help). Schema 1.83.0 frozen; daemon byte-identical. PR-D P2 follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)