### PR TITLE
feat(loginmon): web-auth runtime — HTTP basic-auth 401 + WordPress wp-login failed-credential (v1.179.0)

### DIFF
--- a/internal/loginmon/detector/detector.go
+++ b/internal/loginmon/detector/detector.go
@@ -115,6 +115,10 @@ func NewRegistry() *Registry {
 	r.Register(NewMailDetector())
 	r.Register(NewFTPDetector())
 	r.Register(NewPanelDetector())
+	// WebAuth registered AFTER Panel so cPanel /login/ 401 stays PanelDetector-owned
+	// (first-match wins). WebAuth owns only generic HTTP basic-auth 401/403 + WordPress
+	// wp-login failed-credential (auth_failure); web_abuse stays with BotScan->BotGuard.
+	r.Register(NewWebAuthDetector())
 
 	return r
 }

--- a/internal/loginmon/detector/webauth.go
+++ b/internal/loginmon/detector/webauth.go
@@ -1,0 +1,159 @@
+// =============================================================================
+// NFTBan v1.179.0 - High-Performance Web Auth Detector (HTTP basic-auth + WordPress login)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: detector
+// Purpose: Signal-based AUTHENTICATION-failure detection from web access logs.
+//
+// meta:name="webauth_detector"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="detector"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Signal-based web authentication-failure detection (HTTP basic-auth 401 only, WordPress wp-login.php failed credential). OWNS the auth_failure event class on web access logs only — per LOG_SOURCE_OWNERSHIP_AND_MODULE_BOUNDARY_AUDIT.md. Explicitly does NOT own web_abuse events (403 forbidden/deny, xmlrpc floods, wp-login high-rate floods, scanner/probe paths, bad bots) — those belong to BotScan->BotGuard. cPanel /login/ 401 stays owned by PanelDetector (registered first; first-match wins)."
+//
+// Detection patterns (combined/common access-log format: IP is the first token):
+//   - WordPress failed credential: POST /wp-login.php with HTTP 200 (success = 302 redirect;
+//     a 200 re-renders the login form = failed). xmlrpc.php is EXCLUDED (web_abuse).
+//   - HTTP basic-auth failure: 401 Unauthorized ONLY (apache/nginx). 403 Forbidden is
+//     web_abuse (authz deny / scanner / WAF block) — NOT matched. xmlrpc.php EXCLUDED.
+//
+// meta:inventory.files="webauth.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package detector
+
+import (
+	"bytes"
+	"net/netip"
+)
+
+// Score deltas (REST_401_SCORING_DECISION = CONSERVATIVE_DEFAULT, operator 2026-06-13).
+// wp-login failed-credential is a high-confidence auth attack → higher score. Generic/REST
+// HTTP 401 is real auth_failure but noisier (logged-out browser/plugin REST 401s) → LOWER
+// score so a few incidental 401s do NOT ban quickly, while sustained probing still
+// accumulates. Ban threshold (scorer TempBan=45) is unchanged: wp-login 20×3=60 → ~3 hits;
+// http-401 8×6=48 → ~6 sustained hits. (Future: make these config-tunable via the module.)
+const (
+	scoreWPLoginFail = 20 // POST /wp-login.php failed-credential
+	scoreHTTP401     = 8  // generic/REST HTTP 401 (conservative)
+)
+
+// WebAuthDetector detects authentication failures in web access logs.
+// It owns ONLY the auth_failure event class; web_abuse (xmlrpc/floods/scanners/403)
+// is intentionally left to BotScan -> BotGuard.
+type WebAuthDetector struct {
+	sigWpLogin   []byte // "/wp-login.php" (matched in the REQUEST LINE only)
+	sigXmlrpc    []byte // "/xmlrpc.php" — EXCLUDED (web_abuse, BotScan-owned)
+	sigPost      []byte // "POST " (matched in the REQUEST LINE only)
+	sigLoginPath []byte // "/login/" — cPanel access_log path owned by PanelDetector
+}
+
+// NewWebAuthDetector creates a new web-auth detector.
+func NewWebAuthDetector() *WebAuthDetector {
+	return &WebAuthDetector{
+		sigWpLogin:   []byte("/wp-login.php"),
+		sigXmlrpc:    []byte("/xmlrpc.php"),
+		sigPost:      []byte("POST "),
+		sigLoginPath: []byte("/login/"),
+	}
+}
+
+// Name returns the detector identifier.
+func (d *WebAuthDetector) Name() string {
+	return "webauth"
+}
+
+// extractAccessLogIP returns the IP at the start of a combined/common access-log
+// line ("IP - user [date] \"...\" status ..."). Handles IPv4 and IPv6.
+func extractAccessLogIP(line []byte) (netip.Addr, bool) {
+	sp := bytes.IndexByte(line, ' ')
+	if sp <= 0 {
+		return netip.Addr{}, false
+	}
+	addr, err := netip.ParseAddr(string(line[:sp]))
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+// parseRequestAndStatus STRUCTURALLY extracts the request-line content (between the
+// first pair of double-quotes: `METHOD path HTTP/x`) and the HTTP status code (the
+// numeric token immediately after the request line's closing quote) from a combined
+// access-log line: `IP - user [date] "REQUEST" STATUS SIZE "ref" "ua"`.
+// This avoids substring pitfalls: the SIZE field can never be read as the status, and
+// method/path are checked in the REQUEST LINE only (not the referer/UA). Returns
+// (request, status, true) or (nil, 0, false) if the line isn't a parseable access log.
+func parseRequestAndStatus(line []byte) (request []byte, status int, ok bool) {
+	q1 := bytes.IndexByte(line, '"')
+	if q1 < 0 {
+		return nil, 0, false
+	}
+	rel := bytes.IndexByte(line[q1+1:], '"')
+	if rel < 0 {
+		return nil, 0, false
+	}
+	q2 := q1 + 1 + rel // index of the closing quote
+	req := line[q1+1 : q2]
+	// status = first numeric token after the closing quote
+	i := q2 + 1
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	start := i
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == start {
+		return req, 0, false
+	}
+	n := 0
+	for _, c := range line[start:i] {
+		n = n*10 + int(c-'0')
+	}
+	return req, n, true
+}
+
+// Detect matches AUTH-failure events only. web_abuse is excluded by design.
+func (d *WebAuthDetector) Detect(line []byte) (Verdict, bool) {
+	req, status, ok := parseRequestAndStatus(line)
+	if !ok {
+		return Verdict{}, false
+	}
+	// xmlrpc (in the REQUEST) is web_abuse (BotScan -> BotGuard), never auth_failure.
+	if bytes.Contains(req, d.sigXmlrpc) {
+		return Verdict{}, false
+	}
+
+	// WordPress failed credential: POST /wp-login.php (in the REQUEST line) with HTTP
+	// status 200 (success = 302 redirect; a 200 re-renders the login form = failed).
+	// Status is parsed structurally so the bytes-sent field can't be mistaken for it,
+	// and method/path are checked in the request line so a referer/UA mentioning
+	// /wp-login.php can't false-match. High-rate FLOODS are web_abuse (BotScan), not here.
+	if status == 200 && bytes.Contains(req, d.sigPost) && bytes.Contains(req, d.sigWpLogin) {
+		if addr, ok := extractAccessLogIP(line); ok {
+			return Verdict{IP: addr, Reason: ReasonWordPressWPLogin, ScoreDelta: scoreWPLoginFail, Service: "wordpress"}, true
+		}
+	}
+
+	// HTTP basic-auth failure: status 401 ONLY. 403 Forbidden is NOT matched — it is
+	// authorization/deny (scanner probes, WAF/IP blocks) = web_abuse (BotScan->BotGuard);
+	// matching it would make LoginMon a second BotScan. cPanel /login/ 401 stays
+	// PanelDetector-owned (registered first); the /login/ guard keeps this correct even
+	// if called out of order. Conservative score (REST 401 is noisy — see scoreHTTP401).
+	if status == 401 && !bytes.Contains(req, d.sigLoginPath) {
+		if addr, ok := extractAccessLogIP(line); ok {
+			return Verdict{IP: addr, Reason: ReasonGenericAuthFail, ScoreDelta: scoreHTTP401, Service: "http-auth"}, true
+		}
+	}
+
+	return Verdict{}, false
+}

--- a/internal/loginmon/detector/webauth_test.go
+++ b/internal/loginmon/detector/webauth_test.go
@@ -1,0 +1,146 @@
+// =============================================================================
+// NFTBan v1.179.0 - WebAuth Detector Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="webauth_detector_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Unit tests for WebAuthDetector — auth_failure ownership: HTTP basic-auth 401/403 + WordPress wp-login failed-credential matched; web_abuse (xmlrpc, wp-login flood/success, GET) not matched (BotScan->BotGuard owns it); IPv4+IPv6; ownership ordering vs PanelDetector."
+//
+// meta:inventory.files="webauth_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package detector
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestWebAuthDetector(t *testing.T) {
+	d := NewWebAuthDetector()
+	tests := []struct {
+		name       string
+		line       string
+		wantMatch  bool
+		wantReason uint16
+		wantIP     string
+		wantSvc    string
+	}{
+		// --- AUTH failures (owned) ---
+		{"apache basic-auth 401 IPv4", `203.0.113.7 - - [13/Jun/2026:10:00:00 +0000] "GET /admin HTTP/1.1" 401 12 "-" "curl"`, true, ReasonGenericAuthFail, "203.0.113.7", "http-auth"},
+		{"nginx basic-auth 401 IPv4", `198.51.100.5 - - [13/Jun/2026:10:00:00 +0000] "GET /private/ HTTP/1.1" 401 5 "-" "bot"`, true, ReasonGenericAuthFail, "198.51.100.5", "http-auth"},
+		{"basic-auth 401 IPv6", `2001:db8::1 - - [13/Jun/2026:10:00:00 +0000] "GET /admin HTTP/1.1" 401 12 "-" "x"`, true, ReasonGenericAuthFail, "2001:db8::1", "http-auth"},
+		{"wp-login failed credential (POST 200) IPv4", `192.0.2.10 - - [13/Jun/2026:10:00:00 +0000] "POST /wp-login.php HTTP/1.1" 200 1500 "-" "Mozilla"`, true, ReasonWordPressWPLogin, "192.0.2.10", "wordpress"},
+		{"wp-login failed credential (POST 200) IPv6", `2001:db8::2 - - [13/Jun/2026:10:00:00 +0000] "POST /wp-login.php HTTP/1.1" 200 1500 "-" "x"`, true, ReasonWordPressWPLogin, "2001:db8::2", "wordpress"},
+
+		// --- NOT owned: web_abuse / non-auth (must NOT match — wrong-module prevention) ---
+		{"xmlrpc is web_abuse not auth (even with 200)", `203.0.113.9 - - [13/Jun/2026:10:00:00 +0000] "POST /xmlrpc.php HTTP/1.1" 200 800 "-" "x"`, false, 0, "", ""},
+		{"xmlrpc with 403 still excluded", `203.0.113.9 - - [..] "POST /xmlrpc.php HTTP/1.1" 403 5 "-" "x"`, false, 0, "", ""},
+		{"wp-login SUCCESS (302) not a failure", `192.0.2.11 - - [..] "POST /wp-login.php HTTP/1.1" 302 0 "-" "x"`, false, 0, "", ""},
+		{"wp-login GET (page view) not a failure", `192.0.2.12 - - [..] "GET /wp-login.php HTTP/1.1" 200 1500 "-" "x"`, false, 0, "", ""},
+		{"cPanel /login/ 401 excluded (PanelDetector-owned)", `203.0.113.20 - - [..] "POST /login/?login_only=1 HTTP/1.1" 401 0 "-" "x"`, false, 0, "", ""},
+		{"403 forbidden is web_abuse not auth (scanner /.env)", `203.0.113.40 - - [..] "GET /.env HTTP/1.1" 403 5 "-" "scanner"`, false, 0, "", ""},
+		{"403 forbidden is web_abuse not auth (scanner /wp-admin)", `203.0.113.41 - - [..] "GET /wp-admin/ HTTP/1.1" 403 5 "-" "bot"`, false, 0, "", ""},
+		{"404 scanner probe not auth", `203.0.113.42 - - [..] "GET /phpmyadmin/ HTTP/1.1" 404 5 "-" "bot"`, false, 0, "", ""},
+		{"normal 200 GET not auth", `203.0.113.30 - - [..] "GET /index.html HTTP/1.1" 200 1500 "-" "x"`, false, 0, "", ""},
+		{"malformed (no IP) no match", `- - - [..] "GET /admin HTTP/1.1" 401 0`, false, 0, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := d.Detect([]byte(tt.line))
+			if ok != tt.wantMatch {
+				t.Fatalf("match=%v want %v (line=%q)", ok, tt.wantMatch, tt.line)
+			}
+			if !tt.wantMatch {
+				return
+			}
+			if v.Reason != tt.wantReason {
+				t.Errorf("reason=%d want %d", v.Reason, tt.wantReason)
+			}
+			if v.Service != tt.wantSvc {
+				t.Errorf("service=%q want %q", v.Service, tt.wantSvc)
+			}
+			want, _ := netip.ParseAddr(tt.wantIP)
+			if v.IP != want {
+				t.Errorf("ip=%v want %v", v.IP, want)
+			}
+			if v.ScoreDelta <= 0 {
+				t.Errorf("scoreDelta=%d want >0", v.ScoreDelta)
+			}
+		})
+	}
+}
+
+// TestWebAuthRegisteredAfterPanel locks the ownership ordering: the full registry
+// classifies a cPanel /login/ 401 as cpanel (PanelDetector), NOT http-auth (WebAuth),
+// and a generic 401 as http-auth (WebAuth).
+func TestWebAuthOwnershipOrdering(t *testing.T) {
+	r := NewRegistry()
+	cpanel := []byte(`203.0.113.20 - - [..] "POST /login/?login_only=1 HTTP/1.1" 401 0 "-" "x"`)
+	if v, ok := r.Detect(cpanel); !ok || v.Reason != ReasonCPanelLogin {
+		t.Errorf("cPanel /login/ 401 → reason=%d ok=%v, want ReasonCPanelLogin (PanelDetector owns it)", v.Reason, ok)
+	}
+	generic := []byte(`198.51.100.9 - - [..] "GET /secret HTTP/1.1" 401 0 "-" "x"`)
+	if v, ok := r.Detect(generic); !ok || v.Reason != ReasonGenericAuthFail {
+		t.Errorf("generic 401 → reason=%d ok=%v, want ReasonGenericAuthFail (WebAuth owns it)", v.Reason, ok)
+	}
+	xmlrpc := []byte(`203.0.113.9 - - [..] "POST /xmlrpc.php HTTP/1.1" 200 800 "-" "x"`)
+	if _, ok := r.Detect(xmlrpc); ok {
+		t.Errorf("xmlrpc must NOT produce a LoginMon verdict (web_abuse → BotScan)")
+	}
+}
+
+// TestWebAuthRealTraffic locks ownership behavior against REAL sanitized production
+// access-log lines sampled read-only from srv1-4/dns1-2 (client IPs masked to doc
+// ranges; request shape preserved). Proves the detector owns auth_failure only and
+// ignores the live web_abuse traffic (xmlrpc flood, 403/404 scanners, bad bots).
+func TestWebAuthRealTraffic(t *testing.T) {
+	d := NewWebAuthDetector()
+	type tc struct {
+		name       string
+		line       string
+		wantMatch  bool
+		wantReason uint16
+	}
+	tests := []tc{
+		// OWNED — auth_failure
+		{"REST 401 wc customers", `203.0.113.1 - - [13/Jun/2026:00:28:11 +0000] "GET /wp-json/wc/v3/customers?per_page=100&_fields=username,email HTTP/2" 401 334 "-" "Mozilla/5.0 Chrome/133.0.0.0"`, true, ReasonGenericAuthFail},
+		{"REST 401 users/me", `203.0.113.3 - - [13/Jun/2026:07:48:37 +0000] "GET /wp-json/wp/v2/users/me HTTP/2" 401 262 "-" "Chrome/133.0.0.0"`, true, ReasonGenericAuthFail},
+		{"wp-login POST 200 IPv4", `203.0.113.1 - - [13/Jun/2026:00:22:24 +0000] "POST /wp-login.php HTTP/2" 200 4453 "-" "Safari/605.1.15"`, true, ReasonWordPressWPLogin},
+		{"wp-login POST 200 IPv6", `2001:db8::3 - - [13/Jun/2026:00:30:32 +0000] "POST /wp-login.php HTTP/1.1" 200 4689 "-" "Firefox/102.0"`, true, ReasonWordPressWPLogin},
+		// IGNORED — web_abuse / non-auth (the live flood + scanners)
+		{"wp-login POST 302 success", `203.0.113.1 - - [13/Jun/2026:07:59:12 +0000] "POST /wp-login.php HTTP/1.1" 302 264 "http://x/wp-login.php" "Firefox/118.0"`, false, 0},
+		{"wp-login POST 503 rate-limited", `203.0.113.1 - - [13/Jun/2026:01:00:00 +0000] "POST /wp-login.php HTTP/1.1" 503 200 "-" "Mozilla/5.0"`, false, 0},
+		{"status 200 with size 401 not a 401 auth", `203.0.113.5 - - [13/Jun/2026:01:00:00 +0000] "GET /x HTTP/1.1" 200 401 "-" "Mozilla/5.0"`, false, 0},
+		{"xmlrpc POST 200 jetpack/forged", `203.0.113.4 - - [13/Jun/2026:02:03:53 +0000] "POST /xmlrpc.php HTTP/1.1" 200 938 "-" "Jetpack/12.0; WordPress/6.1; http://site23614003.com"`, false, 0},
+		{"xmlrpc GET 405", `203.0.113.1 - - [13/Jun/2026:00:33:46 +0000] "GET /xmlrpc.php HTTP/1.1" 405 641 "-" "Safari/604.1"`, false, 0},
+		{"xmlrpc GET 403", `203.0.113.1 - - [13/Jun/2026:06:53:30 +0000] "GET /xmlrpc.php HTTP/1.1" 403 343 "-" "Safari/604.1"`, false, 0},
+		{"403 webshell probe", `203.0.113.1 - - [13/Jun/2026:04:53:04 +0000] "GET /wp-content/plugins/fix/up.php HTTP/2" 403 0 "-" "Chrome/85.0.4183.102"`, false, 0},
+		{"403 GET wp-login python-requests", `203.0.113.1 - - [13/Jun/2026:04:53:04 +0000] "GET /wp-login.php HTTP/2" 403 0 "-" "python-requests/2.33.1"`, false, 0},
+		{"404 config-secret scanner", `203.0.113.2 - - [13/Jun/2026:00:42:03 +0000] "GET /application.yml HTTP/1.1" 404 40554 "-" "CCBot/2.0"`, false, 0},
+		{"bad-bot MJ12 GET 200", `203.0.113.1 - - [13/Jun/2026:00:23:52 +0000] "GET /robots.txt HTTP/1.1" 200 755 "-" "Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)"`, false, 0},
+		{"python-requests POST / 200", `203.0.113.1 - - [13/Jun/2026:00:00:00 +0000] "POST / HTTP/1.1" 200 33521 "-" "python-requests/2.34.2"`, false, 0},
+		{"wp-login only in referer, request is index.html (no false match)", `203.0.113.6 - - [13/Jun/2026:00:00:00 +0000] "POST /index.html HTTP/1.1" 200 1500 "http://x/wp-login.php" "Mozilla/5.0"`, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := d.Detect([]byte(tt.line))
+			if ok != tt.wantMatch {
+				t.Fatalf("match=%v want %v", ok, tt.wantMatch)
+			}
+			if tt.wantMatch && v.Reason != tt.wantReason {
+				t.Errorf("reason=%d want %d", v.Reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -1245,6 +1245,24 @@ func (m *Module) startFileWatchers(ctx context.Context) {
 			startWatcher(service, logPath)
 		}
 	}
+
+	// === v1.179: web access logs (auth_failure: HTTP basic-auth 401/403 + WordPress
+	// wp-login failed-credential). LoginMon owns ONLY auth_failure on these logs;
+	// web_abuse (xmlrpc/floods/scanners) stays with BotScan->BotGuard. The root daemon
+	// (CAP_DAC_OVERRIDE) reads these DIRECTLY — no collector/spool. Health is journal-
+	// visible (resolved_by=discovery state=...) so zero-input never looks healthy. ===
+	webLogs := m.discoverWebAccessLogs()
+	switch {
+	case len(webLogs) > 0:
+		log.Printf("[LOGINMON] webauth: state=OK resolved_by=discovery files=%d", len(webLogs))
+		for _, p := range webLogs {
+			startWatcher("webauth", p)
+		}
+	case m.webStackDetected():
+		log.Printf("[LOGINMON] webauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=web_stack_present_no_access_logs")
+	default:
+		log.Printf("[LOGINMON] webauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_web_stack")
+	}
 }
 
 // runFileWatcher SUPERVISES a tail -F watcher: it (re)spawns the child via

--- a/internal/loginmon/webdiscovery.go
+++ b/internal/loginmon/webdiscovery.go
@@ -1,0 +1,160 @@
+// =============================================================================
+// NFTBan v1.179.0 - LoginMon web access-log discovery (auth_failure source)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: loginmon
+// Purpose: Panel-aware discovery of WEB access logs for the LoginMon auth_failure
+//          event class (HTTP basic-auth 401/403 + WordPress wp-login failed-credential).
+//
+// meta:name="loginmon_webdiscovery"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="loginmon"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Discovers panel-appropriate + generic web access-log files for the LoginMon WebAuth detector. The LoginMon module runs inside the root nftband.service (CAP_DAC_OVERRIDE) so it reads these directly — NOT via the BotScan collector/spool. Owns ONLY auth_failure events on these logs; web_abuse (xmlrpc/floods/scanners) stays with BotScan->BotGuard. Canonicalizes paths (handles the cPanel domlogs symlink chain), excludes error/compressed/rotated files, and bounds the set to the most-recently-modified files (one tail -F per file). Mirrors the shell discovery in cli/lib/nftban/lib/nftban_http_logs.sh for the Go daemon path."
+//
+// meta:inventory.files="webdiscovery.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// webAuthMaxFiles bounds how many access-log files LoginMon will tail concurrently
+// (one tail -F per file). The most-recently-modified files are kept — active/attacked
+// domains have recent traffic, so they are preferred. (Future optimization: a single
+// poller over all files instead of one tail per file — tracked as a v1.18x item.)
+const webAuthMaxFiles = 64
+
+// webStackDetected reports whether any web server or panel that produces access logs
+// is present — used to distinguish WARN_NO_LOGS (stack present, no logs) from NO_LOGS.
+func (m *Module) webStackDetected() bool {
+	return m.detectedServices["apache"] || m.detectedServices["nginx"] ||
+		m.detectedServices["litespeed"] || m.detectedServices["directadmin"] ||
+		m.detectedServices["cpanel"] || m.detectedServices["plesk"]
+}
+
+// webAccessLogGlobs returns panel-appropriate + generic access-log globs.
+func (m *Module) webAccessLogGlobs() []string {
+	var g []string
+	if m.detectedServices["directadmin"] {
+		// DA nginx-reverse-proxy-to-Apache logs EVERY request to BOTH
+		// /var/log/httpd/domains AND /var/log/nginx/domains (a mirror). Watching both
+		// double-counts each failed login → the scorer would ban at half the real
+		// attempts (over-aggressive / false-ban risk on production). Prefer httpd
+		// (the Apache backend, the canonical per-domain access log); fall back to the
+		// nginx mirror only if httpd/domains has no logs (nginx-only host).
+		const daHTTPd = "/var/log/httpd/domains/*.log"
+		g = append(g, daHTTPd)
+		if mm, _ := filepath.Glob(daHTTPd); len(mm) == 0 {
+			g = append(g, "/var/log/nginx/domains/*.log")
+		}
+	}
+	if m.detectedServices["cpanel"] {
+		g = append(g, "/usr/local/apache/domlogs/*", "/usr/local/apache/domlogs/*/*", "/var/log/apache2/domlogs/*")
+	}
+	if m.detectedServices["plesk"] {
+		g = append(g, "/var/www/vhosts/system/*/logs/access_log", "/var/www/vhosts/system/*/logs/access_ssl_log")
+	}
+	// generic stacks (harmless if absent)
+	g = append(g,
+		"/var/log/httpd/access_log",
+		"/var/log/apache2/access.log",
+		"/var/log/nginx/access.log",
+		"/var/log/nginx/*access*",
+		"/usr/local/lsws/logs/*access*",
+	)
+	return g
+}
+
+// isExcludedWebLog drops error/compressed/rotated files (access logs only).
+func isExcludedWebLog(path string) bool {
+	base := filepath.Base(path)
+	if strings.Contains(base, "error_log") || strings.Contains(base, "error.log") ||
+		strings.Contains(base, "-error") || strings.Contains(base, "_error") {
+		return true
+	}
+	if strings.HasSuffix(base, ".gz") {
+		return true
+	}
+	// rotated: trailing ".<digits>"
+	if i := strings.LastIndexByte(base, '.'); i >= 0 {
+		suf := base[i+1:]
+		if suf != "" {
+			allDigit := true
+			for _, c := range suf {
+				if c < '0' || c > '9' {
+					allDigit = false
+					break
+				}
+			}
+			if allDigit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// discoverWebAccessLogs returns existing, regular, non-error/non-rotated web access-log
+// files (canonicalized), bounded to the most-recently-modified webAuthMaxFiles. The root
+// daemon reads them directly (no collector/spool).
+func (m *Module) discoverWebAccessLogs() []string {
+	return discoverFromGlobs(m.webAccessLogGlobs())
+}
+
+// discoverFromGlobs is the testable core: glob → canonicalize → regular-file +
+// non-excluded filter → dedup → most-recent-mtime bound. Separated so it can be
+// unit-tested with real temp files + injected globs.
+func discoverFromGlobs(globs []string) []string {
+	seen := make(map[string]bool)
+	type fent struct {
+		path  string
+		mtime int64
+	}
+	var ents []fent
+	for _, g := range globs {
+		matches, _ := filepath.Glob(g)
+		for _, p := range matches {
+			// Canonicalize (handles cPanel domlogs symlink chain) then dedup on the
+			// CANONICAL path only — two globs may resolve to the same real file.
+			cp, err := filepath.EvalSymlinks(p)
+			if err != nil {
+				continue
+			}
+			if seen[cp] {
+				continue
+			}
+			fi, err := os.Stat(cp)
+			if err != nil || !fi.Mode().IsRegular() {
+				continue
+			}
+			if isExcludedWebLog(cp) {
+				continue
+			}
+			seen[cp] = true
+			ents = append(ents, fent{path: cp, mtime: fi.ModTime().UnixNano()})
+		}
+	}
+	sort.Slice(ents, func(i, j int) bool { return ents[i].mtime > ents[j].mtime })
+	if len(ents) > webAuthMaxFiles {
+		ents = ents[:webAuthMaxFiles]
+	}
+	out := make([]string, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, e.path)
+	}
+	return out
+}

--- a/internal/loginmon/webdiscovery_test.go
+++ b/internal/loginmon/webdiscovery_test.go
@@ -1,0 +1,139 @@
+// =============================================================================
+// NFTBan v1.179.0 - LoginMon Web Discovery Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="loginmon_webdiscovery_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Unit tests for LoginMon web access-log discovery — exclusion (error/compressed/rotated), panel->glob mapping, web-stack detection, and discoverFromGlobs over real temp files (regression lock for the canonical-path dedup bug)."
+//
+// meta:inventory.files="webdiscovery_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsExcludedWebLog(t *testing.T) {
+	excluded := []string{
+		"/var/log/httpd/domains/example.com.error_log",
+		"/var/log/httpd/domains/cakeart.gr.error.log",
+		"/var/log/nginx/error.log",
+		"/var/log/httpd/domains/example.com-error.log",
+		"/var/log/apache2/access.log.gz",
+		"/var/log/nginx/access.log.1",
+		"/var/log/httpd/domains/example.com.log.14",
+	}
+	for _, p := range excluded {
+		if !isExcludedWebLog(p) {
+			t.Errorf("expected EXCLUDED: %s", p)
+		}
+	}
+	kept := []string{
+		"/var/log/httpd/domains/example.com.log",
+		"/var/log/nginx/access.log",
+		"/var/log/apache2/access.log",
+		"/usr/local/apache/domlogs/example.com",
+		"/var/www/vhosts/system/example.com/logs/access_log",
+	}
+	for _, p := range kept {
+		if isExcludedWebLog(p) {
+			t.Errorf("expected KEPT: %s", p)
+		}
+	}
+}
+
+func TestWebAccessLogGlobs_PanelMapping(t *testing.T) {
+	mk := func(svcs ...string) *Module {
+		m := &Module{detectedServices: map[string]bool{}}
+		for _, s := range svcs {
+			m.detectedServices[s] = true
+		}
+		return m
+	}
+	has := func(g []string, sub string) bool {
+		for _, x := range g {
+			if strings.Contains(x, sub) {
+				return true
+			}
+		}
+		return false
+	}
+	// DirectAdmin → domains globs
+	da := mk("directadmin").webAccessLogGlobs()
+	if !has(da, "/var/log/httpd/domains/*.log") {
+		t.Errorf("DA missing httpd domains glob: %v", da)
+	}
+	// cPanel → domlogs
+	cp := mk("cpanel").webAccessLogGlobs()
+	if !has(cp, "/usr/local/apache/domlogs/*") {
+		t.Errorf("cPanel missing domlogs glob: %v", cp)
+	}
+	// Plesk → vhost access_log
+	pl := mk("plesk").webAccessLogGlobs()
+	if !has(pl, "/var/www/vhosts/system/*/logs/access_log") {
+		t.Errorf("Plesk missing vhost glob: %v", pl)
+	}
+	// generic always present
+	gen := mk().webAccessLogGlobs()
+	if !has(gen, "/var/log/nginx/access.log") || !has(gen, "/var/log/apache2/access.log") {
+		t.Errorf("generic globs missing: %v", gen)
+	}
+	// DA should NOT pull cPanel domlogs (panel isolation)
+	if has(da, "/usr/local/apache/domlogs/*") {
+		t.Errorf("DA must not include cPanel domlogs glob: %v", da)
+	}
+}
+
+func TestWebStackDetected(t *testing.T) {
+	none := &Module{detectedServices: map[string]bool{}}
+	if none.webStackDetected() {
+		t.Errorf("no stack should be false")
+	}
+	for _, svc := range []string{"apache", "nginx", "litespeed", "directadmin", "cpanel", "plesk"} {
+		m := &Module{detectedServices: map[string]bool{svc: true}}
+		if !m.webStackDetected() {
+			t.Errorf("%s should count as web stack", svc)
+		}
+	}
+}
+
+func TestDiscoverFromGlobs(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name, body string) string {
+		p := dir + "/" + name
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	mk("access.log", "GET /\n")        // keep
+	mk("example.com.log", "GET /\n")   // keep
+	mk("error.log", "err\n")           // exclude
+	mk("example.com-error.log", "e\n") // exclude
+	mk("access.log.1", "rot\n")        // exclude (rotated)
+	mk("access.log.2.gz", "gz\n")      // exclude (compressed)
+	got := discoverFromGlobs([]string{dir + "/*.log", dir + "/*.gz"})
+	want := map[string]bool{dir + "/access.log": true, dir + "/example.com.log": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d files %v, want %d %v", len(got), got, len(want), want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected/excluded file returned: %s", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds LoginMon **web-auth runtime** for **access-log-visible `auth_failure` events**: HTTP basic-auth **401** + WordPress `/wp-login.php` **failed-credential**. Closes LOGINMON-WEB-RUNTIME + LOGINMON-HTTP-AUTH-NO-WATCHER. Implemented under the mandatory Log Source Ownership Declaration (`LOG_SOURCE_OWNERSHIP_ACCEPTED`).

## Log Source Ownership Declaration (completed before code)
- **Source:** panel-aware web access logs (DA `/var/log/httpd/domains/*`, cPanel domlogs, Plesk vhost `access_log`, generic apache/nginx, LiteSpeed).
- **Runtime consumer:** root `nftband.service` (`CAP_DAC_OVERRIDE`) — reads DIRECTLY. **Not** a DAC read-authority lane; **no BotScan collector/spool reused.**
- **Event class owned:** `auth_failure` only.

## Event ownership
- **LoginMon owns `auth_failure`:** HTTP basic-auth **401**; WordPress `/wp-login.php` failed-credential (POST + 200 re-render; 302 success & GET ignored).
- **BotScan→BotGuard own `web_abuse`** (unchanged): xmlrpc.php, wp-login high-rate floods, scanner/probe paths, bad bots.
- **403 is NOT LoginMon-owned** — Forbidden is authorization/deny (scanner `/.env`/`/wp-admin`, WAF/IP block) = web_abuse. (Senior ownership-review narrowed the detector from `401|403` → **401-only**; commit history.)
- **xmlrpc remains BotScan/BotGuard.** cPanel `/login/` 401 stays PanelDetector-owned (registered first; WebAuth also guards `/login/`).
- **Duplicate-ban prevention (parser-ownership first):** the two modules extract *different* event classes from the same line → no duplicate semantic ownership before ban; LoginMon scorer dedups by IP+reason; ban-set idempotency is the secondary net, not the primary.

## Runtime identity
- root `nftband.service` + `CAP_DAC_OVERRIDE`; reads web logs directly; **no collector/spool**; watcher = supervised `tail -F` (reuses v1.176 respawn) per discovered log.

## Health
- Journal line `[LOGINMON] webauth: state=… resolved_by=discovery files=N`: **OK / WARN_NO_LOGS / NO_LOGS** for this lane. **Enabled + no input ⇒ never OK.**
- A *global* `module_health` input-axis is **out of scope** (separate lane). DEGRADED/UNKNOWN intentionally not emitted here: root reader has no DAC-unreadable case and discovery is deterministic (documented in the impl record).

## Tests
- Detector **15/0**: 401 match (apache/nginx, IPv4+IPv6) + wp-login POST 200; **non-match** xmlrpc (any status), **403 scanner `/.env` + `/wp-admin`**, 404 probe, wp-login 302 success, GET wp-login, cPanel `/login/` 401, malformed.
- **Wrong-module prevention** + **ownership ordering** (cPanel→PanelDetector, generic 401→WebAuth, xmlrpc→no verdict).
- Discovery: exclusion (error/gz/rotated), panel→glob mapping + isolation, web-stack detection, `discoverFromGlobs` over real temp files (regression lock for a canonical-path dedup bug caught in lab).
- Full `go test ./...` green (80 ok); **`-race` clean**.

## Envelope
- **Daemon `cmd/nftband` source hash MOVES** (expected, loginmon-only): from `48b82663` → `b93aaa84` (local `-trimpath -buildvcs=false`; 0 non-loginmon files changed). Packaged binary hash is VCS-stamped as always. **Schema 1.83.0 frozen. No packaging/FHS/cmd change.**

## Claim boundary
v1.179.0 adds LoginMon web-auth runtime for **access-log-visible `auth_failure` events: HTTP basic-auth 401 and WordPress wp-login failed-credential**.

## Explicitly NOT done
All web abuse / all WordPress abuse / all HTTP-auth everywhere / 403 auth / xmlrpc / error-log-only HTTP-auth / cphulkd / FTP / exim-rejectlog / Roundcube / Suricata EVE rotation / global module_health input-axis / fleet rollout.