### PR TITLE
feat(distro): v1.140.0 Phase-1 — Ubuntu 26.04 LTS Tier-1 introduction

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -276,6 +276,9 @@ jobs:
           - distro: ubuntu24.04
             container: ubuntu:24.04
             name_suffix: ubuntu24.04
+          - distro: ubuntu26.04
+            container: ubuntu:26.04
+            name_suffix: ubuntu26.04
           - distro: debian12
             container: debian:12
             name_suffix: debian12
@@ -586,6 +589,10 @@ jobs:
           - distro: ubuntu24.04
             container: ubuntu:24.04
             deb_artifact: deb-ubuntu24.04
+            tier: 0
+          - distro: ubuntu26.04
+            container: ubuntu:26.04
+            deb_artifact: deb-ubuntu26.04
             tier: 0
           - distro: debian12
             container: debian:12

--- a/.github/workflows/ci-fresh-install-namespace-guard.yml
+++ b/.github/workflows/ci-fresh-install-namespace-guard.yml
@@ -28,7 +28,7 @@
 # Coverage matrix:
 #   RPM: alma9, rocky9, centos-stream9 (all share rpm-el9 artifact)
 #        centos-stream10 (rpm-el10)
-#   DEB: debian12, debian13, ubuntu22.04, ubuntu24.04
+#   DEB: debian12, debian13, ubuntu22.04, ubuntu24.04, ubuntu26.04
 #
 # Assertions (each with distinct exit code so CI logs are diagnostic):
 #   A1 (exit 2): nftband.service active post-install
@@ -121,6 +121,11 @@ jobs:
             image: ubuntu:24.04
             pkg_type: deb
             artifact: deb-ubuntu24.04
+            systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
+          - distro: ubuntu26.04
+            image: ubuntu:26.04
+            pkg_type: deb
+            artifact: deb-ubuntu26.04
             systemd_install: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd systemd-sysv curl iproute2 nftables jq tar ca-certificates adduser netbase procps
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,9 @@ jobs:
           - distro: ubuntu24.04
             container: ubuntu:24.04
             name_suffix: ubuntu24.04
+          - distro: ubuntu26.04
+            container: ubuntu:26.04
+            name_suffix: ubuntu26.04
           - distro: debian12
             container: debian:12
             name_suffix: debian12
@@ -391,6 +394,7 @@ jobs:
             "nftban-el10-x86_64.rpm"
             "nftban-ubuntu22.04-amd64.deb"
             "nftban-ubuntu24.04-amd64.deb"
+            "nftban-ubuntu26.04-amd64.deb"
             "nftban-debian12-amd64.deb"
             "nftban-debian13-amd64.deb"
             "nftband-linux-amd64"
@@ -468,6 +472,7 @@ jobs:
 
           DEB Packages (Ubuntu + Debian):
             nftban-ubuntu24.04-amd64.deb   Ubuntu 24.04 (Noble) - Tier 0
+            nftban-ubuntu26.04-amd64.deb   Ubuntu 26.04 (Resolute) - Tier 0
             nftban-debian12-amd64.deb      Debian 12 (Bookworm) - Tier 0
             nftban-debian13-amd64.deb      Debian 13 (Trixie) - Tier 1
             nftban-ubuntu22.04-amd64.deb   Ubuntu 22.04 (Jammy) - Tier 2
@@ -507,6 +512,9 @@ jobs:
 
              # Ubuntu 24.04 (Noble) - Tier 0
              wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu24.04-amd64.deb
+
+             # Ubuntu 26.04 (Resolute) - Tier 0
+             wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu26.04-amd64.deb
 
              # Debian 12 (Bookworm) - Tier 0
              wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-debian12-amd64.deb
@@ -622,6 +630,7 @@ jobs:
           | Distribution | Package | Tier |
           |--------------|---------|------|
           | Ubuntu 24.04 (Noble) | `nftban-ubuntu24.04-amd64.deb` | Tier 0 |
