### PR TITLE
fix(ssh): warn and protect external admin-port rebuild paths

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -587,6 +587,14 @@ jobs:
       - name: ssh_ports systemic-alignment invariants (v1.145 PR-G)
         run: bash cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
 
+      # External admin SSH-port guard (OBS-SSHPORT-55000-FAMILY): warn-only +
+      # lockout-net. Asserts the guard warns on an external :55000->:22 redirect,
+      # session-whitelists the admin IP via the IPC whitelist-session path only
+      # (no direct nft write), keeps ssh_ports = {22} (REJECT import), and is a
+      # no-op off-session / on dry-run / on opt-out / on re-entry.
+      - name: External admin SSH-port guard (OBS-SSHPORT-55000)
+        run: bash cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -188,6 +188,11 @@ nftban_cmd_firewall() {
         echo ""
     fi
 
+    # OBS-SSHPORT-55000-FAMILY: external admin SSH-port warn-only + lockout-net guard.
+    # Defines nftban_ssh_pre_rebuild_lockout_guard + nftban_ssh_admin_port_audit; safe no-op
+    # when not in an SSH session / on opt-out. shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_admin_port_guard.sh" 2>/dev/null || true
+
     case "$subcommand" in
         help|-h|--help)
             show_firewall_help
@@ -200,6 +205,7 @@ nftban_cmd_firewall() {
         init)
             # v1.38.0: BUG-002 — alias to rebuild (firewall init was never implemented)
             shift
+            nftban_ssh_pre_rebuild_lockout_guard init "$@" || true
             firewall_rebuild "$@"
             ;;
         validate)
@@ -228,10 +234,12 @@ nftban_cmd_firewall() {
             ;;
         reload)
             shift
+            nftban_ssh_pre_rebuild_lockout_guard reload "$@" || true
             firewall_reload "$@"
             ;;
         rebuild)
             shift
+            nftban_ssh_pre_rebuild_lockout_guard rebuild "$@" || true
             firewall_rebuild "$@"
             ;;
         reset)
@@ -260,11 +268,18 @@ nftban_cmd_firewall() {
             ;;
         takeover)
             shift
+            nftban_ssh_pre_rebuild_lockout_guard takeover "$@" || true
             firewall_takeover "$@"
             ;;
         whitelist-session)
             shift
             firewall_whitelist_session "$@"
+            ;;
+        ssh-audit|ssh-port-audit)
+            # OBS-SSHPORT-55000-FAMILY: read-only report of sshd listeners vs ssh_ports
+            # vs declared external admin ports (NFTBAN_EXTERNAL_ADMIN_SSH_PORTS).
+            shift
+            nftban_ssh_admin_port_audit "$@"
             ;;
         *)
             echo "ERROR: Unknown firewall subcommand: $subcommand" >&2
@@ -3255,6 +3270,7 @@ Validation & Diagnostics:
   check         Check if IP or port is blocked/allowed
   logs          View and filter firewall logs
   record        Snapshot current nft schema to JSON for audit/comparison
+  ssh-audit     Report sshd listeners vs ssh_ports vs declared external admin ports
 
 Operations:
   init          Initialize firewall tables (alias for rebuild)
@@ -3280,6 +3296,9 @@ Examples:
   nftban firewall record --json        # Output to stdout
   nftban firewall record --diff file   # Compare against baseline
 
+  # SSH admin-port audit (external :55000->:22 redirect class)
+  nftban firewall ssh-audit            # sshd listeners vs ssh_ports vs declared
+
   # Recovery operations
   nftban firewall rebuild              # Fix corruption
   nftban firewall reset --force        # Full reset
@@ -3289,6 +3308,20 @@ Examples:
 Global options:
   --json        Output results as JSON (for scripts/API integration)
   -h, --help    Show help for specific subcommand
+
+EXTERNAL ADMIN SSH PORT (lockout-net):
+  If admin SSH arrives on a port that is an EXTERNAL redirect/NAT to the real
+  sshd listener (e.g. :55000 -> :22 via firewalld/iptables-nft/provider/panel),
+  nftban does NOT own that redirect: ssh_ports stays the real listener set and a
+  rebuild/takeover may transiently disrupt the external port. Before rebuild /
+  reload / takeover, nftban session-whitelists your active SSH source IP (via the
+  IPC whitelist-session path) so SSH survives by IP regardless of the port.
+    - Declare the external port for a precise warning:
+        export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS=55000
+    - Opt out of the pre-rebuild lockout-net:  NFTBAN_NO_PREREBUILD_LOCKOUT=1
+    - Lockout-net TTL (default 1h):            NFTBAN_PREREBUILD_LOCKOUT_TTL=2h
+  nftban will NOT import the external port into ssh_ports and will NOT recreate
+  the NAT — keep the redirect in the host firewall layer.
 
 CTRL+C / INTERRUPTION:
   Do NOT interrupt rebuild, reset, restore, reload, or takeover with

