### PR TITLE
feat(v1.155): SSH-port lifecycle / srv1 unblocker

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -595,6 +595,23 @@ jobs:
       - name: External admin SSH-port guard (OBS-SSHPORT-55000)
         run: bash cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
 
+      # v1.155 PR-1 (item 3.2): socket-activated sshd port-mismatch warning.
+      # Asserts the guard warns ONLY when configured (sshd -T) != listening (ss)
+      # AND sshd is socket-activated, prints the exact remediation hint
+      # (`systemctl daemon-reload && systemctl restart ssh.socket`), and is
+      # silent when ports match or on a plain sshd.service. Hermetic.
+      - name: Socket-activated SSH port-mismatch warning (v1.155 PR-1)
+        run: bash cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
+
+      # v1.155 PR-2 (item 3.3): SSH-port-change lifecycle validator invariants.
+      # Exercises tools/validation/ssh_port_change_lifecycle_validate.sh against a
+      # good rendered-ruleset fixture (exit 0) and four injected drifts (listener
+      # not in ssh_ports / not in tcp_ports_in; literal `tcp dport 22 ct count`
+      # instead of @ssh_ports; missing @ssh_ports rule), each failing with the
+      # right invariant message. Hermetic (inputs injected via env).
+      - name: SSH-port-change lifecycle validator (v1.155 PR-2)
+        run: bash cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/lib/ssh_admin_port_guard.sh
+++ b/cli/lib/nftban/lib/ssh_admin_port_guard.sh
@@ -72,6 +72,56 @@ _nftban_ssh_listeners() {
     fi
 }
 
