### PR TITLE
v1.180 LoginMon FTP auth-input

### DIFF
--- a/internal/loginmon/detector/ftp.go
+++ b/internal/loginmon/detector/ftp.go
@@ -45,7 +45,7 @@ type FTPDetector struct {
 	sigFailLogin []byte
 
 	// ProFTPD signals
-	sigProFTPD   []byte
+	sigProFTPD    []byte
 	sigNoSuchUser []byte
 
 	// Common markers
@@ -89,8 +89,12 @@ func (d *FTPDetector) Detect(line []byte) (Verdict, bool) {
 		}
 	}
 
-	// Stage 2: vsftpd detection
-	if bytes.Contains(lineLower, d.sigVsftpd) {
+	// Stage 2: vsftpd detection.
+	// vsftpd's own log file (/var/log/vsftpd.log) does NOT contain the daemon
+	// name "vsftpd" on each line — only the distinctive `FAIL LOGIN: Client "<ip>"`.
+	// The "vsftpd" substring only appears when vsftpd logs via syslog. Gate on the
+	// daemon name OR the distinctive failure phrase so the file source is covered.
+	if bytes.Contains(lineLower, d.sigVsftpd) || bytes.Contains(line, d.sigFailLogin) {
 		if v, ok := d.detectVsftpd(line); ok {
 			return v, true
 		}
@@ -112,8 +116,16 @@ func (d *FTPDetector) detectPureFTPd(line []byte) (Verdict, bool) {
 		return Verdict{}, false
 	}
 
-	// Find IP in brackets
-	addr, ok := d.extractBracketIP(line)
+	// pure-ftpd's real syslog format carries the client IP in the connection
+	// prefix "(<logname>@<ip>)" (logname is "?" on a failed login), e.g.
+	//   pure-ftpd: (?@203.0.113.7) [WARNING] Authentication failed for user [bob]
+	// The bracketed fields are [WARNING] and the *username*, NOT the IP, so try
+	// the paren-at form first and fall back to a bracketed IP (some configs append
+	// a trailing "[<ip>]"). Validated against live srv3 traffic.
+	addr, ok := d.extractParenAtIP(line)
+	if !ok {
+		addr, ok = d.extractBracketIP(line)
+	}
 	if !ok {
 		return Verdict{}, false
 	}
@@ -124,6 +136,25 @@ func (d *FTPDetector) detectPureFTPd(line []byte) (Verdict, bool) {
 		ScoreDelta: 15,
 		Service:    "pure-ftpd",
 	}, true
+}
+
+// extractParenAtIP extracts the IP from pure-ftpd's "(<logname>@<ip>)" connection
+// prefix: the bytes between the first '@' and the following ')'. Handles IPv4 and
+// IPv6. Returns false if no parseable address is present.
+func (d *FTPDetector) extractParenAtIP(line []byte) (netip.Addr, bool) {
+	at := bytes.IndexByte(line, '@')
+	if at == -1 || at+1 >= len(line) {
+		return netip.Addr{}, false
+	}
+	rest := line[at+1:]
+	end := bytes.IndexByte(rest, ')')
+	if end <= 0 {
+		return netip.Addr{}, false
+	}
+	if addr, err := netip.ParseAddr(string(rest[:end])); err == nil {
+		return addr, true
+	}
+	return netip.Addr{}, false
 }
 
 // detectVsftpd handles "vsftpd: ... FAIL LOGIN: Client \"<ip>\""

--- a/internal/loginmon/detector/ftp_test.go
+++ b/internal/loginmon/detector/ftp_test.go
@@ -36,15 +36,22 @@ func TestFTPDetector(t *testing.T) {
 		wantSvc   string
 	}{
 		// --- pure-ftpd auth failures (owned) ---
+		// REAL pure-ftpd syslog format: IP is in "(?@<ip>)", the only [..] brackets
+		// hold [WARNING] and the *username* — NOT the IP. Captured live from srv3.
 		{
-			"pure-ftpd auth fail IPv4",
-			`Jun 13 10:00:00 host pure-ftpd: (?@203.0.113.7) [WARNING] Authentication failed for user [bob] [203.0.113.7]`,
+			"pure-ftpd auth fail IPv4 (real format)",
+			`Jun 13 13:01:29 srv3 pure-ftpd: (?@203.0.113.7) [WARNING] Authentication failed for user [cefaloniaholidays]`,
 			true, "203.0.113.7", "pure-ftpd",
 		},
 		{
-			"pure-ftpd auth fail IPv6",
-			`Jun 13 10:00:00 host pure-ftpd: (?@2001:db8::7) [WARNING] Authentication failed for user [bob] [2001:db8::7]`,
+			"pure-ftpd auth fail IPv6 (real format)",
+			`Jun 13 13:01:29 srv3 pure-ftpd: (?@2001:db8::7) [WARNING] Authentication failed for user [someuser]`,
 			true, "2001:db8::7", "pure-ftpd",
+		},
+		{
+			"pure-ftpd auth fail IPv4 with trailing bracket-IP (alt config)",
+			`Jun 13 10:00:00 host pure-ftpd: (?@203.0.113.8) [WARNING] Authentication failed for user [bob] [203.0.113.8]`,
+			true, "203.0.113.8", "pure-ftpd",
 		},
 		// --- vsftpd auth failures (owned) ---
 		{
@@ -57,11 +64,21 @@ func TestFTPDetector(t *testing.T) {
 			`Mon Jun 13 10:00:00 2026 [pid 1234] [bob] FAIL LOGIN: Client "2001:db8::5"`,
 			true, "2001:db8::5", "vsftpd",
 		},
-		// --- proftpd auth failures (owned) ---
+		// --- proftpd auth failures (owned) — every path covered for BOTH IPv4 and IPv6 ---
 		{
 			"proftpd no such user IPv4",
 			`Jun 13 10:00:00 host proftpd[4321]: host (192.0.2.10[192.0.2.10]) - USER baduser: no such user found from 192.0.2.10 [192.0.2.10] to ::ffff:10.0.0.1:21`,
 			true, "192.0.2.10", "proftpd",
+		},
+		{
+			"proftpd no such user IPv6",
+			`Jun 13 10:00:00 host proftpd[4321]: host (?) - USER baduser: no such user found from 2001:db8::b [2001:db8::b]`,
+			true, "2001:db8::b", "proftpd",
+		},
+		{
+			"proftpd login failed bracket-IP IPv4",
+			`Jun 13 10:00:00 host proftpd[4321]: proftpd login failed for user bob [203.0.113.50]`,
+			true, "203.0.113.50", "proftpd",
 		},
 		{
 			"proftpd login failed bracket-IP IPv6",
@@ -72,6 +89,11 @@ func TestFTPDetector(t *testing.T) {
 			"proftpd authentication failed IPv4",
 			`Jun 13 10:00:00 host proftpd[4321]: SECURITY VIOLATION: authentication failed from 203.0.113.99`,
 			true, "203.0.113.99", "proftpd",
+		},
+		{
+			"proftpd authentication failed IPv6",
+			`Jun 13 10:00:00 host proftpd[4321]: SECURITY VIOLATION: authentication failed from 2001:db8::c`,
+			true, "2001:db8::c", "proftpd",
 		},
 
 		// --- NOT owned: non-auth FTP + unrelated lines (wrong-module prevention) ---

--- a/internal/loginmon/detector/ftp_test.go
+++ b/internal/loginmon/detector/ftp_test.go
@@ -1,0 +1,143 @@
+// =============================================================================
+// NFTBan v1.180.0 - FTP Detector Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="ftp_detector_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Unit tests for FTPDetector — auth_failure ownership: pure-ftpd / vsftpd / proftpd authentication-failure lines matched (ReasonFTPAuthFail, IPv4+IPv6); non-auth FTP lines (successful login, transfers) and unrelated web access-log lines not matched (wrong-module prevention). Uses the real FTPDetector + full registry."
+//
+// meta:inventory.files="ftp_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package detector
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestFTPDetector(t *testing.T) {
+	d := NewFTPDetector()
+	tests := []struct {
+		name      string
+		line      string
+		wantMatch bool
+		wantIP    string
+		wantSvc   string
+	}{
+		// --- pure-ftpd auth failures (owned) ---
+		{
+			"pure-ftpd auth fail IPv4",
+			`Jun 13 10:00:00 host pure-ftpd: (?@203.0.113.7) [WARNING] Authentication failed for user [bob] [203.0.113.7]`,
+			true, "203.0.113.7", "pure-ftpd",
+		},
+		{
+			"pure-ftpd auth fail IPv6",
+			`Jun 13 10:00:00 host pure-ftpd: (?@2001:db8::7) [WARNING] Authentication failed for user [bob] [2001:db8::7]`,
+			true, "2001:db8::7", "pure-ftpd",
+		},
+		// --- vsftpd auth failures (owned) ---
+		{
+			"vsftpd FAIL LOGIN IPv4",
+			`Mon Jun 13 10:00:00 2026 [pid 1234] [bob] FAIL LOGIN: Client "198.51.100.5"`,
+			true, "198.51.100.5", "vsftpd",
+		},
+		{
+			"vsftpd FAIL LOGIN IPv6",
+			`Mon Jun 13 10:00:00 2026 [pid 1234] [bob] FAIL LOGIN: Client "2001:db8::5"`,
+			true, "2001:db8::5", "vsftpd",
+		},
+		// --- proftpd auth failures (owned) ---
+		{
+			"proftpd no such user IPv4",
+			`Jun 13 10:00:00 host proftpd[4321]: host (192.0.2.10[192.0.2.10]) - USER baduser: no such user found from 192.0.2.10 [192.0.2.10] to ::ffff:10.0.0.1:21`,
+			true, "192.0.2.10", "proftpd",
+		},
+		{
+			"proftpd login failed bracket-IP IPv6",
+			`Jun 13 10:00:00 host proftpd[4321]: proftpd login failed for user bob [2001:db8::a]`,
+			true, "2001:db8::a", "proftpd",
+		},
+		{
+			"proftpd authentication failed IPv4",
+			`Jun 13 10:00:00 host proftpd[4321]: SECURITY VIOLATION: authentication failed from 203.0.113.99`,
+			true, "203.0.113.99", "proftpd",
+		},
+
+		// --- NOT owned: non-auth FTP + unrelated lines (wrong-module prevention) ---
+		{
+			"pure-ftpd successful login not a failure",
+			`Jun 13 10:00:00 host pure-ftpd: (bob@203.0.113.7) [INFO] Logged in [203.0.113.7]`,
+			false, "", "",
+		},
+		{
+			"vsftpd OK LOGIN not a failure",
+			`Mon Jun 13 10:00:00 2026 [pid 1234] [bob] OK LOGIN: Client "198.51.100.5"`,
+			false, "", "",
+		},
+		{
+			"proftpd transfer line not an auth failure",
+			`Jun 13 10:00:00 host proftpd[4321]: host (192.0.2.10[192.0.2.10]) - FTP session opened.`,
+			false, "", "",
+		},
+		{
+			"web access-log 401 must NOT match FTP detector",
+			`203.0.113.7 - - [13/Jun/2026:10:00:00 +0000] "GET /admin HTTP/1.1" 401 12 "-" "curl"`,
+			false, "", "",
+		},
+		{
+			"ssh auth-fail line must NOT match FTP detector",
+			`Jun 13 10:00:00 host sshd[111]: Failed password for root from 203.0.113.7 port 2222 ssh2`,
+			false, "", "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := d.Detect([]byte(tt.line))
+			if ok != tt.wantMatch {
+				t.Fatalf("match=%v want %v (line=%q)", ok, tt.wantMatch, tt.line)
+			}
+			if !tt.wantMatch {
+				return
+			}
+			if v.Reason != ReasonFTPAuthFail {
+				t.Errorf("reason=%d want ReasonFTPAuthFail(%d)", v.Reason, ReasonFTPAuthFail)
+			}
+			if v.Service != tt.wantSvc {
+				t.Errorf("service=%q want %q", v.Service, tt.wantSvc)
+			}
+			want, _ := netip.ParseAddr(tt.wantIP)
+			if v.IP != want {
+				t.Errorf("ip=%v want %v", v.IP, want)
+			}
+			if v.ScoreDelta <= 0 {
+				t.Errorf("scoreDelta=%d want >0", v.ScoreDelta)
+			}
+		})
+	}
+}
+
+// TestFTPDetectorViaRegistry confirms the FTPDetector is wired into the default
+// registry and that the registry classifies an FTP auth failure as ReasonFTPAuthFail
+// while NOT misclassifying a normal web access-log line as an FTP event.
+func TestFTPDetectorViaRegistry(t *testing.T) {
+	r := NewRegistry()
+	ftp := []byte(`Jun 13 10:00:00 host pure-ftpd: (?@203.0.113.7) [WARNING] Authentication failed for user [bob] [203.0.113.7]`)
+	if v, ok := r.Detect(ftp); !ok || v.Reason != ReasonFTPAuthFail {
+		t.Errorf("pure-ftpd auth fail → reason=%d ok=%v, want ReasonFTPAuthFail", v.Reason, ok)
+	}
+	web := []byte(`203.0.113.30 - - [13/Jun/2026:10:00:00 +0000] "GET /index.html HTTP/1.1" 200 1500 "-" "x"`)
+	if v, ok := r.Detect(web); ok && v.Reason == ReasonFTPAuthFail {
+		t.Errorf("normal web access-log line must NOT be classified as FTP auth fail")
+	}
+}

--- a/internal/loginmon/ftpdiscovery.go
+++ b/internal/loginmon/ftpdiscovery.go
@@ -12,7 +12,7 @@
 // meta:package="loginmon"
 // meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 // meta:created_date="2026-06-13"
-// meta:description="Discovers FTP daemon log files (pure-ftpd /var/log/pureftpd.log + /var/log/pure-ftpd/*.log, vsftpd /var/log/vsftpd.log, proftpd /var/log/proftpd/*.log + auth.log) for the LoginMon FTPDetector. The LoginMon module runs inside the root nftband.service (CAP_DAC_OVERRIDE) so it reads these directly — NOT via a collector/spool. Owns ONLY the auth_failure event class on these logs (ReasonFTPAuthFail); no other module bans FTP auth failures. Existence + regular-file filter, excludes rotated/.gz, dedups on the canonical path, and bounds the set to the most-recently-modified files (one tail -F per file, reusing the shared discoverFromGlobs core). Mirrors the v1.179 web discovery pattern (webdiscovery.go) for the FTP source-feed."
+// meta:description="Discovers FILE-logging FTP daemon logs (vsftpd /var/log/vsftpd.log, proftpd /var/log/proftpd/*.log + auth.log) for the LoginMon FTPDetector. pure-ftpd is intentionally NOT globbed here: it logs auth failures to syslog facility ftp (11) by default (its dedicated AltLog is stats-only), so it is consumed by runJournalWatcher (SYSLOG_FACILITY=11) — excluding it from files avoids tailing a no-auth file and double-counting clf-configured hosts. Verified against live fleet traffic (srv1-4 run pure-ftpd; pureftpd.log empty/stats while '(?@<ip>) Authentication failed' appears at journal facility 11). The LoginMon module runs inside the root nftband.service (CAP_DAC_OVERRIDE) so it reads these directly — NOT via a collector/spool. Owns ONLY the auth_failure event class (ReasonFTPAuthFail); no other module bans FTP auth failures. Existence + regular-file filter, excludes rotated/.gz, dedups on the canonical path, bounds to the most-recently-modified files (one tail -F per file, reusing discoverFromGlobs). Mirrors the v1.179 web discovery pattern."
 //
 // meta:inventory.files="ftpdiscovery.go"
 // meta:inventory.binaries=""
@@ -34,20 +34,29 @@ func (m *Module) ftpStackDetected() bool {
 		m.detectedServices["proftpd"]
 }
 
-// ftpLogGlobs returns FTP-daemon log globs scoped to the detected FTP daemon(s).
-// pure-ftpd commonly logs to /var/log/pureftpd.log or a /var/log/pure-ftpd/ dir;
-// vsftpd to /var/log/vsftpd.log; proftpd to /var/log/proftpd/*.log (auth.log on
-// some distros). Globs for absent daemons are harmless — discoverFromGlobs just
-// finds no matches.
+// ftpJournalDaemonDetected reports whether a journal-routed FTP daemon is present.
+// pure-ftpd logs auth failures to syslog facility ftp (11) by default — NOT to a
+// dedicated auth file (its AltLog is stats-only) — so it is consumed via the journal
+// watcher (SYSLOG_FACILITY=11), not a file watcher. Verified against live fleet
+// traffic (srv1-4 all run pure-ftpd; /var/log/pureftpd.log is stats/empty while the
+// "(?@<ip>) Authentication failed" lines appear at journal facility 11).
+func (m *Module) ftpJournalDaemonDetected() bool {
+	return m.detectedServices["pure-ftpd"]
+}
+
+// ftpFileDaemonDetected reports whether a file-logging FTP daemon is present. vsftpd
+// (/var/log/vsftpd.log) and proftpd (/var/log/proftpd/*.log) default to their own log
+// files, so they are consumed via FTP file watchers — NOT the journal.
+func (m *Module) ftpFileDaemonDetected() bool {
+	return m.detectedServices["vsftpd"] || m.detectedServices["proftpd"]
+}
+
+// ftpLogGlobs returns FTP-daemon log globs for the FILE-logging daemons only
+// (vsftpd, proftpd). pure-ftpd is intentionally excluded: it is journal-routed
+// (facility 11) and its dedicated file carries stats, not auth failures — globbing
+// it would tail a no-auth file and risk double-counting clf-configured hosts.
 func (m *Module) ftpLogGlobs() []string {
 	var g []string
-	if m.detectedServices["pure-ftpd"] {
-		g = append(g,
-			"/var/log/pureftpd.log",
-			"/var/log/pure-ftpd.log",
-			"/var/log/pure-ftpd/*.log",
-		)
-	}
 	if m.detectedServices["vsftpd"] {
 		g = append(g,
 			"/var/log/vsftpd.log",

--- a/internal/loginmon/ftpdiscovery.go
+++ b/internal/loginmon/ftpdiscovery.go
@@ -1,0 +1,75 @@
+// =============================================================================
+// NFTBan v1.180.0 - LoginMon FTP log discovery (auth_failure source)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: loginmon
+// Purpose: Discovery of FTP daemon logs for the LoginMon auth_failure event class
+//          (pure-ftpd / vsftpd / proftpd authentication-failure lines).
+//
+// meta:name="loginmon_ftpdiscovery"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="loginmon"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Discovers FTP daemon log files (pure-ftpd /var/log/pureftpd.log + /var/log/pure-ftpd/*.log, vsftpd /var/log/vsftpd.log, proftpd /var/log/proftpd/*.log + auth.log) for the LoginMon FTPDetector. The LoginMon module runs inside the root nftband.service (CAP_DAC_OVERRIDE) so it reads these directly — NOT via a collector/spool. Owns ONLY the auth_failure event class on these logs (ReasonFTPAuthFail); no other module bans FTP auth failures. Existence + regular-file filter, excludes rotated/.gz, dedups on the canonical path, and bounds the set to the most-recently-modified files (one tail -F per file, reusing the shared discoverFromGlobs core). Mirrors the v1.179 web discovery pattern (webdiscovery.go) for the FTP source-feed."
+//
+// meta:inventory.files="ftpdiscovery.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+// ftpStackDetected reports whether an FTP daemon that produces auth logs is present
+// — used to distinguish WARN_NO_LOGS (daemon present, no logs) from NO_LOGS. The FTP
+// daemons are recorded in detectedServices by detectServices() under their package
+// names (pure-ftpd / vsftpd / proftpd).
+func (m *Module) ftpStackDetected() bool {
+	return m.detectedServices["pure-ftpd"] || m.detectedServices["vsftpd"] ||
+		m.detectedServices["proftpd"]
+}
+
+// ftpLogGlobs returns FTP-daemon log globs scoped to the detected FTP daemon(s).
+// pure-ftpd commonly logs to /var/log/pureftpd.log or a /var/log/pure-ftpd/ dir;
+// vsftpd to /var/log/vsftpd.log; proftpd to /var/log/proftpd/*.log (auth.log on
+// some distros). Globs for absent daemons are harmless — discoverFromGlobs just
+// finds no matches.
+func (m *Module) ftpLogGlobs() []string {
+	var g []string
+	if m.detectedServices["pure-ftpd"] {
+		g = append(g,
+			"/var/log/pureftpd.log",
+			"/var/log/pure-ftpd.log",
+			"/var/log/pure-ftpd/*.log",
+		)
+	}
+	if m.detectedServices["vsftpd"] {
+		g = append(g,
+			"/var/log/vsftpd.log",
+			"/var/log/vsftpd/*.log",
+		)
+	}
+	if m.detectedServices["proftpd"] {
+		g = append(g,
+			"/var/log/proftpd/*.log",
+			"/var/log/proftpd/auth.log",
+			"/var/log/proftpd.log",
+		)
+	}
+	return g
+}
+
+// discoverFTPLogs returns existing, regular, non-rotated/.gz FTP log files
+// (canonicalized), bounded to the most-recently-modified webAuthMaxFiles. The root
+// daemon reads them directly (no collector/spool). Reuses the shared discoverFromGlobs
+// core (glob → canonicalize → regular-file + non-excluded filter → dedup → mtime bound)
+// — isExcludedWebLog still applies (drops .gz + trailing ".<digits>" rotated files; the
+// "error_log" exclusion is irrelevant to FTP file names).
+func (m *Module) discoverFTPLogs() []string {
+	return discoverFromGlobs(m.ftpLogGlobs())
+}

--- a/internal/loginmon/ftpdiscovery_test.go
+++ b/internal/loginmon/ftpdiscovery_test.go
@@ -1,0 +1,116 @@
+// =============================================================================
+// NFTBan v1.180.0 - LoginMon FTP Discovery Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="loginmon_ftpdiscovery_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Unit tests for LoginMon FTP log discovery — FTP daemon detection (pure-ftpd/vsftpd/proftpd), daemon->glob mapping (scoped to detected daemon only), exclusion of rotated/compressed files, and discoverFromGlobs over real temp FTP log files. Also asserts no globs are produced when no FTP daemon is detected (zero-input path)."
+//
+// meta:inventory.files="ftpdiscovery_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFTPStackDetected(t *testing.T) {
+	none := &Module{detectedServices: map[string]bool{}}
+	if none.ftpStackDetected() {
+		t.Errorf("no FTP daemon should be false")
+	}
+	for _, svc := range []string{"pure-ftpd", "vsftpd", "proftpd"} {
+		m := &Module{detectedServices: map[string]bool{svc: true}}
+		if !m.ftpStackDetected() {
+			t.Errorf("%s should count as FTP daemon", svc)
+		}
+	}
+	// a non-FTP service must not flip ftpStackDetected
+	web := &Module{detectedServices: map[string]bool{"apache": true, "ssh": true}}
+	if web.ftpStackDetected() {
+		t.Errorf("non-FTP services must not be treated as an FTP daemon")
+	}
+}
+
+func TestFTPLogGlobs_DaemonMapping(t *testing.T) {
+	mk := func(svcs ...string) *Module {
+		m := &Module{detectedServices: map[string]bool{}}
+		for _, s := range svcs {
+			m.detectedServices[s] = true
+		}
+		return m
+	}
+	has := func(g []string, sub string) bool {
+		for _, x := range g {
+			if strings.Contains(x, sub) {
+				return true
+			}
+		}
+		return false
+	}
+
+	pure := mk("pure-ftpd").ftpLogGlobs()
+	if !has(pure, "/var/log/pureftpd.log") || !has(pure, "/var/log/pure-ftpd/") {
+		t.Errorf("pure-ftpd missing expected globs: %v", pure)
+	}
+	vs := mk("vsftpd").ftpLogGlobs()
+	if !has(vs, "/var/log/vsftpd.log") {
+		t.Errorf("vsftpd missing expected glob: %v", vs)
+	}
+	pro := mk("proftpd").ftpLogGlobs()
+	if !has(pro, "/var/log/proftpd/") {
+		t.Errorf("proftpd missing expected glob: %v", pro)
+	}
+
+	// daemon isolation: pure-ftpd-only host must not pull vsftpd/proftpd globs
+	if has(pure, "vsftpd") || has(pure, "proftpd") {
+		t.Errorf("pure-ftpd-only host must not include other daemon globs: %v", pure)
+	}
+
+	// no FTP daemon → no globs at all (zero-input path)
+	if g := mk().ftpLogGlobs(); len(g) != 0 {
+		t.Errorf("no FTP daemon should yield no globs, got: %v", g)
+	}
+}
+
+func TestDiscoverFTPLogs_TempFiles(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name, body string) string {
+		p := dir + "/" + name
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	// keep: live FTP log files
+	mk("pureftpd.log", "auth fail\n")
+	mk("vsftpd.log", "FAIL LOGIN\n")
+	// exclude: rotated + compressed
+	mk("pureftpd.log.1", "rotated\n")
+	mk("vsftpd.log.2.gz", "compressed\n")
+
+	// Reuse the shared discoverFromGlobs core with injected temp globs.
+	got := discoverFromGlobs([]string{dir + "/*.log", dir + "/*.gz"})
+	want := map[string]bool{dir + "/pureftpd.log": true, dir + "/vsftpd.log": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d files %v, want %d %v", len(got), got, len(want), want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected/excluded file returned: %s", p)
+		}
+	}
+}

--- a/internal/loginmon/ftpdiscovery_test.go
+++ b/internal/loginmon/ftpdiscovery_test.go
@@ -62,9 +62,12 @@ func TestFTPLogGlobs_DaemonMapping(t *testing.T) {
 		return false
 	}
 
+	// pure-ftpd is journal-routed (facility 11) — it must NOT be globbed as a file
+	// (its dedicated file is stats-only). Globbing it would tail a no-auth file and
+	// risk double-counting. Verified against live fleet traffic.
 	pure := mk("pure-ftpd").ftpLogGlobs()
-	if !has(pure, "/var/log/pureftpd.log") || !has(pure, "/var/log/pure-ftpd/") {
-		t.Errorf("pure-ftpd missing expected globs: %v", pure)
+	if len(pure) != 0 {
+		t.Errorf("pure-ftpd must NOT produce file globs (journal-routed), got: %v", pure)
 	}
 	vs := mk("vsftpd").ftpLogGlobs()
 	if !has(vs, "/var/log/vsftpd.log") {
@@ -75,14 +78,38 @@ func TestFTPLogGlobs_DaemonMapping(t *testing.T) {
 		t.Errorf("proftpd missing expected glob: %v", pro)
 	}
 
-	// daemon isolation: pure-ftpd-only host must not pull vsftpd/proftpd globs
-	if has(pure, "vsftpd") || has(pure, "proftpd") {
-		t.Errorf("pure-ftpd-only host must not include other daemon globs: %v", pure)
+	// daemon isolation: vsftpd-only host must not pull proftpd globs
+	if has(vs, "proftpd") {
+		t.Errorf("vsftpd-only host must not include other daemon globs: %v", vs)
 	}
 
 	// no FTP daemon → no globs at all (zero-input path)
 	if g := mk().ftpLogGlobs(); len(g) != 0 {
 		t.Errorf("no FTP daemon should yield no globs, got: %v", g)
+	}
+}
+
+// TestFTPDaemonRouting asserts the journal-vs-file routing split that matches how
+// each daemon actually logs (verified against live fleet traffic).
+func TestFTPDaemonRouting(t *testing.T) {
+	mk := func(svc string) *Module {
+		return &Module{detectedServices: map[string]bool{svc: true}}
+	}
+	// pure-ftpd → journal facility 11, never a file watcher
+	if pf := mk("pure-ftpd"); !pf.ftpJournalDaemonDetected() || pf.ftpFileDaemonDetected() {
+		t.Errorf("pure-ftpd must be journal-routed, not file-routed")
+	}
+	// vsftpd / proftpd → file watchers, not the journal-daemon path
+	for _, svc := range []string{"vsftpd", "proftpd"} {
+		m := mk(svc)
+		if m.ftpJournalDaemonDetected() || !m.ftpFileDaemonDetected() {
+			t.Errorf("%s must be file-routed, not journal-routed", svc)
+		}
+	}
+	// no FTP daemon → neither path
+	none := &Module{detectedServices: map[string]bool{}}
+	if none.ftpJournalDaemonDetected() || none.ftpFileDaemonDetected() {
+		t.Errorf("no FTP daemon → neither routing path")
 	}
 }
 

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -1263,6 +1263,28 @@ func (m *Module) startFileWatchers(ctx context.Context) {
 	default:
 		log.Printf("[LOGINMON] webauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_web_stack")
 	}
+
+	// === v1.180: FTP daemon logs (auth_failure: pure-ftpd / vsftpd / proftpd
+	// authentication failures → ReasonFTPAuthFail via the existing FTPDetector).
+	// LoginMon is the sole owner + ban authority for FTP auth_failure. The journal
+	// watcher (SYSLOG_FACILITY 4/10 = auth/authpriv) does NOT carry FTP daemon logs,
+	// so the FTPDetector was unfed until now. The root daemon (CAP_DAC_OVERRIDE) reads
+	// these DIRECTLY — no collector/spool. Only started when an FTP daemon is detected.
+	// Health is journal-visible (resolved_by=discovery state=...) so zero-input never
+	// looks healthy. ===
+	if m.ftpStackDetected() {
+		ftpLogs := m.discoverFTPLogs()
+		if len(ftpLogs) > 0 {
+			log.Printf("[LOGINMON] ftpauth: state=OK resolved_by=discovery files=%d", len(ftpLogs))
+			for _, p := range ftpLogs {
+				startWatcher("ftp", p)
+			}
+		} else {
+			log.Printf("[LOGINMON] ftpauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=ftp_daemon_present_no_logs")
+		}
+	} else {
+		log.Printf("[LOGINMON] ftpauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_ftp_daemon")
+	}
 }
 
 // runFileWatcher SUPERVISES a tail -F watcher: it (re)spawns the child via

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -938,6 +938,12 @@ func (m *Module) runJournalWatcher(ctx context.Context) {
 		"-o", "short-iso",
 		"SYSLOG_FACILITY=4",  // Auth facility
 		"SYSLOG_FACILITY=10", // Authpriv facility
+		"SYSLOG_FACILITY=11", // FTP facility (v1.180): pure-ftpd logs auth failures
+		//                       to syslog facility ftp by default (SyslogFacility ftp,
+		//                       its dedicated AltLog is stats-only). Verified against
+		//                       live srv3 traffic: the FTPDetector consumes these via
+		//                       processLine. vsftpd/proftpd that write their own files
+		//                       are covered by the FTP file watchers in startFileWatchers.
 	)
 
 	stdout, err := m.journalCmd.StdoutPipe()
@@ -1266,23 +1272,26 @@ func (m *Module) startFileWatchers(ctx context.Context) {
 
 	// === v1.180: FTP daemon logs (auth_failure: pure-ftpd / vsftpd / proftpd
 	// authentication failures → ReasonFTPAuthFail via the existing FTPDetector).
-	// LoginMon is the sole owner + ban authority for FTP auth_failure. The journal
-	// watcher (SYSLOG_FACILITY 4/10 = auth/authpriv) does NOT carry FTP daemon logs,
-	// so the FTPDetector was unfed until now. The root daemon (CAP_DAC_OVERRIDE) reads
-	// these DIRECTLY — no collector/spool. Only started when an FTP daemon is detected.
-	// Health is journal-visible (resolved_by=discovery state=...) so zero-input never
+	// LoginMon is the sole owner + ban authority for FTP auth_failure. The root daemon
+	// (CAP_DAC_OVERRIDE) reads directly — no collector/spool. Two source paths, by how
+	// each daemon actually logs (verified against live fleet traffic):
+	//   - pure-ftpd → syslog facility ftp (11), consumed by runJournalWatcher (its
+	//     dedicated file is stats-only). No file watcher → no double-count.
+	//   - vsftpd / proftpd → their own log files, consumed by FTP file watchers below.
+	// Health is journal-visible (state=...) so an enabled-but-starved FTP source never
 	// looks healthy. ===
-	if m.ftpStackDetected() {
-		ftpLogs := m.discoverFTPLogs()
-		if len(ftpLogs) > 0 {
-			log.Printf("[LOGINMON] ftpauth: state=OK resolved_by=discovery files=%d", len(ftpLogs))
-			for _, p := range ftpLogs {
-				startWatcher("ftp", p)
-			}
-		} else {
-			log.Printf("[LOGINMON] ftpauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=ftp_daemon_present_no_logs")
+	ftpFileLogs := m.discoverFTPLogs() // vsftpd/proftpd files only (pure-ftpd is journal)
+	journalCovered := m.ftpJournalDaemonDetected()
+	switch {
+	case len(ftpFileLogs) > 0 || journalCovered:
+		log.Printf("[LOGINMON] ftpauth: state=OK resolved_by=journal+files files=%d journal_ftp=%t",
+			len(ftpFileLogs), journalCovered)
+		for _, p := range ftpFileLogs {
+			startWatcher("ftp", p)
 		}
-	} else {
+	case m.ftpFileDaemonDetected():
+		log.Printf("[LOGINMON] ftpauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=ftp_file_daemon_present_no_logs")
+	default:
 		log.Printf("[LOGINMON] ftpauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_ftp_daemon")
 	}
 }


### PR DESCRIPTION
## Summary
v1.180.0 closes **LoginMon FTP auth-input coverage** — specifically the pure-ftpd
**journal facility-11** blind spot plus vsftpd/proftpd parser/source correctness. FTP
authentication failures are now owned and banned by LoginMon (`auth_failure`), for both
IPv4 and IPv6. **FTP-only:** no cphulkd reader, no exim-rejectlog reader, no dead-key
cleanup, no global health axis. Daemon-Go (loginmon-only); schema 1.83.0 frozen; no
packaging/FHS/cmd change.

## Log Source Ownership Declaration (FTP)
- **Event class:** `auth_failure` on FTP daemon logs.
- **Sole owner + ban authority:** LoginMon (`ReasonFTPAuthFail`). No BotScan/BotGuard
  ownership of FTP auth failures; no other module bans them.
- **Files are shared; event ownership is not** — FTP auth failures have exactly one ban owner.
- **Runtime identity:** LoginMon runs inside the **root `nftband.service`** (CAP_DAC_OVERRIDE),
  so it reads these sources directly — no collector/spool.

## Real production evidence (read-only fleet sampling)
- **pure-ftpd** (deployed on all four prod hosts srv1-4) logs auth failures to **syslog
  facility ftp (11)** by default (`SyslogFacility ftp`); captured live on srv3:
  `pure-ftpd: (?@<ip>) [WARNING] Authentication failed for user [<username>]`.
- **`/var/log/pureftpd.log` is empty/stats-only** (`AltLog stats:`) and must NOT be treated
  as an auth source. File-only discovery → `files=0` → zero detection on the real fleet.

## Bugs fixed
1. **vsftpd file-format gate** — `Detect()` required the `"vsftpd"` substring, absent from
   `/var/log/vsftpd.log` (only `FAIL LOGIN: Client "<ip>"`). Gate now accepts that phrase.
2. **pure-ftpd real `(?@<ip>)` extraction** — extractor read a trailing `[<ip>]` bracket
   real pure-ftpd never emits (the brackets hold the level + username). Added `extractParenAtIP`.
3. **IPv4/IPv6 family coverage** — completed both families for every detector path (16/16).
4. **pure-ftpd facility-11 journal feed** — added `SYSLOG_FACILITY=11` to `runJournalWatcher`.

## Runtime identity & routing
- LoginMon inside root `nftband.service`.
- **journal facility 11** added for pure-ftpd (consumed via `processLine`).
- **vsftpd/proftpd remain file-routed** (own log files); pure-ftpd dropped from file globs
  to avoid tailing the no-auth stats file and double-counting clf-configured hosts.

## Event ownership
- FTP auth failures → **LoginMon `auth_failure`**.
- No BotScan/BotGuard ownership.

## Health behavior
- pure-ftpd present → **journal coverage OK even with `files=0`**.
- vsftpd/proftpd present with missing files → **`WARN_NO_LOGS`**.
- No FTP daemon → `NO_LOGS`.

## Tests
- Detector matrix: pure-ftpd / vsftpd / proftpd (every path).
- Real pure-ftpd format (captured live).
- **IPv4 and IPv6** for every path.
- journal-vs-file routing assertion.
- success-login control ignored.
- `go test -race ./internal/loginmon/...` green; `go build ./...` clean; gofmt/vet clean.

## Lab validation (lab2 binary-swap, reversible)
- **IPv4 `192.0.2.123` banned → v4 set (kernel-verified, `nft list ruleset`)**.
- **IPv6 `2001:db8::dead` banned → v6 set (kernel-verified)**.
- success-login control `192.0.2.200` **not banned**.
- SSH preserved; only the known v149 leftover failed unit.
- Test IPs scrubbed (unbanned via IPC); daemon restored to v1.177 packaged binary.

## Claim boundary
FTP auth-input only. **No** cphulkd. **No** exim-rejectlog. **No** Roundcube. **No** global
health axis. **No** fleet rollout. Real source-ownership sampling disproved adding
cphulkd/exim-reject (they duplicate existing cPanel access_log-401 / exim mainlog ownership
and would recreate the v1.179 double-count class; exim rejectlog's unique lines are
spam/RBL/HELO, not auth). Tracked separately as v1.181 (plan-only).

## Proofs
- Daemon `cmd/nftband` source moves **loginmon-only** (local `-trimpath -buildvcs=false`):
  v1.179 `36978621` → v1.180 `cce992a1`. Schema **1.83.0** frozen.
- Implementation record: `V1_180_LOGINMON_FTP_IMPL_RECORD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
