### PR TITLE
fix(packaging): dedup RPM template payload directories

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -665,6 +665,19 @@ jobs:
       - name: RPM %files lib-dir dedup (no double dir listing) (v1.165 PR-B)
         run: bash cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
 
+      # v1.166 PR-C: templates %files dedup via FHS-generator correction. The
+      # bare /usr/share/nftban/templates line both double-listed the generator
+      # %dir-owned dirs and solely owned the email/+partials/ staged .html (no
+      # inc %dir), so it could not be dropped naively. PR-C adds %dir for
+      # templates/email + templates/partials to build/fhs-spec.yaml (regenerated
+      # into nftban-files.inc), lists the 4 content subdirs as <dir>/*, keeps
+      # zabbix as an empty %dir, and strips dotfiles in %install. This guard
+      # asserts the dedup shape + generator ownership; the no-orphan/no-double
+      # parse is confirmed by Build RPM el9/el10. (FHS body changes by design —
+      # the "FHS spec generated files check" gate enforces generator parity.)
+      - name: RPM %files templates dedup (FHS-generator correction) (v1.166 PR-C)
+        run: bash cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -946,6 +946,20 @@ directories:
       description: "Report templates"
       created_by: package
 
+    - path: /usr/share/nftban/templates/email
+      mode: "0755"
+      owner: root
+      group: root
+      description: "Email templates (HTML)"
+      created_by: package
+
+    - path: /usr/share/nftban/templates/partials
+      mode: "0755"
+      owner: root
+      group: root
+      description: "Email/report partial templates (HTML)"
+      created_by: package
+
     - path: /usr/share/nftban/templates/zabbix
       mode: "0755"
       owner: root

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -167,6 +167,8 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates"]="0755|root|root|Templates"
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates/mail"]="0755|root|root|Mail templates"
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates/reports"]="0755|root|root|Report templates"
+    NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates/email"]="0755|root|root|Email templates (HTML)"
+    NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates/partials"]="0755|root|root|Email/report partial templates (HTML)"
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/templates/zabbix"]="0755|root|root|Zabbix import templates (5.x XML, 6.x+ YAML)"
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/dashboards"]="0755|root|root|Monitoring dashboards"
     NFTBAN_FHS_DIRECTORIES["/usr/share/nftban/dashboards/grafana"]="0755|root|root|Grafana dashboard JSON files"

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -902,6 +902,22 @@
         "created_by": "package"
       },
       {
+        "path": "/usr/share/nftban/templates/email",
+        "mode": "0755",
+        "owner": "root",
+        "group": "root",
+        "description": "Email templates (HTML)",
+        "created_by": "package"
+      },
+      {
+        "path": "/usr/share/nftban/templates/partials",
+        "mode": "0755",
+        "owner": "root",
+        "group": "root",
+        "description": "Email/report partial templates (HTML)",
+        "created_by": "package"
+      },
+      {
         "path": "/usr/share/nftban/templates/zabbix",
         "mode": "0755",
         "owner": "root",

--- a/cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
+++ b/cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.166 PR-C guard: templates RPM %files dedup via FHS-generator fix
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rpm_files_templates_dedup_v166_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Hermetic guard for the v1.166 PR-C templates RPM %files dedup. The bare /usr/share/nftban/templates %files line both double-listed the generator %dir-owned dirs AND was the sole owner of the email/ + partials/ staged .html (which had no inc %dir), so it could not simply be dropped. PR-C adds %dir for templates/email + templates/partials to the FHS generator (build/fhs-spec.yaml -> nftban-files.inc), keeps zabbix as an empty %dir, lists the four content subdirs as <dir>/*, and strips dotfiles in %install so the /* glob is complete. This guard asserts: (a) the bare /usr/share/nftban/templates line is gone; (b) mail/reports/email/partials are listed as <dir>/*; (c) the generator inc %dir-owns email + partials (and still mail/reports/zabbix); (d) the templates %install dotfile strip exists; (e) no /usr/share/nftban/templates path is both a bare %files line and an inc %dir entry. Static; no rpmbuild/host."
+# meta:inventory.files="packaging/build_nftban.sh,install/packaging/rpm/nftban-files.inc"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+BS="$REPO_ROOT/packaging/build_nftban.sh"
+INC="$REPO_ROOT/install/packaging/rpm/nftban-files.inc"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$BS"  ]] || { echo "build_nftban.sh not found at $BS"; exit 1; }
+[[ -f "$INC" ]] || { echo "nftban-files.inc not found at $INC"; exit 1; }
+
+echo "rpm-files templates dedup guard (v1.166 PR-C):"
+
+# --- (a) bare /usr/share/nftban/templates %files line is gone -----------------
+bare=$(grep -cE '^/usr/share/nftban/templates[[:space:]]*$' "$BS" || true)
+[[ "$bare" -eq 0 ]] \
+    && ok "no bare /usr/share/nftban/templates %files line" \
+    || no "bare /usr/share/nftban/templates line still present ($bare)"
+
+# --- (b) the four content subdirs are <dir>/* ---------------------------------
+for d in mail reports email partials; do
+    g=$(grep -cE "^/usr/share/nftban/templates/${d}/\*[[:space:]]*\$" "$BS" || true)
+    [[ "$g" -ge 1 ]] \
+        && ok "templates/${d} listed as /usr/share/nftban/templates/${d}/*" \
+        || no "templates/${d} not listed as <dir>/* ($g)"
+done
+
+# --- (c) generator inc %dir-owns email + partials (+ mail/reports/zabbix) ------
+for d in mail reports email partials zabbix; do
+    i=$(grep -cE "^%dir .* /usr/share/nftban/templates/${d}\$" "$INC" || true)
+    [[ "$i" -ge 1 ]] \
+        && ok "inc %dir owns templates/${d}" \
+        || no "inc %dir MISSING for templates/${d} (run build/generate-fhs-outputs.sh)"
+done
+
+# --- (d) templates %install dotfile strip present -----------------------------
+if grep -qE 'find %\{buildroot\}/usr/share/nftban/templates -name .\.\*. -type f -delete' "$BS"; then
+    ok "%install strips dotfiles from the staged templates tree (/* glob safe)"
+else
+    no "missing templates dotfile strip (find %{buildroot}/usr/share/nftban/templates -name '.*' -type f -delete)"
+fi
+
+# --- (e) no templates path is both a bare %files line and an inc %dir ----------
+mapfile -t bare_files < <(grep -E '^/usr/share/nftban/templates[A-Za-z0-9_./-]*[[:space:]]*$' "$BS" \
+    | grep -vE '/\*[[:space:]]*$' | sed 's/[[:space:]]*$//' | sort -u)
+mapfile -t inc_dirs < <(grep -E '^%dir .* /usr/share/nftban/templates' "$INC" \
+    | sed -E 's/^.* (\/usr\/share\/nftban\/templates[A-Za-z0-9_./-]*)[[:space:]]*$/\1/' | sort -u)
+double=""
+for p in "${bare_files[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    for q in "${inc_dirs[@]:-}"; do [[ "$p" == "$q" ]] && double+="$p"$'\n'; done
+done
+[[ -z "$double" ]] \
+    && ok "no templates path is both a bare %files line and an inc %dir entry" \
+    || no "templates double-listed (bare %files AND inc %dir)" "$(printf '%s' "$double" | head -1)"
+
+# --- (f) self-test: detector catches a re-introduced bare templates line ------
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+{ cat "$BS"; echo '/usr/share/nftban/templates'; } > "$tmp"
+reintro=$(grep -cE '^/usr/share/nftban/templates[[:space:]]*$' "$tmp" || true)
+[[ "$reintro" -ge 1 ]] \
+    && ok "self-test: a re-introduced bare templates line is detectable" \
+    || no "self-test FAILED: could not detect a re-introduced bare templates line"
+
+echo ""
+echo "  PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/install/packaging/deb/nftban.dirs
+++ b/install/packaging/deb/nftban.dirs
@@ -75,6 +75,8 @@
 /usr/share/nftban/templates
 /usr/share/nftban/templates/mail
 /usr/share/nftban/templates/reports
+/usr/share/nftban/templates/email
+/usr/share/nftban/templates/partials
 /usr/share/nftban/templates/zabbix
 /usr/share/nftban/dashboards
 /usr/share/nftban/dashboards/grafana

--- a/install/packaging/rpm/nftban-files.inc
+++ b/install/packaging/rpm/nftban-files.inc
@@ -89,6 +89,8 @@
 %dir %attr(0755,root,root) /usr/share/nftban/templates
 %dir %attr(0755,root,root) /usr/share/nftban/templates/mail
 %dir %attr(0755,root,root) /usr/share/nftban/templates/reports
+%dir %attr(0755,root,root) /usr/share/nftban/templates/email
+%dir %attr(0755,root,root) /usr/share/nftban/templates/partials
 %dir %attr(0755,root,root) /usr/share/nftban/templates/zabbix
 %dir %attr(0755,root,root) /usr/share/nftban/dashboards
 %dir %attr(0755,root,root) /usr/share/nftban/dashboards/grafana

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -556,6 +556,12 @@ find install/share/nftban/templates -type f -name "*.html" | while read -r tmpl;
     install -D -m 0644 "\$tmpl" "%{buildroot}/usr/share/nftban/templates/\$rel_path"
 done
 
+# v1.166 PR-C: the template subdirs are listed as <dir>/* in the manifest, and
+# the rpm /<dir>/* glob does NOT match dotfiles. Strip dotfiles from the staged
+# templates tree so no hidden file is left unpackaged on the strict EL9/EL10
+# build. No real shipped template is a dotfile.
+find %{buildroot}/usr/share/nftban/templates -name '.*' -type f -delete
+
 # Man page deliberately not shipped (registry-canonical since v1.95.0).
 # PR #646 deleted the source files; V123 B-1 residual-refs PR completed
 # the surrounding cleanup across DEB+RPM symmetrically — see build_deb()
@@ -1421,7 +1427,17 @@ fi
 /etc/polkit-1/rules.d/20-nftban-auditor.rules
 # Shared data
 /usr/share/nftban/specs/structure_default.json
-/usr/share/nftban/templates
+# v1.166 PR-C: template subdir CONTENTS only (<dir>/*); the dir nodes are
+# %dir-owned by the generator manifest (%include nftban-files.inc). Listing the
+# bare /usr/share/nftban/templates dir here too made strict rpm 4.16 (EL9/EL10)
+# warn "File listed twice". email/ + partials/ now have generator %dir too (so
+# their staged .html are no longer orphaned). zabbix/ stays an empty generator-
+# owned %dir (no source content -> no /* line). Dotfiles are stripped in the
+# install section above so /* is complete.
+/usr/share/nftban/templates/mail/*
+/usr/share/nftban/templates/reports/*
+/usr/share/nftban/templates/email/*
+/usr/share/nftban/templates/partials/*
 /usr/share/nftban/selinux
 /usr/share/bash-completion/completions/nftban
 %attr(644,root,nftban) %config(noreplace) /etc/nftban/commands.registry.yml


### PR DESCRIPTION
PR-C of the RPM `%files` cleanup — the **templates half**, completed as a deliberate **FHS-authority edit** (v1.166 lane). Closes the remaining half of `BUG-RPM-FILES-LISTED-TWICE`.

## Scope (PR-C only — templates/FHS authority correction)
- add FHS-generator `%dir` ownership for `templates/email` + `templates/partials` (`build/fhs-spec.yaml`) — they had staged `.html` but no generator ownership, so the bare line could not be dropped naively (would orphan → v1.161 class)
- keep `templates/zabbix` as an empty owned `%dir` for compatibility (`keep-empty-%dir`)
- **regenerate** FHS outputs from `build/fhs-spec.yaml` (`nftban-files.inc`, `nftban_fhs_spec.sh`, `fhs_directories.json`, `deb/nftban.dirs`)
- replace bare `/usr/share/nftban/templates` RPM payload line with explicit subdir contents (`mail/* reports/* email/* partials/*`)
- add a template **dotfile strip** before `%files` evaluation (mirrors v1.165 PR-B)
- add hermetic templates `%files` dedup guard (`rpm_files_templates_dedup_v166_test.sh`), CI-wired

## Validation
- `generate-fhs-outputs.sh --check` **rc=0** (generator parity)
- **hermetic mini-rpmbuild** clean (templates `%dir` + `/*` + strip + staged `email`/`partials` + planted `.gitkeep`): no "File listed twice", no "Installed but unpackaged"; `.gitkeep` stripped, content packaged, `zabbix` empty-owned — rpm-version-independent → holds for EL9/EL10
- v166 guard **13/0** · PR-A guard **5/0** · PR-B guard **15/0** · v157 guard **6/0**
- `bash -n` / shellcheck clean · YAML valid
- daemon tree unchanged: `cmd/nftband 85a2de3e…`
- schema untouched (1.83.0 frozen)

## Intentional — FHS body changed by design
This is an **FHS-authority edit**; the generated FHS body deliberately changes:
- `nftban-files.inc` → `08e0163f3baefee0e6d43c9e709e4b98098a1f258eb714d6c8ff7da991cb1ccd`
- `nftban_fhs_spec.sh` → `3a389e9a94fa9c96b25f2aa51bbd32a99c098115c3a48b24a7cd5979488bc411`

The Architecture-Policy **"FHS spec generated files check"** gate enforces generator parity.

## Out of scope
- lib-dir `%files` changes (done v1.165) · selinux/specs ownership lines · daemon-Go · schema · switchop · runtime/firewall · live host mutation

No merge / no release-prep / no tag / no publish. **CI Build RPM el9/el10 + the FHS generated-files check are the decisive judges; abort rule active (revert PR-C only on EL/FHS/DEB failure).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)