### PR TITLE
feat(security): v1.145 PR-B runtime SSH-port detection union and set parity

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -236,6 +236,18 @@ build_validator() {
     chmod +x "$BIN_DIR/nftban-validate"
     ok "Built: $BIN_DIR/nftban-validate"
 
+    # v1.145 PR-B: SSH-port union detector — pure Go, zero-side-effect, shared
+    # by installer + runtime shell paths via ssh_port_detect.sh.
+    CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH \
+        go build -trimpath -o "$BIN_DIR/nftban-detect-ssh-ports" \
+        -ldflags="$LDFLAGS" \
+        ./cmd/nftban-detect-ssh-ports || {
+        error "Failed to build nftban-detect-ssh-ports"
+        return 1
+    }
+    chmod +x "$BIN_DIR/nftban-detect-ssh-ports"
+    ok "Built: $BIN_DIR/nftban-detect-ssh-ports"
+
     cd "$SCRIPT_DIR"
     return 0
 }

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -108,43 +108,19 @@ _firewall_substitute_placeholders() {
         return 1
     fi
 
-    # BUG-2: SSH port detection — sshd_config → ss → state file → nft set → default 22
-    # Priority: authoritative config → runtime → saved state → live firewall → fallback
-    # Previous order (nft set first) caused port 20 (FTP) to be picked as "SSH port"
-    # when the nft set contained stale entries.
+    # v1.145 PR-B: single SSH port for this display/CT-limit context. Uses the
+    # NAMED primary helper (lowest of the detected union via the shared Go
+    # detector: ss + sshd_config Port + ListenAddress + state + conf.local) —
+    # NOT a silent head -1. A single value is acceptable HERE because this only
+    # seeds a per-IP CT-limit/display value; full multi-port firewall
+    # ENFORCEMENT is rendered set-driven (@ssh_ports) and kept in parity by the
+    # maintenance/health autofix paths (which use the full union in both sets).
     local _ssh_port=""
-    # 1. sshd_config (authoritative source of truth for SSH port)
-    _ssh_port=$(grep -m1 -oP '^\s*Port\s+\K[0-9]+' /etc/ssh/sshd_config 2>/dev/null) || true
-    if [[ -z "$_ssh_port" ]]; then
-        for _inc in /etc/ssh/sshd_config.d/*.conf; do
-            [[ -f "$_inc" ]] || continue
-            _ssh_port=$(grep -m1 -oP '^\s*Port\s+\K[0-9]+' "$_inc" 2>/dev/null) || true
-            [[ -n "$_ssh_port" ]] && break || true
-        done
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    if declare -f nftban_detect_ssh_primary_port >/dev/null 2>&1; then
+        _ssh_port=$(nftban_detect_ssh_primary_port 2>/dev/null) || true
     fi
-    # 2. ss (what sshd is actually listening on)
-    if [[ -z "$_ssh_port" || ! "$_ssh_port" =~ ^[0-9]+$ ]]; then
-        _ssh_port=$(ss -tlnp 2>/dev/null | grep -oP '"sshd".*:(\K[0-9]+)' | head -1) || true
-    fi
-    # 3. State file
-    if [[ -z "$_ssh_port" || ! "$_ssh_port" =~ ^[0-9]+$ ]]; then
-        local _ssh_port_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/ssh_port_active.state"
-        [[ -f "$_ssh_port_file" ]] && _ssh_port=$(cat "$_ssh_port_file" 2>/dev/null) || true
-    fi
-    # 4. Live nft set (last resort — may contain stale ports)
-    if [[ -z "$_ssh_port" || ! "$_ssh_port" =~ ^[0-9]+$ ]]; then
-        if command -v nft &>/dev/null; then
-            local _live_ports
-            _live_ports=$(nft list set ip nftban tcp_ports_in 2>/dev/null | grep -oP 'elements\s*=\s*\{\s*\K[^}]+' | tr ',' '\n' | tr -d ' ') || true
-            while IFS= read -r _p; do
-                [[ "$_p" =~ ^[0-9]+$ ]] || continue
-                [[ "$_p" == "80" || "$_p" == "443" ]] && continue
-                _ssh_port="$_p"
-                break
-            done <<< "${_live_ports:-}"
-        fi
-    fi
-    # 5. Fallback to port 22
     [[ -z "$_ssh_port" || ! "$_ssh_port" =~ ^[0-9]+$ ]] && _ssh_port=22
 
     # CT limits — use DDoS config when available, else sensible defaults

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -536,6 +536,17 @@ nftban_cmd_port() {
                     if nft_ipc_add_port "$port" "$proto" "$direction" 2>/dev/null; then
                         echo "  ✓ Port $port applied to firewall (IPv4 + IPv6)"
                         add_success=true
+                        # v1.145 PR-B both-set parity: if this port is a detected
+                        # SSH listener, also add it to ssh_ports so the set-driven
+                        # brute-force rate-limit (tcp dport @ssh_ports) covers it.
+                        # shellcheck source=/dev/null
+                        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+                        if declare -f nftban_detect_ssh_ports >/dev/null 2>&1 && \
+                           nftban_detect_ssh_ports 2>/dev/null | grep -qx "$port"; then
+                            nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" ssh_ports "$port" 2>/dev/null || true
+                            nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" ssh_ports "$port" 2>/dev/null || true
+                            echo "  ✓ SSH port $port also added to ssh_ports (brute-force parity)"
+                        fi
                     else
                         echo "  ⚠ Could not add port via daemon" >&2
                     fi
@@ -682,6 +693,12 @@ nftban_cmd_port() {
                     # Use atomic delete_port IPC - remove from all sets (both protocols, both directions)
                     if nft_ipc_delete_port "$port" "both" "both" 2>/dev/null; then
                         echo "  ✓ Port $port removed from firewall (IPv4 + IPv6)"
+                        # v1.145 PR-B both-set parity: also remove from ssh_ports.
+                        # The active SSH_CLIENT port is already guarded above, so
+                        # this cannot drop brute-force protection for the live
+                        # session. No-op if the port was not in ssh_ports.
+                        nft_ipc_delete_element "${NFTBAN_TABLE_IPV4}" ssh_ports "$port" 2>/dev/null || true
+                        nft_ipc_delete_element "${NFTBAN_TABLE_IPV6}" ssh_ports "$port" 2>/dev/null || true
                         echo ""
                         echo "✅ Port $port is now blocked in firewall"
                     else

--- a/cli/lib/nftban/cli/cmd_system.sh
+++ b/cli/lib/nftban/cli/cmd_system.sh
@@ -181,43 +181,43 @@ _nftban_auto_whitelist_ssh_port() {
     local ports_dir="${NFTBAN_CONFIG_DIR}/ports.d"
     local ssh_conf="${ports_dir}/00-ssh.conf"
     local sshd_config="/etc/ssh/sshd_config"
-    local ssh_port="22"
-
-    # Try to detect SSH port from sshd_config
-    if [[ -f "$sshd_config" ]]; then
-        local detected_port
-        detected_port=$(grep -E "^Port\s+" "$sshd_config" 2>/dev/null | awk '{print $2}' | head -1 || true)
-        if [[ -n "$detected_port" && "$detected_port" =~ ^[0-9]+$ ]]; then
-            ssh_port="$detected_port"
-        fi
+    # v1.145 PR-B: detect the full SSH-port union (ListenAddress-aware,
+    # multi-port; ss listeners + sshd_config Port + ListenAddress) instead of
+    # scalar head -1 + ss head -1. Every detected port is whitelisted in
+    # ports.d so all real listeners survive a reload (handles Ubuntu socket
+    # activation and multi-port hosts). ssh_port = primary for display only.
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    local ssh_ports_union=()
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        mapfile -t ssh_ports_union < <(nftban_detect_ssh_ports 2>/dev/null || true)
     fi
-
-    # Fallback: detect from running sshd (handles Ubuntu 24.04 socket activation
-    # where sshd_config Port may not reflect the actual listening port)
-    if [[ "$ssh_port" == "22" ]]; then
-        local ss_port
-        ss_port=$(ss -tlnp 2>/dev/null | grep -E 'sshd|"ssh"' | grep -oP ':(\d+)\s' | head -1 | tr -d ':[:space:]' || true)
-        if [[ -n "$ss_port" && "$ss_port" =~ ^[0-9]+$ && "$ss_port" != "22" ]]; then
-            ssh_port="$ss_port"
-        fi
-    fi
+    [[ ${#ssh_ports_union[@]} -eq 0 ]] && ssh_ports_union=(22)
 
     mkdir -p "$ports_dir" || return 1
 
-    # Create or update SSH port config (Go-compatible PORT/PROTOCOL/DIRECTION format)
-    if [[ ! -f "$ssh_conf" ]] || ! grep -q "^${ssh_port}/" "$ssh_conf" 2>/dev/null; then
-        cat > "$ssh_conf" << EOF
-# Auto-generated SSH port whitelist
-# Created by: nftban system enable
-# Date: $(date -Iseconds)
-# Detected from: $sshd_config
-# Format: PORT/PROTOCOL/DIRECTION (T=TCP, I=Input)
-${ssh_port}/T/I
-EOF
+    # Create or update SSH port config (Go PORT/PROTOCOL/DIRECTION). v1.145
+    # PR-B: write EVERY detected SSH port so multi-port / ListenAddress hosts
+    # keep all listeners whitelisted (lockout-safe).
+    local _missing=0 _p
+    for _p in "${ssh_ports_union[@]}"; do
+        if [[ ! -f "$ssh_conf" ]] || ! grep -q "^${_p}/" "$ssh_conf" 2>/dev/null; then
+            _missing=1
+        fi
+    done
+    if [[ "$_missing" -eq 1 ]]; then
+        {
+            echo "# Auto-generated SSH port whitelist"
+            echo "# Created by: nftban system enable"
+            echo "# Date: $(date -Iseconds)"
+            echo "# Detected from: $sshd_config + ss listeners (union)"
+            echo "# Format: PORT/PROTOCOL/DIRECTION (T=TCP, I=Input)"
+            for _p in "${ssh_ports_union[@]}"; do echo "${_p}/T/I"; done
+        } > "$ssh_conf"
         chmod 644 "$ssh_conf"
-        echo "  ✅ SSH port whitelisted: $ssh_port/tcp"
+        echo "  ✅ SSH port(s) whitelisted: ${ssh_ports_union[*]}/tcp"
     else
-        echo "  ✅ SSH port already whitelisted: $ssh_port/tcp"
+        echo "  ✅ SSH port(s) already whitelisted: ${ssh_ports_union[*]}/tcp"
     fi
 }
 

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -103,22 +103,22 @@ unset _UPDATE_CLI_DIR _update_modules _module _module_path
 # =============================================================================
 
 _update_detect_ssh_port() {
-    # Detect active SSH port using canonical 3-tier fallback:
-    #   1. State file (most reliable, written by nftban)
-    #   2. sshd_config Port directive
-    #   3. Default 22
-    local ssh_port=22
-    local ssh_port_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/ssh_port_active.state"
-    if [[ -f "$ssh_port_file" ]]; then
-        local _sp
-        _sp=$(cat "$ssh_port_file" 2>/dev/null) || true
-        [[ "$_sp" =~ ^[0-9]+$ ]] && ssh_port="$_sp"
-    elif [[ -f /etc/ssh/sshd_config ]]; then
-        local _sp
-        _sp=$(grep -E '^\s*Port\s+[0-9]+' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}' | head -1) || true
-        [[ "$_sp" =~ ^[0-9]+$ ]] && ssh_port="$_sp"
+    # v1.145 PR-B: return the full SSH-port UNION (ListenAddress-aware,
+    # multi-port), ONE PER LINE, via the shared Go detector — replaces the
+    # scalar state-file/sshd_config `head -1` chain. Callers iterate every
+    # detected port through the dual-surface durability check so a multi-port
+    # or ListenAddress host can't have one of its listeners silently unchecked.
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        local _u
+        _u=$(nftban_detect_ssh_ports 2>/dev/null || true)
+        if [[ -n "$_u" ]]; then
+            printf '%s\n' "$_u"
+            return 0
+        fi
     fi
-    echo "$ssh_port"
+    echo 22
 }
 
 # =============================================================================
@@ -584,46 +584,46 @@ _cmd_update_main_locked() {
     # V2: SSH port reachable in whitelist (V121 dual-surface check —
     # D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001 closure)
     if command -v nft &>/dev/null; then
-        local _ssh_port
-        _ssh_port=$(_update_detect_ssh_port)
-        # Surface 1 (live kernel): SSH port in nft set tcp_ports_in
-        local _ssh_in_kernel=0
+        # v1.145 PR-B: iterate EVERY detected SSH port (union) through the
+        # dual-surface check so a multi-port / ListenAddress host can't have one
+        # of its listeners silently unchecked.
+        local _ssh_port _ssh_ports_all
         local _tbl_v4="${NFTBAN_TABLE_IPV4:-ip nftban}"
         local _tbl_v6="${NFTBAN_TABLE_IPV6:-ip6 nftban}"
-        if nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
-            _ssh_in_kernel=1
-        fi
-        if nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
-            _ssh_in_kernel=1
-        fi
-        # Surface 2 (durable config): SSH port reachable via Mechanism A
-        # (TCP_PORTS_IN includes port) OR Mechanism B (SSH_PORT=port drives
-        # render injection of rendered nftables.conf).
-        local _ssh_in_durable=0
-        # Mechanism A: explicit TCP_PORTS_IN list in operator canonical
-        if [[ -f /etc/nftban/nftban.conf.local ]] && \
-           grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
-            _ssh_in_durable=1
-        fi
-        # Mechanism B: SSH_PORT=<port> drives render injection; verify by
-        # checking the rendered nftables.conf actually carries the port.
-        if [[ $_ssh_in_durable -eq 0 ]] && \
-           [[ -f /etc/nftban/nftban.conf.local ]] && \
-           grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
-           grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
-            _ssh_in_durable=1
-        fi
-        # Report
-        if [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 1 ]]; then
-            _update_log OK "SSH port ${_ssh_port}: present in kernel AND durable config"
-        elif [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 0 ]]; then
-            _update_log WARN "SSH port ${_ssh_port}: present in kernel but NOT in durable config — lockout risk on next reload/reboot. Add SSH_PORT=${_ssh_port} or include ${_ssh_port} in TCP_PORTS_IN in /etc/nftban/nftban.conf.local"
-            # WARN (not FAIL) because the current session is safe; operator
-            # needs to act before next reload to make protection durable.
-        elif [[ $_ssh_in_kernel -eq 0 ]]; then
-            _update_log ERROR "SSH port ${_ssh_port}: NOT in kernel set — lockout risk NOW"
-            _verify_fail=1
-        fi
+        _ssh_ports_all=$(_update_detect_ssh_port)
+        while IFS= read -r _ssh_port; do
+            [[ "$_ssh_port" =~ ^[0-9]+$ ]] || continue
+            # Surface 1 (live kernel): SSH port in nft set tcp_ports_in
+            local _ssh_in_kernel=0
+            if nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
+                _ssh_in_kernel=1
+            fi
+            if nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b"; then
+                _ssh_in_kernel=1
+            fi
+            # Surface 2 (durable config): Mechanism A (TCP_PORTS_IN includes
+            # port) OR Mechanism B (SSH_PORT=port drives render injection).
+            local _ssh_in_durable=0
+            if [[ -f /etc/nftban/nftban.conf.local ]] && \
+               grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
+                _ssh_in_durable=1
+            fi
+            if [[ $_ssh_in_durable -eq 0 ]] && \
+               [[ -f /etc/nftban/nftban.conf.local ]] && \
+               grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
+               grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
+                _ssh_in_durable=1
+            fi
+            # Report (per detected port)
+            if [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 1 ]]; then
+                _update_log OK "SSH port ${_ssh_port}: present in kernel AND durable config"
+            elif [[ $_ssh_in_kernel -eq 1 && $_ssh_in_durable -eq 0 ]]; then
+                _update_log WARN "SSH port ${_ssh_port}: present in kernel but NOT in durable config — lockout risk on next reload/reboot. Add SSH_PORT=${_ssh_port} or include ${_ssh_port} in TCP_PORTS_IN in /etc/nftban/nftban.conf.local"
+            elif [[ $_ssh_in_kernel -eq 0 ]]; then
+                _update_log ERROR "SSH port ${_ssh_port}: NOT in kernel set — lockout risk NOW"
+                _verify_fail=1
+            fi
+        done <<< "$_ssh_ports_all"
     fi
 
     # V3: Health check severity — exit 2 = critical failure
@@ -1147,29 +1147,33 @@ _cmd_update_preflight() {
 
     # PF5: SSH port in service ports (V121 dual-surface — D-NONDEFAULT-SSH-PORT-CONFIG-DRIFT-001)
     if command -v nft &>/dev/null; then
-        local _ssh_port
-        _ssh_port=$(_update_detect_ssh_port)
-        local _ssh_kernel=0
+        # v1.145 PR-B: check EVERY detected SSH port (union), not just one.
+        local _ssh_port _ssh_ports_all
         local _tbl_v4="${NFTBAN_TABLE_IPV4:-ip nftban}"
         local _tbl_v6="${NFTBAN_TABLE_IPV6:-ip6 nftban}"
-        nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
-        nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
-        local _ssh_durable=0
-        if [[ -f /etc/nftban/nftban.conf.local ]] && \
-           grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
-            _ssh_durable=1
-        elif [[ -f /etc/nftban/nftban.conf.local ]] && \
-             grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
-             grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
-            _ssh_durable=1
-        fi
-        if [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 1 ]]; then
-            _pf_check "SSH port ${_ssh_port} in service ports (kernel + durable config)" "PASS"
-        elif [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 0 ]]; then
-            _pf_check "SSH port ${_ssh_port}: kernel YES, durable config NO — fix nftban.conf.local before next reload" "WARN"
-        else
-            _pf_check "SSH port ${_ssh_port} NOT in service ports" "FAIL"
-        fi
+        _ssh_ports_all=$(_update_detect_ssh_port)
+        while IFS= read -r _ssh_port; do
+            [[ "$_ssh_port" =~ ^[0-9]+$ ]] || continue
+            local _ssh_kernel=0
+            nft list set ${_tbl_v4} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+            nft list set ${_tbl_v6} tcp_ports_in 2>/dev/null | grep >/dev/null 2>&1 "\\b${_ssh_port}\\b" && _ssh_kernel=1
+            local _ssh_durable=0
+            if [[ -f /etc/nftban/nftban.conf.local ]] && \
+               grep -qE "^[[:space:]]*TCP_PORTS_IN=[^#]*\\b${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null; then
+                _ssh_durable=1
+            elif [[ -f /etc/nftban/nftban.conf.local ]] && \
+                 grep -qE "^[[:space:]]*SSH_PORT=[\"']?${_ssh_port}\\b" /etc/nftban/nftban.conf.local 2>/dev/null && \
+                 grep -qE "\\b${_ssh_port}\\b" /etc/nftban/nftables.conf 2>/dev/null; then
+                _ssh_durable=1
+            fi
+            if [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 1 ]]; then
+                _pf_check "SSH port ${_ssh_port} in service ports (kernel + durable config)" "PASS"
+            elif [[ $_ssh_kernel -eq 1 && $_ssh_durable -eq 0 ]]; then
+                _pf_check "SSH port ${_ssh_port}: kernel YES, durable config NO — fix nftban.conf.local before next reload" "WARN"
+            else
+                _pf_check "SSH port ${_ssh_port} NOT in service ports" "FAIL"
+            fi
+        done <<< "$_ssh_ports_all"
     else
         _pf_check "SSH port check: nft not available" "FAIL"
     fi

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -717,15 +717,18 @@ nftban_health_check_ssh_port() {
     # State file to track the currently active SSH port (for cleanup)
     local ssh_port_active="${NFTBAN_DATA_DIR}/state/ssh_port_active.state"
 
-    # Detect current SSH port from sshd_config
-    local current_ssh_port=22
-    if [[ -f "/etc/ssh/sshd_config" ]]; then
-        local detected_port
-        detected_port=$(grep -E '^\s*Port\s+[0-9]+' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}' | head -1)
-        if [[ -n "$detected_port" ]] && [[ "$detected_port" =~ ^[0-9]+$ ]]; then
-            current_ssh_port=$detected_port
-        fi
+    # v1.145 PR-B: detect the full SSH-port union (ListenAddress-aware,
+    # multi-port) instead of scalar head -1. ssh_ports_union drives both-set
+    # firewall enforcement below; current_ssh_port is the primary for the
+    # single-value ports.d write / mismatch messages (display/back-compat).
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    local ssh_ports_union=()
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        mapfile -t ssh_ports_union < <(nftban_detect_ssh_ports 2>/dev/null || true)
     fi
+    [[ ${#ssh_ports_union[@]} -eq 0 ]] && ssh_ports_union=(22)
+    local current_ssh_port="${ssh_ports_union[0]}"
 
     # Check current whitelisted SSH port in config
     local config_ssh_port=""
@@ -763,31 +766,47 @@ EOF
             # IPC add/delete was fire-and-forget — claimed success without verifying.
             # Direct nft commands give immediate feedback and guaranteed state change.
             if nft list table ${NFTBAN_TABLE_IPV4} >/dev/null 2>&1; then
-                # FIRST: Add new port (safety — ensure SSH access before removing old)
-                local _add_ok=false
-                if nft add element ${NFTBAN_TABLE_IPV4} tcp_ports_in "{ $current_ssh_port }" 2>/dev/null; then
-                    _add_ok=true
-                fi
-                nft add element ${NFTBAN_TABLE_IPV6} tcp_ports_in "{ $current_ssh_port }" 2>/dev/null || true
+                # FIRST: Add new port(s). v1.145 PR-B: add EVERY detected SSH
+                # port to BOTH tcp_ports_in AND ssh_ports (brute-force rate-limit
+                # parity), IPv4+IPv6 — ensure SSH access before removing old.
+                local _add_ok=false _sp _set
+                for _sp in "${ssh_ports_union[@]}"; do
+                    for _set in tcp_ports_in ssh_ports; do
+                        if nft add element ${NFTBAN_TABLE_IPV4} "$_set" "{ $_sp }" 2>/dev/null; then
+                            [[ "$_sp" == "$current_ssh_port" && "$_set" == "tcp_ports_in" ]] && _add_ok=true
+                        fi
+                        nft add element ${NFTBAN_TABLE_IPV6} "$_set" "{ $_sp }" 2>/dev/null || true
+                    done
+                done
 
                 if [[ "$_add_ok" == "true" ]]; then
-                    ssh_issues+=("AUTO-FIXED: Port $current_ssh_port added to nftables tcp_ports_in set")
+                    ssh_issues+=("AUTO-FIXED: SSH port(s) ${ssh_ports_union[*]} ensured in tcp_ports_in + ssh_ports")
                 else
-                    ssh_issues+=("FAILED: Could not add port $current_ssh_port to nftables — run: nftban firewall reload")
+                    ssh_issues+=("FAILED: Could not add SSH port(s) to nftables — run: nftban firewall reload")
                 fi
 
-                # THEN: Remove old port (only after add confirmed)
+                # THEN: Remove old port — only if it is NOT a current listener
+                # (absent from the detected union) and NOT the active SSH_CLIENT
+                # session port. Remove from BOTH sets (parity). v1.145 PR-B:
+                # conservative removal; apply-verification hardening = PR-C.
                 if [[ -n "$old_ssh_port" ]] && [[ "$_add_ok" == "true" ]]; then
-                    local _del_ok=false
-                    if nft delete element ${NFTBAN_TABLE_IPV4} tcp_ports_in "{ $old_ssh_port }" 2>/dev/null; then
-                        _del_ok=true
-                    fi
-                    nft delete element ${NFTBAN_TABLE_IPV6} tcp_ports_in "{ $old_ssh_port }" 2>/dev/null || true
-
-                    if [[ "$_del_ok" == "true" ]]; then
-                        ssh_issues+=("AUTO-FIXED: Old port $old_ssh_port removed from nftables")
+                    local _active_ssh_port="${SSH_CLIENT##* }" _old_listener=0 _u
+                    for _u in "${ssh_ports_union[@]}"; do
+                        if [[ "$_u" == "$old_ssh_port" ]]; then _old_listener=1; break; fi
+                    done
+                    if [[ "$_old_listener" -eq 0 && "$old_ssh_port" != "${_active_ssh_port:-}" ]]; then
+                        local _del_ok=false _dset
+                        for _dset in tcp_ports_in ssh_ports; do
+                            if nft delete element ${NFTBAN_TABLE_IPV4} "$_dset" "{ $old_ssh_port }" 2>/dev/null; then
+                                _del_ok=true
+                            fi
+                            nft delete element ${NFTBAN_TABLE_IPV6} "$_dset" "{ $old_ssh_port }" 2>/dev/null || true
+                        done
+                        if [[ "$_del_ok" == "true" ]]; then
+                            ssh_issues+=("AUTO-FIXED: Stale old port $old_ssh_port removed from tcp_ports_in + ssh_ports")
+                        fi
                     else
-                        ssh_issues+=("WARNING: Could not remove old port $old_ssh_port from nftables — run: nftban firewall reload")
+                        ssh_issues+=("INFO: Kept old port $old_ssh_port (still a listener or active SSH session)")
                     fi
                 fi
             else

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -125,14 +125,19 @@ main() {
     # ==========================================================================
     log "INFO" "[1/10] Checking SSH port configuration..."
 
-    # Auto-detect current SSH port from sshd_config
-    SSH_PORT=22
-    if [[ -f "/etc/ssh/sshd_config" ]]; then
-        DETECTED_PORT=$(grep -E '^\s*Port\s+[0-9]+' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}' | head -1 || true)
-        if [[ -n "$DETECTED_PORT" ]] && [[ "$DETECTED_PORT" =~ ^[0-9]+$ ]]; then
-            SSH_PORT=$DETECTED_PORT
-        fi
+    # Auto-detect current SSH port(s). v1.145 PR-B: use the union detector
+    # (ListenAddress-aware, multi-port) instead of scalar `head -1` sshd_config
+    # parsing. SSH_PORTS = full union for firewall ENFORCEMENT (every real
+    # listener port protected, lockout-safe); SSH_PORT = primary for the
+    # single-value whitelist/state/alert logic below (display/back-compat).
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    SSH_PORTS=()
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        mapfile -t SSH_PORTS < <(nftban_detect_ssh_ports 2>/dev/null || true)
     fi
+    [[ ${#SSH_PORTS[@]} -eq 0 ]] && SSH_PORTS=(22)
+    SSH_PORT="${SSH_PORTS[0]}"
 
     # Check if SSH port is whitelisted
     SSH_WHITELIST="${NFTBAN_CONFIG_DIR}/ports.d/00-ssh.conf"
@@ -145,15 +150,21 @@ main() {
         if grep -qE "^${SSH_PORT}/(T|tcp)" "$SSH_WHITELIST" 2>/dev/null; then
             log "INFO" "SSH port check: config OK (port $SSH_PORT whitelisted)"
 
-            # v1.19.20 FIX: Also verify port is in nftables tcp_ports_in set
-            # After firewall rebuild, config may be OK but nftables set is empty
+            # v1.145 PR-B: ensure EVERY detected SSH port is present in BOTH
+            # tcp_ports_in (reachability) AND ssh_ports (brute-force rate-limit
+            # parity), IPv4+IPv6. Additive + idempotent. Removal of stale ports
+            # is conservative and handled in the port-change branch / PR-C.
             if [[ "$_nft_table_available" == "true" ]]; then
-                if ! nft list set ${NFTBAN_TABLE_IPV4} tcp_ports_in 2>/dev/null | grep -qw "$SSH_PORT"; then
-                    log "WARN" "SSH port $SSH_PORT in config but NOT in nftables - auto-fixing..."
-                    nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
-                    nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
-                    log "INFO" "SSH port $SSH_PORT added to nftables tcp_ports_in set"
-                fi
+                local _sp _set
+                for _sp in "${SSH_PORTS[@]}"; do
+                    for _set in tcp_ports_in ssh_ports; do
+                        if ! nft list set ${NFTBAN_TABLE_IPV4} "$_set" 2>/dev/null | grep -qw "$_sp"; then
+                            log "WARN" "SSH port $_sp missing from $_set - auto-fixing (both-set parity)..."
+                            nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" "$_set" "$_sp" 2>/dev/null || true
+                            nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" "$_set" "$_sp" 2>/dev/null || true
+                        fi
+                    done
+                done
             fi
 
             # Clear alert state if port is now correct (atomic delete - no TOCTOU)
@@ -223,17 +234,32 @@ EOF
                         log "INFO" "SSH port $SSH_PORT added to firewall (via daemon)"
                         # Also add to IPv6 table
                         nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
+                        # v1.145 PR-B both-set parity: ssh_ports must carry the SSH
+                        # port too (brute-force rate-limit rule reads @ssh_ports).
+                        nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" ssh_ports "$SSH_PORT" 2>/dev/null || true
+                        nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" ssh_ports "$SSH_PORT" 2>/dev/null || true
 
-                        # THEN: Remove the OLD port if it was auto-added and is different
+                        # THEN: Remove the OLD port — but ONLY if it is no longer a
+                        # real SSH listener (absent from the detected union) AND is
+                        # not the active SSH_CLIENT session port. v1.145 PR-B:
+                        # conservative removal + both-set parity (tcp_ports_in AND
+                        # ssh_ports). Aggressive removal/apply-verification = PR-C.
                         if [[ -n "$OLD_SSH_PORT" ]]; then
-                            log "INFO" "Removing old SSH port $OLD_SSH_PORT from firewall..."
-                            if nft_ipc_delete_element "${NFTBAN_TABLE_IPV4}" tcp_ports_in "$OLD_SSH_PORT"; then
-                                log "INFO" "Old SSH port $OLD_SSH_PORT removed from IPv4 firewall"
+                            local _active_ssh_port="${SSH_CLIENT##* }"
+                            local _old_still_listener=0 _u
+                            for _u in "${SSH_PORTS[@]}"; do
+                                if [[ "$_u" == "$OLD_SSH_PORT" ]]; then _old_still_listener=1; break; fi
+                            done
+                            if [[ "$_old_still_listener" -eq 0 && "$OLD_SSH_PORT" != "${_active_ssh_port:-}" ]]; then
+                                log "INFO" "Removing stale old SSH port $OLD_SSH_PORT from firewall (both sets)..."
+                                local _dset
+                                for _dset in tcp_ports_in ssh_ports; do
+                                    nft_ipc_delete_element "${NFTBAN_TABLE_IPV4}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
+                                    nft_ipc_delete_element "${NFTBAN_TABLE_IPV6}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
+                                done
                             else
-                                log "WARN" "Failed to remove old port $OLD_SSH_PORT from IPv4 (may not exist)"
+                                log "INFO" "Keeping old SSH port $OLD_SSH_PORT (still a listener or active session)"
                             fi
-                            # Also remove from IPv6
-                            nft_ipc_delete_element "${NFTBAN_TABLE_IPV6}" tcp_ports_in "$OLD_SSH_PORT" 2>/dev/null || true
                         fi
 
                         log "INFO" "ALERT: SSH port changed and firewall updated (no lockout risk)"

--- a/cli/lib/nftban/lib/ssh_port_detect.sh
+++ b/cli/lib/nftban/lib/ssh_port_detect.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - Runtime SSH-port detection wrapper (PR-B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_port_detect" meta:type="lib" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Runtime SSH-port detection: union of all SSH listener/config ports via the Go helper binary, with a conservative ListenAddress-aware pure-shell fallback. Replaces scalar head -1 detectors (PR-B)."
+# meta:inventory.files=""
+# meta:inventory.binaries="nftban-detect-ssh-ports,ss,grep,awk,sort"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_DATA_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files="/etc/ssh/sshd_config,/etc/ssh/sshd_config.d,/etc/nftban/nftban.conf.local"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+#
+# Authority model: the Go binary /usr/lib/nftban/bin/nftban-detect-ssh-ports
+# (DetectSSHPortsUnion) is the single detector authority shared by the installer
+# and runtime. The pure-shell fallback below is conservative and used ONLY when
+# the binary is missing (install-transition / partial install). Both emit a
+# sorted-unique port list, one per line. No scalar `head -1` SSH detection.
+#
+# Per NFTBan coding standards this library declares `set -Eeuo pipefail`
+# (sourcing it enables strict mode caller-side, matching nft_schema.sh). The
+# detection functions below are explicitly hardened to remain correct under
+# errexit/pipefail (non-matching greps and head-pipe SIGPIPE are guarded).
+set -Eeuo pipefail
+
+NFTBAN_SSH_DETECT_BIN="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-detect-ssh-ports"
+
+# nftban_detect_ssh_ports — print the sorted-unique union of all detected SSH
+# ports, one per line. Primary path = the Go helper binary; fallback = shell.
+# Returns 0 if at least one port is printed, 1 if none found.
+nftban_detect_ssh_ports() {
+    # set -e safe: this library is sourced into strict-mode callers, so every
+    # command substitution that may exit non-zero is guarded.
+    local out=""
+    if [[ -x "$NFTBAN_SSH_DETECT_BIN" ]]; then
+        out=$("$NFTBAN_SSH_DETECT_BIN" 2>/dev/null) || out=""
+        if [[ -n "$out" ]]; then
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+    out=$(_nftban_ssh_detect_fallback) || out=""
+    if [[ -n "$out" ]]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+    return 1
+}
+
+# nftban_detect_ssh_primary_port — print ONE port (the lowest of the union).
+# DISPLAY / single-value back-compat ONLY. Enforcement paths MUST use the full
+# union via nftban_detect_ssh_ports. This named helper exists so a single-value
+# need never silently re-introduces `head -1` scalar detection (PR-B rule).
+# Prints nothing and returns 1 if no port is detected.
+nftban_detect_ssh_primary_port() {
+    local first
+    # `| head -1` closes the pipe early (SIGPIPE) — guard for pipefail callers.
+    first=$(nftban_detect_ssh_ports | head -1) || first=""
+    if [[ -n "$first" ]]; then
+        printf '%s\n' "$first"
+        return 0
+    fi
+    return 1
+}
+
+# _nftban_listenaddr_port <token> — echo the port from a ListenAddress address
+# token, or nothing. Mirrors the Go detector's listenAddressPort:
+#   host:port        -> port (exactly one colon)
+#   [ipv6]:port      -> port (bracketed)
+#   host             -> nothing
+#   bare ipv6 (::)   -> nothing (the multi-colon no-bracket trap)
+_nftban_listenaddr_port() {
+    local tok="$1" colons
+    if [[ "$tok" =~ ^\[.*\]:([0-9]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    colons="${tok//[^:]/}"
+    if [[ "${#colons}" -eq 1 && "$tok" =~ :([0-9]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
+}
+
+# _nftban_ssh_detect_fallback — conservative pure-shell union (binary missing).
+# Sources: ss listeners + sshd_config/drop-in Port + ListenAddress + state file
+# + conf.local SSH_PORT. Output: sorted-unique numeric ports. Config paths are
+# overridable (NFTBAN_SSHD_CONFIG / NFTBAN_SSHD_CONFIG_D) for tests.
+_nftban_ssh_detect_fallback() {
+    # Run the whole collection in a subshell with errexit/pipefail OFF so a
+    # non-matching grep (a normal "no such directive" outcome) never aborts a
+    # strict-mode caller. The subshell's final `sort` determines exit status.
+    ( set +e +o pipefail
+    local _sshd="${NFTBAN_SSHD_CONFIG:-/etc/ssh/sshd_config}"
+    local _sshd_d="${NFTBAN_SSHD_CONFIG_D:-/etc/ssh/sshd_config.d}"
+    {
+        # 1. ss listeners (IPv4 / IPv6 / dual-stack); port = last colon of the
+        #    local-address field; works for 0.0.0.0:22 and [::]:55000.
+        ss -tlnp 2>/dev/null | awk '
+            /sshd/ {
+                n = split($4, a, ":");
+                if (a[n] ~ /^[0-9]+$/) print a[n];
+            }'
+
+        # 2. sshd_config + drop-ins: Port and ListenAddress.
+        local _f _line _tok _p
+        for _f in "$_sshd" "$_sshd_d"/*.conf; do
+            [[ -f "$_f" ]] || continue
+            grep -E '^[[:space:]]*Port[[:space:]]+[0-9]+' "$_f" 2>/dev/null | awk '{print $2}'
+            while IFS= read -r _line; do
+                _tok=$(awk '{print $2}' <<<"$_line")
+                _p=$(_nftban_listenaddr_port "$_tok")
+                [[ -n "$_p" ]] && printf '%s\n' "$_p"
+            done < <(grep -iE '^[[:space:]]*ListenAddress[[:space:]]+' "$_f" 2>/dev/null)
+        done
+
+        # 3. state file
+        local _sf="${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/ssh_port_active.state"
+        [[ -f "$_sf" ]] && grep -E '^[0-9]+$' "$_sf" 2>/dev/null
+
+        # 4. conf.local SSH_PORT=
+        local _cl="${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
+        [[ -f "$_cl" ]] && grep -E '^[[:space:]]*SSH_PORT=' "$_cl" 2>/dev/null \
+            | sed -E 's/^[[:space:]]*SSH_PORT=["'"'"']?([0-9]+).*/\1/'
+    } 2>/dev/null | grep -E '^[0-9]+$' | awk '$1>=1 && $1<=65535' | sort -un
+    )
+}

