### PR TITLE
fix(installer,cli): §4.1 session-whitelist cross-language flock + executor fsync (v1.173)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -741,6 +741,14 @@ jobs:
       - name: CLI pipefail-arith sweep (v1.172)
         run: bash cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
 
+      # v1.173 §4.1 session-whitelist flock (shell side): each of the 3
+      # cmd_firewall.sh session RMW funcs serializes its read-modify-write under
+      # flock(9) on the shared cross-language lock /run/nftban/session_whitelist.lock
+      # (same path the Go installer flock(2)s). Go side is covered by
+      # internal/installer/safety/session_whitelist_flock_v173_test.go.
+      - name: session-whitelist flock shell-side (v1.173)
+        run: bash cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -383,8 +383,16 @@ HELP_EOF
     esac
 }
 
-# Internal helper: 00-session.conf path
-_NFTBAN_SESSION_WHITELIST_PATH="/etc/nftban/whitelist.d/00-session.conf"
+# Internal helper: 00-session.conf path (overridable for hermetic tests)
+_NFTBAN_SESSION_WHITELIST_PATH="${_NFTBAN_SESSION_WHITELIST_PATH:-/etc/nftban/whitelist.d/00-session.conf}"
+
+# §4.1: cross-process / cross-language advisory lock shared with the Go installer
+# (internal/installer/safety/session_whitelist.go). Both sides flock(2) this SAME
+# path to serialize the read-modify-write of 00-session.conf so a concurrent
+# `nftban update` (Go) and a CLI add/remove/cleanup can't lose an update (atomic
+# rename only prevents torn reads, not lost updates). Volatile /run, on-demand;
+# overridable for hermetic tests.
+_NFTBAN_SESSION_WL_LOCK="${_NFTBAN_SESSION_WL_LOCK:-/run/nftban/session_whitelist.lock}"
 
 # Internal helper: validate IP or CIDR. Returns 0 if valid, 1 otherwise.
 # Uses basic bash regex; not as strict as Go's net.ParseIP but catches
