### PR TITLE
feat(security): v1.147 MAC profiles with daemon/unit hardening

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -172,7 +172,9 @@ jobs:
 
             # Install build dependencies (curl required for yq download)
             # Note: --allowerasing handles curl-minimal vs curl conflict on Rocky/Alma
-            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl
+            # v1.147: selinux-policy-devel needed to compile the nftban SELinux .pp
+            # (spec BuildRequires); without it rpmbuild aborts on Failed build dependencies.
+            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl selinux-policy-devel
 
             # Build RPM
             chmod +x packaging/build_nftban.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
             set -e  # Exit on any error
 
             # Install build dependencies (curl required for yq download)
-            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl
+            # v1.147: selinux-policy-devel needed to compile the nftban SELinux .pp (spec BuildRequires)
+            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl selinux-policy-devel
 
             # Build RPM
             chmod +x packaging/build_nftban.sh

--- a/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
+++ b/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - MAC profiles test (v1.147-A: AppArmor + SELinux)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_mac_profiles_v147a_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-03"
+# meta:description="v1.147-A — asserts the MAC profile shipment. SELinux: nftban.te policy_module 1.1.0, nftban.if exists, nftban.fc labels /usr/lib/nftban/bin/nftband as nftband_exec_t, .te carries the netlink/capability allows, build path ships+compiles nftban.pp, RPM %post has a selinuxenabled-guarded semodule -i, RPM %postun has a selinuxenabled-guarded semodule -r on final erase, no permissive nftband_t, no unconfined workaround. AppArmor: profile exists in complain mode with net_admin/dac_override/netlink-raw + the nftband.service ReadWritePaths, DEB postinst has an AppArmor-guarded apparmor_parser -r, DEB postrm has an AppArmor-guarded apparmor_parser -R. Guards spelled 'selinuxenabled' (not the plan typo). No polkit-as-SELinux-fix; no Go/daemon/core/schema change. Hermetic — static assertions on repo files, no host contact."
+# meta:input="install/selinux/*, install/apparmor/*, packaging/build_nftban.sh, packaging/deb/postinst, packaging/deb/postrm"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="install/selinux/nftban.te,install/selinux/nftban.if,install/selinux/nftban.fc,install/apparmor/usr.lib.nftban.bin.nftband,packaging/build_nftban.sh,packaging/deb/postinst,packaging/deb/postrm"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+TE="$REPO/install/selinux/nftban.te"
+IF="$REPO/install/selinux/nftban.if"
+FC="$REPO/install/selinux/nftban.fc"
+AA="$REPO/install/apparmor/usr.lib.nftban.bin.nftband"
+BUILD="$REPO/packaging/build_nftban.sh"
+POSTINST="$REPO/packaging/deb/postinst"
+POSTRM="$REPO/packaging/deb/postrm"
+
+# ── SELinux ────────────────────────────────────────────────────────────────
+[[ -f "$TE" ]] && grep -qE 'policy_module\(nftban, 1\.1\.0\)' "$TE" \
+  && ok "S1 nftban.te policy_module is 1.1.0" || no "S1 nftban.te policy_module is 1.1.0" "missing/old"
+[[ -f "$IF" ]] && grep -q 'nftban_domtrans' "$IF" \
+  && ok "S2 nftban.if exists with interfaces" || no "S2 nftban.if exists" "missing"
+[[ -f "$FC" ]] && grep -Eq '/usr/lib/nftban/bin/nftband[[:space:]].*nftband_exec_t' "$FC" \
+  && ok "S3 nftban.fc labels the daemon binary nftband_exec_t" || no "S3 .fc labels daemon binary" "missing"
+if grep -q 'netlink_netfilter_socket' "$TE" && grep -q 'netlink_route_socket' "$TE" \
+   && grep -Eq 'self:capability \{ net_admin net_raw \}' "$TE"; then
+  ok "S4 nftban.te carries netlink + net_admin/net_raw allows"
+else no "S4 .te netlink/capability allows" "missing"; fi
+if grep -qE 'checkmodule .*nftban\.te' "$BUILD" && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD"; then
+  ok "S5 build path compiles + ships nftban.pp"
+else no "S5 build ships nftban.pp" "compile/install missing"; fi
+# RPM %post: selinuxenabled-guarded semodule -i (here-strings avoid pipefail SIGPIPE)
+_post_sec=$(awk '/^%post/{p=1} /^%preun|^%postun/{p=0} p' "$BUILD")
+if grep -q 'selinuxenabled' <<<"$_post_sec" && grep -q 'semodule -i' <<<"$_post_sec"; then
+  ok "S6 RPM %post has selinuxenabled-guarded semodule -i"
+else no "S6 RPM %post semodule -i" "missing/unguarded"; fi
+# RPM %postun: selinuxenabled-guarded semodule -r on final erase ($1 -eq 0)
+_postun_sec=$(awk '/^%postun/{p=1} p' "$BUILD")
+if grep -q 'semodule -r nftban' <<<"$_postun_sec" && grep -q 'selinuxenabled' <<<"$_postun_sec"; then
+  ok "S7 RPM %postun has selinuxenabled-guarded semodule -r"
+else no "S7 RPM %postun semodule -r" "missing/unguarded"; fi
+# enforcing domain only — NO permissive, NO unconfined workaround
+if ! grep -qE 'permissive[[:space:]]+nftband_t' "$TE"; then
+  ok "S8 no 'permissive nftband_t' (enforcing domain)"
+else no "S8 no permissive nftband_t" "permissive present"; fi
+if ! grep -qiE 'unconfined_domain|unconfined_t' "$TE" "$IF"; then
+  ok "S9 no unconfined workaround in policy"
+else no "S9 no unconfined workaround" "unconfined present"; fi
+# guard typo check: must be selinuxenabled, never selinunenabled
+if ! grep -rq 'selinunenabled' "$BUILD" "$POSTINST" "$POSTRM"; then
+  ok "S10 guard spelled 'selinuxenabled' (no 'selinunenabled' typo)"
+else no "S10 selinuxenabled typo" "found selinunenabled"; fi
+
+# ── AppArmor ───────────────────────────────────────────────────────────────
+[[ -f "$AA" ]] && grep -qE 'profile nftband /usr/lib/nftban/bin/nftband flags=\(complain\)' "$AA" \
+  && ok "A1 AppArmor profile exists in complain mode" || no "A1 AppArmor profile complain" "missing/not-complain"
+if grep -q 'capability net_admin,' "$AA" && grep -q 'capability dac_override,' "$AA" \
+   && grep -q 'network netlink raw,' "$AA"; then
+  ok "A2 profile has net_admin + dac_override + netlink raw"
+else no "A2 profile caps/netlink" "missing"; fi
+aa_paths=1
+for p in '/var/lib/nftban/' '/var/log/nftban/' '/run/nftban/' '/var/cache/nftban/' '/etc/nftban/blacklist.d/' '/etc/nftban/rules.d/'; do
+  grep -q "$p" "$AA" || aa_paths=0
+done
+[[ $aa_paths -eq 1 ]] && ok "A3 profile rw-covers the nftband.service ReadWritePaths" || no "A3 profile ReadWritePaths" "a path missing"
+# DEB postinst: AppArmor-guarded apparmor_parser -r
+if grep -q 'apparmor_parser -r' "$POSTINST" && grep -qE 'sys/kernel/security/apparmor|command -v apparmor_parser' "$POSTINST"; then
+  ok "A4 DEB postinst has AppArmor-guarded apparmor_parser -r"
+else no "A4 postinst apparmor_parser -r" "missing/unguarded"; fi
+# DEB postrm: AppArmor-guarded apparmor_parser -R
+if grep -q 'apparmor_parser -R' "$POSTRM" && grep -q 'command -v apparmor_parser' "$POSTRM"; then
+  ok "A5 DEB postrm has AppArmor-guarded apparmor_parser -R"
+else no "A5 postrm apparmor_parser -R" "missing/unguarded"; fi
+# DEB build ships the profile under /etc/apparmor.d/ (install spans 2 lines)
+if grep -q 'install/apparmor/usr.lib.nftban.bin.nftband' "$BUILD" \
+   && grep -q 'etc/apparmor.d/usr.lib.nftban.bin.nftband' "$BUILD"; then
+  ok "A6 DEB build ships the profile under /etc/apparmor.d/"
+else no "A6 DEB ships apparmor profile" "install missing"; fi
+
+# ── Non-goals (147-A is policy-only) ────────────────────────────────────────
+# no polkit-as-SELinux-fix: the MAC files must not introduce polkit
+if ! grep -riq 'polkit' "$TE" "$IF" "$AA"; then
+  ok "N1 no polkit referenced in MAC policy files"
+else no "N1 no polkit in MAC files" "polkit present"; fi
+
+echo
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
+++ b/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
@@ -48,9 +48,11 @@ if grep -q 'netlink_netfilter_socket' "$TE" && grep -q 'netlink_route_socket' "$
    && grep -Eq 'self:capability \{ net_admin net_raw \}' "$TE"; then
   ok "S4 nftban.te carries netlink + net_admin/net_raw allows"
 else no "S4 .te netlink/capability allows" "missing"; fi
