### PR TITLE
fix(installer): v1.146 Shape B neutralize distro nftables skeleton

### DIFF
--- a/internal/installer/render/sysconf.go
+++ b/internal/installer/render/sysconf.go
@@ -92,6 +92,89 @@ func stripNftbanInclude(content string) string {
 	return strings.Join(out, "\n")
 }
 
+// inetFilterEmptySkeleton reports whether a captured `table inet filter` block
+// contains only structural declarations (table/chain/type/hook/policy/braces/
+// comments) and no actual rules — i.e. the benign distro default accept-all
+// skeleton. Mirrors the shell inet-filter classifier heuristic. Pure function.
+func inetFilterEmptySkeleton(block []string) bool {
+	for _, l := range block {
+		t := strings.TrimSpace(l)
+		if t == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(t, "table "),
+			strings.HasPrefix(t, "chain "),
+			strings.HasPrefix(t, "type "),
+			strings.HasPrefix(t, "policy "),
+			strings.HasPrefix(t, "#"),
+			strings.HasPrefix(t, "{"),
+			strings.HasPrefix(t, "}"):
+			continue
+		}
+		return false // a rule line
+	}
+	return true
+}
+
+// neutralizeDistroSkeleton implements v1.146 Shape B (reboot-proven required by
+// V146_BOOT_SUFFICIENCY_GATE2_REBOOT_PROOF_RECORD.md). It:
+//   - comments out a bare `flush ruleset` so a `systemctl reload nftables.service`
+//     cannot wipe the daemon-managed ip/ip6 nftban runtime tables, and
+//   - removes the distro default EMPTY `table inet filter` skeleton (which would
+//     shadow nftban blocking and trip the CVE-2025-NFTBAN-001 guard).
+//
+// A POPULATED, operator-owned `inet filter` table is preserved verbatim (never
+// silently deleted) — symmetric with the shell classify-then-act policy. Pure
+// function (log may be nil).
+func neutralizeDistroSkeleton(content string, log *logging.Logger) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		t := strings.TrimSpace(lines[i])
+
+		if t == "flush ruleset" {
+			out = append(out, "# flush ruleset  # neutralized by nftban (v1.146 Shape B): a flush here wipes daemon-managed ip/ip6 nftban runtime tables on reload (CVE-2025-NFTBAN-001 / lockout-safety)")
+			if log != nil {
+				log.Info("Shape B: neutralized distro `flush ruleset` in system nftables.conf")
+			}
+			continue
+		}
+
+		if strings.HasPrefix(t, "table inet filter") && strings.Contains(lines[i], "{") {
+			depth := 0
+			j := i
+			for ; j < len(lines); j++ {
+				depth += strings.Count(lines[j], "{") - strings.Count(lines[j], "}")
+				if depth <= 0 {
+					break
+				}
+			}
+			if j >= len(lines) {
+				j = len(lines) - 1
+			}
+			block := lines[i : j+1]
+			if inetFilterEmptySkeleton(block) {
+				out = append(out, "# table inet filter { ... }  # default empty skeleton removed by nftban (v1.146 Shape B): would shadow nftban blocking (CVE-2025-NFTBAN-001)")
+				if log != nil {
+					log.Info("Shape B: removed distro default empty `table inet filter` skeleton")
+				}
+				i = j
+				continue
+			}
+			out = append(out, block...) // populated/operator-owned: preserve verbatim
+			i = j
+			if log != nil {
+				log.Warn("Shape B: populated `table inet filter` preserved (operator-owned); review for nftban shadowing (CVE-2025-NFTBAN-001)")
+			}
+			continue
+		}
+
+		out = append(out, lines[i])
+	}
+	return strings.Join(out, "\n")
+}
+
 // IntegrateSystemConf renders exactly one fenced nftban include block into the
 // system nftables.conf. It first strips any prior nftban contribution (legacy
 // unfenced comment/include, duplicates, or an existing fenced block) so the
