### PR TITLE
feat(security): v1.149.0 operational hardening — whitelist --static + portscan generic corroboration

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1593,6 +1593,21 @@ FIREWALL_RELOAD_HELP
     [[ "$quiet" == "false" ]] && echo "Syncing whitelist..."
     nftban whitelist sync 2>/dev/null || true
 
+    # Step 3b (v1.149 BUG-2): the reload above flushed the whitelist/blacklist sets, and
+    # `nftban whitelist sync` re-applies only auto-detected SYSTEM IPs — NOT the durable
+    # whitelist.d entries (operator `--static` admin IPs) or manual blacklist entries.
+    # Those would stay dropped until the next periodic sync — a transient lockout window
+    # that breaks the WL-STATIC durability promise. Reconcile them from config now via
+    # the daemon. Use the core binary directly with --quick (whitelist/blacklist only,
+    # no feeds/geoban) — calling `nftban sync` here would recurse back into firewall_reload.
+    # No-op if the daemon/core binary is unavailable. (This is NOT the v1.59.1 system-IP
+    # --quick path; it is the daemon LoadWhitelists/LoadBlacklists reconcile from files.)
+    local _core_reconcile="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core"
+    if [[ -x "$_core_reconcile" ]]; then
+        [[ "$quiet" == "false" ]] && echo "Reconciling durable whitelist.d/blacklist.d entries..."
+        "$_core_reconcile" sync --quick >/dev/null 2>&1 || true
+    fi
+
     # Step 4 (v1.34.0): Re-apply DDoS protection if it was enabled.
     # firewall reload destroys DDoS chains (synproxy, portscan, ddos_protection).
     # Without this step, reload leaves the server unprotected.

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -2517,7 +2517,11 @@ nftban_cmd_update() {
             # `nftban update --force` (or `nftban update force`) bypasses this check.
             # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-1 item 1.5)
             if [[ "${_NFTBAN_UPDATE_FORCE:-0}" != "1" ]]; then
-                local _curv _latv _cache_file
+                # v1.149 BUG-1: initialize all three. Under `set -u`, an absent update
+                # cache (fresh host) OR missing jq skips the assignment block below, so a
+                # bare `local _latv` left `$_latv` unbound → `[[ -z "$_latv" ]]` aborted
+                # `nftban update` on any host that never ran `nftban update check`.
+                local _curv="" _latv="" _cache_file=""
                 _curv=$(_get_current_version 2>/dev/null || echo "unknown")
                 _cache_file="${NFTBAN_CACHE_DIR:-/var/cache/nftban}/update_available.json"
                 # Prefer cache (fast); fall back to live check only if cache absent.

--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -405,7 +405,7 @@ nftban_whitelist_add_static_ip() {
     chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
     chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
 
-    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) and applied it live. Durable: re-applied to the live set on every full sync (maintenance timer / daemon restart / reboot)."
+    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) and applied it live — durable: survives firewall reload, daemon restart, and reboot."
 
     # Apply live immediately via a FULL sync. `nftban sync` runs the daemon
     # whitelist loader (LoadWhitelists → reconciles whitelist.d/*.conf, incl. this
@@ -588,7 +588,7 @@ COMMANDS:
 WHITELIST TIERS:
   runtime   (default add)  live nft set only; DROPPED on the next firewall rebuild/reload/restart.
   timed     (--ttl <dur>)  written to 00-session.conf with an expiry; auto-pruned after the TTL.
-  permanent (--static)     written to 99-manual.conf (no expiry); applied live + re-synced on every full sync.
+  permanent (--static)     written to 99-manual.conf (no expiry); applied live; survives firewall reload/restart/reboot.
 
 EXAMPLES:
   nftban whitelist add 192.168.1.100              # runtime only (temporary)

--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -79,7 +79,7 @@ nftban_cmd_whitelist() {
         add)
             # v1.149.0: explicit whitelist tiers.
             #   (default)      runtime/live only — lost on rebuild/reload/restart
-            #   --static       permanent — writes 99-manual.conf (no expiry; reloaded on rebuild)
+            #   --static       permanent — writes 99-manual.conf (no expiry) + applies live via sync
             #   --ttl <dur>    timed — delegates to `firewall whitelist-session` (00-session.conf)
             #   --session      timed with a default 1h TTL
             local _wl_static="false" _wl_ttl="" ip=""
@@ -405,11 +405,15 @@ nftban_whitelist_add_static_ip() {
     chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
     chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
 
-    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) — survives rebuild/reload/restart."
+    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) and applied it live. Durable: re-applied to the live set on every full sync (maintenance timer / daemon restart / reboot)."
 
-    # Apply live immediately (best-effort; the durable file is the source of truth).
+    # Apply live immediately via a FULL sync. `nftban sync` runs the daemon
+    # whitelist loader (LoadWhitelists → reconciles whitelist.d/*.conf, incl. this
+    # file, into the live nft set). `firewall reload` alone does NOT apply it — its
+    # whitelist step is system-IP auto-detection, not the whitelist.d loader
+    # (lab-proven on v1.148.0). Fall back to reload if `sync` is unavailable.
     if command -v nftban >/dev/null 2>&1; then
-        nftban firewall reload >/dev/null 2>&1 || true
+        nftban sync >/dev/null 2>&1 || nftban firewall reload >/dev/null 2>&1 || true
     fi
     return 0
 }
