### PR TITLE
feat(security): add whitelist verify and immutable health checks

### DIFF
--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -149,6 +149,11 @@ nftban_cmd_whitelist() {
             # Show whitelist (v1.59.0: added --json support)
             nftban_whitelist_list "$@"
             ;;
+        verify)
+            # v1.163.0 (SEC-WL-VERIFY): READ-ONLY anomaly report comparing the
+            # live kernel whitelist sets against the durable whitelist.d baseline.
+            nftban_whitelist_verify "$@"
+            ;;
         sync|whitelistme)
             # Pass to whitelist-system for these commands
             if [[ -f "${NFTBAN_LIB_DIR}/cli/cmd_whitelist_system.sh" ]]; then
@@ -570,6 +575,235 @@ nftban_whitelist_list() {
     fi
 }
 
+# =============================================================================
+# v1.163.0 — `nftban whitelist verify` (SEC-WL-VERIFY)
+# =============================================================================
+# READ-ONLY anomaly report. Compares the live kernel whitelist sets
+# (@whitelist_ipv4 in `ip nftban`, @whitelist_ipv6 in `ip6 nftban`) against the
+# DURABLE whitelist.d baseline (entries with NO EXPIRES_AT — the 99-manual.conf
+# class loaded permanently on every rebuild by internal/whitelist/loader.go).
+#
+# Anomaly classes (both set rc=1):
+#   IN-KERNEL-NOT-IN-BASELINE  — a kernel entry that is neither a durable baseline
+#                                entry nor a current (unexpired) session entry.
+#                                This is the security-relevant case (possible
+#                                out-of-band injection into the live set).
+#   IN-BASELINE-NOT-IN-KERNEL  — a durable baseline entry not applied to the
+#                                kernel (drift / not-applied).
+#
+# Session/TTL entries (whitelist.d/*.conf lines WITH an EXPIRES_AT that has not
+# yet passed, e.g. 00-session.conf) are INFORMATIONAL only — a legitimate live
+# admin session in the kernel must NOT be flagged as injected. Expired session
+# entries are NOT treated as baseline (the loader would not keep them), so a
+# kernel entry matching only an expired session line is still an anomaly.
+#
+# Strictly read-only: the only nft invocation is `nft list set` (read). No add,
+# no delete, no sync. Remediation is a hint; there is no --fix.
+
+# Directory holding the durable + session whitelist config files.
+_NFTBAN_WHITELIST_CONF_DIR="/etc/nftban/whitelist.d"
+
+# Normalize a single nft `elements` token to a bare IP/CIDR key for comparison.
+# Drops any trailing nft annotation (e.g. ` comment "..."` / ` timeout ...`) and
+# surrounding whitespace, leaving "1.2.3.4" or "1.2.3.0/24". Lowercased so IPv6
+# hex compares stably against config lines.
+_nftban_wl_norm_key() {
+    local tok="$1"
+    tok="${tok%%comment*}"   # strip ` comment "..."`
+    tok="${tok%%timeout*}"   # strip ` timeout ...`
+    tok="${tok%%expires*}"   # strip ` expires ...`
+    # trim surrounding whitespace
+    tok="${tok#"${tok%%[![:space:]]*}"}"
+    tok="${tok%"${tok##*[![:space:]]}"}"
+    printf '%s' "${tok,,}"
+}
+
+# Read one kernel whitelist set, one normalized key per line (read-only).
+# $1 = family table words ("ip nftban" | "ip6 nftban"), $2 = set name.
+# Returns rc 0 on a readable set (even if empty), rc 1 if the set is unreadable
+# (nft absent, daemon down, or no table) so the caller can report gracefully.
+_nftban_wl_read_kernel_set() {
+    local table="$1" set_name="$2" raw tok
+    # shellcheck disable=SC2086
+    raw=$(timeout 10s nft list set ${table} ${set_name} 2>/dev/null) || return 1
+    # Empty/absent elements block is a valid (empty) set, not an error.
+    [[ "$raw" == *"elements"* ]] || return 0
+    printf '%s\n' "$raw" \
+        | tr '\n' ' ' \
+        | sed -n 's/.*elements = { *\([^}]*\).*/\1/p' \
+        | tr ',' '\n' \
+        | while IFS= read -r tok || [[ -n "$tok" ]]; do
+            [[ -z "${tok//[[:space:]]/}" ]] && continue
+            local k; k="$(_nftban_wl_norm_key "$tok")"
+            [[ -n "$k" ]] && printf '%s\n' "$k"
+          done
+    return 0
+}
+
+# Read durable baseline keys (whitelist.d/*.conf entries with NO EXPIRES_AT).
+# $1 = "4" or "6" to filter by family (IPv6 keys contain ':').
+_nftban_wl_read_baseline() {
+    local fam="$1" f line before_hash ip
+    [[ -d "$_NFTBAN_WHITELIST_CONF_DIR" ]] || return 0
+    for f in "$_NFTBAN_WHITELIST_CONF_DIR"/*.conf; do
+        [[ -e "$f" ]] || continue
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            local trimmed="${line#"${line%%[![:space:]]*}"}"
+            [[ -z "$trimmed" ]] && continue
+            [[ "${trimmed:0:1}" == "#" ]] && continue
+            # Durable baseline = NO EXPIRES_AT marker (session/TTL entries excluded).
+            [[ "$line" == *EXPIRES_AT=* ]] && continue
+            before_hash="${line%%#*}"
+            # shellcheck disable=SC2086
+            ip=$(printf '%s' $before_hash | awk '{print $1}')
+            [[ -z "$ip" ]] && continue
+            if [[ "$fam" == "6" && "$ip" == *:* ]]; then
+                printf '%s\n' "${ip,,}"
+            elif [[ "$fam" == "4" && "$ip" != *:* ]]; then
+                printf '%s\n' "${ip,,}"
+            fi
+        done < "$f"
+    done
+}
+
+# Read CURRENT (unexpired) session keys (whitelist.d/*.conf entries WITH an
+# EXPIRES_AT still in the future). $1 = "4"/"6". Used to classify kernel entries
+# as legitimate live sessions rather than injections. Unparseable/expired lines
+# are skipped (NOT counted as session), so they fall through to anomaly checks.
+_nftban_wl_read_sessions() {
+    local fam="$1" f line before_hash ip expires_at expires_unix now_unix
+    now_unix=$(date -u +%s 2>/dev/null) || now_unix=0
+    [[ -d "$_NFTBAN_WHITELIST_CONF_DIR" ]] || return 0
+    for f in "$_NFTBAN_WHITELIST_CONF_DIR"/*.conf; do
+        [[ -e "$f" ]] || continue
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            local trimmed="${line#"${line%%[![:space:]]*}"}"
+            [[ -z "$trimmed" ]] && continue
+            [[ "${trimmed:0:1}" == "#" ]] && continue
+            [[ "$line" == *EXPIRES_AT=* ]] || continue
+            expires_at=$(printf '%s' "$line" | grep -oE 'EXPIRES_AT=[^ ]+' | head -1 | cut -d= -f2)
+            [[ -z "$expires_at" ]] && continue
+            expires_unix=$(date -u -d "$expires_at" +%s 2>/dev/null) || continue
+            [[ "$expires_unix" -le "$now_unix" ]] && continue   # expired => not a current session
+            before_hash="${line%%#*}"
+            # shellcheck disable=SC2086
+            ip=$(printf '%s' $before_hash | awk '{print $1}')
+            [[ -z "$ip" ]] && continue
+            if [[ "$fam" == "6" && "$ip" == *:* ]]; then
+                printf '%s\n' "${ip,,}"
+            elif [[ "$fam" == "4" && "$ip" != *:* ]]; then
+                printf '%s\n' "${ip,,}"
+            fi
+        done < "$f"
+    done
+}
+
+# Verify one family. Echoes report lines; returns the anomaly count for the
+# family via the named-by-convention globals below (bash can't return ints >255
+# cleanly, and we want a precise count). Sets _NFTBAN_WL_VERIFY_ANOM.
+# $1 = family label (IPv4/IPv6), $2 = "4"/"6", $3 = table words, $4 = set name.
+_nftban_wl_verify_family() {
+    local label="$1" fam="$2" table="$3" set_name="$4"
+    local -a kernel=() baseline=() sessions=()
+    local k
+
+    if ! _nftban_wl_read_kernel_set "$table" "$set_name" >/dev/null 2>&1; then
+        # Distinguish "unreadable" from "empty": re-run and capture rc.
+        :
+    fi
+    local kraw krc=0
+    kraw="$(_nftban_wl_read_kernel_set "$table" "$set_name")" || krc=$?
+    if [[ $krc -ne 0 ]]; then
+        echo "  $label: kernel set ${set_name} is UNREADABLE (nft missing, daemon down, or table absent) — cannot verify."
+        _NFTBAN_WL_VERIFY_UNREADABLE=$(( ${_NFTBAN_WL_VERIFY_UNREADABLE:-0} + 1 ))
+        return 0
+    fi
+    while IFS= read -r k; do [[ -n "$k" ]] && kernel+=("$k"); done <<< "$kraw"
+    while IFS= read -r k; do [[ -n "$k" ]] && baseline+=("$k"); done < <(_nftban_wl_read_baseline "$fam")
+    while IFS= read -r k; do [[ -n "$k" ]] && sessions+=("$k"); done < <(_nftban_wl_read_sessions "$fam")
+
+    local anom=0 b kk found
+
+    echo "  ${label} (set ${set_name}):"
+
+    # IN-KERNEL-NOT-IN-BASELINE: kernel keys absent from durable baseline.
+    for kk in "${kernel[@]}"; do
+        found=false
+        for b in "${baseline[@]}"; do [[ "$kk" == "$b" ]] && { found=true; break; }; done
+        if [[ "$found" == "true" ]]; then continue; fi
+        # Not baseline — is it a current session? (informational, not anomaly)
+        local is_session=false
+        for b in "${sessions[@]}"; do [[ "$kk" == "$b" ]] && { is_session=true; break; }; done
+        if [[ "$is_session" == "true" ]]; then
+            echo "    [info]    $kk — active session whitelist (unexpired 00-session.conf); not an anomaly"
+        else
+            echo "    [ANOMALY] $kk — IN-KERNEL-NOT-IN-BASELINE (present in live set, not in durable whitelist.d; possible injection)"
+            anom=$(( anom + 1 ))
+        fi
+    done
+
+    # IN-BASELINE-NOT-IN-KERNEL: durable baseline keys missing from the kernel.
+    for b in "${baseline[@]}"; do
+        found=false
+        for kk in "${kernel[@]}"; do [[ "$b" == "$kk" ]] && { found=true; break; }; done
+        if [[ "$found" == "false" ]]; then
+            echo "    [ANOMALY] $b — IN-BASELINE-NOT-IN-KERNEL (durable whitelist.d entry not applied to live set; drift)"
+            anom=$(( anom + 1 ))
+        fi
+    done
+
+    [[ "$anom" -eq 0 ]] && echo "    OK — kernel matches durable baseline (sessions informational)."
+
+    _NFTBAN_WL_VERIFY_ANOM=$(( ${_NFTBAN_WL_VERIFY_ANOM:-0} + anom ))
+    return 0
+}
+
+# Public entry point: `nftban whitelist verify`. rc=0 clean, rc=1 anomalies.
+nftban_whitelist_verify() {
+    # No write flags accepted — this surface is read-only by contract.
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help) nftban_whitelist_usage; return 0 ;;
+            --fix)     echo "ERROR: 'whitelist verify' is read-only; there is no --fix. Use 'nftban sync' to reapply durable entries." >&2; return 2 ;;
+            --*)       echo "ERROR: Unknown flag for 'whitelist verify': $1" >&2; return 2 ;;
+            *)         echo "ERROR: Unexpected argument: $1" >&2; return 2 ;;
+        esac
+    done
+
+    if ! command -v nft >/dev/null 2>&1; then
+        echo "ERROR: nft (nftables) not found — cannot read the live whitelist sets." >&2
+        return 2
+    fi
+
+    _NFTBAN_WL_VERIFY_ANOM=0
+    _NFTBAN_WL_VERIFY_UNREADABLE=0
+
+    echo "Whitelist verify (read-only) — live kernel sets vs durable whitelist.d baseline"
+    echo "──────────────────────────────────────────────────────────────────────────────"
+    _nftban_wl_verify_family "IPv4" "4" "ip nftban"  "whitelist_ipv4"
+    _nftban_wl_verify_family "IPv6" "6" "ip6 nftban" "whitelist_ipv6"
+    echo ""
+
+    if [[ "${_NFTBAN_WL_VERIFY_UNREADABLE:-0}" -gt 0 && "${_NFTBAN_WL_VERIFY_ANOM:-0}" -eq 0 ]]; then
+        echo "Result: could not read one or more kernel whitelist sets — verification incomplete."
+        echo "Hint: ensure the nftband daemon is running (systemctl status nftband) and re-run."
+        return 2
+    fi
+
+    if [[ "${_NFTBAN_WL_VERIFY_ANOM:-0}" -gt 0 ]]; then
+        echo "Result: ${_NFTBAN_WL_VERIFY_ANOM} anomaly(ies) found."
+        echo "Hint:"
+        echo "  • IN-BASELINE-NOT-IN-KERNEL (drift) → reapply durable entries: nftban sync"
+        echo "  • IN-KERNEL-NOT-IN-BASELINE (possible injection) → review the source of the live entry;"
+        echo "    it is not in whitelist.d and not a current session. Persist it with"
+        echo "    'nftban whitelist add --static <IP>' or remove it if unexpected."
+        return 1
+    fi
+
+    echo "Result: OK — no anomalies. Live whitelist matches the durable baseline."
+    return 0
+}
+
 # Show usage
 nftban_whitelist_usage() {
     cat <<'EOF'
@@ -582,6 +816,7 @@ COMMANDS:
   remove <IP>            Remove IP from the runtime whitelist (live set only)
   remove --static <IP>   Remove IP from the permanent whitelist (99-manual.conf) + live set
   list                   Show all whitelisted IPs
+  verify                 Read-only: compare live kernel sets vs durable whitelist.d baseline (reports anomalies)
   sync                   Auto-detect and whitelist system IPs
   whitelistme            Whitelist your current IP (interactive)
 
@@ -597,6 +832,7 @@ EXAMPLES:
   nftban whitelist add --ttl 30m 192.168.1.100    # 30-minute session
   nftban whitelist remove --static 192.168.1.100  # remove permanent entry + live
   nftban whitelist list
+  nftban whitelist verify                          # read-only anomaly check (live set vs baseline)
   nftban whitelist sync
 
 EOF
@@ -612,6 +848,7 @@ EOF
 command -v nftban_cmd_exit >/dev/null 2>&1 && nftban_cmd_exit "whitelist"
 
 export -f nftban_cmd_whitelist
+export -f nftban_whitelist_verify 2>/dev/null || true
 
 # =============================================================================
 

--- a/cli/lib/nftban/core/nftban_health.sh
+++ b/cli/lib/nftban/core/nftban_health.sh
@@ -515,6 +515,7 @@ nftban_health_check_all() {
     nftban_health_check_set_sizes || { ((warnings++)) || true; }
     nftban_health_check_conflicting_firewalls || { ((warnings++)) || true; }
     nftban_health_check_ruleset_fingerprint || { ((warnings++)) || true; }
+    nftban_health_check_immutable_flags || { ((warnings++)) || true; }
     nftban_health_check_ssh_port || { ((warnings++)) || true; }
     nftban_health_check_systemd_hardening || { ((warnings++)) || true; }
     nftban_health_check_memory_protection || { ((warnings++)) || true; }

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -1386,12 +1386,9 @@ nftban_health_check_immutable_flags() {
     # Allow tests to override the list via NFTBAN_IMMUT_FILES (space-separated).
     local immutable_files
     if [[ -n "${NFTBAN_IMMUT_FILES:-}" ]]; then
-        # Whitespace-split the override regardless of the caller's IFS.
-        local _saved_ifs="${IFS:-}"
-        IFS=$' \t\n'
-        # shellcheck disable=SC2206  # intentional word-split of test override
-        immutable_files=(${NFTBAN_IMMUT_FILES})
-        IFS="$_saved_ifs"
+        # Whitespace-split the override into the array with IFS scoped to this
+        # read only — no persistent IFS= assignment (avoids Semgrep ifs-tampering).
+        IFS=$' \t\n' read -r -a immutable_files <<< "${NFTBAN_IMMUT_FILES}"
     else
         immutable_files=(
             "/etc/nftban/nftban.conf"

--- a/cli/lib/nftban/core/nftban_health_checks_security.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_security.sh
@@ -1368,7 +1368,77 @@ nftban_health_check_ruleset_fingerprint() {
     return "$status"
 }
 
+# SEC-IMMUT (v1.163): advisory verification that the security-critical files
+# still carry the immutable bit (chattr +i). The installer applies +i via
+# internal/installer/validate/authority.go SetImmutableFlags(); this check only
+# READS state with lsattr and reports drift — it NEVER re-applies the flag.
+#   file present + has 'i'   -> OK (no finding)
+#   file present + missing i -> advisory WARNING with remediation hint
+#   file absent              -> silent skip (nft_schema.sh may not exist on all installs)
+#   lsattr unavailable / non-root / unreadable attrs -> INFO skip (not a finding)
+# Advisory-only: appends to NFTBAN_HEALTH_WARNINGS, never to errors/issues, so it
+# does not escalate the health exit code. Read-only — no chattr writes.
+nftban_health_check_immutable_flags() {
+    local status=$HEALTH_OK
+
+    # File list pinned to internal/installer/validate/authority.go:62
+    # (SetImmutableFlags immutableFiles). Keep in sync with that source.
+    # Allow tests to override the list via NFTBAN_IMMUT_FILES (space-separated).
+    local immutable_files
+    if [[ -n "${NFTBAN_IMMUT_FILES:-}" ]]; then
+        # Whitespace-split the override regardless of the caller's IFS.
+        local _saved_ifs="${IFS:-}"
+        IFS=$' \t\n'
+        # shellcheck disable=SC2206  # intentional word-split of test override
+        immutable_files=(${NFTBAN_IMMUT_FILES})
+        IFS="$_saved_ifs"
+    else
+        immutable_files=(
+            "/etc/nftban/nftban.conf"
+            "/usr/lib/nftban/lib/nft_schema.sh"
+        )
+    fi
+
+    # Graceful INFO/skip when the tool is unavailable. lsattr ships with e2fsprogs
+    # and may be absent on minimal images; treat as not-a-finding.
+    if ! command -v lsattr &>/dev/null; then
+        # shellcheck disable=SC2034  # Used by render functions externally
+        NFTBAN_HEALTH_RESULTS["immutable_flags"]=$HEALTH_OK
+        return "$HEALTH_OK"
+    fi
+
+    local f attr_field lsattr_out rc
+    for f in "${immutable_files[@]}"; do
+        # Absent file -> silent skip (not a finding).
+        [[ -e "$f" ]] || continue
+
+        # Read the attribute string. lsattr can fail (EPERM as non-root on some
+        # paths/filesystems, or unsupported fs) -> graceful skip for that file.
+        rc=0
+        lsattr_out=$(lsattr -d "$f" 2>/dev/null) || rc=$?
+        if [[ $rc -ne 0 || -z "$lsattr_out" ]]; then
+            # Could not read attributes (non-root EPERM, unsupported fs, etc.).
+            # Advisory cannot conclude -> skip silently, do NOT warn.
+            continue
+        fi
+
+        # lsattr -d output: "<attr-string> <path>". The immutable bit is the
+        # literal 'i' inside the attribute field (first whitespace-delimited
+        # token), e.g. "----i---------e----- /etc/nftban/nftban.conf".
+        attr_field=${lsattr_out%%[[:space:]]*}
+        if [[ "$attr_field" != *i* ]]; then
+            NFTBAN_HEALTH_WARNINGS+=("Immutable flag missing on security-critical file: ${f} — restore tamper-resistance with 'chattr +i ${f}' (or re-run 'nftban update --repair')")
+            status=$HEALTH_WARNING
+        fi
+    done
+
+    # shellcheck disable=SC2034  # Used by render functions externally
+    NFTBAN_HEALTH_RESULTS["immutable_flags"]=$status
+    return "$status"
+}
+
 # Export functions
+export -f nftban_health_check_immutable_flags
 export -f nftban_health_check_ruleset_fingerprint
 export -f nftban_health_check_nftables_security nftban_health_check_conflicting_firewalls
 export -f nftban_health_check_protection nftban_health_check_memory_protection

--- a/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
+++ b/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.163: SEC-IMMUT immutable-flag HEALTH VERIFICATION (advisory)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="immutable_health_verify_v163_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Locks the v1.163 SEC-IMMUT advisory health check nftban_health_check_immutable_flags in cli/lib/nftban/core/nftban_health_checks_security.sh. The installer applies chattr +i to security-critical files (internal/installer/validate/authority.go SetImmutableFlags); this health check READS state with lsattr and reports drift as an advisory WARNING only — it never re-applies the flag. Asserts: (1) both pinned files present WITH the immutable 'i' bit -> no warning, status OK; (2) a file present WITHOUT 'i' -> exactly one advisory WARNING appended to NFTBAN_HEALTH_WARNINGS with a remediation hint, and the health status is NOT escalated to error/issue (NFTBAN_HEALTH_ERRORS untouched); (3) file absent -> silent skip, no warning; (4) lsattr missing from PATH -> graceful skip, no warning, no crash; (5) non-root/unreadable-attrs simulation (lsattr exits non-zero) -> graceful skip, no warning. Every case asserts the function NEVER invokes chattr (a chattr mock records calls; any call fails the test). Hermetic: a TMPDIR sandbox stands in for the pinned file paths via the NFTBAN_IMMUT_FILES env override; lsattr/chattr are PATH shims; no host mutation, no real chattr, no systemd."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_health_checks_security.sh,cli/lib/nftban/core/nftban_health.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_IMMUT_FILES"
+# meta:inventory.config_files="/etc/nftban/nftban.conf,/usr/lib/nftban/lib/nft_schema.sh"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+SEC_LIB="$REPO_ROOT/cli/lib/nftban/core/nftban_health_checks_security.sh"
+HEALTH_LIB="$REPO_ROOT/cli/lib/nftban/core/nftban_health.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$SEC_LIB" ]] || { echo "lib not found: $SEC_LIB"; exit 1; }
+
+SB="$(mktemp -d)"; trap 'rm -rf "$SB"' EXIT
+
+# --- Health level constants (mirror nftban_health.sh; the lib uses these) ----
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2; HEALTH_CRITICAL=3
+export HEALTH_OK HEALTH_WARNING HEALTH_ERROR HEALTH_CRITICAL
+
+# --- PATH shims: a fake lsattr whose output we control, and a chattr that ----
+# --- records every invocation so we can prove the check NEVER writes. ----------
+BIN="$SB/bin"; mkdir -p "$BIN"
+CHATTR_LOG="$SB/chattr_calls.log"; : > "$CHATTR_LOG"
+
+# lsattr behaviour is driven by per-file marker files in $SB/attr/<basename>:
+#   content "i"   -> attr string contains the immutable bit
+#   content "noi" -> attr string lacks the immutable bit
+#   content "err" -> exit non-zero (simulates EPERM/non-root/unsupported fs)
+mkdir -p "$SB/attr"
+cat > "$BIN/lsattr" <<EOF
+#!/usr/bin/env bash
+# mock lsattr: emulates 'lsattr -d <file>'
+target=""
+for a in "\$@"; do case "\$a" in -*) ;; *) target="\$a";; esac; done
+base="\$(basename "\$target")"
+marker="$SB/attr/\$base"
+state="noi"
+[[ -f "\$marker" ]] && state="\$(cat "\$marker")"
+case "\$state" in
+  i)   printf '%s %s\n' "----i---------e-----" "\$target";;
+  noi) printf '%s %s\n' "--------------e-----" "\$target";;
+  err) exit 1;;
+  *)   exit 1;;
+esac
+EOF
+chmod +x "$BIN/lsattr"
+
+cat > "$BIN/chattr" <<EOF
+#!/usr/bin/env bash
+# mock chattr: record any invocation — the health check must NEVER call this.
+echo "chattr \$*" >> "$CHATTR_LOG"
+exit 0
+EOF
+chmod +x "$BIN/chattr"
+
+# --- Sandbox stand-ins for the two pinned files ------------------------------
+F_CONF="$SB/nftban.conf"
+F_SCHEMA="$SB/nft_schema.sh"
+: > "$F_CONF"
+: > "$F_SCHEMA"
+
+# Helper: run the check in a clean subshell with a controlled environment and
+# capture warnings/errors/status. Echoes "RC|nwarn|nerr" and dumps warnings.
+run_check() {
+    local files="$1" path_extra="${2:-$BIN}" path_mode="${3:-prepend}"
+    (
+        set +e
+        if [[ "$path_mode" == "replace" ]]; then
+            # Fully replace PATH so the real /usr/bin/lsattr is NOT reachable
+            # (simulates lsattr genuinely absent). The function under test needs
+            # no external binary other than lsattr, so an empty PATH is enough.
+            export PATH="$path_extra"
+        else
+            export PATH="$path_extra:$PATH"
+        fi
+        export NFTBAN_IMMUT_FILES="$files"
+        declare -gA NFTBAN_HEALTH_RESULTS=() NFTBAN_HEALTH_ISSUES=()
+        NFTBAN_HEALTH_WARNINGS=(); NFTBAN_HEALTH_ERRORS=()
+        # Source ONLY the security lib (self-contained; uses HEALTH_* env vars).
+        # NB: the lib re-enables 'set -Eeuo pipefail' on source, so disable
+        # errexit AFTER sourcing — otherwise the function's non-zero advisory
+        # return would abort this subshell before we can report it.
+        source "$SEC_LIB" >/dev/null 2>&1
+        set +e
+        nftban_health_check_immutable_flags
+        rc=$?
+        printf 'RC=%s\n' "$rc"
+        printf 'NWARN=%s\n' "${#NFTBAN_HEALTH_WARNINGS[@]}"
+        printf 'NERR=%s\n' "${#NFTBAN_HEALTH_ERRORS[@]}"
+        local w
+        for w in "${NFTBAN_HEALTH_WARNINGS[@]:-}"; do printf 'WARN=%s\n' "$w"; done
+    )
+}
+
+set_attr(){ printf '%s' "$2" > "$SB/attr/$(basename "$1")"; }
+
+echo "=== sanity: function exists and is exported ==="
+grep -q 'nftban_health_check_immutable_flags()' "$SEC_LIB" \
+  && ok "function defined in security lib" || no "function not defined"
+grep -q 'export -f nftban_health_check_immutable_flags' "$SEC_LIB" \
+  && ok "function exported" || no "function not exported"
+grep -q 'nftban_health_check_immutable_flags || ' "$HEALTH_LIB" \
+  && ok "registered/invoked in nftban_health.sh (advisory: warnings++)" \
+  || no "not invoked in nftban_health.sh"
+# Pin comment to authority.go must be present (anti-drift).
+grep -q 'authority.go' "$SEC_LIB" \
+  && ok "file list pinned to authority.go via comment" || no "missing authority.go pin comment"
+
+echo "=== (1) both files present WITH 'i' => no warning, status OK ==="
+: > "$CHATTR_LOG"
+set_attr "$F_CONF" i; set_attr "$F_SCHEMA" i
+out="$(run_check "$F_CONF $F_SCHEMA")"
+rc=$(sed -n 's/^RC=//p' <<<"$out"); nwarn=$(sed -n 's/^NWARN=//p' <<<"$out")
+[[ "$rc" == "0" ]] && ok "status OK (rc=0)" || no "expected rc=0, got $rc"
+[[ "$nwarn" == "0" ]] && ok "no warnings emitted" || no "expected 0 warnings, got $nwarn"
+
+echo "=== (2) a file present WITHOUT 'i' => exactly one advisory WARNING + hint, no escalation ==="
+: > "$CHATTR_LOG"
+set_attr "$F_CONF" noi; set_attr "$F_SCHEMA" i
+out="$(run_check "$F_CONF $F_SCHEMA")"
+rc=$(sed -n 's/^RC=//p' <<<"$out"); nwarn=$(sed -n 's/^NWARN=//p' <<<"$out")
+nerr=$(sed -n 's/^NERR=//p' <<<"$out")
+[[ "$nwarn" == "1" ]] && ok "exactly one advisory WARNING" || no "expected 1 warning, got $nwarn"
+grep -q "^WARN=.*Immutable flag missing.*nftban.conf" <<<"$out" \
+  && ok "warning names the file" || no "warning missing/incorrect file"
+grep -qE "^WARN=.*chattr \+i.*nftban.conf|^WARN=.*update --repair" <<<"$out" \
+  && ok "remediation hint present (chattr +i / update --repair)" || no "no remediation hint"
+# Advisory only: status == WARNING (1), NOT error(2)/critical(3); errors untouched.
+[[ "$rc" == "1" ]] && ok "status is WARNING (rc=1), not escalated to error/critical" \
+  || no "expected rc=1 (WARNING), got $rc"
+[[ "$nerr" == "0" ]] && ok "NFTBAN_HEALTH_ERRORS untouched (no exit-code escalation)" \
+  || no "errors array touched ($nerr), escalation leaked"
+
+echo "=== (3) file absent => silent skip, no warning ==="
+: > "$CHATTR_LOG"
+ABSENT="$SB/does_not_exist.conf"
+out="$(run_check "$ABSENT")"
+rc=$(sed -n 's/^RC=//p' <<<"$out"); nwarn=$(sed -n 's/^NWARN=//p' <<<"$out")
+[[ "$rc" == "0" && "$nwarn" == "0" ]] && ok "absent file silently skipped (rc=0, 0 warnings)" \
+  || no "absent file not skipped (rc=$rc, warnings=$nwarn)"
+
+echo "=== (4) lsattr MISSING from PATH => graceful skip, no warning, no crash ==="
+: > "$CHATTR_LOG"
+# Provide an empty PATH dir (no lsattr, no chattr) but keep coreutils via a
+# minimal real PATH so 'command' works; the lib must not crash under set -u.
+EMPTY="$SB/empty"; mkdir -p "$EMPTY"
+set_attr "$F_CONF" noi   # would warn IF lsattr were present
+out="$(run_check "$F_CONF $F_SCHEMA" "$EMPTY" replace)"
+rc=$(sed -n 's/^RC=//p' <<<"$out"); nwarn=$(sed -n 's/^NWARN=//p' <<<"$out")
+[[ "$rc" == "0" ]] && ok "graceful skip when lsattr absent (rc=0)" || no "expected rc=0, got $rc"
+[[ "$nwarn" == "0" ]] && ok "no warning when lsattr absent" || no "expected 0 warnings, got $nwarn"
+
+echo "=== (5) non-root / unreadable attrs (lsattr exits non-zero) => graceful skip ==="
+: > "$CHATTR_LOG"
+set_attr "$F_CONF" err; set_attr "$F_SCHEMA" err
+out="$(run_check "$F_CONF $F_SCHEMA")"
+rc=$(sed -n 's/^RC=//p' <<<"$out"); nwarn=$(sed -n 's/^NWARN=//p' <<<"$out")
+[[ "$rc" == "0" && "$nwarn" == "0" ]] \
+  && ok "lsattr-error files skipped without warning (rc=0, 0 warnings)" \
+  || no "lsattr-error not skipped (rc=$rc, warnings=$nwarn)"
+
+echo "=== INVARIANT: chattr NEVER invoked across ALL cases ==="
+# Re-run every case once more under a single chattr log to be thorough.
+: > "$CHATTR_LOG"
+set_attr "$F_CONF" i;   set_attr "$F_SCHEMA" i;   run_check "$F_CONF $F_SCHEMA"   >/dev/null
+set_attr "$F_CONF" noi; set_attr "$F_SCHEMA" i;   run_check "$F_CONF $F_SCHEMA"   >/dev/null
+run_check "$SB/does_not_exist.conf"                                                >/dev/null
+run_check "$F_CONF $F_SCHEMA" "$SB/empty"                                          >/dev/null
+set_attr "$F_CONF" err; set_attr "$F_SCHEMA" err; run_check "$F_CONF $F_SCHEMA"   >/dev/null
+if [[ -s "$CHATTR_LOG" ]]; then
+    no "chattr WAS invoked (read-only contract violated)" "$(cat "$CHATTR_LOG")"
+else
+    ok "chattr never invoked (read-only / no flag re-application)"
+fi
+
+echo "================================================================"
+echo "immutable_health_verify_v163: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
+++ b/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
@@ -95,12 +95,14 @@ run_check() {
             export PATH="$path_extra:$PATH"
         fi
         export NFTBAN_IMMUT_FILES="$files"
+        # shellcheck disable=SC2034  # set to satisfy the sourced health function's globals; not read by the test
         declare -gA NFTBAN_HEALTH_RESULTS=() NFTBAN_HEALTH_ISSUES=()
         NFTBAN_HEALTH_WARNINGS=(); NFTBAN_HEALTH_ERRORS=()
         # Source ONLY the security lib (self-contained; uses HEALTH_* env vars).
         # NB: the lib re-enables 'set -Eeuo pipefail' on source, so disable
         # errexit AFTER sourcing — otherwise the function's non-zero advisory
         # return would abort this subshell before we can report it.
+        # shellcheck disable=SC1090  # intentional non-constant source of the security lib under test
         source "$SEC_LIB" >/dev/null 2>&1
         set +e
         nftban_health_check_immutable_flags

--- a/cli/lib/nftban/tests/whitelist_verify_v163_test.sh
+++ b/cli/lib/nftban/tests/whitelist_verify_v163_test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.163: `nftban whitelist verify` (SEC-WL-VERIFY) read-only check
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="whitelist_verify_v163_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Locks v1.163 PR-A SEC-WL-VERIFY: the READ-ONLY 'nftban whitelist verify' command compares the live kernel whitelist sets (@whitelist_ipv4 in ip nftban, @whitelist_ipv6 in ip6 nftban) against the DURABLE whitelist.d baseline (entries with NO EXPIRES_AT). Asserts: (1) kernel == baseline -> rc=0, no anomaly; (2) an extra kernel IP not in baseline and not a current session -> rc=1, IN-KERNEL-NOT-IN-BASELINE; (3) a baseline IP missing from the kernel -> rc=1, IN-BASELINE-NOT-IN-KERNEL; (4) a kernel IP matching an unexpired 00-session.conf entry -> rc=0, informational (NOT anomaly); (5) an IPv6 baseline/kernel pair is exercised; (6) the command performs NO nft writes — a recording nft mock fails the suite if any add/delete/create/flush verb is seen. Hermetic: a TMPDIR stands in for /etc/nftban/whitelist.d and a PATH-shim nft returns controlled 'list set' output; no daemon, no kernel."
+# meta:input="None (self-contained; TMPDIR sandbox + nft PATH shim)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,sed,grep,date"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_whitelist.sh"
+# meta:inventory.binaries="bash,awk,sed,grep,date"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files="/etc/nftban/whitelist.d/99-manual.conf,/etc/nftban/whitelist.d/00-session.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+WL_SRC="$NFTBAN_LIB_DIR/cli/cmd_whitelist.sh"
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+CONF_DIR="$SANDBOX/whitelist.d"
+BIN_DIR="$SANDBOX/bin"
+NFT_LOG="$SANDBOX/nft_calls.log"
+NFT_FIX_V4="$SANDBOX/fix_v4.txt"
+NFT_FIX_V6="$SANDBOX/fix_v6.txt"
+mkdir -p "$CONF_DIR" "$BIN_DIR"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n         expected to contain: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n         did NOT expect: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    fi
+}
+assert_eq() {
+    local actual="$1" expected="$2" name="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected '%s', got '%s')\n" "$name" "$expected" "$actual"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# nft PATH-shim: records every invocation, serves fixtures for `list set`, and
+# FAILS the suite (records a WRITE) if any mutating verb is ever seen. This is
+# how case (6) proves the command is read-only.
+# ---------------------------------------------------------------------------
+cat > "$BIN_DIR/nft" <<NFT_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$NFT_LOG"
+case "\$*" in
+  *" add "*|*" delete "*|*" create "*|*" flush "*|*" insert "*|*" replace "*)
+      printf 'WRITE: %s\n' "\$*" >> "$NFT_LOG" ;;
+esac
+# Serve read-only 'list set' fixtures.
+if [[ "\$*" == *"list set ip nftban whitelist_ipv4"* ]]; then
+    cat "$NFT_FIX_V4" 2>/dev/null || true
+    exit 0
+fi
+if [[ "\$*" == *"list set ip6 nftban whitelist_ipv6"* ]]; then
+    cat "$NFT_FIX_V6" 2>/dev/null || true
+    exit 0
+fi
+exit 0
+NFT_EOF
+chmod +x "$BIN_DIR/nft"
+
+# Build an nft `list set` fixture body from a comma list of elements.
+# $1 = output file, $2 = set family decl line tag (unused), $3.. = elements
+make_fixture() {
+    local out="$1" set_label="$2"; shift 2
+    local joined=""
+    local e
+    for e in "$@"; do
+        [[ -z "$joined" ]] && joined="$e" || joined="$joined, $e"
+    done
+    {
+        echo "table $set_label {"
+        echo "  set $set_label {"
+        echo "    type ipv4_addr"
+        if [[ -n "$joined" ]]; then
+            echo "    elements = { $joined }"
+        fi
+        echo "  }"
+        echo "}"
+    } > "$out"
+}
+
+# Future + past RFC3339 timestamps for session fixtures.
+FUTURE_TS=$(date -u -d "+2 hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+PAST_TS="2000-01-01T00:00:00Z"
+
+# Run verify with the sandbox conf dir + nft shim on PATH, in a subshell.
+run_verify() {
+    (
+        set +e
+        # shellcheck source=/dev/null
+        source "$WL_SRC" >/dev/null 2>&1 || true
+        _NFTBAN_WHITELIST_CONF_DIR="$CONF_DIR"
+        PATH="$BIN_DIR:$PATH"
+        nftban_whitelist_verify "$@"
+    )
+}
+
+# Capture run_verify output + rc WITHOUT tripping the suite's errexit.
+# Sets CAP_OUT and CAP_RC. (No-arg form — verify takes no positional args.)
+cap_verify() {
+    CAP_RC=0
+    CAP_OUT="$(run_verify)" || CAP_RC=$?
+}
+
+reset_state() {
+    : > "$NFT_LOG"
+    rm -f "$CONF_DIR"/*.conf 2>/dev/null || true
+    make_fixture "$NFT_FIX_V4" "whitelist_ipv4"
+    make_fixture "$NFT_FIX_V6" "whitelist_ipv6"
+}
+
+no_write_seen() {
+    ! grep -q '^WRITE:' "$NFT_LOG" 2>/dev/null
+}
+
+echo "================================================="
+echo "v1.163 whitelist verify (SEC-WL-VERIFY) test suite"
+echo "================================================="
+
+# ---------------------------------------------------------------------------
+# T1: kernel == durable baseline -> rc=0, no anomaly
+# ---------------------------------------------------------------------------
+echo; echo "[T1] kernel == durable baseline -> rc=0, OK"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+# durable
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+203.0.113.11  # ADDED_BY=nftban-whitelist-static
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10" "203.0.113.11"
+cap_verify; T1_OUT="$CAP_OUT"; T1_RC="$CAP_RC"
+assert_eq "$T1_RC" "0"                              "T1.1 rc=0 when kernel matches baseline"
+assert_contains "$T1_OUT" "no anomalies"            "T1.2 reports no anomalies"
+assert_not_contains "$T1_OUT" "[ANOMALY]"           "T1.3 no ANOMALY lines"
+
+# ---------------------------------------------------------------------------
+# T2: extra IP in kernel, not in baseline, not a session -> rc=1, IN-KERNEL-NOT-IN-BASELINE
+# ---------------------------------------------------------------------------
+echo; echo "[T2] extra kernel IP (not baseline/session) -> rc=1 injection anomaly"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10" "198.51.100.66"
+cap_verify; T2_OUT="$CAP_OUT"; T2_RC="$CAP_RC"
+assert_eq "$T2_RC" "1"                              "T2.1 rc=1 on injection anomaly"
+assert_contains "$T2_OUT" "IN-KERNEL-NOT-IN-BASELINE" "T2.2 class IN-KERNEL-NOT-IN-BASELINE"
+assert_contains "$T2_OUT" "198.51.100.66"           "T2.3 flags the injected IP"
+
+# ---------------------------------------------------------------------------
+# T3: baseline IP missing from kernel -> rc=1, IN-BASELINE-NOT-IN-KERNEL
+# ---------------------------------------------------------------------------
+echo; echo "[T3] baseline IP missing from kernel -> rc=1 drift anomaly"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+203.0.113.99  # ADDED_BY=nftban-whitelist-static
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10"
+cap_verify; T3_OUT="$CAP_OUT"; T3_RC="$CAP_RC"
+assert_eq "$T3_RC" "1"                              "T3.1 rc=1 on drift anomaly"
+assert_contains "$T3_OUT" "IN-BASELINE-NOT-IN-KERNEL" "T3.2 class IN-BASELINE-NOT-IN-KERNEL"
+assert_contains "$T3_OUT" "203.0.113.99"            "T3.3 flags the missing baseline IP"
+assert_contains "$T3_OUT" "nftban sync"             "T3.4 remediation hint suggests sync"
+
+# ---------------------------------------------------------------------------
+# T4: kernel IP matching an UNEXPIRED 00-session.conf entry -> rc=0, informational
+# ---------------------------------------------------------------------------
+echo; echo "[T4] active session IP in kernel -> rc=0, informational (NOT anomaly)"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+EOF
+cat > "$CONF_DIR/00-session.conf" <<EOF
+192.0.2.50  # EXPIRES_AT=${FUTURE_TS}  REASON=admin  ADDED_BY=test
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10" "192.0.2.50"
+cap_verify; T4_OUT="$CAP_OUT"; T4_RC="$CAP_RC"
+assert_eq "$T4_RC" "0"                              "T4.1 rc=0 — active session is not an anomaly"
+assert_contains "$T4_OUT" "192.0.2.50"              "T4.2 session IP mentioned"
+assert_contains "$T4_OUT" "[info]"                  "T4.3 marked informational"
+assert_not_contains "$T4_OUT" "192.0.2.50 — IN-KERNEL-NOT-IN-BASELINE" "T4.4 NOT flagged as injection"
+
+# ---------------------------------------------------------------------------
+# T4b: EXPIRED session IP in kernel -> still an anomaly (expired != baseline)
+# ---------------------------------------------------------------------------
+echo; echo "[T4b] EXPIRED session IP in kernel -> rc=1 anomaly (not a current session)"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+EOF
+cat > "$CONF_DIR/00-session.conf" <<EOF
+192.0.2.77  # EXPIRES_AT=${PAST_TS}  REASON=stale  ADDED_BY=test
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10" "192.0.2.77"
+cap_verify; T4B_OUT="$CAP_OUT"; T4B_RC="$CAP_RC"
+assert_eq "$T4B_RC" "1"                             "T4b.1 rc=1 — expired session in kernel is an anomaly"
+assert_contains "$T4B_OUT" "IN-KERNEL-NOT-IN-BASELINE" "T4b.2 classed as injection"
+
+# ---------------------------------------------------------------------------
+# T5: IPv6 path exercised — baseline missing from kernel -> rc=1
+# ---------------------------------------------------------------------------
+echo; echo "[T5] IPv6 baseline/kernel comparison exercised"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+2001:db8::10  # ADDED_BY=nftban-whitelist-static
+2001:db8::beef  # ADDED_BY=nftban-whitelist-static
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4"
+make_fixture "$NFT_FIX_V6" "whitelist_ipv6" "2001:db8::10"
+cap_verify; T5_OUT="$CAP_OUT"; T5_RC="$CAP_RC"
+assert_eq "$T5_RC" "1"                              "T5.1 rc=1 — IPv6 baseline drift"
+assert_contains "$T5_OUT" "2001:db8::beef"          "T5.2 flags the missing IPv6 baseline entry"
+assert_contains "$T5_OUT" "whitelist_ipv6"          "T5.3 IPv6 set named in report"
+
+# ---------------------------------------------------------------------------
+# T6: NO nft writes — across ALL the above runs no WRITE verb was recorded.
+# (re-assert on a fresh run for explicitness)
+# ---------------------------------------------------------------------------
+echo; echo "[T6] read-only — no nft add/delete/create/flush ever invoked"
+reset_state
+cat > "$CONF_DIR/99-manual.conf" <<EOF
+203.0.113.10  # ADDED_BY=nftban-whitelist-static
+EOF
+make_fixture "$NFT_FIX_V4" "whitelist_ipv4" "203.0.113.10" "198.51.100.66"
+run_verify >/dev/null 2>&1 || true
+if no_write_seen; then
+    printf "  [PASS] %s\n" "T6.1 no nft write verb recorded"; PASS=$((PASS + 1))
+else
+    printf "  [FAIL] %s\n         write verbs: %s\n" "T6.1 no nft write verb recorded" "$(grep '^WRITE:' "$NFT_LOG" || true)"
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("T6.1")
+fi
+# Confirm the only nft sub-command used is 'list set' (read).
+if grep -qv 'list set' "$NFT_LOG" 2>/dev/null; then
+    # there is at least one non-'list set' line -> investigate
+    NON_LIST=$(grep -v 'list set' "$NFT_LOG" || true)
+    if [[ -n "$NON_LIST" ]]; then
+        printf "  [FAIL] %s\n         non-list nft calls: %s\n" "T6.2 only 'list set' nft calls" "$NON_LIST"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("T6.2")
+    else
+        printf "  [PASS] %s\n" "T6.2 only 'list set' nft calls"; PASS=$((PASS + 1))
+    fi
+else
+    printf "  [PASS] %s\n" "T6.2 only 'list set' nft calls"; PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# T7: --fix is rejected (read-only contract; no auto-fix surface)
+# ---------------------------------------------------------------------------
+echo; echo "[T7] --fix rejected (read-only contract)"
+reset_state
+T7_RC=0; T7_OUT="$(run_verify --fix 2>&1)" || T7_RC=$?
+assert_eq "$T7_RC" "2"                              "T7.1 rc=2 on --fix"
+assert_contains "$T7_OUT" "read-only"               "T7.2 message states read-only"
+
+echo
+echo "================================================="
+echo "whitelist_verify_v163: PASS=$PASS FAIL=$FAIL"
+echo "================================================="
+if [[ "$FAIL" -ne 0 ]]; then
+    printf 'FAILED: %s\n' "${FAILED_TESTS[*]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Scope:
- **PR-A: `nftban whitelist verify`**
  - read-only
  - kernel `@whitelist_ipv4`/`@whitelist_ipv6` vs durable `whitelist.d/` baseline
  - session/TTL entries informational
  - rc=0 clean, rc=1 anomalies
  - no `--fix` and no nft writes
- **PR-B: immutable health verify**
  - advisory WARN-only
  - checks `/etc/nftban/nftban.conf` and `/usr/lib/nftban/lib/nft_schema.sh`
  - list pinned to `authority.go:62`
  - no chattr application and no CLI reapply

Validation:
- shellcheck `-S error` clean
- `bash -n` clean
- `whitelist_verify_v163_test.sh` 23/0
- `immutable_health_verify_v163_test.sh` 16/0
- daemon tree unchanged: `cmd/nftband` `85a2de3e…`
- schema untouched

Out of scope:
- daemon least privilege
- audit-log uid/gid/pid
- whitelist `--fix`
- `permissions --reapply-immutable`
- §2.2/%files/switchop follow-up
- §3.6 daemon ssh_ports counter
- schema unfreeze
- CSF restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)