+# _nftban_sshd_configured_ports — read-only: the Port value(s) sshd is CONFIGURED with
+# (from `sshd -T`), sorted-unique numeric. This is the EFFECTIVE config, which on a
+# socket-activated sshd may differ from what is actually being listened on (the socket
+# unit owns the ListenStream until it is restarted). Empty if sshd is unavailable.
+_nftban_sshd_configured_ports() {
+    command -v sshd >/dev/null 2>&1 || return 0
+    sshd -T 2>/dev/null | awk '/^port /{print $2}' | grep -E '^[0-9]+$' | sort -un || true
+}
+
+# _nftban_ssh_socket_activated — read-only: succeed (rc 0) iff sshd is socket-activated,
+# i.e. an ssh.socket / sshd.socket unit is active. On such a host a changed `Port` in
+# sshd_config does NOT take effect until that socket unit is restarted, because the
+# socket unit (not sshd) owns the ListenStream. Returns 1 on a plain sshd.service host.
+_nftban_ssh_socket_activated() {
+    command -v systemctl >/dev/null 2>&1 || return 1
+    local u st
+    for u in ssh.socket sshd.socket; do
+        st="$(systemctl is-active "$u" 2>/dev/null || true)"
+        [[ "$st" == "active" ]] && return 0
+    done
+    return 1
+}
+
+# nftban_ssh_socket_port_mismatch_audit — PR-1 (item 3.2): on a SOCKET-ACTIVATED sshd,
+# detect when the configured Port (`sshd -T`) no longer matches the actual listeners
+# (the socket unit was not restarted after the config change). Read-only: no nft, no
+# restart. Emits ONE calm warning naming the class + the VERBATIM remediation when, and
+# only when, configured != listening AND sshd is socket-activated. Silent otherwise.
+nftban_ssh_socket_port_mismatch_audit() {
+    # Only socket-activated sshd has this pitfall; plain sshd.service applies Port on
+    # reload, so configured==listening by construction → nothing to warn about.
+    _nftban_ssh_socket_activated || return 0
+    local configured listening
+    configured="$(_nftban_sshd_configured_ports | paste -sd, -)" || true
+    listening="$(_nftban_ssh_listeners 2>/dev/null | sort -un | paste -sd, -)" || true
+    # If we cannot read either side, do not guess.
+    [[ -z "$configured" || -z "$listening" ]] && return 0
+    [[ "$configured" == "$listening" ]] && return 0
+    {
+        echo "  ⚠ socket-activated sshd port mismatch: sshd is CONFIGURED for :${configured}"
+        echo "    but is actually LISTENING on :${listening}. On a socket-activated sshd the"
+        echo "    ssh.socket unit owns the ListenStream, so a changed Port in sshd_config does"
+        echo "    not take effect until the socket unit is restarted. nftban protects the REAL"
+        echo "    listeners; ssh_ports follows :${listening} until the socket is reloaded. To apply"
+        echo "    the configured port, restart the socket unit:"
+        echo "      systemctl daemon-reload && systemctl restart ssh.socket"
+    } >&2
+    return 0
+}
+
 # nftban_ssh_admin_port_audit — S1: read-only report of sshd listeners vs ssh_ports vs
 # declared external admin ports + the active admin session, flagging external redirects.
 nftban_ssh_admin_port_audit() {
@@ -97,6 +147,9 @@ nftban_ssh_admin_port_audit() {
         fi
     done < <(nftban_ssh_external_admin_ports)
     [[ $mismatch -eq 0 ]] && echo "  ✓ no external-admin-port mismatch (ssh_ports reflects the real sshd listeners)."
+    # PR-1 (item 3.2): socket-activated sshd port-mismatch section (text-mode; warns to
+    # stderr only on a real mismatch, otherwise silent — does not break audit output).
+    nftban_ssh_socket_port_mismatch_audit || true
     return 0
 }
 
@@ -163,4 +216,5 @@ nftban_ssh_pre_rebuild_lockout_guard() {
 
 export -f nftban_ssh_external_admin_ports nftban_ssh_active_admin_ip nftban_ssh_active_admin_port \
           _nftban_ssh_ports_kernel _nftban_ssh_listeners _nftban_ssh_external_admin_risk_ports \
+          _nftban_sshd_configured_ports _nftban_ssh_socket_activated nftban_ssh_socket_port_mismatch_audit \
           nftban_ssh_admin_port_audit nftban_ssh_pre_rebuild_lockout_guard 2>/dev/null || true

--- a/cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
+++ b/cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.155 PR-2 SSH-port-change lifecycle validator
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_port_change_lifecycle_v155_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Hermetic tests for tools/validation/ssh_port_change_lifecycle_validate.sh (v1.155 PR-2 / item 3.3). Feeds a good rendered-ruleset+listeners fixture (exit 0, all invariants hold) and four injected drifts (listener not in ssh_ports; listener not in tcp_ports_in; literal 'tcp dport 22 ct count' instead of @ssh_ports; missing @ssh_ports rule), each asserted to fail with the right invariant message and a non-zero exit. Hermetic: inputs injected via NFTBAN_VALIDATE_RULESET_FILE + NFTBAN_VALIDATE_LISTENERS; no host/nft/root."
+# meta:input="None (self-contained sandbox fixtures)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sort,paste,tr"
+# meta:inventory.files="tools/validation/ssh_port_change_lifecycle_validate.sh"
+# meta:inventory.binaries="bash,grep,awk,sort,paste,tr"
+# meta:inventory.env_vars="NFTBAN_VALIDATE_RULESET_FILE,NFTBAN_VALIDATE_LISTENERS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+VALIDATOR="$REPO_ROOT/tools/validation/ssh_port_change_lifecycle_validate.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# run_validator <ruleset-file> <listeners> -> sets RC + OUT
+run_validator() {
+    local rf="$1" listeners="$2"
+    OUT=""; RC=0
+    OUT="$(NFTBAN_VALIDATE_RULESET_FILE="$rf" NFTBAN_VALIDATE_LISTENERS="$listeners" \
+        bash "$VALIDATOR" 2>&1)" || RC=$?
+}
+
+# ---- fixture builders ----------------------------------------------------
+# A well-formed rendered ruleset: tcp_ports_in + ssh_ports both contain the
+# listener(s); brute-force rule is set-driven (@ssh_ports), no literal dport.
+write_good_ruleset() {
+    local f="$1" sshports="$2" tcpin="$3"
+    cat > "$f" <<EOF
+table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { ${tcpin} }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { ${sshports} }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ct state established,related accept
+		tcp dport @ssh_ports ct state new ct count over 10 counter drop comment "SSH brute-force"
+		tcp dport @tcp_ports_in ct state new accept comment "TCP services"
+	}
+}
+EOF
+}
+
+echo "=== GOOD config: all four invariants hold (exit 0) ==="
+GOOD="$SANDBOX/good.nft"; write_good_ruleset "$GOOD" "22" "22, 80, 443"
+run_validator "$GOOD" "22"
+[[ $RC -eq 0 ]] && ok "good config exits 0" || no "good config should exit 0 (rc=$RC)" "$OUT"
+echo "$OUT" | grep -q "PASS  (a)" && ok "(a) passes" || no "(a) should pass" "$OUT"
+echo "$OUT" | grep -q "PASS  (b)" && ok "(b) passes" || no "(b) should pass" "$OUT"
+echo "$OUT" | grep -q "PASS  (c)" && ok "(c) passes" || no "(c) should pass" "$OUT"
+echo "$OUT" | grep -q "PASS  (d)" && ok "(d) passes" || no "(d) should pass" "$OUT"
+
+echo "=== GOOD config: multi-port sshd (22 + 2222 in both sets) ==="
+GOOD2="$SANDBOX/good2.nft"; write_good_ruleset "$GOOD2" "22, 2222" "22, 2222, 80"
+run_validator "$GOOD2" "22 2222"
+[[ $RC -eq 0 ]] && ok "multi-port good config exits 0" || no "multi-port should exit 0 (rc=$RC)" "$OUT"
+
+echo "=== DRIFT (b): listener not in ssh_ports ==="
+# sshd now listens on 2222 but ssh_ports still only has 22.
+DRIFT_B="$SANDBOX/drift_b.nft"; write_good_ruleset "$DRIFT_B" "22" "22, 2222, 80"
+run_validator "$DRIFT_B" "2222"
+[[ $RC -ne 0 ]] && ok "drift-(b) exits non-zero" || no "drift-(b) should fail" "$OUT"
+echo "$OUT" | grep -q "FAIL  (b)" && ok "drift-(b) reports invariant (b) failure" || no "drift-(b) message" "$OUT"
+echo "$OUT" | grep -q "NOT in ssh_ports: 2222" && ok "drift-(b) names the missing port" || no "drift-(b) names port" "$OUT"
+
+echo "=== DRIFT (a): listener not in tcp_ports_in ==="
+# ssh_ports has 2222 but tcp_ports_in does not → service port would be filtered.
+DRIFT_A="$SANDBOX/drift_a.nft"; write_good_ruleset "$DRIFT_A" "2222" "22, 80"
+run_validator "$DRIFT_A" "2222"
+[[ $RC -ne 0 ]] && ok "drift-(a) exits non-zero" || no "drift-(a) should fail" "$OUT"
+echo "$OUT" | grep -q "FAIL  (a)" && ok "drift-(a) reports invariant (a) failure" || no "drift-(a) message" "$OUT"
+echo "$OUT" | grep -q "NOT in tcp_ports_in: 2222" && ok "drift-(a) names the missing port" || no "drift-(a) names port" "$OUT"
+
+echo "=== DRIFT (d)+(c): literal 'tcp dport 22 ct count' instead of @ssh_ports ==="
+DRIFT_D="$SANDBOX/drift_d.nft"
+cat > "$DRIFT_D" <<'EOF'
+table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 22, 80, 443 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { 22 }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		tcp dport 22 ct state new ct count over 10 counter drop comment "SSH brute-force literal"
+		tcp dport @tcp_ports_in ct state new accept
+	}
+}
+EOF
+run_validator "$DRIFT_D" "22"
+[[ $RC -ne 0 ]] && ok "drift-(d) exits non-zero" || no "drift-(d) should fail" "$OUT"
+echo "$OUT" | grep -q "FAIL  (d)" && ok "drift-(d) reports invariant (d) failure (literal dport)" || no "drift-(d) message" "$OUT"
+echo "$OUT" | grep -q "FAIL  (c)" && ok "drift-(d) also fails (c) (no @ssh_ports ct-count rule)" || no "drift-(c) message" "$OUT"
+
+echo "=== DRIFT (c): @ssh_ports set exists but no ct-count rule references it ==="
+DRIFT_C="$SANDBOX/drift_c.nft"
+cat > "$DRIFT_C" <<'EOF'
+table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { 22, 80 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { 22 }
+	}
+	chain input {
+		type filter hook input priority 0; policy drop;
+		tcp dport @tcp_ports_in ct state new accept
+	}
+}
+EOF
+run_validator "$DRIFT_C" "22"
+[[ $RC -ne 0 ]] && ok "drift-(c) exits non-zero" || no "drift-(c) should fail" "$OUT"
+echo "$OUT" | grep -q "FAIL  (c)" && ok "drift-(c) reports invariant (c) failure" || no "drift-(c) message" "$OUT"
+
+echo ""
+echo "================================================================"
+echo "ssh_port_change_lifecycle_v155: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
+++ b/cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.155 PR-1 socket-activated SSH port-mismatch warning
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_socket_port_mismatch_v155_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-06"
+# meta:description="Hermetic tests for nftban_ssh_socket_port_mismatch_audit (lib/ssh_admin_port_guard.sh, v1.155 PR-1 / item 3.2). Verifies the socket-activated sshd port-mismatch warning fires ONLY when configured (sshd -T) != listening (ss) AND sshd is socket-activated, prints the EXACT remediation hint 'systemctl daemon-reload && systemctl restart ssh.socket', and is silent when ports match or when sshd is a plain service (not socket-activated). Also asserts the section is surfaced through nftban_ssh_admin_port_audit. Hermetic: stubs sshd + listeners + systemctl; no host/IPC/root/nft."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sort,paste,tr"
+# meta:inventory.files="cli/lib/nftban/lib/ssh_admin_port_guard.sh"
+# meta:inventory.binaries="bash,grep,awk,sort,paste,tr"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="ssh.socket,sshd.socket"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+GUARD="$REPO_ROOT/cli/lib/nftban/lib/ssh_admin_port_guard.sh"
+
+# The verbatim remediation hint the warning must contain (PR-1 contract).
+HINT="systemctl daemon-reload && systemctl restart ssh.socket"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+NFT_WRITE_LOG="$SANDBOX/nft_writes.log"
+: > "$NFT_WRITE_LOG"
+
+# ---- stubs --------------------------------------------------------------
+# nft: read-only list returns ssh_ports={22}; ANY write is recorded + fails
+# so an accidental nft write in this read-only path is caught.
+nft() {
+    case "$1" in
+        list)
+            if [[ "$*" == *"ssh_ports"* ]]; then
+                echo "table ip nftban { set ssh_ports { type inet_service; elements = { 22 } } }"
+            fi
+            return 0 ;;
+        add|delete|insert|replace|create|flush)
+            echo "$*" >> "$NFT_WRITE_LOG"; return 1 ;;
+        *) return 0 ;;
+    esac
+}
+export -f nft
+
+# sshd: stub `sshd -T` to emit a configurable `port` line; `command -v sshd` works
+# because the function shadows the binary name.
+SSHD_TPORT="22"
+sshd() {
+    if [[ "$1" == "-T" ]]; then
+        local p
+        for p in $SSHD_TPORT; do echo "port $p"; done
+        echo "permitrootlogin no"
+        return 0
+    fi
+    return 0
+}
+export -f sshd
+
+# listeners: configurable actual sshd listener set (newline-separated).
+DETECT_PORTS="22"
+nftban_detect_ssh_ports() { printf '%s\n' $DETECT_PORTS; }
+export -f nftban_detect_ssh_ports
+
+# systemctl: is-active for the socket units is driven by SOCKET_ACTIVE.
+SOCKET_ACTIVE=0
+systemctl() {
+    if [[ "$1" == "is-active" ]]; then
+        case "$2" in
+            ssh.socket|sshd.socket)
+                if [[ "$SOCKET_ACTIVE" == "1" ]]; then echo "active"; return 0; fi
+                echo "inactive"; return 3 ;;
+            *) echo "inactive"; return 3 ;;
+        esac
+    fi
+    return 0
+}
+export -f systemctl
+
+# shellcheck source=/dev/null
+source "$GUARD"
+
+reset_state() {
+    : > "$NFT_WRITE_LOG"
+    SSHD_TPORT="22"; DETECT_PORTS="22"; SOCKET_ACTIVE=0
+    unset SSH_CLIENT SSH_CONNECTION NFTBAN_EXTERNAL_ADMIN_SSH_PORTS 2>/dev/null || true
+}
+
+echo "=== helper: _nftban_sshd_configured_ports parses sshd -T port lines ==="
+reset_state; SSHD_TPORT="2222"
+[[ "$(_nftban_sshd_configured_ports | paste -sd, -)" == "2222" ]] \
+    && ok "configured_ports: single port from sshd -T" || no "configured_ports single"
+reset_state; SSHD_TPORT="22 2222"
+[[ "$(_nftban_sshd_configured_ports | paste -sd, -)" == "22,2222" ]] \
+    && ok "configured_ports: multi-port sorted-unique" || no "configured_ports multi"
+
+echo "=== helper: _nftban_ssh_socket_activated reflects ssh.socket is-active ==="
+reset_state; SOCKET_ACTIVE=1
+_nftban_ssh_socket_activated && ok "socket_activated: true when ssh.socket active" || no "socket_activated true"
+reset_state; SOCKET_ACTIVE=0
+_nftban_ssh_socket_activated && no "socket_activated: false when no socket" || ok "socket_activated: false when plain sshd.service"
+
+echo "=== WARN: socket-activated AND configured != listening ==="
+reset_state; SOCKET_ACTIVE=1; SSHD_TPORT="2222"; DETECT_PORTS="22"
+out="$(nftban_ssh_socket_port_mismatch_audit 2>&1)"
+echo "$out" | grep -q "socket-activated sshd port mismatch" && ok "warns on socket-activated mismatch" || no "warn fires" "$out"
+echo "$out" | grep -q "CONFIGURED for :2222" && ok "names configured port :2222" || no "names configured" "$out"
+echo "$out" | grep -q "LISTENING on :22" && ok "names listening port :22" || no "names listening" "$out"
+echo "$out" | grep -Fq "$HINT" && ok "prints EXACT remediation hint" || no "exact hint" "$out"
+[[ ! -s "$NFT_WRITE_LOG" ]] && ok "no nft write (read-only)" || no "nft write" "$(cat "$NFT_WRITE_LOG")"
+
+echo "=== NO WARN: socket-activated but configured == listening ==="
+reset_state; SOCKET_ACTIVE=1; SSHD_TPORT="22"; DETECT_PORTS="22"
+out="$(nftban_ssh_socket_port_mismatch_audit 2>&1)"
+[[ -z "$out" ]] && ok "silent when ports match" || no "should be silent (match)" "$out"
+
+echo "=== NO WARN: ports differ but NOT socket-activated (plain sshd.service) ==="
+reset_state; SOCKET_ACTIVE=0; SSHD_TPORT="2222"; DETECT_PORTS="22"
+out="$(nftban_ssh_socket_port_mismatch_audit 2>&1)"
+[[ -z "$out" ]] && ok "silent when not socket-activated (plain service applies Port on reload)" || no "should be silent (plain service)" "$out"
+
+echo "=== surfaced via nftban_ssh_admin_port_audit (text-mode) ==="
+reset_state; SOCKET_ACTIVE=1; SSHD_TPORT="2222"; DETECT_PORTS="22"
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -q "socket-activated sshd port mismatch" && ok "ssh-audit surfaces the mismatch section" || no "audit surfaces" "$out"
+echo "$out" | grep -Fq "$HINT" && ok "ssh-audit prints the exact hint" || no "audit hint" "$out"
+echo "$out" | grep -q "no external-admin-port mismatch" && ok "audit still prints its normal verdict line" || no "audit normal verdict" "$out"
+
+echo "=== ssh-audit clean host: no socket section ==="
+reset_state; SOCKET_ACTIVE=1; SSHD_TPORT="22"; DETECT_PORTS="22"
+out="$(nftban_ssh_admin_port_audit 2>&1)"
+echo "$out" | grep -q "socket-activated sshd port mismatch" && no "clean host: must not warn" "$out" || ok "clean host: no socket-mismatch warning"
+
+echo ""
+echo "================================================================"
+echo "ssh_socket_port_mismatch_v155: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/docs/SSH-EXTERNAL-ADMIN-PORT.md
+++ b/docs/SSH-EXTERNAL-ADMIN-PORT.md
@@ -97,6 +97,7 @@ Recommended on srv1/dns2-class hosts: set `NFTBAN_EXTERNAL_ADMIN_SSH_PORTS` to t
 
 ## 6. Related
 
