### PR TITLE
fix(stats): BUG-STATS-IP-HISTORY — single-emit + rotated/compressed log coverage

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -722,6 +722,12 @@ jobs:
       - name: Immutable-flag health verify (v1.163)
         run: bash cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
 
+      # v1.170 BUG-STATS-IP-HISTORY: `nftban stats ip <IP>` must single-emit (no
+      # pipefail double-`[]` arith crash for zero-record IPs) AND read compressed/
+      # rotated bans.log archives (zgrep); + gzip dep stays declared.
+      - name: stats ip history pipefail + compressed-log fix (v1.170)
+        run: bash cli/lib/nftban/tests/stats_ip_history_v170_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -919,9 +919,14 @@ nftban_stats_cmd_ip() {
 
     if command -v jq &>/dev/null; then
         local total
-        total=$(echo "$history" | jq '. | length')
+        # v1.170: defensive — coerce to a single integer. The producer is now
+        # single-emit, but this guarantees the arithmetic test below can never
+        # crash on a multi-line/garbage value (the pre-v1.170 "0\n0" syntax error).
+        total=$(echo "$history" | jq '. | length' 2>/dev/null | head -1)
+        total=${total//[^0-9]/}
+        total=${total:-0}
 
-        if [[ $total -eq 0 ]]; then
+        if [[ "$total" -eq 0 ]]; then
             echo "No ban records found for ${ip}"
             echo ""
             return 0

--- a/cli/lib/nftban/core/nftban_stats_collect.sh
+++ b/cli/lib/nftban/core/nftban_stats_collect.sh
@@ -552,12 +552,39 @@ nftban_stats_ip_history() {
         return 0
     fi
 
-    grep "|${ip}|" "$NFTBAN_BAN_LOG" 2>/dev/null | \
+    # v1.170: read the live ban log AND its rotated/compressed archives
+    # (logrotate keeps bans.log.1 + bans.log.*.gz, rotate 12) so per-IP history
+    # is COMPLETE, not silently truncated to the current uncompressed window.
+    # Build the file list with a nullglob-safe guard (no shopt side effects).
+    local -a _logs=("$NFTBAN_BAN_LOG")
+    local _f
+    for _f in "$NFTBAN_BAN_LOG".*; do
+        [[ -e "$_f" ]] && _logs+=("$_f")
+    done
+
+    # SINGLE-EMIT: capture the matcher into a var first. The pre-v1.170 form
+    # `grep "|ip|" log | awk '…[]…' || echo "[]"` double-emitted under
+    # `set -Eeuo pipefail` — a zero-match grep made the pipeline exit non-zero,
+    # so the `|| echo "[]"` fired IN ADDITION to awk's already-printed "[]",
+    # returning "[]\n[]" → caller's `jq length` → "0\n0" → `[[ -eq ]]` arith
+    # crash (cmd_stats.sh). zgrep transparently reads plain + .gz archives.
+    local _matches=""
+    if command -v zgrep >/dev/null 2>&1; then
+        _matches=$(zgrep -h "|${ip}|" "${_logs[@]}" 2>/dev/null || true)
+    else
+        # Graceful degrade (source/minimal installs without gzip): live log only.
+        echo "Warning: zgrep not found (gzip); ban history limited to ${NFTBAN_BAN_LOG} — rotated/compressed archives skipped." >&2
+        _matches=$(grep -h "|${ip}|" "$NFTBAN_BAN_LOG" 2>/dev/null || true)
+    fi
+
+    # awk emits a valid "[]" on EMPTY input, so NO "|| echo []" fallback is
+    # needed (that fallback was the double-emit bug). Sort by timestamp (field 1).
+    printf '%s\n' "$_matches" | sed '/^$/d' | sort -t'|' -k1,1 | \
     awk -F'|' 'BEGIN{printf "["}
                NR>1{printf ","}
                {printf "{\"timestamp\":\"%s\",\"ip\":\"%s\",\"jail\":\"%s\",\"action\":\"%s\",\"reason\":\"%s\"}",
                        $1, $4, $3, $6, $5}
-               END{printf "]"}' || echo "[]"
+               END{printf "]"}'
 }
 
 # =============================================================================

--- a/cli/lib/nftban/tests/stats_ip_history_v170_test.sh
+++ b/cli/lib/nftban/tests/stats_ip_history_v170_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.170 BUG-STATS-IP-HISTORY: `stats ip` pipefail fix + compressed logs
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="stats_ip_history_v170_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-10"
+# meta:description="Locks the v1.170 fix for nftban_stats_ip_history() (core/nftban_stats_collect.sh). (1) SINGLE-EMIT: a zero-match IP under set -Eeuo pipefail must return exactly one JSON [] (the pre-v1.170 grep|awk||echo[] double-emitted '[]\\n[]' → caller jq length '0\\n0' → cmd_stats.sh:924 [[ -eq ]] arith crash). (2) COMPRESSED-LOG COVERAGE: history reads the live bans.log AND rotated/compressed archives (bans.log.1, bans.log.*.gz) via zgrep, so an IP found only in a .gz appears. (3) SORT: multi-source events sorted by timestamp. (4) CALLER GUARD: cmd_stats.sh sanitizes the jq total to one integer. (5) PACKAGING LOCK: gzip stays a declared dep (DEB Depends + RPM Requires) so zgrep/zcat are guaranteed. Hermetic: sources the real core funcs against a temp ban log via STATS_BAN_LOG; no host/root/nft."
+# meta:input="None (temp ban log + temp .gz archive)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,gzip(zgrep),jq,awk,grep,sort"
+# meta:inventory.files="cli/lib/nftban/core/nftban_stats_collect.sh,cli/lib/nftban/cli/cmd_stats.sh,packaging/deb/control,packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,zgrep,jq"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,STATS_BAN_LOG"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+CORE="$REPO_ROOT/cli/lib/nftban/core"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+command -v jq >/dev/null 2>&1 || { echo "jq required for this test"; exit 1; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+LOG="$WORK/bans.log"
+# live log: 2.2.2.2 (newer) ; rotated .gz: 3.3.3.3 + 4.4.4.4 (older)
+printf '2026-06-08T14:22:00|jailssh|sshd|2.2.2.2|bruteforce|ban\n'  > "$LOG"
+printf '2026-06-09T10:00:00|jailssh|sshd|4.4.4.4|bruteforce|ban\n' >> "$LOG"
+printf '2026-06-01T09:00:00|jailssh|sshd|3.3.3.3|bruteforce|ban\n'  > "$WORK/old.txt"
+printf '2026-05-15T08:00:00|jailssh|sshd|4.4.4.4|bruteforce|ban\n' >> "$WORK/old.txt"
+gzip -c "$WORK/old.txt" > "$LOG.1.gz"
+
+# Call the REAL function (source nftban_stats.sh first — it sets NFTBAN_BAN_LOG
+# from STATS_BAN_LOG — then nftban_stats_collect.sh), under the same strict mode.
+hist(){ NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban" STATS_BAN_LOG="$LOG" bash -c '
+  source "'"$CORE"'/nftban_stats.sh" >/dev/null 2>&1 || true
+  source "'"$CORE"'/nftban_stats_collect.sh" >/dev/null 2>&1 || { echo "SRCFAIL"; exit 99; }
+  nftban_stats_ip_history "$1"' _ "$1"; }
+
+echo "=== (1) zero-match IP under pipefail → exactly one [] (no double-emit) ==="
+out=$(hist 9.9.9.9)
+if [[ "$out" == "[]" ]] && [[ "$(printf '%s' "$out" | wc -l)" -eq 0 ]] && [[ "$(printf '%s' "$out" | jq '. | length')" == "0" ]]; then
+  ok "zero-match → single '[]', jq length 0 (no '[]\\n[]', no arith crash)"
+else
+  no "zero-match double-emit / garbled" "out=[$out]"
+fi
+
+echo "=== (2) live-log IP present ==="
+out=$(hist 2.2.2.2)
+if [[ "$(echo "$out" | jq '. | length')" == "1" && "$(echo "$out" | jq -r '.[0].timestamp')" == "2026-06-08T14:22:00" ]]; then
+  ok "live-log IP 2.2.2.2 → 1 event"
+else no "live-log IP wrong" "out=[$out]"; fi
+
+echo "=== (3) compressed-only IP (.gz) appears → rotated-archive coverage ==="
+out=$(hist 3.3.3.3)
+if [[ "$(echo "$out" | jq '. | length')" == "1" && "$(echo "$out" | jq -r '.[0].action')" == "ban" ]]; then
+  ok "compressed-only IP 3.3.3.3 read from bans.log.1.gz"
+else no "compressed-log coverage failed" "out=[$out]"; fi
+
+echo "=== (4) IP in BOTH live + .gz → merged, sorted by timestamp ==="
+out=$(hist 4.4.4.4)
+n=$(echo "$out" | jq '. | length'); first=$(echo "$out" | jq -r '.[0].timestamp'); last=$(echo "$out" | jq -r '.[-1].timestamp')
+if [[ "$n" == "2" && "$first" == "2026-05-15T08:00:00" && "$last" == "2026-06-09T10:00:00" ]]; then
+  ok "4.4.4.4 → 2 events merged (live+gz), ascending by timestamp"
+else no "merge/sort wrong" "n=$n first=$first last=$last"; fi
+
+echo "=== (5) caller cmd_stats.sh sanitizes jq total to one integer ==="
+if grep -qE 'jq .\. \| length. 2>/dev/null \| head -1' "$REPO_ROOT/cli/lib/nftban/cli/cmd_stats.sh" \
+   && grep -qE 'total=\$\{total//\[\^0-9\]/\}' "$REPO_ROOT/cli/lib/nftban/cli/cmd_stats.sh"; then
+  ok "cmd_stats.sh total sanitized (head -1 + strip non-digits)"
+else no "cmd_stats.sh total not sanitized"; fi
+
+echo "=== (6) packaging lock: gzip declared (DEB Depends + RPM Requires) ==="
+if grep -qE '^[[:space:]]*gzip,' "$REPO_ROOT/packaging/deb/control"; then ok "DEB control Depends: gzip"; else no "DEB control missing gzip"; fi
+if grep -qE '^Requires:[[:space:]]+gzip' "$REPO_ROOT/packaging/build_nftban.sh"; then ok "RPM spec Requires: gzip"; else no "RPM spec missing Requires: gzip"; fi
+
+echo "================================================================"
+echo "stats_ip_history_v170_test: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## BUG-STATS-IP-HISTORY-PIPEFAIL (MED) — `nftban stats ip <IP>` crashed for zero-record IPs

**Symptom (live on lab4 v1.168.0):** `nftban stats ip <IP>` for any IP with no ban records printed a bash arithmetic error + garbled output:
```
/usr/lib/nftban/cli/cmd_stats.sh: line 924: [[: 0
0: syntax error in expression (error token is "0")
Total events: 0
0
```

**Root cause:** `nftban_stats_ip_history()` used `grep "|ip|" log | awk '…[]…' || echo "[]"`. Under `set -Eeuo pipefail`, a zero-match grep makes the pipeline exit non-zero → the `|| echo "[]"` fired **in addition** to awk's already-emitted `[]` → `"[]\n[]"` → caller `jq '. | length'` → `"0\n0"` → `cmd_stats.sh:924 [[ $total -eq 0 ]]` arithmetic crash.

## Fix (shell-only)
- **Single-emit:** capture the matcher into a var first; drop the `|| echo "[]"` fallback (awk emits a valid `[]` on empty input).
- **Compressed/rotated coverage:** read `bans.log` **and** `bans.log.*` (`.1`, `.gz`) via `zgrep`, so per-IP history is complete (logrotate keeps `rotate 12` compressed). Sorted by timestamp.
- **Graceful degrade:** if `zgrep`/`gzip` is absent (source/minimal installs), fall back to the live log + a one-line WARN — never hard-error.
- **Caller hardening:** `cmd_stats.sh` sanitizes the jq total to a single integer.
- **gzip:** already declared (DEB `Depends` + RPM `Requires`) → **CI assertion only, no dependency change.**

## Envelope
- **Shell-only — daemon `cmd/nftband` byte-identical** (0 Go/internal); schema **1.83.0 frozen**; no packaging-dependency mutation.

## Tests
New guard `stats_ip_history_v170_test.sh` (7/0), CI-wired in `ci-architecture.yml`: zero-match→single `[]` (no arith crash) · live-log IP · **compressed-only `.gz` IP** · merged+sorted live+gz · caller total sanitized · gzip dep declared (DEB+RPM). `bash -n` + shellcheck `-S warning` clean.

Scope: `NFTBAN_ROADMAP/V170_STATS_IP_HISTORY_FIX_SCOPE.md`. v1.171 (state-write atomicity, daemon-Go) is kept strictly separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)