### PR TITLE
feat(security): v1.145 PR-A set-driven SSH brute-force rate-limit

### DIFF
--- a/cli/lib/nftban/lib/nft_schema.sh
+++ b/cli/lib/nftban/lib/nft_schema.sh
@@ -107,6 +107,11 @@ declare -g -A NFTBAN_IPV4_SETS=(
     ["udp_ports_in"]="inet_service||Allowed UDP ports (inbound)"
     ["udp_ports_out"]="inet_service||Allowed UDP ports (outbound)"
 
+    # SSH brute-force rate-limit ports (v1.145 PR-A — set-driven ct-count dport)
+    # The input chain's brute-force rule reads `tcp dport @ssh_ports ct count`,
+    # so this set must exist alongside tcp_ports_in for the base ruleset to load.
+    ["ssh_ports"]="inet_service||SSH ports for set-driven brute-force rate-limit"
+
     # HTTP Bot Guard sets (v1.21.4 — always in base schema, empty when disabled)
     ["http_bot_suspect"]="ipv4_addr|timeout|Kernel-populated HTTP bot suspects"
     ["http_bot_pending"]="ipv4_addr|timeout|Awaiting bot classification"
@@ -171,6 +176,11 @@ declare -g -A NFTBAN_IPV6_SETS=(
     ["tcp_ports_out"]="inet_service||Allowed TCP ports (outbound)"
     ["udp_ports_in"]="inet_service||Allowed UDP ports (inbound)"
     ["udp_ports_out"]="inet_service||Allowed UDP ports (outbound)"
+
+    # SSH brute-force rate-limit ports (v1.145 PR-A — set-driven ct-count dport)
+    # The input chain's brute-force rule reads `tcp dport @ssh_ports ct count`,
+    # so this set must exist alongside tcp_ports_in for the base ruleset to load.
+    ["ssh_ports"]="inet_service||SSH ports for set-driven brute-force rate-limit"
 
     # HTTP Bot Guard sets (v1.21.4 — always in base schema, empty when disabled)
     ["http_bot_suspect6"]="ipv6_addr|timeout|Kernel-populated HTTP bot suspects"

--- a/cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh
+++ b/cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - PR-A static regression guard: set-driven SSH rate-limit
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v145_ssh_port_template_set_driven_static_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-01"
+# meta:description="V1.145 PR-A static guard. Asserts the SSH brute-force ct-count rule is set-driven (tcp dport @ssh_ports ct count) in every shipped nftables template, that a `set ssh_ports` block exists, that the retired __SSH_PORTS_LIST__ placeholder is gone, that no literal `tcp dport __SSH_PORT__ ... ct count` rule survives, and that no operator-specific SSH port (e.g. 55000) is hardcoded in shipped templates/schema/renderer (allowed only in tests and comments). Closes Gap 2 from SSH_PORT_CHANGE_FLEET_AUDIT_AND_GAP_STACK.md."
+# meta:input="None (reads repo source files read-only)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+# Resolve repo root from this script's location (.../cli/lib/nftban/tests/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TPL_DIR="install/nftables"
+TEMPLATES=(
+    "$TPL_DIR/nftables.conf.tpl"
+    "$TPL_DIR/nftables-safe.conf"
+    "$TPL_DIR/nftables-ipv4.conf.tmpl"
+)
+RENDERER="internal/installer/render/nftables.go"
+SCHEMA_SRC="cli/lib/nftban/lib/nft_schema.sh"
+SCHEMA_GEN="internal/validator/schema_generated.go"
+
+pass=0
+fail=0
+ok()   { echo "  PASS  $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL  $1"; fail=$((fail+1)); }
+
+echo "== v1.145 PR-A set-driven SSH rate-limit — static guard =="
+
+# 1. No literal `tcp dport __SSH_PORT__ ... ct count` rule in any template.
+for f in "${TEMPLATES[@]}"; do
+    if grep -Eq 'tcp dport __SSH_PORT__[^\n]*ct count' "$f"; then
+        bad "$f still has literal 'tcp dport __SSH_PORT__ ... ct count'"
+    else
+        ok "$f: no literal __SSH_PORT__ ct-count rule"
+    fi
+done
+
+# 2. The retired __SSH_PORTS_LIST__ placeholder must not appear anywhere
+#    in shipped templates or the renderer.
+if grep -rIlq "__SSH_PORTS_LIST__" "${TEMPLATES[@]}" "$RENDERER"; then
+    bad "retired __SSH_PORTS_LIST__ placeholder still present"
+    grep -rIn "__SSH_PORTS_LIST__" "${TEMPLATES[@]}" "$RENDERER" | sed 's/^/        /'
+else
+    ok "no retired __SSH_PORTS_LIST__ placeholder remains"
+fi
+
+# 3. Each template declares a `set ssh_ports` block.
+for f in "${TEMPLATES[@]}"; do
+    if grep -Eq '^[[:space:]]*set ssh_ports \{' "$f"; then
+        ok "$f: declares 'set ssh_ports'"
+    else
+        bad "$f: missing 'set ssh_ports' block"
+    fi
+done
+
+# 4. Each template's SSH ct-count rule is set-driven via @ssh_ports.
+for f in "${TEMPLATES[@]}"; do
+    if grep -Eq 'tcp dport @ssh_ports ct count' "$f"; then
+        ok "$f: SSH ct-count uses @ssh_ports"
+    else
+        bad "$f: SSH ct-count rule does not use @ssh_ports"
+    fi
+done
+
+# 5. ssh_ports must be in the generated validator inventory (required + all).
+if grep -q '"ssh_ports"' "$SCHEMA_GEN"; then
+    ok "$SCHEMA_GEN: ssh_ports present in generated inventory"
+else
+    bad "$SCHEMA_GEN: ssh_ports missing — re-run scripts/generate-go-schema.sh"
+fi
+if grep -q '\["ssh_ports"\]' "$SCHEMA_SRC"; then
+    ok "$SCHEMA_SRC: ssh_ports present in canonical source"
+else
+    bad "$SCHEMA_SRC: ssh_ports missing from canonical nft_schema.sh"
+fi
+
+# 6. No operator-specific SSH port hardcoded in shipped templates/schema.
+#    Templates + schema source must be completely free of 55000.
+for f in "${TEMPLATES[@]}" "$SCHEMA_SRC" "$SCHEMA_GEN"; do
+    if grep -q "55000" "$f"; then
+        bad "$f: hardcoded 55000 found (must come from detection, not be baked in)"
+        grep -n "55000" "$f" | sed 's/^/        /'
+    else
+        ok "$f: no hardcoded 55000"
+    fi
+done
+
+# 7. In the renderer, 55000 may appear ONLY in comments (// …), never in code.
+if grep -n "55000" "$RENDERER" | grep -vE ':[[:space:]]*//' | grep -q .; then
+    bad "$RENDERER: 55000 used outside a comment (must not be hardcoded in logic)"
+    grep -n "55000" "$RENDERER" | grep -vE ':[[:space:]]*//' | sed 's/^/        /'
+else
+    ok "$RENDERER: 55000 only in comments (if present)"
+fi
+
+echo
+echo "RESULT: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/install/nftables/nftables-ipv4.conf.tmpl
+++ b/install/nftables/nftables-ipv4.conf.tmpl
@@ -34,6 +34,13 @@ table ip nftban {
         elements = { 22, 80, 443 }
     }
 
+    # v1.145 PR-A: set-driven SSH brute-force rate-limit (closes Gap 2).
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit"
+        elements = { __SSH_PORT__ }
+    }
+
     set tcp_ports_out {
         type inet_service
         comment "Allowed TCP ports (outbound)"
@@ -84,7 +91,7 @@ table ip nftban {
         ip protocol icmp icmp type { echo-reply, destination-unreachable, echo-request, time-exceeded } counter accept comment "ICMPv4"
 
         # 8. CT LIMITS (DDoS protection - SSH)
-        ct state new tcp dport __SSH_PORT__ ct count over 15 counter drop comment "SSH: max 15 concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over 15 counter drop comment "SSH: max 15 concurrent per IP — v1.145 PR-A set-driven"
 
         # 9. CT LIMITS (DDoS protection - HTTP/HTTPS/MAIL)
         ct state new tcp dport { 80, 443 } ct count over 150 counter drop comment "HTTP(S): max 150 concurrent per IP"

--- a/install/nftables/nftables-safe.conf
+++ b/install/nftables/nftables-safe.conf
@@ -52,6 +52,13 @@ table ip nftban {
         elements = { 22, 80, 443 }
     }
 
+    # v1.145 PR-A: set-driven SSH brute-force rate-limit (closes Gap 2).
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit"
+        elements = { __SSH_PORT__ }
+    }
+
     set tcp_ports_out {
         type inet_service
         comment "Allowed TCP ports (outbound)"
@@ -92,7 +99,7 @@ table ip nftban {
         ip protocol icmp icmp type { echo-reply, destination-unreachable, echo-request, time-exceeded } counter accept comment "ICMPv4"
 
         # 8. CT LIMITS (DDoS protection - SSH)
-        ct state new tcp dport __SSH_PORT__ ct count over 15 counter drop comment "SSH: max 15 concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over 15 counter drop comment "SSH: max 15 concurrent per IP — v1.145 PR-A set-driven"
 
         # 9. CT LIMITS (DDoS protection - HTTP/HTTPS/MAIL)
         ct state new tcp dport { 80, 443 } ct count over 150 counter drop comment "HTTP(S): max 150 concurrent per IP"
@@ -151,6 +158,13 @@ table ip6 nftban {
         elements = { 22, 80, 443 }
     }
 
+    # v1.145 PR-A: set-driven SSH brute-force rate-limit (closes Gap 2).
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit"
+        elements = { __SSH_PORT__ }
+    }
+
     set tcp_ports_out {
         type inet_service
         comment "Allowed TCP ports (outbound)"
@@ -174,7 +188,7 @@ table ip6 nftban {
         ip6 saddr @blacklist_ipv6 counter drop comment "blacklist (permanent + temporary)"
         ct state established,related counter accept comment "established connections"
         meta l4proto ipv6-icmp icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-solicit, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } counter accept comment "ICMPv6 + NDP"
-        ct state new tcp dport __SSH_PORT__ ct count over 15 counter drop comment "SSH: max 15 concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over 15 counter drop comment "SSH: max 15 concurrent per IP — v1.145 PR-A set-driven"
         ct state new tcp dport { 80, 443 } ct count over 150 counter drop comment "HTTP(S): max 150 concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over 150 counter drop comment "MAIL: max 150 concurrent per IP"
         tcp flags syn ct state new meter syn_meter_v6 { ip6 saddr limit rate 25/second burst 50 packets } log prefix "NFTBAN_PORTSCAN: " comment "SYN rate per-IP"

--- a/install/nftables/nftables.conf.tpl
+++ b/install/nftables/nftables.conf.tpl
@@ -132,6 +132,17 @@ table ip nftban {
         elements = { __SSH_PORT__, 80, 443 }
     }
 
+    # v1.145 PR-A: set-driven SSH brute-force rate-limit (closes Gap 2).
+    # The ct-count SSH rule below now reads dport from @ssh_ports instead of
+    # a hardcoded __SSH_PORT__ literal, so a single atomic set update covers
+    # both the allow-set (tcp_ports_in) and the rate-limit dport without a
+    # full ruleset reload.
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit"
+        elements = { __SSH_PORT__ }
+    }
+
     set tcp_ports_out {
         type inet_service
         comment "Allowed outbound TCP ports"
@@ -394,7 +405,7 @@ table ip nftban {
         counter name anchor_detect comment "NFTBAN_ANCHOR:ANCHOR_DETECT"
 
         # 6. CT LIMITS - DDoS protection (per source IP limits)
-        ct state new tcp dport __SSH_PORT__ ct count over __CT_LIMIT_SSH__ counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max __CT_LIMIT_SSH__ concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over __CT_LIMIT_SSH__ counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max __CT_LIMIT_SSH__ concurrent per IP — v1.145 PR-A set-driven"
         ct state new tcp dport { 80, 443 } ct count over __CT_LIMIT_HTTP__ counter name input_ct_http_drop counter name total_input_drop drop comment "HTTP(S): max __CT_LIMIT_HTTP__ concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over __CT_LIMIT_MAIL__ counter name input_ct_mail_drop counter name total_input_drop drop comment "MAIL: max __CT_LIMIT_MAIL__ concurrent per IP"
 
@@ -492,6 +503,13 @@ table ip6 nftban {
         type inet_service
         comment "Allowed inbound TCP ports"
         elements = { __SSH_PORT__, 80, 443 }
+    }
+
+    # v1.145 PR-A: set-driven SSH brute-force rate-limit (v6 — closes Gap 2).
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit (v6)"
+        elements = { __SSH_PORT__ }
     }
 
     set tcp_ports_out {
@@ -763,7 +781,7 @@ table ip6 nftban {
         counter name anchor_detect comment "NFTBAN_ANCHOR:ANCHOR_DETECT"
 
         # 6. CT LIMITS - DDoS protection (per source IP limits)
-        ct state new tcp dport __SSH_PORT__ ct count over __CT_LIMIT_SSH__ counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max __CT_LIMIT_SSH__ concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over __CT_LIMIT_SSH__ counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max __CT_LIMIT_SSH__ concurrent per IP — v1.145 PR-A set-driven"
         ct state new tcp dport { 80, 443 } ct count over __CT_LIMIT_HTTP__ counter name input_ct_http_drop counter name total_input_drop drop comment "HTTP(S): max __CT_LIMIT_HTTP__ concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over __CT_LIMIT_MAIL__ counter name input_ct_mail_drop counter name total_input_drop drop comment "MAIL: max __CT_LIMIT_MAIL__ concurrent per IP"
 

--- a/internal/installer/render/nftables.go
+++ b/internal/installer/render/nftables.go
@@ -38,13 +38,34 @@ var placeholders = []string{
 	"__CT_LIMIT_MAIL__",
 }
 
-// tcpPortsInElementsRe matches the `elements = { … }` line inside a
-// `set tcp_ports_in { … }` block. Group 1 is "elements = {", group 2 is the
-// inner comma-separated port list (possibly multi-line), group 3 is "}". Used
-// by ensureSSHPortInTcpPortsIn to inject the detected SSH port when the
-// template doesn't carry it via __SSH_PORT__ substitution. V121 fix for
-// D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001.
-var tcpPortsInElementsRe = regexp.MustCompile(`(?s)(set tcp_ports_in \{[^{}]*elements = \{)([^}]*)(\})`)
+// portSetElementsRe holds the compiled `elements = { … }` matchers for the
+// named port sets the renderer injects SSH ports into. Group 1 is
+// "set <name> { … elements = {", group 2 is the inner comma-separated element
+// list (possibly multi-line), group 3 is "}". Used by ensureSSHPortsInSet to
+// inject a detected SSH port when the template does not already carry it.
+//
+// V121 introduced this for tcp_ports_in only (D-NONDEFAULT-SSH-PORT-CONFIG-
+// DRIFT-001). v1.145 PR-A generalized it to any named port set so the SAME
+// idempotent injector seeds BOTH tcp_ports_in (the allow-set) and ssh_ports
+// (the set-driven brute-force rate-limit set, `tcp dport @ssh_ports ct count`)
+// from the detected SSH listener ports — no duplicate placeholder machinery.
+// The map is built once at init and only read afterwards (no concurrent
+// writes), so it is safe for parallel renders/tests.
+var portSetElementsRe = map[string]*regexp.Regexp{
+	"tcp_ports_in": regexp.MustCompile(`(?s)(set tcp_ports_in \{[^{}]*elements = \{)([^}]*)(\})`),
+	"ssh_ports":    regexp.MustCompile(`(?s)(set ssh_ports \{[^{}]*elements = \{)([^}]*)(\})`),
+}
+
+// portSetElementsReFor returns the compiled elements matcher for setName.
+// Known sets (tcp_ports_in, ssh_ports) are precompiled; any other name is
+// compiled on demand (QuoteMeta-guarded). Read-only access to the precompiled
+// map keeps the common path race-free.
+func portSetElementsReFor(setName string) *regexp.Regexp {
+	if re, ok := portSetElementsRe[setName]; ok {
+		return re
+	}
+	return regexp.MustCompile(`(?s)(set ` + regexp.QuoteMeta(setName) + ` \{[^{}]*elements = \{)([^}]*)(\})`)
+}
 
 // RenderNftablesConf reads the nftables.conf template, substitutes placeholders,
 // validates syntax, and writes back atomically.
@@ -90,9 +111,17 @@ func RenderNftablesConfMultiPort(exec executor.Executor, sshPorts []int, ct dete
 	// Substitute placeholders. __SSH_PORT__ uses the PRIMARY port — the
 	// per-IP rate-limit rule and other single-port references in the
 	// template stay byte-identical to v1.124 behavior for single-port
-	// hosts. For multi-port hosts, the allow-set carries every port (via
-	// ensureSSHPortInTcpPortsIn below) but per-port rate-limit semantics
-	// for additional ports are deferred to V125 stretch / V126+.
+	// hosts. For multi-port hosts, both port sets carry every port (via
+	// ensureSSHPortsInSet below).
+	//
+	// v1.145 PR-A: the SSH ct-count brute-force rate-limit rule reads its
+	// dport from @ssh_ports (set-driven) instead of the previously-hardcoded
+	// __SSH_PORT__ literal. The templates seed `set ssh_ports` with
+	// __SSH_PORT__ (the primary), and the ensureSSHPortsInSet loop below
+	// injects every additional detected port into ssh_ports alongside
+	// tcp_ports_in. This closes Gap 2 from the V1.145 audit: per-port
+	// rate-limit semantics now cover every detected SSH port, and an atomic
+	// set update can move the rate-limit dport without a full ruleset reload.
 	content = strings.ReplaceAll(content, "__SSH_PORT__", strconv.Itoa(primary))
 	content = strings.ReplaceAll(content, "__CT_LIMIT_SSH__", strconv.Itoa(ct.SSH))
 	content = strings.ReplaceAll(content, "__CT_LIMIT_HTTP__", strconv.Itoa(ct.HTTP))
@@ -116,13 +145,30 @@ func RenderNftablesConfMultiPort(exec executor.Executor, sshPorts []int, ct dete
 	// V125 R-1 extension — multi-port: inject every detected SSH listener
 	// port (primary AND additional) into the tcp_ports_in elements list, so
 	// operators connecting on any of the host's sshd listener ports survive
-	// a firewall reload. ensureSSHPortInTcpPortsIn is idempotent and
-	// safe-to-call-repeatedly: if a port is already present (e.g., from
-	// __SSH_PORT__ substitution above for the primary), the helper is a
-	// no-op for that port.
+	// a firewall reload.
+	//
+	// v1.145 PR-A — set-driven SSH rate-limit: inject the SAME ports into the
+	// ssh_ports set, which the input chain's brute-force ct-count rule reads
+	// via `tcp dport @ssh_ports`. This keeps the rate-limit dport in parity
+	// with the allow-set for every detected SSH port (the primary arrives via
+	// the __SSH_PORT__ substitution above; additional ports are injected
+	// here). ensureSSHPortsInSet is idempotent and safe-to-call-repeatedly:
+	// if a port is already present in the target set, the helper is a no-op.
 	for _, port := range sshPorts {
-		content = ensureSSHPortInTcpPortsIn(content, port, log)
+		content = ensureSSHPortsInSet(content, "tcp_ports_in", port, log)
+		content = ensureSSHPortsInSet(content, "ssh_ports", port, log)
 	}
+
+	// v1.145 PR-A — normalize: guarantee each port set's elements list holds
+	// every whole numeric token at most once. The strict presence check in
+	// ensureSSHPortsInSet prevents the injector from ADDING a duplicate, but it
+	// does NOT remove a duplicate introduced by __SSH_PORT__ substitution when a
+	// detected SSH port coincides with a hardcoded service port in the template
+	// (e.g. sshPorts=[80] → `elements = { 80, 80, 443 }`). nftables sets cannot
+	// hold duplicate elements, so this pass collapses any such collision. It is
+	// a no-op for the common case (SSH port distinct from 80/443/25/465/587).
+	content = dedupePortSetElements(content, "tcp_ports_in", log)
+	content = dedupePortSetElements(content, "ssh_ports", log)
 
 	// Final sanity check (warning only — injection above should have made
 	// this pass, but a malformed template without any tcp_ports_in set
@@ -163,38 +209,43 @@ func RenderNftablesConfMultiPort(exec executor.Executor, sshPorts []int, ct dete
 	return nil
 }
 
-// ensureSSHPortInTcpPortsIn guarantees the detected SSH port appears as a
-// whole numeric token inside at least one `set tcp_ports_in { … elements = { … } … }`
+// ensureSSHPortsInSet guarantees the detected SSH port appears as a whole
+// numeric token inside at least one `set <setName> { … elements = { … } … }`
 // block in the rendered content. If the port is already present (as a comma-
-// separated element token in any tcp_ports_in elements list), the function
-// is a no-op. Otherwise, for each matched `tcp_ports_in` set block, it
-// injects the port at the head of the elements list, preserving existing
-// entries and formatting.
+// separated element token in any matching elements list), the function is a
+// no-op. Otherwise, for each matched set block, it injects the port at the
+// head of the elements list, preserving existing entries and formatting.
 //
-// V121 fix for D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 — closes the gap where
-// hosts using non-default SSH ports could end up with kernel-only safety
-// (transient) instead of durable-config safety (survives reload/restart/
-// reboot/update).
+// V121 introduced this as ensureSSHPortInTcpPortsIn (hardcoded to
+// tcp_ports_in) to fix D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 — closing the
+// gap where hosts using non-default SSH ports could end up with kernel-only
+// safety (transient) instead of durable-config safety (survives reload/
+// restart/reboot/update).
 //
-// v1.125 R-1 hardening: presence check is now strict (exact numeric token
-// inside the parsed elements list), not a loose strings.Contains substring
-// match. The pre-v1.125 substring check incorrectly treated port 22 as
-// "present" when only 2222 (DirectAdmin control port) appeared anywhere in
-// the content; on DA-class multi-port hosts this caused port 22 to silently
-// not get injected. The new check parses the tcp_ports_in elements
-// regex-match, splits on commas, and compares each trimmed token against
-// the port literal — eliminating false-positive presence detection.
+// v1.145 PR-A generalized it to any named port set so the same idempotent
+// injector seeds both tcp_ports_in (allow-set) and ssh_ports (set-driven
+// brute-force rate-limit, `tcp dport @ssh_ports ct count`) without a second
+// placeholder mechanism. setName MUST be one of the known port sets; the
+// matcher is selected via portSetElementsReFor.
+//
+// v1.125 R-1 hardening (preserved): presence check is strict (exact numeric
+// token inside the parsed elements list), not a loose strings.Contains
+// substring match. The pre-v1.125 substring check incorrectly treated port
+// 22 as "present" when only 2222 (DirectAdmin control port) appeared anywhere
+// in the content; on DA-class multi-port hosts this caused port 22 to
+// silently not get injected. The check parses the elements regex-match,
+// splits on commas, and compares each trimmed token against the port literal
+// — eliminating false-positive presence detection.
 //
 // Idempotent: calling on already-correct content returns content unchanged.
-func ensureSSHPortInTcpPortsIn(content string, sshPort int, log *logging.Logger) string {
+func ensureSSHPortsInSet(content string, setName string, sshPort int, log *logging.Logger) string {
 	portStr := strconv.Itoa(sshPort)
+	re := portSetElementsReFor(setName)
 
-	// Strict presence check (v1.125 R-1 hardening): parse every
-	// tcp_ports_in match's elements list and compare port as a whole
-	// numeric token. Replaces the pre-v1.125 loose strings.Contains
-	// check which was vulnerable to substring false positives (22 vs
-	// 2222, 80 vs 8080, etc.).
-	for _, match := range tcpPortsInElementsRe.FindAllStringSubmatch(content, -1) {
+	// Strict presence check (v1.125 R-1 hardening): parse every match's
+	// elements list and compare port as a whole numeric token. Avoids
+	// substring false positives (22 vs 2222, 80 vs 8080, etc.).
+	for _, match := range re.FindAllStringSubmatch(content, -1) {
 		if len(match) < 4 {
 			continue
 		}
@@ -205,10 +256,10 @@ func ensureSSHPortInTcpPortsIn(content string, sshPort int, log *logging.Logger)
 		}
 	}
 
-	// Slow path: port is missing. Inject into every tcp_ports_in set.
+	// Slow path: port is missing. Inject into every matching set block.
 	injections := 0
-	out := tcpPortsInElementsRe.ReplaceAllStringFunc(content, func(match string) string {
-		groups := tcpPortsInElementsRe.FindStringSubmatch(match)
+	out := re.ReplaceAllStringFunc(content, func(match string) string {
+		groups := re.FindStringSubmatch(match)
 		if len(groups) < 4 {
 			return match
 		}
@@ -231,7 +282,57 @@ func ensureSSHPortInTcpPortsIn(content string, sshPort int, log *logging.Logger)
 	})
 
 	if injections > 0 {
-		log.Info("V121 injected SSH port %d into %d tcp_ports_in set(s) in rendered nftables.conf (template did not carry the port via __SSH_PORT__ or hardcoded list)", sshPort, injections)
+		log.Info("v1.145 injected SSH port %d into %d %s set(s) in rendered nftables.conf (template did not carry the port via __SSH_PORT__)", sshPort, injections, setName)
+	}
+	return out
+}
+
+// dedupePortSetElements rewrites the elements list of every
+// `set <setName> { … elements = { … } … }` block so each whole numeric token
+// appears at most once (first occurrence wins, order preserved). It only
+// rewrites a block that actually contains a duplicate, so the common no-dup
+// case is byte-preserving (original formatting/whitespace untouched).
+//
+// nftables sets cannot hold duplicate elements. The strict presence check in
+// ensureSSHPortsInSet stops the injector from ADDING a duplicate, but it does
+// not remove one created by __SSH_PORT__ substitution when a detected SSH port
+// coincides with a hardcoded service port in the template (e.g. sshPorts=[80]
+// renders tcp_ports_in `{ 80, 80, 443 }`). This pass is the backstop that
+// guarantees no duplicate token reaches nft, independent of operational
+// plausibility (we do not rely on "an SSH port is never 80/443").
+func dedupePortSetElements(content string, setName string, log *logging.Logger) string {
+	re := portSetElementsReFor(setName)
+	removed := 0
+	out := re.ReplaceAllStringFunc(content, func(match string) string {
+		groups := re.FindStringSubmatch(match)
+		if len(groups) < 4 {
+			return match
+		}
+		prefix, inner, suffix := groups[1], groups[2], groups[3]
+		seen := make(map[string]bool)
+		kept := make([]string, 0)
+		dup := false
+		for _, tok := range strings.Split(inner, ",") {
+			t := strings.TrimSpace(tok)
+			if t == "" {
+				continue
+			}
+			if seen[t] {
+				dup = true
+				removed++
+				continue
+			}
+			seen[t] = true
+			kept = append(kept, t)
+		}
+		if !dup {
+			// No duplicate — preserve the original block byte-for-byte.
+			return match
+		}
+		return prefix + " " + strings.Join(kept, ", ") + " " + suffix
+	})
+	if removed > 0 {
+		log.Info("v1.145 removed %d duplicate element token(s) from %s set(s) in rendered nftables.conf", removed, setName)
 	}
 	return out
 }

--- a/internal/installer/render/nftables_test.go
+++ b/internal/installer/render/nftables_test.go
@@ -7,7 +7,7 @@
 // meta:version="1.0.0"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-05-19"
-// meta:description="V121 unit tests for ensureSSHPortInTcpPortsIn injection helper. Covers Mechanism A (template hardcodes port via __SSH_PORT__ placeholder substitution), Mechanism B (template hardcodes port directly), Mechanism C (template lacks port — V121 injection fires), idempotency, and multi-set injection (ip + ip6 tcp_ports_in)."
+// meta:description="V121 unit tests for the ensureSSHPortsInSet injection helper (v1.145 PR-A generalized it from the V121 ensureSSHPortInTcpPortsIn). Covers Mechanism A (template hardcodes port via __SSH_PORT__ placeholder substitution), Mechanism B (template hardcodes port directly), Mechanism C (template lacks port — injection fires), idempotency, multi-set injection (ip + ip6 tcp_ports_in), and v1.145 set-driven ssh_ports injection (tcp dport @ssh_ports brute-force rate-limit) for single-port and multi-port hosts."
 // meta:input="None"
 // meta:output="t.Fatalf/t.Errorf on assertion failure"
 // meta:depends="testing,internal/installer/logging"
@@ -51,7 +51,7 @@ func TestEnsureSSHPortInTcpPortsIn_Mechanism_A_PortAlreadyPresent(t *testing.T) 
 		elements = { 22, 55000, 80, 443 }
 	}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	if out != input {
 		t.Errorf("expected no-op for already-present port; got diff:\n--input--\n%s\n--output--\n%s", input, out)
 	}
@@ -72,7 +72,7 @@ func TestEnsureSSHPortInTcpPortsIn_Mechanism_B_PortSubstitutedViaPlaceholder(t *
 		elements = { 55000, 80, 443 }
 	}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	if out != input {
 		t.Errorf("expected no-op when substituted port already present; got diff")
 	}
@@ -90,7 +90,7 @@ func TestEnsureSSHPortInTcpPortsIn_Mechanism_C_InjectIntoSingleSet(t *testing.T)
 		elements = { 80, 443 }
 	}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	if out == input {
 		t.Fatalf("expected injection but output is unchanged")
 	}
@@ -120,7 +120,7 @@ table ip6 nftban {
 		elements = { 80, 443 }
 	}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	// Both sets must now carry the port.
 	count := strings.Count(out, "55000")
 	if count < 2 {
@@ -138,8 +138,8 @@ func TestEnsureSSHPortInTcpPortsIn_Idempotent(t *testing.T) {
 		elements = { 80, 443 }
 	}
 }`
-	once := ensureSSHPortInTcpPortsIn(input, 55000, log)
-	twice := ensureSSHPortInTcpPortsIn(once, 55000, log)
+	once := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
+	twice := ensureSSHPortsInSet(once, "tcp_ports_in", 55000, log)
 	if once != twice {
 		t.Errorf("expected idempotent (second call unchanged); got:\n--once--\n%s\n--twice--\n%s", once, twice)
 	}
@@ -157,7 +157,7 @@ func TestEnsureSSHPortInTcpPortsIn_EmptyElements(t *testing.T) {
 	input := `set tcp_ports_in {
 	elements = {}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	if !strings.Contains(out, "55000") {
 		t.Errorf("expected '55000' to be injected into empty elements list; got:\n%s", out)
 	}
@@ -174,7 +174,7 @@ func TestEnsureSSHPortInTcpPortsIn_NoTcpPortsInSet(t *testing.T) {
 		elements = { 127.0.0.1 }
 	}
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
 	if out != input {
 		t.Errorf("expected unchanged output when no tcp_ports_in set present; got diff")
 	}
@@ -183,8 +183,8 @@ func TestEnsureSSHPortInTcpPortsIn_NoTcpPortsInSet(t *testing.T) {
 // TestEnsureSSHPortInTcpPortsIn_MultilineElements covers the realistic
 // case where elements span multiple lines (large port lists wrapped):
 //
-//   elements = { 20, 21, 25, 53, 80,
-//                110, 143, 443, 465 }
+//	elements = { 20, 21, 25, 53, 80,
+//	             110, 143, 443, 465 }
 //
 // The regex uses (?s) for dotall; injection should still place the port
 // at the head and preserve formatting reasonably.
@@ -195,7 +195,7 @@ func TestEnsureSSHPortInTcpPortsIn_MultilineElements(t *testing.T) {
 	elements = { 20, 21, 25, 53, 80,
 		     110, 143, 443, 465 }
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 22222, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 22222, log)
 	if !strings.Contains(out, "22222") {
 		t.Errorf("expected '22222' in output; got:\n%s", out)
 	}
@@ -213,9 +213,10 @@ func TestEnsureSSHPortInTcpPortsIn_MultilineElements(t *testing.T) {
 // Tests for the new RenderNftablesConfMultiPort entry point that closes the
 // dns2-class lockout vector. The pre-v1.125 RenderNftablesConf path is kept
 // as a back-compat shim around RenderNftablesConfMultiPort with a
-// single-element slice — both paths share the same V121 injection helper
-// (ensureSSHPortInTcpPortsIn), exercised here directly to assert multi-port
-// behavior without spinning up the full executor/file I/O machinery.
+// single-element slice — both paths share the same injection helper
+// (ensureSSHPortsInSet, V121's ensureSSHPortInTcpPortsIn generalized in
+// v1.145 PR-A), exercised here directly to assert multi-port behavior
+// without spinning up the full executor/file I/O machinery.
 //
 // Scope per AUDIT_190_LIFECYCLE/V125_INSTALL_ROBUSTNESS_SCOPE.md §3.1 R-1.
 // =============================================================================
@@ -231,8 +232,8 @@ func TestEnsureSSHPortInTcpPortsIn_MultiPort_BothInjected(t *testing.T) {
 }`
 	// Simulate the v1.125 R-1 multi-port render loop: injection helper
 	// called once per port, in order (primary first).
-	out := ensureSSHPortInTcpPortsIn(input, 22, log)
-	out = ensureSSHPortInTcpPortsIn(out, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 22, log)
+	out = ensureSSHPortsInSet(out, "tcp_ports_in", 55000, log)
 
 	for _, p := range []string{"22", "55000", "80", "443"} {
 		if !strings.Contains(out, p) {
@@ -251,8 +252,8 @@ func TestEnsureSSHPortInTcpPortsIn_MultiPort_PrimaryAlreadyPresent_AdditionalInj
 	elements = { 22, 80, 443 }
 }`
 	// Primary 22 is already present → no-op. Additional 55000 → injection.
-	out := ensureSSHPortInTcpPortsIn(input, 22, log)
-	out = ensureSSHPortInTcpPortsIn(out, 55000, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 22, log)
+	out = ensureSSHPortsInSet(out, "tcp_ports_in", 55000, log)
 
 	if !strings.Contains(out, "22") {
 		t.Errorf("primary port 22 missing from output:\n%s", out)
@@ -276,8 +277,8 @@ func TestEnsureSSHPortInTcpPortsIn_MultiPort_Idempotent_AcrossCalls(t *testing.T
 	input := `set tcp_ports_in {
 	elements = { 80 }
 }`
-	once := ensureSSHPortInTcpPortsIn(input, 55000, log)
-	twice := ensureSSHPortInTcpPortsIn(once, 55000, log)
+	once := ensureSSHPortsInSet(input, "tcp_ports_in", 55000, log)
+	twice := ensureSSHPortsInSet(once, "tcp_ports_in", 55000, log)
 	if once != twice {
 		t.Errorf("multi-port injection NOT idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
 	}
@@ -327,7 +328,7 @@ func TestEnsureSSHPortInTcpPortsIn_PortSubstringDoesNotCount(t *testing.T) {
 	input := `set tcp_ports_in {
 	elements = { 2222, 80, 443 }
 }`
-	out := ensureSSHPortInTcpPortsIn(input, 22, log)
+	out := ensureSSHPortsInSet(input, "tcp_ports_in", 22, log)
 	// Port 22 MUST be injected as an exact whole token (not masked by "2222").
 	if !regexp.MustCompile(`(^|[^0-9])22([^0-9]|$)`).MatchString(out) {
 		t.Fatalf("expected exact port 22 to be injected as a whole token; got:\n%s", out)
@@ -337,7 +338,7 @@ func TestEnsureSSHPortInTcpPortsIn_PortSubstringDoesNotCount(t *testing.T) {
 		t.Errorf("original port 2222 lost from output:\n%s", out)
 	}
 	// Idempotency on the new strict-presence check.
-	out2 := ensureSSHPortInTcpPortsIn(out, 22, log)
+	out2 := ensureSSHPortsInSet(out, "tcp_ports_in", 22, log)
 	if out2 != out {
 		t.Errorf("strict-presence check is NOT idempotent: second call mutated content:\n%s\n---vs---\n%s", out, out2)
 	}
@@ -365,7 +366,7 @@ func TestEnsureSSHPortInTcpPortsIn_AdditionalSubstringDoesNotCount(t *testing.T)
 		t.Run(tt.name, func(t *testing.T) {
 			log := newRenderTestLogger(t)
 			defer log.Close()
-			out := ensureSSHPortInTcpPortsIn(tt.template, tt.target, log)
+			out := ensureSSHPortsInSet(tt.template, "tcp_ports_in", tt.target, log)
 			targetStr := strconv.Itoa(tt.target)
 			// Exact whole-token match for target.
 			tokRe := regexp.MustCompile(`(^|[^0-9])` + targetStr + `([^0-9]|$)`)
@@ -436,5 +437,382 @@ table ip nftban {
 	tokRe := regexp.MustCompile(`(^|[^0-9])22([^0-9]|$)`)
 	if !tokRe.MatchString(out) {
 		t.Errorf("additional port 22 not injected as whole token into tcp_ports_in; rendered output:\n%s", out)
+	}
+}
+
+// =============================================================================
+// v1.145 PR-A — set-driven SSH brute-force rate-limit (`tcp dport @ssh_ports`)
+// =============================================================================
+// These tests cover the generalized injector targeting the ssh_ports set and
+// the integrated multi-port render contract: every detected SSH port must land
+// in BOTH tcp_ports_in (allow-set) and ssh_ports (rate-limit set), the brute-
+// force ct-count rule must read @ssh_ports (no literal SSH dport), and the
+// retired __SSH_PORTS_LIST__ placeholder must never appear in rendered output.
+
+// wholeToken returns a matcher for an exact numeric port token (not masked by
+// a longer number containing it as a substring, e.g. 22 inside 2222).
+func wholeToken(port int) *regexp.Regexp {
+	return regexp.MustCompile(`(^|[^0-9])` + strconv.Itoa(port) + `([^0-9]|$)`)
+}
+
+// ssh_ports block extractor — the inner `elements = { … }` of `set ssh_ports`.
+var sshPortsBlockRe = regexp.MustCompile(`(?s)set ssh_ports \{[^{}]*elements = \{([^}]*)\}`)
+
+func sshPortsElements(t *testing.T, content string) string {
+	t.Helper()
+	m := sshPortsBlockRe.FindStringSubmatch(content)
+	if m == nil {
+		t.Fatalf("no `set ssh_ports { … }` block found in:\n%s", content)
+	}
+	return m[1]
+}
+
+// TestEnsureSSHPortsInSet_V145_TargetsSSHPortsSet asserts the generalized
+// helper injects into the named ssh_ports set (not tcp_ports_in) when asked.
+func TestEnsureSSHPortsInSet_V145_TargetsSSHPortsSet(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set ssh_ports {
+		type inet_service
+		elements = { 22 }
+	}
+}`
+	out := ensureSSHPortsInSet(input, "ssh_ports", 55000, log)
+	if !wholeToken(55000).MatchString(sshPortsElements(t, out)) {
+		t.Errorf("port 55000 not injected into ssh_ports elements; got:\n%s", out)
+	}
+	if !wholeToken(22).MatchString(sshPortsElements(t, out)) {
+		t.Errorf("existing port 22 lost from ssh_ports elements; got:\n%s", out)
+	}
+}
+
+// TestEnsureSSHPortsInSet_V145_DoesNotCrossContaminate asserts that injecting
+// into ssh_ports leaves tcp_ports_in untouched and vice-versa (set targeting
+// is precise — the regex is anchored on the set name).
+func TestEnsureSSHPortsInSet_V145_DoesNotCrossContaminate(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 22, 80, 443 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { 22 }
+	}
+}`
+	// Inject 55000 ONLY into ssh_ports.
+	out := ensureSSHPortsInSet(input, "ssh_ports", 55000, log)
+	if !wholeToken(55000).MatchString(sshPortsElements(t, out)) {
+		t.Errorf("55000 not injected into ssh_ports; got:\n%s", out)
+	}
+	// tcp_ports_in must NOT have gained 55000.
+	tcpRe := regexp.MustCompile(`(?s)set tcp_ports_in \{[^{}]*elements = \{([^}]*)\}`)
+	tcpInner := tcpRe.FindStringSubmatch(out)
+	if tcpInner == nil {
+		t.Fatalf("tcp_ports_in block missing after ssh_ports injection:\n%s", out)
+	}
+	if wholeToken(55000).MatchString(tcpInner[1]) {
+		t.Errorf("ssh_ports injection leaked into tcp_ports_in; got tcp_ports_in elements: %q", tcpInner[1])
+	}
+}
+
+// TestEnsureSSHPortsInSet_V145_SSHPorts_SubstringGuard asserts the v1.125 R-1
+// strict-token presence check carries over to the ssh_ports set (22 must not
+// be considered "present" because 2222 appears).
+func TestEnsureSSHPortsInSet_V145_SSHPorts_SubstringGuard(t *testing.T) {
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	input := `set ssh_ports {
+	elements = { 2222 }
+}`
+	out := ensureSSHPortsInSet(input, "ssh_ports", 22, log)
+	if !wholeToken(22).MatchString(out) {
+		t.Fatalf("port 22 not injected as a whole token into ssh_ports (masked by 2222?); got:\n%s", out)
+	}
+	if !strings.Contains(out, "2222") {
+		t.Errorf("existing 2222 lost from ssh_ports; got:\n%s", out)
+	}
+	// Idempotent on the strict-presence path.
+	if out2 := ensureSSHPortsInSet(out, "ssh_ports", 22, log); out2 != out {
+		t.Errorf("ssh_ports injection not idempotent; second call mutated content")
+	}
+}
+
+// renderSetDrivenMock returns a mock executor seeded with a representative
+// v1.145 template: both port sets seeded via __SSH_PORT__, plus the set-driven
+// ct-count rule reading @ssh_ports.
+func renderSetDrivenTemplate() string {
+	return `# v1.145 set-driven template (test fixture)
+table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { __SSH_PORT__, 80, 443 }
+	}
+	set udp_ports_in {
+		type inet_service
+		elements = { 53 }
+	}
+	set udp_ports_out {
+		type inet_service
+		elements = { 53, 123 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { __SSH_PORT__ }
+	}
+	chain input {
+		ct state new tcp dport @ssh_ports ct count over __CT_LIMIT_SSH__ counter drop comment "SSH set-driven"
+		ct state new tcp dport { 80, 443 } ct count over __CT_LIMIT_HTTP__ counter drop comment "HTTP(S)"
+		ct state new tcp dport { 25, 465, 587 } ct count over __CT_LIMIT_MAIL__ counter drop comment "MAIL"
+	}
+}
+`
+}
+
+// setElements extracts the inner `elements = { … }` text of the named set.
+func setElements(t *testing.T, content, setName string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)set ` + regexp.QuoteMeta(setName) + ` \{[^{}]*elements = \{([^}]*)\}`)
+	m := re.FindStringSubmatch(content)
+	if m == nil {
+		t.Fatalf("no `set %s { … }` block found in:\n%s", setName, content)
+	}
+	return m[1]
+}
+
+// tokenCount returns how many times port appears as a whole numeric token in s.
+func tokenCount(s string, port int) int {
+	return len(regexp.MustCompile(`(^|[^0-9])`+strconv.Itoa(port)+`([^0-9]|$)`).FindAllString(s, -1))
+}
+
+// renderForPorts renders renderSetDrivenTemplate with the given sshPorts and
+// returns the written output.
+func renderForPorts(t *testing.T, sshPorts []int) string {
+	t.Helper()
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	mock := executor.NewMockExecutor()
+	mock.Files["/etc/nftban/nftables.conf"] = []byte(renderSetDrivenTemplate())
+	if err := RenderNftablesConfMultiPort(mock, sshPorts, detect.CTLimits{SSH: 15, HTTP: 200, Mail: 30}, log); err != nil {
+		t.Fatalf("RenderNftablesConfMultiPort(%v): %v", sshPorts, err)
+	}
+	written, ok := mock.WrittenFiles["/etc/nftban/nftables.conf"]
+	if !ok {
+		t.Fatalf("render did not write nftables.conf for sshPorts=%v", sshPorts)
+	}
+	return string(written)
+}
+
+// ADD_V145_PR_A_SET_DEDUP_AND_OVERLAP_TESTS — assertion #2: duplicate INPUT
+// ports collapse to a single token in BOTH sets.
+func TestRenderV145_DuplicateInputPorts_NoDuplicateTokens(t *testing.T) {
+	out := renderForPorts(t, []int{22, 22, 55000, 55000})
+	tcp := setElements(t, out, "tcp_ports_in")
+	ssh := setElements(t, out, "ssh_ports")
+	for _, p := range []int{22, 55000} {
+		if c := tokenCount(tcp, p); c != 1 {
+			t.Errorf("tcp_ports_in: port %d appears %d times, want exactly 1; elements=%q", p, c, tcp)
+		}
+		if c := tokenCount(ssh, p); c != 1 {
+			t.Errorf("ssh_ports: port %d appears %d times, want exactly 1; elements=%q", p, c, ssh)
+		}
+	}
+}
+
+// assertion #3: intentional overlap — both ports in BOTH sets.
+func TestRenderV145_IntentionalOverlap_BothSetsContainBothPorts(t *testing.T) {
+	out := renderForPorts(t, []int{22, 55000})
+	tcp := setElements(t, out, "tcp_ports_in")
+	ssh := setElements(t, out, "ssh_ports")
+	for _, p := range []int{22, 55000} {
+		if tokenCount(tcp, p) != 1 {
+			t.Errorf("tcp_ports_in missing port %d (want exactly 1); elements=%q", p, tcp)
+		}
+		if tokenCount(ssh, p) != 1 {
+			t.Errorf("ssh_ports missing port %d (want exactly 1); elements=%q", p, ssh)
+		}
+	}
+}
+
+// assertion #4: no UDP contamination — SSH ports must NOT reach udp sets.
+func TestRenderV145_NoUDPContamination(t *testing.T) {
+	out := renderForPorts(t, []int{22, 55000})
+	for _, set := range []string{"udp_ports_in", "udp_ports_out"} {
+		elems := setElements(t, out, set)
+		for _, p := range []int{22, 55000} {
+			if tokenCount(elems, p) != 0 {
+				t.Errorf("SSH port %d leaked into %s; elements=%q", p, set, elems)
+			}
+		}
+	}
+}
+
+// assertion #7: HTTP service ports must NOT reach ssh_ports.
+func TestRenderV145_HTTPPortsNotInSSHSet(t *testing.T) {
+	out := renderForPorts(t, []int{22, 55000})
+	ssh := setElements(t, out, "ssh_ports")
+	for _, p := range []int{80, 443} {
+		if tokenCount(ssh, p) != 0 {
+			t.Errorf("HTTP port %d leaked into ssh_ports; elements=%q", p, ssh)
+		}
+	}
+	// And they remain in tcp_ports_in.
+	tcp := setElements(t, out, "tcp_ports_in")
+	for _, p := range []int{80, 443} {
+		if tokenCount(tcp, p) != 1 {
+			t.Errorf("service port %d missing from tcp_ports_in; elements=%q", p, tcp)
+		}
+	}
+}
+
+// assertion #6: SSH ct-count rule is set-driven (@ssh_ports), never literal or
+// @tcp_ports_in.
+func TestRenderV145_CtCountRuleIsSetDriven(t *testing.T) {
+	out := renderForPorts(t, []int{22, 55000})
+	if !strings.Contains(out, "tcp dport @ssh_ports ct count") {
+		t.Errorf("expected `tcp dport @ssh_ports ct count`; got:\n%s", out)
+	}
+	for _, bad := range []string{
+		"tcp dport 22 ct count",
+		"tcp dport 55000 ct count",
+		"tcp dport @tcp_ports_in ct count",
+	} {
+		if strings.Contains(out, bad) {
+			t.Errorf("SSH ct-count rule must not use %q", bad)
+		}
+	}
+}
+
+// assertion #8: reserved-port duplicate edge — sshPorts=[80] / [443] must NOT
+// produce a duplicate token in tcp_ports_in even though the template hardcodes
+// 80/443. (It is acceptable that ssh_ports holds the detected SSH port; the
+// renderer does not validate the daemon's bind policy.)
+func TestRenderV145_ReservedPortDuplicateEdge(t *testing.T) {
+	for _, p := range []int{80, 443} {
+		t.Run(strconv.Itoa(p), func(t *testing.T) {
+			out := renderForPorts(t, []int{p})
+			tcp := setElements(t, out, "tcp_ports_in")
+			if c := tokenCount(tcp, p); c != 1 {
+				t.Errorf("tcp_ports_in: reserved port %d appears %d times, want exactly 1 (dedup failed); elements=%q", p, c, tcp)
+			}
+			// The other reserved port must still be present exactly once.
+			other := 443
+			if p == 443 {
+				other = 80
+			}
+			if c := tokenCount(tcp, other); c != 1 {
+				t.Errorf("tcp_ports_in: service port %d appears %d times, want exactly 1; elements=%q", other, c, tcp)
+			}
+		})
+	}
+}
+
+// TestRenderNftablesConfMultiPort_V145_SetDriven is the integrated render
+// contract for PR-A. For each port shape, the rendered output must:
+//   - contain every SSH port in tcp_ports_in (whole token)
+//   - contain every SSH port in ssh_ports (whole token)
+//   - keep the brute-force rule set-driven (`tcp dport @ssh_ports ct count`)
+//   - carry NO literal `tcp dport <sshport> ct count` rule
+//   - contain no retired __SSH_PORTS_LIST__ placeholder
+func TestRenderNftablesConfMultiPort_V145_SetDriven(t *testing.T) {
+	cases := []struct {
+		name     string
+		sshPorts []int
+	}{
+		{"default single port 22", []int{22}},
+		{"non-default single port 55000", []int{55000}},
+		{"multi-port primary-first 22+55000", []int{22, 55000}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			log := newRenderTestLogger(t)
+			defer log.Close()
+			mock := executor.NewMockExecutor()
+			mock.Files["/etc/nftban/nftables.conf"] = []byte(renderSetDrivenTemplate())
+
+			if err := RenderNftablesConfMultiPort(mock, tc.sshPorts, detect.CTLimits{SSH: 15, HTTP: 200, Mail: 30}, log); err != nil {
+				t.Fatalf("RenderNftablesConfMultiPort: %v", err)
+			}
+			written, ok := mock.WrittenFiles["/etc/nftban/nftables.conf"]
+			if !ok {
+				t.Fatal("render did not write /etc/nftban/nftables.conf")
+			}
+			out := string(written)
+
+			// Retired placeholder must never survive.
+			if strings.Contains(out, "__SSH_PORTS_LIST__") {
+				t.Errorf("retired __SSH_PORTS_LIST__ placeholder present in rendered output:\n%s", out)
+			}
+			// Brute-force rule must be set-driven.
+			if !strings.Contains(out, "tcp dport @ssh_ports ct count") {
+				t.Errorf("expected set-driven `tcp dport @ssh_ports ct count` rule; got:\n%s", out)
+			}
+
+			sshElems := sshPortsElements(t, out)
+			tcpRe := regexp.MustCompile(`(?s)set tcp_ports_in \{[^{}]*elements = \{([^}]*)\}`)
+			tcpM := tcpRe.FindStringSubmatch(out)
+			if tcpM == nil {
+				t.Fatalf("tcp_ports_in block missing:\n%s", out)
+			}
+			tcpElems := tcpM[1]
+
+			for _, p := range tc.sshPorts {
+				if !wholeToken(p).MatchString(sshElems) {
+					t.Errorf("SSH port %d missing from ssh_ports elements %q", p, sshElems)
+				}
+				if !wholeToken(p).MatchString(tcpElems) {
+					t.Errorf("SSH port %d missing from tcp_ports_in elements %q", p, tcpElems)
+				}
+				// No literal per-port ct-count rule (rule is set-driven).
+				if strings.Contains(out, "tcp dport "+strconv.Itoa(p)+" ct count") {
+					t.Errorf("found literal `tcp dport %d ct count` — brute-force rule must be set-driven via @ssh_ports", p)
+				}
+			}
+		})
+	}
+}
+
+// ADD_V145_PR_A_MAIL_RESERVED_PORT_RENDER_TESTS — when the detected SSH port is
+// a mail-reserved port (25/465/587), the renderer must still place exactly one
+// token in each port set, never contaminate UDP sets, leave the MAIL ct-count
+// anonymous set { 25, 465, 587 } untouched (it is an inline rule set, not a
+// named `set { … }` block the injector operates on), and keep the SSH ct-count
+// rule set-driven (@ssh_ports) with no literal SSH ct-count rule.
+func TestRenderV145_MailReservedSSHPort(t *testing.T) {
+	for _, p := range []int{25, 465, 587} {
+		t.Run(strconv.Itoa(p), func(t *testing.T) {
+			out := renderForPorts(t, []int{p})
+
+			tcp := setElements(t, out, "tcp_ports_in")
+			ssh := setElements(t, out, "ssh_ports")
+			if c := tokenCount(tcp, p); c != 1 {
+				t.Errorf("tcp_ports_in: port %d appears %d times, want exactly 1; elements=%q", p, c, tcp)
+			}
+			if c := tokenCount(ssh, p); c != 1 {
+				t.Errorf("ssh_ports: port %d appears %d times, want exactly 1; elements=%q", p, c, ssh)
+			}
+
+			// No UDP contamination.
+			for _, set := range []string{"udp_ports_in", "udp_ports_out"} {
+				if tokenCount(setElements(t, out, set), p) != 0 {
+					t.Errorf("SSH port %d leaked into %s", p, set)
+				}
+			}
+
+			// MAIL ct-count anonymous set must remain intact.
+			if !strings.Contains(out, "tcp dport { 25, 465, 587 } ct count") {
+				t.Errorf("MAIL ct-count anonymous set { 25, 465, 587 } was altered; rendered:\n%s", out)
+			}
+			// SSH ct-count rule stays set-driven; no literal SSH ct-count rule.
+			if !strings.Contains(out, "tcp dport @ssh_ports ct count") {
+				t.Errorf("SSH ct-count rule is not set-driven (@ssh_ports); rendered:\n%s", out)
+			}
+			if strings.Contains(out, "tcp dport "+strconv.Itoa(p)+" ct count") {
+				t.Errorf("found literal `tcp dport %d ct count` — SSH brute-force rule must use @ssh_ports", p)
+			}
+		})
 	}
 }

--- a/internal/validator/schema_generated.go
+++ b/internal/validator/schema_generated.go
@@ -54,6 +54,7 @@ var GeneratedAllHelperChains = []string{
 var GeneratedRequiredSetsIPv4 = []string{
 	"blacklist_ipv4",
 	"blacklist_manual_ipv4",
+	"ssh_ports",
 	"tcp_ports_in",
 	"udp_ports_in",
 	"whitelist_ipv4",
@@ -63,6 +64,7 @@ var GeneratedRequiredSetsIPv4 = []string{
 var GeneratedRequiredSetsIPv6 = []string{
 	"blacklist_ipv6",
 	"blacklist_manual_ipv6",
+	"ssh_ports",
 	"tcp_ports_in",
 	"udp_ports_in",
 	"whitelist_ipv6",
@@ -80,6 +82,7 @@ var GeneratedAllSetsIPv4 = []string{
 	"http_bot_suspect",
 	"port_allow_tcp_ipv4",
 	"port_allow_udp_ipv4",
+	"ssh_ports",
 	"tcp_ports_in",
 	"tcp_ports_out",
 	"udp_ports_in",
@@ -99,6 +102,7 @@ var GeneratedAllSetsIPv6 = []string{
 	"http_bot_suspect6",
 	"port_allow_tcp_ipv6",
 	"port_allow_udp_ipv6",
+	"ssh_ports",
 	"tcp_ports_in",
 	"tcp_ports_out",
 	"udp_ports_in",

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1005,6 +1005,32 @@ if [ -x "\$NFTBAN_INSTALLER" ]; then
         echo "[NFTBan] To retry: /usr/lib/nftban/bin/nftban-installer --repair"
         echo "[NFTBan] Or: nftban firewall rebuild"
     fi
+
+    # --- v1.145 PR-A.1: upgrade-path SSH rate-limit migration ---
+    # On upgrade the installer's rebuild path (switchop.Rebuild ->
+    # \`nftban firewall rebuild\`) rebuilds from the v1.145 template
+    # (/usr/lib/nftban/templates/nftables.conf.tpl) and atomically applies the
+    # set-driven SSH brute-force rule (tcp dport @ssh_ports ct count) via
+    # nft -f. This explicit reload is a defense-in-depth guarantee that an
+    # existing v1.142-1.144 install — whose LIVE kernel still carries the OLD
+    # literal \`tcp dport <port> ct count\` rule — is migrated to the set-driven
+    # form with NO operator action required.
+    #
+    # Gated: runs ONLY on upgrade (\$1 -ge 2 above sets INSTALL_MODE=upgrade),
+    # and ONLY when the installer COMMITTED (0) or DEGRADED (1). Skipped on
+    # authority-abort (3) and hard-fail so it never overrides a deliberate
+    # safe/handoff state. \`nftban firewall reload\` is atomic (nft -f — the
+    # kernel never sees an empty/partial ruleset) and this call is NON-FATAL:
+    # a reload failure is warned and the package upgrade continues.
+    if [ "\$INSTALL_MODE" = "upgrade" ] && [ "\${INSTALLER_EXIT:-0}" -le 1 ] && [ -x /usr/sbin/nftban ]; then
+        echo "[NFTBan] v1.145: re-applying set-driven SSH rate-limit rule (atomic firewall reload)..."
+        if /usr/sbin/nftban firewall reload --quiet >/dev/null 2>&1; then
+            echo "[NFTBan] v1.145: SSH brute-force rule migrated to @ssh_ports (set-driven)."
+        else
+            echo "[NFTBan] WARN: v1.145 firewall reload did not complete; previous ruleset retained — upgrade continues."
+            echo "[NFTBan] WARN: to finish the migration manually, run: nftban firewall reload"
+        fi
+    fi
 else
     echo "[NFTBan ERROR] Installer binary not found: \$NFTBAN_INSTALLER"
     echo "[NFTBan ERROR] Package may be corrupt. Try reinstalling."

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -187,15 +187,14 @@ case "$1" in
         # Must run AFTER nftban group is created. DEB payload ships 0750
         # root:root; postinst converges to root:nftban 0750 so the runtime
         # permissions module does not repeatedly correct drift.
-        # v1.100.1b.A: nftban-ui no longer ships, but the loop tolerates absence.
-        # Old installs may still have /usr/sbin/nftban-ui from a prior package;
-        # the prerm/postrm cleanup paths handle removal of those orphaned files.
-        for _bin in /usr/sbin/nftban; do
-            if [ -f "$_bin" ]; then
-                chown root:nftban "$_bin" 2>/dev/null || true
-                chmod 0750 "$_bin" 2>/dev/null || true
-            fi
-        done
+        # nftban-ui (Web GUI) is decommissioned (GOTH retirement) and no longer
+        # ships, so the only privileged binary to converge here is the nftban
+        # CLI dispatcher. Any orphaned /usr/sbin/nftban-ui left by a pre-GOTH
+        # package is removed by the prerm/postrm cleanup paths, not here.
+        if [ -f /usr/sbin/nftban ]; then
+            chown root:nftban /usr/sbin/nftban 2>/dev/null || true
+            chmod 0750 /usr/sbin/nftban 2>/dev/null || true
+        fi
 
         # --- Critical FHS dirs (Go installer needs state dir to exist) ---
         mkdir -p /var/lib/nftban/state
@@ -289,6 +288,34 @@ case "$1" in
                 log_error "See log: /var/log/nftban/installer.log"
                 log_error "To retry: /usr/lib/nftban/bin/nftban-installer --repair"
                 log_error "Or: nftban firewall rebuild"
+            fi
+
+            # --- v1.145 PR-A.1: upgrade-path SSH rate-limit migration ---
+            # On upgrade the installer's rebuild path (switchop.Rebuild ->
+            # `nftban firewall rebuild`) rebuilds from the v1.145 template
+            # (/usr/lib/nftban/templates/nftables.conf.tpl) and atomically
+            # applies the set-driven SSH brute-force rule (tcp dport @ssh_ports
+            # ct count) via nft -f. This explicit reload is a defense-in-depth
+            # guarantee that an existing v1.142–1.144 install — whose LIVE
+            # kernel still carries the OLD literal `tcp dport <port> ct count`
+            # rule — is migrated to the set-driven form with NO operator action
+            # required.
+            #
+            # Gated: runs ONLY on upgrade, and ONLY when the installer COMMITTED
+            # (0) or DEGRADED (1). Skipped on authority-abort (3) and hard-fail
+            # so it never overrides a deliberate safe/handoff state (e.g. a host
+            # nftban did not take over). `nftban firewall reload` is atomic
+            # (nft -f — the kernel never sees an empty/partial ruleset) and this
+            # call is NON-FATAL: a reload failure is warned and the package
+            # upgrade continues (nft -f retains the previous ruleset on error).
+            if [ "$INSTALL_MODE" = "upgrade" ] && [ "${INSTALLER_EXIT:-0}" -le 1 ] && [ -x /usr/sbin/nftban ]; then
+                log_info "v1.145: re-applying set-driven SSH rate-limit rule (atomic firewall reload)..."
+                if /usr/sbin/nftban firewall reload --quiet >/dev/null 2>&1; then
+                    log_info "v1.145: SSH brute-force rule migrated to @ssh_ports (set-driven)."
+                else
+                    log_warn "v1.145: firewall reload did not complete; previous ruleset retained — upgrade continues."
+                    log_warn "v1.145: to finish the migration manually, run: nftban firewall reload"
+                fi
             fi
         else
             log_error "Installer binary not found: $NFTBAN_INSTALLER"

--- a/scripts/generate-go-schema.sh
+++ b/scripts/generate-go-schema.sh
@@ -108,6 +108,7 @@ required_helper_chains=""
 required_sets_v4=$(printf '%s\n' \
     "blacklist_ipv4" \
     "blacklist_manual_ipv4" \
+    "ssh_ports" \
     "tcp_ports_in" \
     "udp_ports_in" \
     "whitelist_ipv4" | sort)
@@ -115,6 +116,7 @@ required_sets_v4=$(printf '%s\n' \
 required_sets_v6=$(printf '%s\n' \
     "blacklist_ipv6" \
     "blacklist_manual_ipv6" \
+    "ssh_ports" \
     "tcp_ports_in" \
     "udp_ports_in" \
     "whitelist_ipv6" | sort)


### PR DESCRIPTION
## v1.145 PR-A — set-driven SSH brute-force rate-limit (closes Gap 2)

Replaces the hardcoded `tcp dport __SSH_PORT__ ct count` SSH brute-force rule in every shipped template with `tcp dport @ssh_ports ct count`, where `ssh_ports` is a new named set. The rate-limit dport is now set-driven, so it covers every detected SSH port and can be updated atomically without re-rendering the rule expression.

### Key points
- **No schema-version bump** — `SchemaVersionCurrent` remains `1.83.0`.
- `ssh_ports` is **generated validator inventory only** (`nft_schema.sh` → `scripts/generate-go-schema.sh` → `schema_generated.go`); it is not part of the external JSON output schema.
- The duplicate `__SSH_PORTS_LIST__` placeholder is **removed**; the renderer reuses the generalized `ensureSSHPortsInSet` helper (no duplicate machinery).
- The SSH ct-count rule now uses **`tcp dport @ssh_ports`** in all 3 templates (primary, safe, ipv4-only).
- The renderer injects every detected SSH port into **both** `tcp_ports_in` and `ssh_ports`.
- Added **dedup / overlap / no-UDP-contamination / no-HTTP-in-ssh_ports** regression tests, plus a `dedupePortSetElements` backstop for the substitution-created duplicate edge (e.g. `sshPorts=[80]`), and a new static guard (18 assertions incl. no-hardcoded-port).

### PR-A.1 — upgrade-path migration
- DEB `postinst` + RPM `%post` include an upgrade reload hook so existing v1.142–1.144 installs migrate the old literal rule to `@ssh_ports` with no operator action.
- The hook is **upgrade-only**, **atomic** (`nftban firewall reload` = `nft -f`), and **non-fatal** (reload failure warns; the package upgrade continues; previous ruleset retained on error). Gated to installer COMMITTED/DEGRADED so it never overrides an authority-abort.

### Validation
- **lab2 (Ubuntu 24.04) DEB** + **lab4 (EL9) RPM** builds: rc=0; packaged `postinst`/`%post` carry the gated hook.
- `go build/vet/test ./...` = 76 ok / 0 fail; 12 new render tests; static 18/0; `staticcheck`/`gosec`/`shellcheck` clean; schema regen deterministic.
- **No production mutation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
