### PR TITLE
fix(ssh): narrow pre-rebuild lockout-net to external-admin-port risk

### DIFF
--- a/cli/lib/nftban/lib/ssh_admin_port_guard.sh
+++ b/cli/lib/nftban/lib/ssh_admin_port_guard.sh
@@ -100,11 +100,30 @@ nftban_ssh_admin_port_audit() {
     return 0
 }
 
+# _nftban_ssh_external_admin_risk_ports — print the declared external admin ports that
+# are NOT a real sshd listener (i.e. the external :55000->:22 redirect risk class).
+# Empty output = no risk: a normal :22 host (nothing declared) or a host where the
+# declared port is a genuine sshd listener (already in ssh_ports via normal detection).
+_nftban_ssh_external_admin_risk_ports() {
+    local declared listeners p
+    declared=$(nftban_ssh_external_admin_ports) || true
+    [[ -z "$declared" ]] && return 0
+    listeners=$(_nftban_ssh_listeners 2>/dev/null) || true
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        # If the declared port is a real listener it is in-authority (no risk); skip it.
+        printf '%s\n' "$listeners" | grep -qx "$p" || printf '%s\n' "$p"
+    done <<< "$declared"
+}
+
 # nftban_ssh_pre_rebuild_lockout_guard <op> [op-args...] — S2: called BEFORE a