--- a/cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - PR-B runtime static guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v145_pr_b_runtime_static_guard_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Static regression guard for v1.145 PR-B: asserts no scalar head -1 SSH-port detector remains in runtime enforcement paths, that each path consumes the union/primary wrapper, and that both-set (tcp_ports_in + ssh_ports) parity is present in the mutation paths (maintenance, health, cmd_port)."
+# meta:input="None (greps repo source read-only)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+pass=0
+fail=0
+ok()  { echo "  PASS  $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL  $1"; fail=$((fail+1)); }
+
+# Runtime enforcement paths that must NOT contain scalar SSH-port detection.
+ENFORCE_FILES=(
+    cli/lib/nftban/cron/maintenance.sh
+    cli/lib/nftban/core/nftban_health_checks_security.sh
+    cli/lib/nftban/cli/cmd_system.sh
+    cli/lib/nftban/cli/cmd_update.sh
+    cli/lib/nftban/cli/cmd_firewall.sh
+)
+
+echo "== no scalar head -1 SSH-port detector remains =="
+# Patterns that indicate the old scalar detectors. The fallback parser lives
+# only in lib/ssh_port_detect.sh and is intentionally excluded.
+SCALAR_RE='Port[^|]*\| *awk[^|]*\| *head -1|grep -m1 -oP[^|]*Port|sshd[^|]*\| *head -1|grep -oP .sshd.*head -1'
+for f in "${ENFORCE_FILES[@]}"; do
+    if grep -nEq "$SCALAR_RE" "$f"; then
+        bad "$f still has a scalar SSH-port detector"
+        grep -nE "$SCALAR_RE" "$f" | sed 's/^/        /'
+    else
+        ok "$f: no scalar SSH-port detector"
+    fi
+done
+
+echo "== each enforcement path consumes the wrapper =="
+for f in "${ENFORCE_FILES[@]}"; do
+    if grep -q "ssh_port_detect.sh" "$f" && grep -qE "nftban_detect_ssh_(ports|primary_port)" "$f"; then
+        ok "$f: consumes the union/primary wrapper"
+    else
+        bad "$f: does not consume the wrapper"
+    fi
+done
+
+echo "== both-set parity (ssh_ports updated alongside tcp_ports_in) =="
+for f in cli/lib/nftban/cron/maintenance.sh cli/lib/nftban/core/nftban_health_checks_security.sh cli/lib/nftban/cli/cmd_port.sh; do
+    if grep -q "ssh_ports" "$f"; then
+        ok "$f: references ssh_ports (both-set parity)"
+    else
+        bad "$f: no ssh_ports parity"
+    fi
+done
+
+echo "== SSH_CLIENT active-port remove guard preserved in cmd_port =="
+if grep -q 'ACTIVE SSH port' cli/lib/nftban/cli/cmd_port.sh; then
+    ok "cmd_port: SSH_CLIENT remove guard intact"
+else
+    bad "cmd_port: SSH_CLIENT remove guard missing"
+fi
+
+echo
+echo "RESULT: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/cli/lib/nftban/tests/v145_ssh_port_detect_test.sh
+++ b/cli/lib/nftban/tests/v145_ssh_port_detect_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - PR-B SSH-port detection wrapper tests
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v145_ssh_port_detect_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Unit tests for cli/lib/nftban/lib/ssh_port_detect.sh — the ListenAddress-aware pure-bash helper (_nftban_listenaddr_port) and the conservative fallback union (_nftban_ssh_detect_fallback). The Go binary is the primary authority and is covered by internal/installer/detect/ssh_test.go; these cover the install-transition shell fallback."
+# meta:input="None (self-contained; temp sshd_config fixtures)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sort,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,sort,mktemp"
+# meta:inventory.env_vars="NFTBAN_SSHD_CONFIG,NFTBAN_SSHD_CONFIG_D,NFTBAN_DATA_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/cli/lib/nftban/lib/ssh_port_detect.sh"
+
+pass=0
+fail=0
+ok()  { echo "  PASS  $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL  $1"; fail=$((fail+1)); }
+
+echo "== _nftban_listenaddr_port forms =="
+check_la() { # token expected
+    local got; got=$(_nftban_listenaddr_port "$1")
+    if [[ "$got" == "$2" ]]; then ok "'$1' -> '${got:-<none>}'"; else bad "'$1' -> got '$got' want '$2'"; fi
+}
+check_la "0.0.0.0:22" "22"
+check_la "192.0.2.10:55000" "55000"
+check_la "[::]:22" "22"
+check_la "[2001:db8::10]:55000" "55000"
+check_la "0.0.0.0" ""
+check_la "::" ""
+check_la "2001:db8::10" ""   # bare IPv6 no-port trap
+
+echo "== fallback union (config sources; ss may add host port) =="
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+printf 'Port 22\nListenAddress 0.0.0.0:22\nListenAddress [::]:55000\nListenAddress 2001:db8::10\n' > "$tmp/sshd_config"
+export NFTBAN_SSHD_CONFIG="$tmp/sshd_config" NFTBAN_SSHD_CONFIG_D="$tmp/none" \
+       NFTBAN_DATA_DIR="$tmp" NFTBAN_CONFIG_DIR="$tmp"
+out=$(_nftban_ssh_detect_fallback)
+has() { grep -qx "$2" <<<"$1"; }
+if has "$out" 22;    then ok "union contains 22";    else bad "union missing 22"; fi
+if has "$out" 55000; then ok "union contains 55000"; else bad "union missing 55000"; fi
+if has "$out" 10;    then bad "bare-IPv6 port 10 leaked"; else ok "bare-IPv6 port 10 not leaked"; fi
+# sorted-unique: 22 must appear exactly once despite Port+ListenAddress both = 22
+if [[ "$(grep -cx 22 <<<"$out")" == "1" ]]; then ok "22 de-duplicated (exactly one)"; else bad "22 not de-duplicated"; fi
+
+# conf.local SSH_PORT source
+printf 'SSH_PORT="2200"\n' > "$tmp/nftban.conf.local"
+out2=$(_nftban_ssh_detect_fallback)
+if has "$out2" 2200; then ok "conf.local SSH_PORT picked up"; else bad "conf.local SSH_PORT missed"; fi
+
+echo
+echo "RESULT: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/cmd/nftban-detect-ssh-ports/main.go
+++ b/cmd/nftban-detect-ssh-ports/main.go
@@ -1,0 +1,73 @@
+// =============================================================================
+// NFTBan v1.145 - SSH Port Union Detector Command
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-detect-ssh-ports"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-02"
+// meta:description="Prints the conservative union of all detected SSH listener/config ports, one per line, for runtime/timer consumption (PR-B)"
+// meta:inventory.files="cmd/nftban-detect-ssh-ports/main.go"
+// meta:inventory.binaries="nftban-detect-ssh-ports"
+// meta:inventory.env_vars="SSH_CLIENT"
+// meta:inventory.config_files="/etc/ssh/sshd_config,/etc/nftban/nftban.conf.local"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// Usage:
+//
+//	nftban-detect-ssh-ports        # one sorted-unique SSH port per line on stdout
+//	nftban-detect-ssh-ports --help # usage
+//
+// Exit codes:
+//
+//	0 = at least one valid SSH port detected (printed to stdout)
+//	1 = no SSH port detected from any source
+//
+// v1.145 PR-B: this is the single Go detector authority shared by the installer
+// and the runtime/timer shell paths (via cli/lib/nftban/lib/ssh_port_detect.sh),
+// so scalar `head -1` parsers cannot reintroduce drift. Sources unioned:
+// `ss` listeners (IPv4/IPv6/dual-stack), sshd_config `Port` + `ListenAddress`
+// (host:port and [ipv6]:port, plus drop-ins), the install state file, and
+// conf.local SSH_PORT. The union is conservative (over-broad across address
+// families, applied to both ip/ip6 sets) and lockout-safe: it never drops a
+// real listener port. ZERO-SIDE-EFFECT: reads only; never writes files or nft.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func main() {
+	for _, a := range os.Args[1:] {
+		switch a {
+		case "-h", "--help", "help":
+			fmt.Fprintln(os.Stderr, "nftban-detect-ssh-ports — print the conservative union of all detected SSH ports, one per line.")
+			fmt.Fprintln(os.Stderr, "Sources: ss listeners, sshd_config Port + ListenAddress (+drop-ins), state file, conf.local SSH_PORT.")
+			fmt.Fprintln(os.Stderr, "Exit: 0 if >=1 port (printed to stdout), 1 if none.")
+			os.Exit(0)
+		}
+	}
+
+	exec := &executor.RealExecutor{}
+	// Quiet logger: detection diagnostics go to /dev/null so stdout carries
+	// only the port list for the shell wrapper to consume.
+	log := logging.New("/dev/null", false)
+	defer log.Close()
+
+	ports := detect.DetectSSHPortsUnion(exec, log)
+	if len(ports) == 0 {
+		fmt.Fprintln(os.Stderr, "nftban-detect-ssh-ports: no SSH port detected from any source (ss, sshd_config, state, conf.local)")
+		os.Exit(1)
+	}
+	for _, p := range ports {
+		fmt.Println(p)
+	}
+}

