### PR TITLE
feat(v1.151): trust-output cleanup (panelfw weak-gate + exporter rc=143 + build-date + rebuild-log)

### DIFF
--- a/cli/lib/nftban/exporters/nftban_unified_exporter.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter.sh
@@ -44,8 +44,17 @@ set -Eeuo pipefail
 # attributed in the journal instead of exiting silently (status=2/INVALIDARGUMENT
 # observed on monitor). This self-pins the exact failing command on the next
 # occurrence for the Phase-2 surgical guard.
+#
+# v1.151 D-EXPORTER-EXIT2-PHASE-4 (signal-aware, class-killer): a SIGTERM/SIGINT
+# (rc>=128) can interrupt ANY command mid-collection (timer TimeoutStopSec, systemd
+# stop, slow collection killed) — that is NOT a logic error, it is the auxiliary,
+# idempotent collector being asked to stop ("next scheduled run will collect"). The
+# ERR trap previously logged it as ERROR: at whatever random line SIGTERM landed on
+# (whack-a-mole vs the v1.143.1 Phase-3 per-site guards). Now: rc>=128 → one INFO line
+# (graceful interruption, no ERROR); rc<128 (real command/logic failure) keeps the
+# loud diagnosable ERROR: line + re-raises rc. EXIT/TERM cleanup trap (below) still runs.
 # shellcheck disable=SC2154  # 'rc' is assigned (rc=$?) inside the single-quoted trap body
-trap 'rc=$?; printf "ERROR: nftban-unified-exporter aborted rc=%s at %s:%s fn=%s cmd=[%s]\n" "$rc" "${BASH_SOURCE[0]##*/}" "${LINENO}" "${FUNCNAME[0]:-main}" "${BASH_COMMAND}" >&2; exit "$rc"' ERR
+trap 'rc=$?; if [[ "$rc" -ge 128 ]]; then printf "INFO: nftban-unified-exporter interrupted by signal (rc=%s) at %s:%s; next scheduled run will collect\n" "$rc" "${BASH_SOURCE[0]##*/}" "${LINENO}" >&2; exit "$rc"; fi; printf "ERROR: nftban-unified-exporter aborted rc=%s at %s:%s fn=%s cmd=[%s]\n" "$rc" "${BASH_SOURCE[0]##*/}" "${LINENO}" "${FUNCNAME[0]:-main}" "${BASH_COMMAND}" >&2; exit "$rc"' ERR
 
 readonly SCRIPT_VERSION="1.0.0"
 

--- a/cli/lib/nftban/lib/version.sh
+++ b/cli/lib/nftban/lib/version.sh
@@ -69,7 +69,30 @@ readonly NFTBAN_VERSION_PATCH
 # Version details
 readonly NFTBAN_VERSION_NAME="Linux IPS & nftables Firewall"
 readonly NFTBAN_VERSION_DATE="2026-03-18"