-# rebuild/reload/takeover. Warns on an external-admin-port mismatch and ensures the
-# active admin source IP is session-whitelisted (IPC lockout-net), so SSH survives by
-# IP regardless of the external redirect. No-op when not in an SSH session, on dry-run,
-# on opt-out, or on re-entry (the lockout-net's own reload must not recurse).
+# rebuild/reload/takeover. NARROWED (operator N1 decision 2026-06-05): acts ONLY on the
+# external-admin-port RISK class — a declared NFTBAN_EXTERNAL_ADMIN_SSH_PORTS port that
+# is NOT a real sshd listener (external :55000->:22 redirect). For that class it WARNS
+# and session-whitelists the active admin source IP (IPC lockout-net), so SSH survives
+# by IP while the external redirect is disturbed. It is a TRUE no-op on a normal :22
+# host and on a host with a native :55000 listener (no warning, no whitelist, no nested
+# reload), as well as when not in an SSH session, on dry-run, on opt-out, or on re-entry.
 nftban_ssh_pre_rebuild_lockout_guard() {
     local op="${1:-rebuild}"; shift 2>/dev/null || true
     # re-entry / recursion guard: whitelist-session add itself triggers a reload.
@@ -112,17 +131,18 @@ nftban_ssh_pre_rebuild_lockout_guard() {
     [[ "${NFTBAN_NO_PREREBUILD_LOCKOUT:-0}" == "1" ]] && return 0
     local admin_ip; admin_ip=$(nftban_ssh_active_admin_ip 2>/dev/null) || return 0
     [[ -z "$admin_ip" ]] && return 0
+    # NARROWED gate: only the external-admin-port risk class triggers warn + lockout-net.
+    # Normal :22 / native :55000-listener hosts have no risk → true no-op below.
+    local risk; risk=$(_nftban_ssh_external_admin_risk_ports | paste -sd, -) || true
+    [[ -z "$risk" ]] && return 0
     local dry=0 a
     for a in "$@"; do case "$a" in --dry-run|-n) dry=1 ;; esac; done
-    local declared; declared=$(nftban_ssh_external_admin_ports | paste -sd, -) || true
-    if [[ -n "$declared" ]]; then
-        local ssh_set; ssh_set=$(_nftban_ssh_ports_kernel | paste -sd, -) || true
-        {
-            echo "  ⚠ NFTBan ${op}: external admin SSH port(s) declared (:${declared})."
-            echo "    nftban ssh_ports stays the ACTUAL sshd listener set (${ssh_set:-?}); nftban will NOT preserve the"
-            echo "    external NAT/redirect for :${declared} (host-managed: firewalld/iptables-nft/provider)."
-        } >&2
-    fi
+    local ssh_set; ssh_set=$(_nftban_ssh_ports_kernel | paste -sd, -) || true
+    {
+        echo "  ⚠ NFTBan ${op}: external admin SSH port(s) (:${risk}) reach sshd via an EXTERNAL redirect/NAT,"
+        echo "    not an sshd listener. nftban ssh_ports stays the ACTUAL listener set (${ssh_set:-?}); nftban will"
+        echo "    NOT preserve the external NAT/redirect for :${risk} (host-managed: firewalld/iptables-nft/provider)."
+    } >&2
     if [[ $dry -eq 1 ]]; then
         echo "  (dry-run: would session-whitelist ${admin_ip} as a ${op} lockout-net; no change made)" >&2
         return 0
@@ -142,5 +162,5 @@ nftban_ssh_pre_rebuild_lockout_guard() {
 }
 
 export -f nftban_ssh_external_admin_ports nftban_ssh_active_admin_ip nftban_ssh_active_admin_port \
-          _nftban_ssh_ports_kernel _nftban_ssh_listeners nftban_ssh_admin_port_audit \
-          nftban_ssh_pre_rebuild_lockout_guard 2>/dev/null || true
+          _nftban_ssh_ports_kernel _nftban_ssh_listeners _nftban_ssh_external_admin_risk_ports \
+          nftban_ssh_admin_port_audit nftban_ssh_pre_rebuild_lockout_guard 2>/dev/null || true

--- a/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
+++ b/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
@@ -122,54 +122,69 @@ reset_state; DETECT_PORTS=$'22\n2222'
 out="$(nftban_ssh_admin_port_audit 2>&1)"
 echo "$out" | grep -qi "is NOT an sshd listener" && no "multi-port: false warning" "$out" || ok "multi-port: no false warning"
 
+echo "=== risk helper: declared-not-listener = at-risk; declared-listener / none = no risk ==="
+reset_state; DETECT_PORTS="22"; export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+[[ "$(_nftban_ssh_external_admin_risk_ports)" == "55000" ]] && ok "risk: declared :55000 not a listener → at-risk" || no "risk external" "$(_nftban_ssh_external_admin_risk_ports)"
+reset_state; DETECT_PORTS=$'22\n55000'; export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+[[ -z "$(_nftban_ssh_external_admin_risk_ports)" ]] && ok "risk: declared :55000 IS a listener → no risk" || no "risk native"
+reset_state; DETECT_PORTS="22"
+[[ -z "$(_nftban_ssh_external_admin_risk_ports)" ]] && ok "risk: nothing declared → no risk" || no "risk none"
+
 echo "=== S2 lockout-net: external-redirect rebuild (warn + IPC whitelist) ==="
 reset_state; DETECT_PORTS="22"
 export SSH_CLIENT="203.0.113.7 51000 22"
 export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
 out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
-echo "$out" | grep -q "external admin SSH port(s) declared (:55000)" && ok "guard: warns on declared external port" || no "guard warn" "$out"
-echo "$out" | grep -q "will NOT preserve the" && ok "guard: states NAT not preserved" || no "guard nat statement" "$out"
+echo "$out" | grep -q "external admin SSH port(s) (:55000) reach sshd via an EXTERNAL redirect" && ok "guard: warns on external-redirect risk port" || no "guard warn" "$out"
+echo "$out" | grep -q "NOT preserve the" && ok "guard: states NAT not preserved" || no "guard nat statement" "$out"
 grep -q "wl-add 203.0.113.7 --ttl 1h --reason pre-rebuild-lockout-net" "$WL_LOG" \
     && ok "guard: session-whitelists admin IP via IPC (default TTL 1h)" || no "guard wl IPC" "$(cat "$WL_LOG")"
 [[ ! -s "$NFT_WRITE_LOG" ]] && ok "guard: lockout-net uses IPC only — zero direct nft writes" || no "guard nft writes" "$(cat "$NFT_WRITE_LOG")"
 
-echo "=== S2 lockout-net: clean :22 rebuild (no warn, still whitelists admin IP) ==="
+echo "=== S2 NARROWED: normal :22 host is a TRUE no-op (no warn, no whitelist, no nested reload) ==="
 reset_state; DETECT_PORTS="22"
 export SSH_CLIENT="198.51.100.9 40000 22"
 out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
-echo "$out" | grep -qi "external admin SSH port" && no "clean rebuild: should not warn external" "$out" || ok "clean rebuild: no external-port warning"
-grep -q "wl-add 198.51.100.9 --ttl 1h --reason pre-rebuild-lockout-net" "$WL_LOG" \
-    && ok "clean rebuild: still session-whitelists admin IP (general lockout-net)" || no "clean rebuild wl" "$(cat "$WL_LOG")"
+[[ -z "$out" ]] && ok "normal :22: no output (no warning)" || no "normal :22 silent" "$out"
+[[ ! -s "$WL_LOG" ]] && ok "normal :22: no session-whitelist call (so no nested reload)" || no "normal :22 wl" "$(cat "$WL_LOG")"
+echo "$out" | grep -qi "external admin SSH port" && no "normal :22: must not warn external" "$out" || ok "normal :22: no external warning"
 
-echo "=== S2 custom TTL ==="
-reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_PREREBUILD_LOCKOUT_TTL="2h"
+echo "=== S2 NARROWED: native :55000 listener declared is a TRUE no-op ==="
+reset_state; DETECT_PORTS=$'22\n55000'
+export SSH_CLIENT="203.0.113.7 51000 55000" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
+[[ -z "$out" ]] && ok "native :55000: no output (no warning)" || no "native :55000 silent" "$out"
+[[ ! -s "$WL_LOG" ]] && ok "native :55000: no forced whitelist (in-authority listener)" || no "native :55000 wl" "$(cat "$WL_LOG")"
+
+echo "=== S2 custom TTL (risk path) ==="
+reset_state; DETECT_PORTS="22"; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000" NFTBAN_PREREBUILD_LOCKOUT_TTL="2h"
 nftban_ssh_pre_rebuild_lockout_guard takeover >/dev/null 2>&1
 grep -q "wl-add 203.0.113.7 --ttl 2h --reason pre-takeover-lockout-net" "$WL_LOG" \
     && ok "guard: honors NFTBAN_PREREBUILD_LOCKOUT_TTL + per-op reason" || no "guard custom ttl/reason" "$(cat "$WL_LOG")"
 
-echo "=== S2 dry-run: no whitelist write ==="
-reset_state; export SSH_CLIENT="203.0.113.7 51000 22"
+echo "=== S2 dry-run (risk path): no whitelist write ==="
+reset_state; DETECT_PORTS="22"; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
 out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild --dry-run 2>&1)"
 echo "$out" | grep -q "dry-run: would session-whitelist" && ok "dry-run: reports intent" || no "dry-run report" "$out"
 [[ ! -s "$WL_LOG" ]] && ok "dry-run: no whitelist mutation" || no "dry-run no mutation" "$(cat "$WL_LOG")"
 
