### PR TITLE
feat(botscan): v1.187 Lane A — BOTSCAN-SCAN-THROUGHPUT (forward cursor + prefilter + 404 fixed-tail)

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -74,6 +74,13 @@ nftban_botscan_load_config() {
     : "${BOTSCAN_404_THRESHOLD:=50}"
     : "${BOTSCAN_404_WINDOW:=300}"
     : "${BOTSCAN_404_BAN:=3600}"
+    # v1.187 Lane A — BOTSCAN-SCAN-THROUGHPUT. Forward-cursor per-file per-cycle window
+    # (drains backlog forward instead of the v1.185 64 KiB tail-bias), a C-speed candidate
+    # prefilter before the per-line bash matcher, and an independent 404 fixed-tail re-read
+    # window (Option 1) that preserves 404-burst detection the forward cursor would fragment.
+    : "${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:=1048576}"
+    : "${BOTSCAN_SCAN_PREFILTER:=true}"
+    : "${BOTSCAN_404_TAIL_BYTES:=2097152}"
     : "${BOTSCAN_PROGRESSIVE_ENABLED:=true}"
     : "${BOTSCAN_PROGRESSIVE_MULTIPLIER:=2}"
     : "${BOTSCAN_PROGRESSIVE_MAX:=86400}"
@@ -535,6 +542,66 @@ nftban_botscan_analyze() {
     return $banned
 }
 
+# v1.187 Lane A — build a C-speed candidate prefilter (ERE) from the ENABLED patterns
+# plus a 404-status keeper, into file $1. A line is a CANDIDATE if it could match ANY
+# enabled pattern OR (when 404-tracking is on) carries a 404 status. The filter is a
+# SOUND SUPERSET of the accurate bash matcher: patterns are emitted as ERE (same engine
+# semantics as the matcher's `[[ =~ ]]`) with line-anchors (^ $) stripped so a URL/UA-
+# anchored pattern still matches its field anywhere inside the WHOLE log line (broadening
+# only). GNU grep -E is DFA-based → linear time, so this cannot ReDoS-stall (the bash
+# regex matcher then runs only on the surviving candidates). Returns non-zero (→ caller
+# skips the prefilter, no behavior change) when there is nothing to filter on.
+nftban_botscan_build_prefilter() {
+    local out="$1"
+    : > "$out" 2>/dev/null || return 1
+    local n=0 name def pat
+    for name in "${!_BOTSCAN_PATTERNS[@]}"; do
+        def="${_BOTSCAN_PATTERNS[$name]}"
+        IFS='|' read -r pat _ _ _ _ _ <<< "$def"
+        [[ -z "$pat" ]] && continue
+        pat="${pat#^}"; pat="${pat%\$}"   # strip line-anchors → match the field within the line
+        [[ -z "$pat" ]] && continue
+        printf '%s\n' "$pat" >> "$out"
+        n=$((n + 1))
+    done
+    if [[ "${BOTSCAN_404_TRACKING:-true}" == "true" ]]; then
+        # Keep every 404-status line (common/combined format: "...REQUEST..." 404 <bytes>),
+        # independent of patterns, so the 404-flood path never loses candidates.
+        printf '%s\n' '" 404 ' >> "$out"
+        printf '%s\n' ' 404 ' >> "$out"
+        n=$((n + 1))
+    fi
+    [[ "$n" -gt 0 ]]
+}
+
+# v1.187 Lane A — 404-window OPTION 1 (fixed-tail re-read), INDEPENDENT of the forward
+# processor cursor (does NOT read or advance its offset). Each cycle re-reads a bounded
+# tail of each file sized to cover the 404 window, prefilters to 404 lines (C-speed), and
+# (re)counts per-IP 404s into the analyze() arrays — preserving 404-burst detection that
+# the forward cursor (one slice/cycle) would otherwise fragment. Honors the whitelists.
+nftban_botscan_count_404_tail() {
+    [[ "${BOTSCAN_404_TRACKING:-true}" == "true" ]] || return 0
+    local now; now=$(nftban_timestamp_unix 2>/dev/null || date +%s)
+    local tail_bytes="${BOTSCAN_404_TAIL_BYTES:-2097152}"
+    # Reset so the count reflects ONLY the current window's tail (stateless; lowest risk).
+    _BOTSCAN_IP_404_COUNT=()
+    _BOTSCAN_IP_404_FIRST_SEEN=()
+    local f line parsed ip url method status ua
+    for f in "$@"; do
+        [[ -f "$f" && -r "$f" ]] || continue
+        while IFS= read -r line; do
+            parsed=$(nftban_botscan_parse_line "$line") || continue
+            IFS='|' read -r ip url method status ua <<< "$parsed"
+            [[ "$status" == "404" ]] || continue
+            nftban_botscan_is_whitelisted "$ip" "$ua" && continue
+            nftban_botscan_is_path_whitelisted "$url" && continue
+            _BOTSCAN_IP_404_COUNT["$ip"]=$(( ${_BOTSCAN_IP_404_COUNT[$ip]:-0} + 1 ))
+            [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$ip]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$ip"]="$now"
+        done < <( tail -c "$tail_bytes" -- "$f" 2>/dev/null | LC_ALL=C grep -E '" 404 | 404 ' 2>/dev/null || true )
+    done
+    return 0
+}
+
 # Write a batch signal to JSONL for Go daemon (Clock 2) consumption
 # Args: ip, score, action, reasons...
 nftban_botscan_write_signal() {
@@ -673,9 +740,23 @@ nftban_botscan_process_logs() {
     # a budget slice (default 1 MiB; ~5k lines). Scoped to this scan process only — the
     # privileged collector keeps its own (larger) cap. Only narrow it (never widen a
     # caller-set smaller value).
-    local _scan_cap="${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-65536}"
+    local _scan_cap="${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-1048576}"
     if [[ -z "${NFTBAN_HTTP_LOG_MAX_BYTES:-}" || "${NFTBAN_HTTP_LOG_MAX_BYTES}" -gt "$_scan_cap" ]]; then
         export NFTBAN_HTTP_LOG_MAX_BYTES="$_scan_cap"
+    fi
+    # v1.187 Lane A — FORWARD cursor on a DEDICATED offset dir (distinct offset semantics,
+    # and distinct from the collector's offsets) so the scanner drains a backlog FORWARD
+    # across cycles instead of tail-skipping. Auto-discovered incremental path only (an
+    # explicit pinned log_file / interactive `check` keeps the simple tail read).
+    if [[ -z "$log_file" ]]; then
+        export NFTBAN_HTTP_LOG_READ_FORWARD=true
+        export NFTBAN_HTTP_LOG_OFFSET_DIR="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/proc-offsets"
+    fi
+    # v1.187 Lane A — build the C-speed candidate prefilter once for this cycle.
+    local _pf=""
+    if [[ "${BOTSCAN_SCAN_PREFILTER:-true}" == "true" ]]; then
+        _pf="$(mktemp 2>/dev/null)" || _pf=""
+        [[ -n "$_pf" ]] && { nftban_botscan_build_prefilter "$_pf" || { rm -f "$_pf"; _pf=""; }; }
     fi
     # Anti-starvation rotation: persist where the last cycle stopped so a host whose
     # backlog exceeds one budget still scans EVERY file over successive cycles instead
@@ -707,9 +788,11 @@ nftban_botscan_process_logs() {
             nftban_botscan_process_entry "$ip" "$url" "$method" "$status" "$ua"
             processed=$((processed + 1))
         done < <(
-            if [[ -n "$log_file" ]]; then tail -1000 -- "$f" 2>/dev/null
-            elif declare -F nftban_http_read_incremental >/dev/null 2>&1; then nftban_http_read_incremental "$f"
-            else tail -1000 -- "$f" 2>/dev/null; fi
+            {
+                if [[ -n "$log_file" ]]; then tail -1000 -- "$f" 2>/dev/null
+                elif declare -F nftban_http_read_incremental >/dev/null 2>&1; then nftban_http_read_incremental "$f"
+                else tail -1000 -- "$f" 2>/dev/null; fi
+            } | { if [[ -n "$_pf" ]]; then LC_ALL=C grep -E -f "$_pf" 2>/dev/null || true; else cat; fi; }
         )
         files_done=$((files_done + 1))
     done
@@ -723,6 +806,12 @@ nftban_botscan_process_logs() {
     echo "Processed: $processed entries (${files_done}/${n} files this cycle)"
     [[ "$deadline_hit" -eq 1 ]] && echo "Deadline budget (${budget}s) reached — analyzing partial batch; remaining files resume next cycle"
     echo "IPs tracked: ${#_BOTSCAN_IP_HITS[@]}"
+
+    # v1.187 Lane A — 404-window OPTION 1: independent fixed-tail re-read (does NOT touch
+    # the forward cursor offset) so 404-burst detection is preserved despite the forward
+    # cursor only seeing one slice per cycle. Authoritative source for the 404 counters.
+    nftban_botscan_count_404_tail "${logs[@]}"
+    [[ -n "$_pf" ]] && rm -f "$_pf"
 
     # Analyze and ban — ALWAYS runs (even on a partial/deadline-bounded batch) so a
     # high-volume host still produces bans every cycle instead of zero.

--- a/cli/lib/nftban/lib/nftban_http_logs.sh
+++ b/cli/lib/nftban/lib/nftban_http_logs.sh
@@ -325,15 +325,34 @@ nftban_http_read_incremental() {
         start="$prev_off"
     fi
 
-    # Bound the read window to MAX_BYTES (read the newest MAX_BYTES if the gap is huge).
-    if [[ $((size - start)) -gt ${NFTBAN_HTTP_LOG_MAX_BYTES} ]]; then
-        start=$((size - NFTBAN_HTTP_LOG_MAX_BYTES))
+    local new_off="$size"
+    if [[ "${NFTBAN_HTTP_LOG_READ_FORWARD:-false}" == "true" ]]; then
+        # v1.187 Lane A — FORWARD cursor: emit the OLDEST unread window
+        # [start, start+MAX_BYTES) and advance the offset by exactly what is emitted,
+        # so the next cycle resumes where this one stopped and NO bytes are ever
+        # permanently skipped (a backlog larger than MAX_BYTES is drained across
+        # successive cycles instead of tail-biased). Used by the BotScan processor with
+        # its OWN dedicated offset dir; the default tail-biased branch below is unchanged
+        # so the privileged collector is byte-identical.
+        local end="$size"
+        if [[ $((size - start)) -gt ${NFTBAN_HTTP_LOG_MAX_BYTES} ]]; then
+            end=$((start + NFTBAN_HTTP_LOG_MAX_BYTES))
+        fi
+        if [[ "$end" -gt "$start" ]]; then
+            tail -c +$((start + 1)) "$file" 2>/dev/null | head -c $((end - start))
+        fi
+        new_off="$end"
+    else
+        # Default (tail-biased): read the newest MAX_BYTES if the gap is huge; offset → size.
+        if [[ $((size - start)) -gt ${NFTBAN_HTTP_LOG_MAX_BYTES} ]]; then
+            start=$((size - NFTBAN_HTTP_LOG_MAX_BYTES))
+        fi
+        if [[ "$size" -gt "$start" ]]; then
+            tail -c +$((start + 1)) "$file" 2>/dev/null | head -c "${NFTBAN_HTTP_LOG_MAX_BYTES}"
+        fi
+        new_off="$size"
     fi
-
-    if [[ "$size" -gt "$start" ]]; then
-        tail -c +$((start + 1)) "$file" 2>/dev/null | head -c "${NFTBAN_HTTP_LOG_MAX_BYTES}"
-    fi
-    # Persist new offset = current size (atomic-ish).
-    printf '%s:%s\n' "$inode" "$size" > "${statefile}.tmp" 2>/dev/null && mv -f "${statefile}.tmp" "$statefile" 2>/dev/null
+    # Persist new offset (atomic-ish).
+    printf '%s:%s\n' "$inode" "$new_off" > "${statefile}.tmp" 2>/dev/null && mv -f "${statefile}.tmp" "$statefile" 2>/dev/null
     return 0
 }

--- a/cli/lib/nftban/tests/botscan_throughput_v187_test.sh
+++ b/cli/lib/nftban/tests/botscan_throughput_v187_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.187 - BotScan throughput (Lane A) guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_throughput_v187_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-14"
+# meta:description="BOTSCAN-SCAN-THROUGHPUT (v1.187 Lane A) guard. (A) FORWARD cursor drains a backlog larger than the per-file cap across successive cycles with NO skipped bytes (every line processed exactly once; not tail-biased). (B) The C-speed candidate PREFILTER keeps lines that could match a pattern (or carry 404) and drops unrelated lines — soundly (a real hit still recorded). (C) The 404-window OPTION 1 fixed-tail re-read is INDEPENDENT of the forward cursor: a 404 flood is still detected on a cycle where the cursor reads 0 new bytes."
+#
+# meta:inventory.files="botscan_throughput_v187_test.sh"
+# meta:inventory.binaries="bash,grep,tail,head"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_SPOOL_DIR,BOTSCAN_SCAN_MAX_BYTES_PER_FILE,BOTSCAN_404_THRESHOLD"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export NFTBAN_LIB_DIR
+LIB_CORE="$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+procof() { sed -n 's/^Processed: \([0-9]*\) entries.*/\1/p' <<<"$1"; }
+# In batch-signal mode each ban is appended as a JSONL line to this file; that is the
+# authoritative ban evidence (the "Banned:" echo carries analyze stdout, not a count).
+sigfile() { printf '%s\n' "${NFTBAN_DATA_DIR}/botguard/batch_signals.jsonl"; }
+banned_has() { grep -q "\"ip\":\"$1\"" "$(sigfile)" 2>/dev/null; }
+
+# shellcheck source=/dev/null
+source "$LIB_CORE"
+
+# ---------------------------------------------------------------------------
+# (A) FORWARD cursor — backlog > per-file cap drains across cycles, no skip
+# ---------------------------------------------------------------------------
+tA="$(mktemp -d)"; trap 'rm -rf "$tA"' EXIT
+export NFTBAN_DATA_DIR="$tA/data" BOTSCAN_SPOOL_DIR="$tA/spool" \
+       BOTSCAN_PATTERNS_DIR="$tA/patterns" BOTSCAN_STATE_FILE="$tA/state.db" \
+       BOTSCAN_LOG_FILE="$tA/botscan.log" \
+       BOTSCAN_ENABLED=true BOTSCAN_BATCH_SIGNAL_MODE=true BOTSCAN_SCAN_BUDGET_SECS=0
+mkdir -p "$NFTBAN_DATA_DIR" "$BOTSCAN_SPOOL_DIR" "$BOTSCAN_PATTERNS_DIR" "$NFTBAN_DATA_DIR/botguard"
+# Apply pure defaults (no real config dir) so BOTSCAN_DEFAULT_* etc. are bound, matching
+# the production path (nftban_botscan_check → load_config → process_logs).
+export NFTBAN_CONFIG_DIR="$tA/noetc"
+nftban_botscan_load_config
+
+# 6 fixed-length 404 lines, distinct IPs (.101-.106) → identical byte length.
+line='203.0.113.101 - - [14/Jun/2026:10:00:00 +0000] "GET /x HTTP/1.1" 404 12 "-" "ua"'
+L=$(( ${#line} + 1 ))                     # + newline
+: > "$BOTSCAN_SPOOL_DIR/a.log"
+for d in 1 2 3 4 5 6; do
+  printf '203.0.113.10%s - - [14/Jun/2026:10:00:00 +0000] "GET /x HTTP/1.1" 404 12 "-" "ua"\n' "$d" \
+    >> "$BOTSCAN_SPOOL_DIR/a.log"
+done
+export BOTSCAN_SCAN_MAX_BYTES_PER_FILE=$(( 3 * L ))   # cap = exactly 3 lines/cycle
+export BOTSCAN_404_THRESHOLD=999                       # no 404 ban interference here
+
+o1="$(nftban_botscan_process_logs "" 60 2>&1)" || fail "A cycle1 rc!=0: $o1"
+o2="$(nftban_botscan_process_logs "" 60 2>&1)" || fail "A cycle2 rc!=0: $o2"
+o3="$(nftban_botscan_process_logs "" 60 2>&1)" || fail "A cycle3 rc!=0: $o3"
+p1="$(procof "$o1")"; p2="$(procof "$o2")"; p3="$(procof "$o3")"
+[[ "$p1" == "3" ]] || fail "A: cycle1 should process 3 (cap), got '$p1' ($o1)"
+[[ "$p2" == "3" ]] || fail "A: cycle2 should process the NEXT 3 (forward, no tail-skip), got '$p2' ($o2)"
+[[ "$p3" == "0" ]] || fail "A: cycle3 should process 0 (drained), got '$p3'"
+[[ $(( p1 + p2 )) -eq 6 ]] || fail "A: total processed must equal all 6 lines (no skip), got $((p1+p2))"
+echo "PASS A: forward cursor drains backlog across cycles with no skipped bytes"
+
+# ---------------------------------------------------------------------------
+# (B) PREFILTER soundness — candidate kept (hit recorded), unrelated dropped
+# ---------------------------------------------------------------------------
+tB="$(mktemp -d)"; trap 'rm -rf "$tA" "$tB"' EXIT
+export NFTBAN_DATA_DIR="$tB/data" BOTSCAN_SPOOL_DIR="$tB/spool" \
+       BOTSCAN_PATTERNS_DIR="$tB/patterns" BOTSCAN_STATE_FILE="$tB/state.db" \
+       BOTSCAN_LOG_FILE="$tB/botscan.log"
+mkdir -p "$NFTBAN_DATA_DIR" "$BOTSCAN_SPOOL_DIR" "$BOTSCAN_PATTERNS_DIR" "$NFTBAN_DATA_DIR/botguard"
+export BOTSCAN_404_TRACKING=false                     # isolate the pattern keeper (no 404 keeper)
+unset BOTSCAN_SCAN_MAX_BYTES_PER_FILE
+# One enabled useragent pattern. NAME|PATTERN|MATCH|THRESH|WINDOW|BAN|ENABLED|DESC
+printf 'BADUA|BadCrawler|useragent|1|60|3600|true|test bad UA\n' > "$BOTSCAN_PATTERNS_DIR/test.patterns"
+# Line 1: matching UA + 200 (candidate). Line 2: unrelated UA + 200 (must be dropped).
+{
+  printf '203.0.113.7 - - [14/Jun/2026:10:00:00 +0000] "GET /a HTTP/1.1" 200 9 "-" "BadCrawler/1.0"\n'
+  printf '203.0.113.8 - - [14/Jun/2026:10:00:00 +0000] "GET /b HTTP/1.1" 200 9 "-" "Mozilla/5.0"\n'
+} > "$BOTSCAN_SPOOL_DIR/a.log"
+# Run NOT in a subshell so the detector state arrays persist for inspection. Assert at the
+# DETECTION level (what the prefilter actually governs): the candidate reaches the matcher
+# and is tracked; the unrelated line is dropped. (The downstream pattern-BAN word-split is
+# a separate pre-existing IFS defect — see V1_187_FINDING_BOTSCAN_PATTERN_BAN_IFS.md — and
+# is deliberately NOT relied on here so this lane's test stays scoped to throughput.)
+nftban_botscan_process_logs "" 60 > "$tB/out" 2>&1 || fail "B rc!=0: $(cat "$tB/out")"
+pb="$(procof "$(cat "$tB/out")")"
+[[ "$pb" == "1" ]] || fail "B: prefilter must keep ONLY the candidate (1), got '$pb' ($(cat "$tB/out"))"
+[[ -n "${_BOTSCAN_IP_HITS[203.0.113.7]:-}" ]] || fail "B: candidate (matching UA) must reach the matcher and be tracked — prefilter dropped a real candidate"
+[[ -z "${_BOTSCAN_IP_HITS[203.0.113.8]:-}" ]] || fail "B: unrelated line must be dropped by the prefilter (not tracked)"
+echo "PASS B: prefilter drops unrelated lines, keeps candidates (sound — no detection regression)"
+
+# ---------------------------------------------------------------------------
+# (C) 404-window fixed-tail is INDEPENDENT of the forward cursor
+# ---------------------------------------------------------------------------
+tC="$(mktemp -d)"; trap 'rm -rf "$tA" "$tB" "$tC"' EXIT
+export NFTBAN_DATA_DIR="$tC/data" BOTSCAN_SPOOL_DIR="$tC/spool" \
+       BOTSCAN_PATTERNS_DIR="$tC/patterns" BOTSCAN_STATE_FILE="$tC/state.db" \
+       BOTSCAN_LOG_FILE="$tC/botscan.log" \
+       BOTSCAN_404_TRACKING=true BOTSCAN_404_THRESHOLD=3 BOTSCAN_404_WINDOW=300
+mkdir -p "$NFTBAN_DATA_DIR" "$BOTSCAN_SPOOL_DIR" "$BOTSCAN_PATTERNS_DIR" "$NFTBAN_DATA_DIR/botguard"
+# 4 x 404 from ONE IP → exceeds threshold 3.
+for i in 1 2 3 4; do
+  printf '198.51.100.5 - - [14/Jun/2026:10:00:0%s +0000] "GET /m%s HTTP/1.1" 404 12 "-" "ua"\n' "$i" "$i" \
+    >> "$BOTSCAN_SPOOL_DIR/a.log"
+done
+oc1="$(nftban_botscan_process_logs "" 60 2>&1)" || fail "C cycle1 rc!=0: $oc1"
+banned_has "198.51.100.5" || fail "C: 404 flood must ban on cycle1 ($oc1)"
+# Cycle 2: forward cursor reads 0 NEW bytes, yet the fixed-tail re-read still sees the flood.
+: > "$(sigfile)"   # clear so a cycle-2 ban is unambiguously NEW
+oc2="$(nftban_botscan_process_logs "" 60 2>&1)" || fail "C cycle2 rc!=0: $oc2"
+[[ "$(procof "$oc2")" == "0" ]] || fail "C: cycle2 cursor must read 0 new bytes, got '$(procof "$oc2")'"
+banned_has "198.51.100.5" || fail "C: 404 detection must be INDEPENDENT of the cursor (still ban on cycle2 with 0 new bytes) ($oc2)"
+echo "PASS C: 404 fixed-tail re-read is independent of the forward cursor"
+
+echo "PASS: botscan throughput (Lane A) — forward cursor + prefilter + 404 fixed-tail"


### PR DESCRIPTION
## v1.187 Lane A — BOTSCAN-SCAN-THROUGHPUT

Closes the flood-host throughput class that v1.185's per-file cap left as a documented KNOWN LIMITATION (tail-biased → dropped the majority of bytes on busy hosts). **Shell/data only.**

### Changes
- **A1 — Forward-mode per-file cursor.** `nftban_http_read_incremental` gains an opt-in forward mode (`NFTBAN_HTTP_LOG_READ_FORWARD`): emits the OLDEST unread window `[start, start+MAX)` and advances the offset by exactly what it emits → a backlog larger than the per-cycle cap drains **forward across cycles with no skipped bytes**. `process_logs` uses it on a **dedicated** offset dir (`/var/lib/nftban/botscan/proc-offsets`) — distinct offset semantics, distinct from the collector. The default tail-biased branch is unchanged → **the privileged collector stays byte-identical.** Per-file cap default raised 64 KiB → 1 MiB.
- **A2 — Candidate prefilter.** One C-speed `grep -E -f` pass (a *sound ERE superset* of the bash matcher — line-anchors stripped + a 404-status keeper) drops the measured 49–90% droppable fraction before the ~55-eps per-line bash loop. GNU grep is DFA-based → linear, cannot ReDoS-stall.
- **A3 — Regex hygiene.** Literal/regex feed for the prefilter; **no combined bash alternation** (the scope premise was wrong — there is none, and adding one would *create* ReDoS).
- **A4 — 404-window OPTION 1** (operator-locked, `V1_187_DECISION_ADDENDUM.md`): an independent fixed-tail re-read, **independent of the forward cursor** (never reads/rewinds its offset), preserving 404-burst detection the forward cursor would otherwise fragment.

### Envelope
- Daemon `cmd/nftband` **BYTE-IDENTICAL to v1.186 (`c63d8822`)**; schema frozen; no packaging/FHS change. Rebased on v1.186.1 main — the IFS hotfix and Lane A coexist (zero-conflict, verified).

### Tests
- New hermetic `botscan_throughput_v187_test.sh` **PASS 3/3**: forward cursor no-skip across cycles; prefilter soundness (candidate kept / unrelated dropped / no detection regression); 404 fixed-tail independence (bans on a cycle that reads 0 new cursor bytes). v185 regression + v1.186.1 IFS test pass; shellcheck clean.

### NOT in this PR
Lane B badbot/aibot UX (v1.187 Lane B) · adaptive promotion (HOLD, daemon-Go) · FCrDNS verified-crawler (v1.188) · BotGuard counters (separate schema-unfreeze lane). **Lab-first throughput validation on srv2/srv3 is a later gate** (after CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
