### PR TITLE
feat(security): v1.138 PR-B — emit firewall conflict alerts from health checks (SEC-BYPASS-ALERT)

### DIFF
--- a/cli/lib/nftban/core/nftban_firewall_conflicts.sh
+++ b/cli/lib/nftban/core/nftban_firewall_conflicts.sh
@@ -631,15 +631,41 @@ nftban_severity_to_string() {
 #   NFTBAN_FIREWALL_SEVERITY     CONFLICT_NONE|INFO|WARNING|CRITICAL
 #
 # Writes (best-effort, never aborts the caller):
-#   ${NFTBAN_LOG_DIR}/service-alerts.log         — one deterministic line per
-#                                                   primary (non-indented) entry
-#   ${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>
-#                                                — timestamp; reused on next run
-#                                                   for per-service throttling.
+#   ${NFTBAN_LOG_DIR}/service-alerts.log              — one deterministic line
+#                                                       per primary entry
+#   ${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>  — last-emit unix timestamp
+#   ${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>.sev  — last-emit severity
+#                                                            (R3 escalation gate)
+#   ${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>.lock — per-service flock
+#                                                            (R1 parallel safety)
 #
 # Throttle: default 3600s; override via NFTBAN_ALERT_THROTTLE_SECONDS.
 # Namespace: `alert_throttle_firewall_<svc>` — distinct from the OnFailure
 # worker's `alert_throttle_<unit>` so the two cannot collide.
+#
+# Audit residuals R1–R7 from V1_138_PR_B_DUPLICATE_ALERT_LOGS_THIRD_AUDIT.md
+# are closed in this implementation:
+#   R1 — per-service flock around the read/check/emit/write critical section,
+#        so two concurrent invocations (timer + manual `nftban health`) cannot
+#        both observe a stale throttle and both emit. Falls back lock-free if
+#        the `flock` binary is unavailable.
+#   R2 — corrupt/non-numeric throttle file content is treated as stale (0).
+#   R3 — severity escalation (WARNING→CRITICAL) inside the throttle window
+#        re-emits exactly once and stamps the higher severity. The reverse
+#        (CRITICAL stays CRITICAL, or CRITICAL→WARNING) stays throttled.
+#   R4 — future-dated throttle timestamps (clock skew) are clamped to 0 so
+#        the alert is not silently suppressed forever.
+#   R5 — same TAG appearing twice in one array is correctly deduped within
+#        the run (first entry stamps throttle; second entry hits fresh
+#        throttle). Documented + tested.
+#   R6 — non-writable log path: the function exits 0 cleanly (best-effort
+#        contract preserved).
+#   R7 — sanitizer rule below is **firewall-namespace-specific**: it accepts
+#        [a-zA-Z0-9_] and collapses everything else (including '-') to '_'.
+#        This deliberately differs from the OnFailure worker's regex (which
+#        collapses '_' too); both remain namespace-correct because the prefix
+#        `alert_throttle_firewall_` already disambiguates from the worker's
+#        `alert_throttle_`.
 #
 # Line format (deterministic, grep-testable, non-metric):
 #   [YYYY-MM-DD HH:MM:SS] [SEVERITY] [FW-CONFLICT] service=<name> detail=<short>
@@ -660,11 +686,20 @@ nftban_emit_firewall_conflict_alerts() {
     now="$(date +%s)"
     timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-    # Soft-fail mkdirs: never abort the health check on a permission / fs error.
+    # R6: soft-fail mkdirs — non-writable log/data dir returns 0 (the contract
+    # is "never abort the health check on emitter trouble"). Lab-tested by
+    # pointing NFTBAN_LOG_DIR at a read-only /proc/sys path.
     mkdir -p "$log_dir" 2>/dev/null || return 0
     mkdir -p "$data_dir" 2>/dev/null || return 0
 
-    local entry tag detail svc key throttle_file last_alert age
+    # Detect flock once per invocation. If absent, fall back to lock-free
+    # best-effort emission (race-prone — accepted for hosts without util-linux).
+    local _have_flock=0
+    if command -v flock >/dev/null 2>&1; then
+        _have_flock=1
+    fi
+
+    local entry tag detail svc key throttle_file sev_file
     for entry in "${NFTBAN_FIREWALL_CONFLICTS[@]}"; do
         # Skip indented sub-entries ("  └─ …", "  CRITICAL: …" produced by
         # detectors as continuation lines) — only primary "TAG: detail" lines.
@@ -679,29 +714,63 @@ nftban_emit_firewall_conflict_alerts() {
         fi
 
         svc="${tag,,}"
-        # Throttle key — same sanitization rule as nftban-service-alert worker.
+        # R7: firewall-namespace sanitizer (keeps underscore; see header).
         key="${svc//[^a-zA-Z0-9_]/_}"
         throttle_file="${data_dir}/alert_throttle_firewall_${key}"
+        sev_file="${throttle_file}.sev"
 
-        if [[ -f "$throttle_file" ]]; then
-            last_alert="$(cat "$throttle_file" 2>/dev/null || echo 0)"
-            [[ "$last_alert" =~ ^[0-9]+$ ]] || last_alert=0
-            age=$(( now - last_alert ))
-            if (( age < throttle_secs )); then
-                continue
+        # R1: critical section under per-service flock. Subshell so `exit`
+        # cleanly releases the lock (FD 9 closes on subshell end). Errors are
+        # swallowed by the outer `|| true` so one bad service can't break others.
+        (
+            if (( _have_flock )); then
+                # Non-blocking: another invocation holds this service's lock
+                # → skip this service in this run.
+                flock -n 9 || exit 2
             fi
-        fi
 
-        # Deterministic, grep-testable line. Detail is free-form (kept short
-        # by the detector); the `[FW-CONFLICT]` tag distinguishes these lines
-        # from the OnFailure worker's diagnostic blocks in the same log.
-        printf '[%s] [%s] [FW-CONFLICT] service=%s detail=%s\n' \
-            "$timestamp" "$severity_str" "$svc" "$detail" \
-            >> "$alert_log" 2>/dev/null || continue
+            # R2: parse last-emit timestamp; non-numeric / unreadable → stale (0).
+            # R4: future-dated last_alert (clock skew) → clamp to 0 (stale).
+            local last_alert=0 raw_ts age
+            if [[ -f "$throttle_file" ]]; then
+                raw_ts="$(cat "$throttle_file" 2>/dev/null || true)"
+                if [[ "$raw_ts" =~ ^[0-9]+$ ]]; then
+                    last_alert=$raw_ts
+                fi
+            fi
+            if (( last_alert > now )); then
+                last_alert=0
+            fi
 
-        # Update throttle marker. Failure here is non-fatal — worst case the
-        # next run emits a duplicate.
-        echo "$now" > "$throttle_file" 2>/dev/null || true
+            # R3: parse prior severity; non-numeric / missing → 0.
+            local prior_sev=0 raw_sev
+            if [[ -f "$sev_file" ]]; then
+                raw_sev="$(cat "$sev_file" 2>/dev/null || true)"
+                if [[ "$raw_sev" =~ ^[0-9]+$ ]]; then
+                    prior_sev=$raw_sev
+                fi
+            fi
+
+            # Emit decision:
+            #   - if age >= throttle_secs: emit (window expired).
+            #   - else if severity > prior_sev: emit (escalation override).
+            #   - else: throttle (in-window, no escalation).
+            age=$(( now - last_alert ))
+            if (( age < throttle_secs )) && (( severity <= prior_sev )); then
+                exit 3
+            fi
+
+            # Deterministic, grep-testable, non-metric line.
+            printf '[%s] [%s] [FW-CONFLICT] service=%s detail=%s\n' \
+                "$timestamp" "$severity_str" "$svc" "$detail" \
+                >> "$alert_log" 2>/dev/null || exit 4
+
+            # Stamp throttle + severity. Failure here is non-fatal — the worst
+            # case is a duplicate on the next run.
+            echo "$now" > "$throttle_file" 2>/dev/null || true
+            echo "$severity" > "$sev_file" 2>/dev/null || true
+            exit 0
+        ) 9>>"${throttle_file}.lock" 2>/dev/null || true
     done
 
     return 0

--- a/cli/lib/nftban/core/nftban_firewall_conflicts.sh
+++ b/cli/lib/nftban/core/nftban_firewall_conflicts.sh
@@ -618,6 +618,95 @@ nftban_severity_to_string() {
     esac
 }
 
+# =============================================================================
+# SERVICE-ALERTS EMISSION (v1.138 PR-B, SEC-BYPASS-ALERT)
+# =============================================================================
+# Emit firewall conflict/bypass alerts to service-alerts.log when severity is
+# WARNING (2) or CRITICAL (3). No emission for NONE (0) or INFO (1) — INFO is
+# the deliberate cPHulk-coexists state and is not a real alert.
+#
+# Reads (no detector logic here, no kernel reads): the existing globals
+#   NFTBAN_FIREWALL_CONFLICTS[]  ("TAG: detail" primary lines + indented
+#                                 "  └─ …" sub-lines from nftban_detect_*)
+#   NFTBAN_FIREWALL_SEVERITY     CONFLICT_NONE|INFO|WARNING|CRITICAL
+#
+# Writes (best-effort, never aborts the caller):
+#   ${NFTBAN_LOG_DIR}/service-alerts.log         — one deterministic line per
+#                                                   primary (non-indented) entry
+#   ${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>
+#                                                — timestamp; reused on next run
+#                                                   for per-service throttling.
+#
+# Throttle: default 3600s; override via NFTBAN_ALERT_THROTTLE_SECONDS.
+# Namespace: `alert_throttle_firewall_<svc>` — distinct from the OnFailure
+# worker's `alert_throttle_<unit>` so the two cannot collide.
+#
+# Line format (deterministic, grep-testable, non-metric):
+#   [YYYY-MM-DD HH:MM:SS] [SEVERITY] [FW-CONFLICT] service=<name> detail=<short>
+nftban_emit_firewall_conflict_alerts() {
+    # Guard: severity below WARNING → no alert (INFO covers cPHulk coexists).
+    local severity="${NFTBAN_FIREWALL_SEVERITY:-0}"
+    [[ "$severity" -ge "${CONFLICT_WARNING:-2}" ]] || return 0
+    [[ "${#NFTBAN_FIREWALL_CONFLICTS[@]}" -gt 0 ]] || return 0
+
+    local log_dir data_dir alert_log throttle_secs
+    log_dir="${NFTBAN_LOG_DIR:-/var/log/nftban}"
+    data_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}"
+    alert_log="${log_dir}/service-alerts.log"
+    throttle_secs="${NFTBAN_ALERT_THROTTLE_SECONDS:-3600}"
+
+    local severity_str now timestamp
+    severity_str="$(nftban_severity_to_string "$severity")"
+    now="$(date +%s)"
+    timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+
+    # Soft-fail mkdirs: never abort the health check on a permission / fs error.
+    mkdir -p "$log_dir" 2>/dev/null || return 0
+    mkdir -p "$data_dir" 2>/dev/null || return 0
+
+    local entry tag detail svc key throttle_file last_alert age
+    for entry in "${NFTBAN_FIREWALL_CONFLICTS[@]}"; do
+        # Skip indented sub-entries ("  └─ …", "  CRITICAL: …" produced by
+        # detectors as continuation lines) — only primary "TAG: detail" lines.
+        [[ "$entry" =~ ^[[:space:]] ]] && continue
+
+        # Primary line shape: "TAG: detail" where TAG is uppercase + [-_0-9].
+        if [[ "$entry" =~ ^([A-Z][A-Z0-9_-]*):[[:space:]]+(.+)$ ]]; then
+            tag="${BASH_REMATCH[1]}"
+            detail="${BASH_REMATCH[2]}"
+        else
+            continue
+        fi
+
+        svc="${tag,,}"
+        # Throttle key — same sanitization rule as nftban-service-alert worker.
+        key="${svc//[^a-zA-Z0-9_]/_}"
+        throttle_file="${data_dir}/alert_throttle_firewall_${key}"
+
+        if [[ -f "$throttle_file" ]]; then
+            last_alert="$(cat "$throttle_file" 2>/dev/null || echo 0)"
+            [[ "$last_alert" =~ ^[0-9]+$ ]] || last_alert=0
+            age=$(( now - last_alert ))
+            if (( age < throttle_secs )); then
+                continue
+            fi
+        fi
+
+        # Deterministic, grep-testable line. Detail is free-form (kept short
+        # by the detector); the `[FW-CONFLICT]` tag distinguishes these lines
+        # from the OnFailure worker's diagnostic blocks in the same log.
+        printf '[%s] [%s] [FW-CONFLICT] service=%s detail=%s\n' \
+            "$timestamp" "$severity_str" "$svc" "$detail" \
+            >> "$alert_log" 2>/dev/null || continue
+
+        # Update throttle marker. Failure here is non-fatal — worst case the
+        # next run emits a duplicate.
+        echo "$now" > "$throttle_file" 2>/dev/null || true
+    done
+
+    return 0
+}
+
 nftban_report_conflicts_json() {
     # Output conflict report as JSON
     # Useful for API integration

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -246,6 +246,17 @@ nftban_health_check_conflicting_firewalls() {
     fi
 
     NFTBAN_HEALTH_RESULTS["conflicting_firewalls"]=$status
+
+    # v1.138 PR-B (SEC-BYPASS-ALERT): emit detected WARNING/CRITICAL firewall
+    # conflicts to service-alerts.log so the operator-actionable signal is no
+    # longer trapped inside in-memory health arrays. Per-service throttling
+    # (default 3600s, override via NFTBAN_ALERT_THROTTLE_SECONDS) prevents spam
+    # across repeated health-timer firings. Best-effort — never aborts the
+    # health check on emitter failure.
+    if declare -F nftban_emit_firewall_conflict_alerts >/dev/null 2>&1; then
+        nftban_emit_firewall_conflict_alerts || true
+    fi
+
     return $status
 }
 

--- a/cli/lib/nftban/tests/service_alerts_v138_test.sh
+++ b/cli/lib/nftban/tests/service_alerts_v138_test.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - SEC-BYPASS-ALERT service-alerts.log emitter test (v1.138 PR-B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="service_alerts_v138_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.138 PR-B SEC-BYPASS-ALERT emitter test. Asserts nftban_emit_firewall_conflict_alerts: emits one [FW-CONFLICT] line per primary detector entry to service-alerts.log when severity is WARNING/CRITICAL; emits nothing for NONE/INFO; per-service throttling suppresses duplicates within the window; ignores indented sub-entries; respects NFTBAN_ALERT_THROTTLE_SECONDS override. Runs hermetically (scratch dirs, no root, no nft, no host mutation)."
+# meta:input="None (uses scratch dirs)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,wc,date"
+# meta:inventory.files="cli/lib/nftban/core/nftban_firewall_conflicts.sh"
+# meta:inventory.binaries="bash,grep,wc,date,mkdir,rm,cat"
+# meta:inventory.env_vars="NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_ALERT_THROTTLE_SECONDS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SRC="$REPO/cli/lib/nftban/core/nftban_firewall_conflicts.sh"
+
+[[ -f "$SRC" ]] || { echo "FAIL: cannot find $SRC" >&2; exit 1; }
+
+# Hermetic scratch
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+export NFTBAN_LOG_DIR="$SCRATCH/log"
+export NFTBAN_DATA_DIR="$SCRATCH/data"
+mkdir -p "$NFTBAN_LOG_DIR" "$NFTBAN_DATA_DIR"
+ALERT_LOG="$NFTBAN_LOG_DIR/service-alerts.log"
+
+# Source the library. Detectors are not invoked; we drive globals directly.
+# shellcheck source=/dev/null
+source "$SRC"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+reset_scratch() {
+    rm -f "$ALERT_LOG"
+    rm -f "$NFTBAN_DATA_DIR"/alert_throttle_firewall_*
+    # shellcheck disable=SC2034  # consumed by sourced library via the for-loop iterator
+    NFTBAN_FIREWALL_CONFLICTS=()
+    # shellcheck disable=SC2034  # populated by detectors; cleared here for hermetic test
+    NFTBAN_FIREWALL_FIXES=()
+    # shellcheck disable=SC2034  # consumed by sourced library guard at function entry
+    NFTBAN_FIREWALL_SEVERITY=$CONFLICT_NONE
+}
+
+count_fw_lines() {
+    [[ -f "$ALERT_LOG" ]] || { echo 0; return; }
+    grep -c '\[FW-CONFLICT\]' "$ALERT_LOG" 2>/dev/null || echo 0
+}
+
+echo "=========================================================="
+echo "V1.138 PR-B SEC-BYPASS-ALERT emitter test"
+echo "=========================================================="
+
+# -----------------------------------------------------------------------------
+# T1: NONE severity → no file written, no lines
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_NONE
+nftban_emit_firewall_conflict_alerts
+if [[ ! -f "$ALERT_LOG" ]] && [[ "$(count_fw_lines)" -eq 0 ]]; then
+    ok "T1 severity=NONE emits nothing"
+else
+    no "T1 severity=NONE emits nothing" "alert_log exists or lines>0"
+fi
+
+# -----------------------------------------------------------------------------
+# T2: INFO severity (cPHulk coexists) → no emission
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_INFO
+NFTBAN_FIREWALL_CONFLICTS=("CPHULK: Active (cPanel brute-force protection)")
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 0 ]]; then
+    ok "T2 severity=INFO emits nothing"
+else
+    no "T2 severity=INFO emits nothing" "got $(count_fw_lines) line(s)"
+fi
+
+# -----------------------------------------------------------------------------
+# T3: WARNING severity, one primary entry → exactly one [FW-CONFLICT] line
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+NFTBAN_FIREWALL_CONFLICTS=("FAIL2BAN: Active with 3 jail(s), backend=nftables")
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 1 ]]; then
+    ok "T3 WARNING + 1 primary entry → 1 line"
+else
+    no "T3 WARNING + 1 primary entry → 1 line" "got $(count_fw_lines)"
+fi
+
+# T3a: line shape is deterministic and grep-testable
+if grep -qE '^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\] \[WARNING\] \[FW-CONFLICT\] service=fail2ban detail=Active with 3 jail\(s\), backend=nftables$' "$ALERT_LOG"; then
+    ok "T3a line shape matches contract"
+else
+    no "T3a line shape matches contract" "line: $(tail -1 "$ALERT_LOG" 2>/dev/null)"
+fi
+
+# -----------------------------------------------------------------------------
+# T4: CRITICAL severity, multiple primary entries → one line per primary
+#     Indented sub-entries are ignored (do not contribute lines or throttle keys)
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_CRITICAL
+NFTBAN_FIREWALL_CONFLICTS=(
+    "FIREWALLD: ACTIVE - Critical conflict with nftban"
+    "  └─ FIX: systemctl stop firewalld && systemctl disable firewalld"
+    "UFW: ACTIVE - Critical conflict with nftban"
+    "CSF: ACTIVE (production mode)"
+    "  └─ CSF uses iptables which conflicts with nftban"
+)
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 3 ]]; then
+    ok "T4 CRITICAL + 3 primary + 2 indented → 3 lines"
+else
+    no "T4 CRITICAL + 3 primary + 2 indented → 3 lines" "got $(count_fw_lines)"
+fi
+# T4a: each primary service appears exactly once
+for svc in firewalld ufw csf; do
+    n=$(grep -c "service=$svc " "$ALERT_LOG" 2>/dev/null || echo 0)
+    if [[ "$n" -eq 1 ]]; then
+        ok "T4a service=$svc emitted once"
+    else
+        no "T4a service=$svc emitted once" "count=$n"
+    fi
+done
+# T4b: severity label is CRITICAL on all three lines
+if [[ "$(grep -c '\[CRITICAL\] \[FW-CONFLICT\]' "$ALERT_LOG" 2>/dev/null || echo 0)" -eq 3 ]]; then
+    ok "T4b all three lines tagged CRITICAL"
+else
+    no "T4b all three lines tagged CRITICAL" "got $(grep -c '\[CRITICAL\] \[FW-CONFLICT\]' "$ALERT_LOG" 2>/dev/null || echo 0)"
+fi
+# T4c: no sub-entry leaked (no "service=└─" or empty service)
+if ! grep -qE 'service=(└|$| )' "$ALERT_LOG" 2>/dev/null; then
+    ok "T4c indented sub-entries are not emitted"
+else
+    no "T4c indented sub-entries are not emitted" "leak detected"
+fi
+
+# -----------------------------------------------------------------------------
+# T5: re-run within throttle window → no duplicate lines
+# -----------------------------------------------------------------------------
+# Same arrays as T4; throttle files are in place from T4.
+before=$(count_fw_lines)
+nftban_emit_firewall_conflict_alerts
+after=$(count_fw_lines)
+if [[ "$before" -eq "$after" ]]; then
+    ok "T5 re-run within window → no duplicate (lines stayed at $after)"
+else
+    no "T5 re-run within window → no duplicate" "lines $before -> $after"
+fi
+
+# -----------------------------------------------------------------------------
+# T6: expire throttle (backdate timestamps) → re-emission allowed
+# -----------------------------------------------------------------------------
+# Backdate each throttle file by 7200s (2h, > default 3600s).
+old_ts=$(( $(date +%s) - 7200 ))
+for f in "$NFTBAN_DATA_DIR"/alert_throttle_firewall_*; do
+    [[ -f "$f" ]] && echo "$old_ts" > "$f"
+done
+before=$(count_fw_lines)
+nftban_emit_firewall_conflict_alerts
+after=$(count_fw_lines)
+if [[ "$after" -eq $((before + 3)) ]]; then
+    ok "T6 after throttle expiry → 3 new lines (was $before, now $after)"
+else
+    no "T6 after throttle expiry → 3 new lines" "delta=$((after - before))"
+fi
+
+# -----------------------------------------------------------------------------
+# T7: NFTBAN_ALERT_THROTTLE_SECONDS=0 → every call re-emits
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+NFTBAN_FIREWALL_CONFLICTS=("IPTABLES: iptables.service is ACTIVE")
+NFTBAN_ALERT_THROTTLE_SECONDS=0 nftban_emit_firewall_conflict_alerts
+NFTBAN_ALERT_THROTTLE_SECONDS=0 nftban_emit_firewall_conflict_alerts
+NFTBAN_ALERT_THROTTLE_SECONDS=0 nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 3 ]]; then
+    ok "T7 THROTTLE_SECONDS=0 → every call emits (got 3)"
+else
+    no "T7 THROTTLE_SECONDS=0 → every call emits" "got $(count_fw_lines)"
+fi
+
+# -----------------------------------------------------------------------------
+# T8: empty conflicts array even at WARNING → no emission
+# -----------------------------------------------------------------------------
+reset_scratch
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+NFTBAN_FIREWALL_CONFLICTS=()
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 0 ]]; then
+    ok "T8 WARNING but empty array → no emission"
+else
+    no "T8 WARNING but empty array → no emission" "got $(count_fw_lines)"
+fi
+
+# -----------------------------------------------------------------------------
+# T9: hyphenated tag (IPTABLES-NFT) is preserved through lowercase mapping
+# -----------------------------------------------------------------------------
+reset_scratch
+# shellcheck disable=SC2034  # consumed by sourced library
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034  # consumed by sourced library
+NFTBAN_FIREWALL_CONFLICTS=("IPTABLES-NFT: 12 rules (priority check determines safety)")
+nftban_emit_firewall_conflict_alerts
+if grep -q 'service=iptables-nft ' "$ALERT_LOG" 2>/dev/null; then
+    ok "T9 hyphenated tag → lowercase service token preserved"
+else
+    no "T9 hyphenated tag → lowercase service token preserved" "no match"
+fi
+# T9a: throttle key must be sanitized (hyphen → underscore) and file must exist
+if [[ -f "$NFTBAN_DATA_DIR/alert_throttle_firewall_iptables_nft" ]]; then
+    ok "T9a throttle key sanitized (hyphen→underscore)"
+else
+    no "T9a throttle key sanitized (hyphen→underscore)" "throttle file missing"
+fi
+
+# -----------------------------------------------------------------------------
+# Results
+# -----------------------------------------------------------------------------
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/service_alerts_v138_test.sh
+++ b/cli/lib/nftban/tests/service_alerts_v138_test.sh
@@ -167,10 +167,16 @@ fi
 # -----------------------------------------------------------------------------
 # T6: expire throttle (backdate timestamps) → re-emission allowed
 # -----------------------------------------------------------------------------
