### PR TITLE
fix(ci): deterministic help/code doctest — allowlist firewall init + kill SIGPIPE flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests / validation
 - New hermetic `botscan_throughput_v187_test.sh` **PASS 3/3** (forward cursor no-skip across cycles; prefilter soundness / no ban regression; 404 fixed-tail independence). v185 deadline/rotation regression + v1.186.1 IFS test pass; shellcheck clean. Real-host srv2 prefilter 77% drop; bounded-by-design; cross-distro/uutils via the v1.186.1 rollout.
+- **CI determinism fix (unrelated to BotScan): help/code doctest guard** (`v130_subcommand_flag_help_code_test.sh`) — eliminated a SIGPIPE/`pipefail` flake (`printf | grep -qwF` → here-string) that intermittently mis-flagged a *matched* token as undocumented, and allowlisted the deprecated `firewall init` alias (v1.38.0 BUG-002 → rebuild) in `v134_help_code_alias_allowlist.tsv`. Now deterministic 67/0. CI-test + allowlist only; no product/daemon change.
 
 ---
 

--- a/cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh
+++ b/cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh
@@ -84,7 +84,7 @@ for f in "$_cli"/cmd_*.sh; do
         [[ -z "$t" ]] && continue
         _is_structural "$t" && continue
         _allowlisted "$rel" "$t" && continue
-        printf '%s' "$help" | grep -qwF -- "$t" && continue
+        grep -qwF -- "$t" <<<"$help" && continue   # here-string (no upstream pipe → no SIGPIPE/141 flake under pipefail)
         residual+="$t "
     done <<< "$tokens"
     if [[ -z "$residual" ]]; then

--- a/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
+++ b/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
@@ -71,4 +71,4 @@ cli/cmd_portscan.sh	restart	alias	reload
 cli/cmd_portscan.sh	sync	undocumented-subcmd	DOC-CANDIDATE: real subcmd (journalctl log sync; in error-fallback list)
 cli/cmd_sync.sh	status	undocumented-subcmd	DOC-CANDIDATE: real subcmd (nftban_sync_status)
 cli/cmd_firewall.sh	ssh-port-audit	alias	ssh-audit (OBS-SSHPORT-55000 external admin-port audit)
-cli/cmd_firewall.sh	init	deprecated-alias	rebuild (v1.38.0 BUG-002: firewall init never implemented → alias to rebuild)
+cli/cmd_firewall.sh	init	deprecated	rebuild (v1.38.0 BUG-002: firewall init never implemented → alias to rebuild)

--- a/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
+++ b/cli/lib/nftban/tests/v134_help_code_alias_allowlist.tsv
@@ -71,3 +71,4 @@ cli/cmd_portscan.sh	restart	alias	reload
 cli/cmd_portscan.sh	sync	undocumented-subcmd	DOC-CANDIDATE: real subcmd (journalctl log sync; in error-fallback list)
 cli/cmd_sync.sh	status	undocumented-subcmd	DOC-CANDIDATE: real subcmd (nftban_sync_status)
 cli/cmd_firewall.sh	ssh-port-audit	alias	ssh-audit (OBS-SSHPORT-55000 external admin-port audit)
+cli/cmd_firewall.sh	init	deprecated-alias	rebuild (v1.38.0 BUG-002: firewall init never implemented → alias to rebuild)


### PR DESCRIPTION
Fixes the intermittent **Architecture Policy → Help/code doctest guard** failure (seen on post-merge main for the v1.187.0 release).

**Two real fixes (not a re-run):**
1. `firewall init` is a deprecated internal alias (v1.38.0 BUG-002 → rebuild) — dispatched but undocumented + unallowlisted → guard correctly flagged it. Added to `v134_help_code_alias_allowlist.tsv` as `deprecated-alias`.
2. **SIGPIPE/pipefail flake:** `printf '%s' "$help" | grep -qwF` → grep early-exit SIGPIPEs printf (rc 141); under pipefail the pipeline returns 141 even when grep *matched* → matched token mis-flagged as undocumented (intermittent). Fixed with a here-string (no upstream pipe).

Deterministic **67 passed / 0 failed / 2 skipped** 3/3 locally; shellcheck clean. CI-test + allowlist only — no product/daemon/shell-runtime change. Rides v1.187.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)