### PR TITLE
fix(cli+test): v1.134 PR-D P3 Lane 1 — alias allowlist basis + D-26 doc + D-28 fix

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -341,6 +341,8 @@ DIAGNOSTICS:
     config [--verbose]      Show module and config status
     posture, security       Check security posture (low noise)
     botguard                Check BotGuard module status
+    rbl                     Check RBL (DNS blocklist) health
+    fhs                     Check FHS compliance (delegates to 'nftban fhs')
 
 MONITORING:
     summary                 One-line health summary

--- a/cli/lib/nftban/cli/cmd_metrics.sh
+++ b/cli/lib/nftban/cli/cmd_metrics.sh
@@ -438,7 +438,7 @@ nftban_cmd_metrics() {
             ;;
         *)
             echo "Unknown command: $subcommand"
-            echo "Usage: nftban metrics {enable|disable|status|pipeline|help}"
+            echo "Usage: nftban metrics {evidence|evidence-json|enable|disable|status|pipeline|help}"
             return 1
             ;;
     esac

--- a/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
+++ b/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MPL-2.0
+# nftban help/code intentional-alias allowlist (v1.134 PR-D P3, Lane 1)
+# =============================================================================
+# Tokens that are DISPATCHED by a command's case statement but intentionally
+# NOT advertised in its help/usage block. The v1.134 PR-D doctest guard
+# (Lane 2) consumes this as its allowlist so help<->code drift for genuine
+# aliases / internal / universal-flag / deprecated tokens does NOT fail CI,
+# while NEW undocumented subcommands still do.
+#
+# Source: read-only recon on main 04f16c84 (post-v1.133.0) — every token below
+# was confirmed dispatched (case label) AND absent from the command's help.
+# NOT included here: D-26 health rbl/fhs (now DOCUMENTED) and D-28 metrics
+# (error-usage FIXED) — those are real fixes in this lane, not allowlist.
+#
+# Format (tab-separated): cmd_file<TAB>token<TAB>class<TAB>canonical_or_note
+#   class ∈ alias | internal | universal-flag | deprecated | undocumented-subcmd
+#   DOC-CANDIDATE notes = genuine subcommands the operator may later prefer to
+#   DOCUMENT (like D-26) rather than keep allowlisted — flagged, not decided.
+# =============================================================================
+cli/cmd_pro.sh	community	undocumented-subcmd	DOC-CANDIDATE: real subcmd (v1.41.0); in error-usage :957 not main help
+cli/cmd_pro.sh	license-check	internal	timer-only internal command
+cli/cmd_stats.sh	attackers	alias	stats top ips
+cli/cmd_stats.sh	--today	universal-flag	dashboard date filter
+cli/cmd_stats.sh	--week	universal-flag	dashboard date filter
+cli/cmd_stats.sh	--brief	universal-flag	one-line brief output (also -b)
+cli/cmd_suricata.sh	stats	undocumented-subcmd	DOC-CANDIDATE: real subcmd (distinct from documented status)
+cli/cmd_suricata.sh	test	undocumented-subcmd	DOC-CANDIDATE: real subcmd
+cli/cmd_suricata.sh	interface	alias	iface
+cli/cmd_debug.sh	on	alias	enable
+cli/cmd_debug.sh	off	alias	disable
+cli/cmd_debug.sh	log	alias	logs
+cli/cmd_services.sh	status	alias	detailed
+cli/cmd_services.sh	list	alias	detailed
+cli/cmd_services.sh	compact	deprecated	summary
+cli/cmd_services.sh	start	alias	fix
+cli/cmd_connector.sh	delete	alias	remove
+cli/cmd_connector.sh	rm	alias	remove
+cli/cmd_polkit.sh	check	alias	validate
+cli/cmd_sync.sh	quick	internal	postinst quick sync
+cli/cmd_sync.sh	--quick	internal	postinst quick sync
+cli/cmd_sync.sh	-q	internal	postinst quick sync
+cli/cmd_selftest.sh	configs	alias	config
+cli/cmd_selftest.sh	orphans	alias	check
+cli/cmd_port.sh	list	deprecated	status
+cli/cmd_update.sh	auto-run	internal	systemd timer-only
+cli/cmd_whitelist.sh	rm	alias	remove
+cli/cmd_whitelist.sh	del	alias	remove
+cli/cmd_whitelist.sh	delete	alias	remove
+cli/cmd_whitelist.sh	show	alias	list
+cli/cmd_whitelist_system.sh	list	alias	show
+cli/cmd_list.sh	ban	alias	banned
+cli/cmd_list.sh	white	alias	whitelist
+cli/cmd_fhs.sh	status	alias	detailed
+cli/cmd_fhs.sh	check	deprecated	status
+cli/cmd_emulate.sh	--protocol	universal-flag	--proto
+cli/cmd_emulate.sh	--dir	universal-flag	--direction
+cli/cmd_emulate.sh	input	alias	in
+cli/cmd_emulate.sh	output	alias	out
+cli/cmd_emulate.sh	forward	alias	fwd
+cli/cmd_ban.sh	--json	universal-flag	global json mode
+cli/cmd_config.sh	test	alias	validate
+cli/cmd_config.sh	reload	alias	apply

