### PR TITLE
fix(security): v1.145 PR-C2 harden SSH-port apply path and verified state commits

### DIFF
--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -765,24 +765,26 @@ EOF
             # v1.48.0: Direct nft commands with verification (replaces unreliable IPC)
             # IPC add/delete was fire-and-forget — claimed success without verifying.
             # Direct nft commands give immediate feedback and guaranteed state change.
-            if nft list table ${NFTBAN_TABLE_IPV4} >/dev/null 2>&1; then
-                # FIRST: Add new port(s). v1.145 PR-B: add EVERY detected SSH
-                # port to BOTH tcp_ports_in AND ssh_ports (brute-force rate-limit
-                # parity), IPv4+IPv6 — ensure SSH access before removing old.
-                local _add_ok=false _sp _set
+            # v1.145 PR-C2: live apply-readiness re-probe (table + tcp_ports_in +
+            # ssh_ports), add EVERY detected SSH port to BOTH sets (IPv4+IPv6),
+            # then VERIFY the kernel actually carries the port — do NOT trust the
+            # `nft add` return code (it is non-zero when the element already
+            # exists). Success = verified kernel state, never a blind claim.
+            local _hstate _add_ok=false _sp _set
+            _hstate=$(nftban_ssh_apply_state "${NFTBAN_TABLE_IPV4}" 2>/dev/null || echo no-table)
+            if [[ "$_hstate" == "ready" ]]; then
                 for _sp in "${ssh_ports_union[@]}"; do
                     for _set in tcp_ports_in ssh_ports; do
-                        if nft add element ${NFTBAN_TABLE_IPV4} "$_set" "{ $_sp }" 2>/dev/null; then
-                            [[ "$_sp" == "$current_ssh_port" && "$_set" == "tcp_ports_in" ]] && _add_ok=true
-                        fi
+                        nft add element ${NFTBAN_TABLE_IPV4} "$_set" "{ $_sp }" 2>/dev/null || true
                         nft add element ${NFTBAN_TABLE_IPV6} "$_set" "{ $_sp }" 2>/dev/null || true
                     done
                 done
 
-                if [[ "$_add_ok" == "true" ]]; then
-                    ssh_issues+=("AUTO-FIXED: SSH port(s) ${ssh_ports_union[*]} ensured in tcp_ports_in + ssh_ports")
+                if nftban_ssh_port_in_both_sets "${NFTBAN_TABLE_IPV4}" "$current_ssh_port"; then
+                    _add_ok=true
+                    ssh_issues+=("AUTO-FIXED: SSH port(s) ${ssh_ports_union[*]} verified in tcp_ports_in + ssh_ports")
                 else
-                    ssh_issues+=("FAILED: Could not add SSH port(s) to nftables — run: nftban firewall reload")
+                    ssh_issues+=("FAILED: SSH port $current_ssh_port not confirmed in both sets — run: nftban firewall reload")
                 fi
 
                 # THEN: Remove old port — only if it is NOT a current listener
@@ -809,8 +811,10 @@ EOF
                         ssh_issues+=("INFO: Kept old port $old_ssh_port (still a listener or active SSH session)")
                     fi
                 fi
+            elif [[ "$_hstate" == "no-sets" ]]; then
+                ssh_issues+=("WARNING: nftban set-driven schema (tcp_ports_in/ssh_ports) not loaded — config updated but NOT applied. Run: nftban firewall reload")
             else
