### PR TITLE
fix(cli+test): v1.133 PR-D P2 — help/code drift (D-01, D-03..D-11)

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -76,6 +76,8 @@ COMMANDS:
       patterns disable  Disable a pattern
     history             Show detected bots (last 24 hours)
     test                Test pattern matching against sample URLs
+    stats               Show detection statistics (JSON-capable)
+    config              Show detection configuration
     help                Show this help message
 
 DESCRIPTION:
@@ -746,7 +748,7 @@ nftban_cmd_botscan() {
         *)
             echo "ERROR: Unknown command: $action" >&2
             echo ""
-            echo "Available commands: enable, disable, status, stats, check, patterns, history, test, help"
+            echo "Available commands: enable, disable, status, stats, config, check, patterns, history, test, help"
             echo "Run 'nftban botscan help' for detailed usage information"
             return 1
             ;;

--- a/cli/lib/nftban/cli/cmd_ddos.sh
+++ b/cli/lib/nftban/cli/cmd_ddos.sh
@@ -120,7 +120,7 @@ PROFILE SELECTION:
     Instead of manually configuring DDoS protection, you can select
     a pre-configured profile based on your server role:
 
-      nftban profile select
+      nftban wizard
 
     Available profiles:
       • Web Server      - High HTTP/HTTPS traffic

--- a/cli/lib/nftban/cli/cmd_egress.sh
+++ b/cli/lib/nftban/cli/cmd_egress.sh
@@ -513,7 +513,7 @@ nftban_cmd_egress_help() {
     echo "  2. nftban port egress audit 48    # Collect 48h of traffic data"
     echo "  3. nftban port egress recommend   # See suggested additions"
     echo "  4. nftban port add <port> tcp out # Add missing ports"
-    echo "  5. nftban emulate --out :443      # Test if port allowed"
+    echo "  5. nftban emulate 8.8.8.8 --port 443 --direction out   # Test if port allowed"
     echo "  6. nftban port egress enforce     # Enable restrictive mode"
     echo ""
 }

--- a/cli/lib/nftban/cli/cmd_feeds.sh
+++ b/cli/lib/nftban/cli/cmd_feeds.sh
@@ -990,6 +990,9 @@ COMMANDS:
     enable-cat <cat>    Enable all feeds in category
     update [feed]       Update feeds (all or specific)
     status              Show detailed status
+    config              Show feeds configuration
+    stats               Show feeds statistics
+    test                Test feed connectivity/configuration
 
     help                Show this help message
 

--- a/cli/lib/nftban/cli/cmd_geoban.sh
+++ b/cli/lib/nftban/cli/cmd_geoban.sh
@@ -595,6 +595,8 @@ Usage:
   nftban geoban update                     # Update all active countries
   nftban geoban refresh                    # Refresh country IP data from RIRs
   nftban geoban config                     # Show GeoBan configuration
+  nftban geoban stats                      # Show GeoBan statistics
+  nftban geoban test                       # Test GeoBan config/connectivity
   nftban geoban help                       # Show this help
 
 Country Codes:

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -1222,6 +1222,8 @@ COMMANDS:
     run                 Run login monitoring (used by service)
     mode [MODE]         Set email alert mode (realtime|digest|both)
     digest [ACTION]     Manage daily digest (status|send|clear)
+    config [--json]     Show login monitoring configuration
+    install [TARGET]    Install/provision login monitoring
     help                Show this help message
 
 NOTE: Login health checks are handled by 'nftban health check --auto-heal'

--- a/cli/lib/nftban/cli/cmd_menu.sh
+++ b/cli/lib/nftban/cli/cmd_menu.sh
@@ -311,7 +311,7 @@ screen_profile() {
         back "Back")" || return
 
     case "$choice" in
-        select) require_root && run_cmd "Profile Select" nftban profile select ;;
+        select) require_root && run_cmd "Setup Wizard" nftban wizard ;;
         show) run_cmd "Profile Show" nftban profile show ;;
         list) run_cmd "Profile List" nftban profile list ;;
         back) ;;

