### PR TITLE
v1.181 auth-source dead-key cleanup + duplicate-source guard

### DIFF
--- a/cli/lib/nftban/tests/validate_distro_configs.sh
+++ b/cli/lib/nftban/tests/validate_distro_configs.sh
@@ -51,7 +51,7 @@ REQUIRED_FIELDS[package_manager]="type install_cmd update_cmd"
 # v2.1: fail2ban removed - use native login monitoring
 REQUIRED_FIELDS[packages]="nftables curl bash systemd mail golang"
 REQUIRED_FIELDS[services]="cron rsyslog nftables sshd"
-REQUIRED_FIELDS[paths]="nft systemctl journalctl auth_log maillog exim_log exim_reject_log dovecot_log pureftpd_log directadmin_login_log directadmin_security_log"
+REQUIRED_FIELDS[paths]="nft systemctl journalctl auth_log maillog exim_log dovecot_log directadmin_login_log directadmin_security_log"
 
 # BUG-19 (v1.79.3): DirectAdmin officially supports Debian and Ubuntu.
 # DA path keys are now UNIVERSAL — required on every distro family with a

--- a/etc/nftban/distros/almalinux-10.conf
+++ b/etc/nftban/distros/almalinux-10.conf
@@ -76,15 +76,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/almalinux-9.conf
+++ b/etc/nftban/distros/almalinux-9.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/centos-10.conf
+++ b/etc/nftban/distros/centos-10.conf
@@ -76,15 +76,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/centos-9.conf
+++ b/etc/nftban/distros/centos-9.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/centos-stream-10.conf
+++ b/etc/nftban/distros/centos-stream-10.conf
@@ -76,15 +76,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/centos-stream-9.conf
+++ b/etc/nftban/distros/centos-stream-9.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/centos.conf
+++ b/etc/nftban/distros/centos.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/debian-11.conf
+++ b/etc/nftban/distros/debian-11.conf
@@ -75,7 +75,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -84,8 +83,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/debian-12.conf
+++ b/etc/nftban/distros/debian-12.conf
@@ -75,7 +75,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -84,8 +83,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/debian-13.conf
+++ b/etc/nftban/distros/debian-13.conf
@@ -75,7 +75,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -84,8 +83,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/debian-14.conf
+++ b/etc/nftban/distros/debian-14.conf
@@ -75,7 +75,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -84,8 +83,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/debian.conf
+++ b/etc/nftban/distros/debian.conf
@@ -88,7 +88,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -97,8 +96,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/fedora-43.conf
+++ b/etc/nftban/distros/fedora-43.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/fedora.conf
+++ b/etc/nftban/distros/fedora.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/rocky-10.conf
+++ b/etc/nftban/distros/rocky-10.conf
@@ -76,15 +76,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/rocky-8.conf
+++ b/etc/nftban/distros/rocky-8.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/rocky-9.conf
+++ b/etc/nftban/distros/rocky-9.conf
@@ -75,15 +75,12 @@ auth_log = /var/log/secure
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/maillog
 exim_log = /var/log/exim/mainlog
-exim_reject_log = /var/log/exim/rejectlog
 dovecot_log = /var/log/maillog
 
 # === DirectAdmin (BUG-14, RHEL family only) ===
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/messages
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/ubuntu-22.conf
+++ b/etc/nftban/distros/ubuntu-22.conf
@@ -75,7 +75,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -84,8 +83,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/ubuntu-24.conf
+++ b/etc/nftban/distros/ubuntu-24.conf
@@ -77,7 +77,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -86,8 +85,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/ubuntu-26.conf
+++ b/etc/nftban/distros/ubuntu-26.conf
@@ -77,7 +77,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -86,8 +85,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/etc/nftban/distros/ubuntu.conf
+++ b/etc/nftban/distros/ubuntu.conf
@@ -96,7 +96,6 @@ auth_log = /var/log/auth.log
 # === Mail / MTA (BUG-14) ===
 maillog = /var/log/mail.log
 exim_log = /var/log/exim4/mainlog
-exim_reject_log = /var/log/exim4/rejectlog
 dovecot_log = /var/log/mail.log
 
 # === DirectAdmin (BUG-14 + BUG-19) ===