--- a/cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh
+++ b/cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# V134 PR-D P3 (Lane 1) — alias allowlist + D-26 document + D-28 fix guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v134_pr_d_p3_alias_allowlist_test"
+# meta:type="test"
+# meta:version="1.134.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-26"
+# meta:inventory.files="cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv"
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:description="V134 PR-D P3 Lane 1 guard. (1) D-26: health 'rbl'/'fhs' are documented in cmd_health.sh help. (2) D-28: cmd_metrics.sh error-usage string now includes evidence/evidence-json. (3) The intentional-alias allowlist manifest (v134_help_code_alias_allowlist.tsv) is well-formed (4 tab fields, valid class) and every allowlisted (cmd_file, token) pair is actually PRESENT in that command file — so the allowlist (basis for the Lane-2 doctest guard) can never silently allowlist a phantom/removed token. The rigorous per-family help<->dispatch correlation is Lane 2's doctest guard; this guard locks the allowlist basis + the two Lane-1 code fixes."
+# =============================================================================
+set -Eeuo pipefail
+
+_lib=$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)   # .../cli/lib/nftban
+_man="$_lib/tests/v134_help_code_alias_allowlist.tsv"
+
+_pass=0; _fail=0
+_t_assert() {
+    local name="$1" rc="$2" detail="${3:-}"
+    if [[ "$rc" == "0" ]]; then echo "  [PASS] $name"; _pass=$((_pass+1))
+    else echo "  [FAIL] $name${detail:+ — $detail}"; _fail=$((_fail+1)); fi
+}
+
+echo "==============================================================================="
+echo "V134 PR-D P3 (Lane 1) — alias allowlist + D-26/D-28 guard"
+echo "==============================================================================="
+
+echo "[D-26] health rbl/fhs documented in help"
+if grep -qF "Check RBL (DNS blocklist) health" "$_lib/cli/cmd_health.sh"; then _t_assert "D-26: 'rbl' in health help" 0; else _t_assert "D-26: 'rbl' in health help" 1; fi
+if grep -qF "Check FHS compliance" "$_lib/cli/cmd_health.sh"; then _t_assert "D-26: 'fhs' in health help" 0; else _t_assert "D-26: 'fhs' in health help" 1; fi
+
+echo "[D-28] metrics error-usage includes evidence/evidence-json"
+if grep -qF "{evidence|evidence-json|enable|disable|status|pipeline|help}" "$_lib/cli/cmd_metrics.sh"; then _t_assert "D-28: metrics error-usage completed" 0; else _t_assert "D-28: metrics error-usage completed" 1; fi
+
+echo "[allowlist] manifest well-formed"
+if [[ -f "$_man" ]]; then _t_assert "manifest file exists" 0; else _t_assert "manifest file exists" 1 "$_man"; fi
+# data rows = non-comment, non-blank
+_rows() { grep -vE '^[[:space:]]*#' "$_man" | grep -vE '^[[:space:]]*$'; }
+badfields=$(_rows | awk -F'\t' 'NF!=4' | wc -l)
+_t_assert "every row has exactly 4 tab-separated fields (bad=$badfields)" "$([[ "$badfields" -eq 0 ]] && echo 0 || echo 1)"
+badclass=$(_rows | awk -F'\t' '$3 !~ /^(alias|internal|universal-flag|deprecated|undocumented-subcmd)$/' | wc -l)
+_t_assert "every row has a valid class (bad=$badclass)" "$([[ "$badclass" -eq 0 ]] && echo 0 || echo 1)"
+
+echo "[allowlist] D-26/D-28 are fixed, NOT allowlisted"
+if _rows | awk -F'\t' '$1=="cli/cmd_health.sh" && ($2=="rbl"||$2=="fhs")' | grep -q .; then _t_assert "health rbl/fhs NOT in allowlist (documented instead)" 1; else _t_assert "health rbl/fhs NOT in allowlist (documented instead)" 0; fi
+if _rows | awk -F'\t' '$1=="cli/cmd_metrics.sh"' | grep -q .; then _t_assert "metrics NOT in allowlist (fixed instead)" 1; else _t_assert "metrics NOT in allowlist (fixed instead)" 0; fi
+
+echo "[allowlist] every allowlisted token is present in its command file (no phantoms)"
+missing=0
+while IFS=$'\t' read -r cf tok _cls _note; do
+    [[ -z "${cf:-}" ]] && continue
+    if [[ ! -f "$_lib/$cf" ]]; then echo "    MISSING FILE: $cf"; missing=$((missing+1)); continue; fi
+    if ! grep -qF -- "$tok" "$_lib/$cf"; then echo "    token '$tok' not found in $cf"; missing=$((missing+1)); fi
+done < <(_rows)
+_t_assert "all allowlisted tokens present in their command files (missing=$missing)" "$([[ "$missing" -eq 0 ]] && echo 0 || echo 1)"
+
+echo "[syntax] touched files parse"
+for f in cli/cmd_health.sh cli/cmd_metrics.sh; do
+    if bash -n "$_lib/$f" 2>/dev/null; then _t_assert "bash -n $f" 0; else _t_assert "bash -n $f" 1; fi
+done
+
+echo "allowlist rows: $(_rows | wc -l)"
+echo "==============================================================================="
+echo "Results: $_pass passed, $_fail failed"
+echo "==============================================================================="
+[[ "$_fail" -eq 0 ]]