+          | Ubuntu 26.04 (Resolute) | `nftban-ubuntu26.04-amd64.deb` | Tier 0 |
           | Debian 12 (Bookworm) | `nftban-debian12-amd64.deb` | Tier 0 |
           | Debian 13 (Trixie) | `nftban-debian13-amd64.deb` | Tier 1 |
           | Ubuntu 22.04 (Jammy) | `nftban-ubuntu22.04-amd64.deb` | Tier 2 |
@@ -702,6 +711,7 @@ jobs:
             "nftban-debian13-amd64.deb"
             "nftban-ubuntu22.04-amd64.deb"
             "nftban-ubuntu24.04-amd64.deb"
+            "nftban-ubuntu26.04-amd64.deb"
             "nftband-linux-amd64"
             "SHA256SUMS.build"
           )
@@ -905,6 +915,10 @@ jobs:
 
           check_package "nftban-ubuntu24.04-amd64.deb" \
             "dpkg-deb -x /tmp/release-verify/nftban-ubuntu24.04-amd64.deb ." || \
+            GATE2_FAILURES=$((GATE2_FAILURES + 1))
+
+          check_package "nftban-ubuntu26.04-amd64.deb" \
+            "dpkg-deb -x /tmp/release-verify/nftban-ubuntu26.04-amd64.deb ." || \
             GATE2_FAILURES=$((GATE2_FAILURES + 1))
 
           rm -rf /tmp/extract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,7 @@ NFTBan supports platforms by tier. Only Tier 0 platforms define correctness.
 
 **Tier 0 — Focus (CI-required)**
 - Ubuntu 24.04 LTS
+- Ubuntu 26.04 LTS
 - Debian 12
 - Rocky Linux 9.x
 
@@ -131,7 +132,6 @@ A change is correct only if it builds, installs, and passes receipt-based audit 
 **Tier 1 — Future Planning (Limited CI)**
 - Rocky Linux 10.x
 - Debian 13
-- Ubuntu 26.04 LTS
 
 Rules: Architecture must accommodate. No hardcoded assumptions. Failures do not block Tier 0 releases.
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -9,6 +9,7 @@ Every release must pass this checklist.
 ### Tier 0 (required)
 
 - [ ] Build succeeds on Ubuntu 24.04
+- [ ] Build succeeds on Ubuntu 26.04
 - [ ] Build succeeds on Debian 12
 - [ ] Build succeeds on Rocky Linux 9
 
@@ -16,7 +17,6 @@ Every release must pass this checklist.
 
 - [ ] Rocky Linux 10 (warn-only)
 - [ ] Debian 13 (warn-only)
-- [ ] Ubuntu 26.04 (warn-only, when available)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,8 @@ Security fixes are prioritized for Tier 0 platforms first.
 
 | Tier | Platforms | Support Level |
 |------|-----------|---------------|
-| **Tier 0** | Ubuntu 24.04 LTS, Debian 12, Rocky Linux 9.x | Fully supported |
-| **Tier 1** | Rocky Linux 10.x, Debian 13, Ubuntu 26.04 LTS | Planned |
+| **Tier 0** | Ubuntu 24.04 LTS, Ubuntu 26.04 LTS, Debian 12, Rocky Linux 9.x | Fully supported |
+| **Tier 1** | Rocky Linux 10.x, Debian 13 | Planned |
 | **Tier 2** | Rocky/RHEL 8.x, Ubuntu 22.04 LTS, Debian 11 | Best-effort (legacy) |
 
 ---

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -213,7 +213,7 @@ EOF
             ;;
         deb)
             echo "    • Debian packages: debian11, debian12, debian13"
-            echo "    • Ubuntu packages: ubuntu20.04, ubuntu22.04, ubuntu24.04"
+            echo "    • Ubuntu packages: ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu26.04"
             echo "    • Debian packages MAY work on Ubuntu (with warnings)"
             echo "    • Ubuntu packages will NOT work on Debian"
             ;;

