### PR TITLE
feat(botscan): v1.188 B2 — badbot/aibot easy UX + aibots category (Option A migrate-and-preserve)

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -856,22 +856,24 @@ nftban_cmd_botscan() {
             _nftban_botscan_cmd_test "$@"
             ;;
 
-        bots)
-            # v1.188 B2 — friendly category listing: bots [category] [--enabled|--disabled]
-            nftban_botscan_load_config
-            nftban_botscan_bots "$@"
-            ;;
-
-        blockbot)
-            # v1.188 B2 — enable a bot pattern (override.local; refuses never-ban tokens)
-            nftban_botscan_load_config
-            nftban_botscan_blockbot "$@"
-            ;;
-
-        allowbot)
-            # v1.188 B2 — disable a bot pattern (override.local)
-            nftban_botscan_load_config
-            nftban_botscan_allowbot "$@"
+        bots|blockbot|allowbot)
+            # v1.188 B2 — bot-policy UX. Core funcs live in the core module, which
+            # cmd_botscan only sources inside its _cmd_* wrappers (not globally) — so
+            # source it here too. Sourcing runs nftban_botscan_load_config (config) and
+            # is idempotent (core has a double-load guard).
+            if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_botscan.sh" ]]; then
+                # shellcheck source=/dev/null
+                source "${NFTBAN_LIB_DIR}/core/nftban_botscan.sh" || return 1
+            else
+                echo "ERROR: Bot scanner core module not found" >&2
+                return 1
+            fi
+            nftban_botscan_load_config 2>/dev/null || true
+            case "$action" in
+                bots)     nftban_botscan_bots "$@" ;;
+                blockbot) nftban_botscan_blockbot "$@" ;;
+                allowbot) nftban_botscan_allowbot "$@" ;;
+            esac
             ;;
 
         help|--help|-h)

--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -77,6 +77,9 @@ COMMANDS:
       patterns disable  Disable a pattern
     history             Show detected bots (last 24 hours)
     test                Test pattern matching against sample URLs
+    bots [category]     List bot patterns by category (--enabled|--disabled)
+    blockbot <name>     Enable banning a bot (scanner/badbots/aibots/custom)
+    allowbot <name>     Stop banning a bot (allow it)
     stats               Show detection statistics (JSON-capable)
     config              Show detection configuration
     help                Show this help message

--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -853,6 +853,24 @@ nftban_cmd_botscan() {
             _nftban_botscan_cmd_test "$@"
             ;;
 
+        bots)
+            # v1.188 B2 — friendly category listing: bots [category] [--enabled|--disabled]
+            nftban_botscan_load_config
+            nftban_botscan_bots "$@"
+            ;;
+
+        blockbot)
+            # v1.188 B2 — enable a bot pattern (override.local; refuses never-ban tokens)
+            nftban_botscan_load_config
+            nftban_botscan_blockbot "$@"
+            ;;
+
+        allowbot)
+            # v1.188 B2 — disable a bot pattern (override.local)
+            nftban_botscan_load_config
+            nftban_botscan_allowbot "$@"
+            ;;
+
         help|--help|-h)
             _nftban_botscan_help
             ;;
@@ -860,7 +878,7 @@ nftban_cmd_botscan() {
         *)
             echo "ERROR: Unknown command: $action" >&2
             echo ""