### PR DESCRIPTION
## v1.134.0 PR-D P3 — Lane 1 (alias allowlist basis)

First lane of v1.134.0 (text/code-debt closure). Classifies the 19 P3 help/code-drift items (D-12..D-30) into the allowlist the **Lane-2 doctest guard** will consume, plus two real fixes. **Doc/UX-truth only — no Go, no schema, no install/systemd/polkit change.** Plan: `AUDIT_190_LIFECYCLE/V134_SCOPE_PR_D_P3_DOCTEST_AND_PR_E_DOCS.md`.

| Item | Action |
|------|--------|
| **D-26** | **Document** — `health rbl` / `health fhs` are real delegating subcommands → added to `cmd_health.sh` help (not allowlisted) |
| **D-28** | **Fix** — `cmd_metrics.sh` error-usage now lists `evidence`/`evidence-json` (matched main `--help`) |
| **D-12..D-30 (rest)** | **Allowlist** — 43 dispatched-but-intentionally-undocumented tokens (alias / internal / universal-flag / deprecated / undocumented-subcmd), in `tests/v134_help_code_alias_allowlist.tsv` |

### Allowlist manifest
`cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv` — recon-verified every token is genuinely dispatched (no phantoms). Flags **pro `community`** + **suricata `stats`/`test`** as **DOC-CANDIDATEs** — real subcommands the operator may later prefer to *document* rather than keep allowlisted (decision deferred, not changed here).

### Tests
- New `v134_pr_d_p3_alias_allowlist_test.sh` (**11/0**): D-26/D-28 landed; manifest well-formed (4 fields, valid class); **every allowlisted token present in its command file** (drift/phantom lock); D-26/D-28 not allowlisted.
- Adjacent green (v133 PR-B + PR-D P2, v132 PR-C); `bash -n` clean.

### Scope
- **Lane 2** (ship + CI-enforce the full `v130_subcommand_flag_help_code_test.sh` doctest guard, consuming this allowlist) and **Lane 3** (PR-E docs) are separate gates.
- Timer/lifecycle findings remain **v1.135** (`V135_INSTALL_UPDATE_LIFECYCLE_CANDIDATES.md`), not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)