### PR TITLE
feat(v1.158): security-posture MAC visibility (AppArmor/SELinux, advisory)

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -458,22 +458,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: centos-stream9
-            container: quay.io/centos/centos:stream9
-            rpm_artifact: rpm-el9
-            tier: 0
-          - distro: centos-stream10
-            container: quay.io/centos/centos:stream10
-            rpm_artifact: rpm-el10
-            tier: 1
+          # Canonical RPM install targets only (operator 2026-06-07): EL9 = Rocky 9,
+          # EL10 = AlmaLinux 10. CentOS Stream + Alma 9 install legs removed (can be a
+          # separate distro-validation lane later, not part of every release matrix).
           - distro: rocky9
             container: rockylinux:9
             rpm_artifact: rpm-el9
             tier: 0
-          - distro: alma9
-            container: almalinux:9
-            rpm_artifact: rpm-el9
-            tier: 0
+          - distro: alma10
+            container: almalinux:10
+            rpm_artifact: rpm-el10
+            tier: 1
 
     steps:
       # Checkout required so docker mount of $(pwd)/scripts/ resolves to a real

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -390,7 +390,11 @@ EXAMPLES:
     nftban health config --verbose   # Include config file paths
 
     # Security posture (low noise check)
-    nftban health posture            # SSH, sudo, systemd hardening basics
+    nftban health posture            # SSH, sudo, systemd, MAC (AppArmor/SELinux)
+    # Posture is advisory (never changes exit code). Compact summary also shows in
+    # 'nftban status'. Posture output is text-only; --json is accepted but the
+    # posture subcommand does not serialize posture fields as JSON
+    # (see docs/security/MAC_PROFILES_SELINUX_APPARMOR.md §12).
 
 HEALTH STATUS CODES:
     ✅ OK       - All checks passed

