### PR TITLE
v1.183 LoginMon input-readability finding (HEALTH-NO-INPUT-AXIS increment 2)

### DIFF
--- a/internal/validator/health_mapper.go
+++ b/internal/validator/health_mapper.go
@@ -99,6 +99,10 @@ func mapModule(h *ModuleHealth, daemonDependent bool) *ModuleJSON {
 		j.Effective = string(h.Effective)
 	}
 
+	// v1.183: ModuleHealth.Input is intentionally NOT projected into the frozen M81-6
+	// ModuleJSON schema. Enabled-but-starved is surfaced via the CodeLoginMonNoInput
+	// finding (open findings code set, schema-safe). First-class input axis = SCHEMA-UNFREEZE.
+
 	return j
 }
 

--- a/internal/validator/health_output.go
+++ b/internal/validator/health_output.go
@@ -29,15 +29,15 @@ package validator
 // This is the canonical M81-6 schema. Fields MUST NOT be added without a
 // schema version bump. See JSON_SCHEMA_SPEC_v1.81.md Section 8.
 type HealthOutput struct {
-	SchemaVersion string              `json:"schema_version"`
-	Status        string              `json:"status"`
-	Timestamp     string              `json:"timestamp"`
-	ServiceState  ServiceStateJSON    `json:"service_state"`
-	Modules       ModulesJSON         `json:"modules"`
-	Consistency   ConsistencyJSON     `json:"consistency"`
-	Findings      []FindingJSON       `json:"findings"`
-	ChainCounts   ChainCounts         `json:"chain_counts"`
-	Summary       SummaryCounts       `json:"summary"`
+	SchemaVersion string           `json:"schema_version"`
+	Status        string           `json:"status"`
+	Timestamp     string           `json:"timestamp"`
+	ServiceState  ServiceStateJSON `json:"service_state"`
+	Modules       ModulesJSON      `json:"modules"`
+	Consistency   ConsistencyJSON  `json:"consistency"`
+	Findings      []FindingJSON    `json:"findings"`
+	ChainCounts   ChainCounts      `json:"chain_counts"`
+	Summary       SummaryCounts    `json:"summary"`
 }
 
 // ServiceStateJSON is the JSON representation of daemon and timer state.
