### PR TITLE
fix(packaging): dedup RPM lib payload directories

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -654,6 +654,17 @@ jobs:
       - name: RPM spec has no section macro in a comment (v1.165 PR-A)
         run: bash cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
 
+      # v1.165 PR-B: the %files section both %include nftban-files.inc (which
+      # %dir-owns every /usr/lib/nftban payload dir) and used to repeat those
+      # dirs as bare payload paths, so strict rpm 4.16 warned "File listed
+      # twice". PR-B lists the 12 lib dirs as <dir>/* (inc keeps sole %dir
+      # ownership) and strips dotfiles in %install so the /* glob (which skips
+      # dotfiles) does not orphan tests/.gitkeep. This static guard asserts the
+      # dedup shape + the dotfile strip; the full no-double-listing / no-orphan
+      # parse is confirmed by Build RPM el9/el10.
+      - name: RPM %files lib-dir dedup (no double dir listing) (v1.165 PR-B)
+        run: bash cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
+++ b/cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.165 PR-B guard: lib-dir RPM %files dedup (no double dir listing)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rpm_files_no_double_dir_listing_v165_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Hermetic guard for the v1.165 PR-B lib-dir RPM %files dedup. The %files section in packaging/build_nftban.sh both %include nftban-files.inc (which %dir-owns every /usr/lib/nftban payload dir) AND used to repeat those dirs as bare payload paths, so strict rpm 4.16 (EL9/EL10) warned 'File listed twice'. PR-B converts the 12 lib payload dirs to <dir>/* (the inc keeps sole %dir ownership) and strips dotfiles from the buildroot in %install so the /* glob - which skips dotfiles - does not orphan tests/.gitkeep. This guard asserts: (a) each of the 12 lib dirs is listed as <dir>/* and NOT as a bare dir path; (b) the %install dotfile strip exists; (c) no /usr/lib/nftban path is BOTH a bare %files payload line AND an inc %dir entry. Static; no rpmbuild/host. Templates + non-lib trees are out of PR-B scope (PR-C)."
+# meta:inventory.files="packaging/build_nftban.sh,install/packaging/rpm/nftban-files.inc"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+BS="$REPO_ROOT/packaging/build_nftban.sh"
+INC="$REPO_ROOT/install/packaging/rpm/nftban-files.inc"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$BS"  ]] || { echo "build_nftban.sh not found at $BS"; exit 1; }
+[[ -f "$INC" ]] || { echo "nftban-files.inc not found at $INC"; exit 1; }
+
+LIB_DIRS=(bin sbin cli core lib cron helpers setup exporters tests data health)
+
+echo "rpm-files lib-dir dedup guard (v1.165 PR-B):"
+
+# --- (a) each lib dir is <dir>/* and NOT a bare dir line -----------------------
+for d in "${LIB_DIRS[@]}"; do
+    has_glob=$(grep -cE "^/usr/lib/nftban/${d}/\*[[:space:]]*\$" "$BS" || true)
+    has_bare=$(grep -cE "^/usr/lib/nftban/${d}[[:space:]]*\$" "$BS" || true)
+    if [[ "$has_glob" -ge 1 && "$has_bare" -eq 0 ]]; then
+        ok "lib dir '${d}' is /usr/lib/nftban/${d}/* (no bare dir line)"
+    else
+        no "lib dir '${d}' dedup wrong (glob=$has_glob bare=$has_bare; want glob>=1 bare=0)"
+    fi
+done
+
+# --- (b) the %install dotfile strip is present --------------------------------
+if grep -qE 'find %\{buildroot\}/usr/lib/nftban -name .\.\*. -type f -delete' "$BS"; then
+    ok "%install strips dotfiles from the buildroot lib tree (/* glob safe)"
+else
+    no "missing %install dotfile strip (find %{buildroot}/usr/lib/nftban -name '.*' -type f -delete)"
+fi
+
+# --- (c) no /usr/lib/nftban path is BOTH a bare %files line AND an inc %dir ----
+# Bare %files payload lines (no %dir/%attr/%config/%doc/glob), /usr/lib/nftban only.
+mapfile -t bare_files < <(grep -E '^/usr/lib/nftban/[A-Za-z0-9_./-]+[[:space:]]*$' "$BS" \
+    | grep -vE '/\*[[:space:]]*$' | sed 's/[[:space:]]*$//' | sort -u)
+# inc %dir-owned /usr/lib/nftban paths.
+mapfile -t inc_dirs < <(grep -E '^%dir .* /usr/lib/nftban/' "$INC" \
+    | sed -E 's/^.* (\/usr\/lib\/nftban\/[A-Za-z0-9_./-]+)[[:space:]]*$/\1/' | sort -u)
+
+double=""
+for p in "${bare_files[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    for q in "${inc_dirs[@]:-}"; do
+        [[ "$p" == "$q" ]] && double+="$p"$'\n'
+    done
+done
+if [[ -z "$double" ]]; then
+    ok "no /usr/lib/nftban path is both a bare %files line and an inc %dir entry"
+else
+    no "double-listed (bare %files AND inc %dir)" "$(printf '%s' "$double" | head -1)"
+    printf '%s' "$double" | sed 's/^/      /'
+fi
+
+# --- (d) self-test: detector catches a re-introduced bare dir line ------------
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+{ cat "$BS"; echo '/usr/lib/nftban/core'; } > "$tmp"
+reintro_bare=$(grep -cE '^/usr/lib/nftban/core[[:space:]]*$' "$tmp" || true)
+[[ "$reintro_bare" -ge 1 ]] \
+    && ok "self-test: a re-introduced bare '/usr/lib/nftban/core' line is detectable" \
+    || no "self-test FAILED: could not detect a re-introduced bare dir line"
+
+echo ""
+echo "  PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -583,6 +583,14 @@ install -m 0755 scripts/nftban-soak-check.sh %{buildroot}/usr/lib/nftban/scripts
 mkdir -p %{buildroot}/usr/lib/nftban/tests
 find cli/lib/nftban/tests -type f -name "*.sh" -exec install -m 0755 {} %{buildroot}/usr/lib/nftban/tests/ \;
 
+# v1.165 PR-B: the lib payload dirs are listed as <dir>/* in the manifest below,
+# but the rpm /<dir>/* glob does NOT match dotfiles, so any staged dotfile (e.g.
+# tests/.gitkeep brought in by the recursive cp above) would be left unpackaged
+# and fail the strict EL9/EL10 build. Strip dotfiles from the buildroot lib tree
+# so every /usr/lib/nftban/<dir>/* line is complete. No real shipped file under
+# /usr/lib/nftban is a dotfile.
+find %{buildroot}/usr/lib/nftban -name '.*' -type f -delete
+
 # Config directories (must match the files manifest)
 mkdir -p %{buildroot}/etc/nftban/{conf.d,distros,whitelist.d,blacklist.d,ports.d,rules.d,access.d}
 mkdir -p %{buildroot}/etc/nftban/conf.d/botguard
@@ -1376,21 +1384,24 @@ fi
 %include %{_sourcedir}/nftban-files.inc
 # Binary entry point (explicit attr; NOT a directory)
 %attr(0750,root,nftban) /usr/sbin/nftban
-# Package payload trees (bare paths -> recursive include of files within generator-owned dirs)
-/usr/lib/nftban/bin
-/usr/lib/nftban/sbin
+# v1.165 PR-B: payload dir CONTENTS only (<dir>/*); the dir nodes themselves are
+# %dir-owned by the generator manifest (%include nftban-files.inc) so listing the
+# bare dir here too made strict rpm 4.16 (EL9/EL10) warn "File listed twice".
+# Dotfiles under these dirs are stripped earlier in the build so /* is complete.
+/usr/lib/nftban/bin/*
+/usr/lib/nftban/sbin/*
 /usr/lib/nftban/VERSION
 /usr/lib/nftban/BUILD_TARGET
-/usr/lib/nftban/cli
-/usr/lib/nftban/core
-/usr/lib/nftban/lib
-/usr/lib/nftban/cron
-/usr/lib/nftban/helpers
-/usr/lib/nftban/setup
-/usr/lib/nftban/exporters
-/usr/lib/nftban/tests
-/usr/lib/nftban/data
-/usr/lib/nftban/health
+/usr/lib/nftban/cli/*
+/usr/lib/nftban/core/*
+/usr/lib/nftban/lib/*
+/usr/lib/nftban/cron/*
+/usr/lib/nftban/helpers/*
+/usr/lib/nftban/setup/*
+/usr/lib/nftban/exporters/*
+/usr/lib/nftban/tests/*
+/usr/lib/nftban/data/*
+/usr/lib/nftban/health/*
 /usr/lib/nftban/*.sh
 %doc /usr/lib/nftban/README.md
 # v1.50.0: template with placeholders (always replaced on upgrade, NOT %config)


### PR DESCRIPTION
PR-B of the reopened RPM `%files` micro-lane — the **lib-dir dedup** the lint (PR-A, merged) now protects. Closes the `/usr/lib/nftban` half of `BUG-RPM-FILES-LISTED-TWICE`.

## Scope (PR-B only)
- `/usr/lib/nftban` lib-dir RPM `%files` **dedup**
- convert **12 generator-owned bare lib dirs → `<dir>/*`** (`bin sbin cli core lib cron helpers setup exporters tests data health`) so the `%include nftban-files.inc` `%dir` entries keep **sole** ownership (kills "File listed twice")
- **strip dotfiles/`.gitkeep`** from the `/usr/lib/nftban` buildroot before `%files` evaluation (the rpm `<dir>/*` glob skips dotfiles → would orphan `tests/.gitkeep`, the exact v1.161 failure)
- keep `VERSION`, `BUILD_TARGET`, `*.sh`, `README` explicit
- **PR-A spec-comment guard remains the first tripwire** before rpmbuild (it already caught an `%install` slip during this implementation)

## Validation
- **hermetic mini-rpmbuild** (mirrors inc `%dir` + PR-B `/*` + strip, with a planted `tests/.gitkeep`): `Wrote: …rpm` rc=0, **no double-listing**, **no unpackaged `.gitkeep`** — this failure mode is rpm-version-independent, so it holds for EL9/EL10
- PR-A guard **5/0** · PR-B guard **15/0** · v157 guard **6/0**
- `bash -n` / shellcheck `-x -S warning` clean
- daemon tree unchanged: `cmd/nftband 85a2de3e…`
- schema 1.83.0 frozen / FHS body untouched (no FHS generator change)

## Out of scope
- PR-C templates/FHS correction (abortable follow-up)
- FHS generator changes · schema changes · daemon-Go · switchop · live host mutation

No merge / no release-prep / no tag / no publish. **CI Build RPM el9/el10 is the decisive judge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)