--- a/etc/nftban/distros/debian.conf
+++ b/etc/nftban/distros/debian.conf
@@ -1,0 +1,140 @@
+# =============================================================================
+# NFTBan v1.0.0 - Distribution Configuration - Debian (generic fallback)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="distro_debian_generic"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="Terminal-fallback distribution configuration for Debian releases the loader does not have an explicit debian-<N>.conf for. Loaded by cli/lib/nftban/lib/nftban_distro_config.sh:78-112 after the explicit ${id}-${version}.conf and ${id}-${major}.conf misses. Mirrors the centos.conf / fedora.conf terminal-fallback pattern."
+# meta:input="None"
+# meta:output="Distribution-specific variables"
+# meta:depends=""
+# meta:platform="debian"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+#
+# Values held stable across Debian releases (11 → 12 → 13 → 14):
+#   - apt package manager, apt-get install/update/upgrade syntax
+#   - systemd as the init system, polkit rules dir at /usr/share/polkit-1
+#   - /etc/nftables.conf as the nftables config path (Debian-family default)
+#   - AppArmor enforcing, UFW NOT enabled by default (vs Ubuntu which sets ufw_default=true)
+#
+# When to ship an explicit debian-<N>.conf instead: when (a) a real value
+# diverges from this generic, or (b) precision logging at detect-time is
+# operationally important. The generic exists so a missing explicit conf
+# does NOT break the shell loader (which has no forward-fit; the Go
+# loginmon loader does — these are two different loaders).
+# =============================================================================
+
+[distro]
+id = debian
+name = Debian
+version = latest
+family = debian
+version_codename = generic
+
+[package_manager]
+type = apt
+install_cmd = apt-get install -y
+update_cmd = apt-get update
+upgrade_cmd = apt-get upgrade -y
+search_cmd = apt-cache search
+info_cmd = apt-cache show
+
+[packages]
+nftables = nftables
+curl = curl
+iproute = iproute2
+bash = bash
+systemd = systemd
+suricata = suricata
+suricata_update = suricata-update
+mail = mailutils
+golang = golang-go
+golang_min_version = 2:1.21
+# Build dependencies (for compiling from source)
+build_essential = build-essential
+pam_dev = libpam0g-dev
+jq = jq
+socat = socat
+wget = wget
+git = git
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+ncat = ncat
+
+[services]
+cron = cron
+rsyslog = rsyslog
+suricata = suricata
+suricata_update = suricata-update
+nftables = nftables
+sshd = ssh
+polkit = polkit
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+
+[paths]
+# Auth log path (Debian uses /var/log/auth.log)
+auth_log = /var/log/auth.log
+
+# === Mail / MTA (BUG-14) ===
+maillog = /var/log/mail.log
+exim_log = /var/log/exim4/mainlog
+exim_reject_log = /var/log/exim4/rejectlog
+dovecot_log = /var/log/mail.log
+
+# === DirectAdmin (BUG-14 + BUG-19) ===
+# DirectAdmin officially supports Debian and Ubuntu. Real paths apply on
+# every family — the v1.79.2 "n/a on Debian" assumption was wrong.
+directadmin_login_log = /var/log/directadmin/login.log
+directadmin_security_log = /var/log/directadmin/security.log
+
+# === FTP (BUG-14) ===
+pureftpd_log = /var/log/syslog
+
+nft = /usr/sbin/nft
+nftban_cli = /usr/sbin/nftban
+mail = /usr/bin/mail
+systemctl = /bin/systemctl
+journalctl = /usr/bin/journalctl
+cron_d = /etc/cron.d
+systemd_system = /lib/systemd/system
+suricata = /usr/bin/suricata
+suricatasc = /usr/bin/suricatasc
+suricata_conf = /etc/suricata
+suricata_yaml = /etc/suricata/suricata.yaml
+suricata_eve_log = /var/log/nftban/suricata/eve-alerts.json
+suricata_log_dir = /var/log/nftban/suricata
+suricata_rules_dir = /var/lib/suricata/rules
+suricata_stats_log = /var/log/suricata/stats.log
+suricata_iface_config = /etc/nftban/conf.d/suricata/interfaces.conf
+suricata_socket = /var/run/suricata/suricata-command.socket
+nftables_conf = /etc/nftables.conf
+nftables_conf_primary = /etc/nftables.conf
+# Polkit rules directory (Debian: /usr/share, local overrides in /etc)
+polkit_rules_dir = /usr/share/polkit-1/rules.d
+
+[repository]
+epel_required = false
+epel_package =
+epel_install_cmd =
+
+[features]
+systemd_support = true
+firewalld_default = false
+ufw_default = false
+apparmor_default = enforcing
+
+[tier]
+level = 2
+description = Generic Debian fallback (precision via explicit debian-<N>.conf)
+ci_build = false
+ci_test = false

