### PR TITLE
fix(cli): CLI-PIPEFAIL-ARITH full-class sweep (v1.172)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -734,6 +734,13 @@ jobs:
       - name: state-write atomicity call-site lock (v1.171)
         run: bash cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
 
+      # v1.172 CLI-PIPEFAIL-ARITH sweep: zero-match grep / SIGPIPE / jq-parse failures
+      # under set -Eeuo pipefail must not double-emit a numeric ("0\n0") that crashes a
+      # downstream [[ -eq/-gt ]] / jq tonumber. Behavioral single-emit checks + static
+      # lint that the previously-broken arith-fed sites no longer carry the unsafe forms.
+      - name: CLI pipefail-arith sweep (v1.172)
+        run: bash cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_cleanup.sh
+++ b/cli/lib/nftban/cli/cmd_cleanup.sh
@@ -199,7 +199,10 @@ _cleanup_dry_run() {
 
             if command -v jq &>/dev/null; then
                 local ip_count
-                ip_count=$(echo "$ips_json" | jq -r 'length')
+                # 2>/dev/null + strip/default so empty/invalid `$ips_json` can't crash
+                # the `[[ "$ip_count" -eq 0 ]]` arith below.
+                ip_count=$(echo "$ips_json" | jq -r 'length' 2>/dev/null || true)
+                ip_count=${ip_count//[^0-9]/}; ip_count=${ip_count:-0}
                 if [[ "$ip_count" -eq 0 ]]; then
                     echo "  (none)"
                 else

--- a/cli/lib/nftban/cli/cmd_ddos.sh
+++ b/cli/lib/nftban/cli/cmd_ddos.sh
@@ -230,10 +230,13 @@ _nftban_ddos_stats_json() {
         # Count ddos bans in last 24 hours
         local yesterday_ts
         yesterday_ts=$(date -d '24 hours ago' +%s 2>/dev/null || echo "0")
-        blocked_24h=$(jq -r --arg ts "$yesterday_ts" 'select(.source == "ddos" and .event == "ban") | select((.ts | fromdateiso8601) >= ($ts | tonumber))' "${NFTBAN_LOG_DIR:-/var/log/nftban}/nftban-actions.log" 2>/dev/null | jq -s '. | length' 2>/dev/null || echo "0")
+        # pipefail-safe: wrap the filtering jq so a parse error / zero match (rc!=0) can't
+        # combine with the trailing `|| echo "0"` to double-emit "0\n0" (the slurp `jq -s`
+        # already yields a single integer); strip+default below guards the tonumber feed.
+        blocked_24h=$({ jq -r --arg ts "$yesterday_ts" 'select(.source == "ddos" and .event == "ban") | select((.ts | fromdateiso8601) >= ($ts | tonumber))' "${NFTBAN_LOG_DIR:-/var/log/nftban}/nftban-actions.log" 2>/dev/null || true; } | jq -s 'length' 2>/dev/null || true)
 
         # Count total ddos bans
-        blocked_total=$(jq -r 'select(.source == "ddos" and .event == "ban")' "${NFTBAN_LOG_DIR:-/var/log/nftban}/nftban-actions.log" 2>/dev/null | jq -s '. | length' 2>/dev/null || echo "0")
+        blocked_total=$({ jq -r 'select(.source == "ddos" and .event == "ban")' "${NFTBAN_LOG_DIR:-/var/log/nftban}/nftban-actions.log" 2>/dev/null || true; } | jq -s 'length' 2>/dev/null || true)
     fi
 
     # Try to get nftables counter stats (packets/bytes dropped)
@@ -245,16 +248,18 @@ _nftban_ddos_stats_json() {
         if [[ -n "$counter_output" ]]; then
             # Parse packets and bytes from counter output
             # Format: counter packets X bytes Y
-            packets_dropped=$(echo "$counter_output" | grep -oP 'counter packets \K[0-9]+' | head -1 || echo "0")
-            bytes_dropped=$(echo "$counter_output" | grep -oP 'bytes \K[0-9]+' | head -1 || echo "0")
+            # Wrap grep so a no-match (rc=1) or head-closes-pipe SIGPIPE (rc=141) can't
+            # pair with `|| echo "0"` to emit a second line; head -1 keeps it single.
+            packets_dropped=$(echo "$counter_output" | { grep -oP 'counter packets \K[0-9]+' || true; } | head -1)
+            bytes_dropped=$(echo "$counter_output" | { grep -oP 'bytes \K[0-9]+' || true; } | head -1)
         fi
     fi
 
-    # Ensure numeric values
-    packets_dropped=${packets_dropped:-0}
-    bytes_dropped=${bytes_dropped:-0}
-    blocked_24h=${blocked_24h:-0}
-    blocked_total=${blocked_total:-0}
+    # Ensure numeric values (strip any non-digit so the `| tonumber` jq feed never aborts)
+    packets_dropped=${packets_dropped//[^0-9]/}; packets_dropped=${packets_dropped:-0}
+    bytes_dropped=${bytes_dropped//[^0-9]/};     bytes_dropped=${bytes_dropped:-0}
+    blocked_24h=${blocked_24h//[^0-9]/};         blocked_24h=${blocked_24h:-0}
+    blocked_total=${blocked_total//[^0-9]/};     blocked_total=${blocked_total:-0}
 
     if [[ "$json_mode" == "true" ]] && declare -f json_output >/dev/null 2>&1; then
         local data

--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -1026,7 +1026,10 @@ nftban_login_cmd_mode() {
         local digest_count=0
 
         if [[ -f "$digest_file" ]] && command -v jq &>/dev/null; then
-            digest_count=$(jq 'length' "$digest_file" 2>/dev/null || echo "0")
+            # `jq -s 'add // [] | length'` yields one integer for a single array AND for
+            # accidentally-appended arrays; strip/default guards the later display/arith.
+            digest_count=$(jq -s 'add // [] | length' "$digest_file" 2>/dev/null || true)
+            digest_count=${digest_count//[^0-9]/}; digest_count=${digest_count:-0}
         fi
 
         echo "Login Alert Email Mode"
@@ -1100,7 +1103,9 @@ nftban_login_cmd_digest() {
             local count=0
 
             if [[ -f "$digest_file" ]] && command -v jq &>/dev/null; then
-                count=$(jq 'length' "$digest_file" 2>/dev/null || echo "0")
+                # single integer for single/appended arrays; guards the `[[ -gt 0 ]]` below.
+                count=$(jq -s 'add // [] | length' "$digest_file" 2>/dev/null || true)
+                count=${count//[^0-9]/}; count=${count:-0}
             fi
 
             echo "Login Digest Status"

--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -434,7 +434,8 @@ nftban_stats_cmd_dashboard() {
 
         if declare -f nftban_stats_top_countries >/dev/null 2>&1; then
             top_countries=$(nftban_stats_top_countries 10 "$since" "$until" 2>/dev/null || echo "[]")
-            total_countries=$(echo "$top_countries" | jq '. | length' 2>/dev/null) || total_countries=0
+            total_countries=$(echo "$top_countries" | jq '. | length' 2>/dev/null | head -1 || true)
+            total_countries=${total_countries//[^0-9]/}; total_countries=${total_countries:-0}
         fi
 
         # C5: "filters" (ban-source breakdown) replaces the old fail2ban-era
@@ -884,7 +885,11 @@ nftban_stats_cmd_ip() {
         local data
         if command -v jq &>/dev/null; then
             local total
-            total=$(echo "$history" | jq '. | length' 2>/dev/null) || total=0
+            # head -1 + strip/default: the weak `|| total=0` only caught a failed $() —
+            # a multi-value `$history` makes `jq length` emit one number per value, so
+            # collapse to a single integer before it feeds `--arg total`.
+            total=$(echo "$history" | jq '. | length' 2>/dev/null | head -1 || true)
+            total=${total//[^0-9]/}; total=${total:-0}
             data=$(jq -n \
                 --arg ip "$ip" \
                 --arg total "$total" \
@@ -1209,7 +1214,10 @@ nftban_stats_cmd_check_alerts() {
 
     if command -v jq &>/dev/null; then
         local count
-        count=$(echo "$offenders" | jq '. | length')
+        # 2>/dev/null + strip/default so an empty/invalid `$offenders` (jq error → empty
+        # count) can't crash the `[[ $count -gt 0 ]]` arith below.
+        count=$(echo "$offenders" | jq '. | length' 2>/dev/null || true)
+        count=${count//[^0-9]/}; count=${count:-0}
 
         if [[ $count -gt 0 ]]; then
             echo ""

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1040,7 +1040,9 @@ _cmd_update_history() {
     fi
 
     local count
-    count=$(jq 'length' "$history_file" 2>/dev/null || echo 0)
+    # single integer for single/appended arrays; strip/default guards the `[[ -eq 0 ]]`.
+    count=$(jq -s 'add // [] | length' "$history_file" 2>/dev/null || true)
+    count=${count//[^0-9]/}; count=${count:-0}
 
     if [[ "$count" -eq 0 ]]; then
         echo "  (empty)"

--- a/cli/lib/nftban/cli/cmd_watchdog.sh
+++ b/cli/lib/nftban/cli/cmd_watchdog.sh
@@ -773,9 +773,14 @@ nftban_watchdog_cmd_stats_history() {
         echo "$response" | jq '.data'
     else
         local history
-        history=$(echo "$response" | jq '.data.history')
+        # `.data.history // []` coerces a null/absent field to [] so `length` is a
+        # clean 0 (never a jq error → empty count → `[[ -eq ]]` arith crash) on the
+        # daemon-just-started path; sanitize guards any stray output.
+        history=$(echo "$response" | jq -c '.data.history // []' 2>/dev/null || echo '[]')
+        history=${history:-[]}
         local count
-        count=$(echo "$history" | jq 'length')
+        count=$(echo "$history" | jq 'length' 2>/dev/null || true)
+        count=${count//[^0-9]/}; count=${count:-0}
 
         if [[ "$count" -eq 0 ]]; then
             echo "No historical data available (daemon may have just started)"

--- a/cli/lib/nftban/cli/cmd_wizard.sh
+++ b/cli/lib/nftban/cli/cmd_wizard.sh
@@ -39,8 +39,11 @@ source "${NFTBAN_LIB_DIR}/core/nftban_output.sh" 2>/dev/null || true
 # CONFIGURATION
 # =============================================================================
 
-readonly NFTBAN_CONFIG_LOCAL="${NFTBAN_CONFIG_LOCAL:-/etc/nftban/nftban.conf.local}"
-readonly NFTBAN_PROFILE_CURRENT="${NFTBAN_PROFILE_CURRENT:-/var/lib/nftban/profile.current}"
+# Guard the readonly: re-sourcing this module in one shell (e.g. `profile list/select/apply`
+# dispatched after another command already set these) would otherwise hit
+# "readonly variable" on stderr. Only declare when unset.
+[[ -n "${NFTBAN_CONFIG_LOCAL:-}" ]]   || readonly NFTBAN_CONFIG_LOCAL="/etc/nftban/nftban.conf.local"
+[[ -n "${NFTBAN_PROFILE_CURRENT:-}" ]] || readonly NFTBAN_PROFILE_CURRENT="/var/lib/nftban/profile.current"
 
 # =============================================================================
 # ENVIRONMENT DETECTION

--- a/cli/lib/nftban/core/nftban_health_checks_services.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_services.sh
@@ -787,7 +787,9 @@ nftban_health_check_hung_processes() {
             local wchan=""
             wchan=$(cat "/proc/$pid/wchan" 2>/dev/null || echo "")
             local fd_count=0
-            fd_count=$(ls "/proc/$pid/fd" 2>/dev/null | wc -l || echo 0)
+            # wrap ls (rc!=0 when the pid is gone) so wc emits one count, never "0\n0".
+            fd_count=$({ ls "/proc/$pid/fd" 2>/dev/null || true; } | wc -l)
+            fd_count=${fd_count//[^0-9]/}; fd_count=${fd_count:-0}
             if [[ "$wchan" == *"wait_woken"* ]] || [[ "$wchan" == *"pipe_read"* ]]; then
                 root_cause="blocked_on_read(likely_stdin_prompt)"
             elif [[ "$wchan" == *"poll"* ]] || [[ "$wchan" == *"select"* ]]; then

--- a/cli/lib/nftban/core/nftban_login_alert.sh
+++ b/cli/lib/nftban/core/nftban_login_alert.sh
@@ -410,7 +410,9 @@ nftban_login_digest_count() {
     fi
 
     if command -v jq &>/dev/null; then
-        jq 'length' "$digest_file" 2>/dev/null || echo "0"
+        # single integer for single/appended arrays (parity with cmd_login digest count).
+        local _dc; _dc=$(jq -s 'add // [] | length' "$digest_file" 2>/dev/null || true)
+        _dc=${_dc//[^0-9]/}; echo "${_dc:-0}"
     else
         # V131 PR-A.2: capture + numeric fallback so this branch emits a
         # single integer (parity with the jq branch's "0"); grep -c prints

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -69,7 +69,10 @@ nftban_report_email_generate() {
     # Count blocked IPs from nft blacklist sets (IPv4 + IPv6)
     local blocked_ips=0 _blocked_v4=0 _blocked_v6=0
     if timeout 10s nft list set ip nftban blacklist_ipv4 &>/dev/null; then
-        _blocked_v4=$(timeout 10s nft list set ip nftban blacklist_ipv4 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?' | wc -l || echo 0)
+        # pipefail-safe single-emit: wrap zero-match grep (rc=1) so wc emits one count,
+        # never the old "0\n0" double (grep-fail + trailing `|| echo 0`) that crashed `$(( ))`.
+        _blocked_v4=$(timeout 10s nft list set ip nftban blacklist_ipv4 2>/dev/null | { grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?' || true; } | wc -l || true)
+        _blocked_v4=${_blocked_v4//[^0-9]/}; _blocked_v4=${_blocked_v4:-0}
     fi
     if timeout 10s nft list set ip6 nftban blacklist_ipv6 &>/dev/null; then
         _blocked_v6=$(timeout 10s nft list set ip6 nftban blacklist_ipv6 2>/dev/null | grep -cE '[0-9a-f:]+/|[0-9a-f]{2,}:' || true)
@@ -80,7 +83,9 @@ nftban_report_email_generate() {
     # Count whitelist (IPv4 + IPv6)
     local whitelist_count=0 _wl_v4=0 _wl_v6=0
     if timeout 10s nft list set ip nftban whitelist_ipv4 &>/dev/null; then
-        _wl_v4=$(timeout 10s nft list set ip nftban whitelist_ipv4 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?' | wc -l || echo 0)
+        # pipefail-safe single-emit (see blacklist_ipv4 note above).
+        _wl_v4=$(timeout 10s nft list set ip nftban whitelist_ipv4 2>/dev/null | { grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?' || true; } | wc -l || true)
+        _wl_v4=${_wl_v4//[^0-9]/}; _wl_v4=${_wl_v4:-0}
     fi
     if timeout 10s nft list set ip6 nftban whitelist_ipv6 &>/dev/null; then
         _wl_v6=$(timeout 10s nft list set ip6 nftban whitelist_ipv6 2>/dev/null | grep -cE '[0-9a-f:]+/|[0-9a-f]{2,}:' || true)

--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -801,16 +801,12 @@ nftban_stats_trend_collect() {
     hour_end=$(date +%Y-%m-%dT%H:%M:%SZ)
 
     # Count bans/unbans in current hour
-    local today bans unbans
-    today=$(date +%Y-%m-%d)
-    local hour_pattern
-    hour_pattern="^${today}|$(date +%H):"
+    local bans unbans
 
     if [[ -f "$NFTBAN_BAN_LOG" ]]; then
-        bans=$(grep -c "BANNED$" "$NFTBAN_BAN_LOG" 2>/dev/null | grep -cE "$hour_pattern" 2>/dev/null) || bans=0
-        unbans=$(grep -c "UNBANNED$" "$NFTBAN_BAN_LOG" 2>/dev/null | grep -cE "$hour_pattern" 2>/dev/null) || unbans=0
-
-        # Simpler: count today's bans in current hour
+        # Count today's bans/unbans in the current hour via awk on the current %H.
+        # (Removed a dead, buggy `grep -c … | grep -cE …` pair + its now-unused
+        # today/hour_pattern locals that this awk had already superseded.)
         bans=$(awk -F'|' -v h="$(date +%H)" '$1 ~ /^[0-9]/ && $2 ~ "^"h":" && $6=="BANNED" {c++} END {print c+0}' "$NFTBAN_BAN_LOG" 2>/dev/null) || bans=0
         unbans=$(awk -F'|' -v h="$(date +%H)" '$1 ~ /^[0-9]/ && $2 ~ "^"h":" && $6=="UNBANNED" {c++} END {print c+0}' "$NFTBAN_BAN_LOG" 2>/dev/null) || unbans=0
     else

--- a/cli/lib/nftban/lib/nftban_report_data.sh
+++ b/cli/lib/nftban/lib/nftban_report_data.sh
@@ -166,7 +166,9 @@ _count_unique_ips_24h() {
     since=$(date -d '24 hours ago' '+%Y-%m-%d' 2>/dev/null || date '+%Y-%m-%d')
 
     if [[ -f "$ban_log" ]]; then
-        grep "^${since}" "$ban_log" 2>/dev/null | cut -d'|' -f4 | sort -u | wc -l || echo 0
+        # pipefail-safe single-emit: wrap zero-match grep so wc emits exactly one count,
+        # never "0\n0" (grep-fail + trailing `|| echo 0`) which crashed the caller's arith.
+        { grep "^${since}" "$ban_log" 2>/dev/null || true; } | cut -d'|' -f4 | sort -u | wc -l
     else
         echo 0
     fi

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -657,7 +657,9 @@ nftban_enable_all() {
 
     # Check 4: core timers active (at least 1)
     local timers_active=0
-    timers_active=$(systemctl list-timers 'nftban-*' --no-legend 2>/dev/null | wc -l || echo 0)
+    # wrap systemctl (rc!=0 path) so wc emits one count, never "0\n0" into the `[[ -eq 0 ]]`.
+    timers_active=$({ systemctl list-timers 'nftban-*' --no-legend 2>/dev/null || true; } | wc -l)
+    timers_active=${timers_active//[^0-9]/}; timers_active=${timers_active:-0}
     if [[ "$timers_active" -eq 0 ]]; then
         validation_failures+=("timers: 0 active")
     fi

--- a/cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
+++ b/cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.172 CLI-PIPEFAIL-ARITH full-class sweep
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_pipefail_arith_sweep_v172_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-11"
+# meta:description="Locks the v1.172 CLI-PIPEFAIL-ARITH sweep. Under set -Eeuo pipefail a `… | <emit-on-empty> … || <fallback>` inside $() double-emits when an early pipe stage (zero-match grep rc=1, head-closes-pipe SIGPIPE, or a jq parse error) fails while the final stage already printed a default → e.g. '0\\n0'; the consumer's [[ $X -eq/-gt ]] / jq tonumber then crashes. Part A (behavioral): the two fixed report_email count idioms single-emit on an empty nft-style set, and a wrapped grep|wc never doubles. Part B (static source lint): the previously-broken sites no longer carry the unsafe `wc -l || echo`, `grep -c | grep -c`, or `jq length … || echo` forms that feed arith; the re-readonly guard is present in cmd_wizard; the dead grep-c chain is gone from stats_format. Hermetic: no host/root/nft/daemon."
+# meta:input="None (temp files; sources nothing privileged)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,wc,jq"
+# meta:inventory.files="cli/lib/nftban/core/nftban_report_email.sh,cli/lib/nftban/lib/nftban_report_data.sh,cli/lib/nftban/cli/cmd_ddos.sh,cli/lib/nftban/cli/cmd_stats.sh,cli/lib/nftban/cli/cmd_cleanup.sh,cli/lib/nftban/cli/cmd_login.sh,cli/lib/nftban/core/nftban_login_alert.sh,cli/lib/nftban/cli/cmd_update.sh,cli/lib/nftban/cli/cmd_watchdog.sh,cli/lib/nftban/core/nftban_health_checks_services.sh,cli/lib/nftban/lib/service_control.sh,cli/lib/nftban/cli/cmd_wizard.sh,cli/lib/nftban/core/nftban_stats_format.sh"
+# meta:inventory.binaries="bash,jq,grep,wc"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+SRC="$REPO_ROOT/cli/lib/nftban"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+command -v jq >/dev/null 2>&1 || { echo "jq required for this test"; exit 1; }
+
+echo "== Part A: behavioral — the fixed idioms single-emit under pipefail =="
+
+# A1: the report_email v4-count idiom (wrapped grep | wc) on a set with NO IPv4
+# matches must produce exactly one integer line (the old `grep -oE | wc -l || echo 0`
+# produced "0\n0" → `$(( ))` crash).
+emulate_v4_count() {
+  # mimic: nft output piped through the fixed producer
+  printf '%s\n' "$1" | { grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?' || true; } | wc -l
+}
+out=$(emulate_v4_count "table ip nftban { set blacklist_ipv4 { } }")
+out=${out//[^0-9]/}; out=${out:-0}
+if [[ "$out" == "0" ]] && { v=$(( out + 0 )); [[ "$v" -eq 0 ]]; }; then
+  ok "A1 empty-set v4 count single-emits a usable 0 (no arith crash)"
+else
+  no "A1 empty-set v4 count" "got '$out'"
+fi
+
+# A2: a populated set yields the real count, still single-emit.
+out=$(emulate_v4_count "1.2.3.4
+5.6.7.8")
+out=${out//[^0-9]/}; out=${out:-0}
+[[ "$out" == "2" ]] && ok "A2 populated v4 count = 2" || no "A2 populated v4 count" "got '$out'"
+
+# A3: the wrapped `{ grep || true; } | wc -l` never double-emits even when grep
+# fails AND a stray trailing default would have fired.
+probe=$({ grep -oE 'ZZZ' <<<"no match here" || true; } | wc -l)
+probe=${probe//[^0-9]/}
+[[ "$probe" == "0" ]] && ok "A3 wrapped grep|wc emits one 0 on zero match" || no "A3 wrapped grep|wc" "got '$probe'"
+
+# A4: jq -s 'add // [] | length' yields ONE integer for a single array AND for
+# accidentally-appended arrays (the digest/history count idiom).
+single=$(printf '%s' '[1,2,3]' | jq -s 'add // [] | length' 2>/dev/null)
+appended=$(printf '%s' '[1,2][3,4,5]' | jq -s 'add // [] | length' 2>/dev/null)
+empty=$(printf '%s' '' | jq -s 'add // [] | length' 2>/dev/null)
+[[ "$single" == "3" && "$appended" == "5" && "$empty" == "0" ]] \
+  && ok "A4 jq -s add//[]|length single-emits (single=3 appended=5 empty=0)" \
+  || no "A4 jq -s add count" "single='$single' appended='$appended' empty='$empty'"
+
+echo "== Part B: static source lint — unsafe arith-fed idioms are gone =="
+
+# Helper: assert a regex does NOT match in a file.
+absent(){ # <file> <ere> <label>
+  local f="$SRC/$1"
+  if [[ ! -f "$f" ]]; then no "$3" "missing $1"; return; fi
+  if grep -nE "$2" "$f" >/dev/null 2>&1; then
+    no "$3" "still present: $(grep -nE "$2" "$f" | head -1)"
+  else ok "$3"; fi
+}
+present(){ # <file> <ere> <label>
+  local f="$SRC/$1"
+  if [[ -f "$f" ]] && grep -nE "$2" "$f" >/dev/null 2>&1; then ok "$3"; else no "$3" "expected pattern in $1"; fi
+}
+
+# B1: report_email v4 counts no longer use `… | wc -l || echo 0` (the double-emit).
+absent "core/nftban_report_email.sh" 'wc -l \|\| echo 0' "B1 report_email: no 'wc -l || echo 0'"
+# B2: report_data unique-IP count likewise.
+absent "lib/nftban_report_data.sh" 'wc -l \|\| echo 0' "B2 report_data: no 'wc -l || echo 0'"
+# B3: ddos blocked_24h/total no longer end the jq pipe with `|| echo "0"`.
+absent "cli/cmd_ddos.sh" "jq -s '. \| length' 2>/dev/null \|\| echo" "B3 ddos: no 'jq -s length … || echo'"
+# B4: ddos packets/bytes no longer use `head -1 || echo "0"`.
+absent "cli/cmd_ddos.sh" 'head -1 \|\| echo' "B4 ddos: no 'head -1 || echo'"
+# B5: stats repeat-offenders count is now 2>/dev/null guarded (not a bare jq into arith).
+absent "cli/cmd_stats.sh" "jq '. \| length'\)$" "B5 stats: no bare 'jq . | length)' into count"
+# B6: cleanup ip_count is guarded (no bare `jq -r 'length'` straight into [[ -eq ]]).
+absent "cli/cmd_cleanup.sh" "jq -r 'length'\)$" "B6 cleanup: no bare 'jq -r length)'"
+# B7: login + update + login_alert use the robust slurp form.
+present "cli/cmd_login.sh"  "jq -s 'add // \[\] \| length'" "B7a login: uses 'jq -s add//[]|length'"
+present "cli/cmd_update.sh" "jq -s 'add // \[\] \| length'" "B7b update: uses 'jq -s add//[]|length'"
+present "core/nftban_login_alert.sh" "jq -s 'add // \[\] \| length'" "B7c login_alert: uses 'jq -s add//[]|length'"
+absent  "cli/cmd_login.sh"  "jq 'length' \"\\\$digest_file\" 2>/dev/null \|\| echo" "B7d login: old 'jq length || echo' gone"
+# B8: watchdog history count coerces null → [] and sanitizes.
+present "cli/cmd_watchdog.sh" "jq -c '.data.history // \[\]'" "B8 watchdog: history coerced via // []"
+# B9: new arith-fed siblings wrapped (fd_count, timers_active).
+absent "core/nftban_health_checks_services.sh" 'wc -l \|\| echo 0' "B9a health: fd_count no 'wc -l || echo 0'"
+absent "lib/service_control.sh" 'wc -l \|\| echo 0' "B9b service_control: timers no 'wc -l || echo 0'"
+# B10: stats_format dead grep-c | grep-c chain removed (match the real quoted code,
+# not this/other explanatory comments that mention the pattern).
+absent "core/nftban_stats_format.sh" 'grep -c "[A-Z].*\| grep -cE "' "B10 stats_format: dead 'grep -c | grep -cE' gone"
+# B11: cmd_wizard re-readonly guard present (no bare readonly on the two vars).
+present "cli/cmd_wizard.sh" '\|\| readonly NFTBAN_CONFIG_LOCAL=' "B11a wizard: guarded readonly NFTBAN_CONFIG_LOCAL"
+present "cli/cmd_wizard.sh" '\|\| readonly NFTBAN_PROFILE_CURRENT=' "B11b wizard: guarded readonly NFTBAN_PROFILE_CURRENT"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## v1.172 — CLI-PIPEFAIL-ARITH full-class sweep

Merges the former v1.172 (HIGH) + v1.173 (MED+LOW) into ONE shell-only release (operator decision 2026-06-11). Scope: `NFTBAN_ROADMAP/V172_CLI_PIPEFAIL_SWEEP_SCOPE.md`.

### The class
Under `set -Eeuo pipefail`, a `producer | <emit-on-empty> … || <fallback>` inside `$()` double-emits when an early pipe stage fails (zero-match `grep` rc=1, head-closes-pipe SIGPIPE rc=141, or a `jq` parse error) while a later stage already printed a default → `"0\n0"`; the consumer's `[[ $X -eq/-gt ]]` / `jq tonumber` then crashes. Already closed for `stats ip` in v1.170 (A1/B1/C1) — this applies the proven idioms to the remaining siblings.

### Fixed (16 sites — 13 from audit + 3 found via full-class scan)
- **HIGH** — `nftban_report_email.sh` blacklist/whitelist empty-set counts (aborted the daily report on a fresh install); `cmd_watchdog.sh` history count on the daemon-just-started path.
- **MED** — `nftban_report_data.sh` unique-IP count; `cmd_ddos.sh` blocked_24h/total + packets/bytes; `cmd_stats.sh` repeat-offenders / ip-history total / total_countries; `cmd_cleanup.sh` ip_count; `cmd_login.sh` + `cmd_update.sh` digest/history counts (`jq -s 'add // [] | length'`).
- **MED siblings (audit missed)** — `nftban_login_alert.sh` digest count; `nftban_health_checks_services.sh` fd_count; `service_control.sh` timers_active (directly `[[ -eq 0 ]]`-consumed).
- **LOW** — `cmd_wizard.sh` re-`readonly` guard; `nftban_stats_format.sh` dead `grep -c | grep -cE` removal.

### Correctness notes
- Digest/history files are single JSON arrays (`'. += [$entry]'` / `'[$entry] + .'`) → `jq -s 'add // [] | length'` is robust for single + accidental appended arrays.
- These files run under `set -Eeuo pipefail`; dropped `|| echo X` fallbacks were replaced with `|| true` (rc-safe, no second emit) — empirically confirmed bare assignments abort (exit=5) otherwise.

### Envelope
Shell-only · **daemon byte-identical** (0 `cmd/`/`internal/`) · schema **1.83.0 frozen** · FHS body unchanged · hermetic (no lab gate).

### Tests
New `cli_pipefail_arith_sweep_v172_test.sh` (20/0): behavioral single-emit + static lint that the broken forms are gone; CI-wired in `ci-architecture.yml`. Regression: v170 stats 7/0, MAC 17/0; `bash -n` 13/13; shellcheck-error 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)