### PR TITLE
fix(installer): v1.146 Phase D nftables include idempotency and inet-filter policy

### DIFF
--- a/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
@@ -91,9 +91,15 @@ chmod +x "$BIN/nft"
 # shellcheck source=/dev/null
 . "$FN"
 
-run_classify() { # fixture -> echoes verdict; resets delete marker
+run_classify() { # fixture -> echoes verdict; resets delete marker; override OFF
     NFT_DELETE_MARKER="$TMPD/deleted"; : > "$NFT_DELETE_MARKER"
-    export NFT_DELETE_MARKER NFT_FIXTURE="$1"
+    export NFT_DELETE_MARKER NFT_FIXTURE="$1" NFTBAN_ALLOW_REMOVE_INET_FILTER=0
+    PATH="$BIN:$PATH" _nftban_classify_inet_filter
+}
+
+run_classify_override() { # fixture -> echoes verdict with override ON
+    NFT_DELETE_MARKER="$TMPD/deleted"; : > "$NFT_DELETE_MARKER"
+    export NFT_DELETE_MARKER NFT_FIXTURE="$1" NFTBAN_ALLOW_REMOVE_INET_FILTER=1
     PATH="$BIN:$PATH" _nftban_classify_inet_filter
 }
 
@@ -107,7 +113,15 @@ if [[ -s "$TMPD/deleted" ]]; then ok "T-F3 empty skeleton issued nft delete"; el
 
 v=$(run_classify populated)
 if [[ "$v" == "POPULATED" ]]; then ok "T-F4 populated table -> POPULATED"; else no "T-F4 populated table -> POPULATED" "got '$v'"; fi
-if [[ ! -s "$TMPD/deleted" ]]; then ok "T-F5 populated table NOT deleted (operator content preserved)"; else no "T-F5 populated table NOT deleted" "delete was recorded"; fi
+if [[ ! -s "$TMPD/deleted" ]]; then ok "T-F5 populated table NOT deleted by default (operator content preserved)"; else no "T-F5 populated table NOT deleted by default" "delete was recorded"; fi
+
+# explicit opt-in override: NFTBAN_ALLOW_REMOVE_INET_FILTER=1
+v=$(run_classify_override populated)
+if [[ "$v" == "REMOVED_OVERRIDE" ]]; then ok "T-F6 populated + override -> REMOVED_OVERRIDE"; else no "T-F6 populated + override -> REMOVED_OVERRIDE" "got '$v'"; fi
+if [[ -s "$TMPD/deleted" ]]; then ok "T-F7 override issued nft delete on populated table"; else no "T-F7 override issued nft delete" "no delete recorded"; fi
+# empty skeleton must still REMOVE (not OVERRIDE) even with override set
+v=$(run_classify_override empty)
+if [[ "$v" == "REMOVED" ]]; then ok "T-F8 empty skeleton -> REMOVED even with override (not mislabelled)"; else no "T-F8 empty skeleton -> REMOVED with override" "got '$v'"; fi
 
 # --- T-D: DEB refuse semantics ---------------------------------------------
 if grep -q 'will NOT delete operator-owned' "$POSTINST" && grep -qE '^\s*exit 1' "$POSTINST"; then
@@ -131,6 +145,23 @@ if grep -q '_nftban_classify_inet_filter' "$BUILD"; then
     ok "T-R2 build_nftban.sh defines the classifier (RPM previously had none)"
 else
     no "T-R2 build_nftban.sh defines the classifier" "missing"
+fi
+
+# --- T-O: explicit operator override present + deterministic (both PMs) -----
+for f in "$POSTINST" "$BUILD"; do
+    base=$(basename "$f")
+    if grep -q 'NFTBAN_ALLOW_REMOVE_INET_FILTER' "$f"; then
+        ok "T-O override env var honoured in $base"
+    else
+        no "T-O override env var honoured in $base" "missing"
+    fi
+done
+# no interactive PROMPT in either scriptlet (automation-safe). The -p flag is
+# the interactive-prompt signature; `while read -r` file-iteration is fine.
+if ! grep -qE 'read +-[a-z]*p' "$POSTINST" "$BUILD"; then
+    ok "T-O no interactive 'read -p' prompt in postinst/%post (automation-safe)"
+else
+    no "T-O no interactive 'read -p' prompt in postinst/%post" "found a prompt"
 fi
 
 echo

--- a/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - CVE-2025-NFTBAN-001 inet-filter classify-then-act test (v1.146 Phase-D)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_inet_filter_policy_v146_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-03"
+# meta:description="v1.146 Phase-D — asserts the shared CVE-2025-NFTBAN-001 inet-filter classifier and the deliberate DEB/RPM divergence in the terminal 'refuse' action. (1) Functional: the classifier (extracted from packaging/deb/postinst sentinels) returns NONE when no inet filter exists, REMOVED + issues `nft delete` for the empty default distro skeleton, and POPULATED + does NOT delete when operator rules are present — exercised via a PATH-shadow nft stub. (2) Divergence: DEB postinst refuses a populated fresh install with `exit 1` and never deletes operator rules; RPM %post (packaging/build_nftban.sh) carries the verbatim skip-activation runbook message and exits 0 (rpm %post cannot cleanly abort). (3) Both files define the classifier. Hermetic — PATH-shadow nft stub, no real nft, no daemon, no host mutation."
+# meta:input="packaging/deb/postinst, packaging/build_nftban.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep"
+# meta:inventory.files="packaging/deb/postinst,packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+POSTINST="$REPO/packaging/deb/postinst"
+BUILD="$REPO/packaging/build_nftban.sh"
+for f in "$POSTINST" "$BUILD"; do
+    [[ -f "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+REQUIRED_MSG='nftban installed but firewall activation was skipped because an operator-owned inet filter table exists. Remove or migrate the conflicting table, then run: nftban-installer --repair'
+
+TMPD=$(mktemp -d)
+trap 'rm -rf "$TMPD"' EXIT
+
+# --- Extract the classifier from postinst sentinels and source it ----------
+FN="$TMPD/classify.sh"
+awk '/# >>> NFTBAN_INETFILTER_FN_BEGIN >>>/{f=1;next} /# <<< NFTBAN_INETFILTER_FN_END <<</{f=0} f' "$POSTINST" > "$FN"
+if [[ -s "$FN" ]] && grep -q '_nftban_classify_inet_filter' "$FN"; then
+    ok "T0 extracted _nftban_classify_inet_filter from postinst sentinels"
+else
+    no "T0 extracted _nftban_classify_inet_filter from postinst sentinels" "extract empty"
+fi
+
+# --- PATH-shadow nft stub --------------------------------------------------
+BIN="$TMPD/bin"; mkdir -p "$BIN"
+cat > "$BIN/nft" <<'STUB'
+#!/bin/sh
+# Fixture-driven nft stub. NFT_FIXTURE: none|empty|populated.
+# Records `delete` calls to NFT_DELETE_MARKER.
+op="$1 $2 $3 $4"
+case "$op" in
+    "list table inet filter")
+        case "${NFT_FIXTURE:-none}" in
+            none) exit 1 ;;
+            empty)
+                printf '%s\n' 'table inet filter {' \
+                    '	chain input {' \
+                    '		type filter hook input priority 0; policy accept;' \
+                    '	}' \
+                    '	chain forward {' \
+                    '		type filter hook forward priority 0; policy accept;' \
+                    '	}' \
+                    '}'
+                exit 0 ;;
+            populated)
+                printf '%s\n' 'table inet filter {' \
+                    '	chain input {' \
+                    '		type filter hook input priority 0; policy drop;' \
+                    '		tcp dport 22 accept' \
+                    '		ct state established,related accept' \
+                    '	}' \
+                    '}'
+                exit 0 ;;
+        esac ;;
+    "delete table inet filter")
+        echo deleted >> "${NFT_DELETE_MARKER:-/dev/null}"; exit 0 ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/nft"
+
+# shellcheck source=/dev/null
+. "$FN"
+
+run_classify() { # fixture -> echoes verdict; resets delete marker
+    NFT_DELETE_MARKER="$TMPD/deleted"; : > "$NFT_DELETE_MARKER"
+    export NFT_DELETE_MARKER NFT_FIXTURE="$1"
+    PATH="$BIN:$PATH" _nftban_classify_inet_filter
+}
+
+# --- T-F: functional classification ----------------------------------------
+v=$(run_classify none)
+[[ "$v" == "NONE" ]] && ok "T-F1 no inet filter -> NONE" || no "T-F1 no inet filter -> NONE" "got '$v'"
+
+v=$(run_classify empty)
+if [[ "$v" == "REMOVED" ]]; then ok "T-F2 empty skeleton -> REMOVED"; else no "T-F2 empty skeleton -> REMOVED" "got '$v'"; fi
+if [[ -s "$TMPD/deleted" ]]; then ok "T-F3 empty skeleton issued nft delete"; else no "T-F3 empty skeleton issued nft delete" "no delete recorded"; fi
+
+v=$(run_classify populated)
+if [[ "$v" == "POPULATED" ]]; then ok "T-F4 populated table -> POPULATED"; else no "T-F4 populated table -> POPULATED" "got '$v'"; fi
+if [[ ! -s "$TMPD/deleted" ]]; then ok "T-F5 populated table NOT deleted (operator content preserved)"; else no "T-F5 populated table NOT deleted" "delete was recorded"; fi
+
+# --- T-D: DEB refuse semantics ---------------------------------------------
+if grep -q 'will NOT delete operator-owned' "$POSTINST" && grep -qE '^\s*exit 1' "$POSTINST"; then
+    ok "T-D1 postinst refuses populated fresh install (exit 1, no delete)"
+else
+    no "T-D1 postinst refuses populated fresh install" "missing refuse path"
+fi
+if grep -q '_nftban_classify_inet_filter' "$POSTINST"; then
+    ok "T-D2 postinst defines + uses the classifier"
+else
+    no "T-D2 postinst defines + uses the classifier" "missing"
+fi
+
+# --- T-R: RPM skip-activation semantics ------------------------------------
+if grep -Fq "$REQUIRED_MSG" "$BUILD"; then
+    ok "T-R1 build_nftban.sh %post carries the verbatim skip-activation runbook"
+else
+    no "T-R1 build_nftban.sh %post carries the verbatim skip-activation runbook" "message missing/altered"
+fi
+if grep -q '_nftban_classify_inet_filter' "$BUILD"; then
+    ok "T-R2 build_nftban.sh defines the classifier (RPM previously had none)"
+else
+    no "T-R2 build_nftban.sh defines the classifier" "missing"
+fi
+
+echo
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
@@ -109,7 +109,7 @@ v=$(run_classify none)
 
 v=$(run_classify empty)
 if [[ "$v" == "REMOVED" ]]; then ok "T-F2 empty skeleton -> REMOVED"; else no "T-F2 empty skeleton -> REMOVED" "got '$v'"; fi
