### PR TITLE
fix(cli): unify feed counter computations

### DIFF
--- a/cli/lib/nftban/cli/cmd_feeds.sh
+++ b/cli/lib/nftban/cli/cmd_feeds.sh
@@ -40,6 +40,13 @@ fi
 if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_file_utils.sh" ]]; then
     source "${NFTBAN_LIB_DIR}/lib/nftban_file_utils.sh" || return 1
 fi
+
+# Load shared feed-counter helpers (v1.167 PR-1: single source of truth for
+# feed IP-total / enabled-file-count surfaces — BUG-CtCount-feeds)
+# shellcheck source=/usr/lib/nftban/lib/nftban_feed_counters.sh
+if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_feed_counters.sh" ]]; then
+    source "${NFTBAN_LIB_DIR}/lib/nftban_feed_counters.sh" || return 1
+fi
 JSON_HELPER="${NFTBAN_LIB_DIR}/helpers/json_output.sh"
 if [[ -f "$JSON_HELPER" ]]; then
     # shellcheck source=/dev/null
@@ -580,24 +587,38 @@ nftban_feeds_status() {
     # or geoban-derived IPs). Surface them separately so consumers can
     # answer 'how many feeds are enabled' / 'how many IPs across feed files'
     # / 'what does the cache say' independently. (V1_141_0 §2 D-feed-count.)
-    local _feed_files=0 _feed_ip_total=0 _feed_dir
-    _feed_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
-    if [[ -d "$_feed_dir" ]]; then
-        local _all _en
-        _all=$(nftban_feeds_discover_all 2>/dev/null || true)
-        for _en in $_all; do
-            local _is_on
-            _is_on=$(nftban_feeds_get_property "$_en" "ENABLED" 2>/dev/null || echo false)
-            [[ "$_is_on" == "true" ]] || continue
-            local _ff
-            _ff="${_feed_dir}/$(echo "$_en" | tr '[:upper:]' '[:lower:]').txt"
-            if [[ -f "$_ff" ]]; then
-                _feed_files=$((_feed_files + 1))
-                local _ips
-                _ips=$(wc -l < "$_ff" 2>/dev/null || echo 0)
-                _feed_ip_total=$((_feed_ip_total + _ips))
-            fi
-        done
+    # v1.167 PR-1 (BUG-CtCount-feeds): the two labelled surfaces below are now
+    # computed by the shared helpers — the SAME enabled-feed resolution this
+    # block introduced in v1.141 PR-C, lifted into lib/nftban_feed_counters.sh
+    # so cmd_status / the exporter / here all agree. "Feed file count" stays a
+    # FILE count (nftban_feed_file_count); "Feed IP total" stays an IP total
+    # (nftban_feed_ips_total). Fallback keeps the old inline logic if the helper
+    # is somehow unavailable.
+    local _feed_files=0 _feed_ip_total=0
+    if declare -f nftban_feed_file_count >/dev/null 2>&1 \
+        && declare -f nftban_feed_ips_total >/dev/null 2>&1; then
+        _feed_files=$(nftban_feed_file_count)
+        _feed_ip_total=$(nftban_feed_ips_total)
+    else
+        local _feed_dir
+        _feed_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
+        if [[ -d "$_feed_dir" ]]; then
+            local _all _en
+            _all=$(nftban_feeds_discover_all 2>/dev/null || true)
+            for _en in $_all; do
+                local _is_on
+                _is_on=$(nftban_feeds_get_property "$_en" "ENABLED" 2>/dev/null || echo false)
+                [[ "$_is_on" == "true" ]] || continue
+                local _ff
+                _ff="${_feed_dir}/$(echo "$_en" | tr '[:upper:]' '[:lower:]').txt"
+                if [[ -f "$_ff" ]]; then
+                    _feed_files=$((_feed_files + 1))
+                    local _ips
+                    _ips=$(wc -l < "$_ff" 2>/dev/null || echo 0)
+                    _feed_ip_total=$((_feed_ip_total + _ips))
+                fi
+            done
+        fi
     fi
     echo "  Feed file count:  $_feed_files"
     echo "  Feed IP total:    $_feed_ip_total  (sum across enabled feed files)"
@@ -892,12 +913,26 @@ nftban_feeds_stats() {
     local all_feeds
     all_feeds=$(nftban_feeds_discover_all 2>/dev/null || echo "")
 
+    # v1.167 PR-1 (BUG-CtCount-feeds): the IP AGGREGATE is unified via the
+    # shared nftban_feed_ips_total() helper (enabled-only, same resolution as
+    # cmd_status / the exporter). total_feeds / enabled_count remain counted in
+    # this loop (they are not feed-file counters). Fallback sums inline.
     for feed in $all_feeds; do
         ((total_feeds++)) || true
         local enabled
         enabled=$(nftban_feeds_get_property "$feed" "ENABLED" 2>/dev/null || echo "false")
         if [[ "$enabled" == "true" ]]; then
             ((enabled_count++)) || true
+        fi
+    done
+
+    if declare -f nftban_feed_ips_total >/dev/null 2>&1; then
+        total_ips=$(nftban_feed_ips_total)
+    else
+        for feed in $all_feeds; do
+            local enabled_f
+            enabled_f=$(nftban_feeds_get_property "$feed" "ENABLED" 2>/dev/null || echo "false")
+            [[ "$enabled_f" == "true" ]] || continue
             local feed_lower="${feed,,}"
             local feed_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds/${feed_lower}.txt"
             if [[ -f "$feed_file" ]]; then
@@ -905,8 +940,8 @@ nftban_feeds_stats() {
                 count=$(wc -l < "$feed_file" 2>/dev/null || echo "0")
                 total_ips=$((total_ips + count))
             fi
-        fi
-    done
+        done
+    fi
 
     if [[ "$json_mode" == "true" ]] && declare -f json_output >/dev/null 2>&1; then
         local data

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -84,6 +84,15 @@ elif [[ -f "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/lib/nftban
     source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/lib/nftban_service_control.sh" || return 1
 fi
 
+# Load shared feed-counter helpers (v1.167 PR-1: single source of truth for
+# feed IP-total / enabled-file-count surfaces — BUG-CtCount-feeds)
+# shellcheck source=/usr/lib/nftban/lib/nftban_feed_counters.sh
+if [[ -f "${NFTBAN_LIB_DIR}/lib/nftban_feed_counters.sh" ]]; then
+    source "${NFTBAN_LIB_DIR}/lib/nftban_feed_counters.sh" || return 1
+elif [[ -f "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/lib/nftban_feed_counters.sh" ]]; then
+    source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/lib/nftban_feed_counters.sh" || return 1
+fi
+
 # =============================================================================
 # BINARY INTEGRITY VALIDATION
 # =============================================================================
@@ -2066,12 +2075,19 @@ output_json() {
     fi
     echo "    \"tunnel\": {\"enabled\": $json_tunnel_enabled, \"high\": $json_tunnel_high, \"medium\": $json_tunnel_med, \"advisory_only\": true},"
 
-    # Feeds
+    # Feeds — feed FILE count (enabled feed files). v1.167 PR-1: unified via the
+    # shared nftban_feed_file_count() helper (BUG-CtCount-feeds). The pre-v1.167
+    # `find *.txt | wc -l` counted every on-disk file (incl. disabled/orphans);
+    # the helper counts ENABLED feed files via the canonical v1.141 PR-C
+    # resolution, matching the other feed surfaces. The "count" label is a FILE
+    # count, so it routes through nftban_feed_file_count (not the IP-total).
     local feeds_count=0
-    if [[ -d "${NFTBAN_DATA_DIR}/feeds" ]]; then
+    if declare -f nftban_feed_file_count >/dev/null 2>&1; then
+        feeds_count=$(nftban_feed_file_count)
+    elif [[ -d "${NFTBAN_DATA_DIR}/feeds" ]]; then
         feeds_count=$(find "${NFTBAN_DATA_DIR}/feeds" -name "*.txt" -type f 2>/dev/null | wc -l || true)
-        feeds_count="${feeds_count:-0}"
     fi
+    feeds_count="${feeds_count:-0}"
     echo "    \"feeds\": {\"count\": $feeds_count}"
     echo "  },"
 

--- a/cli/lib/nftban/core/nftban_stats_collect.sh
+++ b/cli/lib/nftban/core/nftban_stats_collect.sh
@@ -40,6 +40,19 @@ umask 027
 [[ -n "${NFTBAN_STATS_COLLECT_LOADED:-}" ]] && return 0
 readonly NFTBAN_STATS_COLLECT_LOADED=1
 
+# Load shared feed-counter helpers (v1.167 PR-1: single source of truth for
+# the feed IP-total surface — BUG-CtCount-feeds). Best-effort; helpers degrade
+# to 0 if the feeds-discovery lib is unreachable.
+if ! declare -f nftban_feed_ips_total >/dev/null 2>&1; then
+    _nfc_lib="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_feed_counters.sh"
+    [[ -f "$_nfc_lib" ]] || _nfc_lib="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/lib/nftban_feed_counters.sh"
+    if [[ -f "$_nfc_lib" ]]; then
+        # shellcheck source=/usr/lib/nftban/lib/nftban_feed_counters.sh
+        source "$_nfc_lib" 2>/dev/null || true
+    fi
+    unset _nfc_lib
+fi
+
 # =============================================================================
 # CORE METRICS COLLECTION
 # =============================================================================
@@ -321,14 +334,23 @@ nftban_stats_ban_sources() {
 
     # Fallback: Parse log file for custom date ranges
     if [[ ! -f "$NFTBAN_BAN_LOG" ]]; then
-        # No ban log — still check for loaded feed IPs
+        # No ban log — still check for loaded feed IPs.
+        # v1.167 PR-1: feed IP-total unified via nftban_feed_ips_total()
+        # (BUG-CtCount-feeds). Replaces the prior cat-all `wc -l`, which summed
+        # EVERY .txt (incl. disabled/orphan feeds); the helper sums only ENABLED
+        # feed files (canonical v1.141 PR-C resolution), matching the other
+        # feed IP surfaces.
         local feed_total=0
-        local feeds_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
-        if [[ -d "$feeds_dir" ]]; then
-            # shellcheck disable=SC2312  # cat in subshell is fine here
-            feed_total=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
-            feed_total=${feed_total:-0}
+        if declare -f nftban_feed_ips_total >/dev/null 2>&1; then
+            feed_total=$(nftban_feed_ips_total)
+        else
+            local feeds_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
+            if [[ -d "$feeds_dir" ]]; then
+                # shellcheck disable=SC2312  # cat in subshell is fine here
+                feed_total=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
+            fi
         fi
+        feed_total=${feed_total:-0}
         echo "{\"login\":0,\"portscan\":0,\"ddos\":0,\"manual\":0,\"feeds\":$feed_total,\"suricata\":0}"
         return 0
     fi
@@ -360,15 +382,21 @@ nftban_stats_ban_sources() {
         local log_feeds
         log_feeds=$(echo "$result" | jq -r '.feeds // 0')
         if [[ "$log_feeds" == "0" ]]; then
-            local feeds_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
-            if [[ -d "$feeds_dir" ]]; then
-                local feed_count
-                # shellcheck disable=SC2312  # cat in subshell is fine here
-                feed_count=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
-                feed_count=${feed_count:-0}
-                if [[ "$feed_count" -gt 0 ]]; then
-                    result=$(echo "$result" | jq -c ".feeds = $feed_count")
+            # v1.167 PR-1: feed IP-total unified via nftban_feed_ips_total()
+            # (BUG-CtCount-feeds) — same enabled-only resolution as above.
+            local feed_count=0
+            if declare -f nftban_feed_ips_total >/dev/null 2>&1; then
+                feed_count=$(nftban_feed_ips_total)
+            else
+                local feeds_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
+                if [[ -d "$feeds_dir" ]]; then
+                    # shellcheck disable=SC2312  # cat in subshell is fine here
+                    feed_count=$(cat "$feeds_dir"/*.txt 2>/dev/null | wc -l || true)
                 fi
+            fi
+            feed_count=${feed_count:-0}
+            if [[ "$feed_count" -gt 0 ]]; then
+                result=$(echo "$result" | jq -c ".feeds = $feed_count")
             fi
         fi
     fi

--- a/cli/lib/nftban/lib/nftban_feed_counters.sh
+++ b/cli/lib/nftban/lib/nftban_feed_counters.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_feed_counters" meta:type="lib" meta:version="1.167.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Shared feed-counter helpers: unified IP-total and enabled-file-count across feed files"
+# meta:inventory.files="/usr/lib/nftban/lib/nftban_feed_counters.sh"
+# meta:inventory.binaries="grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+
+set -Eeuo pipefail
+
+# USAGE:
+#   source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_feed_counters.sh"
+#
+#   # Sum of IP lines across all ENABLED feed files
+#   total=$(nftban_feed_ips_total)
+#
+#   # Count of ENABLED feed files that exist on disk
+#   files=$(nftban_feed_file_count)
+#
+# v1.167 PR-1 (BUG-CtCount-feeds): three independent feed-count computations
+# (cmd_status.sh feeds.count, nftban_stats_collect.sh cat-all `wc -l`,
+# cmd_feeds.sh per-feed aggregate) previously disagreed because each rolled
+# its own resolution. These helpers are the single source of truth for the
+# enabled-feed → lowercase → "<data>/feeds/<feed>.txt" mapping (the v1.141
+# PR-C resolution) and the two distinct surfaces it feeds:
+#   - IP total   : sum of non-empty lines across enabled feed files
+#   - file count : number of enabled feed files that exist
+# =============================================================================
+
+set -Eeuo pipefail
+
+# Prevent double-loading
+[[ -n "${_NFTBAN_FEED_COUNTERS_LOADED:-}" ]] && return 0
+_NFTBAN_FEED_COUNTERS_LOADED=1
+
+# Ensure the dynamic feed-discovery primitives are available. These live in
+# core/nftban_feeds.sh; consuming commands that already source it pay no cost
+# (it is idempotent). Best-effort: if it cannot be located, the helpers below
+# degrade to 0 rather than crashing.
+_nftban_feed_counters_ensure_feeds_lib() {
+    if declare -f nftban_feeds_discover_all >/dev/null 2>&1 \
+        && declare -f nftban_feeds_get_property >/dev/null 2>&1; then
+        return 0
+    fi
+    local _lib_dir="${NFTBAN_LIB_DIR:-/usr/lib/nftban}"
+    local _candidate
+    for _candidate in \
+        "${_lib_dir}/core/nftban_feeds.sh" \
+        "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/core/nftban_feeds.sh"; do
+        if [[ -f "$_candidate" ]]; then
+            # shellcheck source=/dev/null
+            source "$_candidate" 2>/dev/null || true
+            declare -f nftban_feeds_discover_all >/dev/null 2>&1 && return 0
+        fi
+    done
+    return 1
+}
+
+# Resolve the list of ENABLED feed files that exist on disk (one absolute path
+# per line). Mirrors the cmd_feeds.sh v1.141 PR-C resolution exactly:
+#   discover all feeds → keep ENABLED==true → lowercase → <data>/feeds/<feed>.txt
+# Emits nothing when the feeds dir is absent or no enabled feed file exists.
+_nftban_feed_counters_enabled_files() {
+    local _feed_dir="${NFTBAN_DATA_DIR:-/var/lib/nftban}/feeds"
+    [[ -d "$_feed_dir" ]] || return 0
+    _nftban_feed_counters_ensure_feeds_lib || return 0
+
+    local _all _feed _on _ff
+    _all=$(nftban_feeds_discover_all 2>/dev/null || true)
+    for _feed in $_all; do
+        _on=$(nftban_feeds_get_property "$_feed" "ENABLED" 2>/dev/null || echo false)
+        [[ "$_on" == "true" ]] || continue
+        _ff="${_feed_dir}/$(echo "$_feed" | tr '[:upper:]' '[:lower:]').txt"
+        [[ -f "$_ff" ]] && printf '%s\n' "$_ff"
+    done
+}
+
+# nftban_feed_ips_total — sum of non-empty IP lines across all ENABLED feed
+# files. Missing files contribute 0. Always prints an integer (0 on any error).
+nftban_feed_ips_total() {
+    local _total=0 _ff _n
+    while IFS= read -r _ff; do
+        [[ -n "$_ff" ]] || continue
+        # Count non-empty lines (robust to a missing trailing newline).
+        _n=$(grep -cve '^[[:space:]]*$' "$_ff" 2>/dev/null || true)
+        [[ "$_n" =~ ^[0-9]+$ ]] || _n=0
+        _total=$((_total + _n))
+    done < <(_nftban_feed_counters_enabled_files)
+    printf '%s\n' "$_total"
+}
+
+# nftban_feed_file_count — number of ENABLED feed files that exist on disk.
+# Always prints an integer (0 on any error).
+nftban_feed_file_count() {
+    local _count=0 _ff
+    while IFS= read -r _ff; do
+        [[ -n "$_ff" ]] && _count=$((_count + 1))
+    done < <(_nftban_feed_counters_enabled_files)
+    printf '%s\n' "$_count"
+}
+
+# Export so subshells / sourced command modules see the helpers.
+export -f nftban_feed_ips_total nftban_feed_file_count \
+    _nftban_feed_counters_enabled_files _nftban_feed_counters_ensure_feeds_lib 2>/dev/null || true

--- a/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
+++ b/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.167 PR-1 guard: unified feed-IP / feed-file counters
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="feed_counters_unify_v167_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Hermetic guard for the v1.167 PR-1 feed-counter unification (BUG-CtCount-feeds). Three feed-count computations (cmd_status feeds.count, nftban_stats_collect cat-all wc -l, cmd_feeds per-feed aggregate) previously disagreed because each rolled its own resolution. PR-1 lifts the canonical v1.141 PR-C enabled-feed resolution (discover_all -> ENABLED==true -> lowercase -> <data>/feeds/<feed>.txt) into lib/nftban_feed_counters.sh with two pure helpers. This test sources that lib with stubbed feed-discovery primitives over a temp feeds dir and asserts: nftban_feed_ips_total sums non-empty lines across ENABLED feed files only (10+5+0=15), nftban_feed_file_count counts existing ENABLED feed files (3), disabled feeds are excluded, and an empty/absent feeds dir yields 0/0. Static; no host/nft/root."
+# meta:inventory.files="cli/lib/nftban/lib/nftban_feed_counters.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$TEST_DIR/../lib/nftban_feed_counters.sh"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$LIB" ]] || { echo "helper lib not found at $LIB"; exit 1; }
+
+echo "feed-counter unification guard (v1.167 PR-1):"
+
+# --- temp feeds workspace -----------------------------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FEEDS="$WORK/feeds"
+mkdir -p "$FEEDS"
+
+# 3 ENABLED feeds with 10, 5, 0 non-empty IP lines; 1 DISABLED feed with 99
+# lines that MUST NOT be counted; 1 orphan .txt with no config entry.
+seq 1 10  | sed 's/^/10.0.0./'       > "$FEEDS/feed_a.txt"   # 10 lines
+seq 1 5   | sed 's/^/10.0.1./'       > "$FEEDS/feed_b.txt"   # 5 lines
+: > "$FEEDS/feed_c.txt"                                       # 0 lines (exists)
+seq 1 99  | sed 's/^/10.9.9./'       > "$FEEDS/feed_dis.txt" # 99 (disabled)
+seq 1 42  | sed 's/^/10.8.8./'       > "$FEEDS/orphan.txt"   # not in config
+
+# Inject a couple of blank/whitespace lines into feed_a — non-empty count must
+# stay 10 (blank lines are not IPs).
+printf '\n   \n' >> "$FEEDS/feed_a.txt"
+
+# --- stub the feed-discovery primitives (the real ones read config files) -----
+nftban_feeds_discover_all() { printf '%s\n' "FEED_A" "FEED_B" "FEED_C" "FEED_DIS"; }
+nftban_feeds_get_property() {
+    # $1=feed name, $2=property (we only answer ENABLED)
+    case "$2" in
+        ENABLED)
+            case "$1" in
+                FEED_DIS) echo "false" ;;
+                *)        echo "true"  ;;
+            esac
+            ;;
+        *) echo "" ;;
+    esac
+}
+export -f nftban_feeds_discover_all nftban_feeds_get_property
+
+# Source helper AFTER stubbing so its ensure-lib step sees the primitives.
+export NFTBAN_DATA_DIR="$WORK"
+# shellcheck source=/dev/null
+source "$LIB"
+
+# --- (a) IP total = 10 + 5 + 0 = 15 (disabled + orphan excluded, blanks skip) -
+ips=$(nftban_feed_ips_total)
+[[ "$ips" == "15" ]] \
+    && ok "nftban_feed_ips_total == 15 (enabled feeds, non-empty lines only)" \
+    || no "nftban_feed_ips_total wrong" "got '$ips', want 15"
+
+# --- (b) file count = 3 enabled feed files exist -----------------------------
+files=$(nftban_feed_file_count)
+[[ "$files" == "3" ]] \
+    && ok "nftban_feed_file_count == 3 (enabled feed files that exist)" \
+    || no "nftban_feed_file_count wrong" "got '$files', want 3"
+
+# --- (c) empty feeds dir -> 0 / 0 --------------------------------------------
+EMPTY="$(mktemp -d)"
+mkdir -p "$EMPTY/feeds"
+(
+    export NFTBAN_DATA_DIR="$EMPTY"
+    e_ips=$(nftban_feed_ips_total)
+    e_files=$(nftban_feed_file_count)
+    [[ "$e_ips" == "0" && "$e_files" == "0" ]]
+) \
+    && ok "empty feeds dir -> ips=0 files=0" \
+    || no "empty feeds dir not zeroed"
+rm -rf "$EMPTY"
+
+# --- (d) absent feeds dir -> 0 / 0 (robust to missing dir) -------------------
+GONE="$(mktemp -d)"   # no feeds/ subdir at all
+(
+    export NFTBAN_DATA_DIR="$GONE"
+    g_ips=$(nftban_feed_ips_total)
+    g_files=$(nftban_feed_file_count)
+    [[ "$g_ips" == "0" && "$g_files" == "0" ]]
+) \
+    && ok "absent feeds dir -> ips=0 files=0" \
+    || no "absent feeds dir not zeroed"
+rm -rf "$GONE"
+
+echo ""
+echo "  PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
PR-1 of the v1.167 UX-residual lane — closes **BUG-CtCount-feeds**, the real feed-count drift.

**Shared v1.167 invariant:** UX residual lane · **shell/CLI only** · daemon tree unchanged `cmd/nftband 85a2de3e69eeeb526b257db0977be8c14f2e1cdb` · schema 1.83.0 untouched · FHS untouched (`generate-fhs-outputs.sh --check` rc=0) · no packaging/switchop/runtime/firewall/live-host/wiki changes.

## What changed
- **New** `cli/lib/nftban/lib/nftban_feed_counters.sh`: shared `nftban_feed_ips_total()` (enabled-feed IP sum) + `nftban_feed_file_count()` (enabled-feed file count).
- Unified the 3 divergent total computations: `cmd_status.sh:~2072` (was `find … *.txt | wc -l` over **all** files incl. disabled/orphans → now enabled-aware `nftban_feed_file_count`; stays a file-count per its `"count"` label), `core/nftban_stats_collect.sh:329,367` (cat-all → `nftban_feed_ips_total`), `cmd_feeds.sh` aggregates (v1.141 "Feed file count"/"Feed IP total" surfaces routed through the helpers; per-single-feed displays untouched).

## Decisive checks
- `feed_counters_unify_v167_test.sh` **4/0** (ips_total=15, file_count=3, empty/absent=0)
- enabled-aware file-count vs IP-total surfaces preserved
- exporter + status + feeds aggregates all route through the shared helpers
- daemon tree `85a2de3e…` unchanged · shellcheck/bash-n clean · check-nft-writes PASS

File-disjoint from PR-2/PR-3 → independently mergeable. No merge/tag/release-prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)