### PR TITLE
feat(fhs): v1.139 PR-A — reconcile tmpfiles-managed directories (FHS-TMPFILES-ZZ)

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -500,6 +500,7 @@ directories:
       group: nftban
       description: "Application state data (root-owned security boundary)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/banned
       mode: "0750"
@@ -507,6 +508,7 @@ directories:
       group: nftban
       description: "Banned IP state files"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/whitelist
       mode: "0750"
@@ -514,6 +516,7 @@ directories:
       group: nftban
       description: "Whitelist state files"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/feeds
       mode: "0750"
@@ -521,6 +524,7 @@ directories:
       group: nftban
       description: "Threat feed data"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/reports
       mode: "0750"
@@ -528,6 +532,7 @@ directories:
       group: nftban
       description: "Generated reports"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/reports/baseline
       mode: "0750"
@@ -535,6 +540,7 @@ directories:
       group: nftban
       description: "Baseline reports"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/reports/watchdog
       mode: "0750"
@@ -542,6 +548,7 @@ directories:
       group: nftban
       description: "Watchdog system reports"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/reports/auditors
       mode: "0770"
@@ -549,6 +556,7 @@ directories:
       group: nftban-auditor
       description: "Auditor reports (nftban-auditor group access)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
       note: |
         D-NEW-10 closure (Slot 6 / 2026-05-09): AUTHORITY EXCEPTION — intentional, NOT drift.
         This is the ONLY directory in the /var/lib/nftban tree owned by `nftban-auditor`
@@ -575,6 +583,7 @@ directories:
       group: nftban
       description: "Metrics database"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/snapshots
       mode: "0750"
@@ -582,6 +591,7 @@ directories:
       group: nftban
       description: "Hourly stats snapshots"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/exports
       mode: "0750"
@@ -589,6 +599,7 @@ directories:
       group: nftban
       description: "User data exports (JSON, CSV)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/geoip
       mode: "0750"
@@ -596,6 +607,7 @@ directories:
       group: nftban
       description: "GeoIP database"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/stats
       mode: "0750"
@@ -603,6 +615,7 @@ directories:
       group: nftban
       description: "Runtime statistics"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/stats/history
       mode: "0750"
@@ -610,6 +623,7 @@ directories:
       group: nftban
       description: "Stats history"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/stats/profiles
       mode: "0750"
@@ -617,6 +631,7 @@ directories:
       group: nftban
       description: "Stats profiles"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/queue
       mode: "0750"
@@ -624,6 +639,7 @@ directories:
       group: nftban
       description: "Task queue root"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/queue/pending
       mode: "0750"
@@ -631,6 +647,7 @@ directories:
       group: nftban
       description: "Pending tasks"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/queue/work
       mode: "0750"
@@ -638,6 +655,7 @@ directories:
       group: nftban
       description: "In-progress tasks"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/queue/dlq
       mode: "0750"
@@ -645,6 +663,7 @@ directories:
       group: nftban
       description: "Dead letter queue"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/mailspool
       mode: "0750"
@@ -652,6 +671,7 @@ directories:
       group: nftban
       description: "Failed mail retry queue"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/botguard
       mode: "0750"
@@ -659,6 +679,7 @@ directories:
       group: nftban
       description: "HTTP Bot Guard state (batch signals, decisions)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/tunnel
       mode: "0750"
@@ -666,6 +687,7 @@ directories:
       group: nftban
       description: "DNS tunnel suspicion state (scores, history)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/community
       mode: "0750"
@@ -680,6 +702,7 @@ directories:
       group: nftban
       description: "Analytics state data"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/backup
       mode: "0750"
@@ -687,6 +710,7 @@ directories:
       group: nftban
       description: "Firewall backup snapshots (root-owned for integrity)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/config
       mode: "0750"
@@ -694,6 +718,7 @@ directories:
       group: nftban
       description: "Runtime configuration state"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/login
       mode: "0750"
@@ -701,6 +726,7 @@ directories:
       group: nftban
       description: "Login monitor state data"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/panels
       mode: "0750"
@@ -708,6 +734,7 @@ directories:
       group: nftban
       description: "Panel integration state"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/portscan
       mode: "0750"
