### PR TITLE
feat(botscan): read-authority B1 cap-scoped collector → nftban-readable spool (v1.178-A)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -793,6 +793,9 @@ jobs:
       - name: HTTP log discovery + BotScan panel paths (v1.177)
         run: bash cli/lib/nftban/tests/http_log_discovery_v177_test.sh
 
+      - name: BotScan read-authority collector + spool-first (v1.178-A)
+        run: bash cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
+
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers
       # =====================================================================

--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -843,6 +843,14 @@ directories:
       created_by: tmpfiles
       tmpfiles_reconcile: "z"
 
+    - path: /var/lib/nftban/botscan-collector
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "BotScan read-collector per-source incremental offset state (v1.178-A). Separate from the scanner's spool offsets so privileged reads only emit new bytes per cycle."
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
+
   # ---------------------------------------------------------------------------
   # Logs (nftban:nftban, 750) - Daemon writes, group reads
   # ---------------------------------------------------------------------------
@@ -940,6 +948,14 @@ directories:
       created_by: tmpfiles
       tmpfiles_reconcile: "z"
       note: "Managed by tmpfiles only - do not use RuntimeDirectory= in units to avoid conflict. 0755 intentional: socket-discovery — non-nftban-group processes (panel adapters, monitoring tools) must stat() the daemon socket; the socket file itself uses unit-level SocketMode=0660 + group ownership for access control. Tightening the parent dir would break socket-discovery for anything outside the nftban group."
+
+    - path: /run/nftban/botscan
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "BotScan read-authority spool (v1.178-A): nftban:nftban access-log lines written by nftban-botscan-collector.service (CAP_DAC_READ_SEARCH) and read by the unprivileged nftban-botscan.service scanner. tmpfs/ephemeral."
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
 
     - path: /run/nftban/firewall-validate
       mode: "2750"

