### PR TITLE
fix(stats): include manual blacklist counts in stats cache path

### DIFF
--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -99,6 +99,9 @@ nftban_stats_generate_dashboard() {
     local black_v4=0 black_v6=0
     local black_v4_temp=0 black_v4_perm=0
     local black_v6_temp=0 black_v6_perm=0
+    # v1.150 F3: manual hash-set subset (already counted within black_v4/black_v6);
+    # surfaced as its own figure on both cache-hit and cache-miss. IPv4 + IPv6.
+    local manual_v4=0 manual_v6=0
 
     if [[ "$use_unified_cache" == "true" ]]; then
         # Read from unified cache (Single Source of Truth)
@@ -108,6 +111,10 @@ nftban_stats_generate_dashboard() {
         black_v6=$(nftban_stats_get_unified ".blacklist.ipv6.total" "0")
         black_v6_perm=$(nftban_stats_get_unified ".blacklist.ipv6.permanent" "0")
         black_v6_temp=$(nftban_stats_get_unified ".blacklist.ipv6.temporary" "0")
+        # v1.150 F3: manual subset from the cache (already folded into .blacklist.*.total
+        # by the exporter producer). IPv4 + IPv6 symmetric.
+        manual_v4=$(nftban_stats_get_unified ".blacklist_manual.ipv4" "0")
+        manual_v6=$(nftban_stats_get_unified ".blacklist_manual.ipv6" "0")
     else
         # Fallback: Direct nftables query
         # v1.150 HLT-09: count BOTH the interval set (blacklist_ipv4/_ipv6:
@@ -132,6 +139,7 @@ nftban_stats_generate_dashboard() {
             v4m_count=$(echo "$v4m_output" | { grep -oP '\d+\.\d+\.\d+\.\d+(/\d+)?' || true; } | wc -l 2>/dev/null || echo "0")
             black_v4=$((black_v4 + ${v4m_count:-0}))
             black_v4_temp=$((black_v4_temp + ${v4m_temp:-0}))
+            manual_v4=${v4m_count:-0}   # v1.150 F3: expose manual subset (cache-miss)
         fi
         black_v4_perm=$((black_v4 - black_v4_temp))
         [[ $black_v4_perm -lt 0 ]] && black_v4_perm=0
@@ -151,6 +159,7 @@ nftban_stats_generate_dashboard() {
             v6m_count=$(echo "$v6m_output" | { grep -oP '[0-9a-fA-F:]+::[0-9a-fA-F:]*(/\d+)?|[0-9a-fA-F:]+:[0-9a-fA-F:]+(/\d+)?' || true; } | wc -l 2>/dev/null || echo "0")
             black_v6=$((black_v6 + ${v6m_count:-0}))
             black_v6_temp=$((black_v6_temp + ${v6m_temp:-0}))
+            manual_v6=${v6m_count:-0}   # v1.150 F3: expose manual subset (cache-miss)
         fi
         black_v6_perm=$((black_v6 - black_v6_temp))
         [[ $black_v6_perm -lt 0 ]] && black_v6_perm=0
@@ -158,6 +167,8 @@ nftban_stats_generate_dashboard() {
 
     black_v4=${black_v4//[^0-9]/}
     black_v6=${black_v6//[^0-9]/}
+    manual_v4=${manual_v4//[^0-9]/}; manual_v4=${manual_v4:-0}
+    manual_v6=${manual_v6//[^0-9]/}; manual_v6=${manual_v6:-0}
     local total_black
     total_black=$((${black_v4:-0} + ${black_v6:-0}))
 
@@ -183,8 +194,8 @@ nftban_stats_generate_dashboard() {
 
     # Direct bans (blacklist sets) - show IPv4/IPv6 and temp/permanent
     echo "  Direct Bans (nftables):"
-    printf "      %-16s %'d (perm: %'d, temp: %'d)\n" "IPv4............" "$black_v4" "$black_v4_perm" "$black_v4_temp"
-    printf "      %-16s %'d (perm: %'d, temp: %'d)\n" "IPv6............" "$black_v6" "$black_v6_perm" "$black_v6_temp"
+    printf "      %-16s %'d (perm: %'d, temp: %'d, manual: %'d)\n" "IPv4............" "$black_v4" "$black_v4_perm" "$black_v4_temp" "$manual_v4"
+    printf "      %-16s %'d (perm: %'d, temp: %'d, manual: %'d)\n" "IPv6............" "$black_v6" "$black_v6_perm" "$black_v6_temp" "$manual_v6"
 
     # Count feeds (SINGLE SOURCE OF TRUTH from unified cache)
     local feeds_ipv4_total=0 feeds_ipv6_total=0

--- a/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
@@ -76,6 +76,9 @@ collect_all_metrics() {
     # Blacklist active counts (declared at function level for JSON cache and EXTENDED group)
     local active_v4=0 active_v6=0 active_total=0
     local blacklist_v4_perm=0 blacklist_v4_temp=0 blacklist_v6_perm=0 blacklist_v6_temp=0
+    # v1.150 F3: manual hash-set subset (blacklist_manual_ipv4/_ipv6), exposed in
+    # the cache so the cache-hit dashboard can surface it. IPv4 + IPv6 symmetric.
+    local manual_v4=0 manual_v6=0
     if group_active "live"; then
 
         # --- Daemon Metrics ---
@@ -158,6 +161,9 @@ collect_all_metrics() {
                     bl_manual_v6=$(echo "$counts_json" | jq -r '.sets.blacklist_manual_ipv6.count // 0')
                     active_v4=$((bl_interval_v4 + bl_manual_v4))
                     active_v6=$((bl_interval_v6 + bl_manual_v6))
+                    # v1.150 F3: expose the manual subset (already summed into active_*).
+                    manual_v4=$bl_manual_v4
+                    manual_v6=$bl_manual_v6
                     # Temp/perm split not available from daemon cache — report all as permanent
                     blacklist_v4_temp=0
                     blacklist_v6_temp=0
@@ -167,6 +173,13 @@ collect_all_metrics() {
                     # Legacy kernel format: .blacklist.ipv4
                     active_v4=$(echo "$counts_json" | jq -r '.blacklist.ipv4 // 0')
                     active_v6=$(echo "$counts_json" | jq -r '.blacklist.ipv6 // 0')
+                    # v1.150 F3: legacy format omitted the manual hash set — fold it in for
+                    # parity with the other branches (.blacklist.*.total = interval + manual)
+                    # and expose the subset. IPv4 + IPv6 symmetric.
+                    manual_v4=$(echo "$counts_json" | jq -r '.blacklist_manual.ipv4 // .sets.blacklist_manual_ipv4.count // 0')
+                    manual_v6=$(echo "$counts_json" | jq -r '.blacklist_manual.ipv6 // .sets.blacklist_manual_ipv6.count // 0')
+                    active_v4=$((active_v4 + manual_v4))
+                    active_v6=$((active_v6 + manual_v6))
                     blacklist_v4_temp=$(echo "$counts_json" | jq -r '.temporary.ipv4 // 0')
                     blacklist_v6_temp=$(echo "$counts_json" | jq -r '.temporary.ipv6 // 0')
                     blacklist_v4_perm=$(echo "$counts_json" | jq -r '.permanent.ipv4 // 0')
@@ -183,6 +196,9 @@ collect_all_metrics() {
             fb_manual_v6=$(nftban_nft_count_set ip6 nftban blacklist_manual_ipv6 2>/dev/null || echo 0)
             active_v4=$((fb_interval_v4 + fb_manual_v4))
             active_v6=$((fb_interval_v6 + fb_manual_v6))
+            # v1.150 F3: expose the manual subset (already summed into active_*).
+            manual_v4=$fb_manual_v4
+            manual_v6=$fb_manual_v6
             blacklist_v4_temp=$(nftban_nft_count_set_with_timeout ip nftban blacklist_ipv4 2>/dev/null || echo 0)
             blacklist_v6_temp=$(nftban_nft_count_set_with_timeout ip6 nftban blacklist_ipv6 2>/dev/null || echo 0)
             blacklist_v4_perm=$((active_v4 - blacklist_v4_temp))
@@ -1545,6 +1561,11 @@ collect_all_metrics() {
       "temporary": ${blacklist_v6_temp:-0}
     },
     "total": ${active_total:-0}
+  },
+  "blacklist_manual": {
+    "ipv4": ${manual_v4:-0},
+    "ipv6": ${manual_v6:-0},
+    "total": $(( ${manual_v4:-0} + ${manual_v6:-0} ))
   },
   "whitelist": {
     "ipv4": ${whitelist_v4:-0},

--- a/cli/lib/nftban/tests/stats_manual_cache_v150_test.sh
+++ b/cli/lib/nftban/tests/stats_manual_cache_v150_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.150 F3: manual blacklist counts in the stats cache
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="stats_manual_cache_v150_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-05"
+# meta:description="Tests for v1.150 F3 (manual-count truth, cache path). The exporter producer (nftban_unified_exporter_collect.sh) now emits a blacklist_manual{ipv4,ipv6,total} block into the stats cache, and the cache-hit dashboard consumer (nftban_stats_format.sh) reads + surfaces it (manual: N). Pre-v1.150 the cache lacked blacklist_manual so manual bans were invisible on cache-hit (cache-miss already counted them via HLT-09). Covers: cache-hit manual read, cache-miss manual read, zero-manual compatibility, existing permanent/temporary unchanged. STRICTLY symmetric IPv4 + IPv6. Hermetic: stubs the unified-cache accessor + kernel-count stubs; no host/nft/IPC, no root."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,grep"
+# meta:inventory.files="cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh,cli/lib/nftban/core/nftban_stats_format.sh"
+# meta:inventory.binaries="bash,jq,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+EXP="$REPO_ROOT/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+FMT="$REPO_ROOT/cli/lib/nftban/core/nftban_stats_format.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+have() { if grep -q "$2" "$1"; then ok "$3"; else no "$3"; fi; }
+
+echo "=== F3 producer (exporter) — structure (IPv4 + IPv6) ==="
+have "$EXP" 'manual_v4=$bl_manual_v4'  "counts-json branch sets manual_v4"
+have "$EXP" 'manual_v6=$bl_manual_v6'  "counts-json branch sets manual_v6"
+have "$EXP" 'manual_v4=$fb_manual_v4'  "fallback branch sets manual_v4"
+have "$EXP" 'manual_v6=$fb_manual_v6'  "fallback branch sets manual_v6"
+have "$EXP" 'blacklist_manual.ipv4 // .sets.blacklist_manual_ipv4.count' "legacy branch reads manual ipv4"
+have "$EXP" 'blacklist_manual.ipv6 // .sets.blacklist_manual_ipv6.count' "legacy branch reads manual ipv6"
+have "$EXP" '"blacklist_manual": {' "cache emits blacklist_manual block"
+have "$EXP" '"ipv4": ${manual_v4:-0}' "cache blacklist_manual.ipv4"
+have "$EXP" '"ipv6": ${manual_v6:-0}' "cache blacklist_manual.ipv6"
+# existing .blacklist block preserved (compat)
+have "$EXP" '"blacklist": {' "existing .blacklist block preserved"
+
+echo "=== F3 producer — functional cache fragment (IPv4 + IPv6 symmetric) ==="
+emit() { # $1 manual_v4 $2 manual_v6 — mirrors the exporter heredoc fragment
+    local manual_v4="$1" manual_v6="$2"
+    printf '{ "blacklist": {"ipv4":{"total":98,"permanent":98,"temporary":0},"ipv6":{"total":10,"permanent":10,"temporary":0},"total":108}, "blacklist_manual": { "ipv4": %s, "ipv6": %s, "total": %s } }\n' \
+        "${manual_v4:-0}" "${manual_v6:-0}" "$(( ${manual_v4:-0} + ${manual_v6:-0} ))"
+}
+J="$(emit 3 1)"
+if printf '%s' "$J" | jq -e . >/dev/null 2>&1; then ok "producer JSON valid"; else no "producer JSON valid" "$J"; fi
+[[ "$(printf '%s' "$J" | jq '.blacklist_manual.ipv4')" == 3 ]] && ok "producer .blacklist_manual.ipv4=3" || no "producer ipv4"
+[[ "$(printf '%s' "$J" | jq '.blacklist_manual.ipv6')" == 1 ]] && ok "producer .blacklist_manual.ipv6=1" || no "producer ipv6"
+[[ "$(printf '%s' "$J" | jq '.blacklist_manual.total')" == 4 ]] && ok "producer .blacklist_manual.total=4 (v4+v6)" || no "producer total"
+# zero-manual compatibility: existing .blacklist fields intact, manual total 0
+JZ="$(emit 0 0)"
+[[ "$(printf '%s' "$JZ" | jq '.blacklist_manual.total')" == 0 ]] && ok "zero-manual: total=0" || no "zero-manual total"
+[[ "$(printf '%s' "$JZ" | jq '.blacklist.ipv4.permanent')" == 98 ]] && ok "zero-manual: existing perm preserved" || no "perm preserved"
+[[ "$(printf '%s' "$JZ" | jq '.blacklist.ipv4.temporary')" == 0 ]] && ok "zero-manual: existing temp preserved" || no "temp preserved"
+
+echo "=== F3 consumer (dashboard) — structure (IPv4 + IPv6) ==="
+have "$FMT" '.blacklist_manual.ipv4' "cache-hit reads .blacklist_manual.ipv4"
+have "$FMT" '.blacklist_manual.ipv6' "cache-hit reads .blacklist_manual.ipv6"
+have "$FMT" 'manual_v4=${v4m_count:-0}' "cache-miss sets manual_v4 from kernel count"
+have "$FMT" 'manual_v6=${v6m_count:-0}' "cache-miss sets manual_v6 from kernel count"
+have "$FMT" 'manual: %'"'"'d).*IPv4\|IPv4.*manual: %'"'"'d' "display: IPv4 shows manual:"
+grep -q '"IPv6............" "\$black_v6" "\$black_v6_perm" "\$black_v6_temp" "\$manual_v6"' "$FMT" \
+    && ok "display: IPv6 shows manual (symmetric)" || no "display: IPv6 manual"
+
+echo "=== F3 consumer — functional read+display harness (drift-guarded above) ==="
+# Mirrors the real cache-hit read + sanitize + display. Stubs the cache accessor.
+declare -A _U
+nftban_stats_get_unified() { local k="$1" d="${2:-0}"; echo "${_U[$k]:-$d}"; }
+render() { # mirrors nftban_stats_format cache-hit manual read + display
+    local black_v4 black_v4_perm black_v4_temp black_v6 black_v6_perm black_v6_temp manual_v4 manual_v6
+    black_v4=$(nftban_stats_get_unified ".blacklist.ipv4.total" "0")
+    black_v4_perm=$(nftban_stats_get_unified ".blacklist.ipv4.permanent" "0")
+    black_v4_temp=$(nftban_stats_get_unified ".blacklist.ipv4.temporary" "0")
+    black_v6=$(nftban_stats_get_unified ".blacklist.ipv6.total" "0")
+    black_v6_perm=$(nftban_stats_get_unified ".blacklist.ipv6.permanent" "0")
+    black_v6_temp=$(nftban_stats_get_unified ".blacklist.ipv6.temporary" "0")
+    manual_v4=$(nftban_stats_get_unified ".blacklist_manual.ipv4" "0")
+    manual_v6=$(nftban_stats_get_unified ".blacklist_manual.ipv6" "0")
+    manual_v4=${manual_v4//[^0-9]/}; manual_v4=${manual_v4:-0}
+    manual_v6=${manual_v6//[^0-9]/}; manual_v6=${manual_v6:-0}
+    printf "IPv4 %d (perm: %d, temp: %d, manual: %d)\n" "$black_v4" "$black_v4_perm" "$black_v4_temp" "$manual_v4"
+    printf "IPv6 %d (perm: %d, temp: %d, manual: %d)\n" "$black_v6" "$black_v6_perm" "$black_v6_temp" "$manual_v6"
+}
+
+# cache-hit: manual present in cache
+_U=([".blacklist.ipv4.total"]=100 [".blacklist.ipv4.permanent"]=98 [".blacklist.ipv4.temporary"]=2 \
+    [".blacklist.ipv6.total"]=10 [".blacklist.ipv6.permanent"]=9 [".blacklist.ipv6.temporary"]=1 \
+    [".blacklist_manual.ipv4"]=5 [".blacklist_manual.ipv6"]=2)
+OUT="$(render)"
+echo "$OUT" | grep -q 'IPv4 100 (perm: 98, temp: 2, manual: 5)' && ok "cache-hit: IPv4 manual=5 surfaced" || no "cache-hit IPv4" "$OUT"
+echo "$OUT" | grep -q 'IPv6 10 (perm: 9, temp: 1, manual: 2)'   && ok "cache-hit: IPv6 manual=2 surfaced" || no "cache-hit IPv6" "$OUT"
+# perm/temp unchanged by F3
+echo "$OUT" | grep -q 'perm: 98, temp: 2' && ok "cache-hit: IPv4 perm/temp unchanged" || no "IPv4 perm/temp"
+echo "$OUT" | grep -q 'perm: 9, temp: 1'  && ok "cache-hit: IPv6 perm/temp unchanged" || no "IPv6 perm/temp"
+
+# zero-manual compatibility (no blacklist_manual in cache → defaults 0)
+_U=([".blacklist.ipv4.total"]=98 [".blacklist.ipv4.permanent"]=98 [".blacklist.ipv4.temporary"]=0 \
+    [".blacklist.ipv6.total"]=0 [".blacklist.ipv6.permanent"]=0 [".blacklist.ipv6.temporary"]=0)
+OUT="$(render)"
+echo "$OUT" | grep -q 'IPv4 98 (perm: 98, temp: 0, manual: 0)' && ok "zero-manual: IPv4 manual=0, fields intact" || no "zero IPv4" "$OUT"
+echo "$OUT" | grep -q 'IPv6 0 (perm: 0, temp: 0, manual: 0)'   && ok "zero-manual: IPv6 manual=0, fields intact" || no "zero IPv6" "$OUT"
+
+# cache-miss parity: manual derived from kernel counts (v4m_count/v6m_count) — mirror
+miss() { local v4m_count="$1" v6m_count="$2" manual_v4 manual_v6; manual_v4=${v4m_count:-0}; manual_v6=${v6m_count:-0}; echo "$manual_v4 $manual_v6"; }
+[[ "$(miss 3 1)" == "3 1" ]] && ok "cache-miss: manual derived from kernel counts (v4=3,v6=1)" || no "cache-miss derive"
+
+echo ""
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## v1.150 F3 — include manual blacklist counts in the stats cache path

Completes the manual-count truth path surfaced during Lane A lab validation (`V150_LANE_A_LAB_VALIDATION_RECORD.md`, F3). Manual bans were invisible on the **cache-HIT** dashboard (the cache-MISS path already counted them via HLT-09). **Fixes F3 only.**

### Scope guarantees
- **Shell-only** — **0 `cmd/nftband` changes, 0 `cmd/nftban-core` changes, 0 Go changes, no schema change**, no package behaviour change.
- **Daemon `watchdog.go` half remains deferred to Lane C** (not touched here).
- 1 commit off main `255bb757`; 3 files.

### What changed
- **Producer** (`nftban_unified_exporter_collect.sh`): emits a `blacklist_manual{ipv4, ipv6, total}` block into the stats cache, and sets `manual_v4`/`manual_v6` in all three collection branches (the legacy branch also folds manual into `.blacklist.*.total` for parity). Existing `.blacklist` cache fields are preserved.
- **Cache-hit consumer** (`nftban_stats_format.sh`): reads `.blacklist_manual.{ipv4,ipv6}` and surfaces it as `manual: N` on the Direct Bans line.
- **Cache-miss path remains covered** (HLT-09) — manual is also exposed there from the kernel counts.
- **IPv4 / IPv6 symmetry** — every change is mirrored for both families.
- perm/temp counts unchanged; no double-counting (manual shown as a subset of the already-inclusive total).
- No live ban/unban and no direct-nft confirmation used (validated from code + hermetic tests).

### Tests
- `cli/lib/nftban/tests/stats_manual_cache_v150_test.sh` — **30/30** (cache-hit manual, cache-miss manual, zero-manual compatibility, existing perm/temp unchanged — each asserting **both IPv4 and IPv6**).
- `stats_status_truth_v150` — still green.
- `stats_json_top_sources_v150` (F2) — still green.
- `shellcheck -S warning` — clean on all changed files.

Reference: `NFTBAN_PENDINGS_AND_BUGS_CURRENT.md` (F3 → IMPLEMENTED_PENDING_PR_CI).

### Not in this PR
No merge / tag / release / release-prep · no F2 changes · no Lane B/C/D · no AUTH expansion · no daemon `watchdog.go` work · no host mutation · no package publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
