### PR TITLE
fix(security): v1.145 PR-B2 — multi-port SSH union (daemon routing + install/reload render + ports.d, no lockout)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -108,20 +108,36 @@ _firewall_substitute_placeholders() {
         return 1
     fi
 
-    # v1.145 PR-B: single SSH port for this display/CT-limit context. Uses the
-    # NAMED primary helper (lowest of the detected union via the shared Go
-    # detector: ss + sshd_config Port + ListenAddress + state + conf.local) —
-    # NOT a silent head -1. A single value is acceptable HERE because this only
-    # seeds a per-IP CT-limit/display value; full multi-port firewall
-    # ENFORCEMENT is rendered set-driven (@ssh_ports) and kept in parity by the
-    # maintenance/health autofix paths (which use the full union in both sets).
-    local _ssh_port=""
+    # v1.145 lockout fix (HOLD_V145_AND_FIX_SHELL_RENDER_PORTSD_UNION):
+    # __SSH_PORT__ appears ONLY inside `elements = { ... }` for ssh_ports and
+    # tcp_ports_in (both ip and ip6) — there is NO single-value context. So we
+    # substitute the FULL detected SSH union (comma-separated), NOT just the
+    # primary. This keeps EVERY detected SSH listener port in BOTH sets on every
+    # reload/rebuild, so a multi-port host can never collapse to primary-only
+    # and `nftban firewall reload` can never drop an operator connected on a
+    # secondary SSH port. Fallback chain: live union -> ports.d union -> primary
+    # -> 22 (never empty, never primary-only when more ports are live).
+    local _ssh_port="" _ssh_ports_csv=""
     # shellcheck source=/dev/null
     source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null || true
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        _ssh_ports_csv=$(nftban_detect_ssh_ports 2>/dev/null | grep -E '^[0-9]+$' | paste -sd, - 2>/dev/null) || true
+    fi
     if declare -f nftban_detect_ssh_primary_port >/dev/null 2>&1; then
         _ssh_port=$(nftban_detect_ssh_primary_port 2>/dev/null) || true
     fi
     [[ -z "$_ssh_port" || ! "$_ssh_port" =~ ^[0-9]+$ ]] && _ssh_port=22
+    # Fallback to the persisted ports.d SSH union if live detection returned nothing.
+    if [[ -z "$_ssh_ports_csv" ]]; then
+        local _portsd="${NFTBAN_CONFIG_DIR:-/etc/nftban}/ports.d/00-ssh.conf"
+        if [[ -f "$_portsd" ]]; then
+            _ssh_ports_csv=$(grep -oE '^[0-9]+' "$_portsd" 2>/dev/null | sort -un | paste -sd, - 2>/dev/null) || true
+        fi
+    fi
+    # Final fallback: primary (then 22 via the guard above).
+    [[ -z "$_ssh_ports_csv" ]] && _ssh_ports_csv="$_ssh_port"
+    # Template style: "22, 2222, 55000"
+    _ssh_ports_csv=$(printf '%s' "$_ssh_ports_csv" | sed 's/,/, /g')
 
     # CT limits — use DDoS config when available, else sensible defaults
     local _ct_ssh=15 _ct_http=150 _ct_mail=150
@@ -137,7 +153,7 @@ _firewall_substitute_placeholders() {
     [[ -n "${DDOS_CLASSIC_HTTP_CONN_LIMIT:-}" ]] && _ct_http="$DDOS_CLASSIC_HTTP_CONN_LIMIT"
     [[ -n "${DDOS_CLASSIC_SMTP_CONN_LIMIT:-}" ]] && _ct_mail="$DDOS_CLASSIC_SMTP_CONN_LIMIT"
 
-    sed -e "s/__SSH_PORT__/${_ssh_port}/g" \
+    sed -e "s/__SSH_PORT__/${_ssh_ports_csv}/g" \
         -e "s/__CT_LIMIT_SSH__/${_ct_ssh}/g" \
         -e "s/__CT_LIMIT_HTTP__/${_ct_http}/g" \
         -e "s/__CT_LIMIT_MAIL__/${_ct_mail}/g" \

--- a/cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
@@ -120,6 +120,22 @@ else
     bad "cmd_port help does not clarify FTP/Pure-FTPd vs ssh_ports boundary"
 fi
 
+echo "== (h) shell reload/rebuild render the SSH UNION, not primary-only (lockout fix) =="
+FW=cli/lib/nftban/cli/cmd_firewall.sh
+# _firewall_substitute_placeholders must source the UNION detector and substitute
+# the comma-joined union into __SSH_PORT__ (which only appears in elements={...}).
+if grep -q 'nftban_detect_ssh_ports' "$FW" && grep -qE 's/__SSH_PORT__/\$\{_ssh_ports_csv\}/' "$FW"; then
+    ok "cmd_firewall substitutes the SSH union (_ssh_ports_csv) into __SSH_PORT__"
+else
+    bad "cmd_firewall still renders primary-only (__SSH_PORT__ not union) — reload could drop a secondary SSH port"
+fi
+# The durable ports.d writer must persist the union (Go PersistSSHPortsUnion).
+if grep -q 'PersistSSHPortsUnion' internal/installer/render/config.go && grep -q 'PersistSSHPortsUnion' cmd/nftban-installer/phases.go; then
+    ok "installer persists the SSH union to ports.d (PersistSSHPortsUnion wired)"
+else
+    bad "installer does not persist the SSH union to ports.d"
+fi
+
 echo ""
 echo "v1.145 PR-G ssh_ports invariants: $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -108,7 +108,12 @@ func phaseDetect(ctx context.Context, exec executor.Executor, sf *state.StateFil
 	// port callers; install_state SSH_PORT field stays single-int), pd.sshPorts
 	// = full list (consumed by phasePrepare → render.RenderNftablesConfMultiPort
 	// so the rendered nftables.conf allow-set covers every detected port).
-	sshPorts, sshPort, err := detect.DetectSSHPorts(exec, log)
+	// v1.145 PR-B2: render the FULL detected union (ss + sshd_config Port +
+	// ListenAddress + state + conf.local), primary-first — not just the
+	// ss-listener subset DetectSSHPorts returns — so every SSH listener port
+	// is seeded into tcp_ports_in + ssh_ports at install time (no missing port
+	// → no external DROP → no multi-port lockout).
+	sshPorts, sshPort, err := detect.DetectSSHPortsForRender(exec, log)
 	if err != nil {
 		log.Error("SSH port detection failed: %v", err)
 		return sf.Transition(state.StateFailedSSH, state.PhaseDetect, err.Error())

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -312,8 +312,11 @@ func phasePrepare(ctx context.Context, exec executor.Executor, sf *state.StateFi
 		}
 	}
 
-	// 8. Persist SSH port to conf.local and state file
+	// 8. Persist SSH port to conf.local and state file (primary), AND the full
+	// detected union to ports.d so durable port intent never collapses to
+	// primary-only on a shell reload/rebuild (v1.145 lockout fix).
 	render.PersistSSHPort(exec, pd.sshPort, log)
+	render.PersistSSHPortsUnion(exec, pd.sshPorts, log)
 
 	log.PhaseEnd("Prepare")
 	return sf.Transition(state.StatePrepareComplete, state.PhasePrepare, "")

--- a/cmd/nftband/daemon_types.go
+++ b/cmd/nftband/daemon_types.go
@@ -77,6 +77,13 @@ var knownNFTBanSets = map[string]bool{
 	"geoban_ipv4": true, "geoban_ipv6": true,
 	"tcp_ports_in": true, "tcp_ports_out": true,
 	"udp_ports_in": true, "udp_ports_out": true,
+	// v1.145 PR-B2: ssh_ports is the set-driven SSH brute-force rate-limit set
+	// (`tcp dport @ssh_ports ct count`). It MUST be daemon-writable so the
+	// runtime union reconciliation (maintenance/health) can keep every detected
+	// SSH listener port in BOTH tcp_ports_in AND ssh_ports. Without it the IPC
+	// rejected ssh_ports ("invalid set") and multi-port hosts left extra SSH
+	// ports out of the rate-limit set (and the runtime could not self-heal).
+	"ssh_ports": true,
 	// HTTP Bot Guard sets (v1.20.0)
 	"http_bot_suspect": true, "http_bot_suspect6": true,
 	"http_bot_allow": true, "http_bot_allow6": true,

--- a/cmd/nftband/daemon_types_test.go
+++ b/cmd/nftband/daemon_types_test.go
@@ -108,9 +108,13 @@ func TestValidNFTBanSet(t *testing.T) {
 
 func TestKnownNFTBanSets_Count(t *testing.T) {
 	// Verify we have the expected number of known sets
-	// 4 blacklist/whitelist + 2 persistent + 2 bogon + 2 geoban + 4 ports + 12 botguard + 4 port_allow = 30
-	if len(knownNFTBanSets) != 30 {
-		t.Errorf("expected 30 known sets, got %d", len(knownNFTBanSets))
+	// 4 blacklist/whitelist + 2 persistent + 2 bogon + 2 geoban + 4 ports
+	// + 1 ssh_ports (v1.145 PR-B2) + 12 botguard + 4 port_allow = 31
+	if len(knownNFTBanSets) != 31 {
+		t.Errorf("expected 31 known sets, got %d", len(knownNFTBanSets))
+	}
+	if !knownNFTBanSets["ssh_ports"] {
+		t.Error("ssh_ports must be a daemon-writable set (v1.145 PR-B2)")
 	}
 }
 

--- a/internal/installer/detect/ssh.go
+++ b/internal/installer/detect/ssh.go
@@ -354,6 +354,33 @@ func parseSSHConfigPorts(exec executor.Executor, path string) []int {
 	return ports
 }
 
+// DetectSSHPortsForRender returns the FULL SSH-port union (primary-first) plus
+// the SSH_CLIENT-aware primary, for the installer render path.
+//
+// v1.145 PR-B2: the render must seed EVERY detected SSH port into tcp_ports_in
+// AND ssh_ports, not just the `ss`-listener subset that DetectSSHPorts returns.
+// On a multi-port host where `ss` detection is partial/ordered, DetectSSHPorts
+// could return a subset (observed: 22+55000 but not 2222), leaving the missing
+// port out of the kernel sets → externally DROPPED → lockout for an operator
+// using it. DetectSSHPortsUnion is the authoritative multi-source detector
+// (ss + sshd_config Port + ListenAddress + state + conf.local); this wraps it
+// primary-first for RenderNftablesConfMultiPort. Falls back to DetectSSHPorts'
+// primary when the union is empty.
+func DetectSSHPortsForRender(exec executor.Executor, log *logging.Logger) (ports []int, primary int, err error) {
+	union := DetectSSHPortsUnion(exec, log)
+	_, primary, err = DetectSSHPorts(exec, log)
+	if len(union) == 0 {
+		if err != nil {
+			return nil, 0, err
+		}
+		return []int{primary}, primary, nil
+	}
+	if primary == 0 {
+		primary = selectPrimarySSHPort(union, sshClientLocalPort())
+	}
+	return primaryFirstPorts(union, primary), primary, nil
+}
+
 // sshConfigAllPorts returns all Port + ListenAddress ports from the main
 // sshd_config and every *.conf drop-in.
 func sshConfigAllPorts(exec executor.Executor) []int {

--- a/internal/installer/render/config.go
+++ b/internal/installer/render/config.go
@@ -29,7 +29,42 @@ import (
 const (
 	confLocal    = "/etc/nftban/nftban.conf.local"
 	sshStateFile = "/var/lib/nftban/state/ssh_port_active.state"
+	// portsDSSHFile is the durable SSH-port whitelist consumed by the ports
+	// loader and by the shell reload/rebuild union fallback.
+	portsDSSHFile = "/etc/nftban/ports.d/00-ssh.conf"
 )
+
+// PersistSSHPortsUnion writes EVERY detected SSH listener port to the durable
+// ports.d SSH file, so reload/rebuild and the ports loader keep all listeners
+// whitelisted (lockout-safe) — not just the primary. Without this, a multi-port
+// host's durable port intent collapses to the shipped default (22 only), and a
+// shell render/reload could drop a secondary SSH management port. Idempotent
+// overwrite; format PORT/PROTOCOL/DIRECTION (T=TCP, I=Input).
+func PersistSSHPortsUnion(exec executor.Executor, ports []int, log *logging.Logger) {
+	if len(ports) == 0 {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("# NFTBan SSH port whitelist (machine-generated — full detected union)\n")
+	b.WriteString("# Keeps every detected SSH listener port allowed so reload/rebuild\n")
+	b.WriteString("# cannot collapse a multi-port host to primary-only (lockout-safe).\n")
+	b.WriteString("# Format: PORT/PROTOCOL/DIRECTION (T=TCP, I=Input)\n")
+	seen := make(map[int]bool, len(ports))
+	count := 0
+	for _, p := range ports {
+		if p < 1 || p > 65535 || seen[p] {
+			continue
+		}
+		seen[p] = true
+		b.WriteString(strconv.Itoa(p) + "/T/I\n")
+		count++
+	}
+	if err := exec.WriteFileAtomic(portsDSSHFile, []byte(b.String()), 0644); err != nil {
+		log.Warn("persist SSH union to %s: %v", portsDSSHFile, err)
+		return
+	}
+	log.Info("persisted SSH port union (%d ports) to %s", count, portsDSSHFile)
+}
 
 // PersistSSHPort writes the detected SSH port to conf.local and state file.
 // Also ensures TCP_PORTS_IN includes the SSH port (lockout prevention).

--- a/internal/nftbackend/backend.go
+++ b/internal/nftbackend/backend.go
@@ -37,6 +37,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -446,6 +447,27 @@ type AddElementRequest struct {
 	Timeout int    // seconds, 0 = permanent
 }
 
+// portSets enumerates the named nftables sets whose key type is inet_service
+// (uint16 port numbers) rather than an IP/CIDR. Generic element add/delete must
+// route these through the port-aware path; the IP interval-set path would try to
+// net.ParseIP the element and fail with "invalid IP or CIDR: <port>".
+//
+// v1.145 PR-B2: ssh_ports joined this list. It is the set-driven SSH brute-force
+// rate-limit set (`tcp dport @ssh_ports ct count`). Runtime union reconciliation
+// (maintenance/health/cmd_port) writes detected SSH ports into ssh_ports AND
+// tcp_ports_in via nft_ipc_add_element; both are inet_service sets, so both must
+// route here. Before this, the generic add path treated the port as an IP and
+// silently failed (callers swallow errors with `|| true`), so multi-port hosts
+// could not self-heal missing SSH ports.
+var portSets = map[string]bool{
+	"tcp_ports_in": true, "tcp_ports_out": true,
+	"udp_ports_in": true, "udp_ports_out": true,
+	"ssh_ports": true,
+}
+
+// isPortSet reports whether setName is an inet_service (port) set.
+func isPortSet(setName string) bool { return portSets[setName] }
+
 // AddElement adds an element to any set
 // This is the ONLY authorized add element implementation
 func (b *Backend) AddElement(ctx context.Context, req AddElementRequest) error {
@@ -473,6 +495,32 @@ func (b *Backend) AddElement(ctx context.Context, req AddElementRequest) error {
 		b.stats.Errors++
 		b.stats.LastError = fmt.Sprintf("get table: %v", err)
 		return fmt.Errorf("failed to get table: %w", err)
+	}
+
+	// v1.145 PR-B2: port sets (inet_service / uint16) must NOT go through the
+	// IP interval-set path — AddIPWithTimeout would net.ParseIP the element and
+	// fail with "invalid IP or CIDR: <port>". Route named port sets to the
+	// port-aware path. Timeout is not applicable to port sets (they are
+	// permanent allow/rate-limit sets), so req.Timeout is ignored here.
+	if isPortSet(req.Set) {
+		port, perr := strconv.Atoi(strings.TrimSpace(req.Element))
+		if perr != nil {
+			b.stats.Errors++
+			b.stats.LastError = fmt.Sprintf("invalid port: %v", perr)
+			return fmt.Errorf("invalid port %q for set %s: %w", req.Element, req.Set, perr)
+		}
+		set, serr := b.nft.GetOrCreatePortSet(table, req.Set)
+		if serr != nil {
+			b.stats.Errors++
+			b.stats.LastError = fmt.Sprintf("get port set: %v", serr)
+			return fmt.Errorf("failed to get port set: %w", serr)
+		}
+		if aerr := b.nft.AddPortElements(set, []int{port}); aerr != nil {
+			b.stats.Errors++
+			b.stats.LastError = fmt.Sprintf("add port element: %v", aerr)
+			return fmt.Errorf("nft add port element failed: %w", aerr)
+		}
+		return nil
 	}
 
 	// Get or create set (assume interval set for IP sets)
@@ -529,6 +577,30 @@ func (b *Backend) DeleteElement(ctx context.Context, req DeleteElementRequest) e
 		b.stats.Errors++
 		b.stats.LastError = fmt.Sprintf("get table: %v", err)
 		return fmt.Errorf("failed to get table: %w", err)
+	}
+
+	// v1.145 PR-B2: route port sets to the port-aware delete path (see AddElement).
+	if isPortSet(req.Set) {
+		port, perr := strconv.Atoi(strings.TrimSpace(req.Element))
+		if perr != nil {
+			b.stats.Errors++
+			b.stats.LastError = fmt.Sprintf("invalid port: %v", perr)
+			return fmt.Errorf("invalid port %q for set %s: %w", req.Element, req.Set, perr)
+		}
+		set, serr := b.nft.GetOrCreatePortSet(table, req.Set)
+		if serr != nil {
+			b.stats.Errors++
+			b.stats.LastError = fmt.Sprintf("get port set: %v", serr)
+			return fmt.Errorf("failed to get port set: %w", serr)
+		}
+		if derr := b.nft.DeletePortElements(set, []int{port}); derr != nil {
+			if !errors.Is(derr, os.ErrNotExist) {
+				b.stats.Errors++
+				b.stats.LastError = fmt.Sprintf("delete port element: %v", derr)
+				return fmt.Errorf("nft delete port element failed: %w", derr)
+			}
+		}
+		return nil
 	}
 
 	// Get set

--- a/internal/nftbackend/backend_test.go
+++ b/internal/nftbackend/backend_test.go
@@ -107,3 +107,37 @@ func TestBackend_StatsErrorIncrement(t *testing.T) {
 		t.Error("LastError should be set after error")
 	}
 }
+
+// =============================================================================
+// Port-set routing (v1.145 PR-B2)
+// =============================================================================
+
+// TestIsPortSet locks the inet_service (port) set classification used by
+// AddElement/DeleteElement to route to the port-aware path. ssh_ports MUST be
+// classified as a port set; an IP set name MUST NOT. This is the guard that
+// keeps generic element writes (nft_ipc_add_element) from treating a port
+// number as an IP ("invalid IP or CIDR: <port>") for SSH-port reconciliation.
+func TestIsPortSet(t *testing.T) {
+	portSetNames := []string{
+		"tcp_ports_in", "tcp_ports_out",
+		"udp_ports_in", "udp_ports_out",
+		"ssh_ports",
+	}
+	for _, name := range portSetNames {
+		if !isPortSet(name) {
+			t.Errorf("isPortSet(%q) = false, want true (port set)", name)
+		}
+	}
+
+	ipSetNames := []string{
+		"blacklist_ipv4", "whitelist_ipv6",
+		"persistent_offenders_ipv4", "geoban_ipv6",
+		"http_bot_ban", "port_allow_tcp_ipv4",
+		"", "random",
+	}
+	for _, name := range ipSetNames {
+		if isPortSet(name) {
+			t.Errorf("isPortSet(%q) = true, want false (not a port set)", name)
+		}
+	}
+}


### PR DESCRIPTION
The headline v1.145 lockout fix. **Stacked on PR-G (#748)** → merge order C2 → G → **B2**.

## Problem
Multi-port SSH hosts (sshd on 22 + 2222 + 55000) lost protection on secondary ports: the daemon IPC rejected `ssh_ports`, the backend treated port values as IPs (`invalid IP or CIDR`), the install/shell render collapsed to primary-only, and `nftban firewall reload` regressed the kernel (`tcp_ports_in [22,80,443,55000] → [22,80,443]`) — dropping a live SSH listener.

## Fix
1. **daemon allowlist** (`daemon_types.go`): `ssh_ports` is daemon-writable (+ count test 30→31).
2. **backend port-set routing** (`backend.go` `isPortSet`): `AddElement`/`DeleteElement` route port sets (`tcp/udp_ports_*` + `ssh_ports`) to `AddPortElements`/`DeletePortElements` instead of the IP path — fixes `invalid IP or CIDR: <port>`.
3. **install render union** (`detect/ssh.go` `DetectSSHPortsForRender`, `phases.go`): render the full detected union.
4. **shell render + ports.d union** (`cmd_firewall.sh`, `render/config.go` `PersistSSHPortsUnion`): `_firewall_substitute_placeholders` substitutes the **live union** into `__SSH_PORT__` (appears only inside `elements = {…}`); install persists the union to `ports.d/00-ssh.conf`. Reload/rebuild can no longer collapse to primary-only.
5. invariant-test guards (union substitution wired; ports.d union persisted).

## Validation
- `NFTBAN_ROADMAP/V145_SHELL_RENDER_PORTSD_UNION_FIX_VALIDATION.md` — tgt-u2404 **14/0 PASS** (union in all 4 sets post-install AND after reload; ports.d=union).
- `NFTBAN_ROADMAP/V145_B2_G_MULTI_DISTRO_MATRIX_VALIDATION.md` — **10/10 distros PASS** (DEB: Ubuntu 22/24/26, Debian 11/12/13; RPM: Alma 8/9, CentOS-Stream 9, Rocky 9).
- `V145_B2_G_TGT_U2404_END_TO_END_MULTI_PORT_PROOF.md` (the BLOCKED proof that found the regression).

No external schema bump (1.83.0). No UDP touched. `@ssh_ports` semantics preserved. Defers to v1.146: SSH_CLIENT primary-select, nftables.service integration, EL SELinux policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)