### PR TITLE
fix(docs+fhs): v1.144.0 PR-A — close D-NFTBAN-GUI-DOC-DRIFT + FHS-SPEC-GUI-MENTION

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -422,7 +422,7 @@ directories:
       mode: "0750"
       owner: root
       group: nftban
-      description: "TLS certificates for GUI/API"
+      description: "TLS certificates for API"
       created_by: package
 
     - path: /etc/nftban/suricata
@@ -997,16 +997,10 @@ conditional:
         created_by: feature_enable
         note: "External service - only create if node_exporter installed"
 
-  # GUI feature directories - created by 'nftban gui enable'
-  gui:
-    condition: "gui_enabled"
-    directories:
-      - path: /etc/nftban/gui
-        mode: "0750"
-        owner: root
-        group: nftban
-        description: "GUI configuration"
-        created_by: feature_enable
+  # GUI feature was retired in v1.139.2 (PR #722) and the feature-directory
+  # entry was removed in v1.144.0 PR-A (FHS-SPEC-GUI-MENTION). There is no
+  # cmd_gui.sh and no `nftban gui enable` command. The /etc/nftban/gui
+  # directory is not created by base nftban.
 
   # Panel directories - created during panel detection/install
   panels:

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -96,7 +96,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/conf.d/geoban"]="0750|root|nftban|Geographic ban configuration"
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/conf.d/geoip"]="0750|root|nftban|GeoIP database configuration"
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/nftables.d"]="0750|root|nftban|NFTBan-managed nftables include fragments"
-    NFTBAN_FHS_DIRECTORIES["/etc/nftban/ssl"]="0750|root|nftban|TLS certificates for GUI/API"
+    NFTBAN_FHS_DIRECTORIES["/etc/nftban/ssl"]="0750|root|nftban|TLS certificates for API"
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/suricata"]="0750|root|nftban|Suricata integration configuration"
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/suricata/profiles"]="0750|root|nftban|Suricata detection profiles"
     NFTBAN_FHS_DIRECTORIES["/etc/nftban/suricata/config"]="0750|root|nftban|Suricata configuration files"

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -394,7 +394,7 @@
         "mode": "0750",
         "owner": "root",
         "group": "nftban",