-# Backdate each throttle file by 7200s (2h, > default 3600s).
+# Backdate each *timestamp* throttle file by 7200s (2h, > default 3600s).
+# Skip the sibling .sev (severity) and .lock files added for R1/R3 — those
+# are not timestamp stores.
 old_ts=$(( $(date +%s) - 7200 ))
 for f in "$NFTBAN_DATA_DIR"/alert_throttle_firewall_*; do
-    [[ -f "$f" ]] && echo "$old_ts" > "$f"
+    [[ -f "$f" ]] || continue
+    case "$f" in
+        *.sev|*.lock) continue ;;
+    esac
+    echo "$old_ts" > "$f"
 done
 before=$(count_fw_lines)
 nftban_emit_firewall_conflict_alerts
@@ -228,6 +234,166 @@ if [[ -f "$NFTBAN_DATA_DIR/alert_throttle_firewall_iptables_nft" ]]; then
     ok "T9a throttle key sanitized (hyphen→underscore)"
 else
     no "T9a throttle key sanitized (hyphen→underscore)" "throttle file missing"
+fi
+
+# =============================================================================
+# Audit residuals R1–R6 (third-audit closure — operator
+# OPEN_V1_138_PR_B_ALERT_RESIDUALS_CLOSE_NOW = GO)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# T10 (R1): per-service flock prevents duplicate concurrent emit.
+# Five emitters fired in parallel against the SAME single-service array →
+# exactly ONE alert line lands (one wins the lock + stamps throttle; the
+# others either lock-skip or hit fresh throttle). Skipped on hosts without
+# `flock`, where lock-free best-effort is the documented fallback.
+# -----------------------------------------------------------------------------
+if command -v flock >/dev/null 2>&1; then
+    reset_scratch
+    # shellcheck disable=SC2034
+    NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+    # shellcheck disable=SC2034
+    NFTBAN_FIREWALL_CONFLICTS=("FAIL2BAN: parallel race test")
+    pids=()
+    for _ in 1 2 3 4 5; do
+        ( nftban_emit_firewall_conflict_alerts ) &
+        pids+=($!)
+    done
+    for p in "${pids[@]}"; do wait "$p"; done
+    n=$(count_fw_lines)
+    if [[ "$n" -eq 1 ]]; then
+        ok "T10 (R1) parallel x5 emit on one service → exactly 1 line"
+    else
+        no "T10 (R1) parallel x5 emit on one service → exactly 1 line" "got $n"
+    fi
+else
+    ok "T10 (R1) SKIP — flock not installed; lock-free best-effort is documented"
+fi
+
+# -----------------------------------------------------------------------------
+# T11 (R2): corrupt (non-numeric) throttle file → treated as stale → emit.
+# -----------------------------------------------------------------------------
+reset_scratch
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_CONFLICTS=("UFW: corrupt-timestamp test")
+echo "garbage-not-a-number" > "$NFTBAN_DATA_DIR/alert_throttle_firewall_ufw"
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 1 ]]; then
+    ok "T11 (R2) corrupt throttle file → treated as stale, 1 line emitted"
+else
+    no "T11 (R2) corrupt throttle file → treated as stale, 1 line emitted" "got $(count_fw_lines)"
+fi
+# T11a: the corrupt file should have been overwritten with a valid timestamp.
+if [[ -s "$NFTBAN_DATA_DIR/alert_throttle_firewall_ufw" ]] \
+   && grep -qE '^[0-9]+$' "$NFTBAN_DATA_DIR/alert_throttle_firewall_ufw"; then
+    ok "T11a corrupt throttle file replaced with valid numeric timestamp"
+else
+    no "T11a corrupt throttle file replaced with valid numeric timestamp" "still corrupt"
+fi
+
+# -----------------------------------------------------------------------------
+# T12 (R3): severity escalation WARNING→CRITICAL inside throttle window
+# must re-emit exactly once (not silently suppressed). The reverse path
+# (CRITICAL stays CRITICAL) must stay throttled.
+# -----------------------------------------------------------------------------
+reset_scratch
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_CONFLICTS=("FIREWALLD: escalation-test")
+nftban_emit_firewall_conflict_alerts            # 1st: WARNING → 1 line
+# Now escalate within the throttle window (no time advance).
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_CRITICAL
+nftban_emit_firewall_conflict_alerts            # 2nd: CRITICAL → +1 line (escalation)
+nftban_emit_firewall_conflict_alerts            # 3rd: CRITICAL → 0 (no further escalation)
+n=$(count_fw_lines)
+if [[ "$n" -eq 2 ]]; then
+    ok "T12 (R3) WARNING→CRITICAL in window → escalation re-emits once (2 lines total)"
+else
+    no "T12 (R3) WARNING→CRITICAL in window → escalation re-emits once" "got $n"
+fi
+# T12a: severity ordering on the two lines must be WARNING then CRITICAL.
+if [[ "$(grep -c '\[WARNING\] \[FW-CONFLICT\] service=firewalld' "$ALERT_LOG" 2>/dev/null || echo 0)" -eq 1 ]] \
+   && [[ "$(grep -c '\[CRITICAL\] \[FW-CONFLICT\] service=firewalld' "$ALERT_LOG" 2>/dev/null || echo 0)" -eq 1 ]]; then
+    ok "T12a (R3) emitted lines tagged WARNING + CRITICAL exactly once each"
+else
+    no "T12a (R3) emitted lines tagged WARNING + CRITICAL exactly once each" "tag mismatch"
+fi
+# T12b: .sev file now records CRITICAL (3).
+sev=$(cat "$NFTBAN_DATA_DIR/alert_throttle_firewall_firewalld.sev" 2>/dev/null || echo 0)
+if [[ "$sev" -eq 3 ]]; then
+    ok "T12b (R3) .sev metadata stamped with last severity (CRITICAL=3)"
+else
+    no "T12b (R3) .sev metadata stamped with last severity (CRITICAL=3)" "sev=$sev"
+fi
+
+# -----------------------------------------------------------------------------
+# T13 (R4): future-dated throttle (clock skew) → clamped to stale → emit.
+# -----------------------------------------------------------------------------
+reset_scratch
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_CONFLICTS=("CSF: future-clamp test")
+future_ts=$(( $(date +%s) + 86400 ))  # +1 day
+echo "$future_ts" > "$NFTBAN_DATA_DIR/alert_throttle_firewall_csf"
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 1 ]]; then
+    ok "T13 (R4) future-dated throttle clamped → 1 line emitted"
+else
+    no "T13 (R4) future-dated throttle clamped → 1 line emitted" "got $(count_fw_lines)"
+fi
+# T13a: throttle file overwritten with current (non-future) timestamp.
+new_ts=$(cat "$NFTBAN_DATA_DIR/alert_throttle_firewall_csf" 2>/dev/null || echo 0)
+if (( new_ts > 0 )) && (( new_ts < future_ts )); then
+    ok "T13a (R4) throttle re-stamped with current time (no longer future)"
+else
+    no "T13a (R4) throttle re-stamped with current time (no longer future)" "ts=$new_ts"
+fi
+
+# -----------------------------------------------------------------------------
+# T14 (R5): same TAG appearing twice in one array → exactly ONE alert line
+# (the first stamps throttle; the second hits fresh throttle, no escalation).
+# -----------------------------------------------------------------------------
+reset_scratch
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_CONFLICTS=("FAIL2BAN: first occurrence" "FAIL2BAN: second occurrence")
+nftban_emit_firewall_conflict_alerts
+if [[ "$(count_fw_lines)" -eq 1 ]]; then
+    ok "T14 (R5) same TAG twice in one array → exactly 1 line (intra-run dedup)"
+else
+    no "T14 (R5) same TAG twice in one array → exactly 1 line (intra-run dedup)" "got $(count_fw_lines)"
+fi
+
+# -----------------------------------------------------------------------------
+# T15 (R6): non-writable log dir (mkdir -p fails) → function returns 0,
+# no emission, no host abort. Uses /proc/sys (read-only fs, even for root)
+# to model the failure hermetically without permission games.
+# -----------------------------------------------------------------------------
+reset_scratch
+saved_log_dir="$NFTBAN_LOG_DIR"
+export NFTBAN_LOG_DIR=/proc/sys/kernel/nftban-v138-prb-test-readonly
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_SEVERITY=$CONFLICT_WARNING
+# shellcheck disable=SC2034
+NFTBAN_FIREWALL_CONFLICTS=("FIREWALLD: readonly-dir test")
+nftban_emit_firewall_conflict_alerts; rc=$?
+export NFTBAN_LOG_DIR="$saved_log_dir"
+if [[ "$rc" -eq 0 ]]; then
+    ok "T15 (R6) non-writable log dir → emitter returns 0 (best-effort)"
+else
+    no "T15 (R6) non-writable log dir → emitter returns 0 (best-effort)" "rc=$rc"
+fi
+# T15a: nothing was emitted to the saved scratch log either.
+if [[ "$(count_fw_lines)" -eq 0 ]]; then
+    ok "T15a (R6) no line emitted to scratch log when target dir was unwritable"
+else
+    no "T15a (R6) no line emitted to scratch log when target dir was unwritable" "got $(count_fw_lines)"
 fi
 
 # -----------------------------------------------------------------------------

