### PR TITLE
fix(fhs,installer,daemon): v1.175 FHS lane — tmpfiles unsafe-path-transition + sid-stats /etc→/var + alert-throttle FHS

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -772,6 +772,14 @@ jobs:
       - name: update messaging recovered + DEGRADED (v1.174)
         run: bash cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
 
+      # v1.175 FHS lane: (T1) GENERIC guard — no root-owned tmpfiles entry under a
+      # non-root declared parent (the systemd-tmpfiles exit-73 "unsafe path transition"
+      # class — structural BUG-TMPFILES regression lock); auditors→package +
+      # firewall-validate→ExecStartPre out of tmpfiles; ALERT-THROTTLE-FHS alerts dir;
+      # FHS-SMELL-SIDSTATS cache.go DataDir relocation + migration.
+      - name: FHS lane invariants — tmpfiles transition guard + relocations (v1.175)
+        run: bash cli/lib/nftban/tests/fhs_lane_v175_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -277,7 +277,7 @@ jobs:
       # G8: PKG-EFFECTIVE-PARITY L4 tmpfiles-managed coverage (Slot 5 / row 14)
       # ------------------------------------------------------------------
       # Runtime Truth runs on real OS images with full systemd. This step
-      # verifies the 6 tmpfiles-managed critical paths (which Test RPM/DEB
+      # verifies the tmpfiles-managed critical paths (which Test RPM/DEB
       # install jobs in build-packages.yml cannot reliably exercise inside
       # vanilla Docker without systemd PID 1).
       #
@@ -285,10 +285,9 @@ jobs:
       #   - /run/nftban (0755 nftban:nftban)
       #   - /var/cache/nftban (0755 nftban:nftban)
       #   - /var/lib/nftban (0750 root:nftban)
-      #   - /var/lib/nftban/reports/auditors (0770 root:nftban-auditor)
       #   - /var/log/nftban (0750 nftban:nftban)
-      #   (Note: /var/lib/nftban/community is package-shipped, NOT tmpfiles —
-      #   asserted in build-packages.yml Test * install jobs)
+      #   (Note: /var/lib/nftban/community AND, since v1.175, /var/lib/nftban/reports/auditors
+      #   are package-shipped, NOT tmpfiles — asserted in build-packages.yml Test * install jobs)
       - name: G8 — PKG-EFFECTIVE-PARITY L4 tmpfiles parity (real-systemd)
         shell: bash
         run: |
@@ -448,22 +447,28 @@ jobs:
           sudo grep -E "reports|auditors|nftban-auditor|skip|ignor|Failed|fail|denied|invalid" /tmp/g8-tmpfiles.log 2>/dev/null \
             | head -40 || echo "(no relevant lines in tmpfiles log)"
 
-          # 5. Assert each of the 6 tmpfiles-managed critical paths (UNCHANGED).
+          # 5. Assert each of the tmpfiles-managed critical paths.
           # Diagnostics above are purely additive; the contract this step enforces
-          # is identical to before — failure on missing/mismatched dirs.
+          # is failure on missing/mismatched dirs. (v1.175: auditors dropped from
+          # this list — now package-created, asserted by the Test * install jobs.)
           fail=0
           # Format: path|expected_mode|expected_owner|expected_group
+          # v1.175 BUG-TMPFILES: /var/lib/nftban/reports/auditors is NO LONGER
+          # tmpfiles-managed (moved created_by tmpfiles→package; the root-under-nftban
+          # tmpfiles transition tripped systemd-tmpfiles exit 73). Like
+          # /var/lib/nftban/community it is now package-created + postinst-converged
+          # and asserted by the Test RPM/DEB install jobs (build-packages.yml L4),
+          # NOT by this tmpfiles-only parity step.
           for entry in \
               "/run/nftban|0755|nftban|nftban" \
               "/var/cache/nftban|0755|nftban|nftban" \
               "/var/lib/nftban|0750|root|nftban" \
-              "/var/lib/nftban/reports/auditors|0770|root|nftban-auditor" \
               "/var/log/nftban|0750|nftban|nftban" \
           ; do
             IFS='|' read -r p exp_mode exp_owner exp_group <<< "$entry"
             # Slot 5b Stage 2-F: sudo-wrap path-existence + stat checks.
             # See diag.4 comment block above — same Bucket F mechanism. The
-            # 5-path mode/owner/group contract below is unchanged; only the
+            # mode/owner/group contract below; only the
             # privilege context of the verifier changes so it can traverse
             # the 0750 root:nftban parent.
             if ! sudo test -d "$p"; then

--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -555,8 +555,7 @@ directories:
       owner: root
       group: nftban-auditor
       description: "Auditor reports (nftban-auditor group access)"
-      created_by: tmpfiles
-      tmpfiles_reconcile: "z"
+      created_by: package
       note: |
         D-NEW-10 closure (Slot 6 / 2026-05-09): AUTHORITY EXCEPTION — intentional, NOT drift.
         This is the ONLY directory in the /var/lib/nftban tree owned by `nftban-auditor`
@@ -565,6 +564,13 @@ directories:
         + group nftban-auditor is intentional.
         DO NOT "normalize" this entry to the 0750 root:nftban / 0750 nftban:nftban defaults
         seen elsewhere in this section — that would break the auditor write-channel.
+        v1.175 BUG-TMPFILES: created_by tmpfiles→package. This root-owned child under the
+        nftban-owned /var/lib/nftban/reports parent made systemd-tmpfiles refuse the
+        non-root-parent→root-child transition (exit 73, both families). The dir is now
+        created+owned at install (RPM %dir %attr — nftban-auditor resolves via the %pre
+        groupadd, which runs before file unpack; DEB nftban.dirs + dir-attrs in postinst,
+        after group creation), so systemd-tmpfiles never attempts the unsafe transition.
+        Contents are still maintained by fhs-permissions.sh (root:nftban-auditor 0660).
         Structural assertion (CI hard-fails on drift):
           - .github/workflows/ci-runtime-truth.yml G8 step (sudo-wrapped post-Slot-5b)
           - scripts/test-package-effective-parity.sh EXPECTED_TABLE entry (line 77)
@@ -776,6 +782,35 @@ directories:
       created_by: tmpfiles
       tmpfiles_reconcile: "z"
 
+    - path: /var/lib/nftban/suricata/cache
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "Suricata SID-statistics cache (sid-stats.json snapshot)"
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
+      note: |
+        v1.175 FHS-SMELL-SIDSTATS: the daemon's suricata SID-stats snapshot moved here from
+        /etc/nftban/suricata/cache/sid-stats.json (mutable runtime cache must not live under
+        /etc, which FHS reserves for config). nftban-owned because the daemon (User=nftban)
+        rewrites it on every auto-save tick via safety.SafeWriteFile (atomic since v1.171).
+        cache.go migrates the old /etc copy on first startup. See internal/suricata/stats/cache.go.
+
+    - path: /var/lib/nftban/alerts
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "Service-failure alert bookkeeping (throttle timestamps + diagnostic reports)"
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
+      note: |
+        v1.175 ALERT-THROTTLE-FHS: nftban-owned home for nftban-alert@.service bookkeeping.
+        The alert worker runs User=nftban; its throttle file + diagnostics previously sat
+        directly under root-owned 0750 /var/lib/nftban (not group-writable) → EACCES → throttle
+        never persisted (v1.174 only made those writes non-fatal). Relocating throttle to
+        /var/lib/nftban/alerts/throttle_<svc> and diagnostics to /var/lib/nftban/alerts/<svc>_<ts>.txt
+        (both nftban:nftban) lets throttling actually persist. See cli/sbin/nftban-service-alert.
+
     - path: /var/lib/nftban/update-backups
       mode: "0750"
       owner: root
@@ -911,8 +946,20 @@ directories:
       owner: root
       group: nftban
       description: "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
-      created_by: tmpfiles
-      tmpfiles_reconcile: "z"
+      created_by: feature_enable
+      note: |
+        v1.175 BUG-TMPFILES: created_by tmpfiles→feature_enable. This root-owned child
+        under the nftban-owned /run/nftban parent made systemd-tmpfiles refuse the
+        non-root-parent→root-child transition (exit 73, both families). It must stay
+        root-owned (integrity: only the audited root service may write last.json; the
+        nftban group only READS it 0640) AND /run is tmpfs (reboot-wiped, so it cannot be
+        package-created). It is now created per-start by the sole authoritative creator —
+        nftban-firewall-validate.service's `+`-prefixed (unsandboxed) ExecStartPre:
+        `/usr/bin/install -d -o root -g nftban -m 2750 /run/nftban/firewall-validate`,
+        which already runs before the sandboxed ExecStart (it must, since ReadWritePaths
+        only binds an existing path). Removing it from tmpfiles loses nothing and kills the
+        exit-73. Still listed in nftban_fhs_spec.sh / fhs_directories.json / fhs-permissions
+        for health/permission awareness; created_by feature_enable = not tmpfiles, not package.
 
   # ---------------------------------------------------------------------------
   # Shared Data (root:root, 755) - Read-only application data

--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -946,20 +946,29 @@ directories:
       owner: root
       group: nftban
       description: "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
-      created_by: feature_enable
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
       note: |