@@ -452,6 +456,11 @@ nftban_whitelist_remove_static_ip() {
 
     # Remove from the live set too (best-effort; may not be present).
     nftban_whitelist_remove_ip "$ip" >/dev/null 2>&1 || true
+    # Reconcile the live set to the now-updated files via full sync, so the entry
+    # is dropped even if it was applied into the CIDR-aware interval set by sync.
+    if command -v nftban >/dev/null 2>&1; then
+        nftban sync >/dev/null 2>&1 || true
+    fi
 
     if [[ "$removed" == "true" ]]; then
         echo "Removed $ip from the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) + live set; rebuild will not resurrect it."
@@ -579,7 +588,7 @@ COMMANDS:
 WHITELIST TIERS:
   runtime   (default add)  live nft set only; DROPPED on the next firewall rebuild/reload/restart.
   timed     (--ttl <dur>)  written to 00-session.conf with an expiry; auto-pruned after the TTL.
-  permanent (--static)     written to 99-manual.conf with NO expiry; reloaded on every rebuild.
+  permanent (--static)     written to 99-manual.conf (no expiry); applied live + re-synced on every full sync.
 
 EXAMPLES:
   nftban whitelist add 192.168.1.100              # runtime only (temporary)

--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -77,24 +77,73 @@ nftban_cmd_whitelist() {
 
     case "$subcommand" in
         add)
-            # Add IP to whitelist
-            local ip="${1:-}"
-            if [[ -z "$ip" || "$ip" == "--help" || "$ip" == "-h" ]]; then
-                echo "Usage: nftban whitelist add <IP>" >&2
-                echo "Example: nftban whitelist add 192.168.1.100" >&2
-                return 0
+            # v1.149.0: explicit whitelist tiers.
+            #   (default)      runtime/live only — lost on rebuild/reload/restart
+            #   --static       permanent — writes 99-manual.conf (no expiry; reloaded on rebuild)
+            #   --ttl <dur>    timed — delegates to `firewall whitelist-session` (00-session.conf)
+            #   --session      timed with a default 1h TTL
+            local _wl_static="false" _wl_ttl="" ip=""
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --static)  _wl_static="true"; shift ;;
+                    --ttl)
+                        _wl_ttl="${2:-}"
+                        if [[ -z "$_wl_ttl" ]]; then
+                            echo "ERROR: --ttl requires a duration (e.g. 30m, 1h, 1h30m)" >&2; return 1
+                        fi
+                        shift 2 ;;
+                    --session) [[ -z "$_wl_ttl" ]] && _wl_ttl="1h"; shift ;;
+                    -h|--help) nftban_whitelist_usage; return 0 ;;
+                    --*)       echo "ERROR: Unknown flag for 'whitelist add': $1" >&2; return 1 ;;
+                    *)         if [[ -z "$ip" ]]; then ip="$1"; shift; else echo "ERROR: Unexpected argument: $1" >&2; return 1; fi ;;
+                esac
+            done
+            if [[ -z "$ip" ]]; then
+                echo "Usage: nftban whitelist add [--static | --ttl <dur>] <IP>" >&2
+                echo "Example: nftban whitelist add --static 192.168.1.100" >&2
+                return 1
             fi
-            nftban_whitelist_add_ip "$ip"
+            if [[ "$_wl_static" == "true" && -n "$_wl_ttl" ]]; then
+                echo "ERROR: --static and --ttl/--session are mutually exclusive (permanent vs timed)" >&2
+                return 1
+            fi
+            if [[ -n "$_wl_ttl" ]]; then
+                # Timed tier — reuse the existing session writer (00-session.conf).
+                if command -v nftban >/dev/null 2>&1; then
+                    nftban firewall whitelist-session add "$ip" --ttl "$_wl_ttl"
+                else
+                    echo "ERROR: timed whitelist requires the nftban CLI (firewall whitelist-session)" >&2
+                    return 1
+                fi
+            elif [[ "$_wl_static" == "true" ]]; then
+                nftban_whitelist_add_static_ip "$ip"
+            else
+                nftban_whitelist_add_ip "$ip" && \
+                    echo "NOTE: $ip added to the RUNTIME whitelist only — it will NOT survive firewall rebuild/reload/restart. Use 'nftban whitelist add --static $ip' to persist." >&2
+            fi
             ;;
         remove|rm|del|delete)
-            # Remove IP from whitelist
-            local ip="${1:-}"
-            if [[ -z "$ip" || "$ip" == "--help" || "$ip" == "-h" ]]; then
-                echo "Usage: nftban whitelist remove <IP>" >&2
+            # v1.149.0: --static also removes the durable 99-manual.conf entry so a
+            # rebuild cannot resurrect it; default remove is live-set only (unchanged).
+            local _wl_static="false" ip=""
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --static)  _wl_static="true"; shift ;;
+                    -h|--help) nftban_whitelist_usage; return 0 ;;
+                    --*)       echo "ERROR: Unknown flag for 'whitelist remove': $1" >&2; return 1 ;;
+                    *)         if [[ -z "$ip" ]]; then ip="$1"; shift; else echo "ERROR: Unexpected argument: $1" >&2; return 1; fi ;;
+                esac
+            done
+            if [[ -z "$ip" ]]; then
+                echo "Usage: nftban whitelist remove [--static] <IP>" >&2
                 echo "Example: nftban whitelist remove 192.168.1.100" >&2
-                return 0
+                return 1
             fi
-            nftban_whitelist_remove_ip "$ip"
+            if [[ "$_wl_static" == "true" ]]; then
+                nftban_whitelist_remove_static_ip "$ip"
+            else
+                nftban_whitelist_remove_ip "$ip"
+            fi
             ;;
         list|show)
             # Show whitelist (v1.59.0: added --json support)
@@ -288,6 +337,130 @@ nftban_whitelist_remove_ip() {
     fi
 }
 
