### PR TITLE
feat(security): v1.138 PR-A — ruleset fingerprint baseline + verify-rules (SEC-RULEFP)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1815,6 +1815,15 @@ firewall_rebuild() {
 
     # Exit 0 = success, no retry needed
     if [[ $_rebuild_exit -eq 0 ]]; then
+        # SEC-RULEFP (v1.138): capture the ruleset fingerprint baseline ONLY after a
+        # successful rebuild (we are inside the exit-0 branch — never on failure).
+        # Best-effort: a capture failure must not fail the rebuild. Same rulefp
+        # baseline format as the daemon apply hook (nftban-core owns the write).
+        local _rulefp_core="${NFTBAN_CORE_BIN:-${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core}"
+        if [[ -x "$_rulefp_core" ]]; then
+            "$_rulefp_core" verify-rules --capture >/dev/null 2>&1 || \
+                echo "  ⚠️  ruleset fingerprint baseline capture failed (non-fatal)" >&2
+        fi
         return 0
     fi
 

--- a/cli/lib/nftban/core/nftban_health.sh
+++ b/cli/lib/nftban/core/nftban_health.sh
@@ -500,6 +500,7 @@ nftban_health_check_all() {
     nftban_health_check_nftables_security || { ((warnings++)) || true; }
     nftban_health_check_set_sizes || { ((warnings++)) || true; }
     nftban_health_check_conflicting_firewalls || { ((warnings++)) || true; }
+    nftban_health_check_ruleset_fingerprint || { ((warnings++)) || true; }
     nftban_health_check_ssh_port || { ((warnings++)) || true; }
     nftban_health_check_systemd_hardening || { ((warnings++)) || true; }
     nftban_health_check_memory_protection || { ((warnings++)) || true; }
@@ -608,6 +609,7 @@ export -f nftban_health_check_all
 # Export check functions (from nftban_health_checks.sh)
 export -f nftban_health_check_nftables_security
 export -f nftban_health_check_conflicting_firewalls
+export -f nftban_health_check_ruleset_fingerprint
 export -f nftban_health_check_binaries
 export -f nftban_health_check_binary_integrity
 export -f nftban_health_check_paths

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -1294,7 +1294,46 @@ nftban_health_check_kernel_parity() {
     return $status
 }
 
+# SEC-RULEFP (v1.138): verify the live nftban ruleset against the captured
+# fingerprint baseline via 'nftban-core verify-rules'.
+#   exit 2 (MISMATCH)        -> security/integrity WARNING (possible rule
+#                               injection or chain-policy flip)
+#   BASELINE_MISSING (exit0) -> deliberate advisory WARNING (run a rebuild to capture)
+#   exit 3 (NFT_UNAVAILABLE) -> skip (not a finding)
+# Read-only: never mutates rules or the baseline.
+nftban_health_check_ruleset_fingerprint() {
+    local status=$HEALTH_OK
+    local core_bin="${NFTBAN_CORE_BIN:-${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core}"
+    if [[ ! -x "$core_bin" ]]; then
+        NFTBAN_HEALTH_RESULTS["ruleset_fingerprint"]=$HEALTH_OK
+        return "$HEALTH_OK"
+    fi
+
+    local out rc
+    out=$("$core_bin" verify-rules 2>&1)
+    rc=$?
+    case "$rc" in
+        0)
+            if [[ "$out" == *BASELINE_MISSING* ]]; then
+                NFTBAN_HEALTH_WARNINGS+=("Ruleset fingerprint baseline not captured yet — run 'nftban firewall rebuild' to establish the integrity baseline")
+                status=$HEALTH_WARNING
+            fi
+            ;;
+        2)
+            NFTBAN_HEALTH_WARNINGS+=("SECURITY: nftban ruleset fingerprint MISMATCH — the live ruleset differs from the trusted baseline (possible rule injection or chain-policy flip). Inspect with 'nftban-core verify-rules'; re-baseline a trusted ruleset with 'nftban firewall rebuild'")
+            status=$HEALTH_WARNING
+            ;;
+        *)
+            # 3 = NFT_UNAVAILABLE (skip), or other inconclusive — not a finding.
+            :
+            ;;
+    esac
+    NFTBAN_HEALTH_RESULTS["ruleset_fingerprint"]=$status
+    return "$status"
+}
+
 # Export functions