@@ -715,6 +742,7 @@ directories:
       group: nftban
       description: "Port scan detection state"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/recorder
       mode: "0750"
@@ -722,6 +750,7 @@ directories:
       group: nftban
       description: "Flight recorder events and snapshots"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/staging
       mode: "0750"
@@ -729,6 +758,7 @@ directories:
       group: nftban
       description: "Feed staging area (temporary download/validation)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/state
       mode: "0750"
@@ -736,6 +766,7 @@ directories:
       group: nftban
       description: "Critical runtime state files"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/suricata
       mode: "0750"
@@ -743,6 +774,7 @@ directories:
       group: nftban
       description: "Suricata integration state"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/update-backups
       mode: "0750"
@@ -750,6 +782,7 @@ directories:
       group: nftban
       description: "Update rollback backups (root-owned for integrity)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/watchdog
       mode: "0750"
@@ -757,6 +790,7 @@ directories:
       group: nftban
       description: "Watchdog reports and state"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/reports/archive
       mode: "0750"
@@ -764,6 +798,7 @@ directories:
       group: nftban
       description: "Archived reports"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/lib/nftban/pro
       mode: "0750"
@@ -771,6 +806,7 @@ directories:
       group: nftban
       description: "Pro subscription data"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
   # ---------------------------------------------------------------------------
   # Logs (nftban:nftban, 750) - Daemon writes, group reads
@@ -782,6 +818,7 @@ directories:
       group: nftban
       description: "Log files"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/watchdog
       mode: "0750"
@@ -789,6 +826,7 @@ directories:
       group: nftban
       description: "Watchdog logs"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/reports
       mode: "0750"
@@ -796,6 +834,7 @@ directories:
       group: nftban
       description: "Report logs"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/rbl
       mode: "0750"
@@ -803,6 +842,7 @@ directories:
       group: nftban
       description: "RBL check cache"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/botguard
       mode: "0750"
@@ -810,6 +850,7 @@ directories:
       group: nftban
       description: "HTTP Bot Guard logs"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/metrics
       mode: "0750"
@@ -817,6 +858,7 @@ directories:
       group: nftban
       description: "Metrics export logs"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/soak
       mode: "0750"
@@ -824,6 +866,7 @@ directories:
       group: nftban
       description: "Soak validation per-run JSON + cron.log (v1.98.1)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /var/log/nftban/suricata
       mode: "0770"
@@ -843,6 +886,7 @@ directories:
       group: nftban
       description: "Cache files"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
       note: "0755 intentional: public-cache traversal — non-sensitive cache contents (timestamps, last-check status) readable by unprivileged tooling. Sensitive subdirs (e.g. /health) are tightened to 0750 individually."
 
     - path: /var/cache/nftban/health
@@ -851,6 +895,7 @@ directories:
       group: nftban
       description: "Health check status cache"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /run/nftban
       mode: "0755"
@@ -858,6 +903,7 @@ directories:
       group: nftban
       description: "Runtime data (PID files, sockets)"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
       note: "Managed by tmpfiles only - do not use RuntimeDirectory= in units to avoid conflict. 0755 intentional: socket-discovery — non-nftban-group processes (panel adapters, monitoring tools) must stat() the daemon socket; the socket file itself uses unit-level SocketMode=0660 + group ownership for access control. Tightening the parent dir would break socket-discovery for anything outside the nftban group."
 
     - path: /run/nftban/firewall-validate
@@ -866,6 +912,7 @@ directories:
       group: nftban
       description: "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
       created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
   # ---------------------------------------------------------------------------
   # Shared Data (root:root, 755) - Read-only application data