--- a/etc/nftban/distros/ubuntu-26.conf
+++ b/etc/nftban/distros/ubuntu-26.conf
@@ -1,0 +1,129 @@
+# =============================================================================
+# NFTBan v1.0.0 - Distribution Configuration - Ubuntu 26.04 LTS
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="distro_ubuntu_26_04"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="Distribution configuration for Ubuntu 26.04 LTS (Resolute Raccoon)"
+# meta:input="None"
+# meta:output="Distribution-specific variables"
+# meta:depends=""
+# meta:platform="ubuntu-26.04"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+[distro]
+id = ubuntu
+name = Ubuntu
+version = 26.04
+family = debian
+version_codename = resolute
+
+[package_manager]
+type = apt
+install_cmd = apt-get install -y
+update_cmd = apt-get update
+upgrade_cmd = apt-get upgrade -y
+search_cmd = apt-cache search
+info_cmd = apt-cache show
+
+[packages]
+nftables = nftables
+curl = curl
+iproute = iproute2
+bash = bash
+systemd = systemd
+suricata = suricata
+suricata_update = suricata-update
+mail = mailutils
+golang = golang-go
+golang_min_version = 2:1.21
+# Build dependencies (for compiling from source)
+build_essential = build-essential
+pam_dev = libpam0g-dev
+jq = jq
+socat = socat
+wget = wget
+git = git
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+ncat = ncat
+
+[services]
+cron = cron
+rsyslog = rsyslog
+suricata = suricata
+suricata_update = suricata-update
+nftables = nftables
+sshd = ssh
+polkit = polkit
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+nftban_sync = nftban-sync
+nftban_unified_exporter = nftban-unified-exporter
+
+[paths]
+# Auth log path (Debian uses /var/log/auth.log)
+auth_log = /var/log/auth.log
+
+# === Mail / MTA (BUG-14) ===
+maillog = /var/log/mail.log
+exim_log = /var/log/exim4/mainlog
+exim_reject_log = /var/log/exim4/rejectlog
+dovecot_log = /var/log/mail.log
+
+# === DirectAdmin (BUG-14 + BUG-19) ===
+# DirectAdmin officially supports Debian and Ubuntu. Real paths apply on
+# every family — the v1.79.2 "n/a on Debian" assumption was wrong.
+directadmin_login_log = /var/log/directadmin/login.log
+directadmin_security_log = /var/log/directadmin/security.log
+
+# === FTP (BUG-14) ===
+pureftpd_log = /var/log/syslog
+
+nft = /usr/sbin/nft
+nftban_cli = /usr/sbin/nftban
+mail = /usr/bin/mail
+systemctl = /bin/systemctl
+journalctl = /usr/bin/journalctl
+cron_d = /etc/cron.d
+systemd_system = /lib/systemd/system
+suricata = /usr/bin/suricata
+suricatasc = /usr/bin/suricatasc
+suricata_conf = /etc/suricata
+suricata_yaml = /etc/suricata/suricata.yaml
+suricata_eve_log = /var/log/nftban/suricata/eve-alerts.json
+suricata_log_dir = /var/log/nftban/suricata
+suricata_rules_dir = /var/lib/suricata/rules
+suricata_stats_log = /var/log/suricata/stats.log
+suricata_iface_config = /etc/nftban/conf.d/suricata/interfaces.conf
+suricata_socket = /var/run/suricata/suricata-command.socket
+nftables_conf = /etc/nftables.conf
+nftables_conf_primary = /etc/nftables.conf
+# Polkit rules directory (Debian/Ubuntu: /usr/share, local overrides in /etc)
+polkit_rules_dir = /usr/share/polkit-1/rules.d
+
+[repository]
+epel_required = false
+epel_package =
+epel_install_cmd =
+
+[features]
+systemd_support = true
+firewalld_default = false
+ufw_default = true
+apparmor_default = enforcing
+
+[tier]
+level = 0
+description = Focus / CI-Required
+ci_build = true
+ci_test = true