@@ -99,9 +182,12 @@ func stripNftbanInclude(content string) string {
 // file. Idempotent: when the file already contains exactly the canonical block
 // and nothing stale, no write occurs (mtime preserved).
 //
-// v1.146 Phase-D NOTE: this does NOT change boot authority — nftban still
-// writes the distro include (Shape A/B is a separate gated decision). It only
-// makes the write fenced + idempotent + duplicate-collapsing.
+// v1.146 Shape B (reboot-proven): nftban KEEPS the distro include (the daemon
+// recreates set structure via netlink but does NOT load the rendered SSH ports
+// / @ssh_ports rate-limit rule — only `nft -f` via this include does, so
+// removing it would silently drop v1.145 protection every reboot). In addition
+// to the fenced include it neutralizes the distro skeleton (flush ruleset +
+// default empty `table inet filter`) via neutralizeDistroSkeleton.
 func IntegrateSystemConf(exec executor.Executor, nftConfPath string, log *logging.Logger) error {
 	if nftConfPath == "" {
 		return fmt.Errorf("system nftables.conf path is empty")
@@ -120,11 +206,14 @@ func IntegrateSystemConf(exec executor.Executor, nftConfPath string, log *loggin
 	// Normalise: strip any prior nftban lines (collapses accumulated
 	// duplicate legacy comments and removes a previous fenced block), then
 	// append exactly one fresh fenced block.
+	// v1.146 Shape B: strip prior nftban lines, neutralize the distro skeleton
+	// (flush ruleset + default empty inet filter), then append one fenced block.
 	stripped := stripNftbanInclude(original)
-	if !strings.HasSuffix(stripped, "\n") && stripped != "" {
-		stripped += "\n"
+	neutralized := neutralizeDistroSkeleton(stripped, log)
+	if !strings.HasSuffix(neutralized, "\n") && neutralized != "" {
+		neutralized += "\n"
 	}
-	updated := stripped + fencedBlock()
+	updated := neutralized + fencedBlock()
 
 	if updated == original {
 		log.Debug("system nftables.conf already carries the canonical nftban include block")

--- a/internal/installer/render/sysconf_test.go
+++ b/internal/installer/render/sysconf_test.go
@@ -1,13 +1,13 @@
 // =============================================================================
-// NFTBan v1.146 Phase-D - sysconf fenced-include idempotency tests
+// NFTBan v1.146 - sysconf fenced-include idempotency + Shape-B skeleton tests
 // =============================================================================
 // SPDX-License-Identifier: MPL-2.0
 // meta:name="installer-render-sysconf-test"
 // meta:type="test"
-// meta:version="1.0.0"
+// meta:version="1.1.0"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-06-03"
-// meta:description="v1.146 Phase-D unit tests for the fenced nftban include writer (IntegrateSystemConf) and its pure stripNftbanInclude twin: collapse of accumulated legacy duplicate comments, single-canonical-block output, no-op idempotency (no write when already canonical), and preservation of all operator-owned distro content (flush ruleset + table inet filter skeleton)."
+// meta:description="v1.146 unit tests for IntegrateSystemConf: Phase-D fenced-include idempotency (one canonical block, legacy duplicate collapse, no-op when already canonical) + Shape-B distro-skeleton neutralization (comment bare flush ruleset, remove default EMPTY inet filter skeleton, PRESERVE a populated/operator-owned inet filter verbatim and genuine operator content). Shape B is reboot-proven required (V146_BOOT_SUFFICIENCY_GATE2_REBOOT_PROOF_RECORD.md)."
 // meta:input="None"
 // meta:output="t.Fatalf/t.Errorf on assertion failure"
 // meta:depends="testing,internal/installer/executor,internal/installer/logging"
@@ -30,42 +30,84 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
+// distroSkeleton is the Debian/Ubuntu default plus a genuine operator sentinel
+// line that must always survive.
+const operatorSentinel = "# OPERATOR_KEEP_ME do not delete"
 const distroSkeleton = `#!/usr/sbin/nft -f
 
 flush ruleset
 
 table inet filter {
 	chain input {
-		type filter hook input priority 0;
+		type filter hook input priority 0; policy accept;
+	}
+	chain forward {
+		type filter hook forward priority 0; policy accept;
+	}
+}
+` + operatorSentinel + "\n"
+
+func countSubstr(s, sub string) int { return strings.Count(s, sub) }
+
+func newTestLogger() *logging.Logger { return logging.New("/dev/null", false) }
+
+// TestNeutralize_EmptySkeletonRemoved_FlushCommented covers the Shape-B pure fn.
+func TestNeutralize_EmptySkeletonRemoved_FlushCommented(t *testing.T) {
+	out := neutralizeDistroSkeleton(distroSkeleton, nil)
+	// bare `flush ruleset` must be gone (commented form retains the words)
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == "flush ruleset" {
+			t.Errorf("bare `flush ruleset` survived neutralization:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "# flush ruleset") {
+		t.Errorf("flush ruleset not commented (expected `# flush ruleset ...`):\n%s", out)
+	}
+	// empty skeleton removed: its inner rule-less chain decls must be gone
+	if strings.Contains(out, "type filter hook input priority 0;") {
+		t.Errorf("empty inet filter skeleton not removed:\n%s", out)
+	}
+	// operator content preserved
+	if !strings.Contains(out, operatorSentinel) {
+		t.Errorf("operator sentinel lost:\n%s", out)
+	}
+	// idempotent: neutralizing already-neutralized content changes nothing
+	if again := neutralizeDistroSkeleton(out, nil); again != out {
+		t.Errorf("neutralize not idempotent:\n--1--\n%s\n--2--\n%s", out, again)
+	}
+}
+
+// TestNeutralize_PopulatedInetFilterPreserved asserts an operator-owned
+// populated inet filter is preserved verbatim (never deleted).
+func TestNeutralize_PopulatedInetFilterPreserved(t *testing.T) {
+	populated := `flush ruleset
+
+table inet filter {
+	chain input {
+		type filter hook input priority 0; policy drop;
+		tcp dport 22 accept
+		ct state established,related accept
 	}
 }
 `
-
-// countSubstr counts non-overlapping occurrences of sub in s.
-func countSubstr(s, sub string) int { return strings.Count(s, sub) }
-
-// assertOperatorContentPreserved fails if the distro skeleton lines were lost.
-func assertOperatorContentPreserved(t *testing.T, body string) {
-	t.Helper()
-	for _, must := range []string{"flush ruleset", "table inet filter", "type filter hook input priority 0;"} {
-		if !strings.Contains(body, must) {
-			t.Errorf("operator content lost: %q missing from:\n%s", must, body)
+	out := neutralizeDistroSkeleton(populated, nil)
+	for _, must := range []string{"table inet filter", "tcp dport 22 accept", "ct state established,related accept"} {
+		if !strings.Contains(out, must) {
+			t.Errorf("populated inet filter content lost (%q):\n%s", must, out)
 		}
+	}
+	// flush ruleset still neutralized even when filter is populated
+	if strings.Contains(out, "\nflush ruleset\n") {
+		t.Errorf("bare flush ruleset survived alongside populated filter:\n%s", out)
 	}
 }
 
 // TestStripNftbanInclude_PureLogic covers the remover twin directly.
 func TestStripNftbanInclude_PureLogic(t *testing.T) {
-	// Polluted file: distro skeleton + a stale fenced block + TWO accumulated
-	// legacy comments + TWO stray legacy includes (the exact pre-v1.146 bug).
 	polluted := distroSkeleton +
 		IncludeBeginMarker + "\n" + IncludeDirective + "\n" + IncludeEndMarker + "\n" +
-		legacyComment + "\n" +
-		IncludeDirective + "\n" +
-		legacyComment + "\n"
-
+		legacyComment + "\n" + IncludeDirective + "\n" + legacyComment + "\n"
 	out := stripNftbanInclude(polluted)
-
 	if strings.Contains(out, IncludeBeginMarker) || strings.Contains(out, IncludeEndMarker) {
 		t.Errorf("fenced markers survived strip:\n%s", out)
 	}
@@ -75,23 +117,22 @@ func TestStripNftbanInclude_PureLogic(t *testing.T) {
 	if strings.Contains(out, "/etc/nftban/nftables.conf") {
 		t.Errorf("include directive survived strip:\n%s", out)
 	}
-	assertOperatorContentPreserved(t, out)
-
-	// Idempotent: stripping clean content changes nothing.
+	if !strings.Contains(out, operatorSentinel) {
+		t.Errorf("operator sentinel lost in strip:\n%s", out)
+	}
 	if again := stripNftbanInclude(out); again != out {
-		t.Errorf("strip not idempotent:\n--first--\n%s\n--second--\n%s", out, again)
+		t.Errorf("strip not idempotent")
 	}
 }
 
-// TestIntegrateSystemConf_FreshAppendsOneFencedBlock asserts a clean distro
-// file gains exactly one fenced block and keeps its content.
-func TestIntegrateSystemConf_FreshAppendsOneFencedBlock(t *testing.T) {
-	log := logging.New("/dev/null", false)
+// TestIntegrateSystemConf_FreshShapeB: one fenced block + skeleton neutralized +
+// operator content preserved.
+func TestIntegrateSystemConf_FreshShapeB(t *testing.T) {
+	log := newTestLogger()
 	defer log.Close()
 	m := executor.NewMockExecutor()
 	const p = "/etc/nftables.conf"
 	m.Files[p] = []byte(distroSkeleton)
-
 	if err := IntegrateSystemConf(m, p, log); err != nil {
 		t.Fatalf("integrate: %v", err)
 	}
@@ -100,63 +141,58 @@ func TestIntegrateSystemConf_FreshAppendsOneFencedBlock(t *testing.T) {
 		t.Errorf("want exactly 1 fenced block, got %d:\n%s", got, body)
 	}
 	if got := countSubstr(body, IncludeDirective); got != 1 {
-		t.Errorf("want exactly 1 include directive, got %d", got)
+		t.Errorf("want exactly 1 include, got %d", got)
 	}
-	if strings.Contains(body, legacyComment) {
-		t.Errorf("new write must not emit the legacy unfenced comment:\n%s", body)
+	for _, line := range strings.Split(body, "\n") {
+		if strings.TrimSpace(line) == "flush ruleset" {
+			t.Errorf("Shape B: bare flush ruleset not neutralized:\n%s", body)
+		}
 	}
-	assertOperatorContentPreserved(t, body)
+	if strings.Contains(body, "type filter hook input priority 0;") {
+		t.Errorf("Shape B: empty inet filter skeleton not removed:\n%s", body)
+	}
+	if !strings.Contains(body, operatorSentinel) {
+		t.Errorf("operator content lost:\n%s", body)
+	}
 }
 
-// TestIntegrateSystemConf_CollapsesAccumulatedDuplicates asserts the
-// self-healing path: a file polluted by the pre-v1.146 bug (multiple legacy
-// comments + includes) is normalised to a single fenced block.
+// TestIntegrateSystemConf_CollapsesAccumulatedDuplicates: self-heal path.
 func TestIntegrateSystemConf_CollapsesAccumulatedDuplicates(t *testing.T) {
-	log := logging.New("/dev/null", false)
+	log := newTestLogger()
 	defer log.Close()
 	m := executor.NewMockExecutor()
 	const p = "/etc/nftables.conf"
 	m.Files[p] = []byte(distroSkeleton +
 		legacyComment + "\n" + IncludeDirective + "\n" +
-		legacyComment + "\n" + IncludeDirective + "\n" +
 		legacyComment + "\n" + IncludeDirective + "\n")
-
 	if err := IntegrateSystemConf(m, p, log); err != nil {
 		t.Fatalf("integrate: %v", err)
 	}
 	body := string(m.Files[p])
 	if got := countSubstr(body, IncludeBeginMarker); got != 1 {
-		t.Errorf("want exactly 1 fenced block after collapse, got %d:\n%s", got, body)
-	}
-	if got := countSubstr(body, IncludeDirective); got != 1 {
-		t.Errorf("want exactly 1 include after collapse, got %d", got)
+		t.Errorf("want 1 fenced block after collapse, got %d:\n%s", got, body)
 	}
 	if strings.Contains(body, legacyComment) {
-		t.Errorf("accumulated legacy comments not collapsed:\n%s", body)
+		t.Errorf("legacy comments not collapsed:\n%s", body)
 	}
-	assertOperatorContentPreserved(t, body)
 }
 
-// TestIntegrateSystemConf_IdempotentNoWrite asserts that a file already
-// carrying exactly the canonical fenced block is left untouched (no write,
-// mtime preserved).
+// TestIntegrateSystemConf_IdempotentNoWrite: second integrate on an
+// already-neutralized canonical file must not write.
 func TestIntegrateSystemConf_IdempotentNoWrite(t *testing.T) {
-	log := logging.New("/dev/null", false)
+	log := newTestLogger()
 	defer log.Close()
 	m := executor.NewMockExecutor()
 	const p = "/etc/nftables.conf"
-
-	// First integrate establishes the canonical block.
 	m.Files[p] = []byte(distroSkeleton)
 	if err := IntegrateSystemConf(m, p, log); err != nil {
 		t.Fatalf("integrate #1: %v", err)
 	}
-	// Reset the write ledger and integrate again — must be a no-op.
 	m.WrittenFiles = map[string][]byte{}
 	if err := IntegrateSystemConf(m, p, log); err != nil {
 		t.Fatalf("integrate #2: %v", err)
 	}
 	if _, wrote := m.WrittenFiles[p]; wrote {
-		t.Errorf("second integrate wrote despite canonical content (not idempotent)")
+		t.Errorf("second integrate wrote despite canonical+neutralized content (not idempotent):\n%s", string(m.Files[p]))
 	}
 }


### PR DESCRIPTION
**Scope: v1.146 Shape B — install/boot-lifecycle authority.** Keep the fenced nftban include and neutralize the distro nftables skeleton. Daemon `cmd/nftband` byte-frozen (installer/render only). No Shape A. No SELinux policy work. No v1.147 work. No production mutation.

## Decision basis
**`V146_BOOT_SUFFICIENCY_SHAPE_B_REQUIRED`** (reboot proof — `NFTBAN_ROADMAP/V146_BOOT_SUFFICIENCY_GATE2_REBOOT_PROOF_RECORD.md`). Plain Shape A (remove the distro include, rely on daemon) is **unsafe**: `nftband` recreates table/set *structure* via netlink but does **not** load the rendered static ruleset (`ssh_ports` elements, `tcp_ports_in` elements, `@ssh_ports` ct-count rule, chains). After removing the include + reboot: Debian 12 + Ubuntu 24 came back with nftban tables present but `ssh_ports` missing, `tcp_ports_in` empty, no rate-limit rule; CentOS Stream 9 under SELinux Enforcing came back with **no nftban tables at all** (daemon netlink denied). So: keep the include, neutralize the skeleton, do **not** remove the include.

## What changed (`internal/installer/render/sysconf.go`)
- **Keep the Phase-D fenced include** — it is the only boot-time `nft -f` loader of the rendered ruleset.
- **Neutralize bare `flush ruleset`** (comment it) so `systemctl reload nftables.service` cannot wipe daemon-managed `ip/ip6 nftban` runtime tables.
- **Remove the empty/default `table inet filter` skeleton** (shadows nftban + trips CVE-2025-NFTBAN-001).
- **Preserve a populated/operator-owned `inet filter`** verbatim (never silently deleted).
- **Phase-D fenced marker/idempotency behavior preserved** (strip → neutralize → one fenced block; no-op when already canonical).

## Validation (`NFTBAN_ROADMAP/V146_SHAPE_B_IMPL_VALIDATION_RECORD.md`)
- gofmt clean, `go vet` rc=0, `go test ./internal/installer/render/` ok (lab2).
- DEB build rc=0 (lab2 Ubuntu 24) + RPM build rc=0 (a9 EL9).
- Phase-D hermetic regression unchanged: `cli_nftables_include_idempotency_v146_test.sh` 19/0 + `cli_inet_filter_policy_v146_test.sh` 16/0.
- **Reboot proof PASSED:** Debian 12 · Ubuntu 24.04 · CentOS Stream 9 (SELinux Enforcing). Each: post-reboot `ssh_ports {22,2222,55000}` + `@ssh_ports` rule restored, inet filter not recreated, operator content preserved.
- **Reload-safe** on tested DEB hosts: `systemctl reload nftables.service` no longer wipes nftban tables.

### EL Enforcing note
Shape B restores the static ruleset through the include's `nft -f` (a permitted SELinux context) **even while the daemon netlink remains denied** under Enforcing. The SELinux **daemon** policy (`.te`/`.if`) remains **v1.147** (forward-looking; production EL is SELinux Disabled).

## Residuals (non-gating)
- Dynamic-ban-on-reload not separately stress-tested (flush neutralized so a reload no longer wipes; table-survives-reload verified).
- Reboot proof on 3 of 7 matrix distros; mechanism is distro-independent (Go integrate + `nft -f` include), remaining hosts expected identical.
- EL daemon-netlink denial deferred to v1.147 SELinux lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
