### PR TITLE
docs(readme): drop 'Tier-0 since v1.140.0' annotation on Ubuntu 26.04 entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu24.
 sudo apt install -y ./nftban-ubuntu24.04-amd64.deb
 ```
 
-#### Ubuntu 26.04 LTS (Resolute Raccoon) — *Tier-0 since v1.140.0*
+#### Ubuntu 26.04 LTS (Resolute Raccoon)
 ```bash
 wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-ubuntu26.04-amd64.deb
 sudo apt install -y ./nftban-ubuntu26.04-amd64.deb


### PR DESCRIPTION
Small docs cleanup. Removes the `— *Tier-0 since v1.140.0*` suffix from the Ubuntu 26.04 LTS Quick Install entry in `README.md` so its formatting matches every other Tier-0 / Tier-1 distro entry (bare header + `wget` + `sudo apt install` block, no provenance suffix).

Ubuntu 26.04 has shipped unchanged through v1.140.0 → v1.141.0 → v1.142.0; the v1.140.0 introduction is already recorded in `NFTBAN_ROADMAP/V1_140_0_RELEASE_CLOSURE.md` and in the release page for v1.140.0. The transitional marker in README isn't earning its keep anymore.

### Diff
```diff
-#### Ubuntu 26.04 LTS (Resolute Raccoon) — *Tier-0 since v1.140.0*
+#### Ubuntu 26.04 LTS (Resolute Raccoon)
```

### Non-goals

- 0 `.go` files
- 0 `packaging/`, `install/`, `systemd/`, `build/`, `schema/`, `docker/`, `.github/`, `fhs-spec.yaml` changes
- 0 cmd_*.sh changes
- 0 schema bump, 0 portal/metrics change
- 0 release-prep
- No tag, no release, no host deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)