--- a/etc/nftban/distros/ubuntu.conf
+++ b/etc/nftban/distros/ubuntu.conf
@@ -1,0 +1,148 @@
+# =============================================================================
+# NFTBan v1.0.0 - Distribution Configuration - Ubuntu (generic fallback)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="distro_ubuntu_generic"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="Terminal-fallback distribution configuration for Ubuntu releases the loader does not have an explicit ubuntu-<N>.conf for. Loaded by cli/lib/nftban/lib/nftban_distro_config.sh:78-112 after the explicit ${id}-${version}.conf and ${id}-${major}.conf misses. Mirrors the centos.conf / fedora.conf terminal-fallback pattern."
+# meta:input="None"
+# meta:output="Distribution-specific variables"
+# meta:depends=""
+# meta:platform="ubuntu"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+#
+# Values held stable across Ubuntu LTS releases (22.04 → 24.04 → 26.04):
+#   - apt package manager, apt-get install/update/upgrade syntax
+#   - systemd as the init system, polkit rules dir at /usr/share/polkit-1
+#   - /etc/nftables.conf as the nftables config path (Debian-family default)
+#   - AppArmor enforcing, UFW enabled
+#   - auth.log at /var/log/auth.log; mail.log + exim4 paths unchanged
+#
+# Values that may drift across future Ubuntu majors:
+#   - codename (per-release; not pinned here so the loader can still serve
+#     a sensible default until an explicit ubuntu-<N>.conf is shipped)
+#   - golang minimum version (the explicit ubuntu-<N>.conf can override)
+#
+# When to ship an explicit ubuntu-<N>.conf instead: when (a) a real value
+# diverges from this generic, or (b) precision logging at detect-time is
+# operationally important. The generic exists so a missing explicit conf
+# does NOT break the shell loader (which has no forward-fit; the Go
+# loginmon loader does — these are two different loaders).
+# =============================================================================
+
+[distro]
+id = ubuntu
+name = Ubuntu
+version = latest
+family = debian
+version_codename = generic
+
+[package_manager]
+type = apt
+install_cmd = apt-get install -y
+update_cmd = apt-get update
+upgrade_cmd = apt-get upgrade -y
+search_cmd = apt-cache search
+info_cmd = apt-cache show
+
+[packages]
+nftables = nftables
+curl = curl
+iproute = iproute2
+bash = bash
+systemd = systemd
+suricata = suricata
+suricata_update = suricata-update
+mail = mailutils
+golang = golang-go
+golang_min_version = 2:1.21
+# Build dependencies (for compiling from source)
+build_essential = build-essential
+pam_dev = libpam0g-dev
+jq = jq
+socat = socat
+wget = wget
+git = git
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+ncat = ncat
+
+[services]
+cron = cron
+rsyslog = rsyslog
+suricata = suricata
+suricata_update = suricata-update
+nftables = nftables
+sshd = ssh
+polkit = polkit
+prometheus = prometheus
+node_exporter = prometheus-node-exporter
+nftban_sync = nftban-sync
+nftban_unified_exporter = nftban-unified-exporter
+
+[paths]
+# Auth log path (Debian uses /var/log/auth.log)
+auth_log = /var/log/auth.log
+
+# === Mail / MTA (BUG-14) ===
+maillog = /var/log/mail.log
+exim_log = /var/log/exim4/mainlog
+exim_reject_log = /var/log/exim4/rejectlog
+dovecot_log = /var/log/mail.log
+
+# === DirectAdmin (BUG-14 + BUG-19) ===
+# DirectAdmin officially supports Debian and Ubuntu. Real paths apply on
+# every family — the v1.79.2 "n/a on Debian" assumption was wrong.
+directadmin_login_log = /var/log/directadmin/login.log
+directadmin_security_log = /var/log/directadmin/security.log
+
+# === FTP (BUG-14) ===
+pureftpd_log = /var/log/syslog
+
+nft = /usr/sbin/nft
+nftban_cli = /usr/sbin/nftban
+mail = /usr/bin/mail
+systemctl = /bin/systemctl
+journalctl = /usr/bin/journalctl
+cron_d = /etc/cron.d
+systemd_system = /lib/systemd/system
+suricata = /usr/bin/suricata
+suricatasc = /usr/bin/suricatasc
+suricata_conf = /etc/suricata
+suricata_yaml = /etc/suricata/suricata.yaml
+suricata_eve_log = /var/log/nftban/suricata/eve-alerts.json
+suricata_log_dir = /var/log/nftban/suricata
+suricata_rules_dir = /var/lib/suricata/rules
+suricata_stats_log = /var/log/suricata/stats.log
+suricata_iface_config = /etc/nftban/conf.d/suricata/interfaces.conf
+suricata_socket = /var/run/suricata/suricata-command.socket
+nftables_conf = /etc/nftables.conf
+nftables_conf_primary = /etc/nftables.conf
+# Polkit rules directory (Debian/Ubuntu: /usr/share, local overrides in /etc)
+polkit_rules_dir = /usr/share/polkit-1/rules.d
+
+[repository]
+epel_required = false
+epel_package =
+epel_install_cmd =
+
+[features]
+systemd_support = true
+firewalld_default = false
+ufw_default = true
+apparmor_default = enforcing
+
+[tier]
+level = 2
+description = Generic Ubuntu fallback (precision via explicit ubuntu-<N>.conf)
+ci_build = false
+ci_test = false