--- a/cli/lib/nftban/lib/ssh_admin_port_guard.sh
+++ b/cli/lib/nftban/lib/ssh_admin_port_guard.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - External admin SSH-port guard (OBS-SSHPORT-55000-FAMILY)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_admin_port_guard" meta:type="lib" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Warn-only + lockout-net guard for hosts where admin SSH arrives on an EXTERNAL redirect/NAT port (e.g. :55000 -> :22 via firewalld/iptables-nft/provider) that nftban does NOT own. nftban's ssh_ports stays the ACTUAL sshd listener set (it is NOT a NAT manager); before a rebuild/takeover that could disrupt the external redirect, this guard WARNS and session-whitelists the active admin source IP (via the existing IPC whitelist-session path) so SSH survives by IP regardless of the external port. It does NOT import the external port into ssh_ports and does NOT recreate/preserve the redirect."
+# meta:inventory.files="/usr/lib/nftban/lib/ssh_port_detect.sh"
+# meta:inventory.binaries="ss,grep,awk,sort,paste,tr,nft"
+# meta:inventory.env_vars="NFTBAN_EXTERNAL_ADMIN_SSH_PORTS,SSH_CLIENT,SSH_CONNECTION,NFTBAN_NO_PREREBUILD_LOCKOUT,NFTBAN_PREREBUILD_LOCKOUT_TTL,NFTBAN_LIB_DIR,NFTBAN_TABLE_IPV4"
+# meta:inventory.config_files="/etc/nftban/conf.d,/etc/nftban/nftban.conf.local"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none (read-only audit); lockout-net write goes through the sanctioned IPC whitelist-session path only"
+# =============================================================================
+# Strategy (operator-locked SELECT_SSHPORT_55000_STRATEGY = WARN_ONLY_PLUS_LOCKOUT_NET):
+#   A warn-only + B lockout-net. REJECT importing :55000 into ssh_ports (ssh_ports
+#   drives the brute-force ct-count on the real sshd LISTENER; the external port is
+#   not a listener). REJECT preserving/recreating the external NAT/redirect (nftban
+#   is an ingress IPS, not a NAT manager). No direct nft writes here — the only
+#   firewall mutation is via _whitelist_session_add (IPC).
+# =============================================================================
+
+# Per NFTBan coding standards this library declares `set -Eeuo pipefail`. It is
+# sourced into already-strict callers (cmd_firewall.sh sets it at file top), so
+# this is a redundant no-op there; every function below is written set-e-safe
+# (failable pipelines/substitutions are guarded with `|| true` / condition context).
+set -Eeuo pipefail
+
+# nftban_ssh_external_admin_ports — print declared external admin SSH ports (operator
+# config NFTBAN_EXTERNAL_ADMIN_SSH_PORTS, comma/space separated), sorted-unique numeric.
+nftban_ssh_external_admin_ports() {
+    local raw="${NFTBAN_EXTERNAL_ADMIN_SSH_PORTS:-}"
+    [[ -z "$raw" ]] && return 0
+    printf '%s\n' "$raw" | tr ', ' '\n' | grep -E '^[0-9]+$' | awk '$1>=1 && $1<=65535' | sort -un
+}
+
+# nftban_ssh_active_admin_ip — source IP of the current SSH session, or nothing.
+nftban_ssh_active_admin_ip() {
+    if [[ -n "${SSH_CLIENT:-}" ]]; then printf '%s\n' "${SSH_CLIENT%% *}"; return 0; fi
+    if [[ -n "${SSH_CONNECTION:-}" ]]; then printf '%s\n' "${SSH_CONNECTION%% *}"; return 0; fi
+    return 1
+}
+
+# nftban_ssh_active_admin_port — server port the current SSH session landed on
+# (post-DNAT, so on an external-redirect host this is the real listener, e.g. 22).
+nftban_ssh_active_admin_port() {
+    if [[ -n "${SSH_CONNECTION:-}" ]]; then printf '%s\n' "${SSH_CONNECTION##* }"; return 0; fi
+    # SSH_CLIENT = "<client-ip> <client-port> <server-port>" — 3rd field is the local port.
+    if [[ -n "${SSH_CLIENT:-}" ]]; then
+        local _p; _p=$(printf '%s\n' "${SSH_CLIENT}" | awk '{print $3}')
+        [[ -n "$_p" ]] && { printf '%s\n' "$_p"; return 0; }
+    fi
+    return 1
+}
+
+# _nftban_ssh_ports_kernel — read-only: the ports currently in the nftban ssh_ports set.
+_nftban_ssh_ports_kernel() {
+    nft list set "${NFTBAN_TABLE_IPV4:-ip nftban}" ssh_ports 2>/dev/null \
+        | grep -oE 'elements = \{[^}]*\}' | grep -oE '[0-9]+' | sort -un
+}
+
+# _nftban_ssh_listeners — sshd listener ports (via the v1.145 detector if present).
+_nftban_ssh_listeners() {
+    if declare -f nftban_detect_ssh_ports >/dev/null 2>&1; then
+        nftban_detect_ssh_ports 2>/dev/null
+    elif [[ -r "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_port_detect.sh" 2>/dev/null
+        nftban_detect_ssh_ports 2>/dev/null
+    else
+        ss -tlnH 2>/dev/null | awk '{print $4}' | grep -oE ':[0-9]+$' | tr -d ':' | sort -un
+    fi
+}
+
+# nftban_ssh_admin_port_audit — S1: read-only report of sshd listeners vs ssh_ports vs
+# declared external admin ports + the active admin session, flagging external redirects.
+nftban_ssh_admin_port_audit() {
+    local listeners ssh_set declared active_ip active_port mismatch=0 p
+    listeners=$(_nftban_ssh_listeners | paste -sd, -) || true
+    ssh_set=$(_nftban_ssh_ports_kernel | paste -sd, -) || true
+    declared=$(nftban_ssh_external_admin_ports | paste -sd, -) || true
+    active_ip=$(nftban_ssh_active_admin_ip 2>/dev/null || echo "(not an ssh session)")
+    active_port=$(nftban_ssh_active_admin_port 2>/dev/null || echo "-")
+    echo "SSH admin-port audit (OBS-SSHPORT-55000-FAMILY):"
+    echo "  sshd listeners (detected):     ${listeners:-none}"
+    echo "  nftban ssh_ports (protected):  ${ssh_set:-none}"
+    echo "  declared external admin ports: ${declared:-none}   (set NFTBAN_EXTERNAL_ADMIN_SSH_PORTS to declare)"
+    echo "  active admin session:          ip=${active_ip}  landed-port=${active_port}"
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        if ! _nftban_ssh_listeners | grep -qx "$p"; then
+            echo "  ⚠ external admin port :$p is NOT an sshd listener → it reaches :$active_port via an EXTERNAL redirect/NAT"
+            echo "    (firewalld / iptables-nft / provider / panel). nftban does NOT own that path; a rebuild/takeover may"
+            echo "    disrupt :$p while ssh_ports (${ssh_set:-?}) stays valid. nftban will NOT import :$p into ssh_ports"
+            echo "    (it is not a listener) and will NOT recreate the NAT — keep the redirect in the host firewall layer."
+            mismatch=1
+        fi
+    done < <(nftban_ssh_external_admin_ports)
+    [[ $mismatch -eq 0 ]] && echo "  ✓ no external-admin-port mismatch (ssh_ports reflects the real sshd listeners)."
+    return 0
+}
+
+# nftban_ssh_pre_rebuild_lockout_guard <op> [op-args...] — S2: called BEFORE a
+# rebuild/reload/takeover. Warns on an external-admin-port mismatch and ensures the
+# active admin source IP is session-whitelisted (IPC lockout-net), so SSH survives by
+# IP regardless of the external redirect. No-op when not in an SSH session, on dry-run,
+# on opt-out, or on re-entry (the lockout-net's own reload must not recurse).
+nftban_ssh_pre_rebuild_lockout_guard() {
+    local op="${1:-rebuild}"; shift 2>/dev/null || true
+    # re-entry / recursion guard: whitelist-session add itself triggers a reload.
+    [[ "${_NFTBAN_PREREBUILD_GUARD_ACTIVE:-0}" == "1" ]] && return 0
+    [[ "${NFTBAN_NO_PREREBUILD_LOCKOUT:-0}" == "1" ]] && return 0
+    local admin_ip; admin_ip=$(nftban_ssh_active_admin_ip 2>/dev/null) || return 0
+    [[ -z "$admin_ip" ]] && return 0
+    local dry=0 a
+    for a in "$@"; do case "$a" in --dry-run|-n) dry=1 ;; esac; done
+    local declared; declared=$(nftban_ssh_external_admin_ports | paste -sd, -) || true
+    if [[ -n "$declared" ]]; then
+        local ssh_set; ssh_set=$(_nftban_ssh_ports_kernel | paste -sd, -) || true
+        {
+            echo "  ⚠ NFTBan ${op}: external admin SSH port(s) declared (:${declared})."
+            echo "    nftban ssh_ports stays the ACTUAL sshd listener set (${ssh_set:-?}); nftban will NOT preserve the"
+            echo "    external NAT/redirect for :${declared} (host-managed: firewalld/iptables-nft/provider)."
+        } >&2
+    fi
+    if [[ $dry -eq 1 ]]; then
+        echo "  (dry-run: would session-whitelist ${admin_ip} as a ${op} lockout-net; no change made)" >&2
+        return 0
+    fi
+    # Lockout-net via the sanctioned IPC whitelist-session path (no direct nft).
+    if declare -f _whitelist_session_add >/dev/null 2>&1; then
+        export _NFTBAN_PREREBUILD_GUARD_ACTIVE=1
+        if _whitelist_session_add "$admin_ip" --ttl "${NFTBAN_PREREBUILD_LOCKOUT_TTL:-1h}" \
+               --reason "pre-${op}-lockout-net" >/dev/null 2>&1; then
+            echo "  ✓ lockout-net: ${admin_ip} session-whitelisted for the ${op} (TTL ${NFTBAN_PREREBUILD_LOCKOUT_TTL:-1h})." >&2
+        else
+            echo "  (lockout-net: could not session-whitelist ${admin_ip}; proceeding — :ssh_ports access unaffected)" >&2
+        fi
+        unset _NFTBAN_PREREBUILD_GUARD_ACTIVE
+    fi
+    return 0
+}
+
+export -f nftban_ssh_external_admin_ports nftban_ssh_active_admin_ip nftban_ssh_active_admin_port \
+          _nftban_ssh_ports_kernel _nftban_ssh_listeners nftban_ssh_admin_port_audit \
+          nftban_ssh_pre_rebuild_lockout_guard 2>/dev/null || true

--- a/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
+++ b/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for OBS-SSHPORT-55000-FAMILY external admin SSH-port guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_admin_port_guard_v150_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-05"
+# meta:description="Hermetic tests for the external admin SSH-port warn-only + lockout-net guard (lib/ssh_admin_port_guard.sh). Strategy WARN_ONLY_PLUS_LOCKOUT_NET. Covers: normal :22 (no warn), native :55000 listener (in-authority, no warn), external :55000->:22 redirect (mismatch warn, ssh_ports stays {22}, NO import), multi-port sshd, lockout-net via the IPC whitelist-session path only (no direct nft write), dry-run/opt-out/re-entry/no-ssh no-ops. Hermetic: stubs nft + nftban_detect_ssh_ports + _whitelist_session_add; no host/IPC/root."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sort,paste,tr"
+# meta:inventory.files="cli/lib/nftban/lib/ssh_admin_port_guard.sh"
+# meta:inventory.binaries="bash,grep,awk,sort,paste,tr"
+# meta:inventory.env_vars="NFTBAN_EXTERNAL_ADMIN_SSH_PORTS,SSH_CLIENT,SSH_CONNECTION,NFTBAN_NO_PREREBUILD_LOCKOUT,NFTBAN_PREREBUILD_LOCKOUT_TTL"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+GUARD="$REPO_ROOT/cli/lib/nftban/lib/ssh_admin_port_guard.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+NFT_WRITE_LOG="$SANDBOX/nft_writes.log"
+WL_LOG="$SANDBOX/whitelist_calls.log"
+: > "$NFT_WRITE_LOG"; : > "$WL_LOG"
+
+# ---- stubs --------------------------------------------------------------
+# nft: read-only `list set` returns a fixed ssh_ports={22}; ANY write is recorded
+# (and fails) so a direct-nft-write regression is caught.
+nft() {
+    case "$1" in
+        list)
+            if [[ "$*" == *"ssh_ports"* ]]; then
+                echo "table ip nftban {"
+                echo "  set ssh_ports {"
+                echo "    type inet_service"
+                echo "    elements = { 22 }"
+                echo "  }"
+                echo "}"
+                return 0
+            fi
+            return 0 ;;
+        add|delete|insert|replace|create|flush)
+            echo "$*" >> "$NFT_WRITE_LOG"; return 1 ;;
+        *) return 0 ;;
+    esac
+}
+export -f nft
+
+# _whitelist_session_add: the sanctioned IPC lockout-net path (recorded, never touches nft).
+_whitelist_session_add() { echo "wl-add $*" >> "$WL_LOG"; return 0; }
+export -f _whitelist_session_add
+
+# nftban_detect_ssh_ports: configurable sshd listener set (newline-separated).
+DETECT_PORTS="22"
+nftban_detect_ssh_ports() { printf '%s\n' $DETECT_PORTS; }
+export -f nftban_detect_ssh_ports
+
+# shellcheck source=/dev/null
+source "$GUARD"
+
+reset_state() {
+    : > "$NFT_WRITE_LOG"; : > "$WL_LOG"
+    unset SSH_CLIENT SSH_CONNECTION NFTBAN_EXTERNAL_ADMIN_SSH_PORTS \
+          NFTBAN_NO_PREREBUILD_LOCKOUT NFTBAN_PREREBUILD_LOCKOUT_TTL \
+          _NFTBAN_PREREBUILD_GUARD_ACTIVE 2>/dev/null || true
+    DETECT_PORTS="22"
+}
+
+echo "=== helper functions ==="
+reset_state
+[[ "$(NFTBAN_EXTERNAL_ADMIN_SSH_PORTS='55000, 22 80' nftban_ssh_external_admin_ports | paste -sd, -)" == "22,80,55000" ]] \
+    && ok "external_admin_ports: parse+dedup+sort+validate" || no "external_admin_ports parse"
+[[ -z "$(nftban_ssh_external_admin_ports)" ]] && ok "external_admin_ports: empty when unset" || no "external_admin_ports empty"
+[[ "$(NFTBAN_EXTERNAL_ADMIN_SSH_PORTS='99999 abc -1' nftban_ssh_external_admin_ports)" == "" ]] \
+    && ok "external_admin_ports: rejects out-of-range/non-numeric" || no "external_admin_ports range"
+[[ "$(SSH_CLIENT='203.0.113.7 51000 22' nftban_ssh_active_admin_ip)" == "203.0.113.7" ]] \
+    && ok "active_admin_ip: from SSH_CLIENT" || no "active_admin_ip SSH_CLIENT"
+[[ "$(SSH_CONNECTION='203.0.113.7 51000 10.0.0.1 22' nftban_ssh_active_admin_ip)" == "203.0.113.7" ]] \
+    && ok "active_admin_ip: from SSH_CONNECTION fallback" || no "active_admin_ip SSH_CONNECTION"
+nftban_ssh_active_admin_ip >/dev/null 2>&1 && no "active_admin_ip: should fail when no ssh env" || ok "active_admin_ip: empty/fail when not in ssh"
+[[ "$(SSH_CONNECTION='203.0.113.7 51000 10.0.0.1 22' nftban_ssh_active_admin_port)" == "22" ]] \
+    && ok "active_admin_port: post-DNAT landed port (22) from SSH_CONNECTION" || no "active_admin_port SSH_CONNECTION"
+[[ "$(SSH_CLIENT='203.0.113.7 51000 22' nftban_ssh_active_admin_port)" == "22" ]] \
+    && ok "active_admin_port: landed port (22) from SSH_CLIENT 3rd field" || no "active_admin_port SSH_CLIENT"
+
+echo "=== S1 audit: normal :22 host (clean) ==="
+reset_state; DETECT_PORTS="22"
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -q "ssh_ports (protected):  22" && ok "audit shows ssh_ports={22}" || no "audit ssh_ports" "$out"
+echo "$out" | grep -q "no external-admin-port mismatch" && ok "audit: clean verdict, no mismatch" || no "audit clean verdict" "$out"
+echo "$out" | grep -qi "is NOT an sshd listener" && no "audit: should NOT warn on clean host" || ok "audit: silent on clean host"
+
+echo "=== S1 audit: external :55000->:22 redirect (declared, NOT a listener) ==="
+reset_state; DETECT_PORTS="22"; export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -q "external admin port :55000 is NOT an sshd listener" && ok "audit: flags :55000 external redirect" || no "audit external flag" "$out"
+echo "$out" | grep -q "will NOT import :55000 into ssh_ports" && ok "audit: states no import" || no "audit no-import statement" "$out"
+echo "$out" | grep -q "ssh_ports (protected):  22" && ok "audit: ssh_ports still {22} (no import)" || no "audit ssh_ports unchanged" "$out"
+[[ ! -s "$NFT_WRITE_LOG" ]] && ok "audit: zero direct nft writes" || no "audit nft writes" "$(cat "$NFT_WRITE_LOG")"
+
+echo "=== S1 audit: native :55000 sshd listener (in-authority, no warn) ==="
+reset_state; DETECT_PORTS=$'22\n55000'; export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -qi "is NOT an sshd listener" && no "native :55000 should NOT warn" "$out" || ok "audit: no mismatch when :55000 is a real listener"
+
+echo "=== S1 audit: multi-port sshd (22 + 2222 native) ==="
+reset_state; DETECT_PORTS=$'22\n2222'
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -qi "is NOT an sshd listener" && no "multi-port: false warning" "$out" || ok "multi-port: no false warning"
+
+echo "=== S2 lockout-net: external-redirect rebuild (warn + IPC whitelist) ==="
+reset_state; DETECT_PORTS="22"
+export SSH_CLIENT="203.0.113.7 51000 22"
+export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
+echo "$out" | grep -q "external admin SSH port(s) declared (:55000)" && ok "guard: warns on declared external port" || no "guard warn" "$out"
+echo "$out" | grep -q "will NOT preserve the" && ok "guard: states NAT not preserved" || no "guard nat statement" "$out"
+grep -q "wl-add 203.0.113.7 --ttl 1h --reason pre-rebuild-lockout-net" "$WL_LOG" \
+    && ok "guard: session-whitelists admin IP via IPC (default TTL 1h)" || no "guard wl IPC" "$(cat "$WL_LOG")"
+[[ ! -s "$NFT_WRITE_LOG" ]] && ok "guard: lockout-net uses IPC only — zero direct nft writes" || no "guard nft writes" "$(cat "$NFT_WRITE_LOG")"
+
+echo "=== S2 lockout-net: clean :22 rebuild (no warn, still whitelists admin IP) ==="
+reset_state; DETECT_PORTS="22"
+export SSH_CLIENT="198.51.100.9 40000 22"
+out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
+echo "$out" | grep -qi "external admin SSH port" && no "clean rebuild: should not warn external" "$out" || ok "clean rebuild: no external-port warning"
+grep -q "wl-add 198.51.100.9 --ttl 1h --reason pre-rebuild-lockout-net" "$WL_LOG" \
+    && ok "clean rebuild: still session-whitelists admin IP (general lockout-net)" || no "clean rebuild wl" "$(cat "$WL_LOG")"
+
+echo "=== S2 custom TTL ==="
+reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_PREREBUILD_LOCKOUT_TTL="2h"
+nftban_ssh_pre_rebuild_lockout_guard takeover >/dev/null 2>&1
+grep -q "wl-add 203.0.113.7 --ttl 2h --reason pre-takeover-lockout-net" "$WL_LOG" \
+    && ok "guard: honors NFTBAN_PREREBUILD_LOCKOUT_TTL + per-op reason" || no "guard custom ttl/reason" "$(cat "$WL_LOG")"
+
+echo "=== S2 dry-run: no whitelist write ==="
+reset_state; export SSH_CLIENT="203.0.113.7 51000 22"
+out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild --dry-run 2>&1)"
+echo "$out" | grep -q "dry-run: would session-whitelist" && ok "dry-run: reports intent" || no "dry-run report" "$out"
+[[ ! -s "$WL_LOG" ]] && ok "dry-run: no whitelist mutation" || no "dry-run no mutation" "$(cat "$WL_LOG")"
+
+echo "=== S2 opt-out: NFTBAN_NO_PREREBUILD_LOCKOUT=1 ==="
+reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_NO_PREREBUILD_LOCKOUT=1
+nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
+[[ ! -s "$WL_LOG" ]] && ok "opt-out: no whitelist, no warn" || no "opt-out" "$(cat "$WL_LOG")"
+
+echo "=== S2 re-entry guard: no recursion ==="
+reset_state; export SSH_CLIENT="203.0.113.7 51000 22" _NFTBAN_PREREBUILD_GUARD_ACTIVE=1
+nftban_ssh_pre_rebuild_lockout_guard reload >/dev/null 2>&1
+[[ ! -s "$WL_LOG" ]] && ok "re-entry: guard short-circuits (no recursive whitelist)" || no "re-entry" "$(cat "$WL_LOG")"
+
+echo "=== S2 not-in-ssh-session: no-op ==="
+reset_state
+nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
+[[ ! -s "$WL_LOG" ]] && ok "no ssh session: guard is a no-op" || no "no-ssh no-op" "$(cat "$WL_LOG")"
+
+echo "=== invariant: guard NEVER imports the external port (ssh_ports unchanged) ==="
+reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
+[[ ! -s "$NFT_WRITE_LOG" ]] && ok "REJECT-C upheld: no ssh_ports import / no nft write at all" || no "import invariant" "$(cat "$NFT_WRITE_LOG")"
+
+echo ""
+echo "================================================================"
+echo "ssh_admin_port_guard: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
+++ b/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
@@ -70,3 +70,4 @@ cli/cmd_sync.sh	validate	undocumented-subcmd	DOC-CANDIDATE: real maintenance sub
 cli/cmd_portscan.sh	restart	alias	reload
 cli/cmd_portscan.sh	sync	undocumented-subcmd	DOC-CANDIDATE: real subcmd (journalctl log sync; in error-fallback list)
 cli/cmd_sync.sh	status	undocumented-subcmd	DOC-CANDIDATE: real subcmd (nftban_sync_status)
