### PR TITLE
fix(cli): force session-whitelist lock to 0600 (cross-language mode parity, v1.173)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -394,6 +394,17 @@ _NFTBAN_SESSION_WHITELIST_PATH="${_NFTBAN_SESSION_WHITELIST_PATH:-/etc/nftban/wh
 # overridable for hermetic tests.
 _NFTBAN_SESSION_WL_LOCK="${_NFTBAN_SESSION_WL_LOCK:-/run/nftban/session_whitelist.lock}"
 
+# Ensure the shared lock file exists at mode 0600 BEFORE the `9>` redirect opens
+# it — the redirect itself honors the process umask (root umask 027 → 0640), so
+# without this the shell would create the lock 0640 while the Go side opens 0600
+# (whichever creates it first wins). Forcing 0600 here gives exact cross-language
+# parity (root-only; matches internal/installer/safety/session_whitelist.go).
+_whitelist_session_ensure_lock() {
+    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    [[ -e "$_NFTBAN_SESSION_WL_LOCK" ]] || ( umask 0177; : > "$_NFTBAN_SESSION_WL_LOCK" ) 2>/dev/null || true
+    chmod 0600 "$_NFTBAN_SESSION_WL_LOCK" 2>/dev/null || true
+}
+
 # Internal helper: validate IP or CIDR. Returns 0 if valid, 1 otherwise.
 # Uses basic bash regex; not as strict as Go's net.ParseIP but catches
 # obvious garbage. Real validation happens at whitelist-load time.
@@ -518,7 +529,7 @@ _whitelist_session_add() {
     # cross-language advisory lock shared with the Go installer (both flock(2)
     # $_NFTBAN_SESSION_WL_LOCK). ensure_header + awk-read + append + rename all
     # run while the lock is held.
-    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    _whitelist_session_ensure_lock
     (
         flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
 
@@ -670,7 +681,7 @@ _whitelist_session_remove() {
 
     # §4.1: serialize the read-modify-write under the shared cross-process /
     # cross-language advisory lock (same path the Go installer flock(2)s).
-    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    _whitelist_session_ensure_lock
     (
         flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
 
@@ -737,7 +748,7 @@ _whitelist_session_cleanup() {
     # cross-language advisory lock (same path the Go installer flock(2)s). The
     # subshell prints the removed-count on stdout so the caller acts on it AFTER
     # the lock is released (the reload runs unlocked).
-    mkdir -p "$(dirname "$_NFTBAN_SESSION_WL_LOCK")" 2>/dev/null || true
+    _whitelist_session_ensure_lock
     local removed
     removed=$(
         flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }

--- a/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
+++ b/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
@@ -49,16 +49,21 @@ func_body(){ awk -v fn="$1" '
 for fn in _whitelist_session_add _whitelist_session_remove _whitelist_session_cleanup; do
   body="$(func_body "$fn")"
   if [[ -z "$body" ]]; then no "B:$fn body" "not found"; continue; fi
-  has_flock=0; has_fd=0; has_mv=0
+  has_flock=0; has_fd=0; has_mv=0; has_ensure=0
   grep -qE 'flock 9' <<<"$body" && has_flock=1
   grep -qE '9>"\$_NFTBAN_SESSION_WL_LOCK"' <<<"$body" && has_fd=1
   grep -qE 'mv "\$tmp" "\$_NFTBAN_SESSION_WHITELIST_PATH"' <<<"$body" && has_mv=1
-  if [[ $has_flock -eq 1 && $has_fd -eq 1 && $has_mv -eq 1 ]]; then
-    ok "B $fn: RMW (mv) runs under flock 9 on the shared lock"
+  grep -qE '_whitelist_session_ensure_lock' <<<"$body" && has_ensure=1
+  if [[ $has_flock -eq 1 && $has_fd -eq 1 && $has_mv -eq 1 && $has_ensure -eq 1 ]]; then
+    ok "B $fn: ensures 0600 lock + RMW (mv) under flock 9 on the shared lock"
   else
-    no "B $fn: flock-wrapped RMW" "flock=$has_flock fd=$has_fd mv=$has_mv"
+    no "B $fn: flock-wrapped RMW" "flock=$has_flock fd=$has_fd mv=$has_mv ensure=$has_ensure"
   fi
 done
+
+echo "== Part B2: ensure-lock helper forces 0600 (cross-language parity with Go) =="
+grep -qE 'chmod 0600 "\$_NFTBAN_SESSION_WL_LOCK"' "$FW" \
+  && ok "B2a helper chmod 0600 present" || no "B2a helper chmod 0600" "missing"
 
 echo "== Part C: flock(1) actually serializes concurrent appenders (mechanism) =="
 if ! command -v flock >/dev/null 2>&1; then
@@ -76,6 +81,20 @@ else
   got=$(wc -l < "$out"); got=${got//[^0-9]/}
   [[ "$got" == "30" ]] && ok "C flock serialized 30 concurrent RMW appenders (no lost update)" \
     || no "C flock mechanism" "expected 30 lines, got $got"
+
+  echo "== Part D: the REAL ensure-lock helper creates the lock at 0600 =="
+  # eval the actual helper definition from cmd_firewall.sh and run it against a
+  # temp lock; assert mode 0600 even under a group-readable umask (027 → 0640).
+  eval "$(awk '/^_whitelist_session_ensure_lock\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$FW")"
+  if declare -f _whitelist_session_ensure_lock >/dev/null 2>&1; then
+    ( umask 027
+      _NFTBAN_SESSION_WL_LOCK="$WORK/parity.lock" _whitelist_session_ensure_lock )
+    mode=$(stat -c '%a' "$WORK/parity.lock" 2>/dev/null)
+    [[ "$mode" == "600" ]] && ok "D ensure-lock created the lock at 0600 (parity with Go 0o600)" \
+      || no "D lock mode parity" "expected 600, got '$mode'"
+  else
+    no "D ensure-lock helper" "could not extract/eval helper"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## LOCK-MODE-PARITY fix (rides v1.173, pre-tag)

Lab validation (lab2 + lab4) of the §4.1 flock found the shared lock `/run/nftban/session_whitelist.lock` landed at **0640**, not 0600: the Go side opens `0o600` but the shell `9>"$lock"` redirect honors the root umask (027 → 0640); whichever language created it first set the mode. Functionally harmless (root-owned, advisory lock — perms don't affect flock), but not exact parity.

**Fix (shell-only):** `_whitelist_session_ensure_lock` helper creates the lock under `umask 0177` + `chmod 0600` before the `9>` redirect, so the shell matches Go `0o600` regardless of creation order. The 3 session funcs call it. Lock interlock behavior unchanged.

**Test:** `session_whitelist_flock_v173_test.sh` 8/0 — asserts each func calls the helper, the helper carries `chmod 0600`, and the **real extracted helper** creates the lock at mode 600 under umask 027.

**Envelope:** shell-only · daemon `cmd/nftband` byte-identical · schema 1.83.0 frozen · FHS body unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)