### PR TITLE
fix(exporter): portable hostname fallback (v1.139.1 hotfix; PRE-EXISTING distro-compat)

### DIFF
--- a/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
@@ -1470,8 +1470,21 @@ collect_all_metrics() {
     # 2. JSON cache (Single Source of Truth for nftban stats and API)
     # This structure EXACTLY matches what nftban_stats.sh dashboard needs
     local json_cache="${NFTBAN_JSON_CACHE_DIR:-/var/cache/nftban/metrics}/stats.json"
+    # v1.139.1 hotfix (FHS / distro-compat): the original fallback
+    # `hostname -f 2>/dev/null || hostname` called the SAME missing binary in
+    # both branches — on hosts that ship no `hostname` binary (CentOS Stream 10
+    # / RHEL 10 base install) the exporter would abort rc=127. The fallback
+    # chain below adds three real fallbacks: hostnamectl --static (systemd-
+    # native), uname -n (POSIX, always available), /etc/hostname (kernel-set
+    # nodename source), plus a literal "unknown" last-resort guard so the
+    # exporter never exits 127 on this line regardless of host shape.
     local hostname
-    hostname=$(hostname -f 2>/dev/null || hostname)
+    hostname=$(hostname -f 2>/dev/null \
+        || hostname 2>/dev/null \
+        || hostnamectl --static 2>/dev/null \
+        || uname -n 2>/dev/null \
+        || cat /etc/hostname 2>/dev/null \
+        || echo unknown)
 
     # Build JSON from collected metrics - SINGLE SOURCE OF TRUTH
     # All fields align with nftban_stats.sh generate_dashboard() requirements

--- a/cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh
+++ b/cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - exporter hostname fallback test (v1.139.1 hotfix)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="hostname_fallback_v1_139_1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.139.1 hotfix test — asserts the nftban-unified-exporter's hostname fallback chain at cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh:~1474 (a) contains every expected fallback link (hostname -f, hostname, hostnamectl --static, uname -n, /etc/hostname, literal 'unknown') and (b) does NOT exit rc=127 when the hostname binary is shadowed/missing (the original v1.137/v1.138/v1.139.0 ship of this line called the same missing 'hostname' binary in both fallback branches → rc=127 on CentOS Stream 10 / RHEL 10 which ship no hostname binary by default; pre-existing since git-blame 97b2c9297 2026-02-04, classified auxiliary so installs still reach COMMITTED). Hermetic — no host contact, uses function-shadow to simulate missing binary."
+# meta:input="cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,uname,cat"
+# meta:inventory.files="cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+# meta:inventory.binaries="bash,grep,uname,cat"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SRC="$REPO/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+
+[[ -f "$SRC" ]] || { echo "FAIL: cannot find $SRC" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=========================================================="
+echo "V1.139.1 hotfix: exporter hostname fallback test"
+echo "=========================================================="
+
+# -----------------------------------------------------------------------------
+# Source-code assertions: the production fallback chain must carry every link.
+# -----------------------------------------------------------------------------
+echo "--- source-code link assertions ---"
+grep -qE 'hostname -f 2>/dev/null'      "$SRC" && ok "T1 'hostname -f' link present"           || no "T1 'hostname -f' link present"      "missing"
+grep -qE '\|\| hostname 2>/dev/null'    "$SRC" && ok "T2 'hostname' bare link present"         || no "T2 'hostname' bare link present"    "missing"
+grep -qE 'hostnamectl --static 2>/dev/null' "$SRC" && ok "T3 'hostnamectl --static' link present" || no "T3 'hostnamectl --static' link present" "missing"
+grep -qE 'uname -n 2>/dev/null'         "$SRC" && ok "T4 'uname -n' link present"              || no "T4 'uname -n' link present"         "missing"
+grep -qE 'cat /etc/hostname 2>/dev/null' "$SRC" && ok "T5 '/etc/hostname' link present"        || no "T5 '/etc/hostname' link present"    "missing"
+grep -qE 'echo unknown'                 "$SRC" && ok "T6 'echo unknown' last-resort guard present" || no "T6 'echo unknown' last-resort guard present" "missing"
+
+# -----------------------------------------------------------------------------
+# Runtime simulation: replay the EXACT fallback chain in a shell where
+# `hostname` is shadowed (always returns 127, matching the EL10 reality of
+# "binary not in PATH").
+# -----------------------------------------------------------------------------
+echo "--- runtime simulations ---"
+
+# The chain itself (kept in lock-step with the production line; T7-T9 prove
+# the runtime semantics; T1-T6 above prove the production source IS this chain).
+fallback_chain() {
+    hostname -f 2>/dev/null \
+        || hostname 2>/dev/null \
+        || hostnamectl --static 2>/dev/null \
+        || uname -n 2>/dev/null \
+        || cat /etc/hostname 2>/dev/null \
+        || echo unknown
+}
+
+# T7: only `hostname` is missing (the EL10 reality — `hostnamectl` is present
+# on every systemd host including EL10; the chain should land on hostnamectl).
+result=$(
+    set +e
+    hostname() { return 127; }
+    result=$(fallback_chain)
+    printf '%s' "$result"
+)
+if [[ -n "$result" && "$result" != "unknown" && "$result" != *"command not found"* ]]; then
+    ok "T7 hostname-shadowed → fallback returns non-empty real value (got: '$result')"
+else
+    no "T7 hostname-shadowed → fallback returns non-empty real value" "got: '$result'"
+fi
+
+# T8: BOTH `hostname` AND `hostnamectl` shadowed (forces uname -n / /etc/hostname).
+result=$(
+    set +e
+    hostname()    { return 127; }
+    hostnamectl() { return 127; }
+    result=$(fallback_chain)
+    printf '%s' "$result"
+)
+expected_uname=$(uname -n 2>/dev/null || true)
+if [[ "$result" == "$expected_uname" && -n "$result" ]]; then
+    ok "T8 hostname+hostnamectl-shadowed → fallback returns uname -n (got: '$result')"
+elif [[ -n "$result" && "$result" != "unknown" ]]; then
+    ok "T8 hostname+hostnamectl-shadowed → fallback returns non-empty real value (got: '$result', uname -n: '$expected_uname')"
+else
+    no "T8 hostname+hostnamectl-shadowed → fallback returns non-empty real value" "got: '$result' uname-n: '$expected_uname'"
+fi
+
+# T9: the chain MUST not exit 127 anywhere — the literal `echo unknown` is the
+# bulletproof terminator. Force every binary to fail and assert the result is
+# literally "unknown" (not a command-not-found error).
+result=$(
+    set +e
+    hostname()    { return 127; }
+    hostnamectl() { return 127; }
+    uname()       { return 127; }
+    cat()         { if [[ "${1:-}" == "/etc/hostname" ]]; then return 127; else command cat "$@"; fi; }
+    result=$(fallback_chain)
+    printf '%s' "$result"
+)
+if [[ "$result" == "unknown" ]]; then
+    ok "T9 all fallbacks shadowed → literal 'unknown' (never command-not-found)"
+else
+    no "T9 all fallbacks shadowed → literal 'unknown'" "got: '$result' (expected 'unknown')"
+fi
+
+# T10: the production source-line region must NOT contain the original
+# pre-existing pattern (the buggy `hostname -f 2>/dev/null || hostname$`
+# without further fallbacks) — guards against regression to the v1.137-era
+# shape.
+if grep -qE '^[[:space:]]+hostname=\$\(hostname -f 2>/dev/null \|\| hostname\)$' "$SRC"; then
+    no "T10 buggy pre-existing pattern absent" "the v1.137-era line is STILL PRESENT — fallback would regress to two-call-of-same-missing-binary"
+else
+    ok "T10 buggy pre-existing pattern absent (no two-call-of-same-binary fallback)"
+fi
+
+# -----------------------------------------------------------------------------
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"


### PR DESCRIPTION
## v1.139.1 hotfix — portable hostname fallback

**Classification:** PRE-EXISTING distro-compat bug — **NOT a v1.139 regression**. Shipped unchanged in v1.137.0, v1.138.0, v1.139.0. Zero v1.139 PRs touched this file.

### Bug

`cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh:1474` previously read:
```bash
hostname=$(hostname -f 2>/dev/null || hostname)
```
Both branches call the **same** `hostname` binary. On hosts that ship no `hostname` binary in PATH — notably the minimal `centos-stream10` Docker base image used in CI's *Fresh-install namespace guard* — both branches fail with `command not found` (rc=127) and the exporter aborts.

Pre-existing since git-blame `97b2c9297` (2026-02-04, itcmsgr). Confirmed reproduced on multiple `main` SHAs:
- run #389 at `7daacb04` (v1.139 PR-B post-merge)
- run #395 at `18e8c917` (v1.139.0 post-publish)

### In-production blast radius = zero

Real-fleet recon shows **all 9 reachable hosts** have `hostname` present, including BOTH EL10 production hosts (`srv1` CentOS Stream 10, `srv4` AlmaLinux 10.1). The CI failure was specifically the minimal Docker base image. Plus the exporter is classified auxiliary / non-fatal at install_state — installs reach COMMITTED on EL10 even when the exporter aborts.

This is defensive hardening, not an active-incident fix.

### Fix

Extends the chain with four real fallbacks + a literal last-resort guard so the line never exits 127 regardless of host shape:

```bash
hostname=$(hostname -f 2>/dev/null \
    || hostname 2>/dev/null \
    || hostnamectl --static 2>/dev/null \
    || uname -n 2>/dev/null \
    || cat /etc/hostname 2>/dev/null \
    || echo unknown)
```

Behavior preserved on Debian/Ubuntu/EL9 — first link still wins where `hostname` is present. `hostnamectl --static` covers EL10 minimal (kept systemd; dropped hostname). `uname -n` is POSIX-always. `/etc/hostname` is the kernel-set nodename source. `echo unknown` is the bulletproof terminator.

### Files (exactly 2; zero production Go)

- `cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh` — extended fallback chain at line 1474 with a 9-line comment block documenting the v1.139.1 attribution + EL10 rationale.
- `cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh` *(new)* — 10 hermetic assertions:
  - T1–T6 source-link asserts (each fallback present in production source).
  - T7 hostname-shadowed → `hostnamectl` returns real value.
  - T8 hostname+hostnamectl shadowed → `uname -n` returns real value.
  - T9 all 4 fallbacks shadowed → literal `unknown`, rc=0 (never 127).
  - T10 buggy two-call-of-same-binary pattern absent (regression guard).

### Verified `V1_139_1_HOSTNAME_FALLBACK_HOTFIX_VERIFY_PASS_DEB_AND_RPM`

| Gate | lab2 (Ubuntu 24.04 / DEB / Go 1.25) | lab4 (AlmaLinux 9.8 / EL9 RPM / Go 1.25) |
|---|---|---|
| Overlay md5 match (2 files) | ✅ | ✅ |
| `bash -n` + `shellcheck -x -S warning` | ✅ CLEAN | ✅ CLEAN |
| 10/10 test PASS | ✅ | ✅ |
| `generate-fhs-outputs.sh --check` | ✅ rc=0 | ✅ rc=0 |
| `go vet ./...` / `go build ./...` | ✅ | ✅ |
| `go test ./internal/nftbanconf/...` (PR-B parity intact) | ✅ | ✅ |
| `staticcheck@v0.7.0 ./...` | ✅ CLEAN | ✅ CLEAN |
| `gosec -nosec ./...` new findings | ✅ 0 (touches no Go) | ✅ 0 |
| Packaging still-builds | ✅ DEB 12 MB | ✅ EL9 RPM 12 MB |
| PATH-shadow proofs (T7/T8/T9) | ✅ all 3 | ✅ all 3 |
| Live host integrity (installed exporter+core unchanged) | ✅ | ✅ |

Daemon byte-identical to v1.139.0 (no Go touched). Schema 1.83.0 frozen.

Record: `NFTBAN_ROADMAP/V1_139_1_HOSTNAME_FALLBACK_HOTFIX_RECORD.md`.

### Out of scope

- No Ubuntu 26 CI matrix expansion (next lane after this ships)
- No FHS work, no logrotate change, no Go fallback perms / RPM %attr rewrite
- No CSF / Registry-2 / daemon-priv / GAP-3 / schema / metrics / portal
- No fleet rollout; no tag/publish until merge + main CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)