-if [[ -s "$TMPD/deleted" ]]; then ok "T-F3 empty skeleton issued nft delete"; else no "T-F3 empty skeleton issued nft delete" "no delete recorded"; fi
+if [[ -s "$TMPD/deleted" ]]; then ok "T-F3 empty skeleton triggered a table-delete"; else no "T-F3 empty skeleton triggered a table-delete" "no delete recorded"; fi
 
 v=$(run_classify populated)
 if [[ "$v" == "POPULATED" ]]; then ok "T-F4 populated table -> POPULATED"; else no "T-F4 populated table -> POPULATED" "got '$v'"; fi
@@ -118,7 +118,7 @@ if [[ ! -s "$TMPD/deleted" ]]; then ok "T-F5 populated table NOT deleted by defa
 # explicit opt-in override: NFTBAN_ALLOW_REMOVE_INET_FILTER=1
 v=$(run_classify_override populated)
 if [[ "$v" == "REMOVED_OVERRIDE" ]]; then ok "T-F6 populated + override -> REMOVED_OVERRIDE"; else no "T-F6 populated + override -> REMOVED_OVERRIDE" "got '$v'"; fi
-if [[ -s "$TMPD/deleted" ]]; then ok "T-F7 override issued nft delete on populated table"; else no "T-F7 override issued nft delete" "no delete recorded"; fi
+if [[ -s "$TMPD/deleted" ]]; then ok "T-F7 override triggered a table-delete on populated table"; else no "T-F7 override triggered a table-delete" "no delete recorded"; fi
 # empty skeleton must still REMOVE (not OVERRIDE) even with override set
 v=$(run_classify_override empty)
 if [[ "$v" == "REMOVED" ]]; then ok "T-F8 empty skeleton -> REMOVED even with override (not mislabelled)"; else no "T-F8 empty skeleton -> REMOVED with override" "got '$v'"; fi