--- a/internal/installer/detect/ssh.go
+++ b/internal/installer/detect/ssh.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -267,18 +268,145 @@ func sshFromConfig(exec executor.Executor) int {
 // portLineRe matches "Port NNN" lines in sshd_config.
 var portLineRe = regexp.MustCompile(`(?i)^\s*Port\s+(\d+)`)
 
+// listenAddrLineRe captures the address token of a `ListenAddress <token>`
+// directive. listenAddrBracketRe captures the port of the IPv6 bracketed form
+// `[addr]:port`. v1.145 PR-B: the historical detector parsed only `Port`
+// lines; a sshd_config that declares ports solely via `ListenAddress`
+// (`0.0.0.0:22`, `[::]:55000`, `192.0.2.10:22`, `[2001:db8::10]:55000`) was
+// invisible to the config sources.
+var listenAddrLineRe = regexp.MustCompile(`(?i)^\s*ListenAddress\s+(\S+)`)
+var listenAddrBracketRe = regexp.MustCompile(`^\[.*\]:(\d+)$`)
+
+// listenAddressPort extracts an explicit port from one `ListenAddress` line,
+// or 0 when the line is not a ListenAddress or carries no explicit port.
+// OpenSSH forms:
+//
+//	ListenAddress host             -> no port (0)
+//	ListenAddress host:port        -> IPv4/hostname (exactly one colon)
+//	ListenAddress [ipv6]:port      -> IPv6 with port (bracketed)
+//	ListenAddress 2001:db8::10      -> bare IPv6, NO port (multiple colons, no brackets)
+//
+// The bare-IPv6 case is the trap: a naive `:(\d+)$` would mis-read `::10` as
+// port 10, so a non-bracketed token is only treated as host:port when it has
+// EXACTLY one colon.
+func listenAddressPort(line string) int {
+	m := listenAddrLineRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0
+	}
+	tok := m[1]
+	if bm := listenAddrBracketRe.FindStringSubmatch(tok); bm != nil {
+		return validatePort(bm[1])
+	}
+	if strings.Count(tok, ":") == 1 {
+		return validatePort(tok[strings.LastIndex(tok, ":")+1:])
+	}
+	return 0
+}
+
+// parseSSHConfig returns a single SSH port from one config file. A `Port`
+// directive wins (first occurrence); when no `Port` line is present it falls
+// back to the first `ListenAddress host:port` it finds (v1.145 PR-B — closes
+// the ListenAddress-only blind spot in the single-port config source). Returns
+// 0 when neither is present.
 func parseSSHConfig(exec executor.Executor, path string) int {
 	data, err := exec.ReadFile(path)
 	if err != nil {
 		return 0
 	}
+	listenPort := 0
 	for _, line := range strings.Split(string(data), "\n") {
-		m := portLineRe.FindStringSubmatch(line)
-		if m != nil {
-			return validatePort(m[1])
+		if m := portLineRe.FindStringSubmatch(line); m != nil {
+			if p := validatePort(m[1]); p > 0 {
+				return p
+			}
+		}
+		if listenPort == 0 {
+			if p := listenAddressPort(line); p > 0 {
+				listenPort = p
+			}
 		}
 	}
-	return 0
+	return listenPort
+}
+
+// parseSSHConfigPorts returns ALL SSH ports declared in one config file via
+// `Port` and `ListenAddress` directives (deduped within the file is left to
+// the caller's union). v1.145 PR-B: the runtime conservative-union detector
+// must see every declared port, not just the first.
+func parseSSHConfigPorts(exec executor.Executor, path string) []int {
+	data, err := exec.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var ports []int
+	for _, line := range strings.Split(string(data), "\n") {
+		if m := portLineRe.FindStringSubmatch(line); m != nil {
+			if p := validatePort(m[1]); p > 0 {
+				ports = append(ports, p)
+			}
+			continue
+		}
+		if p := listenAddressPort(line); p > 0 {
+			ports = append(ports, p)
+		}
+	}
+	return ports
+}
+
+// sshConfigAllPorts returns all Port + ListenAddress ports from the main
+// sshd_config and every *.conf drop-in.
+func sshConfigAllPorts(exec executor.Executor) []int {
+	ports := parseSSHConfigPorts(exec, "/etc/ssh/sshd_config")
+	res := exec.Run("ls", "/etc/ssh/sshd_config.d/")
+	if res.ExitCode == 0 {
+		for _, name := range strings.Fields(res.Stdout) {
+			if !strings.HasSuffix(name, ".conf") {
+				continue
+			}
+			path := filepath.Join("/etc/ssh/sshd_config.d", name)
+			ports = append(ports, parseSSHConfigPorts(exec, path)...)
+		}
+	}
+	return ports
+}
+
+// DetectSSHPortsUnion returns the sorted, de-duplicated union of every SSH port
+// nftban can observe: live `ss` listeners + sshd_config/drop-in `Port` and
+// `ListenAddress` directives + the install state file + conf.local `SSH_PORT`.
+//
+// v1.145 PR-B runtime hardening: runtime/timer paths must protect EVERY real
+// SSH listener port (lockout-safe), so they consume this conservative union
+// rather than scalar `head -1` detection. The union is intentionally over-broad
+// across address families — it is applied to BOTH ip and ip6 sets; per-family
+// (ipv4_ports/ipv6_ports) precision is a deferred stronger variant. Blocking
+// rule: missing a real listener port is a lockout blocker; over-broad is not.
+func DetectSSHPortsUnion(exec executor.Executor, log *logging.Logger) []int {
+	seen := make(map[int]bool)
+	var union []int
+	add := func(p int) {
+		if p > 0 && !seen[p] {
+			seen[p] = true
+			union = append(union, p)
+		}
+	}
+	for _, p := range sshAllListeners(exec) {
+		add(p)
+	}
+	for _, p := range sshConfigAllPorts(exec) {
+		add(p)
+	}
+	add(sshFromStateFile(exec))
+	add(sshFromConfLocal(exec))
+	sort.Ints(union)
+	if log != nil && len(union) > 0 {
+		parts := make([]string, len(union))
+		for i, p := range union {
+			parts[i] = strconv.Itoa(p)
+		}
+		log.Detect("ssh", "union", strings.Join(parts, ","))
+	}
+	return union
 }
 
 // sshFromStateFile reads /var/lib/nftban/state/ssh_port_active.state.

--- a/internal/installer/detect/ssh_test.go
+++ b/internal/installer/detect/ssh_test.go
@@ -501,3 +501,145 @@ func TestSSHPort_LegacySinglePortPathStillWorks(t *testing.T) {
 		t.Errorf("SSHPort source=conf.local: port=%d err=%v, want 44444 nil", port, err)
 	}
 }
