### PR TITLE
fix(cli): v1.144.0 PR-C — close D-UXV-14 + D-UXV-15 (audit+challenge round)

### DIFF
--- a/cli/lib/nftban/cli/cmd_connector.sh
+++ b/cli/lib/nftban/cli/cmd_connector.sh
@@ -230,8 +230,15 @@ _cmd_connector_add() {
     fi
 
     if _connector_exists "$name"; then
+        # v1.144.0 PR-C D-UXV-14: drop the misleading 'nftban connector edit'
+        # hint. The connector dispatch (this file's nftban_cmd_connector at
+        # the bottom) has NO 'edit' arm — only list/add/remove|delete|rm/
+        # enable/disable/test/show/push/help. Following the old hint hit
+        # the catch-all "Unknown command: edit" rc=1. Replace with the
+        # canonical idempotent recreate pattern.
         _connector_print_error "Connector '$name' already exists"
-        echo "Use: nftban connector edit $name"
+        echo "  nftban connector show $name                                       # inspect"
+        echo "  nftban connector remove $name && nftban connector add $name [...] # recreate"
         return 1
     fi
 

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -257,7 +257,7 @@ nftban_cmd_port_help() {
     echo "     cat ${NFTBAN_CONFIG_DIR:-/etc/nftban}/ports.d/90-custom.conf"
     echo ""
     echo "  3. Force reload all ports:"
-    echo "     nftban reload"
+    echo "     nftban firewall reload"
     echo ""
     echo "  4. Verify firewall is initialized:"
     echo "     nftban firewall status"
@@ -555,7 +555,7 @@ nftban_cmd_port() {
                     echo "  systemctl start nftband"
                     echo ""
                     echo "Or reload ports manually after starting daemon:"
-                    echo "  nftban port reload"
+                    echo "  nftban firewall reload"
                 fi
             else
                 echo "⚠ Firewall not initialized - port saved but not active yet"
@@ -686,11 +686,11 @@ nftban_cmd_port() {
                         echo "✅ Port $port is now blocked in firewall"
                     else
                         echo "  ⚠ Could not remove port via daemon" >&2
-                        echo "  Run manually: nftban reload" >&2
+                        echo "  Run manually: nftban firewall reload" >&2
                     fi
                 else
                     echo "  ℹ Daemon not running - port removed from config only"
-                    echo "  Start daemon and reload: systemctl start nftband && nftban reload"
+                    echo "  Start daemon and reload: systemctl start nftband && nftban firewall reload"
                 fi
             else
                 echo "⚠ Firewall not initialized - port removed from config only"

--- a/cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - connector no-edit-hint test (v1.144.0 PR-C D-UXV-14)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_connector_no_edit_hint_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-C D-UXV-14 closure — asserts cmd_connector.sh no longer advertises 'nftban connector edit' (which never existed in the dispatch and would hit the 'Unknown command' catch-all rc=1). The existing-connector branch in _cmd_connector_add() must instead print the canonical idempotent recreate pattern: 'nftban connector show NAME' (inspect) and 'nftban connector remove NAME && nftban connector add NAME [...]' (recreate). The dispatch itself remains intact — list/add/remove|delete|rm/enable/disable/test/show/push/help — verified by re-asserting the case-arm pattern. Hermetic — no daemon, no nft, no host contact."
+# meta:input="cli/lib/nftban/cli/cmd_connector.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_connector.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+CONN="$REPO/cli/lib/nftban/cli/cmd_connector.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+[[ -f "$CONN" ]] || { echo "FAIL: missing $CONN"; exit 1; }
+
+# T1: no echo-printf line emits 'nftban connector edit'. Comment lines
+# (PR-C documentation reference at :233) are allowed; only a non-comment
+# code line emitting the broken hint is forbidden.
+if grep -nE 'echo[[:space:]]+.*"nftban connector edit' "$CONN" >/dev/null 2>&1; then
+    no "T1: no echo line emits 'nftban connector edit'" \
+       "$(grep -nE 'echo.*"nftban connector edit' "$CONN" | head -1)"
+else
+    ok "T1: no echo line emits 'nftban connector edit'"
+fi
+
+# T2: the replacement 2-line hint pattern is present
+if grep -nE 'nftban connector show \$name' "$CONN" >/dev/null 2>&1; then
+    ok "T2: 'nftban connector show \$name' present (inspect hint)"
+else
+    no "T2: 'nftban connector show \$name' present (inspect hint)" "not found"
+fi
+if grep -nE 'nftban connector remove \$name && nftban connector add \$name' "$CONN" >/dev/null 2>&1; then
+    ok "T3: 'nftban connector remove \$name && nftban connector add \$name' present (recreate hint)"
+else
+    no "T3: 'nftban connector remove \$name && nftban connector add \$name' present (recreate hint)" "not found"
+fi
+
+# T4: connector dispatch case-arm is unchanged. Look for the canonical
+# arm list: list/add/remove|delete|rm/enable/disable/test/show/push/help.
+# Use POSIX-portable [[:space:]] (grep -E doesn't reliably grok \s).
+# IMPORTANT: declare arms as an explicit array because the test sets
+# IFS=$'\n\t' at the top — `for arm in $expected_string` would NOT
+# word-split on spaces under that IFS.
+expected_arms=(list add remove delete rm enable disable test show push help)
+missing=()
+for arm in "${expected_arms[@]}"; do
+    if ! grep -nE "^[[:space:]]*${arm}[)|]|\|${arm}[)|]" "$CONN" >/dev/null 2>&1; then
+        missing+=("$arm")
+    fi
+done
+if [[ ${#missing[@]} -eq 0 ]]; then
+    ok "T4: connector dispatch case-arms all present (no regression)"
+else
+    no "T4: connector dispatch case-arms all present (no regression)" \
+       "missing: ${missing[*]}"
+fi
+
+# T5: no NEW 'edit' arm was added (we explicitly did NOT implement edit;
+# the recreate pattern is the canonical idempotent path)
+if awk '/^nftban_cmd_connector\(\)/,/^}/' "$CONN" | grep -nE '^[[:space:]]*edit[)|]|\|edit[)|]' >/dev/null 2>&1; then
+    no "T5: no 'edit' arm in connector dispatch (recreate is the canonical pattern)" \
+       "edit arm found"
+else
+    ok "T5: no 'edit' arm in connector dispatch (recreate is the canonical pattern)"
+fi
+
+# T6: the only remaining 'edit' token in this file is the retirement
+# comment at the changed site. Strip comment lines and assert.
+# Note: the pipeline runs under `set -Eeuo pipefail`, so a successful
+# zero-match (inner grep -v returns 1) would otherwise abort. Wrap with
+# explicit `|| true` to capture the count safely.
+non_comment_edit_count=$( { grep -nE '\bedit\b' "$CONN" || true; } | { grep -vE '^[0-9]+:[[:space:]]*#' || true; } | wc -l)
+if [[ "$non_comment_edit_count" -eq 0 ]]; then
+    ok "T6: no non-comment 'edit' tokens remain in cmd_connector.sh"
+else
+    no "T6: no non-comment 'edit' tokens remain in cmd_connector.sh" \
+       "$( { grep -nE '\bedit\b' "$CONN" || true; } | { grep -vE '^[0-9]+:[[:space:]]*#' || true; } | head -3)"
+fi
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_connector_no_edit_hint_v144_test: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - port reload-hint canonicalization test (v1.144.0 PR-C D-UXV-15)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_port_reload_hint_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-C D-UXV-15 closure — asserts cmd_port.sh no longer emits the four broken reload-hint strings ('nftban reload' / 'nftban port reload'). Neither is a real command at main: cli/sbin/nftban has no cmd_reload.sh autoload target, no 'reload' alias case in lines 1187-1280, and 'reload' is absent from _nftban_canonical_commands at lines 911-995. The canonical reload command is 'nftban firewall reload' (cmd_firewall.sh:1490 firewall_reload). The original 2026-06-01 audit proposed migrating :558 to 'nftban reload' — challenge-verified to ALSO be broken; corrected here. All 4 sites (:260, :558, :689, :693) now emit 'nftban firewall reload'. Hermetic — file-content assertions only; no daemon, no nft, no host contact."
+# meta:input="cli/lib/nftban/cli/cmd_port.sh, cli/sbin/nftban, cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,wc"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_port.sh,cli/sbin/nftban,cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,grep,wc"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PORT="$REPO/cli/lib/nftban/cli/cmd_port.sh"
+DISP="$REPO/cli/sbin/nftban"
+FW="$REPO/cli/lib/nftban/cli/cmd_firewall.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+for f in "$PORT" "$DISP" "$FW"; do
+    [[ -f "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 1: cmd_port.sh — broken hints fully removed
+# ──────────────────────────────────────────────────────────────────────────
+# T1: no echo line emits 'nftban reload' (without 'firewall'). Use a
+# negative-lookahead-style grep: any 'nftban reload' that is NOT preceded
+# by 'firewall '.
+bad_reload=$(grep -nE 'nftban reload\b' "$PORT" || true)
+if [[ -z "$bad_reload" ]]; then
+    ok "T1: no 'nftban reload' literal in cmd_port.sh (top-level reload is not a real command)"
+else
+    no "T1: no 'nftban reload' literal in cmd_port.sh (top-level reload is not a real command)" \
+       "$(echo "$bad_reload" | head -1)"
+fi
+
+# T2: no echo line emits 'nftban port reload' (port has no reload arm)
+bad_port_reload=$(grep -nE 'nftban port reload\b' "$PORT" || true)
+if [[ -z "$bad_port_reload" ]]; then
+    ok "T2: no 'nftban port reload' literal in cmd_port.sh (port dispatch has no reload arm)"
+else
+    no "T2: no 'nftban port reload' literal in cmd_port.sh (port dispatch has no reload arm)" \
+       "$(echo "$bad_port_reload" | head -1)"
+fi
+
+# T3: exactly 4 sites now emit 'nftban firewall reload' (the canonical form)
+fw_reload_count=$(grep -cnE 'nftban firewall reload\b' "$PORT" || true)
+if [[ "$fw_reload_count" -ge 4 ]]; then
+    ok "T3: at least 4 'nftban firewall reload' canonical hints in cmd_port.sh (got $fw_reload_count)"
+else
+    no "T3: at least 4 'nftban firewall reload' canonical hints in cmd_port.sh" \
+       "got $fw_reload_count, expected ≥4"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 2: code-truth — assert 'nftban reload' is NOT a real top-level
+#            command (this is what was wrong with the audit's proposed fix)
+# ──────────────────────────────────────────────────────────────────────────
+# T4: no cmd_reload.sh file exists (autoloader would source it if present)
+if [[ -f "$REPO/cli/lib/nftban/cli/cmd_reload.sh" ]]; then
+    no "T4: no cli/lib/nftban/cli/cmd_reload.sh exists (autoloader target)" \
+       "file present at $REPO/cli/lib/nftban/cli/cmd_reload.sh"
+else
+    ok "T4: no cli/lib/nftban/cli/cmd_reload.sh exists (autoloader target)"
+fi
+
+# T5: 'reload' is NOT in _nftban_canonical_commands() in cli/sbin/nftban
+if awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" | grep -E '^reload$' >/dev/null 2>&1; then
+    no "T5: 'reload' not in _nftban_canonical_commands (typo-suggestion list)" \
+       "$(awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" | grep -nE '^reload$' | head -1)"
+else
+    ok "T5: 'reload' not in _nftban_canonical_commands (typo-suggestion list)"
+fi
+
+# T6: 'reload)' is NOT an alias case in cli/sbin/nftban (lines ~1187-1280)
+if grep -nE '^[[:space:]]+reload\)|\|reload\)' "$DISP" >/dev/null 2>&1; then
+    no "T6: no 'reload' alias case in cli/sbin/nftban dispatcher" \
+       "$(grep -nE '^[[:space:]]+reload\)|\|reload\)' "$DISP" | head -1)"
+else
+    ok "T6: no 'reload' alias case in cli/sbin/nftban dispatcher"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 3: positive control — 'nftban firewall reload' IS a real command
+# ──────────────────────────────────────────────────────────────────────────
+# T7: firewall_reload() function exists at cmd_firewall.sh:1490 (the
+# canonical implementation the new port hints point to)
+if grep -nE '^firewall_reload\(\)' "$FW" >/dev/null 2>&1; then
+    ok "T7: firewall_reload() function defined in cmd_firewall.sh (canonical reload exists)"
+else
+    no "T7: firewall_reload() function defined in cmd_firewall.sh (canonical reload exists)" \
+       "no definition found"
+fi
+
+# T8: firewall dispatch has a 'reload)' arm
+if awk '/^nftban_cmd_firewall\(\)|^_cmd_firewall_dispatch\(\)/,/^}/' "$FW" | grep -nE '^\s*reload\)|\|reload\)' >/dev/null 2>&1; then
+    ok "T8: firewall dispatch has 'reload)' arm"
+else
+    # Fallback: just look for `reload)` somewhere in the file's case arms
+    if grep -nE '^[[:space:]]+reload\)' "$FW" >/dev/null 2>&1; then
+        ok "T8: firewall dispatch has 'reload)' arm"
+    else
+        no "T8: firewall dispatch has 'reload)' arm" \
+           "no reload arm found"
+    fi
+fi
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_port_reload_hint_v144_test: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## v1.144.0 PR-C — D-UXV-14 connector edit + D-UXV-15 four-site port reload

**Plan:** [\`NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md\`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md) §3.5 + §3.6
**Gate:** \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` (operator 2026-06-01)
**Selects locked:** \`SELECT_V1_144_D_UXV_14_15_VEHICLE = include-in-v1.144.0-doc-UX-drift-train\` + \`SELECT_V1_144_PR_C_PR_D_COUPLING = both-must-land\`
**Vehicle:** v1.144.0 doc/UX-drift train, PR 3 of 5

### Coupling constraint (IMPORTANT)

**This PR MUST NOT merge without PR-D** (D-UXV-13 runtime-hint reachability CI guard) per operator-locked decision \`SELECT_V1_144_PR_C_PR_D_COUPLING = both-must-land\`. The audit-was-wrong episode that motivated this PR is direct evidence that human + AI audits miss this defect class without automated reverse-direction checking.

### What this PR does

Closes two runtime-hint drift defects from the 2026-06-01 audit. **The audit's original spec for D-UXV-15 was challenge-verified to be wrong** ("Main bot is correct. The original audit spec must not be used as-is.", operator 2026-06-01); the corrected spec lands here.

### D-UXV-14 fix (1 site)

\`cmd_connector.sh:234\` — drop misleading \`nftban connector edit\` hint:

\`\`\`diff
-        echo "Use: nftban connector edit \$name"
+        echo "  nftban connector show \$name                                       # inspect"
+        echo "  nftban connector remove \$name && nftban connector add \$name [...] # recreate"
\`\`\`

The connector dispatch (cmd_connector.sh:804-819) has NO \`edit\` arm — only list/add/remove|delete|rm/enable/disable/test/show/push/help. Following the old hint hit \"Unknown command: edit\" rc=1.

### D-UXV-15 fix (4 sites — audit-spec was wrong, corrected here)

All four broken sites in \`cmd_port.sh\` now emit \`nftban firewall reload\` (the canonical reload command at \`cmd_firewall.sh:1490 firewall_reload\`):

\`\`\`diff
# cmd_port.sh:260
-    echo "     nftban reload"
+    echo "     nftban firewall reload"

# cmd_port.sh:558
-                    echo "  nftban port reload"
+                    echo "  nftban firewall reload"

# cmd_port.sh:689
-                        echo "  Run manually: nftban reload" >&2
+                        echo "  Run manually: nftban firewall reload" >&2

# cmd_port.sh:693
-                    echo "  Start daemon and reload: systemctl start nftband && nftban reload"
+                    echo "  Start daemon and reload: systemctl start nftband && nftban firewall reload"
\`\`\`

### Why \`nftban reload\` was wrong (the audit's challenge-rejected spec)

The original audit proposed migrating \`:558\` from \`nftban port reload\` to \`nftban reload\` and claimed \`:260/:689/:693\` \"already said it correctly.\" Challenge against code:

- **No \`cmd_reload.sh\` file exists** (autoloader at \`cli/sbin/nftban:1146-1185\` synthesizes \`cmd_file=\${NFTBAN_LIB_DIR}/cli/cmd_reload.sh\` — file absent → autoloader skips).
- **No \`reload\` alias case** in cli/sbin/nftban:1187-1280 (only cloudflare / enable|disable|restart / verify|explain / service / export / rollback).
- **\`reload\` is NOT in \`_nftban_canonical_commands()\`** at cli/sbin/nftban:911-995 (the typo-suggestion source-of-truth).

Net: \`nftban reload\` → \"Unknown command 'reload'\" rc=1.

**Canonical:** \`nftban firewall reload\` — \`cmd_firewall.sh:1490 firewall_reload()\` — atomic ruleset rebuild + NFTBan schema re-apply + whitelist sync. Already used at \`cmd_firewall.sh:537/:689/:746\`.

### Files changed (4)

| File | Change |
|---|---|
| \`cli/lib/nftban/cli/cmd_connector.sh\` | Drop \`connector edit\` hint at :234 → show + remove+add (2 lines) |
| \`cli/lib/nftban/cli/cmd_port.sh\` | 4 sites: all → \`nftban firewall reload\` |
| \`cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh\` | **NEW** 6-assertion hermetic test |
| \`cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh\` | **NEW** 8-assertion hermetic test |

### Test results

- **\`cli_connector_no_edit_hint_v144_test\`** — **6 PASS / 0 FAIL** (NEW)
- **\`cli_port_reload_hint_v144_test\`** — **8 PASS / 0 FAIL** (NEW; includes code-truth tests T4-T6 that prove \`nftban reload\` was wrong + positive control T7-T8 that the new hint is reachable)
- **v133 D-01** (existing 'nftban gui' shell guard): 31/0 (regression)
- **v1.139.2 rollback help guard**: 10/0 (regression)
- **v1.143.0 cli_error_rc_contract**: 10/0 (regression)
- **v1.143.1 cli_exporter_exit2_phase_3**: 37/0 (regression)

### Forbidden-path control

```
.go files touched:        0
internal/ touched:        0
cmd/ touched:             0
build/ touched:           0
install/systemd/ touched: 0
.github/workflows/:       0
schema/ touched:          0
docker/ touched:          0
```

### Daemon byte-identity

Zero \`.go\` files touched. \`cmd/nftban-core\` + \`cmd/nftband\` expected SHA256-identical to v1.143.1. The six-release zero-Go chain (\`v1.140.0 → v1.144.0\`) holds across this PR.

### Out of scope (other PRs in v1.144.0 train)

- **PR-A** (#740): GUI doc drift + FHS-SPEC-GUI-MENTION ← open
- **PR-B** (#741): UX-C2 wall-of-text + UX-C5 doc note ← open
- **PR-D**: D-UXV-13 runtime-hint reachability CI guard ← coupled with this PR
- **PR-PREP**: standard 4-file release-prep envelope (last)

### Schema

1.83.0 **frozen**.

### Operator gate trail

| Gate | State |
|---|---|
| \`OPEN_V1_144_0_DOC_UX_DRIFT_PLAN = GO_PLAN_ONLY\` | ✅ filed |
| \`AMEND_V1_144_0_DOC_UX_DRIFT_PLAN_WITH_D_UXV_13_14_15 = GO_PLAN_ONLY\` | ✅ amended |
| \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` | ✅ fired 2026-06-01 |
| \`SELECT_V1_144_PR_C_PR_D_COUPLING = both-must-land\` | ✅ locked |
| \`MERGE_PR_<this>_WHEN_CI_GREEN = GO\` | ⏳ awaiting PR-D first + CI green |