### PR TITLE
feat(policy): v1.147-A ship MAC profiles

### DIFF
--- a/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
+++ b/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - MAC profiles test (v1.147-A: AppArmor + SELinux)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_mac_profiles_v147a_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-03"
+# meta:description="v1.147-A — asserts the MAC profile shipment. SELinux: nftban.te policy_module 1.1.0, nftban.if exists, nftban.fc labels /usr/lib/nftban/bin/nftband as nftband_exec_t, .te carries the netlink/capability allows, build path ships+compiles nftban.pp, RPM %post has a selinuxenabled-guarded semodule -i, RPM %postun has a selinuxenabled-guarded semodule -r on final erase, no permissive nftband_t, no unconfined workaround. AppArmor: profile exists in complain mode with net_admin/dac_override/netlink-raw + the nftband.service ReadWritePaths, DEB postinst has an AppArmor-guarded apparmor_parser -r, DEB postrm has an AppArmor-guarded apparmor_parser -R. Guards spelled 'selinuxenabled' (not the plan typo). No polkit-as-SELinux-fix; no Go/daemon/core/schema change. Hermetic — static assertions on repo files, no host contact."
+# meta:input="install/selinux/*, install/apparmor/*, packaging/build_nftban.sh, packaging/deb/postinst, packaging/deb/postrm"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="install/selinux/nftban.te,install/selinux/nftban.if,install/selinux/nftban.fc,install/apparmor/usr.lib.nftban.bin.nftband,packaging/build_nftban.sh,packaging/deb/postinst,packaging/deb/postrm"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+TE="$REPO/install/selinux/nftban.te"
+IF="$REPO/install/selinux/nftban.if"
+FC="$REPO/install/selinux/nftban.fc"
+AA="$REPO/install/apparmor/usr.lib.nftban.bin.nftband"
+BUILD="$REPO/packaging/build_nftban.sh"
+POSTINST="$REPO/packaging/deb/postinst"
+POSTRM="$REPO/packaging/deb/postrm"
+
+# ── SELinux ────────────────────────────────────────────────────────────────
+[[ -f "$TE" ]] && grep -qE 'policy_module\(nftban, 1\.1\.0\)' "$TE" \
+  && ok "S1 nftban.te policy_module is 1.1.0" || no "S1 nftban.te policy_module is 1.1.0" "missing/old"
+[[ -f "$IF" ]] && grep -q 'nftban_domtrans' "$IF" \
+  && ok "S2 nftban.if exists with interfaces" || no "S2 nftban.if exists" "missing"
+[[ -f "$FC" ]] && grep -Eq '/usr/lib/nftban/bin/nftband[[:space:]].*nftband_exec_t' "$FC" \
+  && ok "S3 nftban.fc labels the daemon binary nftband_exec_t" || no "S3 .fc labels daemon binary" "missing"
+if grep -q 'netlink_netfilter_socket' "$TE" && grep -q 'netlink_route_socket' "$TE" \
+   && grep -Eq 'self:capability \{ net_admin net_raw \}' "$TE"; then
+  ok "S4 nftban.te carries netlink + net_admin/net_raw allows"
+else no "S4 .te netlink/capability allows" "missing"; fi
+if grep -qE 'checkmodule .*nftban\.te' "$BUILD" && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD"; then
+  ok "S5 build path compiles + ships nftban.pp"
+else no "S5 build ships nftban.pp" "compile/install missing"; fi
+# RPM %post: selinuxenabled-guarded semodule -i (here-strings avoid pipefail SIGPIPE)
+_post_sec=$(awk '/^%post/{p=1} /^%preun|^%postun/{p=0} p' "$BUILD")
+if grep -q 'selinuxenabled' <<<"$_post_sec" && grep -q 'semodule -i' <<<"$_post_sec"; then
+  ok "S6 RPM %post has selinuxenabled-guarded semodule -i"
+else no "S6 RPM %post semodule -i" "missing/unguarded"; fi
+# RPM %postun: selinuxenabled-guarded semodule -r on final erase ($1 -eq 0)
+_postun_sec=$(awk '/^%postun/{p=1} p' "$BUILD")
+if grep -q 'semodule -r nftban' <<<"$_postun_sec" && grep -q 'selinuxenabled' <<<"$_postun_sec"; then
+  ok "S7 RPM %postun has selinuxenabled-guarded semodule -r"
+else no "S7 RPM %postun semodule -r" "missing/unguarded"; fi
+# enforcing domain only — NO permissive, NO unconfined workaround
+if ! grep -qE 'permissive[[:space:]]+nftband_t' "$TE"; then
+  ok "S8 no 'permissive nftband_t' (enforcing domain)"
+else no "S8 no permissive nftband_t" "permissive present"; fi
+if ! grep -qiE 'unconfined_domain|unconfined_t' "$TE" "$IF"; then
+  ok "S9 no unconfined workaround in policy"
+else no "S9 no unconfined workaround" "unconfined present"; fi
+# guard typo check: must be selinuxenabled, never selinunenabled
+if ! grep -rq 'selinunenabled' "$BUILD" "$POSTINST" "$POSTRM"; then
+  ok "S10 guard spelled 'selinuxenabled' (no 'selinunenabled' typo)"
+else no "S10 selinuxenabled typo" "found selinunenabled"; fi
+
+# ── AppArmor ───────────────────────────────────────────────────────────────
+[[ -f "$AA" ]] && grep -qE 'profile nftband /usr/lib/nftban/bin/nftband flags=\(complain\)' "$AA" \
+  && ok "A1 AppArmor profile exists in complain mode" || no "A1 AppArmor profile complain" "missing/not-complain"
+if grep -q 'capability net_admin,' "$AA" && grep -q 'capability dac_override,' "$AA" \
+   && grep -q 'network netlink raw,' "$AA"; then
+  ok "A2 profile has net_admin + dac_override + netlink raw"
+else no "A2 profile caps/netlink" "missing"; fi
+aa_paths=1
+for p in '/var/lib/nftban/' '/var/log/nftban/' '/run/nftban/' '/var/cache/nftban/' '/etc/nftban/blacklist.d/' '/etc/nftban/rules.d/'; do
+  grep -q "$p" "$AA" || aa_paths=0
+done
+[[ $aa_paths -eq 1 ]] && ok "A3 profile rw-covers the nftband.service ReadWritePaths" || no "A3 profile ReadWritePaths" "a path missing"
+# DEB postinst: AppArmor-guarded apparmor_parser -r
+if grep -q 'apparmor_parser -r' "$POSTINST" && grep -qE 'sys/kernel/security/apparmor|command -v apparmor_parser' "$POSTINST"; then
+  ok "A4 DEB postinst has AppArmor-guarded apparmor_parser -r"
+else no "A4 postinst apparmor_parser -r" "missing/unguarded"; fi
+# DEB postrm: AppArmor-guarded apparmor_parser -R
+if grep -q 'apparmor_parser -R' "$POSTRM" && grep -q 'command -v apparmor_parser' "$POSTRM"; then
+  ok "A5 DEB postrm has AppArmor-guarded apparmor_parser -R"
+else no "A5 postrm apparmor_parser -R" "missing/unguarded"; fi
+# DEB build ships the profile under /etc/apparmor.d/ (install spans 2 lines)
+if grep -q 'install/apparmor/usr.lib.nftban.bin.nftband' "$BUILD" \
+   && grep -q 'etc/apparmor.d/usr.lib.nftban.bin.nftband' "$BUILD"; then
+  ok "A6 DEB build ships the profile under /etc/apparmor.d/"
+else no "A6 DEB ships apparmor profile" "install missing"; fi
+
+# ── Non-goals (147-A is policy-only) ────────────────────────────────────────
+# no polkit-as-SELinux-fix: the MAC files must not introduce polkit
+if ! grep -riq 'polkit' "$TE" "$IF" "$AA"; then
+  ok "N1 no polkit referenced in MAC policy files"
+else no "N1 no polkit in MAC files" "polkit present"; fi
+
+echo
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
+++ b/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
@@ -48,9 +48,11 @@ if grep -q 'netlink_netfilter_socket' "$TE" && grep -q 'netlink_route_socket' "$
    && grep -Eq 'self:capability \{ net_admin net_raw \}' "$TE"; then
   ok "S4 nftban.te carries netlink + net_admin/net_raw allows"
 else no "S4 .te netlink/capability allows" "missing"; fi
