### PR TITLE
v1.168.0: CLI-BUG-2 — preserve whitelist TTLs across daemon sync

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -692,6 +692,16 @@ jobs:
       - name: update --dry-run hint rc=1 + CLI-BUG-1 reachability (v1.167)
         run: bash cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
 
+      # v1.168 CLI-BUG-2 whitelist-TTL lane guards: the 4 whitelist set decls
+      # must carry interval,timeout (render prereq) AND the DEB/RPM upgrade path
+      # must re-activate timeout-capable sets (GetOrCreateIntervalSet reuses
+      # existing flagless sets). The TTL-survives-FullSync invariant is a Go test
+      # (internal/setsync) run by ci-go.yml.
+      - name: Whitelist sets carry timeout flag (v1.168 render prereq)
+        run: bash cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
+      - name: Whitelist-TTL upgrade activation backstop (v1.168 deb+rpm)
+        run: bash cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
+++ b/cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.168 CLI-BUG-2: whitelist sets carry the 'timeout' flag (render)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="whitelist_set_timeout_flag_v168_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-09"
+# meta:description="Locks the v1.168 CLI-BUG-2 render prerequisite: the four whitelist set declarations — whitelist_ipv4 + whitelist_ipv6 in BOTH the static boot-baseline install/nftables/nftables.conf AND the rebuild template install/nftables/nftables.conf.tpl — must declare 'flags interval, timeout' (not 'flags interval' alone). Without the timeout flag the kernel set cannot hold a per-element timeout, so 'whitelist add --ttl' entries can never expire in-kernel. The blacklist sets already carry interval+timeout; this aligns whitelist. Necessary-but-not-sufficient on its own: the daemon-Go timeout sync (loader ExpiresAt -> GetWhitelistSnapshotWithExpiry -> FullSync AddIPWithTimeout) is the runtime authority; see the Go guard TestRemainingTimeout_TTLSurvivesFullSync. If the 'nft' binary is available the rendered static file is also syntax-checked (nft -c)."
+# meta:input="None (reads repo source files read-only)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,awk,nft(optional)"
+# meta:inventory.files="install/nftables/nftables.conf,install/nftables/nftables.conf.tpl"
+# meta:inventory.binaries="bash,grep,awk,nft"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+CONF="$REPO_ROOT/install/nftables/nftables.conf"
+TPL="$REPO_ROOT/install/nftables/nftables.conf.tpl"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# assert_set_has_timeout <file> <setname>
+# Within the named set block, the 'flags' line must include 'timeout'.
+assert_set_has_timeout(){
+  local file="$1" set="$2"
+  local flags
+  flags=$(awk -v want="$set" '
+    $0 ~ "set " want " \\{" { inblock=1; next }
+    inblock && /^[[:space:]]*flags/ { print; inblock=0 }
+    inblock && /^[[:space:]]*\}/ { inblock=0 }
+  ' "$file")
+  if [[ -z "$flags" ]]; then
+    no "$(basename "$file"): $set has no flags line"
+  elif grep -qE '\btimeout\b' <<< "$flags"; then
+    ok "$(basename "$file"): $set flags carry timeout (${flags//[[:space:]]/ })"
+  else
+    no "$(basename "$file"): $set flags MISSING timeout" "${flags//[[:space:]]/ }"
+  fi
+}
+
+for f in "$CONF" "$TPL"; do
+  [[ -f "$f" ]] || { echo "file not found: $f"; exit 1; }
+done
+
+echo "=== whitelist sets declare 'timeout' flag (static + template) ==="
+assert_set_has_timeout "$CONF" "whitelist_ipv4"
+assert_set_has_timeout "$CONF" "whitelist_ipv6"
+assert_set_has_timeout "$TPL"  "whitelist_ipv4"
+assert_set_has_timeout "$TPL"  "whitelist_ipv6"
+
+echo "=== regression: no whitelist set left as bare 'flags interval' ==="
+# A whitelist flags line of exactly 'flags interval' (no timeout) is the bug.
+if awk '
+  /set whitelist_ipv[46] \{/ { inblock=1; next }
+  inblock && /^[[:space:]]*flags[[:space:]]+interval[[:space:]]*$/ { found=1 }
+  inblock && /^[[:space:]]*\}/ { inblock=0 }
+  END { exit(found?0:1) }
+' "$CONF" "$TPL"; then
+  no "a whitelist set still declares bare 'flags interval' (no timeout)"
+else
+  ok "no whitelist set declares bare 'flags interval'"
+fi
+
+echo "=== (optional) nft -c syntax check of static boot-baseline ==="
+# nft -c -f on a full ruleset still initializes the netlink cache, which needs
+# root/CAP_NET_ADMIN. Only attempt it as root (CI/lab); otherwise skip — the
+# hermetic grep assertions above are the hard gate, this is best-effort.
+if ! command -v nft >/dev/null 2>&1; then
+  echo "  • nft not installed — skipping syntax check (hermetic grep checks still ran)"
+elif [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "  • not root — skipping nft -c (needs CAP_NET_ADMIN; runs in CI/lab as root)"
+elif nft -c -f "$CONF" >/dev/null 2>&1; then
+  ok "nft -c accepts $CONF"
+else
+  no "nft -c rejected $CONF" "$(nft -c -f "$CONF" 2>&1 | head -1)"
+fi
+
+echo "================================================================"
+echo "whitelist_set_timeout_flag_v168_test: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
+++ b/cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.168 CLI-BUG-2: upgrade-path activates timeout-capable whitelist sets
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="whitelist_timeout_upgrade_activation_v168_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-09"
+# meta:description="Locks the v1.168 CLI-BUG-2 upgrade-activation backstop. A pre-v1.168 live whitelist set is created with bare 'flags interval'; GetOrCreateIntervalSet reuses an existing set without upgrading flags, so a daemon/package swap alone leaves the fix inert until a full firewall rebuild recreates the set as 'flags interval, timeout'. Asserts BOTH packaging scriptlets — the DEB postinst (packaging/deb/postinst) and the RPM %post heredoc (packaging/build_nftban.sh) — carry a v1.168 upgrade-gated block that: (a) is gated on INSTALL_MODE=upgrade and INSTALLER_EXIT<=1 (skips authority-abort/hard-fail); (b) detects a live whitelist_ipv4 set still showing bare 'flags interval' (no timeout); (c) recreates it via an explicit 'nftban firewall rebuild' (which carries its own SSH pre-rebuild lockout guard); (d) is NON-FATAL (warn + continue on failure). Hermetic: reads the two packaging source files read-only; no nft, no dpkg/rpm, no host, no root. The live kernel-level proof that the flag activates after a real package upgrade is the lab/real-host acceptance gate."
+# meta:input="None (reads repo packaging files read-only)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="packaging/deb/postinst,packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+DEB="$REPO_ROOT/packaging/deb/postinst"
+RPM="$REPO_ROOT/packaging/build_nftban.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+for f in "$DEB" "$RPM"; do
+  [[ -f "$f" ]] || { echo "file not found: $f"; exit 1; }
+done
+
+# assert_block <label> <file> : the v1.168 activation block exists with the
+# four required properties. Extract the lines from the v1.168 marker to the
+# next 'firewall rebuild' invocation and assert each property within.
+assert_block(){
+  local label="$1" file="$2"
+  if ! grep -q "v1.168 CLI-BUG-2: activate timeout-capable whitelist sets" "$file"; then
+    no "$label: v1.168 activation block marker missing"; return
+  fi
+  ok "$label: v1.168 activation block present"
+
+  # (a) upgrade-gated + installer committed/degraded (INSTALLER_EXIT <= 1)
+  if grep -qE 'INSTALL_MODE.?[ =]+.?upgrade' "$file" && grep -qE 'INSTALLER_EXIT.{0,12}-le 1' "$file"; then
+    ok "$label: gated on upgrade + INSTALLER_EXIT<=1"
+  else
+    no "$label: missing upgrade / INSTALLER_EXIT<=1 gate"
+  fi
+
+  # (b) detects bare 'flags interval' (no timeout) on the live whitelist set
+  if grep -qE 'whitelist_ipv4' "$file" && grep -qE "flags\[\[:space:\]\]\+interval\[\[:space:\]\]\*" "$file"; then
+    ok "$label: detects bare 'flags interval' live set"
+  else
+    no "$label: missing bare-'flags interval' detection"
+  fi
+
+  # (c) recreates via explicit full 'nftban firewall rebuild' (carries SSH guard)
+  if grep -qE 'nftban firewall rebuild' "$file"; then
+    ok "$label: recreates via 'nftban firewall rebuild'"
+  else
+    no "$label: missing 'nftban firewall rebuild' activation"
+  fi
+
+  # (d) non-fatal: a warn path on failure (deb uses log_warn, rpm uses echo WARN)
+  if awk '/v1.168 CLI-BUG-2: activate/{b=1} b&&/rebuild did not complete/{print; exit}' "$file" | grep -q .; then
+    ok "$label: non-fatal (warns + continues on rebuild failure)"
+  else
+    no "$label: missing non-fatal WARN-on-failure path"
+  fi
+}
+
+echo "=== DEB postinst v1.168 upgrade-activation backstop ==="
+assert_block "deb" "$DEB"
+echo "=== RPM %post v1.168 upgrade-activation backstop ==="
+assert_block "rpm" "$RPM"
+
+echo "================================================================"
+echo "whitelist_timeout_upgrade_activation_v168_test: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -181,8 +181,11 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 		}
 	}
 