+export -f nftban_health_check_ruleset_fingerprint
 export -f nftban_health_check_nftables_security nftban_health_check_conflicting_firewalls
 export -f nftban_health_check_protection nftban_health_check_memory_protection
 export -f nftban_health_check_polkit nftban_health_check_systemd_hardening

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -1305,6 +1305,7 @@ nftban_health_check_ruleset_fingerprint() {
     local status=$HEALTH_OK
     local core_bin="${NFTBAN_CORE_BIN:-${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core}"
     if [[ ! -x "$core_bin" ]]; then
+        # shellcheck disable=SC2034  # Used by render functions externally
         NFTBAN_HEALTH_RESULTS["ruleset_fingerprint"]=$HEALTH_OK
         return "$HEALTH_OK"
     fi
@@ -1328,6 +1329,7 @@ nftban_health_check_ruleset_fingerprint() {
             :
             ;;
     esac
+    # shellcheck disable=SC2034  # Used by render functions externally
     NFTBAN_HEALTH_RESULTS["ruleset_fingerprint"]=$status
     return "$status"
 }

--- a/cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh
+++ b/cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - SEC-RULEFP integration wiring + invariant guard (v1.138 PR-A)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ruleset_fingerprint_v138_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-27"
+# meta:description="v1.138 PR-A SEC-RULEFP integration guard (static, runnable without Go/nft/root). Asserts the rulefp package exists; the daemon capture hook is guarded by !check (no capture on dry-run/failed apply); the verify-rules CLI is wired with MISMATCH=2 / NFT_UNAVAILABLE=3 exit codes; the shell rebuild captures only inside the exit-0 success branch; the health check is defined+registered+exported; reconciliation records a finding; and the no-auto-heal INVARIANT holds — the verify/reconcile paths never call CaptureBaseline/CaptureLive (capture is reachable ONLY behind the apply !check hook, the --capture flag, and the rebuild success branch). The runtime OK/MISMATCH/BASELINE_MISSING/inject-flip behavior is covered by the lab integration verify + internal/rulefp unit tests."
+# meta:input="None (reads repo source)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="internal/rulefp/fingerprint.go,internal/rulefp/baseline.go,cmd/nftban-core/cmd_verify_rules.go,cmd/nftband/daemon_handlers_elements.go,cmd/nftband/daemon_reconciliation.go,cli/lib/nftban/cli/cmd_firewall.sh,cli/lib/nftban/core/nftban_health_checks_security.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ grep -q "$1" "$REPO/$2" 2>/dev/null; }
+
+echo "=========================================================="
+echo "V1.138 PR-A SEC-RULEFP integration wiring + invariant guard"
+echo "=========================================================="
+
+echo "--- core package ---"
+[[ -f "$REPO/internal/rulefp/fingerprint.go" ]] && ok core_fingerprint_present || no core_fingerprint_present "missing"
+[[ -f "$REPO/internal/rulefp/baseline.go" ]] && ok core_baseline_present || no core_baseline_present "missing"
+has 'func Normalize(' internal/rulefp/fingerprint.go && ok core_normalize || no core_normalize "Normalize missing"
+has 'func Verify(' internal/rulefp/baseline.go && ok core_verify || no core_verify "Verify missing"
+
+echo "--- (A) daemon capture hook guarded by !check ---"
+F=cmd/nftband/daemon_handlers_elements.go
+has 'rulefp.CaptureLive' "$F" && ok daemon_capture_present || no daemon_capture_present "no CaptureLive in apply handler"
+# the CaptureLive must sit under an `if !check {` guard (no capture on dry-run / failed apply)
+if grep -Pzoq 'if !check \{[^}]*rulefp\.CaptureLive' "$REPO/$F" 2>/dev/null; then ok daemon_capture_guarded_by_notcheck; else
+  # fallback (grep -P -z may be unavailable): both tokens present + !check above CaptureLive
+  awk '/if !check \{/{g=NR} /rulefp.CaptureLive/{if(g&&NR-g<6){f=1}} END{exit !f}' "$REPO/$F" && ok daemon_capture_guarded_by_notcheck || no daemon_capture_guarded_by_notcheck "CaptureLive not guarded by !check"
+fi
+
+echo "--- (B) verify-rules CLI + exit codes ---"
+has 'case "verify-rules":' cmd/nftban-core/main.go && ok cli_case_wired || no cli_case_wired "no verify-rules case in main.go"
+has 'cmdVerifyRules' cmd/nftban-core/main.go && ok cli_dispatch || no cli_dispatch "cmdVerifyRules not dispatched"
+has 'verifyExitMismatch       = 2' cmd/nftban-core/cmd_verify_rules.go && ok cli_exit_mismatch_2 || no cli_exit_mismatch_2 "MISMATCH exit != 2"
+has 'verifyExitNFTUnavailable = 3' cmd/nftban-core/cmd_verify_rules.go && ok cli_exit_nftunavail_3 || no cli_exit_nftunavail_3 "NFT_UNAVAILABLE exit != 3"
+
+echo "--- (C) shell rebuild capture inside success branch only ---"
+# the --capture call must appear in cmd_firewall.sh; and the rebuild success branch (exit 0) wraps it
+has 'verify-rules --capture' cli/lib/nftban/cli/cmd_firewall.sh && ok shell_rebuild_capture || no shell_rebuild_capture "no --capture in rebuild"
+awk '/_rebuild_exit -eq 0 \]\]; then/{g=NR} /verify-rules --capture/{if(g&&NR-g<12){f=1}} END{exit !f}' "$REPO/cli/lib/nftban/cli/cmd_firewall.sh" && ok shell_capture_in_success_branch || no shell_capture_in_success_branch "capture not inside exit-0 branch"
+
+echo "--- (D) health check defined + registered + exported ---"
+has 'nftban_health_check_ruleset_fingerprint()' cli/lib/nftban/core/nftban_health_checks_security.sh && ok health_fn_defined || no health_fn_defined "health fn missing"
+has 'nftban_health_check_ruleset_fingerprint || ' cli/lib/nftban/core/nftban_health.sh && ok health_registered || no health_registered "not registered in nftban_health.sh"
+has 'export -f nftban_health_check_ruleset_fingerprint' cli/lib/nftban/core/nftban_health.sh && ok health_exported || no health_exported "not exported"
+
+echo "--- (E) reconciliation records finding (no mutation) ---"
+has 'checkRulesetFingerprint' cmd/nftband/daemon_reconciliation.go && ok reconcile_wired || no reconcile_wired "checkRulesetFingerprint missing"
+
+echo "--- INVARIANT: verify/reconcile paths never capture (no auto-heal) ---"
+# cmd_verify_rules.go: CaptureLive only reachable under the `if capture` branch.
+if awk '/if capture \{/{c=NR} /rulefp.CaptureLive/{if(!c||NR<c){bad=1}} END{exit bad}' "$REPO/cmd/nftban-core/cmd_verify_rules.go"; then ok cli_capture_only_behind_flag; else no cli_capture_only_behind_flag "CaptureLive reachable outside --capture"; fi
+# reconcile method must NOT call any Capture (record-only).
+if grep -A30 'func (d \*Daemon) checkRulesetFingerprint' "$REPO/cmd/nftband/daemon_reconciliation.go" | grep -qE 'Capture(Live|Baseline)'; then no reconcile_no_capture "reconcile calls Capture (auto-heal!)"; else ok reconcile_no_capture; fi
+# rulefp.Verify must not write files (no os.WriteFile/Rename in Verify body).
+if awk '/^func Verify\(/{v=1} v&&/os\.(WriteFile|Rename|Create)/{bad=1} v&&/^}/{v=0} END{exit bad}' "$REPO/internal/rulefp/baseline.go"; then ok verify_is_readonly; else no verify_is_readonly "Verify writes to disk"; fi
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/cmd/nftban-core/cmd_verify_rules.go
+++ b/cmd/nftban-core/cmd_verify_rules.go
@@ -1,0 +1,83 @@
+// =============================================================================
+// NFTBan - verify-rules CLI (SEC-RULEFP, v1.138 PR-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cmd_verify_rules"
+// meta:type="go"
+// meta:package="main"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-27"
+// meta:description="nftban-core verify-rules subcommand: recompute the canonical nftban ruleset fingerprint and compare to the captured baseline. Reports OK/MISMATCH/BASELINE_MISSING/NFT_UNAVAILABLE with exit codes (OK/BASELINE_MISSING=0, MISMATCH=2, NFT_UNAVAILABLE=3). With --capture, (re)captures the baseline from the live ruleset — intended ONLY for the trusted apply/rebuild completion path, never auto-run on a mismatch."
+// meta:input="--capture (optional)"
+// meta:output="status line + exit code"
+// meta:depends="context,fmt,os,time,internal/rulefp"
+// meta:inventory.files="/var/lib/nftban/state/ruleset_fingerprint.json"
+// meta:inventory.binaries="nft"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="CAP_NET_ADMIN (nft read); write baseline (state dir)"
+// =============================================================================
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/rulefp"
+)
+
+// Exit codes for verify-rules (OK and BASELINE_MISSING are non-error/advisory).
+const (
+	verifyExitOK             = 0
+	verifyExitMismatch       = 2
+	verifyExitNFTUnavailable = 3
+)
+
+// cmdVerifyRules implements `nftban-core verify-rules [--capture]`.
+func cmdVerifyRules(args []string) int {
+	capture := false
+	for _, a := range args {
+		if a == "--capture" || a == "--refresh-baseline" {
+			capture = true
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if capture {
+		// Trusted-path baseline (re)capture from the live ruleset.
+		if err := rulefp.CaptureLive(ctx, rulefp.BaselineFile); err != nil {
+			fmt.Fprintf(os.Stderr, "verify-rules: baseline capture failed: %v\n", err)
+			return verifyExitNFTUnavailable
+		}
+		fmt.Printf("verify-rules: baseline captured (%s)\n", rulefp.BaselineFile)
+		return verifyExitOK
+	}
+
+	status, expected, actual, err := rulefp.VerifyLive(ctx, rulefp.BaselineFile)
+	switch status {
+	case rulefp.StatusOK:
+		fmt.Println("verify-rules: OK — live ruleset matches the captured baseline")
+		return verifyExitOK
+	case rulefp.StatusBaselineMissing:
+		// Advisory, not a tamper signal: no baseline captured yet.
+		fmt.Println("verify-rules: BASELINE_MISSING — no baseline captured yet (run 'nftban firewall rebuild' to capture)")
+		return verifyExitOK
+	case rulefp.StatusMismatch:
+		fmt.Printf("verify-rules: MISMATCH — live ruleset DIFFERS from the baseline (possible rule injection / chain-policy flip)\n")
+		fmt.Printf("  expected (baseline): %s\n  actual   (live):     %s\n", expected, actual)
+		return verifyExitMismatch
+	case rulefp.StatusNFTUnavailable:
+		fmt.Fprintf(os.Stderr, "verify-rules: NFT_UNAVAILABLE — could not read the live ruleset: %v\n", err)
+		return verifyExitNFTUnavailable
+	default:
+		fmt.Fprintf(os.Stderr, "verify-rules: unexpected status %q\n", status)
+		return verifyExitNFTUnavailable
+	}
+}

--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -160,6 +160,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+	case "verify-rules":
+		// SEC-RULEFP (v1.138): recompute the canonical ruleset fingerprint and
+		// compare to the captured baseline (--capture re-captures from the live
+		// ruleset). Custom exit codes: OK/BASELINE_MISSING=0, MISMATCH=2, NFT_UNAVAILABLE=3.
+		os.Exit(cmdVerifyRules(os.Args[2:]))
 	case "feeds":
 		if len(os.Args) < 3 {
 			errorWithUsage("feeds", "feeds command requires an action")

--- a/cmd/nftband/daemon_handlers_elements.go
+++ b/cmd/nftband/daemon_handlers_elements.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/itcmsgr/nftban/internal/nftbackend"
 	"github.com/itcmsgr/nftban/internal/persistence"
+	"github.com/itcmsgr/nftban/internal/rulefp"
 	"github.com/itcmsgr/nftban/internal/safety"
 )
 
@@ -177,6 +178,17 @@ func (d *Daemon) handleApplyRulesetRequest(params map[string]any) SocketResponse
 	})
 	if err != nil {
 		return SocketResponse{Success: false, Error: err.Error()}
+	}
+
+	// SEC-RULEFP (v1.138): on a trusted successful apply (NOT a dry-run --check),
+	// (re)capture the ruleset fingerprint baseline. Capture failure is logged but
+	// MUST NOT fail the apply nor corrupt active firewall state — the ruleset is
+	// already applied; verify-rules would just report BASELINE_MISSING until the
+	// next successful capture. Never captured on a verify path (no self-heal).
+	if !check {
+		if cerr := rulefp.CaptureLive(d.ctx, rulefp.BaselineFile); cerr != nil {
+			log.Printf("[RULEFP] baseline capture after apply failed (non-fatal): %v", cerr)
+		}
 	}
 
 	action := "applied"