-if grep -qE 'checkmodule .*nftban\.te' "$BUILD" && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD"; then
-  ok "S5 build path compiles + ships nftban.pp"
-else no "S5 build ships nftban.pp" "compile/install missing"; fi
+if grep -qE 'make -f /usr/share/selinux/devel/Makefile nftban\.pp' "$BUILD" \
+   && grep -qE 'install .*nftban\.pp .*selinux/nftban\.pp' "$BUILD" \
+   && grep -q 'BuildRequires:  selinux-policy-devel' "$BUILD"; then
+  ok "S5 build compiles nftban.pp via refpolicy devel Makefile + ships it (BuildRequires set)"
+else no "S5 build ships nftban.pp" "compile/install/BuildRequires missing"; fi
 # RPM %post: selinuxenabled-guarded semodule -i (here-strings avoid pipefail SIGPIPE)
 _post_sec=$(awk '/^%post/{p=1} /^%preun|^%postun/{p=0} p' "$BUILD")
 if grep -q 'selinuxenabled' <<<"$_post_sec" && grep -q 'semodule -i' <<<"$_post_sec"; then

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -46,8 +46,8 @@ import (
 	"github.com/itcmsgr/nftban/internal/portscan"
 	"github.com/itcmsgr/nftban/internal/safeconv"
 	"github.com/itcmsgr/nftban/internal/safety"
-	"github.com/itcmsgr/nftban/pkg/version"
 	"github.com/itcmsgr/nftban/internal/watchdog"
+	"github.com/itcmsgr/nftban/pkg/version"
 )
 
 // Run starts the daemon and blocks until shutdown