-	// Get snapshots from runtime state
-	whitelistIPv4, whitelistIPv6 := state.GetWhitelistSnapshot()
+	// Get snapshots from runtime state.
+	// v1.168 (CLI-BUG-2): the whitelist snapshot carries per-IP absolute
+	// expiry so FullSync can apply kernel timeouts to timed entries instead
+	// of repopulating them as permanent.
+	whitelistIPv4, whitelistIPv6, whitelistExpiry := state.GetWhitelistSnapshotWithExpiry()
 	blacklistIPv4, blacklistIPv6 := state.GetBlacklistSnapshot()
 
 	// Perform full sync
@@ -192,6 +195,7 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 		blacklistIPv4Set, blacklistIPv6Set,
 		whitelistIPv4, whitelistIPv6,
 		blacklistIPv4, blacklistIPv6,
+		whitelistExpiry,
 	)
 
 	if err != nil {

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -100,7 +100,7 @@ table ip nftban {
     #   nftban whitelist add 10.0.0.0/8
     set whitelist_ipv4 {
         type ipv4_addr
-        flags interval
+        flags interval, timeout
         auto-merge
         comment "Trusted IPs and networks"
         elements = {
@@ -480,7 +480,7 @@ table ip6 nftban {
 
     set whitelist_ipv6 {
         type ipv6_addr
-        flags interval
+        flags interval, timeout
         auto-merge
         comment "Trusted IPv6 addresses and networks"
         elements = { ::1 }

--- a/install/nftables/nftables.conf.tpl
+++ b/install/nftables/nftables.conf.tpl
@@ -100,7 +100,7 @@ table ip nftban {
     #   nftban whitelist add 10.0.0.0/8
     set whitelist_ipv4 {
         type ipv4_addr
-        flags interval
+        flags interval, timeout
         auto-merge
         comment "Trusted IPs and networks"
         elements = {
@@ -479,7 +479,7 @@ table ip6 nftban {
 
     set whitelist_ipv6 {
         type ipv6_addr
-        flags interval
+        flags interval, timeout
         auto-merge
         comment "Trusted IPv6 addresses and networks"
         elements = { ::1 }

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -128,8 +128,12 @@ func (rs *RuntimeState) LoadWhitelists() error {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
-	// Load from all whitelist sources
-	ipv4Set, ipv6Set, err := whitelist.LoadAllWhitelists(rs.ConfigDir)
+	// Load from all whitelist sources.
+	// v1.168 (CLI-BUG-2): use the typed loader so per-entry EXPIRES_AT is
+	// carried into runtime state (IPEntry.ExpireAt). The daemon sync then
+	// applies a kernel timeout to timed entries instead of treating every
+	// whitelist element as permanent.
+	ipv4Set, ipv6Set, err := whitelist.LoadAllWhitelistsTyped(rs.ConfigDir)
 	if err != nil {
 		return fmt.Errorf("failed to load whitelists: %w", err)
 	}
@@ -139,21 +143,31 @@ func (rs *RuntimeState) LoadWhitelists() error {
 	rs.WhitelistIPv6 = make(map[string]*IPEntry)
 
 	// Populate IPv4 whitelist
-	for ip := range ipv4Set {
-		rs.WhitelistIPv4[ip] = &IPEntry{
+	for ip, we := range ipv4Set {
+		entry := &IPEntry{
 			IP:      ip,
 			Source:  "whitelist",
 			AddedAt: time.Now(),
 		}
+		if !we.ExpiresAt.IsZero() {
+			exp := we.ExpiresAt
+			entry.ExpireAt = &exp
+		}
+		rs.WhitelistIPv4[ip] = entry
 	}
 
 	// Populate IPv6 whitelist
-	for ip := range ipv6Set {
-		rs.WhitelistIPv6[ip] = &IPEntry{
+	for ip, we := range ipv6Set {
+		entry := &IPEntry{
 			IP:      ip,
 			Source:  "whitelist",
 			AddedAt: time.Now(),
 		}
+		if !we.ExpiresAt.IsZero() {
+			exp := we.ExpiresAt
+			entry.ExpireAt = &exp
+		}
+		rs.WhitelistIPv6[ip] = entry
 	}
 
 	// Update counters
@@ -387,6 +401,38 @@ func (rs *RuntimeState) GetWhitelistSnapshot() ([]string, []string) {
 	}
 
 	return ipv4List, ipv6List
+}
+
+// GetWhitelistSnapshotWithExpiry returns the current whitelist IPs plus a
+// map of ip → absolute expiry for entries that carry an EXPIRES_AT marker.
+// Entries without an expiry are absent from the map (permanent/durable/trust).
+//
+// v1.168 (CLI-BUG-2): the daemon sync uses the expiry map to apply a kernel
+// timeout (remaining = expiry − now) to timed whitelist elements, so a
+// "temporary" whitelist actually expires in-kernel instead of becoming
+// permanent on the next FullSync/rebuild.
+func (rs *RuntimeState) GetWhitelistSnapshotWithExpiry() ([]string, []string, map[string]time.Time) {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+
+	ipv4List := make([]string, 0, len(rs.WhitelistIPv4))
+	ipv6List := make([]string, 0, len(rs.WhitelistIPv6))
+	expiry := make(map[string]time.Time)
+
+	for ip, e := range rs.WhitelistIPv4 {
+		ipv4List = append(ipv4List, ip)
+		if e.ExpireAt != nil {
+			expiry[ip] = *e.ExpireAt
+		}
+	}
+	for ip, e := range rs.WhitelistIPv6 {
+		ipv6List = append(ipv6List, ip)
+		if e.ExpireAt != nil {
+			expiry[ip] = *e.ExpireAt
+		}
+	}
+
+	return ipv4List, ipv6List, expiry
 }
 
 // GetBlacklistSnapshot returns a copy of current blacklist

--- a/internal/runtime/state_whitelist_expiry_v168_test.go
+++ b/internal/runtime/state_whitelist_expiry_v168_test.go
@@ -1,0 +1,101 @@
+// =============================================================================
+// NFTBan v1.168 - CLI-BUG-2 whitelist TTL: runtime ExpireAt + expiry snapshot
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="state_whitelist_expiry_v168_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-09"
+// meta:description="v1.168 CLI-BUG-2: LoadWhitelists must populate IPEntry.ExpireAt from a future EXPIRES_AT marker (zero for permanent), and GetWhitelistSnapshotWithExpiry must surface ip->absolute expiry only for timed entries so the daemon FullSync can apply kernel timeouts."
+// meta:input="None"
+// meta:output="t.Fatal on runtime expiry-carry drift"
+// meta:depends="testing,time,os,path/filepath"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeWL(t *testing.T, dir, name, content string) {
+	t.Helper()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0o755); err != nil {
+		t.Fatalf("mkdir whitelist.d: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wlDir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// TestLoadWhitelists_PopulatesExpireAt asserts a future session entry lands in
+// runtime state with a non-nil ExpireAt, while a plain manual entry has a nil
+// ExpireAt (permanent).
+func TestLoadWhitelists_PopulatesExpireAt(t *testing.T) {
+	dir := t.TempDir()
+	writeWL(t, dir, "00-session.conf", "10.0.0.1  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=keep  ADDED_BY=test\n")
+	writeWL(t, dir, "99-manual.conf", "10.0.0.4\n")
+
+	rs := NewRuntimeState(dir)
+	if err := rs.LoadWhitelists(); err != nil {
+		t.Fatalf("LoadWhitelists: %v", err)
+	}
+
+	timed, ok := rs.WhitelistIPv4["10.0.0.1"]
+	if !ok {
+		t.Fatalf("timed entry 10.0.0.1 not loaded: %v", rs.WhitelistIPv4)
+	}
+	if timed.ExpireAt == nil {
+		t.Fatalf("timed entry 10.0.0.1: ExpireAt nil, want future timestamp")
+	}
+	want, _ := time.Parse(time.RFC3339, "2100-01-01T00:00:00Z")
+	if !timed.ExpireAt.Equal(want) {
+		t.Fatalf("timed entry 10.0.0.1: ExpireAt=%v, want %v", *timed.ExpireAt, want)
+	}
+
+	perm, ok := rs.WhitelistIPv4["10.0.0.4"]
+	if !ok {
+		t.Fatalf("permanent entry 10.0.0.4 not loaded: %v", rs.WhitelistIPv4)
+	}
+	if perm.ExpireAt != nil {
+		t.Fatalf("permanent entry 10.0.0.4: ExpireAt=%v, want nil", *perm.ExpireAt)
+	}
+}
+
+// TestGetWhitelistSnapshotWithExpiry asserts the snapshot lists all whitelist
+// IPs and surfaces an expiry only for timed entries (permanent entries absent
+// from the map → added permanent by the sync).
+func TestGetWhitelistSnapshotWithExpiry(t *testing.T) {
+	dir := t.TempDir()
+	writeWL(t, dir, "00-session.conf", "10.0.0.1  # EXPIRES_AT=2100-01-01T00:00:00Z\n")
+	writeWL(t, dir, "99-manual.conf", "10.0.0.4\n")
+
+	rs := NewRuntimeState(dir)
+	if err := rs.LoadWhitelists(); err != nil {
+		t.Fatalf("LoadWhitelists: %v", err)
+	}
+
+	ipv4, _, expiry := rs.GetWhitelistSnapshotWithExpiry()
+
+	if len(ipv4) != 2 {
+		t.Fatalf("snapshot ipv4 count=%d, want 2 (%v)", len(ipv4), ipv4)
+	}
+	if _, ok := expiry["10.0.0.1"]; !ok {
+		t.Fatalf("expiry map missing timed entry 10.0.0.1: %v", expiry)
+	}
+	if _, ok := expiry["10.0.0.4"]; ok {
+		t.Fatalf("expiry map should NOT contain permanent entry 10.0.0.4: %v", expiry)
+	}
+}

--- a/internal/setsync/diff.go
+++ b/internal/setsync/diff.go
@@ -47,6 +47,98 @@ func ComputeDiff(desiredIPs []string, currentIPs []string) *DiffResult {
 	return &diff
 }
 
+// remainingTimeout computes the kernel timeout to apply to a whitelist element
+// given its absolute expiry. It returns (0, false) for permanent entries — no
+// expiry recorded (durable/trust) — and (expiry−now, true) for timed entries.
+//
+// The duration is anchored to the ABSOLUTE expiry instant and recomputed on
+// every sync, so a re-sync/rebuild REFRESHES the remaining TTL instead of
+// clobbering the element to permanent. This is the CLI-BUG-2 (v1.168) core
+// invariant: a timed whitelist must keep a (shrinking) kernel timeout across
+// FullSync, never silently become permanent. A non-positive result means the
+// entry is already past — the caller skips it (the loader normally drops past
+// entries first; this is defense-in-depth against the load→sync race window).
+func remainingTimeout(expiry map[string]time.Time, ip string, now time.Time) (time.Duration, bool) {
+	if expiry == nil {
+		return 0, false
+	}
+	exp, ok := expiry[ip]
+	if !ok || exp.IsZero() {
+		return 0, false // permanent
+	}
+	return exp.Sub(now), true // timed (may be <= 0 if already past)
+}
+
+// SyncWhitelistSetToNFT performs a differential sync of a whitelist set,
+// applying a per-element kernel timeout to entries that carry an absolute
+// expiry (CLI-BUG-2, v1.168). Permanent entries (no expiry) are added in a
+// single batch exactly as before; timed entries are added individually with
+// AddIPWithTimeout(remaining). Removals are unchanged.
+//
+// Only newly-added elements (diff.ToAdd) receive a timeout. Elements already
+// present in the kernel are left untouched so their existing countdown
+// continues toward the absolute expiry; when the set is flushed/rebuilt they
+// re-enter ToAdd and the remaining TTL is recomputed. Either way a timed
+// entry never reverts to permanent.
+func SyncWhitelistSetToNFT(nft *NFTManager, set *nftables.Set, desiredIPs []string, expiry map[string]time.Time) (*SyncStats, error) {
+	startTime := time.Now()
+
+	stats := &SyncStats{
+		SetName:      set.Name,
+		TotalDesired: len(desiredIPs),
+	}
+
+	currentIPs, err := nft.GetSetElements(set)
+	if err != nil {
+		stats.Error = fmt.Errorf("failed to get current elements: %w", err)
+		stats.Duration = time.Since(startTime)
+		return stats, stats.Error
+	}
+	stats.TotalCurrent = len(currentIPs)
+
+	diff := ComputeDiff(desiredIPs, currentIPs)
+	stats.IPsAdded = len(diff.ToAdd)
+	stats.IPsRemoved = len(diff.ToRemove)
+	stats.IPsUnchanged = diff.Unchanged
+
+	now := time.Now().UTC()
+	permanent := make([]string, 0, len(diff.ToAdd))
+	for _, ip := range diff.ToAdd {
+		d, timed := remainingTimeout(expiry, ip, now)
+		if !timed {
+			permanent = append(permanent, ip)
+			continue
+		}
+		if d <= 0 {
+			// Expired in the load→sync window — skip; the loader will drop
+			// it on the next reload.
+			continue
+		}
+		if err := nft.AddIPWithTimeout(set, ip, d); err != nil {
+			stats.Error = fmt.Errorf("failed to add timed element %s: %w", ip, err)
+			stats.Duration = time.Since(startTime)
+			return stats, stats.Error
+		}
+	}
+	if len(permanent) > 0 {
+		if err := nft.AddSetElements(set, permanent); err != nil {
+			stats.Error = fmt.Errorf("failed to add permanent elements: %w", err)
+			stats.Duration = time.Since(startTime)
+			return stats, stats.Error
+		}
+	}
+	if len(diff.ToRemove) > 0 {
+		if err := nft.DeleteSetElements(set, diff.ToRemove); err != nil {
+			stats.Error = fmt.Errorf("failed to remove elements: %w", err)
+			stats.Duration = time.Since(startTime)
+			return stats, stats.Error
+		}
+	}
+
+	stats.Duration = time.Since(startTime)
+	return stats, nil
+}
+
 // SyncStats holds statistics about a sync operation
 type SyncStats struct {
 	SetName       string
@@ -107,20 +199,25 @@ type SyncResult struct {
 	Success       bool
 }
 
-// FullSync performs a complete sync of all whitelist/blacklist sets
+// FullSync performs a complete sync of all whitelist/blacklist sets.
+//
+// whitelistExpiry maps ip → absolute expiry for timed whitelist entries
+// (CLI-BUG-2, v1.168); pass nil/empty to treat every whitelist element as
+// permanent (the pre-v1.168 behavior). Blacklist sync is unchanged.
 func FullSync(
 	nft *NFTManager,
 	whitelistIPv4Set, whitelistIPv6Set *nftables.Set,
 	blacklistIPv4Set, blacklistIPv6Set *nftables.Set,
 	whitelistIPv4, whitelistIPv6 []string,
 	blacklistIPv4, blacklistIPv6 []string,
+	whitelistExpiry map[string]time.Time,
 ) (*SyncResult, error) {
 	startTime := time.Now()
 	result := &SyncResult{Success: true}
 
-	// Sync whitelist IPv4
+	// Sync whitelist IPv4 (timeout-aware: timed entries get a kernel timeout)
 	if whitelistIPv4Set != nil {
-		stats, err := SyncSetToNFT(nft, whitelistIPv4Set, whitelistIPv4)
+		stats, err := SyncWhitelistSetToNFT(nft, whitelistIPv4Set, whitelistIPv4, whitelistExpiry)
 		result.WhitelistIPv4 = stats
 		if err != nil {
 			result.Success = false
@@ -128,9 +225,9 @@ func FullSync(
 		}
 	}
 
-	// Sync whitelist IPv6
+	// Sync whitelist IPv6 (timeout-aware)
 	if whitelistIPv6Set != nil {
-		stats, err := SyncSetToNFT(nft, whitelistIPv6Set, whitelistIPv6)
+		stats, err := SyncWhitelistSetToNFT(nft, whitelistIPv6Set, whitelistIPv6, whitelistExpiry)
 		result.WhitelistIPv6 = stats
 		if err != nil {
 			result.Success = false

--- a/internal/setsync/whitelist_timeout_v168_test.go
+++ b/internal/setsync/whitelist_timeout_v168_test.go
@@ -1,0 +1,128 @@
+// =============================================================================
+// NFTBan v1.168 - CLI-BUG-2 whitelist TTL: remainingTimeout invariant guard
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="whitelist_timeout_v168_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-09"
+// meta:description="v1.168 CLI-BUG-2 PRIMARY release-blocking acceptance (logic level): a timed whitelist entry's kernel timeout is anchored to its absolute expiry and is RECOMPUTED (refreshed, shrinking) on every sync — it must SURVIVE a FullSync re-run and never be clobbered to permanent; permanent (durable/trust) entries must stay permanent. Kernel-level end-to-end proof is the lab/real-host rebuild-survival gate."
+// meta:input="None"
+// meta:output="t.Fatal on TTL-survival invariant break"
+// meta:depends="testing,time"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package setsync
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRemainingTimeout_PermanentWhenNoExpiry asserts durable/trust entries
+// (no expiry recorded) resolve to permanent — timed=false, so the sync adds
+// them via the plain batch path with no kernel timeout.
+func TestRemainingTimeout_PermanentWhenNoExpiry(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	// nil map → permanent
+	if d, timed := remainingTimeout(nil, "1.2.3.4", now); timed || d != 0 {
+		t.Fatalf("nil expiry: got (%v, %v), want (0, false)", d, timed)
+	}
+	// ip absent from map → permanent
+	expiry := map[string]time.Time{"9.9.9.9": now.Add(time.Hour)}
+	if d, timed := remainingTimeout(expiry, "1.2.3.4", now); timed || d != 0 {
+		t.Fatalf("absent ip: got (%v, %v), want (0, false)", d, timed)
+	}
+	// zero-time value → permanent (defensive: should not be inserted, but guard it)
+	expiry["1.2.3.4"] = time.Time{}
+	if d, timed := remainingTimeout(expiry, "1.2.3.4", now); timed || d != 0 {
+		t.Fatalf("zero expiry: got (%v, %v), want (0, false)", d, timed)
+	}
+}
+
+// TestRemainingTimeout_TimedFuture asserts a future expiry yields a positive
+// remaining duration and timed=true (the element gets a kernel timeout).
+func TestRemainingTimeout_TimedFuture(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(2 * time.Hour)
+	expiry := map[string]time.Time{"1.2.3.4": exp}
+
+	d, timed := remainingTimeout(expiry, "1.2.3.4", now)
+	if !timed {
+		t.Fatalf("future expiry: timed=false, want true")
+	}
+	if d != 2*time.Hour {
+		t.Fatalf("future expiry: remaining=%v, want 2h", d)
+	}
+}
+
+// TestRemainingTimeout_TTLSurvivesFullSync is the PRIMARY release-blocking
+// invariant for CLI-BUG-2 (v1.168): the kernel timeout is anchored to the
+// ABSOLUTE expiry instant, so re-running the sync at a later wall-clock time
+// RECOMPUTES a smaller-but-still-positive remaining TTL. The entry must stay
+// timed across every sync — it must NEVER resolve to permanent (the bug) and
+// the remaining must shrink toward zero (refresh, not clobber).
+func TestRemainingTimeout_TTLSurvivesFullSync(t *testing.T) {
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	exp := base.Add(time.Hour) // absolute expiry, fixed in the durable conf
+	expiry := map[string]time.Time{"1.2.3.4": exp}
+
+	// Sync #1 (fresh add): full hour remaining.
+	d1, timed1 := remainingTimeout(expiry, "1.2.3.4", base)
+	if !timed1 {
+		t.Fatalf("sync#1: timed=false — entry would be added PERMANENT (CLI-BUG-2 regression)")
+	}
+	if d1 != time.Hour {
+		t.Fatalf("sync#1: remaining=%v, want 1h", d1)
+	}
+
+	// Sync #2, 20 min later (e.g. a firewall reload/rebuild re-adds the element).
+	now2 := base.Add(20 * time.Minute)
+	d2, timed2 := remainingTimeout(expiry, "1.2.3.4", now2)
+	if !timed2 {
+		t.Fatalf("sync#2: timed=false — TTL did NOT survive FullSync (clobbered to permanent)")
+	}
+	if d2 <= 0 {
+		t.Fatalf("sync#2: remaining=%v, want > 0 (still active)", d2)
+	}
+	if d2 != 40*time.Minute {
+		t.Fatalf("sync#2: remaining=%v, want 40m (refreshed from absolute expiry)", d2)
+	}
+	if d2 >= d1 {
+		t.Fatalf("sync#2: remaining did not shrink (%v >= %v) — not anchored to absolute expiry", d2, d1)
+	}
+
+	// Sync #3, 59 min in: still a sliver of TTL, still timed (never permanent).
+	now3 := base.Add(59 * time.Minute)
+	d3, timed3 := remainingTimeout(expiry, "1.2.3.4", now3)
+	if !timed3 || d3 != time.Minute {
+		t.Fatalf("sync#3: got (%v, %v), want (1m, true)", d3, timed3)
+	}
+}
+
+// TestRemainingTimeout_PastIsTimedNonPositive asserts an entry whose expiry has
+// already passed (the load→sync race window) returns timed=true with a
+// non-positive duration — the sync caller skips it rather than re-adding it
+// permanent. It must NOT be misclassified as permanent.
+func TestRemainingTimeout_PastIsTimedNonPositive(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(-time.Minute) // already past
+	expiry := map[string]time.Time{"1.2.3.4": exp}
+
+	d, timed := remainingTimeout(expiry, "1.2.3.4", now)
+	if !timed {
+		t.Fatalf("past expiry: timed=false — would be re-added PERMANENT, want timed=true skip-path")
+	}
+	if d > 0 {
+		t.Fatalf("past expiry: remaining=%v, want <= 0", d)
+	}
+}

--- a/internal/whitelist/expiresat_carry_v168_test.go
+++ b/internal/whitelist/expiresat_carry_v168_test.go
@@ -1,0 +1,115 @@
+// =============================================================================
+// NFTBan v1.168 - CLI-BUG-2 whitelist TTL: EXPIRES_AT carry into typed loader
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="expiresat_carry_v168_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-09"
+// meta:description="v1.168 CLI-BUG-2: the typed loader must CARRY the absolute EXPIRES_AT timestamp on WhitelistEntry.ExpiresAt for future markers (not skip-only), leave it zero for non-expiring entries, and still skip past/malformed markers. parseExpiresAt is the shared contract; shouldSkipDueToExpiresAt stays a compatible boolean wrapper."
+// meta:input="None"
+// meta:output="t.Fatal on EXPIRES_AT carry drift"
+// meta:depends="testing,time"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package whitelist
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseExpiresAt_FutureCarriesTimestamp asserts a still-future marker
+// returns the parsed absolute timestamp and skip=false (so the daemon can
+// apply a kernel timeout anchored to it).
+func TestParseExpiresAt_FutureCarriesTimestamp(t *testing.T) {
+	line := `10.0.0.1  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=test  ADDED_BY=test`
+	ts, skip := parseExpiresAt(line)
+	if skip {
+		t.Fatalf("future marker: skip=true, want false")
+	}
+	want, _ := time.Parse(time.RFC3339, "2100-01-01T00:00:00Z")
+	if !ts.Equal(want) {
+		t.Fatalf("future marker: ts=%v, want %v", ts, want)
+	}
+}
+
+// TestParseExpiresAt_NoMarkerZeroNoSkip asserts a line with no marker is a
+// permanent (durable/trust) entry: zero timestamp, skip=false.
+func TestParseExpiresAt_NoMarkerZeroNoSkip(t *testing.T) {
+	ts, skip := parseExpiresAt(`10.0.0.4`)
+	if skip {
+		t.Fatalf("no marker: skip=true, want false")
+	}
+	if !ts.IsZero() {
+		t.Fatalf("no marker: ts=%v, want zero", ts)
+	}
+}
+
+// TestParseExpiresAt_PastAndMalformedSkip asserts past and malformed markers
+// are still dropped (skip=true) with a zero timestamp — and that the legacy
+// boolean wrapper shouldSkipDueToExpiresAt agrees.
+func TestParseExpiresAt_PastAndMalformedSkip(t *testing.T) {
+	cases := []string{
+		`10.0.0.6  # EXPIRES_AT=2000-01-01T00:00:00Z`,
+		`10.0.0.3  # EXPIRES_AT=not-a-timestamp`,
+		`10.0.0.9  # EXPIRES_AT=`,
+	}
+	for _, line := range cases {
+		ts, skip := parseExpiresAt(line)
+		if !skip {
+			t.Fatalf("line %q: skip=false, want true", line)
+		}
+		if !ts.IsZero() {
+			t.Fatalf("line %q: ts=%v, want zero on skip", line, ts)
+		}
+		if !shouldSkipDueToExpiresAt(line) {
+			t.Fatalf("line %q: wrapper shouldSkipDueToExpiresAt disagrees (got false)", line)
+		}
+	}
+}
+
+// TestLoadAllWhitelistsTyped_CarriesExpiresAt asserts the typed loader sets
+// WhitelistEntry.ExpiresAt for a future session entry and leaves it zero for a
+// non-expiring manual entry — the load-bearing change behind the daemon
+// timeout sync (CLI-BUG-2).
+func TestLoadAllWhitelistsTyped_CarriesExpiresAt(t *testing.T) {
+	dir := setupTestConfig(t)
+	writeWhitelistFile(t, dir, "00-session.conf", `10.0.0.1  # EXPIRES_AT=2100-01-01T00:00:00Z  REASON=keep  ADDED_BY=test
+`)
+	writeWhitelistFile(t, dir, "99-manual.conf", `10.0.0.4
+`)
+
+	ipv4, _, err := LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	timed, ok := ipv4["10.0.0.1"]
+	if !ok {
+		t.Fatalf("expected timed entry 10.0.0.1 loaded, ipv4=%v", ipv4)
+	}
+	if timed.ExpiresAt.IsZero() {
+		t.Fatalf("timed entry 10.0.0.1: ExpiresAt is zero, want the future timestamp carried")
+	}
+	want, _ := time.Parse(time.RFC3339, "2100-01-01T00:00:00Z")
+	if !timed.ExpiresAt.Equal(want) {
+		t.Fatalf("timed entry 10.0.0.1: ExpiresAt=%v, want %v", timed.ExpiresAt, want)
+	}
+
+	perm, ok := ipv4["10.0.0.4"]
+	if !ok {
+		t.Fatalf("expected permanent entry 10.0.0.4 loaded, ipv4=%v", ipv4)
+	}
+	if !perm.ExpiresAt.IsZero() {
+		t.Fatalf("permanent entry 10.0.0.4: ExpiresAt=%v, want zero", perm.ExpiresAt)
+	}
+}

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -42,6 +42,14 @@ import (
 type WhitelistEntry struct {
 	Value  string // exact normalized form as written: "1.2.3.4" or "1.2.3.0/27"
 	IsCIDR bool   // true if Value contains "/"
+	// ExpiresAt carries the absolute RFC3339 timestamp from an inline
+	// `# EXPIRES_AT=<ts>` marker (V120 session-whitelist convention). Zero
+	// value = non-expiring (durable/trust entry) → permanent in the kernel.
+	// A future timestamp = the element must carry a kernel timeout anchored
+	// to this absolute instant, so a daemon FullSync/rebuild REFRESHES the
+	// remaining TTL instead of clobbering the entry to permanent (CLI-BUG-2,
+	// v1.168). Past timestamps are skipped at load and never reach here.
+	ExpiresAt time.Time
 }
 
 // LoadAllWhitelists loads IPs from all whitelist sources and returns two
@@ -173,12 +181,16 @@ func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntr
 		}
 		// V120: skip if the entry carries an EXPIRES_AT marker that is past
 		// or unparseable. No marker → load normally (backward compat).
-		if shouldSkipDueToExpiresAt(line) {
+		// v1.168 (CLI-BUG-2): for future markers, carry the absolute timestamp
+		// so the daemon sync can apply a kernel timeout (not skip-only).
+		expiresAt, skip := parseExpiresAt(line)
+		if skip {
 			return nil
 		}
 		we := WhitelistEntry{
-			Value:  entry.Value,
-			IsCIDR: entry.IsCIDR,
+			Value:     entry.Value,
+			IsCIDR:    entry.IsCIDR,
+			ExpiresAt: expiresAt,
 		}
 		if entry.IPv4 {
 			ipv4[entry.Value] = we
@@ -200,24 +212,49 @@ func loadWhitelistFileTyped(filePath string, ipv4, ipv6 map[string]WhitelistEntr
 // V120 (D-UPDATE-OPERATOR-SELF-BAN-GAP-001): keeps the EXPIRES_AT contract
 // in one place so AddSessionWhitelist (writer) and the loader (reader)
 // stay byte-compatible. See internal/installer/safety/session_whitelist.go.
+//
+// v1.168 (CLI-BUG-2): thin wrapper over parseExpiresAt, preserving the
+// original skip-only boolean contract for callers/tests that only care
+// whether an entry must be dropped.
 func shouldSkipDueToExpiresAt(line string) bool {
+	_, skip := parseExpiresAt(line)
+	return skip
+}
+
+// parseExpiresAt inspects the raw whitelist line for an inline
+// `EXPIRES_AT=<RFC3339>` marker and returns:
+//   - expiresAt: the parsed absolute timestamp for a still-future marker
+//     (zero time when there is no marker — i.e. a non-expiring entry);
+//   - skip: true when the entry must be DROPPED — marker present-but-malformed
+//     (no value / unparseable) or already past.
+//
+// v1.168 (CLI-BUG-2): the daemon needs the absolute timestamp (not just a
+// skip decision) so FullSync can apply a kernel timeout anchored to it. A
+// re-sync recomputes remaining = expiresAt − now, so the timeout is REFRESHED
+// rather than clobbered to permanent. Entries with no marker return
+// (zero, false) → loaded as permanent (durable/trust).
+func parseExpiresAt(line string) (expiresAt time.Time, skip bool) {
 	const marker = "EXPIRES_AT="
 	idx := strings.Index(line, marker)
 	if idx < 0 {
-		// No marker — entry is non-expiring; load normally.
-		return false
+		// No marker — entry is non-expiring; load normally as permanent.
+		return time.Time{}, false
 	}
 	rest := line[idx+len(marker):]
 	fields := strings.Fields(rest)
 	if len(fields) == 0 {
 		// Marker present but no value — malformed; skip conservatively.
-		return true
+		return time.Time{}, true
 	}
 	ts, err := time.Parse(time.RFC3339, fields[0])
 	if err != nil {
 		// Unparseable timestamp — skip conservatively.
-		return true
+		return time.Time{}, true
 	}
-	return time.Now().UTC().After(ts)
+	if time.Now().UTC().After(ts) {
+		// Already expired — skip.
+		return time.Time{}, true
+	}
+	// Still future — carry the absolute timestamp for kernel-timeout sync.
+	return ts.UTC(), false
 }
-

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1199,6 +1199,28 @@ if [ -x "\$NFTBAN_INSTALLER" ]; then
             echo "[NFTBan] WARN: to finish the migration manually, run: nftban firewall reload"
         fi
     fi
+
+    # --- v1.168 CLI-BUG-2: activate timeout-capable whitelist sets ---
+    # v1.168 adds \`flags interval, timeout\` to whitelist_ipv4/ipv6 so
+    # \`whitelist add --ttl\` can expire in-kernel. The installer's switchop.Rebuild
+    # (-> \`nftban firewall rebuild\`) above re-renders the v1.168 template and
+    # normally recreates the sets with the new flag on upgrade. This is a
+    # conditional BACKSTOP: a pre-v1.168 live set is created with bare
+    # \`flags interval\`, and GetOrCreateIntervalSet REUSES an existing set without
+    # upgrading its flags — so if the installer rebuild was skipped/DEGRADED and
+    # the live whitelist_ipv4 set still shows \`flags interval\`, recreate it with
+    # an explicit, SSH-guarded full rebuild. Idempotent: a no-op once the flag is
+    # present. NON-FATAL: a failed rebuild is warned and the upgrade continues.
+    if [ "\$INSTALL_MODE" = "upgrade" ] && [ "\${INSTALLER_EXIT:-0}" -le 1 ] && [ -x /usr/sbin/nftban ] && command -v nft >/dev/null 2>&1; then
+        if nft list set ip nftban whitelist_ipv4 2>/dev/null | grep -qE 'flags[[:space:]]+interval[[:space:]]*\$'; then
+            echo "[NFTBan] v1.168: whitelist sets lack the timeout flag; rebuilding to enable --ttl expiry..."
+            if /usr/sbin/nftban firewall rebuild >/dev/null 2>&1; then
+                echo "[NFTBan] v1.168: whitelist sets are now timeout-capable (flags interval, timeout)."
+            else
+                echo "[NFTBan] WARN: v1.168 rebuild did not complete; run 'nftban firewall rebuild' to enable whitelist TTLs."
+            fi
+        fi
+    fi
 else
     echo "[NFTBan ERROR] Installer binary not found: \$NFTBAN_INSTALLER"
     echo "[NFTBan ERROR] Package may be corrupt. Try reinstalling."

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -375,6 +375,33 @@ case "$1" in
                     log_warn "v1.145: to finish the migration manually, run: nftban firewall reload"
                 fi
             fi
+
+            # --- v1.168 CLI-BUG-2: activate timeout-capable whitelist sets ---
+            # v1.168 adds `flags interval, timeout` to whitelist_ipv4/ipv6 so
+            # `whitelist add --ttl` can expire in-kernel. The installer's
+            # switchop.Rebuild (-> `nftban firewall rebuild`) above re-renders the
+            # v1.168 template and normally recreates the sets with the new flag on
+            # upgrade. This is a conditional BACKSTOP: a pre-v1.168 live set is
+            # created with bare `flags interval`, and GetOrCreateIntervalSet REUSES
+            # an existing set without upgrading its flags — so if the installer
+            # rebuild was skipped/DEGRADED and the live whitelist_ipv4 set still
+            # shows `flags interval`, recreate it with an explicit, SSH-guarded
+            # full rebuild (nftban firewall rebuild carries its own pre-rebuild
+            # lockout guard). Idempotent: a no-op once the flag is present.
+            # NON-FATAL: a failed rebuild is warned and the upgrade continues
+            # (nft -f retains the prior ruleset on error).
+            if [ "$INSTALL_MODE" = "upgrade" ] && [ "${INSTALLER_EXIT:-0}" -le 1 ] \
+               && [ -x /usr/sbin/nftban ] && command -v nft >/dev/null 2>&1; then
+                if nft list set ip nftban whitelist_ipv4 2>/dev/null \
+                   | grep -qE 'flags[[:space:]]+interval[[:space:]]*$'; then
+                    log_info "v1.168: whitelist sets lack the timeout flag; rebuilding to enable --ttl expiry..."
+                    if /usr/sbin/nftban firewall rebuild >/dev/null 2>&1; then
+                        log_info "v1.168: whitelist sets are now timeout-capable (flags interval, timeout)."
+                    else
+                        log_warn "v1.168: rebuild did not complete; run 'nftban firewall rebuild' to enable whitelist TTLs."
+                    fi
+                fi
+            fi
         else
             log_error "Installer binary not found: $NFTBAN_INSTALLER"
             log_error "Package may be corrupt. Try reinstalling."


### PR DESCRIPTION
## CLI-BUG-2 (HIGH / security) — `whitelist add --ttl` never expired in-kernel

`whitelist add --ttl <dur>` / `firewall whitelist-session add` reported an expiry, but the daemon's `FullSync` repopulated whitelist sets from an **IP-only snapshot** (`EXPIRES_AT` was load-time skip-only), so any kernel timeout was clobbered and a "temporary" whitelist became **permanent** — exempt from all protection forever.

### Fix — runtime authority (loader → state → snapshot → sync) + render prereq
- **loader** (`internal/whitelist/loader.go`): `WhitelistEntry` carries absolute `ExpiresAt` (`parseExpiresAt`); past/malformed still skipped; `shouldSkipDueToExpiresAt` kept as a compatible wrapper.
- **state** (`internal/runtime/state.go`): `LoadWhitelists` populates `IPEntry.ExpireAt`; new `GetWhitelistSnapshotWithExpiry()` exposes `ip → absolute expiry` for timed entries only.
- **sync** (`internal/setsync/diff.go`): pure `remainingTimeout()` + timeout-aware `SyncWhitelistSetToNFT`; `FullSync` gains `whitelistExpiry` and applies `AddIPWithTimeout(remaining)` **anchored to absolute expiry** → a re-sync/rebuild **refreshes** the remaining TTL, never clobbers to permanent. Blacklist sync unchanged.
- **daemon** (`cmd/nftband/daemon_handlers_sync.go`): passes the expiry snapshot into `FullSync`.
- **render prereq**: `flags interval, timeout` on `whitelist_ipv4/ipv6` in static `nftables.conf` + `.tpl` (blacklist already had it).
- **upgrade activation** (DEB postinst + RPM %post): conditional, SSH-guarded backstop modeled on v1.145 PR-A.1 — recreates a live whitelist set still showing bare `flags interval` via `nftban firewall rebuild`. The live set is reuse-sticky (`GetOrCreateIntervalSet` doesn't upgrade flags of an existing set), so the flag only activates after a full rebuild. Idempotent; non-fatal.

### Tests (acceptance)
1. **TTL survives FullSync** (primary) — `TestRemainingTimeout_TTLSurvivesFullSync` (Go).
2. **whitelist decls carry interval,timeout** — `whitelist_set_timeout_flag_v168_test.sh`.
3. **upgrade path activates timeout-capable sets** — `whitelist_timeout_upgrade_activation_v168_test.sh`.
Plus loader `ExpiresAt`-carry + runtime expiry-snapshot tests. All three shell guards CI-wired in `ci-architecture.yml`. Schema **1.83.0 frozen** (schema-freeze guard green).

### Lab + real-host validation (pre-PR, core invariant) — PASS
| Host | OS/pkg | Set after rebuild | `--ttl` add | After extra FullSync | Durable |
|---|---|---|---|---|---|
| lab2 | Ubuntu 24.04 / deb | `interval,timeout` | `timeout 59m58s` | `59m50s` still timed | permanent |
| lab4 | AlmaLinux 9.8 / rpm | `interval,timeout` | `timeout 59m58s` | `59m57s` still timed | permanent |
| monitor (real) | Ubuntu 24.04 / deb | `interval,timeout` | `timeout 29m58s` | `29m48s` still timed | permanent |

All hosts restored to baseline; dns1/dns2 (production) untouched. Record: `NFTBAN_ROADMAP/V168_CLI_BUG_2_VALIDATION_RECORD.md`.

### Envelope
- **Daemon byte-identity chain (v1.147→v1.167 `85a2de3e`) intentionally ENDS here** — `cmd/nftband` changed.
- Schema 1.83.0 frozen. No tag/release in this PR.

### Release-blocking acceptance still pending (post-CI, before release-prep)
- PR CI green
- lab2 **package-upgrade** path proves the flag active after dpkg upgrade
- lab4 same on RPM/EL9
- monitor (or another real host) proves TTL survives FullSync after upgrade activation
- durable/trust entries remain permanent; SSH preserved throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)