+- SSH-port lifecycle (socket activation + invariants + srv1 gate): [`SSH-PORT-LIFECYCLE.md`](SSH-PORT-LIFECYCLE.md) — v1.155 companion: the socket-activation Port-change pitfall, the lifecycle invariants the validator checks, the read-only OBS-SSHPORT observation procedure, and the srv1 decision matrix.
 - nftables single-writer policy: [`ARCHITECTURE-NFT-POLICY.md`](ARCHITECTURE-NFT-POLICY.md) — the lockout-net writes only through the sanctioned IPC `whitelist-session` path (no direct nft).
 - SSH-port detection authority: `cli/lib/nftban/lib/ssh_port_detect.sh`, `cmd/nftban-detect-ssh-ports` (sources: `ss` listeners + `sshd_config` Port/ListenAddress + state + `conf.local`; **no conntrack source**).
 - Register entry: `OBS-SSHPORT-55000-FAMILY` in `NFTBAN_PENDINGS_AND_BUGS_CURRENT.md` (cluster 3, SSH-port lifecycle).

--- a/docs/SSH-PORT-LIFECYCLE.md
+++ b/docs/SSH-PORT-LIFECYCLE.md
@@ -1,0 +1,108 @@
+# NFTBan — SSH-port lifecycle (socket activation, invariants, and the srv1 gate)
+
+**Status:** operator note. **Added:** v1.155 lane (cluster 3, SSH-port lifecycle). **Class:** SSH-port-change correctness + lockout-adjacent **host-config** debt — **not** an NFTBan regression. Daemon byte-identical to v1.154.0.
+
+This page is the companion to [`SSH-EXTERNAL-ADMIN-PORT.md`](SSH-EXTERNAL-ADMIN-PORT.md). That page covers the **external `:55000 → :22` redirect** class. This page covers two adjacent things:
+
+1. the **socket-activation port-change pitfall** that v1.155 PR-1 warns about, and the **lifecycle invariants** that the v1.155 PR-2 validator checks;
+2. the **read-only observation procedure** and the **decision matrix** for the two srv1 gates, recording that the on-host srv1 proof is a **separate read-only gate after this release**.
+
+Throughout: NFTBan is an ingress IPS, **not a NAT manager**. The external redirect stays host-managed, `:22` is never at risk, and `ssh_ports` only ever holds the **real `sshd` listeners**.
+
+---
+
+## 1. The socket-activation port-change pitfall (plain English)
+
+On modern distros `sshd` can be **socket-activated**: a systemd `ssh.socket` (or `sshd.socket`) unit owns the listening socket and starts `sshd` on demand. The catch:
+
+- When `sshd` runs as a plain service (`sshd.service`), changing `Port` in `sshd_config` and reloading `sshd` moves the listener immediately.
+- When `sshd` is **socket-activated**, the `ssh.socket` unit owns the `ListenStream` (the port). Changing `Port` in `sshd_config` does **not** move the listener until **the socket unit is restarted**. So:
+  - `sshd -T` reports the **configured** (new) port, while
+  - `ss -tlnp` shows the socket still bound to the **old** port.
+
+NFTBan protects the **real listeners** (what `ss` shows), so during that window `ssh_ports` correctly follows the old, still-listening port — not the configured-but-not-yet-active one. The operator can be surprised: "I changed the Port and reloaded sshd, why is the firewall still on the old port?" The answer is that the socket unit was never restarted.
+
+**What v1.155 PR-1 does about it.** On a socket-activated host, `nftban firewall ssh-audit` (and the pre-rebuild guard path) now compares the configured ports (`sshd -T`) against the actual listeners. On a real mismatch it prints **one** calm warning naming the class and the exact remediation:
+
+```
+systemctl daemon-reload && systemctl restart ssh.socket
+```
+
+It is **read-only**: it performs no `nft` write and no service restart — it only tells you what to run. It is silent when the ports match or when `sshd` is a plain service (which applies `Port` on reload, so there is nothing to warn about). The wording is asserted by `cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh` (CI: *Socket-activated SSH port-mismatch warning (v1.155 PR-1)*) — the test is the source of truth if this page and the code ever diverge.
+
+---
+
+## 2. The lifecycle invariants (what the v1.155 PR-2 validator checks)
+
+`tools/validation/ssh_port_change_lifecycle_validate.sh` is a **read-only** validator. Given the rendered nftables ruleset and the real `sshd` listeners, it asserts four invariants that together mean "a Port change has been carried through the whole lifecycle correctly":
+
+| # | Invariant | Why it matters |
+|---|-----------|----------------|
+| (a) | every `sshd` listener ∈ `tcp_ports_in` | otherwise the SSH service port is filtered (no inbound accept) |
+| (b) | every `sshd` listener ∈ `ssh_ports` | otherwise the brute-force rate-limit misses that port |
+| (c) | the brute-force ct-count rule references `@ssh_ports` (the set) | the rate-limit must be set-driven (v1.145), not hardcoded |
+| (d) | there is **no** literal `tcp dport <sshport> … ct count` rule for an sshd port | a hardcoded literal would drift from the set on the next Port change |
+
+Exit `0` means all four hold. On drift it exits non-zero with a precise per-invariant message (e.g. *"(b) sshd listener(s) NOT in ssh_ports: 2222 (brute-force rate-limit would miss this port)"*).
+
+The validator auto-collects inputs on a host (`nft list ruleset` + the listener detector), or accepts injected fixtures via `NFTBAN_VALIDATE_RULESET_FILE` and `NFTBAN_VALIDATE_LISTENERS` (this is how the hermetic CI test exercises it). It mutates **nothing**: no `nft` write, no reload, no restart, no `sshd_config` edit, no SSH-port change.
+
+Run it read-only on a host:
+
+```
+sudo bash tools/validation/ssh_port_change_lifecycle_validate.sh
+```
+
+---
+
+## 3. OBS-SSHPORT observation procedure (srv1 / dns2, read-only)
+
+This is the procedure to **observe** the external `:55000 → :22` behaviour around a rebuild on the affected hosts. It is **strictly read-only — capture, do not mutate.** Do **not** run `nftban firewall rebuild`/`reload`/`takeover`, do not edit `sshd_config`, do not touch the host redirect. The point of this gate is to *watch*, not to change.
+
+Capture, **before** any rebuild (and keep `:22` open in a second session throughout):
+
+1. **Listeners:** `ss -tlnp | grep -i ssh` — confirm `sshd` is on `:22` only.
+2. **Configured ports:** `sshd -T | awk '/^port /{print $2}'`.
+3. **Socket activation:** `systemctl is-active ssh.socket sshd.socket`.
+4. **Host-layer redirect rules** (whoever owns `:55000`):
+   - firewalld: `firewall-cmd --list-forward-ports`
+   - iptables-nft: `nft list ruleset | grep -iE 'redirect|dnat|55000'` and `iptables-save | grep 55000`
+5. **NFTBan picture:** `nftban firewall ssh-audit` (records `ssh_ports = { 22 }`, declared `:55000`, the external-redirect flag, and — on a socket-activated host — the PR-1 socket section).
+6. **Lifecycle invariants:** `sudo bash tools/validation/ssh_port_change_lifecycle_validate.sh`.
+7. **Conntrack for the admin source:** `conntrack -L 2>/dev/null | grep <admin-ip>` (or `ss -tnp` for the established admin connection) — shows the admin path is held by established conntrack regardless of port.
+
+If a rebuild is later performed **under the separate gate** (§4), repeat steps 1–7 **after** it and diff: confirm `sshd`/`:22` never moved, `ssh_ports` stayed `{ 22 }`, no `:55000` rule exists inside NFTBan's ruleset, and whether the **host-layer** `:55000` redirect survived (that is the host's responsibility, not NFTBan's).
+
+> Why this is read-only here: the actual rebuild on srv1 is a **separate gate after this release** (next section). v1.155 ships the warning + validator + this procedure; the on-host proof is run later by the operator.
+
+---
+
+## 4. Decision matrix — the two srv1 gates
+
+The operator tracks two named gates for the srv1 external-`:55000` question. They are mutually exclusive choices about *how much proof* the srv1 rebuild gate requires:
+
+| Gate token | Meaning | What it requires | Selected? |
+|------------|---------|------------------|-----------|
+| `OPEN_SSHPORT_55000_EXTERNAL_REDIRECT_SURVIVES_REBUILD_SCOPE` | **Full lifecycle proof** | Run the §3 observation procedure **before and after** an actual rebuild on srv1; diff every capture; record whether the host-layer `:55000` redirect survived and how it was restored if not. The strongest evidence. | **Selected** (`SELECT_V155_SRV1_GATE_AFTER_RELEASE = full_lifecycle_proof`) |
+| `MARK_V150_SRV1_REBUILD_RETEST_PASS_WITH_OBS_SSHPORT` | Lighter retest mark | Re-confirm the v1.150 OBS-SSHPORT observation on srv1 (audit + ruleset grep) without a fresh full before/after rebuild diff. | not selected |
+
+**Recorded decision:** the operator selected the **full lifecycle proof** path, and the on-host srv1 proof is a **SEPARATE read-only gate that runs AFTER this v1.155 release** — it is not part of this lane. v1.155 delivers the code (PR-1 warning, PR-2 validator) and this documentation; the srv1 rebuild observation is performed and recorded under `OPEN_SSHPORT_55000_EXTERNAL_REDIRECT_SURVIVES_REBUILD_SCOPE` once v1.155 is shipped.
+
+---
+
+## 5. What stays true (the non-negotiables)
+
+- **NFTBan is not a NAT manager.** It does not create, recreate, or preserve the external `:55000 → :22` redirect. That rule lives in the host layer (firewalld / iptables-nft / panel / provider) and stays there.
+- **The external redirect stays host-managed.** If a rebuild disturbs `:55000`, restore it in its own layer (see `SSH-EXTERNAL-ADMIN-PORT.md` §5).
+- **`:22` is never at risk.** `sshd` listens on `:22`; NFTBan protects the real listeners, so `:22` stays up across rebuild/reload/takeover. You can always reconnect on `:22`.
+- **`ssh_ports` = real listeners only.** The external `:55000` is never imported into `ssh_ports` (it is not a listener); `ssh_ports` drives the brute-force rate-limit on the actual `sshd` port.
+
+---
+
+## 6. Related
+
+- External admin redirect class: [`SSH-EXTERNAL-ADMIN-PORT.md`](SSH-EXTERNAL-ADMIN-PORT.md) — the `:55000 → :22` warn-only + lockout-net behaviour.
+- nftables single-writer policy: [`ARCHITECTURE-NFT-POLICY.md`](ARCHITECTURE-NFT-POLICY.md).
+- SSH-port detection authority: `cli/lib/nftban/lib/ssh_port_detect.sh` (sources: `ss` listeners + `sshd_config` Port/ListenAddress + state + `conf.local`; no conntrack source).
+- Guard library + tests: `cli/lib/nftban/lib/ssh_admin_port_guard.sh`, `cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh`, `cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh`.
+- Validator: `tools/validation/ssh_port_change_lifecycle_validate.sh`.

