### PR TITLE
feat(ux): v1.187.3 B1b — converge banner to one compact posture line (BUG-BANNER-INCONSISTENT)

### DIFF
--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -270,15 +270,82 @@ nftban_render_banner() {
     esac
 }
 
-# Simple banner (one line + motto)
-nftban_render_banner_simple() {
-    local icons version motto
+# =============================================================================
+# v1.187.3 B1b — COMPACT BANNER (one shared source, two render modes)
+# =============================================================================
+# The compact one-liner is the non-dashboard render mode (watchdog, reports, and
+# every interactive command that is not version/status/health). It carries the
+# SAME identity as the full box (icons + version) PLUS a posture glyph and an
+# optional cache-only notice — so "is it working / does it need attention?" is
+# visible at a glance without forcing the full box (which would wreck scrollback
+# and pipe-ability). The full box (version/status/health) stays in
+# nftban_banner_unified and keeps the LIVE validator posture.
+
+# Cheap-FRESH posture glyph — perm-safe + no validator fork + no jq. Used ONLY by
+# the compact line (the full box pays for the live validator). Freshness beats
+# precision for a single glyph: a stale cache could paint a false 🟢, so we read
+# the daemon's CURRENT systemd state instead. ⚪ when it cannot be determined.
+nftban_posture_glyph_cheap() {
+    command -v systemctl >/dev/null 2>&1 || { printf '⚪'; return 0; }
+    local st
+    st=$(systemctl is-active nftband.service 2>/dev/null || true)
+    case "$st" in
+        active)                 printf '🟢' ;;
+        activating|reloading)   printf '🟠' ;;
+        failed)                 printf '🔴' ;;
+        inactive|deactivating)  printf '🔴' ;;
+        *)                      printf '⚪' ;;
+    esac
+    return 0
+}
+
+# Cache-ONLY update notice (NEVER hits the network — that would add latency to
+# every interactive command and break offline use). Reads the fresh-TTL
+# update_check cache written by nftban_check_updates_banner; prints the notice
+# string only when current < latest, else nothing.
+nftban_update_notice_cached() {
+    local cache_file="${NFTBAN_CACHE_DIR:-/var/cache/nftban}/update_check"
+    local cache_ttl="${NFTBAN_UPDATE_TTL:-86400}"
+    [[ -f "$cache_file" ]] || return 0
+    local now age
+    now=$(date +%s)
+    age=$(( now - $(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "$now") ))
+    [[ "$age" -lt "$cache_ttl" ]] || return 0
+    local latest current cmp
+    latest="$(cat "$cache_file" 2>/dev/null || true)"
+    [[ -n "$latest" ]] || return 0
+    current="$(nftban_get_version)"
+    [[ "$latest" != "$current" ]] || return 0
+    nftban_version_compare "$current" "$latest"; cmp=$?
+    [[ "$cmp" -eq 1 ]] || return 0   # only when current < latest
+    printf '↑ v%s available — nftban update' "$latest"
+    return 0
+}
+
+# Compact one-liner: icons + posture glyph + version (+ optional cached notice).
+nftban_render_banner_compact() {
+    _v141_banner_suppressed && return 0
+    [[ "${NFTBAN_BANNER_MODE:-auto}" == "none" ]] && return 0
+    [[ "${NFTBAN_OUTPUT_JSON:-false}" == "true" ]] && return 0
+    local icons version glyph notice
     icons="$(nftban_icon_pair)"
     version="$(nftban_get_version)"
-    motto="${NFTBAN_MOTTO:-NFTBan — Open-source Linux IPS and nftables firewall manager}"
+    glyph="$(nftban_posture_glyph_cheap)"
+    notice="$(nftban_update_notice_cached || true)"
+    local bold="${NFTBAN_COLOR_BOLD}" reset="${NFTBAN_COLOR_RESET}" dim="${NFTBAN_COLOR_DIM}"
+    if [[ -n "$notice" ]]; then
+        printf '%b\n' "${icons}  ${glyph} ${bold}NFTBan v${version}${reset}${dim}  · ${notice}${reset}"
+    else
+        printf '%b\n' "${icons}  ${glyph} ${bold}NFTBan v${version}${reset}"
+    fi
+    return 0
+}
 
