### PR TITLE
v1.171: §4.2–§4.3 atomic state writes + §3.6 ssh_ports counter

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -728,6 +728,12 @@ jobs:
       - name: stats ip history pipefail + compressed-log fix (v1.170)
         run: bash cli/lib/nftban/tests/stats_ip_history_v170_test.sh
 
+      # v1.171 §4.2/§4.3/§3.6: daemon state writes are atomic (route through
+      # safety.SafeWriteFile); ssh_ports counter seeded. The atomic mechanism
+      # itself is proven by Go test internal/safety/atomic_write_v171_test.go.
+      - name: state-write atomicity call-site lock (v1.171)
+        run: bash cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
+++ b/cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.171 state-write atomicity (§4.2/§4.3/§3.6) call-site lock
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="state_write_atomicity_v171_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-10"
+# meta:description="Locks the v1.171 daemon-Go atomicity conversions so a future edit cannot regress them back to torn-on-crash raw writes. §4.2: suricata cache.go snapshot writes via safety.SafeWriteFile (no raw os.WriteFile on snapshotPath). §4.3a-c: limits.go SaveProtectionState/FilterState/PermanentBans use SafeWriteFile (no raw os.WriteFile on the three *StateFile/PermanentBansFile). §4.3d: panel_loader.go writes PanelStateFile via SafeWriteFile (no os.Create streaming). §3.6: daemon_init.go reconcile setNames seeds the ssh_ports counter. The atomic MECHANISM itself is proven by the Go test internal/safety/atomic_write_v171_test.go. Hermetic: greps repo source read-only; no build, no host, no root."
+# meta:input="None (reads repo Go source read-only)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep"
+# meta:inventory.files="internal/suricata/stats/cache.go,internal/safety/limits.go,internal/ports/panel_loader.go,cmd/nftband/daemon_init.go"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+CACHE="$REPO_ROOT/internal/suricata/stats/cache.go"
+LIMITS="$REPO_ROOT/internal/safety/limits.go"
+PANEL="$REPO_ROOT/internal/ports/panel_loader.go"
+DINIT="$REPO_ROOT/cmd/nftband/daemon_init.go"
+for f in "$CACHE" "$LIMITS" "$PANEL" "$DINIT"; do [[ -f "$f" ]] || { echo "missing: $f"; exit 1; }; done
+
+echo "=== §4.2 suricata cache snapshot is atomic ==="
+if grep -qE 'safety\.SafeWriteFile\(c\.snapshotPath' "$CACHE"; then ok "cache.go snapshot → SafeWriteFile"; else no "cache.go snapshot not SafeWriteFile"; fi
+if grep -qE 'os\.WriteFile\(c\.snapshotPath' "$CACHE"; then no "cache.go still raw os.WriteFile(snapshotPath)"; else ok "cache.go: no raw os.WriteFile(snapshotPath)"; fi
+
+echo "=== §4.3a-c safety state files are atomic ==="
+for v in ProtectionStateFile FilterStateFile PermanentBansFile; do
+  if grep -qE "SafeWriteFile\($v" "$LIMITS"; then ok "limits.go $v → SafeWriteFile"; else no "limits.go $v not SafeWriteFile"; fi
+  if grep -qE "os\.WriteFile\($v" "$LIMITS"; then no "limits.go still raw os.WriteFile($v)"; fi
+done
+
+echo "=== §4.3d panel state file is atomic (no streamed os.Create) ==="
+if grep -qE 'SafeWriteFile\(PanelStateFile' "$PANEL"; then ok "panel_loader.go → SafeWriteFile(PanelStateFile)"; else no "panel_loader.go not SafeWriteFile"; fi
+if grep -qE 'os\.Create\(PanelStateFile' "$PANEL"; then no "panel_loader.go still os.Create(PanelStateFile) (non-atomic stream)"; else ok "panel_loader.go: no os.Create(PanelStateFile)"; fi
+
+echo "=== §3.6 daemon seeds ssh_ports counter on startup ==="
+if grep -qE '"ssh_ports"' "$DINIT"; then ok "daemon_init.go setNames includes ssh_ports"; else no "daemon_init.go setNames omits ssh_ports"; fi
+
+echo "================================================================"
+echo "state_write_atomicity_v171_test: PASS=$PASS FAIL=$FAIL"
+echo "================================================================"
+[[ $FAIL -eq 0 ]]

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -518,6 +518,7 @@ func (d *Daemon) reconcileSetCountersFromKernel(wrapper *opqueue.NFTBackendWrapp
 		"whitelist_ipv4", "whitelist_ipv6",
 		"tcp_ports_in", "tcp_ports_out",
 		"udp_ports_in", "udp_ports_out",
+		"ssh_ports", // v1.171 §3.6: was omitted → ssh_ports counter never seeded from kernel on startup
 	}
 
 	for _, setName := range setNames {

--- a/internal/ports/panel_loader.go
+++ b/internal/ports/panel_loader.go
@@ -30,6 +30,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/itcmsgr/nftban/internal/safety"
 )
 
 // PanelConfig represents a control panel's port configuration
