### PR TITLE
fix(cli): close v167 dry-run hint and feed-count blockers

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -678,6 +678,20 @@ jobs:
       - name: RPM %files templates dedup (FHS-generator correction) (v1.166 PR-C)
         run: bash cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
 
+      # v1.167 UX-residual lane guards (were merged un-wired; wired here as part
+      # of the v1.167 blocker fix so future regressions are caught in CI).
+      - name: Feed-counter unification (v1.167 PR-1, BUG-CtCount-feeds)
+        run: bash cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
+      - name: CLI output-truth + flag-parity (v1.167 PR-2)
+        run: bash cli/lib/nftban/tests/cli_output_truth_v167_test.sh
+      - name: No re-introduced orphan modules (v1.167 PR-3)
+        run: bash cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh
+      # v1.167 SHIP-BLOCKER guard: `nftban update --dry-run` must return rc=1 with
+      # the 3-line hint (NOT command-not-found rc=127). Also asserts the dispatcher
+      # sources cmd_common.sh so the 6 CLI-BUG-1 sibling error paths are reachable.
+      - name: update --dry-run hint rc=1 + CLI-BUG-1 reachability (v1.167)
+        run: bash cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -908,11 +908,16 @@ _status_section_protection() {
         fi
     fi
 
-    # Feeds
+    # Feeds — v1.167 BUG-CtCount-feeds: route through the shared
+    # nftban_feed_file_count() helper (enabled-aware) instead of counting every
+    # on-disk *.txt (incl. disabled/orphans). Mirrors the status :2086 surface.
     local feeds_enabled=0
-    if [[ -d "${NFTBAN_DATA_DIR}/feeds" ]]; then
+    if declare -f nftban_feed_file_count >/dev/null 2>&1; then
+        feeds_enabled=$(nftban_feed_file_count)
+    elif [[ -d "${NFTBAN_DATA_DIR}/feeds" ]]; then
         feeds_enabled=$(find "${NFTBAN_DATA_DIR}/feeds" -name "*.txt" -type f 2>/dev/null | wc -l)
     fi
+    feeds_enabled="${feeds_enabled:-0}"
     printf "  %-20s %s Active\n" "Threat Feeds........" "$feeds_enabled"
     [[ "$feeds_enabled" -eq 0 ]] && printf "      %-16s %s\n" "" "(list: nftban feeds list | enable: nftban feeds enable <FEED>)"
 

--- a/cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
+++ b/cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.167 blocker guard: `update --dry-run` rc=1 + CLI-BUG-1 reachability
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_update_dry_run_hint_v167_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-08"
+# meta:description="Regression guard for the v1.167 SHIP-BLOCKER (CLI-BUG-1): _v144_error_with_hint() is defined ONLY in lib/cmd_common.sh, but several subcommands (cmd_update, cmd_config, cmd_feeds, cmd_status, cmd_test, cmd_whitelist_system) call it on error paths WITHOUT sourcing cmd_common.sh, and the dispatcher did not source it either -> `nftban update --dry-run` (and the 6 sibling error paths) hit command-not-found rc=127 instead of the intended rc=1 + 3-line hint. Fix: the dispatcher cli/sbin/nftban sources cmd_common.sh once. This guard asserts (a) the dispatcher sources cmd_common.sh; (b) after the dispatcher load chain, _v144_error_with_hint is DEFINED (not rc=127); (c) _v144_error_with_hint itself returns rc=1 and prints ERROR/Hint/Run; (d) the cmd_update --dry-run guard site exists. Hermetic; no real update transaction."
+# meta:inventory.files="cli/sbin/nftban,cli/lib/nftban/lib/cmd_common.sh,cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+DISPATCH="$REPO_ROOT/cli/sbin/nftban"
+LIBDIR="$REPO_ROOT/cli/lib/nftban"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "v1.167 update --dry-run / CLI-BUG-1 guard:"
+
+# --- (a) the dispatcher sources cmd_common.sh ---------------------------------
+if grep -qE 'source "\$\{NFTBAN_LIB_DIR\}/lib/cmd_common\.sh"' "$DISPATCH"; then
+    ok "dispatcher cli/sbin/nftban sources lib/cmd_common.sh"
+else
+    no "dispatcher does NOT source lib/cmd_common.sh (CLI-BUG-1 would recur)"
+fi
+
+# --- (b) after the dispatcher global-load chain, the helper is DEFINED ---------
+# Reproduce the dispatcher's top-level sourcing in a subshell (env + version +
+# cmd_common), then assert _v144_error_with_hint is reachable.
+defined=$(
+  NFTBAN_LIB_DIR="$LIBDIR" bash -c '
+    set +e
+    export NFTBAN_LIB_DIR="'"$LIBDIR"'"
+    source "${NFTBAN_LIB_DIR}/lib/env.sh" 2>/dev/null
+    [[ -f "${NFTBAN_LIB_DIR}/lib/cmd_common.sh" ]] && source "${NFTBAN_LIB_DIR}/lib/cmd_common.sh" 2>/dev/null
+    declare -f _v144_error_with_hint >/dev/null 2>&1 && echo DEFINED || echo MISSING
+  '
+)
+[[ "$defined" == "DEFINED" ]] \
+    && ok "_v144_error_with_hint is DEFINED after the dispatcher load chain (no rc=127)" \
+    || no "_v144_error_with_hint MISSING after dispatcher load chain → rc=127 ship-blocker"
+
+# --- (c) _v144_error_with_hint returns rc=1 and prints ERROR/Hint/Run ----------
+rc_and_out=$(
+  NFTBAN_LIB_DIR="$LIBDIR" bash -c '
+    export NFTBAN_LIB_DIR="'"$LIBDIR"'"
+    source "${NFTBAN_LIB_DIR}/lib/cmd_common.sh" 2>/dev/null
+    # cmd_common.sh re-enables `set -Eeuo pipefail`; disable it here so the
+    # INTENDED rc=1 from _v144_error_with_hint does not abort this probe.
+    set +e
+    out=$(_v144_error_with_hint "test fault" "test hint" "nftban update check" 2>&1)
+    echo "RC=$?"
+    printf "%s\n" "$out"
+  ' || true
+)
+echo "$rc_and_out" | grep -q '^RC=1$' \
+    && ok "_v144_error_with_hint returns rc=1" \
+    || no "_v144_error_with_hint did not return rc=1" "$(echo "$rc_and_out" | grep '^RC=')"
+echo "$rc_and_out" | grep -qiE 'ERROR' && echo "$rc_and_out" | grep -qiE 'hint|run' \
+    && ok "_v144_error_with_hint prints the 3-line ERROR/Hint/Run form" \
+    || no "_v144_error_with_hint output missing ERROR/Hint/Run"
+
+# --- (d) cmd_update has the --dry-run guard calling _v144_error_with_hint ------
+if grep -qE -- '--dry-run' "$LIBDIR/cli/cmd_update.sh" && \
+   grep -A3 -- '"\$cmd" == "--dry-run"' "$LIBDIR/cli/cmd_update.sh" | grep -q '_v144_error_with_hint'; then
+    ok "cmd_update.sh has the --dry-run guard → _v144_error_with_hint"
+else
+    no "cmd_update.sh --dry-run guard missing or not wired to the hint"
+fi
+
+# --- (e) the 6 CLI-BUG-1 callsites are now reachable via the dispatcher --------
+# (they call _v144_error_with_hint; with the dispatcher sourcing cmd_common.sh
+# the function is in scope for all of them — assert each file still calls it AND
+# the dispatcher source is present, which is the runtime bridge.)
+bug1_files=(cmd_config.sh cmd_feeds.sh cmd_whitelist_system.sh cmd_update.sh cmd_status.sh cmd_test.sh)
+missing=""
+for f in "${bug1_files[@]}"; do
+    grep -q '_v144_error_with_hint' "$LIBDIR/cli/$f" || missing+="$f "
+done
+[[ -z "$missing" ]] \
+    && ok "all 6 CLI-BUG-1 callsites present and now dispatcher-reachable" \
+    || no "expected callsites not found in: $missing"
+
+echo ""
+echo "  PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
+++ b/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
@@ -107,6 +107,27 @@ GONE="$(mktemp -d)"   # no feeds/ subdir at all
     || no "absent feeds dir not zeroed"
 rm -rf "$GONE"
 
+# --- (e) BOTH cmd_status.sh feed surfaces route through the helper -----------
+# v1.167 blocker fix: Lane A originally missed the cmd_status.sh:~914 "Threat
+# Feeds … Active" surface (counted all *.txt incl. disabled/orphans). Assert
+# every bare `find … feeds … *.txt … wc -l` in cmd_status.sh is helper-guarded
+# (declare -f nftban_feed_file_count fallback), and the helper is referenced on
+# both surfaces.
+STATUS_SH="$TEST_DIR/../cli/cmd_status.sh"
+if [[ -f "$STATUS_SH" ]]; then
+    helper_refs=$(grep -c 'nftban_feed_file_count' "$STATUS_SH" || true)
+    bare_finds=$(grep -cE 'find .*feeds.*\*\.txt.*-type f.*wc -l' "$STATUS_SH" || true)
+    guards=$(grep -c 'declare -f nftban_feed_file_count' "$STATUS_SH" || true)
+    [[ "$helper_refs" -ge 2 ]] \
+        && ok "cmd_status.sh routes both feed surfaces through nftban_feed_file_count ($helper_refs refs)" \
+        || no "cmd_status.sh feed surfaces not both routed through the helper ($helper_refs)"
+    [[ "$guards" -ge "$bare_finds" ]] \
+        && ok "every bare feed find in cmd_status.sh is helper-guarded (guards=$guards >= finds=$bare_finds)" \
+        || no "unguarded bare feed find remains in cmd_status.sh (guards=$guards < finds=$bare_finds)"
+else
+    no "cmd_status.sh not found for Lane-A coverage check"
+fi
+
 echo ""
 echo "  PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -48,6 +48,23 @@ source "${NFTBAN_LIB_DIR}/lib/version.sh"
 export NFTBAN_VERSION
 
 # =============================================================================
+# LOAD COMMON CLI HELPERS (CLI-BUG-1 fix, v1.167 blocker)
+# =============================================================================
+# _v144_error_with_hint() + cmd_require_arg/cmd_validate_ip/etc. are defined ONLY
+# in lib/cmd_common.sh. Several subcommands call _v144_error_with_hint on their
+# error paths WITHOUT sourcing cmd_common.sh themselves (cmd_update, cmd_config,
+# cmd_feeds, cmd_status, cmd_test, cmd_whitelist_system) -> at runtime that was
+# `command not found` (rc=127) instead of the intended 3-line ERROR/Hint/Run
+# (rc=1). Sourcing it ONCE here makes the helper available to every dispatched
+# subcommand. Safe: this dispatcher is already `set -Eeuo pipefail`; cmd_common.sh
+# is function-only, has no source-time side effects, and is idempotent
+# (NFTBAN_CMD_COMMON_LOADED guard), so a subcommand that also sources it no-ops.
+# shellcheck source=/dev/null
+if [[ -f "${NFTBAN_LIB_DIR}/lib/cmd_common.sh" ]]; then
+    source "${NFTBAN_LIB_DIR}/lib/cmd_common.sh"
+fi
+
+# =============================================================================
 # PERMISSION CHECK
 # =============================================================================
 


### PR DESCRIPTION
v1.167 **blocker fix** — found by the V158→V168 closed-bugs cross-check audit, after release-prep merge but **before tag/publish**.

## Scope (shell/CLI only)
- v1.167 blocker fix after release-prep merge, **before tag/publish** — **no version bump** because v1.167.0 is not tagged or published
- fix `_v144_error_with_hint` runtime availability by sourcing `cmd_common.sh` once from the CLI dispatcher (`cli/sbin/nftban`)
- fix `nftban update --dry-run` **rc=127 regression → intended rc=1 + 3-line hint**
- close the **six sibling CLI-BUG-1** helper-reachability paths (config/feeds/whitelist_system/update/status/test) in one move
- route the remaining `cmd_status.sh` feed-count site (`:914` "Threat Feeds … Active") through `nftban_feed_file_count` (Lane-A remainder)
- wire **all four** v167 tests into `ci-architecture.yml`

## Why safe
The dispatcher is already `set -Eeuo pipefail`; `cmd_common.sh` is function-only, idempotent (`NFTBAN_CMD_COMMON_LOADED` guard), and has no source-time side effects — so the single global source is conflict-free and a subcommand that also sources it no-ops.

## Validation
- `cli_update_dry_run_hint_v167_test.sh` 6/0 (rc=1 + hint, helper reachable, 6 CLI-BUG-1 sites present)
- `feed_counters_unify_v167_test.sh` 6/0 — **both** `cmd_status` feed surfaces covered (7 helper refs, 2/2 bare finds guarded)
- `cli_output_truth_v167_test.sh` 16/0
- `no_reintroduced_orphan_modules_v167_test.sh` 11/0
- shellcheck clean · `bash -n` clean · `check-nft-writes` PASS · `generate-fhs-outputs.sh --check` rc=0
- daemon tree unchanged: `cmd/nftband 85a2de3e69eeeb526b257db0977be8c14f2e1cdb`
- schema 1.83.0 untouched · FHS untouched · wiki untouched

## Out of scope
daemon-Go · schema · FHS/generator · packaging · runtime/firewall · wiki (`WIKI_ALIGN_V166` separate) · CLI-BUG-2 whitelist `timeout` flag (separate, schema-freeze review)

No merge / no tag / no publish. v1.167 tag stays NO-GO until this is merged + main green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)