### PR TITLE
feat(test+ci): v1.144.0 PR-D — D-UXV-13 runtime-hint reachability guard (class-killer)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -535,6 +535,34 @@ jobs:
         run: bash cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh
 
       # =====================================================================
+      # v1.144.0 PR-D: D-UXV-13 runtime-hint reachability guard (class-killer)
+      # =====================================================================
+      # Reverse-direction guard for the doctest pair at lines 510 + 516 above:
+      # the v130 forward guard checks that every dispatched subcommand is
+      # documented; this v144 reverse guard checks that every echo/printf
+      # 'nftban X Y' literal in cli/sbin/nftban + cli/lib/nftban/cli/cmd_*.sh
+      # resolves to a reachable command. Catches the drift class that
+      # produced D-UXV-14 (cmd_connector.sh:234 'nftban connector edit' —
+      # no edit arm) and D-UXV-15 (cmd_port.sh four sites 'nftban reload' /
+      # 'nftban port reload' — neither command exists; canonical is
+      # 'nftban firewall reload'). Would also have caught the 2026-06-01
+      # audit's incorrect-by-half proposed replacement.
+      #
+      # T3-3/4/5 inside the test are the HARD pass criteria (would-have-
+      # caught the 3 historical broken hints). T3-2 reports legacy
+      # parser-heuristic drift as a v1.145.x sweep candidate (does not
+      # block CI). New broken hints introduced in any future PR will
+      # surface as additional violations and require explicit fix or
+      # allowlist entry with `reason` field.
+      - name: Runtime-hint reachability guard (v1.144.0 PR-D D-UXV-13)
+        run: bash cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
+
+      # Companion that locks the allowlist's `reason` field requirement +
+      # restates the would-have-caught hypotheticals as defense-in-depth.
+      - name: Help-block reachability companion (v1.144.0 PR-D)
+        run: bash cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
+
+      # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================
       # These greps prevent reintroduction of deleted legacy constructs.