@@ -133,25 +135,26 @@ func SetPanelEnabled(panelName string, enabled bool) error {
 	}
 	existingState[panelName] = status
 
-	// Write back
-	f, err := os.Create(PanelStateFile)
-	if err != nil {
-		return fmt.Errorf("failed to create panel state file: %w", err)
-	}
-	defer f.Close()
-
-	// Write header
-	fmt.Fprintln(f, "# NFTBan Panel State Configuration")
-	fmt.Fprintln(f, "# Format: panelname=enabled|disabled")
-	fmt.Fprintln(f, "# This file is automatically managed by 'nftban panel' commands")
-	fmt.Fprintln(f, "")
+	// Write back. v1.171 §4.3d: build the body then atomic-write (temp+fsync+
+	// rename, random temp) via the gold helper — torn-on-crash safe and parity
+	// with the shell sibling's temp+mv — instead of streaming into os.Create.
+	// Byte-for-byte the same content as the previous Fprintln/Fprintf stream.
+	var sb strings.Builder
+	sb.WriteString("# NFTBan Panel State Configuration\n")
+	sb.WriteString("# Format: panelname=enabled|disabled\n")
+	sb.WriteString("# This file is automatically managed by 'nftban panel' commands\n")
+	sb.WriteString("\n")
 
 	// Write all panels in alphabetical order
 	panels := []string{"directadmin", "cpanel", "plesk", "cyberpanel", "cwp", "interworx", "vesta"}
 	for _, panel := range panels {
 		if state, exists := existingState[panel]; exists {
-			fmt.Fprintf(f, "%s=%s\n", panel, state)
+			fmt.Fprintf(&sb, "%s=%s\n", panel, state)
 		}
+	}
+
+	if err := safety.SafeWriteFile(PanelStateFile, []byte(sb.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write panel state file: %w", err)
 	}
 
 	return nil

--- a/internal/safety/atomic_write_v171_test.go
+++ b/internal/safety/atomic_write_v171_test.go
@@ -1,0 +1,129 @@
+// =============================================================================
+// NFTBan v1.171 - State-write atomicity (§4.2/§4.3): SafeWriteFile guarantees
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="atomic_write_v171_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-10"
+// meta:description="v1.171 §4.2/§4.3: proves the atomic-write mechanism that the suricata sid-stats snapshot (cache.go), the safety state files (limits.go SaveProtectionState/FilterState/PermanentBans) and panel_loader.go now route through. A concurrent reader during repeated writes must NEVER observe a torn/partial file (atomic temp+fsync+rename), and no stray temp file may remain on success. Pre-v1.171 those sites used a plain os.WriteFile/os.Create which can yield truncated reads on crash/concurrent read."
+// meta:input="None"
+// meta:output="t.Fatal on torn read / stray temp"
+// meta:depends="testing,os,sync,bytes,path/filepath"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package safety
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestSafeWriteFile_AtomicConcurrentRead asserts a reader concurrent with many
+// writers NEVER sees a torn file: each non-empty read must be a uniform block
+// (all 'A' or all 'B', same length) — a mixed/partial read would prove a
+// non-atomic write. With temp+rename the reader only ever observes the old or
+// the new complete inode.
+func TestSafeWriteFile_AtomicConcurrentRead(t *testing.T) {
+	dir := t.TempDir() // 0700, not world-writable → passes ValidateDirectory
+	target := filepath.Join(dir, "state.json")
+
+	const sz = 64 * 1024
+	payA := bytes.Repeat([]byte("A"), sz)
+	payB := bytes.Repeat([]byte("B"), sz)
+
+	// seed so the first reads have a complete file
+	if err := SafeWriteFile(target, payA, 0o644); err != nil {
+		t.Fatalf("seed SafeWriteFile: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// writer: alternate A/B blocks
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 400; i++ {
+			p := payA
+			if i%2 == 1 {
+				p = payB
+			}
+			if err := SafeWriteFile(target, p, 0o644); err != nil {
+				t.Errorf("SafeWriteFile iter %d: %v", i, err)
+				return
+			}
+		}
+		close(stop)
+	}()
+
+	// reader: every non-empty read must be a uniform full-size block
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b, err := os.ReadFile(target)
+			if err != nil {
+				// transient ENOENT is impossible with rename (old inode stays),
+				// but tolerate it rather than flake; never a torn-content pass.
+				continue
+			}
+			if len(b) == 0 {
+				continue
+			}
+			if len(b) != sz {
+				t.Errorf("torn read: len=%d (want %d) — non-atomic write", len(b), sz)
+				return
+			}
+			c := b[0]
+			if c != 'A' && c != 'B' {
+				t.Errorf("torn read: first byte %q", c)
+				return
+			}
+			if !bytes.Equal(b, bytes.Repeat([]byte{c}, sz)) {
+				t.Errorf("torn read: mixed content block — non-atomic write")
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestSafeWriteFile_NoStrayTempOnSuccess asserts the temp file is renamed away
+// (no `.nftban-safe-*` leftover) after a successful write — the dir holds only
+// the target.
+func TestSafeWriteFile_NoStrayTempOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "state.json")
+	if err := SafeWriteFile(target, []byte(`{"ok":true}`), 0o644); err != nil {
+		t.Fatalf("SafeWriteFile: %v", err)
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(ents) != 1 || ents[0].Name() != "state.json" {
+		var names []string
+		for _, e := range ents {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("stray entries after atomic write: %v (want only state.json)", names)
+	}
+}

--- a/internal/safety/limits.go
+++ b/internal/safety/limits.go
@@ -323,7 +323,9 @@ func RecordProtectionTriggered(feedsSkipped bool, geobanSkipped bool, feedsCIDRs
 		return err
 	}
 
-	return os.WriteFile(ProtectionStateFile, data, 0644)
+	// v1.171 §4.3a: atomic write (temp+fsync+rename) via the in-package gold
+	// helper instead of a torn-on-crash os.WriteFile.
+	return SafeWriteFile(ProtectionStateFile, data, 0644)
 }
 
 // ClearProtectionState removes protection state (called when sync succeeds fully)
@@ -423,7 +425,8 @@ func RecordFilterState(total, filtered, bogon, oversize, kept int) error {
 		return err
 	}
 
-	return os.WriteFile(FilterStateFile, data, 0644)
+	// v1.171 §4.3b: atomic write via the in-package gold helper.
+	return SafeWriteFile(FilterStateFile, data, 0644)
 }
 
 // GetFilterState reads current CIDR filter state
@@ -585,7 +588,8 @@ func SavePermanentBans(state *PermanentBansState) error {
 		return err
 	}
 
-	return os.WriteFile(PermanentBansFile, data, 0644)
+	// v1.171 §4.3c: atomic write via the in-package gold helper.
+	return SafeWriteFile(PermanentBansFile, data, 0644)
 }
 
 // TrackPermanentBan adds or updates a permanent ban in tracking

--- a/internal/suricata/stats/cache.go
+++ b/internal/suricata/stats/cache.go
@@ -301,8 +301,10 @@ func (c *Cache) Save() error {
 		return fmt.Errorf("failed to marshal cache: %w", err)
 	}
 
-	// Write to file
-	if err := os.WriteFile(c.snapshotPath, data, 0644); err != nil {
+	// Write to file. v1.171 §4.2: atomic (temp+fsync+rename, random temp) via
+	// the gold helper so a crash mid-write or a concurrent Load() can never see
+	// a truncated/torn JSON snapshot (the dir was MkdirAll'd above).
+	if err := safety.SafeWriteFile(c.snapshotPath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write snapshot: %w", err)
 	}
 


### PR DESCRIPTION
## Daemon state-write atomicity (§4.2–§4.3) + §3.6 ssh_ports counter

Routes the offending state-file writers through the codebase's existing gold atomic helper (`safety.SafeWriteFile` = temp + fsync + rename, random temp) and seeds the `ssh_ports` startup counter.

- **§4.2** `internal/suricata/stats/cache.go` — sid-stats snapshot `os.WriteFile` → `safety.SafeWriteFile` (no torn JSON on crash/concurrent `Load`).
- **§4.3a–c** `internal/safety/limits.go` — ProtectionState/FilterState/PermanentBans `os.WriteFile` → `SafeWriteFile` (in-package).
- **§4.3d** `internal/ports/panel_loader.go` — streamed `os.Create` → buffer + `SafeWriteFile` (byte-identical content; parity with the shell sibling's temp+mv).
- **§3.6** `cmd/nftband/daemon_init.go` — reconcile `setNames` now includes `ssh_ports` (counter was never seeded from the kernel on startup).

## Scope discipline
- **Does NOT close §4.1.** §4.1 (cross-process `flock` on `00-session.conf`, installer-Go + shell) **remains a separate future lane** — explicitly out of this release per the 2026-06-10 scope reconcile (option B). Scope: `NFTBAN_ROADMAP/V171_STATE_WRITE_ATOMICITY_SCOPE.md`.
- **Daemon hash changes intentionally** — this is daemon-Go; the v1.147→v1.167 byte-identical chain already ended at v1.168, this re-breaks it by design.
- **Schema 1.83.0 remains frozen** — only the *write mechanism* changes; on-disk payloads are byte-for-byte identical (readers unchanged).

## Tests
- `internal/safety/atomic_write_v171_test.go` — concurrent-read atomicity (never observes a torn block) + no stray temp on success.
- `cli/lib/nftban/tests/state_write_atomicity_v171_test.sh` (8/0) — call-site lock (all sites route through `SafeWriteFile`; `ssh_ports` seeded). CI-wired in `ci-architecture.yml` (alongside the v1.170 guard).
- Local: `go build/test/vet ./...` + staticcheck green; gofmt clean; shellcheck clean.

## Post-CI gate
**Lab-first mandatory** (daemon-Go): `OPEN_V171_LAB_VALIDATE` — lab2 (DEB) + lab4 (RPM) build/install + restart/crash-survival, daemon SHA256 before/after. **Do not merge before lab validation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)