-            echo "Available commands: enable, disable, status, stats, config, check, patterns, history, test, help"
+            echo "Available commands: enable, disable, status, stats, config, check, patterns, history, test, bots, blockbot, allowbot, help"
             echo "Run 'nftban botscan help' for detailed usage information"
             return 1
             ;;

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -138,6 +138,23 @@ nftban_botscan_load_patterns() {
 
     _BOTSCAN_PATTERNS=()
 
+    # v1.188 B2 — 3-tier no-clobber precedence: shipped *.patterns (config(noreplace))
+    # are the base; operator enable/disable decisions live in override.local
+    # (NAME|true|false), which WINS over the shipped ENABLED column WITHOUT editing
+    # the shipped files. override.local is operator-created (NOT package-owned), so
+    # it survives DEB/RPM upgrades intact. Read first so per-pattern effective-enabled
+    # can consult it. It is NOT a *.patterns file, so the glob below never loads it.
+    local override_file="${patterns_dir}/override.local"
+    local -A _override=()
+    if [[ -r "$override_file" ]]; then
+        local oname ostate
+        while IFS='|' read -r oname ostate _; do
+            [[ -z "$oname" || "$oname" =~ ^# ]] && continue
+            oname="${oname// /}"; ostate="${ostate// /}"
+            [[ "$ostate" == "true" || "$ostate" == "false" ]] && _override["$oname"]="$ostate"
+        done < "$override_file"
+    fi
+
     for pattern_file in "$patterns_dir"/*.patterns; do
         [[ -f "$pattern_file" ]] || continue
 
@@ -145,8 +162,9 @@ nftban_botscan_load_patterns() {
             # Skip comments and empty lines
             [[ -z "$name" || "$name" =~ ^# ]] && continue
 
-            # Skip disabled patterns
-            [[ "$enabled" != "true" ]] && continue
+            # override.local wins over the shipped ENABLED column (no-clobber).
+            local eff_enabled="${_override[$name]:-$enabled}"
+            [[ "$eff_enabled" != "true" ]] && continue
 
             # Store pattern: name -> "pattern|match_type|threshold|window|ban|description"
             _BOTSCAN_PATTERNS["$name"]="${pattern}|${match_type}|${threshold}|${window}|${ban}|${description}"
@@ -257,6 +275,142 @@ nftban_botscan_toggle_pattern() {
     done
 
     [[ $found -eq 0 ]] && echo "ERROR: Pattern '$name' not found" >&2 && return 1
+    return 0
+}
+
+# =============================================================================
+# v1.188 B2 — BOT POLICY (bots / blockbot / allowbot) helpers
+# =============================================================================
+
+# Never-ban guard. These tokens must NEVER be hard-banned on User-Agent:
+#   robots.txt-only control tokens (Google-Extended/Applebot-Extended have NO request
+#   UA → a ban can never match; it is a category error), legitimate index UAs
+#   (Googlebot/Bingbot/Applebot — banning delists the site), and user-action fetchers
+#   (ChatGPT-User/Perplexity-User/Claude-User — a human triggered the fetch).
+# Returns 0 (guarded) / 1 (not guarded). Case-insensitive substring match.
+nftban_botscan_neverban_token() {
+    local q; q=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')
+    [[ -z "$q" ]] && return 1
+    local t
+    for t in google-extended applebot-extended googlebot bingbot applebot \
+             facebookexternalhit chatgpt-user perplexity-user claude-user; do
+        [[ "$q" == *"$t"* ]] && return 0
+    done
+    return 1
+}
+
+# Resolve a user token (pattern NAME or UA substring, case-insensitive) to the
+# canonical pattern NAME used as the override.local / loader key. Echoes NAME, or
+# nothing + rc=1 if not found. Interactive-only (blockbot/allowbot), never hot-path.
+nftban_botscan_resolve_name() {
+    local q; q=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')
+    [[ -z "$q" ]] && return 1
+    local f name pattern lc_name lc_pat
+    for f in "${BOTSCAN_PATTERNS_DIR}"/*.patterns; do
+        [[ -f "$f" ]] || continue
+        while IFS='|' read -r name pattern _; do
+            [[ -z "$name" || "$name" =~ ^# ]] && continue
+            lc_name=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+            lc_pat=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+            if [[ "$q" == "$lc_name" || "$q" == "$lc_pat" ]]; then
+                printf '%s' "$name"; return 0
+            fi
+        done < "$f"
+    done
+    return 1
+}
+
+# Write an enable/disable decision to override.local (3-tier no-clobber; NEVER edits
+# the shipped config(noreplace) *.patterns). Args: NAME, state(true|false). The file
+# is operator-created (not package-owned) so DEB/RPM upgrades never clobber it.
+nftban_botscan_set_override() {
+    local name="${1:-}" state="${2:-}"
+    [[ -n "$name" && ( "$state" == "true" || "$state" == "false" ) ]] || return 2
+    local dir="${BOTSCAN_PATTERNS_DIR}"
+    local override_file="${dir}/override.local"
+    mkdir -p "$dir" 2>/dev/null || true
+    local tmp; tmp=$(mktemp "${override_file}.XXXXXX" 2>/dev/null) || return 1
+    # carry forward all OTHER entries; replace any prior line for this name
+    if [[ -r "$override_file" ]]; then
+        grep -viE "^[[:space:]]*${name}[[:space:]]*\|" "$override_file" 2>/dev/null >> "$tmp" || true
+    fi
+    printf '%s|%s\n' "$name" "$state" >> "$tmp"
+    mv -f "$tmp" "$override_file" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 1; }
+    return 0
+}
+
+# blockbot <token> — enable a bot pattern (operator opt-in) via override.local.
+# Refuses never-ban tokens with an explanation. Resolves token→NAME.
+nftban_botscan_blockbot() {
+    local token="${1:-}"
+    [[ -n "$token" ]] || { echo "Usage: nftban botscan blockbot <bot-name>" >&2; return 2; }
+    if nftban_botscan_neverban_token "$token"; then
+        echo "✗ Refusing to ban '$token': it is a never-ban token." >&2
+        echo "  robots.txt-only (Google-Extended/Applebot-Extended) have no request UA to match;" >&2
+        echo "  legitimate index UAs (Googlebot/Bingbot/Applebot) would delist the site;" >&2
+        echo "  user-action fetchers (ChatGPT-User/Perplexity-User) are human-initiated. Not banned." >&2
+        return 1
+    fi
+    local name; name=$(nftban_botscan_resolve_name "$token") || {
+        echo "✗ Unknown bot '$token'. See: nftban botscan bots" >&2; return 1; }
+    nftban_botscan_set_override "$name" "true" || { echo "✗ Could not write override for $name" >&2; return 1; }
+    echo "✓ blockbot: $name enabled (override.local) — bans on next scan cycle."
+    return 0
+}
+
+# allowbot <token> — disable a bot pattern (operator allow) via override.local.
+nftban_botscan_allowbot() {
+    local token="${1:-}"
+    [[ -n "$token" ]] || { echo "Usage: nftban botscan allowbot <bot-name>" >&2; return 2; }
+    local name; name=$(nftban_botscan_resolve_name "$token") || {
+        echo "✗ Unknown bot '$token'. See: nftban botscan bots" >&2; return 1; }
+    nftban_botscan_set_override "$name" "false" || { echo "✗ Could not write override for $name" >&2; return 1; }
+    echo "✓ allowbot: $name disabled (override.local) — no longer banned."
+    return 0
+}
+
+# bots [category] [--enabled|--disabled] — friendly category listing (override-aware).
+# Shows the EFFECTIVE enabled state (shipped ENABLED column overridden by override.local).
+nftban_botscan_bots() {
+    local category="" filter="all" a
+    for a in "$@"; do
+        case "$a" in
+            --enabled)  filter="enabled" ;;
+            --disabled) filter="disabled" ;;
+            scanner|badbots|aibots|custom|webshell|exploit) category="$a" ;;
+        esac
+    done
+    # Load effective state via the override-aware loader.
+    nftban_botscan_load_patterns >/dev/null 2>&1
+    local override_file="${BOTSCAN_PATTERNS_DIR}/override.local"
+    local -A _ov=()
+    if [[ -r "$override_file" ]]; then
+        local on os
+        while IFS='|' read -r on os _; do
+            [[ -z "$on" || "$on" =~ ^# ]] && continue
+            _ov["${on// /}"]="${os// /}"
+        done < "$override_file"
+    fi
+    printf "%-22s %-9s %-9s %-10s %s\n" "NAME" "CATEGORY" "EFFECTIVE" "MATCH" "DESCRIPTION"
+    printf '%s\n' "$(printf '=%.0s' {1..92})"
+    local f cat name pattern match_type threshold window ban enabled description eff
+    for f in "${BOTSCAN_PATTERNS_DIR}"/*.patterns; do
+        [[ -f "$f" ]] || continue
+        cat=$(basename "$f" .patterns)
+        [[ -n "$category" && "$cat" != "$category" ]] && continue
+        while IFS='|' read -r name pattern match_type threshold window ban enabled description; do
+            [[ -z "$name" || "$name" =~ ^# ]] && continue
+            eff="${_ov[$name]:-$enabled}"
+            case "$filter" in
+                enabled)  [[ "$eff" != "true" ]] && continue ;;
+                disabled) [[ "$eff" == "true" ]] && continue ;;
+            esac
+            local mark="$eff"; [[ -n "${_ov[$name]:-}" ]] && mark="${eff}*"
+            printf "%-22s %-9s %-9s %-10s %s\n" "$name" "$cat" "$mark" "$match_type" "${description:0:38}"
+        done < "$f"
+    done
+    echo ""
+    echo "  EFFECTIVE '*' = set by override.local (your blockbot/allowbot decision)."
     return 0
 }
 

--- a/cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh
+++ b/cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.188 - B2 BOTSCAN-BADBOT-EASY-UX (Option A) guard test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="b2_badbot_aibot_v188_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="B2 BOTSCAN-BADBOT-EASY-UX Option A (migrate-and-preserve). Guards: (1) no duplicate AI token across badbots/aibots; (2) migration preserves active state (GPTBot/CCBot/Bytespider hard-ban, ClaudeBot off); (3) new AI tokens observe/disabled (PerplexityBot off); (4) robots.txt-only tokens never ban (guard + not a pattern); (5) user-action fetchers never ban; (6) blockbot/allowbot change effective state via override.local + blockbot refuses never-ban tokens; (7) override.local survives a simulated upgrade (operator decisions preserved); (8) packaging no-clobber — spec ships *.patterns config(noreplace) glob (covers aibots.patterns) and does NOT package override.local. Hermetic: copies the real pattern files into a temp dir; no host/nft/IPC/daemon."
+#
+# meta:inventory.files="b2_badbot_aibot_v188_test.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,BOTSCAN_PATTERNS_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+REPO_ROOT="$(cd "$NFTBAN_LIB_DIR/../../.." && pwd)"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+SHIPPED="$REPO_ROOT/etc/nftban/patterns.d/botscan"
+[[ -f "$SHIPPED/aibots.patterns" ]] || fail "aibots.patterns not shipped at $SHIPPED"
+
+# Hermetic patterns dir = copies of the real shipped files.
+export BOTSCAN_PATTERNS_DIR="$tmp/patterns" NFTBAN_DATA_DIR="$tmp/data" \
+       BOTSCAN_STATE_FILE="$tmp/s" BOTSCAN_LOG_FILE="$tmp/b.log" NFTBAN_CONFIG_DIR="$tmp/noetc"
+mkdir -p "$BOTSCAN_PATTERNS_DIR" "$NFTBAN_DATA_DIR"
+cp "$SHIPPED"/*.patterns "$BOTSCAN_PATTERNS_DIR/"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
+
+# ---- (1) no duplicate AI token across badbots/aibots ----
+for tok in GPTBOT CCBOT BYTESPIDER CLAUDEBOT; do
+    grep -qE "^${tok}\|" "$BOTSCAN_PATTERNS_DIR/aibots.patterns" || fail "1: $tok missing from aibots"
+    grep -qE "^${tok}\|" "$BOTSCAN_PATTERNS_DIR/badbots.patterns" && fail "1: $tok still in badbots (duplicate owner)"
+done
+echo "PASS 1: AI tokens have one owner (aibots), not duplicated in badbots"
+
+# ---- (2) migration preserves active state ----
+nftban_botscan_load_patterns
+[[ -n "${_BOTSCAN_PATTERNS[GPTBOT]:-}" ]]     || fail "2: GPTBot should be enabled (preserved hard-ban)"
+[[ -n "${_BOTSCAN_PATTERNS[CCBOT]:-}" ]]      || fail "2: CCBot should be enabled (preserved)"
+[[ -n "${_BOTSCAN_PATTERNS[BYTESPIDER]:-}" ]] || fail "2: Bytespider should be enabled (preserved)"
+[[ -z "${_BOTSCAN_PATTERNS[CLAUDEBOT]:-}" ]]  || fail "2: ClaudeBot should be OFF (preserved observe)"
+echo "PASS 2: migration preserved live state (GPTBot/CCBot/Bytespider on, ClaudeBot off)"
+
+# ---- (3) new AI tokens observe/disabled by default ----
+[[ -z "${_BOTSCAN_PATTERNS[PERPLEXITYBOT]:-}" ]] || fail "3: PerplexityBot must ship disabled (observe)"
+grep -qE "^PERPLEXITYBOT\|.*\|false\|" "$BOTSCAN_PATTERNS_DIR/aibots.patterns" || fail "3: PerplexityBot not ENABLED=false in file"
+echo "PASS 3: new AI token (PerplexityBot) ships observe/disabled"
+
+# ---- (4) robots.txt-only tokens never ban (guard + not a pattern) ----
+nftban_botscan_neverban_token "Google-Extended"  || fail "4: Google-Extended must be guarded"
+nftban_botscan_neverban_token "Applebot-Extended" || fail "4: Applebot-Extended must be guarded"
+# data lines only (NAME|...); comments (#) legitimately document the never-ban list
+grep -rhE '^[A-Za-z]' "$BOTSCAN_PATTERNS_DIR"/*.patterns | grep -iqE "applebot-extended|google-extended" && fail "4: robots.txt-only token must NOT be a ban pattern (data line)"
+echo "PASS 4: robots.txt-only tokens guarded + not present as patterns"
+
+# ---- (5) user-action fetchers never ban ----
+nftban_botscan_neverban_token "ChatGPT-User"    || fail "5: ChatGPT-User must be guarded"
+nftban_botscan_neverban_token "Perplexity-User" || fail "5: Perplexity-User must be guarded"
+nftban_botscan_neverban_token "GPTBot" && fail "5: GPTBot must NOT be guarded (it is ban-eligible)"
+echo "PASS 5: user-action fetchers guarded; real scrapers not over-guarded"
+
+# ---- (6) blockbot/allowbot change effective state; blockbot refuses never-ban ----
+nftban_botscan_blockbot "ClaudeBot" >/dev/null || fail "6: blockbot ClaudeBot failed"
+nftban_botscan_load_patterns
+[[ -n "${_BOTSCAN_PATTERNS[CLAUDEBOT]:-}" ]] || fail "6: blockbot did not enable ClaudeBot via override.local"
+nftban_botscan_allowbot "GPTBot" >/dev/null || fail "6: allowbot GPTBot failed"
+nftban_botscan_load_patterns
+[[ -z "${_BOTSCAN_PATTERNS[GPTBOT]:-}" ]] || fail "6: allowbot did not disable GPTBot via override.local"
+rc=0; nftban_botscan_blockbot "googlebot" >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] || fail "6: blockbot googlebot must be REFUSED (never-ban)"
+grep -qiE "^googlebot\|" "$BOTSCAN_PATTERNS_DIR/override.local" 2>/dev/null && fail "6: refused token must not be written to override.local"
+echo "PASS 6: blockbot/allowbot flip effective state via override.local; never-ban refused"
+
+# ---- (7) override.local survives a simulated upgrade ----
+# Upgrade = shipped *.patterns replaced (re-copied), override.local untouched (operator file).
+cp -f "$SHIPPED"/*.patterns "$BOTSCAN_PATTERNS_DIR/"   # simulate package payload refresh
+nftban_botscan_load_patterns
+[[ -n "${_BOTSCAN_PATTERNS[CLAUDEBOT]:-}" ]] || fail "7: override (ClaudeBot on) lost after upgrade"
+[[ -z "${_BOTSCAN_PATTERNS[GPTBOT]:-}" ]]   || fail "7: override (GPTBot off) lost after upgrade"
+echo "PASS 7: override.local decisions survive a simulated package upgrade"
+
+# ---- (8) packaging no-clobber: spec ships *.patterns config(noreplace), NOT override.local ----
+SPEC="$REPO_ROOT/build/packages/SPECS/nftban-core.spec"
+grep -qE "%config\(noreplace\) /etc/nftban/patterns.d/botscan/\*\.patterns" "$SPEC" \
+    || fail "8: spec must ship *.patterns as config(noreplace) glob (covers aibots.patterns)"
+grep -q "override.local" "$SPEC" && fail "8: spec must NOT package override.local (operator-owned; would clobber on upgrade)"
+echo "PASS 8: aibots.patterns auto-covered by config(noreplace) glob; override.local not packaged"
+
+echo "PASS: B2 BOTSCAN-BADBOT-EASY-UX Option A (migrate+preserve, observe-default, never-ban guard, override.local no-clobber)"

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1030,6 +1030,9 @@ botscan:
     - "nftban botscan patterns list"
     - "nftban botscan history"
     - "nftban botscan test"
+    - "nftban botscan bots aibots"
+    - "nftban botscan blockbot ClaudeBot"
+    - "nftban botscan allowbot GPTBot"
   subcommands:
     enable: {description: "Enable bot scanner detection"}
     disable: {description: "Disable bot scanner detection"}
@@ -1040,6 +1043,15 @@ botscan:
       description: "Pattern management"
     history: {description: "Show detection history"}
     test: {description: "Test pattern matching against URLs or User-Agents"}
+    bots:
+      mutates: false
+      description: "List bot patterns by category (scanner/badbots/aibots/custom; --enabled|--disabled)"
+    blockbot:
+      mutates: true
+      description: "Enable banning a bot by name (writes override.local; refuses never-ban tokens)"
+    allowbot:
+      mutates: true
+      description: "Stop banning a bot by name (writes override.local)"
     config:
       mutates: false
       description: "Show botscan configuration"

--- a/etc/nftban/patterns.d/botscan/aibots.patterns
+++ b/etc/nftban/patterns.d/botscan/aibots.patterns
@@ -1,0 +1,34 @@
+# =============================================================================
+# NFTBan Bot Scanner - AI Bots / LLM Scrapers (User-Agent Based Detection)
+# =============================================================================
+# Format: NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION
+#
+# MATCH_TYPE: useragent = match against the User-Agent header.
+#
+# v1.188 B2 (Option A — migrate-and-preserve): AI training-scraper tokens were
+# MOVED here from badbots.patterns. Their ENABLED state is PRESERVED exactly as
+# it was in badbots (no live fleet behavior change): GPTBot/CCBot/Bytespider stay
+# hard-ban; ClaudeBot stays observe (off). NEW AI tokens ship observe/disabled
+# (ENABLED=false) by default — operators opt in with `nftban botscan blockbot`.
+# One owner per token: these tokens are NOT in badbots.patterns anymore.
+#
+# Token provenance: V1_187_AIBOTS_PRIMARY_DOC_TOKENS.md (primary-doc-verified).
+# Substring match, version-agnostic (GPTBot covers GPTBot/1.3, etc).
+#
+# 🚫 NEVER-BAN (NOT listed here as ban tokens — enforced by the CLI never-ban
+#    guard, `nftban botscan blockbot` refuses them):
+#    - Google-Extended, Applebot-Extended : robots.txt-only control tokens — they
+#      have NO request User-Agent, so a UA ban can never match (category error).
+#    - Googlebot, Bingbot, Applebot       : legitimate search-index UAs (banning delists).
+#    - ChatGPT-User, Perplexity-User      : user-action fetchers — a human triggered
+#      the fetch; never hard-ban (observe only).
+# =============================================================================
+
+# --- Migrated from badbots.patterns, state PRESERVED (Option A) ---
+GPTBOT|GPTBot|useragent|10|60|7200|true|OpenAI GPTBot - AI training scraper (migrated from badbots; state preserved)
+CCBOT|CCBot|useragent|20|120|3600|true|Common Crawl CCBot - mass scraper feeding AI training (migrated; state preserved)
+BYTESPIDER|Bytespider|useragent|10|60|7200|true|ByteDance Bytespider - AI data scraper (secondary-source provenance; migrated; state preserved)
+CLAUDEBOT|ClaudeBot|useragent|10|60|7200|false|Anthropic ClaudeBot - AI training crawler (migrated from badbots; observe/off preserved)
+
+# --- New AI tokens: shipped observe/disabled by default (opt in via blockbot) ---
+PERPLEXITYBOT|PerplexityBot|useragent|10|60|7200|false|Perplexity search-index crawler - observe by default (new; primary-doc-verified)

--- a/etc/nftban/patterns.d/botscan/badbots.patterns
+++ b/etc/nftban/patterns.d/botscan/badbots.patterns
@@ -25,13 +25,11 @@ ZOOMINFOBOT|ZoominfoBot|useragent|30|120|3600|true|ZoomInfo scraper bot
 LINKFLUENCE|linkfluence|useragent|30|120|3600|true|Linkfluence crawler
 
 # =============================================================================
-# AI TRAINING BOTS (Content scrapers for LLM training)
+# AI TRAINING BOTS — MOVED to aibots.patterns (v1.188 B2 Option A; one owner per
+# token). GPTBot/CCBot/Bytespider/ClaudeBot migrated with state preserved.
+# AppleBot-Extended REMOVED entirely (robots.txt-only control token — has no
+# request UA, can never match; now in the CLI never-ban guard, not a pattern).
 # =============================================================================
-GPTBOT|GPTBot|useragent|10|60|7200|true|OpenAI GPTBot - AI training scraper
-CLAUDEBOT|ClaudeBot|useragent|10|60|7200|false|Anthropic ClaudeBot - AI training
-CCBOT|CCBot|useragent|20|120|3600|true|Common Crawl - mass scraper
-BYTESPIDER|Bytespider|useragent|10|60|7200|true|ByteDance AI training spider
-APPLEBOT_EXTENDED|AppleBot-Extended|useragent|30|300|1800|false|Apple extended bot
 
 # =============================================================================
 # KNOWN MALICIOUS BOTS


### PR DESCRIPTION
BOTSCAN-BADBOT-EASY-UX. **Shell + pattern-content + packaging-aware only; daemon byte-identical `c63d8822`; schema frozen; NO counters/daemon-Go/cmd/internal/adaptive/VAL-LOGINMON/FCrDNS.** Ownership declaration ACCEPTED.

## Option A (migrate-and-preserve — zero fleet behavior change)
- New `aibots.patterns`; MOVED GPTBot/CCBot/Bytespider/ClaudeBot from `badbots` with **ENABLED state preserved exactly** (GPTBot/CCBot/Bytespider stay hard-ban, ClaudeBot stays observe) → one owner per token, no live un-ban.
- New **PerplexityBot** ships observe/disabled.
- **AppleBot-Extended removed** from patterns (robots.txt-only → never-ban guard only).

## CLI (`nftban botscan …`)
`bots [category] [--enabled|--disabled]` (override-aware), `blockbot <name>`, `allowbot <name>`. Never-ban guard refuses Google-Extended/Applebot-Extended/Googlebot/Bingbot/Applebot/facebookexternalhit/ChatGPT-User/Perplexity-User/Claude-User.

## 3-tier no-clobber
Loader reads **override.local** (NAME|true|false) which wins over the shipped ENABLED column without editing the config(noreplace) `*.patterns`. override.local is operator-owned → survives upgrades; not a `*.patterns` file so never double-loaded.

## Packaging (proven, not assumed)
New `aibots.patterns` auto-packaged by the existing `%config(noreplace) …/*.patterns` glob + auto-loaded — no spec/FHS/%files change, no dedup risk.

## Validation
New `b2_badbot_aibot_v188_test` PASS 1-8 (no-dup, state-preserved, observe-default, robots.txt-only never-ban, user-action never-ban, blockbot/allowbot + refusal, override survives upgrade, packaging no-clobber). botscan regressions pass; shellcheck clean; daemon `c63d8822`.

⚠️ **Lab-first DEB/RPM install+upgrade preservation is mandatory before merge** (new shipped payload) — the "packaging pre-satisfied" claim is a hypothesis this PR's test asserts at file level; a real package build must confirm aibots.patterns installs + override.local survives a real upgrade.

Top-level `nftban blockbot/allowbot` aliases deferred (dispatcher/registry surface) — delivered as `nftban botscan {bots,blockbot,allowbot}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)