--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -766,6 +766,40 @@ nftban_health_cmd_posture() {
     echo ""
 
     # ───────────────────────────────────────────────────────────────────────
+    # 5. MAC POSTURE (AppArmor / SELinux) — v1.158
+    # ───────────────────────────────────────────────────────────────────────
+    # Read-only, non-root-graceful, distro-aware. WARN is advisory only (feeds
+    # `warnings`, never `issues`) so health does not fail solely because a MAC
+    # profile is missing/not-enforcing. The detection helper lives in
+    # nftban_report_data.sh (sourced above when available).
+    echo "Mandatory Access Control (MAC)"
+    echo "  ─────────────────────────────────────"
+    if declare -f _nftban_mac_posture >/dev/null 2>&1; then
+        ((total_checks++)) || true
+        local _mac_line _mac_system _mac_verdict _mac_mode _mac_summary _mac_detail
+        _mac_line=$(_nftban_mac_posture 2>/dev/null) || _mac_line="none|INFO|n/a|MAC not applicable|"
+        IFS='|' read -r _mac_system _mac_verdict _mac_mode _mac_summary _mac_detail <<<"$_mac_line"
+        case "$_mac_verdict" in
+            PASS)
+                printf "  %-28s ✅ %s\n" "MAC profile" "$_mac_summary"
+                [[ -n "$_mac_detail" ]] && printf "      %s\n" "$_mac_detail"
+                ;;
+            WARN)
+                printf "  %-28s ⚠️  %s\n" "MAC profile" "$_mac_summary"
+                [[ -n "$_mac_detail" ]] && printf "      FIX: %s\n" "$_mac_detail"
+                ((warnings++)) || true
+                ;;
+            *)  # INFO / N/A — not applicable on this host; never a warning
+                printf "  %-28s ℹ️  %s\n" "MAC profile" "$_mac_summary"
+                [[ -n "$_mac_detail" ]] && printf "      %s\n" "$_mac_detail"
+                ;;
+        esac
+    else
+        printf "  %-28s ℹ️  %s\n" "MAC profile" "MAC detection unavailable"
+    fi
+    echo ""
+
+    # ───────────────────────────────────────────────────────────────────────
     # SUMMARY
     # ───────────────────────────────────────────────────────────────────────
     echo "─────────────────────────────────────────"

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1287,9 +1287,12 @@ _status_section_health() {
         security_status="${security_issues} systemd issue(s)"
     fi
 
-    # Get posture status + details (SSH, sudo, systemd, config integrity)
+    # Get posture status + details (SSH, sudo, systemd, config integrity, MAC)
     local posture_status="PROTECTED"
     local posture_details=""
+    local posture_mac_verdict="INFO"
+    local posture_mac_summary=""
+    local posture_mac_system="none"
     if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_report_data.sh" ]]; then
         # shellcheck source=/dev/null
         source "${NFTBAN_LIB_DIR}/lib/nftban_report_data.sh" 2>/dev/null || true
@@ -1298,6 +1301,13 @@ _status_section_health() {
             _collect_posture_info _posture_data 2>/dev/null || true
             posture_status="${_posture_data[POSTURE_STATUS]:-OK}"
             posture_details="${_posture_data[POSTURE_DETAILS]:-}"
+            # v1.158: compact MAC posture row (advisory-only). Shown when a MAC
+            # system applies (PASS or WARN); the WARN already feeds the advisory
+            # count + posture_details via the collector, so here we only surface a
+            # terse PASS row. N/A (no MAC system) shows nothing.
+            posture_mac_verdict="${_posture_data[POSTURE_MAC_VERDICT]:-INFO}"
+            posture_mac_summary="${_posture_data[POSTURE_MAC_SUMMARY]:-}"
+            posture_mac_system="${_posture_data[POSTURE_MAC_SYSTEM]:-none}"
             unset _posture_data
         fi
     fi
@@ -1327,6 +1337,14 @@ _status_section_health() {
             done
             unset IFS
         fi
+    fi
+
+    # v1.158: terse MAC posture row. A WARN is already surfaced above (it feeds
+    # posture_details + the advisory count). Here we add a quiet PASS row so the
+    # operator can see MAC is actually enforcing; N/A (no MAC system) prints
+    # nothing to avoid noise on hosts without that MAC system.
+    if [[ "$posture_mac_system" != "none" && "$posture_mac_verdict" == "PASS" && -n "$posture_mac_summary" ]]; then
+        printf "      → MAC: %s\n" "$posture_mac_summary"
     fi
 
     # Show hints if not OK (only in non-quiet mode)

--- a/cli/lib/nftban/lib/nftban_report_data.sh
+++ b/cli/lib/nftban/lib/nftban_report_data.sh
@@ -667,6 +667,161 @@ _ssh_effective_directive() {
     fi
 }
 
+# -----------------------------------------------------------------------------
+# MAC posture detection (v1.158) — AppArmor + SELinux, read-only, non-root-safe.
+#
+# Reports whether NFTBan's OWN MAC profile/module is loaded and enforcing:
+#   - AppArmor profile name : nftband   (install/apparmor/usr.lib.nftban.bin.nftband)
+#   - SELinux module  name  : nftban    (semodule -i nftban.pp; lists as "nftban")
+#
+# Distro-aware: it does NOT WARN about a MAC system the host does not run
+# (no AppArmor WARN on SELinux/RPM hosts; no SELinux WARN on Debian/Ubuntu).
+#
+# Echoes one pipe-delimited line, then sub-results:
+#   SYSTEM|VERDICT|MODE|SUMMARY|DETAIL
+# where
+#   SYSTEM  = apparmor | selinux | none
+#   VERDICT = PASS | WARN | INFO
+#   MODE    = enforcing | complain | permissive | disabled | n/a | unknown
+#   SUMMARY = short compact phrase (e.g. "AppArmor enforcing")
+#   DETAIL  = longer human sentence for the detailed view / remediation
+#
+# All command lookups are guarded; missing tooling degrades to INFO, never WARN,
+# never crash, no noisy stderr.
+# -----------------------------------------------------------------------------
+_nftban_mac_posture() {
+    # Run with relaxed errexit/pipefail: this function intentionally probes
+    # commands that may be absent and runs greps that legitimately find no match.
+    # A non-zero from any of those must NOT abort the function before it echoes
+    # its result line. Callers guard the call too (`... || fallback`), but make
+    # the function self-contained so it is safe under any caller's `set -e`.
+    local _saved_opts
+    _saved_opts=$(set +o)
+    set +eo pipefail
+
+    local aa_profile="nftband"      # AppArmor profile name (the daemon)
+    local se_module="nftban"        # SELinux module name
+    local _result=""
+
+    # Single exit point: restore the caller's shell options, emit, return.
+    _mac_emit() { _result="$1"; }
+
+    # --- AppArmor -------------------------------------------------------------
+    # Prefer aa-status; fall back to the securityfs profiles list if readable.
+    local aa_present="no" aa_enabled="no" aa_profile_state=""
+    if command -v aa-status >/dev/null 2>&1; then
+        aa_present="yes"
+        local aa_out
+        # aa-status exits non-zero when AppArmor is not enabled; tolerate it.
+        aa_out=$(aa-status 2>/dev/null) || true
+        if [[ -n "$aa_out" ]]; then
+            aa_enabled="yes"
+            # Look for the nftband profile and its mode. aa-status prints e.g.
+            # "   /usr/lib/nftban/bin/nftband (enforce)" or "(complain)".
+            local aa_line
+            aa_line=$(printf '%s\n' "$aa_out" | grep -E "(^|[/ ])${aa_profile}( |\()|/nftband( |\()" 2>/dev/null | head -n1)
+            if [[ -n "$aa_line" ]]; then
+                if printf '%s' "$aa_line" | grep -qi 'enforce'; then
+                    aa_profile_state="enforce"
+                elif printf '%s' "$aa_line" | grep -qi 'complain'; then
+                    aa_profile_state="complain"
+                else
+                    aa_profile_state="loaded"
+                fi
+            fi
+        fi
+    elif [[ -r "${NFTBAN_AA_PROFILES_FILE:-/sys/kernel/security/apparmor/profiles}" ]]; then
+        aa_present="yes"
+        aa_enabled="yes"
+        local aa_line
+        aa_line=$(grep -E "(^|/)${aa_profile} " "${NFTBAN_AA_PROFILES_FILE:-/sys/kernel/security/apparmor/profiles}" 2>/dev/null | head -n1)
+        if [[ -n "$aa_line" ]]; then
+            # Format: "<profile name> (enforce)" / "(complain)"
+            if printf '%s' "$aa_line" | grep -qi 'enforce'; then
+                aa_profile_state="enforce"
+            elif printf '%s' "$aa_line" | grep -qi 'complain'; then
+                aa_profile_state="complain"
+            else
+                aa_profile_state="loaded"
+            fi
+        fi
+    fi
+
+    if [[ "$aa_enabled" == "yes" ]]; then
+        case "$aa_profile_state" in
+            enforce)
+                _mac_emit "apparmor|PASS|enforcing|AppArmor enforcing|AppArmor profile '${aa_profile}' is loaded and enforcing." ;;
+            complain)
+                _mac_emit "apparmor|WARN|complain|AppArmor complain-only|AppArmor profile '${aa_profile}' is loaded in complain mode (not enforcing). Enforce with: aa-enforce /etc/apparmor.d/usr.lib.nftban.bin.nftband" ;;
+            loaded)
+                _mac_emit "apparmor|PASS|enforcing|AppArmor loaded|AppArmor profile '${aa_profile}' is loaded." ;;
+            *)
+                _mac_emit "apparmor|WARN|unknown|AppArmor profile missing|AppArmor is enabled but the NFTBan profile '${aa_profile}' is not loaded. Load with: apparmor_parser -r /etc/apparmor.d/usr.lib.nftban.bin.nftband" ;;
+        esac
+    fi
+
+    # --- SELinux --------------------------------------------------------------
+    # Prefer getenforce; sestatus is a secondary signal. Module via semodule -l.
+    # Skipped when AppArmor already produced a verdict (a host runs one primary
+    # MAC system; AppArmor-on-Debian/Ubuntu takes precedence here).
+    local se_mode="" se_present="no"
+    if [[ -z "$_result" ]]; then
+        if command -v getenforce >/dev/null 2>&1; then
+            se_present="yes"
+            se_mode=$(getenforce 2>/dev/null | tr '[:upper:]' '[:lower:]') || se_mode=""
+        elif command -v sestatus >/dev/null 2>&1; then
+            se_present="yes"
+            # "Current mode:                   enforcing"
+            se_mode=$(sestatus 2>/dev/null | awk -F: '/Current mode/{gsub(/^[ \t]+/,"",$2); print tolower($2); exit}') || se_mode=""
+        fi
+    fi
+
+    if [[ -z "$_result" && "$se_present" == "yes" && -n "$se_mode" && "$se_mode" != "disabled" ]]; then
+        # SELinux is active (enforcing or permissive). Is the NFTBan module loaded?
+        local se_module_loaded="no"
+        if command -v semodule >/dev/null 2>&1; then
+            if semodule -l 2>/dev/null | grep -qiE "(^|[[:space:]])${se_module}([[:space:]]|$)"; then
+                se_module_loaded="yes"
+            fi
+        else
+            se_module_loaded="unknown"
+        fi
+
+        if [[ "$se_mode" == "enforcing" ]]; then
+            if [[ "$se_module_loaded" == "yes" ]]; then
+                _mac_emit "selinux|PASS|enforcing|SELinux enforcing|SELinux is Enforcing and the NFTBan module '${se_module}' is loaded."
+            elif [[ "$se_module_loaded" == "unknown" ]]; then
+                _mac_emit "selinux|INFO|enforcing|SELinux enforcing|SELinux is Enforcing; cannot confirm the NFTBan module (semodule unavailable)."
+            else
+                _mac_emit "selinux|WARN|enforcing|SELinux module missing|SELinux is Enforcing but the NFTBan module '${se_module}' is not loaded. Load with: semodule -i /usr/share/nftban/selinux/nftban.pp"
+            fi
+        else
+            # permissive (active but not enforcing)
+            if [[ "$se_module_loaded" == "yes" ]]; then
+                _mac_emit "selinux|WARN|permissive|SELinux permissive|SELinux is Permissive (not enforcing); the NFTBan module '${se_module}' is loaded but not enforced. Set Enforcing for confinement."
+            else
+                _mac_emit "selinux|WARN|permissive|SELinux permissive|SELinux is Permissive and the NFTBan module '${se_module}' is not loaded."
+            fi
+        fi
+    fi
+
+    # --- Neither MAC system active -------------------------------------------
+    # Distinguish "tooling present but disabled" from "no MAC system at all".
+    if [[ -z "$_result" ]]; then
+        if [[ "$aa_present" == "yes" || "$se_present" == "yes" ]]; then
+            _mac_emit "none|INFO|disabled|MAC not enabled|A MAC system is present but not enabled (AppArmor/SELinux disabled). Not applicable."
+        else
+            _mac_emit "none|INFO|n/a|MAC not applicable|No AppArmor/SELinux tooling detected on this host. Not applicable."
+        fi
+    fi
+
+    unset -f _mac_emit
+    # Restore the caller's original shell options before returning.
+    eval "$_saved_opts" 2>/dev/null || true
+    printf '%s\n' "$_result"
+    return 0
+}
+
 _collect_posture_info() {
     local -n _pdata="$1"
     local issues=0
@@ -771,6 +926,24 @@ _collect_posture_info() {
             ((warnings++)) || true
             posture_details+="Config: ${drift_count} file(s) modified; "
         fi
+    fi
+
+    # 5. MAC posture (v1.158) — AppArmor / SELinux for NFTBan's own profile.
+    # Read-only, non-root-graceful, distro-aware (no WARN on a host that does not
+    # run that MAC system). Only an actual WARN contributes to the advisory count
+    # and the compact details; PASS/INFO are recorded for callers but stay quiet
+    # in the compact line so a healthy/N-A host shows no MAC noise.
+    local mac_line mac_system mac_verdict mac_mode mac_summary mac_detail
+    mac_line=$(_nftban_mac_posture 2>/dev/null) || mac_line="none|INFO|n/a|MAC not applicable|"
+    IFS='|' read -r mac_system mac_verdict mac_mode mac_summary mac_detail <<<"$mac_line"
+    _pdata[POSTURE_MAC_SYSTEM]="${mac_system:-none}"
+    _pdata[POSTURE_MAC_VERDICT]="${mac_verdict:-INFO}"
+    _pdata[POSTURE_MAC_MODE]="${mac_mode:-n/a}"
+    _pdata[POSTURE_MAC_SUMMARY]="${mac_summary:-}"
+    _pdata[POSTURE_MAC_DETAIL]="${mac_detail:-}"
+    if [[ "$mac_verdict" == "WARN" ]]; then
+        ((warnings++)) || true
+        posture_details+="MAC: ${mac_summary}; "
     fi
 
     # Determine overall posture status

--- a/cli/lib/nftban/tests/mac_posture_v158_test.sh
+++ b/cli/lib/nftban/tests/mac_posture_v158_test.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - MAC posture test (v1.158: AppArmor + SELinux health-posture summary)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="mac_posture_v158_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-07"
+# meta:description="v1.158 — asserts the read-only MAC posture summary added to _nftban_mac_posture / _collect_posture_info. Hermetic: stubs aa-status/getenforce/sestatus/semodule/sshd via PATH shadow. Verifies: AppArmor absent -> INFO no-WARN no-crash; AppArmor enforcing nftband profile -> PASS; AppArmor enabled but nftband profile missing -> WARN; SELinux absent -> INFO no-WARN; SELinux Enforcing + nftban module -> PASS; SELinux Permissive OR module missing -> WARN; the compact MAC summary is JSON-safe; existing SSH/sudo/systemd posture untouched. Non-root; no host/daemon contact; no Go/schema change."
+# meta:input="cli/lib/nftban/lib/nftban_report_data.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="cli/lib/nftban/lib/nftban_report_data.sh"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+LIB="$REPO/cli/lib/nftban/lib/nftban_report_data.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+[[ -f "$LIB" ]] || { echo "FATAL: lib not found: $LIB"; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Hermetic command-shadow harness.
+# Each scenario builds a private PATH dir holding only the stub commands we want
+# the detector to see; everything else (grep/awk/head/tr) comes from a small set
+# of real-tool symlinks so the detector still functions.
+# ---------------------------------------------------------------------------
+REAL_TOOLS=(grep awk head tr cat sort id basename dirname env bash sed cut sha256sum stat date hostname)
+
+make_stubdir() {
+    local d; d=$(mktemp -d)
+    local t real
+    for t in "${REAL_TOOLS[@]}"; do
+        real=$(command -v "$t" 2>/dev/null || true)
+        [[ -n "$real" ]] && ln -sf "$real" "$d/$t"
+    done
+    echo "$d"
+}
+
+add_stub() {
+    # add_stub <dir> <name> <body...>
+    local d="$1" name="$2"; shift 2
+    {
+        echo '#!/usr/bin/env bash'
+        printf '%s\n' "$@"
+    } > "$d/$name"
+    chmod +x "$d/$name"
+}
+
+# Run _nftban_mac_posture under a given stub PATH; echo its single result line.
+run_mac() {
+    local stubdir="$1"
+    (
+        set +e
+        # securityfs fallback path: point it at a non-readable bogus path unless
+        # the scenario explicitly wants it. We can't easily shadow /sys, so we
+        # rely on aa-status presence/absence to drive AppArmor branches.
+        export PATH="$stubdir"
+        # Hermetic AppArmor securityfs fallback: point the detector at a
+        # test-controlled file (absent unless a scenario creates it) so it never
+        # reads the host's real /sys/kernel/security/apparmor/profiles.
+        export NFTBAN_AA_PROFILES_FILE="$stubdir/.aa_profiles"
+        # shellcheck source=/dev/null
+        source "$LIB" >/dev/null 2>&1
+        # NOTE: the lib re-asserts `set -Eeuo pipefail` on source. We deliberately
+        # do NOT relax it here — the detector must be self-contained and safe to
+        # call under a strict-mode caller (it saves/restores opts internally).
+        _nftban_mac_posture 2>/dev/null
+    )
+}
+
+field() { printf '%s' "$1" | awk -F'|' -v n="$2" '{print $n}'; }
+
+# ===========================================================================
+# CASE 1: AppArmor absent + SELinux absent -> INFO, no WARN, no crash
+# ===========================================================================
+D=$(make_stubdir)
+LINE=$(run_mac "$D"); RC=$?
+if [[ $RC -eq 0 ]] && [[ "$(field "$LINE" 2)" == "INFO" ]] && [[ "$(field "$LINE" 1)" == "none" ]]; then
+    ok "C1 no MAC tooling -> system=none verdict=INFO (no WARN, no crash)"
+else
+    no "C1 no MAC tooling -> INFO" "rc=$RC line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 2: AppArmor enabled + nftband profile ENFORCING -> PASS
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" aa-status \
+  'echo "apparmor module is loaded."' \
+  'echo "2 profiles are in enforce mode."' \
+  'echo "   /usr/lib/nftban/bin/nftband (enforce)"' \
+  'echo "   /usr/sbin/other (enforce)"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "apparmor" ]] && [[ "$(field "$LINE" 2)" == "PASS" ]] && [[ "$(field "$LINE" 3)" == "enforcing" ]]; then
+    ok "C2 AppArmor nftband profile enforcing -> PASS/enforcing"
+else
+    no "C2 AppArmor enforcing -> PASS" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 2b: securityfs fallback (no aa-status) — nftband enforce -> PASS
+# ===========================================================================
+D=$(make_stubdir)
+printf '/usr/lib/nftban/bin/nftband (enforce)\n/usr/sbin/cupsd (enforce)\n' > "$D/.aa_profiles"
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "apparmor" ]] && [[ "$(field "$LINE" 2)" == "PASS" ]]; then
+    ok "C2b AppArmor securityfs fallback, nftband enforce -> PASS"
+else
+    no "C2b securityfs fallback -> PASS" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 3: AppArmor enabled but nftband profile MISSING -> WARN
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" aa-status \
+  'echo "apparmor module is loaded."' \
+  'echo "   /usr/sbin/something_else (enforce)"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "apparmor" ]] && [[ "$(field "$LINE" 2)" == "WARN" ]]; then
+    ok "C3 AppArmor enabled, nftband profile missing -> WARN"
+else
+    no "C3 AppArmor profile missing -> WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 3b: AppArmor nftband profile COMPLAIN-only -> WARN (not enforcing)
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" aa-status \
+  'echo "apparmor module is loaded."' \
+  'echo "   /usr/lib/nftban/bin/nftband (complain)"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "apparmor" ]] && [[ "$(field "$LINE" 2)" == "WARN" ]] && [[ "$(field "$LINE" 3)" == "complain" ]]; then
+    ok "C3b AppArmor nftband profile complain-only -> WARN/complain"
+else
+    no "C3b AppArmor complain -> WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 4: SELinux absent (no aa-status, no getenforce/sestatus) -> INFO no WARN
+#   (covered by C1 too, but assert explicitly that SELinux tooling absence is
+#    not a WARN even when nothing else is present)
+# ===========================================================================
+D=$(make_stubdir)
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 2)" != "WARN" ]]; then
+    ok "C4 SELinux tooling absent -> not a WARN"
+else
+    no "C4 SELinux absent -> no WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 5: SELinux Enforcing + nftban module present -> PASS
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" getenforce 'echo "Enforcing"'
+add_stub "$D" semodule 'echo "base"; echo "nftban"; echo "sshd"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "selinux" ]] && [[ "$(field "$LINE" 2)" == "PASS" ]] && [[ "$(field "$LINE" 3)" == "enforcing" ]]; then
+    ok "C5 SELinux Enforcing + nftban module -> PASS/enforcing"
+else
+    no "C5 SELinux Enforcing + module -> PASS" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 6a: SELinux Enforcing but nftban module MISSING -> WARN
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" getenforce 'echo "Enforcing"'
+add_stub "$D" semodule 'echo "base"; echo "sshd"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "selinux" ]] && [[ "$(field "$LINE" 2)" == "WARN" ]]; then
+    ok "C6a SELinux Enforcing, nftban module missing -> WARN"
+else
+    no "C6a SELinux module missing -> WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 6b: SELinux Permissive (module present) -> WARN
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" getenforce 'echo "Permissive"'
+add_stub "$D" semodule 'echo "base"; echo "nftban"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 1)" == "selinux" ]] && [[ "$(field "$LINE" 2)" == "WARN" ]] && [[ "$(field "$LINE" 3)" == "permissive" ]]; then
+    ok "C6b SELinux Permissive -> WARN/permissive"
+else
+    no "C6b SELinux Permissive -> WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 6c: SELinux Disabled -> INFO/N-A (not a WARN)
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" getenforce 'echo "Disabled"'
+LINE=$(run_mac "$D")
+if [[ "$(field "$LINE" 2)" != "WARN" ]]; then
+    ok "C6c SELinux Disabled -> not a WARN"
+else
+    no "C6c SELinux Disabled -> no WARN" "line=$LINE"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 7: compact MAC summary is JSON-safe (no quotes/backslashes/pipes that
+#   would break valid JSON when embedded as a string value)
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" aa-status \
+  'echo "apparmor module is loaded."' \
+  'echo "   /usr/lib/nftban/bin/nftband (enforce)"'
+LINE=$(run_mac "$D")
+SUMMARY=$(field "$LINE" 4)
+json_safe=1
+case "$SUMMARY" in
+    *'"'*|*'\'*) json_safe=0 ;;
+esac
+[[ -z "$SUMMARY" ]] && json_safe=0
+if [[ $json_safe -eq 1 ]]; then
+    # build a tiny JSON doc with the summary as a value and validate it
+    if command -v jq >/dev/null 2>&1; then
+        if printf '{"mac":"%s"}' "$SUMMARY" | jq empty >/dev/null 2>&1; then
+            ok "C7 compact MAC summary is valid JSON value ('$SUMMARY')"
+        else
+            no "C7 MAC summary valid JSON" "jq rejected: $SUMMARY"
+        fi
+    else
+        ok "C7 compact MAC summary JSON-safe (no quotes/backslashes; jq absent)"
+    fi
+else
+    no "C7 MAC summary JSON-safe" "unsafe chars or empty: '$SUMMARY'"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 8: existing SSH/sudo/systemd posture path still works + MAC fields wired.
+#   Run _collect_posture_info (no MAC tooling) and assert the legacy POSTURE_*
+#   keys are still produced AND the new POSTURE_MAC_* keys are populated, with
+#   MAC not forcing a WARN on a host with no MAC system.
+# ===========================================================================
+D=$(make_stubdir)
+RESULT=$(
+    set +e
+    export PATH="$D"
+    export NFTBAN_AA_PROFILES_FILE="$D/.aa_profiles"
+    # shellcheck source=/dev/null
+    source "$LIB" >/dev/null 2>&1
+    declare -A P
+    _collect_posture_info P 2>/dev/null
+    printf 'STATUS=%s\n' "${P[POSTURE_STATUS]:-__MISSING__}"
+    printf 'DETAILS_KEY=%s\n' "${P[POSTURE_DETAILS]+set}"
+    printf 'MAC_SYSTEM=%s\n' "${P[POSTURE_MAC_SYSTEM]:-__MISSING__}"
+    printf 'MAC_VERDICT=%s\n' "${P[POSTURE_MAC_VERDICT]:-__MISSING__}"
+)
+if printf '%s\n' "$RESULT" | grep -q '^STATUS=' \
+   && ! printf '%s\n' "$RESULT" | grep -q 'STATUS=__MISSING__' \
+   && printf '%s\n' "$RESULT" | grep -q '^DETAILS_KEY=set' \
+   && printf '%s\n' "$RESULT" | grep -q '^MAC_SYSTEM=none' \
+   && ! printf '%s\n' "$RESULT" | grep -q 'MAC_VERDICT=WARN'; then
+    ok "C8 _collect_posture_info preserves POSTURE_* + wires POSTURE_MAC_* (no MAC -> no WARN)"
+else
+    no "C8 collector legacy+MAC wiring" "$(printf '%s' "$RESULT" | tr '\n' ';')"
+fi
+rm -rf "$D"
+
+# ===========================================================================
+# CASE 8b: a MAC WARN is reflected into the collector's POSTURE_DETAILS + count.
+# ===========================================================================
+D=$(make_stubdir)
+add_stub "$D" getenforce 'echo "Enforcing"'
+add_stub "$D" semodule 'echo "base"; echo "sshd"'   # nftban module missing -> WARN
+RESULT=$(
+    set +e
+    export PATH="$D"
+    export NFTBAN_AA_PROFILES_FILE="$D/.aa_profiles"
+    # shellcheck source=/dev/null
+    source "$LIB" >/dev/null 2>&1
+    declare -A P
+    _collect_posture_info P 2>/dev/null
+    printf 'DETAILS=%s\n' "${P[POSTURE_DETAILS]:-}"
+    printf 'MAC_VERDICT=%s\n' "${P[POSTURE_MAC_VERDICT]:-}"
+    printf 'WARNINGS=%s\n' "${P[POSTURE_WARNINGS]:-0}"
+)
+if printf '%s\n' "$RESULT" | grep -q 'MAC_VERDICT=WARN' \
+   && printf '%s\n' "$RESULT" | grep -qi 'DETAILS=.*MAC:'; then
+    ok "C8b MAC WARN flows into POSTURE_DETAILS + advisory count"
+else
+    no "C8b MAC WARN -> details/count" "$(printf '%s' "$RESULT" | tr '\n' ';')"
+fi
+rm -rf "$D"
+
+echo
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/docs/security/MAC_PROFILES_SELINUX_APPARMOR.md
+++ b/docs/security/MAC_PROFILES_SELINUX_APPARMOR.md
@@ -201,6 +201,85 @@ the profile's file rules apply, which restores `sd_notify` readiness.
   shell-outs, then tighten both the SELinux domain and the AppArmor profile and
   consider flipping AppArmor to enforce.
 
+## 12. Health posture surface map
+
+*As of v1.158.* NFTBan reports security posture on two surfaces. Both are
+**advisory** — a posture WARN never changes the exit code of `nftban status`,
+`nftban health`, or the installer. Posture is a low-noise summary, not a security
+audit (use `lynis`/`oscap` for that).
+
+| Surface | Command | Detail level | Source |
+|---|---|---|---|
+| Compact | `nftban status` | one line + per-advisory `→` rows | `_collect_posture_info` (`nftban_report_data.sh`) |
+| Detailed | `nftban health posture` / `nftban health check` | full per-check rows + remediation hints | `nftban_health_cmd_posture` (`cmd_health_analysis.sh`) |
+
+### What posture covers
+- **SSH** — effective `PasswordAuthentication` / `PermitRootLogin` / `X11Forwarding`.
+  Resolved from the **effective** sshd config (`sshd -T` when runnable as root,
+  else the main file merged with `sshd_config.d/*.conf` drop-ins). Added v1.150.
+- **Sudo** — files in `/etc/sudoers.d` carrying **broad** `NOPASSWD: ALL`
+  (constrained command-specific NOPASSWD is *not* flagged; NFTBan's own scoped
+  sudoers file is excluded by design).
+- **Systemd hardening** — `NoNewPrivileges` (and `PrivateTmp`/`ProtectSystem` in
+  the detailed view) on the NFTBan units.
+- **Config integrity** — drift of `/etc/nftban` files vs the install checksums.
+- **MAC posture** — *new in v1.158* — whether NFTBan's own AppArmor profile
+  (`nftband`) / SELinux module (`nftban`) is loaded and enforcing. See §6 for the
+  underlying operator commands and §13 below for the verdict model.
+
+### Intentionally excluded (and why)
+- **`rp_filter`** — high false-positive rate (asymmetric / multi-homed routing and
+  some hosting/panel setups legitimately disable it). Not flagged by default.
+  Deferred to an opt-in advisory.
+- **Panel admin ports** (e.g. `2222` / `2087` / `8443` listening) — *open ≠
+  insecure*; that is the control panel's job. Belongs to panel-firewall handling,
+  not posture.
+- **iptables/ipset/ebtables line-count "bypass"** — compat views and Docker are
+  legitimate; on iptables-nft hosts NFTBan's own rules appear via translation.
+  Firewall-conflict / rule-fingerprint detection owns this, not posture.
+- **sysctl network hardening** (`tcp_syncookies` / `accept_redirects` /
+  `log_martians`) — a narrow low-FP subset is **deferred** (a separate optional
+  lane), not shipped in v1.158.
+
+### `--json` behavior (documented, not a regression)
+`nftban health posture` accepts `--json` (it is parsed and **stripped** by the
+`nftban health` dispatcher before the subcommand runs, so it never errors), but the
+**posture subcommand emits human-readable text only** — it does **not** serialize
+posture fields as JSON. For machine-readable posture today, use the compact posture
+fields surfaced via the status data collector (`_collect_posture_info` populates
+`POSTURE_STATUS` / `POSTURE_DETAILS` / `POSTURE_WARNINGS` / `POSTURE_ISSUES`, which
+`nftban status --json` already serializes through its own status-JSON path). A
+dedicated structured `health posture --json` schema is a future item; this section
+documents current behavior so callers do not assume a JSON posture document exists.
+
+## 13. MAC posture verdicts (v1.158)
+
+The MAC posture summary is read-only and non-root-graceful (no crash and no noisy
+stderr when the tooling is absent). It is **distro-aware**: it does not WARN about a
+MAC system the host does not run.
+
+**AppArmor** (detected via `aa-status`, else `/sys/kernel/security/apparmor/profiles`):
+
+| Condition | Verdict |
+|---|---|
+| `nftband` profile loaded and **enforcing** | PASS |
+| AppArmor enabled but `nftband` profile **missing** or **complain-only** | WARN (advisory) |
+| AppArmor not available / not enabled | INFO / N/A (no WARN — including on SELinux-primary RPM hosts) |
+
+**SELinux** (detected via `getenforce` / `sestatus`, modules via `semodule -l`):
+
+| Condition | Verdict |
+|---|---|
+| **Enforcing** and the `nftban` module is loaded | PASS |
+| Enforcing/Permissive with the `nftban` module **missing**, or **Permissive** while a module is expected | WARN (advisory) |
+| SELinux not available / Disabled | INFO / N/A (no WARN — including on Debian/Ubuntu) |
+
+The compact `nftban status` line stays terse (e.g. `→ MAC: AppArmor enforcing`,
+`→ MAC: SELinux enforcing`, or no MAC row when not applicable) and only contributes
+to the advisory count when the verdict is an actual WARN. The detailed
+`nftban health posture` view shows the MAC system, the profile/module status, the
+enforcement mode, and a remediation hint when missing or not-enforcing.
+
 ## See also
 - `docs/THREAT_MODEL.md`
 - `docs/systemd/` (unit hardening)


### PR DESCRIPTION
**Security posture — MAC visibility (narrow).** Adds Mandatory Access Control (AppArmor/SELinux) posture to the existing `nftban health posture` / `nftban status` surfaces, **advisory-only**. Per `NFTBAN_SECURITY_POSTURE_GAP_ANALYSIS.md`: most posture already exists; the only real deltas are MAC visibility + a doc/test/JSON-behavior pass. **Existing `health posture` / `_collect_posture_info` / `sshd -T` effective-config / broad-only NOPASSWD logic are extended, NOT rebuilt.**

### Commits
- **PR-A** `8fa8c9ff` — document the posture surface map (compact `status` vs detailed `health posture`/`health check`) + `--json` behavior finding; flag MAC posture; record intentionally-excluded rp_filter/panel-port/iptables-line-count + deferred sysctl. (`docs/security/MAC_PROFILES_SELINUX_APPARMOR.md` §12/§13 + `health` help note.)
- **PR-B** `d41b1a54` — MAC posture summary in `_collect_posture_info` + detailed health output + compact `status` row. **AppArmor:** `aa-status`/securityfs; profile `nftband`; PASS loaded+enforce / WARN missing-or-complain / INFO absent. **SELinux:** `getenforce`+`semodule -l`; module `nftban`; PASS Enforcing+module / WARN mismatch-or-missing / INFO absent. Distro-aware (no AppArmor WARN on SELinux hosts, no SELinux WARN on Debian/Ubuntu). **Advisory-only** (MAC WARN increments `warnings`, never `issues`; no exit-code change); non-root-safe.

### Invariants
- `0 cmd/nftband`/`cmd/nftban-core`/`internal` · `0` schema · no CSF · daemon byte-identical to v1.157.0. Rebased on v1.157 main `fe45a7c5`. **sysctl posture deferred** (PR-C, not in this lane).

### Validation (lab2)
shellcheck `-S warning` + `bash -n` clean (5 files); **`mac_posture_v158` 13/13** (all 8 required cases) ; `stats_status_truth_v150` regression PASS. Pre-existing `cli_mac_profiles_v147a` 3-fail is stale-test drift on main (recorded separately), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
