### PR TITLE
test(packaging): guard generated RPM spec comments

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -643,6 +643,17 @@ jobs:
       - name: Static nftables fallback is set-driven (v1.162 PR-B)
         run: bash cli/lib/nftban/tests/static_nftables_ssh_set_driven_v162.sh
 
+      # v1.165 PR-A: generated-spec comment-macro lint. rpm 4.16 (EL9/EL10)
+      # parses a bare unescaped %install token in a SPEC COMMENT as a second
+      # %install section (`error: second %install`) and fails Build RPM
+      # el9/el10 deterministically — this bit twice (v1.157 FIX_V157_PR_A,
+      # v1.164 PR-C revert) because rpm 4.18 (lab2) + rpm 6.x are lenient and
+      # miss it. This hermetic static guard catches the class BEFORE the
+      # expensive el9/el10 rpmbuild: zero %install outside the single section
+      # header, and no bare RPM section macro in any generated-spec comment.
+      - name: RPM spec has no section macro in a comment (v1.165 PR-A)
+        run: bash cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
+++ b/cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.165 guard: no bare RPM section macro in a generated-spec comment
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rpm_spec_no_section_macro_in_comment_v165_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Hermetic regression guard for the twice-fatal RPM-spec-comment-macro class (v1.157 FIX_V157_PR_A_DUPLICATE_RPM_INSTALL + v1.164 PR-C revert). Ground-truth on srv2 rpm 4.16.1.3: a bare unescaped %install token anywhere in a generated-spec COMMENT (even mid-sentence, e.g. '# see %install below') is parsed by rpm 4.16/EL9+EL10 as a SECOND %install section -> 'error: line N: second %install' -> Build RPM el9/el10 fails deterministically; rpm 4.18 (lab2) + rpm 6.x are lenient and miss it. The other section macros (%prep %build %check %clean %files %post %pre %changelog %package) are tolerated in comments by rpm 4.16 but are still forbidden here defensively so the spec cannot drift toward another rpmbuild-only failure. Statically lints the spec heredoc inside packaging/build_nftban.sh; no rpmbuild, no host - runs on lab2 and in CI before the expensive el9/el10 build."
+# meta:inventory.files="packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+BS="$REPO_ROOT/packaging/build_nftban.sh"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$BS" ]] || { echo "build_nftban.sh not found at $BS"; exit 1; }
+
+# Canonical RPM section macros (no-arg script sections + scriptlets + manifest).
+# Longer tokens first so the alternation is unambiguous; a trailing negative
+# lookahead for an ASCII letter keeps '%prefix'/'%description'-substrings honest.
+SECTIONS='install|prep|build|check|clean|files|changelog|package|description|posttrans|postun|post|pretrans|preun|pre|verifyscript|triggerpostun|triggerin|triggerun|trigger|sepolicy'
+
+# extract_heredoc: print the body of the nftban-core.spec heredoc only
+# (between `... <<EOF` that targets nftban-core.spec and the next bare `EOF`).
+extract_heredoc(){
+    awk '
+        /SPECS\/nftban-core\.spec/ && /<<EOF/ { grab=1; next }
+        grab && /^EOF$/            { exit }
+        grab                       { print }
+    ' "$1"
+}
+
+# scan_comment_violations <file>: print "section macro in a spec COMMENT" hits.
+# A comment line starts with optional whitespace then '#'. We flag an UNescaped
+# '%<section>' (not '%%...', not '%{...}') with no trailing ASCII letter.
+scan_comment_violations(){
+    extract_heredoc "$1" \
+        | grep -nE '^[[:space:]]*#' \
+        | grep -P "(?<!%)%(${SECTIONS})(?![A-Za-z])" || true
+}
+
+# scan_stray_install <file>: every UNescaped '%install' token in the heredoc
+# that is NOT the single canonical section header line.
+scan_stray_install(){
+    extract_heredoc "$1" \
+        | grep -nP '(?<!%)%install(?![A-Za-z])' \
+        | grep -vE '^[0-9]+:%install[[:space:]]*$' || true
+}
+
+echo "rpm-spec comment-macro guard (v1.165):"
+
+# --- (1) the spec heredoc is actually found -----------------------------------
+body_lines=$(extract_heredoc "$BS" | wc -l)
+[[ "$body_lines" -gt 100 ]] \
+    && ok "located nftban-core.spec heredoc ($body_lines lines)" \
+    || no "could not locate the nftban-core.spec heredoc (got $body_lines lines)"
+
+# --- (2) exactly one real %install section header -----------------------------
+n_install_hdr=$(extract_heredoc "$BS" | grep -cE '^%install[[:space:]]*$' || true)
+[[ "$n_install_hdr" == "1" ]] \
+    && ok "exactly one %install section header (got $n_install_hdr)" \
+    || no "expected exactly one %install section header, got $n_install_hdr"
+
+# --- (3) NO stray %install token anywhere else in the heredoc (proven-fatal) ---
+stray=$(scan_stray_install "$BS")
+if [[ -z "$stray" ]]; then
+    ok "no stray unescaped %install token outside the section header"
+else
+    no "stray %install token(s) in the spec heredoc (rpm 4.16 -> 'second %install')" "$(printf '%s' "$stray" | head -1)"
+fi
+
+# --- (4) NO section macro in any spec comment (defensive breadth) --------------
+viol=$(scan_comment_violations "$BS")
+if [[ -z "$viol" ]]; then
+    ok "no bare RPM section macro in any generated-spec comment"
+else
+    no "section macro(s) found in spec comment(s) — reword or %%-escape" "$(printf '%s' "$viol" | head -1)"
+    printf '%s\n' "$viol" | sed 's/^/      /'
+fi
+
+# --- (5) self-test: the detector must FLAG a planted regression ----------------
+# Copy the build script, inject a poisoned comment INSIDE the heredoc, and assert
+# the scanner catches it (so a future real %install-in-comment cannot pass mute).
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+awk '
+    { print }
+    /SPECS\/nftban-core\.spec/ && /<<EOF/ { print "# poisoned regression probe: see %install sandbox note" }
+' "$BS" > "$tmp"
+planted_install=$(scan_stray_install "$tmp")
+planted_comment=$(scan_comment_violations "$tmp")
+if [[ -n "$planted_install" && -n "$planted_comment" ]]; then
+    ok "self-test: detector flags a planted '%install' comment (guard is live)"
+else
+    no "self-test FAILED: detector did NOT flag a planted '%install' comment" "install='${planted_install:-}' comment='${planted_comment:-}'"
+fi
+
+echo ""
+echo "  PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -414,7 +414,7 @@ install -D -m 0755 bin/nftban-detect-ssh-ports %{buildroot}/usr/lib/nftban/bin/n
 install -D -m 0755 bin/nftban-installer %{buildroot}/usr/lib/nftban/bin/nftban-installer
 install -D -m 0755 yq_linux_amd64 %{buildroot}/usr/lib/nftban/bin/yq
 # NB-5: privileged binaries ship 0750 (root:nftban), not 0755 (root:root).