@@ -503,39 +511,48 @@ _whitelist_session_add() {
         return 1
     fi
 
-    _whitelist_session_ensure_header
-
     local expires_at
     expires_at=$(date -u -d "@$(( $(date -u +%s) + ttl_sec ))" '+%Y-%m-%dT%H:%M:%SZ')
 
-    # Remove any prior entry for the same IP (refresh semantics).
-    local tmp
-    tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
-    # shellcheck disable=SC2016
-    awk -v ip="$ip" '
-        # Drop entry lines whose first token equals ip
-        {
-            t = $0
-            # Strip leading whitespace
-            gsub(/^[ \t]+/, "", t)
-            # If line starts with # or is empty, keep as-is
-            if (t == "" || substr(t, 1, 1) == "#") { print; next }
-            # Take first whitespace-delimited token; strip trailing comment
-            split(t, a, "#")
-            n = split(a[1], b, /[ \t]+/)
-            if (n >= 1 && b[1] == ip) next   # drop
-            print
-        }
-    ' "$_NFTBAN_SESSION_WHITELIST_PATH" > "$tmp"
+    # §4.1: serialize the whole read-modify-write under the cross-process /
+    # cross-language advisory lock shared with the Go installer (both flock(2)
+    # $_NFTBAN_SESSION_WL_LOCK). ensure_header + awk-read + append + rename all
+    # run while the lock is held.
+    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    (
+        flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
 
-    # Append the new entry.
-    printf '%s  # EXPIRES_AT=%s  REASON=%s  ADDED_BY=nftban-firewall-whitelist-session\n' \
-        "$ip" "$expires_at" "$reason" >> "$tmp"
+        _whitelist_session_ensure_header
 
-    # Atomic rename.
-    mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
-    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
-    chown root:nftban "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+        # Remove any prior entry for the same IP (refresh semantics).
+        local tmp
+        tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+        # shellcheck disable=SC2016
+        awk -v ip="$ip" '
+            # Drop entry lines whose first token equals ip
+            {
+                t = $0
+                # Strip leading whitespace
+                gsub(/^[ \t]+/, "", t)
+                # If line starts with # or is empty, keep as-is
+                if (t == "" || substr(t, 1, 1) == "#") { print; next }
+                # Take first whitespace-delimited token; strip trailing comment
+                split(t, a, "#")
+                n = split(a[1], b, /[ \t]+/)
+                if (n >= 1 && b[1] == ip) next   # drop
+                print
+            }
+        ' "$_NFTBAN_SESSION_WHITELIST_PATH" > "$tmp"
+
+        # Append the new entry.
+        printf '%s  # EXPIRES_AT=%s  REASON=%s  ADDED_BY=nftban-firewall-whitelist-session\n' \
+            "$ip" "$expires_at" "$reason" >> "$tmp"
+
+        # Atomic rename.
+        mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
+        chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+        chown root:nftban "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+    ) 9>"$_NFTBAN_SESSION_WL_LOCK" || return 1
 
     echo "Added: $ip  (expires $expires_at, reason=$reason)"
 
@@ -651,6 +668,12 @@ _whitelist_session_remove() {
         return 0
     fi
 
+    # §4.1: serialize the read-modify-write under the shared cross-process /
+    # cross-language advisory lock (same path the Go installer flock(2)s).
+    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    (
+        flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
+
     local tmp
     tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
     local removed=0
@@ -691,6 +714,7 @@ _whitelist_session_remove() {
     else
         echo "Removed: $ip"
     fi
+    ) 9>"$_NFTBAN_SESSION_WL_LOCK" || return 1
 
     if command -v nftban >/dev/null 2>&1; then
         nftban firewall reload >/dev/null 2>&1 || true
@@ -709,43 +733,55 @@ _whitelist_session_cleanup() {
         return 1
     fi
 
-    local now_unix
-    now_unix=$(date -u +%s)
-    local tmp
-    tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+    # §4.1: serialize the read-modify-write under the shared cross-process /
+    # cross-language advisory lock (same path the Go installer flock(2)s). The
+    # subshell prints the removed-count on stdout so the caller acts on it AFTER
+    # the lock is released (the reload runs unlocked).
+    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    local removed
+    removed=$(
+        flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
 
-    local removed=0
-    local line
-    while IFS= read -r line; do
-        local trimmed="${line#"${line%%[![:space:]]*}"}"
-        if [[ -z "$trimmed" || "${trimmed:0:1}" == "#" ]]; then
+        local now_unix
+        now_unix=$(date -u +%s)
+        local tmp
+        tmp=$(mktemp "${_NFTBAN_SESSION_WHITELIST_PATH}.XXXXXX")
+
+        local _rm=0
+        local line
+        while IFS= read -r line; do
+            local trimmed="${line#"${line%%[![:space:]]*}"}"
+            if [[ -z "$trimmed" || "${trimmed:0:1}" == "#" ]]; then
+                printf '%s\n' "$line" >> "$tmp"
+                continue
+            fi
+
+            # Entry line — check EXPIRES_AT
+            if [[ "$line" == *EXPIRES_AT=* ]]; then
+                local expires_at
+                expires_at=$(echo "$line" | grep -oE 'EXPIRES_AT=[^ ]+' | head -1 | cut -d= -f2)
+                local expires_unix
+                expires_unix=$(date -u -d "$expires_at" +%s 2>/dev/null)
+                if [[ -z "$expires_unix" ]]; then
+                    # Unparseable — drop conservatively
+                    _rm=$(( _rm + 1 ))
+                    continue
+                fi
+                if [[ "$expires_unix" -le "$now_unix" ]]; then
+                    # Expired — drop
+                    _rm=$(( _rm + 1 ))
+                    continue
+                fi
+            fi
+            # No EXPIRES_AT marker OR not expired — keep
             printf '%s\n' "$line" >> "$tmp"
-            continue
-        fi
+        done < "$_NFTBAN_SESSION_WHITELIST_PATH"
 
-        # Entry line — check EXPIRES_AT
-        if [[ "$line" == *EXPIRES_AT=* ]]; then
-            local expires_at
-            expires_at=$(echo "$line" | grep -oE 'EXPIRES_AT=[^ ]+' | head -1 | cut -d= -f2)
-            local expires_unix
-            expires_unix=$(date -u -d "$expires_at" +%s 2>/dev/null)
-            if [[ -z "$expires_unix" ]]; then
-                # Unparseable — drop conservatively
-                removed=$(( removed + 1 ))
-                continue
-            fi
-            if [[ "$expires_unix" -le "$now_unix" ]]; then
-                # Expired — drop
-                removed=$(( removed + 1 ))
-                continue
-            fi
-        fi
-        # No EXPIRES_AT marker OR not expired — keep
-        printf '%s\n' "$line" >> "$tmp"
-    done < "$_NFTBAN_SESSION_WHITELIST_PATH"
-
-    mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
-    chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+        mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
+        chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
+        echo "$_rm"
+    ) 9>"$_NFTBAN_SESSION_WL_LOCK" || return 1
+    removed=${removed//[^0-9]/}; removed=${removed:-0}
 
     if [[ "$removed" -gt 0 ]]; then
         echo "Removed $removed expired entries"

--- a/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
+++ b/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.173 §4.1 session-whitelist flock (shell side)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="session_whitelist_flock_v173_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-11"
+# meta:description="Locks the v1.173 §4.1 shell side: the three session-whitelist read-modify-write funcs in cmd_firewall.sh (_whitelist_session_add/remove/cleanup) each serialize their RMW under flock(9) on the shared cross-language lock \$_NFTBAN_SESSION_WL_LOCK (= /run/nftban/session_whitelist.lock, the SAME path the Go installer flock(2)s) so a concurrent Go \`nftban update\` and a CLI write can't lose an update. (1) the lock var + data path are defined and overridable; (2) each func opens fd 9 on the shared lock and runs its mv (atomic rename) while the lock is held; (3) a behavioral flock-mechanism check proves flock(1) actually serializes concurrent appenders (the real funcs gate on root, so the full shell∥Go behavioral race is a lab step). Hermetic: static source assertions + a temp-file flock mechanism check; no root, no /run, no nft."
+# meta:input="None (reads cmd_firewall.sh; temp file for the mechanism check)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,awk,grep,flock"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="flock"
+# meta:inventory.env_vars="_NFTBAN_SESSION_WL_LOCK,_NFTBAN_SESSION_WHITELIST_PATH"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+FW="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$FW" ]] || { echo "cmd_firewall.sh not found at $FW"; exit 1; }
+
+echo "== Part A: lock + path vars defined and overridable =="
+grep -qE '_NFTBAN_SESSION_WL_LOCK="\$\{_NFTBAN_SESSION_WL_LOCK:-/run/nftban/session_whitelist\.lock\}"' "$FW" \
+  && ok "A1 shared lock var = /run/nftban/session_whitelist.lock (overridable)" \
+  || no "A1 shared lock var" "missing/changed"
+grep -qE '_NFTBAN_SESSION_WHITELIST_PATH="\$\{_NFTBAN_SESSION_WHITELIST_PATH:-/etc/nftban/whitelist\.d/00-session\.conf\}"' "$FW" \
+  && ok "A2 session path overridable" || no "A2 session path overridable" "missing/changed"
+
+echo "== Part B: each RMW func locks the full read-modify-write =="
+# Extract a function body (from `name() {` to the matching closing brace at col 0).
+func_body(){ awk -v fn="$1" '
+  $0 ~ "^"fn"\\(\\) \\{" {inf=1}
+  inf {print}
+  inf && /^\}/ {exit}
+' "$FW"; }
+
+for fn in _whitelist_session_add _whitelist_session_remove _whitelist_session_cleanup; do
+  body="$(func_body "$fn")"
+  if [[ -z "$body" ]]; then no "B:$fn body" "not found"; continue; fi
+  has_flock=0; has_fd=0; has_mv=0
+  grep -qE 'flock 9' <<<"$body" && has_flock=1
+  grep -qE '9>"\$_NFTBAN_SESSION_WL_LOCK"' <<<"$body" && has_fd=1
+  grep -qE 'mv "\$tmp" "\$_NFTBAN_SESSION_WHITELIST_PATH"' <<<"$body" && has_mv=1
+  if [[ $has_flock -eq 1 && $has_fd -eq 1 && $has_mv -eq 1 ]]; then
+    ok "B $fn: RMW (mv) runs under flock 9 on the shared lock"
+  else
+    no "B $fn: flock-wrapped RMW" "flock=$has_flock fd=$has_fd mv=$has_mv"
+  fi
+done
+
+echo "== Part C: flock(1) actually serializes concurrent appenders (mechanism) =="
+if ! command -v flock >/dev/null 2>&1; then
+  echo "  (skip C: flock(1) not available)"
+else
+  WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+  lock="$WORK/lock"; out="$WORK/out"; : > "$out"
+  # 30 concurrent appenders, each does read-count→append under the same flock.
+  # Under a correct lock the final line count is exactly 30 (no lost update);
+  # without it, racing read-modify-append would drop lines.
+  app(){ ( flock 9; n=$(wc -l < "$out"); printf 'line-%s\n' "$((n+1))" >> "$out" ) 9>"$lock"; }
+  pids=()
+  for _ in $(seq 1 30); do app & pids+=("$!"); done
+  for p in "${pids[@]}"; do wait "$p"; done
+  got=$(wc -l < "$out"); got=${got//[^0-9]/}
+  [[ "$got" == "30" ]] && ok "C flock serialized 30 concurrent RMW appenders (no lost update)" \
+    || no "C flock mechanism" "expected 30 lines, got $got"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/internal/installer/executor/real.go
+++ b/internal/installer/executor/real.go
@@ -91,6 +91,15 @@ func (r *RealExecutor) WriteFileAtomic(path string, data []byte, perm os.FileMod
 		os.Remove(tmpName)
 		return fmt.Errorf("chmod temp for %s: %w", path, err)
 	}
+	// fsync the temp file before rename so a crash right after the rename
+	// cannot leave a renamed-but-empty/partial file on the target path.
+	// Directory fsync is intentionally omitted (an old-but-complete version
+	// after a crash is acceptable here; see the F-3 DIR-FSYNC decision note).
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sync temp for %s: %w", path, err)
+	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
 		return fmt.Errorf("close temp for %s: %w", path, err)

--- a/internal/installer/safety/session_whitelist.go
+++ b/internal/installer/safety/session_whitelist.go
@@ -56,7 +56,9 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/installer/executor"
@@ -65,8 +67,47 @@ import (
 
 // sessionWhitelistPath is the canonical path for time-bounded operator-session
 // whitelist entries. Distinct from manualWhitelistPath (99-manual.conf) which
-// holds permanent operator-owned content.
-const sessionWhitelistPath = "/etc/nftban/whitelist.d/00-session.conf"
+// holds permanent operator-owned content. A var (not const) so hermetic tests
+// can redirect it to a temp file and restore via t.Cleanup.
+var sessionWhitelistPath = "/etc/nftban/whitelist.d/00-session.conf"
+
+// sessionWhitelistLockPath is a volatile, on-demand advisory lock file used to
+// serialize the read-modify-write of sessionWhitelistPath ACROSS processes and
+// ACROSS languages: Go takes it via syscall.Flock here; the shell CLI takes the
+// SAME path via flock(1) in cli/lib/nftban/cli/cmd_firewall.sh. Both use
+// flock(2), so they genuinely interlock. It lives under /run (not the config
+// dir) so the whitelist `*.conf` loader glob can never see it. A var so tests
+// can redirect it.
+var sessionWhitelistLockPath = "/run/nftban/session_whitelist.lock"
+
+// lockSessionWhitelist takes an exclusive advisory lock (flock LOCK_EX) on
+// sessionWhitelistLockPath for the full duration of a session-whitelist
+// read-modify-write, returning an unlock func the caller MUST defer.
+//
+// A SEPARATE lock file (not the data file) is used deliberately: the data file
+// is replaced via atomic rename, which changes its inode, so a lock held on the
+// data fd would not exclude a concurrent writer that opens the new inode. Same
+// rationale as internal/persistence/blacklistd.go. The parent runtime dir is
+// created on-demand (volatile /run).
+func lockSessionWhitelist() (func(), error) {
+	if dir := filepath.Dir(sessionWhitelistLockPath); dir != "" {
+		_ = os.MkdirAll(dir, 0o750)
+	}
+	// 0600 root-only: only root processes (installer + CLI firewall verbs) take
+	// this lock. filepath.Clean keeps gosec G304 quiet (matches blacklistd.go).
+	f, err := os.OpenFile(filepath.Clean(sessionWhitelistLockPath), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open session-whitelist lock %s: %w", sessionWhitelistLockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { // #nosec G115 -- fd always fits in int
+		_ = f.Close()
+		return nil, fmt.Errorf("flock session-whitelist lock %s: %w", sessionWhitelistLockPath, err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) // #nosec G115 -- fd always fits in int
+		_ = f.Close()
+	}, nil
+}
 
 // DefaultSessionWhitelistTTL is the default time-to-live for auto-seeded
 // operator SSH peer entries during `nftban update` / `firewall takeover`.
@@ -134,6 +175,14 @@ func AddSessionWhitelist(exec executor.Executor, log *logging.Logger, entry Sess
 		entry.Reason = "session"
 	}
 
+	// Serialize the whole read-modify-write against concurrent Go/shell writers
+	// (cross-process, cross-language lost-update guard, §4.1).
+	unlock, lerr := lockSessionWhitelist()
+	if lerr != nil {
+		return fmt.Errorf("AddSessionWhitelist: %w", lerr)
+	}
+	defer unlock()
+
 	// Read existing content if file exists.
 	var existing []byte
 	if exec.FileExists(sessionWhitelistPath) {
@@ -192,6 +241,13 @@ func AddSessionWhitelist(exec executor.Executor, log *logging.Logger, entry Sess
 // function is OPTIONAL for correctness — it is provided as a file-hygiene
 // helper so the on-disk file doesn't accumulate stale entries indefinitely.
 func CleanupExpiredSessionWhitelist(exec executor.Executor, log *logging.Logger) (int, error) {
+	// Serialize the read-modify-write (cross-process, cross-language, §4.1).
+	unlock, lerr := lockSessionWhitelist()
+	if lerr != nil {
+		return 0, fmt.Errorf("CleanupExpiredSessionWhitelist: %w", lerr)
+	}
+	defer unlock()
+
 	if !exec.FileExists(sessionWhitelistPath) {
 		return 0, nil
 	}
@@ -271,6 +327,13 @@ func RemoveSessionWhitelist(exec executor.Executor, log *logging.Logger, ip stri
 	if ip == "" {
 		return 0, fmt.Errorf("RemoveSessionWhitelist: empty IP")
 	}
+	// Serialize the read-modify-write (cross-process, cross-language, §4.1).
+	unlock, lerr := lockSessionWhitelist()
+	if lerr != nil {
+		return 0, fmt.Errorf("RemoveSessionWhitelist: %w", lerr)
+	}
+	defer unlock()
+
 	if !exec.FileExists(sessionWhitelistPath) {
 		return 0, nil
 	}

--- a/internal/installer/safety/session_whitelist_flock_v173_test.go
+++ b/internal/installer/safety/session_whitelist_flock_v173_test.go
@@ -1,0 +1,110 @@
+// =============================================================================
+// NFTBan v1.173 - §4.1 session-whitelist flock (cross-process lost-update fix)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-safety-session-flock-v173-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-11"
+// meta:description="Locks the v1.173 §4.1 fix: the session-whitelist read-modify-write is serialized by an exclusive flock on /run/nftban/session_whitelist.lock so concurrent writers cannot lose updates, and that lock interlocks cross-language with shell flock(1) (both flock(2)). (1) ConcurrentAdd: N parallel AddSessionWhitelist via the RealExecutor on a temp file → all N entries survive (no lost update). (2) CrossLanguageFlock: while Go holds LOCK_EX, a non-blocking shell `flock -n` on the SAME path fails; after release it succeeds. Hermetic: temp data path + temp lock path (TestMain); no /run, no root, no nft."
+// meta:inventory.files="internal/installer/safety/session_whitelist.go,internal/installer/executor/real.go,cli/lib/nftban/cli/cmd_firewall.sh"
+// meta:inventory.binaries="flock"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package safety
+
+import (
+	osexec "os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// withTempSessionFile redirects sessionWhitelistPath to a per-test temp file
+// and restores it afterwards. sessionWhitelistLockPath is already a temp path
+// (set once in TestMain).
+func withTempSessionFile(t *testing.T) {
+	t.Helper()
+	old := sessionWhitelistPath
+	sessionWhitelistPath = filepath.Join(t.TempDir(), "00-session.conf")
+	t.Cleanup(func() { sessionWhitelistPath = old })
+}
+
+// TestSessionWhitelist_ConcurrentAddNoLostUpdate proves the §4.1 flock
+// serializes the whole read-modify-write: N parallel AddSessionWhitelist calls
+// (real filesystem) all survive. Without a lock around the full RMW, each
+// goroutine would read the file, modify in memory, and the last writer would
+// clobber the others (atomic rename prevents torn reads, NOT lost updates).
+func TestSessionWhitelist_ConcurrentAddNoLostUpdate(t *testing.T) {
+	withTempSessionFile(t)
+	re := &executor.RealExecutor{}
+	log := newSessionTestLogger(t)
+
+	const n = 24
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			e := SessionWhitelistEntry{
+				IP:        "10.0.0." + strconv.Itoa(i),
+				ExpiresAt: time.Now().Add(time.Hour),
+				Reason:    "concurrent",
+				AddedBy:   "test",
+			}
+			if err := AddSessionWhitelist(re, log, e); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent AddSessionWhitelist: %v", err)
+	}
+
+	entries, err := ReadSessionWhitelist(re, log)
+	if err != nil {
+		t.Fatalf("ReadSessionWhitelist: %v", err)
+	}
+	if len(entries) != n {
+		t.Fatalf("lost-update: expected %d entries after %d concurrent adds, got %d", n, n, len(entries))
+	}
+}
+
+// TestSessionWhitelist_CrossLanguageFlockExcludesShell proves the Go lock and
+// the shell flock(1) interlock on the SAME path (both flock(2)): while Go holds
+// LOCK_EX, a non-blocking shell `flock -n` must FAIL; after release it must
+// succeed. This is the cross-language guarantee a Go-only test cannot cover.
+func TestSessionWhitelist_CrossLanguageFlockExcludesShell(t *testing.T) {
+	if _, err := osexec.LookPath("flock"); err != nil {
+		t.Skip("flock(1) not available")
+	}
+
+	unlock, err := lockSessionWhitelist()
+	if err != nil {
+		t.Fatalf("lockSessionWhitelist: %v", err)
+	}
+
+	// While Go holds the lock, a non-blocking shell flock on the same path must fail.
+	if err := osexec.Command("flock", "-n", sessionWhitelistLockPath, "-c", "true").Run(); err == nil {
+		unlock()
+		t.Fatalf("cross-language: shell `flock -n` acquired the lock while Go held it (no exclusion)")
+	}
+
+	// After release, the shell flock must succeed.
+	unlock()
+	if err := osexec.Command("flock", "-n", sessionWhitelistLockPath, "-c", "true").Run(); err != nil {
+		t.Fatalf("cross-language: shell `flock -n` failed after Go released the lock: %v", err)
+	}
+}

--- a/internal/installer/safety/session_whitelist_test.go
+++ b/internal/installer/safety/session_whitelist_test.go
@@ -23,6 +23,8 @@
 package safety
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +32,21 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
+
+// TestMain redirects the cross-process session-whitelist lock to a writable
+// temp path so the package's tests neither require /run/nftban nor root (they
+// run unprivileged in CI). The flock still engages on the temp file, so the
+// concurrency test exercises a real lock.
+func TestMain(m *testing.M) {
+	d, err := os.MkdirTemp("", "nftban-sessionlock-")
+	if err != nil {
+		panic(err)
+	}
+	sessionWhitelistLockPath = filepath.Join(d, "session_whitelist.lock")
+	code := m.Run()
+	_ = os.RemoveAll(d)
+	os.Exit(code)
+}
 
 // newSessionTestLogger returns a Logger writing to /dev/null. The test never
 // asserts on log output; we just need a non-nil Logger.


### PR DESCRIPTION
## v1.173 — §4.1 SESSION-WHITELIST FLOCK (cross-process lost-update fix)

Scope: `NFTBAN_ROADMAP/V173_SESSION_FLOCK_SCOPE.md`. Baseline v1.172.0 (`3f79c727`).

### The defect (code-traced)
`/etc/nftban/whitelist.d/00-session.conf` is written by **6 read-modify-write writers across two languages with no shared lock** → concurrent writers lose updates (atomic rename prevents torn reads, not lost updates):
- Go `internal/installer/safety/session_whitelist.go` Add/Cleanup/Remove (→ `executor.WriteFileAtomic`, no Sync/flock)
- Shell `cli/lib/nftban/cli/cmd_firewall.sh` session add/remove/cleanup (mktemp+`mv`, no flock)
- Race: `nftban update` (Go Add) ∥ `whitelist-session add/remove` (shell).

### Fix
- **One shared cross-process / cross-language advisory lock** `/run/nftban/session_whitelist.lock`, taken for the **full** read→modify→write. Go `syscall.Flock(LOCK_EX)` ↔ shell `flock(1)` both use flock(2) → genuine interlock. Separate lock file (data-file inode changes on rename — `blacklistd.go` rationale).
- `RealExecutor.WriteFileAtomic` now `tmp.Sync()` before rename (FakeExecutor unchanged; dir-fsync omitted per F-3).
- Session paths `const`→`var` for hermetic test injection. **No unrelated CLI cleanup.**

### Envelope
**Installer-Go + shell only. Daemon `cmd/nftband` BYTE-IDENTICAL to v1.172.0** — verified: SHA256 `fdd90f4a…` unchanged, daemon doesn't import `internal/installer/{executor,safety}`, 0 `cmd/nftband/` files changed. Schema **1.83.0 frozen**; FHS body unchanged (volatile `/run` lock, like `maintenance.lock`); no dependency change.

### Tests
- `internal/installer/safety/session_whitelist_flock_v173_test.go` — 24 concurrent adds keep all entries (no lost update) + **cross-language** proof (Go holds LOCK_EX → shell `flock -n` fails, then succeeds after release). Passes under `-race`.
- `cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh` (6/0) — lock-structure guard + flock(1) mechanism check. CI-wired.
- `go build/vet/staticcheck/gofmt` + `bash -n` + shellcheck `-S warning` all green.

### Lab gate (before tag)
The real CLI funcs gate on `EUID==0`, so the full behavioral shell∥Go race is a **lab-first PASS on lab2 (DEB) + lab4 (RPM)** before tag (concurrent add/remove/cleanup ∥ installer add; no lost entry; file always parses; SSH/admin whitelist never dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)