### PR TITLE
ux(v1.153): normalize CLI output truth and banner consistency

### DIFF
--- a/cli/lib/nftban/cli/cmd_list.sh
+++ b/cli/lib/nftban/cli/cmd_list.sh
@@ -309,6 +309,12 @@ nftban_cmd_list() {
                 sorted_keys+=("$key")
             done < <(printf '%s\n' "${!all_ips[@]}" | sort)
 
+            # v1.153 UX-A4: clamp the IP column in the HUMAN table so a long
+            # IPv6 CIDR (e.g. 2400:cb00:…:ffff/128, up to 51 chars) cannot push
+            # the Type/Version columns out of alignment. The clamp affects the
+            # human view ONLY — the --json path above emits the full, unclamped
+            # IP value. Width 40 matches the "%-40s" column header above.
+            local _ipcol_w=40
             for ip in "${sorted_keys[@]}"; do
                 local meta="${all_ips[$ip]}"
                 local set_name="${meta%:*}"
@@ -316,7 +322,14 @@ nftban_cmd_list() {
                 local icon=""
                 [[ "$set_name" == "blacklist" ]] && icon="🚫"
                 [[ "$set_name" == "whitelist" ]] && icon="✅"
-                printf "  %s %-40s %-12s %-8s\n" "$icon" "$ip" "$set_name" "$ip_version"
+                # Display value: clamp to the column width with an ASCII '...'
+                # marker so the table stays aligned (ASCII keeps printf's byte
+                # padding == visual padding). Full value remains in --json.
+                local ip_disp="$ip"
+                if (( ${#ip_disp} > _ipcol_w )); then
+                    ip_disp="${ip_disp:0:_ipcol_w-3}..."
+                fi
+                printf "  %s %-40s %-12s %-8s\n" "$icon" "$ip_disp" "$set_name" "$ip_version"
             done
         else
             echo ""

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -673,9 +673,22 @@ _status_section_authority() {
 
     echo "AUTHORITY"
     echo "───────────────────────────────────────────────────────────────"
-    printf "  %-20s %s\n" "Install authority..." "$authority"
-    if [[ -n "$conflicts" ]]; then
-        printf "  %-20s %s\n" "Active conflicts...." "$conflicts"
+    # v1.153 UX-A1: frame the authority block by what it actually means.
+    # When nftban holds authority (NOT AMBIGUOUS), the recorded CONFLICTS are
+    # legacy firewalls that were *neutralized* at takeover — they are no longer
+    # fighting nftban. The pre-v1.153 line read "Active conflicts.... UFW,…"
+    # which mis-implied four firewalls still contending. Only the AMBIGUOUS
+    # path means they are genuinely still active (handled below).
+    if [[ "$authority" == "AMBIGUOUS" ]]; then
+        nftban_kv "Firewall authority" "⚠️  AMBIGUOUS"
+        if [[ -n "$conflicts" ]]; then
+            nftban_kv "Active conflicts" "$conflicts"
+        fi
+    else
+        nftban_kv "Firewall authority" "🔒 EXCLUSIVE ($authority)"
+        if [[ -n "$conflicts" ]]; then
+            nftban_kv "Legacy firewalls" "🛡️ NEUTRALIZED: $conflicts"
+        fi
     fi
     if [[ "$authority" == "AMBIGUOUS" && -n "$conflicts" ]]; then
         echo ""
@@ -716,7 +729,10 @@ _status_section_protection() {
 
     # Suricata IDS (check binary + service + EVE freshness for consistent reporting)
     # Matches the same 3-tier check used by portscan and ddos modules
-    local suricata_status="NOT INSTALLED"
+    # v1.153 UX-A5: Suricata is an optional add-on — say so, and use one
+    # consistent "not installed (optional add-on)" term (not the bare
+    # "NOT INSTALLED" that read like a fault).
+    local suricata_status="[i] not installed (optional add-on)"
     local suricata_eve_ok=false
     local eve_threshold="${PORTSCAN_EVE_FRESHNESS_THRESHOLD:-60}"
     if command -v suricata &>/dev/null; then
@@ -784,7 +800,7 @@ _status_section_protection() {
             suricata_status="INSTALLED (stopped)"
         fi
     fi
-    printf "  %-20s %s\n" "Suricata IDS........" "$suricata_status"
+    nftban_kv "Suricata IDS" "$suricata_status"
 
     # DDoS Protection — v1.83 DUP-3: read from validator JSON, not config+kernel
     local ddos_status="DISABLED"
@@ -1172,10 +1188,14 @@ _status_section_health() {
     fi
 
     # v1.66.0: If firewall is PROTECTED, don't show misleading ERROR from optional checks
+    # v1.153 UX-A6: this is the HEALTH section's own roll-up, not a second
+    # authoritative posture verdict. Label it "Health" so the authoritative
+    # firewall posture is stated once (in the State line), and the health
+    # roll-up reads as diagnostics rather than a competing PROTECTED claim.
     if [[ "$_health_base_state" == "PROTECTED" ]] && [[ "$health_status" == *"ERROR"* || "$health_status" == *"CRITICAL"* ]]; then
-        printf "  %-20s %s\n" "Overall Status......" "PROTECTED (info notices)"
+        nftban_kv "Health" "OK (info notices)"
     else
-        printf "  %-20s %s\n" "Overall Status......" "$health_status"
+        nftban_kv "Health" "$health_status"
     fi
 
     # Check binary integrity (show warning if corrupted)
@@ -1379,15 +1399,38 @@ _status_section_timers() {
     local timer_count=0
     local timer_active=0
     local timer_output=""
+    # v1.153 UX-A2: partition timers into CORE (always-on, must run) vs
+    # OPTIONAL (config-gated, off by design) so the summary stops reading the
+    # bare "8 / 16" as a 50% failure. The core set mirrors the always-enabled
+    # timers in lib/service_control.sh (health, maintenance, watchdog + the
+    # default-on geoip). FAILED counts only core timers that are enabled but
+    # not active — an optional disabled timer is not a failure.
+    local -A core_timer=(
+        ["nftban-health.timer"]=1
+        ["nftban-maintenance.timer"]=1
+        ["nftban-watchdog.timer"]=1
+        ["nftban-core-geoip.timer"]=1
+    )
+    local core_installed=0 core_active=0
+    local optional_installed=0 optional_disabled=0
+    local timer_failed=0
 
     for timer in "${!timer_desc[@]}"; do
         if systemctl list-unit-files "$timer" --no-legend 2>/dev/null | grep -q "$timer"; then
             timer_count=$((timer_count + 1))
             local status_text="INACTIVE"
             local next_run=""
+            local _is_core=0
+            [[ -n "${core_timer[$timer]:-}" ]] && _is_core=1
+            if [[ $_is_core -eq 1 ]]; then
+                core_installed=$((core_installed + 1))
+            else
+                optional_installed=$((optional_installed + 1))
+            fi
 
             if _unit_is_active "$timer"; then
                 timer_active=$((timer_active + 1))
+                [[ $_is_core -eq 1 ]] && core_active=$((core_active + 1))
 
                 # Get time left until next trigger
                 # systemctl show gives seconds until next elapse (reliable, locale-independent)
@@ -1418,6 +1461,22 @@ _status_section_timers() {
                 fi
             elif systemctl is-enabled "$timer" >/dev/null 2>&1; then
                 status_text="ENABLED (stopped)"
+                # Enabled-but-not-active is only a failure for a core timer;
+                # an optional timer that is enabled-but-stopped is counted as a
+                # core failure only when core, else treated as disabled/optional.
+                if [[ $_is_core -eq 1 ]]; then
+                    timer_failed=$((timer_failed + 1))
+                else
+                    optional_disabled=$((optional_disabled + 1))
+                fi
+            else
+                # Inactive + not enabled = disabled by design for optional,
+                # a failure for a core timer that should always run.
+                if [[ $_is_core -eq 1 ]]; then
+                    timer_failed=$((timer_failed + 1))
+                else
+                    optional_disabled=$((optional_disabled + 1))
+                fi
             fi
 
             # Format timer name (remove .timer suffix and prefix)
@@ -1433,11 +1492,14 @@ _status_section_timers() {
     done
 
     if [[ $timer_count -gt 0 ]]; then
-        printf "  %-20s %s\n" "Active timers......." "$timer_active / $timer_count"
+        # v1.153 UX-A2: report core vs optional vs failed instead of a bare
+        # ratio that reads as a failure. Example:
+        #   Core 4/4 active · Optional 8 disabled · Failed 0
+        nftban_kv "Active timers" "Core ${core_active}/${core_installed} active · Optional ${optional_disabled} disabled · Failed ${timer_failed}"
         echo ""
         echo -n "$timer_output"
     else
-        printf "  %-20s %s\n" "Active timers......." "None installed"
+        nftban_kv "Active timers" "None installed"
     fi
 
     # Timer status explanation
@@ -2039,8 +2101,9 @@ check_service_clean() {
     padded_name="${padded_name// /.}"
 
     # Check if unit exists
+    # v1.153 UX-A5: one consistent term — "not installed (optional add-on)".
     if ! systemctl list-unit-files "$unit" --no-legend 2>/dev/null | grep -q "$unit"; then
-        printf "  %s NOT INSTALLED (optional)\n" "$padded_name"
+        printf "  %s not installed (optional add-on)\n" "$padded_name"
         return 0
     fi
 

--- a/cli/lib/nftban/core/nftban_health_fixes.sh
+++ b/cli/lib/nftban/core/nftban_health_fixes.sh
@@ -95,7 +95,13 @@ nftban_health_fix_auditor_acls() {
     if [[ $acl_errors -eq 0 ]]; then
         echo "  ✓ Auditor ACLs configured successfully"
     else
-        echo "  ⚠ Some auditor ACLs could not be set ($acl_errors errors)"
+        # v1.153 UX-T1: name the warning class instead of silently swallowing.
+        # These setfacl/chown failures on intentionally root-owned FHS child
+        # dirs are non-fatal (the auditor read-only convenience layer is
+        # optional). The stable id WARN_PERMISSIONS_ENFORCE_NONFATAL makes the
+        # message greppable in install/health logs and signals "expected,
+        # non-fatal" rather than reading as an unexplained error.
+        echo "  ⚠ WARN_PERMISSIONS_ENFORCE_NONFATAL: ${acl_errors} auditor ACL(s) could not be set on root-owned FHS dirs (non-fatal; optional read-only auditor layer)"
     fi
 
     return 0
@@ -129,7 +135,15 @@ nftban_health_fix_permissions() {
             if systemd-tmpfiles --create "$tmpfiles_conf" 2>/dev/null; then
                 echo "  ✓ FHS runtime directories restored via tmpfiles.d"
             else
-                echo "  ⚠ systemd-tmpfiles returned non-zero (some dirs may not exist yet)"
+                # v1.153 UX-T2: name the warning class. systemd-tmpfiles can
+                # exit non-zero (commonly exit 73 / EX_CANTCREAT-class) when it
+                # canonicalizes ownership on design-correct, intentionally
+                # root-owned FHS dirs, or when some dirs do not exist yet. This
+                # is non-fatal — the explicit ownership-enforcement step below
+                # is the defense-in-depth backstop. The stable id
+                # WARN_TMPFILES_73 makes it greppable and signals "expected,
+                # non-fatal" rather than an unexplained failure.
+                echo "  ⚠ WARN_TMPFILES_73: systemd-tmpfiles returned non-zero (tmpfiles canonicalization of design-correct ownership, or dirs not yet present); non-fatal — explicit ownership enforcement follows"
             fi
         fi
 

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -321,9 +321,33 @@ nftban_banner_unified() {
     # The cache file is still written by nftban-health.timer for other
     # consumers (nftban_get_cached_health) but is NOT a posture truth source.
 
+    # v1.153 PR-B universal suppression gate (NOBANNER-CONSIST). Honors
+    # --no-banner / --plain / --quiet / NFTBAN_NO_BANNER / NFTBAN_QUIET /
+    # NFTBAN_BANNER_MODE=none uniformly — every callsite flows through here.
+    _v141_banner_suppressed && return 0
+
     # Skip for non-interactive or JSON mode
     [[ "${NFTBAN_BANNER_MODE:-auto}" == "none" ]] && return 0
     [[ "${NFTBAN_OUTPUT_JSON:-false}" == "true" ]] && return 0
+
+    # v1.153 PR-B (UX-A3/UX-C4): resolve the REAL subcommand. Callsites that
+    # pass no mode default to "cli" — replace that with the dispatcher-exported
+    # NFTBAN_SUBCOMMAND so "Cmd:" is honest and the full-box gate is correct.
+    if [[ "$mode" == "cli" && -n "${NFTBAN_SUBCOMMAND:-}" ]]; then
+        mode="${NFTBAN_SUBCOMMAND}"
+    fi
+
+    # v1.153 PR-B: restrict the decorative full box to version / status /
+    # first-run (hello). Every other subcommand prints a single-line header
+    # instead, so `nftban list`, `nftban firewall`, … no longer emit the full
+    # box. This is the ONE banner path — known and unknown commands alike.
+    case "$mode" in
+        version|status|hello|first-run|"") : ;;  # full box allowed
+        *)
+            nftban_render_banner_simple
+            return 0
+            ;;
+    esac
 
     # Get version
     local version

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1078,6 +1078,41 @@ nftban_output() {
 export -f nftban_output 2>/dev/null || true
 
 # =============================================================================
+# SHARED LABEL / COLUMN CONVENTION (v1.153 CMD-CONSIST)
+# =============================================================================
+# One key/value line convention for the report-style commands (status,
+# health, stats, firewall, timers). Pre-v1.153 each section hand-rolled its
+# own `printf "  %-20s %s\n"` with hand-typed dot runs of varying width,
+# which drifted across commands. nftban_kv centralizes that single format so
+# the label column lines up everywhere.
+#
+# Behavior is purely cosmetic — it formats a label + value. No data is
+# computed or changed. The label is right-padded to NFTBAN_KV_WIDTH (default
+# 20) using '.' leaders, matching the historical dot-leader look, then the
+# value follows after one space.
+#
+# Usage: nftban_kv "Label" "value"
+#        nftban_kv "Label" "value" 24      # custom label width
+# Output (stdout): "  Label............... value"
+NFTBAN_KV_WIDTH="${NFTBAN_KV_WIDTH:-20}"
+nftban_kv() {
+    local label="${1:-}"
+    local value="${2:-}"
+    local width="${3:-$NFTBAN_KV_WIDTH}"
+    # Build a dot-leader label padded to width, matching the historical
+    # "Label.............." look used across the status sections. Only the
+    # TRAILING padding is converted to dots — internal spaces in multi-word
+    # labels ("Firewall authority") are preserved.
+    local pad_len=$(( width - ${#label} ))
+    (( pad_len < 1 )) && pad_len=1
+    local dots
+    dots=$(printf '%*s' "$pad_len" '')
+    dots="${dots// /.}"
+    printf "  %s%s %s\n" "$label" "$dots" "$value"
+}
+export -f nftban_kv 2>/dev/null || true
+
+# =============================================================================
 # FOOTER - Debug & Module Info
 # =============================================================================
 

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -180,12 +180,47 @@ cmd_error() {
         json_error "$message"
     else
         echo "ERROR: $message" >&2
+        # v1.153 UX-C2: parse-error paths must NOT reprint the ~30-line usage
+        # block. When a usage_func is supplied we instead emit a single
+        # actionable pointer line. The full usage text remains available via the
+        # explicit `--help` path (which calls the usage_func directly). We derive
+        # the command name from the conventional usage-func name
+        # (nftban_cmd_<name>_usage -> <name>) so the hint points at the right
+        # --help. Falls back to a generic pointer when the name is unconventional.
         if [[ -n "$usage_func" ]] && declare -f "$usage_func" &>/dev/null; then
-            echo "" >&2
-            "$usage_func" >&2
+            local _cmd_name="$usage_func"
+            _cmd_name="${_cmd_name#nftban_cmd_}"   # strip leading nftban_cmd_
+            _cmd_name="${_cmd_name%_usage}"        # strip trailing _usage
+            _cmd_name="${_cmd_name//_/ }"          # underscores -> spaces (subcmds)
+            if [[ -n "$_cmd_name" && "$_cmd_name" != "$usage_func" ]]; then
+                echo "  Run 'nftban ${_cmd_name} --help' for more" >&2
+            else
+                echo "  Run 'nftban <command> --help' for more" >&2
+            fi
         fi
     fi
     return 1
+}
+
+# v1.153 UX-C6 — _require_root_or_sudo_hint: a small guard that prints the
+# inline sudo / root-shell re-run guidance (via _v142_sudo_hint) when the
+# caller is not root, and returns non-zero so the caller can abort. Unlike
+# cmd_require_root this does NOT also emit the PolicyKit advisory line — it is
+# the minimal "you need root, here is how" guard for command entry points that
+# want the hint without the full advisory. Returns 0 when already root.
+#
+# Usage: _require_root_or_sudo_hint ["operation description"] ["$json_mode"]
+_require_root_or_sudo_hint() {
+    local operation="${1:-this operation}"
+    local json_mode="${2:-false}"
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        if [[ "$json_mode" != "true" ]]; then
+            echo "ERROR: '${operation}' requires root privileges" >&2
+        fi
+        _v142_sudo_hint "$operation" "$json_mode"
+        return 1
+    fi
+    return 0
 }
 
 # Print warning message (JSON-aware, doesn't return error)
@@ -537,6 +572,7 @@ export -f cmd_require_root
 export -f cmd_require_daemon
 export -f _v142_sudo_hint  # v1.142 UX-C6 — inline sudo / root-shell guidance
 export -f _v144_error_with_hint  # v1.144.0 PR-B UX-C2 — three-line ERROR/Hint/Run
+export -f _require_root_or_sudo_hint  # v1.153 UX-C6 — root guard + inline sudo hint
 export -f cmd_show_banner
 export -f cmd_section
 export -f cmd_kv

--- a/cli/lib/nftban/nftban_help.sh
+++ b/cli/lib/nftban/nftban_help.sh
@@ -85,33 +85,42 @@ nftban_print_help() {
 # =============================================================================
 
 _nftban_help_essential() {
+    # v1.153 UX-A7: surface the same ⚡/⚠️ risk markers the `help --all` view
+    # carries, so the short list flags state-changing verbs at a glance.
+    #   ⚡ = state-changing (mutates kernel/config); ⚠️ = advanced / use with
+    #   caution. Unmarked = read-only. Markers mirror the registry risk class
+    #   (commands.registry.yml) and scripts/generate-help.sh RISK_ICONS, no
+    #   behavior change.
     cat <<'EOF'
 USAGE:
   nftban <command> [subcommand] [options]
 
 ESSENTIAL COMMANDS:
-  status        System status overview
-  health        Diagnostics and auto-repair
-  ban           Ban an IP address
-  unban         Remove IP ban
-  list          List banned/whitelisted IPs
-  search        Search IP across all sets
-  blacklist     Blacklist management (add/remove/list/flush)
-  whitelist     Whitelist management (add/remove/list)
-  feeds         Threat intelligence feeds
-  firewall      Firewall management (reload/rebuild/record)
+     status        System status overview
+     health        Diagnostics and auto-repair
+  ⚡ ban           Ban an IP address
+  ⚡ unban         Remove IP ban
+     list          List banned/whitelisted IPs
+     search        Search IP across all sets
+  ⚡ blacklist     Blacklist management (add/remove/list/flush)
+  ⚡ whitelist     Whitelist management (add/remove/list)
+  ⚡ feeds         Threat intelligence feeds
+  ⚠️ firewall      Firewall management (reload/rebuild/record)
 
 PROTECTION MODULES:
-  ddos          DDoS protection (enable/disable/status)
-  portscan      Port scan detection (enable/disable/status)
-  login         Login monitor — SSH brute-force protection
-  botguard      HTTP bot guard (enable/disable/status/list)
-  geoban        Geographic IP blocking (enable/disable/list)
+  ⚡ ddos          DDoS protection (enable/disable/status)
+  ⚡ portscan      Port scan detection (enable/disable/status)
+  ⚡ login         Login monitor — SSH brute-force protection
+  ⚡ botguard      HTTP bot guard (enable/disable/status/list)
+  ⚡ geoban        Geographic IP blocking (enable/disable/list)
 
 SYSTEM:
-  config        Configuration management
-  version       Version information
-  update        Update NFTBan
+  ⚡ config        Configuration management
+     version       Version information
+  ⚠️ update        Update NFTBan
+
+LEGEND:
+  ⚡ state-changing    ⚠️ advanced / use with caution    (unmarked = read-only)
 
 EXIT CODES:
   0  Success    1  Error    2  Warning

--- a/cli/lib/nftban/tests/banner_nobanner_v153_test.sh
+++ b/cli/lib/nftban/tests/banner_nobanner_v153_test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-B: banner discipline + --no-banner/--plain/--quiet
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="banner_nobanner_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-B banner discipline: (1) NOBANNER-CONSIST — the dispatcher (cli/sbin/nftban) maps --plain and --quiet to the universal banner-suppression env (NFTBAN_NO_BANNER/NFTBAN_QUIET) the same way --no-banner does, and leaves them in argv so per-subcommand semantics still see them; (2) one banner path — nftban_banner_unified routes through _v141_banner_suppressed and restricts the decorative FULL BOX to version/status/hello/first-run, while every other subcommand (list/firewall/feeds/…) gets the one-line simple header; (3) Cmd: truth — callsites passing no mode resolve to the dispatcher-exported NFTBAN_SUBCOMMAND instead of the literal 'cli'. Hermetic: sources nftban_output.sh and stubs the two render functions to observe routing; drives the dispatcher with --plain/--quiet/--no-banner. No host/nft/IPC."
+# meta:input="cli/lib/nftban/core/nftban_output.sh + cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/core/nftban_output.sh,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_NO_BANNER,NFTBAN_QUIET,NFTBAN_BANNER_MODE,NFTBAN_SUBCOMMAND"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SBIN="$REPO/cli/sbin/nftban"
+OUTPUT="$REPO/cli/lib/nftban/core/nftban_output.sh"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+export NFTBAN_NONINTERACTIVE=1
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# ---------------------------------------------------------------------------
+# Routing harness: source nftban_output.sh, stub the two render functions to
+# emit markers, then call nftban_banner_unified for a given mode/env and
+# observe which path fired.
+# ---------------------------------------------------------------------------
+route() {
+    # $1 = env assignments ; $2 = mode arg (may be empty)
+    local env_assign="$1" mode="${2:-}"
+    bash -c "
+        set +e
+        $env_assign
+        export NFTBAN_LIB_DIR='$NFTBAN_LIB_DIR'
+        source '$OUTPUT' 2>/dev/null || true
+        nftban_render_banner_simple() { echo 'PATH:SIMPLE'; }
+        nftban_render_banner_full()   { echo 'PATH:FULL'; }
+        # Replace the heavy full-box body so we observe the gate decision only:
+        # the gate runs BEFORE the box body, so if we reach the body we mark FULL.
+        nftban_banner_unified_body_marker() { echo 'PATH:FULLBOX'; }
+        nftban_banner_unified '$mode' 2>&1 | grep -E 'PATH:' || echo 'PATH:NONE-OR-FULLBODY'
+    "
+}
+
+echo "=== NOBANNER-CONSIST: dispatcher maps --plain/--quiet to suppression env ==="
+grep -qE '\-\-plain\|--quiet\)' "$SBIN" \
+    && ok "dispatcher argv scan handles --plain|--quiet" || no "--plain/--quiet not handled in dispatcher"
+grep -q 'export NFTBAN_SUBCOMMAND=' "$SBIN" \
+    && ok "dispatcher exports NFTBAN_SUBCOMMAND (Cmd: truth source)" || no "NFTBAN_SUBCOMMAND not exported"
+# --plain/--quiet must NOT be consumed (left in argv like --json)
+awk '/--plain\|--quiet\)/,/;;/' "$SBIN" | grep -q '_filtered+=' \
+    && ok "--plain/--quiet left in argv (subcommand still sees them)" \
+    || no "--plain/--quiet consumed (would break status --quiet)"
+
+echo "=== one banner path: suppression env wins (any subcommand) ==="
+for env in 'export NFTBAN_NO_BANNER=1' 'export NFTBAN_QUIET=1' 'export NFTBAN_BANNER_MODE=none'; do
+    out="$(route "$env" status)"
+    [[ "$out" != *PATH:SIMPLE* && "$out" != *PATH:FULL* ]] \
+        && ok "suppressed ($env) → no banner path fired" \
+        || no "suppression failed for $env" "$out"
+done
+
+echo "=== full box restricted to version/status/hello; others get one-line ==="
+for m in version status hello; do
+    out="$(route 'unset NFTBAN_NO_BANNER NFTBAN_QUIET NFTBAN_BANNER_MODE NFTBAN_SUBCOMMAND' "$m")"
+    # Full-box body is heavy/stubbed-out env; the key assertion is it does NOT
+    # short-circuit to the simple one-line header for these modes.
+    [[ "$out" != *PATH:SIMPLE* ]] \
+        && ok "mode '$m' is NOT downgraded to one-line header (full box allowed)" \
+        || no "mode '$m' wrongly downgraded to simple header" "$out"
+done
+for m in list firewall feeds ban portscan; do
+    out="$(route 'unset NFTBAN_NO_BANNER NFTBAN_QUIET NFTBAN_BANNER_MODE NFTBAN_SUBCOMMAND' "$m")"
+    [[ "$out" == *PATH:SIMPLE* ]] \
+        && ok "subcommand '$m' prints the one-line simple header (no full box)" \
+        || no "subcommand '$m' did not route to the one-line header" "$out"
+done
+
+echo "=== Cmd: truth — no-mode callsite resolves to NFTBAN_SUBCOMMAND ==="
+# When mode defaults to 'cli' but NFTBAN_SUBCOMMAND=feeds, the gate must treat
+# it as the 'feeds' subcommand (one-line header), not the literal 'cli'.
+out="$(route 'unset NFTBAN_NO_BANNER NFTBAN_QUIET NFTBAN_BANNER_MODE; export NFTBAN_SUBCOMMAND=feeds' cli)"
+[[ "$out" == *PATH:SIMPLE* ]] \
+    && ok "no-mode call with NFTBAN_SUBCOMMAND=feeds routes as 'feeds' (one-line)" \
+    || no "Cmd: truth resolution failed" "$out"
+grep -q 'NFTBAN_SUBCOMMAND' "$OUTPUT" \
+    && ok "nftban_banner_unified consults NFTBAN_SUBCOMMAND" || no "NFTBAN_SUBCOMMAND not used in renderer"
+
+echo ""
+echo "================================================================"
+echo "banner_nobanner_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/cmd_status_authority_test.sh
+++ b/cli/lib/nftban/tests/cmd_status_authority_test.sh
@@ -56,11 +56,22 @@ log_fail() { echo "  FAIL  $*"; FAIL=$((FAIL + 1)); }
 # the section function is self-contained and reads only ${NFTBAN_STATE_DIR}.
 run_authority_section() {
     # Extract _status_section_authority() definition from cmd_status.sh
-    # and execute it. The function depends only on grep + printf + echo.
+    # and execute it. The function depends on grep + printf + echo and, as of
+    # v1.153 (UX-A1 / CMD-CONSIST), the shared nftban_kv label helper. Provide
+    # a minimal local nftban_kv mirroring core/nftban_output.sh so the section
+    # can be exercised in isolation without sourcing the full runtime.
     awk '/^_status_section_authority\(\) \{/,/^\}/' \
         "$NFTBAN_LIB_DIR/cli/cmd_status.sh" > "$SANDBOX/section.sh"
     # shellcheck source=/dev/null
-    ( source "$SANDBOX/section.sh"; _status_section_authority )
+    (
+        nftban_kv() {
+            local label="${1:-}" value="${2:-}" width="${3:-20}"
+            local pad_len=$(( width - ${#label} )); (( pad_len < 1 )) && pad_len=1
+            local dots; dots=$(printf '%*s' "$pad_len" ''); dots="${dots// /.}"
+            printf "  %s%s %s\n" "$label" "$dots" "$value"
+        }
+        source "$SANDBOX/section.sh"; _status_section_authority
+    )
 }
 
 write_state() {
@@ -88,11 +99,13 @@ if echo "$F1_OUT" | grep -q "^AUTHORITY$"; then
 else
     log_fail "F1: AUTHORITY header missing"
 fi
-if echo "$F1_OUT" | grep -qE "Install authority\.+ AMBIGUOUS"; then
-    log_pass "F1: Install authority field shows AMBIGUOUS"
+# v1.153 UX-A1: AMBIGUOUS authority now renders "Firewall authority..⚠️  AMBIGUOUS"
+if echo "$F1_OUT" | grep -qE "Firewall authority\.+ .*AMBIGUOUS"; then
+    log_pass "F1: Firewall authority field shows AMBIGUOUS"
 else
     log_fail "F1: Install authority field missing/wrong"
 fi
+# AMBIGUOUS path keeps the literal "Active conflicts" wording (genuinely active)
 if echo "$F1_OUT" | grep -qE "Active conflicts\.+ csf,lfd"; then
     log_pass "F1: Active conflicts field shows csf,lfd"
 else
@@ -136,8 +149,9 @@ fi
 echo "F2: AUTHORITY=UPDATE, CONFLICTS="
 write_state "AUTHORITY=UPDATE" "CONFLICTS="
 F2_OUT=$(run_authority_section)
-if echo "$F2_OUT" | grep -qE "Install authority\.+ UPDATE"; then
-    log_pass "F2: Install authority field shows UPDATE"
+# v1.153 UX-A1: non-AMBIGUOUS authority renders "Firewall authority..🔒 EXCLUSIVE (UPDATE)"
+if echo "$F2_OUT" | grep -qE "Firewall authority\.+ .*EXCLUSIVE \(UPDATE\)"; then
+    log_pass "F2: Firewall authority field shows EXCLUSIVE (UPDATE)"
 else
     log_fail "F2: Install authority field missing/wrong"
 fi
@@ -182,8 +196,9 @@ fi
 echo "F5: AUTHORITY=AMBIGUOUS, CONFLICTS= (ambiguity from orphan table, no external conflict)"
 write_state "AUTHORITY=AMBIGUOUS" "CONFLICTS="
 F5_OUT=$(run_authority_section)
-if echo "$F5_OUT" | grep -qE "Install authority\.+ AMBIGUOUS"; then
-    log_pass "F5: Install authority field shows AMBIGUOUS"
+# v1.153 UX-A1: AMBIGUOUS without conflicts still shows "Firewall authority..⚠️  AMBIGUOUS"
+if echo "$F5_OUT" | grep -qE "Firewall authority\.+ .*AMBIGUOUS"; then
+    log_pass "F5: Firewall authority field shows AMBIGUOUS"
 else
     log_fail "F5: Install authority field missing/wrong"
 fi

--- a/cli/lib/nftban/tests/error_text_3line_v153_test.sh
+++ b/cli/lib/nftban/tests/error_text_3line_v153_test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-C: error-text normalization (UX-C2 + UX-C6)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="error_text_3line_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-C error-text normalization. UX-C2: cmd_error with a usage_func no longer reprints the ~30-line usage block on parse errors — it emits exactly the 'ERROR: <fault>' line plus a single 'Run 'nftban <cmd> --help' for more' pointer, deriving <cmd> from the conventional nftban_cmd_<name>_usage name (underscores -> spaces for subcommands). The full usage text remains available via the explicit --help path (usage_func called directly). UX-C6: _require_root_or_sudo_hint prints the inline sudo/root-shell guidance and returns non-zero when EUID!=0, returns 0 when root. JSON mode stays structured (no pointer/hint chrome). Hermetic: sources lib/cmd_common.sh; no host/nft/IPC."
+# meta:input="cli/lib/nftban/lib/cmd_common.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/lib/cmd_common.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Source cmd_common in a controlled subshell (env.sh deps tolerated).
+load() {
+    # shellcheck source=/dev/null
+    source "$NFTBAN_LIB_DIR/lib/cmd_common.sh" 2>/dev/null || true
+}
+
+# A fake 30-line usage function to prove it is NOT reprinted on parse error.
+make_fake_usage() {
+    cat <<'STUB'
+nftban_cmd_ban_usage() {
+    cat <<'EOF'
+nftban ban — line1
+line2
+line3
+line4
+line5
+line6
+line7
+line8
+line9
+line10
+EOF
+}
+STUB
+}
+
+echo "=== UX-C2: cmd_error with usage_func emits 3-line form, not the block ==="
+out=$(
+    set +e
+    load
+    eval "$(make_fake_usage)"
+    cmd_error "Unknown option: --bogus" false nftban_cmd_ban_usage 2>&1
+) || true
+line_count=$(printf '%s\n' "$out" | grep -c . || true)
+printf '%s\n' "$out" | grep -q "^ERROR: Unknown option: --bogus$" \
+    && ok "first line is 'ERROR: <fault>'" || no "ERROR line missing" "$out"
+printf '%s\n' "$out" | grep -q "Run 'nftban ban --help' for more" \
+    && ok "pointer line names the derived command (ban)" || no "pointer line missing/wrong" "$out"
+printf '%s\n' "$out" | grep -q "^line5$" \
+    && no "full usage block WAS reprinted (UX-C2 violated)" "$out" \
+    || ok "full usage block NOT reprinted"
+[[ "$line_count" -le 3 ]] \
+    && ok "error output is <= 3 lines (was ~30)" || no "too many lines: $line_count" "$out"
+
+echo "=== UX-C2: subcommand usage name -> spaced command in the hint ==="
+out=$(
+    set +e
+    load
+    eval 'nftban_cmd_config_validate_usage() { echo "usage..."; }'
+    cmd_error "bad arg" false nftban_cmd_config_validate_usage 2>&1
+) || true
+printf '%s\n' "$out" | grep -q "Run 'nftban config validate --help' for more" \
+    && ok "underscores in usage name -> spaced subcommand in hint" || no "subcommand hint wrong" "$out"
+
+echo "=== UX-C2: JSON mode stays structured (no pointer chrome) ==="
+out=$(
+    set +e
+    load
+    json_error() { echo "{\"success\":false,\"error\":\"$1\"}"; }
+    eval 'nftban_cmd_ban_usage() { echo "usage"; }'
+    cmd_error "bad" true nftban_cmd_ban_usage 2>&1
+) || true
+printf '%s\n' "$out" | grep -q "Run 'nftban" \
+    && no "JSON mode leaked a pointer hint" "$out" \
+    || ok "JSON mode emits no pointer hint"
+
+echo "=== UX-C6: _require_root_or_sudo_hint prints guidance when not root ==="
+load
+declare -f _require_root_or_sudo_hint >/dev/null 2>&1 \
+    && ok "_require_root_or_sudo_hint is defined" || no "_require_root_or_sudo_hint missing"
+# The test runner is non-root, so the real EUID exercises the not-root branch
+# directly. (EUID is readonly in bash and cannot be shadowed to simulate root.)
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    out=$(
+        set +e
+        load
+        _require_root_or_sudo_hint "ban an IP" false 2>&1
+        echo "RC=$?"
+    ) || true
+    printf '%s\n' "$out" | grep -q "requires root privileges" \
+        && ok "emits a root-required line when EUID!=0" || no "root-required line missing" "$out"
+    printf '%s\n' "$out" | grep -q "Re-run with one of:" \
+        && ok "emits the inline sudo / root-shell re-run guidance" || no "sudo hint missing" "$out"
+    printf '%s\n' "$out" | grep -q "RC=1" \
+        && ok "returns non-zero when not root" || no "did not return non-zero" "$out"
+else
+    ok "skipped not-root runtime check (test running as root)"
+    ok "skipped not-root runtime check (test running as root)"
+    ok "skipped not-root runtime check (test running as root)"
+fi
+# Root path: assert the source contract (EUID==0 -> silent return 0). EUID is
+# readonly so we verify the implemented logic rather than simulate uid 0.
+CC="$NFTBAN_LIB_DIR/lib/cmd_common.sh"
+awk '/^_require_root_or_sudo_hint\(\) \{/,/^\}/' "$CC" | grep -qE '\-ne 0 \]\]' \
+    && ok "root path is guarded by an EUID -ne 0 check (returns 0 when root)" \
+    || no "EUID guard missing in _require_root_or_sudo_hint"
+awk '/^_require_root_or_sudo_hint\(\) \{/,/^\}/' "$CC" | grep -qE '^    return 0$' \
+    && ok "function returns 0 on the root (success) path" || no "return 0 missing"
+
+echo ""
+echo "================================================================"
+echo "error_text_3line_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/help_verb_icons_v153_test.sh
+++ b/cli/lib/nftban/tests/help_verb_icons_v153_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-F: short-help verb icons + wording-truth (UX-A7)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="help_verb_icons_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-F UX-A7: the short 'nftban help' (_nftban_help_essential) now carries the same ⚡/⚠️ risk markers as 'help --all' on state-changing verbs. Asserts: state-changing verbs (ban, unban, blacklist, whitelist, feeds, ddos, portscan, login, botguard, geoban, config) are marked ⚡; advanced/caution verbs (firewall, update) are marked ⚠️; read-only verbs (status, health, list, search, version) are NOT marked; a LEGEND explains the markers. WORDING-TRUTH guard: the short help does not introduce an unproven 'protected/validated' posture claim. Hermetic: sources nftban_help.sh and inspects the rendered text; no host/nft/IPC."
+# meta:input="cli/lib/nftban/nftban_help.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/nftban_help.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HELP="$REPO/cli/lib/nftban/nftban_help.sh"
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Render the short help text.
+OUT="$(
+    set +e
+    # shellcheck source=/dev/null
+    source "$HELP" 2>/dev/null || true
+    _nftban_help_essential 2>&1
+)" || true
+
+# Helper: assert a verb's line begins (after leading spaces) with a marker.
+line_for() { printf '%s\n' "$OUT" | grep -E "[[:space:]]$1([[:space:]]|$)" | head -1; }
+
+echo "=== UX-A7: state-changing verbs carry the ⚡ marker ==="
+for v in ban unban blacklist whitelist feeds ddos portscan login botguard geoban config; do
+    l="$(line_for "$v")"
+    if [[ "$l" == *"⚡ $v"* ]]; then
+        ok "⚡ marks state-changing verb '$v'"
+    else
+        no "verb '$v' not marked ⚡" "$l"
+    fi
+done
+
+echo "=== UX-A7: advanced/caution verbs carry the ⚠️ marker ==="
+for v in firewall update; do
+    l="$(line_for "$v")"
+    if [[ "$l" == *"⚠️ $v"* ]]; then
+        ok "⚠️ marks advanced verb '$v'"
+    else
+        no "verb '$v' not marked ⚠️" "$l"
+    fi
+done
+
+echo "=== UX-A7: read-only verbs are NOT marked ==="
+for v in status health list search version; do
+    l="$(line_for "$v")"
+    if [[ "$l" == *"⚡ $v"* || "$l" == *"⚠️ $v"* ]]; then
+        no "read-only verb '$v' wrongly marked" "$l"
+    else
+        ok "read-only verb '$v' is unmarked"
+    fi
+done
+
+echo "=== UX-A7: a legend explains the markers ==="
+printf '%s\n' "$OUT" | grep -qi 'LEGEND' && ok "LEGEND header present" || no "LEGEND missing"
+printf '%s\n' "$OUT" | grep -q 'state-changing' && ok "legend defines ⚡ = state-changing" || no "state-changing legend text missing"
+printf '%s\n' "$OUT" | grep -qi 'use with caution' && ok "legend defines ⚠️ = advanced/caution" || no "caution legend text missing"
+
+echo "=== WORDING-TRUTH: short help makes no unproven posture claim ==="
+printf '%s\n' "$OUT" | grep -qiE 'PROTECTED|fully protected|validated' \
+    && no "short help leaked an unproven posture/validated claim" \
+    || ok "short help carries no unproven posture/validated claim"
+
+echo ""
+echo "================================================================"
+echo "help_verb_icons_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/installer_wording_v153_test.sh
+++ b/cli/lib/nftban/tests/installer_wording_v153_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-E: installer-output wording (UX-T1..T4)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="installer_wording_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-E installer-output wording. UX-T1 (shell): the auditor-ACL non-fatal failure path in core/nftban_health_fixes.sh names the stable class WARN_PERMISSIONS_ENFORCE_NONFATAL instead of silently swallowing. UX-T2 (shell): the systemd-tmpfiles non-zero path in the same file names WARN_TMPFILES_73 (tmpfiles canonicalization of design-correct ownership; non-fatal). UX-T3 (installer-Go, wording only): panelfw.go portsToString range-compresses contiguous runs (35000-35999) instead of ~1000 comma entries — verified by re-implementing the documented transform and by asserting the source uses sort+range output. UX-T4 (installer-Go, wording only): cmd/nftban-installer/main.go report() prints 'completed with warnings (non-fatal)' for DEGRADED and a mechanism-accurate COMMITTED line, with the flow (state machine) unchanged. Hermetic: greps source + mirrors the range transform; no Go build, no host/nft/IPC."
+# meta:input="core/nftban_health_fixes.sh, internal/installer/panelfw/panelfw.go, cmd/nftban-installer/main.go"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_health_fixes.sh,internal/installer/panelfw/panelfw.go,cmd/nftban-installer/main.go"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HF="$REPO/cli/lib/nftban/core/nftban_health_fixes.sh"
+PG="$REPO/internal/installer/panelfw/panelfw.go"
+MG="$REPO/cmd/nftban-installer/main.go"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "=== UX-T1: WARN_PERMISSIONS_ENFORCE_NONFATAL named (shell) ==="
+grep -q 'WARN_PERMISSIONS_ENFORCE_NONFATAL' "$HF" \
+    && ok "auditor-ACL failure path names WARN_PERMISSIONS_ENFORCE_NONFATAL" \
+    || no "WARN_PERMISSIONS_ENFORCE_NONFATAL class id missing"
+# old bare 'Some auditor ACLs could not be set' (no class id) must be replaced
+grep -qE '⚠ Some auditor ACLs could not be set \(\$acl_errors errors\)$' "$HF" \
+    && no "old un-classed auditor-ACL message still present" \
+    || ok "old un-classed auditor-ACL message replaced"
+
+echo "=== UX-T2: WARN_TMPFILES_73 named (shell) ==="
+grep -q 'WARN_TMPFILES_73' "$HF" \
+    && ok "systemd-tmpfiles non-zero path names WARN_TMPFILES_73" \
+    || no "WARN_TMPFILES_73 class id missing"
+grep -q 'tmpfiles canonicalization of design-correct ownership' "$HF" \
+    && ok "wording explains the canonicalization-of-design-correct-ownership case" \
+    || no "WARN_TMPFILES_73 explanation wording missing"
+
+echo "=== UX-T3: panelfw.go portsToString range-compresses (Go, wording only) ==="
+grep -q 'range-compressed' "$PG" && ok "portsToString documents range-compression" || no "range-compress comment missing"
+grep -q 'sort.Ints' "$PG" && ok "portsToString sorts before run detection" || no "sort.Ints missing"
+grep -qE '"%d-%d"' "$PG" && ok "portsToString emits a 'start-end' range form" || no "range format string missing"
+grep -qE '^[[:space:]]*"sort"$' "$PG" && ok "sort imported" || no "sort import missing"
+
+# Mirror the documented transform and prove it on the canonical fixture.
+compress_ports() {
+    # stdin: space-separated ints; stdout: "[a,b-c,...]"
+    local -a ps; IFS=$' \t\n' read -ra ps <<<"$1"
+    local -a sorted
+    mapfile -t sorted < <(printf '%s\n' "${ps[@]}" | sort -n)
+    local out="" run_start="${sorted[0]}" prev="${sorted[0]}" p i
+    flush() { if [[ "$1" == "$2" ]]; then out+="${out:+,}$1"; else out+="${out:+,}$1-$2"; fi; }
+    for (( i=1; i<${#sorted[@]}; i++ )); do
+        p="${sorted[$i]}"
+        if [[ "$p" == "$prev" || "$p" -eq $((prev+1)) ]]; then prev="$p"; continue; fi
+        flush "$run_start" "$prev"; run_start="$p"; prev="$p"
+    done
+    flush "$run_start" "$prev"
+    printf '[%s]' "$out"
+}
+# contiguous 35000..35999 (build a small contiguous sample that proves the rule)
+sample=""; for p in $(seq 35000 35009); do sample+="$p "; done
+got="$(compress_ports "$sample")"
+[[ "$got" == "[35000-35009]" ]] \
+    && ok "contiguous run compresses to a single range ($got)" || no "range compress wrong" "$got"
+# mixed singletons + a run
+got2="$(compress_ports "21 80 35000 35001 35002 8443")"
+[[ "$got2" == "[21,80,8443,35000-35002]" ]] \
+    && ok "mixed singletons + run render correctly ($got2)" || no "mixed render wrong" "$got2"
+
+echo "=== UX-T4: main.go report() wording (Go, wording only; flow unchanged) ==="
+grep -q 'completed with warnings (non-fatal).' "$MG" \
+    && ok "DEGRADED line says 'completed with warnings (non-fatal)'" || no "DEGRADED wording missing"
+grep -q 'state: COMMITTED, no warnings' "$MG" \
+    && ok "COMMITTED line is mechanism-accurate (no bare 'successfully')" || no "COMMITTED wording missing"
+# flow guard: both state arms still keyed off the state machine (no warn-tally logic added)
+grep -q 'case state.StateCommitted:' "$MG" && grep -q 'case state.StateDegraded:' "$MG" \
+    && ok "state-machine branches unchanged (no flow change)" || no "state branches altered"
+
+echo ""
+echo "================================================================"
+echo "installer_wording_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh
+++ b/cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-D: list/table IPv6 column clamp (UX-A4)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="list_ipv6_clamp_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-D UX-A4: the HUMAN 'nftban list all' table clamps the IP column to its 40-char width with an ASCII '...' marker so a long IPv6 CIDR cannot push the Type/Version columns out of alignment, while the --json path keeps the full unclamped IP. Asserts: (1) cmd_list.sh contains the human-table clamp logic and the comment that --json stays unclamped; (2) the JSON emitter line still prints the raw \$ip (no clamp); (3) the clamp transform itself — short IPs pass through verbatim, long IPv6 CIDRs are truncated to exactly the column width using a trailing '...' so each rendered row's IP field is <= width. Hermetic: re-implements the shipped clamp transform and checks it against the source; no host/nft/IPC."
+# meta:input="cli/lib/nftban/cli/cmd_list.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_list.sh"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+L="$REPO/cli/lib/nftban/cli/cmd_list.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Mirror of the shipped clamp transform (cmd_list.sh human-table path).
+clamp() {
+    local ip="$1" w="${2:-40}"
+    if (( ${#ip} > w )); then
+        printf '%s...' "${ip:0:w-3}"
+    else
+        printf '%s' "$ip"
+    fi
+}
+
+echo "=== source: human table clamps, --json stays full ==="
+grep -q '_ipcol_w=40' "$L" && ok "human-table clamp width (40) present" || no "clamp width missing"
+grep -q 'Full value remains in --json' "$L" \
+    && ok "comment documents --json keeps the full value" || no "json-unclamped comment missing"
+grep -q 'ip_disp' "$L" && ok "human path prints the clamped ip_disp" || no "ip_disp not used in human path"
+# JSON emitter must still print the raw $ip (no ip_disp in the json line).
+# The source line is: echo -n "    {\"ip\": \"$ip\", ...}"
+json_line=$(grep -nF '{\"ip\": \"$ip\"' "$L" | head -1 || true)
+[[ -n "$json_line" ]] && ok "JSON emitter line found (raw \$ip)" || no "JSON emitter line not located"
+# and that the JSON line does NOT use the clamped ip_disp
+printf '%s\n' "$json_line" | grep -q 'ip_disp' \
+    && no "JSON emitter wrongly uses clamped ip_disp" "$json_line" \
+    || ok "JSON emitter still uses raw \$ip (unclamped), not ip_disp"
+
+echo "=== transform: short IP passes through verbatim ==="
+short="2001:db8::1"
+[[ "$(clamp "$short")" == "$short" ]] \
+    && ok "short IPv6 unchanged" || no "short IPv6 mangled" "$(clamp "$short")"
+v4="203.0.113.45"
+[[ "$(clamp "$v4")" == "$v4" ]] && ok "IPv4 unchanged" || no "IPv4 mangled" "$(clamp "$v4")"
+
+echo "=== transform: long IPv6 CIDR is clamped to width with '...' ==="
+long="2400:cb00:0000:1111:2222:3333:4444:ffff/128"   # 43 chars (> 40)
+[[ "${#long}" -gt 40 ]] || no "fixture not long enough" "${#long}"
+clamped="$(clamp "$long")"
+[[ "${#clamped}" -eq 40 ]] \
+    && ok "clamped value is exactly the 40-char column width" || no "clamped width wrong" "${#clamped} ($clamped)"
+[[ "$clamped" == *"..." ]] && ok "clamped value ends with the '...' marker" || no "no '...' marker" "$clamped"
+[[ "$clamped" == "${long:0:37}..." ]] \
+    && ok "clamp keeps the leading 37 chars + '...'" || no "clamp prefix wrong" "$clamped"
+
+echo ""
+echo "================================================================"
+echo "list_ipv6_clamp_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/status_consistency_v153_test.sh
+++ b/cli/lib/nftban/tests/status_consistency_v153_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.153 PR-A: status output-truth + cross-command consistency
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="status_consistency_v153_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Locks v1.153 PR-A status consistency: UX-A1 authority block renders 'Firewall authority..🔒 EXCLUSIVE' for owned authority and 'Legacy firewalls..🛡️ NEUTRALIZED:' for recorded conflicts (only AMBIGUOUS shows 'Active conflicts'); UX-A2 timers summary reads 'Core N/M active · Optional K disabled · Failed F' (not a bare ratio); UX-A5 Suricata + service modules say 'not installed (optional add-on)' once; UX-A6 the health roll-up is labelled 'Health' (single authoritative posture lives in the State line); CMD-CONSIST shared nftban_kv helper preserves internal label spaces while dot-padding trailing width. Hermetic: extracts the section functions + a local nftban_kv mirror; no host/nft/IPC/systemctl reliance for the asserted strings."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_status.sh,cli/lib/nftban/core/nftban_output.sh"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_STATE_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+LIB="$REPO_ROOT/cli/lib/nftban"
+S="$LIB/cli/cmd_status.sh"
+OUT="$LIB/core/nftban_output.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+STATE_DIR="$SANDBOX/state"; mkdir -p "$STATE_DIR"
+export NFTBAN_STATE_DIR="$STATE_DIR"
+
+# Local mirror of core/nftban_output.sh::nftban_kv (kept in lockstep). The
+# trailing-padding-only dot logic is the contract under test for CMD-CONSIST.
+nftban_kv() {
+    local label="${1:-}" value="${2:-}" width="${3:-20}"
+    local pad_len=$(( width - ${#label} )); (( pad_len < 1 )) && pad_len=1
+    local dots; dots=$(printf '%*s' "$pad_len" ''); dots="${dots// /.}"
+    printf "  %s%s %s\n" "$label" "$dots" "$value"
+}
+
+run_authority_section() {
+    awk '/^_status_section_authority\(\) \{/,/^\}/' "$S" > "$SANDBOX/auth.sh"
+    # shellcheck source=/dev/null
+    ( source "$SANDBOX/auth.sh"; _status_section_authority )
+}
+
+write_state() {
+    local f="$STATE_DIR/install_state"; : > "$f"
+    while (( "$#" )); do echo "$1" >> "$f"; shift; done
+}
+
+echo "=== CMD-CONSIST: nftban_kv preserves internal spaces, dot-pads trailing ==="
+kv_line="$(nftban_kv "Firewall authority" "X")"
+if [[ "$kv_line" == *"Firewall authority"* ]]; then
+    ok "nftban_kv keeps the internal label space (no 'Firewall.authority')"
+else
+    no "internal space corrupted" "$kv_line"
+fi
+[[ "$kv_line" == *".."* ]] && ok "nftban_kv emits trailing dot leaders" || no "no dot leaders" "$kv_line"
+grep -q 'nftban_kv()' "$OUT" && ok "shared nftban_kv defined in core/nftban_output.sh" || no "nftban_kv missing from core"
+
+echo "=== UX-A1: owned authority => EXCLUSIVE + NEUTRALIZED legacy firewalls ==="
+write_state "AUTHORITY=UPDATE" "CONFLICTS=UFW,iptables-nft,iptables,CSF"
+A_OUT="$(run_authority_section)"
+echo "$A_OUT" | grep -qE "Firewall authority\.+ .*EXCLUSIVE \(UPDATE\)" \
+    && ok "owned authority shows '🔒 EXCLUSIVE (UPDATE)'" || no "EXCLUSIVE line missing" "$A_OUT"
+echo "$A_OUT" | grep -qE "Legacy firewalls\.+ .*NEUTRALIZED: UFW,iptables-nft,iptables,CSF" \
+    && ok "recorded conflicts framed as '🛡️ NEUTRALIZED: …'" || no "NEUTRALIZED line missing" "$A_OUT"
+echo "$A_OUT" | grep -q "Active conflicts" \
+    && no "owned-authority path must NOT say 'Active conflicts'" "$A_OUT" \
+    || ok "owned-authority path does not mislabel neutralized firewalls as active"
+
+echo "=== UX-A1: AMBIGUOUS => genuinely active conflicts ==="
+write_state "AUTHORITY=AMBIGUOUS" "CONFLICTS=csf,lfd"
+B_OUT="$(run_authority_section)"
+echo "$B_OUT" | grep -qE "Firewall authority\.+ .*AMBIGUOUS" \
+    && ok "AMBIGUOUS authority shows '⚠️  AMBIGUOUS'" || no "AMBIGUOUS line missing" "$B_OUT"
+echo "$B_OUT" | grep -qE "Active conflicts\.+ csf,lfd" \
+    && ok "AMBIGUOUS path keeps literal 'Active conflicts' (still fighting)" || no "Active conflicts line missing" "$B_OUT"
+
+echo "=== UX-A2: timers summary partitions core/optional/failed ==="
+grep -q 'Core ${core_active}/${core_installed} active · Optional ${optional_disabled} disabled · Failed ${timer_failed}' "$S" \
+    && ok "timers summary emits 'Core N/M active · Optional K disabled · Failed F'" \
+    || no "UX-A2 partitioned timers summary string not found in cmd_status.sh"
+grep -q 'core_timer=' "$S" && ok "core-vs-optional timer partition present" || no "core_timer map missing"
+# the bare '$timer_active / $timer_count' summary must be gone
+grep -qE '"Active timers\.+" "\$timer_active / \$timer_count"' "$S" \
+    && no "bare 'N / M' timer ratio still printed" \
+    || ok "bare ratio summary removed"
+
+echo "=== UX-A5: optional add-on wording, one term per service ==="
+grep -q 'not installed (optional add-on)' "$S" \
+    && ok "Suricata / service modules say 'not installed (optional add-on)'" \
+    || no "UX-A5 'not installed (optional add-on)' wording missing"
+# the bare uppercase 'NOT INSTALLED (optional)' service line should be gone
+grep -q 'NOT INSTALLED (optional)' "$S" \
+    && no "old 'NOT INSTALLED (optional)' service term still present" \
+    || ok "old uppercase service term replaced"
+
+echo "=== UX-A6: health roll-up labelled 'Health' (not a 2nd posture verdict) ==="
+grep -q 'nftban_kv "Health"' "$S" \
+    && ok "health section roll-up labelled 'Health'" || no "UX-A6 Health label missing"
+grep -q '"Overall Status\.+"' "$S" 2>/dev/null \
+    && no "old 'Overall Status' second-posture line still present" \
+    || ok "no competing 'Overall Status' posture line"
+
+echo ""
+echo "================================================================"
+echo "status_consistency_v153: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -1077,6 +1077,18 @@ main() {
                 export NFTBAN_BANNER_MODE="none"
                 export NFTBAN_NO_BANNER=1
                 ;;
+            --plain|--quiet)
+                # v1.153 PR-B NOBANNER-CONSIST: --plain / --quiet now suppress
+                # the banner universally via the same gate as --no-banner. The
+                # flags are NOT consumed — like --json they are left in argv so
+                # subcommands that implement their own --quiet semantics (e.g.
+                # `nftban status --quiet` sets quiet_mode) still see them. We
+                # only set the banner-suppression env here.
+                export NFTBAN_BANNER_MODE="none"
+                export NFTBAN_NO_BANNER=1
+                export NFTBAN_QUIET=1
+                _filtered+=("$_arg")
+                ;;
             --json)
                 # Imply NFTBAN_NO_BANNER=1 (PR-B E-NO-BANNER scope) but
                 # do NOT consume the flag; the cmd_*.sh handler must see it.
@@ -1098,6 +1110,13 @@ main() {
     # subcommand args ("$@") are left untouched so case-sensitive values
     # (IPs, country codes, file paths, etc.) are preserved.
     cmd="${cmd,,}"
+
+    # v1.153 PR-B (UX-A3/UX-C4): export the resolved top-level subcommand so the
+    # unified banner renderer can label "Cmd:" with the REAL subcommand instead
+    # of the hard-coded "cli" that callsites passing no mode previously produced.
+    # Also drives the full-box-vs-one-line decision (full box only for
+    # version/status/first-run; every other subcommand gets a one-line header).
+    export NFTBAN_SUBCOMMAND="$cmd"
 
     # Special completion endpoint for bash completion
     # IMPORTANT: Check this BEFORE loading modules (for performance)

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -527,10 +527,18 @@ func report(sf *state.StateFile, log *logging.Logger) int {
 
 	switch sf.State {
 	case state.StateCommitted:
-		log.Result("[NFTBan] Install/upgrade completed successfully.")
+		// v1.153 UX-T4 (message wording only): COMMITTED means every phase
+		// committed with no non-fatal warnings tallied — report completion in
+		// mechanism-accurate terms rather than the bare "successfully" claim.
+		log.Result("[NFTBan] Install/upgrade completed (state: COMMITTED, no warnings).")
 		log.Result("[NFTBan] State: COMMITTED")
 	case state.StateDegraded:
-		log.Result("[NFTBan] Install/upgrade completed with warnings.")
+		// v1.153 UX-T4 (message wording only): DEGRADED is the
+		// committed-with-non-fatal-warnings outcome — say "with warnings"
+		// explicitly so the operator-facing line is selected by the warning
+		// outcome, not the bare success wording. (Flow unchanged: the state
+		// machine still decides COMMITTED vs DEGRADED.)
+		log.Result("[NFTBan] Install/upgrade completed with warnings (non-fatal).")
 		log.Result("[NFTBan] State: DEGRADED")
 		if sf.FailureReason != "" {
 			log.Result("[NFTBan] Issues: %s", sf.FailureReason)

--- a/internal/installer/panelfw/panelfw.go
+++ b/internal/installer/panelfw/panelfw.go
@@ -45,6 +45,7 @@ package panelfw
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
@@ -301,15 +302,42 @@ func computeFatal(policy PanelPolicy) bool {
 	return policy.RequirePanelSuccess
 }
 
-// portsToString renders a port slice as a stable comma-separated
-// string for log output.
+// portsToString renders a port slice as a stable, compact string for log
+// output. v1.153 UX-T3 (display wording only): contiguous runs are
+// range-compressed (e.g. 35000..35999 becomes "35000-35999") so a 1000-port
+// passive-FTP range no longer prints ~1000 comma-separated entries. The set of
+// ports represented is unchanged — this is purely how the log line reads.
 func portsToString(ps []int) string {
 	if len(ps) == 0 {
 		return "[]"
 	}
-	parts := make([]string, len(ps))
-	for i, p := range ps {
-		parts[i] = fmt.Sprintf("%d", p)
+	// Sort a copy so range detection is deterministic regardless of input order;
+	// the caller's slice is not modified.
+	sorted := make([]int, len(ps))
+	copy(sorted, ps)
+	sort.Ints(sorted)
+
+	var parts []string
+	runStart := sorted[0]
+	prev := sorted[0]
+	flush := func(start, end int) {
+		if start == end {
+			parts = append(parts, fmt.Sprintf("%d", start))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d-%d", start, end))
+		}
 	}
+	for i := 1; i < len(sorted); i++ {
+		p := sorted[i]
+		if p == prev || p == prev+1 {
+			// same value (dedup) or contiguous — extend the current run
+			prev = p
+			continue
+		}
+		flush(runStart, prev)
+		runStart = p
+		prev = p
+	}
+	flush(runStart, prev)
 	return "[" + strings.Join(parts, ",") + "]"
 }


### PR DESCRIPTION
**Broad-output-only UX lane** — normalizes CLI output truth, banner discipline, and cross-command consistency. No functional cutover.

### Scope invariants
- **0 `cmd/nftband`** — daemon byte-identical to v1.152.0 (chain v1.147→v1.153 holds)
- **0 schema** — 1.83.0 frozen (`nft_schema.sh` untouched)
- **0 CSF** — no CSF touch
- **Installer-Go = wording only** — `panelfw.go` port-range display + `main.go` completion message strings; no installer behavior/flow change
- **VERSION / STATUS.md / CHANGELOG.md / nftban_fhs_spec.sh untouched** — release-prep is a separate follow-up PR

### Six reviewable commits (A–F)
- **PR-A** `049b0d8a` — status output-truth + cross-command consistency (UX-A1 authority block, A2 timers line, A5 modules `(optional)`, A6 single authoritative state, shared `nftban_kv` label helper)
- **PR-B** `917bf263` — banner discipline + universal `--no-banner`/`--plain`/`--quiet`; `Cmd:` shows the real subcommand; full box restricted to version/status/first-run
- **PR-C** `e144d73a` — error-text normalization: 3-line `ERROR/Hint/Run --help` form (UX-C2) + EUID≠0 sudo hint (UX-C6)
- **PR-D** `db8c7762` — clamp the IPv6 column in the human `list all` table (UX-A4); full range stays in `--json`
- **PR-E** `68454979` — installer-output wording: WARN class ids (UX-T1 `WARN_PERMISSIONS_ENFORCE_NONFATAL`, UX-T2 `WARN_TMPFILES_73` — placed in the editable `nftban_health_fixes.sh`, **not** the gate-frozen generated `nftban_fhs_spec.sh`), UX-T3 port-range compress, UX-T4 "completed with warnings" wording
- **PR-F** `e6460a6d` — short-help verb icons (UX-A7) + output-truth wording sweep

### Validation (lab2, go1.25.11)
- Go: `go mod tidy` clean · `go vet ./...` clean · `go build ./...` rc=0 · `go test -race` PASS (panelfw + cpanel/directadmin/plesk adapters + nftban-installer)
- `shellcheck -S warning` rc=0 on all 7 touched shell files
- 6 new tests: **88/0** (status 15, banner 16, error-text 12, list-clamp 10, installer-wording 13, help-icons 22)
- 10 regression guards PASS (rc-contract v1.139.2, status-rc v152, timers/stats truth v150, no-banner v141, help/runtime-hint reachability v144, status-authority, error-with-hint v144, help-inertness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