--- a/build/generate-fhs-outputs.sh
+++ b/build/generate-fhs-outputs.sh
@@ -156,19 +156,40 @@ generate_tmpfiles() {
 
 EOF
 
+    # Tmpfiles emission, per group: each group emits its `d` lines first
+    # (current behavior, unchanged), then its `z`/`Z` reconcile lines for
+    # entries that carry `tmpfiles_reconcile: "z"` or `"Z"`. The default
+    # (no `tmpfiles_reconcile` field) emits `d` only — preserves backward
+    # behavior for `created_by: package` / `feature_enable` surfaces.
+    #
+    # Two separate yq projections per group (rather than an inline
+    # if/then/else in the per-record format string) so the script works under
+    # both yq variants — mikefarah/Go yq v4 (the build/CI/lab standard) and
+    # Python/jq-wrapped yq. mikefarah yq v4 rejects jq-style `if … then … else
+    # … end` inside string interpolation; plain `select()` projection is
+    # accepted by both. See V1_139_FHS_AUTHORITY_RECHALLENGE_RECORD.md +
+    # V1_139_PR_A_TMPFILES_ZZ_VERIFY_RECORD.md for the HYBRID rationale.
+    #
+    # `z` adjusts mode/owner of the path itself (non-recursive, safe for dirs
+    # whose contents have varied modes like log files); `Z` is recursive and
+    # used only where every item in the subtree shares the dir's mode.
+
     # Data directories (created_by: tmpfiles)
     echo "# Data directories (/var/lib/nftban)" >> "$TMPFILES_OUT"
     yq -r '.directories.data[] | select(.created_by == "tmpfiles") | "d \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
+    yq -r '.directories.data[] | select(.created_by == "tmpfiles" and (.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z")) | "\(.tmpfiles_reconcile) \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
     echo "" >> "$TMPFILES_OUT"
 
     # Log directories
     echo "# Log directories (/var/log/nftban)" >> "$TMPFILES_OUT"
     yq -r '.directories.logs[] | select(.created_by == "tmpfiles") | "d \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
+    yq -r '.directories.logs[] | select(.created_by == "tmpfiles" and (.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z")) | "\(.tmpfiles_reconcile) \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
     echo "" >> "$TMPFILES_OUT"
 
     # Cache and runtime directories
     echo "# Cache and runtime directories" >> "$TMPFILES_OUT"
     yq -r '.directories.runtime[] | select(.created_by == "tmpfiles") | "d \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
+    yq -r '.directories.runtime[] | select(.created_by == "tmpfiles" and (.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z")) | "\(.tmpfiles_reconcile) \(.path) \(.mode) \(.owner) \(.group) -"' "$FHS_SPEC" >> "$TMPFILES_OUT"
 
     print_status "Generated $TMPFILES_OUT"
 }