--- a/cli/lib/nftban/cli/cmd_module.sh
+++ b/cli/lib/nftban/cli/cmd_module.sh
@@ -95,6 +95,7 @@ nftban_cmd_module_help() {
     echo "  nftban module license [--save FILE] [--email ADDR]     # License compliance"
     echo "  nftban module author [--save FILE] [--email ADDR]      # Author attribution"
     echo "  nftban module depends [--save FILE] [--email ADDR]     # Dependency analysis"
+    echo "  nftban module duplicates [--save FILE] [--email ADDR]  # Duplicate name/version conflict check"
     echo "  nftban module html-report [--save FILE] [--email ADDR] # HTML report"
     echo "  nftban module mail-report [path] [recipient]           # Mail report"
     echo "  nftban module help                                      # Show this help"

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -182,7 +182,7 @@ nftban_cmd_port_help() {
     echo "  nftban port egress enforce           # Enable restrictive outbound policy"
     echo ""
     echo "  # Test outbound before enforcing"
-    echo "  nftban emulate --out 8.8.8.8:443    # Test if HTTPS outbound allowed"
+    echo "  nftban emulate 8.8.8.8 --port 443 --direction out   # Test if HTTPS outbound allowed"
     echo ""
     echo "Note: For full panel management, use: nftban panel directadmin <action>"
     echo "      Actions: enable, disable, status, report, repair, test"

--- a/cli/lib/nftban/cli/cmd_portscan.sh
+++ b/cli/lib/nftban/cli/cmd_portscan.sh
@@ -152,7 +152,7 @@ CONFIGURATION:
 PROFILE SELECTION:
     Select a pre-configured profile based on server role:
 
-      nftban profile select
+      nftban wizard
 
     Profile examples:
       • Web Server:    10 ports in 5 min, 1-hour temp ban

--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -113,6 +113,9 @@ SUBCOMMANDS:
   alert       Test alert system
   critical    Manage critical IPs (mail, web, panel servers)
   watchlist   Monitor external IPs of interest (customers, partners)
+  config      Show RBL configuration
+  stats       Show RBL statistics
+  test        Test RBL configuration/connectivity
 
 CHECK OPTIONS:
   --ip IP           Check specific IP address

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -2037,6 +2037,9 @@ DESCRIPTION:
     • Health check summary
     • Recent activity statistics
 
+SUBCOMMANDS:
+  pending, queue  Show pending/queued daemon operations
+
 EXAMPLES:
   nftban status                Show full status dashboard
   nftban status --json         Output as JSON

--- a/cli/lib/nftban/cli/cmd_wizard.sh
+++ b/cli/lib/nftban/cli/cmd_wizard.sh
@@ -346,7 +346,7 @@ _wizard_show_summary() {
         echo "    Web GUI:               ✓ ENABLED"
         echo "    Metrics exporter:      ✓ ENABLED"
     else
-        echo "    Web GUI & Metrics:     ✗ disabled (enable later: nftban gui enable)"
+        echo "    Web GUI & Metrics:     ✗ disabled"
     fi
 
     echo ""
@@ -455,12 +455,6 @@ _wizard_enable_modules() {
         if [[ "$ROLE_WEB" -eq 1 ]]; then
             nftban feeds enable SPAMHAUS_DROP >/dev/null 2>&1 || true
         fi
-    fi
-
-    # GUI
-    if [[ "$ENABLE_GUI" -eq 1 ]]; then
-        echo "    → Enabling web GUI..."
-        nftban gui enable >/dev/null 2>&1 || echo "      (GUI may need manual setup)"
     fi
 
     # Metrics

--- a/cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh
+++ b/cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V133 PR-D P2 — help/code drift regression guard (D-01, D-03..D-11)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v133_pr_d_p2_help_code_drift_test"
+# meta:type="test"
+# meta:version="1.133.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:description="V133 PR-D P2 targeted help/code-drift guard. Asserts the previously-undocumented dispatched subcommands are now documented in their command's help (D-05 status pending/queue; D-06 rbl config/stats/test; D-07 feeds config/stats/test; D-08 botscan stats/config + error fallback; D-09 geoban stats/test; D-10 login config/install; D-11 module duplicates) and that the stale references are gone tree-wide (D-01 'nftban gui', D-03 'emulate --out', D-04 'nftban profile select' — the latter allowed only in cmd_profile.sh which documents it as deprecated). NOT the comprehensive doctest guard or P3 alias allowlist (those are v1.134). D-02 was resolved in v1.132.0 PR-C and is not re-checked here."
+# =============================================================================
+set -Eeuo pipefail
+
+_repo_root=$(cd "${BASH_SOURCE[0]%/*}/../../../.." && pwd)
+_cli="$_repo_root/cli/lib/nftban/cli"
+_scan="$_repo_root/cli/lib/nftban"
+
+_pass=0; _fail=0
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then echo "  [PASS] $name"; _pass=$((_pass+1))
+    else echo "  [FAIL] $name${detail:+ — $detail}"; _fail=$((_fail+1)); fi
+}
+_has()   { if grep -qF "$2" "$1"; then _t_assert "$3" 0; else _t_assert "$3" 1 "missing /$2/ in ${1##*/}"; fi; }
+
+echo "==============================================================================="
+echo "V133 PR-D P2 — help/code drift guard"
+echo "==============================================================================="
+
+echo "[D-05..D-11] dispatched subcommands now documented in help"
+_has "$_cli/cmd_status.sh"  "pending, queue"                       "D-05 status: pending/queue documented"
+_has "$_cli/cmd_rbl.sh"     "Show RBL configuration"               "D-06 rbl: config documented"
+_has "$_cli/cmd_rbl.sh"     "Show RBL statistics"                  "D-06 rbl: stats documented"
+_has "$_cli/cmd_rbl.sh"     "Test RBL configuration"               "D-06 rbl: test documented"
+_has "$_cli/cmd_feeds.sh"   "Show feeds configuration"             "D-07 feeds: config documented"
+_has "$_cli/cmd_feeds.sh"   "Show feeds statistics"                "D-07 feeds: stats documented"
+_has "$_cli/cmd_feeds.sh"   "Test feed connectivity"               "D-07 feeds: test documented"
+_has "$_cli/cmd_botscan.sh" "Show detection statistics"            "D-08 botscan: stats documented"
+_has "$_cli/cmd_botscan.sh" "Show detection configuration"         "D-08 botscan: config documented"
+_has "$_cli/cmd_botscan.sh" "status, stats, config"                "D-08 botscan: config in error fallback"
+_has "$_cli/cmd_geoban.sh"  "Show GeoBan statistics"               "D-09 geoban: stats documented"
+_has "$_cli/cmd_geoban.sh"  "Test GeoBan config"                   "D-09 geoban: test documented"
+_has "$_cli/cmd_login.sh"   "Show login monitoring configuration"  "D-10 login: config documented"
+_has "$_cli/cmd_login.sh"   "Install/provision login monitoring"   "D-10 login: install documented"
+_has "$_cli/cmd_module.sh"  "Duplicate name/version conflict"      "D-11 module: duplicates documented"
+
+echo "[D-01/D-03/D-04] stale references removed tree-wide"
+# D-01: no dead 'nftban gui ...' command anywhere (outside tests)
+if grep -rn 'nftban gui ' --include='*.sh' "$_scan" 2>/dev/null | grep -v '/tests/' | grep -q .; then
+    _t_assert "D-01: no 'nftban gui' command reference" 1 "$(grep -rn 'nftban gui ' --include='*.sh' "$_scan" | grep -v '/tests/' | head -1)"
+else _t_assert "D-01: no 'nftban gui' command reference" 0; fi
+# D-03: no 'emulate --out' (nonexistent flag) anywhere (outside tests)
+if grep -rn 'emulate --out' --include='*.sh' "$_scan" 2>/dev/null | grep -v '/tests/' | grep -q .; then
+    _t_assert "D-03: no 'emulate --out' nonexistent flag" 1 "$(grep -rn 'emulate --out' --include='*.sh' "$_scan" | grep -v '/tests/' | head -1)"
+else _t_assert "D-03: no 'emulate --out' nonexistent flag" 0; fi
+# D-04: no 'nftban profile select' command (allowed only in cmd_profile.sh, which documents it deprecated)
+if grep -rn 'nftban profile select' --include='*.sh' "$_scan" 2>/dev/null | grep -v '/tests/' | grep -v '/cmd_profile.sh:' | grep -q .; then
+    _t_assert "D-04: no 'nftban profile select' outside cmd_profile.sh" 1 "$(grep -rn 'nftban profile select' --include='*.sh' "$_scan" | grep -v '/tests/' | grep -v '/cmd_profile.sh:' | head -1)"
+else _t_assert "D-04: no 'nftban profile select' outside cmd_profile.sh" 0; fi
+
+echo "[SYNTAX] touched files parse"
+for f in cmd_wizard cmd_port cmd_egress cmd_ddos cmd_portscan cmd_menu cmd_status cmd_rbl cmd_feeds cmd_botscan cmd_geoban cmd_login cmd_module; do
+    if bash -n "$_cli/$f.sh" 2>/dev/null; then _t_assert "bash -n $f.sh" 0; else _t_assert "bash -n $f.sh" 1; fi
+done
+
+echo "==============================================================================="
+echo "Results: $_pass passed, $_fail failed"
+echo "==============================================================================="
+[[ "$_fail" -eq 0 ]]


### PR DESCRIPTION
## v1.133.0 PR-D P2 — help/code drift

Aligns command help with the dispatcher (the V130 PR-D **P2** set). **Doc/UX-truth only — no Go, no schema, no install/systemd/polkit change.** Plan: `AUDIT_190_LIFECYCLE/V133_SCOPE_PR_B_AND_PR_D_P2.md`. (D-02 was resolved in v1.132.0 PR-C.)

| Item | Change |
|------|--------|
| **D-01** remove | drop dead `nftban gui enable` (no `gui` command — web GUI retired): wizard's dead invocation + advertised ref removed |
| **D-03** fix example | `nftban emulate --out <ip>:<port>` → real `nftban emulate <ip> --port N --direction out` (no `--out` flag exists) — cmd_port, cmd_egress |
| **D-04** re-steer | deprecated `nftban profile select` → `nftban wizard` (live path; select already redirects there) — cmd_ddos, cmd_portscan, cmd_menu |
| **D-05..D-11** document | add dispatched-but-undocumented subcommands to help: status `pending/queue`; rbl `config/stats/test`; feeds `config/stats/test`; botscan `stats/config` (+ error fallback); geoban `stats/test`; login `config/install`; module `duplicates` |

### Tests
- New `v133_pr_d_p2_help_code_drift_test.sh` (**31/0**): asserts each subcommand is documented + the stale refs (`nftban gui`, `emulate --out`, `nftban profile select`) are gone tree-wide (`profile select` allowed only in `cmd_profile.sh` deprecation docs).
- Adjacent green (PR-B guard, v128 wording, v132 PR-C); `bash -n` clean.

### Scope
- P3 alias allowlist + full subcommand/flag doctest guard + PR-E docs/wiki remain **v1.134**. Schema 1.83.0 frozen; daemon byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)