--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -733,6 +733,18 @@ _nftban_botscan_cmd_logs() {
         printf '      %s\n' "${_NFTBAN_HTTP_LAST_UNREADABLE[@]}"
     fi
     echo ""
+    # v1.178-A: spool-aware override. If direct source readability is DEGRADED/UNKNOWN
+    # but the privileged collector is feeding the spool, the scanner DOES get input →
+    # report OK (via collector spool) while still showing the upstream source reason.
+    local _spool="${BOTSCAN_SPOOL_DIR:-/run/nftban/botscan}" _spool_fed=0 _sf
+    if [[ -d "$_spool" ]]; then
+        for _sf in "$_spool"/*; do [[ -f "$_sf" && -r "$_sf" && -s "$_sf" ]] && { _spool_fed=1; break; }; done
+    fi
+    if [[ "$_spool_fed" -eq 1 && ( "$verdict" == "DEGRADED" || "$verdict" == "UNKNOWN" ) ]]; then
+        echo "  Verdict: OK (served via collector spool) — direct source readability is ${verdict} for"
+        echo "  '${svc}', but nftban-botscan-collector.service is feeding ${_spool} (read-authority active)."
+        return 0
+    fi
     case "$verdict" in
         NO_LOGS)
             echo "  Verdict: NO-LOGS — no web access logs discovered and no web stack detected (inactive)."

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -64,6 +64,8 @@ nftban_botscan_load_config() {
     # preferred; if it resolves to no readable file we fall back to panel-aware
     # auto-detect (never silently blind). Legacy single-path vars above stay honored.
     : "${BOTSCAN_LOG_PATHS:=}"
+    # v1.178-A: read-authority spool produced by nftban-botscan-collector.service.
+    : "${BOTSCAN_SPOOL_DIR:=/run/nftban/botscan}"
     : "${BOTSCAN_DEFAULT_THRESHOLD:=5}"
     : "${BOTSCAN_DEFAULT_WINDOW:=60}"
     : "${BOTSCAN_DEFAULT_BAN_SHORT:=1800}"
@@ -259,6 +261,18 @@ nftban_botscan_toggle_pattern() {
 nftban_botscan_discover_logs() {
     local -a logs=()
     local f
+    # v1.178-A read-authority: SPOOL-FIRST. If the separate privileged collector
+    # (nftban-botscan-collector.service, CAP_DAC_READ_SEARCH) produced a spool, the
+    # unprivileged scanner reads ONLY the spool — it already holds the privileged-read
+    # content the scanner cannot obtain directly on DA/cPanel/0640 hosts. If no spool
+    # (collector absent/empty), fall back to direct discovery (legacy behavior; will
+    # report DEGRADED on blocked hosts via the v1.177 diagnostic).
+    local _spool="${BOTSCAN_SPOOL_DIR:-/run/nftban/botscan}"
+    if [[ -d "$_spool" ]]; then
+        local -a _sp=()
+        for f in "$_spool"/*; do [[ -f "$f" && -r "$f" && -s "$f" ]] && _sp+=("$f"); done
+        if [[ ${#_sp[@]} -gt 0 ]]; then printf '%s\n' "${_sp[@]}"; return 0; fi
+    fi
     if declare -F nftban_http_discover_access_logs >/dev/null 2>&1; then
         while IFS= read -r f; do [[ -n "$f" ]] && logs+=("$f"); done \
             < <(nftban_http_discover_access_logs "${BOTSCAN_LOG_PATHS:-}")
@@ -699,10 +713,19 @@ nftban_botscan_status() {
         local svc="${NFTBAN_BOTSCAN_SERVICE_USER:-nftban}"
         nftban_http_classify_candidates "${BOTSCAN_LOG_PATHS:-}" >/dev/null 2>&1 || true
         local verdict="${_NFTBAN_HTTP_READ_VERDICT:-UNKNOWN}"
-        echo "Readability:    ${verdict} (${_NFTBAN_HTTP_READ_COUNT_READABLE}/${_NFTBAN_HTTP_READ_COUNT_TOTAL} readable by ${svc})"
-        if [[ "$verdict" == "DEGRADED" ]]; then
-            echo "                BOTSCAN_READ_AUTHORITY open: access logs discovered but unreadable by"
-            echo "                the service account — enforcement blocked until a read-authority lane lands."
+        # v1.178-A: collector spool feeds the scanner even when direct source is unreadable.
+        local _spool="${BOTSCAN_SPOOL_DIR:-/run/nftban/botscan}" _spool_fed=0 _sf
+        if [[ -d "$_spool" ]]; then
+            for _sf in "$_spool"/*; do [[ -f "$_sf" && -r "$_sf" && -s "$_sf" ]] && { _spool_fed=1; break; }; done
+        fi
+        if [[ "$_spool_fed" -eq 1 && ( "$verdict" == "DEGRADED" || "$verdict" == "UNKNOWN" ) ]]; then
+            echo "Readability:    OK via collector spool (direct source ${verdict} for ${svc}; collector feeding ${_spool})"
+        else
+            echo "Readability:    ${verdict} (${_NFTBAN_HTTP_READ_COUNT_READABLE}/${_NFTBAN_HTTP_READ_COUNT_TOTAL} readable by ${svc})"
+            if [[ "$verdict" == "DEGRADED" ]]; then
+                echo "                BOTSCAN_READ_AUTHORITY open: access logs discovered but unreadable by the"
+                echo "                service account — install/enable nftban-botscan-collector.service (read-authority)."
+            fi
         fi
     fi
 

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -147,6 +147,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/watchdog"]="0750|nftban|nftban|Watchdog reports and state"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/reports/archive"]="0750|nftban|nftban|Archived reports"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/pro"]="0750|root|nftban|Pro subscription data"
+    NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/botscan-collector"]="0750|nftban|nftban|BotScan read-collector per-source incremental offset state (v1.178-A). Separate from the scanner's spool offsets so privileged reads only emit new bytes per cycle."
 
     # Log Directories
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban"]="0750|nftban|nftban|Log files"
@@ -162,6 +163,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/cache/nftban"]="0755|nftban|nftban|Cache files"
     NFTBAN_FHS_DIRECTORIES["/var/cache/nftban/health"]="0750|nftban|nftban|Health check status cache"
     NFTBAN_FHS_DIRECTORIES["/run/nftban"]="0755|nftban|nftban|Runtime data (PID files, sockets)"
+    NFTBAN_FHS_DIRECTORIES["/run/nftban/botscan"]="0750|nftban|nftban|BotScan read-authority spool (v1.178-A): nftban:nftban access-log lines written by nftban-botscan-collector.service (CAP_DAC_READ_SEARCH) and read by the unprivileged nftban-botscan.service scanner. tmpfs/ephemeral."
     NFTBAN_FHS_DIRECTORIES["/run/nftban/firewall-validate"]="2750|root|nftban|V131.3 D13 — setgid (2750) group-readable handoff dir for nftban-firewall-validate.service output (last.json); setgid makes wrapper-written files inherit group nftban without CAP_CHOWN"
 
     # Shared Directories

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -782,6 +782,14 @@
         "group": "nftban",
         "description": "Pro subscription data",
         "created_by": "tmpfiles"
+      },
+      {
+        "path": "/var/lib/nftban/botscan-collector",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "BotScan read-collector per-source incremental offset state (v1.178-A). Separate from the scanner's spool offsets so privileged reads only emit new bytes per cycle.",
+        "created_by": "tmpfiles"
       }
     ],
     "logs": [
@@ -873,6 +881,14 @@
         "owner": "nftban",
         "group": "nftban",
         "description": "Runtime data (PID files, sockets)",
+        "created_by": "tmpfiles"
+      },
+      {
+        "path": "/run/nftban/botscan",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "BotScan read-authority spool (v1.178-A): nftban:nftban access-log lines written by nftban-botscan-collector.service (CAP_DAC_READ_SEARCH) and read by the unprivileged nftban-botscan.service scanner. tmpfs/ephemeral.",
         "created_by": "tmpfiles"
       },
       {

--- a/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
+++ b/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.178.0 - BotScan read-authority collector (B1) tests
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_read_authority_v178_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Locks the v1.178-A BotScan read-authority B1 design: the separate privileged read-collector (cli/sbin/nftban-botscan-collector) and the scanner spool-first wiring. Hermetic (non-root, no CAP): the collector runs against fixtures the test user can read (proving the read→spool→scanner pipeline), with a test-only allowlist override. Covers collect-to-spool, allowlist enforcement, symlink-escape rejection, regular-file-only, incremental new-bytes, spool byte cap, spool mode 0640, MAX_FILES cap, scanner spool-first + fallback, and unit-hardening invariants (scanner stays User=nftban+NNP+RestrictSUIDSGID and capless; collector carries CAP_DAC_READ_SEARCH on its OWN unit). Real DAC-denial (nftban cannot read but the cap can) is proven in lab, not here."
+# meta:input="None (builds temp fixtures)"
+# meta:output="Pass/fail; exit 0 all-pass, 1 on any failure"
+# meta:depends="bash,realpath,stat,tail,mkfifo"
+# meta:inventory.files="cli/sbin/nftban-botscan-collector,cli/lib/nftban/core/nftban_botscan.sh,install/systemd/nftban-botscan.service,install/systemd/nftban-botscan-collector.service"
+# meta:inventory.binaries="realpath,stat,tail,mkfifo"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,BOTSCAN_SPOOL_DIR,NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR,NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS,BOTSCAN_LOG_PATHS,BOTSCAN_COLLECTOR_MAX_FILES,BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+COLLECTOR="$REPO/cli/sbin/nftban-botscan-collector"
+CORE="$REPO/cli/lib/nftban/core/nftban_botscan.sh"
+SCANNER_UNIT="$REPO/install/systemd/nftban-botscan.service"
+COLLECTOR_UNIT="$REPO/install/systemd/nftban-botscan-collector.service"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+ALLOW="$WORK/logs"; SPOOL="$WORK/spool"; OFF="$WORK/off"
+mkdir -p "$ALLOW" "$WORK/outside"
+
+# run_collector: invoke the collector against fixtures with a test-only allowlist.
+run_collector(){
+  NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" \
+  BOTSCAN_SPOOL_DIR="$SPOOL" \
+  NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR="$OFF" \
+  NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS="$ALLOW" \
+  BOTSCAN_LOG_PATHS="$1" \
+  ${2:+BOTSCAN_COLLECTOR_MAX_FILES=$2} \
+  ${3:+BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES=$3} \
+  bash "$COLLECTOR" 2>&1 || true
+}
+spool_of(){ printf '%s/%s' "$SPOOL" "$(realpath -- "$1" | tr '/' '_')"; }
+
+echo "=== v1.178-A BotScan read-authority (collector + spool-first) ==="
+
+# T1: collector reads an allowlisted fixture → spool file with content.
+printf 'l1 GET /a\nl2 POST /xmlrpc.php\n' > "$ALLOW/site.log"
+run_collector "$ALLOW/*.log" >/dev/null
+sf="$(spool_of "$ALLOW/site.log")"
+[[ -f "$sf" ]] && grep -q 'xmlrpc.php' "$sf" && ok "T1 collector reads allowlisted source → spool populated" || no "T1 collect→spool" "sf=$sf"
+
+# T2: candidate OUTSIDE the allowlist is skipped (not spooled).
+printf 'secret\n' > "$WORK/outside/evil.log"
+out="$(run_collector "$WORK/outside/*.log")"
+[[ ! -f "$(spool_of "$WORK/outside/evil.log")" ]] && echo "$out" | grep -q 'outside-allowlist' && ok "T2 outside-allowlist source skipped + audited" || no "T2 allowlist enforce" "$out"
+
+# T3: symlink-escape — link inside allowlist resolving OUTSIDE is rejected.
+ln -s "$WORK/outside/evil.log" "$ALLOW/escape.log"
+out="$(run_collector "$ALLOW/escape.log")"
+[[ ! -f "$(spool_of "$WORK/outside/evil.log")" ]] && echo "$out" | grep -qE 'outside-allowlist|not-regular' && ok "T3 symlink-escape rejected (canonical path outside allowlist)" || no "T3 symlink escape" "$out"
+rm -f "$ALLOW/escape.log"
+
+# T4: non-regular (fifo) candidate rejected.
+mkfifo "$ALLOW/fifo.log" 2>/dev/null || true
+run_collector "$ALLOW/fifo.log" >/dev/null
+[[ ! -f "$(spool_of "$ALLOW/fifo.log")" ]] && ok "T4 non-regular (fifo) skipped" || no "T4 fifo skip"
+rm -f "$ALLOW/fifo.log"
+
+# T5: incremental — second run emits only NEW bytes.
+rm -rf "$SPOOL" "$OFF"; printf 'first\n' > "$ALLOW/inc.log"
+run_collector "$ALLOW/inc.log" >/dev/null
+printf 'second\n' >> "$ALLOW/inc.log"
+run_collector "$ALLOW/inc.log" >/dev/null
+sf="$(spool_of "$ALLOW/inc.log")"
+[[ "$(grep -c first "$sf")" -eq 1 && "$(grep -c second "$sf")" -eq 1 ]] && ok "T5 incremental: new bytes appended once (no re-read of old)" || no "T5 incremental" "$(cat "$sf" 2>/dev/null)"
+
+# T6: spool byte cap trims.
+rm -rf "$SPOOL" "$OFF"; head -c 5000 /dev/zero | tr '\0' 'x' > "$ALLOW/big.log"; printf '\n' >> "$ALLOW/big.log"
+NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_SPOOL_DIR="$SPOOL" \
+  NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR="$OFF" NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS="$ALLOW" \
+  BOTSCAN_LOG_PATHS="$ALLOW/big.log" BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES=512 \
+  bash "$COLLECTOR" >/dev/null 2>&1 || true
+sf="$(spool_of "$ALLOW/big.log")"
+sz="$(stat -c %s "$sf" 2>/dev/null || echo 99999)"
+[[ "$sz" -le 1024 ]] && ok "T6 spool byte cap enforced (size=$sz ≤ cap)" || no "T6 spool cap" "size=$sz"
+
+# T7: spool file mode 0640.
+rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/mode.log"; run_collector "$ALLOW/mode.log" >/dev/null
+m="$(stat -c %a "$(spool_of "$ALLOW/mode.log")" 2>/dev/null || echo '')"
+[[ "$m" == "640" ]] && ok "T7 spool file mode 0640" || no "T7 spool mode" "mode=$m"
+
+# T8: scanner SPOOL-FIRST — discover returns spool files when spool populated.
+rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/s1.log"; run_collector "$ALLOW/s1.log" >/dev/null
+# shellcheck source=/dev/null
+( export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_SPOOL_DIR="$SPOOL"
+  # shellcheck source=/dev/null
+  source "$CORE" >/dev/null 2>&1
+  nftban_botscan_load_config >/dev/null 2>&1 || true
+  got="$(nftban_botscan_discover_logs 2>/dev/null)"
+  [[ "$got" == "$SPOOL"/* ]] && exit 0 || { echo "got=$got"; exit 1; }
+) && ok "T8 scanner spool-first: discover returns spool when populated" || no "T8 spool-first"
+
+# T9: scanner FALLBACK — empty spool → does NOT return spool paths (falls back).
+rm -rf "$SPOOL"; mkdir -p "$SPOOL"
+( export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_SPOOL_DIR="$SPOOL"
+  # shellcheck source=/dev/null
+  source "$CORE" >/dev/null 2>&1
+  nftban_botscan_load_config >/dev/null 2>&1 || true
+  got="$(BOTSCAN_LOG_PATHS="$ALLOW/s1.log" nftban_botscan_discover_logs 2>/dev/null || true)"
+  [[ "$got" != "$SPOOL"/* ]] && exit 0 || { echo "got=$got"; exit 1; }
+) && ok "T9 scanner fallback when spool empty (no stale spool paths)" || no "T9 fallback"
+
+# T10: MAX_FILES cap.
+rm -rf "$SPOOL" "$OFF"; for i in 1 2 3 4; do printf 'x\n' > "$ALLOW/m$i.log"; done
+out="$(run_collector "$ALLOW/m*.log" 2)"
+echo "$out" | grep -q 'MAX_FILES=2' && ok "T10 MAX_FILES cap enforced + audited" || no "T10 max-files" "$out"
+
+# T11: scanner unit stays hardened + capless.
+if grep -q '^User=nftban' "$SCANNER_UNIT" && grep -q '^NoNewPrivileges=true' "$SCANNER_UNIT" && grep -q '^RestrictSUIDSGID=true' "$SCANNER_UNIT" && ! grep -q 'CAP_DAC_READ_SEARCH' "$SCANNER_UNIT"; then
+  ok "T11 scanner unit: User=nftban + NNP + RestrictSUIDSGID + NO read-cap"
+else no "T11 scanner unit invariants"; fi
+
+# T12: collector unit carries the single read cap (and stays User=nftban + NNP).
+if grep -q '^User=nftban' "$COLLECTOR_UNIT" && grep -q '^AmbientCapabilities=CAP_DAC_READ_SEARCH$' "$COLLECTOR_UNIT" && grep -q '^CapabilityBoundingSet=CAP_DAC_READ_SEARCH$' "$COLLECTOR_UNIT" && grep -q '^NoNewPrivileges=true' "$COLLECTOR_UNIT" && grep -q '^RestrictSUIDSGID=true' "$COLLECTOR_UNIT"; then
+  ok "T12 collector unit: User=nftban + ONLY CAP_DAC_READ_SEARCH + NNP + RestrictSUIDSGID"
+else no "T12 collector unit invariants"; fi
+
+# T13: audit trail emitted (read-authority observability).
+rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/audit.log"
+out="$(run_collector "$ALLOW/audit.log")"
+echo "$out" | grep -qE 'botscan-collector.*(collected|sources=)' && ok "T13 collector emits audit trail" || no "T13 audit" "$out"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/sbin/nftban-botscan-collector
+++ b/cli/sbin/nftban-botscan-collector
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.178.0 - Bot Scanner Read-Authority Collector (B1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="nftban_botscan_collector"
+# meta:type="worker"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Separate minimal privileged read-collector for BotScan read-authority (B1). Runs as User=nftban with AmbientCapabilities=CAP_DAC_READ_SEARCH (read+traverse only) on its OWN hardened unit — NOT a child of the unprivileged nftban-botscan.service (which stays User=nftban, NoNewPrivileges, RestrictSUIDSGID). Reads ONLY allowlisted access-log roots, canonicalizes every path with realpath, re-validates the canonical path remains inside an allowlisted root (rejects symlink escape), regular files only, bounded by max-files/max-bytes, and appends only NEW bytes (incremental per-source offset, rotation/truncation safe) to an nftban:nftban 0640 spool under /run/nftban/botscan. The scanner then reads the spool — solving both fleet blocker shapes (DA drwx--x--- apache:root parent traversal AND generic 0640 root:adm file-read) uniformly without weakening the scanner. Audits every source read to the journal. No network. No shell evaluation of log content."
+# meta:input="allowlisted access logs (DA /var/log/httpd/domains, generic /var/log/{apache2,nginx}, cPanel domlogs, Plesk vhost logs)"
+# meta:output="nftban:nftban 0640 spool files under /run/nftban/botscan (consumed by nftban-botscan-processor)"
+# meta:depends="bash,realpath,stat,tail,nftban_http_logs.sh"
+# meta:trigger="systemd-timer"
+# meta:systemd_timer="nftban-botscan-collector.timer"
+# meta:systemd_service="nftban-botscan-collector.service"
+#
+# meta:inventory.files="nftban_http_logs.sh"
+# meta:inventory.binaries="realpath,stat,tail"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,BOTSCAN_SPOOL_DIR,NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR,BOTSCAN_COLLECTOR_MAX_FILES,BOTSCAN_COLLECTOR_MAX_BYTES,BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES,BOTSCAN_LOG_PATHS"
+# meta:inventory.config_files="/etc/nftban/conf.d/botscan/main.conf"
+# meta:inventory.systemd_units="nftban-botscan-collector.timer,nftban-botscan-collector.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="nftban+CAP_DAC_READ_SEARCH"
+#
+# Exit codes:
+#   0 - cycle completed (including "nothing new" and per-source skips)
+#   1 - fatal setup error (cannot source lib / cannot create spool)
+# =============================================================================
+set -Eeuo pipefail
+
+readonly NFTBAN_LIB_DIR="${NFTBAN_LIB_DIR:-/usr/lib/nftban}"
+SPOOL_DIR="${BOTSCAN_SPOOL_DIR:-/run/nftban/botscan}"
+OFFSET_DIR="${NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR:-/var/lib/nftban/botscan-collector}"
+MAX_FILES="${BOTSCAN_COLLECTOR_MAX_FILES:-500}"
+MAX_BYTES="${BOTSCAN_COLLECTOR_MAX_BYTES:-10485760}"          # per source per cycle
+SPOOL_MAX_BYTES="${BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES:-10485760}"  # per spool file cap
+
+# Allowlisted access-log roots = the security boundary. A discovered candidate is
+# read ONLY if its CANONICAL path stays inside one of these (after realpath). This
+# is what makes the CAP_DAC_READ_SEARCH grant safe: it can read any file the kernel
+# allows, but this collector only ever opens allowlisted access-log trees.
+ALLOW_ROOTS=(
+    /var/log/httpd/domains
+    /var/log/nginx/domains
+    /var/log/apache2
+    /var/log/httpd
+    /var/log/nginx
+    /usr/local/apache/domlogs
+    /etc/apache2/logs/domlogs
+    /var/log/apache2/domlogs
+    /var/www/vhosts/system
+    /usr/local/lsws/logs
+)
+
+# Reuse the shared discovery helpers (candidate globs, panel detect, incremental read).
+# shellcheck source=/dev/null
+if ! source "${NFTBAN_LIB_DIR}/lib/nftban_http_logs.sh" 2>/dev/null; then
+    echo "[botscan-collector] FATAL: cannot source ${NFTBAN_LIB_DIR}/lib/nftban_http_logs.sh" >&2
+    exit 1
+fi
+
+# The collector keeps its OWN per-source offset state (separate from the scanner's
+# spool offsets) so each privileged read only emits NEW bytes since the last cycle.
+export NFTBAN_HTTP_LOG_OFFSET_DIR="$OFFSET_DIR"
+export NFTBAN_HTTP_LOG_MAX_BYTES="$MAX_BYTES"
+
+audit() { echo "[botscan-collector] $*"; }
+
+# Test-only allowlist override (hermetic CI fixtures). Space-separated roots.
+# Never set in production; the hardcoded ALLOW_ROOTS above is the real boundary.
+if [[ -n "${NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS:-}" ]]; then
+    read -ra ALLOW_ROOTS <<< "${NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS}"
+fi
+
+# Canonicalize the allow roots once (handles symlink chains like cPanel domlogs).
+CANON_ROOTS=()
+for _r in "${ALLOW_ROOTS[@]}"; do
+    _c="$(realpath -m -- "$_r" 2>/dev/null)" || continue
+    CANON_ROOTS+=("$_c")
+done
+
+# in_allowlist <canonical-path> : 0 if inside an allowlisted root, else 1.
+in_allowlist() {
+    local p="$1" root
+    for root in "${CANON_ROOTS[@]}"; do
+        [[ "$p" == "$root" || "$p" == "$root"/* ]] && return 0
+    done
+    return 1
+}
+
+if ! mkdir -p "$SPOOL_DIR" "$OFFSET_DIR" 2>/dev/null; then
+    echo "[botscan-collector] FATAL: cannot create spool/offset dir" >&2
+    exit 1
+fi
+chmod 0750 "$SPOOL_DIR" 2>/dev/null || true
+
+# Build candidate globs (panel-aware + generic + operator override).
+panel="$(nftban_http_detect_panel)"
+globs=()
+while IFS= read -r g; do [[ -n "$g" ]] && globs+=("$g"); done < <(nftban_http_candidate_globs "$panel")
+if [[ -n "${BOTSCAN_LOG_PATHS:-}" ]]; then
+    IFS=$' \t\n' read -ra _ov <<< "$BOTSCAN_LOG_PATHS"   # IFS scoped to this read only
+    globs+=("${_ov[@]}")
+fi
+
+declare -A seen=()
+count=0 collected=0 skipped=0
+for g in "${globs[@]}"; do
+    while IFS= read -r f; do
+        [[ -f "$f" ]] || continue
+        case "$f" in *error_log|*error.log|*-error*|*_error*|*.gz|*.[0-9]) continue ;; esac
+        # SECURITY: canonicalize then re-validate inside an allowlisted root.
+        canon="$(realpath -- "$f" 2>/dev/null)" || { skipped=$((skipped+1)); audit "skip realpath-failed: $f"; continue; }
+        [[ -f "$canon" && ! -L "$canon" ]] || { skipped=$((skipped+1)); audit "skip not-regular: $f"; continue; }
+        in_allowlist "$canon" || { skipped=$((skipped+1)); audit "skip outside-allowlist: $f -> $canon"; continue; }
+        [[ -n "${seen[$canon]:-}" ]] && continue
+        seen[$canon]=1
+        count=$((count+1))
+        if [[ $count -gt $MAX_FILES ]]; then audit "MAX_FILES=$MAX_FILES reached; remaining skipped"; break 2; fi
+        # Privileged incremental read of NEW bytes since the last cycle.
+        new="$(nftban_http_read_incremental "$canon" 2>/dev/null)" || new=""
+        [[ -z "$new" ]] && continue
+        spf="$SPOOL_DIR/$(printf '%s' "$canon" | tr '/' '_')"
+        if ! printf '%s\n' "$new" >> "$spf" 2>/dev/null; then audit "spool-write-failed: $spf"; continue; fi
+        chmod 0640 "$spf" 2>/dev/null || true
+        sz="$(stat -c %s "$spf" 2>/dev/null || echo 0)"
+        if [[ "$sz" -gt "$SPOOL_MAX_BYTES" ]]; then
+            if tail -c "$SPOOL_MAX_BYTES" "$spf" > "$spf.trim" 2>/dev/null; then
+                mv -f "$spf.trim" "$spf" 2>/dev/null || true
+                chmod 0640 "$spf" 2>/dev/null || true
+            fi
+        fi
+        collected=$((collected+1))
+    done < <(compgen -G "$g" 2>/dev/null || true)
+done
+
+audit "panel=${panel:-none} sources=$count collected=$collected skipped=$skipped spool=$SPOOL_DIR"
+exit 0

--- a/docs/systemd/UNITS.md
+++ b/docs/systemd/UNITS.md
@@ -14,7 +14,7 @@ package inventory projection: `install/packaging/systemd/nftban-systemd-install.
 > `OnBootSec=` directives where applicable. The unit file is authoritative; this
 > table is a curated projection.
 
-## Timers (22)
+## Timers (23)
 
 | Timer | Schedule | Purpose |
 |-------|----------|---------|
@@ -35,13 +35,14 @@ package inventory projection: `install/packaging/systemd/nftban-systemd-install.
 | `nftban-update-apply.timer` | Weekly Sun 4:00 | Auto-update apply (gated) |
 | `nftban-rollback.timer` | Manual-trigger (`OnActiveSec=5min`) | Emergency rollback — started by `nftban-apply`, stopped by `nftban-confirm` |
 | `nftban-botscan.timer` | 5min boot, then every 10min | Bot scanner cycle (Clock 3) |
+| `nftban-botscan-collector.timer` | 2min boot, then every 5min | BotScan read-authority collector (feeds spool ahead of scan) |
 | `nftban-community-stats.timer` | Daily | Anonymous community stats submission (opt-in) |
 | `nftban-rebuild-recovery.timer` | 60s boot, deferred retry | Post-boot rebuild recovery |
 | `nftban-report-daily.timer` | Daily 6:00 | Daily report generation |
 | `nftban-soak.timer` | Every 2h at HH:17 (staggered off cron storm) | Soak validation (read-only checks + bounded rebuild) |
 | `nftban-tunnel.timer` | Every 5min | DNS tunnel suspicion scan |
 
-## Services (29)
+## Services (30)
 
 | Service | Category | Purpose |
 |---------|----------|---------|
@@ -69,6 +70,7 @@ package inventory projection: `install/packaging/systemd/nftban-systemd-install.
 | `nftban-pro-license.service` | oneshot | Pro license check |
 | `nftban-alert@.service` | template | Alert notifications |
 | `nftban-botscan.service` | oneshot | Bot scanner processor (Clock 3) |
+| `nftban-botscan-collector.service` | oneshot | BotScan read-authority collector (cap-scoped read → nftban spool) |
 | `nftban-community-stats.service` | oneshot | Anonymous community stats submission |
 | `nftban-rebuild-recovery.service` | oneshot | Rebuild recovery (deferred retry) |
 | `nftban-report-daily.service` | oneshot | Daily report generation |

--- a/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
+++ b/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
@@ -35,6 +35,8 @@ mask_if_exists() {
 # Templates (*@.service) are skipped: the template itself is not a runnable unit;
 # only instances are stoppable.
 for unit in \
+    nftban-botscan-collector.service \
+    nftban-botscan-collector.timer \
     nftban-botscan.service \
     nftban-botscan.timer \
     nftban-community-stats.service \

--- a/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
+++ b/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
@@ -37,6 +37,8 @@ mask_if_exists() {
 # Templates (*@.service) are skipped: the template itself is not a runnable unit;
 # only instances (e.g., nftban-alert@INSTANCE.service) are stoppable.
 for unit in \
+    nftban-botscan-collector.service \
+    nftban-botscan-collector.timer \
     nftban-botscan.service \
     nftban-botscan.timer \
     nftban-community-stats.service \

--- a/install/packaging/systemd/nftban-systemd-install.list
+++ b/install/packaging/systemd/nftban-systemd-install.list
@@ -14,6 +14,8 @@
 # imply enable. See V106_LANE_MFST_C1_SCOPE.md §7 for safety analysis.
 # =============================================================================
 nftban-alert@.service
+nftban-botscan-collector.service
+nftban-botscan-collector.timer
 nftban-botscan.service
 nftban-botscan.timer
 nftban-community-stats.service

--- a/install/systemd/nftban-botscan-collector.service
+++ b/install/systemd/nftban-botscan-collector.service
@@ -1,0 +1,76 @@
+# =============================================================================
+# NFTBan - Bot Scanner Read-Authority Collector
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# Purpose: Separate privileged read-collector (B1) — reads allowlisted access logs
+#          and writes an nftban-readable spool for the unprivileged scanner.
+#
+# meta:name="nftban_botscan_collector_service"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Oneshot collector that reads allowlisted access logs (CAP_DAC_READ_SEARCH) and writes a nftban:nftban spool for nftban-botscan.service. SEPARATE unit so the scanner stays unprivileged."
+# meta:input="allowlisted access logs"
+# meta:output="/run/nftban/botscan spool for nftban-botscan.service"
+# meta:depends="nftban-botscan-collector"
+#
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-botscan-collector.timer"
+# meta:inventory.network=""
+# meta:inventory.privileges="CAP_DAC_READ_SEARCH"
+# =============================================================================
+
+[Unit]
+Description=NFTBan Bot Scanner Read-Authority Collector
+Documentation=man:nftban(8)
+After=network.target nftables.service
+# Run before the scanner so the spool is fresh
+Before=nftban-botscan.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/nftban/sbin/nftban-botscan-collector
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=nftban-botscan-collector
+
+# Unprivileged user + the SINGLE capability needed to read/traverse access logs
+# the nftban user otherwise cannot (covers DA drwx--x--- apache:root traversal AND
+# generic 0640 root:adm file-read). Read+search ONLY — never write, never anything
+# else. This capability is on THIS collector unit, NOT on nftban-botscan.service.
+User=nftban
+Group=nftban
+AmbientCapabilities=CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+
+# Resource limits
+MemoryMax=256M
+TasksMax=50
+
+# Security hardening (kept even with the read cap)
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+PrivateDevices=yes
+RestrictNamespaces=true
+LockPersonality=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+RestrictAddressFamilies=AF_UNIX
+# Writes ONLY to the spool + its own offset state — nothing else. Tightened to the
+# exact two dirs (not the whole /run/nftban); both are tmpfiles-pre-created at boot.
+ReadWritePaths=/run/nftban/botscan /var/lib/nftban/botscan-collector
+
+# Timeout after 5 minutes (bounded read should be quick)
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/install/systemd/nftban-botscan-collector.timer
+++ b/install/systemd/nftban-botscan-collector.timer
@@ -1,0 +1,40 @@
+# =============================================================================
+# NFTBan - Bot Scanner Read-Authority Collector Timer
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# Purpose: Trigger the read-collector every 5 minutes so the spool is fresh
+#          ahead of the 10-minute scanner cycle.
+#
+# meta:name="nftban_botscan_collector_timer"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-12"
+# meta:description="Timer that triggers the NFTBan botscan read-collector every 5 minutes (ahead of the 10-minute scanner)"
+# meta:input="None"
+# meta:output="Triggers nftban-botscan-collector.service"
+# meta:depends="nftban-botscan-collector.service"
+#
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-botscan-collector.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+[Unit]
+Description=NFTBan Bot Scanner Read-Authority Collector Timer
+Documentation=man:nftban(8)
+
+[Timer]
+# 5-minute interval — keep the spool fresher than the 10-minute scan
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+RandomizedDelaySec=1min
+FixedRandomDelay=true
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -64,6 +64,7 @@ d /var/lib/nftban/update-backups 0750 root nftban -
 d /var/lib/nftban/watchdog 0750 nftban nftban -
 d /var/lib/nftban/reports/archive 0750 nftban nftban -
 d /var/lib/nftban/pro 0750 root nftban -
+d /var/lib/nftban/botscan-collector 0750 nftban nftban -
 z /var/lib/nftban 0750 root nftban -
 z /var/lib/nftban/banned 0750 nftban nftban -
 z /var/lib/nftban/whitelist 0750 nftban nftban -
@@ -101,6 +102,7 @@ z /var/lib/nftban/update-backups 0750 root nftban -
 z /var/lib/nftban/watchdog 0750 nftban nftban -
 z /var/lib/nftban/reports/archive 0750 nftban nftban -
 z /var/lib/nftban/pro 0750 root nftban -
+z /var/lib/nftban/botscan-collector 0750 nftban nftban -
 
 # Log directories (/var/log/nftban)
 d /var/log/nftban 0750 nftban nftban -
@@ -122,8 +124,10 @@ z /var/log/nftban/soak 0750 nftban nftban -
 d /var/cache/nftban 0755 nftban nftban -
 d /var/cache/nftban/health 0750 nftban nftban -
 d /run/nftban 0755 nftban nftban -
+d /run/nftban/botscan 0750 nftban nftban -
 d /run/nftban/firewall-validate 2750 root nftban -
 z /var/cache/nftban 0755 nftban nftban -
 z /var/cache/nftban/health 0750 nftban nftban -
 z /run/nftban 0755 nftban nftban -
+z /run/nftban/botscan 0750 nftban nftban -
 z /run/nftban/firewall-validate 2750 root nftban -

--- a/internal/installer/payload/payload.go
+++ b/internal/installer/payload/payload.go
@@ -391,6 +391,7 @@ func buildEntries(distro *detect.DistroInfo) []entry {
 		{category: "cli-bin", srcRel: "cli/sbin/nftban-rollback", dstGlob: "/usr/lib/nftban/sbin/nftban-rollback", mode: 0755, policy: policyAlways},
 		{category: "cli-bin", srcRel: "cli/sbin/nftban-service-alert", dstGlob: "/usr/lib/nftban/sbin/nftban-service-alert", mode: 0755, policy: policyAlways},
 		{category: "cli-bin", srcRel: "cli/sbin/nftban-botscan-processor", dstGlob: "/usr/lib/nftban/sbin/nftban-botscan-processor", mode: 0755, policy: policyAlways},
+		{category: "cli-bin", srcRel: "cli/sbin/nftban-botscan-collector", dstGlob: "/usr/lib/nftban/sbin/nftban-botscan-collector", mode: 0755, policy: policyAlways},
 
 		// -----------------------------------------------------------------
 		// G-14-C: Shell payload under /usr/lib/nftban/

--- a/internal/installer/services/timers.go
+++ b/internal/installer/services/timers.go
@@ -40,6 +40,7 @@ var coreTimers = []string{
 // optionalTimers are started only if their unit file exists (panel-dependent).
 var optionalTimers = []string{
 	"nftban-botscan.timer",
+	"nftban-botscan-collector.timer",
 }
 
 // allKnownTimers is the canonical, exhaustive list of every nftban systemd
@@ -53,6 +54,7 @@ var optionalTimers = []string{
 // is removed), this slice MUST be updated — the drift-parity test
 // (timers_post_install_parity_test.go) fails otherwise.
 var allKnownTimers = []string{
+	"nftban-botscan-collector.timer",
 	"nftban-botscan.timer",
 	"nftban-community-stats.timer",
 	"nftban-core-feeds.timer",
@@ -121,8 +123,8 @@ func ReconcileTimers(exec executor.Executor, log *logging.Logger) {
 
 	for _, timer := range optionalTimers {
 		// Only start if unit file exists
-		if exec.FileExists("/etc/systemd/system/" + timer) ||
-			exec.FileExists("/usr/lib/systemd/system/" + timer) {
+		if exec.FileExists("/etc/systemd/system/"+timer) ||
+			exec.FileExists("/usr/lib/systemd/system/"+timer) {
 			enableAndStart(exec, timer, log)
 		} else {
 			log.Debug("optional timer %s not installed — skipping", timer)

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -496,6 +496,7 @@ func defaultInventoryPaths() map[string]bool {
 		"/usr/lib/nftban/sbin/nftban-rollback":          true,
 		"/usr/lib/nftban/sbin/nftban-service-alert":     true,
 		"/usr/lib/nftban/sbin/nftban-botscan-processor": true,
+		"/usr/lib/nftban/sbin/nftban-botscan-collector": true,
 		// PR26.5: shell payload destinations referenced by installed
 		// systemd units. Each lives at the corresponding source-side
 		// path under cli/lib/nftban/{core,cron,exporters} or scripts/

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -426,6 +426,7 @@ install -m 0755 cli/sbin/nftban-queue-processor %{buildroot}/usr/lib/nftban/sbin
 install -m 0755 cli/sbin/nftban-rollback %{buildroot}/usr/lib/nftban/sbin/
 install -m 0755 cli/sbin/nftban-service-alert %{buildroot}/usr/lib/nftban/sbin/
 install -m 0755 cli/sbin/nftban-botscan-processor %{buildroot}/usr/lib/nftban/sbin/
+install -m 0755 cli/sbin/nftban-botscan-collector %{buildroot}/usr/lib/nftban/sbin/
 
 # Version file
 install -D -m 0644 VERSION %{buildroot}/usr/lib/nftban/VERSION
@@ -1875,7 +1876,7 @@ build_deb() {
     # Bug fix v1.9.4: Ensure sbin scripts are always installed with correct permissions
     local sbin_count=0
     for script in nftban-apply nftban-confirm nftban-queue-processor \
-                  nftban-botscan-processor nftban-rollback nftban-service-alert; do
+                  nftban-botscan-processor nftban-botscan-collector nftban-rollback nftban-service-alert; do
         if [[ -f "${PROJECT_ROOT}/cli/sbin/${script}" ]]; then
             install -m 0755 "${PROJECT_ROOT}/cli/sbin/${script}" "${deb_root}/usr/lib/nftban/sbin/"
             ((sbin_count++))

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -49,6 +49,8 @@ case "$1" in
         # Templates (*@.service) are skipped: the template itself is not a runnable unit;
         # only instances are stoppable.
         for unit in \
+            nftban-botscan-collector.service \
+            nftban-botscan-collector.timer \
             nftban-botscan.service \
             nftban-botscan.timer \
             nftban-community-stats.service \


### PR DESCRIPTION
Closes the **BOTSCAN_READ_AUTHORITY** enforcement gap that v1.177 surfaced. Implements the scoped **B1** design (`BOTSCAN_READ_AUTHORITY_SCOPE.md`, `BOTSCAN_READ_AUTHORITY_POLKIT_DESIGN.md`); record `BOTSCAN_READ_AUTHORITY_IMPL_RECORD.md`.

## What changed
- **NEW `cli/sbin/nftban-botscan-collector`** — a separate **cap-scoped** collector: reads ONLY allowlisted access-log roots, `realpath`-canonicalizes + re-validates each path stays inside an allowlisted root (rejects symlink escape), regular-files only, bounded (MAX_FILES/MAX_BYTES + per-spool byte cap), incremental new-bytes per source, **audits every read**. Appends to an `nftban:nftban 0640` spool under `/run/nftban/botscan`.
- **NEW `install/systemd/nftban-botscan-collector.{service,timer}`** — runs `User=nftban` + `AmbientCapabilities=CAP_DAC_READ_SEARCH` (+ matching `CapabilityBoundingSet`), read+traverse ONLY, on its OWN hardened unit (`ProtectSystem=strict`, `RestrictAddressFamilies=AF_UNIX` (no network), `NoNewPrivileges=true`, `RestrictSUIDSGID=true`, `ReadWritePaths=/run/nftban/botscan /var/lib/nftban/botscan-collector` only). Timer every 5 min, `Before=nftban-botscan.service`.
- **Scanner unchanged + capless** — `nftban_botscan_discover_logs` is now **spool-first** (reads spool when populated, else falls back to direct discovery). `botscan logs --detect` / `status` report **"OK via collector spool"** when the source is DEGRADED/UNKNOWN but the spool is feeding.
- **Packaging/FHS/systemd first-class** — `build/fhs-spec.yaml` adds the spool + offset dirs → regenerated tmpfiles/`fhs_directories.json`/`nftban_fhs_spec.sh`; `build_nftban.sh` installs the collector (RPM + DEB); systemd install list regenerated. **Not shell-only.**

## Why B1 cap-scoped collector→spool
Fleet evidence (`V1_177_DIAGNOSTIC_FLEET_VALIDATION.md`): **8/9 hosts DEGRADED**, **two blocker shapes** — DA `/var/log/httpd/domains` `drwx--x--- apache:root` (parent traversal) and generic/Plesk `/var/log/{apache2,nginx}` `0640 root:adm` (file read). No single group/ACL covers both. A cap-scoped collector covers both uniformly and survives panel resets/new domains, while keeping the scanner unprivileged. (Cap-scoped `User=nftban`+`CAP_DAC_READ_SEARCH` is **tighter than root** — single read/traverse cap, bounded set.)

## Security model
- **Scanner** stays `User=nftban` + `NoNewPrivileges` + `RestrictSUIDSGID`, **no capability**.
- **Collector** holds ONLY `CAP_DAC_READ_SEARCH` (read+traverse), bounded set, no network, `ProtectSystem=strict`.
- **Source read path:** realpath canonicalize → revalidate inside hardcoded allowlist roots → symlink-escape reject → regular-file-only → max files/bytes caps → per-read audit.
- **Output path:** spool filename and offset key both flatten `/`→`_` (of a canonical allowlisted source) so neither can escape `SPOOL_DIR`/`OFFSET_DIR`; spool `nftban:nftban 0640`; unit `ReadWritePaths` limited to exactly the spool + offset dirs (no attacker-controlled output path).

## Lab proof (lab2, reversible)
- Shape A (0710 parent) **direct nftban read fails (rc=1)** → collector recovers it.
- Shape B (0640 file) **direct nftban read fails (rc=1)** → collector recovers it.
- **No-cap collector control → 0 spool files** (proves the capability is the grant).
- nftban-botscan.timer active; SSH intact; no new failed units.

## Tests
`cli/lib/nftban/tests/botscan_read_authority_v178_test.sh` **13/0** (CI-wired): collect→spool, allowlist enforce, symlink-escape reject, regular-file-only, incremental, spool cap, mode 0640, MAX_FILES, scanner spool-first + fallback, scanner-stays-hardened-capless, collector-only-read-cap, audit.

## Envelope
- Daemon `cmd/nftband` **BYTE-IDENTICAL `48b82663`** (no Go). Schema **1.83.0 frozen**. FHS `--check` rc=0. **No VERSION bump** (deferred to v1.178 release-prep).

## Claim boundaries
MAY claim BotScan read-authority **implementation** (lab-proven), pending CI + a packaged-install lab proof. MUST NOT claim: Go LoginMon web runtime fixed; FTP/cphulkd/exim-reject/http-auth fixed; global health input-axis fixed; **fleet rollout / fleet enforcement restored** (not rolled out).

**Next after green CI:** a packaged-install lab run (deb lab2 + rpm lab4 against real panel logs) BEFORE any tag/publish/rollout.