### PR TITLE
feat(v1.154): install timer-reload hardening

### DIFF
--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -550,6 +550,15 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	// 4. Set immutable flags on security-critical files (G8)
 	validate.SetImmutableFlags(exec, log)
 
+	// 5. D-INSTALL-TIMER-RELOAD hardening (v1.154.0): conditional daemon-reload
+	// + restart of any nftban timer left in the dns2-class wedged state
+	// (active but never scheduled — Trigger=n/a). Single call site; covers all
+	// terminal paths below (VALIDATE_1 COMMITTED, VALIDATE_2 COMMITTED, and
+	// DEGRADED) because it runs after every unit/permission mutation in this
+	// phase has settled and before any state transition. Warn-only / non-fatal,
+	// matching the existing installer daemon-reload at phaseSwitch step 6.
+	services.RestartWedgedTimers(ctx, exec, log, services.KnownTimers())
+
 	if validate.AllPassed(results) {
 		log.Info("all post-install assertions passed — COMMITTED")
 		_ = exec.Remove(fhs.InstallFailedMarker)

--- a/internal/installer/services/timers.go
+++ b/internal/installer/services/timers.go
@@ -41,6 +41,52 @@ var optionalTimers = []string{
 	"nftban-botscan.timer",
 }
 
+// allKnownTimers is the canonical, exhaustive list of every nftban systemd
+// timer unit shipped under install/systemd/*.timer. It is the single source of
+// truth for any code that must iterate over the full set of nftban timers
+// (e.g. the D-INSTALL-TIMER-RELOAD post-install wedge-recovery hardening in
+// timers_post_install.go).
+//
+// coreTimers / optionalTimers above are reconcile-policy SUBSETS of this list;
+// this slice is the SUPERSET. If a new install/systemd/*.timer is added (or one
+// is removed), this slice MUST be updated — the drift-parity test
+// (timers_post_install_parity_test.go) fails otherwise.
+var allKnownTimers = []string{
+	"nftban-botscan.timer",
+	"nftban-community-stats.timer",
+	"nftban-core-feeds.timer",
+	"nftban-core-geoip.timer",
+	"nftban-geoban-refresh.timer",
+	"nftban-health.timer",
+	"nftban-maintenance.timer",
+	"nftban-pro-inventory.timer",
+	"nftban-pro-license.timer",
+	"nftban-queue.timer",
+	"nftban-rbl-check.timer",
+	"nftban-rebuild-recovery.timer",
+	"nftban-report-daily.timer",
+	"nftban-rollback.timer",
+	"nftban-snapshot.timer",
+	"nftban-soak.timer",
+	"nftban-suricata-update.timer",
+	"nftban-tunnel.timer",
+	"nftban-unified-exporter.timer",
+	"nftban-update-apply.timer",
+	"nftban-update-check.timer",
+	"nftban-watchdog.timer",
+}
+
+// KnownTimers returns a copy of the canonical full list of nftban timer unit
+// names (every install/systemd/*.timer). Callers that need to iterate all
+// nftban timers — such as the post-install wedge-recovery hardening — use this
+// rather than duplicating a const list. The returned slice is a copy; callers
+// may sort/mutate it freely.
+func KnownTimers() []string {
+	out := make([]string, len(allKnownTimers))
+	copy(out, allKnownTimers)
+	return out
+}
+
 // criticalCoreTimers is the subset of coreTimers whose failure to be enabled
 // + (active OR scheduled) DEGRADES the install (v1.135 D-MAINTENANCE-TIMER-
 // SILENT-ENABLE). nftban-maintenance.timer backs maintenance, trend data,

--- a/internal/installer/services/timers_post_install.go
+++ b/internal/installer/services/timers_post_install.go
@@ -1,0 +1,145 @@
+// =============================================================================
+// NFTBan v1.154.0 - Installer Post-Install Timer Wedge Recovery
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-services-timers-post-install"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-06"
+// meta:description="D-INSTALL-TIMER-RELOAD: conditional daemon-reload + restart of wedged nftban timers at end of phaseValidate"
+// meta:inventory.files="internal/installer/services/timers_post_install.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-*.timer"
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+package services
+
+import (
+	"context"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// RestartWedgedTimers performs the D-INSTALL-TIMER-RELOAD post-install
+// hardening pass: a defensive, CONDITIONAL daemon-reload + timer-restart for
+// any nftban timer left in the "wedged" state after install.
+//
+// Background (fleet finding, V1_142_0_FLEET_ROLLOUT_RECORD §3.3): on one of ten
+// hosts (dns2), nftban-unified-exporter.timer ended up:
+//
+//	Active:  active (elapsed)   ← active but NOT "waiting"
+//	Trigger: n/a                ← never scheduled
+//	0 runs in 24h               ← never fired
+//
+// The manual fix that resolved it was exactly:
+//
+//	systemctl daemon-reload && systemctl restart nftban-unified-exporter.timer
+//
+// after which the timer returned to `active (waiting), Trigger in Xs`.
+//
+// This function reproduces that fix defensively at the END of phaseValidate.
+// It is CONDITIONAL (audit-bot 2026-06-01): only timers that are actually
+// wedged are restarted — healthy and inactive timers are left untouched, so the
+// blast radius is "restart only the wedged ones" rather than "restart all
+// timers on every install".
+//
+// Failure policy is WARN-ONLY / non-fatal (operator-locked), matching the
+// existing installer daemon-reload at phases.go (phaseSwitch step 6). Any error
+// from daemon-reload, the wedge probe, or a restart is logged at Warn and
+// iteration continues; the install state machine is never affected.
+//
+// installedTimers is the canonical full timer set to consider (pass
+// services.KnownTimers()); timers whose unit file is not installed on this host
+// are skipped.
+func RestartWedgedTimers(ctx context.Context, exec executor.Executor, log *logging.Logger, installedTimers []string) {
+	log.Info("D-INSTALL-TIMER-RELOAD hardening: probing %d nftban timers for wedged state", len(installedTimers))
+
+	// Defensive daemon-reload first — half of the documented manual fix, and a
+	// prerequisite for systemd to recompute next-elapse times. Non-fatal.
+	if err := exec.DaemonReload(); err != nil {
+		log.Warn("timer hardening daemon-reload: %v (non-fatal)", err)
+	}
+
+	restarted := 0
+	for _, timer := range installedTimers {
+		// Skip timers not installed on this host (pro-/panel-/feature-gated
+		// units that this install did not deploy).
+		if !timerUnitInstalled(exec, timer) {
+			log.Debug("timer hardening: %s not installed — skipping", timer)
+			continue
+		}
+
+		if !timerIsWedged(ctx, exec, timer) {
+			log.Debug("timer hardening: %s healthy (or inactive) — skipping", timer)
+			continue
+		}
+
+		// A wedged timer is already "active", so ServiceStart would be a no-op;
+		// only a restart re-arms it (this is exactly the documented manual fix).
+		log.Warn("timer hardening: %s is wedged (active but no next trigger) — restarting", timer)
+		if res := exec.RunContext(ctx, "systemctl", "restart", timer); res.ExitCode != 0 {
+			log.Warn("timer hardening restart %s: exit %d %s (non-fatal)", timer, res.ExitCode, strings.TrimSpace(res.Stderr))
+			continue
+		}
+		restarted++
+	}
+
+	if restarted == 0 {
+		log.Info("D-INSTALL-TIMER-RELOAD hardening: no wedged timers found")
+	} else {
+		log.Info("D-INSTALL-TIMER-RELOAD hardening: restarted %d wedged timer(s)", restarted)
+	}
+}
+
+// timerUnitInstalled reports whether the timer unit file is present on this
+// host (either the admin-override location or the package location). Mirrors
+// the optional-timer presence check in ReconcileTimers.
+func timerUnitInstalled(exec executor.Executor, timer string) bool {
+	return exec.FileExists("/etc/systemd/system/"+timer) ||
+		exec.FileExists("/usr/lib/systemd/system/"+timer) ||
+		exec.FileExists("/lib/systemd/system/"+timer)
+}
+
+// timerIsWedged reports whether a timer is in the dns2-class wedged state:
+// ACTIVE but with NO scheduled next trigger. Detection uses
+//
+//	systemctl show <timer> -p ActiveState -p NextElapseUSecRealtime --value
+//
+// A timer is considered wedged when ActiveState=="active" AND the next-elapse
+// value is absent / "0" / "n/a" / "infinity". Inactive timers (disabled or
+// stopped) legitimately have no next trigger and are NOT treated as wedged —
+// re-arming them would be an out-of-scope policy change.
+//
+// On any probe error (non-zero exit, unparseable output) the timer is treated
+// as NOT wedged: warn-only means we never restart on uncertain evidence, which
+// keeps false positives at zero (a healthy timer is never needlessly bounced).
+func timerIsWedged(ctx context.Context, exec executor.Executor, timer string) bool {
+	res := exec.RunContext(ctx, "systemctl", "show", timer,
+		"-p", "ActiveState", "-p", "NextElapseUSecRealtime", "--value")
+	if res.ExitCode != 0 {
+		return false
+	}
+
+	// With multiple -p properties and --value, systemctl prints one value per
+	// line in the order requested: ActiveState, then NextElapseUSecRealtime.
+	lines := strings.Split(strings.TrimSpace(res.Stdout), "\n")
+	if len(lines) < 2 {
+		return false
+	}
+	activeState := strings.TrimSpace(lines[0])
+	nextElapse := strings.TrimSpace(lines[1])
+
+	if activeState != "active" {
+		return false
+	}
+	switch nextElapse {
+	case "", "0", "n/a", "infinity":
+		return true
+	}
+	return false
+}

--- a/internal/installer/services/timers_post_install_parity_test.go
+++ b/internal/installer/services/timers_post_install_parity_test.go
@@ -1,0 +1,144 @@
+// =============================================================================
+// NFTBan v1.154.0 - Timer Hardening Drift-Parity Test
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-services-timers-post-install-parity-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-06"
+// meta:description="Assert KnownTimers() covers exactly every install/systemd/*.timer (drift guard)"
+// meta:inventory.files="internal/installer/services/timers_post_install_parity_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-*.timer"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Mirrors the v1.137 B-12 LogInventory authority + drift-test pattern: the
+// hardening's timer coverage (services.KnownTimers()) must equal EXACTLY the
+// set of install/systemd/*.timer unit files shipped in the repo. If a new
+// .timer is added (or one removed) without updating allKnownTimers in
+// timers.go, this test fails — closing the future-drift risk where a freshly
+// added timer would silently escape the D-INSTALL-TIMER-RELOAD wedge-recovery
+// pass.
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// installSystemdTimerBasenames returns the sorted basenames of every
+// install/systemd/*.timer file in the repo, resolved relative to this test
+// source file (same runtime.Caller pattern as the fhs paths-parity test).
+func installSystemdTimerBasenames(t *testing.T) []string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed — cannot locate repo root")
+	}
+	// internal/installer/services/<this file> -> repo root is three dirs up.
+	repoRoot := filepath.Join(filepath.Dir(filename), "..", "..", "..")
+	systemdDir := filepath.Join(repoRoot, "install", "systemd")
+
+	matches, err := filepath.Glob(filepath.Join(systemdDir, "*.timer"))
+	if err != nil {
+		t.Fatalf("glob install/systemd/*.timer: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no *.timer files found under %s — repo layout changed?", systemdDir)
+	}
+
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		// Defensive: skip anything that is somehow a directory.
+		if info, err := os.Stat(m); err == nil && info.IsDir() {
+			continue
+		}
+		out = append(out, filepath.Base(m))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestKnownTimersMatchInstallSystemd asserts exact set equality between
+// services.KnownTimers() and install/systemd/*.timer.
+func TestKnownTimersMatchInstallSystemd(t *testing.T) {
+	onDisk := installSystemdTimerBasenames(t)
+
+	known := KnownTimers()
+	sort.Strings(known)
+
+	onDiskSet := make(map[string]bool, len(onDisk))
+	for _, n := range onDisk {
+		onDiskSet[n] = true
+	}
+	knownSet := make(map[string]bool, len(known))
+	for _, n := range known {
+		knownSet[n] = true
+	}
+
+	var missing []string // on disk but NOT in KnownTimers()
+	for _, n := range onDisk {
+		if !knownSet[n] {
+			missing = append(missing, n)
+		}
+	}
+	var extra []string // in KnownTimers() but NOT on disk
+	for _, n := range known {
+		if !onDiskSet[n] {
+			extra = append(extra, n)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Errorf("install/systemd/*.timer units NOT covered by services.KnownTimers() "+
+			"(add them to allKnownTimers in timers.go): %s", strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		t.Errorf("services.KnownTimers() lists units with NO install/systemd/*.timer file "+
+			"(remove them from allKnownTimers in timers.go): %s", strings.Join(extra, ", "))
+	}
+}
+
+// TestKnownTimersNoDuplicates guards against a copy-paste duplicate entry in
+// allKnownTimers, which would make the hardening probe (and the parity set
+// comparison) silently iterate a unit twice.
+func TestKnownTimersNoDuplicates(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, n := range KnownTimers() {
+		if seen[n] {
+			t.Errorf("duplicate timer in allKnownTimers: %s", n)
+		}
+		seen[n] = true
+	}
+}
+
+// TestCoreAndOptionalTimersAreKnown asserts the reconcile-policy subsets
+// (coreTimers, optionalTimers) are themselves members of the canonical
+// KnownTimers() superset — i.e. KnownTimers() really is the superset it claims
+// to be, so the hardening pass cannot miss a timer that the installer actively
+// reconciles.
+func TestCoreAndOptionalTimersAreKnown(t *testing.T) {
+	knownSet := make(map[string]bool)
+	for _, n := range KnownTimers() {
+		knownSet[n] = true
+	}
+	for _, n := range coreTimers {
+		if !knownSet[n] {
+			t.Errorf("coreTimer %s missing from KnownTimers() superset", n)
+		}
+	}
+	for _, n := range optionalTimers {
+		if !knownSet[n] {
+			t.Errorf("optionalTimer %s missing from KnownTimers() superset", n)
+		}
+	}
+}

--- a/internal/installer/services/timers_post_install_test.go
+++ b/internal/installer/services/timers_post_install_test.go
@@ -1,0 +1,182 @@
+// =============================================================================
+// NFTBan v1.154.0 - Timer Wedge-Recovery Mock Test
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-services-timers-post-install-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-06"
+// meta:description="Mock-Executor test: only wedged nftban timers are restarted; healthy/inactive/uninstalled ones are not"
+// meta:inventory.files="internal/installer/services/timers_post_install_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-*.timer"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// showKey builds the RunResults map key for the wedge-probe command the
+// implementation issues: systemctl show <timer> -p ActiveState -p
+// NextElapseUSecRealtime --value. The mock keys on "name:arg1:arg2:...".
+func showKey(timer string) string {
+	return strings.Join([]string{
+		"systemctl", "show", timer,
+		"-p", "ActiveState", "-p", "NextElapseUSecRealtime", "--value",
+	}, ":")
+}
+
+// restartCalled reports whether `systemctl restart <timer>` was recorded.
+func restartCalled(m *executor.MockExecutor, timer string) bool {
+	for _, c := range m.Commands {
+		if c.Name == "systemctl" && len(c.Args) >= 2 && c.Args[0] == "restart" && c.Args[1] == timer {
+			return true
+		}
+	}
+	return false
+}
+
+// installTimer marks a timer unit file as present so timerUnitInstalled() is true.
+func installTimer(m *executor.MockExecutor, timer string) {
+	m.Files["/usr/lib/systemd/system/"+timer] = []byte("[Timer]\n")
+}
+
+// TestRestartWedgedTimers_OnlyWedgedRestarted is the core contract: given a mix
+// of wedged, healthy, inactive, and uninstalled timers, ONLY the wedged ones
+// are restarted, daemon-reload is issued exactly once, and the implementation
+// never aborts (warn-only).
+func TestRestartWedgedTimers_OnlyWedgedRestarted(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	// wedged: active + no next trigger
+	wedged := "nftban-unified-exporter.timer"
+	// wedged2: active + next trigger == "0"
+	wedged2 := "nftban-health.timer"
+	// healthy: active + real next trigger
+	healthy := "nftban-maintenance.timer"
+	// inactive: legitimately no trigger (disabled/stopped)
+	inactive := "nftban-queue.timer"
+	// uninstalled: probe never reached (unit file absent)
+	uninstalled := "nftban-core-feeds.timer"
+
+	for _, tmr := range []string{wedged, wedged2, healthy, inactive} {
+		installTimer(mock, tmr)
+	}
+	// uninstalled: deliberately NOT installed.
+
+	// Probe results. With multiple -p props + --value, systemctl prints one
+	// value per line in request order: ActiveState, then NextElapseUSecRealtime.
+	mock.RunResults[showKey(wedged)] = executor.Result{ExitCode: 0, Stdout: "active\nn/a\n"}
+	mock.RunResults[showKey(wedged2)] = executor.Result{ExitCode: 0, Stdout: "active\n0\n"}
+	mock.RunResults[showKey(healthy)] = executor.Result{ExitCode: 0, Stdout: "active\n1717689600000000\n"}
+	mock.RunResults[showKey(inactive)] = executor.Result{ExitCode: 0, Stdout: "inactive\n0\n"}
+
+	timers := []string{wedged, wedged2, healthy, inactive, uninstalled}
+	RestartWedgedTimers(context.Background(), mock, newTestLogger(), timers)
+
+	// daemon-reload exactly once.
+	if n := mock.CommandCallCount("systemctl", "daemon-reload"); n != 1 {
+		t.Errorf("expected exactly 1 daemon-reload, got %d", n)
+	}
+
+	// Wedged timers restarted.
+	if !restartCalled(mock, wedged) {
+		t.Errorf("%s is wedged (Trigger=n/a) but was NOT restarted", wedged)
+	}
+	if !restartCalled(mock, wedged2) {
+		t.Errorf("%s is wedged (next-elapse=0) but was NOT restarted", wedged2)
+	}
+
+	// Healthy / inactive / uninstalled timers NOT restarted.
+	if restartCalled(mock, healthy) {
+		t.Errorf("%s is healthy but was needlessly restarted", healthy)
+	}
+	if restartCalled(mock, inactive) {
+		t.Errorf("%s is inactive but was needlessly restarted", inactive)
+	}
+	if restartCalled(mock, uninstalled) {
+		t.Errorf("%s is not installed but was restarted", uninstalled)
+	}
+
+	// Uninstalled timer must not even be probed.
+	if _, probed := mock.RunResults[showKey(uninstalled)]; probed {
+		t.Fatalf("test setup error: uninstalled timer should have no probe result")
+	}
+	for _, c := range mock.Commands {
+		if c.Name == "systemctl" && len(c.Args) >= 3 && c.Args[0] == "show" && c.Args[1] == uninstalled {
+			t.Errorf("uninstalled timer %s was probed; should be skipped before probe", uninstalled)
+		}
+	}
+}
+
+// TestRestartWedgedTimers_RestartErrorNonFatal asserts a failing restart does
+// NOT abort the pass: a wedged timer ordered before another wedged timer fails
+// to restart, yet the later wedged timer is still probed and restarted.
+func TestRestartWedgedTimers_RestartErrorNonFatal(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	first := "nftban-unified-exporter.timer"
+	second := "nftban-health.timer"
+	installTimer(mock, first)
+	installTimer(mock, second)
+
+	mock.RunResults[showKey(first)] = executor.Result{ExitCode: 0, Stdout: "active\nn/a\n"}
+	mock.RunResults[showKey(second)] = executor.Result{ExitCode: 0, Stdout: "active\nn/a\n"}
+
+	// First restart fails (non-zero exit); must not stop the loop.
+	mock.RunResults["systemctl:restart:"+first] = executor.Result{ExitCode: 1, Stderr: "boom"}
+
+	RestartWedgedTimers(context.Background(), mock, newTestLogger(), []string{first, second})
+
+	if !restartCalled(mock, first) {
+		t.Errorf("%s restart should have been attempted", first)
+	}
+	if !restartCalled(mock, second) {
+		t.Errorf("%s should still be restarted after %s's restart failed (warn-only)", second, first)
+	}
+}
+
+// TestRestartWedgedTimers_ProbeErrorTreatedHealthy asserts that a probe failure
+// (non-zero exit) is treated as NOT wedged — never restart on uncertain
+// evidence (zero false positives).
+func TestRestartWedgedTimers_ProbeErrorTreatedHealthy(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	tmr := "nftban-unified-exporter.timer"
+	installTimer(mock, tmr)
+	mock.RunResults[showKey(tmr)] = executor.Result{ExitCode: 1, Stderr: "Failed to get properties"}
+
+	RestartWedgedTimers(context.Background(), mock, newTestLogger(), []string{tmr})
+
+	if restartCalled(mock, tmr) {
+		t.Errorf("%s probe errored; must NOT be restarted (uncertain evidence)", tmr)
+	}
+}
+
+// TestRestartWedgedTimers_NoneWedged asserts daemon-reload still runs once and
+// nothing is restarted when every installed timer is healthy.
+func TestRestartWedgedTimers_NoneWedged(t *testing.T) {
+	mock := executor.NewMockExecutor()
+
+	tmr := "nftban-maintenance.timer"
+	installTimer(mock, tmr)
+	mock.RunResults[showKey(tmr)] = executor.Result{ExitCode: 0, Stdout: "active\n1717689600000000\n"}
+
+	RestartWedgedTimers(context.Background(), mock, newTestLogger(), KnownTimers())
+
+	if n := mock.CommandCallCount("systemctl", "daemon-reload"); n != 1 {
+		t.Errorf("expected exactly 1 daemon-reload, got %d", n)
+	}
+	if restartCalled(mock, tmr) {
+		t.Errorf("healthy %s should not be restarted", tmr)
+	}
+}


### PR DESCRIPTION
**installer-Go only.** Fixes the post-install systemd **timer wedge / elapsed-timer recovery path** (D-INSTALL-TIMER-RELOAD) seen on the v1.142.0 fleet rollout: one host (dns2) ended with `nftban-unified-exporter.timer` `active (elapsed)` + `Trigger: n/a` + 0 runs/24h; manual `daemon-reload && restart` fixed it. This makes the installer self-heal that case.

### What changed (5 files)
- `internal/installer/services/timers_post_install.go` (new) — `RestartWedgedTimers`: at end of installer `phaseValidate` (after `SetImmutableFlags`, before `StateCommitted`), `daemon-reload` then restart **only wedged timers** (`ActiveState=active` with no next-elapse). Warn-only / non-fatal; probe errors treated as healthy (zero false positives).
- `internal/installer/services/timers.go` — 22-timer single-source-of-truth superset + `KnownTimers()` accessor.
- `cmd/nftban-installer/phases.go` — single call site (covers all three `phaseValidate` terminal paths, incl. the VALIDATE_1-pass path where the dns2 wedge occurred).
- `internal/installer/services/timers_post_install_test.go` (new) — mock wedge-recovery: only wedged restarted, errors non-fatal, none-wedged no-op.
- `internal/installer/services/timers_post_install_parity_test.go` (new) — drift-parity: `KnownTimers()` ≡ `install/systemd/*.timer`.

### Invariants
- **daemon `cmd/nftband` byte-frozen** (diff empty; chain v1.147→v1.153.0 holds). Installer binary intentionally changes (installer byte-identity not frozen).
- **0 schema** (1.83.0 frozen) · **0 CSF** · no UX/shell spillover.
- **5 expected files only.**

### Validation
- **Rebased on v1.153.0 main `f1a92d3a`** (clean, no conflicts).
- **lab2 re-validation green** (go1.25.11): `go vet ./...` rc=0 · `go build ./...` rc=0 · `go test -race` PASS (internal/installer/services + cmd/nftban-installer); `go mod tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