-echo "=== S2 opt-out: NFTBAN_NO_PREREBUILD_LOCKOUT=1 ==="
-reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_NO_PREREBUILD_LOCKOUT=1
-nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
-[[ ! -s "$WL_LOG" ]] && ok "opt-out: no whitelist, no warn" || no "opt-out" "$(cat "$WL_LOG")"
+echo "=== S2 opt-out beats risk: NFTBAN_NO_PREREBUILD_LOCKOUT=1 ==="
+reset_state; DETECT_PORTS="22"; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000" NFTBAN_NO_PREREBUILD_LOCKOUT=1
+out="$(nftban_ssh_pre_rebuild_lockout_guard rebuild 2>&1)"
+{ [[ ! -s "$WL_LOG" ]] && [[ -z "$out" ]]; } && ok "opt-out: no whitelist, no warn (even with risk)" || no "opt-out" "$(cat "$WL_LOG") | $out"
 
-echo "=== S2 re-entry guard: no recursion ==="
-reset_state; export SSH_CLIENT="203.0.113.7 51000 22" _NFTBAN_PREREBUILD_GUARD_ACTIVE=1
+echo "=== S2 re-entry beats risk: no recursion ==="
+reset_state; DETECT_PORTS="22"; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000" _NFTBAN_PREREBUILD_GUARD_ACTIVE=1
 nftban_ssh_pre_rebuild_lockout_guard reload >/dev/null 2>&1
 [[ ! -s "$WL_LOG" ]] && ok "re-entry: guard short-circuits (no recursive whitelist)" || no "re-entry" "$(cat "$WL_LOG")"
 
