### PR TITLE
fix(cli): v1.143 PR-B close FS3 DA rc-swallow paths

### DIFF
--- a/cli/lib/nftban/cli/cmd_permissions.sh
+++ b/cli/lib/nftban/cli/cmd_permissions.sh
@@ -232,7 +232,26 @@ nftban_permissions_cmd_enforce() {
         return 1
     fi
 
-    # Run enforcement
+    # v1.143 PR-B (FS3-DA): rc-truth lock + actionable failure path.
+    # The wrapper already returned $result truthfully — that is what
+    # caused the lab4 v1.142 installer log to print
+    # `permissions enforce failed (exit 1) — non-fatal` at
+    # cmd/nftban-installer/phases.go:573. The installer auto-fix retry
+    # intentionally classifies the warning as non-fatal and re-validates;
+    # this v1.143 fix does NOT touch that consumer (operator-locked
+    # SELECT_V1_143_INSTALL_UPDATE_SCOPE = permission-enforce-only). What
+    # we DO change here:
+    #   (a) the ❌ failure line now goes to STDERR (not stdout) so script
+    #       consumers piping `nftban permissions enforce 2>/dev/null` get
+    #       a clean STDOUT — same E1 contract v1.141 PR-B established for
+    #       the unknown-command path.
+    #   (b) actionable advice (log file location + retry instructions)
+    #       follows the ❌ line, also on stderr. The advice helps the
+    #       audit's R-PERM-1 follow-up: an operator reading the
+    #       installer's swallowed "non-fatal" line now has a path to the
+    #       same evidence the wrapper had.
+    # (Scope: V1_143_0_PLAN.md §4 PR-B. Audit ref: V1_142_LAB4_UPDATE_LOG_
+    # SAFETY_AUDIT.md §4 R-PERM-1.)
     local result=0
     nftban_permissions_enforce_all || result=$?
 
@@ -246,8 +265,14 @@ nftban_permissions_cmd_enforce() {
             echo "✅ Permissions enforced successfully"
         fi
     else
-        echo ""
-        echo "❌ Permission enforcement failed with errors"
+        # v1.143 PR-B: failure → stderr with actionable advice.
+        {
+            echo ""
+            echo "❌ Permission enforcement failed with errors"
+            echo "   See log: ${NFTBAN_LOG_DIR:-/var/log/nftban}/installer.log"
+            echo "   Re-check: nftban permissions check"
+            echo "   Re-run:   sudo nftban permissions enforce"
+        } >&2
     fi
 
     return $result

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -1724,7 +1724,18 @@ nftban_port_allow_directadmin() {
     echo "  • 123 (UDP OUT)    - NTP"
     echo ""
 
-    # Handle CloudFlare whitelist
+    # v1.143 PR-B (FS3-DA): CloudFlare whitelist rc was discarded. The
+    # body above repeatedly stresses that DirectAdmin LICENSING REQUIRES
+    # CloudFlare IPs to be whitelisted ("DirectAdmin licensing servers
+    # are behind CloudFlare CDN. You MUST whitelist CloudFlare IP ranges
+    # for licensing to work!"). Pre-v1.143 the trust enable+update arm
+    # printed ⚠️ to stdout on failure but the function continued to a
+    # downstream `return 0` — the licensing-critical failure was hidden
+    # from the operator's rc, exactly the FS3 family. Now the rc is
+    # captured into _v143_da_rc and propagated at function exit. Trust-
+    # subcommand failures get a stderr ⚠ with manual-remediation advice.
+    # (V1_143_0_PLAN.md §4 PR-B.)
+    local _v143_da_rc=0
     if [[ "$enable_cloudflare" == "yes" ]]; then
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "Enabling CloudFlare IP Whitelist"
@@ -1738,8 +1749,14 @@ nftban_port_allow_directadmin() {
             echo ""
             echo "CloudFlare IP ranges are now whitelisted for DirectAdmin licensing."
         else
-            echo "⚠️  Failed to enable CloudFlare whitelist"
-            echo "   Please enable manually: nftban trust enable CLOUDFLARE && nftban trust update"
+            # v1.143 PR-B: stderr + rc=1 propagation. Licensing-critical
+            # path; operator must know via rc that DA licensing is at risk.
+            {
+                echo "⚠️  Failed to enable CloudFlare whitelist"
+                echo "    DirectAdmin licensing REQUIRES this — operator action required."
+                echo "    Re-run manually: nftban trust enable CLOUDFLARE && nftban trust update"
+            } >&2
+            _v143_da_rc=1
         fi
         echo ""
     else
@@ -1775,7 +1792,12 @@ nftban_port_allow_directadmin() {
 
     # Exit marker for testing validation
     command -v nftban_cmd_exit >/dev/null 2>&1 && nftban_cmd_exit "port"
-    return 0
+
+    # v1.143 PR-B (FS3-DA): return the accumulated rc instead of an
+    # unconditional `return 0`. _v143_da_rc tracks the licensing-critical
+    # CloudFlare whitelist failure above; ports-add failures already
+    # triggered an earlier `return 1` at the `rules_failed > 0` guard.
+    return $_v143_da_rc
 }
 
 # Export function for auto-loading

--- a/cli/lib/nftban/tests/cli_fs3_da_v143_test.sh
+++ b/cli/lib/nftban/tests/cli_fs3_da_v143_test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - FS3-DA rc-swallow regression test (v1.143 PR-B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_fs3_da_v143_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-05-29"
+# meta:description="v1.143 PR-B — asserts that the two FS3-class DA / permissions functions propagate child-operation rc truthfully. Pre-v1.143 nftban_port_allow_directadmin swallowed CloudFlare trust enable+update failure (licensing-critical path) under an unconditional `return 0`; nftban_permissions_cmd_enforce already returned truthful rc but printed ❌ to stdout with no actionable advice, leaving the lab4 v1.142 installer's swallowed 'permissions enforce failed (exit 1) — non-fatal' line without an audit trail. Same FS3 family as v1.142 PR-FS and v1.143 PR-A. Stubbed-callable mirror pattern matches PR-A test."
+# meta:input="cli/lib/nftban/cli/cmd_port.sh, cli/lib/nftban/cli/cmd_permissions.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_port.sh,cli/lib/nftban/cli/cmd_permissions.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NO_BANNER=1
+export NFTBAN_NONINTERACTIVE=1
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+MIRROR=$(mktemp -d -t nftban-fs3da.XXXXXX)
+trap 'rm -rf "$MIRROR"' EXIT
+
+# ──────────────────────────────────────────────────────────────────────────
+# T-MIRROR-PERMISSIONS  —  nftban_permissions_cmd_enforce wrapper
+# ──────────────────────────────────────────────────────────────────────────
+cat >"$MIRROR/permissions_enforce.sh" <<'EOF'
+#!/usr/bin/env bash
+set +e
+# Stub the per-step helper. Returns rc based on NF_HELPER_RC env var.
+nftban_permissions_enforce_all() {
+    return "${NF_HELPER_RC:-0}"
+}
+# Pretend we're root so the EUID gate doesn't fire (the gate isn't on the
+# FS3 surface — the wrapper-around-helper rc is).
+NFTBAN_LOG_DIR=/tmp
+
+# Mirror of v1.143 PR-B code in cmd_permissions.sh nftban_permissions_cmd_enforce
+# (just the post-EUID-gate enforcement section).
+result=0
+nftban_permissions_enforce_all || result=$?
+
+if [[ $result -eq 0 ]]; then
+    echo ""
+    echo "✅ Permissions enforced successfully"
+else
+    {
+        echo ""
+        echo "❌ Permission enforcement failed with errors"
+        echo "   See log: ${NFTBAN_LOG_DIR:-/var/log/nftban}/installer.log"
+        echo "   Re-check: nftban permissions check"
+        echo "   Re-run:   sudo nftban permissions enforce"
+    } >&2
+fi
+exit $result
+EOF
+chmod +x "$MIRROR/permissions_enforce.sh"
+
+# ──────────────────────────────────────────────────────────────────────────
+# T-MIRROR-DA  —  nftban_port_allow_directadmin CloudFlare arm
+# ──────────────────────────────────────────────────────────────────────────
+cat >"$MIRROR/directadmin_cf.sh" <<'EOF'
+#!/usr/bin/env bash
+set +e
+# Stub nftban: trust enable + update either succeed or fail based on env.
+nftban() {
+    case "$1 $2" in
+        "trust enable")
+            [[ "${NF_TRUST_ENABLE_FAIL:-0}" == "1" ]] && return 1
+            return 0
+            ;;
+        "trust update"|"trust update ")
+            [[ "${NF_TRUST_UPDATE_FAIL:-0}" == "1" ]] && return 1
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Mirror of v1.143 PR-B CloudFlare-arm code in cmd_port.sh.
+_v143_da_rc=0
+enable_cloudflare="${NF_ENABLE_CF:-yes}"
+if [[ "$enable_cloudflare" == "yes" ]]; then
+    echo "Enabling CloudFlare whitelist..."
+    if nftban trust enable CLOUDFLARE 2>/dev/null && nftban trust update 2>/dev/null; then
+        echo "✓ CloudFlare whitelist enabled"
+    else
+        {
+            echo "⚠️  Failed to enable CloudFlare whitelist"
+            echo "    DirectAdmin licensing REQUIRES this — operator action required."
+            echo "    Re-run manually: nftban trust enable CLOUDFLARE && nftban trust update"
+        } >&2
+        _v143_da_rc=1
+    fi
+fi
+exit $_v143_da_rc
+EOF
+chmod +x "$MIRROR/directadmin_cf.sh"
+
+run() {
+    local script="$1"; shift
+    local rc=0
+    local stdoutf; stdoutf=$(mktemp -t nftban-fs3da-out.XXX)
+    local stderrf; stderrf=$(mktemp -t nftban-fs3da-err.XXX)
+    "$script" "$@" >"$stdoutf" 2>"$stderrf" || rc=$?
+    LAST_RC=$rc
+    LAST_OUT=$(cat "$stdoutf")
+    LAST_ERR=$(cat "$stderrf")
+    rm -f "$stdoutf" "$stderrf"
+}
+
+assert_rc() {
+    local label="$1" expected="$2"
+    if (( LAST_RC == expected )); then ok "$label (rc=$LAST_RC)";
+    else no "$label" "rc=$LAST_RC (expected $expected)"; fi
+}
+assert_contains_stderr() {
+    local label="$1" needle="$2"
+    if [[ "$LAST_ERR" == *"$needle"* ]]; then ok "$label"; else no "$label" "stderr missing '$needle'"; fi
+}
+assert_not_contains_stdout() {
+    local label="$1" needle="$2"
+    if [[ "$LAST_OUT" != *"$needle"* ]]; then ok "$label"; else no "$label" "stdout had forbidden '$needle'"; fi
+}
+assert_contains_stdout() {
+    local label="$1" needle="$2"
+    if [[ "$LAST_OUT" == *"$needle"* ]]; then ok "$label"; else no "$label" "stdout missing '$needle'"; fi
+}
+
+echo "=========================================================="
+echo "v1.143 PR-B — FS3-DA rc-truth contract"
+echo "=========================================================="
+
+# ──────────────────────────────────────────────────────────────────────────
+# T-PERMS — nftban_permissions_cmd_enforce wrapper rc-truth + stderr advice
+# ──────────────────────────────────────────────────────────────────────────
+echo "--- T-PERMS-1: permissions enforce helper fail → rc=1, ❌ to STDERR, no '✅' on STDOUT ---"
+NF_HELPER_RC=1 run "$MIRROR/permissions_enforce.sh"
+assert_rc "T-PERMS-1a permissions wrapper rc=1 on helper fail" 1
+assert_contains_stderr "T-PERMS-1b ❌ failure line on STDERR" "❌ Permission enforcement failed"
+assert_contains_stderr "T-PERMS-1c log location advice on STDERR" "/installer.log"
+assert_contains_stderr "T-PERMS-1d re-run advice on STDERR" "Re-run:"
+assert_not_contains_stdout "T-PERMS-1e no '✅' on STDOUT on failure" "✅ Permissions enforced"
+
+echo "--- T-PERMS-2: permissions enforce helper succeeds → rc=0, ✅ to STDOUT, no ❌ ---"
+NF_HELPER_RC=0 run "$MIRROR/permissions_enforce.sh"
+assert_rc "T-PERMS-2a rc=0 on helper success" 0
+assert_contains_stdout "T-PERMS-2b ✅ on STDOUT" "✅ Permissions enforced successfully"
+assert_not_contains_stdout "T-PERMS-2c no ❌ on STDOUT" "❌"
+
+# ──────────────────────────────────────────────────────────────────────────
+# T-DA — nftban_port_allow_directadmin CloudFlare arm rc-truth
+# ──────────────────────────────────────────────────────────────────────────
+echo "--- T-DA-1: trust enable fails → rc=1, ⚠ to STDERR, no '✓ enabled' on STDOUT ---"
+NF_ENABLE_CF=yes NF_TRUST_ENABLE_FAIL=1 NF_TRUST_UPDATE_FAIL=0 run "$MIRROR/directadmin_cf.sh"
+assert_rc "T-DA-1a directadmin rc=1 on trust-enable fail" 1
+assert_contains_stderr "T-DA-1b ⚠ to STDERR" "Failed to enable CloudFlare whitelist"
+assert_contains_stderr "T-DA-1c 'licensing REQUIRES this' on STDERR" "REQUIRES this"
+assert_contains_stderr "T-DA-1d manual-remediation hint on STDERR" "Re-run manually:"
+assert_not_contains_stdout "T-DA-1e no '✓ CloudFlare whitelist enabled' on STDOUT" "✓ CloudFlare whitelist enabled"
+
+echo "--- T-DA-2: trust update fails → rc=1 ---"
+NF_ENABLE_CF=yes NF_TRUST_ENABLE_FAIL=0 NF_TRUST_UPDATE_FAIL=1 run "$MIRROR/directadmin_cf.sh"
+assert_rc "T-DA-2a directadmin rc=1 on trust-update fail" 1
+assert_contains_stderr "T-DA-2b ⚠ on STDERR" "Failed to enable CloudFlare whitelist"
+
+echo "--- T-DA-3: trust enable+update both succeed → rc=0 + ✓ enabled ---"
+NF_ENABLE_CF=yes NF_TRUST_ENABLE_FAIL=0 NF_TRUST_UPDATE_FAIL=0 run "$MIRROR/directadmin_cf.sh"
+assert_rc "T-DA-3a directadmin rc=0 on full success" 0
+assert_contains_stdout "T-DA-3b '✓ CloudFlare whitelist enabled' on STDOUT" "✓ CloudFlare whitelist enabled"
+assert_not_contains_stdout "T-DA-3c no ⚠ on STDOUT" "Failed to enable CloudFlare"
+
+echo "--- T-DA-4: CloudFlare arm disabled → rc=0 (no trust calls) ---"
+NF_ENABLE_CF=no NF_TRUST_ENABLE_FAIL=1 NF_TRUST_UPDATE_FAIL=1 run "$MIRROR/directadmin_cf.sh"
+assert_rc "T-DA-4 rc=0 when CF arm disabled (skip path)" 0
+
+# ──────────────────────────────────────────────────────────────────────────
+# T-DRIFT — assert live PR-B markers are present
+# ──────────────────────────────────────────────────────────────────────────
+echo "--- T-DRIFT: live cmd_*.sh carry v1.143 PR-B markers ---"
+declare -A EXPECTED_MARKERS=(
+    ["cli/lib/nftban/cli/cmd_port.sh"]=2          # CloudFlare arm + final return marker
+    ["cli/lib/nftban/cli/cmd_permissions.sh"]=1   # wrapper rc-truth + actionable advice
+)
+for f in "${!EXPECTED_MARKERS[@]}"; do
+    expected="${EXPECTED_MARKERS[$f]}"
+    actual=$(grep -cE 'v1.143 PR-B \(FS3-DA\)' "$REPO/$f" || true)
+    if [[ "$actual" -eq "$expected" ]]; then
+        ok "T-DRIFT $f has $expected PR-B marker(s)"
+    else
+        no "T-DRIFT $f marker count" "got $actual; expected $expected"
+    fi
+done
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"


### PR DESCRIPTION
## v1.143.0 PR-B — RC-AUDIT-2 Phase 2 Batch FS3-DA

Second PR of the v1.143.0 cleanup release, after PR-A [#735](https://github.com/itcmsgr/nftban/pull/735) (`b8887e30`). Closes Batch **FS3-DA** per `NFTBAN_ROADMAP/V1_143_0_PLAN.md §4 PR-B`.

Operator authorities honored:
- `OPEN_V1_143_0_PR_B_FS3_DA_IMPL = GO_IMPLEMENTATION_ONLY` (operator 2026-05-29)
- `SELECT_V1_143_INSTALL_UPDATE_SCOPE = permission-enforce-only` — install/update boundary locked (`V1_143_0_PLAN.md §2.1`)
- `SELECT_V1_143_CSF = excluded-parked` · `SELECT_V1_143_SCHEMA = frozen-1.83.0`

---

### Two FS3-class fixes — before / after rc contract

| # | Function | Before (rc swallowed) | After (rc truth) |
|---|---|---|---|
| 1 | `cmd_port::nftban_port_allow_directadmin` (CloudFlare arm + final return) | `nftban trust enable CLOUDFLARE && nftban trust update` failure printed `⚠️` to STDOUT but function returned 0 unconditionally. Body of function says **three times** that 'DirectAdmin LICENSING REQUIRES CloudFlare IPs' — licensing-critical failure silent to rc. | rc captured into `_v143_da_rc`; stderr `⚠️ Failed to enable CloudFlare whitelist / DirectAdmin licensing REQUIRES this — operator action required / Re-run manually: …` + `return $_v143_da_rc` |
| 2 | `cmd_permissions::nftban_permissions_cmd_enforce` (wrapper rc-truth lock) | Wrapper already returned `$result` truthfully — that IS what produced the lab4 `exit 1 — non-fatal` line. But the `❌` failure line went to **STDOUT** with no actionable advice. | Failure block (❌ + log location + re-check + re-run advice) now goes to **STDERR** (E1 contract). rc propagation unchanged (already correct). Contract now LOCKED by the new test. |

### Lab4 audit linkage

`V1_142_LAB4_UPDATE_LOG_SAFETY_AUDIT.md §4 R-PERM-1` classified the lab4 `permissions enforce failed (exit 1) — non-fatal` line as **WARN / BUG-CANDIDATE** aligned with the RC-AUDIT-2 FS3-DA batch. The audit's recommended fix shape was: lift `nftban_permissions_cmd_enforce` so the installer's auto-fix retry sees a truthful rc. The wrapper **already had** truthful rc (lab4 installer log proves this); v1.143 PR-B (a) locks that contract with a test, and (b) improves the failure UX so an operator reading the swallowed 'non-fatal' line gets the actionable advice the installer log already had.

**The installer-side consumer** (Go code at `cmd/nftban-installer/phases.go:571-575`) is **intentionally unchanged** per operator's `SELECT_V1_143_INSTALL_UPDATE_SCOPE = permission-enforce-only` — this PR fixes the shell-side producer rc only.

### Test evidence

| Test | Result |
|---|---|
| `cli_fs3_da_v143_test.sh` (new) | **21 PASS / 0 FAIL** |
| v1.143 PR-A `cli_fs3_mutation_v143_test` | 28/0 |
| v1.142 PR-FS `cli_feeds_select_input_contract_test` | 23/0 |
| v1.142 PR-UX-C6 `cli_sudo_hint_v142_test` | 19/0 |
| v1.141 PR-A/B/C regressions | 115/0 (+4 SKIP) |
| v1.139.2 `rollback_help_guard_v1_139_2_test` | 10/0 |
| **Total at this commit** | **216 PASS / 0 FAIL** across 17 hermetic suites |
| Local shellcheck on all 3 modified files | CLEAN |

Stubbed-callable mirror pattern matches PR-A test. T-DRIFT row asserts three `v1.143 PR-B (FS3-DA)` markers exist in the live `cmd_*.sh` files (cmd_port=2, cmd_permissions=1).

### Pre-push proofs (all 6 green)

1. `git diff --stat` — 3 files / +197 / −7
2. `git diff --name-only` — 2 `cmd_*.sh` + 1 new test under `cli/`
3. Forbidden-path negative control — 0 hits / 13 patterns
4. No `.go` diff — 0 Go files. **Daemon byte-identical to v1.142.0 expected.**
5. `bash -n` on every modified shell file — 3/3 OK
6. Shellcheck `-x -S warning` — CLEAN on all 3 modified files

---

### Non-goals (locked v1.143-wide per plan §2 + §2.1)

- 0 `.go` files. Daemon byte-identical to v1.142.0 → continues the v1.140→v1.141→v1.142→v1.143 four-release-zero-Go chain.
- 0 `internal/`, `cmd/`, `build/`, `packaging/`, `install/`, `systemd/`, `schema/`, `docker/`, `.github/`, `fhs-spec.yaml`.
- 0 schema bump. Schema 1.83.0 frozen.
- 0 portal / metrics labels / Go-installer change.
- **0 CSF / takeover / uninstall-restore / INST-CVE-PARITY work** (hard exclusion).
- **0 broad install/update lifecycle refactor.** The installer's auto-fix retry consumer at `phases.go:571-575` stays unchanged; this PR fixes the shell-side producer rc only.
- 0 package-manager / RPM-DEB-scriptlet / systemd-tmpfiles policy / unsafe-path-transition / session-whitelist-sequencing / install_state-schema changes.
- 0 RBL batch — deferred.
- 0 heuristic batch — audit-doc-only.
- 0 release-prep — separate PR at v1.143.0 tag time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)