### PR TITLE
feat(loginmon): v1.186 Roundcube webmail auth source (DirectAdmin central /var/log/roundcube layout)

### DIFF
--- a/internal/loginmon/detector/detector.go
+++ b/internal/loginmon/detector/detector.go
@@ -52,6 +52,7 @@ const (
 	ReasonCPanelLogin          uint16 = 4002
 	ReasonWordPressXMLRPC      uint16 = 5001
 	ReasonWordPressWPLogin     uint16 = 5002
+	ReasonRoundcubeAuthFail    uint16 = 5003
 	ReasonPleskLogin           uint16 = 4003
 	ReasonGenericAuthFail      uint16 = 9001
 )
@@ -72,6 +73,7 @@ var ReasonName = map[uint16]string{
 	ReasonCPanelLogin:        "cpanel_login_fail",
 	ReasonWordPressXMLRPC:    "wordpress_xmlrpc",
 	ReasonWordPressWPLogin:   "wordpress_wp_login",
+	ReasonRoundcubeAuthFail:  "roundcube_auth_fail",
 	ReasonPleskLogin:         "plesk_login_fail",
 	ReasonGenericAuthFail:    "generic_auth_fail",
 }
@@ -119,6 +121,13 @@ func NewRegistry() *Registry {
 	// (first-match wins). WebAuth owns only generic HTTP basic-auth 401/403 + WordPress
 	// wp-login failed-credential (auth_failure); web_abuse stays with BotScan->BotGuard.
 	r.Register(NewWebAuthDetector())
+	// Roundcube webmail userlogins.log "Failed login for <user> from <IP> …" (v1.186,
+	// DirectAdmin-only coverage claim). Owns ONLY webmail interactive auth_failure on
+	// the Roundcube userlogins log; tight prefilter cannot match access/mail/ssh lines.
+	// Contains a MANDATORY public-IP-only guard (never bans loopback/RFC1918/link-local/
+	// ULA/malformed) so the fleet-wide binary is safe on proxied panels that may log
+	// 127.0.0.1, and the dovecot rip=localhost webmail mirror is auto-neutralized.
+	r.Register(NewRoundcubeDetector())
 
 	return r
 }