--- a/internal/nftbanconf/logs.go
+++ b/internal/nftbanconf/logs.go
@@ -37,20 +37,21 @@ import (
 type LogCategory string
 
 const (
-	LogCategoryMain        LogCategory = "main"
-	LogCategoryAudit       LogCategory = "audit"
-	LogCategoryBans        LogCategory = "bans"
-	LogCategoryPortscan    LogCategory = "portscan"
-	LogCategoryDDoS        LogCategory = "ddos"
-	LogCategoryLoginAlert  LogCategory = "login_alert"
-	LogCategoryFeeds       LogCategory = "feeds"
-	LogCategoryGeoban      LogCategory = "geoban"
-	LogCategoryCron        LogCategory = "cron"
-	LogCategoryMaintenance LogCategory = "maintenance"
-	LogCategoryCLIErrors   LogCategory = "cli_errors"
-	LogCategorySuricata    LogCategory = "suricata"
-	LogCategoryBotguard    LogCategory = "botguard"
-	LogCategoryDebug       LogCategory = "debug"
+	LogCategoryMain          LogCategory = "main"
+	LogCategoryAudit         LogCategory = "audit"
+	LogCategoryBans          LogCategory = "bans"
+	LogCategoryPortscan      LogCategory = "portscan"
+	LogCategoryDDoS          LogCategory = "ddos"
+	LogCategoryLoginAlert    LogCategory = "login_alert"
+	LogCategoryFeeds         LogCategory = "feeds"
+	LogCategoryGeoban        LogCategory = "geoban"
+	LogCategoryCron          LogCategory = "cron"
+	LogCategoryMaintenance   LogCategory = "maintenance"
+	LogCategoryCLIErrors     LogCategory = "cli_errors"
+	LogCategorySuricata      LogCategory = "suricata"
+	LogCategoryBotguard      LogCategory = "botguard"
+	LogCategoryDebug         LogCategory = "debug"
+	LogCategoryServiceAlerts LogCategory = "service_alerts" // v1.138 PR-B (SEC-BYPASS-ALERT)
 )
 
 // LogTemplate names a packaged logrotate template that executes rotation policy.
@@ -112,6 +113,9 @@ func LogInventory() []LogPolicy {
 		{Name: "nftban.log", Category: LogCategoryMain, Rotation: "weekly", Retain: 4, Template: TemplateMain},
 		{Name: "nftban-actions.log", Category: LogCategoryAudit, Rotation: "daily", Retain: 90, Template: TemplateMain},
 		{Name: "audit.log", Category: LogCategoryAudit, Rotation: "daily", Retain: 90, Template: TemplateMain},
+		// service-alerts.log: OnFailure worker output + v1.138 PR-B firewall-conflict
+		// emissions (SEC-BYPASS-ALERT). weekly/4 matches install/config/nftban.logrotate.
+		{Name: "service-alerts.log", Category: LogCategoryServiceAlerts, Rotation: "weekly", Retain: 4, Template: TemplateMain},
 		{Name: "bans.log", Category: LogCategoryBans, Rotation: "weekly", Retain: 12, Template: TemplateMain},
 		{Name: "portscan.log", Category: LogCategoryPortscan, Rotation: "daily", Retain: 30, Template: TemplateMain},
 		{Name: "portscan-classic.log", Category: LogCategoryPortscan, Rotation: "daily", Retain: 30, Template: TemplateMain},


### PR DESCRIPTION
## v1.138 PR-B — SEC-BYPASS-ALERT (service-alert emission only)

Second slice of the v1.138 firewall-integrity lane. The 9-detector shell library (`nftban_firewall_conflicts.sh`) already populates `NFTBAN_FIREWALL_CONFLICTS[]` + `NFTBAN_FIREWALL_SEVERITY` on every health-timer run; until now that signal was trapped in in-memory arrays. This slice bridges it to the existing logrotate-managed `/var/log/nftban/service-alerts.log` with a thin, hermetic emitter — **service-alert emission only**, scoped to 4 files.

### What it does
- **`internal/nftbanconf/logs.go`** — new `LogCategoryServiceAlerts` + `service-alerts.log` entry in `LogInventory()` (weekly/4, `TemplateMain`). Closes the v1.137 B-12 silent inventory-authority gap (the path was in logrotate but absent from the Go authority — tolerated only because the drift-test is one-directional).
- **`cli/lib/nftban/core/nftban_firewall_conflicts.sh`** — new `nftban_emit_firewall_conflict_alerts()`. Severity ≥ WARNING only (NONE/INFO suppressed; INFO covers cPHulk-coexists). Per-service throttling via `${NFTBAN_DATA_DIR}/alert_throttle_firewall_<svc>` (default 3600s, env override `NFTBAN_ALERT_THROTTLE_SECONDS`) — distinct namespace from the existing OnFailure worker's `alert_throttle_<unit>`. Best-effort; never aborts caller. Skips indented sub-entries (`  └─ …`).
- **`cli/lib/nftban/core/nftban_health_checks_security.sh`** — single wire call from `nftban_health_check_conflicting_firewalls()` after `NFTBAN_HEALTH_RESULTS["conflicting_firewalls"]` is set. Guarded with `declare -F` + `|| true` so emitter failure cannot break the health check.
- **`cli/lib/nftban/tests/service_alerts_v138_test.sh`** *(new)* — 16-assertion hermetic test driving the emitter through scratch `NFTBAN_LOG_DIR`/`NFTBAN_DATA_DIR`.

### Line shape (deterministic, grep-testable, non-metric)
```
[YYYY-MM-DD HH:MM:SS] [SEVERITY] [FW-CONFLICT] service=<name> detail=<short>
```
The `[FW-CONFLICT]` tag distinguishes these lines from the existing OnFailure worker's diagnostic blocks in the same log.

### Verification (read-only)
`V1_138_PR_B_BYPASS_ALERT_VERIFY_PASS_DEB_AND_RPM` — lab2 (Ubuntu 24/DEB) + lab4 (AlmaLinux 9.7/EL9 RPM):
- gofmt clean / `go vet ./...` / `go build ./...` / `go test ./internal/nftbanconf/` (4 critical drift tests ×2 incl. `TestLogInventoryCoveredByTemplates`)
- **`staticcheck ./...` CLEAN** / **`gosec -nosec ./...` zero new findings in `internal/nftbanconf/`** (lab-gate corrections from PR-A applied)
- `shellcheck -x -S warning` CLEAN on all 3 touched shell files
- `service_alerts_v138_test.sh` **16/0 PASS** on both labs
- DEB + EL9 RPM still-build (no packaging spec touched)
- Live host installed package + sshd + cPanel + (absent) live `service-alerts.log` untouched

Record: `NFTBAN_ROADMAP/V1_138_PR_B_BYPASS_ALERT_RECORD.md` (re-challenge + implementation + lab-verify).

### Out of scope (intentionally not here, per re-challenge + operator gate)
Registry-2 refactor (`NFTBAN_CONFLICT_REGISTRY` unchanged), banner change (`nftban_output.sh` unchanged), `conflict_cache` writer (still NOT created), daemon detector (`cmd/nftband/` unchanged), Go-side detector (`internal/installer/extfw/detect.go` unchanged), schema / metrics / portal / CSF / FHS / daemon-user / release / fleet.

### Tracked debt (separate cleanup, not in this PR)
- D-V138-FMT-1 — two pre-existing gofmt nits in `bfe5e286` (carried from PR-A): `cmd/nftban-core/main.go:111` double-space comment; `cmd/nftband/daemon_reconciliation.go setPair` field alignment. End-of-lane `gofmt -w` cleanup.
- D-V138-FMT-2 — empty-set first-element normalization in PR-A SEC-RULEFP (documented behavior; optional future refinement).
- Registry-2 unification (banner + health on `NFTBAN_CONFLICT_REGISTRY`) — separate PR-C lane, NOT a prerequisite for PR-B emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)