### PR TITLE
v1.169: hygiene/UX residuals (CLI-BUG-3 label · CI-TEST-GAP · README tiers · unit banner)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -702,6 +702,26 @@ jobs:
       - name: Whitelist-TTL upgrade activation backstop (v1.168 deb+rpm)
         run: bash cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
 
+      # v1.169 CLI-BUG-3: `whitelist list` labels timed/session vs durable entries.
+      - name: Whitelist list timed/session label (v1.169 CLI-BUG-3)
+        run: bash cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
+
+      # v1.169 CI-TEST-GAP: wire 6 substantive guards that shipped with their
+      # lanes (v1.158–v1.163) but were never added to any workflow. Each is
+      # hermetic (no host/root) — they only catch a future regression once run.
+      - name: MAC posture advisory surface (v1.158)
+        run: bash cli/lib/nftban/tests/mac_posture_v158_test.sh
+      - name: Geoban-refresh ExecCondition skip-not-fail (v1.159)
+        run: bash cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
+      - name: Firewall-pkg state-aware wording (v1.160)
+        run: bash cli/lib/nftban/tests/firewall_pkg_wording_v160.sh
+      - name: Permissions optional-module skip (v1.160)
+        run: bash cli/lib/nftban/tests/permissions_optional_module_skip_v160.sh
+      - name: Whitelist verify read-only (v1.163)
+        run: bash cli/lib/nftban/tests/whitelist_verify_v163_test.sh
+      - name: Immutable-flag health verify (v1.163)
+        run: bash cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Interpretation rules:
 
 ## Quick Install
 
+> All tiers below are built, released, and install-tested in CI every release. Tiers reflect **recommendation/age**, not support level: **Tier 0** = primary/recommended · **Tier 1** = newer releases · **Tier 2** = older LTS still supported.
+
 ### Tier 0 — Primary Platforms
 
 #### Ubuntu 24.04 LTS (Noble)
@@ -126,7 +128,7 @@ wget https://github.com/itcmsgr/nftban/releases/latest/download/nftban-el9-x86_6
 sudo dnf install -y ./nftban-el9-x86_64.rpm
 ```
 
-### Tier 1 — Future Platforms
+### Tier 1 — Newer Platforms
 
 #### Debian 13 (Trixie)
 ```bash

--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -476,6 +476,35 @@ nftban_whitelist_remove_static_ip() {
 }
 
 # List whitelisted IPs
