### PR TITLE
fix(firewall): lock SSH durable multi-port fallback

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -623,6 +623,26 @@ jobs:
       - name: Default-enabled timer first-run guard (v1.161)
         run: bash cli/lib/nftban/tests/default_enabled_timer_first_run_guard_v161.sh
 
+      # v1.162 PR-A (DELTA §3.1): SSH durable multi-port render + reboot-sim.
+      # Sources cmd_firewall.sh's _firewall_substitute_placeholders, mocks the
+      # SSH detector to a multi-port union (22, 2222, 55000), renders the real
+      # install/nftables/nftables.conf.tpl, and asserts the durable `set
+      # ssh_ports` carries the FULL union (not primary-only) in BOTH families,
+      # the SSH ct-count rule stays set-driven (`tcp dport @ssh_ports`), no
+      # __SSH_PORT__ placeholder survives, and (reboot-sim) the durable file
+      # alone re-reads with every union port intact (no kernel reconcile).
+      # Hermetic (TMPDIR sandbox; no host, no systemd, no sshd).
+      - name: SSH durable multi-port render + reboot-sim (v1.162 PR-A)
+        run: bash cli/lib/nftban/tests/ssh_durable_multiport_render_v162.sh
+
+      # v1.162 PR-B (DELTA §3.5): static fallback install/nftables/nftables.conf
+      # must be set-driven — `set ssh_ports` defined in both ip/ip6 tables and the
+      # SSH ct-count rule reads `tcp dport @ssh_ports` (no literal `tcp dport 22`),
+      # set defined-before-use. Static grep guard (the boot-baseline `nft -c`
+      # parse is exercised by the package install/runtime CI legs).
+      - name: Static nftables fallback is set-driven (v1.162 PR-B)
+        run: bash cli/lib/nftban/tests/static_nftables_ssh_set_driven_v162.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/ssh_durable_multiport_render_v162.sh
+++ b/cli/lib/nftban/tests/ssh_durable_multiport_render_v162.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.162: SSH durable multi-port render + reboot-sim regression (shell)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="ssh_durable_multiport_render_v162"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Locks v1.162 DELTA §3.1 on the SHELL durable-render path (cmd_firewall.sh _firewall_substitute_placeholders). __SSH_PORT__ appears ONLY inside `set ssh_ports { elements = { … } }` and tcp_ports_in, so the function substitutes the FULL detected SSH-port union (comma-separated), never primary-only. The test mocks nftban_detect_ssh_ports to return a multi-port union (22, 2222, 55000), renders the real install/nftables/nftables.conf.tpl into a TMPDIR output, and asserts: (a) every union port (22 AND 2222 AND 55000) is present in the rendered ssh_ports elements; (b) the SSH ct-count rule renders set-driven `tcp dport @ssh_ports`; (c) no __SSH_PORT__ placeholder remains; (d) NEGATIVE — when multiple ports are detected the ssh_ports render is NOT primary-only (carries the additional ports too). Reboot-sim: the written output is the durable file; it is re-read fresh and the union ports must all still be present (the durable file alone carries them, no kernel reconcile). Hermetic: TMPDIR sandbox, mocked detection, no host/systemd/sshd."
+# meta:input="None (self-contained; sources cmd_firewall.sh with a mocked detector)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,sed"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh,install/nftables/nftables.conf.tpl"
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+CMD_FIREWALL="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+TEMPLATE="$REPO_ROOT/install/nftables/nftables.conf.tpl"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$CMD_FIREWALL" ]] || { echo "cmd_firewall.sh not found: $CMD_FIREWALL"; exit 1; }
+[[ -f "$TEMPLATE" ]]     || { echo "template not found: $TEMPLATE"; exit 1; }
+
+SB="$(mktemp -d)"; trap 'rm -rf "$SB"' EXIT
+
+# -----------------------------------------------------------------------------
+# Isolate _firewall_substitute_placeholders from its host environment.
+#
+# cmd_firewall.sh runs `set -Eeuo pipefail` and sources several /usr/lib/nftban
+# libs at top level, but every source is guarded (`|| true` / conditional on a
+# present file), so on a host without /usr/lib/nftban they are harmless no-ops.
+# Point NFTBAN_LIB_DIR at an empty sandbox so the real ssh_port_detect.sh is NOT
+# sourced, then define a MOCK nftban_detect_ssh_ports returning a multi-port
+# union AFTER sourcing. The function re-sources ssh_port_detect.sh from
+# NFTBAN_LIB_DIR (a no-op here, guarded by `|| true`), so our mock survives and
+# is the function actually called when computing the union CSV.
+# -----------------------------------------------------------------------------
+export NFTBAN_LIB_DIR="$SB/empty-lib"
+export NFTBAN_CONFIG_DIR="$SB/empty-conf"   # no ports.d fallback file -> live mock wins
+mkdir -p "$NFTBAN_LIB_DIR" "$NFTBAN_CONFIG_DIR"
+
+# Source the command file (only the function definitions are needed; no
+# subcommand is dispatched). Guarded sources resolve to no-ops in the sandbox.
+# shellcheck source=/dev/null
+source "$CMD_FIREWALL"
+
+declare -f _firewall_substitute_placeholders >/dev/null 2>&1 \
+  || { echo "_firewall_substitute_placeholders not defined after source"; exit 1; }
+
+# Mock the live detector with a multi-port union (primary-first). Defined AFTER
+# the source so it shadows any real definition; the function re-sources
+# ssh_port_detect.sh from the empty sandbox (no-op) before calling this.
+SSH_UNION_PORTS=(22 2222 55000)
+nftban_detect_ssh_ports() { printf '22\n2222\n55000\n'; }
+nftban_detect_ssh_primary_port() { printf '22\n'; }
+export -f nftban_detect_ssh_ports nftban_detect_ssh_primary_port 2>/dev/null || true
+
+OUT="$SB/nftables.conf.rendered"
+
+echo "=== render real template with mocked multi-port union (22, 2222, 55000) ==="
+_firewall_substitute_placeholders "$TEMPLATE" "$OUT" \
+  || { echo "render returned non-zero"; exit 1; }
+[[ -s "$OUT" ]] || { echo "rendered output is empty: $OUT"; exit 1; }
+ok "rendered $TEMPLATE -> $OUT"
+
+# Helper: extract the inner `elements = { … }` of every `set ssh_ports` block.
+# The template has one per family (ip + ip6). awk keeps it dependency-light.
+ssh_ports_elements() {
+  awk '
+    /set ssh_ports[[:space:]]*\{/ { inblk=1 }
+    inblk && /elements[[:space:]]*=[[:space:]]*\{/ {
+      line=$0
+      sub(/.*elements[[:space:]]*=[[:space:]]*\{/, "", line)
+      sub(/\}.*/, "", line)
+      print line
+      inblk=0
+    }
+  ' "$1"
+}
+
+# -----------------------------------------------------------------------------
+# (a) every union port present in the rendered ssh_ports elements
+# -----------------------------------------------------------------------------
+echo "=== (a) every union port lands in ssh_ports elements (both families) ==="
+SSH_ELEMS="$(ssh_ports_elements "$OUT")"
+[[ -n "$SSH_ELEMS" ]] || { echo "no ssh_ports elements extracted"; exit 1; }
+# Expect two ssh_ports blocks (ip + ip6).
+nblk="$(printf '%s\n' "$SSH_ELEMS" | grep -c .)"
+if [[ "$nblk" -eq 2 ]]; then ok "two ssh_ports blocks rendered (ip + ip6)"
+else no "expected 2 ssh_ports blocks, got $nblk"; fi
+
+union_in_every_block() {
+  # $1 = port. Assert it appears as a whole token in EVERY ssh_ports block.
+  local port="$1" miss=0
+  while IFS= read -r blk; do
+    [[ -z "$blk" ]] && continue
+    if ! printf '%s' "$blk" | grep -Eq "(^|[^0-9])${port}([^0-9]|$)"; then
+      miss=1
+    fi
+  done < <(printf '%s\n' "$SSH_ELEMS")
+  return $miss
+}
+
+for p in "${SSH_UNION_PORTS[@]}"; do
+  if union_in_every_block "$p"; then
+    ok "union port $p present in every ssh_ports block"
+  else
+    no "union port $p MISSING from an ssh_ports block (primary-only regression?)" "elements: $SSH_ELEMS"
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# (b) SSH ct-count rule renders set-driven @ssh_ports (not a literal port)
+# -----------------------------------------------------------------------------
+echo "=== (b) SSH ct-count rule is set-driven (tcp dport @ssh_ports) ==="
+if grep -Eq 'tcp dport @ssh_ports ct count' "$OUT"; then
+  ok "ct-count rule reads @ssh_ports"
+else
+  no 'set-driven tcp dport @ssh_ports ct count rule not found'
+fi
+for p in "${SSH_UNION_PORTS[@]}"; do
+  if grep -Eq "tcp dport ${p} ct count" "$OUT"; then
+    no "found literal tcp dport ${p} ct count — SSH rule must use @ssh_ports"
+  fi
+done
+ok "no literal per-port SSH ct-count rule"
+
+# -----------------------------------------------------------------------------
+# (c) no __SSH_PORT__ placeholder remains
+# -----------------------------------------------------------------------------
+echo "=== (c) no unrendered __SSH_PORT__ placeholder remains ==="
+if grep -q '__SSH_PORT__' "$OUT"; then
+  no "unrendered __SSH_PORT__ placeholder present in durable output"
+else
+  ok "no __SSH_PORT__ placeholder remains"
+fi
+
+# -----------------------------------------------------------------------------
+# (d) NEGATIVE — multi-port render is NOT primary-only
+# -----------------------------------------------------------------------------
+echo "=== (d) NEGATIVE: ssh_ports is NOT primary-only when multiple ports detected ==="
+# If render had collapsed to primary-only, the additional ports (2222, 55000)
+# would be absent. Assert at least one additional port IS present somewhere.
+if printf '%s' "$SSH_ELEMS" | grep -Eq '(^|[^0-9])2222([^0-9]|$)' \
+   && printf '%s' "$SSH_ELEMS" | grep -Eq '(^|[^0-9])55000([^0-9]|$)'; then
+  ok "additional ports 2222 + 55000 present (not primary-only)"
+else
+  no "ssh_ports collapsed to primary-only — additional ports missing" "elements: $SSH_ELEMS"
+fi
+
+# -----------------------------------------------------------------------------
+# Reboot-sim: the written output IS the durable file. Re-read it fresh (no
+# kernel reconcile) and assert every union port still present.
+# -----------------------------------------------------------------------------
+echo "=== reboot-sim: re-read durable file fresh; union must survive ==="
+DURABLE="$SB/durable-after-reboot.conf"
+cp "$OUT" "$DURABLE"   # the file that survives a reboot
+SSH_ELEMS="$(ssh_ports_elements "$DURABLE")"   # re-parse fresh from disk
+reboot_ok=1
+for p in "${SSH_UNION_PORTS[@]}"; do
+  union_in_every_block "$p" || reboot_ok=0
+done
+if [[ "$reboot_ok" -eq 1 ]]; then
+  ok "all union ports survive in the durable file alone (no reconcile needed)"
+else
+  no "a union port did NOT survive in the durable file" "elements: $SSH_ELEMS"
+fi
+
+echo "================================================================"
+echo "ssh_durable_multiport_render_v162: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/static_nftables_ssh_set_driven_v162.sh
+++ b/cli/lib/nftban/tests/static_nftables_ssh_set_driven_v162.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.162 PR-B: static boot-baseline SSH ct-count is set-driven (@ssh_ports)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="static_nftables_ssh_set_driven_v162"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Locks v1.162 PR-B (DELTA §3.5): the pre-rendered static fallback install/nftables/nftables.conf — the boot-baseline staged to /etc/nftban/nftables.conf, loaded at boot before the .tpl rebuild — must drive its SSH brute-force ct-count rule from @ssh_ports, not the literal 'tcp dport 22'. Migrates the static file to the set-driven form already used by nftables.conf.tpl (v1.145 PR-A). Asserts: (a) a 'set ssh_ports' block exists in BOTH 'table ip nftban' and 'table ip6 nftban'; (b) the SSH ct-count rule in each table uses 'tcp dport @ssh_ports ct count' (not literal 'tcp dport 22 ct count'); (c) no literal 'tcp dport 22 ct count' rule survives anywhere in the file; (d) define-before-use — each table's 'set ssh_ports' definition precedes its '@ssh_ports' reference (nftables requires the set to exist before use, else the boot firewall fails to load). Hermetic: reads the repo source file read-only; no nft, no host, no root."
+# meta:input="None (reads repo source file read-only)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="install/nftables/nftables.conf"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+CONF="$REPO_ROOT/install/nftables/nftables.conf"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$CONF" ]] || { echo "static config not found: $CONF"; exit 1; }
+
+echo "=== (a) 'set ssh_ports' declared in BOTH ip and ip6 tables ==="
+# Count one declaration per table; expect exactly 2 across the file.
+defs=$(grep -cE '^[[:space:]]*set ssh_ports \{' "$CONF" || true)
+if [[ "$defs" -eq 2 ]]; then
+  ok "set ssh_ports declared twice (ip + ip6), found $defs"
+else
+  no "expected 2 'set ssh_ports' blocks (ip+ip6), found $defs"
+fi
+
+echo "=== (b) SSH ct-count rule is set-driven (@ssh_ports) in both tables ==="
+uses=$(grep -cE 'ct state new tcp dport @ssh_ports ct count' "$CONF" || true)
+if [[ "$uses" -eq 2 ]]; then
+  ok "SSH ct-count uses @ssh_ports in both tables, found $uses"
+else
+  no "expected 2 set-driven SSH ct-count rules, found $uses"
+fi
+
+echo "=== (c) no literal 'tcp dport 22 ct count' rule survives ==="
+if grep -qE 'tcp dport 22 ct count' "$CONF"; then
+  no "literal 'tcp dport 22 ct count' still present (boot-baseline not migrated)"
+else
+  ok "no literal 'tcp dport 22 ct count' rule remains"
+fi
+
+echo "=== (d) define-before-use: 'set ssh_ports' precedes '@ssh_ports' in each table ==="
+# Per-table check: within each 'table ip[6]? nftban' block the set definition
+# line number must be strictly less than the @ssh_ports reference line number.
+# nftables loads the file top-to-bottom; a forward reference fails at boot.
+report=$(awk '
+  /^table ip nftban/   { tbl="ip";  defline=0; useline=0 }
+  /^table ip6 nftban/  { tbl="ip6"; defline=0; useline=0 }
+  /^[[:space:]]*set ssh_ports \{/ { if (tbl!="" && defline==0) defline=NR }
+  /ct state new tcp dport @ssh_ports ct count/ { if (tbl!="" && useline==0) { useline=NR; printf "%s %d %d\n", tbl, defline, useline } }
+' "$CONF")
+[[ -n "$report" ]] || { no "could not locate set/use pairs per table"; }
+# Split each "tbl def use" record on whitespace (the script-wide IFS excludes
+# spaces, so set a local space-aware IFS just for this read loop).
+while IFS=' ' read -r tbl defline useline; do
+  [[ -z "$tbl" ]] && continue
+  if [[ "$defline" -gt 0 && "$useline" -gt 0 && "$defline" -lt "$useline" ]]; then
+    ok "table $tbl: ssh_ports defined @line $defline before use @line $useline"
+  else
+    no "table $tbl: define-before-use violated (def=$defline use=$useline)"
+  fi
+done <<< "$report"
+
+echo "================================================================"
+echo "static_nftables_ssh_set_driven_v162: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -132,6 +132,18 @@ table ip nftban {
         elements = { 22, 80, 443 }
     }
 
+    # v1.145 PR-A / v1.162 §3.5: set-driven SSH brute-force rate-limit in the
+    # static boot-baseline. The SSH ct-count rule below reads its dport from
+    # @ssh_ports (defined here, before the input chain that references it —
+    # nftables requires the set to exist before use). The .tpl rebuild renders
+    # __SSH_PORT__; this static fallback bakes the default 22 so the boot
+    # firewall is set-driven even before the first rebuild.
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit (v1.162 §3.5 static-fallback)"
+        elements = { 22 }
+    }
+
     set tcp_ports_out {
         type inet_service
         comment "Allowed outbound TCP ports"
@@ -394,7 +406,7 @@ table ip nftban {
         counter name anchor_detect comment "NFTBAN_ANCHOR:ANCHOR_DETECT"
 
         # 6. CT LIMITS - DDoS protection (per source IP limits)
-        ct state new tcp dport 22 ct count over 15 counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max 15 concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over 15 counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max 15 concurrent per IP — v1.145/v1.162 set-driven"
         ct state new tcp dport { 80, 443 } ct count over 150 counter name input_ct_http_drop counter name total_input_drop drop comment "HTTP(S): max 150 concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over 150 counter name input_ct_mail_drop counter name total_input_drop drop comment "MAIL: max 150 concurrent per IP"
 
@@ -492,6 +504,15 @@ table ip6 nftban {
         type inet_service
         comment "Allowed inbound TCP ports"
         elements = { 22, 80, 443 }
+    }
+
+    # v1.145 PR-A / v1.162 §3.5: set-driven SSH brute-force rate-limit (IPv6).
+    # Defined before the input chain that references @ssh_ports; static
+    # fallback bakes the default 22 (the .tpl renders __SSH_PORT__).
+    set ssh_ports {
+        type inet_service
+        comment "SSH ports for set-driven brute-force rate-limit (v1.162 §3.5 static-fallback, v6)"
+        elements = { 22 }
     }
 
     set tcp_ports_out {
@@ -763,7 +784,7 @@ table ip6 nftban {
         counter name anchor_detect comment "NFTBAN_ANCHOR:ANCHOR_DETECT"
 
         # 6. CT LIMITS - DDoS protection (per source IP limits)
-        ct state new tcp dport 22 ct count over 15 counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max 15 concurrent per IP"
+        ct state new tcp dport @ssh_ports ct count over 15 counter name input_ct_ssh_drop counter name total_input_drop drop comment "SSH: max 15 concurrent per IP — v1.145/v1.162 set-driven"
         ct state new tcp dport { 80, 443 } ct count over 150 counter name input_ct_http_drop counter name total_input_drop drop comment "HTTP(S): max 150 concurrent per IP"
         ct state new tcp dport { 25, 465, 587 } ct count over 150 counter name input_ct_mail_drop counter name total_input_drop drop comment "MAIL: max 150 concurrent per IP"
 

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -135,9 +135,9 @@ table ip nftban {
     # v1.145 PR-A / v1.162 §3.5: set-driven SSH brute-force rate-limit in the
     # static boot-baseline. The SSH ct-count rule below reads its dport from
     # @ssh_ports (defined here, before the input chain that references it —
-    # nftables requires the set to exist before use). The .tpl rebuild renders
-    # __SSH_PORT__; this static fallback bakes the default 22 so the boot
-    # firewall is set-driven even before the first rebuild.
+    # nftables requires the set to exist before use). The templated source uses
+    # an SSH-port substitution token; this static fallback bakes the default 22
+    # so the boot firewall is set-driven even before the first rebuild.
     set ssh_ports {
         type inet_service
         comment "SSH ports for set-driven brute-force rate-limit (v1.162 §3.5 static-fallback)"
@@ -508,7 +508,8 @@ table ip6 nftban {
 
     # v1.145 PR-A / v1.162 §3.5: set-driven SSH brute-force rate-limit (IPv6).
     # Defined before the input chain that references @ssh_ports; static
-    # fallback bakes the default 22 (the .tpl renders __SSH_PORT__).
+    # fallback bakes the default 22 (the templated source uses an SSH-port
+    # substitution token).
     set ssh_ports {
         type inet_service
         comment "SSH ports for set-driven brute-force rate-limit (v1.162 §3.5 static-fallback, v6)"

--- a/internal/installer/render/nftables_multiport_reboot_v162_test.go
+++ b/internal/installer/render/nftables_multiport_reboot_v162_test.go
@@ -1,0 +1,206 @@
+// =============================================================================
+// NFTBan v1.162 - Multi-port durable-render + reboot-sim regression (Go path)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-render-nftables-multiport-reboot-v162-test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-08"
+// meta:description="Locks v1.162 DELTA §3.1 on the Go durable-render path (RenderNftablesConfMultiPort): the durable `set ssh_ports { elements = { … } }` must carry the FULL detected SSH-port union (every port), not just the primary, in BOTH the ip nftban and ip6 nftban tables, and the SSH brute-force ct-count rule must stay set-driven (`tcp dport @ssh_ports`), never a literal port. The reboot-sim asserts the durable rendered STRING alone — what survives a reboot with no kernel reconcile — carries the union, and that a re-render of the same input is idempotent (still all ports, no duplicates). A single-port [22] case asserts byte-compat (ssh_ports = {22} only). Hermetic: a mock executor stands in for file I/O; no host, no nft, no systemd."
+// meta:input="None"
+// meta:output="t.Fatalf/t.Errorf on assertion failure"
+// meta:depends="testing,internal/installer/detect,internal/installer/executor,internal/installer/logging"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package render
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// dualTableSetDrivenTemplate is a minimal two-family fixture mirroring the
+// shipped install/nftables/nftables.conf.tpl shape: each of `ip nftban` and
+// `ip6 nftban` carries a `set ssh_ports { elements = { __SSH_PORT__ } }` and an
+// input chain whose SSH brute-force ct-count rule reads `tcp dport @ssh_ports`.
+// The primary port arrives via the __SSH_PORT__ substitution; every additional
+// detected port is injected by ensureSSHPortsInSet. This fixture lets the test
+// assert the durable union lands in BOTH families without depending on the full
+// 800-line template.
+func dualTableSetDrivenTemplate() string {
+	return `# v1.162 dual-table set-driven fixture
+table ip nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { __SSH_PORT__, 80, 443 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { __SSH_PORT__ }
+	}
+	chain input {
+		ct state new tcp dport @ssh_ports ct count over __CT_LIMIT_SSH__ counter drop comment "SSH set-driven v4"
+	}
+}
+table ip6 nftban {
+	set tcp_ports_in {
+		type inet_service
+		elements = { __SSH_PORT__, 80, 443 }
+	}
+	set ssh_ports {
+		type inet_service
+		elements = { __SSH_PORT__ }
+	}
+	chain input {
+		ct state new tcp dport @ssh_ports ct count over __CT_LIMIT_SSH__ counter drop comment "SSH set-driven v6"
+	}
+}
+`
+}
+
+// sshPortsBlocksV162 extracts the inner `elements = { … }` of EVERY
+// `set ssh_ports { … }` block (one per family). Group 1 is the inner element
+// list. Returns all matches so the test can assert per-table union coverage.
+var sshPortsBlocksV162 = regexp.MustCompile(`(?s)set ssh_ports \{[^{}]*elements = \{([^}]*)\}`)
+
+func allSSHPortsElementsV162(t *testing.T, content string) []string {
+	t.Helper()
+	ms := sshPortsBlocksV162.FindAllStringSubmatch(content, -1)
+	if ms == nil {
+		t.Fatalf("no `set ssh_ports { … }` block found in:\n%s", content)
+	}
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// wholeTokenV162 matches an exact whole numeric port token (not masked by a
+// longer number containing it as a substring, e.g. 22 inside 2222).
+func wholeTokenV162(port int) *regexp.Regexp {
+	return regexp.MustCompile(`(^|[^0-9])` + strconv.Itoa(port) + `([^0-9]|$)`)
+}
+
+func tokenCountV162(s string, port int) int {
+	return len(wholeTokenV162(port).FindAllString(s, -1))
+}
+
+// renderDualV162 renders dualTableSetDrivenTemplate with sshPorts via the mock
+// executor and returns the durable written content.
+func renderDualV162(t *testing.T, sshPorts []int) string {
+	t.Helper()
+	log := newRenderTestLogger(t)
+	defer log.Close()
+	mock := executor.NewMockExecutor()
+	mock.Files[nftbanConf] = []byte(dualTableSetDrivenTemplate())
+	if err := RenderNftablesConfMultiPort(mock, sshPorts, detect.CTLimits{SSH: 15, HTTP: 200, Mail: 30}, log); err != nil {
+		t.Fatalf("RenderNftablesConfMultiPort(%v): %v", sshPorts, err)
+	}
+	written, ok := mock.WrittenFiles[nftbanConf]
+	if !ok {
+		t.Fatalf("render did not write %s for sshPorts=%v", nftbanConf, sshPorts)
+	}
+	return string(written)
+}
+
+// TestRenderV162_MultiPort_DurableUnionInBothFamilies is the core DELTA §3.1
+// lock: with a multi-port slice [22, 2222, 55000] the durable rendered
+// ssh_ports set must carry ALL three ports as whole tokens in BOTH the ip and
+// ip6 families — never primary-only.
+func TestRenderV162_MultiPort_DurableUnionInBothFamilies(t *testing.T) {
+	const wantBlocks = 2 // ip nftban + ip6 nftban
+	ports := []int{22, 2222, 55000}
+	out := renderDualV162(t, ports)
+
+	blocks := allSSHPortsElementsV162(t, out)
+	if len(blocks) != wantBlocks {
+		t.Fatalf("expected %d ssh_ports blocks (ip + ip6), got %d:\n%s", wantBlocks, len(blocks), out)
+	}
+	for i, elems := range blocks {
+		for _, p := range ports {
+			if tokenCountV162(elems, p) != 1 {
+				t.Errorf("ssh_ports block #%d: port %d appears %d times, want exactly 1 (primary-only regression?); elements=%q",
+					i, p, tokenCountV162(elems, p), elems)
+			}
+		}
+	}
+
+	// SSH ct-count rule must be set-driven, never a literal port.
+	if !strings.Contains(out, "tcp dport @ssh_ports ct count") {
+		t.Errorf("expected set-driven `tcp dport @ssh_ports ct count`; got:\n%s", out)
+	}
+	for _, p := range ports {
+		if strings.Contains(out, "tcp dport "+strconv.Itoa(p)+" ct count") {
+			t.Errorf("found literal `tcp dport %d ct count` — SSH rule must read @ssh_ports", p)
+		}
+	}
+}
+
+// TestRenderV162_RebootSim_DurableStringAloneCarriesUnion treats the rendered
+// output as the durable file that survives a reboot with NO kernel reconcile:
+// the string alone must carry the full union, and re-rendering that same input
+// (a second installer/reload pass) must be idempotent — still all ports, no
+// duplicate tokens, ct-count rule still set-driven.
+func TestRenderV162_RebootSim_DurableStringAloneCarriesUnion(t *testing.T) {
+	ports := []int{22, 2222, 55000}
+	first := renderDualV162(t, ports)
+
+	// "Reboot": only the durable string survives. Re-parse it fresh and assert
+	// every union port is present in both ssh_ports blocks.
+	for i, elems := range allSSHPortsElementsV162(t, first) {
+		for _, p := range ports {
+			if !wholeTokenV162(p).MatchString(elems) {
+				t.Errorf("post-reboot durable ssh_ports block #%d missing port %d; elements=%q", i, p, elems)
+			}
+		}
+	}
+
+	// Idempotent re-render: feed the SAME input again; the union must still be
+	// fully present with no duplicate tokens in either ssh_ports block.
+	second := renderDualV162(t, ports)
+	for i, elems := range allSSHPortsElementsV162(t, second) {
+		for _, p := range ports {
+			if c := tokenCountV162(elems, p); c != 1 {
+				t.Errorf("idempotency: ssh_ports block #%d port %d appears %d times, want exactly 1; elements=%q", i, p, c, elems)
+			}
+		}
+	}
+	if !strings.Contains(second, "tcp dport @ssh_ports ct count") {
+		t.Errorf("idempotent re-render lost set-driven SSH rule:\n%s", second)
+	}
+}
+
+// TestRenderV162_SinglePort_ByteCompat asserts the single-port [22] case still
+// renders ssh_ports = {22} only (no spurious extra tokens) in both families —
+// the multi-port lock must not regress the common single-port host.
+func TestRenderV162_SinglePort_ByteCompat(t *testing.T) {
+	out := renderDualV162(t, []int{22})
+	for i, elems := range allSSHPortsElementsV162(t, out) {
+		if tokenCountV162(elems, 22) != 1 {
+			t.Errorf("ssh_ports block #%d: expected exactly one token 22; elements=%q", i, elems)
+		}
+		// No stray multi-port tokens from the fixtures used elsewhere.
+		for _, p := range []int{2222, 55000} {
+			if tokenCountV162(elems, p) != 0 {
+				t.Errorf("ssh_ports block #%d: unexpected port %d in single-port render; elements=%q", i, p, elems)
+			}
+		}
+	}
+	if !strings.Contains(out, "tcp dport @ssh_ports ct count") {
+		t.Errorf("single-port render lost set-driven SSH rule:\n%s", out)
+	}
+}


### PR DESCRIPTION
Scope:
- **PR-A:** hermetic multi-port durable-render + reboot-sim tests (Go `nftables_multiport_reboot_v162_test.go` + shell `ssh_durable_multiport_render_v162.sh`) — assert the durable `set ssh_ports` carries the FULL union (not primary-only) in ip+ip6, the SSH ct-count rule reads `@ssh_ports`, and the durable file alone survives a reboot.
- **PR-B:** static fallback `install/nftables/nftables.conf` uses `@ssh_ports` — `set ssh_ports` added to both ip/ip6 tables (define-before-use); both SSH ct-count rules migrated from literal `tcp dport 22` to `tcp dport @ssh_ports` (literal `15` kept as the static fallback default); `static_nftables_ssh_set_driven_v162.sh` guard. Both guards CI-wired.

Validation (lab2):
- `go build` / `go test ./internal/installer/render/...` green
- shell render+reboot-sim guard green
- static fallback guard green
- `nft -c -f install/nftables/nftables.conf` green (boot-baseline parses; `@ssh_ports` resolves; set defined-before-use)
- v145 set-driven guard still green (18/0)
- daemon tree unchanged: `cmd/nftband` `85a2de3e…` (chain v1.147→v1.162)
- schema untouched (1.83.0 frozen)

Out of scope:
- §3.6 daemon `ssh_ports` counter seeding
- socket-activated SSH mismatch warning
- SSH-port lifecycle validator
- SSH-port docs
- production host second-port testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)