### PR TITLE
chore(fmt): v1.138 end-of-lane gofmt debt close (D-V138-FMT-1)

### DIFF
--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -111,7 +111,7 @@ func main() {
 		ip := os.Args[2]
 
 		// Parse flags
-		var timeout int = 0  // 0 = permanent
+		var timeout int = 0 // 0 = permanent
 		var reason string = ""
 		var source string = "manual"
 

--- a/cmd/nftband/daemon_reconciliation.go
+++ b/cmd/nftband/daemon_reconciliation.go
@@ -138,8 +138,8 @@ func (d *Daemon) checkWhitelistOverlap(wrapper *opqueue.NFTBackendWrapper) {
 
 	// Whitelist/blacklist_manual pairs per address family
 	type setPair struct {
-		whitelist    string
-		manualBans   string
+		whitelist  string
+		manualBans string
 	}
 	pairs := []setPair{
 		{"whitelist_ipv4", "blacklist_manual_ipv4"},


### PR DESCRIPTION
## v1.138 end-of-lane debt close — D-V138-FMT-1

Pure whitespace cleanup, no logic change. Closes the two pre-existing gofmt nits the PR-A lab verify surfaced on `bfe5e286` and that the register parked as **"fix at END of v1.138 lane"**. Operator gate: `OPEN_V1_138_END_OF_LANE_DEBT_CLOSE = GO`.

### Changes
- `cmd/nftban-core/main.go:114` — `var timeout int = 0␣␣// 0 = permanent` → single space before the inline comment.
- `cmd/nftband/daemon_reconciliation.go:140-143` — `setPair` struct field padding was column 13; gofmt's minimal alignment for this block (longest name `manualBans` = 10) is column 11. Re-padded.

`git diff -w` is empty — pure whitespace, zero semantic change.

### Verified on lab2 (Ubuntu 24 / Go 1.25 / staticcheck v0.7.0 / gosec latest)
- `gofmt -l` on touched files: **CLEAN**
- `go vet ./...`: rc=0
- `go build ./...`: rc=0
- `go test -count=2 ./cmd/nftban-core/ ./cmd/nftband/ ./internal/rulefp/`: PASS
- `staticcheck ./...`: **CLEAN**
- `gosec -nosec ./...`: zero new findings on touched files. The G104 hit at `main.go:121` (`fmt.Sscanf` return value) is pre-existing — git-blame `61defa9f6` (2025-12-17), predates v1.138; out of scope.

### Out of scope (left for an optional later cleanup if you open it)
Three other files are gofmt-flagged on pristine `1147699e` (the PR-A lab agent's grep missed them — different namespace):
- `cmd/nftban-validate/main.go`
- `cmd/validate-test/main.go`
- `internal/installer/validate/panel_survival_test.go`

Not touched here to keep this PR strictly scope-limited to D-V138-FMT-1.

### D-V138-FMT-2 disposition
**`DOCUMENTED_BY_DESIGN`** per operator default. The empty-set first-element normalization (adding the first element to an empty dynamic set creates a new `elements = { … }` line where none existed — `Normalize()` correctly does not collapse it, so it registers as a structural MISMATCH) is correct behavior, not a defect. No code change. Register updated.

### Forbidden (per operator gate, all honored)
- No feature work / no PR-C Registry-2 / no CSF / no FHS v1.139 / no schema / no metrics / no portal / no fleet / no tag / no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)