### PR TITLE
fix(botscan): v1.187.1 — fix BotScan cycle-timeout (remove main-scan per-line forks; keep A4 bound)

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -81,6 +81,9 @@ nftban_botscan_load_config() {
     : "${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:=1048576}"
     : "${BOTSCAN_SCAN_PREFILTER:=true}"
     : "${BOTSCAN_404_TAIL_BYTES:=2097152}"
+    # v1.187.1 — per-cycle A4 404-tail total-bytes backstop (bounds budget=0/interactive runs;
+    # the shared soft-deadline bounds normal cycles). Default 32 MiB.
+    : "${BOTSCAN_404_TAIL_TOTAL_BYTES:=33554432}"
     : "${BOTSCAN_PROGRESSIVE_ENABLED:=true}"
     : "${BOTSCAN_PROGRESSIVE_MULTIPLIER:=2}"
     : "${BOTSCAN_PROGRESSIVE_MAX:=86400}"
@@ -574,21 +577,48 @@ nftban_botscan_build_prefilter() {
     [[ "$n" -gt 0 ]]
 }
 
-# v1.187 Lane A — 404-window OPTION 1 (fixed-tail re-read), INDEPENDENT of the forward
-# processor cursor (does NOT read or advance its offset). Each cycle re-reads a bounded
-# tail of each file sized to cover the 404 window, prefilters to 404 lines (C-speed), and
-# (re)counts per-IP 404s into the analyze() arrays — preserving 404-burst detection that
-# the forward cursor (one slice/cycle) would otherwise fragment. Honors the whitelists.
+# v1.187 Lane A / v1.187.1 — 404-window OPTION 1 (fixed-tail re-read), INDEPENDENT of the
+# forward processor cursor (does NOT read/advance its offset). Re-reads a bounded tail of
+# each file, prefilters to 404 lines (C-speed), counts per-IP 404s into analyze()'s arrays.
+# v1.187.1 BOUNDS this stage (v1.187.0 A4 was unbounded → srv2 126-log/131MB cycle blew past
+# TimeoutStartSec=300; `V1_187_1_BOTSCAN_404_TAIL_BOUND_HOTFIX_SCOPE.md`):
+#   (1) shares the cycle soft-deadline (start_secs + BOTSCAN_SCAN_BUDGET_SECS) — checked
+#       BETWEEN files, breaks cleanly (always processing ≥1 file so 404 coverage + rotation
+#       make forward progress even when the main loop consumed most of the budget);
+#   (2) a per-cycle total-bytes backstop (BOTSCAN_404_TAIL_TOTAL_BYTES) for budget=0 runs;
+#   (3) an anti-starvation rotation cursor (404-rotate, separate from the main scan-rotate)
+#       so every file's 404 tail is covered across successive cycles.
+# 404-flood detection is preserved: each scanned file's full tail is counted; rotation +
+# the (steady-state) freed budget cover the rest across cycles. Honors the whitelists.
+# Args: <start_secs> <budget_secs> -- <file>...
 nftban_botscan_count_404_tail() {
     [[ "${BOTSCAN_404_TRACKING:-true}" == "true" ]] || return 0
+    local start_secs="${1:-$SECONDS}" budget="${2:-0}"; shift 2
     local now; now=$(nftban_timestamp_unix 2>/dev/null || date +%s)
     local tail_bytes="${BOTSCAN_404_TAIL_BYTES:-2097152}"
-    # Reset so the count reflects ONLY the current window's tail (stateless; lowest risk).
+    local max_total="${BOTSCAN_404_TAIL_TOTAL_BYTES:-33554432}"
+    # Reset so the count reflects ONLY this cycle's scanned tails.
     _BOTSCAN_IP_404_COUNT=()
     _BOTSCAN_IP_404_FIRST_SEEN=()
-    local f line parsed ip url method status ua
-    for f in "$@"; do
+    local files=("$@") n=${#files[@]}
+    [[ "$n" -eq 0 ]] && return 0
+    # Anti-starvation rotation cursor (next cycle resumes where this one stopped).
+    local rot_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/404-rotate" rot=0
+    mkdir -p "${rot_file%/*}" 2>/dev/null || true
+    [[ -r "$rot_file" ]] && IFS= read -r rot < "$rot_file" 2>/dev/null
+    [[ "$rot" =~ ^[0-9]+$ ]] || rot=0
+    rot=$(( rot % n ))
+    local consumed=0 covered=0 i idx f line parsed ip url method status ua
+    for (( i=0; i<n; i++ )); do
+        # Shared cycle soft-deadline — but always cover ≥1 file (forward 404 progress + rotation).
+        if [[ "$covered" -gt 0 && "$budget" -gt 0 && $(( SECONDS - start_secs )) -ge "$budget" ]]; then break; fi
+        # Per-cycle total-bytes backstop (bounds budget=0 / interactive runs); ≥1 file always.
+        if [[ "$covered" -gt 0 && "$max_total" -gt 0 && "$consumed" -ge "$max_total" ]]; then break; fi
+        idx=$(( (rot + i) % n ))
+        f="${files[$idx]}"
+        covered=$(( covered + 1 ))
         [[ -f "$f" && -r "$f" ]] || continue
+        consumed=$(( consumed + tail_bytes ))
         while IFS= read -r line; do
             parsed=$(nftban_botscan_parse_line "$line") || continue
             IFS='|' read -r ip url method status ua <<< "$parsed"
@@ -599,6 +629,8 @@ nftban_botscan_count_404_tail() {
             [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$ip]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$ip"]="$now"
         done < <( tail -c "$tail_bytes" -- "$f" 2>/dev/null | LC_ALL=C grep -E '" 404 | 404 ' 2>/dev/null || true )
     done
+    # Persist rotation: next cycle starts after the last file covered this cycle.
+    printf '%s\n' "$(( (rot + covered) % n ))" > "${rot_file}.tmp" 2>/dev/null && mv -f "${rot_file}.tmp" "$rot_file" 2>/dev/null || true
     return 0
 }
 
@@ -810,7 +842,7 @@ nftban_botscan_process_logs() {
     # v1.187 Lane A — 404-window OPTION 1: independent fixed-tail re-read (does NOT touch
     # the forward cursor offset) so 404-burst detection is preserved despite the forward
     # cursor only seeing one slice per cycle. Authoritative source for the 404 counters.
-    nftban_botscan_count_404_tail "${logs[@]}"
+    nftban_botscan_count_404_tail "$start_secs" "$budget" "${logs[@]}"
     [[ -n "$_pf" ]] && rm -f "$_pf"
 
     # Analyze and ban — ALWAYS runs (even on a partial/deadline-bounded batch) so a

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -307,31 +307,42 @@ nftban_botscan_find_log() {
 
 # Parse access log line
 # Returns: IP|URL|METHOD|STATUS|USER_AGENT
-nftban_botscan_parse_line() {
+# v1.187.1 — NO-FORK parser. Sets the globals _BS_IP/_BS_URL/_BS_METHOD/_BS_STATUS/_BS_UA
+# and returns 0 (parsed) / 1 (no match). The hot scan loops call THIS directly so a busy
+# host no longer forks a subshell per log line (the v1.187.1 cycle-timeout fix: a 4.2 MB DA
+# log was ~123s / 5497 lines = ~22 ms/line, dominated by per-line command-substitution forks
+# — parse + match + timestamp). Regex semantics are byte-identical to the previous version.
+nftban_botscan_parse_line_g() {
     local line="$1"
-    local ip url method status ua
 
     # Combined Log Format: IP - - [date] "METHOD URL PROTO" STATUS SIZE "REFERER" "UA"
     # IPv4 and IPv6 compatible (v1.19.0, v1.19.12 bracket fix R22)
     # Handles: 192.168.1.1, 2001:db8::1, [2001:db8::1]:8080
     if [[ "$line" =~ ^\[?([0-9a-fA-F.:]+)\]?.*\"([A-Z]+)\ ([^\"\ ]+).*\"\ ([0-9]+) ]]; then
-        ip="${BASH_REMATCH[1]}"
-        method="${BASH_REMATCH[2]}"
-        url="${BASH_REMATCH[3]}"
-        status="${BASH_REMATCH[4]}"
+        _BS_IP="${BASH_REMATCH[1]}"
+        _BS_METHOD="${BASH_REMATCH[2]}"
+        _BS_URL="${BASH_REMATCH[3]}"
+        _BS_STATUS="${BASH_REMATCH[4]}"
 
         # Extract user agent
         if [[ "$line" =~ \"([^\"]+)\"$ ]]; then
-            ua="${BASH_REMATCH[1]}"
+            _BS_UA="${BASH_REMATCH[1]}"
         else
-            ua="-"
+            _BS_UA="-"
         fi
 
-        echo "${ip}|${url}|${method}|${status}|${ua}"
         return 0
     fi
 
     return 1
+}
+
+# Echo-API wrapper — UNCHANGED output contract (IP|URL|METHOD|STATUS|UA). Used by
+# cmd_botscan (emulate) and existing tests. Delegates to the no-fork parser so the two
+# can never drift.
+nftban_botscan_parse_line() {
+    nftban_botscan_parse_line_g "$1" || return 1
+    echo "${_BS_IP}|${_BS_URL}|${_BS_METHOD}|${_BS_STATUS}|${_BS_UA}"
 }
 
 # Check if IP is whitelisted — v1.19.0: IPv4/IPv6 parity
@@ -388,15 +399,19 @@ nftban_botscan_is_path_whitelisted() {
 
 # Match URL against patterns
 # Returns: matched pattern name or empty
-nftban_botscan_match_url() {
+# v1.187.1 — NO-FORK matcher. Sets _BS_MATCHED to the matched pattern name ("" if none) and
+# returns 0 (match) / 1 (no match). Same iteration order + match-type semantics as the echo
+# API; called directly from the hot path (process_entry) to drop the per-line subshell fork.
+nftban_botscan_match_url_g() {
     local url="$1"
     local method="$2"
     local status="$3"
     local ua="${4:-}"
+    _BS_MATCHED=""
 
+    local name def pattern match_type
     for name in "${!_BOTSCAN_PATTERNS[@]}"; do
-        local def="${_BOTSCAN_PATTERNS[$name]}"
-        local pattern match_type
+        def="${_BOTSCAN_PATTERNS[$name]}"
 
         IFS='|' read -r pattern match_type _ _ _ _ <<< "$def"
 
@@ -405,42 +420,34 @@ nftban_botscan_match_url() {
             url-404)
                 [[ "$status" != "404" ]] && continue
                 # Match URL pattern
-                if [[ "$url" =~ $pattern ]]; then
-                    echo "$name"
-                    return 0
-                fi
+                if [[ "$url" =~ $pattern ]]; then _BS_MATCHED="$name"; return 0; fi
                 ;;
             url-post)
                 [[ "$method" != "POST" ]] && continue
-                if [[ "$url" =~ $pattern ]]; then
-                    echo "$name"
-                    return 0
-                fi
+                if [[ "$url" =~ $pattern ]]; then _BS_MATCHED="$name"; return 0; fi
                 ;;
             url-get)
                 [[ "$method" != "GET" ]] && continue
-                if [[ "$url" =~ $pattern ]]; then
-                    echo "$name"
-                    return 0
-                fi
+                if [[ "$url" =~ $pattern ]]; then _BS_MATCHED="$name"; return 0; fi
                 ;;
             url-any)
-                if [[ "$url" =~ $pattern ]]; then
-                    echo "$name"
-                    return 0
-                fi
+                if [[ "$url" =~ $pattern ]]; then _BS_MATCHED="$name"; return 0; fi
                 ;;
             useragent)
                 # Match against user-agent string
-                if [[ -n "$ua" && "$ua" =~ $pattern ]]; then
-                    echo "$name"
-                    return 0
-                fi
+                if [[ -n "$ua" && "$ua" =~ $pattern ]]; then _BS_MATCHED="$name"; return 0; fi
                 ;;
         esac
     done
 
     return 1
+}
+
+# Echo-API wrapper — UNCHANGED contract (echoes the matched pattern name, returns 1 on no
+# match). Used by cmd_botscan (emulate). Delegates to the no-fork matcher.
+nftban_botscan_match_url() {
+    nftban_botscan_match_url_g "$@" || return 1
+    echo "$_BS_MATCHED"
 }
 
 # Process log entry
@@ -450,8 +457,11 @@ nftban_botscan_process_entry() {
     local method="$3"
     local status="$4"
     local ua="$5"
+    # v1.187.1 — fork-free per-line timestamp (was now=$(nftban_timestamp_unix||date), a third
+    # subshell fork per log line). printf '%(%s)T' is a bash builtin (4.2+, all targets 5.x);
+    # falls back to the old fork only on ancient bash. Same epoch-seconds value.
     local now
-    now=$(nftban_timestamp_unix 2>/dev/null || date +%s)
+    printf -v now '%(%s)T' -1 2>/dev/null || now=$(nftban_timestamp_unix 2>/dev/null || date +%s)
 
     # Check whitelists
     nftban_botscan_is_whitelisted "$ip" "$ua" && return 0
@@ -463,9 +473,10 @@ nftban_botscan_process_entry() {
         [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$ip]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$ip"]="$now"
     fi
 
-    # Match against patterns (URL and user-agent)
-    local matched_pattern
-    matched_pattern=$(nftban_botscan_match_url "$url" "$method" "$status" "$ua") || true
+    # Match against patterns (URL and user-agent) — v1.187.1 no-fork matcher (was a per-line
+    # command-substitution fork). errexit-safe: the && only assigns on a match.
+    local matched_pattern=""
+    nftban_botscan_match_url_g "$url" "$method" "$status" "$ua" && matched_pattern="$_BS_MATCHED"
 
     if [[ -n "$matched_pattern" ]]; then
         # Update tracking
@@ -609,7 +620,7 @@ nftban_botscan_count_404_tail() {
     [[ -r "$rot_file" ]] && IFS= read -r rot < "$rot_file" 2>/dev/null
     [[ "$rot" =~ ^[0-9]+$ ]] || rot=0
     rot=$(( rot % n ))
-    local consumed=0 covered=0 i idx f line parsed ip url method status ua
+    local consumed=0 covered=0 i idx f line
     for (( i=0; i<n; i++ )); do
         # Shared cycle soft-deadline — but always cover ≥1 file (forward 404 progress + rotation).
         if [[ "$covered" -gt 0 && "$budget" -gt 0 && $(( SECONDS - start_secs )) -ge "$budget" ]]; then break; fi
@@ -621,13 +632,12 @@ nftban_botscan_count_404_tail() {
         [[ -f "$f" && -r "$f" ]] || continue
         consumed=$(( consumed + tail_bytes ))
         while IFS= read -r line; do
-            parsed=$(nftban_botscan_parse_line "$line") || continue
-            IFS='|' read -r ip url method status ua <<< "$parsed"
-            [[ "$status" == "404" ]] || continue
-            nftban_botscan_is_whitelisted "$ip" "$ua" && continue
-            nftban_botscan_is_path_whitelisted "$url" && continue
-            _BOTSCAN_IP_404_COUNT["$ip"]=$(( ${_BOTSCAN_IP_404_COUNT[$ip]:-0} + 1 ))
-            [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$ip]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$ip"]="$now"
+            nftban_botscan_parse_line_g "$line" || continue   # v1.187.1 no-fork
+            [[ "$_BS_STATUS" == "404" ]] || continue
+            nftban_botscan_is_whitelisted "$_BS_IP" "$_BS_UA" && continue
+            nftban_botscan_is_path_whitelisted "$_BS_URL" && continue
+            _BOTSCAN_IP_404_COUNT["$_BS_IP"]=$(( ${_BOTSCAN_IP_404_COUNT[$_BS_IP]:-0} + 1 ))
+            [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$_BS_IP]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$_BS_IP"]="$now"
         done < <( tail -c "$tail_bytes" -- "$f" 2>/dev/null | LC_ALL=C grep -E '" 404 | 404 ' 2>/dev/null || true )
     done
     # Persist rotation: next cycle starts after the last file covered this cycle.
@@ -769,11 +779,14 @@ nftban_botscan_process_logs() {
     local budget="${BOTSCAN_SCAN_BUDGET_SECS:-0}"
     local start_secs=$SECONDS
     local deadline_hit=0
-    # Bound each file's per-cycle read so a single whole file is always processable inside
-    # a budget slice (default 1 MiB; ~5k lines). Scoped to this scan process only — the
-    # privileged collector keeps its own (larger) cap. Only narrow it (never widen a
-    # caller-set smaller value).
-    local _scan_cap="${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-1048576}"
+    # Bound each file's per-cycle read so a single whole file is always processable inside a
+    # budget slice. v1.187.1 lowered the default 1 MiB → 256 KiB (~1.3k lines) as a cheap
+    # time backstop: combined with the no-fork parse/match path a 256 KiB slice processes in
+    # well under a second, so no single file can push the cycle toward TimeoutStartSec even on
+    # a 126-log/921 MB DA host. The rotation cursor still covers every file across cycles.
+    # Scoped to this scan process only — the privileged collector keeps its own (larger) cap.
+    # Only narrow it (never widen a caller-set smaller value).
+    local _scan_cap="${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-262144}"
     if [[ -z "${NFTBAN_HTTP_LOG_MAX_BYTES:-}" || "${NFTBAN_HTTP_LOG_MAX_BYTES}" -gt "$_scan_cap" ]]; then
         export NFTBAN_HTTP_LOG_MAX_BYTES="$_scan_cap"
     fi
@@ -814,11 +827,8 @@ nftban_botscan_process_logs() {
         idx=$(( (rot + i) % n ))
         f="${logs[$idx]}"
         while IFS= read -r line; do
-            local parsed
-            parsed=$(nftban_botscan_parse_line "$line") || continue
-            local ip url method status ua
-            IFS='|' read -r ip url method status ua <<< "$parsed"
-            nftban_botscan_process_entry "$ip" "$url" "$method" "$status" "$ua"
+            nftban_botscan_parse_line_g "$line" || continue   # v1.187.1 no-fork (was $(parse_line))
+            nftban_botscan_process_entry "$_BS_IP" "$_BS_URL" "$_BS_METHOD" "$_BS_STATUS" "$_BS_UA"
             processed=$((processed + 1))
         done < <(
             {

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -600,7 +600,8 @@ nftban_botscan_count_404_tail() {
     # Reset so the count reflects ONLY this cycle's scanned tails.
     _BOTSCAN_IP_404_COUNT=()
     _BOTSCAN_IP_404_FIRST_SEEN=()
-    local files=("$@") n=${#files[@]}
+    local files=("$@")
+    local n=${#files[@]}
     [[ "$n" -eq 0 ]] && return 0
     # Anti-starvation rotation cursor (next cycle resumes where this one stopped).
     local rot_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/404-rotate" rot=0

--- a/cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh
+++ b/cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.187.1 - BotScan A4 404-tail bounding guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_404_tail_bound_v1871_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-14"
+# meta:description="BOTSCAN-404-TAIL-UNBOUNDED (v1.187.1) guard: nftban_botscan_count_404_tail is now BOUNDED. (A) per-cycle total-bytes backstop covers only a subset of files per cycle and the 404-rotate cursor advances so the remaining files are covered next cycle (anti-starvation). (B) the shared cycle soft-deadline breaks A4 cleanly between files but always covers >=1 file (forward progress). (C) 404-flood detection is preserved: a flooding IP in a covered file's tail still reaches the threshold. Deterministic (byte-cap + rotation + past-deadline), no timing flakiness."
+#
+# meta:inventory.files="botscan_404_tail_bound_v1871_test.sh"
+# meta:inventory.binaries="bash,tail,grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_404_TAIL_BYTES,BOTSCAN_404_TAIL_TOTAL_BYTES"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_PATTERNS_DIR="$tmp/patterns" \
+       BOTSCAN_STATE_FILE="$tmp/s.db" BOTSCAN_LOG_FILE="$tmp/b.log" \
+       NFTBAN_CONFIG_DIR="$tmp/noetc" BOTSCAN_ENABLED=true BOTSCAN_404_TRACKING=true
+mkdir -p "$NFTBAN_DATA_DIR/botscan" "$BOTSCAN_PATTERNS_DIR" "$tmp/spool"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"; nftban_botscan_load_config
+
+# 4 spool files; file "c" carries a 404 flood (5x from 198.51.100.9). One 404 line each elsewhere.
+mk() { printf '%s - - [14/Jun/2026:10:00:0%s +0000] "GET /x%s HTTP/1.1" 404 9 "-" "ua"\n' "$1" "${3:-0}" "${3:-0}"; }
+mk 203.0.113.1 > "$tmp/spool/a.log"
+mk 203.0.113.2 > "$tmp/spool/b.log"
+for i in 1 2 3 4 5; do mk 198.51.100.9 _ "$i"; done > "$tmp/spool/c.log"
+mk 203.0.113.4 > "$tmp/spool/d.log"
+FILES=("$tmp/spool/a.log" "$tmp/spool/b.log" "$tmp/spool/c.log" "$tmp/spool/d.log")
+rotf="$NFTBAN_DATA_DIR/botscan/404-rotate"
+
+# --- (A) byte-cap covers 2 files/cycle + rotation advances; flood caught when "c" is covered ---
+export BOTSCAN_404_TAIL_BYTES=4096 BOTSCAN_404_TAIL_TOTAL_BYTES=8192   # 8192/4096 = 2 files/cycle
+rm -f "$rotf"
+nftban_botscan_count_404_tail 0 0 "${FILES[@]}"          # cycle 1: covers idx 0,1 (a,b)
+v="$(cat "$rotf")"; [[ "$v" == "2" ]] || fail "A: cycle1 should cover 2 files → rot=2, got '$v'"
+[[ -z "${_BOTSCAN_IP_404_COUNT[198.51.100.9]:-}" ]] || fail "A: flood file c (idx2) not covered yet in cycle1"
+nftban_botscan_count_404_tail 0 0 "${FILES[@]}"          # cycle 2: covers idx 2,3 (c,d)
+v="$(cat "$rotf")"; [[ "$v" == "0" ]] || fail "A: cycle2 should wrap → rot=0, got '$v'"
+[[ "${_BOTSCAN_IP_404_COUNT[198.51.100.9]:-0}" -ge 3 ]] || fail "A: flood IP must reach threshold when c covered (got ${_BOTSCAN_IP_404_COUNT[198.51.100.9]:-0})"
+echo "PASS A: byte-cap covers a subset/cycle, rotation advances, all files covered across cycles, flood preserved"
+
+# --- (B) shared soft-deadline already exceeded → A4 covers exactly 1 file (forward progress), then breaks ---
+export BOTSCAN_404_TAIL_TOTAL_BYTES=33554432   # cap not the limiter here
+rm -f "$rotf"
+# start_secs far in the past so (SECONDS - start_secs) >= budget immediately
+nftban_botscan_count_404_tail $(( SECONDS - 9999 )) 1 "${FILES[@]}"
+v="$(cat "$rotf")"; [[ "$v" == "1" ]] || fail "B: past-deadline must still cover >=1 file → rot=1, got '$v'"
+echo "PASS B: soft-deadline breaks cleanly but always covers >=1 file (no starvation)"
+
+# --- (C) no budget, no tight cap → covers ALL files in one cycle (back-compat for small fleets) ---
+export BOTSCAN_404_TAIL_TOTAL_BYTES=33554432
+rm -f "$rotf"
+nftban_botscan_count_404_tail 0 0 "${FILES[@]}"
+v="$(cat "$rotf")"; [[ "$v" == "0" ]] || fail "C: covering all 4 files wraps rot to 0, got '$v'"
+[[ "${_BOTSCAN_IP_404_COUNT[198.51.100.9]:-0}" -ge 3 ]] || fail "C: flood counted when all files covered"
+echo "PASS C: unbounded-budget small-fleet path still covers all files in one cycle"
+
+echo "PASS: botscan A4 404-tail bounding (cap + rotation + soft-deadline + flood preserved)"

--- a/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
+++ b/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.187.1 - BotScan no-fork parse/match parity test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_nofork_parity_v1871_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-14"
+# meta:description="v1.187.1 cycle-timeout fix removed the per-line subshell forks in the BotScan main scan loop (parse_line + match_url + timestamp). This proves the new no-fork _g variants are byte-for-byte equivalent to the kept echo-API functions: (P) nftban_botscan_parse_line_g sets _BS_IP/_BS_URL/_BS_METHOD/_BS_STATUS/_BS_UA identically to what nftban_botscan_parse_line echoes, across IPv4/IPv6/bracketed/quoted-UA/no-UA/malformed lines; (M) nftban_botscan_match_url_g sets _BS_MATCHED identically to what nftban_botscan_match_url echoes, across every match_type (url-404/url-post/url-get/url-any/useragent) and the no-match case. Guards the echo API used by cmd_botscan + existing tests against drift."
+#
+# meta:inventory.files="botscan_nofork_parity_v1871_test.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_PATTERNS_DIR="$tmp/patterns" \
+       BOTSCAN_STATE_FILE="$tmp/s.db" BOTSCAN_LOG_FILE="$tmp/b.log" \
+       NFTBAN_CONFIG_DIR="$tmp/noetc" BOTSCAN_ENABLED=true
+mkdir -p "$NFTBAN_DATA_DIR" "$BOTSCAN_PATTERNS_DIR"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"; nftban_botscan_load_config
+
+# ----------------------------------------------------------------------------
+# (P) parse_line: echo API vs no-fork _g, across formats
+# ----------------------------------------------------------------------------
+parse_lines=(
+  '203.0.113.5 - - [14/Jun/2026:10:00:00 +0000] "GET /wp-login.php HTTP/1.1" 404 120 "-" "evilbot/1.0"'
+  '2001:db8::1 - - [14/Jun/2026:10:00:00 +0000] "POST /xmlrpc.php HTTP/1.1" 200 5 "-" "Mozilla/5.0"'
+  '[2001:db8::2]:8080 - - [x] "HEAD /robots.txt HTTP/1.0" 301 0 "-" "-"'
+  '198.51.100.9 - - [x] "GET /noua HTTP/1.1" 500 9'
+  'this is not a log line at all'
+  ''
+)
+for line in "${parse_lines[@]}"; do
+    # echo API (the authority); rc captured errexit-safe
+    echo_out=""; echo_rc=0
+    echo_out="$(nftban_botscan_parse_line "$line")" || echo_rc=$?
+    # no-fork _g
+    g_rc=0
+    nftban_botscan_parse_line_g "$line" || g_rc=$?
+    # return codes must agree
+    [[ "$echo_rc" -eq "$g_rc" ]] || fail "P: rc mismatch echo=$echo_rc g=$g_rc for <$line>"
+    if [[ "$g_rc" -eq 0 ]]; then
+        g_out="${_BS_IP}|${_BS_URL}|${_BS_METHOD}|${_BS_STATUS}|${_BS_UA}"
+        [[ "$g_out" == "$echo_out" ]] || fail "P: field mismatch for <$line>: echo=[$echo_out] g=[$g_out]"
+    fi
+done
+# spot-check exact expected fields (IP|URL|METHOD|STATUS|UA order)
+nftban_botscan_parse_line_g '203.0.113.5 - - [x] "GET /a HTTP/1.1" 404 1 "-" "ua x"'
+[[ "$_BS_IP" == "203.0.113.5" && "$_BS_URL" == "/a" && "$_BS_METHOD" == "GET" && "$_BS_STATUS" == "404" && "$_BS_UA" == "ua x" ]] \
+    || fail "P: explicit field check failed (ip=$_BS_IP url=$_BS_URL m=$_BS_METHOD s=$_BS_STATUS ua=$_BS_UA)"
+echo "PASS P: parse_line_g globals == parse_line echo across all formats + explicit fields"
+
+# ----------------------------------------------------------------------------
+# (M) match_url: echo API vs no-fork _g, every match_type + no-match
+# ----------------------------------------------------------------------------
+# def format: pattern|match_type|threshold|window|ban|desc
+_BOTSCAN_PATTERNS=(
+  [WP_LOGIN]='wp-login|url-404|2|60|3600|wp'
+  [XMLRPC]='xmlrpc|url-post|2|60|3600|xr'
+  [GITCFG]='\.git/config|url-get|1|60|86400|git'
+  [ANYEVIL]='/evil|url-any|1|60|3600|any'
+  [BADUA]='evilbot|useragent|1|60|3600|ua'
+)
+# cases: url method status ua  -> expected match name ("" = no match)
+m_cases=(
+  "/wp-login.php|GET|404||WP_LOGIN"        # url-404 hits only on 404
+  "/wp-login.php|GET|200||"                # url-404 misses on non-404
+  "/xmlrpc.php|POST|200||XMLRPC"           # url-post hits only on POST
+  "/xmlrpc.php|GET|200||"                  # url-post misses on GET
+  "/x/.git/config|GET|200||GITCFG"        # url-get
+  "/x/.git/config|POST|200||"             # url-get misses on POST
+  "/evil/thing|HEAD|301||ANYEVIL"         # url-any any method/status
+  "/clean|GET|200|evilbot here|BADUA"     # useragent
+  "/clean|GET|200|firefox|"               # nothing matches
+)
+for c in "${m_cases[@]}"; do
+    IFS='|' read -r url method status ua expect <<< "$c"
+    echo_out=""; echo_rc=0
+    echo_out="$(nftban_botscan_match_url "$url" "$method" "$status" "$ua")" || echo_rc=$?
+    g_rc=0
+    nftban_botscan_match_url_g "$url" "$method" "$status" "$ua" || g_rc=$?
+    [[ "$echo_rc" -eq "$g_rc" ]] || fail "M: rc mismatch echo=$echo_rc g=$g_rc for <$c>"
+    [[ "$_BS_MATCHED" == "$echo_out" ]] || fail "M: name mismatch for <$c>: echo=[$echo_out] g=[$_BS_MATCHED]"
+    if [[ -n "$expect" ]]; then
+        [[ "$_BS_MATCHED" == "$expect" && "$g_rc" -eq 0 ]] || fail "M: expected [$expect] got [$_BS_MATCHED] rc=$g_rc for <$c>"
+    else
+        [[ "$g_rc" -eq 1 && -z "$_BS_MATCHED" ]] || fail "M: expected NO match for <$c> got [$_BS_MATCHED] rc=$g_rc"
+    fi
+done
+echo "PASS M: match_url_g _BS_MATCHED == match_url echo across every match_type + no-match"
+
+echo "PASS: botscan no-fork parse/match parity (v1.187.1)"


### PR DESCRIPTION
Surgical hotfix for the **v1.187.0 fleet-rollout NO-GO on srv2** (`V1_187_0_FLEET_ROLLOUT_RECORD.md`).

## Root cause — re-scoped after diagnosis
Timing markers on srv2 (`V1_187_1_TIMEOUT_ROOT_CAUSE_DIAGNOSIS.md`) proved the 300s `TimeoutStartSec` SIGTERM is **not A4**: a single 4.2 MB DA log took **123s / 5497 lines = 22 ms/line**, while `count_404_tail` (A4) = **0s** (the original #858 bound fires) and `analyze` = ~1s. The cost is the **main scan loop's three per-line command-substitution forks** — `parsed=$(parse_line)`, `matched=$(match_url)` (in `process_entry`), `now=$(timestamp)`. Budget is checked between files only, so one slow file straddling the 180s soft budget overruns toward 300s. v1.187 Lane A's forward cursor (≤1 MiB ≈ 5k lines/file vs old `tail -1000`) exposed the latent fork cost.

## Fix (shell-only; daemon byte-identical `c63d8822`; schema 1.83.0 frozen)
- `parse_line` → no-fork `parse_line_g` (globals); echo API kept as a delegating wrapper (no drift for `cmd_botscan` + tests).
- `match_url` → no-fork `match_url_g` (global `_BS_MATCHED`); echo wrapper kept.
- `process_entry` `now` → fork-free `printf -v '%(%s)T'`.
- Backstop: `BOTSCAN_SCAN_MAX_BYTES_PER_FILE` 1 MiB → 256 KiB; rotation cursor still covers every file.
- **Keeps the A4 404-tail budget bound** (correct, insufficient alone).

## Preserved
Parse + all match-type semantics, 404-flood, v1.186.1 IFS pattern-ban fix, signal format, thresholds/windows/durations.

## Verification
New `botscan_nofork_parity_v1871_test` (parse/match `_g` == echo, all formats + match_types + no-match) PASS; v187/v185/v1.186.1/A4-bound/discovery regressions pass; shellcheck `-S warning` clean; daemon `c63d8822`. **NO** Lane B / aibots / schema / BotGuard counters / banner-UX / daemon-Go / packaging. Final gate: **srv2 production cycle exits status=0/SUCCESS, never 300s timeout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)