+cli/cmd_firewall.sh	ssh-port-audit	alias	ssh-audit (OBS-SSHPORT-55000 external admin-port audit)

--- a/docs/ARCHITECTURE-NFT-POLICY.md
+++ b/docs/ARCHITECTURE-NFT-POLICY.md
@@ -40,6 +40,8 @@ These are allowlisted in `scripts/ci/check-nft-writes.sh` (each with a one-line 
 
 A write **outside** these allowlisted paths is a violation and fails CI.
 
+**Note — external admin SSH-port lockout-net.** The pre-rebuild/reload/takeover lockout-net (`cli/lib/nftban/lib/ssh_admin_port_guard.sh`, OBS-SSHPORT-55000-FAMILY) makes **no** direct nft write: it session-whitelists the admin source IP through the existing IPC `whitelist-session` path, so it is **not** a new exception. See [`SSH-EXTERNAL-ADMIN-PORT.md`](SSH-EXTERNAL-ADMIN-PORT.md).
+
 ## 4. CI enforcement contract
 
 `scripts/ci/check-nft-writes.sh` (wired in `ci-architecture.yml`, "Policy Gates"):

--- a/docs/SSH-EXTERNAL-ADMIN-PORT.md
+++ b/docs/SSH-EXTERNAL-ADMIN-PORT.md
@@ -1,0 +1,102 @@
+# NFTBan — admin SSH on an external redirect port (e.g. `:55000` → `:22`)
+
+**Status:** operator note. **Added:** v1.150 lane (OBS-SSHPORT-55000-FAMILY). **Class:** SSH-lockout-adjacent **host-config** debt — **not** an NFTBan regression. Behaves identically on v1.142 and v1.150 (daemon byte-identical chain v1.147→v1.150).
+
+This page explains, in plain English, **why a `nftban firewall rebuild` can briefly drop SSH on `:55000` while `:22` keeps working**, what NFTBan does about it, and what stays the host's job. It also records the **exact** CLI text so the wording can be checked against the code.
+
+---
+
+## 1. Root cause — in plain English
+
+1. You connect to the server on **port 55000**.
+2. **Something other than NFTBan** rewrites that to port 22 before `sshd` sees it. That "something" is an external redirect/NAT layer — **firewalld** forward-port, **iptables-nft** `REDIRECT`/`DNAT`, the hosting **panel** (DirectAdmin/CSF), or the **provider's** edge firewall. NFTBan does not create or manage that redirect.
+3. `sshd` is actually **listening on port 22 only**. It never listens on 55000. You only *reach* it on 55000 because of step 2.
+4. NFTBan figures out which SSH ports to protect by looking at **real `sshd` listeners + `sshd_config` Port lines + saved state + its own config** — it has **no way to see port 55000**, because 55000 is not a listener and not in any SSH config. So NFTBan correctly protects **`ssh_ports = { 22 }`**. That is the right answer for what `sshd` is doing.
+5. `nftban firewall rebuild` (and `takeover`) re-apply NFTBan's own nftables **and disarm competing firewall layers** (that is the whole point of takeover — one firewall, not several fighting). If the **`:55000 → :22` redirect lives in one of those competing layers** (firewalld/iptables-nft), disarming it can **momentarily drop port 55000**. Port 22 stays up the whole time (NFTBan protects it), so an admin who only knows `:55000` can be surprised by a lockout while `:22` is perfectly fine.
+
+**One sentence:** the `:55000 → :22` redirect is owned by the host's *other* firewall layer, not NFTBan; a rebuild that tidies up those other layers can disturb `:55000`, even though `sshd`/`:22` are never at risk.
+
+Confirmed on **srv1** (CentOS Stream 10, +firewalld +iptables-nft layers) and **dns2** (CentOS Stream 9). Both: `ss` shows `sshd` on `:22` only; NFTBan renders `ssh_ports = { 22 }`; there is **no `:55000` rule anywhere in NFTBan's ruleset** (grep confirms none).
+
+---
+
+## 2. What NFTBan does about it (warn-only + lockout-net)
+
+NFTBan does **not** try to own the redirect. Instead:
+
+- **Warn-only (S1/S2).** Before a `rebuild`/`reload`/`takeover`, and on demand via `nftban firewall ssh-audit`, NFTBan reports the mismatch in plain language so the operator is never surprised.
+- **Lockout-net (S2).** Before that rebuild/reload/takeover, NFTBan **session-whitelists your current admin source IP** through the existing, sanctioned IPC `whitelist-session` path (the same single-writer channel used everywhere else — **no direct nftables write**). That means **you stay reachable by IP regardless of which port the redirect was on**, even if the external `:55000` redirect flickers during the rebuild.
+
+What NFTBan **deliberately does not do** (both rejected by design):
+
+- It does **not** add `:55000` to `ssh_ports`. `ssh_ports` drives the brute-force rate-limit on the *actual* `sshd` **listener**; `sshd` is not on `:55000`, so adding it would not restore the redirect and would pollute the rate-limit set with a dead port.
+- It does **not** recreate or "preserve" the `:55000 → :22` NAT. NFTBan is an ingress IPS, not a NAT/redirect manager. **Keep the redirect in the host firewall layer** (firewalld/iptables-nft/panel/provider).
+
+---
+
+## 3. Exact CLI text (recorded verbatim from the code)
+
+On an affected host (`sshd` on `:22`, external `:55000` redirect declared via `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS=55000`, admin connected):
+
+### `nftban firewall ssh-audit`
+
+```
+SSH admin-port audit (OBS-SSHPORT-55000-FAMILY):
+  sshd listeners (detected):     22
+  nftban ssh_ports (protected):  22
+  declared external admin ports: 55000   (set NFTBAN_EXTERNAL_ADMIN_SSH_PORTS to declare)
+  active admin session:          ip=203.0.113.7  landed-port=22
+  ⚠ external admin port :55000 is NOT an sshd listener → it reaches :22 via an EXTERNAL redirect/NAT
+    (firewalld / iptables-nft / provider / panel). nftban does NOT own that path; a rebuild/takeover may
+    disrupt :55000 while ssh_ports (22) stays valid. nftban will NOT import :55000 into ssh_ports
+    (it is not a listener) and will NOT recreate the NAT — keep the redirect in the host firewall layer.
+```
+
+On a normal host (no external redirect) the last block is replaced by:
+
+```
+  ✓ no external-admin-port mismatch (ssh_ports reflects the real sshd listeners).
+```
+
+### Warning + lockout-net printed automatically before `nftban firewall rebuild`
+
+```
+  ⚠ NFTBan rebuild: external admin SSH port(s) declared (:55000).
+    nftban ssh_ports stays the ACTUAL sshd listener set (22); nftban will NOT preserve the
+    external NAT/redirect for :55000 (host-managed: firewalld/iptables-nft/provider).
+  ✓ lockout-net: 203.0.113.7 session-whitelisted for the rebuild (TTL 1h).
+```
+
+The same lockout-net line (`✓ lockout-net: <ip> session-whitelisted …`) prints before **every** interactive `rebuild`/`reload`/`takeover` you run over SSH, even on a normal `:22` host — that is the general safety net. It is suppressed only off-session, on `--dry-run`, on opt-out, or on re-entry.
+
+> These blocks are produced by `cli/lib/nftban/lib/ssh_admin_port_guard.sh` and are asserted character-for-character by `cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh` (CI step *External admin SSH-port guard (OBS-SSHPORT-55000)* in `ci-architecture.yml`). If the code text and this page ever diverge, the test/CI is the source of truth.
+
+---
+
+## 4. Operator controls
+
+| Setting | Effect | Default |
+|---------|--------|---------|
+| `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS=55000` | Declares your external admin port so the warning is **precise** (otherwise NFTBan still applies the lockout-net, just without naming the port). Comma/space-separated list allowed. **Warning input only — never imported into `ssh_ports`.** | unset |
+| `NFTBAN_NO_PREREBUILD_LOCKOUT=1` | Opt out of the pre-rebuild lockout-net entirely. | `0` (lockout-net on) |
+| `NFTBAN_PREREBUILD_LOCKOUT_TTL=2h` | TTL of the session-whitelist entry added before a rebuild. | `1h` |
+
+Recommended on srv1/dns2-class hosts: set `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS` to the real external port in `/etc/nftban/nftban.conf.local` (or a `conf.d/*.local`), and **keep the `:55000 → :22` redirect in firewalld/iptables-nft/panel** — that is the layer that owns it.
+
+---
+
+## 5. Remediation if `:55000` is dropped after a rebuild
+
+`:22` is never dropped (NFTBan protects it), so you can always recover:
+
+1. Reconnect on **`:22`** directly (it stayed valid the entire time).
+2. Re-apply the external redirect in **its own layer**, e.g. firewalld: `firewall-cmd --add-forward-port=port=55000:proto=tcp:toport=22 && firewall-cmd --runtime-to-permanent`, or restore the panel/provider rule. NFTBan does not own this rule and will not recreate it.
+3. Run `nftban firewall ssh-audit` to confirm the picture (`ssh_ports = { 22 }`, declared `:55000`, mismatch flagged).
+
+---
+
+## 6. Related
+
+- nftables single-writer policy: [`ARCHITECTURE-NFT-POLICY.md`](ARCHITECTURE-NFT-POLICY.md) — the lockout-net writes only through the sanctioned IPC `whitelist-session` path (no direct nft).
+- SSH-port detection authority: `cli/lib/nftban/lib/ssh_port_detect.sh`, `cmd/nftban-detect-ssh-ports` (sources: `ss` listeners + `sshd_config` Port/ListenAddress + state + `conf.local`; **no conntrack source**).
+- Register entry: `OBS-SSHPORT-55000-FAMILY` in `NFTBAN_PENDINGS_AND_BUGS_CURRENT.md` (cluster 3, SSH-port lifecycle).


### PR DESCRIPTION
## Summary

Hosts where admin SSH arrives on an **external** redirect/NAT port (e.g. `:55000 → :22` via firewalld / iptables-nft / provider / panel) can have that port **transiently dropped** by `nftban firewall rebuild`/`takeover`, which disarms competing firewall layers. `sshd` listens only on `:22`, so NFTBan correctly renders `ssh_ports = { 22 }` and has no detection source that can see `:55000` (no conntrack). `:22` is never at risk — but an admin who only knows `:55000` can be surprised by a lockout.

**Class:** pre-existing host-config debt (`OBS-SSHPORT-55000-FAMILY`), **NOT a v1.150 regression** (behaves identically v1.142↔v1.150, daemon byte-identical). **Affected:** srv1 (+ firewalld/iptables-nft conflict) and dns2.

## Strategy: `SELECT_SSHPORT_55000_STRATEGY = WARN_ONLY_PLUS_LOCKOUT_NET`

- **S1 — `nftban firewall ssh-audit`** (new, read-only): reports sshd listeners vs `ssh_ports` vs declared `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS`, flags external redirects.
- **S2 — pre-rebuild guard**: before `init`/`reload`/`rebuild`/`takeover`, warn on the mismatch and **session-whitelist the active admin source IP** via the existing IPC `whitelist-session` path, so SSH survives **by IP** regardless of the external port. Recursion-guarded; opt-out `NFTBAN_NO_PREREBUILD_LOCKOUT=1`; TTL `NFTBAN_PREREBUILD_LOCKOUT_TTL` (default `1h`).

### Decisions
- ✅ `SELECT_SSHPORT_55000_STRATEGY = WARN_ONLY_PLUS_LOCKOUT_NET`
- ❌ **rejected import-to-`ssh_ports`** — `ssh_ports` drives the brute-force rate-limit on the real sshd **listener**; sshd is not on `:55000`, so importing it would be wrong and unsafe.
- ❌ **rejected NAT / firewalld / redirect preservation** — NFTBan is an ingress IPS, not a NAT manager; the `:55000 → :22` redirect stays **host-managed**.

### Invariants held
- **shell + CI + docs only**
- **no `cmd/nftband` changes**
- **no `cmd/nftban-core` changes**
- **no internal Go changes**
- **no schema change** (1.83.0 frozen; daemon byte-identical chain v1.147→v1.150 preserved)
- **no direct nft writes** — lockout-net uses the existing **IPC `whitelist-session`** path only
- **`ssh_ports` remains the actual sshd listener set** (`{ 22 }`)
- **`:55000` external redirect is reported/warned, not imported**

## Verbatim CLI text (asserted by the test)

`nftban firewall ssh-audit` on an affected host:
```
SSH admin-port audit (OBS-SSHPORT-55000-FAMILY):
  sshd listeners (detected):     22
  nftban ssh_ports (protected):  22
  declared external admin ports: 55000   (set NFTBAN_EXTERNAL_ADMIN_SSH_PORTS to declare)
  active admin session:          ip=203.0.113.7  landed-port=22
  ⚠ external admin port :55000 is NOT an sshd listener → it reaches :22 via an EXTERNAL redirect/NAT
    ... nftban will NOT import :55000 into ssh_ports ... will NOT recreate the NAT ...
```
Printed automatically before `nftban firewall rebuild`:
```
  ⚠ NFTBan rebuild: external admin SSH port(s) declared (:55000).
    nftban ssh_ports stays the ACTUAL sshd listener set (22); nftban will NOT preserve the
    external NAT/redirect for :55000 (host-managed: firewalld/iptables-nft/provider).
  ✓ lockout-net: 203.0.113.7 session-whitelisted for the rebuild (TTL 1h).
```

## Tests / gates (local, green)

| Gate | Result |
|------|--------|
| `ssh_admin_port_guard_v150_test.sh` | **30/30 PASS** (warn, IPC-only lockout, `ssh_ports` stays `{22}` / zero nft writes, dry-run/opt-out/re-entry/no-ssh no-ops) — wired as CI step |
| `check-nft-writes.sh` | **0 WRITE violations** |
| shellcheck | clean (`-S warning` lib+cli, `-S error` test) |
| v145 SSH detection (`v145_ssh_port_detect_test.sh`) | **12/0 green** |
| v145 PR-G invariants (`v145_pr_g_ssh_ports_invariants_test.sh`) | **14/0 green** |
| nft-writer authority (`nft_writer_authority_v150_test.sh`) | **24/0 green** |

## Files (6)
- **NEW** `cli/lib/nftban/lib/ssh_admin_port_guard.sh` — S1 audit + S2 guard (no direct nft; IPC lockout-net only)
- `cli/lib/nftban/cli/cmd_firewall.sh` — source guard, hook init/reload/rebuild/takeover, `ssh-audit` subcommand + help
- **NEW** `cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh` — 30/30 hermetic
- `.github/workflows/ci-architecture.yml` — CI step
- **NEW** `docs/SSH-EXTERNAL-ADMIN-PORT.md` — plain-English root cause + verbatim CLI text
- `docs/ARCHITECTURE-NFT-POLICY.md` — note: lockout-net is not a new nft-write exception

Register: `OBS-SSHPORT-55000-FAMILY` → `IMPLEMENTED_PENDING_PR_CI`. srv1 stays `DEPLOYED_COMMITTED_TRIAGED_NOT_PASS`; dns2 stays `PASS_WITH_OBS_SSHPORT`. Not closed; no merge/tag/release/rollout in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