-                ssh_issues+=("Action required: Run 'nftban firewall reload' to apply changes")
+                ssh_issues+=("Action required: nftban firewall table absent — config updated but NOT applied. Run: nftban firewall reload")
             fi
 
             status=$HEALTH_WARNING  # Warning — port was changed

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -150,29 +150,38 @@ main() {
         if grep -qE "^${SSH_PORT}/(T|tcp)" "$SSH_WHITELIST" 2>/dev/null; then
             log "INFO" "SSH port check: config OK (port $SSH_PORT whitelisted)"
 
-            # v1.145 PR-B: ensure EVERY detected SSH port is present in BOTH
-            # tcp_ports_in (reachability) AND ssh_ports (brute-force rate-limit
-            # parity), IPv4+IPv6. Additive + idempotent. Removal of stale ports
-            # is conservative and handled in the port-change branch / PR-C.
-            if [[ "$_nft_table_available" == "true" ]]; then
-                local _sp _set
-                for _sp in "${SSH_PORTS[@]}"; do
-                    for _set in tcp_ports_in ssh_ports; do
-                        if ! nft list set ${NFTBAN_TABLE_IPV4} "$_set" 2>/dev/null | grep -qw "$_sp"; then
-                            log "WARN" "SSH port $_sp missing from $_set - auto-fixing (both-set parity)..."
-                            nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" "$_set" "$_sp" 2>/dev/null || true
-                            nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" "$_set" "$_sp" 2>/dev/null || true
-                        fi
+            # v1.145 PR-C2: re-probe the LIVE kernel (NEVER the once-cached
+            # _nft_table_available) immediately before applying. A table absent
+            # at timer-start but present now must not be skipped; conversely
+            # state must not advance when the kernel is not actually ready.
+            # Ensure EVERY detected SSH port is in BOTH tcp_ports_in AND
+            # ssh_ports (additive, idempotent). Removal stays conservative.
+            local _apply_state _sp _set
+            _apply_state=$(nftban_ssh_apply_state "${NFTBAN_TABLE_IPV4}" 2>/dev/null || echo no-table)
+            case "$_apply_state" in
+                ready)
+                    for _sp in "${SSH_PORTS[@]}"; do
+                        for _set in tcp_ports_in ssh_ports; do
+                            if ! nft list set ${NFTBAN_TABLE_IPV4} "$_set" 2>/dev/null | grep -qw "$_sp"; then
+                                log "WARN" "SSH port $_sp missing from $_set - auto-fixing (both-set parity)..."
+                                nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" "$_set" "$_sp" 2>/dev/null || true
+                                nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" "$_set" "$_sp" 2>/dev/null || true
+                            fi
+                        done
                     done
-                done
-            fi
-
-            # Clear alert state if port is now correct (atomic delete - no TOCTOU)
-            rm -f "$SSH_PORT_STATE" 2>/dev/null || true
-
-            # Ensure active port state is current (atomic write)
-            mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
-            echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
+                    # Clear alert state + refresh active-port marker ONLY when the
+                    # kernel is verified ready (PR-C2: never claim success blind).
+                    rm -f "$SSH_PORT_STATE" 2>/dev/null || true
+                    mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
+                    echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
+                    ;;
+                no-table)
+                    log "WARN" "nftban firewall table absent — SSH-port enforcement skipped this run (state NOT advanced). Run: nftban firewall reload"
+                    ;;
+                no-sets)
+                    log "WARN" "nftban set-driven schema (tcp_ports_in/ssh_ports) not loaded — SSH-port enforcement skipped (state NOT advanced). Run: nftban firewall reload"
+                    ;;
+            esac
         else
             # Check if we already alerted about this port change
             if [[ -f "$SSH_PORT_STATE" ]]; then
@@ -223,76 +232,68 @@ EOF
 
             log "INFO" "SSH port $SSH_PORT added to whitelist"
 