--- a/cmd/nftband/daemon_reconciliation.go
+++ b/cmd/nftband/daemon_reconciliation.go
@@ -27,6 +27,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/metrics"
 	"github.com/itcmsgr/nftban/internal/nftlock"
 	"github.com/itcmsgr/nftban/internal/opqueue"
+	"github.com/itcmsgr/nftban/internal/rulefp"
 )
 
 // startPeriodicReconciliation runs reconciliation on a schedule (v1.34.0)
@@ -77,6 +78,11 @@ func (d *Daemon) runReconciliation(wrapper *opqueue.NFTBackendWrapper) {
 
 	// Check whitelist-blacklist overlap (hash sets only — interval sets too expensive)
 	d.checkWhitelistOverlap(wrapper)
+
+	// SEC-RULEFP (v1.138): verify the live ruleset against the fingerprint baseline.
+	// Record-only — never mutate rules, never refresh the baseline here, never
+	// downgrade protection. A mismatch is logged for the operator / health to act on.
+	d.checkRulesetFingerprint()
 
 	duration := time.Since(start)
 
@@ -171,6 +177,24 @@ func (d *Daemon) checkWhitelistOverlap(wrapper *opqueue.NFTBackendWrapper) {
 	metrics.SetWhitelistOverlapCount(overlapCount)
 	if overlapCount > 0 {
 		log.Printf("[RECONCILE] Whitelist-blacklist overlap: %d IPs in both sets", overlapCount)
+	}
+}
+
+// checkRulesetFingerprint (SEC-RULEFP, v1.138) verifies the live nftban ruleset
+// against the captured fingerprint baseline during periodic reconciliation.
+// It is RECORD-ONLY: it logs a mismatch for the operator / health to act on, and
+// MUST NOT mutate rules, refresh the baseline, or downgrade protection — otherwise
+// an injected rule could silently become the new "truth".
+func (d *Daemon) checkRulesetFingerprint() {
+	status, expected, actual, err := rulefp.VerifyLive(d.ctx, rulefp.BaselineFile)
+	switch status {
+	case rulefp.StatusMismatch:
+		log.Printf("[RULEFP] MISMATCH — live ruleset differs from baseline (possible rule injection / chain-policy flip); expected=%s actual=%s (run 'nftban-core verify-rules' to inspect; 'nftban firewall rebuild' to re-baseline a trusted ruleset)", expected, actual)
+	case rulefp.StatusNFTUnavailable:
+		log.Printf("[RULEFP] verify skipped during reconcile: %v", err)
+	case rulefp.StatusBaselineMissing, rulefp.StatusOK:
+		// OK: nothing to report. BASELINE_MISSING: no baseline captured yet
+		// (a successful apply/rebuild will capture it) — not logged each cycle.
 	}
 }
 

--- a/internal/rulefp/baseline.go
+++ b/internal/rulefp/baseline.go
@@ -1,0 +1,162 @@
+// =============================================================================
+// NFTBan - Ruleset fingerprint baseline + verify (SEC-RULEFP, v1.138 PR-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="rulefp_baseline"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-27"
+// meta:description="Capture/verify the canonical nftban ruleset fingerprint baseline. CaptureBaseline writes the expected digest (atomic temp+rename, 0640) after a successful apply/rebuild; Verify recomputes the live digest and reports OK / MISMATCH / BASELINE_MISSING / NFT_UNAVAILABLE without mutating any rules. LiveRuleset fetches the nftban ip/ip6 table text via nft."
+// meta:input="baseline file path; live nftban ruleset text"
+// meta:output="VerifyStatus + expected/actual digests"
+// meta:depends="context,encoding/json,os,os/exec,path/filepath,time"
+// meta:inventory.files="/var/lib/nftban/state/ruleset_fingerprint.json"
+// meta:inventory.binaries="nft"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="CAP_NET_ADMIN (nft read)"
+// =============================================================================
+
+package rulefp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// VerifyStatus is the outcome of a verify-rules check.
+type VerifyStatus string
+
+const (
+	// StatusOK — live digest matches the baseline.
+	StatusOK VerifyStatus = "OK"
+	// StatusMismatch — live digest differs (possible rule injection / chain-policy flip).
+	StatusMismatch VerifyStatus = "MISMATCH"
+	// StatusBaselineMissing — no baseline captured yet.
+	StatusBaselineMissing VerifyStatus = "BASELINE_MISSING"
+	// StatusNFTUnavailable — nft / kernel ruleset not readable.
+	StatusNFTUnavailable VerifyStatus = "NFT_UNAVAILABLE"
+)
+
+// baselineSchema is the on-disk baseline format (extensible).
+// Fields: Schema="rulefp-1", Digest=hex sha256 of normalized ruleset, CapturedAt=RFC3339.
+type baselineSchema struct {
+	Schema     string `json:"schema"`
+	Digest     string `json:"digest"`
+	CapturedAt string `json:"captured_at"`
+}
+
+const baselineSchemaTag = "rulefp-1"
+
+// BaselineFile is the canonical baseline location under the FHS state dir
+// (/var/lib/nftban/state, 0750 nftban:nftban — see internal/installer/fhs/paths.go
+// StateDir). Both the daemon apply hook and the verify-rules CLI use this one path
+// so there is a single baseline format/location.
+const BaselineFile = "/var/lib/nftban/state/ruleset_fingerprint.json"
+
+// CaptureLive fetches the live nftban ruleset and writes its fingerprint baseline
+// to path. Call this ONLY after a trusted, successful apply/rebuild — never from
+// a verify path (otherwise an injected rule could become the new "truth").
+func CaptureLive(ctx context.Context, path string) error {
+	text, err := LiveRuleset(ctx)
+	if err != nil {
+		return err
+	}
+	return CaptureBaseline(path, text)
+}
+
+// CaptureBaseline writes the fingerprint of rulesetText to path atomically
+// (temp + rename), mode 0640. Called after a successful apply/rebuild.
+func CaptureBaseline(path, rulesetText string) error {
+	b := baselineSchema{
+		Schema:     baselineSchemaTag,
+		Digest:     Digest(rulesetText),
+		CapturedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o640); err != nil { // #nosec G306 -- 0640 group-readable by design
+		return fmt.Errorf("write baseline tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename baseline: %w", err)
+	}
+	return nil
+}
+
+// Verify recomputes the live fingerprint and compares it to the baseline at
+// path. It NEVER mutates rules. Returns the status plus the expected (baseline)
+// and actual (live) digests for diagnostics.
+func Verify(path, currentRulesetText string) (status VerifyStatus, expected, actual string) {
+	actual = Digest(currentRulesetText)
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return StatusBaselineMissing, "", actual
+		}
+		// Unreadable baseline is treated as missing (caller logs the error).
+		return StatusBaselineMissing, "", actual
+	}
+
+	var b baselineSchema
+	if err := json.Unmarshal(data, &b); err != nil || b.Digest == "" {
+		return StatusBaselineMissing, "", actual
+	}
+	expected = b.Digest
+	if expected == actual {
+		return StatusOK, expected, actual
+	}
+	return StatusMismatch, expected, actual
+}
+
+// LiveRuleset returns the concatenated nftban table text for the ip and ip6
+// families (whichever exist). It is the canonical input for Digest/Verify.
+// Returns ("", error) only when neither family table can be read (→ caller maps
+// to NFT_UNAVAILABLE). A missing ip6 table alone is not fatal.
+func LiveRuleset(ctx context.Context) (string, error) {
+	var combined string
+	var firstErr error
+	got := false
+	for _, fam := range []string{"ip", "ip6"} {
+		// #nosec G204 -- fam is a constant from the literal slice; table name fixed.
+		out, err := exec.CommandContext(ctx, "nft", "list", "table", fam, "nftban").Output()
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		combined += "# family " + fam + "\n" + string(out) + "\n"
+		got = true
+	}
+	if !got {
+		return "", fmt.Errorf("nft list table failed for all families: %w", firstErr)
+	}
+	return combined, nil
+}
+
+// VerifyLive fetches the live ruleset and verifies it against the baseline at
+// path, mapping an nft failure to NFT_UNAVAILABLE.
+func VerifyLive(ctx context.Context, path string) (status VerifyStatus, expected, actual string, err error) {
+	text, lerr := LiveRuleset(ctx)
+	if lerr != nil {
+		return StatusNFTUnavailable, "", "", lerr
+	}
+	status, expected, actual = Verify(path, text)
+	return status, expected, actual, nil
+}