+
+// =============================================================================
+// v1.145 PR-B — ListenAddress / AddressFamily parsing + conservative union
+// =============================================================================
+
+func TestListenAddressPort_Forms(t *testing.T) {
+	cases := []struct {
+		line string
+		want int
+	}{
+		{"ListenAddress 0.0.0.0:22", 22},
+		{"ListenAddress 192.0.2.10:55000", 55000},
+		{"ListenAddress [::]:22", 22},
+		{"ListenAddress [2001:db8::10]:55000", 55000},
+		{"  ListenAddress 0.0.0.0:2222  ", 2222},
+		{"listenaddress 10.0.0.1:443", 443}, // case-insensitive
+		{"ListenAddress 0.0.0.0", 0},        // no port
+		{"ListenAddress ::", 0},             // bare IPv6, no port
+		{"ListenAddress 2001:db8::10", 0},   // bare IPv6, no port — the trap
+		{"Port 22", 0},                      // not a ListenAddress line
+		{"# ListenAddress 0.0.0.0:22", 0},   // comment
+	}
+	for _, c := range cases {
+		if got := listenAddressPort(c.line); got != c.want {
+			t.Errorf("listenAddressPort(%q) = %d, want %d", c.line, got, c.want)
+		}
+	}
+}
+
+func TestParseSSHConfig_ListenAddressFallback(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// Port directive wins even if a ListenAddress is also present.
+	mock.Files["/etc/ssh/p"] = []byte("ListenAddress 0.0.0.0:2200\nPort 22\n")
+	if got := parseSSHConfig(mock, "/etc/ssh/p"); got != 22 {
+		t.Errorf("Port should win: got %d, want 22", got)
+	}
+	// ListenAddress-only config falls back to the ListenAddress port.
+	mock.Files["/etc/ssh/la"] = []byte("# no Port line\nListenAddress [::]:55000\n")
+	if got := parseSSHConfig(mock, "/etc/ssh/la"); got != 55000 {
+		t.Errorf("ListenAddress fallback: got %d, want 55000", got)
+	}
+}
+
+// equalInts compares two int slices for order-sensitive equality.
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDetectSSHPortsUnion(t *testing.T) {
+	noDropins := executor.Result{ExitCode: 1}
+	noListeners := executor.Result{ExitCode: 0, Stdout: ""}
+
+	cases := []struct {
+		name string
+		ss   string // ss -tlnp stdout
+		sshd string // /etc/ssh/sshd_config content
+		want []int  // sorted unique union
+	}{
+		{
+			name: "Port only single",
+			sshd: "Port 22\n",
+			want: []int{22},
+		},
+		{
+			name: "Port only multi",
+			sshd: "Port 22\nPort 55000\n",
+			want: []int{22, 55000},
+		},
+		{
+			name: "ListenAddress only IPv4",
+			sshd: "ListenAddress 0.0.0.0:22\n",
+			want: []int{22},
+		},
+		{
+			name: "ListenAddress only IPv6",
+			sshd: "ListenAddress [::]:55000\n",
+			want: []int{55000},
+		},
+		{
+			name: "mixed IPv4/IPv6 ListenAddress",
+			sshd: "ListenAddress 0.0.0.0:22\nListenAddress [::]:55000\n",
+			want: []int{22, 55000},
+		},
+		{
+			name: "AddressFamily inet + Port",
+			sshd: "AddressFamily inet\nPort 22\n",
+			want: []int{22},
+		},
+		{
+			name: "AddressFamily inet6 + ListenAddress",
+			sshd: "AddressFamily inet6\nListenAddress [2001:db8::10]:55000\n",
+			want: []int{55000},
+		},
+		{
+			name: "bare IPv6 no port is not detected",
+			sshd: "ListenAddress 2001:db8::10\n",
+			want: nil,
+		},
+		{
+			name: "union ss + config sorted unique",
+			ss: `State Recv-Q Send-Q Local:Port Peer Process
+LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=1,fd=3))
+`,
+			sshd: "Port 55000\nListenAddress 0.0.0.0:22\n", // 22 duplicated across ss+config
+			want: []int{22, 55000},
+		},
+		{
+			name: "ss dual-stack",
+			ss: `State Recv-Q Send-Q Local:Port Peer Process
+LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=1,fd=3))
+LISTEN 0 128 [::]:55000 [::]:* users:(("sshd",pid=1,fd=4))
+`,
+			sshd: "",
+			want: []int{22, 55000},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mock := executor.NewMockExecutor()
+			if c.ss != "" {
+				mock.RunResults["ss:-tlnp"] = executor.Result{ExitCode: 0, Stdout: c.ss}
+			} else {
+				mock.RunResults["ss:-tlnp"] = noListeners
+			}
+			mock.RunResults["ls:/etc/ssh/sshd_config.d/"] = noDropins
+			mock.Files["/etc/ssh/sshd_config"] = []byte(c.sshd)
+
+			got := DetectSSHPortsUnion(mock, newTestLogger())
+			if !equalInts(got, c.want) {
+				t.Errorf("DetectSSHPortsUnion() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -393,6 +393,7 @@ echo "\${YQ_SHA256}  yq_linux_amd64" | sha256sum -c - || { echo "yq checksum ver
 install -D -m 0755 bin/nftban-core %{buildroot}/usr/lib/nftban/bin/nftban-core
 install -D -m 0755 bin/nftband %{buildroot}/usr/lib/nftban/bin/nftband
 install -D -m 0755 bin/nftban-validate %{buildroot}/usr/lib/nftban/bin/nftban-validate
+install -D -m 0755 bin/nftban-detect-ssh-ports %{buildroot}/usr/lib/nftban/bin/nftban-detect-ssh-ports
 install -D -m 0755 bin/nftban-installer %{buildroot}/usr/lib/nftban/bin/nftban-installer
 install -D -m 0755 yq_linux_amd64 %{buildroot}/usr/lib/nftban/bin/yq
 # NB-5: privileged binaries ship 0750 (root:nftban), not 0755 (root:root).
@@ -1613,6 +1614,7 @@ build_deb() {
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-core" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftband" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-validate" "${deb_root}/usr/lib/nftban/bin/"
+    install -m 0755 "${PROJECT_ROOT}/bin/nftban-detect-ssh-ports" "${deb_root}/usr/lib/nftban/bin/"
     # NB-5: privileged binaries ship 0750 in .deb payload; postinst converges
     # ownership to root:nftban after the group is created.
     install -m 0750 "${PROJECT_ROOT}/cli/sbin/nftban" "${deb_root}/usr/sbin/"


### PR DESCRIPTION
## v1.145 PR-B — runtime SSH-port detection union and set parity

Closes the runtime/detection half of the SSH-port lifecycle bug class. Builds on **PR-A baseline: main `75d8ea48`** (set-driven `@ssh_ports` rule shape).

### Detector
- **Conservative-union** detector — over-broad across address families (applied to both `ip`/`ip6` sets), **not family-aware** (per-family precision deferred; lockout-safe is the priority).
- The **Go helper is the authority** (`DetectSSHPortsUnion`); the pure-shell wrapper fallback is for install-transition only.
- Supports `ListenAddress host:port` and `ListenAddress [ipv6]:port`; **bare IPv6 without a port (e.g. `2001:db8::10`) is NOT misparsed** as a port.

### Helper + wrapper
- Helper binary packaged at **`/usr/lib/nftban/bin/nftban-detect-ssh-ports`** (DEB + RPM); zero-side-effect; one port per line; exit 1 if none.
- Shell wrapper `cli/lib/nftban/lib/ssh_port_detect.sh` exposes:
  - `nftban_detect_ssh_ports` — **enforcement** (full union)
  - `nftban_detect_ssh_primary_port` — **display/back-compat only** (named; never silent `head -1`)

### Runtime wiring
- **8 scalar `head -1` sites replaced** (maintenance, health, system, update ×2 durability callers, firewall).
- Runtime SSH add/remove paths update **`tcp_ports_in` and `ssh_ports` together** (maintenance/health autofix; `cmd_port` add/remove).
- **`SSH_CLIENT` active-port remove guard preserved**; stale-port removal is conservative (only if no longer a listener and not the active session port).

### Explicitly NOT solved here — PR-C debt (marked in code)
- Apply-path hardening.
- State/config commit only after verified kernel success.
- `_nft_table_available` false-negative root-cause.

### Validation
- lab2 (Ubuntu 24.04) DEB + lab4 (EL9) RPM: `go build ./...` OK, detector tests green, shellcheck 0 warning+ across all touched files, wrapper 12/0, static guard 14/0, binary+wrapper packaged, packaged binary runs end-to-end.
- **No production mutation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