-if grep -qE 'checkmodule .*nftban\.te' "$BUILD" && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD"; then
-  ok "S5 build path compiles + ships nftban.pp"
-else no "S5 build ships nftban.pp" "compile/install missing"; fi
+if grep -qE 'make -f /usr/share/selinux/devel/Makefile nftban\.pp' "$BUILD" \
+   && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD" \
+   && grep -q 'BuildRequires:  selinux-policy-devel' "$BUILD"; then
+  ok "S5 build compiles nftban.pp via refpolicy devel Makefile + ships it (BuildRequires set)"
+else no "S5 build ships nftban.pp" "compile/install/BuildRequires missing"; fi
 # RPM %post: selinuxenabled-guarded semodule -i (here-strings avoid pipefail SIGPIPE)
 _post_sec=$(awk '/^%post/{p=1} /^%preun|^%postun/{p=0} p' "$BUILD")
 if grep -q 'selinuxenabled' <<<"$_post_sec" && grep -q 'semodule -i' <<<"$_post_sec"; then

--- a/install/apparmor/usr.lib.nftban.bin.nftband
+++ b/install/apparmor/usr.lib.nftban.bin.nftband
@@ -1,0 +1,55 @@
+# NFTBan firewall daemon AppArmor profile (v1.147-A)
+# SPDX-License-Identifier: MPL-2.0
+#
+# Ships in COMPLAIN mode (flags=(complain)) for safe fleet soak — logs
+# would-be denials without enforcing. Flip to enforce in a follow-up after
+# soak (operator SELECT_V147_A_APPARMOR_DEFAULT_MODE = complain).
+#
+# Confines ONLY the long-running nftband daemon. The CLI dispatcher
+# (/usr/sbin/nftban) and helper scripts are intentionally NOT confined in
+# 147-A. Loaded by packaging/deb/postinst when AppArmor is present; no-op
+# otherwise. Mirrors the unit's AmbientCapabilities + ReadWritePaths
+# (install/systemd/nftband.service).
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+profile nftband /usr/lib/nftban/bin/nftband flags=(complain) {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+
+  # nftables management via netlink (google/nftables) — internal/nftbackend
+  capability net_admin,
+  capability dac_override,
+  network netlink raw,
+
+  # daemon network surfaces (Unix socket + HTTP :9580)
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network unix stream,
+
+  # own executable
+  /usr/lib/nftban/bin/nftband mr,
+
+  # read-only application tree + config
+  /usr/lib/nftban/{,**} r,
+  /etc/nftban/{,**} r,
+
+  # read-write: exactly the nftband.service ReadWritePaths
+  /etc/nftban/blacklist.d/{,**} rw,
+  /etc/nftban/rules.d/{,**} rw,
+  /var/lib/nftban/{,**} rw,
+  /var/log/nftban/{,**} rw,
+  /run/nftban/{,**} rw,
+  /var/cache/nftban/{,**} rw,
+
+  # nft binary (defense-in-depth: daemon uses netlink, but some paths shell out)
+  /{,usr/}sbin/nft rmix,
+  /{,usr/}bin/nft rmix,
+
+  # proc/self + runtime essentials
+  @{PROC}/@{pid}/{stat,status,cmdline} r,
+  /sys/kernel/security/apparmor/.null rw,
+}