-        v1.175 BUG-TMPFILES: created_by tmpfiles→feature_enable. This root-owned child
-        under the nftban-owned /run/nftban parent made systemd-tmpfiles refuse the
-        non-root-parent→root-child transition (exit 73, both families). It must stay
-        root-owned (integrity: only the audited root service may write last.json; the
-        nftban group only READS it 0640) AND /run is tmpfs (reboot-wiped, so it cannot be
-        package-created). It is now created per-start by the sole authoritative creator —
-        nftban-firewall-validate.service's `+`-prefixed (unsandboxed) ExecStartPre:
-        `/usr/bin/install -d -o root -g nftban -m 2750 /run/nftban/firewall-validate`,
-        which already runs before the sandboxed ExecStart (it must, since ReadWritePaths
-        only binds an existing path). Removing it from tmpfiles loses nothing and kills the
-        exit-73. Still listed in nftban_fhs_spec.sh / fhs_directories.json / fhs-permissions
-        for health/permission awareness; created_by feature_enable = not tmpfiles, not package.
+        v1.175 BUG-TMPFILES — ACCEPTED SECURITY EXCEPTION (intentionally retained as tmpfiles).
+        This is the ONE root-owned child (2750 root:nftban, setgid) under the nftban-owned
+        /run/nftban parent. systemd-tmpfiles flags the non-root-parent→root-child transition
+        (exit 73, both families) — but the dir IS still created (the exit-73 is NON-FATAL;
+        the entire production fleet runs with it). It MUST stay root-owned: the integrity
+        boundary is that only the audited root service may WRITE last.json, while the nftban
+        group only READS it (0640). Owning the dir nftban:nftban (which would clear exit-73)
+        is REJECTED: a compromised nftban daemon could then delete+replace last.json and
+        forge the independent firewall-validation result operators trust. /run is tmpfs
+        (reboot-wiped), so it cannot be package-created.
+        REJECTED ALTERNATIVE (v1.175 D-1, lab-disproven): making the service ExecStartPre the
+        SOLE creator and dropping this tmpfiles entry is REBOOT-LATENT-BROKEN — the unit has
+        ReadWritePaths=/run/nftban/firewall-validate, which systemd binds at MOUNT-NAMESPACE
+        SETUP; on a fresh-boot tmpfs the path is absent at that point and the unit fails
+        226/NAMESPACE before ExecStartPre can create it (proven on lab4, systemd 255).
+        So tmpfiles MUST create it at boot. The `+`-prefixed per-start ExecStartPre in the
+        unit remains as an idempotent belt-and-suspenders (not the sole creator).
+        Net v1.175 scope: this path's exit-73 is an accepted non-fatal SECURITY EXCEPTION
+        (BUG-TMPFILES-FIREWALL-VALIDATE-SECURITY-EXCEPTION) — NOT closed; the AUDITORS unsafe
+        transition IS closed. Any future nftban:nftban change requires an explicit security review.
 
   # ---------------------------------------------------------------------------
   # Shared Data (root:root, 755) - Read-only application data

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -141,6 +141,8 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/staging"]="0750|nftban|nftban|Feed staging area (temporary download/validation)"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/state"]="0750|nftban|nftban|Critical runtime state files"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/suricata"]="0750|nftban|nftban|Suricata integration state"
+    NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/suricata/cache"]="0750|nftban|nftban|Suricata SID-statistics cache (sid-stats.json snapshot)"
+    NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/alerts"]="0750|nftban|nftban|Service-failure alert bookkeeping (throttle timestamps + diagnostic reports)"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/update-backups"]="0750|root|nftban|Update rollback backups (root-owned for integrity)"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/watchdog"]="0750|nftban|nftban|Watchdog reports and state"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/reports/archive"]="0750|nftban|nftban|Archived reports"

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -533,7 +533,7 @@
         "owner": "root",
         "group": "nftban-auditor",
         "description": "Auditor reports (nftban-auditor group access)",