-            # ATOMIC firewall update - only update whitelist, don't touch other rules
-            log "INFO" "Atomically updating firewall whitelist for SSH port..."
-            if [[ "$_nft_table_available" == "true" ]]; then
-                # Firewall is active - do atomic whitelist update
-                # This only updates the tcp_ports_in set, not the entire firewall
-                if nft list set ${NFTBAN_TABLE_IPV4} tcp_ports_in >/dev/null 2>&1; then
-                    # FIRST: Add the NEW port (safety - ensure SSH access before removing old)
-                    if nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" tcp_ports_in "$SSH_PORT"; then
-                        log "INFO" "SSH port $SSH_PORT added to firewall (via daemon)"
-                        # Also add to IPv6 table
-                        nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
-                        # v1.145 PR-B both-set parity: ssh_ports must carry the SSH
-                        # port too (brute-force rate-limit rule reads @ssh_ports).
-                        nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" ssh_ports "$SSH_PORT" 2>/dev/null || true
-                        nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" ssh_ports "$SSH_PORT" 2>/dev/null || true
+            # Firewall update for the changed SSH port. v1.145 PR-C2: re-probe
+            # the LIVE kernel (never the once-cached _nft_table_available);
+            # add-before-delete; VERIFY both sets carry the new port; advance the
+            # active-port state ONLY on verified kernel success.
+            log "INFO" "Applying SSH-port change to firewall (verified)..."
+            local _kernel_applied=false
+            local _autofix_state
+            _autofix_state=$(nftban_ssh_apply_state "${NFTBAN_TABLE_IPV4}" 2>/dev/null || echo no-table)
+            if [[ "$_autofix_state" == "ready" ]]; then
+                # FIRST: add the NEW port to BOTH sets (IPv4+IPv6) before removing old.
+                nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
+                nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" tcp_ports_in "$SSH_PORT" 2>/dev/null || true
+                nft_ipc_add_element "${NFTBAN_TABLE_IPV4}" ssh_ports "$SSH_PORT" 2>/dev/null || true
+                nft_ipc_add_element "${NFTBAN_TABLE_IPV6}" ssh_ports "$SSH_PORT" 2>/dev/null || true
 
-                        # THEN: Remove the OLD port — but ONLY if it is no longer a
-                        # real SSH listener (absent from the detected union) AND is
-                        # not the active SSH_CLIENT session port. v1.145 PR-B:
-                        # conservative removal + both-set parity (tcp_ports_in AND
-                        # ssh_ports). Aggressive removal/apply-verification = PR-C.
-                        if [[ -n "$OLD_SSH_PORT" ]]; then
-                            local _active_ssh_port="${SSH_CLIENT##* }"
-                            local _old_still_listener=0 _u
-                            for _u in "${SSH_PORTS[@]}"; do
-                                if [[ "$_u" == "$OLD_SSH_PORT" ]]; then _old_still_listener=1; break; fi
+                # VERIFY the kernel actually carries the new port in BOTH sets.
+                if nftban_ssh_port_in_both_sets "${NFTBAN_TABLE_IPV4}" "$SSH_PORT"; then
+                    _kernel_applied=true
+                    log "INFO" "SSH port $SSH_PORT verified in tcp_ports_in + ssh_ports (kernel applied)"
+                    # THEN: conservatively remove the OLD port from BOTH sets,
+                    # only if it is no longer a listener and not the active session.
+                    if [[ -n "$OLD_SSH_PORT" ]]; then
+                        local _active_ssh_port="${SSH_CLIENT##* }" _old_still_listener=0 _u
+                        for _u in "${SSH_PORTS[@]}"; do
+                            if [[ "$_u" == "$OLD_SSH_PORT" ]]; then _old_still_listener=1; break; fi
+                        done
+                        if [[ "$_old_still_listener" -eq 0 && "$OLD_SSH_PORT" != "${_active_ssh_port:-}" ]]; then
+                            log "INFO" "Removing stale old SSH port $OLD_SSH_PORT from firewall (both sets)..."
+                            local _dset
+                            for _dset in tcp_ports_in ssh_ports; do
+                                nft_ipc_delete_element "${NFTBAN_TABLE_IPV4}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
+                                nft_ipc_delete_element "${NFTBAN_TABLE_IPV6}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
                             done
-                            if [[ "$_old_still_listener" -eq 0 && "$OLD_SSH_PORT" != "${_active_ssh_port:-}" ]]; then
-                                log "INFO" "Removing stale old SSH port $OLD_SSH_PORT from firewall (both sets)..."
-                                local _dset
-                                for _dset in tcp_ports_in ssh_ports; do
-                                    nft_ipc_delete_element "${NFTBAN_TABLE_IPV4}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
-                                    nft_ipc_delete_element "${NFTBAN_TABLE_IPV6}" "$_dset" "$OLD_SSH_PORT" 2>/dev/null || true
-                                done
-                            else
-                                log "INFO" "Keeping old SSH port $OLD_SSH_PORT (still a listener or active session)"
-                            fi
-                        fi
-
-                        log "INFO" "ALERT: SSH port changed and firewall updated (no lockout risk)"
-                    else
-                        # IPC failed - daemon may be down, try systemctl restart
-                        log "WARN" "Daemon IPC failed, restarting nftables service..."
-                        if systemctl restart nftables 2>/dev/null; then
-                            log "INFO" "Firewall reloaded - SSH port $SSH_PORT now allowed"
                         else