--- a/cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - nftables.conf fenced-include idempotency test (v1.146 Phase-D)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_nftables_include_idempotency_v146_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-03"
+# meta:description="v1.146 Phase-D — asserts the fenced nftban include marker is the single contract shared by the Go writer (internal/installer/render/sysconf.go), the DEB remover (packaging/deb/postrm) and the RPM %postun remover (packaging/build_nftban.sh). (1) Contract: both marker strings + the legacy comment string appear verbatim in all three files. (2) Functional: the postrm strip function (extracted between its sentinels) removes a stale fenced block, every legacy comment, and every stray include from a polluted distro nftables.conf, collapses accumulated duplicates, preserves all operator content (flush ruleset + table inet filter), and is idempotent. (3) Structural: postrm purge AND remove branches both call the strip fn (the remove-branch dangling-include gap fix), and the pre-v1.146 loose 'sed /nftban/d' is gone from both postrm and build_nftban.sh. (4) Syntax: sh -n postrm clean. Hermetic — no host contact, no nft, no daemon."
+# meta:input="internal/installer/render/sysconf.go, packaging/deb/postrm, packaging/build_nftban.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,sh"
+# meta:inventory.files="internal/installer/render/sysconf.go,packaging/deb/postrm,packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,awk,grep,sh"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+GO="$REPO/internal/installer/render/sysconf.go"
+POSTRM="$REPO/packaging/deb/postrm"
+BUILD="$REPO/packaging/build_nftban.sh"
+for f in "$GO" "$POSTRM" "$BUILD"; do
+    [[ -f "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+BEGIN_MARKER='# >>> nftban firewall include (managed; do not edit between markers) >>>'
+END_MARKER='# <<< nftban firewall include (managed) <<<'
+LEGACY='# NFTBan firewall configuration'
+INCLUDE='include "/etc/nftban/nftables.conf"'
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 1: contract — markers shared verbatim across all three files
+# ──────────────────────────────────────────────────────────────────────────
+for label in "BEGIN:$BEGIN_MARKER" "END:$END_MARKER" "LEGACY:$LEGACY"; do
+    name="${label%%:*}"; needle="${label#*:}"
+    for f in "$GO" "$POSTRM" "$BUILD"; do
+        base=$(basename "$f")
+        if grep -Fq "$needle" "$f"; then
+            ok "T1 $name marker present in $base"
+        else
+            no "T1 $name marker present in $base" "missing"
+        fi
+    done
+done
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 2: functional — extract postrm strip fn and exercise it
+# ──────────────────────────────────────────────────────────────────────────
+TMPD=$(mktemp -d)
+trap 'rm -rf "$TMPD"' EXIT
+
+FN="$TMPD/strip_fn.sh"
+awk '/# >>> NFTBAN_STRIP_FN_BEGIN >>>/{f=1;next} /# <<< NFTBAN_STRIP_FN_END <<</{f=0} f' "$POSTRM" > "$FN"
+if [[ -s "$FN" ]] && grep -q '_nftban_strip_conf_include' "$FN"; then
+    ok "T2-0 extracted _nftban_strip_conf_include from postrm sentinels"
+else
+    no "T2-0 extracted _nftban_strip_conf_include from postrm sentinels" "extract empty"
+fi
+# shellcheck source=/dev/null
+. "$FN"
+
+SAMPLE="$TMPD/nftables.conf"
+{
+    printf '%s\n' '#!/usr/sbin/nft -f'
+    printf '%s\n' ''
+    printf '%s\n' 'flush ruleset'
+    printf '%s\n' ''
+    printf '%s\n' 'table inet filter {'
+    printf '%s\n' '	chain input {'
+    printf '%s\n' '		type filter hook input priority 0;'
+    printf '%s\n' '	}'
+    printf '%s\n' '}'
+    # stale fenced block
+    printf '%s\n' "$BEGIN_MARKER"
+    printf '%s\n' "$INCLUDE"
+    printf '%s\n' "$END_MARKER"
+    # accumulated legacy duplicates (the pre-v1.146 bug)
+    printf '%s\n' "$LEGACY"
+    printf '%s\n' "$INCLUDE"
+    printf '%s\n' "$LEGACY"
+    printf '%s\n' "$INCLUDE"
+} > "$SAMPLE"
+
+_nftban_strip_conf_include "$SAMPLE"
+
+if ! grep -Fq "$BEGIN_MARKER" "$SAMPLE" && ! grep -Fq "$END_MARKER" "$SAMPLE"; then
+    ok "T2-1 fenced markers removed"
+else
+    no "T2-1 fenced markers removed" "marker survived"
+fi
+if ! grep -Fq "$LEGACY" "$SAMPLE"; then
+    ok "T2-2 all legacy comments removed (dupes collapsed)"
+else
+    no "T2-2 all legacy comments removed (dupes collapsed)" "$(grep -cF "$LEGACY" "$SAMPLE") left"
+fi
+if ! grep -Fq '/etc/nftban/nftables.conf' "$SAMPLE"; then
+    ok "T2-3 all include directives removed"
+else
+    no "T2-3 all include directives removed" "include survived"
+fi
+operator_ok=1
+for must in 'flush ruleset' 'table inet filter' 'type filter hook input priority 0;'; do
+    grep -Fq "$must" "$SAMPLE" || operator_ok=0
+done
+if [[ $operator_ok -eq 1 ]]; then
+    ok "T2-4 operator content preserved (flush ruleset + inet filter)"
+else
+    no "T2-4 operator content preserved (flush ruleset + inet filter)" "lost a distro line"
+fi
+# idempotent: second strip changes nothing
+BEFORE=$(cat "$SAMPLE"); _nftban_strip_conf_include "$SAMPLE"; AFTER=$(cat "$SAMPLE")
+if [[ "$BEFORE" == "$AFTER" ]]; then
+    ok "T2-5 strip is idempotent"
+else
+    no "T2-5 strip is idempotent" "second run changed output"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 3: structural — both branches call the fn; loose sed is gone
+# ──────────────────────────────────────────────────────────────────────────
+# purge + remove branches: count calls (expect >=2: one per branch loop)
+calls=$(grep -cE '_nftban_strip_conf_include "\$nft_conf"' "$POSTRM" || true)
+if [[ "${calls:-0}" -ge 2 ]]; then
+    ok "T3-1 postrm calls strip fn in both purge and remove branches ($calls)"
+else
+    no "T3-1 postrm calls strip fn in both purge and remove branches" "only $calls call(s)"
+fi
+# Match only ACTIVE (non-comment) lines — explanatory comments may still name
+# the old loose sed without it being live code.
+active_sed_postrm=$(grep -E "sed -i '/nftban/d'" "$POSTRM" | grep -vE '^[[:space:]]*#' || true)
+if [[ -z "$active_sed_postrm" ]]; then
+    ok "T3-2 loose 'sed /nftban/d' gone from active postrm code"
+else
+    no "T3-2 loose 'sed /nftban/d' gone from active postrm code" "$active_sed_postrm"
+fi
+active_sed_build=$(grep -E "sed -i '/nftban/d'" "$BUILD" | grep -vE '^[[:space:]]*#' || true)
+if [[ -z "$active_sed_build" ]]; then
+    ok "T3-3 loose 'sed /nftban/d' gone from active build_nftban.sh (%postun) code"
+else
+    no "T3-3 loose 'sed /nftban/d' gone from active build_nftban.sh (%postun) code" "$active_sed_build"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Section 4: syntax
+# ──────────────────────────────────────────────────────────────────────────
+if sh -n "$POSTRM" 2>/dev/null; then
+    ok "T4-1 sh -n postrm clean"
+else
+    no "T4-1 sh -n postrm clean" "syntax error"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+echo
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+exit 0

--- a/internal/installer/render/sysconf.go
+++ b/internal/installer/render/sysconf.go
@@ -25,10 +25,83 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
-const includeDirective = `include "/etc/nftban/nftables.conf"`
+// IncludeDirective is the line nftban adds to the distro nftables.conf so a
+// plain `systemctl reload nftables.service` re-includes the nftban ruleset.
+const IncludeDirective = `include "/etc/nftban/nftables.conf"`
 
-// IntegrateSystemConf appends the NFTBan include directive to the system
-// nftables.conf if not already present. Idempotent.
+// v1.146 PR Phase-D — fenced marker idempotency.
+//
+// Before v1.146 the writer emitted a bare comment + include with no end
+// sentinel, and the purge remover used a loose case-sensitive `sed /nftban/d`.
+// Result: the capitalised legacy comment ("# NFTBan firewall configuration")
+// was orphaned and accumulated one line per install cycle, and there was no
+// atomic way to remove exactly nftban's contribution.
+//
+// The fenced markers below bracket the managed region so both the writer
+// (here) and the shell removers (deb postrm / rpm %postun) can strip exactly
+// nftban's lines and nothing the operator added. Markers are lowercase so a
+// stale pre-v1.146 `sed /nftban/d` from an older package still matches them.
+// IncludeBeginMarker / IncludeEndMarker are the canonical sentinels; the shell
+// scriptlets MUST match these byte-for-byte (drift-guarded by hermetic test).
+const (
+	IncludeBeginMarker = "# >>> nftban firewall include (managed; do not edit between markers) >>>"
+	IncludeEndMarker   = "# <<< nftban firewall include (managed) <<<"
+
+	// legacyComment is the unfenced comment emitted by pre-v1.146 writers.
+	// stripNftbanInclude removes it (and any accumulated duplicates) so a
+	// repair/upgrade self-heals an already-polluted distro file.
+	legacyComment = "# NFTBan firewall configuration"
+)
+
+// fencedBlock is the exact managed region the writer emits.
+func fencedBlock() string {
+	return IncludeBeginMarker + "\n" + IncludeDirective + "\n" + IncludeEndMarker + "\n"
+}
+
+// stripNftbanInclude removes every nftban-owned line from a distro
+// nftables.conf body, preserving all operator content. It removes:
+//   - any fenced managed block (begin..end inclusive),
+//   - standalone legacy comment lines ("# NFTBan firewall configuration"),
+//   - standalone include directive lines for /etc/nftban/nftables.conf.
+//
+// It is the Go twin of the shell remover in packaging/deb/postrm and the RPM
+// %postun. Idempotent: running it on already-clean content returns it
+// unchanged. Pure function — unit-testable without an executor.
+func stripNftbanInclude(content string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == IncludeBeginMarker:
+			inFence = true
+			continue
+		case trimmed == IncludeEndMarker:
+			inFence = false
+			continue
+		case inFence:
+			continue
+		case trimmed == legacyComment:
+			continue
+		case trimmed == IncludeDirective || strings.Contains(trimmed, `"/etc/nftban/nftables.conf"`):
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// IntegrateSystemConf renders exactly one fenced nftban include block into the
+// system nftables.conf. It first strips any prior nftban contribution (legacy
+// unfenced comment/include, duplicates, or an existing fenced block) so the
+// result is always a single canonical block — self-healing an already-polluted
+// file. Idempotent: when the file already contains exactly the canonical block
+// and nothing stale, no write occurs (mtime preserved).
+//
+// v1.146 Phase-D NOTE: this does NOT change boot authority — nftban still
+// writes the distro include (Shape A/B is a separate gated decision). It only
+// makes the write fenced + idempotent + duplicate-collapsing.
 func IntegrateSystemConf(exec executor.Executor, nftConfPath string, log *logging.Logger) error {
 	if nftConfPath == "" {
 		return fmt.Errorf("system nftables.conf path is empty")
@@ -42,24 +115,30 @@ func IntegrateSystemConf(exec executor.Executor, nftConfPath string, log *loggin
 	if err != nil {
 		return fmt.Errorf("read %s: %w", nftConfPath, err)
 	}
+	original := string(data)
 
-	content := string(data)
-	if strings.Contains(content, "/etc/nftban/nftables.conf") {
-		log.Debug("system nftables.conf already includes NFTBan config")
+	// Normalise: strip any prior nftban lines (collapses accumulated
+	// duplicate legacy comments and removes a previous fenced block), then
+	// append exactly one fresh fenced block.
+	stripped := stripNftbanInclude(original)
+	if !strings.HasSuffix(stripped, "\n") && stripped != "" {
+		stripped += "\n"
+	}
+	updated := stripped + fencedBlock()
+
+	if updated == original {
+		log.Debug("system nftables.conf already carries the canonical nftban include block")
 		return nil
 	}
 
-	// Append include directive
-	if !strings.HasSuffix(content, "\n") {
-		content += "\n"
-	}
-	content += "# NFTBan firewall configuration\n"
-	content += includeDirective + "\n"
-
-	if err := exec.WriteFileAtomic(nftConfPath, []byte(content), 0644); err != nil {
+	if err := exec.WriteFileAtomic(nftConfPath, []byte(updated), 0644); err != nil {
 		return fmt.Errorf("write %s: %w", nftConfPath, err)
 	}
 
-	log.Info("added NFTBan config to %s", nftConfPath)
+	if strings.Contains(original, "/etc/nftban/nftables.conf") {
+		log.Info("normalised NFTBan include in %s (collapsed to one fenced block)", nftConfPath)
+	} else {
+		log.Info("added fenced NFTBan include block to %s", nftConfPath)
+	}
 	return nil
 }

--- a/internal/installer/render/sysconf_test.go
+++ b/internal/installer/render/sysconf_test.go
@@ -1,0 +1,162 @@
+// =============================================================================
+// NFTBan v1.146 Phase-D - sysconf fenced-include idempotency tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-render-sysconf-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-03"
+// meta:description="v1.146 Phase-D unit tests for the fenced nftban include writer (IntegrateSystemConf) and its pure stripNftbanInclude twin: collapse of accumulated legacy duplicate comments, single-canonical-block output, no-op idempotency (no write when already canonical), and preservation of all operator-owned distro content (flush ruleset + table inet filter skeleton)."
+// meta:input="None"
+// meta:output="t.Fatalf/t.Errorf on assertion failure"
+// meta:depends="testing,internal/installer/executor,internal/installer/logging"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+const distroSkeleton = `#!/usr/sbin/nft -f
+
+flush ruleset
+
+table inet filter {
+	chain input {
+		type filter hook input priority 0;
+	}
+}
+`
+
+// countSubstr counts non-overlapping occurrences of sub in s.
+func countSubstr(s, sub string) int { return strings.Count(s, sub) }
+
+// assertOperatorContentPreserved fails if the distro skeleton lines were lost.
+func assertOperatorContentPreserved(t *testing.T, body string) {
+	t.Helper()
+	for _, must := range []string{"flush ruleset", "table inet filter", "type filter hook input priority 0;"} {
+		if !strings.Contains(body, must) {
+			t.Errorf("operator content lost: %q missing from:\n%s", must, body)
+		}
+	}
+}
+
+// TestStripNftbanInclude_PureLogic covers the remover twin directly.
+func TestStripNftbanInclude_PureLogic(t *testing.T) {
+	// Polluted file: distro skeleton + a stale fenced block + TWO accumulated
+	// legacy comments + TWO stray legacy includes (the exact pre-v1.146 bug).
+	polluted := distroSkeleton +
+		IncludeBeginMarker + "\n" + IncludeDirective + "\n" + IncludeEndMarker + "\n" +
+		legacyComment + "\n" +
+		IncludeDirective + "\n" +
+		legacyComment + "\n"
+
+	out := stripNftbanInclude(polluted)
+
+	if strings.Contains(out, IncludeBeginMarker) || strings.Contains(out, IncludeEndMarker) {
+		t.Errorf("fenced markers survived strip:\n%s", out)
+	}
+	if strings.Contains(out, legacyComment) {
+		t.Errorf("legacy comment survived strip:\n%s", out)
+	}
+	if strings.Contains(out, "/etc/nftban/nftables.conf") {
+		t.Errorf("include directive survived strip:\n%s", out)
+	}
+	assertOperatorContentPreserved(t, out)
+
+	// Idempotent: stripping clean content changes nothing.
+	if again := stripNftbanInclude(out); again != out {
+		t.Errorf("strip not idempotent:\n--first--\n%s\n--second--\n%s", out, again)
+	}
+}
+
+// TestIntegrateSystemConf_FreshAppendsOneFencedBlock asserts a clean distro
+// file gains exactly one fenced block and keeps its content.
+func TestIntegrateSystemConf_FreshAppendsOneFencedBlock(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	defer log.Close()
+	m := executor.NewMockExecutor()
+	const p = "/etc/nftables.conf"
+	m.Files[p] = []byte(distroSkeleton)
+
+	if err := IntegrateSystemConf(m, p, log); err != nil {
+		t.Fatalf("integrate: %v", err)
+	}
+	body := string(m.Files[p])
+	if got := countSubstr(body, IncludeBeginMarker); got != 1 {
+		t.Errorf("want exactly 1 fenced block, got %d:\n%s", got, body)
+	}
+	if got := countSubstr(body, IncludeDirective); got != 1 {
+		t.Errorf("want exactly 1 include directive, got %d", got)
+	}
+	if strings.Contains(body, legacyComment) {
+		t.Errorf("new write must not emit the legacy unfenced comment:\n%s", body)
+	}
+	assertOperatorContentPreserved(t, body)
+}
+
+// TestIntegrateSystemConf_CollapsesAccumulatedDuplicates asserts the
+// self-healing path: a file polluted by the pre-v1.146 bug (multiple legacy
+// comments + includes) is normalised to a single fenced block.
+func TestIntegrateSystemConf_CollapsesAccumulatedDuplicates(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	defer log.Close()
+	m := executor.NewMockExecutor()
+	const p = "/etc/nftables.conf"
+	m.Files[p] = []byte(distroSkeleton +
+		legacyComment + "\n" + IncludeDirective + "\n" +
+		legacyComment + "\n" + IncludeDirective + "\n" +
+		legacyComment + "\n" + IncludeDirective + "\n")
+
+	if err := IntegrateSystemConf(m, p, log); err != nil {
+		t.Fatalf("integrate: %v", err)
+	}
+	body := string(m.Files[p])
+	if got := countSubstr(body, IncludeBeginMarker); got != 1 {
+		t.Errorf("want exactly 1 fenced block after collapse, got %d:\n%s", got, body)
+	}
+	if got := countSubstr(body, IncludeDirective); got != 1 {
+		t.Errorf("want exactly 1 include after collapse, got %d", got)
+	}
+	if strings.Contains(body, legacyComment) {
+		t.Errorf("accumulated legacy comments not collapsed:\n%s", body)
+	}
+	assertOperatorContentPreserved(t, body)
+}
+
+// TestIntegrateSystemConf_IdempotentNoWrite asserts that a file already
+// carrying exactly the canonical fenced block is left untouched (no write,
+// mtime preserved).
+func TestIntegrateSystemConf_IdempotentNoWrite(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	defer log.Close()
+	m := executor.NewMockExecutor()
+	const p = "/etc/nftables.conf"
+
+	// First integrate establishes the canonical block.
+	m.Files[p] = []byte(distroSkeleton)
+	if err := IntegrateSystemConf(m, p, log); err != nil {
+		t.Fatalf("integrate #1: %v", err)
+	}
+	// Reset the write ledger and integrate again — must be a no-op.
+	m.WrittenFiles = map[string][]byte{}
+	if err := IntegrateSystemConf(m, p, log); err != nil {
+		t.Fatalf("integrate #2: %v", err)
+	}
+	if _, wrote := m.WrittenFiles[p]; wrote {
+		t.Errorf("second integrate wrote despite canonical content (not idempotent)")
+	}
+}

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -931,12 +931,21 @@ _nftban_classify_inet_filter() {
         nft delete table inet filter 2>/dev/null || true
         echo REMOVED; return 0
     fi
+    # Explicit opt-in NFTBAN_ALLOW_REMOVE_INET_FILTER=1 authorises a high-risk
+    # removal of a populated/operator-owned table (deterministic + logged; no
+    # interactive prompt — rpm installs run non-interactively).
+    if [ "\${NFTBAN_ALLOW_REMOVE_INET_FILTER:-0}" = "1" ]; then
+        nft delete table inet filter 2>/dev/null || true
+        echo REMOVED_OVERRIDE; return 0
+    fi
     echo POPULATED; return 0
 }
 _ifverdict=\$(_nftban_classify_inet_filter)
 case "\$_ifverdict" in
     REMOVED)
-        echo "[NFTBan] Removed empty default 'inet filter' skeleton (CVE-2025-NFTBAN-001; would shadow nftban)." ;;
+        echo "[NFTBan] Removed default accept-all inet filter skeleton due to CVE-2025-NFTBAN-001 guard." ;;
+    REMOVED_OVERRIDE)
+        echo "[NFTBan WARN] HIGH-RISK: removed a POPULATED operator-owned 'inet filter' table because NFTBAN_ALLOW_REMOVE_INET_FILTER=1 was set (explicit opt-in). Any rules it held are gone." >&2 ;;
     POPULATED)
         if [ "\$1" -ge 2 ] 2>/dev/null; then
             echo "[NFTBan WARN] Populated 'inet filter' table present - NOT removed (operator-owned)." >&2

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1140,10 +1140,32 @@ if [ \$1 -eq 0 ]; then
     rm -rf /run/nftban /run/nftban-ui 2>/dev/null || true
 
     # STEP 3: Remove NFTBan include from nftables.conf BEFORE table deletion
-    for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
-        if [ -f "\$nft_conf" ]; then
-            sed -i '/nftban/d' "\$nft_conf" 2>/dev/null || true
+    # v1.146 Phase-D fenced remover — drift-checked twin of
+    # packaging/deb/postrm:_nftban_strip_conf_include and Go
+    # render.stripNftbanInclude. The marker strings below MUST match
+    # render.IncludeBeginMarker/IncludeEndMarker byte-for-byte (enforced by
+    # cli_nftables_include_idempotency_v146_test.sh). Replaces the pre-v1.146
+    # loose, case-sensitive \`sed -i '/nftban/d'\` that orphaned the capitalised
+    # legacy comment.
+    _nftban_strip_conf_include() {
+        _f="\$1"
+        [ -f "\$_f" ] || return 0
+        _tmp="\${_f}.nftban-strip.\$\$"
+        awk '
+            \$0 == "# >>> nftban firewall include (managed; do not edit between markers) >>>" { infence=1; next }
+            \$0 == "# <<< nftban firewall include (managed) <<<" { infence=0; next }
+            infence { next }
+            \$0 == "# NFTBan firewall configuration" { next }
+            index(\$0, "\"/etc/nftban/nftables.conf\"") > 0 { next }
+            { print }
+        ' "\$_f" > "\$_tmp" 2>/dev/null || { rm -f "\$_tmp" 2>/dev/null || true; return 0; }
+        if [ -s "\$_tmp" ] || [ ! -s "\$_f" ]; then
+            cat "\$_tmp" > "\$_f" 2>/dev/null || true
         fi
+        rm -f "\$_tmp" 2>/dev/null || true
+    }
+    for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
+        _nftban_strip_conf_include "\$nft_conf"
     done
 
     # STEP 4: Flush and delete nftables tables (CRITICAL — rules persist otherwise)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -912,6 +912,42 @@ else
 fi
 
 # =============================================================================
+# v1.146 Phase-D: CVE-2025-NFTBAN-001 inet-filter classify-then-act
+# =============================================================================
+# Drift-checked twin of packaging/deb/postinst:_nftban_classify_inet_filter
+# (RPM previously had NO inet-filter guard at all). Empty/default distro
+# skeleton -> auto-remove (both modes; it would shadow nftban). Populated,
+# operator-owned table -> never delete: fresh install prints the runbook and
+# SKIPS activation via exit 0 (rpm %post cannot cleanly abort; a non-zero exit
+# leaves a confusing scriptlet-failed-but-installed state); upgrade warns and
+# continues.
+_nftban_classify_inet_filter() {
+    command -v nft >/dev/null 2>&1 || { echo NONE; return 0; }
+    nft list table inet filter >/dev/null 2>&1 || { echo NONE; return 0; }
+    _rules=\$(nft list table inet filter 2>/dev/null \
+        | grep -vE '^[[:space:]]*(table|chain|type |policy|[}]|#)' \
+        | grep -cE '[^[:space:]]' || true)
+    if [ "\${_rules:-0}" -eq 0 ]; then
+        nft delete table inet filter 2>/dev/null || true
+        echo REMOVED; return 0
+    fi
+    echo POPULATED; return 0
+}
+_ifverdict=\$(_nftban_classify_inet_filter)
+case "\$_ifverdict" in
+    REMOVED)
+        echo "[NFTBan] Removed empty default 'inet filter' skeleton (CVE-2025-NFTBAN-001; would shadow nftban)." ;;
+    POPULATED)
+        if [ "\$1" -ge 2 ] 2>/dev/null; then
+            echo "[NFTBan WARN] Populated 'inet filter' table present - NOT removed (operator-owned)." >&2
+            echo "[NFTBan WARN] It may shadow nftban blocking (CVE-2025-NFTBAN-001)." >&2
+        else
+            echo "[NFTBan ERROR] nftban installed but firewall activation was skipped because an operator-owned inet filter table exists. Remove or migrate the conflicting table, then run: nftban-installer --repair" >&2
+            exit 0
+        fi ;;
+esac
+
+# =============================================================================
 # STEP 0: yq link (must happen before Go installer, used by CLI commands)
 # =============================================================================
 if command -v yq >/dev/null 2>&1; then

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -35,6 +35,29 @@ log_info()  { echo "[NFTBan] $*"; }
 log_warn()  { echo "[NFTBan WARN] $*"; }
 log_error() { echo "[NFTBan ERROR] $*"; }
 
+# v1.146 Phase-D — CVE-2025-NFTBAN-001 inet-filter classifier (drift-checked
+# twin of the RPM %post copy in packaging/build_nftban.sh). Classifies a
+# pre-existing `inet filter` table: the benign empty distro skeleton is removed
+# (it would shadow nftban blocking — CVE-2025-NFTBAN-001); a populated,
+# operator-owned table is NEVER deleted (caller decides refuse vs warn).
+# Echoes exactly one token: NONE | REMOVED | POPULATED. The "is it a rule?"
+# heuristic mirrors internal/installer/extfw/detect.go (structural lines —
+# table/chain/type/policy/brace/comment — are not rules).
+# >>> NFTBAN_INETFILTER_FN_BEGIN >>>
+_nftban_classify_inet_filter() {
+    command -v nft >/dev/null 2>&1 || { echo NONE; return 0; }
+    nft list table inet filter >/dev/null 2>&1 || { echo NONE; return 0; }
+    _rules=$(nft list table inet filter 2>/dev/null \
+        | grep -vE '^[[:space:]]*(table|chain|type |policy|[}]|#)' \
+        | grep -cE '[^[:space:]]' || true)
+    if [ "${_rules:-0}" -eq 0 ]; then
+        nft delete table inet filter 2>/dev/null || true
+        echo REMOVED; return 0
+    fi
+    echo POPULATED; return 0
+}
+# <<< NFTBAN_INETFILTER_FN_END <<<
+
 case "$1" in
     configure)
 
@@ -42,21 +65,31 @@ case "$1" in
         # PRE-GO BOOTSTRAP (must run before any nftban binary)
         # =================================================================
 
-        # --- CVE-2025-NFTBAN-001: conflicting inet filter table ---
-        if command -v nft >/dev/null 2>&1; then
-            if nft list table inet filter >/dev/null 2>&1; then
+        # --- CVE-2025-NFTBAN-001: conflicting inet filter table (v1.146 Phase-D) ---
+        # Classify-then-act, shared with RPM %post. Empty/default distro skeleton
+        # is auto-removed in BOTH modes (it would shadow nftban). A populated,
+        # operator-owned table is NEVER deleted: fresh install refuses (exit 1 —
+        # dpkg surfaces postinst failure clearly); upgrade warns and continues
+        # (don't abort a running host's upgrade over an operator's own rules).
+        _ifverdict=$(_nftban_classify_inet_filter)
+        case "$_ifverdict" in
+            REMOVED)
+                log_info "Removed empty default 'inet filter' skeleton (CVE-2025-NFTBAN-001 — would shadow nftban)"
+                ;;
+            POPULATED)
                 if [ -n "${2:-}" ]; then
-                    log_warn "Conflicting 'inet filter' table detected — auto-removing for upgrade"
-                    nft delete table inet filter 2>/dev/null || true
+                    log_warn "Populated 'inet filter' table present — NOT removed (operator-owned)."
+                    log_warn "It may shadow nftban blocking (CVE-2025-NFTBAN-001). If it is the distro"
+                    log_warn "default, run: nft delete table inet filter   (then: nftban firewall reload)"
                 else
-                    log_error "Conflicting 'inet filter' table detected!"
-                    log_error "This table will bypass nftban blocking (CVE-2025-NFTBAN-001)."
-                    log_error "Please run: nft delete table inet filter"
-                    log_error "Then re-install the package."
+                    log_error "Conflicting populated 'inet filter' table detected (CVE-2025-NFTBAN-001)."
+                    log_error "nftban will NOT delete operator-owned firewall rules."
+                    log_error "Remove or migrate the conflicting table, then re-install:"
+                    log_error "  nft delete table inet filter"
                     exit 1
                 fi
-            fi
-        fi
+                ;;
+        esac
 
         # --- Remove immutable flags so package manager can overwrite files ---
         for immutable_file in /etc/nftban/nftban.conf /usr/lib/nftban/lib/nft_schema.sh; do

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -54,6 +54,16 @@ _nftban_classify_inet_filter() {
         nft delete table inet filter 2>/dev/null || true
         echo REMOVED; return 0
     fi
+    # Populated/operator-owned. Default: NEVER delete. Explicit opt-in
+    # NFTBAN_ALLOW_REMOVE_INET_FILTER=1 authorises a high-risk removal so an
+    # operator can fully automate an install on a host they KNOW carries a
+    # stale/unwanted populated inet filter. No interactive prompt — installs run
+    # non-interactively (apt/dnf -y, cloud-init, panels); a prompt would hang or
+    # be auto-answered unsafely. The override is deterministic + logged.
+    if [ "${NFTBAN_ALLOW_REMOVE_INET_FILTER:-0}" = "1" ]; then
+        nft delete table inet filter 2>/dev/null || true
+        echo REMOVED_OVERRIDE; return 0
+    fi
     echo POPULATED; return 0
 }
 # <<< NFTBAN_INETFILTER_FN_END <<<
@@ -74,7 +84,11 @@ case "$1" in
         _ifverdict=$(_nftban_classify_inet_filter)
         case "$_ifverdict" in
             REMOVED)
-                log_info "Removed empty default 'inet filter' skeleton (CVE-2025-NFTBAN-001 — would shadow nftban)"
+                log_info "Removed default accept-all inet filter skeleton due to CVE-2025-NFTBAN-001 guard."
+                ;;
+            REMOVED_OVERRIDE)
+                log_warn "HIGH-RISK: removed a POPULATED operator-owned 'inet filter' table because NFTBAN_ALLOW_REMOVE_INET_FILTER=1 was set (explicit opt-in)."
+                log_warn "Any firewall rules that table held are now gone. This action was deliberate and is logged here for audit."
                 ;;
             POPULATED)
                 if [ -n "${2:-}" ]; then

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -1,6 +1,42 @@
 #!/bin/sh
 set -e
 
+# =============================================================================
+# v1.146 Phase-D — fenced nftban include remover (drift-checked)
+# -----------------------------------------------------------------------------
+# Removes exactly nftban-owned lines from a distro nftables.conf, preserving all
+# operator content. Twin of Go render.stripNftbanInclude and the RPM %postun
+# copy in packaging/build_nftban.sh. The marker strings and the awk body below
+# MUST match those two byte-for-byte (enforced by the hermetic drift test
+# cli_nftables_include_idempotency_v146_test.sh).
+#
+# Replaces the pre-v1.146 loose `sed -i '/nftban/d'`, which was case-sensitive
+# (orphaned the capitalised "# NFTBan firewall configuration" comment) and only
+# ran on purge — so duplicate comments accumulated and `remove` (non-purge) left
+# a dangling include pointing at a deleted /etc/nftban/nftables.conf.
+# >>> NFTBAN_STRIP_FN_BEGIN >>>
+_nftban_strip_conf_include() {
+    _f="$1"
+    [ -f "$_f" ] || return 0
+    _tmp="${_f}.nftban-strip.$$"
+    awk '
+        $0 == "# >>> nftban firewall include (managed; do not edit between markers) >>>" { infence=1; next }
+        $0 == "# <<< nftban firewall include (managed) <<<" { infence=0; next }
+        infence { next }
+        $0 == "# NFTBan firewall configuration" { next }
+        index($0, "\"/etc/nftban/nftables.conf\"") > 0 { next }
+        { print }
+    ' "$_f" > "$_tmp" 2>/dev/null || { rm -f "$_tmp" 2>/dev/null || true; return 0; }
+    # Replace in place (cat-redirect preserves inode/owner/mode + statoverride).
+    # Guard against awk truncation: only commit when output is non-empty OR the
+    # original was already empty (a distro nftables.conf is never only-our-lines).
+    if [ -s "$_tmp" ] || [ ! -s "$_f" ]; then
+        cat "$_tmp" > "$_f" 2>/dev/null || true
+    fi
+    rm -f "$_tmp" 2>/dev/null || true
+}
+# <<< NFTBAN_STRIP_FN_END <<<
+
 case "$1" in
     purge)
         # =============================================================================
@@ -61,9 +97,7 @@ case "$1" in
         #  try to reload our tables after we delete them)
         # -----------------------------------------------------------------
         for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
-            if [ -f "$nft_conf" ]; then
-                sed -i '/nftban/d' "$nft_conf" 2>/dev/null || true
-            fi
+            _nftban_strip_conf_include "$nft_conf"
         done
 
         # -----------------------------------------------------------------
@@ -152,6 +186,16 @@ case "$1" in
             echo "nftban: Firewall rules flushed (tables preserved for reinstall)."
             echo "nftban: Config preserved in /etc/nftban/. Purge with: apt remove --purge nftban-core"
         fi
+
+        # v1.146 Phase-D D-NFTABLES-POSTRM-MARKER-IDEMPOTENCY (remove-branch gap):
+        # On `remove` (non-purge) the package files are gone, so the distro
+        # include would dangle at a deleted /etc/nftban/nftables.conf — a plain
+        # `systemctl reload nftables.service` would then error on the missing
+        # include. Strip our fenced block here too (config under /etc/nftban is
+        # preserved for reinstall, but the *distro-file* include must not dangle).
+        for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
+            _nftban_strip_conf_include "$nft_conf"
+        done
         ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
**Scope: v1.146 Phase D only.** Install-lifecycle authority — `nftables.conf` include idempotency + CVE-2025-NFTBAN-001 inet-filter classify-then-act. No boot-authority Shape A/B change. No SELinux work. No v1.145 artifact change. **Daemon `cmd/nftband` byte-frozen** (installer + packaging + render only).

Gates: `OPEN_V146_PHASE_D_IMPL=GO_IMPLEMENTATION`, `ADD_V146_INET_FILTER_OPERATOR_POLICY=GO_IMPLEMENTATION`, `OPEN_V146_PHASE_D_LAB_VALIDATE=GO_LAB_MUTATING` → `V146_PHASE_D_LAB_VALIDATE_PASS`, `PROCEED_V146_PHASE_D_PUSH_PR=GO`.

## What changed
**Idempotency (`internal/installer/render/sysconf.go`)**
- Fenced begin/end marker writer/remover (ASCII, lowercase `nftban`).
- `IntegrateSystemConf` strips any prior nftban lines first, then writes exactly one canonical fenced block — self-heals files already polluted by the pre-v1.146 accumulation bug; no write when already canonical.
- Collapses accumulated duplicate legacy `# NFTBan firewall configuration` comments.

**Removers (`packaging/deb/postrm` + `packaging/build_nftban.sh` RPM `%postun`)**
- Replace the loose case-sensitive `sed '/nftban/d'` (orphaned the capitalised legacy comment) with a fenced+legacy-aware awk strip that preserves all operator content.
- DEB **purge** cleanup fixed; DEB **remove-branch** cleanup added (previously absent → `apt remove` left a dangling include at a deleted `/etc/nftban/nftables.conf`).
- RPM `%postun` symmetry.

**Inet-filter classify-then-act (`packaging/deb/postinst` + RPM `%post` twin)**
- Shared classifier: empty/default distro skeleton → auto-remove (both modes); populated/operator-owned → never silently deleted.
- DEB fresh + populated → **refuse (`exit 1`)** with runbook; upgrade → warn + continue.
- RPM fresh + populated → **skip activation + `exit 0` + verbatim runbook** (rpm `%post` cannot cleanly abort); upgrade → warn + continue.
- Explicit opt-in `NFTBAN_ALLOW_REMOVE_INET_FILTER=1` → high-risk removal of a populated table, logged for audit. No interactive prompt (automation-safe).

## Tests
- `internal/installer/render/sysconf_test.go` (Go unit) + `cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh` (19/0) + `cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh` (16/0).

## Validation
- Record: `NFTBAN_ROADMAP/V146_PHASE_D_LAB_VALIDATION_RECORD.md` — `V146_PHASE_D_LAB_VALIDATE_PASS`.
- DEB build (lab2 Ubuntu 24) + RPM build (a9 EL9) rc=0; gofmt/vet/`go test`/shellcheck/hermetic clean.
- DEB idempotency/dedup/remove/purge live PASS on Debian 12; DEB inet-filter empty-auto-remove + populated-refuse + override live PASS.
- RPM lifecycle R1–R4 live PASS on EL9; populated-skip validated via built-RPM `%post` artifact + the artifact's classifier on real EL `nft`.

## R5 residual — disclosed, non-gating
**R5 full live RPM populated-skip install was NOT run because of an EL mirror/DNS outage** (a9 could not resolve `mirrors.almalinux.org` to fetch nftban-core's hard deps, so `dnf`/`rpm` could not complete a fresh install to fire `%post`). **Artifact + real-EL classifier evidence accepted as non-gating.**

**Do not overclaim full live RPM populated-skip install.** Evidence is the built-RPM `%post` artifact (carries the verbatim runbook + `exit 0` skip branch + override env) plus the artifact's classifier executed on real EL `nft` (returns POPULATED / REMOVED_OVERRIDE+delete / REMOVED) — accepted as non-gating per `V146_PHASE_D_LAB_VALIDATE_PASS`. Optional confirmatory follow-up: one live `dnf install` populated-skip case on a network-healthy EL VM; not a code blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