-echo "=== S2 not-in-ssh-session: no-op ==="
-reset_state
+echo "=== S2 not-in-ssh beats risk: no-op ==="
+reset_state; DETECT_PORTS="22"; export NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
 nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
-[[ ! -s "$WL_LOG" ]] && ok "no ssh session: guard is a no-op" || no "no-ssh no-op" "$(cat "$WL_LOG")"
+[[ ! -s "$WL_LOG" ]] && ok "no ssh session: guard is a no-op (even with risk declared)" || no "no-ssh no-op" "$(cat "$WL_LOG")"
 
 echo "=== invariant: guard NEVER imports the external port (ssh_ports unchanged) ==="
-reset_state; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
+reset_state; DETECT_PORTS="22"; export SSH_CLIENT="203.0.113.7 51000 22" NFTBAN_EXTERNAL_ADMIN_SSH_PORTS="55000"
 nftban_ssh_pre_rebuild_lockout_guard rebuild >/dev/null 2>&1
 [[ ! -s "$NFT_WRITE_LOG" ]] && ok "REJECT-C upheld: no ssh_ports import / no nft write at all" || no "import invariant" "$(cat "$NFT_WRITE_LOG")"
 


### PR DESCRIPTION
## Summary

Narrows the v1.150.1 SSHPORT pre-rebuild guard so the lockout-net fires **only** for the external-admin-port risk class — per `OPERATOR_DECISION_V150_1_N1 = NARROW_LOCKOUT_NET_ONLY_FOR_EXTERNAL_ADMIN_PORT_RISK`.

Previously the guard auto-session-whitelisted the operator source IP on **every** interactive `firewall reload/rebuild/init/takeover` over SSH, even on a normal `:22` host (the v1.150.1 code-logic review's **N1**). That is broader than the target risk class and creates unnecessary temporary trust expansion.

- **general interactive lockout-net rejected** — `REJECT_GENERAL_INTERACTIVE_LOCKOUT_NET = YES`.
- **normal `:22` host is now a true no-op** — no warning, no session-whitelist, no nested reload.
- **external `:55000→:22` declared-risk path** — when `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS` declares a port that is NOT a real sshd listener: **warn + IPC session-whitelist** the active admin source IP (existing `whitelist-session` path).
- **`:55000` is never imported into `ssh_ports`** unless `sshd` actually listens there.
- **no NAT/firewalld redirect ownership** — the redirect stays host-managed.

## How

New helper `_nftban_ssh_external_admin_risk_ports` returns declared ports that are not real sshd listeners; the guard gates **both** the warning and the lockout-net on a non-empty risk set, returning early (true no-op) otherwise. A native `:55000` listener has empty risk → no-op (it is already in `ssh_ports` via normal detection).

## Invariants

- **shell-only** (2 files: guard lib + test)
- **no daemon/core/internal Go** (`0 cmd/nftband`, `0 cmd/nftban-core`, `0 internal`)
- **no schema** change (1.83.0 frozen; daemon byte-identical)
- **no direct nft writes** (lockout-net uses the sanctioned IPC `whitelist-session` path; `check-nft-writes` 0 violations)
- preserved: recursion guard, `NFTBAN_NO_PREREBUILD_LOCKOUT=1` opt-out, `NFTBAN_PREREBUILD_LOCKOUT_TTL`

## Tests

`ssh_admin_port_guard_v150_test.sh` **36/36** (was 30/30): adds risk-helper cases, **normal-`:22` true-no-op**, **native-`:55000` no-op**, risk-path warn+IPC-whitelist, and opt-out/re-entry/no-ssh-beat-risk. shellcheck clean; `check-nft-writes.sh` 0 WRITE violations. CI step (blocking) runs it.

Review: `NFTBAN_ROADMAP/V150_1_SSHPORT_55000_CODE_LOGIC_REVIEW_FINAL.md` → verdict `SAFE_TO_TAG_V150_1_AFTER_N1_NARROWING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
