### PR TITLE
fix(v1.159): geoban-refresh skips when geoip helper is absent

### DIFF
--- a/cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
+++ b/cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.159: nftban-geoban-refresh.service ExecCondition skip-not-fail
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="geoban_refresh_execcondition_v159_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-07"
+# meta:description="Locks the v1.159 fix for BUG-GEOBAN-REFRESH-UNSHIPPED-GEOIP-DEGRADES-INSTALL. v1.156 enabled nftban-geoban-refresh.timer in coreTimers; its service runs the geoip CIDR refresh which needs the unshipped nftban-geoip helper. The service's ExecCondition only checked the geoban CONFIG, so on hosts with config present + binary absent it HARD-FAILED -> installer failed_units_postinstall_ok -> INSTALL_STATE=DEGRADED (fleet-wide). Fix adds a second ExecCondition gating on the geoip helper binary so a missing binary yields a SKIPPED (condition-not-met) unit, not a FAILED one. Asserts: (a) both ExecConditions present in the shipped unit; (b) the geoip-binary condition returns non-zero (=> systemd 'condition not met' => skipped) when no helper binary exists; (c) returns 0 when the arch-specific .real binary exists; (d) returns 0 with only the bin/nftban-geoip fallback. Hermetic: a TMPDIR stands in for /usr/lib/nftban; no systemd, no host."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,sed"
+# meta:inventory.files="install/systemd/nftban-geoban-refresh.service,cli/lib/nftban/core/nftban_geoban.sh"
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-geoban-refresh.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+UNIT="$REPO_ROOT/install/systemd/nftban-geoban-refresh.service"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$UNIT" ]] || { echo "unit not found: $UNIT"; exit 1; }
+
+echo "=== (a) both ExecConditions present in the shipped unit ==="
+grep -qE '^ExecCondition=/usr/bin/test -f /etc/nftban/conf.d/geoban/main.conf' "$UNIT" \
+  && ok "config-file ExecCondition present" || no "config-file ExecCondition missing"
+grep -qE '^ExecCondition=/bin/sh -c .*nftban-geoip' "$UNIT" \
+  && ok "geoip-binary ExecCondition present (v1.159 fix)" || no "geoip-binary ExecCondition missing"
+# ExecStart must remain the geoip refresh (fix must not change behaviour-when-set-up)
+grep -qE '^ExecStart=/usr/sbin/nftban geoip refresh$' "$UNIT" \
+  && ok "ExecStart unchanged (nftban geoip refresh)" || no "ExecStart changed unexpectedly"
+
+# Extract the geoip-binary ExecCondition payload and retarget /usr/lib/nftban -> sandbox
+cond=$(grep -E "^ExecCondition=/bin/sh -c " "$UNIT" | grep nftban-geoip | head -1 | sed -E "s|^ExecCondition=/bin/sh -c '(.*)'$|\1|")
+[[ -n "$cond" ]] || { echo "could not extract geoip ExecCondition payload"; exit 1; }
+SB="$(mktemp -d)"; trap 'rm -rf "$SB"' EXIT
+arch="$(uname -m)"
+run_cond(){ local p="${cond//\/usr\/lib\/nftban/$SB}"; sh -c "$p"; }   # returns the condition rc
+
+echo "=== (b) missing helper binary => condition NOT met (rc 1..254 => systemd SKIPS, not fails) ==="
+mkdir -p "$SB/bin/.real"
+rc=0; run_cond || rc=$?
+{ [[ "$rc" -ge 1 && "$rc" -le 254 ]]; } && ok "no binary -> rc=$rc (condition-not-met => unit skipped, NOT failed)" || no "expected rc 1..254 with no binary, got $rc"
+
+echo "=== (c) arch-specific .real binary present => condition met (rc 0 => run) ==="
+printf '#!/bin/sh\nexit 0\n' > "$SB/bin/.real/nftban-geoip-$arch"; chmod +x "$SB/bin/.real/nftban-geoip-$arch"
+rc=0; run_cond || rc=$?
+[[ "$rc" -eq 0 ]] && ok "arch .real binary -> rc=0 (condition met => run)" || no "expected rc=0 with .real binary, got $rc"
+
+echo "=== (d) only bin/nftban-geoip fallback present => condition met (rc 0) ==="
+rm -f "$SB/bin/.real/nftban-geoip-$arch"
+printf '#!/bin/sh\nexit 0\n' > "$SB/bin/nftban-geoip"; chmod +x "$SB/bin/nftban-geoip"
+rc=0; run_cond || rc=$?
+[[ "$rc" -eq 0 ]] && ok "fallback bin/nftban-geoip -> rc=0 (condition met => run)" || no "expected rc=0 with fallback, got $rc"
+
+echo "=== (e) non-executable binary => condition NOT met (skip) ==="
+rm -f "$SB/bin/nftban-geoip"; : > "$SB/bin/.real/nftban-geoip-$arch"; chmod -x "$SB/bin/.real/nftban-geoip-$arch" 2>/dev/null || true
+rc=0; run_cond || rc=$?
+{ [[ "$rc" -ge 1 && "$rc" -le 254 ]]; } && ok "non-executable binary -> rc=$rc (skip)" || no "expected skip rc with non-exec binary, got $rc"
+
+echo "================================================================"
+echo "geoban_refresh_execcondition_v159: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/install/systemd/nftban-geoban-refresh.service
+++ b/install/systemd/nftban-geoban-refresh.service
@@ -49,6 +49,17 @@ Group=root
 # Skip the run entirely when GeoBan is not configured on this host.
 ExecCondition=/usr/bin/test -f /etc/nftban/conf.d/geoban/main.conf
 