-        "description": "TLS certificates for GUI/API",
+        "description": "TLS certificates for API",
         "created_by": "package"
       },
       {

--- a/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - no GUI doc drift test (v1.144.0 PR-A)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_no_gui_doc_drift_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-A — asserts D-NFTBAN-GUI-DOC-DRIFT + FHS-SPEC-GUI-MENTION are closed. (1) commands.registry.yml has no top-level `gui:` entry and no `gui` row in `missing_json:`. (2) build/fhs-spec.yaml has no `gui:` feature block and no 'GUI/API' description. (3) cli/lib/nftban/core/nftban_fhs_spec.sh — regenerated from (2) — contains 'TLS certificates for API' (not 'GUI/API') and no /etc/nftban/gui directory entry. (4) `nftban gui` dispatch through cli/sbin/nftban falls through to the 'Unknown command' catch-all (verified by absence of dispatch case AND absence of alias). Hermetic — no host contact; no daemon, no nft. Closes the operator-visible UX confusion surfaced by the v1.142.0 fleet rollout (V1_142_0_FLEET_ROLLOUT_RECORD.md §3.2)."
+# meta:input="commands.registry.yml, build/fhs-spec.yaml, cli/lib/nftban/core/nftban_fhs_spec.sh, cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="commands.registry.yml,build/fhs-spec.yaml,cli/lib/nftban/core/nftban_fhs_spec.sh,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 1: commands.registry.yml — help-output source-of-truth
+# ──────────────────────────────────────────────────────────────────────────
+REG="$REPO/commands.registry.yml"
+[[ -f "$REG" ]] || { echo "FAIL: missing $REG"; exit 1; }
+
+# T1-1: no top-level 'gui:' entry in the registry. The registry is YAML and
+# the top-level entries are at column 0; comments starting with '#' are
+# allowed (and used to record the retirement reason).
+if grep -nE '^gui:' "$REG" >/dev/null 2>&1; then
+    no "T1-1: commands.registry.yml has no top-level 'gui:' entry" \
+       "$(grep -nE '^gui:' "$REG" | head -1)"
+else
+    ok "T1-1: commands.registry.yml has no top-level 'gui:' entry"
+fi
+
+# T1-2: no 'nftban gui ...' invocation examples remain
+if grep -nE '"nftban gui ' "$REG" >/dev/null 2>&1; then
+    no "T1-2: commands.registry.yml has no 'nftban gui' example strings" \
+       "$(grep -nE '"nftban gui ' "$REG" | head -1)"
+else
+    ok "T1-2: commands.registry.yml has no 'nftban gui' example strings"
+fi
+
+# T1-3: 'gui' removed from the metadata 'missing_json:' list. The retirement
+# comment is allowed; only a bare list-item line '    - gui' is forbidden.
+if grep -nE '^[[:space:]]+- gui$' "$REG" >/dev/null 2>&1; then
+    no "T1-3: commands.registry.yml 'missing_json:' has no '- gui' item" \
+       "$(grep -nE '^[[:space:]]+- gui$' "$REG" | head -1)"
+else
+    ok "T1-3: commands.registry.yml 'missing_json:' has no '- gui' item"
+fi
+
+# T1-4: total_commands counter is one lower than it was before the retirement
+# (66, not 67) — guards against silent re-introduction by a future PR that
+# adds 'gui' back without bumping the counter.
+if grep -nE '^[[:space:]]+total_commands:[[:space:]]+66\b' "$REG" >/dev/null 2>&1; then
+    ok "T1-4: total_commands = 66 (reflects gui retirement)"
+else
+    no "T1-4: total_commands = 66 (reflects gui retirement)" \
+       "$(grep -nE 'total_commands:' "$REG" | head -1 || echo 'absent')"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 2: build/fhs-spec.yaml — FHS spec source-of-truth
+# ──────────────────────────────────────────────────────────────────────────
+FHS_SRC="$REPO/build/fhs-spec.yaml"
+[[ -f "$FHS_SRC" ]] || { echo "FAIL: missing $FHS_SRC"; exit 1; }
+
+# T2-1: SSL directory description should say "TLS certificates for API"
+# (NOT "TLS certificates for GUI/API"). Permits the leading comment block
+# at the top of fhs-spec.yaml which has historical text about GUI retirement.
+if grep -nE 'description: "TLS certificates for API"' "$FHS_SRC" >/dev/null 2>&1; then
+    ok "T2-1: build/fhs-spec.yaml SSL description = 'TLS certificates for API'"
+else
+    no "T2-1: build/fhs-spec.yaml SSL description = 'TLS certificates for API'" \
+       "$(grep -nE 'description.*TLS certificates' "$FHS_SRC" | head -1 || echo 'absent')"
+fi
+
+# T2-2: no 'TLS certificates for GUI/API' string remains
+if grep -nE 'TLS certificates for GUI/API' "$FHS_SRC" >/dev/null 2>&1; then
+    no "T2-2: build/fhs-spec.yaml has no 'TLS certificates for GUI/API'" \
+       "$(grep -nE 'TLS certificates for GUI/API' "$FHS_SRC" | head -1)"
+else
+    ok "T2-2: build/fhs-spec.yaml has no 'TLS certificates for GUI/API'"
+fi
+
+# T2-3: no `gui:` feature block (under feature_directories.gui:). The block
+# would manifest as a 2-space-indented 'gui:' line followed by an indented
+# 'condition: "gui_enabled"' line. Match the conjunction to avoid false
+# positives on any unrelated 'gui:' that might exist elsewhere.
+if grep -nE '^[[:space:]]{2}gui:' "$FHS_SRC" >/dev/null 2>&1; then
+    no "T2-3: build/fhs-spec.yaml has no 'gui:' feature block" \
+       "$(grep -nE '^[[:space:]]{2}gui:' "$FHS_SRC" | head -1)"
+else
+    ok "T2-3: build/fhs-spec.yaml has no 'gui:' feature block"
+fi
+
+# T2-4: no 'gui_enabled' condition string
+if grep -nE 'gui_enabled' "$FHS_SRC" >/dev/null 2>&1; then
+    no "T2-4: build/fhs-spec.yaml has no 'gui_enabled' condition" \
+       "$(grep -nE 'gui_enabled' "$FHS_SRC" | head -1)"
+else
+    ok "T2-4: build/fhs-spec.yaml has no 'gui_enabled' condition"
+fi
+
+# T2-5: no '/etc/nftban/gui' YAML path entry. Retirement-rationale COMMENT
+# lines (prefixed with `#`) are allowed; only a non-comment yaml line
+# containing the path is forbidden. Standard hermetic-test convention
+# (matches T3-2 / T3-3 / T2-3 same-file semantics).
+if grep -nE '/etc/nftban/gui' "$FHS_SRC" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' >/dev/null 2>&1; then
+    no "T2-5: build/fhs-spec.yaml has no '/etc/nftban/gui' path (non-comment)" \
+       "$(grep -nE '/etc/nftban/gui' "$FHS_SRC" | grep -vE '^[0-9]+:[[:space:]]*#' | head -1)"
+else
+    ok "T2-5: build/fhs-spec.yaml has no '/etc/nftban/gui' path (non-comment)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 3: cli/lib/nftban/core/nftban_fhs_spec.sh — regenerated output
+# ──────────────────────────────────────────────────────────────────────────
+FHS_OUT="$REPO/cli/lib/nftban/core/nftban_fhs_spec.sh"
+[[ -f "$FHS_OUT" ]] || { echo "FAIL: missing $FHS_OUT"; exit 1; }
+
+# T3-1: regenerated description reflects source edit
+if grep -nE 'TLS certificates for API' "$FHS_OUT" >/dev/null 2>&1; then
+    ok "T3-1: nftban_fhs_spec.sh contains 'TLS certificates for API'"
+else
+    no "T3-1: nftban_fhs_spec.sh contains 'TLS certificates for API'" \
+       "$(grep -nE 'TLS certificates' "$FHS_OUT" | head -1 || echo 'absent')"
+fi
+
+# T3-2: no 'GUI/API' string in the regenerated output (the lines 30-31
+# historical comment block uses 'GOTH GUI' / 'GUI is display-only' but never
+# the 'GUI/API' compound — those are different strings and harmless context).
+if grep -nE 'GUI/API' "$FHS_OUT" >/dev/null 2>&1; then
+    no "T3-2: nftban_fhs_spec.sh has no 'GUI/API' compound string" \
+       "$(grep -nE 'GUI/API' "$FHS_OUT" | head -1)"
+else
+    ok "T3-2: nftban_fhs_spec.sh has no 'GUI/API' compound string"
+fi
+
+# T3-3: no /etc/nftban/gui directory entry in the generated output
+if grep -nE '/etc/nftban/gui' "$FHS_OUT" >/dev/null 2>&1; then
+    no "T3-3: nftban_fhs_spec.sh has no /etc/nftban/gui directory entry" \
+       "$(grep -nE '/etc/nftban/gui' "$FHS_OUT" | head -1)"
+else
+    ok "T3-3: nftban_fhs_spec.sh has no /etc/nftban/gui directory entry"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 4: cli/sbin/nftban — dispatcher reachability for `nftban gui`
+# ──────────────────────────────────────────────────────────────────────────
+DISP="$REPO/cli/sbin/nftban"
+[[ -f "$DISP" ]] || { echo "FAIL: missing $DISP"; exit 1; }
+
+# T4-1: 'gui' not in canonical command list. The function _nftban_canonical_commands
+# emits one command per line from a heredoc; ensure no bare 'gui' line appears.
+if awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" | grep -E '^gui$' >/dev/null 2>&1; then
+    no "T4-1: _nftban_canonical_commands has no bare 'gui' line" \
+       "$(awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" | grep -nE '^gui$' | head -1)"
+else
+    ok "T4-1: _nftban_canonical_commands has no bare 'gui' line"
+fi
+
+# T4-2: 'gui' not in the alias-case block (cloudflare/enable|disable|restart/
+# verify|explain/service/export/rollback). Pattern: '^[[:space:]]+gui)' or
+# '|gui)' inside the alias-case lines after the autoloader fallthrough.
+if grep -nE '^[[:space:]]+gui\)|gui\|.+\)|\|gui\)' "$DISP" >/dev/null 2>&1; then
+    no "T4-2: dispatcher has no 'gui' case alias" \
+       "$(grep -nE '^[[:space:]]+gui\)|gui\|.+\)|\|gui\)' "$DISP" | head -1)"
+else
+    ok "T4-2: dispatcher has no 'gui' case alias"
+fi
+
+# T4-3: no autoloader sourcing of cmd_gui.sh — assert the autoloader walks
+# ${NFTBAN_LIB_DIR}/cli/cmd_${cmd}.sh and assert the file doesn't exist on
+# disk. (The dispatcher pattern itself doesn't name 'gui'; it builds the
+# path dynamically. So we just assert cmd_gui.sh isn't present in the tree.)
+if [[ -f "$REPO/cli/lib/nftban/cli/cmd_gui.sh" ]]; then
+    no "T4-3: cli/lib/nftban/cli/cmd_gui.sh not present" \
+       "found at $REPO/cli/lib/nftban/cli/cmd_gui.sh"
+else
+    ok "T4-3: cli/lib/nftban/cli/cmd_gui.sh not present"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 5: cross-tree string drift — only test files and harmless comments
+#            may mention 'gui'/'GUI' from this point forward
+# ──────────────────────────────────────────────────────────────────────────
+# T5-1: no shell .sh source advertises 'nftban gui <subcmd>' (the v133 D-01
+# guard already enforces this; this is an explicit v144 regression-lock).
+# Scope: cli/ excluding tests and tabular health-render array key.
+HITS=$(grep -rnE 'nftban gui ' --include='*.sh' "$REPO/cli/" 2>/dev/null | grep -v '/tests/' || true)
+if [[ -n "$HITS" ]]; then
+    no "T5-1: no shell source advertises 'nftban gui <subcmd>'" \
+       "$(echo "$HITS" | head -1)"
+else
+    ok "T5-1: no shell source advertises 'nftban gui <subcmd>'"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────────────────────────
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_no_gui_doc_drift_v144_test results: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+exit 0

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -2740,22 +2740,11 @@ pro:
           mutates: true
           description: "Submit stats now (called by timer)"
 