+# v1.169 (CLI-BUG-3): format one kernel whitelist set element for display,
+# labeling timed (session / `--ttl`, carries an nft `timeout`) vs durable
+# entries. Since v1.168 a timed element renders as
+# "1.2.3.4 timeout 30m expires 29m55s"; without this the list printed that raw
+# text appended to the IP, unlabeled. Input = one element line from
+# `nft list set` (timed or a bare "1.2.3.4"). Output = "  <ip>   <LABEL>".
+# Pure/string-only — no nft calls, no writes (unit-testable).
+nftban_whitelist_fmt_element() {
+    local _el="$1" _bare _rem
+    _bare="${_el%% *}"
+    if [[ "$_el" == *" timeout "* ]]; then
+        if [[ "$_el" == *" expires "* ]]; then
+            _rem="${_el##* expires }"; _rem="${_rem%% *}"
+            printf '  %-18s TIMED (expires in %s)\n' "$_bare" "$_rem"
+        else
+            printf '  %-18s TIMED\n' "$_bare"
+        fi
+    else
+        printf '  %-18s DURABLE\n' "$_bare"
+    fi
+}
+
+# nftban_whitelist_bare_ip — first whitespace-delimited field of an element line
+# (strips any `timeout …`/`expires …` suffix). Keeps --json values valid IPs.
+nftban_whitelist_bare_ip() {
+    local _el="$1"
+    printf '%s' "${_el%% *}"
+}
+
 nftban_whitelist_list() {
     # v1.59.0 UX-2: Added --json support for scripting/monitoring
     local _json_mode="false"
@@ -525,14 +554,14 @@ nftban_whitelist_list() {
         while IFS= read -r _ip; do
             [[ -z "$_ip" ]] && continue
             [[ "$_first" == "true" ]] && _first=false || _json+=","
-            _json+="\"$_ip\""
+            _json+="\"$(nftban_whitelist_bare_ip "$_ip")\""
         done <<< "$_wl_v4"
         _json+='],"ipv6":['
         _first=true
         while IFS= read -r _ip; do
             [[ -z "$_ip" ]] && continue
             [[ "$_first" == "true" ]] && _first=false || _json+=","
-            _json+="\"$_ip\""
+            _json+="\"$(nftban_whitelist_bare_ip "$_ip")\""
         done <<< "$_wl_v6"
         _json+=']}}'
         echo "$_json"
@@ -558,7 +587,7 @@ nftban_whitelist_list() {
     echo "───────────────"
     if [[ -n "$_wl_v4" ]]; then
         while IFS= read -r _ip; do
-            [[ -n "$_ip" ]] && echo "  $_ip"
+            [[ -n "$_ip" ]] && nftban_whitelist_fmt_element "$_ip"
         done <<< "$_wl_v4"
     else
         echo "  (empty or not available)"
@@ -568,7 +597,7 @@ nftban_whitelist_list() {
     echo "───────────────"
     if [[ -n "$_wl_v6" ]]; then
         while IFS= read -r _ip; do
-            [[ -n "$_ip" ]] && echo "  $_ip"
+            [[ -n "$_ip" ]] && nftban_whitelist_fmt_element "$_ip"
         done <<< "$_wl_v6"
     else
         echo "  (empty or not available)"

--- a/cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
+++ b/cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.169 CLI-BUG-3: `whitelist list` timed/session vs durable labeling
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="whitelist_list_timed_label_v169_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-09"
+# meta:description="Locks v1.169 CLI-BUG-3: nftban whitelist list must LABEL timed/session entries distinctly from durable ones. Since v1.168 a timed kernel element renders as '1.2.3.4 timeout 30m expires 29m55s'; the pre-v1.169 list printed that raw text appended to the IP, unlabeled. Exercises the two pure formatters sourced from cmd_whitelist.sh: nftban_whitelist_fmt_element (labels TIMED (expires in …) vs DURABLE, IP first) and nftban_whitelist_bare_ip (strips the timeout suffix so --json values stay valid IPs). Hermetic: sources the real cmd_whitelist.sh from the repo with NFTBAN_LIB_DIR pointed at the repo tree; no nft, no host, no root, no writes."
+# meta:input="None (sources repo cmd_whitelist.sh, calls pure formatters)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_whitelist.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+WL_SRC="$REPO_ROOT/cli/lib/nftban/cli/cmd_whitelist.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$WL_SRC" ]] || { echo "source not found: $WL_SRC"; exit 1; }
+
+# Run a formatter in a subshell that sources the real module against the repo
+# tree (avoids the installed /usr/lib path + the direct-exec tail guard).
+fmt(){ NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban" bash -c '
+  source "'"$WL_SRC"'" >/dev/null 2>&1 || true
+  nftban_whitelist_fmt_element "$1"' _ "$1"; }
+bare(){ NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban" bash -c '
+  source "'"$WL_SRC"'" >/dev/null 2>&1 || true
+  nftban_whitelist_bare_ip "$1"' _ "$1"; }
+
+echo "=== nftban_whitelist_fmt_element: timed entry is LABELED (not raw) ==="
+out=$(fmt "203.0.113.77 timeout 30m expires 29m55s102ms")
+if grep -q "203.0.113.77" <<<"$out" && grep -q "TIMED" <<<"$out" && grep -q "expires in 29m55s102ms" <<<"$out"; then
+  ok "timed → 'TIMED (expires in 29m55s102ms)' (${out//[[:space:]]/ })"
+else
+  no "timed entry not labeled correctly" "${out//[[:space:]]/ }"
+fi
+# the raw 'timeout 30m expires' run must NOT appear verbatim after the IP
+if grep -qE '203\.0\.113\.77[[:space:]]+timeout 30m expires' <<<"$out"; then
+  no "raw 'timeout … expires …' still printed verbatim (CLI-BUG-3 not fixed)"
+else
+  ok "raw nft timeout text not printed verbatim"
+fi
+
+echo "=== durable (bare) entry is LABELED DURABLE, no TIMED ==="
+out=$(fmt "192.168.1.5")
+if grep -q "192.168.1.5" <<<"$out" && grep -q "DURABLE" <<<"$out" && ! grep -q "TIMED" <<<"$out"; then
+  ok "durable → DURABLE (${out//[[:space:]]/ })"
+else
+  no "durable entry mislabeled" "${out//[[:space:]]/ }"
+fi
+
+echo "=== timed without expires token (edge) → TIMED, no crash ==="
+out=$(fmt "10.0.0.1 timeout 30m")
+if grep -q "10.0.0.1" <<<"$out" && grep -q "TIMED" <<<"$out"; then
+  ok "timed-no-expires → TIMED (${out//[[:space:]]/ })"
+else
+  no "timed-no-expires mishandled" "${out//[[:space:]]/ }"
+fi
+
+echo "=== nftban_whitelist_bare_ip strips timeout suffix (valid --json value) ==="
+b=$(bare "203.0.113.77 timeout 30m expires 29m55s")
+if [[ "$b" == "203.0.113.77" ]]; then ok "timed → bare '203.0.113.77'"; else no "bare_ip(timed)='$b' want 203.0.113.77"; fi
+b=$(bare "192.168.1.5")
+if [[ "$b" == "192.168.1.5" ]]; then ok "bare → '192.168.1.5'"; else no "bare_ip(bare)='$b' want 192.168.1.5"; fi
+
+echo "================================================================"
+echo "whitelist_list_timed_label_v169_test: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/packaging/systemd/nftban-firewall-init.service
+++ b/packaging/systemd/nftban-firewall-init.service
@@ -1,5 +1,5 @@
 # =============================================================================
-# NFTBan v1.0.0 - Firewall Initialization Service
+# NFTBan - Firewall Initialization Service
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 # meta:name="nftban-firewall-init.service"


### PR DESCRIPTION
## v1.169 low-risk hygiene/UX bundle — shell + CI-yaml + docs only

Bundled PR-A/B/C per `NFTBAN_ROADMAP/V169_HYGIENE_UX_SCOPE.md`. **No daemon-Go, no schema, no FHS/packaging-authority change.** Daemon `cmd/nftband` byte-identical to v1.168.0; schema 1.83.0 frozen.

### PR-A — CLI-BUG-3: `whitelist list` timed/session label
Since v1.168 a timed kernel element renders as `1.2.3.4 timeout 30m expires 29m55s`; the list printed that raw text appended to the IP, unlabeled. `cmd_whitelist.sh` now has two pure helpers — `nftban_whitelist_fmt_element` (labels **TIMED (expires in …)** vs **DURABLE**) and `nftban_whitelist_bare_ip` (strips the timeout suffix so `--json` values stay valid IPs) — wired into both text loops and both JSON loops. Read-only display; no nft writes. New guard `whitelist_list_timed_label_v169_test.sh` (6/0).

### PR-B — CI-TEST-GAP: wire 6 existing guards (+ the new v169 guard)
Six substantive guards shipped with v1.158–v1.163 but were never in any workflow. Wired into `ci-architecture.yml` (hermetic; no host/root): `mac_posture_v158`, `geoban_refresh_execcondition_v159`, `firewall_pkg_wording_v160`, `permissions_optional_module_skip_v160`, `whitelist_verify_v163`, `immutable_health_verify_v163` — plus the new `whitelist_list_timed_label_v169`.

### PR-C — REPO-DOC-HYGIENE
- README: `Tier 1 — Future Platforms` → `Tier 1 — Newer Platforms` + a truthful clarifier (all tiers are built/released/CI-tested every release; tiers reflect recommendation/age, not support level). Verified against artifact truth — all 7 packages (ubuntu22/24/26, debian12/13, el9/10) are built + install-tested in CI. Tier-0 anchor untouched.
- Stripped the stale `# NFTBan v1.0.0` banner in `packaging/systemd/nftban-firewall-init.service` (comment-only, behavior-identical). The `install/systemd/` copy was already clean since #552 (verified) — no change needed.

### Envelope / verification
- **0** `cmd/nftband` + `internal` changes (daemon byte-identical) · schema **1.83.0** frozen.
- Local: `bash -n` + shellcheck `-S warning` (0 new) on touched shell; new test + all 6 wired guards pass; `ci-architecture.yml` YAML valid.

### Out of scope (not in this PR)
DDoS wiki drift (PR-D, separate `nftban.wiki` repo — does not block v1.169) · fleet rollout · §4.1–4.3 state-write atomicity · §3.6 ssh_ports counter · any daemon-Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)