+# v1.159: also skip (not fail) when the geoip helper binary is absent. The CIDR
+# refresh needs the nftban-geoip helper (see GEOIP_BINARY resolution in
+# core/nftban_geoban.sh: arch-specific bin/.real/nftban-geoip-$(uname -m) or the
+# bin/nftban-geoip fallback). That binary is not shipped in the base package, so
+# on hosts without it the run cannot succeed — a MISSING binary is part of "not
+# set up". A failed ExecCondition marks the unit skipped (condition-not-met),
+# NOT failed, so it does not trip the installer's failed_units_postinstall_ok
+# assertion (fixes BUG-GEOBAN-REFRESH-UNSHIPPED-GEOIP-DEGRADES-INSTALL, where
+# v1.156 enabling this timer turned a latent gap into INSTALL_STATE=DEGRADED).
+ExecCondition=/bin/sh -c 'test -x /usr/lib/nftban/bin/.real/nftban-geoip-$(uname -m) || test -x /usr/lib/nftban/bin/nftban-geoip'
+
 # Refresh all active GeoBan country CIDR sets.
 ExecStart=/usr/sbin/nftban geoip refresh
 


### PR DESCRIPTION
Fixes **`BUG-GEOBAN-REFRESH-UNSHIPPED-GEOIP-DEGRADES-INSTALL`** (HIGH — fleet-rollout blocker, found on lab2 during the v1.158 rollout).

### Root cause
Latent packaging/setup defect surfaced by v1.156. `nftban-geoban-refresh.service` runs `nftban geoip refresh`, which needs the `nftban-geoip` helper (`core/nftban_geoban.sh`: `bin/.real/nftban-geoip-$(uname -m)` or `bin/nftban-geoip` fallback) — **not shipped** in the base package. The service's only `ExecCondition` checked the geoban **config** (package-owned, ships `GEOBAN_ENABLED="true"`). Pre-v1.156 the timer was shipped-**disabled** → service never ran → dormant. **v1.156 added the timer to the installer core-timer set** → service runs → missing helper → exit-fail → installer `failed_units_postinstall_ok` → `INSTALL_STATE=DEGRADED` (every host with geoban config).

### Fix
- Adds an `ExecCondition` for the **nftban-geoip helper presence** (mirrors the resolver in `core/nftban_geoban.sh`). Now: *config exists AND geoip helper exists → run; otherwise skip cleanly.*
- A failed `ExecCondition` = **condition-not-met → unit SKIPPED, not failed** → no longer poisons `INSTALL_STATE`.
- **`ExecStart` unchanged** — if the helper is installed later, the service runs normally.

### Invariants
- **0 Go · 0 `cmd/nftband` · 0 `cmd/nftban-core` · 0 schema · no CSF · no firewall behaviour change.** Only the unit + a test changed.

### Validation
- `geoban_refresh_execcondition_v159_test.sh` **7/0** (both ExecConditions present, ExecStart intact, missing→skip, .real→run, fallback→run, non-exec→skip).
- **`systemd-analyze verify` rc=0 on lab2.**

> Recovery: only **lab2** is already contaminated with the stale failed-unit state (it was upgraded to v1.158); a one-time `systemctl reset-failed` on lab2 post-v1.159 clears it (`SELECT_V159_LAB2_RECOVERY = one_time_reset_failed`). The other 8 hosts upgrade v1.150.1→v1.159.0 directly and skip cleanly — **no** installer-Go reset logic added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