-gui:
-  category: intelligence_reporting
-  description: "Web GUI management"
-  risk: setup
-  audience: [cli]
-  capability: service_control
-  mutates: conditional
-  supports_dry_run: false
-  requires_root: true
-  panel_expose: false
-  output_modes: [text]
-  has_json: false
-  examples:
-    - "nftban gui status"
-    - "nftban gui enable"
-    - "nftban gui disable"
+# v1.144.0 PR-A: GUI command entry retired. The Web GUI was retired in v1.139.2
+# (PR #722); there is no cmd_gui.sh, no dispatcher case, and `nftban gui`
+# returns "Unknown command" rc=1. Use `nftban report html-report` for similar
+# functionality or external hosting panels for a browser UI.
+# (D-NFTBAN-GUI-DOC-DRIFT closure; V1_144_0_DOC_UX_DRIFT_PLAN.md §3.1)
 
 geoip:
   category: intelligence_reporting
@@ -3561,13 +3550,12 @@ _metadata:
     - "Arguments with type validation (string, int, bool, enum)"
     - "Zabbix LLD discovery support"
     - "Auto-help generation support"
-  total_commands: 67
+  total_commands: 66  # v1.144.0 PR-A: -1 (gui retired)
   commands_with_json: 46
-  commands_without_json: 11
+  commands_without_json: 10  # v1.144.0 PR-A: -1 (gui retired)
   commands_with_full_options: 27
   missing_json:
     - debug
