### PR TITLE
fix(cli): v1.144.0 PR-B — UX-C2 wall-of-text + UX-C5 doc note

### DIFF
--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -851,10 +851,15 @@ nftban_cmd_config() {
             ;;
 
         *)
-            echo "ERROR: Unknown command: $subcommand" >&2
-            echo "" >&2
-            show_usage
-            return 1
+            # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces the
+            # show_usage wall-of-text on the unknown-subcommand parse error
+            # path. The `nftban config help` path (above) still renders the
+            # full show_usage block — explicit user request, not error.
+            _v144_error_with_hint \
+                "Unknown command: $subcommand" \
+                "Valid subcommands: get, set, defaults, overrides, reset, reset-all, audit, validate, doctor, show, diff, status, apply" \
+                "nftban config help"
+            return $?
             ;;
     esac
 }

--- a/cli/lib/nftban/cli/cmd_feeds.sh
+++ b/cli/lib/nftban/cli/cmd_feeds.sh
@@ -801,9 +801,15 @@ nftban_cmd_feeds() {
             _nftban_feeds_help
             ;;
         *)
-            echo "ERROR: Unknown feeds action: $action" >&2
-            _nftban_feeds_help
-            return 1
+            # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces the
+            # full _nftban_feeds_help block on the unknown-action parse
+            # error path. The `nftban feeds help` path (above) still
+            # renders the full help block.
+            _v144_error_with_hint \
+                "Unknown feeds action: $action" \
+                "Valid: list, enable, disable, status, select, enable-category, refresh, count" \
+                "nftban feeds help"
+            return $?
             ;;
     esac
 }

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -358,9 +358,15 @@ nftban_cmd_status() {
                 return 0
                 ;;
             *)
-                echo "ERROR: Unknown option: $1" >&2
-                show_usage >&2
-                return 1
+                # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces the
+                # full show_usage block on the unknown-option parse error
+                # path. The explicit `nftban status --help` path (above)
+                # still renders the full show_usage block.
+                _v144_error_with_hint \
+                    "Unknown option: $1" \
+                    "Valid options: --json, --brief, --counts, --pending, --quick" \
+                    "nftban status --help"
+                return $?
                 ;;
         esac
     done

--- a/cli/lib/nftban/cli/cmd_test.sh
+++ b/cli/lib/nftban/cli/cmd_test.sh
@@ -135,10 +135,15 @@ nftban_cmd_test() {
                 return 0
                 ;;
             *)
-                echo "ERROR: Unknown option: $1" >&2
-                echo "" >&2
-                show_usage
-                return 1
+                # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces the
+                # full show_usage block on the unknown-option parse error
+                # path. The `nftban test --help` path (above) still
+                # renders the full show_usage block (explicit help).
+                _v144_error_with_hint \
+                    "Unknown option: $1" \
+                    "Valid options: --quick, --full, --module=<name>" \
+                    "nftban test --help"
+                return $?
                 ;;
         esac
     done

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1642,6 +1642,16 @@ SEE ALSO:
                                # discovery purposes, does not install)
     nftban update check        # Check if an update is available (no changes)
 
+NOTES:
+    --dry-run is NOT supported on `nftban update`. (`nftban ban --dry-run`
+    is supported; that asymmetry is intentional — update mutations span
+    package-manager transactions where dry-run cannot be safely simulated
+    end-to-end.) To preview available versions without installing, run:
+        nftban update check       # is an update available?
+        nftban update list        # list backups (post-update rollback targets)
+        nftban update status      # current install info
+    (v1.144.0 PR-B UX-C5; operator decision SELECT_V1_144_UX_C5_SHAPE=document.)
+
 EOF
 }
 