-# Canonical ownership set declaratively via %attr() in %files below.
+# Canonical ownership set declaratively via %attr() in the files manifest below.
 install -D -m 0750 cli/sbin/nftban %{buildroot}/usr/sbin/nftban
 # v1.100.1b.A: nftban-ui + nftban-ui-auth binaries no longer installed.
 
@@ -536,11 +536,11 @@ install -D -m 0644 install/selinux/nftban.te %{buildroot}/usr/share/nftban/selin
 install -D -m 0644 install/selinux/nftban.fc %{buildroot}/usr/share/nftban/selinux/nftban.fc
 install -D -m 0644 install/selinux/nftban.if %{buildroot}/usr/share/nftban/selinux/nftban.if
 install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinux/Makefile
-# v1.147-A: compile the policy module (.pp) at build so %post can semodule -i it
+# v1.147-A: compile the policy module (.pp) at build so the post scriptlet can semodule -i it
 # without requiring selinux-policy-devel on the target. MUST use the refpolicy
 # devel Makefile — checkmodule alone errors on policy_module()/init_daemon_domain
 # (refpolicy m4 interfaces). Guarded: if the devel Makefile is absent the .pp is
-# simply not shipped and %post falls back to compile-on-target (or no-ops).
+# simply not shipped and the post scriptlet falls back to compile-on-target (or no-ops).
 if [ -f /usr/share/selinux/devel/Makefile ]; then
     ( cd install/selinux && make -f /usr/share/selinux/devel/Makefile nftban.pp ) \
         && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
