### PR TITLE
v1.174: install/health reliability

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -749,6 +749,29 @@ jobs:
       - name: session-whitelist flock shell-side (v1.173)
         run: bash cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
 
+      # v1.174 HEALTH-OOM-JOURNALCTL: every actual journalctl invocation on the
+      # nftban-health.service health-check path is bounded (-n/--since), and the
+      # unit's MemoryMax is raised 128M->256M for the validator + concurrent-
+      # children RSS on large journals. The Go validator read is already bounded
+      # (internal/validator/journal.go --since -15m -n 200). The stale failed-
+      # unit classification half is covered by Go test
+      # internal/installer/validate/systemd_payload_v174_test.go.
+      - name: health journalctl bounded + MemoryMax 256M (v1.174)
+        run: bash cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
+
+      # v1.174 ALERT-THROTTLE-NONFATAL: a state-write (throttle/diagnostics/
+      # failure-metric) permission failure must NOT fail/latch nftban-alert@*.service
+      # (monitor root cause), but a real alert DELIVERY failure still follows the rc
+      # contract. cli/sbin/nftban-service-alert.
+      - name: alert bookkeeping non-fatal, delivery keeps rc (v1.174)
+        run: bash cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
+
+      # v1.174 update-summary messaging: surface an auto-recovered pre-existing
+      # failed unit to the operator (transparency) + fix the misleading DEGRADED
+      # "known transient on the exporter" wording. cli/lib/nftban/cli/cmd_update.sh.
+      - name: update messaging recovered + DEGRADED (v1.174)
+        run: bash cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -409,6 +409,15 @@ _cmd_update_main_locked() {
     install_type=$(_detect_install_type)
     current_version=$(_get_current_version)
 
+    # v1.174: record the installer.log line count BEFORE the install so the final
+    # verdict can detect a WARN_PRE_EXISTING_RECOVERED (a stale pre-existing failed
+    # nftban unit cleared during THIS run) scoped to this update only — not a marker
+    # left by a prior run.
+    local _ilog_file="${NFTBAN_LOG_DIR:-/var/log/nftban}/installer.log"
+    local _ilog_before_lines
+    _ilog_before_lines=$(wc -l < "$_ilog_file" 2>/dev/null || echo 0)
+    _ilog_before_lines=${_ilog_before_lines//[^0-9]/}; _ilog_before_lines=${_ilog_before_lines:-0}
+
     # Auto-detect source if needed
     # V108 Item 6: handle "source" (canonical from history.json) + "mixed" cleanly.
     # "git" is kept as a backward-compatible alias for "source" (same update path).
@@ -752,6 +761,25 @@ _cmd_update_main_locked() {
             echo "  Updated: v$current_version → v$new_version (${_update_duration}s)"
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
             echo ""
+
+            # v1.174 transparency: if this run auto-recovered a PRE-EXISTING failed
+            # nftban unit (failed before the upgrade, live health clean → stale
+            # systemd failed-state cleared), tell the operator. Scoped to THIS run's
+            # installer.log lines so a clean COMMITTED with no recovery stays quiet.
+            local _recovered_units=""
+            if [[ -f "$_ilog_file" ]] && tail -n +$((_ilog_before_lines + 1)) "$_ilog_file" 2>/dev/null | grep -q "WARN_PRE_EXISTING_RECOVERED"; then
+                _recovered_units=$(tail -n +$((_ilog_before_lines + 1)) "$_ilog_file" 2>/dev/null \
+                    | sed -n 's/.*reset-failed \([^ ]*\): cleared stale.*/\1/p' | sort -u | tr '\n' ' ')
+                _recovered_units="${_recovered_units% }"
+            fi
+            if [[ -n "$_recovered_units" ]]; then
+                echo "  ℹ️  A pre-existing failed NFTBan unit was found before this upgrade:"
+                echo "        ${_recovered_units}"
+                echo "      Live NFTBan health is clean, so the stale systemd failed-state was"
+                echo "      cleared automatically. No action is required."
+                echo ""
+            fi
+
             echo "  Log: $UPDATE_LOG_FILE"
             echo "  History: nftban update history"
             echo ""
@@ -780,13 +808,14 @@ _cmd_update_main_locked() {
                 echo "  Reason: $_failure_reason"
                 echo ""
             fi
-            echo "  The package was upgraded but the installer's post-install validation"
-            echo "  reported non-fatal assertion failures (often a known transient on the"
-            echo "  exporter or related auxiliary service)."
+            echo "  A failed NFTBan unit was found during post-install validation."
+            echo "  This may be a CURRENT failure, or a STALE pre-existing systemd failed-state"
+            echo "  (a unit that failed BEFORE this upgrade) — the system may already be healthy."
             echo ""
-            echo "  Recommended:"
+            echo "  Verify and re-validate:"
+            echo "      nftban health                                   # check live four-axis health"
             echo "      /usr/lib/nftban/bin/nftban-installer --repair   # re-run post-install validation"
-            echo "      nftban support                                  # capture diagnostic bundle"
+            echo "      nftban support                                  # capture diagnostic bundle (optional)"
             echo ""
             echo "  Kernel-state verification (trust but verify):"
             echo "      nft list tables"

--- a/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
+++ b/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.174 ALERT-THROTTLE-NONFATAL (alert bookkeeping best-effort)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="alert_bookkeeping_nonfatal_v174_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Locks the v1.174 ALERT-THROTTLE-NONFATAL fix in cli/sbin/nftban-service-alert: a state-write (throttle / diagnostics / failure-metric) permission failure must NOT fail/latch nftban-alert@*.service, but a real alert DELIVERY failure must still follow the rc contract. Root cause (monitor 2026-06-09): the alert unit runs User=nftban while the throttle/diag paths sit under root-owned 0750 /var/lib/nftban → EACCES → script exit 1 → systemd failed-state latch → installer DEGRADED. (1) data-dir read-only + no mail recipient => exit 0 (bookkeeping non-fatal); (2) WARN logged, raw error not fatal; (3) delivery failure (recipient set + mail module absent) => non-zero (contract preserved); (4) happy path writable => exit 0 + throttle persisted. Hermetic: temp dirs, no root, no systemd mutation."
+# meta:input="None (temp NFTBAN_LOG_DIR/NFTBAN_DATA_DIR)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash"
+# meta:inventory.files="cli/sbin/nftban-service-alert"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_CONFIG_DIR,NFTBAN_LIB_DIR,NFTBAN_MAIL_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-alert@.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+ALERT="$REPO_ROOT/cli/sbin/nftban-service-alert"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+[[ -f "$ALERT" ]] || { echo "alert script not found: $ALERT"; exit 1; }
+
+WORK="$(mktemp -d)"
+# Cleanup: the read-only (0500) test dir is intentionally empty (all writes to it
+# fail by design), so rm -rf removes it via the writable parent. Restore that one
+# dir's mode first (scoped, per-dir; no recursive permission change is used here).
+cleanup(){ [[ -d "$WORK/ro_data" ]] && chmod u+rwx "$WORK/ro_data" 2>/dev/null || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# run_alert <datadir> <recipient> <libdir> -> sets RC + LOG
+run_alert() {
+  local datadir="$1" recipient="$2" libdir="$3"
+  local logdir="$WORK/log.$RANDOM"; mkdir -p "$logdir"
+  set +e
+  NFTBAN_LOG_DIR="$logdir" \
+  NFTBAN_DATA_DIR="$datadir" \
+  NFTBAN_CONFIG_DIR="$WORK/noconfig" \
+  NFTBAN_LIB_DIR="$libdir" \
+  NFTBAN_MAIL_RECIPIENT="$recipient" \
+    bash "$ALERT" nftband.service >/dev/null 2>&1
+  RC=$?
+  set -e
+  LOG="$logdir/service-alerts.log"
+}
+
+echo "== Test A: read-only data dir + no recipient => alert unit exits 0 (bookkeeping non-fatal) =="
+ro="$WORK/ro_data"; mkdir -p "$ro"; chmod 0500 "$ro"   # owner r-x, no write -> EACCES on writes
+run_alert "$ro" "" "$WORK/nolib"
+[[ "$RC" -eq 0 ]] && ok "A exit 0 despite throttle/diag write EACCES (RC=$RC)" || no "A exit 0" "got RC=$RC"
+
+echo "== Test B: WARN logged (not fatal) + throttle file NOT created under EACCES =="
+if [[ -f "$LOG" ]] && grep -q "throttle state write failed" "$LOG"; then ok "B throttle WARN logged"; else no "B throttle WARN" "missing in $LOG"; fi
+[[ ! -e "$ro/alert_throttle_nftband_service" ]] && ok "B throttle file not created (write was non-fatal)" || no "B throttle file" "unexpectedly created"
+
+echo "== Test C: delivery contract — recipient set + mail module absent => non-zero =="
+rw="$WORK/rw_data"; mkdir -p "$rw"
+run_alert "$rw" "ops@example.test" "$WORK/nolib"   # nolib has no core/nftban_mail.sh -> send_email_alert returns 1
+[[ "$RC" -ne 0 ]] && ok "C delivery failure still fails the unit (RC=$RC)" || no "C delivery contract" "expected non-zero, got 0"
+
+echo "== Test D: happy path — writable data dir + no recipient => exit 0 + throttle persisted =="
+rw2="$WORK/rw_data2"; mkdir -p "$rw2"
+run_alert "$rw2" "" "$WORK/nolib"
+[[ "$RC" -eq 0 ]] && ok "D exit 0 (RC=$RC)" || no "D exit 0" "got RC=$RC"
+[[ -f "$rw2/alert_throttle_nftband_service" ]] && ok "D throttle file persisted when writable" || no "D throttle persisted" "file missing"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
+++ b/cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.174 HEALTH-OOM-JOURNALCTL guard (shell side)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="health_journalctl_bounded_v174_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-11"
+# meta:description="Locks v1.174 HEALTH-OOM-JOURNALCTL: (A) every actual journalctl INVOCATION in the nftban-health.service health-check path (cmd_health.sh + the core/helper modules it sources for `health check --auto-heal`) is BOUNDED (carries -n/--lines or a small --since); advisory hint strings (\`check: journalctl -u ...\`) and the required-binaries probe list are not invocations and are exempt. The Go validator journalctl read (internal/validator/journal.go) is already bounded (--since -15m -n 200) and out of this shell guard. (B) nftban-health.service declares MemoryMax=256M (raised 128M->256M for the validator + concurrent-children RSS on large journals). Hermetic: static source scan; no journalctl run, no root."
+# meta:input="None (reads health-path shell modules + nftban-health.service)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,awk"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_health.sh,install/systemd/nftban-health.service"
+# meta:inventory.binaries="journalctl"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-health.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Files on the `nftban health check --auto-heal --cache-status` runtime path:
+# the dispatcher + the modules it sources + the auto-heal helper.
+HEALTH_PATH_FILES=(
+  "cli/lib/nftban/cli/cmd_health.sh"
+  "cli/lib/nftban/cli/cmd_health_core.sh"
+  "cli/lib/nftban/cli/cmd_health_components.sh"
+  "cli/lib/nftban/cli/cmd_health_analysis.sh"
+  "cli/lib/nftban/core/nftban_health_checks_core.sh"
+  "cli/lib/nftban/core/nftban_health_checks_services.sh"
+  "cli/lib/nftban/helpers/autoheal.sh"
+)
+
+# is_journalctl_invocation: true when a line actually RUNS journalctl, as
+# opposed to (a) mentioning it inside a quoted advisory hint like
+# `check: journalctl -u nftband.service`, or (b) listing it as a required
+# binary token. We treat a line as an invocation only when `journalctl`
+# appears as a command word (start of line / after a pipe, `$(`, `;`, `&&`,
+# `||`, or `=` for a capture) and NOT preceded on the line by `check:` /
+# `check logs:` / `required_binaries`.
+echo "== Part A: no UNBOUNDED journalctl invocation on the health-check path =="
+unbounded_hits=0
+scanned_invocations=0
+for rel in "${HEALTH_PATH_FILES[@]}"; do
+  f="$REPO_ROOT/$rel"
+  [[ -f "$f" ]] || { no "A:$rel present" "missing"; continue; }
+  while IFS= read -r line; do
+    # skip comments
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    # skip advisory hint strings and the required-binaries probe list
+    [[ "$line" == *"check:"* || "$line" == *"check logs:"* ]] && continue
+    [[ "$line" == *"required_binaries"* ]] && continue
+    # only consider lines where journalctl is a command word
+    if [[ "$line" =~ (^|[\|\;\&\(\=\`[:space:]])journalctl([[:space:]]|$) ]]; then
+      scanned_invocations=$((scanned_invocations+1))
+      # bounded if it carries a line cap or a bounded --since
+      if [[ "$line" == *" -n "* || "$line" == *"--lines"* || "$line" == *"--since"* ]]; then
+        ok "A bounded invocation in $rel: ${line//[[:space:]]/ }"
+      else
+        no "A UNBOUNDED journalctl in $rel" "${line}"
+        unbounded_hits=$((unbounded_hits+1))
+      fi
+    fi
+  done < "$f"
+done
+if [[ $scanned_invocations -eq 0 ]]; then
+  ok "A no journalctl invocation on the health-check path (only advisory hints / probe list) — nothing to bound"
+fi
+[[ $unbounded_hits -eq 0 ]] && ok "A no unbounded journalctl invocation on the health-check path" \
+  || no "A unbounded journalctl present" "$unbounded_hits hit(s)"
+
+echo "== Part B: nftban-health.service MemoryMax raised to 256M (v1.174 HEALTH-OOM) =="
+UNIT="$REPO_ROOT/install/systemd/nftban-health.service"
+[[ -f "$UNIT" ]] || { no "B unit present" "missing"; }
+if [[ -f "$UNIT" ]]; then
+  grep -qE '^MemoryMax=256M[[:space:]]*$' "$UNIT" \
+    && ok "B MemoryMax=256M" || no "B MemoryMax=256M" "not set / not 256M"
+  grep -qE '^MemoryMax=128M' "$UNIT" \
+    && no "B stale 128M still present" "remove old cap" || ok "B no stale MemoryMax=128M"
+fi
+
+echo
+echo "Result: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
+++ b/cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.174 update-summary messaging (recovered transparency + DEGRADED text)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="update_msg_recovered_v174_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Locks the v1.174 user-facing update messaging in cmd_update.sh. (A) the this-run-scoped recovered-unit detection pipeline (tail from the pre-install installer.log line count → grep WARN_PRE_EXISTING_RECOVERED → extract reset-failed unit names) detects a recovery in this run and stays silent for a prior-run-only marker. (B) message contract: the COMMITTED branch surfaces a guarded ℹ️ 'pre-existing failed unit ... cleared automatically. No action is required' note (quiet when none); the DEGRADED branch no longer says 'known transient on the exporter' and instead says it may be a current OR stale pre-existing failure and to run nftban health + --repair. Hermetic: synthetic installer.log + static source assertions; no host."
+# meta:input="None (temp installer.log fixture)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,sed,sort,tail"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+U="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+[[ -f "$U" ]] || { echo "cmd_update.sh not found: $U"; exit 1; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# detect() mirrors the exact pipeline in cmd_update.sh's COMMITTED branch; Part B
+# statically asserts the source still carries the same pipeline so this can't drift.
+detect(){ # <logfile> <before-lines>
+  local f="$1" b="$2" u=""
+  if [[ -f "$f" ]] && tail -n +$((b + 1)) "$f" 2>/dev/null | grep -q "WARN_PRE_EXISTING_RECOVERED"; then
+    u=$(tail -n +$((b + 1)) "$f" 2>/dev/null | sed -n 's/.*reset-failed \([^ ]*\): cleared stale.*/\1/p' | sort -u | tr '\n' ' ')
+    u="${u% }"
+  fi
+  printf '%s' "$u"
+}
+
+echo "== Part A: this-run-scoped recovered detection =="
+ilog="$WORK/installer.log"
+printf 'old line 1\nold line 2\n' > "$ilog"
+before=$(wc -l < "$ilog"); before=${before//[^0-9]/}
+cat >> "$ilog" <<'EOF'
+[NFTBan] ASSERT failed_units_postinstall_ok: PASS — WARN_PRE_EXISTING_RECOVERED (pre-existing failed unit(s), live health clean): nftban-alert@nftband.service.service(exit-code)
+[NFTBan] reset-failed nftban-alert@nftband.service.service: cleared stale pre-existing systemd failed-state latch (failure pre-dates the install window; live health clean)
+EOF
+got=$(detect "$ilog" "$before")
+[[ "$got" == "nftban-alert@nftband.service.service" ]] && ok "A1 recovered unit detected this-run" || no "A1 detect" "got '$got'"
+
+# prior-run marker present but BEFORE this run's window → must NOT surface
+printf 'WARN_PRE_EXISTING_RECOVERED prior\nreset-failed prior.service: cleared stale x\n' > "$ilog"
+before2=$(wc -l < "$ilog"); before2=${before2//[^0-9]/}
+printf 'this run: clean, no recovery\n' >> "$ilog"
+got2=$(detect "$ilog" "$before2")
+[[ -z "$got2" ]] && ok "A2 prior-run marker NOT surfaced (this-run scoped → quiet COMMITTED)" || no "A2 scope" "got '$got2'"
+
+echo "== Part B: cmd_update.sh message contract =="
+grep -q '_ilog_before_lines' "$U" && grep -q 'WARN_PRE_EXISTING_RECOVERED' "$U" \
+  && ok "B1 this-run recovered detection wired (installer.log line-delta)" || no "B1 detection" "missing"
+grep -q 'A pre-existing failed NFTBan unit was found before this upgrade' "$U" \
+  && grep -q 'cleared automatically. No action is required' "$U" \
+  && ok "B2 recovered transparency message present" || no "B2 recovered msg" "missing"
+grep -q 'if \[\[ -n "\$_recovered_units" \]\]; then' "$U" \
+  && ok "B3 recovered message GUARDED (quiet when no recovery)" || no "B3 guard" "missing"
+if grep -q "known transient on the" "$U"; then no "B4 misleading exporter line" "still present"; else ok "B4 misleading 'known transient on the exporter' removed"; fi
+grep -q "may be a CURRENT failure, or a STALE pre-existing" "$U" \
+  && ok "B5 DEGRADED reworded (current OR stale pre-existing)" || no "B5 DEGRADED wording" "missing"
+grep -q "nftban health" "$U" && ok "B6 DEGRADED suggests nftban health" || no "B6 health hint" "missing"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/sbin/nftban-service-alert
+++ b/cli/sbin/nftban-service-alert
@@ -34,8 +34,8 @@
 set -Eeuo pipefail
 
 readonly FAILED_SERVICE="${1:-unknown}"
-readonly TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
-readonly HOSTNAME=$(hostname -f 2>/dev/null || hostname)
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); readonly TIMESTAMP
+HOSTNAME=$(hostname -f 2>/dev/null || hostname); readonly HOSTNAME
 
 # Load config
 NFTBAN_CONFIG_DIR="${NFTBAN_CONFIG_DIR:-/etc/nftban}"
@@ -84,7 +84,12 @@ should_throttle() {
 
 update_throttle() {
     mkdir -p "$(dirname "$ALERT_THROTTLE_FILE")" 2>/dev/null || true
-    date +%s > "$ALERT_THROTTLE_FILE"
+    # Best-effort: a throttle-state write failure (e.g. EACCES — the alert unit
+    # runs as User=nftban while the path may be root-owned 0750) returns non-zero
+    # so the caller can WARN and continue. It must NOT fail/latch the alert unit
+    # (v1.174 ALERT-THROTTLE-NONFATAL). Proper relocation to an nftban-owned dir
+    # is a separate lane (ALERT-THROTTLE-FHS).
+    date +%s > "$ALERT_THROTTLE_FILE" 2>/dev/null
 }
 
 # =============================================================================
@@ -92,7 +97,8 @@ update_throttle() {
 # =============================================================================
 
 collect_diagnostics() {
-    local diag_file="${NFTBAN_DATA_DIR}/alerts/${FAILED_SERVICE}_$(date +%Y%m%d_%H%M%S).txt"
+    local diag_file
+    diag_file="${NFTBAN_DATA_DIR}/alerts/${FAILED_SERVICE}_$(date +%Y%m%d_%H%M%S).txt"
     mkdir -p "$(dirname "$diag_file")" 2>/dev/null || true
 
     {
@@ -129,7 +135,13 @@ collect_diagnostics() {
         uptime 2>&1 || true
         echo ""
 
-    } > "$diag_file"
+    } > "$diag_file" 2>/dev/null || {
+        # Diagnostics are best-effort bookkeeping; a write failure (e.g. EACCES on
+        # a root-owned data dir while the alert unit runs as User=nftban) must NOT
+        # fail/latch the alert unit. Return empty so the caller continues (v1.174).
+        echo ""
+        return 0
+    }
 
     echo "$diag_file"
 }
@@ -245,18 +257,32 @@ main() {
         exit 0
     fi
 
-    # Update throttle timestamp
-    update_throttle
+    # Update throttle timestamp — best-effort bookkeeping (v1.174
+    # ALERT-THROTTLE-NONFATAL). A state-write failure (EACCES) must NOT fail or
+    # latch the alert unit; only a real alert-delivery failure may. The throttle
+    # simply does not persist this round (alert still sends).
+    if ! update_throttle; then
+        log_alert "WARN" "throttle state write failed (permission denied?); continuing without throttle persistence"
+    fi
 
-    # Increment failure counter (for metrics)
-    increment_failure_metric
+    # Increment failure counter — best-effort bookkeeping.
+    if ! increment_failure_metric; then
+        log_alert "WARN" "failure-metric update failed; continuing"
+    fi
 
-    # Collect diagnostic information
+    # Collect diagnostic information — best-effort bookkeeping (collect_diagnostics
+    # returns "" on a write failure rather than failing the unit).
     local diag_file
     diag_file=$(collect_diagnostics)
-    log_alert "INFO" "Diagnostic report saved: $diag_file"
+    if [[ -n "$diag_file" ]]; then
+        log_alert "INFO" "Diagnostic report saved: $diag_file"
+    else
+        log_alert "WARN" "diagnostic collection failed (permission denied?); continuing without diagnostics"
+    fi
 
-    # Send email alert
+    # Send email alert — DELIVERY: keeps its existing rc contract. A real
+    # alert-delivery failure still fails the alert unit (deliberately NOT
+    # made best-effort).
     send_email_alert "$diag_file"
 
     log_alert "INFO" "Alert processing completed for $FAILED_SERVICE"

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/installer/lock"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/installer/validate"
 	"github.com/itcmsgr/nftban/pkg/version"
 
 	// PR26.3: panel adapter registration via blank import. The package
@@ -61,6 +62,15 @@ func main() {
 	// Write run header to log file for post-mortem analysis
 	hostname, osInfo := systemIdentity()
 	log.RunHeader(version.Version, cfg.mode, hostname, osInfo)
+
+	// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: record the install-
+	// window start ONCE, before any phase runs, so post-install validation can
+	// distinguish a unit that failed during this run (in-window → DEGRADED)
+	// from a stale latch carried over from before it (pre-existing → eligible
+	// for WARN_PRE_EXISTING_RECOVERED when live health is clean). This is the
+	// window START — distinct from state INSTALL_TIMESTAMP, which is the end/
+	// write time.
+	validate.SetInstallWindowStart(time.Now())
 
 	log.Info("nftban-installer %s starting (mode=%s, repair=%v)", version.Version, cfg.mode, cfg.repair)
 	log.Debug("flags: rpm=%v takeover=%v force=%v dry-run=%v verbose=%v", cfg.rpm, cfg.takeover, cfg.force, cfg.dryRun, cfg.verbose)

--- a/install/systemd/nftban-health.service
+++ b/install/systemd/nftban-health.service
@@ -79,7 +79,16 @@ ReadWritePaths=/var/lib/nftban /var/cache/nftban /var/log/nftban /run/nftban
 RestrictAddressFamilies=AF_UNIX AF_NETLINK
 
 # Resource limits
-MemoryMax=128M
+# v1.174 HEALTH-OOM-JOURNALCTL: raised 128M->256M. On hosts with a large/
+# noisy journal (multi-GB, e.g. portscan-log flood) the aggregate concurrent
+# child RSS in the health-check path — the Go nftban-validate validator plus
+# the many short-lived nft/jq children it spawns, all on the Go 1.25 runtime —
+# crosses the old 128M cgroup cap and OOM-kills the unit, while a quiet host
+# peaks at single-digit MB. The validator's own journalctl reads are already
+# bounded (internal/validator/journal.go: --since "-15m" -n 200); the
+# amplifier was the cap + concurrency on a multi-GB journal, not an unbounded
+# read. ExecStart behavior is unchanged.
+MemoryMax=256M
 # Mirror of the nftban-core-geoip.service TasksMax fix (#525). The health
 # check shells out to nftban-core subcommands, including geoip status,
 # which exercise the same Go 1.25 runtime + finalizer-goroutine surface.

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -116,6 +116,9 @@ func RunAssertionsWithOpts(exec executor.Executor, sshPort int, log *logging.Log
 		assertSystemdPayloadInventory(spr, log),
 		assertFailedUnitsPostInstall(spr, log),
 	)
+	// v1.174: clear the stale systemd failed-state latch for units classified
+	// WARN_PRE_EXISTING_RECOVERED (and ONLY those) — see resetRecoveredPreExistingUnits.
+	resetRecoveredPreExistingUnits(exec, log, spr)
 
 	// v1.135 CORE-TIMER-ENABLED-001: critical core timers must be enabled +
 	// active/scheduled (or NFTBAN_RECONCILE_CORE_TIMERS=false — intentional).
@@ -387,6 +390,24 @@ func assertCriticalTimersEnabled(tvr TimerValidationResult, log *logging.Logger)
 func assertFailedUnitsPostInstall(spr SystemdPayloadValidationResult, log *logging.Logger) AssertionResult {
 	r := AssertionResult{Name: "failed_units_postinstall_ok", Passed: spr.FailedUnitsOK()}
 	if r.Passed {
+		// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: a protection-
+		// critical unit that was ALREADY failed before this install window
+		// AND whose live `nftban health` probe is clean is a stale latch, not
+		// a fresh break. The assertion still PASSES (install COMMITTED-with-
+		// warning, not DEGRADED), but the recovered units are surfaced so the
+		// operator can reset-failed them. A newly-failed unit, or a pre-
+		// existing one with live health not clean/unknown, is in FailedUnits
+		// and would have failed FailedUnitsOK() above (fail safe → DEGRADED).
+		if len(spr.FailedUnitsPreExistingRecovered) > 0 {
+			rec := make([]string, 0, len(spr.FailedUnitsPreExistingRecovered))
+			for _, f := range spr.FailedUnitsPreExistingRecovered {
+				rec = append(rec, f.Unit+"("+f.Detail+")")
+			}
+			r.Detail = "WARN_PRE_EXISTING_RECOVERED: pre-existing failed unit(s), live health clean — non-fatal: " + strings.Join(rec, "; ")
+			log.Warn("ASSERT failed_units_postinstall_ok: PASS — WARN_PRE_EXISTING_RECOVERED (pre-existing failed unit(s), live health clean): %s",
+				strings.Join(rec, "; "))
+			return r
+		}
 		// v1.135 D-EXPORTER-SETTLE-WINDOW: a failed auxiliary (metrics/
 		// observability) unit does NOT fail this assertion, but it IS
 		// surfaced as a non-fatal warning so operators still see it.
@@ -418,6 +439,35 @@ func assertFailedUnitsPostInstall(spr SystemdPayloadValidationResult, log *loggi
 	log.Warn("ASSERT failed_units_postinstall_ok: FAIL — %d failed: %s",
 		len(spr.FailedUnits), strings.Join(parts, "; "))
 	return r
+}
+
+// resetRecoveredPreExistingUnits issues a BOUNDED `systemctl reset-failed` for
+// exactly the nftban units classified WARN_PRE_EXISTING_RECOVERED — i.e. units
+// that (a) failed strictly before the install window, (b) on a host whose live
+// nftban health is known-clean, and (c) had no in-window failure. Those three
+// conditions are already proven by membership in spr.FailedUnitsPreExistingRecovered
+// (ValidateInstalledSystemdPayload), so clearing exactly that set is safe and keeps
+// the fail-safe rule intact: IN_WINDOW / unknown-timestamp / unknown-or-unhealthy-
+// live-health units are NOT in this bucket and stay DEGRADED (they remain in
+// spr.FailedUnits). Without this, v1.174 leaves install_state COMMITTED-with-warning
+// but `systemctl --failed` polluted, so the next diagnostic/support/operator check
+// still distrusts the host.
+//
+// Contract: always an explicit unit name (never a blanket `reset-failed`), never a
+// non-nftban unit. A reset-failed error is NON-FATAL — the host is already proven
+// healthy, so failing to clear cosmetic systemd state must not re-poison the
+// install; it is logged WARN and the install stays COMMITTED-with-warning.
+func resetRecoveredPreExistingUnits(exec executor.Executor, log *logging.Logger, spr SystemdPayloadValidationResult) {
+	for _, f := range spr.FailedUnitsPreExistingRecovered {
+		if !IsNftbanUnit(f.Unit) { // defense-in-depth; the bucket is already nftban-only
+			continue
+		}
+		if err := exec.ServiceResetFailed(f.Unit); err != nil {
+			log.Warn("reset-failed %s (WARN_PRE_EXISTING_RECOVERED) failed: %v — leaving cosmetic systemd failed-state; install stays COMMITTED-with-warning", f.Unit, err)
+			continue
+		}
+		log.Info("reset-failed %s: cleared stale pre-existing systemd failed-state latch (failure pre-dates the install window; live health clean)", f.Unit)
+	}
 }
 
 // defaultInventoryPaths returns the set of nftban-owned paths the

--- a/internal/installer/validate/systemd_payload.go
+++ b/internal/installer/validate/systemd_payload.go
@@ -40,6 +40,7 @@ package validate
 
 import (
 	"strings"
+	"time"
 )
 
 // nftbanUnitExtensions lists the systemd unit suffixes considered in
@@ -167,6 +168,19 @@ type FailedUnitFinding struct {
 	Active string // e.g., "failed"
 	Sub    string // e.g., "failed", "exit-code"
 	Detail string // best-effort short description, may be empty
+
+	// FailureTime is the unit's last-failure timestamp (most recent of
+	// InactiveEnterTimestamp / ExecMainExitTimestamp from `systemctl show`).
+	// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: used to classify
+	// a failed unit as pre-existing (failed before the install window) vs
+	// in-window. Zero value when unknown.
+	FailureTime time.Time
+
+	// FailureTimeKnown is true only when FailureTime was parsed
+	// successfully. When false, the unit is treated as a hard failure
+	// (fail closed) — an unparseable timestamp can never be classified as
+	// pre-existing/recovered.
+	FailureTimeKnown bool
 }
 
 // PayloadInventory describes which paths are considered known after
@@ -224,6 +238,29 @@ type SystemdPayloadInputs struct {
 	// by SYSTEMD-TIMER-PAIR-001 to confirm a timer's target service
 	// is installed alongside it.
 	AllUnitNames map[string]bool
+
+	// InstallWindowStart is the wall-clock instant the current installer
+	// run began (set once at the very start of the run via
+	// SetInstallWindowStart). A failed unit whose FailureTime is strictly
+	// before this instant is "pre-existing"; one at/after is "in-window".
+	// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE.
+	InstallWindowStart time.Time
+
+	// InstallWindowStartKnown is true only when InstallWindowStart was
+	// set. When false, no failed unit can be classified as pre-existing —
+	// all non-aux failures stay fatal (fail closed).
+	InstallWindowStartKnown bool
+
+	// LiveHealthClean reports whether a bounded live `nftban health` probe
+	// returned a clean overall status (Overall OK/IDLE, Findings: none, no
+	// CRITICAL). Only consulted to downgrade a PRE_EXISTING latched failure.
+	LiveHealthClean bool
+
+	// LiveHealthKnown is true only when the live-health probe produced a
+	// confident clean/not-clean verdict. When false (probe timeout, missing
+	// binary, unparseable output, non-zero exit), no downgrade is permitted
+	// — pre-existing failures stay fatal (fail closed).
+	LiveHealthKnown bool
 }
 
 // MissingExecPath records one SYSTEMD-EXECSTART-001 hit.
@@ -252,6 +289,14 @@ type UnknownPayloadRef struct {
 type FailedUnitPostInstall struct {
 	Unit   string
 	Detail string
+
+	// Classification is the v1.174 disposition of the failure, one of:
+	// "" (default / in-window fatal), "IN_WINDOW", "PRE_EXISTING_FATAL"
+	// (pre-existing but live health not clean/unknown), or
+	// "WARN_PRE_EXISTING_RECOVERED" (pre-existing + live health clean —
+	// non-fatal). Diagnostic only; the fatal/non-fatal decision is encoded
+	// by which result bucket the entry lands in.
+	Classification string
 }
 
 // SystemdPayloadValidationResult is the structured outcome.
@@ -278,6 +323,16 @@ type SystemdPayloadValidationResult struct {
 	// transient exporter exit-2 cannot DEGRADE the install — D-EXPORTER-
 	// SETTLE-WINDOW, v1.135).
 	FailedAuxiliaryUnits []FailedUnitPostInstall
+
+	// FailedUnitsPreExistingRecovered holds protection-critical nftban units
+	// that were ALREADY in a failed state before this install window started
+	// AND whose live `nftban health` probe is clean. v1.174 D-INSTALL-FAILED-
+	// UNITS-STALE-LATCHED-STATE: these are a stale latch, not a fresh break,
+	// so they are surfaced as WARN_PRE_EXISTING_RECOVERED and do NOT fail
+	// FAILED-UNIT-POSTINSTALL-001 (install COMMITTED-with-warning). A newly-
+	// failed unit, or a pre-existing one with live health not clean/unknown,
+	// stays in FailedUnits (fatal) — fail safe toward DEGRADED.
+	FailedUnitsPreExistingRecovered []FailedUnitPostInstall
 
 	// FailedUnitQueryError mirrors SystemdPayloadInputs.FailedUnitQueryError
 	// for the assertion-side detail message. When non-empty,
@@ -360,6 +415,28 @@ func ValidateInstalledSystemdPayload(in SystemdPayloadInputs) SystemdPayloadVali
 		if IsAuxiliaryUnit(f.Unit) {
 			res.FailedAuxiliaryUnits = append(res.FailedAuxiliaryUnits, entry)
 			continue
+		}
+
+		// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: classify a
+		// protection-critical failure as pre-existing (failed strictly before
+		// the install window started) vs in-window. A pre-existing latch with
+		// a clean live `nftban health` probe is a stale flag from before this
+		// run — downgrade to non-fatal WARN_PRE_EXISTING_RECOVERED. Everything
+		// else (in-window failure, unparseable failure time, unknown window
+		// start, live health not clean / unknown) stays FATAL — fail safe
+		// toward DEGRADED. A newly-failed unit is NEVER labeled recovered.
+		preExisting := in.InstallWindowStartKnown &&
+			f.FailureTimeKnown &&
+			f.FailureTime.Before(in.InstallWindowStart)
+		if preExisting && in.LiveHealthKnown && in.LiveHealthClean {
+			entry.Classification = "WARN_PRE_EXISTING_RECOVERED"
+			res.FailedUnitsPreExistingRecovered = append(res.FailedUnitsPreExistingRecovered, entry)
+			continue
+		}
+		if preExisting {
+			entry.Classification = "PRE_EXISTING_FATAL"
+		} else {
+			entry.Classification = "IN_WINDOW"
 		}
 		res.FailedUnits = append(res.FailedUnits, entry)
 	}

--- a/internal/installer/validate/systemd_payload_gather.go
+++ b/internal/installer/validate/systemd_payload_gather.go
@@ -25,6 +25,7 @@
 package validate
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,6 +45,38 @@ import (
 const auxiliarySettleAttempts = 3
 
 var auxiliarySettleDelay = 2 * time.Second
+
+// installWindowStart records the wall-clock instant the current installer
+// run began. It is set ONCE via SetInstallWindowStart at the very start of
+// the run (before any phase executes) and consumed by
+// GatherSystemdPayloadInputs to classify pre-existing vs in-window unit
+// failures. Zero value => unknown (no downgrade is permitted; fail closed).
+// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE.
+var installWindowStart time.Time
+
+// SetInstallWindowStart records the install-window start instant. Call once
+// at the very start of the installer run, before the phases execute. The
+// validate gatherer reads this when building SystemdPayloadInputs. Note:
+// state/file.go INSTALL_TIMESTAMP is the END/write time and must NOT be
+// reused as the window start.
+func SetInstallWindowStart(t time.Time) { installWindowStart = t }
+
+// liveHealthProbeTimeout bounds the live `nftban health` probe so a hung or
+// pathologically slow health run cannot stall install validation. On
+// timeout the probe reports known=false (no downgrade — fail closed).
+const liveHealthProbeTimeout = 20 * time.Second
+
+// systemdTimestampLayouts lists the layouts accepted when parsing a systemd
+// timestamp property value such as "Thu 2026-06-11 03:06:02 UTC". systemd
+// renders the weekday + zone abbreviation; a numeric-zone fallback is kept
+// for environments that emit one. Empty / unparseable => FailureTimeKnown
+// stays false (fatal via the classification rules).
+var systemdTimestampLayouts = []string{
+	"Mon 2006-01-02 15:04:05 MST",
+	"Mon 2006-01-02 15:04:05 -0700",
+	"2006-01-02 15:04:05 MST",
+	"2006-01-02 15:04:05 -0700",
+}
 
 // DefaultUnitDirs is the canonical systemd unit search path for
 // nftban-owned units. Both vendor and operator-owned dirs are scanned
@@ -129,7 +162,105 @@ func GatherSystemdPayloadInputs(exec executor.Executor, log *logging.Logger, inv
 
 	in.FailedNftbanUnits, in.FailedUnitQueryError = listFailedNftbanUnits(exec, log)
 
+	// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: hand the pure
+	// validator the install-window start and a bounded live-health verdict so
+	// it can downgrade a stale pre-existing latch (and ONLY that) to a
+	// non-fatal warning. Both are fail-closed: an unset window start or an
+	// inconclusive probe leaves the failure fatal.
+	in.InstallWindowStart = installWindowStart
+	in.InstallWindowStartKnown = !installWindowStart.IsZero()
+	in.LiveHealthClean, in.LiveHealthKnown = gatherLiveHealthClean(exec, log)
+
 	return in, nil
+}
+
+// gatherLiveHealthClean runs a bounded live `nftban health` text probe and
+// reports whether overall health is clean. clean=true requires ALL of:
+//   - an "Overall:" line whose value is OK or IDLE (case-insensitive),
+//   - a "Findings: none" line, and
+//   - no "CRITICAL" anywhere in the output.
+//
+// known=false (no confident verdict) on: missing nftban binary, non-zero
+// exit, context timeout, or output with no parseable "Overall:" line. The
+// caller treats known=false as "do not downgrade" (fail closed). Text only
+// — deliberately not --json.
+func gatherLiveHealthClean(exec executor.Executor, log *logging.Logger) (clean bool, known bool) {
+	if !exec.CommandExists("nftban") {
+		if log != nil {
+			log.Debug("systemd_payload: live-health probe skipped — nftban binary not in PATH (known=false)")
+		}
+		return false, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), liveHealthProbeTimeout)
+	defer cancel()
+	res := exec.RunContext(ctx, "nftban", "health")
+	if ctx.Err() != nil {
+		if log != nil {
+			log.Warn("systemd_payload: live-health probe timed out after %s (known=false)", liveHealthProbeTimeout)
+		}
+		return false, false
+	}
+	if res.ExitCode != 0 {
+		if log != nil {
+			log.Debug("systemd_payload: live-health probe exit=%d (known=false)", res.ExitCode)
+		}
+		return false, false
+	}
+	return parseLiveHealthClean(res.Stdout)
+}
+
+// parseLiveHealthClean parses the text output of `nftban health` and applies
+// the conservative clean/known rules described on gatherLiveHealthClean.
+// Pure function so it is unit-testable without an executor.
+// parseLiveHealthClean reads `nftban health` text output and decides whether the
+// system is healthy enough to downgrade a PRE_EXISTING failed-unit latch.
+//
+// Uses the real four-axis health vocabulary (cli/lib/nftban/cli/cmd_health.sh):
+//   - Overall: OK / IDLE / PROTECTED are ALL healthy — PROTECTED is the NORMAL
+//     active-protection state and MUST count as clean, else the v1.174 downgrade
+//     never fires on a protecting host. DOWN / DEGRADED / WARN / other = not clean.
+//   - Findings: "none" OR "none (N INFO finding(s) hidden ...)" are BOTH clean —
+//     hidden INFO findings are informational, not problems.
+//   - Any CRITICAL / FAIL / ERROR token anywhere → unambiguously not clean.
+//   - Missing Overall OR missing Findings → unknown verdict → fail-safe.
+func parseLiveHealthClean(out string) (clean bool, known bool) {
+	up := strings.ToUpper(out)
+	if strings.Contains(up, "CRITICAL") || strings.Contains(up, "FAIL") || strings.Contains(up, "ERROR") {
+		// Unambiguous not-clean (covers Truth: FAILED, CRITICAL findings, errors).
+		return false, true
+	}
+	overallSeen := false
+	overallHealthy := false
+	findingsSeen := false
+	findingsClean := false
+	for _, line := range strings.Split(out, "\n") {
+		t := strings.TrimSpace(line)
+		lower := strings.ToLower(t)
+		if strings.HasPrefix(lower, "overall:") {
+			overallSeen = true
+			fields := strings.Fields(strings.ToUpper(strings.TrimSpace(t[len("overall:"):])))
+			if len(fields) > 0 {
+				switch fields[0] {
+				case "OK", "IDLE", "PROTECTED":
+					overallHealthy = true
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(lower, "findings:") {
+			findingsSeen = true
+			val := strings.ToLower(strings.TrimSpace(t[len("findings:"):]))
+			// "none" or "none (N INFO finding(s) hidden ...)" — INFO-only is clean.
+			if val == "none" || strings.HasPrefix(val, "none ") || strings.HasPrefix(val, "none(") {
+				findingsClean = true
+			}
+		}
+	}
+	if !overallSeen || !findingsSeen {
+		// Need both axes to form a verdict — fail safe to unknown.
+		return false, false
+	}
+	return overallHealthy && findingsClean, true
 }
 
 // isUnitFilename returns true for systemd unit filenames we care about.
@@ -244,12 +375,81 @@ func queryFailedNftbanUnitsOnce(exec executor.Executor, log *logging.Logger) (fi
 		if !IsNftbanUnit(unit) {
 			continue
 		}
-		findings = append(findings, FailedUnitFinding{
+		finding := FailedUnitFinding{
 			Unit:   unit,
 			Active: fields[2],
 			Sub:    fields[3],
 			Detail: strings.Join(fields[4:], " "),
-		})
+		}
+		// v1.174 D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: capture the
+		// unit's last-failure timestamp so the validator can classify it as
+		// pre-existing vs in-window. Parse error => FailureTimeKnown stays
+		// false (fail closed → fatal).
+		finding.FailureTime, finding.FailureTimeKnown = queryUnitFailureTime(exec, unit, log)
+		findings = append(findings, finding)
 	}
 	return findings, ""
+}
+
+// queryUnitFailureTime asks systemd for a unit's last-failure timestamp via
+// `systemctl show` and returns the most recent of InactiveEnterTimestamp /
+// ExecMainExitTimestamp. Robust by design: any error, missing property, or
+// unparseable value yields known=false so the unit is treated as a hard
+// failure (fail closed).
+func queryUnitFailureTime(exec executor.Executor, unit string, log *logging.Logger) (time.Time, bool) {
+	res := exec.Run("systemctl", "show",
+		"-p", "InactiveEnterTimestamp",
+		"-p", "ExecMainExitTimestamp",
+		unit)
+	if res.ExitCode != 0 {
+		if log != nil {
+			log.Debug("systemd_payload: systemctl show %s exit=%d (failure-time unknown)", unit, res.ExitCode)
+		}
+		return time.Time{}, false
+	}
+	var best time.Time
+	bestKnown := false
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if key != "InactiveEnterTimestamp" && key != "ExecMainExitTimestamp" {
+			continue
+		}
+		val := strings.TrimSpace(line[eq+1:])
+		if val == "" {
+			continue
+		}
+		t, ok := parseSystemdTimestamp(val)
+		if !ok {
+			continue
+		}
+		if !bestKnown || t.After(best) {
+			best = t
+			bestKnown = true
+		}
+	}
+	if !bestKnown && log != nil {
+		log.Debug("systemd_payload: no parseable failure timestamp for %s (failure-time unknown)", unit)
+	}
+	return best, bestKnown
+}
+
+// parseSystemdTimestamp parses a systemd timestamp property value (e.g.
+// "Thu 2026-06-11 03:06:02 UTC") against systemdTimestampLayouts. Empty or
+// unparseable input returns ok=false.
+func parseSystemdTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range systemdTimestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/internal/installer/validate/systemd_payload_v174_test.go
+++ b/internal/installer/validate/systemd_payload_v174_test.go
@@ -1,0 +1,435 @@
+// =============================================================================
+// NFTBan v1.174 - Stale Failed-Unit Classification Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-validate-systemd-payload-v174-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-11"
+// meta:description="D-INSTALL-FAILED-UNITS-STALE-LATCHED-STATE: pre-existing vs in-window failed-unit classification + live-health downgrade + systemd timestamp parse"
+// meta:inventory.files="internal/installer/validate/systemd_payload_v174_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validate
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+// windowStart is a fixed install-window-start instant used across the matrix.
+var v174WindowStart = time.Date(2026, 6, 11, 18, 54, 0, 0, time.UTC)
+
+// failedUnit builds a non-auxiliary protection-critical failed finding.
+func v174FailedUnit(t time.Time, known bool) FailedUnitFinding {
+	return FailedUnitFinding{
+		Unit:             "nftban-health.service",
+		Active:           "failed",
+		Sub:              "failed",
+		Detail:           "exit-code",
+		FailureTime:      t,
+		FailureTimeKnown: known,
+	}
+}
+
+// TestValidateFailedUnitClassificationMatrix exercises every HARD-RULE row of
+// the v1.174 fail-safe classification matrix purely through
+// SystemdPayloadInputs fixtures.
+func TestValidateFailedUnitClassificationMatrix(t *testing.T) {
+	preExistingTime := v174WindowStart.Add(-16 * time.Hour) // 03:06 the day before
+	inWindowTime := v174WindowStart.Add(5 * time.Minute)
+
+	cases := []struct {
+		name             string
+		in               SystemdPayloadInputs
+		wantOK           bool
+		wantFatalLen     int
+		wantRecoveredLen int
+		wantAuxLen       int
+	}{
+		{
+			name: "a_pre_existing_latch_live_clean_recovered",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(preExistingTime, true)},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         true,
+				LiveHealthKnown:         true,
+			},
+			wantOK:           true,
+			wantFatalLen:     0,
+			wantRecoveredLen: 1,
+		},
+		{
+			name: "b_pre_existing_live_not_clean_degraded",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(preExistingTime, true)},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         false,
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			name: "c_pre_existing_live_unknown_degraded",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(preExistingTime, true)},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         false,
+				LiveHealthKnown:         false,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			name: "d_in_window_failure_degraded",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(inWindowTime, true)},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         true, // even with clean health, in-window stays fatal
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			name: "e_failure_time_unknown_degraded",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(time.Time{}, false)},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         true,
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			name: "f_window_start_unknown_degraded",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(preExistingTime, true)},
+				InstallWindowStartKnown: false,
+				LiveHealthClean:         true,
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			name: "g_query_error_fail_closed",
+			in: SystemdPayloadInputs{
+				FailedUnitQueryError:    "systemctl missing",
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         true,
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 0, // query error path: FailedUnits empty but OK=false
+		},
+		{
+			name: "h_auxiliary_only_non_fatal",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits: []FailedUnitFinding{{
+					Unit:             "nftban-unified-exporter.service",
+					Active:           "failed",
+					Sub:              "exit-code",
+					Detail:           "exit-2",
+					FailureTime:      inWindowTime, // in-window, but auxiliary
+					FailureTimeKnown: true,
+				}},
+				InstallWindowStart:      v174WindowStart,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         false,
+				LiveHealthKnown:         false,
+			},
+			wantOK:       true,
+			wantFatalLen: 0,
+			wantAuxLen:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := ValidateInstalledSystemdPayload(tc.in)
+			if res.FailedUnitsOK() != tc.wantOK {
+				t.Errorf("FailedUnitsOK()=%v want %v (fatal=%d recovered=%d aux=%d qerr=%q)",
+					res.FailedUnitsOK(), tc.wantOK,
+					len(res.FailedUnits), len(res.FailedUnitsPreExistingRecovered),
+					len(res.FailedAuxiliaryUnits), res.FailedUnitQueryError)
+			}
+			if len(res.FailedUnits) != tc.wantFatalLen {
+				t.Errorf("len(FailedUnits)=%d want %d", len(res.FailedUnits), tc.wantFatalLen)
+			}
+			if len(res.FailedUnitsPreExistingRecovered) != tc.wantRecoveredLen {
+				t.Errorf("len(FailedUnitsPreExistingRecovered)=%d want %d",
+					len(res.FailedUnitsPreExistingRecovered), tc.wantRecoveredLen)
+			}
+			if len(res.FailedAuxiliaryUnits) != tc.wantAuxLen {
+				t.Errorf("len(FailedAuxiliaryUnits)=%d want %d",
+					len(res.FailedAuxiliaryUnits), tc.wantAuxLen)
+			}
+		})
+	}
+}
+
+// TestNeverClassifyNewFailureAsRecovered guards the cardinal HARD RULE: a
+// unit that failed exactly at the window start (boundary) or after must NOT
+// land in the recovered bucket even with clean live health.
+func TestNeverClassifyNewFailureAsRecovered(t *testing.T) {
+	for _, ft := range []time.Time{v174WindowStart, v174WindowStart.Add(time.Nanosecond)} {
+		in := SystemdPayloadInputs{
+			FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(ft, true)},
+			InstallWindowStart:      v174WindowStart,
+			InstallWindowStartKnown: true,
+			LiveHealthClean:         true,
+			LiveHealthKnown:         true,
+		}
+		res := ValidateInstalledSystemdPayload(in)
+		if len(res.FailedUnitsPreExistingRecovered) != 0 {
+			t.Errorf("failure at %v wrongly recovered", ft)
+		}
+		if res.FailedUnitsOK() {
+			t.Errorf("failure at %v wrongly passed FailedUnitsOK()", ft)
+		}
+	}
+}
+
+// TestRecoveredEntryCarriesClassification confirms the diagnostic field.
+func TestRecoveredEntryCarriesClassification(t *testing.T) {
+	in := SystemdPayloadInputs{
+		FailedNftbanUnits:       []FailedUnitFinding{v174FailedUnit(v174WindowStart.Add(-time.Hour), true)},
+		InstallWindowStart:      v174WindowStart,
+		InstallWindowStartKnown: true,
+		LiveHealthClean:         true,
+		LiveHealthKnown:         true,
+	}
+	res := ValidateInstalledSystemdPayload(in)
+	if len(res.FailedUnitsPreExistingRecovered) != 1 {
+		t.Fatalf("want 1 recovered, got %d", len(res.FailedUnitsPreExistingRecovered))
+	}
+	if got := res.FailedUnitsPreExistingRecovered[0].Classification; got != "WARN_PRE_EXISTING_RECOVERED" {
+		t.Errorf("Classification=%q want WARN_PRE_EXISTING_RECOVERED", got)
+	}
+}
+
+// TestParseSystemdTimestamp exercises the timestamp parse helper.
+func TestParseSystemdTimestamp(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantKnown bool
+	}{
+		{"systemd_weekday_tz", "Thu 2026-06-11 03:06:02 UTC", true},
+		{"systemd_weekday_numeric_zone", "Thu 2026-06-11 03:06:02 +0000", true},
+		{"no_weekday_tz", "2026-06-11 03:06:02 UTC", true},
+		{"empty", "", false},
+		{"garbage", "not-a-timestamp", false},
+		{"epoch_zero_marker", "0", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, ok := parseSystemdTimestamp(tc.in)
+			if ok != tc.wantKnown {
+				t.Fatalf("parseSystemdTimestamp(%q) known=%v want %v", tc.in, ok, tc.wantKnown)
+			}
+			if ok && ts.IsZero() {
+				t.Errorf("parsed %q but got zero time", tc.in)
+			}
+		})
+	}
+}
+
+// TestParseLiveHealthClean exercises the conservative text parse rules.
+func TestParseLiveHealthClean(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantClean bool
+		wantKnown bool
+	}{
+		{"ok_none", "Overall: OK\nFindings: none\n", true, true},
+		{"idle_none", "Overall: IDLE\nFindings: none\n", true, true},
+		{"protected_none", "Overall: PROTECTED\nFindings: none\n", true, true},
+		{"ok_lowercase", "overall: ok\nfindings: none\n", true, true},
+		// The exact monitor/lab real-host shape: PROTECTED + hidden INFO findings.
+		{"protected_info_hidden", "  Overall:       PROTECTED\n  Daemon:        RUNNING\n  Consistency:   ok\n  Findings: none (1 INFO finding(s) hidden — use --verbose to show)\n", true, true},
+		{"idle_info_hidden", "Overall: IDLE\nFindings: none (3 INFO finding(s) hidden — use --verbose to show)\n", true, true},
+		{"ok_with_findings", "Overall: OK\nFindings: 2\n", false, true},
+		// "Findings (N):" header (real findings) has no "Findings: none" line →
+		// unknown → fail-safe not-clean (safe: never downgrade with real findings).
+		{"findings_header", "Overall: OK\nFindings (2):\n  - something\n", false, false},
+		{"critical_present", "Overall: OK\nFindings: none\nCRITICAL: nft set missing\n", false, true},
+		{"degraded_overall", "Overall: DEGRADED\nFindings: none\n", false, true},
+		{"down_overall", "Overall: DOWN\nFindings: none\n", false, true},
+		{"warn_overall", "Overall: WARNING\nFindings: none\n", false, true},
+		{"fail_token", "Overall: PROTECTED\nFindings: none\nTruth: FAILED\n", false, true},
+		{"error_token", "Overall: PROTECTED\nFindings: none\nvalidator ERROR: x\n", false, true},
+		{"no_overall_line", "Findings: none\n", false, false},
+		{"overall_no_findings", "Overall: PROTECTED\nDaemon: RUNNING\n", false, false},
+		{"empty", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clean, known := parseLiveHealthClean(tc.in)
+			if clean != tc.wantClean || known != tc.wantKnown {
+				t.Errorf("parseLiveHealthClean(%q)=(clean=%v,known=%v) want (clean=%v,known=%v)",
+					tc.in, clean, known, tc.wantClean, tc.wantKnown)
+			}
+		})
+	}
+}
+
+// TestMonitorAlertUnitV174 covers the monitor live case: a templated
+// nftban-alert@<svc>.service that latched failed BEFORE the install window must
+// flow through the v1.174 timestamp classification (NOT the auxiliary carve-out),
+// recover to WARN_PRE_EXISTING_RECOVERED when live health is clean (so --repair
+// reaches COMMITTED), but stay DEGRADED when it failed in-window or live health
+// is not clean (alert failure can be real).
+func TestMonitorAlertUnitV174(t *testing.T) {
+	const alertUnit = "nftban-alert@nftband.service.service"
+	if !IsNftbanUnit(alertUnit) {
+		t.Fatalf("IsNftbanUnit(%q) = false; want true (templated alert unit is nftban-owned)", alertUnit)
+	}
+	if IsAuxiliaryUnit(alertUnit) {
+		t.Fatalf("IsAuxiliaryUnit(%q) = true; alert@ must NOT be auxiliary — alert failure can be real, classify by timestamp", alertUnit)
+	}
+
+	windowStart := time.Date(2026, 6, 11, 21, 42, 0, 0, time.UTC)
+	preExisting := time.Date(2026, 6, 9, 16, 37, 52, 0, time.UTC) // monitor: failed ~2 days earlier
+	inWindow := windowStart.Add(30 * time.Second)
+	log := logging.New("/dev/null", false)
+
+	mk := func(ft time.Time) FailedUnitFinding {
+		return FailedUnitFinding{Unit: alertUnit, Active: "failed", Sub: "failed", Detail: "exit-code", FailureTime: ft, FailureTimeKnown: true}
+	}
+
+	// 1) pre-existing + clean live health -> recovered (not DEGRADED); assertion PASSES (repair -> COMMITTED).
+	r := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{mk(preExisting)}, InstallWindowStart: windowStart,
+		InstallWindowStartKnown: true, LiveHealthClean: true, LiveHealthKnown: true,
+	})
+	if !r.FailedUnitsOK() || len(r.FailedUnitsPreExistingRecovered) != 1 || len(r.FailedUnits) != 0 {
+		t.Fatalf("pre-existing alert@ + clean health: want recovered/OK; got OK=%v recovered=%d fatal=%d",
+			r.FailedUnitsOK(), len(r.FailedUnitsPreExistingRecovered), len(r.FailedUnits))
+	}
+	if a := assertFailedUnitsPostInstall(r, log); !a.Passed {
+		t.Fatalf("recovered alert@: failed_units_postinstall_ok must PASS so --repair reaches COMMITTED; detail=%q", a.Detail)
+	}
+
+	// 2) in-window failure -> DEGRADED (alert failure can be real); assertion FAILS.
+	r2 := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{mk(inWindow)}, InstallWindowStart: windowStart,
+		InstallWindowStartKnown: true, LiveHealthClean: true, LiveHealthKnown: true,
+	})
+	if r2.FailedUnitsOK() || len(r2.FailedUnits) != 1 {
+		t.Fatalf("in-window alert@: want DEGRADED/fatal; got OK=%v fatal=%d", r2.FailedUnitsOK(), len(r2.FailedUnits))
+	}
+	if a := assertFailedUnitsPostInstall(r2, log); a.Passed {
+		t.Fatalf("in-window alert@: failed_units_postinstall_ok must FAIL (stays DEGRADED)")
+	}
+
+	// 3) pre-existing but live health NOT clean -> DEGRADED (fail-safe).
+	r3 := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{mk(preExisting)}, InstallWindowStart: windowStart,
+		InstallWindowStartKnown: true, LiveHealthClean: false, LiveHealthKnown: true,
+	})
+	if r3.FailedUnitsOK() {
+		t.Fatalf("pre-existing alert@ + unhealthy live health must stay DEGRADED")
+	}
+}
+
+// TestResetRecoveredPreExistingUnitsV174 locks the bounded reset-failed contract:
+// reset-failed is issued ONLY for WARN_PRE_EXISTING_RECOVERED units (exact names),
+// never for IN_WINDOW / unknown-timestamp / unknown-or-unhealthy-live-health, never
+// blanket, and a reset-failed error is non-fatal.
+func TestResetRecoveredPreExistingUnitsV174(t *testing.T) {
+	log := logging.New("/dev/null", false)
+	win := time.Date(2026, 6, 11, 21, 42, 0, 0, time.UTC)
+	pre := win.Add(-48 * time.Hour)
+	inw := win.Add(time.Minute)
+	mk := func(unit string, ft time.Time, ftk bool) FailedUnitFinding {
+		return FailedUnitFinding{Unit: unit, Active: "failed", Sub: "failed", Detail: "exit-code", FailureTime: ft, FailureTimeKnown: ftk}
+	}
+	in := func(units []FailedUnitFinding, clean, known, wsKnown bool) SystemdPayloadInputs {
+		return SystemdPayloadInputs{FailedNftbanUnits: units, InstallWindowStart: win, InstallWindowStartKnown: wsKnown, LiveHealthClean: clean, LiveHealthKnown: known}
+	}
+	resetCalls := func(m *executor.MockExecutor) []string {
+		var u []string
+		for _, c := range m.Commands {
+			if c.Name == "systemctl" && len(c.Args) == 2 && c.Args[0] == "reset-failed" {
+				u = append(u, c.Args[1])
+			}
+		}
+		return u
+	}
+
+	// 1) pre-existing + clean -> reset-failed exactly that unit.
+	m := executor.NewMockExecutor()
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-alert@nftband.service.service", pre, true)}, true, true, true)))
+	if got := resetCalls(m); len(got) != 1 || got[0] != "nftban-alert@nftband.service.service" {
+		t.Fatalf("1 pre-existing+clean: want reset of exact unit; got %v", got)
+	}
+
+	// 2) in-window -> no reset.
+	m = executor.NewMockExecutor()
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-health.service", inw, true)}, true, true, true)))
+	if got := resetCalls(m); len(got) != 0 {
+		t.Fatalf("2 in-window: must NOT reset; got %v", got)
+	}
+
+	// 3) timestamp unknown -> no reset.
+	m = executor.NewMockExecutor()
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-health.service", time.Time{}, false)}, true, true, true)))
+	if got := resetCalls(m); len(got) != 0 {
+		t.Fatalf("3 unknown-ts: must NOT reset; got %v", got)
+	}
+
+	// 4a) live health unknown -> no reset.
+	m = executor.NewMockExecutor()
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-health.service", pre, true)}, false, false, true)))
+	if got := resetCalls(m); len(got) != 0 {
+		t.Fatalf("4a unknown-health: must NOT reset; got %v", got)
+	}
+	// 4b) live health unhealthy -> no reset.
+	m = executor.NewMockExecutor()
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-health.service", pre, true)}, false, true, true)))
+	if got := resetCalls(m); len(got) != 0 {
+		t.Fatalf("4b unhealthy: must NOT reset; got %v", got)
+	}
+
+	// 5) mixed: only the recovered pre-existing unit is reset; the in-window fatal stays.
+	m = executor.NewMockExecutor()
+	spr := ValidateInstalledSystemdPayload(in([]FailedUnitFinding{
+		mk("nftban-alert@x.service.service", pre, true),
+		mk("nftban-health.service", inw, true),
+	}, true, true, true))
+	resetRecoveredPreExistingUnits(m, log, spr)
+	if got := resetCalls(m); len(got) != 1 || got[0] != "nftban-alert@x.service.service" {
+		t.Fatalf("5 mixed: only recovered reset; got %v", got)
+	}
+	if len(spr.FailedUnits) != 1 || spr.FailedUnits[0].Unit != "nftban-health.service" {
+		t.Fatalf("5 mixed: in-window fatal unit must remain in FailedUnits; got %+v", spr.FailedUnits)
+	}
+
+	// 6) reset-failed error is non-fatal (attempted once, no panic/escalation).
+	m = executor.NewMockExecutor()
+	m.ServiceResetFailedErr = fmt.Errorf("dbus down")
+	resetRecoveredPreExistingUnits(m, log, ValidateInstalledSystemdPayload(in([]FailedUnitFinding{mk("nftban-health.service", pre, true)}, true, true, true)))
+	if got := resetCalls(m); len(got) != 1 {
+		t.Fatalf("6 reset error: attempt recorded once; got %v", got)
+	}
+}


### PR DESCRIPTION
## v1.174: install/health reliability

Two-item install/health bundle from the dns2 v1.159→v1.172 DEGRADED classification (`NFTBAN_ROADMAP/V1_173_INSTALL_WARNINGS_CLASSIFICATION.md`). Scope: `NFTBAN_ROADMAP/V1_174_INSTALL_HEALTH_RELIABILITY_SCOPE.md`.

### Includes
- **stale failed nftban unit classification with install-window timestamping** — the installer's `failed_units_postinstall_ok` no longer latches a *pre-existing* failed unit into DEGRADED; it compares each failed unit's `systemctl` failure timestamp against an install-window-start (`SetInstallWindowStart` at installer startup).
- **`WARN_PRE_EXISTING_RECOVERED` only for pre-existing latch + clean live health** — a unit that failed strictly before the window AND a bounded live `nftban health` probe is clean → non-fatal warning (install COMMITTED-with-warning).
- **fail-safe DEGRADED** for new/in-window failures, unknown/unparseable timestamps, unknown install-window-start, query errors, or unhealthy/unknown live health. A newly-failed unit is **never** labeled recovered.
- **`nftban-health.service` MemoryMax 128M → 256M** (health validator + concurrent children RSS on large journals; the Go validator's journalctl is already bounded `--since -15m -n 200`).

### Excludes (explicitly out of scope)
- CSF (csf.service / takeover restore — separate CSF lane)
- tmpfiles / FHS / sid-stats
- FSYNC-RESIDUAL
- daemon `cmd/nftband` changes
- fleet rollout

### Envelope
- **Daemon `cmd/nftband` byte-identical to v1.173** — 0 `cmd/nftband` files; daemon's dep graph does not include `internal/installer/validate`; code-only (`-buildvcs=false`) build SHA256 identical to v1.173. The default `-trimpath` build differs **only** by Go's VCS-dirty stamp (non-code build metadata from the working tree state), **not** a daemon code delta — the release daemon (built from a clean tag) is byte-identical.
- Schema **1.83.0 frozen**; FHS body unchanged (`generate-fhs-outputs.sh --check` rc=0).

### Tests
- `internal/installer/validate/systemd_payload_v174_test.go` — classification matrix (recovered / live-not-clean / live-unknown / in-window / failure-ts-unknown / window-unknown / query-error fail-closed / aux-only) + boundary "never classify a new failure as recovered" + systemd-timestamp + live-health parse helpers. Passes under `-race`.
- `cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh` (4/0) — health-path journalctl bounded + `MemoryMax=256M`. CI-wired.
- `go build/vet/staticcheck/gofmt` + shellcheck `-S warning` clean.

**CI only — no merge.** Lab-first PASS (lab2+lab4) required before tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)