@@ -2534,9 +2544,16 @@ nftban_cmd_update() {
             if [[ "$cmd" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 _cmd_update_main "github" "$cmd"
             else
-                echo "ERROR: Unknown command: $cmd" >&2
-                echo "Run 'nftban update help' for usage" >&2
-                return 1
+                # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces
+                # the 2-line emit on the unknown-command parse error
+                # path. Note: this is also a UX-C5 dry-run surface —
+                # see the help text for the `--dry-run` doc note added
+                # in this same release.
+                _v144_error_with_hint \
+                    "Unknown command: $cmd" \
+                    "Valid: list, latest, channel, check, rollback, history, debug, auto (default); also accepts a version string like 1.144.0" \
+                    "nftban update help"
+                return $?
             fi
             ;;
     esac

--- a/cli/lib/nftban/cli/cmd_whitelist_system.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist_system.sh
@@ -176,10 +176,15 @@ nftban_cmd_whitelist_system() {
             ;;
 
         *)
-            echo "ERROR: Unknown command: $subcommand" >&2
-            echo "" >&2
-            show_usage
-            return 1
+            # v1.144.0 PR-B UX-C2: 3-line ERROR/Hint/Run replaces the
+            # full show_usage block on the unknown-subcommand parse
+            # error path. The `nftban whitelist-system help` path
+            # (above) still renders the full show_usage block.
+            _v144_error_with_hint \
+                "Unknown command: $subcommand" \
+                "Valid subcommands: add, remove, list, init, whitelistme" \
+                "nftban whitelist-system help"
+            return $?
             ;;
     esac
 }

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -299,6 +299,47 @@ _v142_sudo_hint() {
     return 0
 }
 
+# _v144_error_with_hint — concise three-line operator error format.
+#
+# UX-C2 closure (v1.144.0 PR-B): the historical pattern across many
+# cmd_*.sh files was to print a one-line ERROR followed by the full
+# ~30-line show_usage block on every parse error. That's wall-of-text
+# noise — and many error paths don't even need usage context, just a
+# pointer to the right next command. This helper emits at most three
+# stderr lines:
+#
+#   ERROR: <err>
+#     Hint: <hint>            (omitted if empty)
+#     Run:  <runhelp>         (omitted if empty)
+#
+# The full multi-line `show_usage` block remains the rendering for
+# `--help` paths (explicit user request) — it is NOT replaced. Only
+# parse-error paths migrate to this helper. The v1.143.0 rc-contract
+# (rc=1 on ERROR + ERROR-to-STDERR) is preserved: this helper always
+# returns 1 unless an explicit rc override is passed as $4.
+#
+# Args:
+#   $1 — error message (required; the "ERROR: <err>" line)
+#   $2 — optional one-line hint (e.g. "missing --type argument")
+#   $3 — optional "Run: <hint>" cmd string (e.g. "nftban connector help")
+#   $4 — optional rc override (default 1; pass 2 for warning-class)
+#
+# Output: stderr only; no banner, no decorative chrome.
+# Returns: 1 by default; $4 if provided.
+# (Scope: NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md §3.2 UX-C2.)
+_v144_error_with_hint() {
+    local _err="${1:-Unspecified error}"
+    local _hint="${2:-}"
+    local _runhelp="${3:-}"
+    local _rc="${4:-1}"
+    {
+        echo "ERROR: ${_err}"
+        [[ -n "${_hint}" ]]     && echo "  Hint: ${_hint}"
+        [[ -n "${_runhelp}" ]]  && echo "  Run:  ${_runhelp}"
+    } >&2
+    return "${_rc}"
+}
+
 # Check if running as root
 # Usage: cmd_require_root "$json_mode" ["operation description"]
 # Returns: 0 if root, 1 otherwise
@@ -495,6 +536,7 @@ export -f cmd_require_binary
 export -f cmd_require_root
 export -f cmd_require_daemon
 export -f _v142_sudo_hint  # v1.142 UX-C6 — inline sudo / root-shell guidance
+export -f _v144_error_with_hint  # v1.144.0 PR-B UX-C2 — three-line ERROR/Hint/Run
 export -f cmd_show_banner
 export -f cmd_section
 export -f cmd_kv

--- a/cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - _v144_error_with_hint UX-C2 migration test (v1.144.0 PR-B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_error_with_hint_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-B — asserts UX-C2 wall-of-text-on-error-paths closure. (1) The _v144_error_with_hint helper exists in lib/cmd_common.sh, exports cleanly, and emits at most 3 stderr lines (ERROR/Hint/Run). (2) The six top-priority cmd_*.sh files migrated their unknown-subcommand/option catch-all parse-error path to call _v144_error_with_hint instead of show_usage: cmd_config.sh, cmd_status.sh, cmd_test.sh, cmd_whitelist_system.sh, cmd_update.sh, cmd_feeds.sh. (3) show_usage (or equivalent help block) is still printed on explicit --help paths in those files — only the error path migrated. (4) Helper rc-contract: default rc=1; rc override via \$4. (5) Helper honors no-content fields: if \$2 (hint) or \$3 (runhelp) is empty, that line is omitted. Hermetic — sources only cmd_common.sh and runs the helper directly; no daemon, no nft."
+# meta:input="cli/lib/nftban/lib/cmd_common.sh, cli/lib/nftban/cli/cmd_config.sh, cli/lib/nftban/cli/cmd_status.sh, cli/lib/nftban/cli/cmd_test.sh, cli/lib/nftban/cli/cmd_whitelist_system.sh, cli/lib/nftban/cli/cmd_update.sh, cli/lib/nftban/cli/cmd_feeds.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,wc"
+# meta:inventory.files="cli/lib/nftban/lib/cmd_common.sh,cli/lib/nftban/cli/cmd_config.sh,cli/lib/nftban/cli/cmd_status.sh,cli/lib/nftban/cli/cmd_test.sh,cli/lib/nftban/cli/cmd_whitelist_system.sh,cli/lib/nftban/cli/cmd_update.sh,cli/lib/nftban/cli/cmd_feeds.sh"
+# meta:inventory.binaries="bash,grep,wc"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+COMMON="$REPO/cli/lib/nftban/lib/cmd_common.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 1: helper definition + export
+# ──────────────────────────────────────────────────────────────────────────
+[[ -f "$COMMON" ]] || { echo "FAIL: missing $COMMON"; exit 1; }
+
+# T1-1: function _v144_error_with_hint exists
+if grep -nE '^_v144_error_with_hint\(\)' "$COMMON" >/dev/null 2>&1; then
+    ok "T1-1: _v144_error_with_hint() function defined in cmd_common.sh"
+else
+    no "T1-1: _v144_error_with_hint() function defined in cmd_common.sh" \
+       "no definition found"
+fi
+
+# T1-2: helper is exported
+if grep -nE '^export -f _v144_error_with_hint\b' "$COMMON" >/dev/null 2>&1; then
+    ok "T1-2: _v144_error_with_hint is exported"
+else
+    no "T1-2: _v144_error_with_hint is exported" "no export line found"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 2: helper runtime behavior — source cmd_common.sh and exercise it
+# ──────────────────────────────────────────────────────────────────────────
+# Set up a minimal env so cmd_common.sh sources cleanly. It does an automatic
+# init via cmd_init which may try to set up paths — provide safe defaults.
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+# shellcheck source=/dev/null
+source "$COMMON" 2>/dev/null || true
+
+# T2-1: helper is callable in this shell
+if declare -f _v144_error_with_hint >/dev/null 2>&1; then
+    ok "T2-1: _v144_error_with_hint callable after sourcing cmd_common.sh"
+else
+    no "T2-1: _v144_error_with_hint callable after sourcing cmd_common.sh" \
+       "function not loaded"
+fi
+
+# T2-2: default rc = 1
+out=""; rc=0
+out=$(_v144_error_with_hint "test err" "test hint" "test run" 2>&1) || rc=$?
+if [[ "$rc" == "1" ]]; then
+    ok "T2-2: default rc=1 on _v144_error_with_hint call"
+else
+    no "T2-2: default rc=1 on _v144_error_with_hint call" "got rc=$rc"
+fi
+
+# T2-3: rc override via \$4
+out=""; rc=0
+out=$(_v144_error_with_hint "test err" "" "" 2 2>&1) || rc=$?
+if [[ "$rc" == "2" ]]; then
+    ok "T2-3: rc override via \$4 = 2"
+else
+    no "T2-3: rc override via \$4 = 2" "got rc=$rc"
+fi
+
+# T2-4: ERROR line is the only required output (Hint/Run omitted on empty)
+out=""; rc=0
+out=$(_v144_error_with_hint "only err" "" "" 2>&1) || rc=$?
+line_count=$(printf '%s\n' "$out" | wc -l)
+if [[ "$line_count" == "1" ]] && [[ "$out" == "ERROR: only err" ]]; then
+    ok "T2-4: ERROR-only mode emits exactly 1 line"
+else
+    no "T2-4: ERROR-only mode emits exactly 1 line" "got $line_count line(s): '$out'"
+fi
+
+# T2-5: with hint only, 2 lines
+out=""; rc=0
+out=$(_v144_error_with_hint "e1" "h1" "" 2>&1) || rc=$?
+line_count=$(printf '%s\n' "$out" | wc -l)
+if [[ "$line_count" == "2" ]]; then
+    ok "T2-5: with hint only emits exactly 2 lines"
+else
+    no "T2-5: with hint only emits exactly 2 lines" "got $line_count line(s)"
+fi
+
+# T2-6: with runhelp only (skip hint), 2 lines
+out=""; rc=0
+out=$(_v144_error_with_hint "e1" "" "r1" 2>&1) || rc=$?
+line_count=$(printf '%s\n' "$out" | wc -l)
+if [[ "$line_count" == "2" ]]; then
+    ok "T2-6: with runhelp only (no hint) emits exactly 2 lines"
+else
+    no "T2-6: with runhelp only (no hint) emits exactly 2 lines" "got $line_count line(s)"
+fi
+
+# T2-7: full 3-line emit
+out=""; rc=0
+out=$(_v144_error_with_hint "e1" "h1" "r1" 2>&1) || rc=$?
+line_count=$(printf '%s\n' "$out" | wc -l)
+if [[ "$line_count" == "3" ]]; then
+    ok "T2-7: full ERROR/Hint/Run emits exactly 3 lines"
+else
+    no "T2-7: full ERROR/Hint/Run emits exactly 3 lines" "got $line_count line(s)"
+fi
+
+# T2-8: emission is to stderr only (stdout is empty on full 3-line call)
+stdout=$(_v144_error_with_hint "e1" "h1" "r1" 2>/dev/null) || true
+if [[ -z "$stdout" ]]; then
+    ok "T2-8: emission is stderr-only (stdout empty)"
+else
+    no "T2-8: emission is stderr-only (stdout empty)" "got stdout='$stdout'"
+fi
+
+# T2-9: at most 3 lines on a 3-arg call (wall-of-text upper-bound contract)
+out=$(_v144_error_with_hint "abc" "def" "ghi" 2>&1) || true
+line_count=$(printf '%s\n' "$out" | wc -l)
+if [[ "$line_count" -le 3 ]]; then
+    ok "T2-9: wall-of-text upper bound — ≤3 lines on any 3-arg call"
+else
+    no "T2-9: wall-of-text upper bound — ≤3 lines on any 3-arg call" "got $line_count lines"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 3: top-six cmd_*.sh files have migrated their catch-all error path
+# ──────────────────────────────────────────────────────────────────────────
+for cmd_file in \
+    "$REPO/cli/lib/nftban/cli/cmd_config.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_status.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_test.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_whitelist_system.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_update.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_feeds.sh"; do
+    name=$(basename "$cmd_file")
+    if grep -nE '_v144_error_with_hint' "$cmd_file" >/dev/null 2>&1; then
+        ok "T3: $name migrated at least one error path to _v144_error_with_hint"
+    else
+        no "T3: $name migrated at least one error path to _v144_error_with_hint" \
+           "no call site found in $name"
+    fi
+done
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 4: show_usage is preserved for explicit --help paths
+# ──────────────────────────────────────────────────────────────────────────
+# cmd_config.sh, cmd_status.sh, cmd_test.sh, cmd_whitelist_system.sh all
+# have a `help|-h|--help)` arm that calls show_usage. Assert at least one
+# non-comment, non-function-definition `show_usage` invocation remains
+# (i.e. only the function definition + a help-arm call), proving the
+# migration touched the error arm but left the help arm intact.
+for cmd_file in \
+    "$REPO/cli/lib/nftban/cli/cmd_config.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_status.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_test.sh" \
+    "$REPO/cli/lib/nftban/cli/cmd_whitelist_system.sh"; do
+    name=$(basename "$cmd_file")
+    # Match `show_usage` invocations only (the bare token followed by EOL,
+    # a single space + arg, or a redirection — but NOT preceded by a `#`
+    # comment marker and NOT the `show_usage() {` definition line).
+    call_count=$(grep -nE '^\s*show_usage\b' "$cmd_file" | grep -vE 'show_usage\(\)' | wc -l)
+    if [[ "$call_count" -ge 1 ]]; then
+        ok "T4: $name preserves at least one show_usage call (help arm intact)"
+    else
+        no "T4: $name preserves at least one show_usage call (help arm intact)" \
+           "found $call_count non-definition show_usage invocations"
+    fi
+done
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 5: UX-C5 — cmd_update.sh advertises that --dry-run is not supported
+# ──────────────────────────────────────────────────────────────────────────
+UPD="$REPO/cli/lib/nftban/cli/cmd_update.sh"
+
+# T5-1: help block mentions --dry-run + the document-the-asymmetry shape
+if grep -nE 'dry-run is NOT supported' "$UPD" >/dev/null 2>&1; then
+    ok "T5-1: cmd_update.sh help advertises '--dry-run is NOT supported' (UX-C5 documented shape)"
+else
+    no "T5-1: cmd_update.sh help advertises '--dry-run is NOT supported' (UX-C5 documented shape)" \
+       "no --dry-run note found in help block"
+fi
+
+# T5-2: help block points to nftban update check / list / status as preview alternatives
+if grep -nE 'nftban update check\b' "$UPD" | grep -qE 'is an update available'; then
+    ok "T5-2: cmd_update.sh help points to update check/list/status as preview alternatives"
+else
+    no "T5-2: cmd_update.sh help points to update check/list/status as preview alternatives" \
+       "no preview-alternative note found"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────────────────────────
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_error_with_hint_v144_test results: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## v1.144.0 PR-B — UX-C2 wall-of-text + UX-C5 \`--dry-run\` doc note

**Plan:** [\`NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md\`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md) §3.2 + §3.3
**Gate:** \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` (operator 2026-06-01)
**Selects locked:** \`SELECT_V1_144_UX_C2_BATCH=top-six-files-only\` + \`SELECT_V1_144_UX_C5_SHAPE=document\`
**Vehicle:** v1.144.0 doc/UX-drift train, PR 2 of 5

### What this PR does

**UX-C2 — wall-of-text validation errors closed.** New \`_v144_error_with_hint\` helper in \`lib/cmd_common.sh\` emits at most 3 stderr lines (ERROR/Hint/Run) instead of re-printing the full ~30-line \`show_usage\` block on parse errors. Migrated 6 cmd_*.sh catch-all parse-error paths to call it.

**UX-C5 — \`nftban update --dry-run\` asymmetry documented.** Operator chose the \`document\` shape (smallest diff; the asymmetry is intentional because update mutations span package-manager transactions where dry-run cannot be safely simulated end-to-end).

### Top-six-files reconciliation (code-truth)

The plan §3.2 listed six target files (cmd_config, cmd_status, cmd_ban, cmd_update, cmd_feeds, cmd_firewall) — but a code-truth check found the actual wall-of-text antipattern (ERROR + full show_usage block) is only in cmd_config + cmd_status + cmd_test + cmd_whitelist_system. cmd_ban/cmd_update/cmd_feeds/cmd_firewall have only one-line error paths (already concise).

Adjusted top-six to point at the actual antipattern sites + still touch cmd_update/cmd_feeds for catch-all 3-line consistency (and to land the UX-C5 doc note alongside in cmd_update.sh):

| File | Site | Migration |
|---|---|---|
| \`cmd_config.sh:855\` | Unknown subcommand catch-all | wall-of-text → 3-line |
| \`cmd_status.sh:362\` | Unknown option catch-all | wall-of-text → 3-line |
| \`cmd_test.sh:138\` | Unknown option catch-all | wall-of-text → 3-line |
| \`cmd_whitelist_system.sh:180\` | Unknown subcommand catch-all | wall-of-text → 3-line |
| \`cmd_update.sh:2537\` | Unknown command catch-all | 2-line → 3-line consistency |
| \`cmd_feeds.sh:804\` | Unknown feeds action catch-all | full help → 3-line |

### Files changed (8)

- \`cli/lib/nftban/lib/cmd_common.sh\` (+42 LOC) — new helper + export
- 6 cmd_*.sh files — each migrates one catch-all error path
- \`cli/lib/nftban/cli/cmd_update.sh\` — additionally adds UX-C5 doc note in help block
- \`cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh\` — **NEW** 23-assertion hermetic test

### Test results

- **\`cli_error_with_hint_v144_test.sh\`** — **23 PASS / 0 FAIL** (NEW)
- **v133 D-01** (existing 'nftban gui' shell guard): 31/0 (regression)
- **v1.139.2 rollback help guard**: 10/0 (regression)
- **v1.143.0 cli_error_rc_contract**: 10/0 (regression — verifies rc-contract preserved)
- **v1.143.1 cli_exporter_exit2_phase_3**: 37/0 (regression)
- **v1.142 cli_sudo_hint_v142**: 19/0 (regression — we modified cmd_common.sh, verifies prior helper not broken)

### Forbidden-path control

```
.go files touched:        0
internal/ touched:        0
cmd/ touched:             0
build/ touched:           0
install/systemd/ touched: 0
.github/workflows/:       0
schema/ touched:          0
docker/ touched:          0
```

### Daemon byte-identity

- \`cmd/nftban-core\` and \`cmd/nftband\` SHA256-identical to v1.143.1 expected (zero \`.go\` diff).
- **The six-release zero-Go chain** \`v1.140.0 → v1.141.0 → v1.142.0 → v1.143.0 → v1.143.1 → v1.144.0\` holds across this PR.
- \`cli/lib/nftban/core/nftban_fhs_spec.sh\` — unchanged in this PR (PR-A in the same v1.144.0 train breaks the body SHA256 chain).

### Out of scope (other PRs in v1.144.0 train)

- **PR-A** (#740): GUI doc drift + FHS-SPEC-GUI-MENTION ← already open
- **PR-C**: D-UXV-14 connector edit hint + D-UXV-15 four-site port reload hints
- **PR-D**: D-UXV-13 runtime-hint reachability CI guard (MUST land with PR-C)
- **PR-PREP**: standard 4-file release-prep envelope (last)

### Schema

1.83.0 **frozen**.

### Operator gate trail

| Gate | State |
|---|---|
| \`OPEN_V1_144_0_DOC_UX_DRIFT_PLAN = GO_PLAN_ONLY\` | ✅ filed |
| \`AMEND_V1_144_0_DOC_UX_DRIFT_PLAN_WITH_D_UXV_13_14_15 = GO_PLAN_ONLY\` | ✅ amended |
| \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` | ✅ fired 2026-06-01 |
| \`MERGE_PR_<this>_WHEN_CI_GREEN = GO\` | ⏳ awaiting after CI green |