### PR TITLE
feat(v1.156): installer/CI rollout-safety cleanup

### DIFF
--- a/.github/workflows/ci-empty-env-smoke.yml
+++ b/.github/workflows/ci-empty-env-smoke.yml
@@ -1,0 +1,148 @@
+# =============================================================================
+# NFTBan — CI: Empty-Env Smoke Guard (H4)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# H4 — the next guard in the H-series (after H3.2 Migration Coverage Gate and
+# H3.3 Shell-Delete Guard). The internal H-series spec (H3.1) lives in an
+# audit/wiki workspace and is intentionally NOT shipped in this repo; the
+# concrete assertions are inlined here.
+#
+# What H4 asserts (rollout-safety): the read-only CLI + installer entrypoints
+# survive a SCRUBBED / empty environment. NFTBan's shell runs under
+# `set -Eeuo pipefail`, so any code path that dereferences an environment
+# variable without a `${VAR:-default}` would abort with an "unbound variable"
+# diagnostic on a host with a minimal env (cron, a systemd ExecStart with a
+# clean environment, a freshly-scrubbed login). This gate runs version/help
+# under `env -i` (only PATH + NFTBAN_LIB_DIR passed through) and fails if the
+# entrypoint crashes on an unbound variable.
+#
+# Read-only commands ONLY (version, help, --version, -h). No host mutation.
+# =============================================================================
+
+name: Empty-Env Smoke Guard (H4)
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'cli/**'
+      - 'cmd/nftban-installer/**'
+      - 'internal/installer/**'
+      - 'cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh'
+      - '.github/workflows/ci-empty-env-smoke.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-empty-env-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  empty-env-smoke:
+    name: Empty-Env Smoke Guard (H4)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.6.0
+        with:
+          go-version: '1.25'
+
+      # ------------------------------------------------------------------
+      # H4.1 — CLI empty-env smoke (shell). Hermetic test: runs the CLI
+      # entrypoint (version, help, status --help) under `env -i` with only
+      # PATH + NFTBAN_LIB_DIR and asserts no unbound-variable crash under
+      # `set -u`. No host install needed — runs straight from the checkout.
+      # ------------------------------------------------------------------
+      - name: H4.1 — CLI empty-env smoke (no set -u unbound crash)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          chmod +x cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
+          bash cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
+
+      # ------------------------------------------------------------------
+      # H4.2 — installer empty-env smoke (Go binary). Build the installer,
+      # then run its read-only `--version` and `-h` under a scrubbed env.
+      # `--version` prints the version line and exits 0; `-h` prints usage
+      # via the flag package and exits 2 (Go's default for -h). Neither
+      # mutates anything. We fail only on an unexpected crash signature
+      # (panic / runtime error) — both invocations are read-only.
+      # ------------------------------------------------------------------
+      - name: H4.2 — build installer
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p bin
+          go build -trimpath -o bin/nftban-installer ./cmd/nftban-installer/
+          test -x bin/nftban-installer
+
+      - name: H4.2 — installer --version under empty env (read-only)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          rc=0
+          out=$(env -i PATH="/usr/sbin:/usr/bin:/sbin:/bin" \
+                  ./bin/nftban-installer --version 2>&1) || rc=$?
+          echo "$out"
+          echo "installer --version exit code: $rc"
+          if grep -qiE 'panic:|runtime error|goroutine [0-9]+ \[' <<<"$out"; then
+            echo "::error::H4.2 FAIL: installer --version panicked under empty env"
+            exit 1
+          fi
+          if [[ "$rc" != "0" ]]; then
+            echo "::error::H4.2 FAIL: installer --version expected rc=0 under empty env, got rc=$rc"
+            exit 1
+          fi
+          # Must actually print a version line (proves the read-only path ran).
+          grep -qi 'nftban-installer' <<<"$out" || {
+            echo "::error::H4.2 FAIL: installer --version produced no version line"
+            exit 1
+          }
+          echo "H4.2 PASS — installer --version clean under empty env"
+
+      - name: H4.2 — installer -h under empty env (read-only)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          rc=0
+          # -h with no -mode is a usage request; the flag package prints usage
+          # to stderr and exits 2. We assert no panic and the documented rc.
+          out=$(env -i PATH="/usr/sbin:/usr/bin:/sbin:/bin" \
+                  ./bin/nftban-installer -h 2>&1) || rc=$?
+          echo "$out"
+          echo "installer -h exit code: $rc"
+          if grep -qiE 'panic:|runtime error|goroutine [0-9]+ \[' <<<"$out"; then
+            echo "::error::H4.2 FAIL: installer -h panicked under empty env"
+            exit 1
+          fi
+          case "$rc" in
+            0|2) echo "H4.2 PASS — installer -h clean under empty env (rc=$rc)" ;;
+            *) echo "::error::H4.2 FAIL: installer -h unexpected rc=$rc under empty env"; exit 1 ;;
+          esac
+          # Usage text must mention a known flag (proves flag.Usage ran).
+          grep -qi -- '-mode' <<<"$out" || {
+            echo "::error::H4.2 FAIL: installer -h printed no usage"
+            exit 1
+          }
+
+  summary:
+    name: Empty-Env Smoke Guard summary
+    needs: empty-env-smoke
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verdict
+        run: |
+          if [[ "${{ needs.empty-env-smoke.result }}" != "success" ]]; then
+            echo "::error::Empty-Env Smoke Guard (H4) FAILED — see job output"
+            exit 1
+          fi
+          echo "Empty-Env Smoke Guard (H4) PASSED"

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -635,9 +635,14 @@ nftban_portscan_classic_cleanup_old_entries() {
         local new_timestamps=""
         local has_recent=false
 
-        # Use read -ra to properly split into array
+        # Use read -ra to properly split into array. v1.156 PR-D: timestamps
+        # are space-joined (see assignment "${current_timestamps} ${timestamp}"
+        # at the tracker), so split on whitespace EXPLICITLY. A bare read -ra
+        # would inherit a strict IFS=$'\n\t' (strict.sh) from the caller and
+        # collapse the whole string into one element — same bug family as the
+        # v1.152 feeds-select fix.
         local -a ts_array
-        read -ra ts_array <<< "$timestamps"
+        IFS=$' \t\n' read -ra ts_array <<< "$timestamps"
 
         for ts in "${ts_array[@]}"; do
             # Skip empty or non-numeric entries
@@ -727,9 +732,11 @@ nftban_portscan_classic_detect_scan_type() {
     # Check for strobe scan (rapid scanning of common ports)
     if [[ $port_count -ge $strobe_ports ]]; then
         local timestamps="${_PORTSCAN_CLASSIC_IP_TIMESTAMPS[$ip]}"
-        # Convert to array, filtering empty elements
+        # Convert to array, filtering empty elements. v1.156 PR-D: timestamps
+        # are space-joined, so split on whitespace EXPLICITLY — a bare read -ra
+        # would collapse them into one element under a strict IFS=$'\n\t' caller.
         local -a ts_array
-        read -ra ts_array <<< "$timestamps"
+        IFS=$' \t\n' read -ra ts_array <<< "$timestamps"
         local ts_count=${#ts_array[@]}
 
         if [[ $ts_count -gt 1 ]]; then

--- a/cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
+++ b/cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - empty-env smoke test (v1.156 PR-B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_empty_env_smoke_v156_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-07"
+# meta:description="v1.156 PR-B — empty-env smoke. Runs the read-only CLI entrypoints (version, help) under a SCRUBBED environment (env -i with only PATH + NFTBAN_LIB_DIR) and asserts the dispatcher does NOT crash on an unbound variable under set -u. The CLI runs with set -Eeuo pipefail, so any code path that dereferences an environment variable without a default would abort with 'unbound variable' on a host with a minimal/empty env (cron, systemd ExecStart with a scrubbed environment, etc.). This is a regression-prevention gate: read-only commands only, no host mutation."
+# meta:input="cli/sbin/nftban"
+# meta:output="Pass/fail assertions per command; exit 0 on all-pass"
+# meta:depends="bash,grep,env"
+# meta:inventory.files="cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep,env"
+# meta:inventory.env_vars="PATH,NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+LIB_DIR="$REPO/cli/lib/nftban"
+
+[[ -x "$NFTBAN_SBIN" ]] || { echo "FAIL: missing $NFTBAN_SBIN" >&2; exit 1; }
+[[ -d "$LIB_DIR" ]]     || { echo "FAIL: missing $LIB_DIR" >&2; exit 1; }
+
+# A minimal but real PATH so bash + the coreutils the dispatcher reaches for
+# resolve. This is deliberately the ONLY env we pass through env -i besides
+# NFTBAN_LIB_DIR — the whole point is to prove the CLI does not depend on any
+# other ambient variable being set under `set -u`.
+MIN_PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# Run a read-only CLI invocation under a scrubbed environment and assert:
+#   (a) the run does NOT abort with an 'unbound variable' diagnostic, and
+#   (b) the exit code is one of the expected codes (rc=0 for help/version on a
+#       repo checkout; some commands legitimately rc=1 without a daemon, but the
+#       smoke target commands here are inert and must succeed).
+# Expected-rc is supplied per command.
+assert_empty_env_ok(){
+    local label="$1"; local want_rc="$2"; shift 2
+    local args=("$@")
+    local rc=0 out
+    out=$(env -i PATH="$MIN_PATH" NFTBAN_LIB_DIR="$LIB_DIR" \
+            bash "$NFTBAN_SBIN" "${args[@]}" 2>&1) || rc=$?
+
+    if grep -qi 'unbound variable' <<<"$out"; then
+        no "$label" "set -u unbound-variable crash under empty env: $(grep -i 'unbound variable' <<<"$out" | head -1)"
+        return
+    fi
+    if grep -qiE 'line [0-9]+:.*(bad substitution|parameter null or not set)' <<<"$out"; then
+        no "$label" "shell parameter expansion error under empty env"
+        return
+    fi
+    if [[ "$rc" != "$want_rc" ]]; then
+        no "$label" "rc=$rc (expected $want_rc); output head: $(head -1 <<<"$out")"
+        return
+    fi
+    ok "$label (rc=$rc, no unbound-variable crash)"
+}
+
+echo "=========================================================="
+echo "v1.156 PR-B — empty-env smoke (scrubbed env -i, read-only)"
+echo "=========================================================="
+
+# version is fully self-contained (sources lib/version.sh) and must run clean.
+assert_empty_env_ok "version (empty env)"        0 version
+assert_empty_env_ok "version --json (empty env)" 0 version --json
+# help is inert and self-contained.
+assert_empty_env_ok "help (empty env)"           0 help
+# --help on a representative subcommand must also survive a scrubbed env.
+assert_empty_env_ok "status --help (empty env)"  0 status --help
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS — no unbound-variable crash under empty/scrubbed env"

--- a/cli/lib/nftban/tests/read_ra_ifs_v156_test.sh
+++ b/cli/lib/nftban/tests/read_ra_ifs_v156_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.156 PR-D: read -ra <<< strict-IFS regression lock
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="read_ra_ifs_v156_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-07"
+# meta:description="Locks the v1.156 PR-D fix for the genuinely-bare 'read -ra <<<' sites in nftban_portscan_classic.sh (the IP-timestamp splitter). Timestamps are space-joined (assignment \"\${current_timestamps} \${timestamp}\"), so under the CLI's strict IFS=\$'\\n\\t' (strict.sh, no space) a BARE 'read -ra' collapses the whole string into one element — same bug family as the v1.152 feeds-select fix. Proves (a) the bug condition under strict IFS; (b) the fix mechanism 'IFS=\$' \\t\\n' read -ra' splits correctly; (c) the SHIPPED file carries the IFS fix at both sites and no unfixed bare 'read -ra ts_array' remains. Hermetic: no host/nft/IPC/root."
+# meta:input="cli/lib/nftban/core/nftban_portscan_classic.sh,cli/lib/nftban/lib/strict.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_portscan_classic.sh,cli/lib/nftban/lib/strict.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+PORTSCAN="$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh"
+STRICT="$REPO_ROOT/cli/lib/nftban/lib/strict.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1${2:+ — $2}"; }
+
+echo "=== preconditions ==="
+[[ -f "$PORTSCAN" ]] && ok "portscan_classic.sh present" || no "missing $PORTSCAN"
+if grep -qE "^IFS=\\\$'\\\\n\\\\t'" "$STRICT"; then
+  ok "strict.sh sets IFS=\$'\\\\n\\\\t' (no space) — the contaminating root condition"
+else
+  no "expected strict.sh IFS=\$'\\n\\t'" "$(grep -nE '^IFS=' "$STRICT" | head -1)"
+fi
+
+echo "=== bug condition vs fix mechanism, under strict IFS (space-joined timestamps) ==="
+# Mirror the runtime value shape: timestamps space-joined like "1700000001 1700000002 1700000003".
+( IFS=$'\n\t'; read -ra a <<< "1700000001 1700000002 1700000003"; [[ "${#a[@]}" -eq 1 ]] ) \
+  && ok "bug condition reproduced: bare 'read -ra' under IFS=\$'\\\\n\\\\t' → 1 token" \
+  || no "bug condition not reproduced (bare split unexpectedly produced multiple tokens)"
+( IFS=$'\n\t'; IFS=$' \t\n' read -ra a <<< "1700000001 1700000002 1700000003"; [[ "${#a[@]}" -eq 3 ]] ) \
+  && ok "fix mechanism: 'IFS=\$' \\\\t\\\\n' read -ra' → 3 tokens despite contaminated outer IFS" \
+  || no "fix mechanism failed to split space-joined timestamps"
+
+echo "=== the SHIPPED splitter carries the IFS fix at BOTH sites ==="
+# Both timestamp splitters in portscan_classic.sh must use the explicit whitespace IFS.
+fix_count=$(grep -cE "IFS=\\\$' \\\\t\\\\n' read -ra ts_array <<< \"\\\$timestamps\"" "$PORTSCAN" || true)
+if [[ "$fix_count" -eq 2 ]]; then
+  ok "both ts_array splitters use 'IFS=\$' \\\\t\\\\n' read -ra' (count=$fix_count)"
+else
+  no "expected 2 fixed ts_array splitters, found $fix_count" "$(grep -nE 'read -ra ts_array' "$PORTSCAN")"
+fi
+# No unfixed bare 'read -ra ts_array' may remain.
+if grep -qE "^[[:space:]]*read -ra ts_array <<<" "$PORTSCAN"; then
+  no "an UNFIXED bare 'read -ra ts_array' still present" "$(grep -nE '^[[:space:]]*read -ra ts_array <<<' "$PORTSCAN")"
+else
+  ok "no unfixed bare 'read -ra ts_array' remains"
+fi
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASS — read -ra timestamp splitters are strict-IFS-safe"

--- a/cmd/nftban-installer/phase_markers_test.go
+++ b/cmd/nftban-installer/phase_markers_test.go
@@ -1,0 +1,195 @@
+// =============================================================================
+// NFTBan v1.156 PR-C — Installer [PHASE] boundary-marker tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-phase-markers-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-07"
+// meta:description="Assert each installer phase emits greppable [PHASE] start/end markers and that the marker name set is 1:1 with the phase function set"
+// meta:inventory.files="cmd/nftban-installer/phase_markers_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// PR-C is logging-string-only observability. These tests assert:
+//
+//   T-PM1  phaseStartMarker / phaseEndMarker emit the exact greppable
+//          "[PHASE] <name> start" / "[PHASE] <name> end" strings.
+//   T-PM2  every phase function emits its "start" marker at runtime (proven
+//          by driving each phase with a cancelled context — the start marker
+//          is at the top of each phase function, before the ctx guard, so it
+//          always fires regardless of how the phase then returns).
+//   T-PM3  PARITY — the phaseNames set is exactly 1:1 with the phase
+//          functions defined in phases.go AND every phase function body
+//          contains both a start and an end marker call for its own name.
+//          This is the drift guard: a new phase added without markers (or a
+//          phaseNames entry without a function, or vice-versa) fails here.
+//
+// =============================================================================
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+)
+
+// newMarkerLogger returns a Logger writing to a tempfile + the path to read
+// back. Mirrors newLoggingTestLogger in update_apply_logging_test.go.
+func newMarkerLogger(t *testing.T) (*logging.Logger, string) {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "phase.log")
+	return logging.New(logPath, true), logPath
+}
+
+func readMarkerLog(t *testing.T, logPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	return string(data)
+}
+
+// T-PM1 — the marker helpers emit the exact greppable strings.
+func TestPhaseMarkerStrings(t *testing.T) {
+	log, logPath := newMarkerLogger(t)
+	for _, name := range phaseNames {
+		phaseStartMarker(log, name)
+		phaseEndMarker(log, name)
+	}
+	log.Close()
+
+	content := readMarkerLog(t, logPath)
+	for _, name := range phaseNames {
+		if !strings.Contains(content, "[PHASE] "+name+" start") {
+			t.Errorf("missing start marker for phase %q:\n%s", name, content)
+		}
+		if !strings.Contains(content, "[PHASE] "+name+" end") {
+			t.Errorf("missing end marker for phase %q:\n%s", name, content)
+		}
+	}
+}
+
+// T-PM2 — every phase function emits its start marker at runtime. Driven with
+// a cancelled context so each phase returns deterministically right after the
+// entry guard; the start marker is above the guard so it always fires.
+func TestPhaseFunctionsEmitStartMarker(t *testing.T) {
+	type phaseEntry struct {
+		marker string
+		fn     func(context.Context, executor.Executor, *state.StateFile, *logging.Logger) error
+	}
+	phases := []phaseEntry{
+		{"detect", phaseDetect},
+		{"prepare", phasePrepare},
+		{"switch", phaseSwitch},
+		{"configure", phaseConfigure},
+		{"validate", phaseValidate},
+	}
+
+	for _, p := range phases {
+		p := p
+		t.Run(p.marker, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // pre-cancelled — phase returns right after the entry guard
+
+			mock := executor.NewMockExecutor()
+			sf := state.NewStateFile(t.TempDir())
+			log, logPath := newMarkerLogger(t)
+			_ = p.fn(ctx, mock, sf, log)
+			log.Close()
+
+			content := readMarkerLog(t, logPath)
+			if !strings.Contains(content, "[PHASE] "+p.marker+" start") {
+				t.Errorf("phase %q did not emit its start marker:\n%s", p.marker, content)
+			}
+		})
+	}
+}
+
+// phasesGoSource returns the contents of phases.go, resolved relative to this
+// test file (same runtime.Caller pattern as the timers parity test).
+func phasesGoSource(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed — cannot locate phases.go")
+	}
+	src := filepath.Join(filepath.Dir(filename), "phases.go")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read phases.go: %v", err)
+	}
+	return string(data)
+}
+
+// T-PM3 — parity: phaseNames ≡ the phase functions defined in phases.go, AND
+// every phase function carries both a start and end marker for its own name.
+func TestPhaseMarkerParity(t *testing.T) {
+	src := phasesGoSource(t)
+
+	// Discover every phase function declared in phases.go. A phase function
+	// is identified by its canonical signature (ctx context.Context, exec
+	// executor.Executor, ...) — this deliberately excludes the marker helpers
+	// phaseStartMarker/phaseEndMarker, which take (*logging.Logger, string).
+	//   func phaseDetect(ctx context.Context, ... -> "detect"
+	fnRe := regexp.MustCompile(`(?m)^func phase([A-Z][A-Za-z]*)\(ctx context\.Context,`)
+	var fnNames []string
+	for _, m := range fnRe.FindAllStringSubmatch(src, -1) {
+		fnNames = append(fnNames, strings.ToLower(m[1]))
+	}
+	if len(fnNames) == 0 {
+		t.Fatal("no phase functions discovered in phases.go — regex drift?")
+	}
+
+	// Set equality: phaseNames must equal the discovered function set.
+	wantNames := append([]string{}, phaseNames...)
+	sort.Strings(wantNames)
+	gotNames := append([]string{}, fnNames...)
+	sort.Strings(gotNames)
+
+	nameSet := func(xs []string) map[string]bool {
+		m := make(map[string]bool, len(xs))
+		for _, x := range xs {
+			m[x] = true
+		}
+		return m
+	}
+	wantSet := nameSet(wantNames)
+	gotSet := nameSet(gotNames)
+
+	for _, n := range gotNames {
+		if !wantSet[n] {
+			t.Errorf("phase function for %q has NO entry in phaseNames (add %q so it gets [PHASE] markers)", n, n)
+		}
+	}
+	for _, n := range wantNames {
+		if !gotSet[n] {
+			t.Errorf("phaseNames lists %q but there is no matching phase function in phases.go", n)
+		}
+	}
+
+	// Each phase must have BOTH a start and an end marker call for its name.
+	for _, n := range phaseNames {
+		if !strings.Contains(src, `phaseStartMarker(log, "`+n+`")`) {
+			t.Errorf("phases.go is missing phaseStartMarker(log, %q) for phase %q", n, n)
+		}
+		if !strings.Contains(src, `phaseEndMarker(log, "`+n+`")`) {
+			t.Errorf("phases.go is missing phaseEndMarker(log, %q) for phase %q", n, n)
+		}
+	}
+}

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -80,6 +80,36 @@ type phaseData struct {
 // This is intentionally package-level since phases run sequentially in a single process.
 var globalPhaseData phaseData
 
+// phaseNames is the canonical set of installer phase identifiers used for the
+// greppable [PHASE] boundary markers (v1.156 PR-C). The strings are stable,
+// lowercase, and MUST match the phase function set 1:1 (phaseDetect →
+// "detect", phasePrepare → "prepare", phaseSwitch → "switch",
+// phaseConfigure → "configure", phaseValidate → "validate"). The parity test
+// (phase_markers_test.go) fails if a phase function is added/removed without
+// updating this set, so a new phase cannot silently ship without markers.
+var phaseNames = []string{
+	"detect",
+	"prepare",
+	"switch",
+	"configure",
+	"validate",
+}
+
+// phaseStartMarker / phaseEndMarker are logging-string-only boundary markers
+// written to installer.log so post-mortem tooling can grep phase boundaries
+// (e.g. `grep '\[PHASE\] switch' installer.log`). They emit NO control-flow
+// effect — purely an Info log line. "start" is emitted at the top of each
+// phase function; "end" only on the successful terminal return (an error
+// transition deliberately leaves no "end" marker, which is itself a signal
+// that the phase did not complete).
+func phaseStartMarker(log *logging.Logger, name string) {
+	log.Info("[PHASE] %s start", name)
+}
+
+func phaseEndMarker(log *logging.Logger, name string) {
+	log.Info("[PHASE] %s end", name)
+}
+
 // phaseDetect discovers SSH port, panel, conflicts, distro, authority decision.
 //
 // V125 R-3: honors ctx cancellation at the phase entry and before the final
@@ -87,6 +117,7 @@ var globalPhaseData phaseData
 // hosts) but interior checks let `--timeout` reclaim wall-clock if a single
 // detector hangs on a slow kernel/distro probe.
 func phaseDetect(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
+	phaseStartMarker(log, "detect")
 	pd := &globalPhaseData
 
 	// V125 R-3: context cancellation guard at phase entry. Returns before
@@ -197,6 +228,7 @@ func phaseDetect(ctx context.Context, exec executor.Executor, sf *state.StateFil
 	}
 
 	log.PhaseEnd("Detect")
+	phaseEndMarker(log, "detect")
 	return sf.Transition(state.StateDetectComplete, state.PhaseDetect, "")
 }
 
@@ -208,6 +240,7 @@ func phaseDetect(ctx context.Context, exec executor.Executor, sf *state.StateFil
 // chmod, tmpfiles) are interior to fhs/services packages and reach their
 // own kernel boundaries quickly; we don't add ctx checks for those.
 func phasePrepare(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
+	phaseStartMarker(log, "prepare")
 	pd := &globalPhaseData
 
 	// V125 R-3: context cancellation guard at phase entry.
@@ -319,6 +352,7 @@ func phasePrepare(ctx context.Context, exec executor.Executor, sf *state.StateFi
 	render.PersistSSHPortsUnion(exec, pd.sshPorts, log)
 
 	log.PhaseEnd("Prepare")
+	phaseEndMarker(log, "prepare")
 	return sf.Transition(state.StatePrepareComplete, state.PhasePrepare, "")
 }
 
@@ -340,6 +374,7 @@ func phasePrepare(ctx context.Context, exec executor.Executor, sf *state.StateFi
 //     from the emergency table to the nftban ruleset. Cancelling mid-chain
 //     could leave the host with neither protector.
 func phaseSwitch(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
+	phaseStartMarker(log, "switch")
 	pd := &globalPhaseData
 	emergencyInjected := false
 
@@ -427,6 +462,7 @@ func phaseSwitch(ctx context.Context, exec executor.Executor, sf *state.StateFil
 	}
 
 	log.PhaseEnd("Switch")
+	phaseEndMarker(log, "switch")
 	return sf.Transition(state.StateSwitchComplete, state.PhaseSwitch, "")
 }
 
@@ -437,6 +473,7 @@ func phaseSwitch(ctx context.Context, exec executor.Executor, sf *state.StateFil
 // existing between-phase check in main.go covers the realistic
 // cancellation surface without splitting service-start ordering.
 func phaseConfigure(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
+	phaseStartMarker(log, "configure")
 	pd := &globalPhaseData
 
 	// V125 R-3: context cancellation guard at phase entry.
@@ -505,6 +542,7 @@ func phaseConfigure(ctx context.Context, exec executor.Executor, sf *state.State
 	services.RestartPolkit(exec, log)
 
 	log.PhaseEnd("Configure")
+	phaseEndMarker(log, "configure")
 	return sf.Transition(state.StateServicesComplete, state.PhaseConfigure, "")
 }
 
@@ -524,6 +562,7 @@ func phaseConfigure(ctx context.Context, exec executor.Executor, sf *state.State
 // inside phaseValidate where a meaningful wall-clock budget is at risk
 // — assertions themselves are quick.
 func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) error {
+	phaseStartMarker(log, "validate")
 	pd := &globalPhaseData
 
 	// V125 R-3: context cancellation guard at phase entry.
@@ -562,6 +601,7 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	if validate.AllPassed(results) {
 		log.Info("all post-install assertions passed — COMMITTED")
 		_ = exec.Remove(fhs.InstallFailedMarker)
+		phaseEndMarker(log, "validate")
 		return sf.Transition(state.StateCommitted, state.PhaseValidate, "")
 	}
 
@@ -596,6 +636,7 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	if validate.AllPassed(results2) {
 		log.Info("VALIDATE_2: all assertions passed after safe auto-fix — COMMITTED")
 		_ = exec.Remove(fhs.InstallFailedMarker)
+		phaseEndMarker(log, "validate")
 		return sf.Transition(state.StateCommitted, state.PhaseValidate, "")
 	}
 

--- a/internal/installer/services/services_test.go
+++ b/internal/installer/services/services_test.go
@@ -89,6 +89,65 @@ func TestReconcileTimers_Default(t *testing.T) {
 	}
 }
 
+// TestReconcileTimers_GeobanRefreshEnabled — v1.156 PR-A. The geoban-refresh
+// timer ships under install/systemd/ and is listed in the install set, but
+// before v1.156 it was absent from coreTimers, so a default install left it
+// installed-but-not-auto-enabled. This asserts the reconcile (coreTimers) loop
+// now issues BOTH `systemctl enable` and `systemctl start` for it, matching the
+// best-effort enableAndStart path used by the other core timers (it is NOT in
+// criticalCoreTimers — failure must not DEGRADE the install).
+func TestReconcileTimers_GeobanRefreshEnabled(t *testing.T) {
+	mock := executor.NewMockExecutor()
+	// No config file → default is reconcile=true.
+	ReconcileTimers(mock, newTestLogger())
+
+	enabled, started := false, false
+	for _, cmd := range mock.Commands {
+		if cmd.Name != "systemctl" || len(cmd.Args) < 2 {
+			continue
+		}
+		if cmd.Args[1] != "nftban-geoban-refresh.timer" {
+			continue
+		}
+		switch cmd.Args[0] {
+		case "enable":
+			enabled = true
+		case "start":
+			started = true
+		}
+	}
+	if !enabled {
+		t.Error("expected nftban-geoban-refresh.timer to be enabled (added to coreTimers in v1.156 PR-A)")
+	}
+	if !started {
+		t.Error("expected nftban-geoban-refresh.timer to be started (best-effort enableAndStart)")
+	}
+}
+
+// TestGeobanRefreshTimerInCoreTimers asserts the geoban-refresh timer is a
+// member of the coreTimers reconcile set but is NOT in criticalCoreTimers
+// (best-effort, must not DEGRADE the install on failure).
+func TestGeobanRefreshTimerInCoreTimers(t *testing.T) {
+	const geoban = "nftban-geoban-refresh.timer"
+
+	inCore := false
+	for _, n := range coreTimers {
+		if n == geoban {
+			inCore = true
+			break
+		}
+	}
+	if !inCore {
+		t.Errorf("%s must be in coreTimers (v1.156 PR-A)", geoban)
+	}
+
+	for _, n := range criticalCoreTimers {
+		if n == geoban {
+			t.Errorf("%s must NOT be in criticalCoreTimers — keep best-effort", geoban)
+		}
+	}
+}
+
 func TestReconcileTimers_Disabled(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Files["/etc/nftban/nftban.conf"] = []byte("NFTBAN_RECONCILE_CORE_TIMERS=\"false\"\n")

--- a/internal/installer/services/timers.go
+++ b/internal/installer/services/timers.go
@@ -11,7 +11,7 @@
 // meta:inventory.binaries=""
 // meta:inventory.env_vars=""
 // meta:inventory.config_files="/etc/nftban/nftban.conf"
-// meta:inventory.systemd_units="nftban-maintenance.timer, nftban-health.timer, nftban-unified-exporter.timer, nftban-core-geoip.timer, nftban-core-feeds.timer, nftban-watchdog.timer, nftban-queue.timer, nftban-update-check.timer"
+// meta:inventory.systemd_units="nftban-maintenance.timer, nftban-health.timer, nftban-unified-exporter.timer, nftban-core-geoip.timer, nftban-core-feeds.timer, nftban-watchdog.timer, nftban-queue.timer, nftban-update-check.timer, nftban-geoban-refresh.timer"
 // meta:inventory.network=""
 // meta:inventory.privileges="root"
 // =============================================================================
@@ -34,6 +34,7 @@ var coreTimers = []string{
 	"nftban-watchdog.timer",
 	"nftban-queue.timer",
 	"nftban-update-check.timer",
+	"nftban-geoban-refresh.timer",
 }
 
 // optionalTimers are started only if their unit file exists (panel-dependent).


### PR DESCRIPTION
**Bounded installer/CI rollout-safety cleanup** — small, rollout-relevant items only; no backlog absorption. The installer binary changes intentionally; the daemon does not.

### 4 commits (preserved)
- **PR-A** `7d1afa47` — enable `nftban-geoban-refresh.timer` as a **best-effort core timer** (`internal/installer/services/timers.go` → `coreTimers`; not `criticalCoreTimers`). Closes the v1.150 "geoban timer installed-but-disabled" caveat. 2 hermetic enablement tests (mock-executor asserts reconcile enables+starts it; membership/criticality assertions). On-host "active (waiting)" is a lab/fleet step.
- **PR-B** `d89dcfc1` — **empty-env smoke CI guard** (`ci-empty-env-smoke.yml`, H4): runs CLI (`version`/`help`/`status --help`) + installer (`--version`/`-h`) under `env -i` to catch `set -u`/unbound-variable crashes — read-only, no mutation. Hermetic test `cli_empty_env_smoke_v156_test.sh`.
- **PR-C** `951ec59c` — **installer.log `[PHASE]` start/end markers** across all 5 phases (`cmd/nftban-installer/phases.go`, logging-string only, no flow change) + parity test (`phase_markers_test.go`: marker-set ≡ phase-set, fails CI on a future phase without markers).
- **PR-D** `e325cd04` — **strict-IFS `read -ra` fix** for the 2 space-joined portscan timestamp splitters (`nftban_portscan_classic.sh`) — same bug family as v1.152 feeds-select — with test (`read_ra_ifs_v156_test.sh`). The cmd_emulate/tunnel candidates already set `IFS` inline (safe) → left as recorded triage.

### Invariants
- **0 `cmd/nftband`** · **0 `cmd/nftban-core`** · **0 schema** · **no CSF** · **no Lane-C daemon-Go**
- **daemon byte-identical to v1.155.0** (diff empty); installer binary (`cmd/nftban-installer`/`internal/installer`) **intentionally changes** (PR-A/PR-C)

### Validation (lab2, go1.25.11)
- Go: `go vet ./...` clean · `go build ./...` rc=0 · `go test -race` PASS (internal/installer/services + cmd/nftban-installer) · `go mod tidy` clean
- Shell: `shellcheck -S warning` rc=0 · `bash -n` clean · empty-env 4/0 · read-ra 6/0
- `ci-empty-env-smoke.yml` valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