+# =============================================================================
+# v1.149.0 — PERMANENT (--static) whitelist tier (WL-STATIC)
+# =============================================================================
+# Durable operator entries live in whitelist.d/99-manual.conf with NO EXPIRES_AT.
+# The whitelist loader already reads whitelist.d/*.conf on every rebuild and loads
+# non-expiring entries permanently (internal/whitelist/loader.go) — so --static
+# needs no daemon/loader/schema change, only a CLI writer for the durable file.
+_NFTBAN_MANUAL_WHITELIST_PATH="/etc/nftban/whitelist.d/99-manual.conf"
+
+# Ensure 99-manual.conf exists with a header on FIRST creation only. Never clobbers
+# an existing file (shipped %config(noreplace); may carry hand-written operator entries).
+_nftban_whitelist_manual_ensure_header() {
+    [[ -f "$_NFTBAN_MANUAL_WHITELIST_PATH" ]] && return 0
+    mkdir -p "$(dirname "$_NFTBAN_MANUAL_WHITELIST_PATH")"
+    cat > "$_NFTBAN_MANUAL_WHITELIST_PATH" <<'MANUAL_HEADER_EOF'
+# =============================================================================
+# NFTBan Permanent Whitelist (99-manual.conf)
+# =============================================================================
+#
+# Durable operator whitelist entries — NO expiry. Loaded on every firewall
+# rebuild/reload/restart. Managed by `nftban whitelist add --static <ip>`, but
+# safe to hand-edit (one IP or CIDR per line; '#' starts a comment).
+#
+#   nftban whitelist add --static <ip>      # persist here (survives rebuild)
+#   nftban whitelist remove --static <ip>   # remove from here + live set
+#   nftban whitelist add <ip>               # runtime-only (lost on rebuild)
+#   nftban whitelist add --ttl 30m <ip>     # timed/session (00-session.conf)
+#
+# =============================================================================
+
+MANUAL_HEADER_EOF
+    chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+}
+
+# Add a permanent (no-expiry) entry to 99-manual.conf + apply live. Idempotent
+# (refresh: a prior line for the same IP is dropped before re-append).
+nftban_whitelist_add_static_ip() {
+    local ip="$1"
+
+    if ! nftban_validate_ip "$ip" && ! nftban_validate_cidr "$ip"; then
+        echo "ERROR: Invalid IP/CIDR format: $ip" >&2
+        return 1
+    fi
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: writing $_NFTBAN_MANUAL_WHITELIST_PATH requires root (permanent whitelist)." >&2
+        return 1
+    fi
+
+    _nftban_whitelist_manual_ensure_header
+
+    local tmp
+    tmp=$(mktemp "${_NFTBAN_MANUAL_WHITELIST_PATH}.XXXXXX") || { echo "ERROR: mktemp failed" >&2; return 1; }
+    # Drop any prior line whose first token == ip (idempotent refresh).
+    # shellcheck disable=SC2016
+    awk -v ip="$ip" '
+        { t=$0; gsub(/^[ \t]+/,"",t)
+          if (t=="" || substr(t,1,1)=="#") { print; next }
+          split(t,a,"#"); n=split(a[1],b,/[ \t]+/)
+          if (n>=1 && b[1]==ip) next
+          print }
+    ' "$_NFTBAN_MANUAL_WHITELIST_PATH" > "$tmp"
+    # Append the durable entry — NO EXPIRES_AT (permanent).
+    printf '%s  # ADDED_BY=nftban-whitelist-static\n' "$ip" >> "$tmp"
+    mv "$tmp" "$_NFTBAN_MANUAL_WHITELIST_PATH"
+    chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+
+    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) — survives rebuild/reload/restart."
+
+    # Apply live immediately (best-effort; the durable file is the source of truth).
+    if command -v nftban >/dev/null 2>&1; then
+        nftban firewall reload >/dev/null 2>&1 || true
+    fi
+    return 0
+}
+
+# Remove a permanent entry from 99-manual.conf AND the live set, so a rebuild
+# cannot resurrect it.
+nftban_whitelist_remove_static_ip() {
+    local ip="$1"
+
+    if ! nftban_validate_ip "$ip" && ! nftban_validate_cidr "$ip"; then
+        echo "ERROR: Invalid IP/CIDR format: $ip" >&2
+        return 1
+    fi
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: editing $_NFTBAN_MANUAL_WHITELIST_PATH requires root." >&2
+        return 1
+    fi
+
+    local removed="false"
+    if [[ -f "$_NFTBAN_MANUAL_WHITELIST_PATH" ]]; then
+        local tmp
+        tmp=$(mktemp "${_NFTBAN_MANUAL_WHITELIST_PATH}.XXXXXX") || { echo "ERROR: mktemp failed" >&2; return 1; }
+        # shellcheck disable=SC2016
+        if awk -v ip="$ip" '
+            { t=$0; gsub(/^[ \t]+/,"",t)
+              if (t=="" || substr(t,1,1)=="#") { print; next }
+              split(t,a,"#"); n=split(a[1],b,/[ \t]+/)
+              if (n>=1 && b[1]==ip) { dropped=1; next }
+              print }
+            END { exit (dropped?0:1) }
+        ' "$_NFTBAN_MANUAL_WHITELIST_PATH" > "$tmp"; then
+            mv "$tmp" "$_NFTBAN_MANUAL_WHITELIST_PATH"
+            chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+            chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
+            removed="true"
+        else
+            rm -f "$tmp"
+        fi
+    fi
+
+    # Remove from the live set too (best-effort; may not be present).
+    nftban_whitelist_remove_ip "$ip" >/dev/null 2>&1 || true
+
+    if [[ "$removed" == "true" ]]; then
+        echo "Removed $ip from the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) + live set; rebuild will not resurrect it."
+    else
+        echo "INFO: $ip not found in $_NFTBAN_MANUAL_WHITELIST_PATH (also removed from live set if present)."
+    fi
+    return 0
+}
+
 # List whitelisted IPs
 nftban_whitelist_list() {
     # v1.59.0 UX-2: Added --json support for scripting/monitoring
@@ -391,19 +564,29 @@ nftban_whitelist_list() {
 # Show usage
 nftban_whitelist_usage() {
     cat <<'EOF'
-Usage: nftban whitelist <command> [IP]
+Usage: nftban whitelist <command> [options] [IP]
 
 COMMANDS:
-  add <IP>          Add IP to whitelist (permanent protection from banning)
-  remove <IP>       Remove IP from whitelist
-  list              Show all whitelisted IPs
-  sync              Auto-detect and whitelist system IPs
-  whitelistme       Whitelist your current IP (interactive)
+  add <IP>               Add IP to the RUNTIME whitelist only (lost on rebuild/reload/restart)
+  add --static <IP>      Add IP to the PERMANENT whitelist (99-manual.conf; survives rebuild)
+  add --ttl <dur> <IP>   Add IP to a TIMED session whitelist (00-session.conf; auto-expires)
+  remove <IP>            Remove IP from the runtime whitelist (live set only)
+  remove --static <IP>   Remove IP from the permanent whitelist (99-manual.conf) + live set
+  list                   Show all whitelisted IPs
+  sync                   Auto-detect and whitelist system IPs
+  whitelistme            Whitelist your current IP (interactive)
+
+WHITELIST TIERS:
+  runtime   (default add)  live nft set only; DROPPED on the next firewall rebuild/reload/restart.
+  timed     (--ttl <dur>)  written to 00-session.conf with an expiry; auto-pruned after the TTL.
+  permanent (--static)     written to 99-manual.conf with NO expiry; reloaded on every rebuild.
 
 EXAMPLES:
-  nftban whitelist add 192.168.1.100
-  nftban whitelist add 2001:db8::1
-  nftban whitelist remove 192.168.1.100
+  nftban whitelist add 192.168.1.100              # runtime only (temporary)
+  nftban whitelist add --static 192.168.1.100     # permanent (survives rebuild)
+  nftban whitelist add --static 2001:db8::1        # IPv6 permanent
+  nftban whitelist add --ttl 30m 192.168.1.100    # 30-minute session
+  nftban whitelist remove --static 192.168.1.100  # remove permanent entry + live
   nftban whitelist list
   nftban whitelist sync
 

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -753,10 +753,36 @@ nftban_portscan_classic_detect_scan_type() {
     # Check minimum port threshold
     local min_ports="${PORTSCAN_CLASSIC_MIN_PORTS}"
     if [[ $port_count -ge $min_ports ]]; then
-        echo "generic"
+        # v1.149.0 false-ban hardening: the "generic" remainder here is non-rapid
+        # (rapid low-port bursts were already caught by the strobe path above),
+        # single-target (horizontal caught multi-target above), with MIN_PORTS..
+        # (VERTICAL-1) distinct ports — the bursty/NAT/admin multi-service profile.
+        # Require DIVERSITY corroboration before this auto-bans; otherwise downgrade
+        # to log/alert only so a legitimate source is not banned on port-count alone.
+        if _nftban_portscan_classic_generic_corroborated "$port_count"; then
+            echo "generic"
+        else
+            echo "generic-observe"
+        fi
         return 0
     fi
 
+    return 1
+}
+
+# v1.149.0 — corroboration gate for the "generic" classification (classic mode
+# only; suricata mode bans on IDS-alert score and is left untouched). Returns 0
+# (corroborated → may ban) when the distinct-port count reaches the corroboration
+# floor (default: the vertical-scan threshold), else 1 (downgrade to log/alert).
+# Corroboration is diversity-only by design: sensitive-port or event-volume
+# corroboration would re-ban the admin/NAT case this hardening exists to prevent.
+_nftban_portscan_classic_generic_corroborated() {
+    local port_count="$1"
+    # Disabled → restore pre-v1.149 behavior (generic bans at MIN_PORTS).
+    [[ "${PORTSCAN_CLASSIC_GENERIC_CORROBORATE:-true}" != "true" ]] && return 0
+    local floor="${PORTSCAN_CLASSIC_GENERIC_CORROBORATE_PORTS:-}"
+    [[ -z "$floor" ]] && floor="${PORTSCAN_CLASSIC_VERTICAL_PORTS:-10}"
+    [[ "$port_count" -ge "$floor" ]] && return 0
     return 1
 }
 
@@ -770,6 +796,17 @@ nftban_portscan_classic_handle_detection() {
     local scan_type="$2"
 
     local action="${PORTSCAN_CLASSIC_ACTION}"
+
+    # v1.149.0: an uncorroborated "generic" detection is observe-only — it is
+    # logged/alerted but NEVER auto-banned, regardless of PORTSCAN_CLASSIC_ACTION.
+    # This is the false-ban guard for bursty/NAT/admin multi-service traffic.
+    if [[ "$scan_type" == "generic-observe" ]]; then
+        _nftban_portscan_classic_log "INFO" "Observed uncorroborated generic activity from ${ip} (below diversity floor — NOT banned; set PORTSCAN_CLASSIC_GENERIC_CORROBORATE=false to restore legacy banning)"
+        if [[ "$action" == "alert" || "$action" == "block_and_alert" ]]; then
+            nftban_portscan_classic_send_alert "$ip" "generic-observe"
+        fi
+        return 0
+    fi
 
     _nftban_portscan_classic_log "WARN" "Detected ${scan_type} scan from ${ip}"
 

--- a/cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh
+++ b/cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Regression test for v1.149 BUG-1: nftban update _latv unbound crash
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_update_latv_unbound_v149_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-05"
+# meta:description="Regression guard for v1.149 BUG-1: the no-arg same-version short-circuit in cmd_update.sh declared local _curv _latv _cache_file WITHOUT initializing them, so under set -u a fresh host (no update cache) or missing jq left _latv unbound and `nftban update` aborted at `[[ -z \"$_latv\" ]]`. Asserts the declaration initializes all three, that no uninitialized declaration remains, and (behaviorally) that the cache-absent code shape does not abort under set -u."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SRC="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "================================================="
+echo "v1.149 BUG-1 — nftban update _latv unbound regression"
+echo "================================================="
+
+# 1. Declaration must initialize all three (the fix).
+if grep -qE 'local[[:space:]]+_curv=""[[:space:]]+_latv=""[[:space:]]+_cache_file=""' "$SRC"; then
+    ok "1.1 _curv/_latv/_cache_file declared initialized"
+else
+    no "1.1 initialized declaration NOT found"
+fi
+
+# 2. No uninitialized `local _curv _latv _cache_file` remains (regression guard).
+if grep -qE 'local[[:space:]]+_curv[[:space:]]+_latv[[:space:]]+_cache_file[[:space:]]*$' "$SRC"; then
+    no "2.1 uninitialized 'local _curv _latv _cache_file' still present"
+else
+    ok "2.1 no uninitialized declaration remains"
+fi
+
+# 3. Behavioral: the cache-absent code shape must NOT abort under set -u.
+#    Replicates the guard: with no cache file the assignment block is skipped, so
+#    `[[ -z "$_latv" ]]` must still be safe (only true when _latv is initialized).
+behav=$(
+    bash -uc '
+        _get_current_version(){ echo "1.149.0"; }
+        _get_latest_release(){ echo "1.149.0"; }
+        _curv="" _latv="" _cache_file="/nonexistent/update_available.json"
+        _curv=$(_get_current_version 2>/dev/null || echo unknown)
+        if [[ -f "$_cache_file" ]] && command -v jq >/dev/null 2>&1; then
+            _latv="from-cache"   # skipped: file absent
+        fi
+        if [[ -z "$_latv" ]]; then
+            _latv=$(_get_latest_release 2>/dev/null || echo unknown)
+        fi
+        echo "curv=$_curv latv=$_latv"
+    ' 2>&1
+) && rc=0 || rc=$?
+if [[ $rc -eq 0 ]] && [[ "$behav" != *"unbound variable"* ]]; then
+    ok "3.1 cache-absent update path does not abort under set -u ($behav)"
+else
+    no "3.1 cache-absent path aborted/unbound (rc=$rc): $behav"
+fi
+
+# 4. Negative control: the OLD shape (uninitialized) WOULD abort — proves the test bites.
+neg=$(bash -uc 'local_test(){ local _latv; [[ -z "$_latv" ]] && echo z; }; local_test' 2>&1 || true)
+if [[ "$neg" == *"unbound variable"* ]]; then
+    ok "4.1 negative control: uninitialized local DOES abort under set -u (test is meaningful)"
+else
+    ok "4.1 negative control inconclusive on this bash (non-fatal)"
+fi
+
+echo
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then printf '  - %s\n' "${FAILED[@]}"; exit 1; fi
+echo "All tests passed."
+exit 0

--- a/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.149.0 whitelist --static (permanent tier, WL-STATIC)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_whitelist_static_v149_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-04"
+# meta:description="Tests for v1.149.0 nftban whitelist --static permanent tier. Asserts add --static writes whitelist.d/99-manual.conf with NO EXPIRES_AT (durable — the loader keeps no-EXPIRES_AT entries across rebuild), re-adding refreshes (no dup), remove --static drops the durable line, invalid IP rejected, ensure-header never clobbers an existing file, and the dispatcher routes --static/--ttl/default + the runtime-only warning correctly. Live-apply + survives-rebuild are lab integration tests."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sed,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,sed,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-contained sandbox; no host contact; no root required. We extract the
+# v1.149 --static functions (+ dispatcher) from cmd_whitelist.sh by name, patch
+# out the `[[ $EUID -ne 0 ]]` root guards, redirect $_NFTBAN_MANUAL_WHITELIST_PATH
+# to a tempfile, and stub the leaf helpers (validation, runtime remove, nftban CLI).
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+WL_SRC="$NFTBAN_LIB_DIR/cli/cmd_whitelist.sh"
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+MANUAL_FILE="$SANDBOX/99-manual.conf"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n         expected to contain: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n         did NOT expect: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    fi
+}
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Harness: load the --static functions in a subshell with stubs.
+# ---------------------------------------------------------------------------
+static_env() {
+    # Stubs (defined BEFORE eval so the real funcs call them):
+    #  - validation: accept obvious IPv4/IPv6/CIDR, reject garbage.
+    #  - runtime remove: no-op success (no nft/daemon in sandbox).
+    #  - nftban CLI: absent (command -v nftban → false → reload skipped).
+    cat <<'STUBS'
+nftban_validate_ip()   { [[ "$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || { [[ "$1" == *:* && "$1" =~ ^[0-9a-fA-F:]+$ ]]; }; }
+nftban_validate_cidr() { [[ "$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]] || { [[ "$1" == *:* && "$1" =~ ^[0-9a-fA-F:]+/[0-9]{1,3}$ ]]; }; }
+nftban_whitelist_remove_ip() { return 0; }
+STUBS
+    # Extract the v1.149 --static block (path var + 3 functions), patch the EUID guard.
+    awk '/^_NFTBAN_MANUAL_WHITELIST_PATH=/{c=1} /^# List whitelisted IPs/{c=0} c{print}' "$WL_SRC" \
+        | sed -E 's@\[\[ \$EUID -ne 0 \]\]@[[ 1 -eq 0 ]]@g'
+    printf '_NFTBAN_MANUAL_WHITELIST_PATH=%q\n' "$MANUAL_FILE"
+}
+
+call_add_static()    { ( set +e; eval "$(static_env)"; nftban_whitelist_add_static_ip "$@" ); }
+call_remove_static() { ( set +e; eval "$(static_env)"; nftban_whitelist_remove_static_ip "$@" ); }
+
+echo "================================================="
+echo "v1.149.0 whitelist --static (WL-STATIC) test suite"
+echo "================================================="
+
+# ---------------------------------------------------------------------------
+# T1: add --static creates 99-manual.conf with header + entry, NO EXPIRES_AT
+# ---------------------------------------------------------------------------
+echo; echo "[T1] add --static creates durable file with NO EXPIRES_AT"
+rm -f "$MANUAL_FILE"
+T1_OUT=$(call_add_static 62.38.150.122 2>&1)
+assert_contains "$T1_OUT" "PERMANENT whitelist"                       "T1.1 stdout confirms permanent"
+assert_contains "$T1_OUT" "survives rebuild"                          "T1.2 durability stated"
+[[ -f "$MANUAL_FILE" ]] && { printf "  [PASS] %s\n" "T1.3 file created"; PASS=$((PASS+1)); } \
+                        || { printf "  [FAIL] %s\n" "T1.3 file created"; FAIL=$((FAIL+1)); FAILED_TESTS+=("T1.3"); }
+T1C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+assert_contains "$T1C" "Permanent Whitelist (99-manual.conf)"         "T1.4 header present"
+assert_contains "$T1C" "62.38.150.122"                               "T1.5 IP present"
+assert_contains "$T1C" "ADDED_BY=nftban-whitelist-static"            "T1.6 traceability tag"
+assert_not_contains "$T1C" "EXPIRES_AT"                              "T1.7 NO EXPIRES_AT (durable — loader keeps it across rebuild)"
+
+# ---------------------------------------------------------------------------
+# T2: re-add same IP → refresh (exactly one entry, no duplicate)
+# ---------------------------------------------------------------------------
+echo; echo "[T2] re-add same IP → refresh (no duplicate)"
+call_add_static 62.38.150.122 >/dev/null 2>&1 || true
+T2C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+T2N=$(printf '%s\n' "$T2C" | grep -c "^62\.38\.150\.122" || true)
+assert_eq "$T2N" "1"                                                 "T2.1 exactly one entry for IP"
+
+# ---------------------------------------------------------------------------
+# T3: IPv6 + CIDR accepted as durable entries
+# ---------------------------------------------------------------------------
+echo; echo "[T3] IPv6 + CIDR durable entries"
+call_add_static 2001:db8::1 >/dev/null 2>&1 || true
+call_add_static 10.0.0.0/24 >/dev/null 2>&1 || true
+T3C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+assert_contains "$T3C" "2001:db8::1"                                 "T3.1 IPv6 entry present"
+assert_contains "$T3C" "10.0.0.0/24"                                 "T3.2 CIDR entry present"
+assert_not_contains "$T3C" "EXPIRES_AT"                              "T3.3 still no EXPIRES_AT anywhere"
+
+# ---------------------------------------------------------------------------
+# T4: invalid IP rejected (no write)
+# ---------------------------------------------------------------------------
+echo; echo "[T4] invalid IP rejected"
+T4_OUT=$(call_add_static not-an-ip 2>&1 || true)
+assert_contains "$T4_OUT" "Invalid IP/CIDR"                          "T4.1 invalid IP rejected"
+T4C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+assert_not_contains "$T4C" "not-an-ip"                               "T4.2 garbage not written"
+
+# ---------------------------------------------------------------------------
+# T5: remove --static drops the durable line (not resurrected on reload)
+# ---------------------------------------------------------------------------
+echo; echo "[T5] remove --static drops the durable entry"
+T5_OUT=$(call_remove_static 62.38.150.122 2>&1)
+assert_contains "$T5_OUT" "Removed 62.38.150.122 from the PERMANENT" "T5.1 stdout confirms removal"
+T5C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+assert_not_contains "$T5C" "62.38.150.122"                          "T5.2 durable line gone (won't resurrect on rebuild)"
+assert_contains "$T5C" "2001:db8::1"                                "T5.3 other entries untouched"
+
+# ---------------------------------------------------------------------------
+# T6: remove --static on absent IP → INFO not-found (idempotent)
+# ---------------------------------------------------------------------------
+echo; echo "[T6] remove --static on absent IP → INFO"
+T6_OUT=$(call_remove_static 203.0.113.9 2>&1)
+assert_contains "$T6_OUT" "not found"                               "T6.1 absent IP reported, no error"
+
+# ---------------------------------------------------------------------------
+# T7: ensure-header NEVER clobbers an existing (operator/shipped) file
+# ---------------------------------------------------------------------------
+echo; echo "[T7] ensure-header preserves an existing file"
+rm -f "$MANUAL_FILE"
+printf '# operator hand-written\n198.51.100.7  # ADDED_BY=operator\n' > "$MANUAL_FILE"
+call_add_static 192.0.2.50 >/dev/null 2>&1 || true
+T7C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
+assert_contains "$T7C" "198.51.100.7"                              "T7.1 pre-existing operator entry preserved"
+assert_contains "$T7C" "192.0.2.50"                               "T7.2 new entry appended"
+assert_not_contains "$T7C" "Permanent Whitelist (99-manual.conf)"  "T7.3 canonical header NOT injected over existing file"
+
+# ---------------------------------------------------------------------------
+# T8: dispatcher routing — --static / --ttl / default / remove --static
+# ---------------------------------------------------------------------------
+echo; echo "[T8] dispatcher routes flags correctly"
+dispatch_env() {
+    cat <<'DSTUBS'
+nftban_whitelist_add_ip()         { echo "ROUTE_ADD_RUNTIME $1"; return 0; }
+nftban_whitelist_add_static_ip()  { echo "ROUTE_ADD_STATIC $1"; return 0; }
+nftban_whitelist_remove_ip()      { echo "ROUTE_REMOVE_RUNTIME $1"; return 0; }
+nftban_whitelist_remove_static_ip(){ echo "ROUTE_REMOVE_STATIC $1"; return 0; }
+nftban_whitelist_usage()          { echo "ROUTE_USAGE"; return 0; }
+nftban_whitelist_list()           { echo "ROUTE_LIST"; return 0; }
+DSTUBS
+    awk '/^nftban_cmd_whitelist\(\)/{c=1} c{print} /^}/{if(c){c=0}}' "$WL_SRC"
+}
+call_dispatch() { ( set +e; eval "$(dispatch_env)"; nftban_cmd_whitelist "$@" ); }
+
+T8A=$(call_dispatch add --static 1.2.3.4 2>&1)
+assert_contains "$T8A" "ROUTE_ADD_STATIC 1.2.3.4"                  "T8.1 add --static → static writer"
+T8B=$(call_dispatch add 1.2.3.4 2>&1)
+assert_contains "$T8B" "ROUTE_ADD_RUNTIME 1.2.3.4"                "T8.2 default add → runtime writer"
+assert_contains "$T8B" "RUNTIME whitelist only"                   "T8.3 default add prints honest runtime-only warning"
+T8C=$(call_dispatch remove --static 1.2.3.4 2>&1)
+assert_contains "$T8C" "ROUTE_REMOVE_STATIC 1.2.3.4"             "T8.4 remove --static → static remover"
+T8D=$(call_dispatch remove 1.2.3.4 2>&1)
+assert_contains "$T8D" "ROUTE_REMOVE_RUNTIME 1.2.3.4"            "T8.5 default remove → runtime remover"
+T8E=$(call_dispatch add --static --ttl 30m 1.2.3.4 2>&1 || true)
+assert_contains "$T8E" "mutually exclusive"                       "T8.6 --static + --ttl rejected"
+T8F=$(call_dispatch add 2>&1 || true)
+assert_contains "$T8F" "Usage: nftban whitelist add"             "T8.7 add with no IP shows usage"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo; echo "================================================="
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"; for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
@@ -104,7 +104,8 @@ echo; echo "[T1] add --static creates durable file with NO EXPIRES_AT"
 rm -f "$MANUAL_FILE"
 T1_OUT=$(call_add_static 62.38.150.122 2>&1)
 assert_contains "$T1_OUT" "PERMANENT whitelist"                       "T1.1 stdout confirms permanent"
-assert_contains "$T1_OUT" "survives rebuild"                          "T1.2 durability stated"
+assert_contains "$T1_OUT" "applied it live"                          "T1.2 live-apply stated"
+assert_contains "$T1_OUT" "Durable"                                  "T1.2b durability stated"
 [[ -f "$MANUAL_FILE" ]] && { printf "  [PASS] %s\n" "T1.3 file created"; PASS=$((PASS+1)); } \
                         || { printf "  [FAIL] %s\n" "T1.3 file created"; FAIL=$((FAIL+1)); FAILED_TESTS+=("T1.3"); }
 T1C=$(cat "$MANUAL_FILE" 2>/dev/null || true)

--- a/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
@@ -105,7 +105,7 @@ rm -f "$MANUAL_FILE"
 T1_OUT=$(call_add_static 62.38.150.122 2>&1)
 assert_contains "$T1_OUT" "PERMANENT whitelist"                       "T1.1 stdout confirms permanent"
 assert_contains "$T1_OUT" "applied it live"                          "T1.2 live-apply stated"
-assert_contains "$T1_OUT" "Durable"                                  "T1.2b durability stated"
+assert_contains "$T1_OUT" "survives firewall reload"                 "T1.2b durability stated (BUG-2: survives reload)"
 [[ -f "$MANUAL_FILE" ]] && { printf "  [PASS] %s\n" "T1.3 file created"; PASS=$((PASS+1)); } \
                         || { printf "  [FAIL] %s\n" "T1.3 file created"; FAIL=$((FAIL+1)); FAILED_TESTS+=("T1.3"); }
 T1C=$(cat "$MANUAL_FILE" 2>/dev/null || true)

--- a/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
+++ b/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.149.0 portscan "generic" corroboration (PORTSCAN-RATE)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="portscan_generic_corroborate_v149_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-05"
+# meta:description="Tests for v1.149.0 classic-mode portscan generic-scan corroboration. A non-rapid, single-target, 5..(vertical-1) distinct-port detection (bursty/NAT/admin multi-service profile) is downgraded to generic-observe (log/alert, NEVER banned); a diversity-corroborated detection (>= corroboration floor) still classifies generic and bans; corroboration can be disabled to restore legacy banning; vertical/horizontal/block/strobe paths are unchanged. Classic-mode only — suricata mode (IDS score-based) and DDoS are intentionally NOT touched."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,sort,tr"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,awk,grep,sort,tr"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-contained sandbox; no host contact; no root. Extracts the classify +
+# corroboration + handler functions from nftban_portscan_classic.sh by name,
+# populates the per-IP tracking globals, and asserts the classification + that
+# an uncorroborated generic detection never reaches a ban call.
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SRC="$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh"
+
+PASS=0; FAIL=0; FAILED_TESTS=()
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then printf "  [PASS] %s\n" "$name"; PASS=$((PASS+1))
+    else printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$name"); fi
+}
+assert_contains() {
+    local hay="$1" needle="$2" name="$3"
+    if printf '%s' "$hay" | grep -F -q -- "$needle"; then printf "  [PASS] %s\n" "$name"; PASS=$((PASS+1))
+    else printf "  [FAIL] %s (missing '%s')\n" "$name" "$needle"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$name"); fi
+}
+assert_not_contains() {
+    local hay="$1" needle="$2" name="$3"
+    if printf '%s' "$hay" | grep -F -q -- "$needle"; then printf "  [FAIL] %s (unexpected '%s')\n" "$name" "$needle"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$name")
+    else printf "  [PASS] %s\n" "$name"; PASS=$((PASS+1)); fi
+}
+
+# Extract the three functions under test by name (header line ends with '{',
+# body closes with a column-0 '}').
+extract_funcs() {
+    awk '
+      /^(nftban_portscan_classic_detect_scan_type|_nftban_portscan_classic_generic_corroborated|nftban_portscan_classic_handle_detection)\(\) \{/ { cap=1 }
+      cap { print }
+      cap && /^\}/ { cap=0 }
+    ' "$SRC"
+}
+
+# Build a subshell environment: config + tracking globals + stubs + the funcs.
+classic_env() {
+    cat <<'STUBS'
+# Config (defaults from classic.conf)
+PORTSCAN_CLASSIC_MIN_PORTS=5
+PORTSCAN_CLASSIC_VERTICAL_PORTS=10
+PORTSCAN_CLASSIC_HORIZONTAL_TARGETS=5
+PORTSCAN_CLASSIC_BLOCK_RANGE=20
+PORTSCAN_CLASSIC_STROBE_PORTS=5
+PORTSCAN_SENSITIVE_PORTS=""
+PORTSCAN_CLASSIC_ACTION="block"
+PORTSCAN_CLASSIC_GENERIC_CORROBORATE="true"
+PORTSCAN_CLASSIC_GENERIC_CORROBORATE_PORTS=""
+declare -gA _PORTSCAN_CLASSIC_IP_PORTS=()
+declare -gA _PORTSCAN_CLASSIC_IP_TARGETS=()
+declare -gA _PORTSCAN_CLASSIC_IP_TIMESTAMPS=()
+declare -gA _PORTSCAN_CLASSIC_IP_BAN_COUNT=()
+# Stubs: record ban attempts; quiet logger; alert recorder.
+_nftban_portscan_classic_log() { :; }
+nftban_portscan_classic_send_alert() { echo "ALERT $1 $2"; }
+nftban_portscan_classic_block_ip() { echo "BAN_CALLED $1 $2"; }
+nftban_ban() { echo "BAN_CALLED $1"; }
+nft_ipc_ban() { echo "BAN_CALLED $1"; }
+STUBS
+    extract_funcs
+}
+
+# classify <ip> "<ports>" "<targets>" "<timestamps>" [corroborate] [floor]
+classify() {
+    ( set +e
+      eval "$(classic_env)"
+      # These are read by the eval'd functions at call time (dynamic use).
+      # shellcheck disable=SC2034
+      [[ -n "${5:-}" ]] && PORTSCAN_CLASSIC_GENERIC_CORROBORATE="$5"
+      # shellcheck disable=SC2034
+      [[ -n "${6:-}" ]] && PORTSCAN_CLASSIC_GENERIC_CORROBORATE_PORTS="$6"
+      _PORTSCAN_CLASSIC_IP_PORTS["$1"]="$2"
+      _PORTSCAN_CLASSIC_IP_TARGETS["$1"]="$3"
+      _PORTSCAN_CLASSIC_IP_TIMESTAMPS["$1"]="$4"
+      nftban_portscan_classic_detect_scan_type "$1" )
+}
+# handle <ip> <scan_type>
+handle() {
+    ( set +e
+      eval "$(classic_env)"
+      nftban_portscan_classic_handle_detection "$1" "$2" )
+}
+
+echo "================================================="
+echo "v1.149.0 portscan generic-corroboration test suite"
+echo "================================================="
+
+# Timestamps spanning 20s so the strobe path (port>=5 within 10s) does NOT fire.
+TS_SLOW="1000 1020"
+
+# T1: 6 distinct ports, 1 target, non-rapid → generic-observe (the admin/NAT profile)
+echo; echo "[T1] 6 ports / 1 target / non-rapid → generic-observe (not banned)"
+T1=$(classify 62.38.150.122 "22 80 443 25 110 143" "10.0.0.1" "$TS_SLOW")
+assert_eq "$T1" "generic-observe" "T1.1 uncorroborated generic downgraded to observe"
+
+# T2: 12 distinct ports across 2 targets, non-rapid → corroborated generic (bans)
+#     (not vertical: target_count>1; not block: <20; not horizontal: ports>3)
+echo; echo "[T2] 12 ports / 2 targets → corroborated generic"
+T2=$(classify 9.9.9.9 "1 2 3 4 5 6 7 8 9 10 11 12" "10.0.0.1 10.0.0.2" "$TS_SLOW")
+assert_eq "$T2" "generic" "T2.1 diversity >= floor → still classifies generic (bannable)"
+
+# T3: corroboration disabled → legacy behavior (6 ports → generic)
+echo; echo "[T3] corroboration disabled → legacy generic ban"
+T3=$(classify 8.8.8.8 "22 80 443 25 110 143" "10.0.0.1" "$TS_SLOW" "false")
+assert_eq "$T3" "generic" "T3.1 GENERIC_CORROBORATE=false restores legacy generic at MIN_PORTS"
+
+# T4: custom corroboration floor of 6 → 6 ports now corroborates
+echo; echo "[T4] custom corroboration floor (6) → 6 ports corroborates"
+T4=$(classify 7.7.7.7 "22 80 443 25 110 143" "10.0.0.1" "$TS_SLOW" "true" "6")
+assert_eq "$T4" "generic" "T4.1 floor honored (port_count>=floor)"
+
+# T5: vertical path unchanged (10 ports, single target → vertical)
+echo; echo "[T5] vertical path unchanged"
+T5=$(classify 6.6.6.6 "1 2 3 4 5 6 7 8 9 10" "10.0.0.1" "$TS_SLOW")
+assert_eq "$T5" "vertical" "T5.1 >=10 ports single target still vertical"
+
+# T6: block path unchanged (>=20 ports → block)
+echo; echo "[T6] block path unchanged"
+T6=$(classify 5.5.5.5 "$(seq 1 22 | tr '\n' ' ')" "10.0.0.1" "$TS_SLOW")
+assert_eq "$T6" "block" "T6.1 >=20 ports still block"
+
+# T7: below MIN_PORTS → no detection at all (return non-zero, empty output)
+echo; echo "[T7] below MIN_PORTS → no detection"
+T7=$(classify 4.4.4.4 "22 80 443" "10.0.0.1" "$TS_SLOW" || true)
+assert_eq "$T7" "" "T7.1 <5 ports → no scan type emitted"
+
+# T8: handler NEVER bans on generic-observe (even with ACTION=block)
+echo; echo "[T8] handle_detection(generic-observe) does not ban"
+T8=$(handle 62.38.150.122 "generic-observe")
+assert_not_contains "$T8" "BAN_CALLED" "T8.1 generic-observe is never banned (ACTION=block)"
+
+# T9: handler DOES ban on corroborated generic (regression guard)
+echo; echo "[T9] handle_detection(generic) bans (corroborated path intact)"
+T9=$(handle 9.9.9.9 "generic")
+assert_contains "$T9" "BAN_CALLED 9.9.9.9" "T9.1 corroborated generic still bans"
+
+echo; echo "================================================="
+echo "Results: PASS=$PASS  FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"; for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/etc/nftban/conf.d/portscan/classic.conf
+++ b/etc/nftban/conf.d/portscan/classic.conf
@@ -54,6 +54,30 @@ PORTSCAN_CLASSIC_TIME_WINDOW="60"
 PORTSCAN_CLASSIC_MIN_TARGETS="3"
 
 # -----------------------------------------------------------------------------
+# GENERIC-SCAN CORROBORATION (v1.149.0 — false-ban hardening)
+# -----------------------------------------------------------------------------
+# The "generic" classification fires on MIN_PORTS distinct ports alone. Rapid
+# low-port bursts are already caught upstream by the strobe path, and diverse
+# scans by the vertical/block paths — so the uncorroborated "generic" remainder
+# is non-rapid, single-target, MIN_PORTS..(VERTICAL-1) distinct ports: the
+# profile of bursty/NAT/admin multi-service traffic (e.g. an admin connecting to
+# ssh+http+https+smtp+... = 5-6 ports), NOT a scan. Auto-banning it produced the
+# real-world false-ban that motivated this lane.
+#
+# When corroboration is enabled, a "generic" detection auto-bans ONLY if the
+# distinct-port count reaches the corroboration floor (default: the vertical
+# threshold). Below the floor it is downgraded to log/alert (NO ban). Set to
+# "false" to restore the pre-v1.149 behavior (generic bans at MIN_PORTS).
+#
+# NOTE: corroboration is intentionally DIVERSITY-based only. Sensitive-port or
+# event-volume corroboration would re-ban the very incident this fixes (SSH/22 is
+# a sensitive port; SYN-retransmit feedback inflates volume), so they are not used.
+PORTSCAN_CLASSIC_GENERIC_CORROBORATE="true"
+# Distinct-port floor required to corroborate a "generic" auto-ban.
+# Empty → falls back to PORTSCAN_CLASSIC_VERTICAL_PORTS.
+PORTSCAN_CLASSIC_GENERIC_CORROBORATE_PORTS=""
+
+# -----------------------------------------------------------------------------
 # SCAN TYPE DETECTION
 # -----------------------------------------------------------------------------
 # Different thresholds for different scan types


### PR DESCRIPTION
Operational hardening from the 49.x EL10-prep auto-ban incident. **Shell-only**; daemon `cmd/nftband` **byte-identical** (0 daemon files); **schema 1.83.0 frozen**. **Suricata and DDoS deliberately NOT touched** (both already corroborated).

## Cluster 1 — WL-STATIC (`cmd_whitelist.sh`)
- `whitelist add` stays runtime-only but prints an **honest warning** (no more false "permanent").
- `whitelist add --static <ip>` → durable `whitelist.d/99-manual.conf` (**no `EXPIRES_AT`**) + live reload; survives rebuild/reload/restart. Go loader already keeps no-`EXPIRES_AT` entries → **no daemon/loader/schema change**.
- `whitelist add --ttl <dur>` → delegates to existing `firewall whitelist-session`.
- `whitelist remove --static <ip>` → drops durable line + live entry (no resurrect).
- Help rewritten to document the three tiers. **Test: `cmd_whitelist_static_v149_test` 27/27.**

## Cluster 2 — PORTSCAN-RATE (classic mode only — corrected mechanism)
Code review corrected the scope premise: the `10/sec` is a **log-flood limiter** (`nftables.conf.tpl:418`), not a ban gate — raising it would feed *more* events → *more* false-bans. **So the log rate is NOT raised** (operator-confirmed).

The real false-ban path = the realtime **`generic`** classifier banning on `port_count >= MIN_PORTS(5)` / 60s with **zero corroboration** (the admin's 6 ports → `portscan:generic`). Added a **diversity corroboration gate**: an uncorroborated generic detection (5..vertical-1 distinct ports — rapid caught upstream by *strobe*, diverse by *vertical*; = bursty/NAT/admin profile) is downgraded to **`generic-observe`** (log/alert, **never banned**). Corroborated generic (≥ floor, default vertical 10) still bans. New config `PORTSCAN_CLASSIC_GENERIC_CORROBORATE`(+`_PORTS`). `vertical`/`horizontal`/`block`/`strobe`/`stealth` unchanged. **Test: `portscan_generic_corroborate_v149_test` 9/9.**

## Not touched (code-verified safe)
- **Suricata** portscan bans on accumulated IDS-alert *score* (not port count) — already corroborated.
- **DDoS** classic: 12-strike escalation ladder + 2h strike prune + whitelist-skip → no analogous false-ban; the only direct ban is the manual `nftban ddos ban` command.

## Invariants
Daemon byte-identical to v1.148.0 · schema 1.83.0 frozen · shellcheck `-S warning` clean.
**Lab DEB+RPM validation pending** (survives-rebuild + live observe-not-ban) per lab-first policy.

Scope/record: `NFTBAN_ROADMAP/V1_149_0_OPERATIONAL_HARDENING_SCOPE.md §9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)