--- a/internal/loginmon/detector/roundcube.go
+++ b/internal/loginmon/detector/roundcube.go
@@ -1,0 +1,147 @@
+// =============================================================================
+// NFTBan v1.186.0 - Roundcube webmail auth-failure detector (DirectAdmin-only claim)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: detector
+//
+// meta:name="roundcube_detector"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="detector"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-14"
+// meta:description="Signal-based Roundcube webmail interactive auth-failure detection from the Roundcube userlogins.log (log_logins=true). OWNS ONLY the webmail auth_failure event class on that log (source=roundcube, reason 5003) — disjoint from dovecot IMAP/POP3 brute (which logs webmail-proxied logins as rip=localhost = wrong IP), from WebAuth (HTTP 401/wp-login), and from BotScan web_abuse. Matches ONLY 'Failed login for ... from <IP> ...'; 'Successful login ...' never produces a verdict. Contains a MANDATORY public-IP-only guard: never bans loopback/RFC1918/link-local/ULA/multicast/unspecified/malformed IPs, so the fleet-wide binary is safe on proxied panels (cPanel/Plesk) that may log 127.0.0.1, and the dovecot rip=localhost webmail mirror is auto-neutralized. v1.186 claims DirectAdmin/OpenLiteSpeed coverage only (Gate-0 captured); cPanel (per-user log discovery) and Plesk are deferred."
+//
+// Captured DA format (real, dns1 2026-06-14):
+//   [14-Jun-2026 10:54:37 +0000]: <8b84adea> Failed login for user@dom from 62.38.150.122 in session 8b84adea7d5ff1df (error: 0)
+//   Successful variant (NEVER matched): Successful login for user (ID: 1) from <IP> in session <sid>
+//
+// meta:inventory.files="roundcube.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package detector
+
+import (
+	"bytes"
+	"net/netip"
+)
+
+// scoreRoundcubeAuthFail — a failed webmail login is a real credential attempt
+// (same risk class as an SSH failed-password, scoreDelta 15). With the scorer
+// TempBan threshold at 45, ~3 sustained failures in-window ban; isolated typos do
+// not. (Future: make config-tunable via the module, like the webauth scores.)
+const scoreRoundcubeAuthFail = 15
+
+// RoundcubeDetector detects webmail interactive auth failures in the Roundcube
+// userlogins.log. It owns ONLY the auth_failure event class on that log.
+type RoundcubeDetector struct {
+	sigFailed    []byte // "Failed login for " — the only line shape we match
+	sigSuccess   []byte // "Successful login" — explicit non-match (defense-in-depth)
+	sigFrom      []byte // " from " — precedes the client IP
+	sigInSession []byte // " in session" — the IP is the token immediately before this
+}
+
+// NewRoundcubeDetector creates a new Roundcube webmail-auth detector.
+func NewRoundcubeDetector() *RoundcubeDetector {
+	return &RoundcubeDetector{
+		sigFailed:    []byte("Failed login for "),
+		sigSuccess:   []byte("Successful login"),
+		sigFrom:      []byte(" from "),
+		sigInSession: []byte(" in session"),
+	}
+}
+
+// Name returns the detector identifier.
+func (d *RoundcubeDetector) Name() string {
+	return "roundcube"
+}
+
+// isPublicLoginIP reports whether addr is a public, bannable client address.
+// MANDATORY guard (v1.186): a webmail source must NEVER ban a non-routable IP —
+// loopback (127.0.0.0/8, ::1), RFC1918 + RFC4193 ULA (IsPrivate), link-local
+// (169.254/16, fe80::/10), multicast, or unspecified. IsGlobalUnicast() already
+// excludes loopback/link-local/multicast/unspecified; !IsPrivate() excludes
+// RFC1918 and ULA. Invalid addrs are rejected by the !IsValid check.
+func isPublicLoginIP(addr netip.Addr) bool {
+	return addr.IsValid() && addr.IsGlobalUnicast() && !addr.IsPrivate()
+}
+
+// roundcubeExtractIP returns the client IP token from a Roundcube userlogins line.
+// Primary anchor: the token immediately before " in session" (the format is
+// "... from <IP> in session <sid> ..."), which is robust to a username containing
+// " from ". On a proxied panel that logs "from 127.0.0.1 (X-Forwarded-For: <ip>)"
+// the token before " in session" is the parenthetical close → ParseAddr fails →
+// no verdict (safe no-op; cPanel/Plesk real-IP extraction is deferred to v1.186.x).
+func (d *RoundcubeDetector) roundcubeExtractIP(line []byte) (netip.Addr, bool) {
+	var tok []byte
+	if si := bytes.Index(line, d.sigInSession); si > 0 {
+		seg := line[:si]
+		if sp := bytes.LastIndexByte(seg, ' '); sp >= 0 && sp+1 < len(seg) {
+			tok = seg[sp+1:]
+		}
+	}
+	if len(tok) == 0 {
+		// Fallback: first whitespace-delimited token after " from ".
+		fi := bytes.Index(line, d.sigFrom)
+		if fi < 0 {
+			return netip.Addr{}, false
+		}
+		rest := line[fi+len(d.sigFrom):]
+		if end := bytes.IndexByte(rest, ' '); end >= 0 {
+			tok = rest[:end]
+		} else {
+			tok = rest
+		}
+	}
+	addr, err := netip.ParseAddr(string(tok))
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+// Detect matches ONLY Roundcube failed-login events with a PUBLIC client IP.
+func (d *RoundcubeDetector) Detect(line []byte) (Verdict, bool) {
+	// Prefilter: only failed webmail logins. "Successful login for ..." does not
+	// contain "Failed login for "; the explicit success check is defense-in-depth so
+	// a success line can NEVER produce a verdict (hard stop).
+	if !bytes.Contains(line, d.sigFailed) {
+		return Verdict{}, false
+	}
+	if bytes.Contains(line, d.sigSuccess) {
+		return Verdict{}, false
+	}
+
+	addr, ok := d.roundcubeExtractIP(line)
+	if !ok {
+		return Verdict{}, false // malformed / unparseable IP → no ban (hard stop)
+	}
+
+	// MANDATORY public-IP-only guard.
+	if !isPublicLoginIP(addr) {
+		return Verdict{}, false
+	}
+
+	// Username (best-effort): between "Failed login for " and " from ".
+	user := ""
+	if ui := bytes.Index(line, d.sigFailed); ui >= 0 {
+		useg := line[ui+len(d.sigFailed):]
+		if uf := bytes.Index(useg, d.sigFrom); uf > 0 {
+			user = string(useg[:uf])
+		}
+	}
+
+	return Verdict{
+		IP:         addr,
+		Reason:     ReasonRoundcubeAuthFail,
+		ScoreDelta: scoreRoundcubeAuthFail,
+		User:       user,
+		Service:    "roundcube",
+	}, true
+}

--- a/internal/loginmon/detector/roundcube_test.go
+++ b/internal/loginmon/detector/roundcube_test.go
@@ -1,0 +1,117 @@
+// =============================================================================
+// NFTBan v1.186.0 - Roundcube detector tests (parser match/non-match + public-IP guard)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="roundcube_detector_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-14"
+// meta:description="Hard-stop tests: Failed-login match, Successful-login non-match, and the mandatory public-IP-only guard (localhost/private/link-local/ULA/unspecified/malformed = NO ban)."
+// meta:inventory.files="roundcube_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package detector
+
+import "testing"
+
+// real captured DA line shape (dns1 2026-06-14), public IP.
+const rcFailedPublic = `[14-Jun-2026 10:54:37 +0000]: <8b84adea> Failed login for user@example.gr from 62.38.150.122 in session 8b84adea7d5ff1df (error: 0)`
+
+func TestRoundcube_FailedPublic_Match(t *testing.T) {
+	d := NewRoundcubeDetector()
+	v, ok := d.Detect([]byte(rcFailedPublic))
+	if !ok {
+		t.Fatal("expected a verdict for a public failed-login line")
+	}
+	if v.Reason != ReasonRoundcubeAuthFail {
+		t.Errorf("reason = %d, want %d (roundcube)", v.Reason, ReasonRoundcubeAuthFail)
+	}
+	if v.Service != "roundcube" {
+		t.Errorf("service = %q, want roundcube", v.Service)
+	}
+	if v.IP.String() != "62.38.150.122" {
+		t.Errorf("ip = %s, want 62.38.150.122", v.IP)
+	}
+	if v.User != "user@example.gr" {
+		t.Errorf("user = %q, want user@example.gr", v.User)
+	}
+	if v.ScoreDelta != scoreRoundcubeAuthFail {
+		t.Errorf("score = %d, want %d", v.ScoreDelta, scoreRoundcubeAuthFail)
+	}
+}
+
+func TestRoundcube_IPv6Public_Match(t *testing.T) {
+	d := NewRoundcubeDetector()
+	line := `[14-Jun-2026 10:54:37 +0000]: <s> Failed login for u@d from 2a01:4f8:c012:57::99 in session abcd (error: 0)`
+	v, ok := d.Detect([]byte(line))
+	if !ok || v.IP.String() != "2a01:4f8:c012:57::99" {
+		t.Fatalf("expected IPv6 public match, got ok=%v ip=%s", ok, v.IP)
+	}
+}
+
+// HARD STOP: a "Successful login" line must NEVER produce a verdict.
+func TestRoundcube_SuccessfulLogin_NoVerdict(t *testing.T) {
+	d := NewRoundcubeDetector()
+	line := `[14-Jun-2026 10:55:01 +0000]: <s> Successful login for user@example.gr (ID: 1) from 62.38.150.122 in session deadbeef`
+	if _, ok := d.Detect([]byte(line)); ok {
+		t.Fatal("HARD STOP VIOLATION: success line produced a verdict")
+	}
+}
+
+// HARD STOP: the public-IP-only guard — no non-public IP may ever ban.
+func TestRoundcube_PublicIPGuard(t *testing.T) {
+	d := NewRoundcubeDetector()
+	noBan := []string{
+		"127.0.0.1",       // loopback v4
+		"::1",             // loopback v6
+		"10.0.0.5",        // RFC1918
+		"172.16.4.9",      // RFC1918
+		"192.168.1.50",    // RFC1918
+		"169.254.10.10",   // link-local v4
+		"fe80::1",         // link-local v6
+		"fc00::1234",      // ULA v6
+		"fd12:3456::1",    // ULA v6
+		"0.0.0.0",         // unspecified
+		"::",              // unspecified v6
+		"224.0.0.1",       // multicast
+		"not-an-ip",       // malformed
+		"999.999.999.999", // malformed
+	}
+	for _, ip := range noBan {
+		line := "[14-Jun-2026 10:54:37 +0000]: <s> Failed login for u@d from " + ip + " in session abcd (error: 0)"
+		if v, ok := d.Detect([]byte(line)); ok {
+			t.Errorf("HARD STOP VIOLATION: non-public/malformed IP %q produced a ban verdict (ip=%s)", ip, v.IP)
+		}
+	}
+}
+
+// A username containing " from " must not derail IP extraction (anchor on " in session").
+func TestRoundcube_UserWithFromWord(t *testing.T) {
+	d := NewRoundcubeDetector()
+	line := `[14-Jun-2026 10:54:37 +0000]: <s> Failed login for weird from user@d from 62.38.150.122 in session abcd (error: 0)`
+	v, ok := d.Detect([]byte(line))
+	if !ok || v.IP.String() != "62.38.150.122" {
+		t.Fatalf("expected IP 62.38.150.122 despite 'from' in username, got ok=%v ip=%s", ok, v.IP)
+	}
+}
+
+// Non-Roundcube lines (access log, ssh) must not match.
+func TestRoundcube_ForeignLines_NoMatch(t *testing.T) {
+	d := NewRoundcubeDetector()
+	foreign := []string{
+		`62.38.150.122 - - [14/Jun/2026:04:37:53 +0000] "POST /wp-login.php HTTP/1.1" 200 1141 "-" "-"`,
+		`Jun 14 10:00:00 host sshd[1]: Failed password for root from 62.38.150.122 port 2222 ssh2`,
+		``,
+	}
+	for _, line := range foreign {
+		if _, ok := d.Detect([]byte(line)); ok {
+			t.Errorf("foreign line wrongly matched roundcube: %q", line)
+		}
+	}
+}

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -1309,6 +1309,31 @@ func (m *Module) startFileWatchers(ctx context.Context) {
 		m.recordInputState("webauth", inputStateNoLogs)
 	}
 
+	// === v1.186: Roundcube webmail userlogins.log (auth_failure: interactive webmail
+	// login failures → ReasonRoundcubeAuthFail via RoundcubeDetector). DirectAdmin-only
+	// coverage claim (Gate-0 captured the real client IP in the central
+	// /var/log/roundcube/userlogins.log). cPanel (per-user log) + Plesk are DEFERRED and
+	// not discovered. The root daemon (CAP_DAC_OVERRIDE) reads the central log directly —
+	// Option A; the webapps log dir is drwx--x--- so a cap-scoped nftban-user collector
+	// cannot traverse it. The detector's mandatory public-IP-only guard keeps a proxied /
+	// non-default host that logs 127.0.0.1 a safe no-op. Health is journal-visible so an
+	// enabled-but-starved Roundcube source (log_logins off) never looks healthy. ===
+	rcLogs := m.discoverRoundcubeLogs()
+	switch {
+	case len(rcLogs) > 0:
+		log.Printf("[LOGINMON] roundcube: state=OK resolved_by=discovery files=%d", len(rcLogs))
+		m.recordInputState("roundcube", inputStateOK)
+		for _, p := range rcLogs {
+			startWatcher("roundcube", p)
+		}
+	case m.roundcubeDetected():
+		log.Printf("[LOGINMON] roundcube: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=roundcube_present_log_logins_off_or_no_userlogins")
+		m.recordInputState("roundcube", inputStateWarnNoLogs)
+	default:
+		log.Printf("[LOGINMON] roundcube: state=NO_LOGS resolved_by=discovery files=0 reason=no_roundcube")
+		m.recordInputState("roundcube", inputStateNoLogs)
+	}
+
 	// === v1.180: FTP daemon logs (auth_failure: pure-ftpd / vsftpd / proftpd
 	// authentication failures → ReasonFTPAuthFail via the existing FTPDetector).
 	// LoginMon is the sole owner + ban authority for FTP auth_failure. The root daemon

--- a/internal/loginmon/roundcubediscovery.go
+++ b/internal/loginmon/roundcubediscovery.go
@@ -1,0 +1,63 @@
+// =============================================================================
+// NFTBan v1.186.0 - LoginMon Roundcube userlogins.log discovery (DirectAdmin-only)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: loginmon
+// Purpose: Discovery of the Roundcube webmail userlogins.log for the LoginMon
+//          auth_failure event class (source=roundcube), DirectAdmin-only in v1.186.
+//
+// meta:name="loginmon_roundcubediscovery"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="loginmon"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-14"
+// meta:description="Discovers the DirectAdmin/OpenLiteSpeed central Roundcube userlogins.log (Gate-0 captured: /var/log/roundcube/userlogins.log, real client IP, root-readable). v1.186 claims DirectAdmin coverage ONLY: cPanel (per-user $HOME/logs/roundcube/userlogins.log) and Plesk (/var/log/plesk-roundcube/userlogins.log) are DEFERRED and intentionally NOT globbed here — no coverage is claimed for them. The root nftband.service (CAP_DAC_OVERRIDE) reads the central log directly (Option A; the webapps log dir is drwx--x--- so a cap-scoped nftban-user collector cannot traverse it). The RoundcubeDetector's mandatory public-IP-only guard keeps any non-DA/proxied host that logs 127.0.0.1 a safe no-op."
+//
+// meta:inventory.files="roundcubediscovery.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package loginmon
+
+import "os"
+
+// roundcubeLogGlobs returns the DirectAdmin central Roundcube userlogins log glob.
+// v1.186 DA-only: cPanel/Plesk paths are deliberately absent (deferred, not claimed).
+// /var/log/roundcube/ is both the DA default and the Gate-0-captured path; a
+// config-driven log_dir override is a deferred refinement (the default holds on DA).
+func (m *Module) roundcubeLogGlobs() []string {
+	return []string{
+		"/var/log/roundcube/userlogins.log",
+	}
+}
+
+// discoverRoundcubeLogs returns the existing DA Roundcube userlogins.log (canonicalized,
+// regular-file filtered) — or nil. DA-only: returns nil unless DirectAdmin is detected,
+// so the source is never even attempted on cPanel/Plesk hosts (no coverage claim).
+func (m *Module) discoverRoundcubeLogs() []string {
+	if !m.detectedServices["directadmin"] {
+		return nil
+	}
+	return discoverFromGlobs(m.roundcubeLogGlobs())
+}
+
+// roundcubeDetected reports whether Roundcube appears installed on this (DA) host —
+// used to distinguish WARN_NO_LOGS (Roundcube present but log_logins off / no
+// userlogins.log yet) from NO_LOGS (no Roundcube at all). DA-only.
+func (m *Module) roundcubeDetected() bool {
+	if !m.detectedServices["directadmin"] {
+		return false
+	}
+	for _, p := range []string{"/var/log/roundcube", "/var/www/html/roundcube"} {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/loginmon/roundcubediscovery_test.go
+++ b/internal/loginmon/roundcubediscovery_test.go
@@ -1,0 +1,53 @@
+// =============================================================================
+// NFTBan v1.186.0 - Roundcube discovery tests (DA-only hard-stops #9/#10)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="loginmon_roundcubediscovery_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-14"
+// meta:description="Pins v1.186 hard stops: DA-only discovery (returns nil unless directadmin detected) and NO cPanel/Plesk path globbed (no coverage claim)."
+// meta:inventory.files="roundcubediscovery_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package loginmon
+
+import (
+	"strings"
+	"testing"
+)
+
+// HARD STOP #9/#10: discovery must be DirectAdmin-only — nil unless DA detected,
+// so the source is never even attempted on cPanel/Plesk hosts.
+func TestRoundcubeDiscovery_DAOnly(t *testing.T) {
+	m := &Module{detectedServices: map[string]bool{}}
+	if got := m.discoverRoundcubeLogs(); got != nil {
+		t.Errorf("non-DA host: discoverRoundcubeLogs = %v, want nil (DA-only claim)", got)
+	}
+	if m.roundcubeDetected() {
+		t.Error("non-DA host: roundcubeDetected = true, want false")
+	}
+	// cPanel + Plesk detected but NOT DirectAdmin → still nil (not claimed).
+	m2 := &Module{detectedServices: map[string]bool{"cpanel": true, "plesk": true}}
+	if got := m2.discoverRoundcubeLogs(); got != nil {
+		t.Errorf("cPanel/Plesk host: discoverRoundcubeLogs = %v, want nil (deferred, not claimed)", got)
+	}
+}
+
+// HARD STOP #10: the DA glob set must NOT include any cPanel or Plesk path.
+func TestRoundcubeGlobs_NoCPanelNoPlesk(t *testing.T) {
+	m := &Module{detectedServices: map[string]bool{"directadmin": true}}
+	for _, g := range m.roundcubeLogGlobs() {
+		if strings.Contains(g, "cpanel") || strings.Contains(g, "domlogs") ||
+			strings.Contains(g, "plesk-roundcube") || strings.Contains(g, "vhosts") ||
+			strings.Contains(g, "$HOME") || strings.Contains(g, "/home/") {
+			t.Errorf("glob %q references a cPanel/Plesk/per-user path — v1.186 is DA-only", g)
+		}
+	}
+}


### PR DESCRIPTION
Adds the **Roundcube webmail interactive auth-failure** source to LoginMon.

## Coverage claim (narrow, code-and-lab-validated)
v1.186 adds Roundcube webmail auth detection for **DirectAdmin hosts using the central `/var/log/roundcube/userlogins.log` layout** (Gate-0 captured a real failed-login line on dns1 with the real external client IP `192.0.2.122`; lab-first validated fleet-wide). Daemon-Go (hash moves `dc4e1a33`→`c63d8822`). Gate: `OPEN_V1_186_ROUNDCUBE_DA_ONLY_IMPL = GO_IMPLEMENTATION`.

### NOT claimed in v1.186
- all DirectAdmin Roundcube installs
- cPanel
- Plesk
- app-local Roundcube `log_dir` installs (e.g. RC with unset `log_dir` → `<install>/logs/`)
- all webmail brute-force coverage

> srv4 (DirectAdmin + RC 1.6.15, unset `log_dir`) proves the caveat: it uses an app-local log and is **not** covered by the central glob — a safe no-op (never a wrong ban), queued for the v1.186.x config-driven `log_dir` refinement.

## The 10 required items
1. Detector parser for the DA `userlogins.log` failed-login format (`detector/roundcube.go`).
2. Strict match **Failed login** only.
3. **Successful login** never produces a verdict (prefilter + explicit guard + test).
4. **MANDATORY public-IP-only guard** before any verdict — `isPublicLoginIP` rejects loopback/RFC1918/link-local/ULA/multicast/unspecified/malformed.
5. Root `nftband.service` direct read path (discovery → watcher → registry; Option A, the `webapps` log dir is `drwx--x---`).
6. `[LOGINMON] roundcube: state=...` input-state line.
7. `WARN_NO_LOGS`/`NO_LOGS` when `log_logins`/input absent — never HEALTHY.
8. Guard tests (12 non-public/malformed IPs = no ban) + parser tests.
9. **No** cPanel per-user discovery (DA-only glob; nil unless DA).
10. **No** Plesk coverage claim (not globbed).

## Hard stops — all satisfied (tested + lab-proven)
- Cannot ban 127.0.0.1/private/internal → `TestRoundcube_PublicIPGuard` (and live: localhost + RFC1918 lines rejected on dns1).
- cPanel/Plesk not claimed → `TestRoundcubeDiscovery_DAOnly`, `TestRoundcubeGlobs_NoCPanelNoPlesk` (and live: lab2 Plesk + lab4 cPanel → `NO_LOGS no_roundcube`, clean no-op).
- Successful-login cannot verdict → `TestRoundcube_SuccessfulLogin_NoVerdict` (and live: success line not counted on dns1).
- Zero-input → WARN_NO_LOGS/NO_LOGS (input-state wiring; live on all DA hosts without a log).
- Ownership disjoint from BotScan/WebAuth/dovecot (tight prefilter, distinct source `roundcube` + reason `5003`); independent ownership audit = PASS.

## Lab-first validation — PASS (reversible daemon-swap, 0 live bans)
- **dns1** (Ubuntu 24.04, DA 1.7.1): WARN_NO_LOGS → OK on discovery → **2 public detections** (IPv4+IPv6), guards held, **0 bans**; reverted clean.
- **dns2/srv1/srv2/srv3/srv4**: WARN_NO_LOGS (present, log off); all reverted `==PRE`.
- **lab2 (Plesk) / lab4 (cPanel) / monitor (no RC)**: `NO_LOGS no_roundcube`, clean no-op.
- Cross-distro: Ubuntu 22.04/24.04/26.04, CentOS Stream 9/10, AlmaLinux 9.8/10.1.
- Record: `V1_186_ROUNDCUBE_LABFIRST_VALIDATION_RECORD.md`.

## Envelope
- Daemon `cmd/nftband` hash **moves** (expected; daemon-Go) `dc4e1a33`→`c63d8822`. Schema unchanged. No packaging/FHS change.
- `go vet` clean; `go build ./...` OK; full `internal/loginmon/...` suite green.
- **cPanel + Plesk + app-local `log_dir` DEFERRED to v1.186.x.** Refs: `V1_186_ROUNDCUBE_DA_ONLY_DECISION.md`, ownership declaration, `ROUNDCUBE_GATE0_CAPTURE_RECORD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