### PR DESCRIPTION
## v1.140.0 Phase-1 — Ubuntu 26.04 LTS Tier-1 introduction

Promotes **Ubuntu 26.04 LTS ("Resolute Raccoon")** to repo Tier-0 (fully supported) per `SECURITY.md` taxonomy. CI matrix expansion + 3 new distro confs + 3 tier-doc reshuffles + 1 hint-string line.

**Daemon byte-identical to v1.139.2** (zero Go touched; SHA256-identical confirmed in lab validation). **Schema 1.83.0 frozen.** Zero packaging dep change.

### Controlling spec

`NFTBAN_ROADMAP/V1_140_0_UBUNTU26_PHASE1_TIGHT_SPEC.md` — operator-locked 10-file envelope, byte-strict.

### 10 files (envelope locked)

| Category | Files |
|---|---|
| **CI / release matrix expansion (3)** | `.github/workflows/build-packages.yml` (+ubuntu26.04 to build-deb Tier-0 + test-deb-install tier:0); `.github/workflows/release.yml` (+ubuntu26.04 to build-deb + 5 asset enumerations); `.github/workflows/ci-fresh-install-namespace-guard.yml` (+ubuntu26.04 matrix row + coverage comment) |
| **Distro confs (3 new)** | `etc/nftban/distros/ubuntu-26.conf` (explicit, `[tier] level = 0`); `etc/nftban/distros/ubuntu.conf` (generic Ubuntu fallback — **mandatory** because the shell loader has no forward-fit unlike the Go loginmon loader; closes v1.139.1 verify Finding #1 structurally); `etc/nftban/distros/debian.conf` (generic Debian fallback — Debian 14+ forward-fit symmetry) |
| **CLI hint (1)** | `cli/lib/nftban/cli/cmd_update.sh:216` — append `, ubuntu26.04` to the Ubuntu packages hint |
| **Tier docs (3)** | `SECURITY.md` (Ubuntu 26 → Tier-0); `CONTRIBUTING.md` (same reshuffle); `RELEASE-CHECKLIST.md` (warn-only → required-pass) |

### Operator decisions (locked 2026-05-28)

| Decision | Value |
|---|---|
| `SELECT_UBUNTU26_TIER1_VERSION` | v1.140.0 |
| OQ-1 — Tier vocabulary | (a) promote Ubuntu 26 to repo Tier-0 / fully supported |
| OQ-5 — Build runner | container (`runs-on: ubuntu-latest` + Docker `ubuntu:26.04`, matching existing 22/24/debian12/13 pattern) |
| OQ-6 — AppArmor flip | phase2 (preserves Phase-1 daemon byte-identical) |
| OQ-3 — Ubuntu 22.04 status | keep-tier2 |
| OQ-4 — Debian 13 co-promotion | defer (Ubuntu 26 ships alone) |
| Generic `debian.conf` | ship (Debian 14+ forward-fit) |

### Lab validation evidence

`NFTBAN_ROADMAP/V140_172_LAB_VALIDATION_RECORD.md` — verdict `V140_172_LAB_VALIDATION_PARTIAL_PASS_B`.

**Set B (`203.0.113.155` Ubuntu 26.04 LTS) — FULL PASS** on every §5.1–§5.7 step:

- Candidate DEB built natively (sha256 `5981afc5ebfd34ef19f97f8d1a97da68ec27a56af341753003c5d2dddaa89251`, 13.6 MB).
- Install via `apt-get install` → `NFTBAN_TAKEOVER=1 nftban-installer --repair` → `INSTALL_STATE=COMMITTED`.
- 16/16 install assertions PASS.
- `nftban version`: no "No configuration file found" (proves the Phase-1 conf-fix).
- All 3 new confs (`ubuntu-26.conf` explicit, `ubuntu.conf` generic, `debian.conf` generic) resolve correctly via loader.
- **Daemon SHA256-identical** between baseline `main @ 3ba23da9` and candidate (`nftban-core` sha256 `cd605ca7…`, `nftband` sha256 `b48362cf…`) — not just modulo `.note.go.buildid`.
- All negative-control gates PASS (`build/fhs-spec.yaml` MD5, `packaging/deb/control` MD5, `nftban_fhs_spec.sh` MD5, `cmd/`+`internal/` git diff = empty).

**Set A (172.x lab)** — deferred per operator's PARTIAL_PASS_B acceptance: `.3`/`.39` powered off; `.20` is the Ubuntu 24 hypervisor; the Ubuntu 26 guest `tgt-u2604` at `10.88.88.112` didn't authorize the deputy's SSH keys. Operator gate "continue to 140 and lets release the UBUNTU 26" accepted given the SHA256-identical daemon proof.

### Local pre-push proofs

| Gate | Result |
|---|---|
| Envelope file count | **10/10** (cap 10) ✓ |
| Forbidden-path negative control | 0 `.go`, 0 `build/fhs-spec.yaml`, 0 `packaging/{deb,rpm}/control`, 0 `cmd/`, 0 `internal/`, 0 `install/systemd/nftban-core*` ✓ |
| `bash -n` on touched files | clean ✓ |
| YAML parse on 3 workflows | clean ✓ |
| Shell distro-loader smoke | 5/5 routes correctly (`ubuntu:26.04`→`ubuntu-26.conf`, `ubuntu:27.04`→`ubuntu.conf` proves NEXT-major forward-fit, `ubuntu:99.99`→`ubuntu.conf`, `debian:14.0`→`debian-14.conf`, `debian:99.99`→`debian.conf`) ✓ |

### Out of scope (deferred to Phase-2 / later lanes)

- Canonization workflows (`ci-{install,uninstall,update,restore}-canonization.yml`, `ci-runtime-truth.yml`) — Phase-2
- AppArmor + Landlock + Go-1.25 enablement re-test on `nftban-core-geoip.service` / `nftban-core-feeds.service` — Phase-2 (OQ-6)
- `nftban uninstall` CLI wrapper — separate lane (v1.139.1 install verify Finding #2)
- Ubuntu `inet filter` postinst handling under CVE-2025-NFTBAN-001 guard — Phase-2 behavioral (Finding #3)
- systemd 259 path-transition warnings — non-fatal, FHS-spec adjacent (Finding #4)
- `mailutils` via Recommends — release-notes only (Finding #5)
- SLSA per-distro provenance — single hermetic Go binary attests for all
- `nftban_fhs_spec.sh` source-side GUI cleanup — separate fhs-spec lane

### Post-merge follow-up (NOT in this PR)

- Release-prep PR (4-file envelope: VERSION + STATUS.md + CHANGELOG.md + `nftban_fhs_spec.sh` header)
- Tag `v1.140.0` annotated + push → Release Packages + Docker + SLSA
- Option-B body curation
- Closure doc at `NFTBAN_ROADMAP/V1_140_0_RELEASE_CLOSURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