-    - gui
     - menu
     - profile
     - smoke
@@ -3577,13 +3565,14 @@ _metadata:
     - timers
     - update
     - wizard
+    # gui: retired in v1.144.0 PR-A (was retired functionally in v1.139.2 PR #722)
     # trust: now has JSON support (v1.19.13)
   task_groups:
     setup_discovery: 10
     immediate_action: 12
     active_protection: 9
     infrastructure: 11
-    intelligence_reporting: 12
+    intelligence_reporting: 11  # v1.144.0 PR-A: -1 (gui retired)
     developer_sysadmin: 13
   risk_levels:
     core: 26


### PR DESCRIPTION
## v1.144.0 PR-A — D-NFTBAN-GUI-DOC-DRIFT + FHS-SPEC-GUI-MENTION

**Plan:** [`NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md) §3.1 + §3.4
**Gate:** `OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY` (operator 2026-06-01)
**Selects locked:** `SELECT_V1_144_GUI_DRIFT_SHAPE=drop` + `SELECT_V1_144_FHS_BODY_CHAIN_BREAK=accept`
**Vehicle:** v1.144.0 doc/UX-drift train, PR 1 of 5

### What this PR does

Retires the GUI command entry from the help-registry source-of-truth (`commands.registry.yml`) and removes \"GUI/API\" wording + dormant gui-feature scaffolding from `build/fhs-spec.yaml`. The Web GUI was functionally retired in v1.139.2 (#722); this PR cleans up the four documentation drift sites that survived because the v133 D-01 forward guard only checked shell sources, not YAML registry / FHS spec source.

### Files changed (5)

| File | Change |
|---|---|
| `commands.registry.yml` | Drop top-level \`gui:\` entry + drop \`- gui\` from \`missing_json:\` + adjust counters (total_commands 67→66; commands_without_json 11→10; intelligence_reporting 12→11) |
| `build/fhs-spec.yaml` | Line 425: \"TLS certificates for GUI/API\" → \"TLS certificates for API\"; lines 1000-1015: remove \`gui:\` feature directory block |
| `cli/lib/nftban/core/nftban_fhs_spec.sh` | Regenerated by \`build/generate-fhs-outputs.sh\` — body SHA256 `4e618bd7…1d1f242` → `5cc86594…6906971` (breaks five-release chain by design) |
| `cli/lib/nftban/data/fhs_directories.json` | Regenerated (meta header) |
| `cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh` | **NEW** 16-assertion hermetic test |

### Test results

- **`cli_no_gui_doc_drift_v144_test.sh`** — **16 PASS / 0 FAIL** (NEW)
- **v133 D-01** (existing 'nftban gui' shell guard): 31 PASS / 0 FAIL (regression-locked)
- **v1.139.2 rollback help guard**: 10 PASS / 0 FAIL (regression)
- **v1.143.1 cli_exporter_exit2_phase_3**: 37 PASS / 0 FAIL (regression)
- **v1.139 tmpfiles_zz** (47 d + 47 z + 0 Z invariant): 10 PASS / 0 FAIL (regression — FHS-spec source-side edit did not disturb the invariant)
- **`build/generate-fhs-outputs.sh --check`**: idempotent — committed generated files match deterministic regeneration

### Forbidden-path control

```
.go files touched:        0
internal/ touched:        0
cmd/ touched:             0
install/systemd/ touched: 0
.github/workflows/:       0
schema/ touched:          0
docker/ touched:          0
```

### Daemon byte-identity

- `cmd/nftban-core` and `cmd/nftband` SHA256-identical to v1.143.1 expected (zero `.go` diff).
- **The five-release zero-Go chain** `v1.140.0 → v1.141.0 → v1.142.0 → v1.143.0 → v1.143.1` **extends to six releases** when v1.144.0 publishes.
- `cli/lib/nftban/core/nftban_fhs_spec.sh` **body SHA256 chain breaks here by design** — operator gate `SELECT_V1_144_FHS_BODY_CHAIN_BREAK=accept` explicitly authorized this. Was a 5-release side-effect, never a contract.

### Out of scope (other PRs in the v1.144.0 train)

- **PR-B**: UX-C2 wall-of-text + UX-C5 \`--dry-run\` doc note (separate PR)
- **PR-C**: D-UXV-14 connector edit hint + D-UXV-15 four-site port reload hints (separate PR)
- **PR-D**: D-UXV-13 runtime-hint reachability CI guard (separate PR; MUST land with PR-C per operator coupling constraint)
- **PR-PREP**: standard 4-file release-prep envelope (last)

### Schema

1.83.0 **frozen**.

### Lab-gate readiness (operator-controlled lab validation)

Per memory `feedback_lab_first_release_policy`: v1.144.0 introduces no new release surfaces (no new packages, no new distros, no new Go binaries, no new CLI commands). The change is shell-only + YAML source-side regen. CI green + the new hermetic test + the 4 regression suites green is the standard discharge.

### Operator gate trail

| Gate | State |
|---|---|
| `OPEN_V1_144_0_DOC_UX_DRIFT_PLAN = GO_PLAN_ONLY` | ✅ filed |
| `AMEND_V1_144_0_DOC_UX_DRIFT_PLAN_WITH_D_UXV_13_14_15 = GO_PLAN_ONLY` | ✅ amended |
| `OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY` | ✅ fired 2026-06-01 |
| `MERGE_PR_<this>_WHEN_CI_GREEN = GO` | ⏳ awaiting after CI green |