### PR TITLE
fix(packaging): correct RPM %changelog weekday (Mon→Tue Mar 24 2026)

### DIFF
--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1271,7 +1271,7 @@ fi
 /etc/nftban/templates/nftban-suricata.logrotate
 
 %changelog
-* Mon Mar 24 2026 NFTBan Team <noreply@nftban.com> - 1.39.0-1
+* Tue Mar 24 2026 NFTBan Team <noreply@nftban.com> - 1.39.0-1
 - v1.39.0 Bug Fixes + UX Hardening + Security Quick Wins
 - CIDR ban/unban routing fix, emulate blacklist_manual coverage
 - Install auto-takeover on panel servers


### PR DESCRIPTION
Tiny packaging fix, independent of the v1.145 SSH work (own PR per untangle plan).

`build_nftban.sh` emits `%changelog` with `* Mon Mar 24 2026` — but that date is a **Tuesday**. Stricter `rpm` (Ubuntu/newer rpmbuild) rejects it: `bogus date in %changelog`. EL9/CI (rockylinux:9) tolerated it as a warning, so CI was green, but it blocks RPM builds on stricter hosts. One-character weekday fix → portable across rpm versions.

Found during the v1.145 multi-distro matrix RPM build (`NFTBAN_ROADMAP/V145_B2_G_MULTI_DISTRO_MATRIX_VALIDATION.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)