-                            log "WARN" "Reload failed - SSH port whitelisted but not yet applied"
-                            log "WARN" "Please run: systemctl restart nftables"
+                            log "INFO" "Keeping old SSH port $OLD_SSH_PORT (still a listener or active session)"
                         fi
                     fi
                 else
-                    log "WARN" "Whitelist sets not found - firewall may need reinitialization"
+                    log "WARN" "SSH port $SSH_PORT NOT confirmed in kernel sets after add — apply incomplete, active state NOT advanced. Run: nftban firewall reload"
                 fi
+            elif [[ "$_autofix_state" == "no-sets" ]]; then
+                log "WARN" "nftban set-driven schema not loaded (tcp_ports_in/ssh_ports missing) — SSH port whitelisted in config but NOT applied. Run: nftban firewall reload"
             else
-                log "WARN" "Firewall not initialized - whitelist updated but not applied"
-                log "INFO" "Run 'nftban firewall rebuild' to activate firewall"
+                log "WARN" "nftban firewall table absent — SSH port whitelisted in config but NOT applied. Run: nftban firewall reload"
             fi
 
-            # Save alert state to prevent spam (only alert once per port change)
-            # Use atomic writes to prevent TOCTOU race conditions
+            # Alert-dedup marker (independent of apply outcome — prevents spam).
             mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
             echo "$SSH_PORT" > "${SSH_PORT_STATE}.tmp" && mv -f "${SSH_PORT_STATE}.tmp" "$SSH_PORT_STATE"
-            # Update active port state for future cleanup (atomic)
-            echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
+            # v1.145 PR-C2: advance the ACTIVE-port marker ONLY on verified kernel
+            # success — never record success when the kernel did not change.
+            if [[ "$_kernel_applied" == "true" ]]; then
+                echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
+            else
+                log "WARN" "Active SSH-port state NOT advanced to $SSH_PORT (kernel apply unverified) — prevents a false 'applied' record."
+            fi
 
             # Send alert via NFTBan unified mail mechanism (ONLY ONCE)
             if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/mail.conf" ]]; then
                 local alert_msg="NFTBan Security Alert: SSH port changed to $SSH_PORT"
                 [[ -n "$OLD_SSH_PORT" ]] && alert_msg+=", old port $OLD_SSH_PORT removed"
-                alert_msg+=", auto-whitelisted and firewall reloaded on $(hostname) at $(date)"
+                alert_msg+=", auto-whitelisted on $(hostname) at $(date) (kernel applied=$_kernel_applied)"
                 nftban_mail_send "$alert_msg" 2>/dev/null || true
             fi
         fi

--- a/cli/lib/nftban/lib/ssh_port_detect.sh
+++ b/cli/lib/nftban/lib/ssh_port_detect.sh
@@ -126,3 +126,41 @@ _nftban_ssh_detect_fallback() {
     } 2>/dev/null | grep -E '^[0-9]+$' | awk '$1>=1 && $1<=65535' | sort -un
     )
 }