@@ -583,7 +583,7 @@ install -m 0755 scripts/nftban-soak-check.sh %{buildroot}/usr/lib/nftban/scripts
 mkdir -p %{buildroot}/usr/lib/nftban/tests
 find cli/lib/nftban/tests -type f -name "*.sh" -exec install -m 0755 {} %{buildroot}/usr/lib/nftban/tests/ \;
 
-# Config directories (must match %files section)
+# Config directories (must match the files manifest)
 mkdir -p %{buildroot}/etc/nftban/{conf.d,distros,whitelist.d,blacklist.d,ports.d,rules.d,access.d}
 mkdir -p %{buildroot}/etc/nftban/conf.d/botguard
 mkdir -p %{buildroot}/etc/nftban/conf.d/botguard/profiles
@@ -981,7 +981,7 @@ usermod -a -G nftban root 2>/dev/null || true
 
 %post
 # =============================================================================
-# NFTBan v1.73.0 - Go-based installer (replaces shell %post)
+# NFTBan v1.73.0 - Go-based installer (replaces the shell post scriptlet)
 # =============================================================================
 # The Go binary handles: detection, rendering, switchop, services, validation.
 # This thin wrapper just determines install mode and calls the binary.
@@ -1026,7 +1026,7 @@ fi
 # (RPM previously had NO inet-filter guard at all). Empty/default distro
 # skeleton -> auto-remove (both modes; it would shadow nftban). Populated,
 # operator-owned table -> never delete: fresh install prints the runbook and
-# SKIPS activation via exit 0 (rpm %post cannot cleanly abort; a non-zero exit
+# SKIPS activation via exit 0 (the rpm post scriptlet cannot cleanly abort; a non-zero exit
 # leaves a confusing scriptlet-failed-but-installed state); upgrade warns and
 # continues.
 _nftban_classify_inet_filter() {
@@ -1240,7 +1240,7 @@ if [ -f "/usr/lib/nftban/lib/nftban_pro.sh" ]; then
     ) &
 fi
 
-# Ensure %post exits 0 (RPM treats non-zero as scriptlet failure)
+# Ensure the post scriptlet exits 0 (RPM treats non-zero as scriptlet failure)
 exit 0
 
 %preun


### PR DESCRIPTION
Lint-first PR-A of the reopened RPM `%files` micro-lane. Closes the **build-spec parser hazard** before any `%files` cleanup is re-attempted.

## The hidden bug (build-only, not runtime / not SSH / not production-risk)
rpm **4.16** (EL9/EL10) parses a bare unescaped `%install` token inside a generated-spec **comment** as a *second* `%install` section → `error: second %install` → `Build RPM el9/el10` fails deterministically. rpm 4.18 (lab2) / 6.x (local) are lenient and miss it — so it bit twice (v1.157 `FIX_V157_PR_A`, v1.164 PR-C revert). Two wrong assumptions corrected: (1) "comments are harmless" — false for rpm 4.16; (2) "lab validation is enough" — false, the real judge is EL9/EL10 rpm 4.16 CI. Ground-truth reproduced on srv2 (rpm 4.16.1.3): only `%install` is fatal-in-comment, but the guard forbids the **full section-macro family** defensively so the class cannot return.

## Scope (PR-A only)
- generated RPM spec **comment macro lint** (`cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh`)
- catches rpm 4.16-class "second %install" parser regressions **before rpmbuild**
- **rewords** existing spec comments to avoid bare RPM section macro tokens (`%post`/`%files` → prose; `%attr` kept — not a section macro)
- **CI-wired** before the RPM build (after the v1.162 PR-B static guard)

## Validation
- hermetic guard passes 5/5 incl. a live self-test (planted `%install` comment is flagged)
- `bash -n` clean
- shellcheck `-x -S warning` clean
- existing v1.157 RPM guard still green
- daemon tree unchanged: `cmd/nftband 85a2de3e…`
- schema 1.83.0 frozen / FHS body untouched

## Out of scope
- PR-B lib-dir `%files` dedup
- PR-C templates/FHS correction (abortable follow-up)
- daemon-Go · schema changes · live host mutation

No merge / no release-prep / no tag / no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)