--- a/tools/validation/ssh_port_change_lifecycle_validate.sh
+++ b/tools/validation/ssh_port_change_lifecycle_validate.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.155 - SSH-port-change lifecycle validator (READ-ONLY)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_port_change_lifecycle_validate" meta:type="tool" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="READ-ONLY validator (v1.155 PR-2 / item 3.3) for the SSH-port-change lifecycle invariants. Given the rendered nftables ruleset and the real sshd listeners, it asserts: (a) every sshd listener is in tcp_ports_in; (b) every sshd listener is in ssh_ports; (c) the brute-force ct-count rule references @ssh_ports (the set); (d) there is NO literal 'tcp dport <port>' ct-count rule for an sshd port (must use the set). Exit 0 iff all invariants hold. Mutates NOTHING: no nft write, no reload, no restart, no SSH-port change. Inputs auto-collected on a host, or injected via env for hermetic testing."
+# meta:input="Live ruleset + listeners on a host, OR injected via NFTBAN_VALIDATE_RULESET_FILE / NFTBAN_VALIDATE_LISTENERS"
+# meta:output="PASS/FAIL lines on stdout; exit 0 on all-pass, non-zero on drift"
+# meta:depends="bash,grep,awk,sort,paste,tr"
+# meta:inventory.files="cli/lib/nftban/lib/ssh_admin_port_guard.sh,cli/lib/nftban/lib/ssh_port_detect.sh"
+# meta:inventory.binaries="nft,ss,sshd,grep,awk,sort,paste,tr"
+# meta:inventory.env_vars="NFTBAN_TABLE_IPV4,NFTBAN_VALIDATE_RULESET_FILE,NFTBAN_VALIDATE_LISTENERS,NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root for live collection (read-only nft/ss/sshd -T); none when inputs injected"
+# =============================================================================
+#
+# READ-ONLY by construction: every external call is a query (nft list / ss /
+# sshd -T). There is NO nft add/delete/flush, NO reload/rebuild, NO restart,
+# NO sshd_config edit, NO SSH-port change.
+set -Eeuo pipefail
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  PASS  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; }
+
+# --- Input 1: rendered ruleset --------------------------------------------
+# Hermetic override: NFTBAN_VALIDATE_RULESET_FILE points at a captured
+# `nft list ruleset` (or equivalent) fixture. Otherwise read live (read-only).
+_collect_ruleset() {
+    if [[ -n "${NFTBAN_VALIDATE_RULESET_FILE:-}" ]]; then
+        cat "${NFTBAN_VALIDATE_RULESET_FILE}" 2>/dev/null || true
+        return 0
+    fi
+    command -v nft >/dev/null 2>&1 || return 0
+    nft list ruleset 2>/dev/null || true
+}
+
+# --- Input 2: sshd listeners ----------------------------------------------
+# Hermetic override: NFTBAN_VALIDATE_LISTENERS = space/comma/newline-separated
+# port list. Otherwise use the guard lib's detector (read-only).
+_collect_listeners() {
+    if [[ -n "${NFTBAN_VALIDATE_LISTENERS:-}" ]]; then
+        printf '%s\n' "${NFTBAN_VALIDATE_LISTENERS}" | tr ', ' '\n' | grep -E '^[0-9]+$' | sort -un || true
+        return 0
+    fi
+    local guard="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/ssh_admin_port_guard.sh"
+    if [[ -r "$guard" ]]; then
+        # shellcheck source=/dev/null
+        source "$guard" 2>/dev/null || true
+        if declare -f _nftban_ssh_listeners >/dev/null 2>&1; then
+            _nftban_ssh_listeners 2>/dev/null | sort -un || true
+            return 0
+        fi
+    fi
+    # Last-resort direct query (read-only).
+    if command -v sshd >/dev/null 2>&1; then
+        sshd -T 2>/dev/null | awk '/^port /{print $2}' | sort -un || true
+    fi
+}
+
+# --- elements of an nftables named set, from a rendered ruleset -----------
+# Matches a `set <name> { ... elements = { 22, 2222 } ... }` block (single- or
+# multi-line) and prints the numeric elements, sorted-unique.
+_set_elements() {
+    local ruleset="$1" name="$2"
+    # Normalize to a single stream; the `elements = { ... }` clause may span lines.
+    printf '%s\n' "$ruleset" \
+        | tr '\n' ' ' \
+        | grep -oE "set[[:space:]]+${name}[[:space:]]*\{[^}]*elements[[:space:]]*=[[:space:]]*\{[^}]*\}" \
+        | grep -oE 'elements[[:space:]]*=[[:space:]]*\{[^}]*\}' \
+        | grep -oE '[0-9]+' \
+        | sort -un || true
+}
+
+main() {
+    local ruleset listeners
+    ruleset="$(_collect_ruleset)"
+    listeners="$(_collect_listeners)"
+
+    echo "============================================================"
+    echo "SSH-port-change lifecycle validator (READ-ONLY)"
+    echo "MODE: read-only — no nft mutation, no reload, no restart"
+    echo "============================================================"
+
+    if [[ -z "$ruleset" ]]; then
+        bad "no rendered ruleset available (NFTBAN_VALIDATE_RULESET_FILE unset and 'nft list ruleset' empty)"
+    fi
+    if [[ -z "$listeners" ]]; then
+        bad "no sshd listeners detected (NFTBAN_VALIDATE_LISTENERS unset and detector returned nothing)"
+    fi
+    if [[ -z "$ruleset" || -z "$listeners" ]]; then
+        echo "------------------------------------------------------------"
+        echo "RESULT: PASS=$PASS FAIL=$FAIL (cannot validate without both inputs)"
+        return 1
+    fi
+
+    local tcp_in ssh_set lp
+    tcp_in="$(_set_elements "$ruleset" tcp_ports_in)"
+    ssh_set="$(_set_elements "$ruleset" ssh_ports)"
+    echo "  listeners:     $(printf '%s' "$listeners" | paste -sd, -)"
+    echo "  tcp_ports_in:  $(printf '%s' "$tcp_in" | paste -sd, -)"
+    echo "  ssh_ports:     $(printf '%s' "$ssh_set" | paste -sd, -)"
+    echo "------------------------------------------------------------"
+
+    # (a) every sshd listener ∈ tcp_ports_in
+    local miss_a=""
+    while IFS= read -r lp; do
+        [[ -z "$lp" ]] && continue
+        printf '%s\n' "$tcp_in" | grep -qx "$lp" || miss_a+="${miss_a:+,}$lp"
+    done <<< "$listeners"
+    if [[ -z "$miss_a" ]]; then
+        ok "(a) every sshd listener is in tcp_ports_in"
+    else
+        bad "(a) sshd listener(s) NOT in tcp_ports_in: $miss_a (SSH service port would be filtered)"
+    fi
+
+    # (b) every sshd listener ∈ ssh_ports
+    local miss_b=""
+    while IFS= read -r lp; do
+        [[ -z "$lp" ]] && continue
+        printf '%s\n' "$ssh_set" | grep -qx "$lp" || miss_b+="${miss_b:+,}$lp"
+    done <<< "$listeners"
+    if [[ -z "$miss_b" ]]; then
+        ok "(b) every sshd listener is in ssh_ports"
+    else
+        bad "(b) sshd listener(s) NOT in ssh_ports: $miss_b (brute-force rate-limit would miss this port)"
+    fi
+
+    # (c) the brute-force ct-count rule references @ssh_ports (the set)
+    if printf '%s\n' "$ruleset" | grep -Eq 'tcp[[:space:]]+dport[[:space:]]+@ssh_ports[[:space:]].*ct[[:space:]]+count'; then
+        ok "(c) brute-force ct-count rule references @ssh_ports"
+    else
+        bad "(c) no 'tcp dport @ssh_ports ... ct count' rule found (set-driven rate-limit missing)"
+    fi
+
+    # (d) NO literal 'tcp dport <sshport> ... ct count' rule for an sshd port
+    #     (it must go through the set, not a hardcoded literal).
+    local lit_bad=""
+    while IFS= read -r lp; do
+        [[ -z "$lp" ]] && continue
+        if printf '%s\n' "$ruleset" \
+            | grep -E "tcp[[:space:]]+dport[[:space:]]+${lp}[[:space:]].*ct[[:space:]]+count" \
+            | grep -qv '@ssh_ports'; then
+            lit_bad+="${lit_bad:+,}$lp"
+        fi
+    done <<< "$listeners"
+    if [[ -z "$lit_bad" ]]; then
+        ok "(d) no literal 'tcp dport <sshport> ... ct count' rule (set-driven only)"
+    else
+        bad "(d) literal ct-count rule for sshd port(s) $lit_bad — must use @ssh_ports, not a literal dport"
+    fi
+
+    echo "------------------------------------------------------------"
+    echo "RESULT: PASS=$PASS FAIL=$FAIL"
+    [[ $FAIL -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
**SSH-port lifecycle / srv1 rollout-unblocker.** Removes the srv1 / external-`:55000` ambiguity blocking the fleet rollout by adding the two missing SSH lifecycle pieces + a reproducible proof procedure. **Read-only / no host mutation; shell + tests + docs only.**

### 3 commits (preserved)
- **PR-1** `d2d8f2b6` — socket-activated SSH port-mismatch warning (item 3.2): on a socket-activated sshd, when `sshd -T` Port ≠ actual listeners, emit the verbatim `systemctl daemon-reload && systemctl restart ssh.socket` hint (extends the v1.150.1 `ssh_admin_port_guard.sh`; read-only — never restarts).
- **PR-2** `3ce8c726` — SSH-port-change lifecycle validator (item 3.3): `tools/validation/ssh_port_change_lifecycle_validate.sh` asserts listeners ⊆ `tcp_ports_in` ∧ ⊆ `ssh_ports` ∧ ct-count uses `@ssh_ports` ∧ no literal `tcp dport <sshport>`; env-injectable for hermetic tests; **CI wiring** added.
- **PR-3** `66666e5e` — `docs/SSH-PORT-LIFECYCLE.md` / OBS-SSHPORT decision matrix (docs only): pitfall explainer + read-only srv1/dns2 reproduction procedure; records the on-host srv1 proof as a **separate post-release read-only gate** (full lifecycle proof).

### Invariants
- read-only / **no host mutation** · **no direct nft writes** · **0 Go** · **0 `cmd/nftband`** · **0 schema** · **no CSF**
- **daemon byte-identical to v1.154.0** (by construction — no Go touched)
- nftban is not a NAT manager; the external `:55000→:22` redirect stays host-managed; `:22` never at risk; `ssh_ports` = real sshd listeners only.

### Validation (lab2)
- `shellcheck -S warning` clean · `bash -n` clean (4 shell files)
- `ssh_socket_port_mismatch_v155` **15/0** · `ssh_port_change_lifecycle_v155` **17/0** · `ssh_admin_port_guard_v150` (regression) **36/0**
- `ci-architecture.yml` valid YAML (2 test steps wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
