### PR TITLE
fix(botscan): v1.186.1 — BotScan URL/UA pattern-ban correctness (IFS word-split)

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -487,7 +487,14 @@ nftban_botscan_analyze() {
         local ban_duration="$BOTSCAN_DEFAULT_BAN_SHORT"
         local window="$BOTSCAN_DEFAULT_WINDOW"
 
-        for pattern_name in $patterns; do
+        # Split the space-joined matched-pattern list IFS-INDEPENDENTLY. The lib sets a
+        # global IFS=$'\n\t' (no space) at source time, so an unquoted `for x in $patterns`
+        # over " NAME" keeps the leading space → key lookup misses → the pattern threshold
+        # is never applied → URL/UA pattern bans never fire (only 404-flood did). Use the
+        # same `IFS=$' \t\n' read -ra` idiom already used for the http-log override split.
+        local -a _ip_pats=()
+        IFS=$' \t\n' read -ra _ip_pats <<< "$patterns"
+        for pattern_name in "${_ip_pats[@]}"; do
             [[ -z "$pattern_name" ]] && continue
             local def="${_BOTSCAN_PATTERNS[$pattern_name]:-}"
             [[ -z "$def" ]] && continue

--- a/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.186.1 - BotScan pattern-ban IFS word-split guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_pattern_ban_ifs_v1861_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-14"
+# meta:description="Regression guard for the pre-existing BotScan pattern-ban defect: the lib sets a global IFS=\$'\\n\\t' (no space) at source time, so the unquoted 'for pattern_name in \$patterns' over a space-joined list (\" NAME\") kept the leading space, the pattern key lookup missed, and the per-pattern threshold/window/ban-duration were never applied — analyze fell back to defaults (threshold=5/window=60/ban=1800). Effect: threshold=1 single-request patterns (sqlmap, nikto, Log4Shell, webshells) required 5 hits instead of 1 (single-shot probes evaded banning), and high-threshold matches were downgraded to a weaker grey signal. This test uses threshold=1 patterns under the lib's REAL runtime IFS (no manual reset) with the 404-flood path disabled, so a ban can ONLY come from the pattern path — proving useragent AND url-404 pattern bans fire on the FIRST matching hit. Fails before the v1.186.1 fix, passes after."
+#
+# meta:inventory.files="botscan_pattern_ban_ifs_v1861_test.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_PATTERNS_DIR,BOTSCAN_BATCH_SIGNAL_MODE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+banned_has() { grep -q "\"ip\":\"$1\"" "${NFTBAN_DATA_DIR}/botguard/batch_signals.jsonl" 2>/dev/null; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_SPOOL_DIR="$tmp/spool" \
+       BOTSCAN_PATTERNS_DIR="$tmp/patterns" BOTSCAN_STATE_FILE="$tmp/state.db" \
+       BOTSCAN_LOG_FILE="$tmp/botscan.log" NFTBAN_CONFIG_DIR="$tmp/noetc" \
+       BOTSCAN_ENABLED=true BOTSCAN_BATCH_SIGNAL_MODE=true \
+       BOTSCAN_404_THRESHOLD=999    # disable 404-flood → a ban can ONLY be a pattern ban
+mkdir -p "$NFTBAN_DATA_DIR/botguard" "$BOTSCAN_SPOOL_DIR" "$BOTSCAN_PATTERNS_DIR"
+
+# useragent + url-404 patterns, each threshold 1.
+{
+  printf 'BADUA|BadCrawler|useragent|1|60|3600|true|UA pattern\n'
+  printf 'WPLOGIN|/wp-login|url-404|1|60|3600|true|url-404 pattern\n'
+} > "$BOTSCAN_PATTERNS_DIR/test.patterns"
+
+# One UA-match line (198.51.100.10) + one url-404-match line (198.51.100.11).
+{
+  printf '198.51.100.10 - - [14/Jun/2026:10:00:00 +0000] "GET /a HTTP/1.1" 200 9 "-" "BadCrawler/1.0"\n'
+  printf '198.51.100.11 - - [14/Jun/2026:10:00:00 +0000] "GET /wp-login HTTP/1.1" 404 9 "-" "Mozilla/5.0"\n'
+} > "$BOTSCAN_SPOOL_DIR/a.log"
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
+nftban_botscan_load_config
+# IMPORTANT: do NOT reset IFS here — exercise the lib's real runtime IFS=$'\n\t'.
+nftban_botscan_process_logs "" 60 >/dev/null 2>&1 || fail "process_logs rc!=0"
+
+banned_has "198.51.100.10" || fail "useragent pattern ban did not fire under runtime IFS (IFS word-split defect)"
+banned_has "198.51.100.11" || fail "url-404 pattern ban did not fire under runtime IFS (IFS word-split defect)"
+
+echo "PASS: BotScan pattern bans (useragent + url-404) fire under the lib's runtime IFS"


### PR DESCRIPTION
## v1.186.1 — BotScan URL/UA pattern-ban correctness (IFS word-split)

**v1.186.1 fixes BotScan URL/UA pattern ban correctness under the production runtime IFS. It restores catalog/custom pattern ban behavior. It does not fix BotScan throughput — `BOTSCAN-SCAN-THROUGHPUT` remains open for v1.187, and `BOTSCAN-BOT-POLICY-UX` remains open for v1.187.**

### The defect (pre-existing, fleet-wide)
`nftban_botscan.sh` sets a global `IFS=$'\n\t'` (no space) at source time, and `cli/sbin/nftban-botscan-processor` inherits it. `nftban_botscan_analyze` iterated the per-IP matched-pattern list with an unquoted `for pattern_name in $patterns`; the list is space-joined (`" NAME"`), so under that IFS the leading space was kept → the pattern key lookup missed → the per-pattern **threshold/window/ban-duration were never applied**, falling back to defaults (5/60/1800).

**Impact (measured):** `threshold=1` single-request patterns (sqlmap, nikto, masscan, Log4Shell/CVE_*, webshells WS_*) required **5 hits instead of 1** → single-shot exploit/scanner/webshell probes evaded banning; high-threshold matches were downgraded from a hard ban (score 80) to a weaker grey signal (50). The 404-flood path (quoted IP-key iteration) was unaffected.

### The fix
Split IFS-independently: `IFS=$' \t\n' read -ra` — the same idiom already used for the http-log override split (`nftban_http_logs.sh:127`). 8 lines in `nftban_botscan_analyze`.

### Tests
- New hermetic `botscan_pattern_ban_ifs_v1861_test.sh`: proves useragent + url-404 pattern bans fire on the FIRST matching hit under the lib's real runtime IFS (404-flood disabled so the ban can only come from the pattern path). **Fails pre-fix, passes post-fix.**
- v185 regression passes; shellcheck clean.

### Envelope
- Shell-only → **daemon byte-identical to v1.186 (`c63d8822`)**, schema frozen, no packaging/FHS change.

### Lab validation — PASS 9/9 (`V1_186_1_LAB_VALIDATION_RECORD.md`)
A/B, zero install mutation, signal-only, reserved IP, production auto-discover path. On every fleet host (Ubuntu 22.04/24.04/26.04, CentOS Stream 10, AlmaLinux 9.8/10.1; GNU + uutils coreutils): installed=NO_BAN → fixed=BAN(pattern), 0 nftban failed units, nft authority intact.

### Out of scope (deliberately)
v1.187 throughput cursor/prefilter; Lane B bot-UX; aibots.patterns; packaging/FHS; daemon Go; schema; FCrDNS. (Separately noted follow-up: uutils `tail -<N>` incompat on Ubuntu 26.04 affects the interactive pinned-log path; production banning uses the incremental reader and is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