+
+# =============================================================================
+# v1.145 PR-C2 — apply-path readiness + verification (LIVE, never cached)
+# =============================================================================
+# These replace the once-cached _nft_table_available gate for SSH-port apply
+# blocks. The fw1-class fragility was: _nft_table_available is computed ONCE at
+# maintenance start; if the table is genuinely absent at that instant (reset/
+# rollback/failed-or-fresh init), the false is cached for the whole run and all
+# apply blocks skip — advancing state/config without a kernel change. These
+# helpers re-probe the live kernel immediately before each apply and verify the
+# kernel actually changed before the caller commits state/config.
+
+# nftban_ssh_apply_state <table-spec> — echo the live apply-readiness of a
+# family: "ready" (table + tcp_ports_in + ssh_ports all present),
+# "no-table" (firewall not loaded), or "no-sets" (table present but the
+# v1.145 set-driven schema, incl. ssh_ports, is not loaded → needs reload).
+nftban_ssh_apply_state() {
+    local _tbl="$1"
+    # shellcheck disable=SC2086  # table spec is two words (family name)
+    nft list table $_tbl >/dev/null 2>&1 || { printf 'no-table\n'; return 0; }
+    # shellcheck disable=SC2086
+    if nft list set $_tbl tcp_ports_in >/dev/null 2>&1 && nft list set $_tbl ssh_ports >/dev/null 2>&1; then
+        printf 'ready\n'
+    else
+        printf 'no-sets\n'
+    fi
+}
+
+# nftban_ssh_port_in_both_sets <table-spec> <port> — 0 iff <port> is present in
+# BOTH tcp_ports_in AND ssh_ports in the live kernel (post-apply verification).
+nftban_ssh_port_in_both_sets() {
+    local _tbl="$1" _port="$2"
+    # shellcheck disable=SC2086
+    nft list set $_tbl tcp_ports_in 2>/dev/null | grep -qw "$_port" || return 1
+    # shellcheck disable=SC2086
+    nft list set $_tbl ssh_ports 2>/dev/null | grep -qw "$_port" || return 1
+    return 0
+}