--- a/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
+++ b/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - FHS-TMPFILES-ZZ behavior test (v1.139 PR-A)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="tmpfiles_zz_v139_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.139 PR-A FHS-TMPFILES-ZZ behavior contract: asserts the generated install/systemd/tmpfiles.d/nftban.conf carries the HYBRID reconcile policy — every `created_by: tmpfiles` entry in build/fhs-spec.yaml has both a `d` create-if-missing line AND a sibling `z` (non-recursive) reconcile line with matching path/mode/owner/group. Asserts NO `Z` (recursive) directives are present (recursive would clobber file modes inside log dirs). Asserts no z line exists for paths whose spec entry lacks tmpfiles_reconcile (package/feature_enable surfaces stay d-only). Pure static assertion against repo files; no host contact, no Go, no systemd."
+# meta:input="build/fhs-spec.yaml, install/systemd/tmpfiles.d/nftban.conf"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,yq,sort,wc"
+# meta:inventory.files="build/fhs-spec.yaml,install/systemd/tmpfiles.d/nftban.conf,build/generate-fhs-outputs.sh"
+# meta:inventory.binaries="bash,grep,awk,yq,sort,wc,diff,comm"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SPEC="$REPO/build/fhs-spec.yaml"
+TMPF="$REPO/install/systemd/tmpfiles.d/nftban.conf"
+
+command -v yq >/dev/null 2>&1 || { echo "FAIL: yq not installed" >&2; exit 1; }
+[[ -f "$SPEC" ]] || { echo "FAIL: spec missing $SPEC" >&2; exit 1; }
+[[ -f "$TMPF" ]] || { echo "FAIL: generated tmpfiles missing $TMPF" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=========================================================="
+echo "V1.139 PR-A FHS-TMPFILES-ZZ behavior test"
+echo "=========================================================="
+
+# -----------------------------------------------------------------------------
+# T1: every `created_by: tmpfiles` entry has tmpfiles_reconcile set to z or Z.
+# (HYBRID schema contract: explicit metadata, no implicit reconcile.)
+# -----------------------------------------------------------------------------
+TOTAL_TMPFILES=$(yq -r '[.directories.data[], .directories.logs[], .directories.runtime[]] | map(select(.created_by == "tmpfiles")) | length' "$SPEC")
+WITH_RECONCILE=$(yq -r '[.directories.data[], .directories.logs[], .directories.runtime[]] | map(select(.created_by == "tmpfiles" and (.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z"))) | length' "$SPEC")
+if [[ "$TOTAL_TMPFILES" -gt 0 ]] && [[ "$WITH_RECONCILE" == "$TOTAL_TMPFILES" ]]; then
+    ok "T1 every tmpfiles entry has tmpfiles_reconcile annotation ($WITH_RECONCILE/$TOTAL_TMPFILES)"
+else
+    no "T1 every tmpfiles entry has tmpfiles_reconcile annotation" "annotated=$WITH_RECONCILE total=$TOTAL_TMPFILES"
+fi
+
+# -----------------------------------------------------------------------------
+# T2: NO `created_by: package` / `feature_enable` entry carries tmpfiles_reconcile.
+# (HYBRID safety: only nftban-owned-lifecycle dirs get reconciled.)
+# -----------------------------------------------------------------------------
+LEAKED=$(yq -r '[.directories.data[], .directories.config[], .directories.system[], .directories.shared[], .directories.logs[]] | map(select(.created_by != "tmpfiles" and (.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z"))) | length' "$SPEC")
+if [[ "$LEAKED" == "0" ]]; then
+    ok "T2 no package/feature_enable entry carries tmpfiles_reconcile (operator surfaces safe)"
+else
+    no "T2 no package/feature_enable entry carries tmpfiles_reconcile" "leaked=$LEAKED — operator surfaces would be reconciled by tmpfiles"
+fi
+
+# -----------------------------------------------------------------------------
+# T3: generated file's `d`/`z` counts match the spec.
+# -----------------------------------------------------------------------------
+D_COUNT=$(awk '/^d / {n++} END {print n+0}' "$TMPF")
+Z_COUNT=$(awk '/^z / {n++} END {print n+0}' "$TMPF")
+ZZ_COUNT=$(awk '/^Z / {n++} END {print n+0}' "$TMPF")
+SPEC_Z=$(yq -r '[.directories.data[], .directories.logs[], .directories.runtime[]] | map(select(.tmpfiles_reconcile == "z")) | length' "$SPEC")
+SPEC_ZZ=$(yq -r '[.directories.data[], .directories.logs[], .directories.runtime[]] | map(select(.tmpfiles_reconcile == "Z")) | length' "$SPEC")
+
+if [[ "$D_COUNT" == "$TOTAL_TMPFILES" ]]; then
+    ok "T3 generated d-count matches spec tmpfiles count ($D_COUNT)"
+else
+    no "T3 generated d-count matches spec tmpfiles count" "generated=$D_COUNT spec=$TOTAL_TMPFILES"
+fi
+if [[ "$Z_COUNT" == "$SPEC_Z" ]]; then
+    ok "T3a generated z-count matches spec z-annotated count ($Z_COUNT)"
+else
+    no "T3a generated z-count matches spec z-annotated count" "generated=$Z_COUNT spec=$SPEC_Z"
+fi
+if [[ "$ZZ_COUNT" == "$SPEC_ZZ" ]]; then
+    ok "T3b generated Z-count matches spec Z-annotated count ($ZZ_COUNT, currently 0 by HYBRID design)"
+else
+    no "T3b generated Z-count matches spec Z-annotated count" "generated=$ZZ_COUNT spec=$SPEC_ZZ"
+fi
+
+# -----------------------------------------------------------------------------
+# T4: every `d` line for a tmpfiles entry has a SIBLING `z` (or `Z`) line for
+# the SAME path. (The generator emits paired d+z; missing pair = drift.)
+# -----------------------------------------------------------------------------
+# Extract spec paths whose tmpfiles_reconcile is set.
+RECONCILED_PATHS=$(yq -r '[.directories.data[], .directories.logs[], .directories.runtime[]] | map(select(.tmpfiles_reconcile == "z" or .tmpfiles_reconcile == "Z")) | .[].path' "$SPEC" | sort -u)
+MISSING_Z=0
+while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    # Use -F fixed-strings with explicit space prefix/suffix; paths contain no regex.
+    if ! grep -qF "z $p " "$TMPF" && ! grep -qF "Z $p " "$TMPF"; then
+        MISSING_Z=$((MISSING_Z+1))
+    fi
+done <<< "$RECONCILED_PATHS"
+if [[ "$MISSING_Z" == "0" ]]; then
+    ok "T4 every reconcile-annotated path has a paired z/Z line in the generated file"
+else
+    no "T4 every reconcile-annotated path has a paired z/Z line" "$MISSING_Z reconciled spec paths missing their z/Z sibling"
+fi
+
+# -----------------------------------------------------------------------------
+# T5: z/Z lines' mode/owner/group MATCH the corresponding d line's
+# mode/owner/group. (Protects against silent generator drift.)
+# -----------------------------------------------------------------------------
+MISMATCH=0
+while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    d_line=$(grep -F "d $p " "$TMPF" | head -1)
+    z_line=$(grep -F "z $p " "$TMPF" | head -1)
+    if [[ -z "$d_line" || -z "$z_line" ]]; then continue; fi
+    d_tail=$(echo "$d_line" | cut -d' ' -f3-)
+    z_tail=$(echo "$z_line" | cut -d' ' -f3-)
+    if [[ "$d_tail" != "$z_tail" ]]; then
+        MISMATCH=$((MISMATCH+1))
+    fi
+done <<< "$RECONCILED_PATHS"
+if [[ "$MISMATCH" == "0" ]]; then
+    ok "T5 d/z line tails (mode owner group -) match for every paired path"
+else
+    no "T5 d/z line tails match" "$MISMATCH paths have d/z mode-owner-group drift"
+fi
+
+# -----------------------------------------------------------------------------
+# T6: the auditor authority exception (/var/lib/nftban/reports/auditors) is
+# annotated `z` (non-recursive) — recursive Z would clobber auditor-written
+# report files. Required by the HYBRID design.
+# -----------------------------------------------------------------------------
+AUD_REC=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/reports/auditors") | .tmpfiles_reconcile // "missing"' "$SPEC")
+if [[ "$AUD_REC" == "z" ]]; then
+    ok "T6 auditor authority exception path uses non-recursive z (operator-writable subtree safe)"
+else
+    no "T6 auditor authority exception uses non-recursive z" "got tmpfiles_reconcile=$AUD_REC"
+fi
+
+# -----------------------------------------------------------------------------
+# T7: NO `Z` (recursive) directives in the generated file (HYBRID design
+# locks all 47 to non-recursive `z`; later operator decision could opt-in
+# specific subtrees, but v1.139 PR-A ships with zero Z).
+# -----------------------------------------------------------------------------
+if [[ "$ZZ_COUNT" == "0" ]]; then
+    ok "T7 no recursive Z directives in v1.139 PR-A (HYBRID locked to z)"
+else
+    no "T7 no recursive Z directives in v1.139 PR-A" "found $ZZ_COUNT — HYBRID violated"
+fi
+
+# -----------------------------------------------------------------------------
+# T8: generator --check passes (idempotency: regenerate matches committed).
+# -----------------------------------------------------------------------------
+if (cd "$REPO" && bash build/generate-fhs-outputs.sh --check >/dev/null 2>&1); then
+    ok "T8 build/generate-fhs-outputs.sh --check PASS (deterministic regen matches committed)"
+else
+    no "T8 generator --check PASS" "regenerate diverges from committed — run generator + commit"
+fi
+
+# -----------------------------------------------------------------------------
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -63,6 +63,42 @@ d /var/lib/nftban/update-backups 0750 root nftban -
 d /var/lib/nftban/watchdog 0750 nftban nftban -
 d /var/lib/nftban/reports/archive 0750 nftban nftban -
 d /var/lib/nftban/pro 0750 root nftban -
+z /var/lib/nftban 0750 root nftban -
+z /var/lib/nftban/banned 0750 nftban nftban -
+z /var/lib/nftban/whitelist 0750 nftban nftban -
+z /var/lib/nftban/feeds 0750 nftban nftban -
+z /var/lib/nftban/reports 0750 nftban nftban -
+z /var/lib/nftban/reports/baseline 0750 nftban nftban -
+z /var/lib/nftban/reports/watchdog 0750 nftban nftban -
+z /var/lib/nftban/reports/auditors 0770 root nftban-auditor -
+z /var/lib/nftban/metrics 0750 nftban nftban -
+z /var/lib/nftban/snapshots 0750 nftban nftban -
+z /var/lib/nftban/exports 0750 nftban nftban -
+z /var/lib/nftban/geoip 0750 nftban nftban -
+z /var/lib/nftban/stats 0750 nftban nftban -
+z /var/lib/nftban/stats/history 0750 nftban nftban -
+z /var/lib/nftban/stats/profiles 0750 nftban nftban -
+z /var/lib/nftban/queue 0750 nftban nftban -
+z /var/lib/nftban/queue/pending 0750 nftban nftban -
+z /var/lib/nftban/queue/work 0750 nftban nftban -
+z /var/lib/nftban/queue/dlq 0750 nftban nftban -
+z /var/lib/nftban/mailspool 0750 nftban nftban -
+z /var/lib/nftban/botguard 0750 nftban nftban -
+z /var/lib/nftban/tunnel 0750 nftban nftban -
+z /var/lib/nftban/analytics 0750 nftban nftban -
+z /var/lib/nftban/backup 0750 root nftban -
+z /var/lib/nftban/config 0750 nftban nftban -
+z /var/lib/nftban/login 0750 nftban nftban -
+z /var/lib/nftban/panels 0750 nftban nftban -
+z /var/lib/nftban/portscan 0750 nftban nftban -
+z /var/lib/nftban/recorder 0750 nftban nftban -
+z /var/lib/nftban/staging 0750 nftban nftban -
+z /var/lib/nftban/state 0750 nftban nftban -
+z /var/lib/nftban/suricata 0750 nftban nftban -
+z /var/lib/nftban/update-backups 0750 root nftban -
+z /var/lib/nftban/watchdog 0750 nftban nftban -
+z /var/lib/nftban/reports/archive 0750 nftban nftban -
+z /var/lib/nftban/pro 0750 root nftban -
 
 # Log directories (/var/log/nftban)
 d /var/log/nftban 0750 nftban nftban -
@@ -72,9 +108,20 @@ d /var/log/nftban/rbl 0750 nftban nftban -
 d /var/log/nftban/botguard 0750 nftban nftban -
 d /var/log/nftban/metrics 0750 nftban nftban -
 d /var/log/nftban/soak 0750 nftban nftban -
+z /var/log/nftban 0750 nftban nftban -
+z /var/log/nftban/watchdog 0750 nftban nftban -
+z /var/log/nftban/reports 0750 nftban nftban -
+z /var/log/nftban/rbl 0750 nftban nftban -
+z /var/log/nftban/botguard 0750 nftban nftban -
+z /var/log/nftban/metrics 0750 nftban nftban -
+z /var/log/nftban/soak 0750 nftban nftban -
 
 # Cache and runtime directories
 d /var/cache/nftban 0755 nftban nftban -
 d /var/cache/nftban/health 0750 nftban nftban -
 d /run/nftban 0755 nftban nftban -
 d /run/nftban/firewall-validate 2750 root nftban -
+z /var/cache/nftban 0755 nftban nftban -
+z /var/cache/nftban/health 0750 nftban nftban -
+z /run/nftban 0755 nftban nftban -
+z /run/nftban/firewall-validate 2750 root nftban -


### PR DESCRIPTION
## v1.139 PR-A — FHS-TMPFILES-ZZ (reconcile policy for tmpfiles-managed dirs)

First slice of the v1.139 FHS authority hardening lane. Closes the gap surfaced in the re-challenge ([`NFTBAN_ROADMAP/V1_139_FHS_AUTHORITY_RECHALLENGE_RECORD.md`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_139_FHS_AUTHORITY_RECHALLENGE_RECORD.md)):
- `install/systemd/tmpfiles.d/nftban.conf` carried **47 `d` directives and zero `z`/`Z` reconcile directives**.
- On systemd < 252, a pre-existing nftban-owned dir with wrong mode/owner silently stayed wrong under `systemd-tmpfiles --create`.
- On systemd ≥ 252 (Ubuntu 24.04 / EL9), `d` already adjusts mode/owner — so `z` is belt-and-suspenders + explicit intent + backward-compat.

### HYBRID policy (operator-decided)
- Every `created_by: tmpfiles` nftban-owned-lifecycle entry gets a sibling **non-recursive `z`** reconcile line.
- **Zero recursive `Z`** in this PR — would clobber file modes inside log/data dirs (logs are 0640 in a 0750 parent; recursive `Z` would force everything to 0750).
- The `/var/lib/nftban/reports/auditors` authority exception (operator-writable, 0770 root:nftban-auditor) uses `z` (non-recursive) — does not touch auditor-written report files.
- Operator-administered surfaces (`created_by: package` / `feature_enable`) carry no `tmpfiles_reconcile` field; primary safety is **path exclusion** — those paths are not in tmpfiles.d at all.

### Files (exactly 4, no Go touched)
```
build/fhs-spec.yaml                                  +47 tmpfiles_reconcile: "z"
build/generate-fhs-outputs.sh                        generate_tmpfiles() two-pass yq
install/systemd/tmpfiles.d/nftban.conf               regenerated: 47 d + 47 z + 0 Z
cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh        new (10 assertions)
```

### Generator yq-compatibility note
First-iteration extension used jq-style inline `if/then/else/end` in the yq format string — that works under python-yq but **mikefarah yq v4 (the build/CI standard) rejects it**. Final design uses **two separate `yq` passes per group** (one for `d`, one for `z`/`Z`), `select(...)` projection only. Compatible with both yq variants. Lab2 caught the original defect; the fix was re-verified on both labs using the **system mikefarah yq** explicitly.

### Verification — `V1_139_PR_A_TMPFILES_ZZ_VERIFY_PASS_DEB_AND_RPM`

| Gate | lab2 (DEB, mikefarah yq v4.44.1) | lab4 (EL9 RPM, mikefarah yq v4.44.1) |
|---|---|---|
| `generate-fhs-outputs.sh --check` | ✅ rc=0 | ✅ rc=0 |
| `tmpfiles_zz_v139_test.sh` | ✅ **10/10 PASS** | ✅ **10/10 PASS** |
| go vet / go build / go test (incl. 2 parity tests ×2) | ✅ | ✅ |
| staticcheck CLEAN · gosec 0 new on touched (no Go) | ✅ / ✅ | ✅ / ✅ |
| shellcheck on new test | ✅ CLEAN | ✅ CLEAN |
| Packaging still-builds | ✅ DEB 12.36 MB | ✅ EL9 RPM ~12 MB |
| Live perm-reconcile scratch proof (`/tmp/v139-zz-proof/`) | ✅ positive + operator-surface negative-control | ✅ same |
| Live host integrity (190 packaged files md5-identical pre/post) | ✅ | ✅ |

Record: [`NFTBAN_ROADMAP/V1_139_PR_A_TMPFILES_ZZ_VERIFY_RECORD.md`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_139_PR_A_TMPFILES_ZZ_VERIFY_RECORD.md) (8 sections + iteration history + systemd 252+ semantic note).

### Out of scope (intentionally NOT in this PR, per operator gate)
- **logrotate-create parity** — PR-B, gated `HOLD_UNTIL_PR_A_MERGED`
- **ATG formalization** — later docs PR after both code slices
- **FHS-UNGEN (a) Go fallback perms** + **(b) RPM file-level `%attr`** — re-challenge classified both as already CI-parity-bounded
- **CSF restore / firewall-integrity / Registry-2 / daemon least-privilege / schema / metrics / portal / release-prep / fleet** — all held

🤖 Generated with [Claude Code](https://claude.com/claude-code)