@@ -105,8 +104,6 @@ dovecot_log = /var/log/mail.log
 directadmin_login_log = /var/log/directadmin/login.log
 directadmin_security_log = /var/log/directadmin/security.log
 
-# === FTP (BUG-14) ===
-pureftpd_log = /var/log/syslog
 
 nft = /usr/sbin/nft
 nftban_cli = /usr/sbin/nftban

--- a/internal/loginmon/distroconf/distroconf_test.go
+++ b/internal/loginmon/distroconf/distroconf_test.go
@@ -113,11 +113,9 @@ func TestLoadFromFile_Almalinux9(t *testing.T) {
 		"auth_log":                 "/var/log/secure",
 		"maillog":                  "/var/log/maillog",
 		"exim_log":                 "/var/log/exim/mainlog",
-		"exim_reject_log":          "/var/log/exim/rejectlog",
 		"dovecot_log":              "/var/log/maillog",
 		"directadmin_login_log":    "/var/log/directadmin/login.log",
 		"directadmin_security_log": "/var/log/directadmin/security.log",
-		"pureftpd_log":             "/var/log/messages",
 	}
 	for k, want := range cases {
 		if got := l.Path(k); got != want {
@@ -143,9 +141,7 @@ func TestLoadFromFile_Debian12(t *testing.T) {
 		"auth_log":                 "/var/log/auth.log",
 		"maillog":                  "/var/log/mail.log",
 		"exim_log":                 "/var/log/exim4/mainlog",
-		"exim_reject_log":          "/var/log/exim4/rejectlog",
 		"dovecot_log":              "/var/log/mail.log",
-		"pureftpd_log":             "/var/log/syslog",
 		"directadmin_login_log":    "/var/log/directadmin/login.log",
 		"directadmin_security_log": "/var/log/directadmin/security.log",
 	}
@@ -250,9 +246,7 @@ func TestAllDistros_HaveAllRequiredKeys(t *testing.T) {
 		"auth_log",
 		"maillog",
 		"exim_log",
-		"exim_reject_log",
 		"dovecot_log",
-		"pureftpd_log",
 	}
 	rhelOnly := []string{
 		"directadmin_login_log",

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -928,23 +928,29 @@ func (m *Module) detectMode() Mode {
 	}
 }
 
+// journalAuthFacilities is the exact set of syslog facilities the LoginMon journal
+// watcher consumes, by facility NAME (for the source-ownership guard) → numeric value:
+//
+//	auth (4) · authpriv (10) · ftp (11, v1.180: pure-ftpd logs auth failures here by
+//	default since SyslogFacility ftp; its dedicated AltLog is stats-only).
+//
+// Changing this set feeds new input to the detector registry → requires a
+// LOG_SOURCE_OWNERSHIP_DECLARATION (guarded by TestSourceOwnershipGuard_JournalFacilities).
+var journalAuthFacilities = []string{"4", "10", "11"}
+
 // runJournalWatcher watches journalctl for login failures
 func (m *Module) runJournalWatcher(ctx context.Context) {
 	// Build journalctl command
-	m.journalCmd = exec.CommandContext(ctx, "journalctl",
+	args := []string{
 		"-f",      // Follow mode
 		"-n", "0", // Don't show historical entries
 		"--no-pager",
 		"-o", "short-iso",
-		"SYSLOG_FACILITY=4",  // Auth facility
-		"SYSLOG_FACILITY=10", // Authpriv facility
-		"SYSLOG_FACILITY=11", // FTP facility (v1.180): pure-ftpd logs auth failures
-		//                       to syslog facility ftp by default (SyslogFacility ftp,
-		//                       its dedicated AltLog is stats-only). Verified against
-		//                       live srv3 traffic: the FTPDetector consumes these via
-		//                       processLine. vsftpd/proftpd that write their own files
-		//                       are covered by the FTP file watchers in startFileWatchers.
-	)
+	}
+	for _, f := range journalAuthFacilities {
+		args = append(args, "SYSLOG_FACILITY="+f)
+	}
+	m.journalCmd = exec.CommandContext(ctx, "journalctl", args...)
 
 	stdout, err := m.journalCmd.StdoutPipe()
 	if err != nil {

--- a/internal/loginmon/source_ownership_guard_test.go
+++ b/internal/loginmon/source_ownership_guard_test.go
@@ -1,0 +1,98 @@
+// =============================================================================
+// NFTBan v1.181.0 - LoginMon source-ownership / duplicate-source guard
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="loginmon_source_ownership_guard_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Source-ownership guard (v1.181): fails CI if a future change wires a known DUPLICATE/non-auth log source into the LoginMon ban path without a fresh LOG_SOURCE_OWNERSHIP_DECLARATION + non-duplicate proof. Real-production sampling in v1.180 proved that (a) cphulkd /usr/local/cpanel/logs/login_log duplicates the cPanel access_log-401 events the PanelDetector already bans, and (b) the exim rejectlog auth subset duplicates exim mainlog (already owned by the MailDetector) while its unique lines are spam/RBL/HELO rejects (web_abuse, NOT auth_failure). Adding either as a ban source would recreate the v1.179 mirror double-count class and, for rejectlog, ban legitimate mail senders. This guard asserts panelLogPaths / mailLogPaths / the FTP file globs / the journal facilities stay free of those sources. Scope: NFTBAN_ROADMAP/V1_181_AUTH_SOURCE_DEAD_KEY_AND_DUPLICATE_GUARD_SCOPE.md."
+//
+// meta:inventory.files="source_ownership_guard_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+import (
+	"strings"
+	"testing"
+)
+
+// declRef is the remediation pointer printed when the guard trips.
+const declRef = "requires a LOG_SOURCE_OWNERSHIP_DECLARATION + non-duplicate proof " +
+	"(NFTBAN_ROADMAP/V1_181_AUTH_SOURCE_DEAD_KEY_AND_DUPLICATE_GUARD_SCOPE.md)"
+
+// TestSourceOwnershipGuard_NoCphulkdLoginLog asserts cphulkd's login_log is not wired as a
+// panel ban source: cPanel WHM/cPanel login failures are already owned by the PanelDetector
+// via access_log 401 on POST /login/ (v1.180 real-prod proof: lab4 login_log = whostmgrd/
+// cpaneld only). Adding login_log double-counts the same events.
+func TestSourceOwnershipGuard_NoCphulkdLoginLog(t *testing.T) {
+	for svc, paths := range panelLogPaths {
+		for _, p := range paths {
+			if strings.Contains(p, "login_log") {
+				t.Errorf("panelLogPaths[%q] wires a cphulkd-style login_log source (%q): "+
+					"cPanel login failures are already banned via access_log 401 (PanelDetector); "+
+					"login_log duplicates them. %s", svc, p, declRef)
+			}
+		}
+	}
+}
+
+// TestSourceOwnershipGuard_NoEximRejectlog asserts exim rejectlog is not wired as a mail ban
+// source: its auth subset (535 Incorrect authentication data) is already in exim mainlog
+// (owned by the MailDetector), and its UNIQUE lines are spam/RBL/HELO rejects = web_abuse,
+// not auth_failure. Banning those = false positives on legitimate mail.
+func TestSourceOwnershipGuard_NoEximRejectlog(t *testing.T) {
+	for svc, paths := range mailLogPaths {
+		for _, p := range paths {
+			if strings.Contains(p, "rejectlog") || strings.Contains(p, "reject_log") {
+				t.Errorf("mailLogPaths[%q] wires an exim rejectlog source (%q): the auth subset "+
+					"already lives in exim mainlog (MailDetector) and the unique lines are "+
+					"spam/RBL/HELO (web_abuse, not auth). %s", svc, p, declRef)
+			}
+		}
+	}
+}
+
+// TestSourceOwnershipGuard_FTPGlobsNoPureFTPdOrReject asserts the FTP FILE globs never include
+// pure-ftpd (journal-routed at facility 11 since v1.180 — globbing its stats-only file would
+// add a no-auth source and risk double-counting) nor any rejectlog.
+func TestSourceOwnershipGuard_FTPGlobsNoPureFTPdOrReject(t *testing.T) {
+	m := &Module{detectedServices: map[string]bool{
+		"pure-ftpd": true, "vsftpd": true, "proftpd": true,
+	}}
+	for _, g := range m.ftpLogGlobs() {
+		if strings.Contains(g, "pureftpd") || strings.Contains(g, "pure-ftpd") {
+			t.Errorf("ftpLogGlobs includes a pure-ftpd file glob (%q): pure-ftpd is journal-routed "+
+				"(SYSLOG_FACILITY=11) and its dedicated file is stats-only; globbing it double-counts. %s",
+				g, declRef)
+		}
+		if strings.Contains(g, "rejectlog") || strings.Contains(g, "reject_log") {
+			t.Errorf("ftpLogGlobs includes a rejectlog source (%q) — not an FTP auth source. %s", g, declRef)
+		}
+	}
+}
+
+// TestSourceOwnershipGuard_JournalFacilities pins the journal facility set the watcher
+// consumes. Any change feeds new input to the detector registry and must come with a
+// LOG_SOURCE_OWNERSHIP_DECLARATION. Expected: auth(4), authpriv(10), ftp(11, v1.180).
+func TestSourceOwnershipGuard_JournalFacilities(t *testing.T) {
+	want := map[string]bool{"4": true, "10": true, "11": true}
+	if len(journalAuthFacilities) != len(want) {
+		t.Fatalf("journalAuthFacilities=%v, want exactly %v — a change here %s",
+			journalAuthFacilities, []string{"4", "10", "11"}, declRef)
+	}
+	for _, f := range journalAuthFacilities {
+		if !want[f] {
+			t.Errorf("unexpected journal facility %q wired into LoginMon — %s", f, declRef)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

v1.181 LoginMon **auth-source dead-key cleanup + duplicate-source guard**. **No new ban source** — this is a hygiene + guardrail lane. Scope: `NFTBAN_ROADMAP/V1_181_AUTH_SOURCE_DEAD_KEY_AND_DUPLICATE_GUARD_SCOPE.md`.

## What was removed (dead keys — proven zero readers)

Only `directadmin_login_log` / `exim_log` / `dovecot_log` are actually consumed via `DistroKey`; pure-ftpd is journal facility-11 (since v1.180) and exim uses `mainlog`. The following keys had **zero readers**:

- Removed `pureftpd_log` + `exim_reject_log` (and the orphaned FTP section comment) from **all 21 `etc/nftban/distros/*.conf`**.
- Removed them from the validator `REQUIRED_FIELDS` (`cli/lib/nftban/tests/validate_distro_configs.sh`).
- Removed them from `internal/loginmon/distroconf/distroconf_test.go`.

## What was added (duplicate-source guard)

New `internal/loginmon/source_ownership_guard_test.go` — fails CI if a future change wires a known duplicate/non-auth source into the LoginMon ban path without a fresh `LOG_SOURCE_OWNERSHIP_DECLARATION` + non-duplicate proof:

- **cphulkd `login_log` NOT in `panelLogPaths`** (duplicates cPanel access_log-401, PanelDetector-owned).
- **exim `rejectlog` NOT in `mailLogPaths`** (auth subset duplicates `mainlog`; unique lines are spam/RBL/HELO = `web_abuse`, not auth).
- **FTP file globs exclude pure-ftpd** (journal-routed) and any `rejectlog`.
- **journal facilities pinned to `{auth 4, authpriv 10, ftp 11}`** — extracted to `journalAuthFacilities` so the set is testable.

## Envelope

- Daemon `cmd/nftband` source moves **loginmon-only** (`cce992a1`→`b9a462a4`; journal-watcher arg refactor, no behavior change).
- **Schema 1.83.0 frozen. No packaging/FHS/cmd change.**
- `go test -race ./...` + `go build ./...` green.

## Note

`validate_distro_configs.sh` has a **pre-existing rc=1** on the `NFTBAN_LOGIN_*` line-format check that is **unrelated to this lane** (diff vs main for that behavior is empty — this PR only removes the two dead REQUIRED_FIELDS entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
