### PR TITLE
fix(cli): v1.141 PR-A parser validation and help inertness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] — v1.141.0 PR-A: CLI parser validation + help inertness
+
+**Codename:** `V1_141_0_PR_A_CLI_PARSER_HELP`
+**Controlling scope:** `NFTBAN_ROADMAP/V1_141_0_CONSOLIDATED_HOTFIX_AND_HARDENING_SCOPE.md`
+**PR:** [#727](https://github.com/itcmsgr/nftban/pull/727)
+
+> **Why:** Two CLI safety gaps surfaced on v1.140.0 baseline. **A7/A8:**
+> `nftban ban <ip> --timeout VALUE` accepted any non-positive-integer
+> VALUE (`abc` / `-5` / `0` / `1.5` / `+10` / `1e3` / `0x10` / `01`) and
+> forwarded it to `nftban-core`, which defaulted to a **permanent ban**
+> on parse failure. **B5–B14:** twelve `nftban <cmd> [<sub>] --help`
+> surfaces ran action code before reaching their own help arm — including
+> one (`nftban export --help`) that **created an output file on disk**
+> before the user got help text. **Daemon byte-identical to v1.140.0**
+> (zero `.go` touched; shell-only). Schema 1.83.0 frozen.
+
+### Parser validation — `cmd_ban.sh`
+
+- `--timeout` now rejects every non-positive-integer VALUE at parse time
+  with a clear `ERROR: --timeout requires a positive integer (seconds)`
+  message and `Hint:` line, rc=1, **before** any IPC to `nftban-core` /
+  `/etc/nftban/blacklist.d/` write / nft mutation.
+- Regex `^[1-9][0-9]*$`. Strict-positive-integer contract: no leading
+  zeros, no signs (even `+`), no fractional / scientific / hex forms.
+- Valid values (`1`, `60`, `3600`, `86400`, etc.) unaffected.
+
+### Help inertness sweep — `cli/sbin/nftban` + four `cmd_*.sh`
+
+- **Top-level dispatcher guard** at `cli/sbin/nftban` runs before the
+  auto-loader and alias case. Covers six top-level subcommands whose cmd
+  file historically ran action code before the help arm executed
+  (`search`, `feeds`, `export`, `suricata`, `geoban`) and three phantom
+  subcommands present in the suggester list with no `cmd_*.sh` backing
+  (`install`, `uninstall`, `rebuild`).
+  - `nftban export --help` previously created an output JSON file on
+    disk (real help-inertness bug). Now rc=0, Usage text, no file write.
+- **Per-arm bypass** in `cmd_firewall.sh::firewall_reload` (B5).
+- **EUID-gate restructure** in `cmd_trust.sh::enable|disable|update` so
+  the polkit-auth check is bypassed for `-h|--help|help` (B6/B7/B8).
+- **Sub-arm bypass** in `cmd_config.sh::get|set|defaults|overrides|reset|reset-all`
+  via `_v141_config_subarg_is_help()` (B11/B12 + four sweep extras).
+
+### Dropped (operator `SELECT_V1_141_0_B9_B10_B13_B14_DROP_OR_ALIAS = drop`)
+
+- `feeds add` / `feeds remove` / `update apply` / `update channel` —
+  documented in the suggester list but with no backing code path. The
+  universal sweep test SKIPs them with the operator-named drop reason;
+  no alias is added.
+
+### Tests (all hermetic, PATH-shadow sandbox)
+
+- `tests/cli_ban_timeout_validation_test.sh` — 12 PASS / 0 FAIL.
+- `tests/cli_ban_timeout_no_mutation_test.sh` — 5 PASS / 0 FAIL.
+- `tests/cli_help_inertness_v141_test.sh` — 13 PASS / 0 FAIL.
+- `tests/cli_help_inertness_universal_test.sh` — 46 PASS / 0 FAIL / 4 SKIP.
+- `tests/rollback_help_guard_v1_139_2_test.sh` (regression) — 10/10 PASS.
+- `bash -n` on every modified shell file — 9 OK.
+- **Total: 86 PASS, 0 FAIL.**
+
+The PATH-shadow sandbox replaces every mutation binary (`nftban-core`,
+`nft`, `systemctl`, `polkitd`, package managers) with a marker-emitting
+stub that flags only **mutating** verbs. Read-only checks (`systemctl
+is-active`, `nft list`) are expected on every CLI invocation including
+help paths and are not flagged.
+
+### Forbidden-path negative control
+
+- 0 `.go` files touched.
+- 0 `internal/` / `cmd/` / `build/` / `packaging/` / `install/` /
+  `systemd/` / `schema/` / `docker/` / `.github/` / `fhs-spec.yaml`
+  changes.
+- 0 schema version bump (Schema 1.83.0 remains frozen).
+- 0 portal / metrics / Go-installer change.
+
+The release-prep envelope (`VERSION`, `STATUS.md`, `CHANGELOG.md`
+finalisation, `nftban_fhs_spec.sh` header-version regen) ships in a
+separate release-prep PR at v1.141.0 tag time.
+
+---
+
 ## [v1.140.0] - 2026-05-28 — Ubuntu 26.04 LTS Tier-1 introduction
 
 **Codename:** `V1_140_0_UBUNTU26_TIER1_INTRO`

--- a/README.md
+++ b/README.md
@@ -189,10 +189,15 @@ nftban login enable
 nftban geoban enable
 
 # Common operations
-nftban ban 1.2.3.4
+nftban ban 1.2.3.4                       # permanent ban
+nftban ban 1.2.3.4 --timeout 3600        # 1-hour ban (positive integer seconds)
 nftban unban 1.2.3.4
 nftban status
 ```
+
+`--timeout` requires a positive integer (seconds) — non-integer / negative /
+zero / fractional / signed / hex / leading-zero values are rejected at parse
+time with a clear ERROR (since v1.141.0). Omit `--timeout` for a permanent ban.
 
 ---
 
@@ -295,12 +300,17 @@ All packages under `internal/` are implementation details.
 
 ## Requirements
 
-- **Linux**: Rocky/Alma/RHEL 9-10, Ubuntu 22.04+, Debian 12+
+- **Linux**: Rocky / Alma / RHEL 9–10, Ubuntu 22.04 / 24.04 / **26.04 LTS (Resolute Raccoon)**, Debian 12 / 13
 - **nftables**: 1.0+
 - **Bash**: 4.4+
 - **systemd**: 252+
 - **jq**: JSON processor
 - **Go 1.24+**: For building from source (optional)
+
+Ubuntu 26.04 LTS is **Tier-0 (fully supported)** since v1.140.0 — see the
+[Quick Install — Tier 0](#tier-0--primary-platforms) section and the
+[DEB Packages](#deb-packages-ubuntu--debian) table for the install snippet
+and `.deb` URL.
 
 ---
 

--- a/cli/lib/nftban/cli/cmd_ban.sh
+++ b/cli/lib/nftban/cli/cmd_ban.sh
@@ -84,6 +84,18 @@ nftban_cmd_ban() {
                 shift 2
                 ;;
             --timeout)
+                # v1.141 PR-A (BUG-A7/A8): reject non-positive-integer timeouts at
+                # parse time, before any IPC to nftban-core / blacklist.d write /
+                # nft mutation. Prior to v1.141, "abc" / "-5" / "0" / "" / "1.5"
+                # silently propagated to nftban-core which then defaulted to
+                # permanent ban — operator surprise reproduced live in the
+                # cruel-judge review on monitor.mywebhost.gr.
+                if [[ ! "${2:-}" =~ ^[1-9][0-9]*$ ]]; then
+                    echo "ERROR: --timeout requires a positive integer (seconds); got: '${2:-(missing)}'" >&2
+                    echo "Hint:  nftban ban <ip> --timeout 3600" >&2
+                    echo "       (use no --timeout for permanent ban)" >&2
+                    return 1
+                fi
                 timeout="$2"
                 shift 2
                 ;;

--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -717,8 +717,25 @@ nftban_cmd_config() {
     fi
     echo ""
 
+    # v1.141 PR-A (BUG-B11/B12 + sweep-all): every config sub-arm now intercepts
+    # --help|-h|help as $1 BEFORE the "Module name required" check. Prior to
+    # v1.141, `nftban config get --help` etc. returned rc=1 with "Module name
+    # required" because --help was treated as the module name positional.
+    _v141_config_subarg_is_help() {
+        case "${1:-}" in -h|--help|help) return 0 ;; *) return 1 ;; esac
+    }
+
     case "$subcommand" in
         get)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config get <module> [--json] — read effective module config"
+                echo ""
+                echo "Usage:"
+                echo "    nftban config get <module>            Print KEY=VALUE lines"
+                echo "    nftban config get <module> --json     Print as JSON"
+                echo "    nftban config get --help              Show this help text"
+                return 0
+            fi
             if [[ -z "${1:-}" ]]; then
                 echo "ERROR: Module name required" >&2
                 echo "Usage: nftban config get <module> [--json]" >&2
@@ -728,6 +745,11 @@ nftban_cmd_config() {
             ;;
 
         defaults)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config defaults <module> [--json] — show schema-default module config"
+                echo "Usage: nftban config defaults <module> [--json]"
+                return 0
+            fi
             if [[ -z "${1:-}" ]]; then
                 echo "ERROR: Module name required" >&2
                 echo "Usage: nftban config defaults <module> [--json]" >&2
@@ -737,6 +759,11 @@ nftban_cmd_config() {
             ;;
 
         overrides)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config overrides <module> [--json] — show operator overrides over defaults"
+                echo "Usage: nftban config overrides <module> [--json]"
+                return 0
+            fi
             if [[ -z "${1:-}" ]]; then
                 echo "ERROR: Module name required" >&2
                 echo "Usage: nftban config overrides <module> [--json]" >&2
@@ -746,6 +773,14 @@ nftban_cmd_config() {
             ;;
 
         set)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config set <module> KEY=VALUE — set an operator override"
+                echo ""
+                echo "Usage:"
+                echo "    nftban config set <module> KEY=VALUE  Set override KEY to VALUE for module"
+                echo "    nftban config set --help              Show this help text"
+                return 0
+            fi
             if [[ -z "${1:-}" ]] || [[ -z "${2:-}" ]]; then
                 echo "ERROR: Module name and KEY=VALUE required" >&2
                 echo "Usage: nftban config set <module> KEY=VALUE" >&2
@@ -755,6 +790,11 @@ nftban_cmd_config() {
             ;;
 
         reset)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config reset <module> KEY — remove a single operator override"
+                echo "Usage: nftban config reset <module> KEY"
+                return 0
+            fi
             if [[ -z "${1:-}" ]] || [[ -z "${2:-}" ]]; then
                 echo "ERROR: Module name and KEY required" >&2
                 echo "Usage: nftban config reset <module> KEY" >&2
@@ -764,6 +804,11 @@ nftban_cmd_config() {
             ;;
 
         reset-all)
+            if _v141_config_subarg_is_help "${1:-}"; then
+                echo "nftban config reset-all <module> — remove ALL operator overrides for module"
+                echo "Usage: nftban config reset-all <module>"
+                return 0
+            fi
             if [[ -z "${1:-}" ]]; then
                 echo "ERROR: Module name required" >&2
                 echo "Usage: nftban config reset-all <module>" >&2

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1494,6 +1494,34 @@ firewall_reload() {
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --help|-h|help)
+                # v1.141 PR-A (BUG-B5): help-guard. Prior to v1.141, this parser
+                # had only --quiet|-q and *) → ERROR; `nftban firewall reload --help`
+                # returned rc=1 with "Unknown option". help is now inert (no nft,
+                # systemctl, daemon IPC, or filesystem mutation).
+                cat <<'FIREWALL_RELOAD_HELP'
+nftban firewall reload — atomic rebuild of nftables ruleset
+
+Usage:
+    nftban firewall reload                Reload + re-apply NFTBan schema + whitelist sync
+    nftban firewall reload --quiet        Reload silently (script-friendly; rc indicates result)
+    nftban firewall reload --help         Show this help text
+
+What it does:
+  * Reloads /etc/nftables.conf via systemd or nft -f (per distro).
+  * Re-applies the NFTBan schema (whitelist, blacklist, etc.) after the kernel
+    ruleset is replaced.
+  * Atomic: kernel never sees an empty/partial ruleset.
+
+Exit codes:
+    0    Reload committed
+    1    Reload failed; previous ruleset retained (or other error)
+    2    Conflict with another firewall manager (UFW, firewalld, etc.)
+
+Privilege: root required (operations on /etc/nftables.conf + nft kernel writes).
+FIREWALL_RELOAD_HELP
+                return 0
+                ;;
             --quiet|-q)
                 quiet=true
                 shift

--- a/cli/lib/nftban/cli/cmd_trust.sh
+++ b/cli/lib/nftban/cli/cmd_trust.sh
@@ -83,9 +83,27 @@ nftban_cmd_trust() {
         return 1
     fi
 
-    # Check root for state-changing operations
+    # v1.141 PR-A (BUG-B6/B7/B8 + help-inertness contract): if the user is asking
+    # for --help|-h|help on enable|disable|update, BYPASS the EUID gate. Help text
+    # is operator-side guidance and must be readable without root. Prior to v1.141,
+    # `nftban trust enable --help` as non-root short-circuited at the EUID gate
+    # below with rc=1 BEFORE the action arm got a chance to print help.
     case "$action" in
-        enable|disable|update|load)
+        enable|disable|update)
+            case "$provider" in -h|--help|help)
+                # fall through to action arm; action arm handles help itself
+                ;;
+                *)
+                    if [[ "$EUID" -ne 0 ]]; then
+                        echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
+                        echo "Hint: trust $action requires elevated privileges; members of the nftban" >&2
+                        echo "      group are authorized via PolicyKit/polkit rules." >&2
+                        return 1
+                    fi
+                    ;;
+            esac
+            ;;
+        load)
             if [[ "$EUID" -ne 0 ]]; then
                 echo "ERROR: PolicyKit/polkit authorization failed or insufficient privileges" >&2
                 echo "Hint: trust $action requires elevated privileges; members of the nftban" >&2
@@ -100,6 +118,25 @@ nftban_cmd_trust() {
             nftban_trust_list
             ;;
         enable)
+            # v1.141 PR-A (BUG-B6): intercept --help BEFORE invoking nftban_trust_enable
+            # (which upcases ${1^^} and treats --HELP as "Unknown provider").
+            case "$provider" in -h|--help|help)
+                cat <<'TRUST_ENABLE_HELP'
+nftban trust enable <PROVIDER> — enable a trusted-IP provider
+
+Usage:
+    nftban trust enable <PROVIDER>        Enable the named provider
+    nftban trust enable --help            Show this help text
+
+Run `nftban trust list` to see available providers on this host.
+
+Exit codes:
+    0    Provider enabled (or already enabled)
+    1    Unknown provider or enablement failed
+TRUST_ENABLE_HELP
+                return 0
+                ;;
+            esac
             if [[ -z "$provider" ]]; then
                 echo "ERROR: Provider name required" >&2
                 echo "Usage: nftban trust enable <PROVIDER>" >&2
@@ -111,6 +148,24 @@ nftban_cmd_trust() {
             nftban_trust_enable "$provider"
             ;;
         disable)
+            # v1.141 PR-A (BUG-B7): same upcase trap as enable.
+            case "$provider" in -h|--help|help)
+                cat <<'TRUST_DISABLE_HELP'
+nftban trust disable <PROVIDER> — disable a trusted-IP provider
+
+Usage:
+    nftban trust disable <PROVIDER>       Disable the named provider
+    nftban trust disable --help           Show this help text
+
+Run `nftban trust list` to see currently enabled providers.
+
+Exit codes:
+    0    Provider disabled (or already disabled)
+    1    Unknown provider or disable failed
+TRUST_DISABLE_HELP
+                return 0
+                ;;
+            esac
             if [[ -z "$provider" ]]; then
                 echo "ERROR: Provider name required" >&2
                 echo "Usage: nftban trust disable <PROVIDER>" >&2
@@ -119,6 +174,25 @@ nftban_cmd_trust() {
             nftban_trust_disable "$provider"
             ;;
         update)
+            # v1.141 PR-A (BUG-B8): same upcase trap as enable/disable.
+            case "$provider" in -h|--help|help)
+                cat <<'TRUST_UPDATE_HELP'
+nftban trust update [PROVIDER] — refresh trusted-IP provider state
+
+Usage:
+    nftban trust update                   Refresh all enabled providers
+    nftban trust update <PROVIDER>        Refresh only the named provider
+    nftban trust update --help            Show this help text
+
+Run `nftban trust list` to see currently enabled providers.
+
+Exit codes:
+    0    Refresh completed
+    1    Unknown provider or provider not enabled
+TRUST_UPDATE_HELP
+                return 0
+                ;;
+            esac
             if [[ -n "$provider" ]]; then
                 nftban_trust_update "$provider"
             else

--- a/cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh
+++ b/cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - ban --timeout invalid no-mutation test (v1.141 PR-A BUG-A7/A8)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_ban_timeout_no_mutation_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.141 PR-A — asserts that invalid --timeout values short-circuit BEFORE any mutation surface is touched. Specifically: nftban-core is never invoked, /etc/nftban/blacklist.d/ is never written, nft is never called. Uses PATH-shadow stubs for nftban-core, nft, systemctl. Each stub writes to a marker file on invocation; the assertion is marker-file MUST NOT exist after an invalid --timeout call. Prior to v1.141, the unvalidated --timeout value flowed all the way to nftban-core, which then interpreted the bogus value as permanent ban — silent mutation."
+# meta:input="cli/lib/nftban/cli/cmd_ban.sh + cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_ban.sh"
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,PATH"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+export NFTBAN_NO_BANNER=1
+
+[[ -x "$NFTBAN_SBIN" ]] || { echo "FAIL: missing $NFTBAN_SBIN" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# Build a PATH-shadow sandbox that contains marker-writing stubs for every
+# mutation binary the ban pipeline might invoke. If any of them runs, a marker
+# file appears in the sandbox.
+build_sandbox(){
+    local sb="$1"
+    mkdir -p "$sb/bin" "$sb/state"
+    for binname in nftban-core nft systemctl polkitd; do
+        cat >"$sb/bin/$binname" <<EOF
+#!/usr/bin/env bash
+echo "$binname \$*" >> '$sb/state/marker'
+exit 0
+EOF
+        chmod +x "$sb/bin/$binname"
+    done
+}
+
+assert_no_mutation_on_invalid(){
+    local label="$1" value="$2"
+    local sb; sb=$(mktemp -d -t nftban-noamut.XXXXXX)
+    build_sandbox "$sb"
+    local rc=0
+    # Prefix sandbox bin so stubs win over real binaries; otherwise rely on the
+    # parser short-circuiting before any system binary is called.
+    PATH="$sb/bin:$PATH" bash "$NFTBAN_SBIN" ban 10.0.0.1 --timeout "$value" >/dev/null 2>&1 || rc=$?
+    if (( rc == 0 )); then
+        no "$label" "rc=0 (expected non-zero on invalid)"
+    elif [[ -f "$sb/state/marker" ]]; then
+        no "$label" "MUTATION OCCURRED — marker file contents: $(tr '\n' '|' < "$sb/state/marker")"
+    else
+        ok "$label (invalid timeout=$value rc=$rc, NO mutation marker)"
+    fi
+    rm -rf "$sb"
+}
+
+echo "=========================================================="
+echo "v1.141 PR-A — ban --timeout no-mutation test"
+echo "=========================================================="
+
+assert_no_mutation_on_invalid "T1 abc (non-integer)"        "abc"
+assert_no_mutation_on_invalid "T2 -5 (negative)"             "-5"
+assert_no_mutation_on_invalid "T3 0 (zero)"                   "0"
+assert_no_mutation_on_invalid "T4 1.5 (float)"                "1.5"
+assert_no_mutation_on_invalid "T5 +10 (signed)"               "+10"
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh
+++ b/cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - ban --timeout parser validation test (v1.141 PR-A BUG-A7/A8)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_ban_timeout_validation_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.141 PR-A — asserts that `nftban ban X --timeout VALUE` rejects every non-positive-integer VALUE at parse time with rc=1 and a clear ERROR message, and accepts every positive integer (parse-time only — downstream daemon IPC is out of scope for this test). Prior to v1.141, the --timeout arm at cli/lib/nftban/cli/cmd_ban.sh:86-89 had no validation; values like 'abc' / '-5' / '0' / '' / '1.5' propagated to nftban-core which interpreted invalid values as permanent ban — operator surprise reproduced live in the cruel-judge review on monitor.mywebhost.gr. Hermetic — runs against the source tree."
+# meta:input="cli/lib/nftban/cli/cmd_ban.sh + cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_ban.sh,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+export NFTBAN_NO_BANNER=1
+
+[[ -x "$NFTBAN_SBIN" ]] || { echo "FAIL: missing $NFTBAN_SBIN" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# Invariant: invalid values must rc!=0 AND stderr must mention "--timeout".
+assert_reject(){
+    local label="$1" value="$2"
+    local rc=0 out
+    out=$(bash "$NFTBAN_SBIN" ban 10.0.0.1 --timeout "$value" 2>&1) || rc=$?
+    if (( rc == 0 )); then
+        no "$label" "rc=0 (expected non-zero on invalid timeout=$value)"
+    elif [[ "$out" != *"--timeout"* ]]; then
+        no "$label" "rc=$rc but stderr missing '--timeout' marker"
+    elif [[ "$out" != *"ERROR"* && "$out" != *"Error"* ]]; then
+        no "$label" "rc=$rc but stderr missing ERROR marker"
+    else
+        ok "$label (rc=$rc, ERROR mentions --timeout)"
+    fi
+}
+
+# Invariant: valid positive integer must NOT be rejected by the parser. The
+# command may still fail downstream (no daemon in dev env), but the failure
+# must NOT be a parser-side --timeout rejection. We check stderr does NOT
+# contain "--timeout requires a positive integer".
+assert_accept(){
+    local label="$1" value="$2"
+    local rc=0 out
+    out=$(bash "$NFTBAN_SBIN" ban 10.0.0.1 --timeout "$value" 2>&1) || rc=$?
+    if [[ "$out" == *"--timeout requires a positive integer"* ]]; then
+        no "$label" "parser rejected valid timeout=$value: $out"
+    else
+        ok "$label (valid timeout=$value passes parser; rc=$rc downstream)"
+    fi
+}
+
+echo "=========================================================="
+echo "v1.141 PR-A — ban --timeout validation test"
+echo "=========================================================="
+
+echo "--- invalid values must rc!=0 with --timeout ERROR ---"
+assert_reject "T1 abc (non-integer)"                  "abc"
+assert_reject "T2 -5 (negative)"                       "-5"
+assert_reject "T3 0 (zero)"                             "0"
+assert_reject "T4 1.5 (float)"                          "1.5"
+assert_reject "T5 +10 (signed positive — strict positive int)" "+10"
+assert_reject "T6 1e3 (scientific notation)"            "1e3"
+assert_reject "T7 0x10 (hex)"                            "0x10"
+assert_reject "T8 01 (leading zero)"                     "01"
+
+echo "--- valid positive integers must pass parser ---"
+assert_accept "T9 1 (smallest valid)"                    "1"
+assert_accept "T10 60 (one minute)"                     "60"
+assert_accept "T11 3600 (one hour)"                     "3600"
+assert_accept "T12 86400 (one day)"                     "86400"
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/cli_help_inertness_universal_test.sh
+++ b/cli/lib/nftban/tests/cli_help_inertness_universal_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - universal help-inertness sweep test (v1.141 PR-A sweep-all)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_help_inertness_universal_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.141 PR-A — sweep-all-subcommands help-inertness audit. Every top-level subcommand the dispatcher recognises must satisfy the help contract: `nftban <cmd> --help` returns rc=0, is inert (no nftban-core, nft, systemctl, package-manager mutation in PATH-shadow sandbox), and emits usage/help/Available text. Non-existent subcommands are SKIPPED (operator-chosen 'drop' for feeds add / feeds remove / update apply / update channel — doc-vs-code drift, not aliased). This test is a regression-prevention gate: any future PR that breaks help inertness on any swept subcommand fails CI."
+# meta:input="cli/sbin/nftban + every cli/lib/nftban/cli/cmd_*.sh"
+# meta:output="Pass/fail assertions per subcommand; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,PATH"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+export NFTBAN_NO_BANNER=1
+
+[[ -x "$NFTBAN_SBIN" ]] || { echo "FAIL: missing $NFTBAN_SBIN" >&2; exit 1; }
+
+PASS=0; FAIL=0; SKIP=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+sk(){ printf '  [SKIP] %s (%s)\n' "$1" "$2"; SKIP=$((SKIP+1)); }
+
+build_sandbox(){
+    local sb="$1"
+    mkdir -p "$sb/bin" "$sb/state"
+    # Mutating verbs only — the dispatcher legitimately READS (systemctl
+    # is-active firewalld, nft list ruleset) on every CLI invocation including
+    # help paths. We mark only mutations.
+    for binname in nftban-core nftban-validate nftban-installer nft systemctl polkitd policy-rc.d apt-get dnf rpm dpkg yum; do
+        cat >"$sb/bin/$binname" <<EOF
+#!/usr/bin/env bash
+case "$binname \$1 \$2" in
+    "nftban-core "*|"nftban-validate "*|"nftban-installer "*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "nft "list*|"nft "show*)      : ;;
+    "nft "*)                      echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "systemctl "is-active*|"systemctl "is-enabled*|"systemctl "is-failed*|"systemctl "show*|"systemctl "status*|"systemctl "list-*|"systemctl "cat*) : ;;
+    "systemctl "*)                echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "apt-get "install*|"apt-get "remove*|"apt-get "purge*|"apt-get "upgrade*|"apt-get "update*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "dnf "install*|"dnf "remove*|"dnf "upgrade*|"dnf "update*|"yum "install*|"yum "remove*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "rpm "-i*|"rpm "-U*|"rpm "-e*|"rpm "--install*|"rpm "--erase*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "dpkg "-i*|"dpkg "--install*|"dpkg "--remove*|"dpkg "--purge*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "polkitd "*)                  echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "policy-rc.d "*)              echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+esac
+exit 0
+EOF
+        chmod +x "$sb/bin/$binname"
+    done
+}
+
+# Top-level subcommands the dispatcher in cli/sbin/nftban recognises.
+TOP_LEVEL=(
+    ban unban search list status health version
+    whitelist blacklist feeds watchdog stats
+    install uninstall update rebuild rollback
+    login metrics export portscan ddos suricata
+    config service services timers geoip geoban
+    emulate fhs botguard tunnel firewall trust help
+)
+
+# Sub-action surfaces PR-A fixed — each must satisfy the contract under sweep.
+SUB_ACTIONS=(
+    "firewall reload"
+    "trust enable"
+    "trust disable"
+    "trust update"
+    "config get"
+    "config set"
+    "config defaults"
+    "config overrides"
+    "config reset"
+    "config reset-all"
+)
+
+assert_help_inert(){
+    local label="$1"; shift
+    local args=("$@")
+    local sb; sb=$(mktemp -d -t nftban-univ.XXXXXX)
+    build_sandbox "$sb"
+    local rc=0 out
+    out=$(PATH="$sb/bin:$PATH" bash "$NFTBAN_SBIN" "${args[@]}" --help 2>&1) || rc=$?
+    if (( rc != 0 )); then
+        no "$label" "rc=$rc"
+    elif [[ -f "$sb/state/marker" ]]; then
+        no "$label" "MUTATION on help path: $(tr '\n' '|' < "$sb/state/marker")"
+    elif [[ "$out" != *[Uu]sage* && "$out" != *Help* && "$out" != *help* && "$out" != *Available* ]]; then
+        no "$label" "rc=0 but output missing usage/help/Available marker"
+    else
+        ok "$label (rc=0, no mutation, usage text present)"
+    fi
+    rm -rf "$sb"
+}
+
+SKIP_BECAUSE_DROP_PER_OPERATOR=(
+    "feeds add"
+    "feeds remove"
+    "update apply"
+    "update channel"
+)
+
+echo "=========================================================="
+echo "v1.141 PR-A — universal help-inertness sweep"
+echo "=========================================================="
+
+echo "--- top-level subcommands ---"
+for cmd in "${TOP_LEVEL[@]}"; do
+    assert_help_inert "TL: nftban $cmd --help" "$cmd"
+done
+
+echo "--- sub-action surfaces (PR-A-fixed paths must satisfy contract) ---"
+for sa in "${SUB_ACTIONS[@]}"; do
+    # IFS at the top of this file is \n\t (no space), so a vanilla unquoted
+    # $sa would not word-split. Use read -ra with explicit IFS=' ' to split.
+    IFS=' ' read -ra _sa_parts <<< "$sa"
+    assert_help_inert "SA: nftban $sa --help" "${_sa_parts[@]}"
+done
+
+echo "--- dropped per operator (doc-vs-code drift; SKIP not FAIL) ---"
+for sa in "${SKIP_BECAUSE_DROP_PER_OPERATOR[@]}"; do
+    sk "DROP: nftban $sa --help" "operator SELECT_V1_141_0_B9_B10_B13_B14_DROP_OR_ALIAS = drop — non-existent subcommand"
+done
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS (regression-prevention gate)"

--- a/cli/lib/nftban/tests/cli_help_inertness_v141_test.sh
+++ b/cli/lib/nftban/tests/cli_help_inertness_v141_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - focused help-inertness test (v1.141 PR-A BUG-B5/B6/B7/B8/B11/B12)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_help_inertness_v141_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-28"
+# meta:description="v1.141 PR-A — asserts every targeted help-inert defect is fixed: `nftban firewall reload --help`, `nftban trust enable --help`, `nftban trust disable --help`, `nftban trust update --help`, `nftban config get --help`, `nftban config set --help`. Plus sweep-all helpers (config defaults/overrides/reset/reset-all). Each invocation must (1) return rc=0, (2) emit help text mentioning the subcommand name, and (3) leave NO mutation marker in a PATH-shadow sandbox. Hermetic — no host contact."
+# meta:input="cli/lib/nftban/cli/cmd_firewall.sh, cmd_trust.sh, cmd_config.sh, cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh,cli/lib/nftban/cli/cmd_trust.sh,cli/lib/nftban/cli/cmd_config.sh"
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,PATH"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+export NFTBAN_NO_BANNER=1
+
+[[ -x "$NFTBAN_SBIN" ]] || { echo "FAIL: missing $NFTBAN_SBIN" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+build_sandbox(){
+    local sb="$1"
+    mkdir -p "$sb/bin" "$sb/state"
+    # Mutating verbs only — the dispatcher legitimately READS (systemctl
+    # is-active firewalld, nft list ruleset) on every CLI invocation including
+    # help paths. We mark only mutations.
+    for binname in nftban-core nft systemctl polkitd policy-rc.d apt-get dnf rpm dpkg; do
+        cat >"$sb/bin/$binname" <<EOF
+#!/usr/bin/env bash
+# v1.141 PR-A test stub — flag mutations only (read-only checks are
+# expected on help paths and not flagged).
+case "$binname \$1 \$2" in
+    "nftban-core "*)             echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "nft "list*|"nft "show*)      : ;;
+    "nft "*)                      echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "systemctl "is-active*|"systemctl "is-enabled*|"systemctl "is-failed*|"systemctl "show*|"systemctl "status*|"systemctl "list-*|"systemctl "cat*) : ;;
+    "systemctl "*)                echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "apt-get "install*|"apt-get "remove*|"apt-get "purge*|"apt-get "upgrade*|"apt-get "update*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "dnf "install*|"dnf "remove*|"dnf "upgrade*|"dnf "update*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "rpm "-i*|"rpm "-U*|"rpm "-e*|"rpm "--install*|"rpm "--erase*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "dpkg "-i*|"dpkg "--install*|"dpkg "--remove*|"dpkg "--purge*) echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "polkitd "*)                  echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+    "policy-rc.d "*)              echo "MUTATE: $binname \$*" >> '$sb/state/marker' ;;
+esac
+exit 0
+EOF
+        chmod +x "$sb/bin/$binname"
+    done
+}
+
+# Contract: --help is inert (rc=0, no mutation marker, output mentions help/usage).
+assert_help_inert(){
+    local label="$1"; shift
+    local args=("$@")
+    local sb; sb=$(mktemp -d -t nftban-helpinert.XXXXXX)
+    build_sandbox "$sb"
+    local rc=0 out
+    out=$(PATH="$sb/bin:$PATH" bash "$NFTBAN_SBIN" "${args[@]}" 2>&1) || rc=$?
+    if (( rc != 0 )); then
+        no "$label" "rc=$rc (expected 0); last 3 lines: $(echo "$out" | tail -3 | tr '\n' '|')"
+    elif [[ -f "$sb/state/marker" ]]; then
+        no "$label" "MUTATION OCCURRED — marker: $(tr '\n' '|' < "$sb/state/marker")"
+    elif [[ "$out" != *[Uu]sage* && "$out" != *Help* && "$out" != *Usage* ]]; then
+        no "$label" "rc=0 but output missing 'Usage:' / 'Help' marker"
+    else
+        ok "$label (rc=0, no mutation, usage text present)"
+    fi
+    rm -rf "$sb"
+}
+
+echo "=========================================================="
+echo "v1.141 PR-A — focused help-inertness test"
+echo "=========================================================="
+
+echo "--- Required focused rows (operator-named) ---"
+assert_help_inert "T1 firewall reload --help (B5)"  firewall reload --help
+assert_help_inert "T2 trust enable --help (B6)"     trust enable --help
+assert_help_inert "T3 trust disable --help (B7)"    trust disable --help
+assert_help_inert "T4 trust update --help (B8)"     trust update --help
+assert_help_inert "T5 config get --help (B11)"      config get --help
+assert_help_inert "T6 config set --help (B12)"      config set --help
+
+echo "--- Sweep-all extras (config defaults/overrides/reset/reset-all) ---"
+assert_help_inert "T7 config defaults --help"       config defaults --help
+assert_help_inert "T8 config overrides --help"      config overrides --help
+assert_help_inert "T9 config reset --help"          config reset --help
+assert_help_inert "T10 config reset-all --help"     config reset-all --help
+
+echo "--- Short-flag parity: -h and 'help' must work the same ---"
+assert_help_inert "T11 firewall reload -h"          firewall reload -h
+assert_help_inert "T12 trust enable -h"             trust enable -h
+assert_help_inert "T13 config get help (bareword)"  config get help
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -1083,6 +1083,49 @@ main() {
         source "${NFTBAN_LIB_DIR}/nftban_help.sh"
     fi
 
+    # v1.141 PR-A — top-level help-inertness guard.
+    # Runs BEFORE the auto-loader and BEFORE the alias case below, so that:
+    #   - cmd_search prints USAGE only after a banner-action chain that
+    #     historically swallowed --help as the search target;
+    #   - the `export` alias arm doesn't forward `--help` to stats export,
+    #     which creates an output file on disk (real help-inertness bug);
+    #   - cross-module sources from hardcoded /usr/lib/nftban/ paths that
+    #     fail in dev (cmd_geoban → /usr/lib/.../cmd_geoip.sh,
+    #     cmd_suricata → cmd_suricata_rules.sh) don't fire on help paths;
+    #   - phantom commands with no cmd_*.sh backing (install/uninstall/
+    #     rebuild — in the suggester list, not actually implemented)
+    #     produce inert Usage text instead of an "Unknown command" echo.
+    # Pure-shell — no daemon, nft, systemctl, package-manager, or filesystem
+    # mutation. Scope: V1_141_0_CONSOLIDATED_HOTFIX_AND_HARDENING_SCOPE.md PR-A.
+    _v141_args_have_help_flag() {
+        local a
+        for a in "$@"; do
+            case "$a" in -h|--help|help) return 0 ;; esac
+        done
+        return 1
+    }
+    case "$cmd" in
+        search|feeds|export|suricata|geoban|install|uninstall|rebuild)
+            if _v141_args_have_help_flag "$@"; then
+                echo "Usage: nftban $cmd [options]"
+                case "$cmd" in
+                    search)   echo "  Search IPs/ports across feeds, ban lists, whitelists." ;;
+                    feeds)    echo "  Manage and inspect threat-intelligence feeds." ;;
+                    export)   echo "  Export stats snapshot. Alias for 'nftban stats export'." ;;
+                    suricata) echo "  Manage Suricata IDS (install, enable, rules, status, profile)." ;;
+                    geoban)   echo "  Country-based IP blocking (ban, unban, whitelist, list, status, update)." ;;
+                    install|uninstall|rebuild)
+                        echo "  Note: '$cmd' is handled by the distro package (DEB/RPM) and the"
+                        echo "  systemd nftband service — not a CLI subcommand in this build."
+                        ;;
+                esac
+                echo ""
+                echo "For the full command index, run: nftban help"
+                return 0
+            fi
+            ;;
+    esac
+
     # Auto-load modular commands from cli/ directory
     # This keeps the main CLI small and manageable
     local cmd_file="${NFTBAN_LIB_DIR}/cli/cmd_${cmd}.sh"


### PR DESCRIPTION
## v1.141.0 PR-A — CLI parser validation + help inertness sweep

Closes BUG-A7/A8 (parser) and BUG-B5/B6/B7/B8/B9/B10/B11/B12/B13/B14 (help inertness) from `NFTBAN_ROADMAP/V1_141_0_CONSOLIDATED_HOTFIX_AND_HARDENING_SCOPE.md`.

Gates honored:
- `OPEN_V1_141_0_PR_A_CLI_PARSER_HELP_IMPL = GO_IMPLEMENTATION_ONLY`
- `SELECT_V1_141_0_B9_B10_B13_B14_DROP_OR_ALIAS = drop` (phantom subcommand handling)
- `SELECT_V1_141_0_HELP_INERTNESS_KERNEL_OR_DEFENSE_IN_DEPTH = defense_in_depth` (top-level dispatcher guard + per-arm bypass)

---

### A7/A8 — `ban --timeout` parser validation

| Input         | Before v1.141                                       | After v1.141                                |
| ------------- | --------------------------------------------------- | ------------------------------------------- |
| `--timeout abc`   | propagated to nftban-core → permanent ban             | rc=1, `ERROR: --timeout requires a positive integer...` |
| `--timeout -5`    | propagated → permanent ban                            | rc=1                                        |
| `--timeout 0`     | propagated → permanent ban                            | rc=1                                        |
| `--timeout 1.5`   | propagated → permanent ban                            | rc=1                                        |
| `--timeout +10`   | propagated (signed treated as positive on host)       | rc=1 (strict positive int)                  |
| `--timeout 1e3`   | propagated → permanent ban                            | rc=1                                        |
| `--timeout 0x10`  | propagated → permanent ban                            | rc=1                                        |
| `--timeout 01`    | propagated, downstream OCT parse ambiguity            | rc=1                                        |
| `--timeout 1`     | OK                                                  | OK (unchanged)                              |
| `--timeout 3600`  | OK                                                  | OK                                          |

Regex used: `^[1-9][0-9]*$`. Rejection fires at parse time **before** any IPC to nftban-core / write to `/etc/nftban/blacklist.d/` / nft mutation.

---

### B5..B14 — Help inertness sweep

| Surface                              | Before                                          | After                                  |
| ------------------------------------ | ----------------------------------------------- | -------------------------------------- |
| `nftban firewall reload --help`    | rc=1, action arm fell through                   | rc=0, Usage text                       |
| `nftban trust enable --help`       | rc=1, EUID gate fired before help arm           | rc=0, Usage text                       |
| `nftban trust disable --help`      | rc=1, EUID gate fired                           | rc=0, Usage text                       |
| `nftban trust update --help`       | rc=1, EUID gate fired                           | rc=0, Usage text                       |
| `nftban config get/set --help`     | rc=1, action proceeded                          | rc=0, Usage text                       |
| `nftban config defaults/overrides/reset/reset-all --help` | rc=1            | rc=0, Usage text                       |
| `nftban search --help`             | rc=0 but "--help" treated as search target     | rc=0, Usage stub via dispatcher guard  |
| `nftban export --help`             | **rc=0 but CREATED A FILE** on disk (real bug)  | rc=0, Usage stub via dispatcher guard  |
| `nftban suricata --help`           | rc=0 but no Usage; sourced missing submodule    | rc=0, Usage stub via dispatcher guard  |
| `nftban geoban --help`             | rc=1; sourced hardcoded /usr/lib path           | rc=0, Usage stub via dispatcher guard  |
| `nftban feeds --help`              | rc=1 on local dev (strict-mode trap chain)      | rc=0, Usage stub via dispatcher guard  |
| `nftban install/uninstall/rebuild --help` | rc=1, fuzzy-match "Did you mean nftban X?" echo | rc=0, Usage stub explaining distro-package handling |

The top-level dispatcher guard at `cli/sbin/nftban` runs **before** the auto-loader and the alias case, so action code never executes on a help path.

---

### Drops (operator SELECT `= drop`)

`feeds add`, `feeds remove`, `update apply`, `update channel` — documented in the CLI suggester but with no backing code path. Universal sweep test SKIPs them with the operator-named drop reason. No alias was added.

---

### Test evidence (all hermetic, PATH-shadow sandbox)

| Test                                                | Result                       |
| --------------------------------------------------- | ---------------------------- |
| `cli_ban_timeout_validation_test.sh`              | 12 PASS / 0 FAIL             |
| `cli_ban_timeout_no_mutation_test.sh`             | 5 PASS / 0 FAIL              |
| `cli_help_inertness_v141_test.sh`                 | 13 PASS / 0 FAIL             |
| `cli_help_inertness_universal_test.sh`            | 46 PASS / 0 FAIL / 4 SKIP    |
| `rollback_help_guard_v1_139_2_test.sh` (regression)| 10 PASS / 0 FAIL             |
| `bash -n` on every modified shell file            | 9 OK / 0 FAIL                |
| **Total**                                           | **86 PASS, 0 FAIL**          |

The PATH-shadow sandbox replaces every mutation binary (nftban-core, nft, systemctl, polkitd, package managers) with a marker-emitting stub. Only **MUTATING** verbs are flagged (systemctl is-active, nft list, etc. are expected on every CLI invocation including help paths and are not flagged). Help paths must emit Usage text and rc=0 with NO marker file.

---

### Non-goals / forbidden-path negative control

- 0 `.go` files touched. `cmd/nftband` + `cmd/nftban-core` daemons remain **byte-identical** to v1.140.0 in .text/.data/.rodata (modulo .note.go.buildid vcs.modified stamp on dirty trees).
- 0 `internal/`, `cmd/`, `build/`, `packaging/`, `install/`, `systemd/`, `schema/`, `docker/`, `.github/`, `fhs-spec.yaml` changes.
- 0 schema version bump. Schema 1.83.0 remains frozen.
- 0 portal/metrics/Go-installer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)