### PR TITLE
docs: add Ubuntu 26.04 install URLs to README + REPRODUCIBLE_BUILDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu24.
 sudo apt install -y ./nftban-ubuntu24.04-amd64.deb
 ```
 
+#### Ubuntu 26.04 LTS (Resolute Raccoon) — *Tier-0 since v1.140.0*
+```bash
+wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu26.04-amd64.deb
+sudo apt install -y ./nftban-ubuntu26.04-amd64.deb
+```
+
 #### Debian 12 (Bookworm)
 ```bash
 wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-debian12-amd64.deb
@@ -157,6 +163,7 @@ sudo apt install -y ./nftban-ubuntu22.04-amd64.deb
 | Tier | Distribution | Version | Package |
 |------|--------------|---------|---------|
 | 0 | Ubuntu | 24.04 (Noble) | [nftban-ubuntu24.04-amd64.deb](https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu24.04-amd64.deb) |
+| 0 | Ubuntu | 26.04 (Resolute Raccoon) | [nftban-ubuntu26.04-amd64.deb](https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu26.04-amd64.deb) |
 | 0 | Debian | 12 (Bookworm) | [nftban-debian12-amd64.deb](https://github.com/itcmsgr/nftban/releases/latest/download/nftban-debian12-amd64.deb) |
 | 1 | Debian | 13 (Trixie) | [nftban-debian13-amd64.deb](https://github.com/itcmsgr/nftban/releases/latest/download/nftban-debian13-amd64.deb) |
 | 2 | Ubuntu | 22.04 (Jammy) | [nftban-ubuntu22.04-amd64.deb](https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu22.04-amd64.deb) |

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -195,7 +195,7 @@ https://github.com/itcmsgr/nftban/releases/download/vX.Y.Z/SHA256SUMS
 The `SHA256SUMS` file contains checksums for:
 
 - **RPM packages:** `nftban-el9-x86_64.rpm`, `nftban-el10-x86_64.rpm`
-- **DEB packages:** `nftban-ubuntu22.04-amd64.deb`, `nftban-ubuntu24.04-amd64.deb`, `nftban-debian12-amd64.deb`, `nftban-debian13-amd64.deb`
+- **DEB packages:** `nftban-ubuntu22.04-amd64.deb`, `nftban-ubuntu24.04-amd64.deb`, `nftban-ubuntu26.04-amd64.deb`, `nftban-debian12-amd64.deb`, `nftban-debian13-amd64.deb`
 - **Binaries:** `nftban-core-linux-amd64`, `nftband-linux-amd64`
 
 ### Verification Commands


### PR DESCRIPTION
Operator-flagged 2026-05-28 post v1.140.0 publish: `README.md` install-by-tier section and `docs/REPRODUCIBLE_BUILDS.md` DEB-package list were missing Ubuntu 26.04.

The `release.yml` CI itself is **correct** — it produces the right URLs in the auto-generated RELEASE_NOTES.md tier table + latest-URLs block + verification list (verified 302 → live `nftban-ubuntu26.04-amd64.deb` asset on v1.140.0). The gap was in hand-maintained README files that PR #724's locked envelope didn't cover.

## Changes

- `README.md` (+7 / -0):
  - Adds **Tier-0 "Ubuntu 26.04 LTS (Resolute Raccoon) — *Tier-0 since v1.140.0*"** install snippet under §Quick Install.
  - Adds **Ubuntu 26.04 row** to the Available Packages DEB tier table.
- `docs/REPRODUCIBLE_BUILDS.md` (+1 / -1):
  - Adds `nftban-ubuntu26.04-amd64.deb` to the DEB packages list.

## Verification

- URL correctness: `https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu26.04-amd64.deb` returns HTTP 302 → live asset (size 12,358,048; sha256 `ae746304…`).
- No Go, no schema, no packaging, no service-files touched.
- Docs-only change; takes effect on github.com README rendering as soon as merged.

## Follow-up tracked

Master TODO `README-TIER-INSTALL-SNIPPETS` entry in `NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md` (operator-filed for the wiki mirror + future distro additions). This PR addresses the README portion; wiki/extra-docs sync remains a separate operator-gated task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)