### PR TITLE
fix(cli+installer): v1.135 Phase 2 — update-lifecycle (lock cleanup + mixed-drift unblock + exporter settle)

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -51,8 +51,11 @@ NFTBAN_GIT_REPO="${NFTBAN_GIT_REPO:-/opt/nftban}"
 NFTBAN_GIT_BRANCH="${NFTBAN_GIT_BRANCH:-main}"
 NFTBAN_UPDATE_BACKUP_COUNT="${NFTBAN_UPDATE_BACKUP_COUNT:-3}"
 
-# Lock file for preventing concurrent updates
-readonly UPDATE_LOCK_FILE="/run/nftban/update.lock"
+# Lock file for preventing concurrent updates. Derives from NFTBAN_RUN_DIR
+# (the codebase-wide runtime-dir convention) so it resolves to the real
+# /run/nftban/update.lock in production but can be redirected to a sandbox
+# in tests.
+readonly UPDATE_LOCK_FILE="${NFTBAN_RUN_DIR:-/run/nftban}/update.lock"
 
 # Internal flags (exported for submodules)
 export _NFTBAN_UPDATE_FORCE=0
@@ -333,9 +336,29 @@ _cmd_update_check() {
     return 0
 }
 
+_release_update_lock() {
+    # Release the exclusive update lock held on fd 9 and remove the lock file.
+    # MUST only be called by the flock holder (_cmd_update_main, after a
+    # successful `flock -n 9`). We remove the file BEFORE closing the fd: while
+    # the fd is still open we continue to hold the kernel lock, so no concurrent
+    # updater can exist during the unlink — this is the strongest guarantee that
+    # we never clobber a live updater's lock. Closing fd 9 then releases the
+    # kernel lock. Removing the file prevents the empty left-behind marker that
+    # confused operators (D-UPDATE-LOCK-LEFT-BEHIND, v1.135 — observed as a
+    # 2-day stale /run/nftban/update.lock on dns2).
+    rm -f "$UPDATE_LOCK_FILE" 2>/dev/null || true
+    exec 9>&- 2>/dev/null || true
+}
+
 _cmd_update_main() {
-    # Main update command
+    # Main update command (lock wrapper)
     # Args: $1 = source (auto/github/git/local), $2 = version/path (optional)
+    #
+    # Acquires the exclusive update lock, delegates the actual update to
+    # _cmd_update_main_locked, then releases the lock file on EVERY terminal
+    # path (success / DEGRADED / handled failure). Pre-v1.135 the flock fd was
+    # released on process exit but the empty /run/nftban/update.lock file was
+    # left behind (D-UPDATE-LOCK-LEFT-BEHIND).
 
     local source="${1:-auto}"
     local arg="${2:-}"
@@ -343,7 +366,7 @@ _cmd_update_main() {
     _update_banner
     echo ""
 
-    # Check root
+    # Check root (pre-lock — nothing acquired yet, nothing to release)
     if [[ $EUID -ne 0 ]]; then
         _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
         _update_log INFO "Hint: update requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
@@ -352,14 +375,33 @@ _cmd_update_main() {
 
     # Acquire exclusive lock to prevent concurrent updates
     _update_log INFO "Acquiring update lock..."
-    mkdir -p /run/nftban 2>/dev/null || true
+    mkdir -p "${NFTBAN_RUN_DIR:-/run/nftban}" 2>/dev/null || true
     exec 9>"$UPDATE_LOCK_FILE"
     if ! flock -n 9; then
         _update_log ERROR "Another update is in progress"
         _update_log INFO "If no update is running, use 'nftban update force' to clear stale lock"
+        # We did NOT acquire the lock — a live updater holds it. Close our fd
+        # but DO NOT remove the file: it belongs to the running updater.
+        exec 9>&- 2>/dev/null || true
         return 1
     fi
     _update_log INFO "Lock acquired"
+
+    # Run the update body under the held lock, then always release the lock
+    # file (cleanup on success / DEGRADED / handled failure alike).
+    local _update_rc=0
+    _cmd_update_main_locked "$source" "$arg" || _update_rc=$?
+    _release_update_lock
+    return $_update_rc
+}
+
+_cmd_update_main_locked() {
+    # Update body — runs while the caller (_cmd_update_main) holds the exclusive
+    # flock on fd 9. Every terminal `return` here propagates to the wrapper,
+    # which releases the lock file afterward via _release_update_lock.
+
+    local source="${1:-auto}"
+    local arg="${2:-}"
 
     _load_config
 

--- a/cli/lib/nftban/cli/cmd_update_detection.sh
+++ b/cli/lib/nftban/cli/cmd_update_detection.sh
@@ -196,6 +196,63 @@ _probe_git_repo_present() {
     [[ -d "${NFTBAN_GIT_REPO:-}/.git" ]]
 }
 
+# -----------------------------------------------------------------------------
+# v1.135 D-UPDATE-MIXED-DRIFT: "clean and complete" on-disk package-ownership
+# probes.
+#
+# These are STRONGER than _probe_rpm_owns_nftban / _probe_dpkg_owns_nftban
+# (which only query the package NAME). They confirm that every core nftban
+# binary actually present on disk is still owned by the package database. A
+# source `make install` over a package install (a genuine mix) leaves at least
+# one core binary unowned, so these probes return non-zero on a real mix while
+# returning 0 on a cleanly package-managed host — even one whose update-history
+# is stale source-era (the dns2 shape, where no nftban-updater update ran after
+# the migration so the last SUCCESS history entry is still "source").
+#
+# Default probe set: both Go daemon binaries under ${NFTBAN_LIB_DIR}/bin.
+# Override for tests via NFTBAN_OWNERSHIP_PROBE_BINS (space/newline-separated).
+# -----------------------------------------------------------------------------
+_nftban_ownership_probe_bins() {
+    if [[ -n "${NFTBAN_OWNERSHIP_PROBE_BINS:-}" ]]; then
+        printf '%s\n' ${NFTBAN_OWNERSHIP_PROBE_BINS}
+        return 0
+    fi
+    local libdir="${NFTBAN_LIB_DIR:-/usr/lib/nftban}"
+    printf '%s\n' "${libdir}/bin/nftban-core" "${libdir}/bin/nftband"
+}
+
+_probe_rpm_owns_all_binaries() {
+    # Returns 0 only if rpm cleanly owns EVERY core nftban binary on disk.
+    if [[ -n "${NFTBAN_TEST_RPM_OWNS_BINARIES:-}" ]]; then
+        [[ "$NFTBAN_TEST_RPM_OWNS_BINARIES" == "yes" ]] && return 0 || return 1
+    fi
+    command -v rpm &>/dev/null || return 1
+    local b had=0
+    while IFS= read -r b; do
+        [[ -n "$b" ]] || continue
+        had=1
+        [[ -e "$b" ]] || return 1             # binary missing → not complete
+        rpm -qf "$b" &>/dev/null || return 1  # unowned by any rpm → not clean
+    done < <(_nftban_ownership_probe_bins)
+    [[ "$had" -eq 1 ]]
+}
+
+_probe_dpkg_owns_all_binaries() {
+    # Returns 0 only if dpkg cleanly owns EVERY core nftban binary on disk.
+    if [[ -n "${NFTBAN_TEST_DPKG_OWNS_BINARIES:-}" ]]; then
+        [[ "$NFTBAN_TEST_DPKG_OWNS_BINARIES" == "yes" ]] && return 0 || return 1
+    fi
+    command -v dpkg &>/dev/null || return 1
+    local b had=0
+    while IFS= read -r b; do
+        [[ -n "$b" ]] || continue
+        had=1
+        [[ -e "$b" ]] || return 1               # binary missing → not complete
+        dpkg -S "$b" &>/dev/null || return 1    # unowned by any deb → not clean
+    done < <(_nftban_ownership_probe_bins)
+    [[ "$had" -eq 1 ]]
+}
+
 _detect_install_type() {
     # Detect how NFTBan was installed.
     # Returns one of: rpm, deb, source, mixed, unknown
@@ -242,6 +299,15 @@ _detect_install_type() {
                 echo "rpm"
                 return 0
             fi
+            # v1.135 D-UPDATE-MIXED-DRIFT: clean & complete on-disk ownership.
+            # If rpm cleanly owns every core binary, the host IS an rpm install
+            # regardless of stale source-era history (dns2 case: migrated but no
+            # nftban-updater update ran post-migration). Partial/incomplete
+            # ownership falls through to "mixed" — no unsafe bypass.
+            if _probe_rpm_owns_all_binaries; then
+                echo "rpm"
+                return 0
+            fi
             echo "mixed"
             return 0
         fi
@@ -258,6 +324,12 @@ _detect_install_type() {
             last_successful_type=$(_read_history_last_successful_type)
             if [[ "$last_successful_type" == "deb" ]] && \
                _probe_install_state_committed_update_authority; then
+                echo "deb"
+                return 0
+            fi
+            # v1.135 D-UPDATE-MIXED-DRIFT: clean & complete on-disk ownership
+            # (symmetric to the rpm branch above).
+            if _probe_dpkg_owns_all_binaries; then
                 echo "deb"
                 return 0
             fi

--- a/cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.135 mixed-drift clean-ownership unblock
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_update_detection_v135_clean_ownership_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-27"
+# meta:description="Tests for the v1.135 D-UPDATE-MIXED-DRIFT fix: a third migration-clean unblock path in _detect_install_type based on clean & complete on-disk package ownership (rpm -qf / dpkg -S owns EVERY core binary). Closes the dns2 residual where a genuinely-RPM-migrated host whose last SUCCESS history entry is still source-era (no nftban-updater update ran post-migration) was permanently classified 'mixed' because the v1.126 unblock requires last-successful=rpm + install_state COMMITTED+UPDATE. Cases: (a) dns2 clean-ownership rpm + symmetric deb NEW positive paths, (b) partial/incomplete ownership stays 'mixed' (no unsafe bypass for a genuine source-over-package mix), (c) v1.126 path still fires independently, (d) clean-host regression guards, (e) direct probe unit checks. Uses NFTBAN_TEST_RPM_OWNS_BINARIES / NFTBAN_TEST_DPKG_OWNS_BINARIES / NFTBAN_OWNERSHIP_PROBE_BINS overrides. No host contact; no root required."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq-optional,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_detection.sh"
+# meta:inventory.binaries="bash,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_TEST_HISTORY_FILE,NFTBAN_TEST_INSTALL_STATE_FILE,NFTBAN_TEST_RPM_OWNS,NFTBAN_TEST_DPKG_OWNS,NFTBAN_TEST_RPM_OWNS_BINARIES,NFTBAN_TEST_DPKG_OWNS_BINARIES,NFTBAN_OWNERSHIP_PROBE_BINS,NFTBAN_TEST_GIT_REPO_PRESENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Defect closed:  D-UPDATE-MIXED-DRIFT (v1.135 Phase 2)
+# Scope file:     AUDIT_190_LIFECYCLE/V135_INSTALL_UPDATE_LIFECYCLE_SCOPE.md §2
+# Reproduction:   V131_4_FLEET_ROLLOUT_CLOSURE.md Section E (dns2 mixed-drift)
+# Fix mechanism:  cmd_update_detection.sh adds _probe_rpm_owns_all_binaries /
+#                 _probe_dpkg_owns_all_binaries (clean & complete on-disk
+#                 ownership) as a THIRD unblock in _detect_install_type. When
+#                 the package db cleanly owns EVERY core binary on disk, the
+#                 host is the corresponding package family regardless of stale
+#                 source-era history. Incomplete/partial ownership preserves
+#                 the "mixed" refusal (no unsafe bypass for a genuine mix).
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/cli/cmd_update_detection.sh"
+
+clean_env() {
+    unset NFTBAN_TEST_HISTORY_FILE NFTBAN_TEST_INSTALL_STATE_FILE
+    unset NFTBAN_TEST_RPM_OWNS NFTBAN_TEST_DPKG_OWNS
+    unset NFTBAN_TEST_RPM_OWNS_BINARIES NFTBAN_TEST_DPKG_OWNS_BINARIES
+    unset NFTBAN_OWNERSHIP_PROBE_BINS NFTBAN_TEST_GIT_REPO_PRESENT
+}
+
+write_history() {
+    local file="$1"; shift
+    {
+        echo "["
+        local first=1
+        local entry
+        for entry in "$@"; do
+            local etype estatus
+            etype="${entry%%:*}"
+            estatus="${entry#*:}"
+            if (( first )); then first=0; else echo ","; fi
+            printf '  {\n'
+            printf '    "timestamp": "2026-05-27T00:00:00Z",\n'
+            printf '    "from": "1.0.0",\n'
+            printf '    "to": "1.0.0",\n'
+            printf '    "status": "%s",\n' "$estatus"
+            printf '    "type": "%s",\n' "$etype"
+            printf '    "duration_s": 1,\n'
+            printf '    "host": "test"\n'
+            printf '  }'
+        done
+        echo ""
+        echo "]"
+    } > "$file"
+}
+
+write_install_state() {
+    local file="$1" state="$2" authority="$3"
+    cat > "$file" <<EOF
+INSTALL_STATE=${state}
+INSTALL_MODE=install
+INSTALL_VERSION=1.0.0
+INSTALL_TIMESTAMP=2026-05-27T00:00:00Z
+SSH_PORT=22
+AUTHORITY=${authority}
+PANEL=
+CONFLICTS=
+PREFLIGHT_PASSED=1
+EOF
+}
+
+echo "=========================================================="
+echo "V135 D-UPDATE-MIXED-DRIFT — clean-ownership unblock test"
+echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# CASE 1: dns2 residual — rpm-db owns + oldest=source + last-successful=source
+#         (NOT rpm: no nftban-updater update ran since migration) + install_state
+#         COMMITTED+UPDATE + rpm cleanly owns ALL core binaries on disk.
+# v1.126 unblock CANNOT fire (last-successful != rpm). v1.135 clean-ownership
+# unblock fires.
+# Expected: rpm (V135 NEW POSITIVE PATH — was "mixed" through v1.134)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case1.json"
+write_history "$HISTORY" "source:success" "source:success"
+STATE="$SANDBOX/case1.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    NFTBAN_TEST_RPM_OWNS_BINARIES=yes \
+    _detect_install_type)
+assert_eq "$result" "rpm" "new_1_dns2_clean_binary_ownership_unblocks_rpm"
+
+# ---------------------------------------------------------------------------
+# CASE 2: Symmetric DEB — dpkg-db owns + oldest=source + last-successful=source
+#         + dpkg cleanly owns ALL core binaries.
+# Expected: deb (V135 NEW POSITIVE PATH — symmetric to case 1)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case2.json"
+write_history "$HISTORY" "source:success" "source:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" \
+    NFTBAN_TEST_RPM_OWNS=no NFTBAN_TEST_DPKG_OWNS=yes NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    NFTBAN_TEST_DPKG_OWNS_BINARIES=yes \
+    _detect_install_type)
+assert_eq "$result" "deb" "new_2_symmetric_deb_clean_binary_ownership_unblocks_deb"
+
+# ---------------------------------------------------------------------------
+# CASE 3: Genuine source-over-rpm mix — rpm-db owns the package NAME but a
+#         source `make install` clobbered a binary, so on-disk ownership is
+#         INCOMPLETE. last-successful=source, COMMITTED+UPDATE.
+# Neither v1.126 (last-successful != rpm) nor v1.135 (binary ownership = no)
+# unblock fires.
+# Expected: mixed (PRESERVED REFUSAL — no unsafe bypass for a genuine mix)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case3.json"
+write_history "$HISTORY" "source:success" "source:success"
+STATE="$SANDBOX/case3.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    NFTBAN_TEST_RPM_OWNS_BINARIES=no \
+    _detect_install_type)
+assert_eq "$result" "mixed" "preserve_3_incomplete_binary_ownership_stays_mixed"
+
+# ---------------------------------------------------------------------------
+# CASE 4: v1.126 path independence — rpm-db owns + last-successful=rpm +
+#         COMMITTED+UPDATE, but binary-ownership probe says NO. The v1.126
+#         unblock must still fire on its own signals (it is checked first).
+# Expected: rpm (v1.126 regression guard; proves v1.135 probe is additive)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case4.json"
+write_history "$HISTORY" "rpm:success" "source:success"
+STATE="$SANDBOX/case4.state"
+write_install_state "$STATE" "COMMITTED" "UPDATE"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" NFTBAN_TEST_INSTALL_STATE_FILE="$STATE" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    NFTBAN_TEST_RPM_OWNS_BINARIES=no \
+    _detect_install_type)
+assert_eq "$result" "rpm" "regress_4_v126_unblock_still_fires_independently"
+
+# ---------------------------------------------------------------------------
+# CASE 5: Clean RPM host, no source drift at all — binary probe not reached.
+# Expected: rpm (regression guard — happy path unaffected)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case5.json"
+write_history "$HISTORY" "rpm:success" "rpm:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" \
+    NFTBAN_TEST_RPM_OWNS=yes NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    NFTBAN_TEST_RPM_OWNS_BINARIES=no \
+    _detect_install_type)
+assert_eq "$result" "rpm" "regress_5_clean_rpm_no_drift_returns_rpm"
+
+# ---------------------------------------------------------------------------
+# CASE 6: Pure source install — no pkg-db ownership at all. Clean-ownership
+#         probe is never consulted (no rpm/dpkg ownership branch entered).
+# Expected: source (regression guard)
+# ---------------------------------------------------------------------------
+clean_env
+HISTORY="$SANDBOX/case6.json"
+write_history "$HISTORY" "source:success" "source:success"
+result=$(NFTBAN_TEST_HISTORY_FILE="$HISTORY" \
+    NFTBAN_TEST_RPM_OWNS=no NFTBAN_TEST_DPKG_OWNS=no NFTBAN_TEST_GIT_REPO_PRESENT=no \
+    _detect_install_type)
+assert_eq "$result" "source" "regress_6_pure_source_returns_source"
+
+# ---------------------------------------------------------------------------
+# Direct probe unit checks (real filesystem, no rpm/dpkg db calls — the
+# override short-circuits AND the on-disk completeness path is exercised via
+# NFTBAN_OWNERSHIP_PROBE_BINS).
+# ---------------------------------------------------------------------------
+echo
+echo "--- direct probe checks ---"
+
+# d1: override=yes → 0
+clean_env
+NFTBAN_TEST_RPM_OWNS_BINARIES=yes _probe_rpm_owns_all_binaries && d1=0 || d1=$?
+assert_eq "$d1" "0" "probe_d1_rpm_override_yes_returns_0"
+
+# d2: override=no → 1
+clean_env
+NFTBAN_TEST_RPM_OWNS_BINARIES=no _probe_rpm_owns_all_binaries && d2=0 || d2=$?
+assert_eq "$d2" "1" "probe_d2_rpm_override_no_returns_1"
+
+# d3: dpkg override=yes → 0
+clean_env
+NFTBAN_TEST_DPKG_OWNS_BINARIES=yes _probe_dpkg_owns_all_binaries && d3=0 || d3=$?
+assert_eq "$d3" "0" "probe_d3_dpkg_override_yes_returns_0"
+
+# d4: probe-bin list points at a MISSING file → incomplete → non-zero
+# (exercises the [[ -e ]] completeness guard without touching rpm db; rpm may
+# be absent on the dev host, in which case the command-check returns 1 first —
+# either way the contract "missing/unowned binary ⇒ non-zero" holds).
+clean_env
+NFTBAN_OWNERSHIP_PROBE_BINS="$SANDBOX/definitely-not-present-binary" \
+    _probe_rpm_owns_all_binaries && d4=0 || d4=$?
+assert_eq "$d4" "1" "probe_d4_missing_binary_returns_nonzero"
+
+echo
+echo "=========================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=========================================================="
+if (( FAIL > 0 )); then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All v1.135 mixed-drift clean-ownership tests passed."
+exit 0

--- a/cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.135 update-lock cleanup (D-UPDATE-LOCK-LEFT-BEHIND)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_update_lock_cleanup_v135_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-27"
+# meta:description="Tests for the v1.135 fix that removes /run/nftban/update.lock on every terminal update path. Pre-v1.135 the flock fd was released on process exit but the empty lock file was left behind (observed as a 2-day stale lock on dns2). Verifies: (a) _release_update_lock removes the lock file AND releases the kernel lock (a fresh flock then succeeds), (b) release is idempotent / safe when the file is already absent, (c) the lock file path honors NFTBAN_RUN_DIR, (d) STATIC guards that _cmd_update_main wraps _cmd_update_main_locked and calls _release_update_lock on every terminal path while NOT removing the file on the lock-contention path. Uses NFTBAN_RUN_DIR sandbox override. No host contact; no root required."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,flock,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,flock,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_RUN_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Defect closed:  D-UPDATE-LOCK-LEFT-BEHIND (v1.135 Phase 2)
+# Scope file:     AUDIT_190_LIFECYCLE/V135_INSTALL_UPDATE_LIFECYCLE_SCOPE.md §2
+# Fix mechanism:  cmd_update.sh splits _cmd_update_main into a lock WRAPPER
+#                 (acquire flock fd9 → run _cmd_update_main_locked → release)
+#                 and the locked body. _release_update_lock removes the lock
+#                 file (while still holding the flock, so no live updater can
+#                 exist) then closes fd 9. The lock-contention path closes the
+#                 fd but does NOT remove the file (it belongs to the holder).
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+SANDBOX=$(mktemp -d)
+export NFTBAN_RUN_DIR="$SANDBOX/run"
+mkdir -p "$NFTBAN_RUN_DIR"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+CMD_UPDATE="${NFTBAN_LIB_DIR}/cli/cmd_update.sh"
+
+echo "=========================================================="
+echo "V135 D-UPDATE-LOCK-LEFT-BEHIND — lock cleanup test"
+echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# BEHAVIORAL — source cmd_update.sh (NFTBAN_RUN_DIR points at the sandbox so
+# UPDATE_LOCK_FILE resolves under it) and drive the real helpers. We run these
+# in a subshell because cmd_update.sh sets `set -Eeuo pipefail` and has a
+# one-shot load guard.
+# ---------------------------------------------------------------------------
+
+# CASE 1: _release_update_lock removes the lock file.
+result=$(
+    # shellcheck source=/dev/null
+    source "$CMD_UPDATE"
+    exec 9>"$UPDATE_LOCK_FILE"
+    flock -n 9 || { echo "ACQUIRE_FAILED"; exit 0; }
+    [[ -f "$UPDATE_LOCK_FILE" ]] || { echo "NO_FILE_AFTER_ACQUIRE"; exit 0; }
+    _release_update_lock
+    if [[ -e "$UPDATE_LOCK_FILE" ]]; then echo "STILL_PRESENT"; else echo "REMOVED"; fi
+)
+assert_eq "$result" "REMOVED" "behav_1_release_removes_lock_file"
+
+# CASE 2: after release the kernel lock is gone — a fresh flock succeeds.
+result=$(
+    # shellcheck source=/dev/null
+    source "$CMD_UPDATE"
+    exec 9>"$UPDATE_LOCK_FILE"; flock -n 9 || { echo "ACQUIRE1_FAILED"; exit 0; }
+    _release_update_lock
+    # Re-acquire from scratch — must succeed (lock truly released).
+    exec 8>"$UPDATE_LOCK_FILE"
+    if flock -n 8; then echo "REACQUIRED"; else echo "STILL_LOCKED"; fi
+    flock -u 8; exec 8>&-
+)
+assert_eq "$result" "REACQUIRED" "behav_2_release_frees_kernel_lock"
+
+# CASE 3: release is idempotent / safe when file already absent.
+result=$(
+    # shellcheck source=/dev/null
+    source "$CMD_UPDATE"
+    rm -f "$UPDATE_LOCK_FILE"
+    _release_update_lock && echo "OK" || echo "ERRORED"
+    [[ -e "$UPDATE_LOCK_FILE" ]] && echo "EXISTS" || echo "ABSENT"
+)
+assert_eq "$result" $'OK\nABSENT' "behav_3_release_idempotent_when_absent"
+
+# CASE 4: UPDATE_LOCK_FILE honors NFTBAN_RUN_DIR.
+result=$(
+    # shellcheck source=/dev/null
+    source "$CMD_UPDATE"
+    echo "$UPDATE_LOCK_FILE"
+)
+assert_eq "$result" "${NFTBAN_RUN_DIR}/update.lock" "behav_4_lock_path_honors_run_dir"
+
+# CASE 5: while the lock is HELD, a second non-blocking flock fails (contention
+# is real — proves the wrapper's "another update in progress" branch can trip).
+result=$(
+    # shellcheck source=/dev/null
+    source "$CMD_UPDATE"
+    exec 9>"$UPDATE_LOCK_FILE"; flock -n 9 || { echo "ACQUIRE_FAILED"; exit 0; }
+    # Second holder in a sub-subshell attempts non-blocking lock on same file.
+    if ( exec 7>"$UPDATE_LOCK_FILE"; flock -n 7 ); then
+        echo "SECOND_ACQUIRED"   # would be a bug
+    else
+        echo "SECOND_BLOCKED"    # correct
+    fi
+    _release_update_lock
+)
+assert_eq "$result" "SECOND_BLOCKED" "behav_5_held_lock_blocks_second_acquire"
+
+# ---------------------------------------------------------------------------
+# STATIC — wiring guards on the production source (cheap, durable regressions).
+# ---------------------------------------------------------------------------
+echo
+echo "--- static wiring guards ---"
+
+# s1: wrapper delegates to the locked inner body.
+if grep -q "_cmd_update_main_locked \"\$source\" \"\$arg\"" "$CMD_UPDATE"; then
+    assert_eq "wired" "wired" "static_s1_wrapper_calls_locked_body"
+else
+    assert_eq "missing" "wired" "static_s1_wrapper_calls_locked_body"
+fi
+
+# s2: wrapper releases the lock after the body (single canonical release call).
+if grep -q "_cmd_update_main_locked \"\$source\" \"\$arg\" || _update_rc=\$?" "$CMD_UPDATE" \
+   && grep -qE "^\s*_release_update_lock\s*$" "$CMD_UPDATE"; then
+    assert_eq "wired" "wired" "static_s2_wrapper_releases_after_body"
+else
+    assert_eq "missing" "wired" "static_s2_wrapper_releases_after_body"
+fi
+
+# s3: lock-contention path closes fd but does NOT call _release_update_lock
+#     (must not remove a live updater's file). Verify the contention branch
+#     uses `exec 9>&-` and not `_release_update_lock`.
+contention_block=$(awk '/Another update is in progress/{f=1} f{print} /return 1/{if(f){exit}}' "$CMD_UPDATE")
+if grep -q "exec 9>&-" <<<"$contention_block" \
+   && ! grep -q "_release_update_lock" <<<"$contention_block"; then
+    assert_eq "safe" "safe" "static_s3_contention_path_does_not_remove_holders_file"
+else
+    assert_eq "unsafe" "safe" "static_s3_contention_path_does_not_remove_holders_file"
+fi
+
+# s4: _release_update_lock removes the file BEFORE closing fd 9 (hold-then-rm
+#     ordering — strongest no-clobber guarantee).
+release_fn=$(awk '/^_release_update_lock\(\) \{/{f=1} f{print} /^\}/{if(f){exit}}' "$CMD_UPDATE")
+rm_line=$(grep -n "rm -f \"\$UPDATE_LOCK_FILE\"" <<<"$release_fn" | head -1 | cut -d: -f1)
+close_line=$(grep -n "exec 9>&-" <<<"$release_fn" | head -1 | cut -d: -f1)
+if [[ -n "$rm_line" && -n "$close_line" && "$rm_line" -lt "$close_line" ]]; then
+    assert_eq "ordered" "ordered" "static_s4_release_rm_before_close"
+else
+    assert_eq "unordered" "ordered" "static_s4_release_rm_before_close"
+fi
+
+echo
+echo "=========================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=========================================================="
+if (( FAIL > 0 )); then
+    echo "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    exit 1
+fi
+echo "All v1.135 update-lock cleanup tests passed."
+exit 0

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -387,6 +387,19 @@ func assertCriticalTimersEnabled(tvr TimerValidationResult, log *logging.Logger)
 func assertFailedUnitsPostInstall(spr SystemdPayloadValidationResult, log *logging.Logger) AssertionResult {
 	r := AssertionResult{Name: "failed_units_postinstall_ok", Passed: spr.FailedUnitsOK()}
 	if r.Passed {
+		// v1.135 D-EXPORTER-SETTLE-WINDOW: a failed auxiliary (metrics/
+		// observability) unit does NOT fail this assertion, but it IS
+		// surfaced as a non-fatal warning so operators still see it.
+		if len(spr.FailedAuxiliaryUnits) > 0 {
+			aux := make([]string, 0, len(spr.FailedAuxiliaryUnits))
+			for _, f := range spr.FailedAuxiliaryUnits {
+				aux = append(aux, f.Unit+"("+f.Detail+")")
+			}
+			r.Detail = "auxiliary (non-protection) units degraded — non-fatal: " + strings.Join(aux, "; ")
+			log.Warn("ASSERT failed_units_postinstall_ok: PASS — auxiliary units degraded (non-fatal): %s",
+				strings.Join(aux, "; "))
+			return r
+		}
 		log.Debug("ASSERT failed_units_postinstall_ok: PASS")
 		return r
 	}
@@ -421,11 +434,11 @@ func assertFailedUnitsPostInstall(spr SystemdPayloadValidationResult, log *loggi
 func defaultInventoryPaths() map[string]bool {
 	return map[string]bool{
 		// CLI shim + Go binaries
-		"/usr/sbin/nftban":                              true,
-		"/usr/lib/nftban/bin/nftban-core":               true,
-		"/usr/lib/nftban/bin/nftband":                   true,
-		"/usr/lib/nftban/bin/nftban-validate":           true,
-		"/usr/lib/nftban/bin/nftban-installer":          true,
+		"/usr/sbin/nftban":                     true,
+		"/usr/lib/nftban/bin/nftban-core":      true,
+		"/usr/lib/nftban/bin/nftband":          true,
+		"/usr/lib/nftban/bin/nftban-validate":  true,
+		"/usr/lib/nftban/bin/nftban-installer": true,
 		// Shell-side privileged helpers (cli/sbin/* → /usr/lib/nftban/sbin/)
 		"/usr/lib/nftban/sbin/nftban-apply":             true,
 		"/usr/lib/nftban/sbin/nftban-confirm":           true,

--- a/internal/installer/validate/systemd_payload.go
+++ b/internal/installer/validate/systemd_payload.go
@@ -90,6 +90,32 @@ func IsNftbanUnit(basename string) bool {
 	return false
 }
 
+// auxiliaryUnitStems lists nftban unit stems (basename without extension)
+// whose failure is an observability/metrics degradation, NOT a loss of
+// firewall protection. A failure in one of these is surfaced as a non-fatal
+// warning and does NOT flip failed_units_postinstall_ok — so a transient
+// auxiliary failure (notably the unified exporter's exit-2 during a package
+// swap, D-EXPORTER-SETTLE-WINDOW) cannot DEGRADE the install or poison an
+// update. Protection-critical units (nftband, nftban-core, firewall-init)
+// are deliberately absent and remain hard failures.
+var auxiliaryUnitStems = map[string]bool{
+	"nftban-unified-exporter": true,
+}
+
+// IsAuxiliaryUnit reports whether an nftban unit basename is an auxiliary
+// (metrics/observability) unit per auxiliaryUnitStems. Non-nftban units are
+// never auxiliary (they are out of scope for these invariants entirely).
+func IsAuxiliaryUnit(basename string) bool {
+	if !IsNftbanUnit(basename) {
+		return false
+	}
+	dot := strings.LastIndexByte(basename, '.')
+	if dot <= 0 {
+		return false
+	}
+	return auxiliaryUnitStems[basename[:dot]]
+}
+
 // ParsedUnit is the minimum subset of a systemd unit file needed for
 // PR26.1 validation. Constructed by the host-side gatherer or by
 // tests directly.
@@ -242,8 +268,16 @@ type SystemdPayloadValidationResult struct {
 	// UnknownPayloadRefs is the PAYLOAD-INVENTORY-001 finding set.
 	UnknownPayloadRefs []UnknownPayloadRef
 
-	// FailedUnits is the FAILED-UNIT-POSTINSTALL-001 finding set.
+	// FailedUnits is the FAILED-UNIT-POSTINSTALL-001 finding set, restricted
+	// to protection-critical units. A non-empty slice fails the invariant.
 	FailedUnits []FailedUnitPostInstall
+
+	// FailedAuxiliaryUnits holds failed nftban units classified as auxiliary
+	// (metrics/observability — see IsAuxiliaryUnit). These are surfaced as a
+	// non-fatal warning and do NOT fail FAILED-UNIT-POSTINSTALL-001 (so a
+	// transient exporter exit-2 cannot DEGRADE the install — D-EXPORTER-
+	// SETTLE-WINDOW, v1.135).
+	FailedAuxiliaryUnits []FailedUnitPostInstall
 
 	// FailedUnitQueryError mirrors SystemdPayloadInputs.FailedUnitQueryError
 	// for the assertion-side detail message. When non-empty,
@@ -319,10 +353,15 @@ func ValidateInstalledSystemdPayload(in SystemdPayloadInputs) SystemdPayloadVali
 		if detail == "" {
 			detail = strings.TrimSpace(f.Active + " " + f.Sub)
 		}
-		res.FailedUnits = append(res.FailedUnits, FailedUnitPostInstall{
-			Unit:   f.Unit,
-			Detail: detail,
-		})
+		entry := FailedUnitPostInstall{Unit: f.Unit, Detail: detail}
+		// v1.135 D-EXPORTER-SETTLE-WINDOW: route auxiliary (metrics/
+		// observability) failures into a separate non-fatal bucket so they
+		// do not flip FailedUnitsOK(). Protection units stay in FailedUnits.
+		if IsAuxiliaryUnit(f.Unit) {
+			res.FailedAuxiliaryUnits = append(res.FailedAuxiliaryUnits, entry)
+			continue
+		}
+		res.FailedUnits = append(res.FailedUnits, entry)
 	}
 
 	res.OK = res.ExecStartOK() && res.TimerPairOK() && res.PayloadInventoryOK() && res.FailedUnitsOK()

--- a/internal/installer/validate/systemd_payload_gather.go
+++ b/internal/installer/validate/systemd_payload_gather.go
@@ -29,10 +29,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
+
+// auxiliarySettleAttempts / auxiliarySettleDelay bound the re-poll window that
+// lets a transient AUXILIARY-only failure (notably the unified exporter's
+// exit-2 during a package swap) self-heal before it is recorded
+// (D-EXPORTER-SETTLE-WINDOW, v1.135). A protection-critical failure
+// short-circuits the wait immediately. auxiliarySettleDelay is a var so tests
+// can drive the settle logic without real sleeping.
+const auxiliarySettleAttempts = 3
+
+var auxiliarySettleDelay = 2 * time.Second
 
 // DefaultUnitDirs is the canonical systemd unit search path for
 // nftban-owned units. Both vendor and operator-owned dirs are scanned
@@ -138,6 +149,71 @@ func isUnitFilename(name string) bool {
 // surfaces the enumeration failure as an assertion failure instead of
 // silently returning an empty list and false-passing.
 func listFailedNftbanUnits(exec executor.Executor, log *logging.Logger) (findings []FailedUnitFinding, queryErr string) {
+	findings, queryErr = queryFailedNftbanUnitsOnce(exec, log)
+	if queryErr != "" {
+		return findings, queryErr
+	}
+	// v1.135 D-EXPORTER-SETTLE-WINDOW: when the only failures are auxiliary,
+	// give them a bounded settle window to self-heal (the exporter's exit-2
+	// during a package swap recovers within seconds). A protection-critical
+	// failure is never waited on.
+	findings = settleAuxiliaryFailures(findings,
+		func() ([]FailedUnitFinding, string) { return queryFailedNftbanUnitsOnce(exec, log) },
+		auxiliarySettleAttempts,
+		func() { time.Sleep(auxiliarySettleDelay) },
+		log)
+	return findings, ""
+}
+
+// hasProtectionCriticalFailure reports whether any finding is a non-auxiliary
+// (protection-critical) nftban unit. These are never waited on during settle.
+func hasProtectionCriticalFailure(fs []FailedUnitFinding) bool {
+	for _, f := range fs {
+		if IsNftbanUnit(f.Unit) && !IsAuxiliaryUnit(f.Unit) {
+			return true
+		}
+	}
+	return false
+}
+
+// settleAuxiliaryFailures re-polls failed units up to maxAttempts total polls
+// (the first poll is the passed-in initial set) WHILE the only failures are
+// auxiliary, sleeping between polls, to let a transient auxiliary failure
+// recover. It returns as soon as: nothing is failing, a protection-critical
+// unit is failing (fail fast — do not wait), a requery errors (keep what we
+// had), or attempts are exhausted. Pure logic with injected requery+sleep so
+// it is fully unit-testable without real time or systemctl.
+func settleAuxiliaryFailures(
+	initial []FailedUnitFinding,
+	requery func() ([]FailedUnitFinding, string),
+	maxAttempts int,
+	sleep func(),
+	log *logging.Logger,
+) []FailedUnitFinding {
+	cur := initial
+	for attempt := 1; attempt < maxAttempts; attempt++ {
+		if len(cur) == 0 {
+			return cur
+		}
+		if hasProtectionCriticalFailure(cur) {
+			return cur
+		}
+		// Only auxiliary failures remain — wait and re-poll.
+		if log != nil {
+			log.Debug("systemd_payload: auxiliary-only failure(s) present; settle re-poll %d/%d",
+				attempt, maxAttempts-1)
+		}
+		sleep()
+		next, qerr := requery()
+		if qerr != "" {
+			return cur
+		}
+		cur = next
+	}
+	return cur
+}
+
+func queryFailedNftbanUnitsOnce(exec executor.Executor, log *logging.Logger) (findings []FailedUnitFinding, queryErr string) {
 	if !exec.CommandExists("systemctl") {
 		queryErr = "systemctl binary not available — cannot enumerate failed units"
 		if log != nil {

--- a/internal/installer/validate/systemd_payload_settle_test.go
+++ b/internal/installer/validate/systemd_payload_settle_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-validate-systemd-payload-settle-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-27"
+// meta:description="Unit tests for v1.135 D-EXPORTER-SETTLE-WINDOW: auxiliary (metrics/observability) failed-unit classification + bounded settle re-poll. A transient exporter failure must not DEGRADE the install; protection-critical failures stay hard."
+// meta:inventory.files="internal/installer/validate/systemd_payload_settle_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-unified-exporter.service"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsAuxiliaryUnit(t *testing.T) {
+	cases := []struct {
+		unit string
+		want bool
+	}{
+		{"nftban-unified-exporter.service", true},
+		{"nftban-unified-exporter.timer", true},
+		{"nftband.service", false},     // Go daemon — protection critical
+		{"nftban-core.service", false}, // protection critical
+		{"nftban-firewall-init.service", false},
+		{"nftban-maintenance.timer", false}, // critical core timer, not auxiliary
+		{"sshd.service", false},             // not an nftban unit
+		{"node_exporter.service", false},    // not an nftban unit (third-party)
+	}
+	for _, c := range cases {
+		if got := IsAuxiliaryUnit(c.unit); got != c.want {
+			t.Errorf("IsAuxiliaryUnit(%q) = %v, want %v", c.unit, got, c.want)
+		}
+	}
+}
+
+// A failed auxiliary unit (exporter) must NOT fail FAILED-UNIT-POSTINSTALL-001
+// — it is routed to the non-fatal FailedAuxiliaryUnits bucket.
+func TestSystemdPayload_FailedAuxiliaryUnitDoesNotFail(t *testing.T) {
+	res := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		PathExists: pathSet(),
+		Inventory:  inv(),
+		FailedNftbanUnits: []FailedUnitFinding{
+			{Unit: "nftban-unified-exporter.service", Active: "failed", Sub: "failed", Detail: "exit-code 2"},
+		},
+	})
+	if !res.OK {
+		t.Fatalf("expected OK (auxiliary failure is non-fatal); got %#v", res)
+	}
+	if !res.FailedUnitsOK() {
+		t.Errorf("FailedUnitsOK should be true when only auxiliary units failed")
+	}
+	if len(res.FailedUnits) != 0 {
+		t.Errorf("auxiliary failure must NOT be in FailedUnits; got %#v", res.FailedUnits)
+	}
+	if len(res.FailedAuxiliaryUnits) != 1 {
+		t.Fatalf("expected 1 FailedAuxiliaryUnit; got %d", len(res.FailedAuxiliaryUnits))
+	}
+	if !strings.Contains(res.FailedAuxiliaryUnits[0].Detail, "exit-code 2") {
+		t.Errorf("auxiliary detail should preserve reason; got %q", res.FailedAuxiliaryUnits[0].Detail)
+	}
+}
+
+// A protection-critical failure alongside an auxiliary failure still fails the
+// invariant; the auxiliary one is bucketed separately.
+func TestSystemdPayload_MixedAuxiliaryAndProtectionFails(t *testing.T) {
+	res := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		PathExists: pathSet(),
+		Inventory:  inv(),
+		FailedNftbanUnits: []FailedUnitFinding{
+			{Unit: "nftban-unified-exporter.service", Active: "failed", Sub: "failed", Detail: "exit-code 2"},
+			{Unit: "nftband.service", Active: "failed", Sub: "failed", Detail: "exit-code 1"},
+		},
+	})
+	if res.OK {
+		t.Fatalf("expected NOT OK (protection unit failed)")
+	}
+	if len(res.FailedUnits) != 1 || res.FailedUnits[0].Unit != "nftband.service" {
+		t.Errorf("expected only nftband.service in FailedUnits; got %#v", res.FailedUnits)
+	}
+	if len(res.FailedAuxiliaryUnits) != 1 || res.FailedAuxiliaryUnits[0].Unit != "nftban-unified-exporter.service" {
+		t.Errorf("expected exporter in FailedAuxiliaryUnits; got %#v", res.FailedAuxiliaryUnits)
+	}
+}
+
+func TestAssertFailedUnits_AuxiliaryNonFatalDetail(t *testing.T) {
+	spr := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		PathExists: pathSet(),
+		Inventory:  inv(),
+		FailedNftbanUnits: []FailedUnitFinding{
+			{Unit: "nftban-unified-exporter.service", Active: "failed", Sub: "failed", Detail: "exit-code 2"},
+		},
+	})
+	r := assertFailedUnitsPostInstall(spr, newTestLogger())
+	if !r.Passed {
+		t.Fatalf("assertion must PASS when only auxiliary units failed")
+	}
+	if !strings.Contains(r.Detail, "auxiliary") || !strings.Contains(r.Detail, "nftban-unified-exporter.service") {
+		t.Errorf("Detail should surface the auxiliary degradation; got %q", r.Detail)
+	}
+}
+
+func ff(unit string) FailedUnitFinding {
+	return FailedUnitFinding{Unit: unit, Active: "failed", Sub: "failed"}
+}
+
+func TestSettleAuxiliaryFailures(t *testing.T) {
+	exporter := "nftban-unified-exporter.service"
+	daemon := "nftband.service"
+
+	t.Run("auxiliary-only clears on re-poll", func(t *testing.T) {
+		calls := 0
+		requery := func() ([]FailedUnitFinding, string) {
+			calls++
+			return nil, "" // recovered
+		}
+		got := settleAuxiliaryFailures([]FailedUnitFinding{ff(exporter)}, requery, 3, func() {}, newTestLogger())
+		if len(got) != 0 {
+			t.Errorf("expected cleared after re-poll; got %#v", got)
+		}
+		if calls != 1 {
+			t.Errorf("expected exactly 1 requery; got %d", calls)
+		}
+	})
+
+	t.Run("auxiliary-only persists across the whole window", func(t *testing.T) {
+		calls := 0
+		requery := func() ([]FailedUnitFinding, string) {
+			calls++
+			return []FailedUnitFinding{ff(exporter)}, "" // never recovers
+		}
+		got := settleAuxiliaryFailures([]FailedUnitFinding{ff(exporter)}, requery, 3, func() {}, newTestLogger())
+		if len(got) != 1 || got[0].Unit != exporter {
+			t.Errorf("persistent auxiliary failure should still be reported; got %#v", got)
+		}
+		if calls != 2 { // maxAttempts=3 → initial + 2 requeries
+			t.Errorf("expected 2 requeries for maxAttempts=3; got %d", calls)
+		}
+	})
+
+	t.Run("protection-critical fails fast without waiting", func(t *testing.T) {
+		calls, slept := 0, 0
+		requery := func() ([]FailedUnitFinding, string) { calls++; return nil, "" }
+		got := settleAuxiliaryFailures([]FailedUnitFinding{ff(daemon)}, requery, 3, func() { slept++ }, newTestLogger())
+		if len(got) != 1 || got[0].Unit != daemon {
+			t.Errorf("protection failure must be returned immediately; got %#v", got)
+		}
+		if calls != 0 || slept != 0 {
+			t.Errorf("must not requery/sleep when a protection unit failed; calls=%d slept=%d", calls, slept)
+		}
+	})
+
+	t.Run("requery error keeps the current set", func(t *testing.T) {
+		requery := func() ([]FailedUnitFinding, string) { return nil, "dbus unavailable" }
+		got := settleAuxiliaryFailures([]FailedUnitFinding{ff(exporter)}, requery, 3, func() {}, newTestLogger())
+		if len(got) != 1 || got[0].Unit != exporter {
+			t.Errorf("requery error should preserve prior findings; got %#v", got)
+		}
+	})
+
+	t.Run("empty initial returns empty without requery", func(t *testing.T) {
+		calls := 0
+		requery := func() ([]FailedUnitFinding, string) { calls++; return nil, "" }
+		got := settleAuxiliaryFailures(nil, requery, 3, func() {}, newTestLogger())
+		if len(got) != 0 || calls != 0 {
+			t.Errorf("empty initial should short-circuit; got=%#v calls=%d", got, calls)
+		}
+	})
+}

--- a/internal/installer/validate/systemd_payload_test.go
+++ b/internal/installer/validate/systemd_payload_test.go
@@ -216,11 +216,15 @@ ExecStart=/usr/lib/nftban/sbin/rogue-helper
 // (e) Failed unit injected → FAILED-UNIT-POSTINSTALL-001 fails
 // ----------------------------------------------------------------------------
 func TestSystemdPayload_FailedUnit(t *testing.T) {
+	// A failed PROTECTION-critical unit (the Go daemon) is a hard failure.
+	// (v1.135: must use a protection unit here — a failed auxiliary unit like
+	// the exporter no longer fails this invariant; see TestSystemdPayload_
+	// FailedAuxiliaryUnitDoesNotFail.)
 	res := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
 		PathExists: pathSet(),
 		Inventory:  inv(),
 		FailedNftbanUnits: []FailedUnitFinding{
-			{Unit: "nftban-unified-exporter.service", Active: "failed", Sub: "failed", Detail: "exit-code 203/EXEC"},
+			{Unit: "nftband.service", Active: "failed", Sub: "failed", Detail: "exit-code 203/EXEC"},
 		},
 	})
 
@@ -397,7 +401,7 @@ func TestSystemdPayload_NftbanUnitNaming(t *testing.T) {
 		"nftban-maintenance.target":       true,
 
 		// hyphenated nftband-*
-		"nftband-rpc.socket":   true,
+		"nftband-rpc.socket":    true,
 		"nftband-watch.service": true,
 
 		// negatives — name not a complete identifier prefix
@@ -407,11 +411,11 @@ func TestSystemdPayload_NftbanUnitNaming(t *testing.T) {
 		"fake-nftban.service": false,
 
 		// negatives — non-systemd unit suffix
-		"nftban.conf":     false,
-		"nftban.txt":      false,
-		"nftban":          false,
-		"nftban.":         false,
-		"nftban-foo":      false, // missing extension entirely
+		"nftban.conf": false,
+		"nftban.txt":  false,
+		"nftban":      false,
+		"nftban.":     false,
+		"nftban-foo":  false, // missing extension entirely
 	}
 	for name, want := range cases {
 		if got := IsNftbanUnit(name); got != want {


### PR DESCRIPTION
## v1.135.0 Phase 2 — update-lifecycle correctness (3 low-severity lanes)

Scope: `AUDIT_190_LIFECYCLE/V135_INSTALL_UPDATE_LIFECYCLE_SCOPE.md` §4 lanes 2–4. Phase 1 (timers + install_state finalization) merged in #703. Schema frozen at 1.83.0.

### Lane 2.1 — `D-UPDATE-LOCK-LEFT-BEHIND` (shell)
`_cmd_update_main` opened the flock fd but never removed `/run/nftban/update.lock`, leaving an empty file behind on exit (2-day stale lock on dns2). Split into a lock **wrapper** + `_cmd_update_main_locked` body; `_release_update_lock` removes the file *while still holding the flock* (can't clobber a live updater) then closes fd 9. Contention path closes the fd but does **not** remove the holder's file. `UPDATE_LOCK_FILE` now derives from `NFTBAN_RUN_DIR` (testable).
- Test: `cmd_update_lock_cleanup_v135_test.sh` (9/9)

### Lane 2.2 — `D-UPDATE-MIXED-DRIFT` (shell)
A genuinely RPM/DEB-owned host with stale source-era history classified as `mixed` (→ `return 13` abort) when the v1.126 unblock couldn't fire; `github`/`force` didn't bypass → manual `dnf`/`apt` (dns2). Added `_probe_rpm_owns_all_binaries` / `_probe_dpkg_owns_all_binaries` — a **clean & complete** on-disk ownership signal (`rpm -qf`/`dpkg -S` owns *every* core binary) as a third unblock. A genuine source-over-package mix (a binary unowned) stays `mixed`: **no unsafe bypass**.
- Test: `cmd_update_detection_v135_clean_ownership_test.sh` (10/10); v126 regression 20/20 intact

### Lane 2.3 — `D-EXPORTER-SETTLE-WINDOW` (Go)
`failed_units_postinstall_ok` failed on *any* failed nftban unit, so a transient `nftban-unified-exporter` exit-2 drove DEGRADED even though it self-heals. `IsAuxiliaryUnit` routes metrics/observability failures into a non-fatal `FailedAuxiliaryUnits` bucket (only protection-critical failures DEGRADE), surfaced as a warning Detail. Gatherer adds a **bounded settle re-poll** (`settleAuxiliaryFailures`) that lets auxiliary-only failures self-heal; protection failures short-circuit immediately. `nftband`/`nftban-core`/tables/validator stay **hard** failures.
- Tests: `systemd_payload_settle_test.go`; `TestSystemdPayload_FailedUnit` retargeted to a protection unit

## Verification
- lab2 (Go 1.25.0): `go build ./...` + `go vet` + full `go test ./...` **ALL PASS**; gofmt-clean.
- Shell suites green on Fedora dev host **and** lab2 Ubuntu; adjacent update suites (ssh-port-durability 8/8, version-normalization 21/21) unaffected.

Closing gate (separate): package-install DEB+RPM validation on lab2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)