-    echo -e "${NFTBAN_COLOR_BOLD}${icons} NFTBan v${version}${NFTBAN_COLOR_RESET}"
-    echo -e "${NFTBAN_COLOR_DIM}${motto}${NFTBAN_COLOR_RESET}"
+# Back-compat shim — the old 2-line motto renderer is superseded by the compact
+# posture line. Kept so existing callers (`nftban_render_banner simple`, etc.)
+# converge to the one compact path instead of the orphaned motto.
+nftban_render_banner_simple() {
+    nftban_render_banner_compact
 }
 
 # =============================================================================
@@ -342,9 +409,11 @@ nftban_banner_unified() {
     # instead, so `nftban list`, `nftban firewall`, … no longer emit the full
     # box. This is the ONE banner path — known and unknown commands alike.
     case "$mode" in
-        version|status|hello|first-run|"") : ;;  # full box allowed
+        version|status|hello|first-run|"") : ;;  # full box allowed (live validator posture)
         *)
-            nftban_render_banner_simple
+            # v1.187.3 B1b — every other command gets the compact one-liner with a
+            # cheap-fresh posture glyph + optional cached notice (not the full box).
+            nftban_render_banner_compact
             return 0
             ;;
     esac

--- a/cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh
+++ b/cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.187.3 - B1b compact-banner convergence guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="b1b_banner_compact_v1873_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="B1b banner convergence (v1.187.3): non-dashboard commands render ONE compact one-liner carrying a posture glyph, not the old 2-line motto and not the full box. Guards: (A) compact posture glyph is driven by the CHEAP-FRESH daemon systemd state, NOT the live validator — proven by setting a bogus _NFTBAN_VALIDATOR_CACHE 'down' and a systemctl shim 'active' and asserting the glyph is 🟢 (validator ignored on the hot path); (B) failed daemon → 🔴; (C) cache-only update notice appears only when a FRESH cache has a higher version, never via network; (D) suppression — --json / NFTBAN_BANNER_MODE=none emit nothing; (E) full-box gate intact — version mode still renders the box tagline, a non-dashboard mode renders the compact glyph line. Hermetic: systemctl shimmed, temp cache; no host/nft/IPC/validator."
+#
+# meta:inventory.files="b1b_banner_compact_v1873_test.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CACHE_DIR,NFTBAN_BANNER_MODE,NFTBAN_OUTPUT_JSON"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_CACHE_DIR="$tmp/cache" NFTBAN_TTY=true NFTBAN_COLOR=false
+mkdir -p "$NFTBAN_CACHE_DIR"
+
+# Shim systemctl BEFORE sourcing so the cheap glyph reads our controlled state.
+_SYSTEMCTL_STATE="active"
+systemctl() { case "$*" in *"is-active nftband"*) echo "$_SYSTEMCTL_STATE";; *) echo "unknown";; esac; return 0; }
+export -f systemctl
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/lib/version.sh"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_output.sh"
+
+# ---- (A) compact glyph is CHEAP-FRESH (systemctl), NOT the validator ----
+# Bogus validator cache says "down"; if compact wrongly consulted it, glyph→🔴.
+export _NFTBAN_VALIDATOR_CACHE='{"status":"down"}'
+_SYSTEMCTL_STATE="active"
+out="$(nftban_render_banner_compact)"
+grep -q "🟢" <<<"$out" || fail "A: active daemon should give 🟢 (got: $out)"
+grep -q "🔴" <<<"$out" && fail "A: compact must IGNORE validator cache (showed 🔴 from bogus validator 'down')"
+grep -q "NFTBan v" <<<"$out" || fail "A: compact missing version (got: $out)"
+[[ "$(printf '%s' "$out" | wc -l)" -le 1 ]] || fail "A: compact must be ONE line (got multi-line: $out)"
+unset _NFTBAN_VALIDATOR_CACHE
+echo "PASS A: compact glyph is cheap-fresh (systemctl-driven), validator NOT consulted; single line"
+
+# ---- (B) failed daemon → 🔴 ----
+_SYSTEMCTL_STATE="failed"
+out="$(nftban_render_banner_compact)"
+grep -q "🔴" <<<"$out" || fail "B: failed daemon should give 🔴 (got: $out)"
+echo "PASS B: failed daemon → 🔴"
+_SYSTEMCTL_STATE="active"
+
+# ---- (C) cache-only update notice ----
+out="$(nftban_render_banner_compact)"
+grep -q "available" <<<"$out" && fail "C: no cache → must show NO update notice (got: $out)"
+printf '9.9.9\n' > "$NFTBAN_CACHE_DIR/update_check"   # fresh cache, higher version
+out="$(nftban_render_banner_compact)"
+grep -q "↑ v9.9.9 available — nftban update" <<<"$out" || fail "C: fresh higher-version cache should show notice (got: $out)"
+# stale cache → no notice
+export NFTBAN_UPDATE_TTL=0
+out="$(nftban_render_banner_compact)"
+grep -q "available" <<<"$out" && fail "C: stale cache (ttl=0) must show NO notice (got: $out)"
+unset NFTBAN_UPDATE_TTL
+echo "PASS C: update notice is cache-only (fresh+higher shows; absent/stale hides)"
+
+# ---- (D) suppression ----
+[[ -z "$(NFTBAN_OUTPUT_JSON=true nftban_render_banner_compact)" ]] || fail "D: --json/JSON mode must suppress banner"
+[[ -z "$(NFTBAN_BANNER_MODE=none nftban_render_banner_compact)" ]] || fail "D: NFTBAN_BANNER_MODE=none must suppress banner"
+echo "PASS D: JSON / banner-mode=none suppress the compact banner"
+
+# ---- (E) full-box gate intact: version=box(tagline), other=compact(glyph) ----
+box="$(NFTBAN_BANNER_MODE=full nftban_banner_unified version 2>/dev/null || true)"
+if [[ -n "$box" ]]; then
+    grep -qF "Open-source Linux Firewall & IPS for nftables" <<<"$box" || fail "E: version mode lost the full-box tagline"
+fi
+compact="$(NFTBAN_BANNER_MODE=full nftban_banner_unified watchdog 2>/dev/null || true)"
+grep -qE "🟢|🟠|🔴|⚪" <<<"$compact" || fail "E: non-dashboard (watchdog) must render the compact posture line (got: $compact)"
+grep -qF "ban · unban · protect" <<<"$compact" && fail "E: old 2-line motto must be gone from non-dashboard banner"
+echo "PASS E: full box on version (tagline), compact posture line on watchdog (no old motto)"
+
+echo "PASS: B1b compact-banner convergence (v1.187.3)"