-NFTBAN_BUILD_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
+
+# v1.151 BUG-VERSION-BUILD-DATE-RUNTIME: "Build Date" must reflect the PACKAGE
+# build, not the current clock. The old `$(date)` here made `nftban version`
+# print the run-second on every invocation (useless for support / CVE-patch
+# tracking). Resolution order — NEVER the current clock:
+#   1. a build-written stamp file (forward-compat; future packaging may write it)
+#   2. the package manager's recorded BUILD time (rpm) — real on RPM hosts
+#   3. "unknown" — honest fallback (source builds / DEB without a stamp)
+_nftban_resolve_build_date() {
+    local _stamp="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/.build_date" _d _t
+    if [[ -r "$_stamp" ]]; then
+        _d=$(head -n1 "$_stamp" 2>/dev/null | tr -d '\r')
+        [[ -n "$_d" ]] && { printf '%s' "$_d"; return 0; }
+    fi
+    if command -v rpm >/dev/null 2>&1; then
+        _t=$(rpm -q --qf '%{BUILDTIME}' nftban-core 2>/dev/null) || _t=""
+        if [[ "$_t" =~ ^[0-9]+$ ]]; then
+            _d=$(date -u -d "@${_t}" '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null) || _d=""
+            [[ -n "$_d" ]] && { printf '%s' "$_d"; return 0; }
+        fi
+    fi
+    printf 'unknown'
+}
+NFTBAN_BUILD_DATE="$(_nftban_resolve_build_date)"
 readonly NFTBAN_BUILD_DATE
 
 # Component versions (kept in sync with main version)

--- a/cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh
+++ b/cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.151 D-EXPORTER-EXIT2-PHASE-4: signal-aware ERR trap (class-killer)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="exporter_sigterm_graceful_v151_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Exercises the REAL permanent ERR trap shipped in nftban_unified_exporter.sh: a signal-induced rc (>=128, e.g. 143 SIGTERM / 130 SIGINT) must be reported as a graceful INFO interruption (no ERROR:), while a real command/logic failure (rc<128) must keep the loud diagnosable ERROR: line. The trap is extracted verbatim from the source so the test verifies the shipped behavior, not a copy. Hermetic: temp scripts only; no host/nft/IPC."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/exporters/nftban_unified_exporter.sh"
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+SRC="$REPO_ROOT/cli/lib/nftban/exporters/nftban_unified_exporter.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Extract the REAL ERR trap line shipped in the exporter (single line ending in ' ERR').
+TRAP_LINE="$(grep -E "^trap '.*' ERR$" "$SRC" | head -1)"
+[[ -n "$TRAP_LINE" ]] && ok "extracted the shipped ERR trap from the exporter" \
+                      || no "could not find the ERR trap in $SRC"
+
+# run_case <exit-code> → prints the trap's stderr output followed by 'RC=<rc>'
+run_case() {
+    local code="$1" tmp out rc
+    tmp="$(mktemp)"
+    {
+        echo 'set -Eeuo pipefail'
+        printf '%s\n' "$TRAP_LINE"
+        echo "( exit $code )"   # a command that returns <code> → fires the ERR trap
+    } > "$tmp"
+    out="$(bash "$tmp" 2>&1)"; rc=$?
+    rm -f "$tmp"
+    printf '%s\nRC=%s' "$out" "$rc"
+}
+
+echo "=== rc=143 (SIGTERM) → graceful INFO, NOT ERROR ==="
+r="$(run_case 143)"
+echo "$r" | grep -q "interrupted by signal (rc=143)" && ok "143: emits graceful INFO interruption" || no "143 INFO" "$r"
+echo "$r" | grep -q "next scheduled run will collect" && ok "143: reassures next run collects" || no "143 next-run" "$r"
+echo "$r" | grep -qi "ERROR: nftban-unified-exporter aborted" && no "143: must NOT emit ERROR" "$r" || ok "143: no ERROR line"
+echo "$r" | grep -q "RC=143" && ok "143: preserves exit code 143" || no "143 rc" "$r"
+
+echo "=== rc=130 (SIGINT) → graceful INFO ==="
+r="$(run_case 130)"
+echo "$r" | grep -q "interrupted by signal (rc=130)" && ok "130: graceful INFO" || no "130 INFO" "$r"
+echo "$r" | grep -qi "ERROR:.*aborted" && no "130: must NOT emit ERROR" "$r" || ok "130: no ERROR line"
+
+echo "=== rc=1 (real logic failure) → loud ERROR (regression guard) ==="
+r="$(run_case 1)"
+echo "$r" | grep -q "ERROR: nftban-unified-exporter aborted rc=1" && ok "1: keeps diagnosable ERROR line" || no "1 ERROR" "$r"
+echo "$r" | grep -q "interrupted by signal" && no "1: must NOT be treated as a signal" "$r" || ok "1: not mislabeled as signal"
+echo "$r" | grep -q "RC=1" && ok "1: preserves exit code 1" || no "1 rc" "$r"
+
+echo "=== rc=2 (INVALIDARGUMENT class) → loud ERROR ==="
+r="$(run_case 2)"
+echo "$r" | grep -q "ERROR: nftban-unified-exporter aborted rc=2" && ok "2: keeps ERROR line" || no "2 ERROR" "$r"
+
+echo ""
+echo "================================================================"
+echo "exporter_sigterm_graceful_v151: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/version_build_date_v151_test.sh
+++ b/cli/lib/nftban/tests/version_build_date_v151_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.151 BUG-VERSION-BUILD-DATE-RUNTIME: build-date resolver
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="version_build_date_v151_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Verifies _nftban_resolve_build_date in lib/version.sh never returns the current clock. Resolution order: (1) build-stamp file ${NFTBAN_LIB_DIR}/.build_date, (2) rpm BUILDTIME of nftban-core, (3) literal 'unknown'. Asserts the stamp wins, the rpm path formats the real build epoch (UTC, not today), and the absent path is 'unknown' — never \$(date)-now. Hermetic: temp NFTBAN_LIB_DIR + rpm() stub; no host/nft/IPC."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,date,grep"
+# meta:inventory.files="cli/lib/nftban/lib/version.sh"
+# meta:inventory.binaries="bash,date"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+VS="$REPO_ROOT/cli/lib/nftban/lib/version.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# resolve <setup-shell-snippet> → runs the snippet then prints _nftban_resolve_build_date,
+# each in its own subshell (version.sh sets readonly vars / strict mode).
+resolve() {
+    local setup="$1"
+    bash -c '
+        set +e
+        eval "$1"
+        # shellcheck source=/dev/null
+        source "$2" >/dev/null 2>&1 || true
+        _nftban_resolve_build_date
+    ' _ "$setup" "$VS"
+}
+
+TODAY="$(date '+%Y-%m-%d')"
+
+echo "=== resolver exists in version.sh ==="
+grep -q '_nftban_resolve_build_date' "$VS" && ok "function present" || no "function missing"
+grep -qE 'NFTBAN_BUILD_DATE="\$\(date ' "$VS" && no "still uses \$(date) for build date!" || ok "no raw \$(date) build-date assignment"
+
+echo "=== 1. build-stamp file wins ==="
+D1="$(mktemp -d)"; printf 'STAMP-2026-06-01 09:00:00 UTC\n' > "$D1/.build_date"
+out="$(resolve "NFTBAN_LIB_DIR='$D1'; rpm() { echo 9999999999; }")"
+[[ "$out" == "STAMP-2026-06-01 09:00:00 UTC" ]] && ok "stamp file used verbatim (beats rpm)" || no "stamp" "$out"
+rm -rf "$D1"
+
+echo "=== 2. rpm BUILDTIME → real UTC date (not today) ==="
+D2="$(mktemp -d)"  # empty: no stamp
+EPOCH=1717286400   # fixed past build epoch
+EXP="$(date -u -d "@$EPOCH" '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null)"
+out="$(resolve "NFTBAN_LIB_DIR='$D2'; rpm() { echo $EPOCH; }")"
+[[ "$out" == "$EXP" ]] && ok "rpm path formats real BUILDTIME ($EXP)" || no "rpm path" "got=$out exp=$EXP"
+[[ "$out" != "$TODAY"* ]] && ok "rpm path is NOT today's date" || no "rpm-today regression" "$out"
+rm -rf "$D2"
+
+echo "=== 3. no stamp + package-absent rpm → 'unknown' (safe fallback, never now) ==="
+D3="$(mktemp -d)"
+out="$(resolve "NFTBAN_LIB_DIR='$D3'; rpm() { return 1; }")"
+[[ "$out" == "unknown" ]] && ok "absent → 'unknown'" || no "unknown fallback" "$out"
+[[ "$out" != "$TODAY"* ]] && ok "fallback is NOT today's date (no \$(date)-now leak)" || no "fallback-today regression" "$out"
+rm -rf "$D3"
+
+echo "=== 4. rpm emits non-numeric → 'unknown' (no bogus date) ==="
+D4="$(mktemp -d)"
+out="$(resolve "NFTBAN_LIB_DIR='$D4'; rpm() { echo 'not-installed'; }")"
+[[ "$out" == "unknown" ]] && ok "non-numeric BUILDTIME → 'unknown'" || no "non-numeric" "$out"
+rm -rf "$D4"
+
+echo ""
+echo "================================================================"
+echo "version_build_date_v151: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/internal/installer/panelfw/panelfw.go
+++ b/internal/installer/panelfw/panelfw.go
@@ -231,6 +231,16 @@ func EvaluateAdapters(ctx context.Context, exec executor.Executor, log *logging.
 		if !det.Detected {
 			continue
 		}
+		// v1.151 BUG-PANELFW-WEAK-DA-FALSE-POSITIVE: a "weak" detection is a single
+		// host-environment signal (e.g. a bare alt-SSH listener such as :2222 on a
+		// no-panel host), not a confirmed panel. It must NOT be validated or have its
+		// panel port set printed as if integrated. Treat it as not-confirmed and keep
+		// scanning; if no adapter is confirmed the host falls through to no-panel.
+		if det.Confidence == "weak" {
+			log.Info("panelfw: weak %s signal ignored (confidence=weak); no confirmed panel — not validating or printing panel ports",
+				string(det.ID))
+			continue
+		}
 		log.Info("panelfw: detected panel id=%s confidence=%s",
 			string(det.ID), det.Confidence)
 		return finalizeDetected(ctx, exec, log, a, det, policy)

--- a/internal/installer/panelfw/panelfw_test.go
+++ b/internal/installer/panelfw/panelfw_test.go
@@ -388,3 +388,65 @@ func TestEvaluateAdapters_NilLoggerTolerated(t *testing.T) {
 		t.Errorf("nil logger + empty adapters + default policy should be non-fatal")
 	}
 }
+
+// ----------------------------------------------------------------------------
+// v1.151 BUG-PANELFW-WEAK-DA-FALSE-POSITIVE: a "weak" detection (single
+// host-env signal, e.g. a bare :2222 listener on a no-panel host) must NOT be
+// validated or have its panel port set printed as if confirmed.
+// ----------------------------------------------------------------------------
+
+func TestFake_WeakDetection_NotValidated_FallsToNoPanel(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue: "directadmin",
+		DetectResult: PanelDetection{
+			ID:         "directadmin",
+			Detected:   true,
+			Confidence: "weak", // single indicator → must be ignored
+			Evidence:   []string{"listener-tcp:2222"},
+		},
+		RequiredTCP: []int{35000, 35999}, // would be printed if (wrongly) finalized
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+
+	// Weak → not confirmed → no panel ports queried/validated/printed.
+	if fake.RequiredCalls != 0 || fake.ReachabilityCalls != 0 {
+		t.Errorf("weak detection must NOT validate/print ports; got Required=%d Reachability=%d",
+			fake.RequiredCalls, fake.ReachabilityCalls)
+	}
+	// Falls through to no-panel (DefaultPolicy allows absent → non-fatal).
+	if res.Detection.Detected {
+		t.Errorf("weak detection must NOT be reported as a confirmed panel")
+	}
+	if res.PortsApplied {
+		t.Errorf("PortsApplied must be false for a weak (unconfirmed) detection")
+	}
+	if res.Fatal {
+		t.Errorf("weak-only host with AllowPanelAbsent=true must be non-fatal; got %#v", res)
+	}
+	if fake.DetectCalls != 1 {
+		t.Errorf("Detect should be called once; got %d", fake.DetectCalls)
+	}
+}
+
+// Regression guard: a STRONG detection still finalizes (validates + applies ports).
+func TestFake_StrongDetection_StillFinalizes(t *testing.T) {
+	fake := &FakePanelAdapter{
+		IDValue: "directadmin",
+		DetectResult: PanelDetection{
+			ID:         "directadmin",
+			Detected:   true,
+			Confidence: "strong",
+		},
+		RequiredTCP: []int{2222, 2086},
+	}
+	res := EvaluateAdapters(context.Background(), executor.NewMockExecutor(), newTestLogger(),
+		[]PanelAdapter{fake}, DefaultPolicy())
+	if fake.RequiredCalls != 1 || fake.ReachabilityCalls != 1 {
+		t.Errorf("strong detection must validate/apply ports; got Required=%d Reachability=%d",
+			fake.RequiredCalls, fake.ReachabilityCalls)
+	}
+	if !res.PortsApplied || !res.Detection.Detected {
+		t.Errorf("strong detection must finalize as a confirmed panel; got %#v", res)
+	}
+}

--- a/internal/installer/switchop/rebuild.go
+++ b/internal/installer/switchop/rebuild.go
@@ -19,6 +19,7 @@ package switchop
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
@@ -26,15 +27,29 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
+// lastNonEmptyLine returns the last non-empty, trimmed line of s, or "".
+// Used to recover a degraded-rebuild reason when the shell emits it to stdout
+// (marker line) rather than stderr.
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
 // rebuildTimeout is the wall-clock limit for nftban firewall rebuild.
 const rebuildTimeout = 60 * time.Second
 
 // Rebuild runs "nftban firewall rebuild" and returns an error if it fails.
 // Shell rebuild exit code contract (authoritative — do not redefine):
-//   0 = PROTECTED (all checks passed)
-//   1 = DEGRADED  (firewall operational, some module checks failed)
-//   2 = FAILED    (rollback happened)
-//   3 = FATAL     (rollback also failed)
+//
+//	0 = PROTECTED (all checks passed)
+//	1 = DEGRADED  (firewall operational, some module checks failed)
+//	2 = FAILED    (rollback happened)
+//	3 = FATAL     (rollback also failed)
 //
 // Exit 1 (DEGRADED) is expected during upgrade: module-scoped chains
 // require the daemon to be running, which may not be the case yet.
@@ -49,7 +64,20 @@ func Rebuild(exec executor.Executor, log *logging.Logger) error {
 		// DEGRADED: firewall base schema is loaded but module chains may be
 		// missing (daemon was down during module re-enable). This is recoverable
 		// — module chains will be re-created when daemon starts with modules enabled.
-		log.Warn("firewall rebuild DEGRADED (exit 1): %s", res.Stderr)
+		//
+		// v1.151 BUG-REBUILD-DEGRADED-EMPTY-REASON: the recoverable exit-1 case emits
+		// its reason to stdout (marker), not stderr, so res.Stderr was empty → the log
+		// read "DEGRADED (exit 1): " (blank). Recover a real reason (stderr → last
+		// stdout line → static explanation) so the operator is never told "DEGRADED"
+		// with no cause during the most safety-critical Switch phase.
+		reason := strings.TrimSpace(res.Stderr)
+		if reason == "" {
+			reason = lastNonEmptyLine(res.Stdout)
+		}
+		if reason == "" {
+			reason = "base schema loaded; module chains deferred to daemon start"
+		}
+		log.Warn("firewall rebuild DEGRADED (exit 1): %s", reason)
 		log.Warn("module chains may be absent — will be created on daemon start")
 		// Continue — do not fail the install for a degraded rebuild
 	} else if res.ExitCode >= 2 {
@@ -60,7 +88,14 @@ func Rebuild(exec executor.Executor, log *logging.Logger) error {
 		return fmt.Errorf("nftban firewall rebuild failed (exit %d): %s", res.ExitCode, res.Stderr)
 	}
 
-	log.Info("firewall rebuild completed (exit %d)", res.ExitCode)
+	// v1.151 BUG-REBUILD-DEGRADED-EMPTY-REASON: never log "completed (exit 1)" — that
+	// contradicts the DEGRADED warning above and reads as a FAILED takeover, tempting
+	// the operator to Ctrl+C / rollback at the worst moment when it actually recovered.
+	if res.ExitCode == 0 {
+		log.Info("firewall rebuild completed")
+	} else {
+		log.Info("firewall rebuild finished DEGRADED (exit %d) — module chains deferred to daemon start (recovery expected)", res.ExitCode)
+	}
 
 	// Write schema version file (G7 parity with shell postinst).
 	// The shell postinst wrote: echo "$CURRENT_SCHEMA" > /etc/nftban/.schema_version

--- a/internal/installer/switchop/rebuild_test.go
+++ b/internal/installer/switchop/rebuild_test.go
@@ -18,6 +18,9 @@
 package switchop
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
@@ -68,5 +71,74 @@ func TestRebuild_Failure(t *testing.T) {
 	// Verify install-failed marker was written
 	if !mock.FileExists("/run/nftban/install_failed") {
 		t.Error("expected install_failed marker to be written")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// v1.151 BUG-REBUILD-DEGRADED-EMPTY-REASON: degraded rebuild must log a real
+// reason and must NOT log the self-contradictory "completed (exit 1)".
+// ----------------------------------------------------------------------------
+
+func readLog(t *testing.T) (*logging.Logger, func() string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "installer.log")
+	l := logging.New(p, false)
+	return l, func() string {
+		l.Close()
+		b, _ := os.ReadFile(p)
+		return string(b)
+	}
+}
+
+func TestRebuild_DegradedReason_FromStdout_NoContradiction(t *testing.T) {
+	// Real recoverable case: exit 1 with EMPTY stderr; reason is on stdout.
+	mock := executor.NewMockExecutor()
+	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{
+		ExitCode: 1, Stderr: "", Stdout: "base schema applied\nmodule chains pending daemon",
+	}
+	log, dump := readLog(t)
+	if err := Rebuild(mock, log); err != nil {
+		t.Fatalf("exit 1 (DEGRADED) must not error: %v", err)
+	}
+	out := dump()
+	if !strings.Contains(out, "DEGRADED (exit 1): module chains pending daemon") {
+		t.Errorf("expected reason recovered from stdout; got:\n%s", out)
+	}
+	if strings.Contains(out, "completed (exit 1)") {
+		t.Errorf("must NOT log self-contradictory 'completed (exit 1)'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "finished DEGRADED (exit 1)") {
+		t.Errorf("expected 'finished DEGRADED (exit 1)' wording; got:\n%s", out)
+	}
+}
+
+func TestRebuild_DegradedEmptyOutput_StaticReason(t *testing.T) {
+	// exit 1 with empty stderr AND empty stdout → static fallback reason (never blank).
+	mock := executor.NewMockExecutor()
+	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{ExitCode: 1}
+	log, dump := readLog(t)
+	_ = Rebuild(mock, log)
+	out := dump()
+	if !strings.Contains(out, "DEGRADED (exit 1): base schema loaded; module chains deferred to daemon start") {
+		t.Errorf("expected static fallback reason (never blank); got:\n%s", out)
+	}
+	if strings.Contains(out, "completed (exit 1)") {
+		t.Errorf("must NOT log 'completed (exit 1)'; got:\n%s", out)
+	}
+}
+
+func TestRebuild_Success_PlainCompleted(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	mock.RunResults["/usr/sbin/nftban:firewall:rebuild"] = executor.Result{ExitCode: 0}
+	log, dump := readLog(t)
+	if err := Rebuild(mock, log); err != nil {
+		t.Fatalf("exit 0 must not error: %v", err)
+	}
+	out := dump()
+	if !strings.Contains(out, "firewall rebuild completed") {
+		t.Errorf("expected 'firewall rebuild completed'; got:\n%s", out)
+	}
+	if strings.Contains(out, "completed (exit") {
+		t.Errorf("exit 0 must log plain 'completed', not 'completed (exit N)'; got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary

v1.151.0 — **small cleanup / trust-output hotfix**. Four operator-visible false/confusing-output fixes, no functional cutover. **Daemon byte-identical to v1.150.1** (`0 cmd/nftband`, `0 cmd/nftban-core`); **`0` schema**; **no CSF**. Installer-Go limited to panelfw + rebuild-log (output/decision wording only).

| Item | Fix |
|------|-----|
| **BUG-PANELFW-WEAK-DA-FALSE-POSITIVE** | `panelfw.go` — gate `finalizeDetected` on `Confidence != "weak"`. A weak single-signal detection (e.g. a bare `:2222` listener on a no-panel host) is no longer validated and does **not** print the DirectAdmin port set as if confirmed; logs "weak signal ignored". |
| **D-EXPORTER-EXIT2-PHASE-4 (rc=143)** | `nftban_unified_exporter.sh:48` — signal-aware ERR trap: `rc>=128` (SIGTERM/SIGINT) → graceful **INFO** ("interrupted by signal; next run will collect"), no `ERROR:`; `rc<128` keeps the loud diagnosable line. Class-killer vs the v1.143.1 per-site whack-a-mole. |
| **BUG-VERSION-BUILD-DATE-RUNTIME** | `version.sh` — `nftban version` no longer prints the current clock as "Build Date". Resolves build-stamp file → `rpm` BUILDTIME → `"unknown"`; **never `$(date)`-now**. |
| **BUG-REBUILD-DEGRADED-EMPTY-REASON** | `rebuild.go` — degraded rebuild logs a real reason (stderr → last stdout line → static) and never the self-contradictory "completed (exit 1)". |

## Envelope / invariants
- `0 cmd/nftband` (daemon byte-identical) · `0 cmd/nftban-core` · `0` schema · no direct nft · no CSF.
- Installer-Go (`cmd/nftban-installer`) touched only for panelfw weak-gate + rebuild-log wording.
- Shell + build-tooling for exporter + build-date.

## Tests (all green)
- **Go (lab2 go1.25):** `gofmt` clean · `go vet ./...` clean · `go build ./...` clean · all tests PASS — `panelfw_test.go` +2 (weak-skip, strong-finalizes), `rebuild_test.go` +3 (degraded-reason-from-stdout, static-fallback, plain-completed), plus existing.
- **Shell (local):** `exporter_sigterm_graceful_v151_test.sh` **11/0** · `version_build_date_v151_test.sh` **8/0** · shellcheck `-S warning`/`-S error` clean.
- `check-nft-writes.sh` **0 WRITE violations**.

Part of the locked cleanup train: **v1.151 (this)** → v1.152 feeds+stats truth → v1.153 UX-consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