--- a/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - PR-C2 apply-path hardening tests
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v145_pr_c2_apply_hardening_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Tests for v1.145 PR-C2 apply-path hardening: the live (never-cached) readiness helper nftban_ssh_apply_state (ready/no-table/no-sets) and the post-apply verifier nftban_ssh_port_in_both_sets, plus static assertions that maintenance/health advance state/config only on verified kernel success and no longer gate SSH-port apply on the once-cached _nft_table_available."
+# meta:input="None (mocks nft)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/cli/lib/nftban/lib/ssh_port_detect.sh"
+
+pass=0; fail=0
+ok()  { echo "  PASS  $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL  $1"; fail=$((fail+1)); }
+
+# Mock nft. MODE controls table/set presence; TCP_ELEMS/SSH_ELEMS the contents.
+MODE="ready"; TCP_ELEMS="22, 80, 443"; SSH_ELEMS="22"
+nft() {
+    local a="$*"
+    case "$a" in
+        "list table ip nftban")
+            [[ "$MODE" == "no-table" ]] && return 1; return 0 ;;
+        "list set ip nftban tcp_ports_in")
+            [[ "$MODE" == "no-table" ]] && return 1
+            echo "set tcp_ports_in { elements = { $TCP_ELEMS } }"; return 0 ;;
+        "list set ip nftban ssh_ports")
+            { [[ "$MODE" == "no-table" || "$MODE" == "no-sets" ]]; } && return 1
+            echo "set ssh_ports { elements = { $SSH_ELEMS } }"; return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (got '$1')"; fi; }
+
+echo "== nftban_ssh_apply_state =="
+MODE=ready;    eq "$(nftban_ssh_apply_state 'ip nftban')" "ready"    "ready when table+both sets present"
+MODE=no-table; eq "$(nftban_ssh_apply_state 'ip nftban')" "no-table" "no-table when table absent"
+MODE=no-sets;  eq "$(nftban_ssh_apply_state 'ip nftban')" "no-sets"  "no-sets when ssh_ports missing"
+
+echo "== nftban_ssh_port_in_both_sets =="
+MODE=ready; TCP_ELEMS="22, 80, 443"; SSH_ELEMS="22"
+if nftban_ssh_port_in_both_sets "ip nftban" 22; then ok "22 in BOTH sets -> verified"; else bad "22 both"; fi
+TCP_ELEMS="55000, 80, 443"; SSH_ELEMS="22"   # 55000 only in tcp, not ssh_ports
+if nftban_ssh_port_in_both_sets "ip nftban" 55000; then bad "55000 only-in-tcp wrongly verified"; else ok "55000 only-in-tcp -> NOT verified"; fi
+TCP_ELEMS="22, 80, 443"; SSH_ELEMS="55000"   # 55000 only in ssh_ports, not tcp
+if nftban_ssh_port_in_both_sets "ip nftban" 55000; then bad "55000 only-in-ssh wrongly verified"; else ok "55000 only-in-ssh -> NOT verified"; fi
+
+echo "== static: verified-commit gating in maintenance/health =="
+M="$REPO_ROOT/cli/lib/nftban/cron/maintenance.sh"
+H="$REPO_ROOT/cli/lib/nftban/core/nftban_health_checks_security.sh"
+has() { if grep -q "$2" "$1"; then ok "$3"; else bad "$3"; fi; }
+has "$M" 'nftban_ssh_apply_state' "maintenance uses live nftban_ssh_apply_state"
+has "$M" 'nftban_ssh_port_in_both_sets' "maintenance verifies both sets"
+if grep -q '_kernel_applied' "$M" && grep -q 'kernel apply unverified' "$M"; then ok "maintenance gates active-state on _kernel_applied"; else bad "maintenance state-gate"; fi
+has "$H" 'nftban_ssh_apply_state' "health uses live nftban_ssh_apply_state"
+has "$H" 'nftban_ssh_port_in_both_sets' "health verifies both sets via kernel (not the add return code)"
+# the SSH-port apply blocks must no longer gate on the once-cached value
+if grep -nE '_nft_table_available == "true"' "$M" | grep -q .; then bad "maintenance still has _nft_table_available gate in an apply block"; else ok "maintenance: no _nft_table_available gate on SSH apply blocks"; fi
+
+echo
+echo "RESULT: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/tools/validation/v145_pr_c1_apply_path_collector.sh
+++ b/tools/validation/v145_pr_c1_apply_path_collector.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.145 - PR-C1 apply-path root-cause collector (READ-ONLY)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="v145_pr_c1_apply_path_collector" meta:type="tool" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="READ-ONLY diagnostic collector for the v1.145 PR-C1 apply-path root-cause (why _nft_table_available can be false while the nftban table exists). Captures table-probe transience, lock/concurrency correlation, systemd context, socket-activation state, and SSH-port config/state. Mutates NOTHING: no nft add/delete/flush, no reload, no restart, no SSH-port change."
+# meta:input="None"
+# meta:output="Structured diagnostic record on stdout"
+# meta:depends="bash,nft,ss,systemctl,journalctl,sshd"
+# meta:inventory.files=""
+# meta:inventory.binaries="nft,ss,systemctl,journalctl,sshd,fuser"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR,NFTBAN_DATA_DIR,NFTBAN_TABLE_IPV4,NFTBAN_TABLE_IPV6"
+# meta:inventory.config_files="/etc/nftban/nftban.conf,/etc/nftban/nftban.conf.local,/etc/ssh/sshd_config"
+# meta:inventory.systemd_units="nftban-maintenance.service,ssh.socket"
+# meta:inventory.network=""
+# meta:inventory.privileges="root (read-only nft/ss/journal/sshd -T)"
+# =============================================================================
+#
+# READ-ONLY by construction: every external call is a query (list/show/read).
+# There is NO nft add/delete/flush, NO firewall reload/rebuild, NO service
+# restart, NO sshd_config edit, NO SSH-port change. Safe to run on lab and
+# (read-only) service hosts. Probe count defaults to 50 quick `nft list table`
+# calls to detect transient rc flaps (H1/H2); override with arg1.
+set -Eeuo pipefail
+
+PROBES="${1:-50}"
+HOSTN="$(hostname 2>/dev/null || echo unknown)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+
+echo "============================================================"
+echo "V145 PR-C1 apply-path collector (READ-ONLY)"
+echo "host=$HOSTN  utc=$TS  probes=$PROBES"
+echo "MODE: read-only — no nft mutation, no reload, no restart"
+echo "============================================================"
+
+# Effective table vars — mirror maintenance.sh resolution (conf then default).
+NFTBAN_CONFIG_DIR="${NFTBAN_CONFIG_DIR:-/etc/nftban}"
+# shellcheck source=/dev/null
+source "$NFTBAN_CONFIG_DIR/nftban.conf" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$NFTBAN_CONFIG_DIR/nftban.conf.local" 2>/dev/null || true
+: "${NFTBAN_TABLE_IPV4:=ip nftban}"
+: "${NFTBAN_TABLE_IPV6:=ip6 nftban}"
+echo "[vars] NFTBAN_TABLE_IPV4='$NFTBAN_TABLE_IPV4'  NFTBAN_TABLE_IPV6='$NFTBAN_TABLE_IPV6'  (H4: override iff not ip/ip6 nftban)"
+
+# --- H1/H2: rapid re-probe of the once-cached existence check ---------------
+echo "[probe] rapid 'nft list table' x$PROBES (detect transient rc flaps)"
+probe_set() {
+    local label="$1"; shift
+    local fails=0 i rc h
+    for ((i=0; i<PROBES; i++)); do
+        rc=0; nft list table "$@" >/dev/null 2>&1 || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            fails=$((fails+1))
+            h=""
+            if command -v fuser >/dev/null 2>&1; then
+                h="$(fuser /run/nftban/nft_operations.lock 2>/dev/null | tr -s ' ' || true)"
+            fi
+            echo "    FLAP $label iter=$i rc=$rc nft_operations.lock-holders='${h:-none}'"
+        fi
+    done
+    echo "  $label: $((PROBES-fails))/$PROBES ok, $fails transient failures"
+}
+# NOTE: $NFTBAN_TABLE_IPV4 is intentionally unquoted (two words: family name).
+# shellcheck disable=SC2086
+probe_set "ip nftban " $NFTBAN_TABLE_IPV4
+# shellcheck disable=SC2086
+probe_set "ip6 nftban" $NFTBAN_TABLE_IPV6
+
+# Single explicit probe with rc + stderr captured.
+_rc=0
+# shellcheck disable=SC2086  # table var is intentionally two words (family name)
+_err="$(nft list table $NFTBAN_TABLE_IPV4 2>&1 >/dev/null || true)"
+# shellcheck disable=SC2086
+nft list table $NFTBAN_TABLE_IPV4 >/dev/null 2>&1 || _rc=$?
+echo "[probe] single ip nftban: rc=$_rc stderr='${_err}'"
+
+# --- all tables (family/legacy/inet mismatch — H4) --------------------------
+echo "[tables] nft list tables:"
+nft list tables 2>&1 | sed 's/^/  /' || true
+
+# --- locks / concurrency (H2) ----------------------------------------------
+echo "[locks] /run/nftban lock state + holders:"
+for L in maintenance.lock nft_operations.lock update.lock; do
+    p="/run/nftban/$L"
+    if [[ -e "$p" ]]; then
+        hold="none"
+        command -v fuser >/dev/null 2>&1 && hold="$(fuser "$p" 2>/dev/null | tr -s ' ' || echo none)"
+        echo "  $L: present  holders='${hold:-none}'  mtime=$(stat -c %y "$p" 2>/dev/null || echo ?)"
+    else
+        echo "  $L: absent"
+    fi
+done
+
+# --- systemd context (H3) ---------------------------------------------------
+echo "[systemd] nftban-maintenance.service:"
+systemctl show nftban-maintenance.service \
+    -p User -p CapabilityBoundingSet -p AmbientCapabilities -p PrivateNetwork \
+    -p RestrictNamespaces -p ActiveState -p Result -p ExecMainStatus 2>/dev/null \
+    | sed 's/^/  /' || true
+echo "  maintenance.timer active=$(systemctl is-active nftban-maintenance.timer 2>/dev/null || echo n/a)"
+
+# --- socket activation (ties to PR-D) ---------------------------------------
+echo "[ssh] socket/service state:"
+for u in ssh.socket sshd.socket ssh.service sshd.service; do
+    # is-active returns non-zero for inactive units; capture its word regardless.
+    _st="$(systemctl is-active "$u" 2>/dev/null || true)"
+    echo "  $u: ${_st:-unknown}"
+done
+echo "  sshd -T port: $(sshd -T 2>/dev/null | grep '^port ' | awk '{print $2}' | tr '\n' ' ' || echo n/a)"
+echo "  ss sshd listeners:"
+ss -tlnp 2>/dev/null | grep -i sshd | sed 's/^/    /' || echo "    (none)"
+
+# --- SSH-port config/state (alignment / migration check) --------------------
+echo "[state] ssh_port_active.state: $(cat "${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/ssh_port_active.state" 2>/dev/null || echo none)"
+echo "[state] ports.d/00-ssh.conf: $(grep -vhE '^#|^$' "${NFTBAN_CONFIG_DIR}/ports.d/00-ssh.conf" 2>/dev/null | tr '\n' ' ' || echo none)"
+echo "[state] sshd_config Port lines: $(grep -hE '^[[:space:]]*Port[[:space:]]' /etc/ssh/sshd_config 2>/dev/null | tr '\n' ' ' || echo '(default 22)')"
+echo "[state] sshd_config ListenAddress: $(grep -hiE '^[[:space:]]*ListenAddress[[:space:]]' /etc/ssh/sshd_config 2>/dev/null | tr '\n' ' ' || echo none)"
+
+# --- journals (recent, read-only; bounded + timeout-guarded so the collector
+#     never hangs on a high-volume host) ---------------------------------------
+echo "[journal] nftban-maintenance (last 5):"
+timeout 15 journalctl -u nftban-maintenance.service --no-pager -n 5 2>/dev/null | sed 's/^/  /' || echo "  (none / timed out)"
+echo "[journal] reload/rebuild/not-applied markers (unit-scoped, last 5):"
+# Unit-scoped + journalctl-side grep (-g) + line cap; whole call timeout-bounded.
+timeout 20 journalctl -u nftban-maintenance.service -u nftban-firewall-init.service \
+    --no-pager -n 400 -g 'firewall reload|firewall rebuild|nft_table_available|not applied|nftban-installer' 2>/dev/null \
+    | tail -5 | sed 's/^/  /' || echo "  (none / timed out)"
+
+echo "============================================================"
+echo "END collector — READ-ONLY, no mutation performed."
+echo "============================================================"


### PR DESCRIPTION
## v1.145 PR-C2 — harden SSH-port apply path + verified state commits

Closes the apply-path half of the SSH-port lifecycle bug class. **Base: main `1b8305e8`** (PR-A + PR-B). **The PR-C1 read-only collector is folded into this PR.**

### Root-cause evidence (PR-C1)
- Controlled lab2 reproduction: a **benign reload/rebuild race is NOT reproduced** — both paths keep the nftban table present (reload = atomic `nft -f`; rebuild = `nft flush table`, which empties but does not delete). 0 flaps across 7,476 probes.
- Root cause refined: `_nft_table_available=false` requires **genuine table absence** (reset/rollback `nft flush ruleset`, failed/fresh init, broken transition like fw1). The real fragility is the **once-cached** check — computed once at maintenance start and reused for the whole run, so a brief/early absence disables apply for the entire run, advancing state/config without a kernel change.

### Hardening
- SSH apply paths (maintenance + health) now **re-probe the LIVE kernel before each mutation** — never the once-cached `_nft_table_available`.
- **Verify `tcp_ports_in` + `ssh_ports` both carry the port before treating apply as success** (`nftban_ssh_apply_state` / `nftban_ssh_port_in_both_sets`).
- **Add-before-delete preserved**; **`SSH_CLIENT` active-port remove guard preserved**; conservative stale-port removal preserved.
- State/config (`ssh_port_active.state`) advances **only after verified kernel success**; otherwise a **loud failure instructing `nftban firewall reload`**.

### Out of scope (not done here)
- No PR-D socket-activation warning · No PR-E lifecycle validator · No docs.

### Validation
- lab2 (Ubuntu 24.04): `go build ./...` + detect tests, shellcheck (0 warn+ on all touched files), wrapper + PR-B static guard + C2 tests, **DEB rc=0**; live no-sets demo on real pre-v1.145 host returns `no-sets` as designed.
- lab4 (EL9): **RPM rc=0**; wrapper + helper binary + collector packaged.
- **No production mutation** (lab2 repro/demo on the designated lab only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