-        "created_by": "tmpfiles"
+        "created_by": "package"
       },
       {
         "path": "/var/lib/nftban/metrics",
@@ -736,6 +736,22 @@
         "created_by": "tmpfiles"
       },
       {
+        "path": "/var/lib/nftban/suricata/cache",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "Suricata SID-statistics cache (sid-stats.json snapshot)",
+        "created_by": "tmpfiles"
+      },
+      {
+        "path": "/var/lib/nftban/alerts",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "Service-failure alert bookkeeping (throttle timestamps + diagnostic reports)",
+        "created_by": "tmpfiles"
+      },
+      {
         "path": "/var/lib/nftban/update-backups",
         "mode": "0750",
         "owner": "root",
@@ -865,7 +881,7 @@
         "owner": "root",
         "group": "nftban",
         "description": "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN",
-        "created_by": "tmpfiles"
+        "created_by": "feature_enable"
       }
     ],
     "shared": [

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -881,7 +881,7 @@
         "owner": "root",
         "group": "nftban",
         "description": "V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN",
-        "created_by": "feature_enable"
+        "created_by": "tmpfiles"
       }
     ],
     "shared": [

--- a/cli/lib/nftban/helpers/firewall_validate_run.sh
+++ b/cli/lib/nftban/helpers/firewall_validate_run.sh
@@ -46,11 +46,13 @@ _bin="${NFTBAN_VALIDATE_BIN:-/usr/lib/nftban/bin/nftban-validate}"
 rm -f "$_file" 2>/dev/null || true
 
 # Ensure the runtime dir exists and is group-readable by the nftban group.
-# V131.2 D13: the dir is now pre-created by tmpfiles (root:nftban 0750) and
-# bound writable via the unit's ReadWritePaths=/run/nftban/firewall-validate.
-# This mkdir is a best-effort no-op for the standalone/dev path; under the
-# narrow ReadWritePaths a parent-write mkdir of the bound subdir would fail,
-# so it MUST NOT abort the wrapper under set -e before the write attempt.
+# V131.2 D13 / v1.175: under the service the dir is created per-start by the
+# unit's `+`-prefixed ExecStartPre (/usr/bin/install -d -o root -g nftban -m 2750);
+# it is NO LONGER created by tmpfiles (v1.175 BUG-TMPFILES: the root-under-nftban
+# transition tripped systemd-tmpfiles exit 73). ReadWritePaths binds that
+# existing dir writable. This mkdir is a best-effort no-op for the standalone/dev
+# path; under the narrow ReadWritePaths a parent-write mkdir of the bound subdir
+# would fail, so it MUST NOT abort the wrapper under set -e before the write attempt.
 mkdir -p "$_dir" 2>/dev/null || true
 chgrp nftban "$_dir" 2>/dev/null || true
 chmod 0750 "$_dir" 2>/dev/null || true

--- a/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
+++ b/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
@@ -60,7 +60,8 @@ run_alert "$ro" "" "$WORK/nolib"
 
 echo "== Test B: WARN logged (not fatal) + throttle file NOT created under EACCES =="
 if [[ -f "$LOG" ]] && grep -q "throttle state write failed" "$LOG"; then ok "B throttle WARN logged"; else no "B throttle WARN" "missing in $LOG"; fi
-[[ ! -e "$ro/alert_throttle_nftband_service" ]] && ok "B throttle file not created (write was non-fatal)" || no "B throttle file" "unexpectedly created"
+# v1.175 ALERT-THROTTLE-FHS: throttle relocated to <data>/alerts/throttle_<svc>.
+[[ ! -e "$ro/alerts/throttle_nftband_service" ]] && ok "B throttle file not created (write was non-fatal)" || no "B throttle file" "unexpectedly created"
 
 echo "== Test C: delivery contract — recipient set + mail module absent => non-zero =="
 rw="$WORK/rw_data"; mkdir -p "$rw"
@@ -71,7 +72,8 @@ echo "== Test D: happy path — writable data dir + no recipient => exit 0 + thr
 rw2="$WORK/rw_data2"; mkdir -p "$rw2"
 run_alert "$rw2" "" "$WORK/nolib"
 [[ "$RC" -eq 0 ]] && ok "D exit 0 (RC=$RC)" || no "D exit 0" "got RC=$RC"
-[[ -f "$rw2/alert_throttle_nftband_service" ]] && ok "D throttle file persisted when writable" || no "D throttle persisted" "file missing"
+# v1.175 ALERT-THROTTLE-FHS: throttle persists under <data>/alerts/ (nftban-owned).
+[[ -f "$rw2/alerts/throttle_nftband_service" ]] && ok "D throttle file persisted when writable (under alerts/)" || no "D throttle persisted" "file missing at alerts/throttle_nftband_service"
 
 echo ""
 echo "=== RESULT: $PASS passed, $FAIL failed ==="

--- a/cli/lib/nftban/tests/fhs_lane_v175_test.sh
+++ b/cli/lib/nftban/tests/fhs_lane_v175_test.sh
@@ -8,7 +8,7 @@
 # meta:version="1.0.0"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 # meta:created_date="2026-06-12"
-# meta:description="Locks the v1.175 FHS-authority lane. (T1) GENERIC GUARD: no generated tmpfiles.d d/z entry is root-owned under a non-root-owned declared parent (the systemd-tmpfiles 'unsafe path transition' / exit-73 class — prevents BUG-TMPFILES regressions structurally). (T2) auditors created_by=package + absent from tmpfiles. (T3) firewall-validate created_by=feature_enable + absent from tmpfiles + created by the unit +ExecStartPre. (T4) /var/lib/nftban/alerts declared nftban:nftban + in tmpfiles (ALERT-THROTTLE-FHS). (T5) /var/lib/nftban/suricata/cache declared nftban:nftban + in tmpfiles (FHS-SMELL-SIDSTATS). (T6) cache.go snapshot uses DataDir not ConfigDir. (T7) nftban-service-alert throttle relocated under alerts/. Hermetic: reads committed generated files + spec; no root, no systemd."
+# meta:description="Locks the v1.175 FHS-authority lane. (T1) GENERIC GUARD: no generated tmpfiles.d d/z entry is root-owned under a non-root-owned declared parent (the systemd-tmpfiles 'unsafe path transition' / exit-73 class), EXCEPT the documented security-exception allowlist (firewall-validate root-only-writer boundary) — prevents BUG-TMPFILES regressions structurally while permitting the reviewed exception. (T2) auditors created_by=package + absent from tmpfiles (AUDITORS unsafe-transition CLOSED). (T3) firewall-validate created_by=tmpfiles + PRESENT in tmpfiles as the accepted root-only-writer SECURITY EXCEPTION (exit-73 NOT closed; ExecStartPre-sole was lab-disproven 226/NAMESPACE) + unit +ExecStartPre belt-and-suspenders. (T4) /var/lib/nftban/alerts declared nftban:nftban + in tmpfiles (ALERT-THROTTLE-FHS). (T5) /var/lib/nftban/suricata/cache declared nftban:nftban + in tmpfiles (FHS-SMELL-SIDSTATS). (T6) cache.go snapshot uses DataDir not ConfigDir. (T7) nftban-service-alert throttle relocated under alerts/. Hermetic: reads committed generated files + spec; no root, no systemd."
 # meta:input="None (reads repo files)"
 # meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
 # meta:depends="bash,yq"
@@ -40,13 +40,31 @@ echo "=== v1.175 FHS lane invariants ==="
 # parent (systemd-tmpfiles refuses that transition: exit 73 / "unsafe path
 # transition"). This is the structural lock for the whole BUG-TMPFILES class.
 # -----------------------------------------------------------------------------
+# Intentional, security-reviewed exceptions: root-owned children DELIBERATELY kept
+# under a non-root parent because the root-only-writer property IS the security
+# boundary. These emit a NON-FATAL systemd-tmpfiles exit-73 that is ACCEPTED and
+# documented (fhs-spec.yaml + the unit). T1 still FAILS for any OTHER (new)
+# root-under-non-root transition — the guard is not weakened, only this exact path
+# is allowlisted with its integrity reason.
+declare -A TMPFILES_ROOT_EXCEPTION=(
+    # only the audited root service may WRITE last.json; nftban group READS it 0640.
+    # nftban:nftban would let a compromised daemon forge the independent validation
+    # result. /run is tmpfs → must be tmpfiles-created at boot (ExecStartPre-sole was
+    # lab-disproven: 226/NAMESPACE, ReadWritePaths binds before ExecStartPre runs).
+    ["/run/nftban/firewall-validate"]="root-only-writer integrity boundary for last.json (BUG-TMPFILES-FIREWALL-VALIDATE-SECURITY-EXCEPTION)"
+)
+
 declare -A OWNER
-while read -r typ path _mode owner _group _rest; do
+# NOTE: explicit IFS=' ' for THIS read — the file-level IFS=$'\n\t' has no space,
+# which would dump the whole line into $typ and silently build an EMPTY map
+# (vacuous guard). Split tmpfiles columns on whitespace here.
+while IFS=' ' read -r typ path _mode owner _group _rest; do
     [[ "$typ" =~ ^[dzZ]$ ]] || continue
     OWNER["$path"]="$owner"
 done < <(grep -E '^[dzZ] ' "$TMPFILES")
+[[ "${#OWNER[@]}" -gt 0 ]] || { no "T1 PRECONDITION: tmpfiles parse built a non-empty OWNER map" "0 entries — guard would be vacuous"; }
 
-unsafe=""
+unsafe=""; accepted=""
 for path in "${!OWNER[@]}"; do
     [[ "${OWNER[$path]}" == "root" ]] || continue   # only a root child can trip it
     p="$path"
@@ -54,15 +72,22 @@ for path in "${!OWNER[@]}"; do
         p="${p%/*}"
         [[ -z "$p" ]] && break
         if [[ -n "${OWNER[$p]:-}" ]]; then           # nearest declared ancestor
-            [[ "${OWNER[$p]}" != "root" ]] && unsafe+="${path}(root) under ${p}(${OWNER[$p]}); "
+            if [[ "${OWNER[$p]}" != "root" ]]; then
+                if [[ -n "${TMPFILES_ROOT_EXCEPTION[$path]:-}" ]]; then
+                    accepted+="${path} [${TMPFILES_ROOT_EXCEPTION[$path]}]; "
+                else
+                    unsafe+="${path}(root) under ${p}(${OWNER[$p]}); "
+                fi
+            fi
             break
         fi
     done
 done
 if [[ -z "$unsafe" ]]; then
-    ok "T1 no root-under-non-root tmpfiles transition (BUG-TMPFILES class guard)"
+    ok "T1 no UNEXPECTED root-under-non-root tmpfiles transition (BUG-TMPFILES class guard; allowlisted exceptions excluded)"
+    [[ -n "$accepted" ]] && echo "      accepted security exception(s): $accepted"
 else
-    no "T1 unsafe tmpfiles transition present" "$unsafe"
+    no "T1 unexpected unsafe tmpfiles transition present (not in security-exception allowlist)" "$unsafe"
 fi
 
 # -----------------------------------------------------------------------------
@@ -75,17 +100,20 @@ grep -qE '/var/lib/nftban/reports/auditors' "$TMPFILES" \
     || ok "T2b auditors absent from tmpfiles"
 
 # -----------------------------------------------------------------------------
-# T3: firewall-validate — created_by=feature_enable, absent from tmpfiles,
-# created by the unit's +ExecStartPre (sole creator).
+# T3: firewall-validate — ACCEPTED SECURITY EXCEPTION (NOT closed). created_by=
+# tmpfiles (the boot creator; required because ReadWritePaths binds at mount-
+# namespace setup on tmpfs — ExecStartPre-sole was lab-disproven, 226/NAMESPACE).
+# PRESENT in tmpfiles as the allowlisted root-only-writer exception. The unit's
+# +ExecStartPre remains as an idempotent per-start belt-and-suspenders.
 # -----------------------------------------------------------------------------
 F_CB=$(yq -r '.directories.runtime[] | select(.path == "/run/nftban/firewall-validate") | .created_by' "$SPEC")
-[[ "$F_CB" == "feature_enable" ]] && ok "T3 firewall-validate created_by=feature_enable" || no "T3 firewall-validate created_by=feature_enable" "got $F_CB"
-grep -qE '/run/nftban/firewall-validate' "$TMPFILES" \
-    && no "T3b firewall-validate absent from tmpfiles" "still present" \
-    || ok "T3b firewall-validate absent from tmpfiles"
+[[ "$F_CB" == "tmpfiles" ]] && ok "T3 firewall-validate created_by=tmpfiles (security exception, boot creator)" || no "T3 firewall-validate created_by=tmpfiles" "got $F_CB"
+grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -' "$TMPFILES" \
+    && ok "T3b firewall-validate present in tmpfiles (2750 root:nftban — accepted exit-73 security exception)" \
+    || no "T3b firewall-validate in tmpfiles (security exception)" "missing"
 grep -qE '^ExecStartPre=\+/usr/bin/install -d .*-m 2750 .*/run/nftban/firewall-validate' "$UNIT" \
-    && ok "T3c unit +ExecStartPre creates firewall-validate (2750, sole creator)" \
-    || no "T3c unit +ExecStartPre creates firewall-validate" "missing"
+    && ok "T3c unit +ExecStartPre also creates firewall-validate (2750, per-start belt-and-suspenders)" \
+    || no "T3c unit +ExecStartPre present" "missing"
 
 # -----------------------------------------------------------------------------
 # T4: ALERT-THROTTLE-FHS — /var/lib/nftban/alerts declared nftban:nftban + tmpfiles.

--- a/cli/lib/nftban/tests/fhs_lane_v175_test.sh
+++ b/cli/lib/nftban/tests/fhs_lane_v175_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.175 FHS LANE invariants
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="fhs_lane_v175_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Locks the v1.175 FHS-authority lane. (T1) GENERIC GUARD: no generated tmpfiles.d d/z entry is root-owned under a non-root-owned declared parent (the systemd-tmpfiles 'unsafe path transition' / exit-73 class — prevents BUG-TMPFILES regressions structurally). (T2) auditors created_by=package + absent from tmpfiles. (T3) firewall-validate created_by=feature_enable + absent from tmpfiles + created by the unit +ExecStartPre. (T4) /var/lib/nftban/alerts declared nftban:nftban + in tmpfiles (ALERT-THROTTLE-FHS). (T5) /var/lib/nftban/suricata/cache declared nftban:nftban + in tmpfiles (FHS-SMELL-SIDSTATS). (T6) cache.go snapshot uses DataDir not ConfigDir. (T7) nftban-service-alert throttle relocated under alerts/. Hermetic: reads committed generated files + spec; no root, no systemd."
+# meta:input="None (reads repo files)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,yq"
+# meta:inventory.files="build/fhs-spec.yaml,install/systemd/tmpfiles.d/nftban.conf,install/systemd/nftban-firewall-validate.service,internal/suricata/stats/cache.go,cli/sbin/nftban-service-alert"
+# meta:inventory.binaries="bash,yq,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-firewall-validate.service,nftban-alert@.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+SPEC="$REPO/build/fhs-spec.yaml"
+TMPFILES="$REPO/install/systemd/tmpfiles.d/nftban.conf"
+UNIT="$REPO/install/systemd/nftban-firewall-validate.service"
+CACHE="$REPO/internal/suricata/stats/cache.go"
+ALERT="$REPO/cli/sbin/nftban-service-alert"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "=== v1.175 FHS lane invariants ==="
+
+# -----------------------------------------------------------------------------
+# T1: GENERIC GUARD — no root-owned tmpfiles entry under a non-root declared
+# parent (systemd-tmpfiles refuses that transition: exit 73 / "unsafe path
+# transition"). This is the structural lock for the whole BUG-TMPFILES class.
+# -----------------------------------------------------------------------------
+declare -A OWNER
+while read -r typ path _mode owner _group _rest; do
+    [[ "$typ" =~ ^[dzZ]$ ]] || continue
+    OWNER["$path"]="$owner"
+done < <(grep -E '^[dzZ] ' "$TMPFILES")
+
+unsafe=""
+for path in "${!OWNER[@]}"; do
+    [[ "${OWNER[$path]}" == "root" ]] || continue   # only a root child can trip it
+    p="$path"
+    while [[ "$p" == */* ]]; do
+        p="${p%/*}"
+        [[ -z "$p" ]] && break
+        if [[ -n "${OWNER[$p]:-}" ]]; then           # nearest declared ancestor
+            [[ "${OWNER[$p]}" != "root" ]] && unsafe+="${path}(root) under ${p}(${OWNER[$p]}); "
+            break
+        fi
+    done
+done
+if [[ -z "$unsafe" ]]; then
+    ok "T1 no root-under-non-root tmpfiles transition (BUG-TMPFILES class guard)"
+else
+    no "T1 unsafe tmpfiles transition present" "$unsafe"
+fi
+
+# -----------------------------------------------------------------------------
+# T2: auditors — created_by=package, absent from tmpfiles.
+# -----------------------------------------------------------------------------
+A_CB=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/reports/auditors") | .created_by' "$SPEC")
+[[ "$A_CB" == "package" ]] && ok "T2 auditors created_by=package" || no "T2 auditors created_by=package" "got $A_CB"
+grep -qE '/var/lib/nftban/reports/auditors' "$TMPFILES" \
+    && no "T2b auditors absent from tmpfiles" "still present" \
+    || ok "T2b auditors absent from tmpfiles"
+
+# -----------------------------------------------------------------------------
+# T3: firewall-validate — created_by=feature_enable, absent from tmpfiles,
+# created by the unit's +ExecStartPre (sole creator).
+# -----------------------------------------------------------------------------
+F_CB=$(yq -r '.directories.runtime[] | select(.path == "/run/nftban/firewall-validate") | .created_by' "$SPEC")
+[[ "$F_CB" == "feature_enable" ]] && ok "T3 firewall-validate created_by=feature_enable" || no "T3 firewall-validate created_by=feature_enable" "got $F_CB"
+grep -qE '/run/nftban/firewall-validate' "$TMPFILES" \
+    && no "T3b firewall-validate absent from tmpfiles" "still present" \
+    || ok "T3b firewall-validate absent from tmpfiles"
+grep -qE '^ExecStartPre=\+/usr/bin/install -d .*-m 2750 .*/run/nftban/firewall-validate' "$UNIT" \
+    && ok "T3c unit +ExecStartPre creates firewall-validate (2750, sole creator)" \
+    || no "T3c unit +ExecStartPre creates firewall-validate" "missing"
+
+# -----------------------------------------------------------------------------
+# T4: ALERT-THROTTLE-FHS — /var/lib/nftban/alerts declared nftban:nftban + tmpfiles.
+# -----------------------------------------------------------------------------
+AL=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/alerts") | "\(.owner):\(.group):\(.created_by)"' "$SPEC")
+[[ "$AL" == "nftban:nftban:tmpfiles" ]] && ok "T4 /var/lib/nftban/alerts is nftban:nftban tmpfiles" || no "T4 alerts dir spec" "got $AL"
+grep -qE '^d /var/lib/nftban/alerts 0750 nftban nftban -' "$TMPFILES" \
+    && ok "T4b alerts dir in tmpfiles (0750 nftban nftban)" || no "T4b alerts in tmpfiles" "missing"
+
+# -----------------------------------------------------------------------------
+# T5: FHS-SMELL-SIDSTATS — /var/lib/nftban/suricata/cache declared nftban:nftban.
+# -----------------------------------------------------------------------------
+SC=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/suricata/cache") | "\(.owner):\(.group):\(.created_by)"' "$SPEC")
+[[ "$SC" == "nftban:nftban:tmpfiles" ]] && ok "T5 /var/lib/nftban/suricata/cache is nftban:nftban tmpfiles" || no "T5 suricata/cache dir spec" "got $SC"
+grep -qE '^d /var/lib/nftban/suricata/cache 0750 nftban nftban -' "$TMPFILES" \
+    && ok "T5b suricata/cache dir in tmpfiles" || no "T5b suricata/cache in tmpfiles" "missing"
+
+# -----------------------------------------------------------------------------
+# T6: cache.go snapshot path uses DataDir (/var/lib), NOT ConfigDir (/etc).
+# -----------------------------------------------------------------------------
+if grep -qE 'snapshotPath := filepath\.Join\(cfg\.DataDir, "suricata/cache/sid-stats\.json"\)' "$CACHE" \
+   && ! grep -qE 'snapshotPath := filepath\.Join\(cfg\.ConfigDir' "$CACHE"; then
+    ok "T6 cache.go snapshot uses cfg.DataDir (not ConfigDir)"
+else
+    no "T6 cache.go snapshot uses DataDir" "still references ConfigDir or path changed"
+fi
+grep -qE 'func migrateLegacySnapshot' "$CACHE" \
+    && ok "T6b cache.go has migrateLegacySnapshot (old /etc snapshot migrated)" \
+    || no "T6b migrateLegacySnapshot present" "missing"
+
+# -----------------------------------------------------------------------------
+# T7: nftban-service-alert throttle relocated under the nftban-owned alerts dir.
+# -----------------------------------------------------------------------------
+if grep -qE 'ALERT_STATE_DIR="\$\{NFTBAN_DATA_DIR\}/alerts"' "$ALERT" \
+   && grep -qE 'ALERT_THROTTLE_FILE="\$\{ALERT_STATE_DIR\}/throttle_' "$ALERT"; then
+    ok "T7 alert worker throttle under \${DATA}/alerts/throttle_<svc>"
+else
+    no "T7 throttle relocated under alerts/" "still at bare data-dir root"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
+++ b/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
@@ -131,15 +131,26 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# T6: the auditor authority exception (/var/lib/nftban/reports/auditors) is
-# annotated `z` (non-recursive) — recursive Z would clobber auditor-written
-# report files. Required by the HYBRID design.
+# T6: the auditor authority exception (/var/lib/nftban/reports/auditors) is now
+# created_by=package, NOT tmpfiles. v1.175 BUG-TMPFILES: this root-owned child
+# (0770 root:nftban-auditor) under the nftban-owned /var/lib/nftban/reports parent
+# made systemd-tmpfiles refuse the non-root-parent→root-child transition (exit 73).
+# It is created+owned at install (RPM %dir %attr — nftban-auditor resolves via the
+# %pre groupadd; DEB nftban.dirs + dir-attrs in postinst), so tmpfiles never
+# attempts the unsafe transition. The authority exception (root:nftban-auditor 0770)
+# is preserved — only the CREATOR changed (tmpfiles → package).
 # -----------------------------------------------------------------------------
-AUD_REC=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/reports/auditors") | .tmpfiles_reconcile // "missing"' "$SPEC")
-if [[ "$AUD_REC" == "z" ]]; then
-    ok "T6 auditor authority exception path uses non-recursive z (operator-writable subtree safe)"
+AUD_CB=$(yq -r '.directories.data[] | select(.path == "/var/lib/nftban/reports/auditors") | .created_by // "missing"' "$SPEC")
+if [[ "$AUD_CB" == "package" ]]; then
+    ok "T6 auditor authority exception is created_by=package (v1.175 BUG-TMPFILES; not tmpfiles → no exit-73)"
 else
-    no "T6 auditor authority exception uses non-recursive z" "got tmpfiles_reconcile=$AUD_REC"
+    no "T6 auditor authority exception created_by=package" "got created_by=$AUD_CB"
+fi
+# T6b: and it is therefore absent from the generated tmpfiles.d.
+if grep -qE '/var/lib/nftban/reports/auditors' "$REPO/install/systemd/tmpfiles.d/nftban.conf"; then
+    no "T6b auditors absent from tmpfiles.d" "still present — generator emitted a tmpfiles entry"
+else
+    ok "T6b auditors absent from generated tmpfiles.d (created by package, not tmpfiles)"
 fi
 
 # -----------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
+++ b/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
@@ -107,28 +107,31 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# B: the handoff dir is created by the unit's +ExecStartPre, NOT by tmpfiles.
-# v1.175 BUG-TMPFILES: the root-under-nftban (2750 root:nftban under nftban-owned
-# /run/nftban) entry made systemd-tmpfiles refuse the transition (exit 73). It is
-# removed from tmpfiles; the per-start +ExecStartPre install -d is the sole creator
-# (and /run is tmpfs so it cannot be package-created either). See the unit comment.
+# B: the handoff dir is created by tmpfiles at boot (the authoritative creator),
+# with the unit's +ExecStartPre as an idempotent per-start belt-and-suspenders.
+# v1.175 BUG-TMPFILES D-1 (Option I): this root-owned child (2750 root:nftban)
+# under the nftban-owned /run/nftban is RETAINED in tmpfiles as an ACCEPTED
+# non-fatal exit-73 SECURITY EXCEPTION — root-only-writer of last.json. The
+# ExecStartPre-SOLE-creator alternative was REJECTED (lab-disproven 226/NAMESPACE:
+# ReadWritePaths binds at namespace setup on tmpfs, before ExecStartPre runs).
 # ----------------------------------------------------------------------------
-echo "--- B: handoff dir creator (ExecStartPre, not tmpfiles) ---"
+echo "--- B: handoff dir creator (tmpfiles at boot + ExecStartPre belt-and-suspenders) ---"
 
-# B1: tmpfiles.d does NOT carry the firewall-validate dir (v1.175 — exit-73 fix).
-if grep -qE '/run/nftban/firewall-validate' "$_tmpfiles"; then
-    _t_assert "B1: tmpfiles.d/nftban.conf does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES)" 1 \
-        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
+# B1: tmpfiles.d carries the exact handoff dir entry (boot creator; required —
+# ReadWritePaths needs the path to pre-exist at namespace setup on tmpfs).
+if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
+    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -' (security-exception boot creator)" 0
 else
-    _t_assert "B1: tmpfiles.d/nftban.conf does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES)" 0
+    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -' (security-exception boot creator)" 1 \
+        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
 fi
 
-# B1b: the unit's +-prefixed ExecStartPre creates the dir (2750 root:nftban) — the
-# sole authoritative creator now that tmpfiles no longer does.
+# B1b: the unit's +-prefixed ExecStartPre ALSO creates the dir (2750 root:nftban)
+# as an idempotent per-start belt-and-suspenders (NOT the sole creator).
 if grep -qE '^ExecStartPre=\+/usr/bin/install -d .*-m 2750 .*/run/nftban/firewall-validate' "$_unit_file"; then
-    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 creates the handoff dir (sole creator)" 0
+    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 also creates the handoff dir (per-start belt-and-suspenders)" 0
 else
-    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 creates the handoff dir (sole creator)" 1 \
+    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 also creates the handoff dir (per-start belt-and-suspenders)" 1 \
         "line: [$(grep -E '^ExecStartPre=' "$_unit_file" | head -1)]"
 fi
 

--- a/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
+++ b/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
@@ -107,14 +107,29 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# B: generated tmpfiles contains the handoff dir entry.
+# B: the handoff dir is created by the unit's +ExecStartPre, NOT by tmpfiles.
+# v1.175 BUG-TMPFILES: the root-under-nftban (2750 root:nftban under nftban-owned
+# /run/nftban) entry made systemd-tmpfiles refuse the transition (exit 73). It is
+# removed from tmpfiles; the per-start +ExecStartPre install -d is the sole creator
+# (and /run is tmpfs so it cannot be package-created either). See the unit comment.
 # ----------------------------------------------------------------------------
-echo "--- B: tmpfiles ---"
+echo "--- B: handoff dir creator (ExecStartPre, not tmpfiles) ---"
 
-if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
-    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -'" 0
+# B1: tmpfiles.d does NOT carry the firewall-validate dir (v1.175 — exit-73 fix).
+if grep -qE '/run/nftban/firewall-validate' "$_tmpfiles"; then
+    _t_assert "B1: tmpfiles.d/nftban.conf does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES)" 1 \
+        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
 else
-    _t_assert "B1: tmpfiles.d/nftban.conf has 'd /run/nftban/firewall-validate 2750 root nftban -'" 1
+    _t_assert "B1: tmpfiles.d/nftban.conf does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES)" 0
+fi
+
+# B1b: the unit's +-prefixed ExecStartPre creates the dir (2750 root:nftban) — the
+# sole authoritative creator now that tmpfiles no longer does.
+if grep -qE '^ExecStartPre=\+/usr/bin/install -d .*-m 2750 .*/run/nftban/firewall-validate' "$_unit_file"; then
+    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 creates the handoff dir (sole creator)" 0
+else
+    _t_assert "B1b: unit +ExecStartPre install -d -m 2750 creates the handoff dir (sole creator)" 1 \
+        "line: [$(grep -E '^ExecStartPre=' "$_unit_file" | head -1)]"
 fi
 
 # ----------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
+++ b/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
@@ -55,24 +55,29 @@ echo "  Repo root: $_repo_root"
 echo "==============================================================================="
 
 # ----------------------------------------------------------------------------
-# A: generated tmpfiles — setgid (2750) handoff dir, exact line.
+# A: the setgid (2750 root:nftban) handoff dir is created by the unit's
+# +ExecStartPre, NOT by tmpfiles. v1.175 BUG-TMPFILES: the root-under-nftban
+# entry tripped systemd-tmpfiles exit 73; it is removed from tmpfiles and the
+# +ExecStartPre install -d (asserted in B1 below) is the sole creator. The setgid
+# semantics (2750 root:nftban → last.json inherits group nftban without CAP_CHOWN)
+# are preserved by the ExecStartPre's `-m 2750 -o root -g nftban`.
 # ----------------------------------------------------------------------------
 echo "--- A: tmpfiles (generated) ---"
 
-# A1: exact setgid line (must match exactly; mode 2750, owner root, group nftban).
-if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
-    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -'" 0
-else
-    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -'" 1 \
+# A1: tmpfiles no longer carries the firewall-validate dir (v1.175 — exit-73 fix).
+if grep -qE '/run/nftban/firewall-validate' "$_tmpfiles"; then
+    _t_assert "A1: tmpfiles does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES; created by +ExecStartPre)" 1 \
         "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
+else
+    _t_assert "A1: tmpfiles does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES; created by +ExecStartPre)" 0
 fi
 
-# A2: the old non-setgid 0750 form is GONE (no stale mode left behind).
-if grep -qE '^d /run/nftban/firewall-validate 0750 ' "$_tmpfiles"; then
-    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 1 \
-        "0750 entry still present — generator did not pick up the 2750 mode"
+# A2: (kept) no stale tmpfiles entry of any mode remains for the dir.
+if grep -qE '^[dz] /run/nftban/firewall-validate ' "$_tmpfiles"; then
+    _t_assert "A2: no stale tmpfiles d/z entry for the handoff dir" 1 \
+        "entry still present — generator still emits firewall-validate"
 else
-    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 0
+    _t_assert "A2: no stale tmpfiles d/z entry for the handoff dir" 0
 fi
 
 # ----------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
+++ b/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
@@ -55,29 +55,30 @@ echo "  Repo root: $_repo_root"
 echo "==============================================================================="
 
 # ----------------------------------------------------------------------------
-# A: the setgid (2750 root:nftban) handoff dir is created by the unit's
-# +ExecStartPre, NOT by tmpfiles. v1.175 BUG-TMPFILES: the root-under-nftban
-# entry tripped systemd-tmpfiles exit 73; it is removed from tmpfiles and the
-# +ExecStartPre install -d (asserted in B1 below) is the sole creator. The setgid
-# semantics (2750 root:nftban → last.json inherits group nftban without CAP_CHOWN)
-# are preserved by the ExecStartPre's `-m 2750 -o root -g nftban`.
+# A: the setgid (2750 root:nftban) handoff dir is created by tmpfiles at boot
+# (the authoritative creator) AND by the unit's +ExecStartPre per-start.
+# v1.175 BUG-TMPFILES D-1 (Option I): the root-under-nftban tmpfiles entry is
+# RETAINED as an ACCEPTED non-fatal exit-73 SECURITY EXCEPTION (root-only-writer
+# of last.json). ExecStartPre-sole was REJECTED (lab-disproven 226/NAMESPACE).
+# The setgid semantics (2750 root:nftban → last.json inherits group nftban without
+# CAP_CHOWN) are carried by BOTH the tmpfiles entry and the ExecStartPre `-m 2750`.
 # ----------------------------------------------------------------------------
 echo "--- A: tmpfiles (generated) ---"
 
-# A1: tmpfiles no longer carries the firewall-validate dir (v1.175 — exit-73 fix).
-if grep -qE '/run/nftban/firewall-validate' "$_tmpfiles"; then
-    _t_assert "A1: tmpfiles does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES; created by +ExecStartPre)" 1 \
-        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
+# A1: exact setgid line present (mode 2750, owner root, group nftban) — boot creator.
+if grep -qE '^d /run/nftban/firewall-validate 2750 root nftban -$' "$_tmpfiles"; then
+    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -' (security-exception boot creator)" 0
 else
-    _t_assert "A1: tmpfiles does NOT list /run/nftban/firewall-validate (v1.175 BUG-TMPFILES; created by +ExecStartPre)" 0
+    _t_assert "A1: tmpfiles has exact 'd /run/nftban/firewall-validate 2750 root nftban -' (security-exception boot creator)" 1 \
+        "got: [$(grep -E '/run/nftban/firewall-validate' "$_tmpfiles" | head -1)]"
 fi
 
-# A2: (kept) no stale tmpfiles entry of any mode remains for the dir.
-if grep -qE '^[dz] /run/nftban/firewall-validate ' "$_tmpfiles"; then
-    _t_assert "A2: no stale tmpfiles d/z entry for the handoff dir" 1 \
-        "entry still present — generator still emits firewall-validate"
+# A2: the old non-setgid 0750 form is GONE (no stale mode left behind).
+if grep -qE '^[dz] /run/nftban/firewall-validate 0750 ' "$_tmpfiles"; then
+    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 1 \
+        "0750 entry still present — generator did not pick up the 2750 mode"
 else
-    _t_assert "A2: no stale tmpfiles d/z entry for the handoff dir" 0
+    _t_assert "A2: stale non-setgid 0750 tmpfiles entry is absent" 0
 fi
 
 # ----------------------------------------------------------------------------

--- a/cli/sbin/nftban-service-alert
+++ b/cli/sbin/nftban-service-alert
@@ -47,7 +47,13 @@ NFTBAN_LIB_DIR="${NFTBAN_LIB_DIR:-/usr/lib/nftban}"
 [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf" ]] && source "${NFTBAN_CONFIG_DIR}/nftban.conf"
 
 readonly ALERT_LOG="${NFTBAN_LOG_DIR}/service-alerts.log"
-readonly ALERT_THROTTLE_FILE="${NFTBAN_DATA_DIR}/alert_throttle_${FAILED_SERVICE//[^a-zA-Z0-9]/_}"
+# v1.175 ALERT-THROTTLE-FHS: throttle + diagnostics live under the nftban-OWNED
+# ${NFTBAN_DATA_DIR}/alerts (0750 nftban:nftban) so this worker — which runs
+# User=nftban — can actually persist them. Pre-v1.175 the throttle file sat
+# directly under root-owned 0750 ${NFTBAN_DATA_DIR} → EACCES → throttling never
+# persisted (v1.174 only made the write non-fatal; it did not fix persistence).
+readonly ALERT_STATE_DIR="${NFTBAN_DATA_DIR}/alerts"
+readonly ALERT_THROTTLE_FILE="${ALERT_STATE_DIR}/throttle_${FAILED_SERVICE//[^a-zA-Z0-9]/_}"
 readonly ALERT_THROTTLE_SECONDS="${NFTBAN_ALERT_THROTTLE_SECONDS:-3600}"
 
 # =============================================================================
@@ -84,11 +90,10 @@ should_throttle() {
 
 update_throttle() {
     mkdir -p "$(dirname "$ALERT_THROTTLE_FILE")" 2>/dev/null || true
-    # Best-effort: a throttle-state write failure (e.g. EACCES — the alert unit
-    # runs as User=nftban while the path may be root-owned 0750) returns non-zero
-    # so the caller can WARN and continue. It must NOT fail/latch the alert unit
-    # (v1.174 ALERT-THROTTLE-NONFATAL). Proper relocation to an nftban-owned dir
-    # is a separate lane (ALERT-THROTTLE-FHS).
+    # v1.175 ALERT-THROTTLE-FHS relocated this into the nftban-owned alerts dir, so
+    # the happy path now persists. The non-fatal guard is KEPT as defense-in-depth:
+    # if the write still fails (unexpected perms edge), return non-zero so the caller
+    # WARNs and continues — it must NOT fail/latch the alert unit (v1.174 contract).
     date +%s > "$ALERT_THROTTLE_FILE" 2>/dev/null
 }
 
@@ -98,7 +103,7 @@ update_throttle() {
 
 collect_diagnostics() {
     local diag_file
-    diag_file="${NFTBAN_DATA_DIR}/alerts/${FAILED_SERVICE}_$(date +%Y%m%d_%H%M%S).txt"
+    diag_file="${ALERT_STATE_DIR}/${FAILED_SERVICE}_$(date +%Y%m%d_%H%M%S).txt"
     mkdir -p "$(dirname "$diag_file")" 2>/dev/null || true
 
     {

--- a/install/packaging/deb/nftban-dir-attrs.list
+++ b/install/packaging/deb/nftban-dir-attrs.list
@@ -51,5 +51,6 @@
 /etc/nftban/suricata/state/last-good|0750|root|nftban
 /etc/nftban/connectors|0750|root|nftban
 /etc/nftban/distros|0750|root|nftban
+/var/lib/nftban/reports/auditors|0770|root|nftban-auditor
 /var/lib/nftban/community|0750|nftban|nftban
 /var/lib/nftban|0750|root|nftban

--- a/install/packaging/deb/nftban.dirs
+++ b/install/packaging/deb/nftban.dirs
@@ -69,6 +69,7 @@
 /etc/nftban/suricata/state/last-good
 /etc/nftban/connectors
 /etc/nftban/distros
+/var/lib/nftban/reports/auditors
 /var/lib/nftban/community
 /var/lib/nftban
 /usr/share/nftban

--- a/install/packaging/rpm/nftban-files.inc
+++ b/install/packaging/rpm/nftban-files.inc
@@ -79,6 +79,7 @@
 # ---------------------------------------------------------------------------
 # DATA DIRECTORIES (package-territory only; tmpfiles-managed runtime dirs excluded)
 # ---------------------------------------------------------------------------
+%dir %attr(0770,root,nftban-auditor) /var/lib/nftban/reports/auditors
 %dir %attr(0750,nftban,nftban) /var/lib/nftban/community
 %dir %attr(0750,root,nftban) /var/lib/nftban
 

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -78,10 +78,14 @@ CapabilityBoundingSet=CAP_NET_ADMIN
 # it can create the handoff dir even though ProtectSystem=strict makes /run
 # read-only for the (sandboxed) main process. The `+` exemption is required:
 # ReadWritePaths=<subdir> only binds an EXISTING path writable, so the subdir
-# must exist before the sandboxed ExecStart runs. tmpfiles creates it at boot
-# (d /run/nftban/firewall-validate 2750 root nftban); this guarantees it
-# per-start too (idempotent mkdir+chown+chmod via /usr/bin/install). Absolute
-# path is required by systemd for ExecStartPre.
+# must exist before the sandboxed ExecStart runs. This ExecStartPre is the SOLE
+# creator (idempotent mkdir+chown+chmod via /usr/bin/install). Absolute path is
+# required by systemd for ExecStartPre.
+# v1.175 BUG-TMPFILES: this dir is NO LONGER created by tmpfiles. A root-owned
+# child (2750 root:nftban) under the nftban-owned /run/nftban parent made
+# systemd-tmpfiles refuse the non-root-parent→root-child transition (exit 73,
+# both families). /run is tmpfs so it can't be package-created either; this
+# per-start ExecStartPre is the correct and only creator.
 #
 # V131.3 D13 fix: the dir mode is now SETGID (2750, not 0750). The setgid bit
 # makes a file created in this dir inherit the dir's GROUP (nftban) regardless
@@ -106,9 +110,10 @@ StandardError=journal
 # fix: the unit now WRITES one group-readable handoff file via the
 # firewall_validate_run.sh wrapper, so it needs exactly one writable path.
 # ProtectSystem=strict makes all of /run (and the whole filesystem) read-only;
-# grant write to ONLY the dedicated status subdir, which tmpfiles creates as
-# setgid root:nftban 2750 (d /run/nftban/firewall-validate 2750 root nftban). This
-# does NOT expose the daemon's /run/nftban (which holds the live socket) and
+# grant write to ONLY the dedicated status subdir, which the `+`-prefixed
+# ExecStartPre above creates as setgid root:nftban 2750 (v1.175: no longer in
+# tmpfiles — see the ExecStartPre note). This does NOT expose the daemon's
+# /run/nftban (which holds the live socket) and
 # does NOT re-chown /run/nftban — it is the narrowest writable surface that
 # lets the validator drop last.json for nftban-group operators to read.
 PrivateTmp=yes

--- a/install/systemd/nftban-firewall-validate.service
+++ b/install/systemd/nftban-firewall-validate.service
@@ -78,14 +78,19 @@ CapabilityBoundingSet=CAP_NET_ADMIN
 # it can create the handoff dir even though ProtectSystem=strict makes /run
 # read-only for the (sandboxed) main process. The `+` exemption is required:
 # ReadWritePaths=<subdir> only binds an EXISTING path writable, so the subdir
-# must exist before the sandboxed ExecStart runs. This ExecStartPre is the SOLE
-# creator (idempotent mkdir+chown+chmod via /usr/bin/install). Absolute path is
-# required by systemd for ExecStartPre.
-# v1.175 BUG-TMPFILES: this dir is NO LONGER created by tmpfiles. A root-owned
-# child (2750 root:nftban) under the nftban-owned /run/nftban parent made
-# systemd-tmpfiles refuse the non-root-parent→root-child transition (exit 73,
-# both families). /run is tmpfs so it can't be package-created either; this
-# per-start ExecStartPre is the correct and only creator.
+# must exist before the sandboxed ExecStart runs. tmpfiles creates it at boot
+# (d /run/nftban/firewall-validate 2750 root nftban); this guarantees it
+# per-start too (idempotent mkdir+chown+chmod via /usr/bin/install). Absolute
+# path is required by systemd for ExecStartPre.
+# v1.175 BUG-TMPFILES (ACCEPTED SECURITY EXCEPTION): tmpfiles emits a NON-FATAL
+# exit-73 for this one root-owned child under the nftban-owned /run/nftban (the
+# dir is still created — the whole fleet runs with it). It is RETAINED in tmpfiles
+# deliberately (see fhs-spec.yaml). Dropping the tmpfiles entry and relying on this
+# ExecStartPre as the SOLE creator was REJECTED (lab-disproven, systemd 255):
+# ReadWritePaths is bound at mount-namespace setup, which on fresh-boot tmpfs
+# precedes ExecStartPre, so the unit fails 226/NAMESPACE before this line can run.
+# tmpfiles MUST create it at boot; this ExecStartPre stays as an idempotent
+# per-start belt-and-suspenders, NOT the sole creator.
 #
 # V131.3 D13 fix: the dir mode is now SETGID (2750, not 0750). The setgid bit
 # makes a file created in this dir inherit the dir's GROUP (nftban) regardless
@@ -110,10 +115,9 @@ StandardError=journal
 # fix: the unit now WRITES one group-readable handoff file via the
 # firewall_validate_run.sh wrapper, so it needs exactly one writable path.
 # ProtectSystem=strict makes all of /run (and the whole filesystem) read-only;
-# grant write to ONLY the dedicated status subdir, which the `+`-prefixed
-# ExecStartPre above creates as setgid root:nftban 2750 (v1.175: no longer in
-# tmpfiles — see the ExecStartPre note). This does NOT expose the daemon's
-# /run/nftban (which holds the live socket) and
+# grant write to ONLY the dedicated status subdir, which tmpfiles creates as
+# setgid root:nftban 2750 (d /run/nftban/firewall-validate 2750 root nftban). This
+# does NOT expose the daemon's /run/nftban (which holds the live socket) and
 # does NOT re-chown /run/nftban — it is the narrowest writable surface that
 # lets the validator drop last.json for nftban-group operators to read.
 PrivateTmp=yes

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -34,7 +34,6 @@ d /var/lib/nftban/feeds 0750 nftban nftban -
 d /var/lib/nftban/reports 0750 nftban nftban -
 d /var/lib/nftban/reports/baseline 0750 nftban nftban -
 d /var/lib/nftban/reports/watchdog 0750 nftban nftban -
-d /var/lib/nftban/reports/auditors 0770 root nftban-auditor -
 d /var/lib/nftban/metrics 0750 nftban nftban -
 d /var/lib/nftban/snapshots 0750 nftban nftban -
 d /var/lib/nftban/exports 0750 nftban nftban -
@@ -59,6 +58,8 @@ d /var/lib/nftban/recorder 0750 nftban nftban -
 d /var/lib/nftban/staging 0750 nftban nftban -
 d /var/lib/nftban/state 0750 nftban nftban -
 d /var/lib/nftban/suricata 0750 nftban nftban -
+d /var/lib/nftban/suricata/cache 0750 nftban nftban -
+d /var/lib/nftban/alerts 0750 nftban nftban -
 d /var/lib/nftban/update-backups 0750 root nftban -
 d /var/lib/nftban/watchdog 0750 nftban nftban -
 d /var/lib/nftban/reports/archive 0750 nftban nftban -
@@ -70,7 +71,6 @@ z /var/lib/nftban/feeds 0750 nftban nftban -
 z /var/lib/nftban/reports 0750 nftban nftban -
 z /var/lib/nftban/reports/baseline 0750 nftban nftban -
 z /var/lib/nftban/reports/watchdog 0750 nftban nftban -
-z /var/lib/nftban/reports/auditors 0770 root nftban-auditor -
 z /var/lib/nftban/metrics 0750 nftban nftban -
 z /var/lib/nftban/snapshots 0750 nftban nftban -
 z /var/lib/nftban/exports 0750 nftban nftban -
@@ -95,6 +95,8 @@ z /var/lib/nftban/recorder 0750 nftban nftban -
 z /var/lib/nftban/staging 0750 nftban nftban -
 z /var/lib/nftban/state 0750 nftban nftban -
 z /var/lib/nftban/suricata 0750 nftban nftban -
+z /var/lib/nftban/suricata/cache 0750 nftban nftban -
+z /var/lib/nftban/alerts 0750 nftban nftban -
 z /var/lib/nftban/update-backups 0750 root nftban -
 z /var/lib/nftban/watchdog 0750 nftban nftban -
 z /var/lib/nftban/reports/archive 0750 nftban nftban -
@@ -120,8 +122,6 @@ z /var/log/nftban/soak 0750 nftban nftban -
 d /var/cache/nftban 0755 nftban nftban -
 d /var/cache/nftban/health 0750 nftban nftban -
 d /run/nftban 0755 nftban nftban -
-d /run/nftban/firewall-validate 2750 root nftban -
 z /var/cache/nftban 0755 nftban nftban -
 z /var/cache/nftban/health 0750 nftban nftban -
 z /run/nftban 0755 nftban nftban -
-z /run/nftban/firewall-validate 2750 root nftban -

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -122,6 +122,8 @@ z /var/log/nftban/soak 0750 nftban nftban -
 d /var/cache/nftban 0755 nftban nftban -
 d /var/cache/nftban/health 0750 nftban nftban -
 d /run/nftban 0755 nftban nftban -
+d /run/nftban/firewall-validate 2750 root nftban -
 z /var/cache/nftban 0755 nftban nftban -
 z /var/cache/nftban/health 0750 nftban nftban -
 z /run/nftban 0755 nftban nftban -
+z /run/nftban/firewall-validate 2750 root nftban -

--- a/internal/suricata/stats/cache.go
+++ b/internal/suricata/stats/cache.go
@@ -110,19 +110,12 @@ func migrateLegacySnapshot(oldPath, newPath string) {
 	if err := os.MkdirAll(filepath.Dir(newPath), 0750); err != nil {
 		return
 	}
-	if err := os.Rename(oldPath, newPath); err == nil {
-		return
-	}
-	// Rename failed (e.g. cross-filesystem EXDEV): copy then remove. If the copy
-	// fails, leave the old file untouched and let Load() start fresh.
-	data, err := os.ReadFile(oldPath)
-	if err != nil {
-		return
-	}
-	if err := safety.SafeWriteFile(newPath, data, 0644); err != nil {
-		return
-	}
-	_ = os.Remove(oldPath)
+	// Best-effort rename. If it fails (e.g. EXDEV when /etc and /var are separate
+	// mounts), leave the old file in place; Load() then starts fresh and the cache
+	// rebuilds from live SID-trigger events. We deliberately do NOT read+copy as a
+	// fallback: it would add an os.ReadFile(variable) file-inclusion surface
+	// (gosec G304) for a non-critical, self-rebuilding cache — not worth it.
+	_ = os.Rename(oldPath, newPath)
 }
 
 // RecordTrigger records a SID trigger event

--- a/internal/suricata/stats/cache.go
+++ b/internal/suricata/stats/cache.go
@@ -11,7 +11,7 @@
 // meta:input="SID trigger events"
 // meta:output="Statistics per SID"
 // meta:depends="github.com/itcmsgr/nftban/internal/nftbanconf,github.com/itcmsgr/nftban/internal/safety"
-// meta:inventory.files="/etc/nftban/suricata/cache/sid-stats.json"
+// meta:inventory.files="/var/lib/nftban/suricata/cache/sid-stats.json"
 // meta:inventory.binaries=""
 // meta:inventory.env_vars=""
 // meta:inventory.config_files=""
@@ -37,25 +37,25 @@ import (
 
 // SIDStats holds statistics for a single SID
 type SIDStats struct {
-	SID           string    `json:"sid"`
-	Category      string    `json:"category"`
-	Signature     string    `json:"signature"`
-	TriggerCount  int       `json:"trigger_count"`
-	LastTrigger   time.Time `json:"last_trigger"`
-	FirstTrigger  time.Time `json:"first_trigger"`
+	SID           string          `json:"sid"`
+	Category      string          `json:"category"`
+	Signature     string          `json:"signature"`
+	TriggerCount  int             `json:"trigger_count"`
+	LastTrigger   time.Time       `json:"last_trigger"`
+	FirstTrigger  time.Time       `json:"first_trigger"`
 	UniqueSources map[string]bool `json:"-"` // Not serialized (capped in memory)
-	SourceCount   int       `json:"source_count"`
-	SourceIPs     []string  `json:"source_ips,omitempty"` // Top 10 for display
+	SourceCount   int             `json:"source_count"`
+	SourceIPs     []string        `json:"source_ips,omitempty"` // Top 10 for display
 }
 
 // Cache holds in-memory SID statistics
 // Implements bounded memory via caps on SIDs and sources per SID.
 // Protects against CWE-400 (Uncontrolled Resource Consumption).
 type Cache struct {
-	mu            sync.RWMutex
-	stats         map[string]*SIDStats // Key: SID
-	snapshotPath  string
-	lastSnapshot  time.Time
+	mu           sync.RWMutex
+	stats        map[string]*SIDStats // Key: SID
+	snapshotPath string
+	lastSnapshot time.Time
 
 	// Memory limits (CWE-400 mitigation)
 	maxSIDs          int
@@ -65,7 +65,13 @@ type Cache struct {
 // NewCache creates a new statistics cache with bounded memory
 func NewCache() (*Cache, error) {
 	cfg := nftbanconf.MustLoad()
-	snapshotPath := filepath.Join(cfg.ConfigDir, "suricata/cache/sid-stats.json")
+	// v1.175 FHS-SMELL-SIDSTATS: the snapshot lives under DataDir (/var/lib/nftban),
+	// NOT ConfigDir (/etc). FHS reserves /etc for configuration; this is a mutable
+	// runtime cache rewritten on every auto-save tick. Write atomicity is unchanged
+	// (still safety.SafeWriteFile, v1.171) — only the location moved.
+	snapshotPath := filepath.Join(cfg.DataDir, "suricata/cache/sid-stats.json")
+	// Migrate a pre-v1.175 snapshot from the old /etc location on first startup.
+	migrateLegacySnapshot(filepath.Join(cfg.ConfigDir, "suricata/cache/sid-stats.json"), snapshotPath)
 
 	limits := safety.GetMemoryLimits()
 
@@ -82,6 +88,41 @@ func NewCache() (*Cache, error) {
 	}
 
 	return cache, nil
+}
+
+// migrateLegacySnapshot moves the pre-v1.175 SID-stats snapshot from its old
+// location under /etc (ConfigDir) to the new location under /var/lib (DataDir)
+// on first startup. Best-effort: any failure leaves the old file in place and the
+// subsequent Load() simply starts fresh — no panic, no data-integrity risk (the
+// cache rebuilds from live SID-trigger events). v1.175 FHS-SMELL-SIDSTATS.
+func migrateLegacySnapshot(oldPath, newPath string) {
+	if oldPath == newPath {
+		return
+	}
+	// New snapshot already present → nothing to migrate.
+	if _, err := os.Stat(newPath); err == nil {
+		return
+	}
+	// No legacy snapshot → nothing to do (fresh install / already migrated).
+	if _, err := os.Stat(oldPath); err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), 0750); err != nil {
+		return
+	}
+	if err := os.Rename(oldPath, newPath); err == nil {
+		return
+	}
+	// Rename failed (e.g. cross-filesystem EXDEV): copy then remove. If the copy
+	// fails, leave the old file untouched and let Load() start fresh.
+	data, err := os.ReadFile(oldPath)
+	if err != nil {
+		return
+	}
+	if err := safety.SafeWriteFile(newPath, data, 0644); err != nil {
+		return
+	}
+	_ = os.Remove(oldPath)
 }
 
 // RecordTrigger records a SID trigger event
@@ -390,9 +431,9 @@ func (c *Cache) GetStats() map[string]int {
 	}
 
 	return map[string]int{
-		"sids":                 len(c.stats),
-		"max_sids":             c.maxSIDs,
-		"total_sources":        totalSources,
-		"max_sources_per_sid":  c.maxSourcesPerSID,
+		"sids":                len(c.stats),
+		"max_sids":            c.maxSIDs,
+		"total_sources":       totalSources,
+		"max_sources_per_sid": c.maxSourcesPerSID,
 	}
 }

--- a/internal/suricata/stats/cache_test.go
+++ b/internal/suricata/stats/cache_test.go
@@ -23,9 +23,77 @@
 package stats
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
+
+// TestMigrateLegacySnapshot locks the v1.175 FHS-SMELL-SIDSTATS relocation:
+// the SID-stats snapshot moved from /etc (ConfigDir) to /var/lib (DataDir), and
+// migrateLegacySnapshot moves a pre-v1.175 file on first startup. Best-effort:
+// failures must never panic; Load() just starts fresh.
+func TestMigrateLegacySnapshot(t *testing.T) {
+	t.Run("moves legacy file and removes old", func(t *testing.T) {
+		dir := t.TempDir()
+		oldPath := filepath.Join(dir, "etc/suricata/cache/sid-stats.json")
+		newPath := filepath.Join(dir, "var/suricata/cache/sid-stats.json")
+		if err := os.MkdirAll(filepath.Dir(oldPath), 0750); err != nil {
+			t.Fatal(err)
+		}
+		want := []byte(`[{"sid":"1","trigger_count":7}]`)
+		if err := os.WriteFile(oldPath, want, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		migrateLegacySnapshot(oldPath, newPath)
+
+		got, err := os.ReadFile(newPath)
+		if err != nil {
+			t.Fatalf("new snapshot not created: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("content not preserved: got %q want %q", got, want)
+		}
+		if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+			t.Errorf("old snapshot should be removed after migration, stat err=%v", err)
+		}
+	})
+
+	t.Run("no-op when new already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		oldPath := filepath.Join(dir, "etc/sid-stats.json")
+		newPath := filepath.Join(dir, "var/sid-stats.json")
+		_ = os.MkdirAll(filepath.Dir(oldPath), 0750)
+		_ = os.MkdirAll(filepath.Dir(newPath), 0750)
+		if err := os.WriteFile(oldPath, []byte("OLD"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(newPath, []byte("NEW"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		migrateLegacySnapshot(oldPath, newPath)
+
+		// New must be untouched; old must remain (we never overwrite/clobber).
+		if got, _ := os.ReadFile(newPath); string(got) != "NEW" {
+			t.Errorf("existing new snapshot was overwritten: got %q", got)
+		}
+		if _, err := os.Stat(oldPath); err != nil {
+			t.Errorf("old snapshot should be left intact when new exists, err=%v", err)
+		}
+	})
+
+	t.Run("no-op when neither exists", func(t *testing.T) {
+		dir := t.TempDir()
+		newPath := filepath.Join(dir, "var/sid-stats.json")
+		// Must not panic and must not create anything.
+		migrateLegacySnapshot(filepath.Join(dir, "etc/sid-stats.json"), newPath)
+		if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+			t.Errorf("nothing should be created when neither file exists")
+		}
+	})
+}
 
 // newTestCache creates a Cache without calling nftbanconf.MustLoad() or
 // safety.GetMemoryLimits() so tests can run without production config files.

--- a/scripts/test-package-deb-l3-exceptions.list
+++ b/scripts/test-package-deb-l3-exceptions.list
@@ -69,3 +69,14 @@
 # 0750 by name on the target host, which is verified by Test * install Phase 4.
 
 /var/lib/nftban|postinst-converged
+
+# =============================================================================
+# v1.175 BUG-TMPFILES: /var/lib/nftban/reports/auditors moved created_by
+# tmpfiles→package (root-under-nftban tmpfiles transition tripped systemd-tmpfiles
+# exit 73). RPM ships the final group via name-based %attr(0770,root,nftban-auditor)
+# (nftban-auditor resolves at the %pre groupadd); DEB ships root:root in the
+# archive and converges to root:nftban-auditor at postinst via nftban-dir-attrs.list.
+# Same postinst-converged authority model as the entries above. L4 (installed-fs
+# stat) still requires both packagers to converge to root:nftban-auditor 0770.
+# =============================================================================
+/var/lib/nftban/reports/auditors|postinst-converged


### PR DESCRIPTION
## v1.175 FHS-authority lane (three items, all driven from `build/fhs-spec.yaml`)

**Byte-identical:** every shipped binary is unchanged vs v1.174.0 (daemon SHA256 `65ac698d…`, verified before/after build). `internal/suricata/stats` is in **no** `cmd/` binary graph (`go list -deps`), so the cache.go edit moves no binary. Schema **1.83.0 frozen**. `build/generate-fhs-outputs.sh --check` rc=0.

### 1. BUG-TMPFILES-UNSAFE-PATH-TRANSITION (systemd-tmpfiles exit 73, both families)
Two root-owned children under non-root-owned parents made systemd-tmpfiles refuse the transition.
- `/var/lib/nftban/reports/auditors`: `created_by` tmpfiles→**package** (dir created+owned at install; RPM `%dir %attr` resolves `nftban-auditor` via the `%pre` groupadd; DEB `nftban.dirs`+dir-attrs). Authority exception (`root:nftban-auditor 0770`) preserved — only the creator changed.
- `/run/nftban/firewall-validate`: `created_by` tmpfiles→**feature_enable**. `/run` is tmpfs (can't be package-created) and the dir must stay root-owned (integrity: only the audited root service writes `last.json`; nftban group only reads `0640`). The unit's existing `+ExecStartPre install -d -o root -g nftban -m 2750` is now the sole creator.

### 2. FHS-SMELL-SIDSTATS-UNDER-ETC
`cache.go` snapshot moved from `cfg.ConfigDir` (`/etc/nftban/...`) to `cfg.DataDir` (`/var/lib/nftban/suricata/cache/sid-stats.json`) + `migrateLegacySnapshot()` moves a pre-v1.175 `/etc` copy on first start. Smell is latent (pkg unwired) but the fix is correct and protects once wired.

### 3. ALERT-THROTTLE-FHS
Relocate `nftban-alert@` throttle + diagnostics to the new nftban-owned `/var/lib/nftban/alerts` (`0750 nftban:nftban`). v1.174 made these writes non-fatal; this makes throttling actually **persist** on `User=nftban` hosts. v1.174 non-fatal guards kept as defense-in-depth.

## Tests
- **New** `fhs_lane_v175_test.sh` (13/13): a **generic** "no root-under-non-root tmpfiles entry" lint = structural regression lock for the whole BUG-TMPFILES class, plus all lane invariants. CI-wired in `ci-architecture.yml`.
- `cache.go` migration unit test (`-race`): migrate / no-op-when-new-exists / no-op-when-neither.
- Updated to the new design: `v131_2`, `v131_3`, `tmpfiles_zz_v139`, `alert_bookkeeping_nonfatal_v174` — all pass.

## Validation
`go build ./...` · `go vet` · `go test -race` · gofmt clean · shellcheck `-S warning` clean · `--check` rc=0 · daemon byte-identical · schema 1.83.0 frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)