### PR TITLE
fix(cli): tighten UX output truth and update dry-run hint

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -298,7 +298,14 @@ _nftban_botscan_stats_json() {
         else
             local enabled_json="false"
             [[ "$botscan_enabled" == "true" ]] && enabled_json="true"
-            data="{\"botscan\":{\"enabled\":$enabled_json,\"action_mode\":\"$action_mode\",\"patterns_total\":$patterns_total,\"patterns_enabled\":$patterns_enabled,\"blocked_24h\":$blocked_24h,\"blocked_total\":$blocked_total}}"
+            # v1.167 PR-2 (B): escape the only free-form string field
+            # ($action_mode) so a value containing a quote/backslash/newline
+            # cannot break the hand-built JSON in the no-jq fallback path.
+            local action_mode_esc="$action_mode"
+            if declare -f json_escape >/dev/null 2>&1; then
+                action_mode_esc=$(json_escape "$action_mode")
+            fi
+            data="{\"botscan\":{\"enabled\":$enabled_json,\"action_mode\":\"$action_mode_esc\",\"patterns_total\":$patterns_total,\"patterns_enabled\":$patterns_enabled,\"blocked_24h\":$blocked_24h,\"blocked_total\":$blocked_total}}"
         fi
 
         json_output "true" "$data"

--- a/cli/lib/nftban/cli/cmd_debug.sh
+++ b/cli/lib/nftban/cli/cmd_debug.sh
@@ -34,6 +34,15 @@ source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" 2>/dev/null || true
 [[ -z "${NFTBAN_LIB_DIR:-}" ]] && readonly NFTBAN_LIB_DIR="/usr/lib/nftban"
 [[ -z "${NFTBAN_CONFIG_DIR:-}" ]] && readonly NFTBAN_CONFIG_DIR="/etc/nftban"
 
+# v1.167 PR-2 (B): load the JSON helper so the no-jq JSON fallback below can
+# escape free-form string fields ($trace_log path, $log_level) via
+# json_escape(). Guarded + best-effort: if the helper is absent we fall back
+# to raw interpolation (unchanged pre-v1.167 behaviour).
+if [[ -f "${NFTBAN_LIB_DIR}/helpers/json_output.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR}/helpers/json_output.sh" 2>/dev/null || true
+fi
+
 # Prevent double-loading
 [[ -n "${CMD_DEBUG_LOADED:-}" ]] && return 0
 readonly CMD_DEBUG_LOADED=1
@@ -126,7 +135,16 @@ nftban_debug_status() {
         fi
         local orphans=$((start_count - end_count))
         [[ $orphans -lt 0 ]] && orphans=0
-        echo "{\"trace_enabled\":$([ "$trace_enabled" == "true" ] && echo true || echo false),\"trace_log\":\"$trace_log\",\"trace_size_bytes\":$trace_size,\"trace_entries\":$trace_lines,\"log_level\":\"$log_level\",\"start_count\":$start_count,\"end_count\":$end_count,\"potential_orphans\":$orphans,\"timestamp\":\"$(date -Iseconds)\"}"
+        # v1.167 PR-2 (B): escape the free-form string fields so a path or
+        # log-level value containing a quote/backslash/newline cannot break
+        # the hand-built JSON in this no-jq fallback.
+        local trace_log_esc="$trace_log"
+        local log_level_esc="$log_level"
+        if declare -f json_escape >/dev/null 2>&1; then
+            trace_log_esc=$(json_escape "$trace_log")
+            log_level_esc=$(json_escape "$log_level")
+        fi
+        echo "{\"trace_enabled\":$([ "$trace_enabled" == "true" ] && echo true || echo false),\"trace_log\":\"$trace_log_esc\",\"trace_size_bytes\":$trace_size,\"trace_entries\":$trace_lines,\"log_level\":\"$log_level_esc\",\"start_count\":$start_count,\"end_count\":$end_count,\"potential_orphans\":$orphans,\"timestamp\":\"$(date -Iseconds)\"}"
         return 0
     fi
 

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1036,6 +1036,14 @@ firewall_validate() {
     local output_json=false
     local strict_mode=false
     local quiet_mode=false
+    # v1.167 PR-2 (D) UX-INFO: by default the human-readable validate output
+    # drops INFO-severity findings (mirrors the `nftban health` text filter at
+    # cmd_health.sh:~581-605) so an idle host does not surface alarming-but-
+    # useless "[INFO]" lines. Opt back in with --verbose or NFTBAN_VALIDATE_VERBOSE=1.
+    # JSON output (--json) is unaffected: consumers always see the full findings
+    # array straight from the validator. SHELL-SIDE filter only — no Go change.
+    local verbose_mode=false
+    [[ "${NFTBAN_VALIDATE_VERBOSE:-0}" == "1" ]] && verbose_mode=true
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -1050,6 +1058,10 @@ firewall_validate() {
                 ;;
             --quiet|-q)
                 quiet_mode=true
+                shift
+                ;;
+            --verbose|-v)
+                verbose_mode=true
                 shift
                 ;;
             -h|--help)
@@ -1153,7 +1165,19 @@ firewall_validate() {
             local _val_status
             _val_status=$(echo "$_val_json" | jq -r '.status' 2>/dev/null)
             echo "Validator Status: $(echo "$_val_status" | tr '[:lower:]' '[:upper:]')"
-            echo "$_val_json" | jq -r '.findings[] | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null || true
+            # v1.167 PR-2 (D): shell-side INFO filter (mirrors cmd_health.sh).
+            # Default drops info-severity findings; --verbose / NFTBAN_VALIDATE_VERBOSE=1
+            # shows them. Count hidden INFO so the operator knows they exist.
+            if [[ "$verbose_mode" == "true" ]]; then
+                echo "$_val_json" | jq -r '.findings[] | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null || true
+            else
+                echo "$_val_json" | jq -r '.findings[] | select((.severity | ascii_downcase) != "info") | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null || true
+                local _info_hidden
+                _info_hidden=$(echo "$_val_json" | jq '[.findings[] | select((.severity | ascii_downcase) == "info")] | length' 2>/dev/null || echo 0)
+                if [[ "${_info_hidden:-0}" -gt 0 ]]; then
+                    echo "  (${_info_hidden} INFO finding(s) hidden — use --verbose to show)"
+                fi
+            fi
         elif [[ -n "$_val_json" ]]; then
             echo "$_val_json"
         fi
@@ -3424,9 +3448,11 @@ Strict Mode (--strict): Single Firewall Authority
   - No non-NFTBan active input hooks in nftables
 
 Options:
-  --strict, -s  Enforce Single Firewall Authority (recommended)
-  --json        Output results as JSON
-  -h, --help    Show this help message
+  --strict, -s   Enforce Single Firewall Authority (recommended)
+  --json         Output results as JSON
+  --verbose, -v  Show INFO-severity findings (hidden by default; same effect
+                 as NFTBAN_VALIDATE_VERBOSE=1)
+  -h, --help     Show this help message
 
 Exit codes:
   0   All validation checks passed (OK)

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -2366,6 +2366,22 @@ nftban_cmd_update() {
         fi
     done
 
+    # v1.167 PR-2 (C) UX-C5 flag-parity: `--dry-run` is intentionally NOT
+    # supported on `nftban update` (the help NOTES section documents the
+    # asymmetry — package-manager transactions cannot be safely simulated
+    # end-to-end). Before subcommand dispatch, catch `--dry-run` in any
+    # position (bare `nftban update --dry-run` captures it as $cmd; a
+    # trailing `nftban update auto --dry-run` lands in "$@") and emit the
+    # canonical 3-line ERROR/Hint/Run via _v144_error_with_hint instead of
+    # routing it to the generic "Unknown command" path. rc=1.
+    if [[ "$cmd" == "--dry-run" ]] || printf '%s\n' "$@" | grep -qx -- '--dry-run'; then
+        _v144_error_with_hint \
+            "--dry-run is not supported for 'nftban update'" \
+            "package transactions cannot be safely simulated" \
+            "nftban update check"
+        return 1
+    fi
+
     # v1.120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): capture the operator's
     # SSH peer IP from $SSH_CLIENT and propagate it to the installer via
     # the env mirror NFTBAN_OPERATOR_SESSION_IP. The installer's

--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -87,7 +87,10 @@ nftban_stats_generate_dashboard() {
     # values or derived live-aggregation values from the awk fallback.
     # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-3 item 2.3)
     if [[ "$use_unified_cache" == "true" ]]; then
-        printf "  %-20s %s\n" "Data source........." "unified cache"
+        # v1.167 PR-2 (E): casing-consistency. The two Data source values are
+        # siblings; align the cache-hit value to the all-caps convention used
+        # by its sibling ("DERIVED ...") and the section headers (SYSTEM, etc.).
+        printf "  %-20s %s\n" "Data source........." "UNIFIED CACHE"
     else
         printf "  %-20s %s\n" "Data source........." "DERIVED (cache miss; live aggregation from nftables + bans.log)"
     fi

--- a/cli/lib/nftban/tests/cli_output_truth_v167_test.sh
+++ b/cli/lib/nftban/tests/cli_output_truth_v167_test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.167 PR-2 guard: CLI output-truth / flag-parity
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_output_truth_v167_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Hermetic guard for v1.167 PR-2 (CLI output-truth + flag-parity, shell-only, daemon byte-identical). Covers four fixes. (B) JSON no-jq fallback escaping: json_escape() in helpers/json_output.sh produces valid JSON for input containing a double-quote and a backslash, and the cmd_botscan.sh + cmd_debug.sh no-jq fallbacks route their free-form string fields through json_escape(). (C) UX-C5 flag-parity: nftban update --dry-run is caught by an explicit early guard in cmd_update.sh that emits the 3-line ERROR/Hint/Run via _v144_error_with_hint and returns rc=1, instead of routing to the generic Unknown-command path. (D) UX-INFO: the human-readable validate render in cmd_firewall.sh applies a shell-side INFO-severity filter by default (mirrors cmd_health.sh) with a --verbose / NFTBAN_VALIDATE_VERBOSE=1 opt-in; --json output is unaffected. (E) stats label casing: the cache-hit Data source value is all-caps (UNIFIED CACHE) consistent with its DERIVED sibling and the all-caps section headers; the legitimate logic-backed DERIVED cache-miss label is retained (it is NOT spec residue), and no DERIVED badge leaks into cmd_stats.sh / cmd_status.sh. Static + hermetic; sources only helpers/json_output.sh; no daemon, no nft, no host mutation."
+# meta:inventory.files="cli/lib/nftban/helpers/json_output.sh,cli/lib/nftban/cli/cmd_botscan.sh,cli/lib/nftban/cli/cmd_debug.sh,cli/lib/nftban/cli/cmd_update.sh,cli/lib/nftban/cli/cmd_firewall.sh,cli/lib/nftban/core/nftban_stats_format.sh"
+# meta:inventory.binaries="bash,grep,jq"
+# meta:inventory.env_vars="NFTBAN_VALIDATE_VERBOSE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$TEST_DIR/.." && pwd)"   # cli/lib/nftban
+
+JSON_HELPER="$LIB_DIR/helpers/json_output.sh"
+BOTSCAN="$LIB_DIR/cli/cmd_botscan.sh"
+DEBUG="$LIB_DIR/cli/cmd_debug.sh"
+UPDATE="$LIB_DIR/cli/cmd_update.sh"
+FIREWALL="$LIB_DIR/cli/cmd_firewall.sh"
+STATS_FMT="$LIB_DIR/core/nftban_stats_format.sh"
+STATS_CMD="$LIB_DIR/cli/cmd_stats.sh"
+STATUS_CMD="$LIB_DIR/cli/cmd_status.sh"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+for f in "$JSON_HELPER" "$BOTSCAN" "$DEBUG" "$UPDATE" "$FIREWALL" "$STATS_FMT" "$STATS_CMD" "$STATUS_CMD"; do
+    [[ -f "$f" ]] || { echo "FATAL: missing required file: $f" >&2; exit 1; }
+done
+
+echo "v1.167 PR-2 CLI output-truth / flag-parity guard:"
+
+# =============================================================================
+# (B) JSON no-jq fallback escaping
+# =============================================================================
+echo "[B] JSON no-jq fallback escaping"
+
+# json_escape() must exist in the helper and produce valid JSON for nasty input.
+# Source the helper in a subshell so its `set -Eeuo pipefail` / module guard
+# does not leak into this test's shell.
+B_IN='val with "quote" and \backslash'
+B_OUT="$(
+    set +e
+    # shellcheck source=/dev/null
+    source "$JSON_HELPER" >/dev/null 2>&1
+    json_escape "$B_IN"
+)"
+
+if [[ -n "$B_OUT" ]]; then
+    ok "json_escape() is defined and returns output"
+else
+    no "json_escape() produced no output (helper missing the escaper?)"
+fi
+
+# Build a tiny JSON document the same way the fallbacks do and validate it.
+B_DOC="{\"field\":\"$B_OUT\"}"
+if command -v jq >/dev/null 2>&1; then
+    if printf '%s' "$B_DOC" | jq -e . >/dev/null 2>&1; then
+        ok "escaped value yields valid JSON (jq parses {\"field\":\"...\"})"
+    else
+        no "escaped value did NOT yield valid JSON" "$B_DOC"
+    fi
+    # Round-trip: the decoded value must equal the original raw input.
+    B_BACK="$(printf '%s' "$B_DOC" | jq -r '.field' 2>/dev/null || echo '__FAIL__')"
+    if [[ "$B_BACK" == "$B_IN" ]]; then
+        ok "escaped value round-trips back to the original (quote + backslash preserved)"
+    else
+        no "round-trip mismatch" "got:[$B_BACK] want:[$B_IN]"
+    fi
+else
+    echo "  (jq not installed — skipping JSON-parse assertions for (B))"
+fi
+
+# The fallback branches must actually call json_escape (not raw-interpolate).
+if grep -q 'json_escape "\$action_mode"' "$BOTSCAN"; then
+    ok "cmd_botscan.sh no-jq fallback escapes \$action_mode"
+else
+    no "cmd_botscan.sh fallback does not call json_escape on \$action_mode"
+fi
+if grep -q 'json_escape "\$trace_log"' "$DEBUG" && grep -q 'json_escape "\$log_level"' "$DEBUG"; then
+    ok "cmd_debug.sh no-jq fallback escapes \$trace_log and \$log_level"
+else
+    no "cmd_debug.sh fallback does not escape \$trace_log / \$log_level"
+fi
+
+# =============================================================================
+# (C) UX-C5 flag-parity: update --dry-run
+# =============================================================================
+echo "[C] update --dry-run flag-parity guard"
+
+# Static guard present, routed through _v144_error_with_hint, before dispatch.
+if grep -qE '\$cmd" == "--dry-run"|grep -qx -- .--dry-run' "$UPDATE"; then
+    ok "cmd_update.sh has an explicit --dry-run guard"
+else
+    no "cmd_update.sh missing the explicit --dry-run guard"
+fi
+if grep -q -- '--dry-run is not supported' "$UPDATE" \
+   && grep -q '_v144_error_with_hint' "$UPDATE"; then
+    ok "guard emits the 'not supported' message via _v144_error_with_hint"
+else
+    no "guard message / helper wiring missing"
+fi
+
+# The guard must sit BEFORE the case dispatch (so it never reaches Unknown-command).
+guard_ln=$(grep -nE 'is not supported for .nftban update' "$UPDATE" | head -1 | cut -d: -f1 || true)
+case_ln=$(grep -nE '^[[:space:]]*case "\$cmd" in' "$UPDATE" | head -1 | cut -d: -f1 || true)
+if [[ -n "$guard_ln" && -n "$case_ln" && "$guard_ln" -lt "$case_ln" ]]; then
+    ok "guard precedes the 'case \$cmd' dispatch (guard@$guard_ln < case@$case_ln)"
+else
+    no "guard not strictly before dispatch" "guard@${guard_ln:-?} case@${case_ln:-?}"
+fi
+
+# =============================================================================
+# (D) UX-INFO: validate shell-side INFO filter
+# =============================================================================
+echo "[D] validate INFO-severity shell filter"
+
+if grep -q 'select((.severity | ascii_downcase) != "info")' "$FIREWALL"; then
+    ok "cmd_firewall.sh default render drops INFO-severity findings (jq select)"
+else
+    no "cmd_firewall.sh default render does NOT filter INFO findings"
+fi
+if grep -qF -- '--verbose|-v' "$FIREWALL" && grep -q 'NFTBAN_VALIDATE_VERBOSE' "$FIREWALL"; then
+    ok "INFO filter has --verbose / NFTBAN_VALIDATE_VERBOSE opt-in"
+else
+    no "missing --verbose / NFTBAN_VALIDATE_VERBOSE opt-in"
+fi
+# verbose path must still emit ALL findings (un-filtered branch present)
+if grep -q 'verbose_mode" == "true"' "$FIREWALL"; then
+    ok "verbose branch present (shows all findings when opted in)"
+else
+    no "verbose branch missing"
+fi
+
+# Hermetic behavior check: emulate the exact render branch on a sample payload.
+if command -v jq >/dev/null 2>&1; then
+    SAMPLE='{"status":"protected","findings":[{"severity":"info","code":"VAL-X-001","message":"m1"},{"severity":"warn","code":"VAL-Y-002","message":"m2"}]}'
+    default_render="$(printf '%s' "$SAMPLE" | jq -r '.findings[] | select((.severity | ascii_downcase) != "info") | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"')"
+    verbose_render="$(printf '%s' "$SAMPLE" | jq -r '.findings[] | "  [\(.severity | ascii_upcase)] \(.code): \(.message)"')"
+    if ! grep -q 'VAL-X-001' <<<"$default_render" && grep -q 'VAL-Y-002' <<<"$default_render"; then
+        ok "default filter hides INFO (VAL-X-001) but keeps WARN (VAL-Y-002)"
+    else
+        no "default filter behavior wrong" "$default_render"
+    fi
+    if grep -q 'VAL-X-001' <<<"$verbose_render"; then
+        ok "verbose render surfaces the hidden INFO finding"
+    else
+        no "verbose render did not surface INFO" "$verbose_render"
+    fi
+else
+    echo "  (jq not installed — skipping behavioral INFO-filter assertions for (D))"
+fi
+
+# =============================================================================
+# (E) stats DERIVED residue + label casing
+# =============================================================================
+echo "[E] stats label casing + DERIVED residue"
+
+# No DERIVED badge leaks into the command surfaces named for badge removal.
+if ! grep -qi 'DERIVED' "$STATS_CMD" && ! grep -qi 'DERIVED' "$STATUS_CMD"; then
+    ok "no DERIVED badge in cmd_stats.sh / cmd_status.sh"
+else
+    no "DERIVED token present in cmd_stats.sh / cmd_status.sh (expected none)"
+fi
+
+# The cache-hit Data source value is now all-caps (casing-consistent).
+if grep -qE 'Data source[.]+" "UNIFIED CACHE"' "$STATS_FMT"; then
+    ok "cache-hit Data source value is UNIFIED CACHE (casing-consistent)"
+else
+    no "cache-hit Data source value not aligned to UNIFIED CACHE"
+fi
+
+# The legitimate cache-miss DERIVED label (logic-backed, V127 UX-3) is RETAINED.
+if grep -qE 'Data source[.]+" "DERIVED \(cache miss' "$STATS_FMT"; then
+    ok "legitimate DERIVED cache-miss data-source label retained (not spec residue)"
+else
+    no "legitimate DERIVED cache-miss label was lost"
+fi
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo
+echo "v1.167 PR-2 guard: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
PR-2 of the v1.167 UX-residual lane — CLI output-truth + flag-parity (items B/C/D/E).

**Shared v1.167 invariant:** UX residual lane · **shell/CLI only** · daemon tree unchanged `cmd/nftband 85a2de3e69eeeb526b257db0977be8c14f2e1cdb` · schema 1.83.0 untouched · FHS untouched (`generate-fhs-outputs.sh --check` rc=0) · no packaging/switchop/runtime/firewall/live-host/wiki changes.

## What changed
- **(B)** no-jq JSON fallbacks now escape via existing `json_output.sh json_escape()`: `cmd_botscan.sh:300` (`$action_mode`), `cmd_debug.sh:135` (`$trace_log`/`$log_level`). jq-primary paths unchanged.
- **(C)** `cmd_update.sh:2369` explicit `--dry-run` guard → `_v144_error_with_hint` ("package transactions cannot be safely simulated / use `nftban update check`"), rc=1.
- **(D)** shell-side INFO filter in `cmd_firewall.sh firewall_validate()` — drops `severity=info` by default + `--verbose`/`NFTBAN_VALIDATE_VERBOSE=1` opt-in. **No `internal/validator` Go touched**; `--json` unaffected.
- **(E)** casing fix `unified cache`→`UNIFIED CACHE` (`nftban_stats_format.sh:90`); the only `DERIVED` token is a logic-backed cache-miss label (pinned by v127 test) — **not** spec residue → retained.

## Decisive checks
- `cli_output_truth_v167_test.sh` **16/0**
- existing UX regressions green: error_text_3line_v153 12/0 · banner_nobanner_v153 16/0 · status_consistency_v153 15/0 · status_rc_contract_v152 7/0 · v127_ux3_stats_banlog 30/0
- **no internal/validator Go touch** confirmed · `--json` validate behavior unaffected
- daemon tree `85a2de3e…` unchanged · shellcheck/bash-n clean · check-nft-writes PASS

File-disjoint from PR-1/PR-3 → independently mergeable. No merge/tag/release-prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)