@@ -61,10 +61,13 @@ type ModulesJSON struct {
 // ModuleJSON is the standard 4-axis module output.
 // Fields are omitted when not applicable (e.g. runtime for kernel-only modules).
 type ModuleJSON struct {
-	Config     string `json:"config"`                // enabled|disabled (always present)
-	Structural string `json:"structural,omitempty"`  // present|missing (omitted if disabled)
-	Runtime    string `json:"runtime,omitempty"`     // running|stopped (omitted if not daemon-dependent)
-	Effective  string `json:"effective,omitempty"`   // enforcing|observing|idle (omitted if disabled)
+	Config     string `json:"config"`               // enabled|disabled (always present)
+	Structural string `json:"structural,omitempty"` // present|missing (omitted if disabled)
+	Runtime    string `json:"runtime,omitempty"`    // running|stopped (omitted if not daemon-dependent)
+	Effective  string `json:"effective,omitempty"`  // enforcing|observing|idle (omitted if disabled)
+	// NOTE: the v1.183 input-readability axis is intentionally NOT a field here — the
+	// M81-6 health-output schema is frozen (1.83.0). Enabled-but-starved is surfaced via
+	// the CodeLoginMonNoInput finding instead; a first-class input axis awaits SCHEMA-UNFREEZE.
 }
 
 // BlacklistJSON is the composite blacklist module output.
@@ -77,9 +80,9 @@ type BlacklistJSON struct {
 
 // BlacklistSubJSON represents one blacklist source.
 type BlacklistSubJSON struct {
-	State   string `json:"state"`            // enforcing|primed|idle|loaded|stale|degraded|disabled
+	State   string `json:"state"`             // enforcing|primed|idle|loaded|stale|degraded|disabled
 	Entries int    `json:"entries,omitempty"` // element count (omitted if 0 or not applicable)
-	Drops   int64  `json:"drops,omitempty"`  // counter value (omitted if 0 or not attributable)
+	Drops   int64  `json:"drops,omitempty"`   // counter value (omitted if 0 or not attributable)
 }
 
 // ConsistencyJSON holds cross-source agreement status.
@@ -91,7 +94,7 @@ type ConsistencyJSON struct {
 // FindingJSON is a single validation finding in the output.
 type FindingJSON struct {
 	Code        string `json:"code"`
-	Severity    string `json:"severity"`              // info|warn|error|critical
+	Severity    string `json:"severity"` // info|warn|error|critical
 	Component   string `json:"component"`
 	Family      string `json:"family,omitempty"`
 	Message     string `json:"message"`

--- a/internal/validator/loginmon_input_axis_test.go
+++ b/internal/validator/loginmon_input_axis_test.go
@@ -1,0 +1,112 @@
+// =============================================================================
+// NFTBan v1.183.0 - Validator LoginMon Input-axis tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="validator_loginmon_input_axis_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-13"
+// meta:description="Tests for v1.183 HEALTH-NO-INPUT-AXIS increment 2: the validator derives an internal LoginMon input-readability state from the daemon's '[LOGINMON] <src>: state=...' journal lines (parseLoginMonState/worseInputState/loginMonInputState). An enabled-but-starved source (WARN_NO_LOGS/NO_LOGS) emits a CodeLoginMonNoInput finding so it is visible in nftban health instead of reading healthy; worst-of precedence across sources. The frozen M81-6 health-output schema is NOT extended (Input stays internal json:- ; a first-class JSON axis awaits SCHEMA-UNFREEZE)."
+//
+// meta:inventory.files="loginmon_input_axis_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package validator
+
+import "testing"
+
+func TestParseLoginMonState(t *testing.T) {
+	cases := map[string]InputState{
+		"2026/06/13 [LOGINMON] webauth: state=OK resolved_by=discovery files=2":                    InputOK,
+		"2026/06/13 [LOGINMON] webauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=x": InputWarnNoLogs,
+		"2026/06/13 [LOGINMON] ftpauth: state=NO_LOGS resolved_by=discovery files=0 reason=y":      InputNoLogs,
+		"2026/06/13 [LOGINMON] ftpauth: state=BOGUS":                                               InputUnknown,
+		"no marker here": InputUnknown,
+	}
+	for line, want := range cases {
+		if got := parseLoginMonState(line); got != want {
+			t.Errorf("parseLoginMonState(%q)=%q want %q", line, got, want)
+		}
+	}
+}
+
+func TestWorseInputState(t *testing.T) {
+	if worseInputState(InputOK, InputNoLogs) != InputNoLogs {
+		t.Error("no_logs must beat ok")
+	}
+	if worseInputState(InputWarnNoLogs, InputOK) != InputWarnNoLogs {
+		t.Error("warn_no_logs must beat ok")
+	}
+	if worseInputState(InputNoLogs, InputWarnNoLogs) != InputNoLogs {
+		t.Error("no_logs must beat warn_no_logs")
+	}
+	if worseInputState(InputUnknown, InputOK) != InputOK {
+		t.Error("ok must beat unknown")
+	}
+}
+
+// TestLoginMonInputAxis_Starved drives evaluateLoginMon with an enabled config + a
+// journal that reports webauth NO_LOGS → Input axis = no_logs + a CodeLoginMonNoInput
+// finding (enabled-but-starved is now visible, not healthy).
+func TestLoginMonInputAxis_Starved(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	SetJournalReader(mockJournalReader{lines: []string{
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] webauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_web_stack",
+		"Jun 13 nftband[1]: 2026/06/13 module_start: loginmon",
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] exim: maillog=/var/log/exim/mainlog resolved_by=distroconf",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	h := evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+	if h.Input != InputNoLogs {
+		t.Fatalf("Input=%q want %q", h.Input, InputNoLogs)
+	}
+	found := false
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoInput {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a CodeLoginMonNoInput finding for an enabled-but-starved source")
+	}
+}
+
+// TestLoginMonInputAxis_OK: a healthy webauth source → Input=ok, no starvation finding.
+func TestLoginMonInputAxis_OK(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	SetJournalReader(mockJournalReader{lines: []string{
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] webauth: state=OK resolved_by=discovery files=3",
+		"Jun 13 nftband[1]: 2026/06/13 module_start: loginmon",
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] exim: resolved_by=distroconf",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	h := evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+	if h.Input != InputOK {
+		t.Fatalf("Input=%q want %q", h.Input, InputOK)
+	}
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoInput {
+			t.Errorf("did not expect a starvation finding when input is OK")
+		}
+	}
+}

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -318,7 +318,74 @@ func evaluateLoginMon(svcState ServiceState) *ModuleHealth {
 	// Default to idle from validator perspective.
 	h.Effective = EffectiveIdle
 
+	// Input axis (v1.183 HEALTH-NO-INPUT-AXIS increment 2): derive input-readability
+	// from the daemon's "[LOGINMON] <src>: state=..." startup lines (v1.179 webauth +
+	// v1.180 ftpauth). The daemon is the authority on its own watchers; the kernel-truth
+	// validator reads it from the journal it already queries. An enabled-but-starved
+	// source now surfaces in `nftban health` instead of reading healthy.
+	h.Input = loginMonInputState(context.Background())
+	if h.Config == ConfigEnabled && (h.Input == InputNoLogs || h.Input == InputWarnNoLogs) {
+		moduleFindings = append(moduleFindings, Finding{
+			Code:      CodeLoginMonNoInput,
+			Severity:  SeverityWarn,
+			Component: "module",
+			Message:   "LoginMon enabled but a detection source reports no input (" + string(h.Input) + ")",
+		})
+	}
+
 	return h
+}
+
+// loginMonInputState derives the worst-case input readability across LoginMon's
+// discovered sources from the daemon's "[LOGINMON] <src>: state=..." journal lines.
+// Precedence (worst wins): no_logs > warn_no_logs > ok > unknown.
+func loginMonInputState(ctx context.Context) InputState {
+	worst := InputUnknown
+	for _, src := range []string{"webauth", "ftpauth"} {
+		ev := queryJournal(ctx, JournalQuery{
+			Patterns: []string{"[LOGINMON] " + src + ": state="},
+			Since:    15 * time.Minute,
+		})
+		if ev.ErrKind != ErrNone || !ev.Found {
+			continue
+		}
+		worst = worseInputState(worst, parseLoginMonState(ev.MatchedLine))
+	}
+	return worst
+}
+
+// parseLoginMonState extracts the input-state token from a "[LOGINMON] <src>: state=<TOK> ..."
+// line and maps it to the InputState vocabulary.
+func parseLoginMonState(line string) InputState {
+	const marker = "state="
+	i := strings.Index(line, marker)
+	if i < 0 {
+		return InputUnknown
+	}
+	tok := line[i+len(marker):]
+	if j := strings.IndexAny(tok, " \t\r\n"); j >= 0 {
+		tok = tok[:j]
+	}
+	switch tok {
+	case "OK":
+		return InputOK
+	case "WARN_NO_LOGS":
+		return InputWarnNoLogs
+	case "NO_LOGS":
+		return InputNoLogs
+	default:
+		return InputUnknown
+	}
+}
+
+// worseInputState returns the higher-severity of two input states
+// (no_logs > warn_no_logs > ok > unknown).
+func worseInputState(a, b InputState) InputState {
+	rank := map[InputState]int{InputUnknown: 0, InputOK: 1, InputWarnNoLogs: 2, InputNoLogs: 3}
+	if rank[b] > rank[a] {
+		return b
+	}
+	return a
 }
 
 // =============================================================================

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -45,16 +45,16 @@ const (
 
 // ValidationResult is the complete output of kernel validation.
 type ValidationResult struct {
-	SchemaVersion string           `json:"schema_version"`
-	Status        Status           `json:"status"`
-	Timestamp     time.Time        `json:"timestamp"`
-	Families      []FamilyResult   `json:"families"`
-	Findings      []Finding        `json:"findings"`
-	Summary       SummaryCounts    `json:"summary"`
-	ChainCount    ChainCounts      `json:"chain_counts"`
-	ServiceState  ServiceState     `json:"service_state"`
-	Modules              ModuleHealthMap  `json:"modules"`                // M81-4
-	ConsistencyOverall   string           `json:"consistency_overall"`    // v1.82: "ok" | "mismatch"
+	SchemaVersion      string          `json:"schema_version"`
+	Status             Status          `json:"status"`
+	Timestamp          time.Time       `json:"timestamp"`
+	Families           []FamilyResult  `json:"families"`
+	Findings           []Finding       `json:"findings"`
+	Summary            SummaryCounts   `json:"summary"`
+	ChainCount         ChainCounts     `json:"chain_counts"`
+	ServiceState       ServiceState    `json:"service_state"`
+	Modules            ModuleHealthMap `json:"modules"`             // M81-4
+	ConsistencyOverall string          `json:"consistency_overall"` // v1.82: "ok" | "mismatch"
 
 	// v1.89 INV-M-001/002: Expose kernel state for evidence layer.
 	// These fields are internal — not serialized to the frozen JSON schema.
@@ -152,12 +152,30 @@ const (
 	EffectivePrimed    EffectiveState = "primed"
 )
 
-// ModuleHealth holds the 4-axis health evaluation for one module.
+// InputState represents detection-source input readability (v1.183 HEALTH-NO-INPUT-AXIS
+// increment 2). It makes an enabled-but-starved module visible in `nftban health` instead
+// of reading healthy. Derived from the daemon's "[LOGINMON] <src>: state=..." journal
+// lines (the daemon is the authority on its own watchers). Omitted unless determinable.
+type InputState string
+
+const (
+	InputOK         InputState = "ok"           // a source is present + producing input
+	InputWarnNoLogs InputState = "warn_no_logs" // stack present but no logs / no recent lines
+	InputNoLogs     InputState = "no_logs"      // no source/daemon for an enabled module
+	InputUnknown    InputState = "unknown"      // no input-state evidence available
+)
+
+// ModuleHealth holds the per-module health evaluation. v1.183 adds the Input axis
+// (input-readability) as an INTERNAL field (json:"-") — it drives a findings-array signal
+// (CodeLoginMonNoInput) which is the schema-safe way to surface enabled-but-starved in
+// `nftban health`. The frozen M81-6 health-output schema (ModuleJSON) is NOT extended here;
+// promoting Input to a first-class JSON axis is deferred to the SCHEMA-UNFREEZE major.
 type ModuleHealth struct {
 	Config     ConfigState     `json:"config"`
 	Structural StructuralState `json:"structural,omitempty"`
 	Runtime    RuntimeState    `json:"runtime,omitempty"`
 	Effective  EffectiveState  `json:"effective,omitempty"`
+	Input      InputState      `json:"-"` // internal (v1.183); surfaced via CodeLoginMonNoInput finding, not the frozen schema
 }
 
 // BlacklistHealth holds the split blacklist state per M81-3 contract.
@@ -170,7 +188,7 @@ type BlacklistHealth struct {
 // BlacklistSubHealth represents a blacklist sub-source state.
 type BlacklistSubHealth struct {
 	State   string `json:"state"`             // enforcing|primed|idle|loaded|stale|disabled
-	Entries int    `json:"entries,omitempty"`  // element count (manual/feeds)
+	Entries int    `json:"entries,omitempty"` // element count (manual/feeds)
 	Drops   int64  `json:"drops,omitempty"`   // counter value (manual only — attributable)
 }
 
@@ -199,20 +217,20 @@ const (
 type ServiceState struct {
 	Nftband       RuntimeState `json:"nftband"`
 	NftbandDetail string       `json:"nftband_detail,omitempty"`
-	TimerCount    int          `json:"timer_count"`    // v1.83: active nftban-* timer count
+	TimerCount    int          `json:"timer_count"` // v1.83: active nftban-* timer count
 }
 
 // FamilyResult holds validation results for a single address family (ip/ip6).
 type FamilyResult struct {
-	Family       string       `json:"family"` // "ip" or "ip6"
-	Status       Status       `json:"status"`
-	TablePresent bool         `json:"table_present"`
-	ChainCount   int          `json:"chain_count"`
-	SetCount     int          `json:"set_count"`
-	BaseChains   ChainCheck   `json:"base_chains"`
-	HelperChains ChainCheck   `json:"helper_chains"`
-	Anchors      AnchorCheck  `json:"anchors"`
-	Sets         SetCheck     `json:"sets"`
+	Family       string      `json:"family"` // "ip" or "ip6"
+	Status       Status      `json:"status"`
+	TablePresent bool        `json:"table_present"`
+	ChainCount   int         `json:"chain_count"`
+	SetCount     int         `json:"set_count"`
+	BaseChains   ChainCheck  `json:"base_chains"`
+	HelperChains ChainCheck  `json:"helper_chains"`
+	Anchors      AnchorCheck `json:"anchors"`
+	Sets         SetCheck    `json:"sets"`
 }
 
 // ChainCheck holds chain validation results.
@@ -303,22 +321,23 @@ const (
 	CodeModuleDegraded = "VAL-MODULE-001"
 
 	// Service findings (B80-4)
-	CodeServiceDown  = "VAL-SERVICE-001" // required service not active
-	CodeTimerNone    = "VAL-TIMER-001"   // v1.83: no nftban timers active
-	CodeTimerError   = "VAL-TIMER-002"   // v1.83: timer query failed
+	CodeServiceDown = "VAL-SERVICE-001" // required service not active
+	CodeTimerNone   = "VAL-TIMER-001"   // v1.83: no nftban timers active
+	CodeTimerError  = "VAL-TIMER-002"   // v1.83: timer query failed
 
 	// Module-specific findings (M81-4)
-	CodeGeobanDBMissing     = "VAL-GEOBAN-001"   // geoip database missing/empty
-	CodeBotGuardNoEvidence  = "VAL-BOTGUARD-001" // v1.84: no recent BotGuard runtime evidence
-	CodeLoginMonNoEvidence  = "VAL-LOGINMON-001" // v1.84: no recent LoginMon runtime evidence
+	CodeGeobanDBMissing    = "VAL-GEOBAN-001"   // geoip database missing/empty
+	CodeBotGuardNoEvidence = "VAL-BOTGUARD-001" // v1.84: no recent BotGuard runtime evidence
+	CodeLoginMonNoEvidence = "VAL-LOGINMON-001" // v1.84: no recent LoginMon runtime evidence
+	CodeLoginMonNoInput    = "VAL-LOGINMON-002" // v1.183: enabled but a detection source reports no input
 
 	// Consistency findings (v1.82)
 	CodeConsistencyMismatch = "VAL-CONS-001" // config/kernel disagreement
 
 	// System findings
-	CodeNftFailed    = "VAL-SYSTEM-001"
-	CodeNftNoOutput  = "VAL-SYSTEM-002"
-	CodeParseError   = "VAL-SYSTEM-003"
+	CodeNftFailed   = "VAL-SYSTEM-001"
+	CodeNftNoOutput = "VAL-SYSTEM-002"
+	CodeParseError  = "VAL-SYSTEM-003"
 )
 
 // Required anchors in strict order.


### PR DESCRIPTION
## Summary
Completes HEALTH-NO-INPUT-AXIS: `nftban health` now flags an enabled-but-starved LoginMon source (a `VAL-LOGINMON-002` warning finding) instead of reading healthy. **No new ban surface.**

## How (schema-safe)
The validator already queries the journal (`queryJournal`). `evaluateLoginMon` reads the daemon's own `[LOGINMON] <src>: state=…` startup lines (v1.179 webauth + v1.180 ftpauth) and derives an internal input-readability state — the daemon is the authority on its own watchers; no IPC client, no state file. Enabled-but-starved (WARN_NO_LOGS/NO_LOGS) → `CodeLoginMonNoInput` finding.

**Frozen M81-6 health-output schema (1.83.0) is NOT extended** — `Input` stays internal (`json:"-"`, drives the finding); `ModuleJSON` unchanged; `ToJSONLegacy`/rebuild parsers untouched. A first-class JSON input axis is deferred to the SCHEMA-UNFREEZE major.

## Tests
parse/precedence units + starved→finding + ok→no-finding (mock journal reader). `go test ./internal/validator/...` + `go build ./...` green; health_mapper_test still asserts schema_version 1.83.0.

## Envelope
Daemon `cmd/nftband` source moves (validator compiled in) `6fdfd975`→`dc4e1a33`; schema 1.83.0 frozen; no packaging/FHS/cmd change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)