### PR TITLE
fix(daemon): restore loginmon watcher liveness and fsync residual state writes

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -780,6 +780,12 @@ jobs:
       - name: FHS lane invariants — tmpfiles transition guard + relocations (v1.175)
         run: bash cli/lib/nftban/tests/fhs_lane_v175_test.sh
 
+      # v1.176 DAEMON RELIABILITY: FSYNC-RESIDUAL durability-idiom class lock —
+      # no NEW hand-rolled temp+rename Go state writer outside internal/safety
+      # (route through safety.SafeWriteFile); regression-guards the F-1/F-2 fixes.
+      - name: FSYNC-RESIDUAL durability-idiom guard (v1.176)
+        run: bash cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
+++ b/cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.176 — FSYNC-RESIDUAL durability-idiom CI guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="fsync_residual_guard_v176_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Locks the v1.176 FSYNC-RESIDUAL class: any hand-rolled temp+rename state writer in Go (os.Rename + CreateTemp/.tmp) OUTSIDE internal/safety must be either routed through safety.SafeWriteFile OR explicitly baselined here. FAILS on a NEW unguarded temp+rename writer (and on a regression of the v1.176-fixed set_counters.go / rebuild/marker.go, which are intentionally absent from the baseline). Pre-existing writers (13) are baselined as separate tech-debt, NOT v1.176 scope. Includes a positive-control self-test (a fixture bad file must be detected) and a negative self-test (a SafeWriteFile-style file must not)."
+# meta:input="repo Go tree (read-only)"
+# meta:output="pass/fail; exit 0 all-pass, 1 on a new unguarded writer"
+# meta:depends="bash,grep,find,sort,comm"
+# meta:inventory.files="internal/stats/set_counters.go,internal/rebuild/marker.go,internal/safety/file.go"
+# meta:inventory.binaries="bash,grep,find,sort,comm,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# Detect hand-rolled temp+rename writers under <root>: a .go file (not *_test.go,
+# not under internal/safety/) that contains BOTH os.Rename( AND a temp-write
+# marker (CreateTemp or a "*.tmp" path). Prints repo-relative paths, sorted.
+scan_temp_rename_writers() {
+    local root="$1" f rel
+    while IFS= read -r f; do
+        case "$f" in
+            *_test.go) continue ;;
+            */internal/safety/*) continue ;;
+        esac
+        if grep -qE 'os\.Rename\(' "$f" 2>/dev/null \
+           && grep -qE 'CreateTemp|\.tmp"' "$f" 2>/dev/null; then
+            rel="${f#"$root"/}"
+            echo "$rel"
+        fi
+    done < <(find "$root" -type f -name '*.go' 2>/dev/null) | sort -u
+}
+
+# -----------------------------------------------------------------------------
+# BASELINE — pre-existing hand-rolled temp+rename writers (2026-06-12).
+# These are SEPARATE tech debt (the "three durability idioms" sprawl), NOT in
+# v1.176 scope. Adding a NEW file here requires review (prefer safety.SafeWriteFile).
+# NOTE: internal/stats/set_counters.go and internal/rebuild/marker.go are
+# DELIBERATELY ABSENT — v1.176 routed them through safety.SafeWriteFile, so if
+# either reappears in the scan it is a REGRESSION and this guard fails.
+# -----------------------------------------------------------------------------
+read -r -d '' BASELINE <<'EOF' || true
+cmd/nftban-core/cmd_feeds.go
+cmd/nftban-core/cmd_geoip.go
+internal/analytics/state.go
+internal/installer/executor/real.go
+internal/installer/history/history.go
+internal/installer/state/file.go
+internal/metrics/collector.go
+internal/opqueue/source_index.go
+internal/persistence/blacklistd.go
+internal/rulefp/baseline.go
+internal/stats/writer.go
+internal/suricata/profile/applier.go
+internal/suricata/stats/cache.go
+internal/util/fileloader.go
+EOF
+
+echo "=== v1.176 FSYNC-RESIDUAL guard ==="
+
+# T1: no NEW temp+rename writer outside the baseline (this is the class lock).
+CURRENT="$(scan_temp_rename_writers "$REPO")"
+NEWADDS="$(comm -13 <(printf '%s\n' "$BASELINE" | sort -u) <(printf '%s\n' "$CURRENT" | sort -u) | grep -vE '^$' || true)"
+if [[ -z "$NEWADDS" ]]; then
+    ok "T1 no NEW unguarded temp+rename writer (all current sites are baselined; route new state writers through safety.SafeWriteFile)"
+else
+    no "T1 NEW unguarded temp+rename writer(s) detected — route through safety.SafeWriteFile or justify+baseline" "$(echo "$NEWADDS" | tr '\n' ' ')"
+fi
+
+# T2: v1.176 regression check — the two fixed files must NOT be temp+rename writers.
+if printf '%s\n' "$CURRENT" | grep -qxE 'internal/stats/set_counters\.go|internal/rebuild/marker\.go'; then
+    no "T2 v1.176 FSYNC fix regressed (set_counters.go / marker.go re-introduced raw temp+rename)" "$(printf '%s\n' "$CURRENT" | grep -E 'set_counters|rebuild/marker' | tr '\n' ' ')"
+else
+    ok "T2 set_counters.go + rebuild/marker.go remain routed through safety.SafeWriteFile (no raw temp+rename)"
+fi
+
+# T3: positive-control self-test — a fixture introducing a temp+rename writer
+# outside internal/safety MUST be detected by the scanner.
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/internal/badpkg" "$FIX/internal/safety"
+cat > "$FIX/internal/badpkg/writer.go" <<'GO'
+package badpkg
+func bad() { _ = os.WriteFile(p+".tmp", b, 0640); _ = os.Rename(p+".tmp", p) }
+GO
+cat > "$FIX/internal/safety/file.go" <<'GO'
+package safety
+func ok() { f,_ := os.CreateTemp(d,"x"); _ = os.Rename(f.Name(), p) }
+GO
+SELF="$(scan_temp_rename_writers "$FIX")"
+if printf '%s\n' "$SELF" | grep -qx 'internal/badpkg/writer.go'; then
+    ok "T3 self-test: scanner detects a NEW temp+rename writer (positive control)"
+else
+    no "T3 self-test: scanner FAILED to detect a planted temp+rename writer" "scan=[$SELF]"
+fi
+# T4: negative self-test — an internal/safety file must NOT be flagged.
+if printf '%s\n' "$SELF" | grep -qx 'internal/safety/file.go'; then
+    no "T4 self-test: scanner wrongly flagged internal/safety (must be exempt)"
+else
+    ok "T4 self-test: internal/safety exempt (negative control)"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -135,6 +135,15 @@ type Module struct {
 	// (DirectAdmin, cPanel, Plesk use their own log files)
 	fileWatcherCmds []*exec.Cmd
 
+	// v1.176 LOGINMON-WATCHER-NO-RESPAWN: supervise/respawn knobs. A file-watcher
+	// child (tail -F) that dies while ctx is alive is respawned with bounded
+	// exponential backoff so a detection source never silently goes dark.
+	// newWatcherCmd is overridable in tests; nil → the default tail -F builder.
+	newWatcherCmd       func(ctx context.Context, logPath string) *exec.Cmd
+	watcherBackoffMin   time.Duration
+	watcherBackoffMax   time.Duration
+	watcherHealthyReset time.Duration // a run lasting ≥ this resets backoff to min
+
 	// v1.80 Phase B: Go pipeline (runs alongside legacy when PipelineEnabled=true)
 	pipeline *pipelineRuntime.Pipeline
 }
@@ -148,6 +157,10 @@ func New() *Module {
 		config:           DefaultConfig(),
 		mode:             ModeAuto,
 		detectedServices: make(map[string]bool),
+		// v1.176 watcher-respawn defaults (production): 1s → 60s, reset after 30s healthy.
+		watcherBackoffMin:   1 * time.Second,
+		watcherBackoffMax:   60 * time.Second,
+		watcherHealthyReset: 30 * time.Second,
 	}
 }
 
@@ -425,8 +438,14 @@ func (m *Module) Stop() error {
 		m.journalCmd.Process.Kill()
 	}
 
-	// v1.48.0: Clean up file watcher commands
-	for _, cmd := range m.fileWatcherCmds {
+	// v1.48.0 / v1.176: Clean up file watcher commands. Snapshot under the lock —
+	// the supervise loop (register/unregisterWatcherCmd) mutates this slice
+	// concurrently. ctx cancellation already stops respawns; this reaps any
+	// child still live at Stop().
+	m.mu.Lock()
+	watcherCmds := append([]*exec.Cmd(nil), m.fileWatcherCmds...)
+	m.mu.Unlock()
+	for _, cmd := range watcherCmds {
 		if cmd != nil && cmd.Process != nil {
 			cmd.Process.Kill()
 		}
@@ -913,8 +932,8 @@ func (m *Module) detectMode() Mode {
 func (m *Module) runJournalWatcher(ctx context.Context) {
 	// Build journalctl command
 	m.journalCmd = exec.CommandContext(ctx, "journalctl",
-		"-f",             // Follow mode
-		"-n", "0",        // Don't show historical entries
+		"-f",      // Follow mode
+		"-n", "0", // Don't show historical entries
 		"--no-pager",
 		"-o", "short-iso",
 		"SYSLOG_FACILITY=4",  // Auth facility
@@ -950,14 +969,16 @@ func (m *Module) runJournalWatcher(ctx context.Context) {
 // v1.48.0: Verified against real servers (srv2=DA, lab4=cPanel, lab2=Plesk)
 var panelLogPaths = map[string][]string{
 	"directadmin": {"/var/log/directadmin/login.log"},
-	"cpanel":      {"/usr/local/cpanel/logs/access_log"},   // 401 on POST /login/
-	"plesk":       {"/var/log/plesk/panel.log"},              // "[Action Log] Failed login attempt"
+	"cpanel":      {"/usr/local/cpanel/logs/access_log"}, // 401 on POST /login/
+	"plesk":       {"/var/log/plesk/panel.log"},          // "[Action Log] Failed login attempt"
 }
 
 // mailLogPaths maps mail services to their log file paths.
 // Mail services (Exim, Dovecot, Postfix) log to plain files, NOT journalctl.
 // v1.69.0: Verified against lab (Debian 13), lab2 (Ubuntu 24.04/Plesk),
-//          lab4 (AlmaLinux 9/cPanel), srv2 (AlmaLinux 9/DirectAdmin).
+//
+//	lab4 (AlmaLinux 9/cPanel), srv2 (AlmaLinux 9/DirectAdmin).
+//
 // Zero journal entries for SYSLOG_FACILITY=4+10 from mail on all 4 servers.
 var mailLogPaths = map[string][]string{
 	"exim": {
@@ -966,10 +987,10 @@ var mailLogPaths = map[string][]string{
 		"/var/log/exim4/mainlog", // Debian/Ubuntu
 	},
 	"dovecot": {
-		"/var/log/maillog",   // EL9, Ubuntu via rsyslog
-		"/var/log/mail.log",  // Debian default
-		"/var/log/secure",    // EL9 PAM auth (dovecot:auth)
-		"/var/log/auth.log",  // Debian/Ubuntu PAM auth
+		"/var/log/maillog",  // EL9, Ubuntu via rsyslog
+		"/var/log/mail.log", // Debian default
+		"/var/log/secure",   // EL9 PAM auth (dovecot:auth)
+		"/var/log/auth.log", // Debian/Ubuntu PAM auth
 	},
 	"postfix": {
 		"/var/log/maillog",  // EL9, Ubuntu via rsyslog
@@ -1226,36 +1247,106 @@ func (m *Module) startFileWatchers(ctx context.Context) {
 	}
 }
 
-// runFileWatcher tails a log file and feeds lines through the detector pipeline.
+// runFileWatcher SUPERVISES a tail -F watcher: it (re)spawns the child via
+// runFileWatcherOnce and, if the child dies while ctx is still alive, respawns
+// it with bounded exponential backoff. Without this, a killed tail child (OOM,
+// abnormal stream end) would leave that log source DARK until daemon restart —
+// a silent detection-availability hole (v1.176 LOGINMON-WATCHER-NO-RESPAWN).
+// On ctx cancellation (clean shutdown) it returns without respawning.
 func (m *Module) runFileWatcher(ctx context.Context, service, logPath string) {
-	cmd := exec.CommandContext(ctx, "tail", "-F", "-n", "0", logPath)
+	backoff := m.watcherBackoffMin
+	for attempt := 0; ; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		start := time.Now()
+		err := m.runFileWatcherOnce(ctx, service, logPath, attempt)
+		// Clean shutdown → do not respawn.
+		if ctx.Err() != nil {
+			return
+		}
+		// A run that lasted long enough is "healthy" → reset backoff.
+		if time.Since(start) >= m.watcherHealthyReset {
+			backoff = m.watcherBackoffMin
+		}
+		m.status.RecordError(fmt.Errorf("file watcher %s exited (ran %s): %v — respawning in %s",
+			service, time.Since(start).Round(time.Millisecond), err, backoff))
+		m.bus.Publish(eventbus.NewEvent(eventbus.EventError, ModuleName).
+			WithMessage(fmt.Sprintf("File watcher DOWN: %s (%s) — respawning in %s", service, logPath, backoff)))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > m.watcherBackoffMax {
+			backoff = m.watcherBackoffMax
+		}
+	}
+}
+
+// runFileWatcherOnce runs a single tail -F child and feeds its lines through the
+// detector pipeline until the child dies or ctx is cancelled. Returns the reason
+// the run ended (nil on clean ctx cancellation). The child cmd is registered in
+// fileWatcherCmds for the duration of the run and unregistered on exit so the
+// slice always reflects the currently-live watchers (no leak across respawns).
+func (m *Module) runFileWatcherOnce(ctx context.Context, service, logPath string, attempt int) error {
+	var cmd *exec.Cmd
+	if m.newWatcherCmd != nil {
+		cmd = m.newWatcherCmd(ctx, logPath)
+	} else {
+		cmd = exec.CommandContext(ctx, "tail", "-F", "-n", "0", logPath)
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		m.status.RecordError(fmt.Errorf("file watcher %s: pipe: %w", service, err))
-		return
+		return fmt.Errorf("pipe: %w", err)
 	}
 	defer stdout.Close()
 
 	if err := cmd.Start(); err != nil {
-		m.status.RecordError(fmt.Errorf("file watcher %s: start: %w", service, err))
-		return
+		return fmt.Errorf("start: %w", err)
 	}
+	m.registerWatcherCmd(cmd)
+	defer m.unregisterWatcherCmd(cmd)
 
-	// Track for cleanup on Stop()
-	m.mu.Lock()
-	m.fileWatcherCmds = append(m.fileWatcherCmds, cmd)
-	m.mu.Unlock()
-
+	verb := "started"
+	if attempt > 0 {
+		verb = "RESPAWNED"
+	}
 	m.bus.Publish(eventbus.NewEvent(eventbus.EventModuleStart, ModuleName).
-		WithMessage(fmt.Sprintf("File watcher started: %s (%s)", service, logPath)))
+		WithMessage(fmt.Sprintf("File watcher %s: %s (%s)", verb, service, logPath)))
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 			m.processLine(scanner.Bytes())
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan: %w", err)
+	}
+	_ = cmd.Wait()
+	return fmt.Errorf("log stream ended (child exited)")
+}
+
+// registerWatcherCmd / unregisterWatcherCmd keep m.fileWatcherCmds equal to the
+// set of currently-live watcher children so Stop() can reap them and respawns
+// don't leak stale *exec.Cmd entries.
+func (m *Module) registerWatcherCmd(cmd *exec.Cmd) {
+	m.mu.Lock()
+	m.fileWatcherCmds = append(m.fileWatcherCmds, cmd)
+	m.mu.Unlock()
+}
+
+func (m *Module) unregisterWatcherCmd(cmd *exec.Cmd) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, c := range m.fileWatcherCmds {
+		if c == cmd {
+			m.fileWatcherCmds = append(m.fileWatcherCmds[:i], m.fileWatcherCmds[i+1:]...)
+			return
 		}
 	}
 }

--- a/internal/loginmon/watcher_respawn_v176_test.go
+++ b/internal/loginmon/watcher_respawn_v176_test.go
@@ -1,0 +1,154 @@
+// =============================================================================
+// NFTBan v1.176 — LOGINMON-WATCHER-NO-RESPAWN regression tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="loginmon-watcher-respawn-v176-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-12"
+// meta:description="Locks v1.176 LOGINMON-WATCHER-NO-RESPAWN: the file-watcher supervisor respawns a dead tail -F child while ctx is alive (detection does NOT go dark) with bounded backoff, and stops cleanly on ctx cancellation (no respawn, no leaked *exec.Cmd). (1) RespawnsOnChildDeath_AndStopsClean: a fast-exiting injected child is respawned >=3x, then respawns STOP after ctx cancel and no live watcher cmd leaks. (2) KillRealTailRespawns: a real tail -F child killed mid-run is replaced by a different live child. Hermetic: injected/temp-file watchers, no root, no nft; run under -race."
+// meta:inventory.files="internal/loginmon/module.go"
+// meta:inventory.binaries="tail,true"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package loginmon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/eventbus"
+)
+
+// newTestModule builds a Module with a live bus and fast (test) backoff so the
+// supervise loop respawns quickly.
+func newTestModule() *Module {
+	m := New()
+	m.bus = eventbus.New()
+	m.watcherBackoffMin = 2 * time.Millisecond
+	m.watcherBackoffMax = 8 * time.Millisecond
+	m.watcherHealthyReset = time.Hour // never "healthy" in-test; keep backoff small+capped
+	return m
+}
+
+func (m *Module) liveWatcherCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.fileWatcherCmds)
+}
+
+// Item A core: a child that keeps dying is respawned while ctx is alive, and
+// respawns STOP immediately on ctx cancellation (clean shutdown, no leak).
+func TestFileWatcherRespawnsOnChildDeath_AndStopsClean(t *testing.T) {
+	m := newTestModule()
+
+	var spawns int64
+	// Fake watcher child that exits immediately (no output) → drives the
+	// supervisor to respawn each time.
+	m.newWatcherCmd = func(ctx context.Context, _ string) *exec.Cmd {
+		atomic.AddInt64(&spawns, 1)
+		return exec.CommandContext(ctx, "true")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go m.runFileWatcher(ctx, "test", "/var/log/does-not-exist.log")
+
+	// Respawn proof: the supervisor must invoke the builder many times.
+	deadline := time.Now().Add(3 * time.Second)
+	for atomic.LoadInt64(&spawns) < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&spawns); got < 3 {
+		t.Fatalf("watcher did not respawn: only %d spawns (want >=3) — detection would go dark", got)
+	}
+
+	// Clean shutdown: after cancel, spawns must stop increasing.
+	cancel()
+	time.Sleep(60 * time.Millisecond)
+	c1 := atomic.LoadInt64(&spawns)
+	time.Sleep(80 * time.Millisecond)
+	c2 := atomic.LoadInt64(&spawns)
+	if c2 != c1 {
+		t.Fatalf("watcher kept respawning after ctx cancel: %d -> %d (clean shutdown broken)", c1, c2)
+	}
+
+	// No leaked watcher cmds after shutdown.
+	for i := 0; i < 40 && m.liveWatcherCount() != 0; i++ {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := m.liveWatcherCount(); n != 0 {
+		t.Fatalf("leaked %d live watcher cmd(s) after shutdown", n)
+	}
+}
+
+// Item A end-to-end with a REAL tail -F child: killing the live child triggers a
+// respawn (a new, different child becomes the registered watcher) — the exact
+// failure the audit caught. Skips if `tail` is unavailable.
+func TestFileWatcherKillRealTailRespawns(t *testing.T) {
+	if _, err := exec.LookPath("tail"); err != nil {
+		t.Skip("tail not available")
+	}
+	m := newTestModule()
+
+	f, err := os.CreateTemp(t.TempDir(), "access-*.log")
+	if err != nil {
+		t.Fatalf("temp log: %v", err)
+	}
+	logPath := f.Name()
+	_ = f.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.runFileWatcher(ctx, "test", logPath) // default builder = real tail -F
+
+	// Wait for the first child to register.
+	first := waitForLiveChild(t, m, nil, 3*time.Second)
+
+	// Kill it (simulates OOM-kill / abnormal death) while ctx is alive.
+	if first.Process != nil {
+		_ = first.Process.Kill()
+	}
+
+	// A DIFFERENT child must take over (respawn), not stay dark.
+	second := waitForLiveChild(t, m, first, 3*time.Second)
+	if second == first {
+		t.Fatal("watcher did not respawn after the live tail child was killed")
+	}
+
+	// Clean shutdown reaps the watcher.
+	cancel()
+	for i := 0; i < 60 && m.liveWatcherCount() != 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := m.liveWatcherCount(); n != 0 {
+		t.Fatalf("leaked %d live watcher cmd(s) after shutdown", n)
+	}
+}
+
+// waitForLiveChild returns the registered watcher cmd once one exists that is
+// different from `exclude` (pass nil to accept the first). Fails on timeout.
+func waitForLiveChild(t *testing.T, m *Module, exclude *exec.Cmd, d time.Duration) *exec.Cmd {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		var cur *exec.Cmd
+		if len(m.fileWatcherCmds) > 0 {
+			cur = m.fileWatcherCmds[len(m.fileWatcherCmds)-1]
+		}
+		m.mu.RUnlock()
+		if cur != nil && cur != exclude {
+			return cur
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for a live watcher child")
+	return nil
+}

--- a/internal/rebuild/marker.go
+++ b/internal/rebuild/marker.go
@@ -29,6 +29,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/safety"
 )
 
 // DefaultMarkerPath is the canonical location for the recovery marker.
@@ -124,14 +126,11 @@ func (m *RecoveryMarker) WriteTo(path string) error {
 		return fmt.Errorf("create marker directory: %w", err)
 	}
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0640); err != nil { // #nosec G306 — intentional 0640
-		return fmt.Errorf("write temp marker: %w", err)
-	}
-
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp) // best-effort cleanup
-		return fmt.Errorf("rename marker: %w", err)
+	// v1.176 FSYNC-RESIDUAL (F-2): route through safety.SafeWriteFile — temp +
+	// fsync + atomic rename (was os.WriteFile(tmp)+Rename with NO Sync → a crash
+	// could leave a torn/zero-length recovery marker, defeating its crash-safety).
+	if err := safety.SafeWriteFile(path, data, 0640); err != nil {
+		return fmt.Errorf("write recovery marker: %w", err)
 	}
 
 	return nil

--- a/internal/rebuild/marker_fsync_v176_test.go
+++ b/internal/rebuild/marker_fsync_v176_test.go
@@ -1,0 +1,60 @@
+// =============================================================================
+// NFTBan v1.176 — FSYNC-RESIDUAL F-2 regression test (rebuild recovery marker)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="rebuild-marker-fsync-v176-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-12"
+// meta:description="Locks v1.176 FSYNC-RESIDUAL F-2: RecoveryMarker.WriteTo persists via safety.SafeWriteFile (durable temp+fsync+atomic rename) — valid JSON round-trip and NO leftover temp residue. Broader write/read/clear behavior is covered by TestMarkerWriteReadClear. Hermetic: t.TempDir, no root."
+// meta:inventory.files="internal/rebuild/marker.go,internal/safety/file.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package rebuild
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMarkerWriteTo_DurableNoResidue_F2(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	path := filepath.Join(stateDir, "rebuild_recovery.json")
+
+	m := NewMarker(ClassModuleRestoreIncomplete, ResultFailedDegraded)
+	m.LastHealthState = "degraded"
+	if err := m.WriteTo(path); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var rt map[string]any
+	if err := json.Unmarshal(data, &rt); err != nil {
+		t.Fatalf("recovery marker is not valid JSON (torn write?): %v", err)
+	}
+
+	// No temp residue (old .tmp or safety-helper temp) left in the state dir.
+	ents, err := os.ReadDir(stateDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range ents {
+		n := e.Name()
+		if n == "rebuild_recovery.json" {
+			continue
+		}
+		if filepath.Ext(n) == ".tmp" || (len(n) > 0 && n[0] == '.') {
+			t.Fatalf("unexpected temp residue after atomic write: %s", n)
+		}
+	}
+}

--- a/internal/stats/set_counters.go
+++ b/internal/stats/set_counters.go
@@ -37,6 +37,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/safety"
 )
 
 // Scale levels for set size classification
@@ -80,10 +82,10 @@ type SetCounters struct {
 	trendHistory map[string][]trendSample // last N samples per set
 
 	// Cache file
-	cacheDir     string
-	cacheDirty   atomic.Bool
+	cacheDir       string
+	cacheDirty     atomic.Bool
 	lastCacheWrite time.Time
-	daemonPID    int
+	daemonPID      int
 
 	// Debounce timer for cache writes
 	writeMu sync.Mutex
@@ -97,11 +99,11 @@ type trendSample struct {
 
 // SetCountSnapshot is the JSON-serializable snapshot of all counters
 type SetCountSnapshot struct {
-	Timestamp       string                       `json:"timestamp"`
-	DaemonPID       int                          `json:"daemon_pid"`
-	ScaleMode       string                       `json:"scale_mode"`
-	ExporterInterval int                         `json:"exporter_interval_seconds"`
-	Sets            map[string]SetCountEntry     `json:"sets"`
+	Timestamp        string                   `json:"timestamp"`
+	DaemonPID        int                      `json:"daemon_pid"`
+	ScaleMode        string                   `json:"scale_mode"`
+	ExporterInterval int                      `json:"exporter_interval_seconds"`
+	Sets             map[string]SetCountEntry `json:"sets"`
 }
 
 // SetCountEntry is per-set data in the snapshot
@@ -304,16 +306,13 @@ func (sc *SetCounters) WriteCacheFile() error {
 	}
 
 	cacheFile := filepath.Join(sc.cacheDir, "set_counts.json")
-	tmpFile := cacheFile + ".tmp"
 
-	// 0640: root-rw, group-r — shell scripts read this via nftban group
-	if err := os.WriteFile(tmpFile, data, 0640); err != nil { // #nosec G306
-		return fmt.Errorf("write %s: %w", tmpFile, err)
-	}
-
-	if err := os.Rename(tmpFile, cacheFile); err != nil {
-		os.Remove(tmpFile)
-		return fmt.Errorf("rename %s: %w", cacheFile, err)
+	// v1.176 FSYNC-RESIDUAL (F-1): route through safety.SafeWriteFile — temp +
+	// fsync + atomic rename (was os.WriteFile(tmp)+Rename with NO Sync → a crash
+	// between rename and writeback could leave a torn/zero-length set_counts.json).
+	// 0640: root-rw, group-r — shell scripts read this via nftban group.
+	if err := safety.SafeWriteFile(cacheFile, data, 0640); err != nil {
+		return fmt.Errorf("write %s: %w", cacheFile, err)
 	}
 
 	sc.lastCacheWrite = time.Now()

--- a/internal/stats/set_counters_fsync_v176_test.go
+++ b/internal/stats/set_counters_fsync_v176_test.go
@@ -1,0 +1,70 @@
+// =============================================================================
+// NFTBan v1.176 — FSYNC-RESIDUAL F-1 regression test (set_counts.json)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="set-counters-fsync-v176-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-12"
+// meta:description="Locks v1.176 FSYNC-RESIDUAL F-1: WriteCacheFile persists set_counts.json via safety.SafeWriteFile (durable temp+fsync+atomic rename) — valid JSON round-trip, perms 0640, and NO leftover temp residue (no torn-write). The 'no raw os.WriteFile(tmp)+Rename' property is locked separately by fsync_residual_guard_v176_test.sh. Hermetic: t.TempDir, no root."
+// meta:inventory.files="internal/stats/set_counters.go,internal/safety/file.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package stats
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteCacheFile_DurableRoundTrip_F1(t *testing.T) {
+	dir := t.TempDir()
+	sc := NewSetCounters(dir)
+	sc.Add("blacklist_ipv4", 7)
+	sc.Add("blacklist_ipv6", 3)
+	sc.cacheDirty.Store(true) // ensure the debounced writer runs
+
+	if err := sc.WriteCacheFile(); err != nil {
+		t.Fatalf("WriteCacheFile: %v", err)
+	}
+
+	cacheFile := filepath.Join(dir, "set_counts.json")
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("read set_counts.json: %v", err)
+	}
+	var snap map[string]any
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("set_counts.json is not valid JSON (torn write?): %v", err)
+	}
+
+	// Perms preserved at 0640 (group-readable for the nftban shell consumers).
+	fi, err := os.Stat(cacheFile)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0640 {
+		t.Fatalf("set_counts.json perm = %o, want 0640", perm)
+	}
+
+	// No leftover temp residue from the atomic write (old .tmp or safe-write temp).
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range ents {
+		n := e.Name()
+		if n == "set_counts.json" {
+			continue
+		}
+		if filepath.Ext(n) == ".tmp" || (len(n) > 0 && n[0] == '.') {
+			t.Fatalf("unexpected temp residue after atomic write: %s", n)
+		}
+	}
+}


### PR DESCRIPTION
v1.176 DAEMON RELIABILITY — two pure-Go reliability fixes (scope `V1_176_DAEMON_RELIABILITY_SCOPE.md`). Local commit `01faa053`.

## LOGINMON-WATCHER-NO-RESPAWN (detection-availability)
- The `tail -F` LoginMon watcher is now **supervised and respawns with bounded exponential backoff** (1s→60s, reset after a 30s-healthy run) when its child dies while the context is alive — a killed `tail` child no longer leaves that log source dark until daemon restart.
- **Watcher shutdown via context cancel remains clean and does NOT respawn** (no goroutine leak; `fileWatcherCmds` tracks only currently-live watchers).

## FSYNC-RESIDUAL F-1/F-2 (crash-consistency)
- **`internal/stats/set_counters.go` (F-1) and `internal/rebuild/marker.go` (F-2) now use `safety.SafeWriteFile`** (temp + fsync + atomic rename), replacing `os.WriteFile(tmp)+os.Rename` with no Sync. Perms 0640 preserved.
- The **fsync guard** (`cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh`, wired into CI) fixes F-1/F-2 and **blocks any new unapproved temp+rename state writer** outside `internal/safety`.
- The **13 pre-existing hand-rolled temp+rename writers are explicitly baselined as separate tech debt — NOT claimed fixed** by this PR.

## Envelope
- **Daemon hash moved as expected: `65ac698d…` → `48b82663…`** (code-only `-trimpath -buildvcs=false`), attributable to `internal/loginmon` + `internal/stats`; the rebuild change lands in nftban-core/installer, not the daemon.
- **Schema remains 1.83.0 frozen.**

## Validation already run locally
- `go build ./...`
- `go test -race` for loginmon / stats / rebuild / safety / pipelines
- `go vet`
- `gofmt`
- `fsync_residual_guard_v176_test.sh` (4/0, incl. self-tests)
- pre-commit hooks (header + no-recursive-perm)

Scope-only: no SEC/VX, no v1.177 HTTP/BotScan, no SUPPORT-DIAG/UX/DOC hygiene, no FHS or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)