--- a/install/selinux/Makefile
+++ b/install/selinux/Makefile
@@ -5,7 +5,7 @@
 # Requirements: selinux-policy-devel, checkpolicy
 
 POLICY_NAME = nftban
-POLICY_VERSION = 1.0.0
+POLICY_VERSION = 1.1.0
 
 all: $(POLICY_NAME).pp
 

--- a/install/selinux/nftban.if
+++ b/install/selinux/nftban.if
@@ -1,0 +1,72 @@
+## <summary>NFTBan firewall daemon SELinux policy interfaces.</summary>
+## <desc>
+##   <p>
+##     Interface stubs for the nftban policy module (v1.147-A). The module
+##     itself (nftban.te) confines the nftband daemon to the nftband_t domain
+##     with the netlink + capability permissions it needs to manage nftables.
+##     These interfaces let other policy compose against nftban types without
+##     editing the base module. Closes D-OSH-1 (.te + .fc shipped, .if missing).
+##   </p>
+## </desc>
+
+########################################
+## <summary>
+##   Execute nftband in the nftband_t domain (automatic domain transition).
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed to transition.</summary>
+## </param>
+#
+interface(`nftban_domtrans',`
+	gen_require(`
+		type nftband_t, nftband_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, nftband_exec_t, nftband_t)
+')
+
+########################################
+## <summary>
+##   Read nftban configuration files (nftban_conf_t).
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed access.</summary>
+## </param>
+#
+interface(`nftban_read_config',`
+	gen_require(`
+		type nftban_conf_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, nftban_conf_t, nftban_conf_t)
+	list_dirs_pattern($1, nftban_conf_t, nftban_conf_t)
+')
+
+########################################
+## <summary>
+##   All-in-one administrative access to the nftban daemon domain + types.
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed access.</summary>
+## </param>
+## <param name="role">
+##   <summary>Role allowed access.</summary>
+## </param>
+## <rolecap/>
+#
+interface(`nftban_admin',`
+	gen_require(`
+		type nftband_t, nftban_conf_t, nftban_var_lib_t;
+		type nftban_log_t, nftban_var_run_t;
+	')
+
+	allow $1 nftband_t:process { ptrace signal_perms };
+	ps_process_pattern($1, nftband_t)
+
+	admin_pattern($1, nftban_conf_t)
+	admin_pattern($1, nftban_var_lib_t)
+	admin_pattern($1, nftban_log_t)
+	admin_pattern($1, nftban_var_run_t)
+')

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -5,7 +5,7 @@
 #          semodule_package -o nftban.pp -m nftban.mod
 #          semodule -i nftban.pp
 
-policy_module(nftban, 1.0.0)
+policy_module(nftban, 1.1.0)
 
 ########################################
 # Type Declarations

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -300,6 +300,11 @@ Source1:        nftban-files.inc
 Source2:        nftban-systemd-install.list
 
 BuildRequires:  systemd-rpm-macros
+# v1.147-A: compile the SELinux policy module (.pp) at build via the refpolicy
+# devel Makefile. checkmodule alone cannot resolve refpolicy interfaces
+# (init_daemon_domain, logging_log_file, ...) used by nftban.te.
+BuildRequires:  selinux-policy-devel
+BuildRequires:  make
 
 Requires:       nftables >= 0.9.0
 Requires:       systemd
@@ -517,14 +522,15 @@ install -D -m 0644 install/selinux/nftban.te %{buildroot}/usr/share/nftban/selin
 install -D -m 0644 install/selinux/nftban.fc %{buildroot}/usr/share/nftban/selinux/nftban.fc
 install -D -m 0644 install/selinux/nftban.if %{buildroot}/usr/share/nftban/selinux/nftban.if
 install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinux/Makefile
-# v1.147-A: compile the policy module at build so %post can semodule -i it
-# without requiring policycoreutils-devel on the target. Guarded: if the build
-# host lacks checkmodule/semodule_package the .pp is simply absent and %post
-# falls back to compile-on-target (or no-ops on SELinux Disabled/absent).
-if command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
-    ( cd install/selinux && checkmodule -M -m -o nftban.mod nftban.te && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc ) \
+# v1.147-A: compile the policy module (.pp) at build so %post can semodule -i it
+# without requiring selinux-policy-devel on the target. MUST use the refpolicy
+# devel Makefile — checkmodule alone errors on policy_module()/init_daemon_domain
+# (refpolicy m4 interfaces). Guarded: if the devel Makefile is absent the .pp is
+# simply not shipped and %post falls back to compile-on-target (or no-ops).
+if [ -f /usr/share/selinux/devel/Makefile ]; then
+    ( cd install/selinux && make -f /usr/share/selinux/devel/Makefile nftban.pp ) \
         && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
-        || echo "[NFTBan build] SELinux .pp compile skipped/failed; %post will compile on target"
+        || echo "[NFTBan build] SELinux .pp compile failed; %post will compile on target"
 fi
 
 # Validator spec file
@@ -935,9 +941,8 @@ if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
     _nftban_sel=/usr/share/nftban/selinux
     if [ -f "\$_nftban_sel/nftban.pp" ]; then
         semodule -i "\$_nftban_sel/nftban.pp" 2>/dev/null || true
-    elif command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
-        ( cd "\$_nftban_sel" && checkmodule -M -m -o nftban.mod nftban.te 2>/dev/null \
-            && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc 2>/dev/null \
+    elif [ -f /usr/share/selinux/devel/Makefile ]; then
+        ( cd "\$_nftban_sel" && make -f /usr/share/selinux/devel/Makefile nftban.pp 2>/dev/null \
             && semodule -i nftban.pp 2>/dev/null ) || true
     fi
     restorecon -R /usr/sbin/nftban /usr/lib/nftban/bin /etc/nftban /var/lib/nftban /var/log/nftban /run/nftban /var/cache/nftban 2>/dev/null || true

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -515,7 +515,17 @@ install -D -m 0644 packaging/polkit-1/rules.d/20-nftban-auditor.rules %{buildroo
 mkdir -p %{buildroot}/usr/share/nftban/selinux
 install -D -m 0644 install/selinux/nftban.te %{buildroot}/usr/share/nftban/selinux/nftban.te
 install -D -m 0644 install/selinux/nftban.fc %{buildroot}/usr/share/nftban/selinux/nftban.fc
+install -D -m 0644 install/selinux/nftban.if %{buildroot}/usr/share/nftban/selinux/nftban.if
 install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinux/Makefile
+# v1.147-A: compile the policy module at build so %post can semodule -i it
+# without requiring policycoreutils-devel on the target. Guarded: if the build
+# host lacks checkmodule/semodule_package the .pp is simply absent and %post
+# falls back to compile-on-target (or no-ops on SELinux Disabled/absent).
+if command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
+    ( cd install/selinux && checkmodule -M -m -o nftban.mod nftban.te && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc ) \
+        && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
+        || echo "[NFTBan build] SELinux .pp compile skipped/failed; %post will compile on target"
+fi
 
 # Validator spec file
 install -D -m 0644 install/share/nftban/specs/structure_default.json %{buildroot}/usr/share/nftban/specs/structure_default.json
@@ -912,6 +922,29 @@ else
 fi
 
 # =============================================================================
+# v1.147-A: load the nftban SELinux policy module (D-NFTBAN-EL-SELINUX-DAEMON-NETLINK)
+# =============================================================================
+# The .te/.fc shipped since v1.19.12 but were never compiled or loaded, so on
+# SELinux Enforcing the daemon ran unlabeled (init_t) and its netlink socket was
+# denied ("failed to list tables: socket: permission denied"). Load the module
+# (enforcing nftband_t domain; NOT permissive) and relabel BEFORE the Go
+# installer starts the daemon, so nftband transitions to nftband_t on first
+# start. Prefer the build-shipped nftban.pp; fall back to compile-on-target.
+# Guarded + idempotent + strict no-op on SELinux Disabled/absent.
+if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
+    _nftban_sel=/usr/share/nftban/selinux
+    if [ -f "\$_nftban_sel/nftban.pp" ]; then
+        semodule -i "\$_nftban_sel/nftban.pp" 2>/dev/null || true
+    elif command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
+        ( cd "\$_nftban_sel" && checkmodule -M -m -o nftban.mod nftban.te 2>/dev/null \
+            && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc 2>/dev/null \
+            && semodule -i nftban.pp 2>/dev/null ) || true
+    fi
+    restorecon -R /usr/sbin/nftban /usr/lib/nftban/bin /etc/nftban /var/lib/nftban /var/log/nftban /run/nftban /var/cache/nftban 2>/dev/null || true
+    unset _nftban_sel
+fi
+
+# =============================================================================
 # v1.146 Phase-D: CVE-2025-NFTBAN-001 inet-filter classify-then-act
 # =============================================================================
 # Drift-checked twin of packaging/deb/postinst:_nftban_classify_inet_filter
@@ -1168,6 +1201,12 @@ fi
 # =============================================================================
 if [ \$1 -eq 0 ]; then
     echo "[NFTBan] Complete removal — cleaning up all artifacts..."
+
+    # v1.147-A: remove the nftban SELinux policy module on final erase
+    # (guarded, idempotent, no-op on SELinux Disabled/absent).
+    if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
+        semodule -r nftban 2>/dev/null || true
+    fi
 
     # STEP 1: Backup user configuration before removal
     BACKUP_DIR="/var/tmp/nftban-config-backup-\$(date +%%Y%%m%%d-%%H%%M%%S)"
@@ -1713,6 +1752,13 @@ build_deb() {
         fi
     done
     log_info "Installed ${sbin_count} sbin helper scripts"
+
+    # v1.147-A: AppArmor profile for the nftband daemon (DEB only; complain mode).
+    # Loaded by postinst when AppArmor is present; no-op otherwise. Shipped under
+    # /etc/apparmor.d/ so dpkg treats it as a conffile (auto-removed on purge).
+    install -D -m 0644 "${PROJECT_ROOT}/install/apparmor/usr.lib.nftban.bin.nftband" \
+        "${deb_root}/etc/apparmor.d/usr.lib.nftban.bin.nftband"
+    log_info "Installed AppArmor profile (complain mode)"
 
     # Copy VERSION file (WARN-005: ensure it's non-empty)
     if [[ -s "${PROJECT_ROOT}/VERSION" ]]; then

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -243,6 +243,17 @@ case "$1" in
             chmod 0750 /usr/sbin/nftban 2>/dev/null || true
         fi
 
+        # --- v1.147-A: load the nftband AppArmor profile (complain mode) ---
+        # Loaded before the Go installer starts the daemon so nftband is
+        # confined on first start. Complain logs would-be denials without
+        # enforcing (safe soak; flip to enforce in a follow-up). Strict no-op
+        # when AppArmor is absent.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -d /sys/kernel/security/apparmor ] \
+           && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -r -W -T /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+            log_info "AppArmor: nftband profile loaded (complain mode)"
+        fi
+
         # --- Critical FHS dirs (Go installer needs state dir to exist) ---
         mkdir -p /var/lib/nftban/state
         mkdir -p /var/log/nftban

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -131,6 +131,14 @@ case "$1" in
         rm -f /etc/polkit-1/rules.d/*nftban*.rules 2>/dev/null || true
         rm -f /usr/share/polkit-1/rules.d/*nftban*.rules 2>/dev/null || true
 
+        # v1.147-A: unload + remove the nftband AppArmor profile (guarded; no-op
+        # when AppArmor absent). The profile is a conffile under /etc/apparmor.d/;
+        # unload it from the kernel here and remove the file on purge.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -R /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+        fi
+        rm -f /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+
         # Remove yq symlink (only if it points to our bundled binary)
         if [ -L /usr/bin/yq ] && readlink /usr/bin/yq | grep -q nftban; then
             rm -f /usr/bin/yq 2>/dev/null || true
@@ -196,6 +204,13 @@ case "$1" in
         for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
             _nftban_strip_conf_include "$nft_conf"
         done
+
+        # v1.147-A: unload the nftband AppArmor profile (guarded; no-op when
+        # AppArmor absent). On non-purge `remove` the conffile is kept by dpkg
+        # for reinstall — unload from the kernel only, do NOT delete the file.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -R /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+        fi
         ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
**v1.147 Security Hardening umbrella — sub-lane 147-A (MAC profiles).** Policy-only: no Go/daemon/core change, no schema, no polkit, no 147-B, no 147-C, no release-prep. **Daemon `cmd/nftband` + `cmd/nftban-core` byte-identical to v1.146.0.**

Controlling docs: `NFTBAN_ROADMAP/V147_A_MAC_PROFILES_SCOPE_REFINEMENT.md` · `V147_A_MAC_PROFILES_IMPL_PLAN.md`.

## Operator decisions
- `SELECT_V147_A_APPARMOR_DEFAULT_MODE = complain`
- `SELECT_V147_A_MAC_ENABLEMENT = selinux-load-by-default + apparmor-complain-by-default`
- `SELECT_V147_A_SELINUX_DOMAIN = enforcing-domain`

## SELinux (EL) — fixes D-NFTBAN-EL-SELINUX-DAEMON-NETLINK
**The existing policy was correct but never loaded.** `nftban.te`/`.fc` have shipped since v1.19.12 but were never compiled or `semodule -i`'d (`semodule -l | grep nftban = 0` on every host), so under Enforcing the daemon ran unlabeled (init_t) and its netlink socket was denied (`failed to list tables: socket: permission denied` — the cs9 reboot-proof finding). Now:
- add `install/selinux/nftban.if` (closes D-OSH-1); bump `nftban.te` → 1.1.0.
- compile `nftban.pp` at RPM build (build-host guarded) + ship to `/usr/share/nftban/selinux/nftban.pp`.
- RPM `%post`: **`selinuxenabled`-guarded `semodule -i`** (prefer shipped `.pp`, fall back to compile-on-target) + `restorecon`, loaded **before** the daemon starts so it transitions to the **enforcing `nftband_t`** domain; idempotent; no-op on Disabled/absent.
- RPM `%postun` final erase: `selinuxenabled`-guarded `semodule -r nftban`.
- **No `permissive nftband_t`, no unconfined workaround.**

## AppArmor (Debian/Ubuntu) — net new
- `install/apparmor/usr.lib.nftban.bin.nftband`, **daemon-only**, `flags=(complain)` (net_admin + dac_override + netlink raw + the `nftband.service` ReadWritePaths).
- DEB ships it under `/etc/apparmor.d/` (conffile); `postinst` AppArmor-guarded `apparmor_parser -r` before the daemon starts; `postrm` AppArmor-guarded `apparmor_parser -R` (remove + purge). **Complain = safe soak; flip to enforce later.**

## Test evidence
`cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh` **17/0** — policy version, `.if`/`.fc`/`.te` allows, `.pp` ship, guarded `semodule -i`/`-r` (`selinuxenabled`, not the plan typo), apparmor complain + caps + rw paths, no permissive/unconfined, no polkit. v1.146 regression **19/0 + 16/0** unaffected. Pre-push: 7 files, 0 forbidden paths (0 `.go`/`cmd/`/`internal/`/schema/metrics/portal/polkit), `bash -n`/`sh -n` clean.

> Note: GitHub CI exercises build/install but not SELinux **Enforcing** behavior; a lab Enforcing (Alma/Rocky/CentOS Stream, cs9 baseline) + AppArmor enforce-mode-load matrix is recommended (separately gated) to prove the daemon manages nft under MAC.

## Non-goals
no Go/daemon/core change · no schema · no polkit · no 147-B daemon least-privilege · no 147-C audit/integrity · no release-prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