@@ -225,7 +225,17 @@ func (d *Daemon) Run() error {
 	if err := d.startSocket(); err != nil {
 		return fmt.Errorf("failed to start socket: %w", err)
 	}
-	defer d.socketLn.Close()
+	// v1.147: guard the deferred close against a nil listener. Under MAC
+	// confinement a systemd-passed socket fd can be mediated to nil (AppArmor
+	// "disconnected path"); degrade gracefully instead of nil-panicking here.
+	if d.socketLn == nil {
+		return fmt.Errorf("socket listener is nil after startSocket (socket activation may have been blocked by MAC confinement)")
+	}
+	defer func() {
+		if d.socketLn != nil {
+			d.socketLn.Close()
+		}
+	}()
 
 	// Start HTTP server
 	log.Println("Starting HTTP API...")
@@ -622,4 +632,3 @@ func printHelp() {
 	fmt.Println("    curl http://127.0.0.1:6060/debug/pprof/goroutine?debug=2")
 	fmt.Println()
 }
-

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -233,7 +233,7 @@ func (d *Daemon) Run() error {
 	}
 	defer func() {
 		if d.socketLn != nil {
-			d.socketLn.Close()
+			_ = d.socketLn.Close() // best-effort close at shutdown; nothing actionable on error
 		}
 	}()
 

--- a/cmd/nftband/daemon_socket.go
+++ b/cmd/nftband/daemon_socket.go
@@ -51,8 +51,8 @@ func init() {
 
 // startSocket starts the Unix socket listener
 // Supports two modes:
-//   1. Socket activation (systemd): uses pre-created socket from nftband.socket
-//   2. Manual start: creates socket directly (for testing/development)
+//  1. Socket activation (systemd): uses pre-created socket from nftband.socket
+//  2. Manual start: creates socket directly (for testing/development)
 func (d *Daemon) startSocket() error {
 	socketPath := getSocketPath()
 
@@ -62,13 +62,19 @@ func (d *Daemon) startSocket() error {
 		log.Printf("Warning: failed to check systemd activation: %v", err)
 	}
 
-	if len(listeners) > 0 {
+	if len(listeners) > 0 && listeners[0] != nil {
 		// Systemd socket activation - use the pre-configured socket
 		// Socket permissions (0660 root:nftban) are set by nftband.socket unit
 		d.socketLn = listeners[0]
 		log.Printf("Using systemd socket activation (socket from nftband.socket)")
 		go d.acceptSocketConnections()
 		return nil
+	}
+	// v1.147: if activation reported listeners but the fd was mediated to nil
+	// under MAC confinement, fall through to manual socket creation rather than
+	// storing a nil listener (which would nil-panic on the deferred close).
+	if len(listeners) > 0 {
+		log.Printf("Warning: systemd reported %d socket(s) but listener[0] is nil (MAC confinement?); creating socket manually", len(listeners))
 	}
 
 	// Manual start - create socket ourselves (for testing/development)

--- a/docs/security/MAC_PROFILES_SELINUX_APPARMOR.md
+++ b/docs/security/MAC_PROFILES_SELINUX_APPARMOR.md
@@ -1,0 +1,207 @@
+# MAC Profiles: SELinux and AppArmor
+
+*As of v1.147.* Operator-facing reference for NFTBan's Mandatory Access Control
+(MAC) integration: SELinux on EL/RHEL-family systems, AppArmor on Debian/Ubuntu.
+
+NFTBan uses MAC profiles as defense-in-depth around the `nftband` daemon.
+
+Normal Linux permissions decide whether a service may run. SELinux and AppArmor
+decide what that service may access after it is running. This matters because
+`nftband` manages nftables firewall state, SSH-protection sets, ban/unban state,
+whitelists, and runtime firewall objects — if a bug, a bad helper path, or an
+exploit reaches the daemon, the MAC profile limits what the damage can touch.
+
+---
+
+## 1. Why NFTBan uses MAC profiles
+
+`nftband` runs privileged (it programs nftables via netlink). Standard
+permissions answer *"can this service run?"*. MAC answers *"even as root, what
+exactly is this process allowed to touch?"*.
+
+- Without MAC: a daemon compromise has broad system reach.
+- With MAC: `nftband` is confined to NFTBan paths plus the netlink/nftables
+  operations it actually needs, and is blocked from everything else.
+
+This is defense-in-depth. It does **not** replace normal file permissions,
+systemd unit hardening (which v1.146 and the unit already apply), or polkit.
+
+## 2. SELinux vs AppArmor
+
+Both are Mandatory Access Control systems that confine a *running* process after
+normal Linux permissions have already allowed execution. Linux distributions ship
+different MAC systems, so NFTBan ships both:
+
+| Family | MAC system | NFTBan profile |
+|---|---|---|
+| EL / RHEL family (AlmaLinux, Rocky, CentOS Stream, RHEL) | SELinux | policy module `nftban` |
+| Debian / Ubuntu | AppArmor | profile `usr.lib.nftban.bin.nftband` |
+
+## 3. What v1.147 changes
+
+### SELinux (EL family)
+- Ships the policy sources `nftban.te` / `nftban.if` / `nftban.fc` and a compiled
+  `nftban.pp`, under `/usr/share/nftban/selinux/`.
+- The `.pp` is compiled at **package build** via the refpolicy devel Makefile
+  (`make -f /usr/share/selinux/devel/Makefile nftban.pp`); the RPM `%post`
+  installs it with `semodule -i` (guarded by `selinuxenabled`), and falls back to
+  compile-on-target if the prebuilt module is unavailable.
+- Labels the daemon binary `/usr/lib/nftban/bin/nftband` (and `/usr/sbin/nftban`,
+  `nftban-core`) as **`nftband_exec_t`**; `%post` runs `restorecon` over the
+  NFTBan paths.
+- Transitions the daemon from `init_t` into the **`nftband_t`** domain on exec
+  (`type_transition` + entrypoint).
+- Keeps **`NoNewPrivileges=true`** on the unit and still transitions, via the
+  `process2:nnp_transition` permission — NNP is *not* relaxed on any host.
+- Defines NFTBan file types: `nftban_conf_t` (`/etc/nftban`),
+  `nftban_var_lib_t` (`/var/lib`, `/var/cache`), `nftban_log_t` (`/var/log/nftban`),
+  `nftban_var_run_t` (`/run/nftban`).
+- Allows the netlink/nftables operations the daemon needs, plus the system reads
+  and helper executions it performs today.
+- **Fixes the EL Enforcing failure** where the daemon could not program nftables:
+  `cannot list tables: socket: permission denied`.
+
+The `nftband_t` domain in v1.147 is deliberately **broad** — it reflects what the
+daemon does today (it shells out to `bash`/`nft`/`iptables`/`journalctl`/
+`systemctl`/`rpm`/`ssh` and reads several system resources). Tightening it is a
+tracked follow-up (`D-V147-REDUCE-NFTBAND-SHELLOUTS-AND-TIGHTEN-MAC-DOMAIN`) and
+must follow a reduction in daemon shell-outs, not precede it.
+
+### AppArmor (Debian / Ubuntu)
+- Ships the daemon profile to `/etc/apparmor.d/usr.lib.nftban.bin.nftband`.
+- Confines the daemon path `/usr/lib/nftban/bin/nftband`.
+- Default mode: **complain** (denials are logged, not enforced) for safe fleet soak.
+- Profile flag **`attach_disconnected`** is required: the unit runs the daemon in a
+  private mount namespace (`ProtectSystem=strict` + `ReadWritePaths` + `ProtectHome`),
+  so without it AppArmor cannot resolve the systemd/dbus runtime sockets
+  (`/run/systemd/notify`, etc.) and the daemon's `sd_notify` readiness fails. See §10.
+- Allows NFTBan paths (read-only app tree/config; read-write only the unit's
+  `ReadWritePaths`) and the netlink/nftables operations the daemon needs.
+- The DEB `postinst` loads the profile with `apparmor_parser -r` (guarded by
+  AppArmor being present); `postrm` removes it with `apparmor_parser -R`.
+
+### Daemon
+The daemon received **two small defensive nil-guards** (in `daemon_init.go` and
+`daemon_socket.go`) so it degrades gracefully — rather than nil-panicking — when a
+systemd-passed socket fd is mediated to nil under confinement. This is a robustness
+fix, **not** a least-privilege redesign (that is v1.147-B). Because of these two
+changes the daemon binary is **not** byte-identical to v1.146.0.
+
+## 4. What v1.147 MAC does NOT do
+- Does **not** use polkit to fix SELinux (see §5).
+- Does **not** redesign the daemon's least-privilege model — that is **v1.147-B**.
+- Does **not** add audit uid/gid/pid logging or whitelist/immutable-file verification
+  — those are **v1.147-C**.
+- Does **not** change the public JSON schema (stays `1.83.0`).
+- Does **not** change NFTBan firewall ruleset semantics.
+- Does **not** remove the v1.146 Shape-B boot include or change
+  `nftban-firewall-init` / `nftables.service` behavior.
+
+## 5. Why polkit is not the fix
+
+> Polkit answers whether a *user* may request a privileged action. SELinux answers
+> whether a *process domain* may access a kernel/socket/object type. If SELinux
+> denies `nftband` netlink access, polkit cannot override it.
+
+The EL Enforcing `socket: permission denied` is a kernel MAC denial against the
+daemon's domain. The only correct fix is a SELinux policy module that grants the
+daemon's domain the netlink/nftables access it needs — which is what v1.147 ships.
+
+## 6. Operator commands and checks
+
+### SELinux
+```sh
+sestatus                                  # Enforcing / Permissive / Disabled
+semodule -l | grep nftban                 # nftban module loaded?
+ps -eZ | grep nftband                     # daemon should run in ...:nftband_t:...
+restorecon -Rv /usr/sbin/nftban /usr/lib/nftban/bin /etc/nftban \
+  /var/lib/nftban /var/log/nftban /run/nftban /var/cache/nftban
+ausearch -m avc -ts recent | grep -i nftban   # AVC denials (expect none)
+```
+
+### AppArmor
+```sh
+aa-status                                 # is the nftband profile loaded?
+apparmor_parser -r /etc/apparmor.d/usr.lib.nftban.bin.nftband   # (re)load profile
+# Mode helpers (if apparmor-utils installed):
+aa-complain /etc/apparmor.d/usr.lib.nftban.bin.nftband
+aa-enforce  /etc/apparmor.d/usr.lib.nftban.bin.nftband
+# Denials (complain logs them without enforcing):
+journalctl -k | grep -i 'apparmor=.*profile="nftband"'
+dmesg | grep -i apparmor | grep nftband
+```
+
+## 7. Expected behavior
+
+**SELinux Enforcing:** `nftband` runs in `nftband_t`; it lists and manages the
+NFTBan nftables objects; no `socket: permission denied`; no NFTBan AVC denials.
+
+**SELinux Permissive / Disabled:** install hooks are no-ops or non-disruptive
+(`%post` is guarded by `selinuxenabled`); behavior is unchanged.
+
+**AppArmor complain:** the profile is loaded; the daemon works normally; any
+would-be denials are logged but not enforced. A future enforce flip is a separate
+lane/release.
+
+## 8. Troubleshooting
+
+**SELinux module not loaded** — `semodule -l | grep nftban` empty: re-run
+`semodule -i /usr/share/nftban/selinux/nftban.pp` (needs `selinuxenabled`). On EL
+the policy requires the EL9+ refpolicy; EL8 is out of scope for v1.147 (see §9).
+
+**`nftband` not labeled / wrong context** — `ps -eZ | grep nftband` shows `init_t`
+instead of `nftband_t`: run the `restorecon` line in §6, then
+`systemctl restart nftband`. Confirm the binary is `nftband_exec_t`
+(`ls -Z /usr/lib/nftban/bin/nftband`).
+
+**AVC denials still appear** — collect them with
+`ausearch -m avc -ts recent | grep nftband` and attach to a bug report. Do not
+set the domain permissive as a fix; report the denial.
+
+**AppArmor profile not loaded** — `aa-status` does not list `nftband`: load with
+`apparmor_parser -r /etc/apparmor.d/usr.lib.nftban.bin.nftband`. Confirm AppArmor
+is enabled (`cat /sys/module/apparmor/parameters/enabled` = `Y`).
+
+**Daemon stuck "activating" under AppArmor** — almost always the
+`attach_disconnected` flag missing/edited out; the systemd notify socket then
+fails as a "disconnected path". Confirm the profile line reads
+`flags=(complain attach_disconnected)` and reload.
+
+**Collecting evidence for a bug report** — include: distro + version,
+`sestatus`/`aa-status`, `ps -eZ | grep nftband`, the relevant `ausearch`/
+`journalctl -k` AppArmor lines since the daemon restart, and
+`systemctl status nftband`.
+
+## 9. Scope: distro coverage
+
+| Family | Status (v1.147) |
+|---|---|
+| Ubuntu 22.04 / 24.04 / 26.04, Debian 12 / 13 (AppArmor, complain) | validated |
+| AlmaLinux 9, Rocky 9, CentOS Stream 9 (SELinux Enforcing) | validated |
+| EL10 family (AlmaLinux 10 / Rocky 10 / CentOS Stream 10) | validation in progress |
+| EL8 (SELinux Enforcing) | out of scope / deferred — its older refpolicy lacks types the module requires |
+
+## 10. Why `attach_disconnected` (background)
+
+The `nftband.service` unit hardens the daemon with `ProtectSystem=strict`,
+`ReadWritePaths`, and `ProtectHome`, which place it in a private mount namespace.
+Inside that namespace AppArmor could not resolve `/run/systemd/notify`,
+`/run/systemd/private`, or `/run/dbus/system_bus_socket` against the namespace
+root — it returned a *"Failed name lookup - disconnected path"* error (EACCES)
+even in complain mode. The daemon's `sd_notify(READY=1)` then never reached systemd
+(the unit is `Type=notify`), so the service hung in "activating" and restart-looped.
+The `attach_disconnected` profile flag attaches such paths to the namespace root so
+the profile's file rules apply, which restores `sd_notify` readiness.
+
+## 11. Related and future work
+- **v1.147-B** — daemon least-privilege redesign (run as a dedicated user, reduce
+  capabilities/syscalls).
+- **v1.147-C** — audit-log uid/gid/pid and whitelist/immutable-file verification.
+- `D-V147-REDUCE-NFTBAND-SHELLOUTS-AND-TIGHTEN-MAC-DOMAIN` — reduce daemon
+  shell-outs, then tighten both the SELinux domain and the AppArmor profile and
+  consider flipping AppArmor to enforce.
+
+## See also
+- `docs/THREAT_MODEL.md`
+- `docs/systemd/` (unit hardening)
+- Wiki: *MAC Profiles: SELinux and AppArmor*

--- a/install/apparmor/usr.lib.nftban.bin.nftband
+++ b/install/apparmor/usr.lib.nftban.bin.nftband
@@ -1,9 +1,19 @@
 # NFTBan firewall daemon AppArmor profile (v1.147-A)
 # SPDX-License-Identifier: MPL-2.0
 #
-# Ships in COMPLAIN mode (flags=(complain)) for safe fleet soak — logs
-# would-be denials without enforcing. Flip to enforce in a follow-up after
-# soak (operator SELECT_V147_A_APPARMOR_DEFAULT_MODE = complain).
+# Ships in COMPLAIN mode for safe fleet soak — logs would-be denials without
+# enforcing. Flip to enforce in a follow-up after soak (operator
+# SELECT_V147_A_APPARMOR_DEFAULT_MODE = complain).
+#
+# attach_disconnected is REQUIRED, not optional: nftband.service runs the daemon
+# in a private mount namespace (ProtectSystem=strict + ReadWritePaths +
+# ProtectHome). Without attach_disconnected, AppArmor cannot resolve the
+# systemd/dbus runtime sockets (/run/systemd/notify, /run/systemd/private,
+# /run/dbus/system_bus_socket) against the namespace root — it returns
+# "Failed name lookup - disconnected path" → EACCES, the daemon's sd_notify
+# READY=1 never reaches systemd (Type=notify), the unit hangs in "activating"
+# and crash-loops. attach_disconnected attaches such paths to root so the file
+# rules below can match. Verified on Ubuntu 24.04 (D-V147A-APPARMOR-UBUNTU24).
 #
 # Confines ONLY the long-running nftband daemon. The CLI dispatcher
 # (/usr/sbin/nftban) and helper scripts are intentionally NOT confined in
@@ -15,7 +25,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-profile nftband /usr/lib/nftban/bin/nftband flags=(complain) {
+profile nftband /usr/lib/nftban/bin/nftband flags=(complain attach_disconnected) {
   include <abstractions/base>
   include <abstractions/nameservice>
 
@@ -29,6 +39,19 @@ profile nftband /usr/lib/nftban/bin/nftband flags=(complain) {
   network inet6 stream,
   network inet dgram,
   network unix stream,
+  network unix dgram,
+
+  # v1.147 (D-V147A-APPARMOR-UBUNTU24): systemd Type=notify + dbus + systemctl-
+  # child runtime sockets. These need BOTH the file rules below AND the
+  # attach_disconnected profile flag (see header) — the flag makes the paths
+  # resolvable inside the unit's private mount namespace; these rules then grant
+  # access. sd_notify's sendmsg to /run/systemd/notify is mediated as a file op.
+  /run/systemd/notify rw,
+  /run/systemd/private rw,
+  /run/dbus/system_bus_socket rw,
+  /run/nftban/nftband.sock rw,
+  unix (connect, send, receive, bind, listen, accept) type=stream,
+  unix (connect, send, receive) type=dgram,
 
   # own executable
   /usr/lib/nftban/bin/nftband mr,
@@ -45,9 +68,15 @@ profile nftband /usr/lib/nftban/bin/nftband flags=(complain) {
   /run/nftban/{,**} rw,
   /var/cache/nftban/{,**} rw,
 
-  # nft binary (defense-in-depth: daemon uses netlink, but some paths shell out)
-  /{,usr/}sbin/nft rmix,
-  /{,usr/}bin/nft rmix,
+  # v1.147-A fix (D-V147A-APPARMOR-UBUNTU24-PANIC): the daemon shells out
+  # (bash/nft/helpers). Without explicit exec rules, child execs fall into
+  # AppArmor's restrictive `null-` profile, which crash-loops the daemon on
+  # Ubuntu 24.04 even in complain mode. Let child execs INHERIT this profile
+  # (ix) so they are never confined to the crashing null- transition.
+  /{,usr/}bin/* rmix,
+  /{,usr/}sbin/* rmix,
+  /usr/lib/nftban/{helpers,sbin,bin,cron,exporters}/** rmix,
+  /usr/sbin/nftban rmix,
 
   # proc/self + runtime essentials
   @{PROC}/@{pid}/{stat,status,cmdline} r,

--- a/install/apparmor/usr.lib.nftban.bin.nftband
+++ b/install/apparmor/usr.lib.nftban.bin.nftband
@@ -1,0 +1,55 @@
+# NFTBan firewall daemon AppArmor profile (v1.147-A)
+# SPDX-License-Identifier: MPL-2.0
+#
+# Ships in COMPLAIN mode (flags=(complain)) for safe fleet soak — logs
+# would-be denials without enforcing. Flip to enforce in a follow-up after
+# soak (operator SELECT_V147_A_APPARMOR_DEFAULT_MODE = complain).
+#
+# Confines ONLY the long-running nftband daemon. The CLI dispatcher
+# (/usr/sbin/nftban) and helper scripts are intentionally NOT confined in
+# 147-A. Loaded by packaging/deb/postinst when AppArmor is present; no-op
+# otherwise. Mirrors the unit's AmbientCapabilities + ReadWritePaths
+# (install/systemd/nftband.service).
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+profile nftband /usr/lib/nftban/bin/nftband flags=(complain) {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+
+  # nftables management via netlink (google/nftables) — internal/nftbackend
+  capability net_admin,
+  capability dac_override,
+  network netlink raw,
+
+  # daemon network surfaces (Unix socket + HTTP :9580)
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network unix stream,
+
+  # own executable
+  /usr/lib/nftban/bin/nftband mr,
+
+  # read-only application tree + config
+  /usr/lib/nftban/{,**} r,
+  /etc/nftban/{,**} r,
+
+  # read-write: exactly the nftband.service ReadWritePaths
+  /etc/nftban/blacklist.d/{,**} rw,
+  /etc/nftban/rules.d/{,**} rw,
+  /var/lib/nftban/{,**} rw,
+  /var/log/nftban/{,**} rw,
+  /run/nftban/{,**} rw,
+  /var/cache/nftban/{,**} rw,
+
+  # nft binary (defense-in-depth: daemon uses netlink, but some paths shell out)
+  /{,usr/}sbin/nft rmix,
+  /{,usr/}bin/nft rmix,
+
+  # proc/self + runtime essentials
+  @{PROC}/@{pid}/{stat,status,cmdline} r,
+  /sys/kernel/security/apparmor/.null rw,
+}

--- a/install/selinux/Makefile
+++ b/install/selinux/Makefile
@@ -5,7 +5,7 @@
 # Requirements: selinux-policy-devel, checkpolicy
 
 POLICY_NAME = nftban
-POLICY_VERSION = 1.0.0
+POLICY_VERSION = 1.1.0
 
 all: $(POLICY_NAME).pp
 

--- a/install/selinux/nftban.if
+++ b/install/selinux/nftban.if
@@ -1,0 +1,72 @@
+## <summary>NFTBan firewall daemon SELinux policy interfaces.</summary>
+## <desc>
+##   <p>
+##     Interface stubs for the nftban policy module (v1.147-A). The module
+##     itself (nftban.te) confines the nftband daemon to the nftband_t domain
+##     with the netlink + capability permissions it needs to manage nftables.
+##     These interfaces let other policy compose against nftban types without
+##     editing the base module. Closes D-OSH-1 (.te + .fc shipped, .if missing).
+##   </p>
+## </desc>
+
+########################################
+## <summary>
+##   Execute nftband in the nftband_t domain (automatic domain transition).
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed to transition.</summary>
+## </param>
+#
+interface(`nftban_domtrans',`
+	gen_require(`
+		type nftband_t, nftband_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, nftband_exec_t, nftband_t)
+')
+
+########################################
+## <summary>
+##   Read nftban configuration files (nftban_conf_t).
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed access.</summary>
+## </param>
+#
+interface(`nftban_read_config',`
+	gen_require(`
+		type nftban_conf_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, nftban_conf_t, nftban_conf_t)
+	list_dirs_pattern($1, nftban_conf_t, nftban_conf_t)
+')
+
+########################################
+## <summary>
+##   All-in-one administrative access to the nftban daemon domain + types.
+## </summary>
+## <param name="domain">
+##   <summary>Domain allowed access.</summary>
+## </param>
+## <param name="role">
+##   <summary>Role allowed access.</summary>
+## </param>
+## <rolecap/>
+#
+interface(`nftban_admin',`
+	gen_require(`
+		type nftband_t, nftban_conf_t, nftban_var_lib_t;
+		type nftban_log_t, nftban_var_run_t;
+	')
+
+	allow $1 nftband_t:process { ptrace signal_perms };
+	ps_process_pattern($1, nftband_t)
+
+	admin_pattern($1, nftban_conf_t)
+	admin_pattern($1, nftban_var_lib_t)
+	admin_pattern($1, nftban_log_t)
+	admin_pattern($1, nftban_var_run_t)
+')

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -5,7 +5,7 @@
 #          semodule_package -o nftban.pp -m nftban.mod
 #          semodule -i nftban.pp
 
-policy_module(nftban, 1.0.0)
+policy_module(nftban, 1.1.0)
 
 ########################################
 # Type Declarations

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -5,12 +5,17 @@
 #   make -f /usr/share/selinux/devel/Makefile nftban.pp && semodule -i nftban.pp
 #
 # v1.147 (combined daemon+unit hardening + MAC): completes the nftband_t domain
-# so the daemon runs confined under SELinux Enforcing on EL. Operator decisions:
+# so the daemon runs confined under SELinux Enforcing on EL9/EL10. Operator decisions:
 #   SELECT_V147_SELINUX_NNP_STRATEGY    = KEEP_NNP_WITH_NNP_TRANSITION
-#   SELECT_V147_SELINUX_DOMAIN_BREADTH  = ACCEPT_BROAD_DOMAIN_NOW_REDUCE_LATER
+#   SELECT_V147_SELINUX_DOMAIN_SCOPE    = KEEP_BROAD_TRACK_DEBT
 # The broad rule-set reflects the daemon's CURRENT behaviour (it shells out to
 # bash/nft/iptables/journalctl/systemctl/rpm/ssh and reads several system
-# resources). Tightening is deferred to D-V147-REDUCE-NFTBAND-SHELLOUTS.
+# resources). Tightening is the filed follow-up
+# D-V147-REDUCE-NFTBAND-SHELLOUTS-AND-TIGHTEN-MAC-DOMAIN (do NOT slim until the
+# daemon stops shelling out). Targets: EL9 + EL10. EL8 is out of scope (deferred
+# Tier-2: gen_require below references systemd_userdbd_runtime_t /
+# journalctl_exec_t / systemd_systemctl_exec_t which EL8 refpolicy 3.14.3 lacks;
+# wrap in optional_policy() if EL8 is ever in scope).
 
 policy_module(nftban, 1.2.0)
 
@@ -81,9 +86,13 @@ allow nftband_t nftban_conf_t:file map;
 manage_files_pattern(nftband_t, nftban_var_lib_t, nftban_var_lib_t)
 manage_dirs_pattern(nftband_t, nftban_var_lib_t, nftban_var_lib_t)
 
-# Logs append/create
+# Logs append/create. NOTE: the dir:watch (inotify) permission is intentionally
+# omitted — it is undefined for class dir in EL8's refpolicy (3.14.3) and breaks
+# the module compile there. Omitting it keeps ONE portable .te across EL8/9/10;
+# EL9/10 validation confirmed 0 AVC without it (daemon does not inotify-watch
+# these dirs in normal operation). Same rationale for syslogd_var_run_t:dir below.
 allow nftband_t nftban_log_t:file { append_file_perms create_file_perms read_file_perms };
-allow nftband_t nftban_log_t:dir { list_dir_perms add_entry_dir_perms watch };
+allow nftband_t nftban_log_t:dir { list_dir_perms add_entry_dir_perms };
 
 # Runtime (PID/lock/socket/json) — own type
 manage_files_pattern(nftband_t, nftban_var_run_t, nftban_var_run_t)
@@ -149,7 +158,7 @@ can_exec(nftband_t, nftband_exec_t)
 can_exec(nftband_t, { iptables_exec_t rpm_exec_t ssh_exec_t journalctl_exec_t systemd_systemctl_exec_t })
 
 # rpm/systemd/journal runtime state the daemon inspects
-allow nftband_t syslogd_var_run_t:dir { getattr open read search watch };
+allow nftband_t syslogd_var_run_t:dir { getattr open read search };
 allow nftband_t systemd_userdbd_runtime_t:dir read;
 allow nftband_t rpm_var_lib_t:dir search;
 allow nftband_t rpm_var_lib_t:file { getattr open read };

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -1,76 +1,159 @@
-# NFTBan SELinux Type Enforcement Policy (R39 v1.19.12)
+# NFTBan SELinux Type Enforcement Policy
 # SPDX-License-Identifier: MPL-2.0
 #
-# Install: checkmodule -M -m -o nftban.mod nftban.te
-#          semodule_package -o nftban.pp -m nftban.mod
-#          semodule -i nftban.pp
+# Build (refpolicy devel — NOT raw checkmodule):
+#   make -f /usr/share/selinux/devel/Makefile nftban.pp && semodule -i nftban.pp
+#
+# v1.147 (combined daemon+unit hardening + MAC): completes the nftband_t domain
+# so the daemon runs confined under SELinux Enforcing on EL. Operator decisions:
+#   SELECT_V147_SELINUX_NNP_STRATEGY    = KEEP_NNP_WITH_NNP_TRANSITION
+#   SELECT_V147_SELINUX_DOMAIN_BREADTH  = ACCEPT_BROAD_DOMAIN_NOW_REDUCE_LATER
+# The broad rule-set reflects the daemon's CURRENT behaviour (it shells out to
+# bash/nft/iptables/journalctl/systemctl/rpm/ssh and reads several system
+# resources). Tightening is deferred to D-V147-REDUCE-NFTBAND-SHELLOUTS.
 
-policy_module(nftban, 1.1.0)
+policy_module(nftban, 1.2.0)
+
+########################################
+# External type requires
+########################################
+gen_require(`
+	type init_t;
+	type initrc_t;
+	type iptables_exec_t;
+	type rpm_exec_t;
+	type ssh_exec_t;
+	type journalctl_exec_t;
+	type systemd_systemctl_exec_t;
+	type kernel_t;
+	type var_run_t;
+	type syslogd_var_run_t;
+	type systemd_userdbd_runtime_t;
+	type rpm_var_lib_t;
+')
 
 ########################################
 # Type Declarations
 ########################################
-
-# Main daemon type
 type nftband_t;
 type nftband_exec_t;
 init_daemon_domain(nftband_t, nftband_exec_t)
 
-# Config files
 type nftban_conf_t;
 files_config_file(nftban_conf_t)
 
-# Runtime state (var/lib)
 type nftban_var_lib_t;
 files_type(nftban_var_lib_t)
 
-# Log files
 type nftban_log_t;
 logging_log_file(nftban_log_t)
 
-# Runtime socket/PID
 type nftban_var_run_t;
 files_pid_file(nftban_var_run_t)
 
 ########################################
-# Daemon Permissions
+# systemd domain transition (EL9)
 ########################################
+# init_daemon_domain only transitions from initrc_domain/direct_run_init (SysV).
+# Native systemd (init_t) + socket activation (nftband.socket) needs the
+# transition forced from init_t.
+allow init_t nftband_t:process transition;
+type_transition init_t nftband_exec_t:process nftband_t;
+allow nftband_t nftband_exec_t:file entrypoint;
+allow init_t nftband_exec_t:file { read open getattr execute map };
 
-# Config access (read-only)
-allow nftband_t nftban_conf_t:file read_file_perms;
-allow nftband_t nftban_conf_t:dir list_dir_perms;
+# v1.147 KEEP_NNP_WITH_NNP_TRANSITION: nftband.service keeps NoNewPrivileges=true
+# (preserved on ALL hosts — Enforcing, Disabled prod, AppArmor). NNP normally
+# blocks SELinux domain transitions; process2:nnp_transition explicitly permits
+# this one, so we transition into nftband_t WITHOUT relaxing NNP anywhere.
+allow init_t nftband_t:process2 nnp_transition;
+allow initrc_t nftband_t:process2 nnp_transition;
 
-# State access (read-write)
-allow nftband_t nftban_var_lib_t:file manage_file_perms;
-allow nftband_t nftban_var_lib_t:dir manage_dir_perms;
+########################################
+# Own config / state / log / runtime
+########################################
+# Config: read AND write (daemon rewrites conf.local / rendered files).
+manage_files_pattern(nftband_t, nftban_conf_t, nftban_conf_t)
+manage_dirs_pattern(nftband_t, nftban_conf_t, nftban_conf_t)
+allow nftband_t nftban_conf_t:file map;
 
-# Log access (append-only)
-allow nftband_t nftban_log_t:file { append_file_perms create_file_perms };
-allow nftband_t nftban_log_t:dir { list_dir_perms add_entry_dir_perms };
+# State (var/lib) read-write
+manage_files_pattern(nftband_t, nftban_var_lib_t, nftban_var_lib_t)
+manage_dirs_pattern(nftband_t, nftban_var_lib_t, nftban_var_lib_t)
 
-# Runtime files (socket, PID)
-allow nftband_t nftban_var_run_t:file manage_file_perms;
-allow nftband_t nftban_var_run_t:sock_file manage_sock_file_perms;
-allow nftband_t nftban_var_run_t:dir manage_dir_perms;
+# Logs append/create
+allow nftband_t nftban_log_t:file { append_file_perms create_file_perms read_file_perms };
+allow nftband_t nftban_log_t:dir { list_dir_perms add_entry_dir_perms watch };
 
-# Network access
+# Runtime (PID/lock/socket/json) — own type
+manage_files_pattern(nftband_t, nftban_var_run_t, nftban_var_run_t)
+manage_sock_files_pattern(nftband_t, nftban_var_run_t, nftban_var_run_t)
+manage_dirs_pattern(nftband_t, nftban_var_run_t, nftban_var_run_t)
+# /run/nftban files are created at runtime on tmpfs and were getting var_run_t
+# (.fc does not apply to runtime-created files) → daemon could not write its PID
+# and exited. File-name-transition so daemon-created pid-dir files are labelled
+# nftban_var_run_t. (D-V147A: PID-write-denied root cause.)
+files_pid_filetrans(nftband_t, nftban_var_run_t, { file dir sock_file })
+# Belt-and-suspenders for the brief window before relabel / on stock var_run_t.
+allow nftband_t var_run_t:dir { search getattr add_name remove_name write };
+allow nftband_t var_run_t:file { create getattr open read write rename unlink lock map };
+allow nftband_t var_run_t:sock_file { create getattr write unlink };
+
+########################################
+# Network (nftables via netlink + HTTP API + IPC sockets)
+########################################
 allow nftband_t self:tcp_socket create_stream_socket_perms;
 allow nftband_t self:udp_socket create_socket_perms;
 allow nftband_t self:netlink_netfilter_socket create_socket_perms;
-allow nftband_t self:netlink_route_socket create_socket_perms;
-
-# nftables management (critical for firewall control)
-allow nftband_t self:capability { net_admin net_raw };
+allow nftband_t self:netlink_route_socket { create_socket_perms nlmsg_read };
 allow nftband_t self:netlink_nflog_socket create_socket_perms;
+allow nftband_t self:unix_dgram_socket create_socket_perms;
+allow nftband_t self:unix_stream_socket { create_stream_socket_perms connectto };
+corenet_tcp_bind_generic_node(nftband_t)
+corenet_tcp_bind_all_unreserved_ports(nftband_t)
+corenet_tcp_connect_http_port(nftband_t)
+# sd_notify (Type=notify) to systemd over its dgram socket
+allow nftband_t kernel_t:unix_dgram_socket sendto;
 
-# Systemd integration
+########################################
+# Capabilities + process
+########################################
+# net_admin/net_raw: nftables. dac_override/dac_read_search: write nftban-owned
+# dirs + read across ownership. execmem/setpgid: Go runtime + process group.
+allow nftband_t self:capability { net_admin net_raw dac_override dac_read_search };
+allow nftband_t self:process { signal_perms setcap setpgid execmem };
+
+########################################
+# System reads (broad — daemon inspects host state)
+########################################
+kernel_read_system_state(nftband_t)
+kernel_read_network_state(nftband_t)
+sysnet_read_config(nftband_t)
+dev_read_sysfs(nftband_t)
+fs_read_cgroup_files(nftband_t)
+fs_getattr_all_fs(nftband_t)
+auth_use_nsswitch(nftband_t)
+miscfiles_read_generic_certs(nftband_t)
+logging_read_generic_logs(nftband_t)
 init_use_fds(nftband_t)
 init_read_state(nftband_t)
-
-# Process capabilities
-allow nftband_t self:process { signal_perms setcap };
+init_status(nftband_t)
 
 ########################################
-# File Context Specifications
+# Shell-outs (ACCEPT_BROAD_DOMAIN_NOW_REDUCE_LATER — see D-V147-REDUCE-NFTBAND-SHELLOUTS)
 ########################################
-# See nftban.fc for file context definitions
+# Children inherit nftband_t (execute_no_trans) — the daemon runs them inline.
+corecmd_exec_bin(nftband_t)
+corecmd_exec_shell(nftband_t)
+can_exec(nftband_t, nftband_exec_t)
+can_exec(nftband_t, { iptables_exec_t rpm_exec_t ssh_exec_t journalctl_exec_t systemd_systemctl_exec_t })
+
+# rpm/systemd/journal runtime state the daemon inspects
+allow nftband_t syslogd_var_run_t:dir { getattr open read search watch };
+allow nftband_t systemd_userdbd_runtime_t:dir read;
+allow nftband_t rpm_var_lib_t:dir search;
+allow nftband_t rpm_var_lib_t:file { getattr open read };
+
+########################################
+# File Context Specifications — see nftban.fc
+########################################

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -300,6 +300,11 @@ Source1:        nftban-files.inc
 Source2:        nftban-systemd-install.list
 
 BuildRequires:  systemd-rpm-macros
+# v1.147-A: compile the SELinux policy module (.pp) at build via the refpolicy
+# devel Makefile. checkmodule alone cannot resolve refpolicy interfaces
+# (init_daemon_domain, logging_log_file, ...) used by nftban.te.
+BuildRequires:  selinux-policy-devel
+BuildRequires:  make
 
 Requires:       nftables >= 0.9.0
 Requires:       systemd
@@ -517,14 +522,15 @@ install -D -m 0644 install/selinux/nftban.te %{buildroot}/usr/share/nftban/selin
 install -D -m 0644 install/selinux/nftban.fc %{buildroot}/usr/share/nftban/selinux/nftban.fc
 install -D -m 0644 install/selinux/nftban.if %{buildroot}/usr/share/nftban/selinux/nftban.if
 install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinux/Makefile
-# v1.147-A: compile the policy module at build so %post can semodule -i it
-# without requiring policycoreutils-devel on the target. Guarded: if the build
-# host lacks checkmodule/semodule_package the .pp is simply absent and %post
-# falls back to compile-on-target (or no-ops on SELinux Disabled/absent).
-if command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
-    ( cd install/selinux && checkmodule -M -m -o nftban.mod nftban.te && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc ) \
+# v1.147-A: compile the policy module (.pp) at build so %post can semodule -i it
+# without requiring selinux-policy-devel on the target. MUST use the refpolicy
+# devel Makefile — checkmodule alone errors on policy_module()/init_daemon_domain
+# (refpolicy m4 interfaces). Guarded: if the devel Makefile is absent the .pp is
+# simply not shipped and %post falls back to compile-on-target (or no-ops).
+if [ -f /usr/share/selinux/devel/Makefile ]; then
+    ( cd install/selinux && make -f /usr/share/selinux/devel/Makefile nftban.pp ) \
         && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
-        || echo "[NFTBan build] SELinux .pp compile skipped/failed; %post will compile on target"
+        || echo "[NFTBan build] SELinux .pp compile failed; %post will compile on target"
 fi
 
 # Validator spec file
@@ -935,9 +941,8 @@ if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
     _nftban_sel=/usr/share/nftban/selinux
     if [ -f "\$_nftban_sel/nftban.pp" ]; then
         semodule -i "\$_nftban_sel/nftban.pp" 2>/dev/null || true
-    elif command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
-        ( cd "\$_nftban_sel" && checkmodule -M -m -o nftban.mod nftban.te 2>/dev/null \
-            && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc 2>/dev/null \
+    elif [ -f /usr/share/selinux/devel/Makefile ]; then
+        ( cd "\$_nftban_sel" && make -f /usr/share/selinux/devel/Makefile nftban.pp 2>/dev/null \
             && semodule -i nftban.pp 2>/dev/null ) || true
     fi
     restorecon -R /usr/sbin/nftban /usr/lib/nftban/bin /etc/nftban /var/lib/nftban /var/log/nftban /run/nftban /var/cache/nftban 2>/dev/null || true

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -515,7 +515,17 @@ install -D -m 0644 packaging/polkit-1/rules.d/20-nftban-auditor.rules %{buildroo
 mkdir -p %{buildroot}/usr/share/nftban/selinux
 install -D -m 0644 install/selinux/nftban.te %{buildroot}/usr/share/nftban/selinux/nftban.te
 install -D -m 0644 install/selinux/nftban.fc %{buildroot}/usr/share/nftban/selinux/nftban.fc
+install -D -m 0644 install/selinux/nftban.if %{buildroot}/usr/share/nftban/selinux/nftban.if
 install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinux/Makefile
+# v1.147-A: compile the policy module at build so %post can semodule -i it
+# without requiring policycoreutils-devel on the target. Guarded: if the build
+# host lacks checkmodule/semodule_package the .pp is simply absent and %post
+# falls back to compile-on-target (or no-ops on SELinux Disabled/absent).
+if command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
+    ( cd install/selinux && checkmodule -M -m -o nftban.mod nftban.te && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc ) \
+        && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
+        || echo "[NFTBan build] SELinux .pp compile skipped/failed; %post will compile on target"
+fi
 
 # Validator spec file
 install -D -m 0644 install/share/nftban/specs/structure_default.json %{buildroot}/usr/share/nftban/specs/structure_default.json
@@ -912,6 +922,29 @@ else
 fi
 
 # =============================================================================
+# v1.147-A: load the nftban SELinux policy module (D-NFTBAN-EL-SELINUX-DAEMON-NETLINK)
+# =============================================================================
+# The .te/.fc shipped since v1.19.12 but were never compiled or loaded, so on
+# SELinux Enforcing the daemon ran unlabeled (init_t) and its netlink socket was
+# denied ("failed to list tables: socket: permission denied"). Load the module
+# (enforcing nftband_t domain; NOT permissive) and relabel BEFORE the Go
+# installer starts the daemon, so nftband transitions to nftband_t on first
+# start. Prefer the build-shipped nftban.pp; fall back to compile-on-target.
+# Guarded + idempotent + strict no-op on SELinux Disabled/absent.
+if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
+    _nftban_sel=/usr/share/nftban/selinux
+    if [ -f "\$_nftban_sel/nftban.pp" ]; then
+        semodule -i "\$_nftban_sel/nftban.pp" 2>/dev/null || true
+    elif command -v checkmodule >/dev/null 2>&1 && command -v semodule_package >/dev/null 2>&1; then
+        ( cd "\$_nftban_sel" && checkmodule -M -m -o nftban.mod nftban.te 2>/dev/null \
+            && semodule_package -o nftban.pp -m nftban.mod -f nftban.fc 2>/dev/null \
+            && semodule -i nftban.pp 2>/dev/null ) || true
+    fi
+    restorecon -R /usr/sbin/nftban /usr/lib/nftban/bin /etc/nftban /var/lib/nftban /var/log/nftban /run/nftban /var/cache/nftban 2>/dev/null || true
+    unset _nftban_sel
+fi
+
+# =============================================================================
 # v1.146 Phase-D: CVE-2025-NFTBAN-001 inet-filter classify-then-act
 # =============================================================================
 # Drift-checked twin of packaging/deb/postinst:_nftban_classify_inet_filter
@@ -1168,6 +1201,12 @@ fi
 # =============================================================================
 if [ \$1 -eq 0 ]; then
     echo "[NFTBan] Complete removal — cleaning up all artifacts..."
+
+    # v1.147-A: remove the nftban SELinux policy module on final erase
+    # (guarded, idempotent, no-op on SELinux Disabled/absent).
+    if command -v semodule >/dev/null 2>&1 && selinuxenabled 2>/dev/null; then
+        semodule -r nftban 2>/dev/null || true
+    fi
 
     # STEP 1: Backup user configuration before removal
     BACKUP_DIR="/var/tmp/nftban-config-backup-\$(date +%%Y%%m%%d-%%H%%M%%S)"
@@ -1713,6 +1752,13 @@ build_deb() {
         fi
     done
     log_info "Installed ${sbin_count} sbin helper scripts"
+
+    # v1.147-A: AppArmor profile for the nftband daemon (DEB only; complain mode).
+    # Loaded by postinst when AppArmor is present; no-op otherwise. Shipped under
+    # /etc/apparmor.d/ so dpkg treats it as a conffile (auto-removed on purge).
+    install -D -m 0644 "${PROJECT_ROOT}/install/apparmor/usr.lib.nftban.bin.nftband" \
+        "${deb_root}/etc/apparmor.d/usr.lib.nftban.bin.nftband"
+    log_info "Installed AppArmor profile (complain mode)"
 
     # Copy VERSION file (WARN-005: ensure it's non-empty)
     if [[ -s "${PROJECT_ROOT}/VERSION" ]]; then

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -243,6 +243,17 @@ case "$1" in
             chmod 0750 /usr/sbin/nftban 2>/dev/null || true
         fi
 
+        # --- v1.147-A: load the nftband AppArmor profile (complain mode) ---
+        # Loaded before the Go installer starts the daemon so nftband is
+        # confined on first start. Complain logs would-be denials without
+        # enforcing (safe soak; flip to enforce in a follow-up). Strict no-op
+        # when AppArmor is absent.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -d /sys/kernel/security/apparmor ] \
+           && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -r -W -T /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+            log_info "AppArmor: nftband profile loaded (complain mode)"
+        fi
+
         # --- Critical FHS dirs (Go installer needs state dir to exist) ---
         mkdir -p /var/lib/nftban/state
         mkdir -p /var/log/nftban

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -131,6 +131,14 @@ case "$1" in
         rm -f /etc/polkit-1/rules.d/*nftban*.rules 2>/dev/null || true
         rm -f /usr/share/polkit-1/rules.d/*nftban*.rules 2>/dev/null || true
 
+        # v1.147-A: unload + remove the nftband AppArmor profile (guarded; no-op
+        # when AppArmor absent). The profile is a conffile under /etc/apparmor.d/;
+        # unload it from the kernel here and remove the file on purge.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -R /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+        fi
+        rm -f /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+
         # Remove yq symlink (only if it points to our bundled binary)
         if [ -L /usr/bin/yq ] && readlink /usr/bin/yq | grep -q nftban; then
             rm -f /usr/bin/yq 2>/dev/null || true
@@ -196,6 +204,13 @@ case "$1" in
         for nft_conf in /etc/sysconfig/nftables.conf /etc/nftables.conf; do
             _nftban_strip_conf_include "$nft_conf"
         done
+
+        # v1.147-A: unload the nftband AppArmor profile (guarded; no-op when
+        # AppArmor absent). On non-purge `remove` the conffile is kept by dpkg
+        # for reinstall — unload from the kernel only, do NOT delete the file.
+        if command -v apparmor_parser >/dev/null 2>&1 && [ -f /etc/apparmor.d/usr.lib.nftban.bin.nftband ]; then
+            apparmor_parser -R /etc/apparmor.d/usr.lib.nftban.bin.nftband 2>/dev/null || true
+        fi
         ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
## v1.147 — MAC profiles (SELinux + AppArmor) with minimal daemon/unit hardening

Combined lane: **MAC profiles + the minimal daemon/unit hardening that MAC validation proved necessary.** Supersedes #757.

### What this ships
- **SELinux (EL):** completes the `nftband_t` domain so the daemon runs confined under Enforcing — labels the binary `nftband_exec_t`, transitions `init_t → nftband_t` via `type_transition`, and **keeps `NoNewPrivileges=true`** by allowing `process2:nnp_transition` (NNP is not relaxed on any host). Ships `.te`/`.if`/`.fc` + a build-compiled `.pp` (refpolicy devel Makefile), `%post` `semodule -i` (selinuxenabled-guarded), `%postun` `semodule -r`. Fixes the EL Enforcing failure `cannot list tables: socket: permission denied`.
- **AppArmor (Debian/Ubuntu):** ships the daemon profile in **complain** mode with `flags=(complain attach_disconnected)`. `attach_disconnected` is required: the unit's private mount namespace (`ProtectSystem=strict`+`ReadWritePaths`+`ProtectHome`) otherwise makes `/run/systemd/notify` a "disconnected path", breaking `sd_notify` and crash-looping the `Type=notify` unit.
- **Daemon:** two defensive nil-guards (`daemon_init.go`, `daemon_socket.go`) so it degrades gracefully instead of nil-panicking when a systemd-passed socket fd is mediated to nil under confinement.
- Docs: `docs/security/MAC_PROFILES_SELINUX_APPARMOR.md` (+ wiki page).

### Validation (lab + real host)
- **AppArmor:** Ubuntu 22.04 / 24.04 / 26.04 + Debian 12 / 13 (lab) **and real Ubuntu 26.04** — active, confined `nftband (complain)`, `sd_notify READY`, 0 panics, 0 disconnected-path, ban verified.
- **SELinux Enforcing — EL9:** AlmaLinux 9.7, CentOS Stream 9, Rocky 9.7 — `nftband_t`, NNP kept, non-permissive, **0 AVC**, ban verified.
- **SELinux Enforcing — EL10:** CentOS Stream 10, AlmaLinux 10.1, Rocky 10.1 — same, all PASS (real operator host; the lab hypervisor can't boot EL10 due to x86-64-v3/AVX2).

### Scope boundaries (explicitly NOT in this PR)
- No schema bump — `SchemaVersionCurrent` stays **1.83.0**.
- No nftables table/set semantic change.
- Daemon **not** byte-frozen (the two nil-guards) — ends the zero-Go chain, by design.
- No `User=root → nftban` conversion (that is v1.147-B).
- No broad `SystemCallFilter` / `RestrictAddressFamilies` expansion.
- No SEC-AUDITLOG / WL-VERIFY / IMMUT (those are v1.147-C).
- **EL8 SELinux Enforcing out of scope** (its older refpolicy lacks types the module requires).
- Both core fixes are documented **known-upstream** standard remedies (not workarounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