### PR DESCRIPTION
BotScan-train **B1b (banner half)**. Shell-only; daemon byte-identical `c63d8822`; schema frozen; no validator-Go/cmd/internal/packaging.

Closes **BUG-BANNER-INCONSISTENT**: `version`/`status`/`health` keep the **full box** (live validator posture); every other command now renders **one compact posture line** instead of the old motto 2-liner that showed no posture.

**Design (refined over the two AI proposals):**
- One shared path — non-dashboard branch → `nftban_render_banner_compact`; `render_banner_simple` → shim. No second mode selector.
- Compact posture = **cheap-fresh** `systemctl is-active nftband` (perm-safe, no jq, no validator fork) → 🟢/🟠/🔴/⚪. Full box keeps the **live validator**. (A daily cache could paint a false 🟢 — rejected.)
- Dynamic notice = **cache-only** (`↑ vX available — nftban update`), never network.
- Suppression via existing `_v141_banner_suppressed` (incl. `--json`/`--quiet`/`--no-banner`).
- Notices on the compact line, never inside the emoji-fragile box.

**Validation:** new `b1b_banner_compact_v1873_test.sh` PASS A-E — incl. the proof compact **ignores a bogus validator cache** (no hot-path validator fork), failed→🔴, cache-only notice, JSON/none suppression, full-box gate intact. shellcheck `-S warning` clean; v1.187.2 regression passes; daemon `c63d8822`.

**Deferred (B1b-2):** shared `nftban_render_findings` helper + UX-VERBOSE-FINDINGS adoption (surface-scoping first; no orphan code). VAL-LOGINMON-002-UX = separate validator-Go lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)