--- a/internal/rulefp/baseline.go
+++ b/internal/rulefp/baseline.go
@@ -87,8 +87,10 @@ func CaptureBaseline(path, rulesetText string) error {
 	}
 	data = append(data, '\n')
 
+	// The baseline file is daemon-owned (nftband writes, nftban-core verify-rules
+	// + health read — all root). 0600 is sufficient; no group-read consumer.
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o640); err != nil { // #nosec G306 -- 0640 group-readable by design
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write baseline tmp: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
@@ -129,21 +131,28 @@ func Verify(path, currentRulesetText string) (status VerifyStatus, expected, act
 // Returns ("", error) only when neither family table can be read (→ caller maps
 // to NFT_UNAVAILABLE). A missing ip6 table alone is not fatal.
 func LiveRuleset(ctx context.Context) (string, error) {
+	// Unrolled per family so every exec.CommandContext argument is a string
+	// literal (no variable subprocess arg — gosec G204-clean under `gosec -nosec`).
+	// Semantics preserved: both families attempted, ip6 absence is soft, and
+	// NFT_UNAVAILABLE is mapped only when BOTH families are unreadable.
 	var combined string
 	var firstErr error
 	got := false
-	for _, fam := range []string{"ip", "ip6"} {
-		// #nosec G204 -- fam is a constant from the literal slice; table name fixed.
-		out, err := exec.CommandContext(ctx, "nft", "list", "table", fam, "nftban").Output()
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		combined += "# family " + fam + "\n" + string(out) + "\n"
+
+	if out, err := exec.CommandContext(ctx, "nft", "list", "table", "ip", "nftban").Output(); err == nil {
+		combined += "# family ip\n" + string(out) + "\n"
 		got = true
+	} else {
+		firstErr = err
 	}
+
+	if out, err := exec.CommandContext(ctx, "nft", "list", "table", "ip6", "nftban").Output(); err == nil {
+		combined += "# family ip6\n" + string(out) + "\n"
+		got = true
+	} else if firstErr == nil {
+		firstErr = err
+	}
+
 	if !got {
 		return "", fmt.Errorf("nft list table failed for all families: %w", firstErr)
 	}

--- a/internal/rulefp/fingerprint.go
+++ b/internal/rulefp/fingerprint.go
@@ -1,0 +1,106 @@
+// =============================================================================
+// NFTBan - Ruleset fingerprint (SEC-RULEFP, v1.138 PR-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="rulefp"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-27"
+// meta:description="Canonical nftban ruleset fingerprint: normalize the nftban table ruleset text (strip volatile counters/handles/timestamps and dynamic-set elements; preserve structural rule text, chains, policies, hooks, priorities) and digest it, so an injected rule or chain-policy flip is detectable while normal counter/ban churn is not. Used by the apply-time baseline capture and the verify-rules mechanism."
+// meta:input="nft list table ip/ip6 nftban ruleset text"
+// meta:output="normalized text + sha256 digest"
+// meta:depends="crypto/sha256,encoding/hex,regexp,strings"
+// meta:inventory.files=""
+// meta:inventory.binaries="nft"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package rulefp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// Volatile fragments that must NOT contribute to the fingerprint — they change
+// during normal operation without any structural rule change.
+var (
+	// "counter packets 12 bytes 340" → counters tick on every match.
+	reCounter = regexp.MustCompile(`packets \d+ bytes \d+`)
+	// "last used 1234" / "expires 30s" style volatile time fields.
+	reLastUsed = regexp.MustCompile(`\blast used \d+`)
+	reExpires  = regexp.MustCompile(`\bexpires \d+[a-z]*`)
+	// "# handle 17" — only present with `nft -a`; we fetch without -a, but strip
+	// defensively so the digest is stable regardless of how the text was produced.
+	reHandle = regexp.MustCompile(`\s*#\s*handle \d+`)
+)
+
+// Normalize canonicalizes nftban-table ruleset text for fingerprinting.
+//
+// It STRIPS volatile content (packet/byte counters, rule handles, last-used /
+// expires timers, and the contents of dynamic set/map `elements = { … }` blocks
+// — ban/unban churn) while PRESERVING the structural skeleton: table/chain
+// declarations, chain type/hook/priority/policy, and every static rule body.
+//
+// Consequences (the SEC-RULEFP detection contract):
+//   - an injected rule (e.g. `ip saddr 1.2.3.4 accept`) is a chain rule line →
+//     preserved → digest changes → DETECTED.
+//   - a chain-policy flip (`policy drop;` → `policy accept;`) is in the chain
+//     header → preserved → digest changes → DETECTED.
+//   - counter ticks, banned-IP set churn, and timer drift → stripped → digest
+//     UNCHANGED (no false positive).
+func Normalize(rulesetText string) string {
+	lines := strings.Split(rulesetText, "\n")
+	out := make([]string, 0, len(lines))
+	inElements := false
+
+	for _, ln := range lines {
+		ln = reHandle.ReplaceAllString(ln, "")
+
+		// Inside a multi-line dynamic element block: skip until its closing brace.
+		if inElements {
+			if strings.Contains(ln, "}") {
+				inElements = false
+			}
+			continue
+		}
+
+		if idx := strings.Index(ln, "elements = {"); idx >= 0 {
+			prefix := strings.TrimRight(stripVolatile(ln[:idx]), " \t")
+			out = append(out, prefix+"elements = { ... }")
+			// Multi-line block unless the closing brace is on this same line.
+			if !strings.Contains(ln[idx:], "}") {
+				inElements = true
+			}
+			continue
+		}
+
+		t := strings.TrimRight(stripVolatile(ln), " \t")
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func stripVolatile(s string) string {
+	s = reCounter.ReplaceAllString(s, "packets 0 bytes 0")
+	s = reLastUsed.ReplaceAllString(s, "last used 0")
+	s = reExpires.ReplaceAllString(s, "expires 0")
+	return s
+}
+
+// Digest returns the hex sha256 of the normalized ruleset.
+func Digest(rulesetText string) string {
+	sum := sha256.Sum256([]byte(Normalize(rulesetText)))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/rulefp/fingerprint_test.go
+++ b/internal/rulefp/fingerprint_test.go
@@ -1,0 +1,229 @@
+// =============================================================================
+// NFTBan - Ruleset fingerprint tests (SEC-RULEFP, v1.138 PR-A)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="rulefp_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-05-27"
+// meta:description="Unit tests for the SEC-RULEFP fingerprint: deterministic digest; immune to counter/handle/timestamp/dynamic-set-element churn; detects an injected accept rule and a chain-policy flip; Verify returns OK/MISMATCH/BASELINE_MISSING. No nft/root required (pure text fixtures)."
+// meta:input="in-test ruleset fixtures"
+// meta:output="None"
+// meta:depends="testing,path/filepath"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package rulefp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const baseRuleset = `# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = { 1.2.3.4 timeout 3600s, 5.6.7.8 timeout 7200s }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ct state established,related accept
+		ip saddr @whitelist_manual accept
+		ip saddr @blacklist_manual counter packets 12 bytes 340 drop
+	}
+	chain output {
+		type filter hook output priority 0; policy accept;
+	}
+}
+`
+
+// same structure, counters ticked + different element set + a timer + a handle
+const churnedRuleset = `# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = { 9.9.9.9 timeout 100s, 8.8.8.8 timeout 5s, 7.7.7.7 timeout 42s }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ct state established,related accept
+		ip saddr @whitelist_manual accept
+		ip saddr @blacklist_manual counter packets 998877 bytes 1234567 drop # handle 19
+	}
+	chain output {
+		type filter hook output priority 0; policy accept;
+	}
+}
+`
+
+// multi-line elements block (nft wraps long sets) — element churn must still be ignored
+const multilineElems = `# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = {
+			1.1.1.1 timeout 10s,
+			2.2.2.2 timeout 20s,
+			3.3.3.3 timeout 30s
+		}
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ip saddr @blacklist_manual counter packets 1 bytes 1 drop
+	}
+}
+`
+
+// B-8: an injected accept rule inside the input chain (structural change)
+const injectedAccept = `# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = { 1.2.3.4 timeout 3600s, 5.6.7.8 timeout 7200s }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ct state established,related accept
+		ip saddr 6.6.6.6 accept
+		ip saddr @whitelist_manual accept
+		ip saddr @blacklist_manual counter packets 12 bytes 340 drop
+	}
+	chain output {
+		type filter hook output priority 0; policy accept;
+	}
+}
+`
+
+// B-9: input chain policy flipped drop → accept (structural change)
+const policyFlip = `# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = { 1.2.3.4 timeout 3600s, 5.6.7.8 timeout 7200s }
+	}
+	chain input {
+		type filter hook input priority 0; policy accept;
+		ct state established,related accept
+		ip saddr @whitelist_manual accept
+		ip saddr @blacklist_manual counter packets 12 bytes 340 drop
+	}
+	chain output {
+		type filter hook output priority 0; policy accept;
+	}
+}
+`
+
+func TestDigest_Deterministic(t *testing.T) {
+	if Digest(baseRuleset) != Digest(baseRuleset) {
+		t.Fatal("digest not deterministic for identical input")
+	}
+}
+
+func TestDigest_IgnoresChurn(t *testing.T) {
+	// counters + dynamic-set elements + handles + timers must not move the digest.
+	if Digest(baseRuleset) != Digest(churnedRuleset) {
+		t.Errorf("digest changed under counter/element/handle churn:\n base=%s\n churn=%s",
+			Digest(baseRuleset), Digest(churnedRuleset))
+	}
+}
+
+func TestDigest_IgnoresMultilineElementChurn(t *testing.T) {
+	a := Digest(multilineElems)
+	// swap the multi-line element list contents only
+	b := Digest(`# family ip
+table ip nftban {
+	set blacklist_manual {
+		type ipv4_addr
+		flags timeout
+		elements = {
+			9.9.9.9 timeout 99s
+		}
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ip saddr @blacklist_manual counter packets 50 bytes 60 drop
+	}
+}
+`)
+	if a != b {
+		t.Errorf("multi-line element churn changed the digest: %s vs %s", a, b)
+	}
+}
+
+func TestDigest_DetectsInjectedAccept(t *testing.T) {
+	if Digest(baseRuleset) == Digest(injectedAccept) {
+		t.Error("injected accept rule did NOT change the digest (B-8 undetected)")
+	}
+}
+
+func TestDigest_DetectsPolicyFlip(t *testing.T) {
+	if Digest(baseRuleset) == Digest(policyFlip) {
+		t.Error("chain-policy flip did NOT change the digest (B-9 undetected)")
+	}
+}
+
+func TestVerify_MatchMismatchMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ruleset_fingerprint.json")
+
+	// missing baseline
+	if st, _, _ := Verify(path, baseRuleset); st != StatusBaselineMissing {
+		t.Errorf("no baseline: got %s, want BASELINE_MISSING", st)
+	}
+
+	// capture, then identical → OK (incl. churn immunity)
+	if err := CaptureBaseline(path, baseRuleset); err != nil {
+		t.Fatalf("CaptureBaseline: %v", err)
+	}
+	if st, exp, act := Verify(path, churnedRuleset); st != StatusOK {
+		t.Errorf("churned-but-same-structure: got %s (exp=%s act=%s), want OK", st, exp, act)
+	}
+
+	// injected accept → MISMATCH
+	if st, exp, act := Verify(path, injectedAccept); st != StatusMismatch {
+		t.Errorf("injected accept: got %s (exp=%s act=%s), want MISMATCH", st, exp, act)
+	}
+	// policy flip → MISMATCH
+	if st, _, _ := Verify(path, policyFlip); st != StatusMismatch {
+		t.Errorf("policy flip: got %s, want MISMATCH", st)
+	}
+}
+
+// TestVerify_DoesNotRefreshBaseline is the core SEC-RULEFP invariant: a verify
+// that finds a MISMATCH must NEVER rewrite the baseline (no auto-heal/self-heal),
+// otherwise an injected rule could silently become the new "truth".
+func TestVerify_DoesNotRefreshBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ruleset_fingerprint.json")
+	if err := CaptureBaseline(path, baseRuleset); err != nil {
+		t.Fatalf("CaptureBaseline: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read baseline: %v", err)
+	}
+
+	if st, _, _ := Verify(path, injectedAccept); st != StatusMismatch {
+		t.Fatalf("expected MISMATCH, got %s", st)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read baseline after verify: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("Verify MUTATED the baseline on mismatch (auto-refresh/self-heal is forbidden)")
+	}
+}

--- a/internal/rulefp/fingerprint_test.go
+++ b/internal/rulefp/fingerprint_test.go
@@ -128,8 +128,13 @@ table ip nftban {
 `
 
 func TestDigest_Deterministic(t *testing.T) {
-	if Digest(baseRuleset) != Digest(baseRuleset) {
-		t.Fatal("digest not deterministic for identical input")
+	// Capture both calls into named locals: same input -> identical digest.
+	// (Splitting the call sites also keeps staticcheck SA4000 happy without
+	// changing the semantics of the determinism check.)
+	a := Digest(baseRuleset)
+	b := Digest(baseRuleset)
+	if a != b {
+		t.Fatalf("digest not deterministic for identical input: %s vs %s", a, b)
 	}
 }
 


### PR DESCRIPTION
## v1.138 PR-A — SEC-RULEFP (ruleset fingerprint)

First slice of the v1.138 firewall-integrity lane. Adds a canonical nftables ruleset fingerprint so the daemon/CLI/health can detect rule injection or chain-policy tampering against a trusted baseline. **PR-A only** — no SEC-BYPASS-ALERT, no `service-alerts.log`, no Registry-2.

### What it does
- **`internal/rulefp`** — `Normalize()` strips volatile noise (counters `packets/bytes`, `# handle N`, `last used`, `expires`, dynamic-set `elements = { … }` incl. multi-line) leaving only structural text; `Digest()` = sha256(Normalize). `CaptureBaseline()` writes an atomic 0640 JSON; `Verify()` is **read-only** and never refreshes the baseline.
- **`nftban-core verify-rules`** — `--capture` to (re)baseline; bare verify to compare. Exit codes: **OK / BASELINE_MISSING = 0, MISMATCH = 2, NFT_UNAVAILABLE = 3**.
- **`nftband`** — captures the baseline only after a successful (`!check`) apply; a **record-only** fingerprint check during reconciliation (logs MISMATCH, never mutates rules / never auto-heals).
- **CLI** — `firewall rebuild` captures the baseline only in the exit-0 success branch.
- **health** — `ruleset_fingerprint` check: MISMATCH → WARNING; BASELINE_MISSING → advisory.
- **tests** — `internal/rulefp` unit tests (7, incl. `TestVerify_DoesNotRefreshBaseline`) + a 19-assert shell wiring/invariant guard.

### Verification (read-only, both packaging families)
`VERIFY_V1_138_PR_A_RULESET_FINGERPRINT_LAB2_LAB4 = PASS` — lab2 (Ubuntu 24/DEB) + lab4 (AlmaLinux 9.7/EL9 RPM):
- gofmt (PR-A code) / `go vet ./...` / `go build ./...` / `go test ./internal/rulefp/` (7/7) / `go test ./cmd/...` — all PASS
- shell guard 19/19; EL9 RPM still-builds
- controlled live inject + new-chain flip → **MISMATCH(2)** → restore; counter/timer/populated-set churn → **OK(0)**; hosts fully restored, baseline removed, package untouched (1.135.0)

Record: `NFTBAN_ROADMAP/V1_138_PR_A_RULESET_FINGERPRINT_VERIFY_RECORD.md`.

### Out of scope (intentionally not here)
SEC-BYPASS-ALERT / `service-alerts.log` / Registry-2 / schema / metrics / portal / CSF / FHS / daemon-user / release / fleet.

### Tracked debt (separate cleanup, not in this PR)
- Two **pre-existing** gofmt nits in `bfe5e286` (`cmd/nftban-core/main.go:111` double-space comment; `cmd/nftband/daemon_reconciliation.go` `setPair` field alignment) — confirmed not introduced by PR-A; CI does not gate gofmt. Slated for an end-of-lane `gofmt -w` cleanup.
- Empty-set churn (first element into an empty dynamic set) registers as a structural change — by design; populated-set churn is correctly OK. Noted as documented behavior / optional future normalization refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)