### PR TITLE
feat(ux): v1.187.2 B1 — CLI/text-UX (banner tagline + update-lock friendliness)

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -378,8 +378,21 @@ _cmd_update_main() {
     mkdir -p "${NFTBAN_RUN_DIR:-/run/nftban}" 2>/dev/null || true
     exec 9>"$UPDATE_LOCK_FILE"
     if ! flock -n 9; then
-        _update_log ERROR "Another update is in progress"
-        _update_log INFO "If no update is running, use 'nftban update force' to clear stale lock"
+        _update_log ERROR "Another update is already in progress — not starting a second one."
+        # Best-effort: name the running updater so the user knows what holds the lock.
+        # (Our own PID also has the lock file open via fd 9, so exclude $$.)
+        local _holder="" _hstart=""
+        if command -v fuser >/dev/null 2>&1; then
+            _holder=$(fuser "$UPDATE_LOCK_FILE" 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+$' | grep -vx "$$" | head -1)
+        elif command -v lsof >/dev/null 2>&1; then
+            _holder=$(lsof -t "$UPDATE_LOCK_FILE" 2>/dev/null | grep -vx "$$" | head -1)
+        fi
+        if [[ -n "$_holder" ]] && kill -0 "$_holder" 2>/dev/null; then
+            _hstart=$(ps -o lstart= -p "$_holder" 2>/dev/null | sed 's/^[[:space:]]*//')
+            _update_log INFO "In-progress update: PID ${_holder}${_hstart:+ (started ${_hstart})}"
+        fi
+        _update_log INFO "Watch it finish:  tail -f ${UPDATE_LOG_FILE}"
+        _update_log INFO "Only if you are sure none is running (e.g. after a crash or reboot), 'nftban update force' clears a STALE lock."
         # We did NOT acquire the lock — a live updater holds it. Close our fd
         # but DO NOT remove the file: it belongs to the running updater.
         exec 9>&- 2>/dev/null || true

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -487,7 +487,7 @@ nftban_banner_unified() {
     local emoji_offset=5
 
     # Line 1: Icon + Health + Protection + Conflicts + Version + Tagline
-    local line1="${icons}  (${health_icon}${protection_icon}${conflict_icon})  ${bold}NFTBan v${version}${reset}${dim} - Open-source Linux IPS & nftables FW${reset}"
+    local line1="${icons}  (${health_icon}${protection_icon}${conflict_icon})  ${bold}NFTBan v${version}${reset}${dim} - Open-source Linux Firewall & IPS for nftables${reset}"
     printf "${dim}|${reset} %-$((width - 2 + emoji_offset))b ${dim}|${reset}\n" "$line1"
 
     # Line 2: Host, Kernel, Uptime (no emojis, no offset)

--- a/cli/lib/nftban/lib/version.sh
+++ b/cli/lib/nftban/lib/version.sh
@@ -67,7 +67,7 @@ readonly NFTBAN_VERSION_MINOR
 readonly NFTBAN_VERSION_PATCH
 
 # Version details
-readonly NFTBAN_VERSION_NAME="Linux IPS & nftables Firewall"
+readonly NFTBAN_VERSION_NAME="Linux Firewall & IPS for nftables"
 readonly NFTBAN_VERSION_DATE="2026-03-18"
 
 # v1.151 BUG-VERSION-BUILD-DATE-RUNTIME: "Build Date" must reflect the PACKAGE

--- a/cli/lib/nftban/tests/b1_text_ux_v1872_test.sh
+++ b/cli/lib/nftban/tests/b1_text_ux_v1872_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.187.2 - B1 CLI/text-UX guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="b1_text_ux_v1872_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="B1 CLI/text-UX lane (v1.187.2) guards: (1) UX-BANNER-TEXT — the unified banner tagline is the Firewall-first wording 'Open-source Linux Firewall & IPS for nftables' and the old IPS-first 'Open-source Linux IPS & nftables FW' is gone; NFTBAN_VERSION_NAME is 'Linux Firewall & IPS for nftables'. (2) UX-UPDATE-LOCK — the lock-contention message points the user to 'tail -f .../update.log', explains 'nftban update force' clears only a STALE lock, and best-effort names the in-progress PID; the old terse 'Another update is in progress / clear stale lock' wording is gone. Hermetic: behavioral banner render + source-content guards; no host/nft/IPC."
+#
+# meta:inventory.files="b1_text_ux_v1872_test.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_BANNER_MODE,NFTBAN_TTY"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+NEW_TAGLINE="Open-source Linux Firewall & IPS for nftables"
+OLD_TAGLINE="Open-source Linux IPS & nftables FW"
+NEW_VNAME="Linux Firewall & IPS for nftables"
+
+# ---- (1a) NFTBAN_VERSION_NAME ----
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/lib/version.sh"
+[[ "${NFTBAN_VERSION_NAME:-}" == "$NEW_VNAME" ]] \
+    || fail "version_name = '${NFTBAN_VERSION_NAME:-}' (expected '$NEW_VNAME')"
+echo "PASS 1a: NFTBAN_VERSION_NAME is Firewall-first"
+
+# ---- (1b) unified banner tagline (behavioral render) ----
+export NFTBAN_BANNER_MODE=full NFTBAN_TTY=true NFTBAN_COLOR=false
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_output.sh"
+banner_out="$(NFTBAN_BANNER_MODE=full nftban_banner_unified status 2>/dev/null || true)"
+if [[ -n "$banner_out" ]]; then
+    grep -qF -- "$NEW_TAGLINE" <<<"$banner_out" || fail "rendered banner missing new tagline; got: $(printf '%s' "$banner_out" | head -2)"
+    grep -qF -- "$OLD_TAGLINE" <<<"$banner_out" && fail "rendered banner still has OLD tagline"
+    echo "PASS 1b: rendered unified banner carries the Firewall-first tagline"
+else
+    echo "INFO 1b: banner render empty in this env — falling back to source guard"
+fi
+
+# ---- (1c) source-content guard: new tagline present, old absent ----
+out_src="$NFTBAN_LIB_DIR/core/nftban_output.sh"
+grep -qF -- "$NEW_TAGLINE" "$out_src" || fail "new tagline not in nftban_output.sh"
+grep -qF -- "$OLD_TAGLINE" "$out_src" && fail "OLD tagline still in nftban_output.sh"
+echo "PASS 1c: nftban_output.sh tagline source is Firewall-first"
+
+# ---- (2) UX-UPDATE-LOCK friendly message ----
+upd="$NFTBAN_LIB_DIR/cli/cmd_update.sh"
+# the contention block must point to the log tail + explain STALE-only force
+grep -qF -- "tail -f \${UPDATE_LOG_FILE}" "$upd" || fail "update-lock message missing 'tail -f \${UPDATE_LOG_FILE}' hint"
+grep -qiF -- "clears a STALE lock" "$upd" || fail "update-lock message missing STALE-only clarification"
+grep -qF -- "In-progress update: PID" "$upd" || fail "update-lock message missing best-effort PID line"
+# old terse wording gone
+grep -qF -- "If no update is running, use 'nftban update force' to clear stale lock" "$upd" \
+    && fail "old terse update-lock wording still present"
+echo "PASS 2: UX-UPDATE-LOCK message is friendly (PID + tail -f + STALE-only force)"
+
+echo "PASS: B1 CLI/text-UX (tagline + version_name + update-lock) v1.187.2"


### PR DESCRIPTION
BotScan-train **B1** (shell-only, presentation; daemon byte-identical `c63d8822`; no schema/packaging/detection-content). Two operator-requested UX items.

**UX-BANNER-TEXT** — Firewall-first tagline:
- unified banner: `Open-source Linux IPS & nftables FW` → `Open-source Linux Firewall & IPS for nftables`
- `NFTBAN_VERSION_NAME`: `Linux IPS & nftables Firewall` → `Linux Firewall & IPS for nftables`

**UX-UPDATE-LOCK** — friendlier lock-contention message: names the in-progress updater (PID + start time, best-effort, only when alive), points to `tail -f /var/log/nftban/update.log`, clarifies `nftban update force` clears only a STALE lock. No flock-mechanism change.

**Deferred (B1b, need a design call):** BUG-BANNER-INCONSISTENT (two banner renderers; root cause pinned — main dispatcher sets `NFTBAN_MOTTO='ban · unban · protect'` consumed only by the simple renderer) · UX-VERBOSE-FINDINGS. VAL-LOGINMON-002-UX is validator-Go (separate).

**Validation:** new `b1_text_ux_v1872_test.sh` (behavioral render + content guards) PASS; shellcheck `-S warning` clean; daemon `c63d8822`; diff = 3 shell files + 1 test (no cmd/internal/packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)