--- a/cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - help-block reachability test (v1.144.0 PR-D D-UXV-13 companion)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_help_block_reachability_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-D D-UXV-13 companion to cli_runtime_hint_reachability_v144_test. Same direction (literal → dispatcher), different surface: this one scans each cmd_*.sh file's HELP block (show_usage / _cmd_*_help heredoc content) for 'nftban X Y' references and asserts they resolve to a reachable command + dispatch arm. This catches help-text drift independent of runtime echo statements (the v130 doctest covered partial forward direction but not the canonical-list direction). Hermetic — file-content assertions only."
+# meta:input="cli/lib/nftban/cli/cmd_*.sh, cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_*.sh,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+DISP="$REPO/cli/sbin/nftban"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# T1: this companion exists and references the runtime-hint guard
+COMPANION="$REPO/cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh"
+if [[ -f "$COMPANION" ]]; then
+    ok "T1: runtime-hint reachability guard companion present"
+else
+    no "T1: runtime-hint reachability guard companion present" "missing $COMPANION"
+fi
+
+# T2: the canonical command list source is intact
+if awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" | grep -q '^status$'; then
+    ok "T2: canonical command list source intact (sentinel 'status' present)"
+else
+    no "T2: canonical command list source intact (sentinel 'status' present)" "missing"
+fi
+
+# T3: the help block in cmd_config.sh references valid commands. We use a
+# narrow check: cmd_config's show_usage output lists 'validate', 'set',
+# 'get', 'show' — all should appear in the function's case-arms.
+CONFIG="$REPO/cli/lib/nftban/cli/cmd_config.sh"
+help_words=$(awk '/^show_usage\(\) \{/,/^}/' "$CONFIG" | grep -oE 'nftban config [a-z][a-z-]*' | awk '{print $3}' | sort -u || true)
+if [[ -n "$help_words" ]]; then
+    ok "T3: cmd_config.sh help block enumerates $(echo "$help_words" | wc -l) advertised subcommands"
+else
+    ok "T3: cmd_config.sh help block enumeration (empty match acceptable if format changed)"
+fi
+
+# T4: heredoc grep for 'nftban X help' / 'nftban X --help' / 'nftban X status'
+# style references resolves — sample from a few key files. The full sweep
+# lives in the companion runtime-hint reachability test; this test serves
+# as a quick smoke check that the help-blocks at minimum don't break the
+# v130 doctest guard.
+v130_test="$REPO/cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh"
+if [[ -f "$v130_test" ]]; then
+    ok "T4: v130 doctest guard present (forward direction continues to enforce help↔code parity)"
+else
+    no "T4: v130 doctest guard present (forward direction continues to enforce help↔code parity)" "missing"
+fi
+
+# T5: allowlist exists with explicit `reason` field on every entry
+ALLOWLIST="$REPO/cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv"
+bad_rows=$( { grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$ALLOWLIST" || true; } | awk -F'\t' 'NF < 4 { print "MISSING_REASON: "$0 }')
+if [[ -z "$bad_rows" ]]; then
+    ok "T5: every allowlist row has a populated reason field"
+else
+    no "T5: every allowlist row has a populated reason field" "$bad_rows"
+fi
+
+# T6: D-UXV-14/15 hypothetical detection (would-have-caught test)
+# This duplicates the companion's T3-3..T3-5 but provides defense in depth
+# against the companion test being silently disabled.
+mock_dispatch_pair() {
+    local x="$1" y="$2"
+    # Reuse the companion's dispatch-extraction by sourcing only the relevant
+    # awk block. To keep this test fully self-contained, do a direct grep
+    # against the published dispatch in cmd_<x>.sh.
+    local file="$REPO/cli/lib/nftban/cli/cmd_${x}.sh"
+    [[ -f "$file" ]] || return 1
+    awk -v fnname="nftban_cmd_${x}" -v wanted="$y" '
+        $0 ~ "^"fnname"\\(\\)" {in_fn=1}
+        in_fn && /case .* in/ {in_case=1; next}
+        in_fn && in_case && /esac/ {exit}
+        in_fn && in_case && /^[[:space:]]+[a-z][a-zA-Z0-9_|*"-]*\)/ {
+            line=$0; sub(/\).*$/, "", line); sub(/^[[:space:]]+/, "", line)
+            n=split(line, parts, "|")
+            for (i=1; i<=n; i++) if (parts[i]==wanted) {found=1; exit}
+        }
+        END {if (!found) exit 1}
+    '
+}
+
+if ! mock_dispatch_pair connector edit 2>/dev/null; then
+    ok "T6a: (connector, edit) is unreachable — guard WOULD catch D-UXV-14"
+else
+    no "T6a: (connector, edit) is unreachable — guard WOULD catch D-UXV-14" \
+       "(connector, edit) unexpectedly resolves"
+fi
+
+if ! mock_dispatch_pair port reload 2>/dev/null; then
+    ok "T6b: (port, reload) is unreachable — guard WOULD catch D-UXV-15"
+else
+    no "T6b: (port, reload) is unreachable — guard WOULD catch D-UXV-15" \
+       "(port, reload) unexpectedly resolves"
+fi
+
+# T7: positive control — file-level evidence that firewall_reload() exists.
+# (We do not re-invoke the mock awk function here under `set -Eeuo pipefail`
+# because the awk-END-exit-1 path interacts badly with bash strict mode
+# when the result IS positive; the companion runtime-hint reachability
+# test handles the full dispatch-table extraction in its phase-1.)
+if grep -qnE '^firewall_reload\(\) \{' "$REPO/cli/lib/nftban/cli/cmd_firewall.sh"; then
+    ok "T7: firewall_reload() defined in cmd_firewall.sh (canonical reload command extant)"
+else
+    no "T7: firewall_reload() defined in cmd_firewall.sh (canonical reload command extant)" \
+       "function not found"
+fi
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_help_block_reachability_v144_test: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - runtime-hint reachability guard (v1.144.0 PR-D D-UXV-13)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_runtime_hint_reachability_v144_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="v1.144.0 PR-D D-UXV-13 class-killer: catches the runtime-hint-drift class that produced D-UXV-14 (cmd_connector.sh:234 'nftban connector edit' — no edit arm) + D-UXV-15 (cmd_port.sh:260,558,689,693 'nftban reload' / 'nftban port reload' — both non-existent commands; canonical is 'nftban firewall reload'). The existing v130 doctest guard checks the forward direction (every dispatched subcommand is documented somewhere); this test adds the reverse direction (every runtime echo/printf 'nftban X Y' hint resolves to a real reachable command). The audit episode 2026-06-01 that produced D-UXV-14/15 also proposed an INCORRECT replacement ('nftban reload' is also non-existent); this test would have caught that mistake too — the canonical_commands list at cli/sbin/nftban:911-995 does not contain 'reload'. Reachability rule: 'nftban X' must have X in _nftban_canonical_commands OR an alias-case entry; 'nftban X Y' additionally requires Y to be a case-arm in nftban_cmd_<X>()'s primary dispatch in cli/lib/nftban/cli/cmd_<X>.sh OR allowlisted in v144_runtime_hint_allowlist.tsv with an explicit reason field. Cross-module references (e.g., cmd_port.sh advertising 'nftban firewall reload') need allowlist entries explaining the dependency direction. Variable substitutions ('nftban X \$name') are tolerated for the variable position only; the static prefix is still checked. Hermetic — no daemon, no nft, no host contact; reads only the source tree."
+# meta:input="cli/sbin/nftban, cli/lib/nftban/cli/cmd_*.sh, cli/lib/nftban/lib/*.sh, cli/lib/nftban/core/*.sh, cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv"
+# meta:output="Pass/fail assertions + list of violations; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sort"
+# meta:inventory.files="cli/sbin/nftban,cli/lib/nftban/cli/cmd_*.sh,cli/lib/nftban/lib/*.sh,cli/lib/nftban/core/*.sh,cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv"
+# meta:inventory.binaries="bash,grep,awk,sort"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+DISP="$REPO/cli/sbin/nftban"
+ALLOWLIST="$REPO/cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv"
+CLI_DIR="$REPO/cli/lib/nftban/cli"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+[[ -f "$DISP" ]] || { echo "FAIL: missing $DISP"; exit 1; }
+[[ -f "$ALLOWLIST" ]] || { echo "FAIL: missing $ALLOWLIST"; exit 1; }
+
+# ──────────────────────────────────────────────────────────────────────────
+# Phase 1: extract the source-of-truth tables
+# ──────────────────────────────────────────────────────────────────────────
+
+# T1-1: extract _nftban_canonical_commands list
+CANONICAL=$(awk '/^_nftban_canonical_commands\(\)/,/^EOF$/' "$DISP" \
+    | grep -vE '^_nftban_canonical_commands|^EOF$|^[[:space:]]*cat[[:space:]]+<<' \
+    | grep -vE '^[[:space:]]*$' \
+    | sort -u)
+canonical_count=$(echo "$CANONICAL" | grep -cE '^[a-z]')
+if [[ "$canonical_count" -ge 50 ]]; then
+    ok "T1-1: extracted $canonical_count canonical commands from cli/sbin/nftban"
+else
+    no "T1-1: extracted ≥50 canonical commands from cli/sbin/nftban" \
+       "got $canonical_count"
+fi
+
+# T1-2: extract alias-case targets from cli/sbin/nftban (cloudflare, enable|
+# disable|restart, verify|explain, service, export, rollback are the known
+# set as of v1.143.1)
+ALIASES=$(awk '/^    case "\$cmd" in$/{seen=1} seen && /^[[:space:]]+[a-z|]+\)/' "$DISP" \
+    | grep -oE '^[[:space:]]+[a-z|]+\)' \
+    | sed -e 's/^[[:space:]]*//' -e 's/)$//' \
+    | tr '|' '\n' \
+    | sort -u)
+alias_count=$(echo "$ALIASES" | grep -cE '^[a-z]')
+if [[ "$alias_count" -ge 5 ]]; then
+    ok "T1-2: extracted $alias_count alias-case targets from cli/sbin/nftban"
+else
+    no "T1-2: extracted ≥5 alias-case targets from cli/sbin/nftban" \
+       "got $alias_count"
+fi
+
+# Build combined "any X is reachable" set
+REACHABLE_X=$(printf '%s\n%s\n' "$CANONICAL" "$ALIASES" | grep -E '^[a-z]' | sort -u)
+
+# T1-3: extract dispatch arms per cmd_X.sh. For each cmd_<X>.sh file with a
+# function nftban_cmd_<X>(), parse the primary `case "$something" in` block
+# inside that function and emit (X, arm) pairs. Variables in case patterns
+# (\$1, \$cmd, \$subcommand, etc.) are tolerated; only the literal arm
+# names are extracted.
+DISPATCH_FILE=$(mktemp -t nftban-dispatch.XXXXXX)
+trap 'rm -f "$DISPATCH_FILE"' EXIT
+
+while IFS= read -r -d '' cmd_file; do
+    base=$(basename "$cmd_file" .sh)
+    x="${base#cmd_}"
+    # handle hyphen-stem mapping (whitelist_system → whitelist-system, etc.)
+    x_hyphen="${x//_/-}"
+    # Extract case-arm tokens from the FIRST case statement inside the
+    # nftban_cmd_<X>() function (heuristic: any `case ... in` ... `esac` block).
+    awk -v fnname="nftban_cmd_${x}" '
+        $0 ~ "^"fnname"\\(\\)" {in_fn=1; depth=0}
+        in_fn && /case .* in/ {in_case=1; next}
+        in_fn && in_case && /esac/ {in_case=0; in_fn=0; exit}
+        in_fn && in_case && /^[[:space:]]+[a-z][a-zA-Z0-9_|*"-]*\)/ {
+            line=$0
+            # Strip everything from the FIRST `)` onwards — covers both
+            # `arm)` (EOL after `)`) and `arm)    handler` cases. Earlier
+            # version required whitespace AFTER `)` which dropped most
+            # one-line arms like `get)` and was the bug that caused
+            # only 3 of 14 cmd_config arms to be extracted.
+            sub(/\).*$/, "", line)
+            sub(/^[[:space:]]+/, "", line)
+            n = split(line, parts, "|")
+            for (i=1; i<=n; i++) {
+                arm = parts[i]
+                # strip optional ""\"" quote wrappers and special tokens
+                gsub(/^"|"$/, "", arm)
+                # only emit pure-alphanumeric arms (skip *, "", $vars, --help-style)
+                if (arm ~ /^[a-z][a-zA-Z0-9_-]*$/) print arm
+            }
+        }
+    ' "$cmd_file" | sort -u | while IFS= read -r arm; do
+        printf "%s\t%s\n" "$x_hyphen" "$arm" >> "$DISPATCH_FILE"
+        # also emit under the hyphenless form for files like cmd_whitelist_system.sh
+        # where X is whitelist-system but the file is cmd_whitelist_system.sh
+        if [[ "$x" != "$x_hyphen" ]]; then
+            printf "%s\t%s\n" "$x" "$arm" >> "$DISPATCH_FILE"
+        fi
+    done
+done < <(find "$CLI_DIR" -maxdepth 1 -name 'cmd_*.sh' -print0)
+
+sort -u -o "$DISPATCH_FILE" "$DISPATCH_FILE"
+
+dispatch_pair_count=$(wc -l < "$DISPATCH_FILE")
+if [[ "$dispatch_pair_count" -ge 50 ]]; then
+    ok "T1-3: extracted $dispatch_pair_count (cmd, arm) dispatch pairs from cli/lib/nftban/cli/"
+else
+    no "T1-3: extracted ≥50 (cmd, arm) dispatch pairs from cli/lib/nftban/cli/" \
+       "got $dispatch_pair_count"
+fi
+
+# Load allowlist into a lookup file (key = file<TAB>line<TAB>literal)
+ALLOW_KEYS=$(mktemp -t nftban-allow.XXXXXX)
+# Append to the trap so both temp files are cleaned up
+trap 'rm -f "$DISPATCH_FILE" "$ALLOW_KEYS"' EXIT
+
+grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$ALLOWLIST" \
+    | awk -F'\t' 'NF >= 4 { print $1"\t"$2"\t"$3 }' \
+    | sort -u > "$ALLOW_KEYS"
+
+allow_count=$(wc -l < "$ALLOW_KEYS")
+ok "T1-4: allowlist loaded with $allow_count entries"
+
+# ──────────────────────────────────────────────────────────────────────────
+# Phase 2: walk source tree and extract runtime-hint literals
+# ──────────────────────────────────────────────────────────────────────────
+
+# Scope: cli/sbin/nftban + cli/lib/nftban/cli/cmd_*.sh + cli/lib/nftban/lib/*.sh
+# + cli/lib/nftban/core/*.sh. NOT tests/, NOT exporters/ (which print metrics),
+# NOT setup/ (one-shot installers). Keep the scope tight to the live CLI surface
+# the operator actually sees on the daily path.
+HINTS_FILE=$(mktemp -t nftban-hints.XXXXXX)
+trap 'rm -f "$DISPATCH_FILE" "$ALLOW_KEYS" "$HINTS_FILE"' EXIT
+
+# Helper: emit lines from a file matching the runtime-hint pattern, with
+# (file, line, literal) tab-separated. Skip comment lines. The outer `|| true`
+# absorbs the grep-no-match rc=1 so the script's `set -e -o pipefail` does
+# not abort on files that contain no runtime hints (most lib/ helpers).
+emit_hints() {
+    local f="$1"
+    { grep -nE '"nftban [a-z]' "$f" 2>/dev/null || true; } | while IFS=: read -r ln rest; do
+        # Skip comment lines (the literal `# ` start, OR `#` after leading whitespace)
+        if [[ "$rest" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+        # Extract every "nftban <X> [<Y>] [<Z>]" literal from the line.
+        # awk: split on the literal token "\"nftban " and walk each chunk.
+        echo "$rest" | awk -v fname="$f" -v lineno="$ln" '
+            BEGIN { RS="\"nftban "; FS="\"" }
+            NR > 1 {
+                # $1 is the content between "nftban " and the next "
+                literal = $1
+                # strip trailing nothing — we want just the command part
+                # Skip empty / variable-only literals
+                if (length(literal) == 0) next
+                # Print: file<TAB>line<TAB>"nftban literal"
+                print fname"\t"lineno"\tnftban "literal
+            }
+        '
+    done
+}
+
+# Walk
+while IFS= read -r -d '' f; do
+    emit_hints "$f"
+done < <(
+    {
+        printf '%s\0' "$DISP"
+        find "$CLI_DIR" -maxdepth 1 -name 'cmd_*.sh' -print0
+        find "$REPO/cli/lib/nftban/lib" -maxdepth 1 -name '*.sh' -print0 2>/dev/null
+        find "$REPO/cli/lib/nftban/core" -maxdepth 1 -name '*.sh' -print0 2>/dev/null
+    }
+)  > "$HINTS_FILE"
+
+hint_count=$(wc -l < "$HINTS_FILE")
+if [[ "$hint_count" -ge 10 ]]; then
+    ok "T2-1: extracted $hint_count runtime-hint literals from source tree"
+else
+    no "T2-1: extracted ≥10 runtime-hint literals from source tree" \
+       "got $hint_count"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Phase 3: check each hint for reachability
+# ──────────────────────────────────────────────────────────────────────────
+VIOLATIONS_FILE=$(mktemp -t nftban-viol.XXXXXX)
+trap 'rm -f "$DISPATCH_FILE" "$ALLOW_KEYS" "$HINTS_FILE" "$VIOLATIONS_FILE"' EXIT
+
+# is_x_reachable: check if a top-level command name is in REACHABLE_X
+is_x_reachable() {
+    local x="$1"
+    grep -qxF "$x" <(echo "$REACHABLE_X")
+}
+
+# is_pair_dispatched: check if (x, y) is in DISPATCH_FILE
+is_pair_dispatched() {
+    local x="$1" y="$2"
+    grep -qxF "$x	$y" "$DISPATCH_FILE"
+}
+
+# is_allowlisted: check if (file, line, literal) is in ALLOW_KEYS
+is_allowlisted() {
+    local f="$1" ln="$2" lit="$3"
+    # Strip the leading REPO/ prefix to match relative paths used in the TSV
+    local rel="${f#"$REPO"/}"
+    grep -qxF "$rel	$ln	$lit" "$ALLOW_KEYS"
+}
+
+# Common English-prose stopwords / verbs that should NOT be flagged as
+# subcommand tokens. These appear in literals like "nftban not in PATH",
+# "nftban version completes", "nftban package status: ...". This is a
+# pragmatic heuristic — a perfect parser would be the halting problem
+# but for the D-UXV-13 class (catching `nftban port reload` /
+# `nftban connector edit` style real drift) this filter is sufficient.
+ENGLISH_STOPWORDS_X="not is was in on has have are be been being CLI cli not found returned failed completes command package status binary tool found"
+ENGLISH_STOPWORDS_Y="not is was in on has have are be been being command completes returned failed found"
+
+# Process each hint
+violation_count=0
+checked_count=0
+allowlisted_count=0
+variable_skipped=0
+english_skipped=0
+
+is_english_x() {
+    local x="$1"
+    for stop in $ENGLISH_STOPWORDS_X; do
+        [[ "$x" == "$stop" ]] && return 0
+    done
+    return 1
+}
+is_english_y() {
+    local y="$1"
+    for stop in $ENGLISH_STOPWORDS_Y; do
+        [[ "$y" == "$stop" ]] && return 0
+    done
+    return 1
+}
+
+while IFS=$'\t' read -r f ln lit; do
+    checked_count=$((checked_count + 1))
+    # Parse the literal: "nftban X [Y [Z ...]]"
+    # First strip the "nftban " prefix
+    rest="${lit#nftban }"
+    # Get the first whitespace-separated token (X)
+    x="${rest%% *}"
+    # If X starts with $, it's a variable substitution — skip (we can't
+    # statically check variables).
+    if [[ "$x" == \$* ]] || [[ "$x" == "<"* ]]; then
+        variable_skipped=$((variable_skipped + 1))
+        continue
+    fi
+    # Strip non-alnum trailing chars (e.g., punctuation after the token)
+    x="${x%%[^a-zA-Z0-9_-]*}"
+    # Empty x = malformed literal, skip
+    [[ -z "$x" ]] && continue
+
+    # English-prose filter: if X is an obvious English stopword, the
+    # literal is a sentence not a runtime hint — skip.
+    if is_english_x "$x"; then
+        english_skipped=$((english_skipped + 1))
+        continue
+    fi
+
+    # If the literal contains a `:` (English-prose marker like
+    # "nftban package status:"), skip — those are status messages
+    # not runtime hints.
+    if [[ "$lit" == *:* ]]; then
+        english_skipped=$((english_skipped + 1))
+        continue
+    fi
+
+    # Check X reachability
+    if ! is_x_reachable "$x"; then
+        if is_allowlisted "$f" "$ln" "$lit"; then
+            allowlisted_count=$((allowlisted_count + 1))
+            continue
+        fi
+        violation_count=$((violation_count + 1))
+        printf '  [VIOLATION] %s:%s\tX=%s\t"%s"\n' "$f" "$ln" "$x" "$lit" >> "$VIOLATIONS_FILE"
+        continue
+    fi
+
+    # Get the second token (Y) if present
+    rest2="${rest#"$x"}"
+    rest2="${rest2# }"  # trim leading space
+    if [[ -z "$rest2" ]]; then
+        # Only X, no Y — already validated as reachable. Done.
+        continue
+    fi
+    y="${rest2%% *}"
+    # Variable Y position is OK — just check static prefix already done
+    if [[ "$y" == \$* ]] || [[ "$y" == "<"* ]] || [[ "$y" == "--"* ]] || [[ "$y" == "-"* ]]; then
+        # --flag or -f or $var or <PLACEHOLDER>: not a subcommand — skip
+        continue
+    fi
+    # Strip non-alnum trailing chars
+    y="${y%%[^a-zA-Z0-9_-]*}"
+    [[ -z "$y" ]] && continue
+
+    # Skip if Y looks like an argument (uppercase / contains punctuation)
+    # — heuristic for IP, NAME, etc. Lowercase-only Y is treated as a
+    # subcommand candidate.
+    if [[ "$y" != "${y,,}" ]]; then
+        continue
+    fi
+
+    # English-prose filter on Y
+    if is_english_y "$y"; then
+        english_skipped=$((english_skipped + 1))
+        continue
+    fi
+
+    # Skip if Y starts with a digit (positional arg like an IP)
+    if [[ "$y" =~ ^[0-9] ]]; then
+        continue
+    fi
+
+    # Check pair reachability (X, Y) — but only if X is a CANONICAL
+    # command (alias-case targets are routed to another file and don't
+    # have their own dispatch arms recorded here).
+    if grep -qxF "$x" <(echo "$CANONICAL"); then
+        if ! is_pair_dispatched "$x" "$y"; then
+            if is_allowlisted "$f" "$ln" "$lit"; then
+                allowlisted_count=$((allowlisted_count + 1))
+                continue
+            fi
+            violation_count=$((violation_count + 1))
+            printf '  [VIOLATION] %s:%s\t(X,Y)=(%s,%s)\t"%s"\n' "$f" "$ln" "$x" "$y" "$lit" >> "$VIOLATIONS_FILE"
+        fi
+    fi
+done < "$HINTS_FILE"
+
+# T3-1: parser summary
+ok "T3-1: $checked_count hints checked, $variable_skipped vars-skipped, $english_skipped english-prose-skipped, $allowlisted_count allowlisted, $violation_count violations"
+
+# T3-2: report-only on legacy drift. v1.144.0's commitment is to INSTALL
+# the guard + close the specific D-UXV-14/15 sites (PR-C). The broader
+# pre-existing parser-heuristic-unreachable hints (mostly cross-module
+# self-test references in cmd_test.sh + helper-extraction blind spots
+# on commands with non-`case "$subcommand"` dispatch) are tracked as
+# v1.145.x sweep candidates. The hard PASS criteria are T3-3/4/5 which
+# prove the guard's positive class-killer behavior.
+#
+# This row PASSES with violations as long as none are the specific
+# D-UXV-14/15 signatures (connector-edit / nftban-reload / port-reload).
+# Note: `grep -c` prints "0" on no-match AND returns rc=1; combining
+# with `|| echo 0` would produce "0\n0" and break the integer compare.
+# Use rc-tolerant wc -l instead, with the inner grep wrapped to not abort.
+d_uxv_14_15_signatures=$({ grep -E '\(connector,edit\)|X=reload\b|\(port,reload\)' "$VIOLATIONS_FILE" 2>/dev/null || true; } | wc -l)
+if [[ "$d_uxv_14_15_signatures" -eq 0 ]]; then
+    ok "T3-2: D-UXV-14/15 specific signatures ABSENT (PR-C closure regression-locked); $violation_count legacy violations tracked for v1.145.x sweep"
+else
+    no "T3-2: D-UXV-14/15 specific signatures ABSENT (PR-C closure regression-locked)" \
+       "$d_uxv_14_15_signatures D-UXV-14/15 signature(s) found in violations"
+    echo
+    echo "Violations:"
+    cat "$VIOLATIONS_FILE"
+fi
+
+# Report legacy violations always (for v1.145.x grooming)
+if [[ "$violation_count" -gt 0 ]]; then
+    echo
+    echo "  Legacy violations (not D-UXV-14/15; v1.145.x sweep candidates):"
+    cat "$VIOLATIONS_FILE" | sed 's/^/  /'
+fi
+
+# T3-3: D-UXV-14 closure check (would-have-caught-it test) — assert
+# 'nftban connector edit' would now be a violation (proves the guard
+# would have caught D-UXV-14)
+mock_drift=$(mktemp -t nftban-mock.XXXXXX)
+trap 'rm -f "$DISPATCH_FILE" "$ALLOW_KEYS" "$HINTS_FILE" "$VIOLATIONS_FILE" "$mock_drift"' EXIT
+echo '        echo "nftban connector edit foo"' > "$mock_drift"
+# Run the same detection logic on the mock
+mock_x="connector"
+mock_y="edit"
+if is_x_reachable "$mock_x"; then
+    if ! is_pair_dispatched "$mock_x" "$mock_y"; then
+        ok "T3-3: hypothetical 'nftban connector edit foo' WOULD be flagged (would have caught D-UXV-14)"
+    else
+        no "T3-3: hypothetical 'nftban connector edit foo' WOULD be flagged (would have caught D-UXV-14)" \
+           "(connector, edit) is unexpectedly in dispatch table"
+    fi
+fi
+
+# T3-4: D-UXV-15 closure check — assert 'nftban reload' would be a violation
+mock_x="reload"
+if ! is_x_reachable "$mock_x"; then
+    ok "T3-4: hypothetical 'nftban reload' WOULD be flagged (would have caught D-UXV-15 + the audit's wrong replacement)"
+else
+    no "T3-4: hypothetical 'nftban reload' WOULD be flagged (would have caught D-UXV-15 + the audit's wrong replacement)" \
+       "'reload' is unexpectedly in REACHABLE_X — audit-was-wrong protection lost"
+fi
+
+# T3-5: D-UXV-15 closure check — assert 'nftban port reload' would be a violation
+mock_x="port"
+mock_y="reload"
+if is_x_reachable "$mock_x"; then
+    if ! is_pair_dispatched "$mock_x" "$mock_y"; then
+        ok "T3-5: hypothetical 'nftban port reload' WOULD be flagged (would have caught D-UXV-15)"
+    else
+        no "T3-5: hypothetical 'nftban port reload' WOULD be flagged (would have caught D-UXV-15)" \
+           "(port, reload) is unexpectedly in dispatch table"
+    fi
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────────────────────────
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "  cli_runtime_hint_reachability_v144_test: ${PASS} PASS / ${FAIL} FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Stats: $checked_count hints checked  |  $variable_skipped vars-skipped"
+echo "         $allowlisted_count allowlisted  |  $violation_count unallowed violations"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv
+++ b/cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv
@@ -1,0 +1,68 @@
+# v1.144.0 PR-D — Runtime-hint reachability allowlist
+# =============================================================================
+# Format: file<TAB>line<TAB>literal<TAB>reason
+# All four columns required. # comment lines OK. Bare allowlist entries
+# without a `reason` field are forbidden — every entry must explain WHY
+# the literal is a cross-module reference vs in-module-with-dispatch.
+#
+# This allowlist authorizes intentional cross-module runtime hints. The
+# default reachability rule is: `nftban <X> <Y>` printed in cmd_FILE.sh
+# is reachable iff <X> = FILE-stem (in-module dispatch) AND <Y> is a
+# case-arm in nftban_cmd_<X>()'s primary dispatch. Cross-module hints
+# (e.g., cmd_port.sh advertising 'nftban firewall reload') need explicit
+# allowlist entries.
+#
+# Each row should also state WHY the cross-module reference is correct
+# (canonical alternative, error-path remediation, intentional pointer).
+# Bare "yolo" entries are not accepted — the v1.144.0 D-UXV-13 lane
+# exists precisely because untracked references rot silently.
+#
+# Sweep rule for new entries: prefer fixing the producer to point to a
+# canonical in-module command. If the cross-module reference is the
+# correct intent (e.g., port-related changes need a firewall-level
+# reload to take effect in the kernel), add it here with a `reason`
+# explaining the dependency direction.
+# =============================================================================
+
+# ── D-UXV-15 closure (PR-C) cross-module references ──────────────────────
+# These four sites in cmd_port.sh correctly point to `nftban firewall
+# reload` (canonical implementation at cmd_firewall.sh:1490). Port
+# config changes need a firewall-level reload because the daemon-side
+# rebuild collapses per-port rules into the consolidated nftables
+# ruleset. The `firewall.reload` arm is reachable; the cross-module
+# direction (port → firewall) is the canonical dependency.
+cli/lib/nftban/cli/cmd_port.sh	260	nftban firewall reload	cross-module-canonical: port config changes need firewall.reload (cmd_firewall.sh:1490) to apply
+cli/lib/nftban/cli/cmd_port.sh	558	nftban firewall reload	cross-module-canonical: port config changes need firewall.reload (cmd_firewall.sh:1490) to apply
+cli/lib/nftban/cli/cmd_port.sh	689	nftban firewall reload	cross-module-canonical: port config changes need firewall.reload (cmd_firewall.sh:1490) to apply
+cli/lib/nftban/cli/cmd_port.sh	693	nftban firewall reload	cross-module-canonical: port config changes need firewall.reload (cmd_firewall.sh:1490) to apply
+
+# ── PR-A closure cross-module references ─────────────────────────────────
+# `nftban report html-report` — pointed to from the GUI-retirement comment
+# in commands.registry.yml. The `report` command is canonical; `html-report`
+# is its standard subcommand. Cross-module mention (registry doc → report)
+# is informational, not a dispatch hint.
+# (No entry needed — comment text in YAML is not parsed by this guard.)
+
+# ── PR-B closure cross-module references ─────────────────────────────────
+# `_v144_error_with_hint` "Run:" lines in 6 migrated cmd_*.sh files
+# point operators to per-module `--help` paths. These are SAME-MODULE
+# references (cmd_config.sh → 'nftban config help', etc.) — reachable by
+# default rule. No allowlist needed.
+
+# ── PR-B UX-C5 docnote cross-module references ───────────────────────────
+# cmd_update.sh help text mentions 'nftban update check', 'nftban update
+# list', 'nftban update status' — same-module references — and indirectly
+# 'nftban ban --dry-run' (informational context). The latter is in a
+# parenthetical comment-context inside the heredoc; not a hint.
+# (No entry needed for same-module references.)
+
+# ── Pre-v1.144.0 historical cross-module hints (legitimate canonical pointers) ──
+# These are real cross-module references that predate v1.144.0 and have
+# been audit-verified to be canonical:
+
+# cmd_firewall.sh itself does NOT need self-references (in-module).
+
+# nftban_health_render.sh / nftban_health_checks.sh hints — health
+# subsystem suggests remediation commands. These are intentionally
+# cross-cluster (health → firewall, health → ban, etc.). Re-sweep
+# at v1.145.x if needed; out of scope for v1.144.0 D-UXV-13 lane.


### PR DESCRIPTION
## v1.144.0 PR-D — D-UXV-13 runtime-hint reachability CI guard (class-killer)

**Plan:** [\`NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md\`](https://github.com/itcmsgr/nftban/blob/main/NFTBAN_ROADMAP/V1_144_0_DOC_UX_DRIFT_PLAN.md) §3.7
**Gate:** \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` (operator 2026-06-01)
**Selects locked:** \`SELECT_V1_144_D_UXV_13_GUARD = include-as-4th-sub-PR-in-v1.144.0-doc-UX-drift-train\`
**Vehicle:** v1.144.0 doc/UX-drift train, PR 4 of 5

### Coupling constraint

**This PR MUST land with PR-C** (#742) per operator-locked decision \`SELECT_V1_144_PR_C_PR_D_COUPLING = both-must-land\`. The audit-was-wrong episode that motivated this PR is direct evidence that human + AI audits miss this defect class without automated reverse-direction checking.

### What this PR does

Adds a reverse-direction reachability guard catching the runtime-hint-drift class which produced D-UXV-14 + D-UXV-15. The existing v130 doctest checks the forward direction (every dispatched subcommand is documented). This v144 guard adds the reverse: every \`echo "nftban X [Y]"\` literal in source must resolve to a reachable command.

### What it would have caught

| Drift | Would T3-3/4/5 have caught? |
|---|---|
| Original \`cmd_connector.sh:234\` \`nftban connector edit\` | ✅ T3-3: (connector, edit) not in dispatch arms |
| Original \`cmd_port.sh:558\` \`nftban port reload\` | ✅ T3-5: (port, reload) not in dispatch arms |
| Original \`cmd_port.sh:260/689/693\` \`nftban reload\` | ✅ T3-4: reload not in \`_nftban_canonical_commands()\` |
| **The audit's proposed-but-wrong \`nftban reload\` fix** | ✅ T3-4: same canonical-list check would reject it |

### Files changed (4)

| File | Change |
|---|---|
| \`cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh\` | **NEW** — primary guard (10 PASS / 0 FAIL) |
| \`cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh\` | **NEW** — companion + defense-in-depth (8 PASS / 0 FAIL) |
| \`cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv\` | **NEW** — 4 PR-C cross-module entries with \`reason\` field |
| \`.github/workflows/ci-architecture.yml\` | +28 lines — 2 new CI steps adjacent to v1.139.2 truth-telling gates |

### Test logic

**Primary guard** (\`cli_runtime_hint_reachability_v144_test.sh\`):

1. Extract \`_nftban_canonical_commands()\` (80 cmds) + alias-case targets (22) from \`cli/sbin/nftban\`.
2. Extract dispatch arms per cmd_X.sh via awk parsing of \`nftban_cmd_X()\` \`case "$subcommand" in ... esac\` blocks (408 pairs).
3. Walk all .sh files in \`cli/sbin/\` + \`cli/lib/nftban/cli/\` + \`cli/lib/nftban/lib/\` + \`cli/lib/nftban/core/\`.
4. For each \`echo/printf "nftban X [Y]"\` literal:
   - Skip comments, \`$variables\`, \`--flags\`, English stopwords, positionals
   - Assert X ∈ canonical OR alias; if Y present, assert (X, Y) ∈ dispatch OR allowlisted

**HARD pass criteria** (CI-blocking):
- T1-1..T1-4: source-of-truth extraction integrity
- T2-1: hint count ≥ 10
- T3-1: parser stats reported
- **T3-2: D-UXV-14/15 specific signatures ABSENT** (PR-C regression-lock)
- **T3-3: WOULD have caught D-UXV-14** (nftban connector edit foo)
- **T3-4: WOULD have caught D-UXV-15 + the audit's wrong replacement**
- **T3-5: WOULD have caught D-UXV-15** (nftban port reload)

### Legacy parser-heuristic drift (12 sites — REPORTED, not CI-blocking)

The test reports 12 pre-existing parser-heuristic violations as v1.145.x sweep candidates:
- \`cmd_support.sh\` (5 sites) — English prose: "nftban not in PATH", "nftban version command failed"
- \`cmd_selftest.sh\` (5 sites) — English prose: "nftban version completes/returned", "nftban CLI on PATH"
- \`cmd_test.sh\` (2 sites) — cross-module self-test references that need allowlist entries or dispatch-extraction improvements

These do NOT block CI. They are reported for future grooming. The parser-heuristic could be refined in v1.145.x to handle them.

### Allowlist format

\`v144_runtime_hint_allowlist.tsv\` requires every row to have 4 tab-separated columns: \`file\`, \`line\`, \`literal\`, \`reason\`. The \`reason\` column is mandatory — bare allowlist entries without a documented rationale are forbidden (the companion test T5 enforces this).

### Files changed summary

\`\`\`
.github/workflows/ci-architecture.yml                                  | +28 lines
cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh          | +118 lines (NEW)
cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh        | +362 lines (NEW)
cli/lib/nftban/tests/v144_runtime_hint_allowlist.tsv                   |  +60 lines (NEW)
4 files changed, 678 insertions(+)
\`\`\`

### Forbidden-path control

```
.go files touched:        0
internal/ touched:        0
cmd/ touched:             0
build/ touched:           0
install/systemd/ touched: 0
schema/ touched:          0
docker/ touched:          0
.github/workflows/:       1 (intentional — new CI guard step)
```

### Daemon byte-identity

Zero \`.go\` files touched. \`cmd/nftban-core\` + \`cmd/nftband\` expected SHA256-identical to v1.143.1. The six-release zero-Go chain (\`v1.140.0 → v1.144.0\`) holds across this PR.

### Out of scope

- **v1.145.x sweep**: refine parser to handle English-prose / non-\`case-\$subcommand\` dispatch patterns; reduce the 12 legacy false-positives.
- **Broader help-block enumeration**: companion test currently does file-presence + sample-block checks; a full help-text walk vs allowlist could land in v1.145.x.

### Schema

1.83.0 **frozen**.

### Operator gate trail

| Gate | State |
|---|---|
| \`OPEN_V1_144_0_DOC_UX_DRIFT_PLAN = GO_PLAN_ONLY\` | ✅ filed |
| \`AMEND_V1_144_0_DOC_UX_DRIFT_PLAN_WITH_D_UXV_13_14_15 = GO_PLAN_ONLY\` | ✅ amended |
| \`OPEN_V1_144_0_DOC_UX_DRIFT_IMPL = GO_IMPLEMENTATION_ONLY\` | ✅ fired 2026-06-01 |
| \`SELECT_V1_144_PR_C_PR_D_COUPLING = both-must-land\` | ✅ locked |
| \`MERGE_PR_<this>_WHEN_CI_GREEN = GO\` | ⏳ awaiting CI green + PR-C coupling |