### PR TITLE
feat(schema): v1.190.0 SCHEMA-UNFREEZE — counters contract/scaffolding + IP-family (1.83.0→1.84.0)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -479,7 +479,7 @@ nftban_health_cmd_truth() {
                 --argjson rc "$validator_rc" \
                 --arg err "$summary_err" \
                 '{
-                    schema_version: "1.83.0",
+                    schema_version: "1.84.0",
                     status: "down",
                     truth: "failed",
                     validator: { binary: $bin, exit_code: $rc, stderr: $err }
@@ -506,7 +506,7 @@ nftban_health_cmd_truth() {
     # v1.83: Schema version guard
     local _schema_version
     _schema_version=$(echo "$output" | jq -r '.schema_version // empty' 2>/dev/null)
-    local _expected_schema="1.83.0"
+    local _expected_schema="1.84.0"
     if [[ -n "$_schema_version" && "$_schema_version" != "$_expected_schema" ]]; then
         echo "WARNING: validator schema $_schema_version does not match expected $_expected_schema" >&2
     fi

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -512,8 +512,13 @@ nftban_health_cmd_truth() {
     fi
 
     if [[ "$json_mode" == "true" ]]; then
-        # JSON mode: pass through the frozen schema directly
-        echo "$output" | jq '{schema_version, status, service_state, modules, consistency}' 2>/dev/null
+        # JSON mode: pass through the frozen schema directly.
+        # v1.84 (v1.190.0): include the counters-contract surface — counters_phase is
+        # ALWAYS present (the anti-false-zero gate); counters/nft are added only when
+        # present so the contract-phase "absent ≠ zero" rule is preserved. Without this
+        # the view would advertise schema_version 1.84.0 while hiding its new fields.
+        echo "$output" | jq '{schema_version, status, service_state, modules, consistency, counters_phase}
+            + ({counters, nft} | with_entries(select(.value != null)))' 2>/dev/null
         return $?
     fi
 

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -242,7 +242,7 @@ _nftban_protection_state_validator() {
 
     # v1.83: Schema version guard — warn if validator schema doesn't match expected.
     # Prevents silent breakage if validator binary is from a different version.
-    local _expected_schema="1.83.0"
+    local _expected_schema="1.84.0"
     if [[ -n "$_schema_version" && "$_schema_version" != "$_expected_schema" ]]; then
         echo "WARNING: validator schema $_schema_version does not match expected $_expected_schema — binary may be outdated" >&2
     fi

--- a/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
+++ b/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.190 — NFT COUNTING-MODEL / SCHEMA-UNFREEZE contract CI guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nft_counting_model_guard_v190_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="Locks the v1.190.0 NFT counting-model contract decisions (SOS-1/2/3). Source-truth grep guard: (1) nftban_nft_rules_total has exactly ONE promauto owner (watchdog); (2) NO dedicated nftban_nft_anchor_* Prometheus metric exists (SOS-2 Option A reuse, no double-count); (3) the generic nft_named_counter_packets_total/_bytes_total source is preserved (the anchor Prometheus surface); (4) firewall_rules_total alias present + marked DEPRECATED; (5) nftban_suricata_rules_total present + distinct (not aliased to nft_rules_total); (6) collector.go does not re-introduce a raw nft_rules_total textfile emit; (7) SOS-1: stats schema stays int 2 (counters NOT surfaced via nftban stats); (8) validator output schema bumped to 1.84.0; (9) counters_population_phase gauge declared + Set(0) at contract phase (anti-false-zero gate); (10) SOS-3: validator exposes NormalizeNFTFamily + NFTAnchorJSON and JSON never hardcodes raw nft family ip/ip6. Includes positive/negative self-tests for the two highest-risk checks (no-anchor-metric, single-rules-owner)."
+# meta:input="repo Go tree (read-only)"
+# meta:output="pass/fail; exit 0 all-pass, 1 on any contract regression"
+# meta:depends="bash,grep,find"
+# meta:inventory.files="internal/watchdog/metrics.go,internal/metrics/rule_counters.go,internal/metrics/sampler.go,internal/metrics/collector.go,internal/suricata/stats/metrics.go,internal/stats/types.go,internal/validator/types.go,internal/validator/health_output.go"
+# meta:inventory.binaries="bash,grep,find"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+# count promauto declarations of a given metric Name across the Go tree (no tests)
+count_metric_owner() {
+    local name="$1"
+    grep -rEl "Name:[[:space:]]*\"${name}\"" --include='*.go' "$REPO/internal" "$REPO/cmd" 2>/dev/null \
+        | grep -v '_test\.go$' | xargs -r grep -cE "Name:[[:space:]]*\"${name}\"" 2>/dev/null \
+        | awk -F: '{s+=$NF} END{print s+0}'
+}
+
+echo "=== v1.190 NFT counting-model contract guard ==="
+
+# T1 — single canonical rule-count owner (watchdog promauto). Class: rule-count.
+N_RULES="$(count_metric_owner 'nft_rules_total')"
+if [[ "$N_RULES" == "1" ]]; then
+    ok "T1 nftban_nft_rules_total has exactly ONE promauto owner (watchdog)"
+else
+    no "T1 nftban_nft_rules_total owner count != 1 (single-owner invariant broken)" "count=$N_RULES"
+fi
+
+# T2 — SOS-2: NO dedicated anchor Prometheus metric (reuse named-counter source).
+if grep -rEq 'Name:[[:space:]]*"nft_anchor|nft_anchor_(packets|bytes)_total' --include='*.go' "$REPO/internal" "$REPO/cmd" 2>/dev/null; then
+    no "T2 SOS-2 violation: a dedicated nftban_nft_anchor_* Prometheus metric exists (double-count risk)" "$(grep -rEn 'nft_anchor' --include='*.go' "$REPO/internal" "$REPO/cmd" | tr '\n' ' ')"
+else
+    ok "T2 no dedicated nft_anchor_* Prometheus metric (SOS-2 Option A reuse — no double-count)"
+fi
+
+# T3 — generic named-counter source preserved (this IS the anchor Prometheus surface).
+if grep -q 'Name:.*"nft_named_counter_packets_total"' "$REPO/internal/metrics/rule_counters.go" \
+   && grep -q 'Name:.*"nft_named_counter_bytes_total"' "$REPO/internal/metrics/rule_counters.go"; then
+    ok "T3 nft_named_counter_{packets,bytes}_total{family,counter} preserved (anchor Prometheus source)"
+else
+    no "T3 generic named-counter source missing — anchors lose their Prometheus surface"
+fi
+
+# T4 — firewall_rules_total alias present AND marked DEPRECATED (2-minor window).
+if grep -q 'Name:.*"firewall_rules_total"' "$REPO/internal/metrics/sampler.go" \
+   && grep -qi 'DEPRECATED' "$REPO/internal/metrics/sampler.go"; then
+    ok "T4 firewall_rules_total alias present + marked DEPRECATED"
+else
+    no "T4 firewall_rules_total alias missing or not marked DEPRECATED"
+fi
+
+# T5 — suricata_rules_total present + DISTINCT (Suricata SID count, not an nft alias).
+if grep -q 'suricata_rules_total' "$REPO/internal/suricata/stats/metrics.go"; then
+    ok "T5 nftban_suricata_rules_total present + distinct (NOT aliased to nft_rules_total)"
+else
+    no "T5 nftban_suricata_rules_total missing (distinct Suricata SID metric)"
+fi
+
+# T6 — collector.go must NOT re-introduce a raw nft_rules_total textfile emit.
+if grep -qE 'nft_rules_total' "$REPO/internal/metrics/collector.go" \
+   && grep -qE 'Fprint.*nft_rules_total' "$REPO/internal/metrics/collector.go"; then
+    no "T6 collector.go re-introduced a raw nft_rules_total emit (dual-source G-12 regression)"
+else
+    ok "T6 collector.go does not emit raw nft_rules_total (watchdog is sole owner)"
+fi
+
+# T7 — SOS-1: stats schema stays int 2 (counters NOT surfaced via nftban stats).
+if grep -qE '^const SchemaVersion = 2$' "$REPO/internal/stats/types.go"; then
+    ok "T7 SOS-1 stats schema untouched (const SchemaVersion = 2; counters stay out of nftban stats)"
+else
+    no "T7 SOS-1 violation: internal/stats/types.go SchemaVersion changed (must remain 2)"
+fi
+# T7b — no counters-contract leakage into the stats schema types.
+if grep -qiE 'CountersPhase|counters_phase|BotScanCounters|NFTAnchor' "$REPO/internal/stats/types.go"; then
+    no "T7b counters-contract types leaked into stats schema (must live only in validator output schema)"
+else
+    ok "T7b no counters-contract leakage into stats schema"
+fi
+
+# T8 — validator output schema bumped to 1.84.0 (the ONE deliberate bump).
+if grep -q 'SchemaVersionCurrent = "1.84.0"' "$REPO/internal/validator/types.go"; then
+    ok "T8 validator output schema = 1.84.0 (the single deliberate bump)"
+else
+    no "T8 validator SchemaVersionCurrent != 1.84.0"
+fi
+
+# T9 — anti-false-zero gate: phase gauge declared + Set(0) at contract phase.
+if grep -q 'Name:.*"counters_population_phase"' "$REPO/internal/watchdog/metrics.go" \
+   && grep -q 'countersPopulationPhase.Set(0)' "$REPO/internal/watchdog/metrics.go"; then
+    ok "T9 counters_population_phase gauge declared + Set(0) (contract phase, anti-false-zero)"
+else
+    no "T9 counters_population_phase gauge or Set(0) missing"
+fi
+
+# T10 — SOS-3: JSON family normalization exists; JSON never hardcodes raw nft ip/ip6.
+if grep -q 'func NormalizeNFTFamily' "$REPO/internal/validator/health_output.go" \
+   && grep -q 'type NFTAnchorJSON struct' "$REPO/internal/validator/health_output.go"; then
+    ok "T10 SOS-3 NormalizeNFTFamily + NFTAnchorJSON present (ip→ipv4, ip6→ipv6 bridge)"
+else
+    no "T10 SOS-3 normalization helper / NFTAnchorJSON missing"
+fi
+# T10b — the JSON family vocabulary constants must be ipv4/ipv6/inet/unknown (not ip/ip6).
+if grep -qE 'FamilyIPv4[[:space:]]*=[[:space:]]*"ipv4"' "$REPO/internal/validator/health_output.go" \
+   && ! grep -qE 'Family(IPv4|IPv6)[[:space:]]*=[[:space:]]*"ip6?"' "$REPO/internal/validator/health_output.go"; then
+    ok "T10b JSON family vocabulary is ipv4/ipv6/inet/unknown (no raw ip/ip6 in JSON contract)"
+else
+    no "T10b JSON family vocabulary drifted toward raw nft ip/ip6"
+fi
+
+# -----------------------------------------------------------------------------
+# Self-tests (positive + negative controls) for the two highest-risk checks.
+# -----------------------------------------------------------------------------
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/internal/bad" "$FIX/cmd"
+# planted dedicated anchor metric (must trip T2-style detection)
+cat > "$FIX/internal/bad/m.go" <<'GO'
+package bad
+var x = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "nft_anchor_packets_total"}, nil)
+GO
+if grep -rEq 'Name:[[:space:]]*"nft_anchor' --include='*.go' "$FIX" 2>/dev/null; then
+    ok "T11 self-test: scanner detects a planted dedicated nft_anchor_* metric (positive control)"
+else
+    no "T11 self-test: scanner FAILED to detect a planted nft_anchor metric"
+fi
+# planted duplicate rules owner (must make count==2)
+cat > "$FIX/cmd/dup.go" <<'GO'
+package main
+var y = promauto.NewGauge(prometheus.GaugeOpts{Name: "nft_rules_total"})
+var z = promauto.NewGauge(prometheus.GaugeOpts{Name: "nft_rules_total"})
+GO
+DUPN="$(grep -rE 'Name:[[:space:]]*"nft_rules_total"' --include='*.go' "$FIX" | wc -l | tr -d ' ')"
+if [[ "$DUPN" == "2" ]]; then
+    ok "T12 self-test: duplicate-owner detection counts >1 (positive control)"
+else
+    no "T12 self-test: duplicate-owner detection miscounted" "count=$DUPN"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
+++ b/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
@@ -127,6 +127,18 @@ else
     no "T10b JSON family vocabulary drifted toward raw nft ip/ip6"
 fi
 
+# T13 — CONTRACT-SURFACE projection: `nftban health --json` must NOT advertise
+# schema_version 1.84.0 while stripping the 1.84 counters-contract fields. The shell
+# jq projection in cmd_health.sh must include counters_phase (the always-present gate).
+# (Found 2026-06-15 in lab-first: the projection dropped counters_phase → the surface
+# claimed 1.84.0 but hid its fields. Consumer-parse validation caught it.)
+HEALTHSH="$REPO/cli/lib/nftban/cli/cmd_health.sh"
+if grep -qE "jq '\{schema_version" "$HEALTHSH" && grep -qE 'counters_phase' "$HEALTHSH"; then
+    ok "T13 cmd_health.sh --json projection includes counters_phase (contract surface not stripped)"
+else
+    no "T13 cmd_health.sh --json projection MISSING counters_phase — surface would advertise 1.84.0 but hide its fields"
+fi
+
 # -----------------------------------------------------------------------------
 # Self-tests (positive + negative controls) for the two highest-risk checks.
 # -----------------------------------------------------------------------------

--- a/cmd/nftban-installer/update_apply_test.go
+++ b/cmd/nftban-installer/update_apply_test.go
@@ -74,7 +74,7 @@ func seedHappyApplyHost(mock *executor.MockExecutor) {
 	// Validator gate — success with a plausible JSON body.
 	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{
 		ExitCode: 0,
-		Stdout:   `{"schema_version":"1.83.0","status":"protected"}`,
+		Stdout:   `{"schema_version":"1.84.0","status":"protected"}`,
 	}
 }
 
@@ -299,7 +299,7 @@ func TestUpdateApply_DoesNotReinterpretValidatorOutput(t *testing.T) {
 	// the exit code, not the body.
 	mock.RunResults["/usr/lib/nftban/bin/nftban-validate:--json"] = executor.Result{
 		ExitCode: 2,
-		Stdout:   `{"schema_version":"1.83.0","status":"protected"}`,
+		Stdout:   `{"schema_version":"1.84.0","status":"protected"}`,
 	}
 
 	cfg := &config{mode: "upgrade", stateDir: t.TempDir()}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/prometheus/procfs v0.20.1
 	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,8 +24,6 @@ require (
 	github.com/mdlayher/netlink v1.9.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/internal/blacklist/schema_freeze_test.go
+++ b/internal/blacklist/schema_freeze_test.go
@@ -46,7 +46,7 @@ import (
 // site of the V119 A1 fix; placing the guard adjacent to the typed-loader
 // changes makes drift-detection blast radius local.
 func TestSchemaVersionUnchangedByManualCIDRFix(t *testing.T) {
-	const expectedSchema = "1.83.0"
+	const expectedSchema = "1.84.0"
 	if validator.SchemaVersionCurrent != expectedSchema {
 		t.Fatalf("SchemaVersionCurrent = %q, want %q — V119 A1 Manual CIDR fix MUST NOT bump schema "+
 			"(per V119_MANUAL_CIDR_SCHEMA_IMPACT_DECISION.md verdict SCHEMA_STAYS_FROZEN). "+

--- a/internal/installer/render/schema_freeze_test.go
+++ b/internal/installer/render/schema_freeze_test.go
@@ -54,7 +54,7 @@ import (
 // (mirrors v1.119's adjacency at internal/blacklist/schema_freeze_test.go
 // and v1.120's adjacency at internal/whitelist/schema_freeze_test.go).
 func TestSchemaVersionUnchangedByV121OperatorSafetyHardening(t *testing.T) {
-	const expectedSchema = "1.83.0"
+	const expectedSchema = "1.84.0"
 	if validator.SchemaVersionCurrent != expectedSchema {
 		t.Fatalf("SchemaVersionCurrent = %q, want %q — V121 operator-safety hardening "+
 			"MUST NOT bump schema (per V121_OPERATOR_SAFETY_HARDENING_SCHEMA_IMPACT_DECISION.md "+

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -253,7 +253,8 @@ func (c *Collector) writeHealthMetrics(f *os.File) error {
 // nftban_nft_rules_total is now SINGLE-OWNED by the watchdog promauto path
 // (internal/watchdog/metrics.go). The duplicate raw-textfile emit that used to live
 // here is dropped to remove the same-name dual source across exporters. Kept as a
-// no-op (callers unchanged); countNFTablesRules() remains for other callers.
+// no-op so callers are unchanged; the former rule-counting helper was removed with
+// its only caller (the canonical count is the watchdog gauge nftban_nft_rules_total).
 func (c *Collector) writeNFTablesMetrics(_ *os.File) error {
 	return nil
 }
@@ -455,26 +456,6 @@ func (c *Collector) isServiceActive(service string) bool {
 		return false
 	}
 	return strings.TrimSpace(string(output)) == "active"
-}
-
-// countNFTablesRules counts total nftables rules
-func (c *Collector) countNFTablesRules() (int, error) {
-	cmd := exec.Command("nft", "list", "ruleset")
-	output, err := cmd.Output()
-	if err != nil {
-		return 0, err
-	}
-
-	count := 0
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "ip ") || strings.HasPrefix(line, "ip6 ") {
-			count++
-		}
-	}
-
-	return count, nil
 }
 
 // TCPStats represents TCP protocol statistics

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -249,18 +249,12 @@ func (c *Collector) writeHealthMetrics(f *os.File) error {
 	return nil
 }
 
-// writeNFTablesMetrics writes nftables-specific metrics
-func (c *Collector) writeNFTablesMetrics(f *os.File) error {
-	// Count rules efficiently
-	ruleCount, err := c.countNFTablesRules()
-	if err != nil {
-		ruleCount = 0
-	}
-
-	fmt.Fprintf(f, "# HELP nftban_nft_rules_total Total number of nftables rules\n")
-	fmt.Fprintf(f, "# TYPE nftban_nft_rules_total gauge\n")
-	fmt.Fprintf(f, "nftban_nft_rules_total %d\n\n", ruleCount)
-
+// writeNFTablesMetrics — v1.190.0 SCHEMA-UNFREEZE name-drift (G-12): the canonical
+// nftban_nft_rules_total is now SINGLE-OWNED by the watchdog promauto path
+// (internal/watchdog/metrics.go). The duplicate raw-textfile emit that used to live
+// here is dropped to remove the same-name dual source across exporters. Kept as a
+// no-op (callers unchanged); countNFTablesRules() remains for other callers.
+func (c *Collector) writeNFTablesMetrics(_ *os.File) error {
 	return nil
 }
 

--- a/internal/metrics/sampler.go
+++ b/internal/metrics/sampler.go
@@ -149,9 +149,12 @@ func (s *Sampler) initPrometheus() {
 	})
 
 	s.ruleCountGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		// v1.190.0 SCHEMA-UNFREEZE name-drift (G-12): DEPRECATED alias of the canonical
+		// nftban_nft_rules_total. Emits the same value through the 2-minor window
+		// (v1.190.x + v1.191.x); remove only after an explicit later gate.
 		Namespace: "nftban",
 		Name:      "firewall_rules_total",
-		Help:      "Total number of firewall rules",
+		Help:      "DEPRECATED (use nftban_nft_rules_total; removal after v1.191.x): total number of nftables rules",
 	})
 
 	// BUG-001 FIX: Aligned semantics with collector.go (0=OK, higher=worse)

--- a/internal/metricscontract/doc.go
+++ b/internal/metricscontract/doc.go
@@ -1,0 +1,21 @@
+// =============================================================================
+// NFTBan v1.190 - OpenMetrics / Prometheus scrape-contract validation (SOS-4)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="metricscontract"
+// meta:type="lib"
+// meta:version="1.190.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Hermetic OpenMetrics/Prometheus scrape-contract validation harness (SOS-4). Holds no runtime code — it exists so the _test.go gather/parse contract validation has a home package that imports the real metric registrants (internal/metrics, internal/watchdog). The exposition text emitted by the default registry must be parser-valid, type-consistent, duplicate-safe, anchor-double-emit-free, and false-zero-free in the v1.190.0 contract phase."
+// meta:inventory.files="internal/metricscontract/doc.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+// Package metricscontract is a test-only home for the v1.190.0 SOS-4
+// OpenMetrics scrape-contract validation. It has no runtime API.
+package metricscontract

--- a/internal/metricscontract/openmetrics_v190_test.go
+++ b/internal/metricscontract/openmetrics_v190_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 
+	"github.com/itcmsgr/nftban/internal/validator"
+
 	// Import the REAL metric registrants so their package-level promauto vars
 	// register on the default registry before we gather (init-time registration).
 	_ "github.com/itcmsgr/nftban/internal/metrics"
@@ -142,5 +144,63 @@ func TestOpenMetrics_NoNewCounterSeriesInContract(t *testing.T) {
 				t.Errorf("false-zero risk: new v1.190 counter series registered before population: %s (matches %q)", name, f)
 			}
 		}
+	}
+}
+
+// (6) Naming rule: nftban_* COUNTERS end in _total; GAUGES do NOT end in _total,
+// EXCEPT the documented legacy gauges historically named _total (a global rename
+// would break shipped dashboards — rejected). New v1.190 metrics must comply.
+func TestOpenMetrics_CounterGaugeNamingRule(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	// BASELINE — pre-existing GAUGES historically named _total (a Prometheus
+	// anti-pattern). These shipped long before v1.190; a global rename is a BREAKING
+	// dashboard change and is OUT of v1.190 scope (and an explicit hard exclusion).
+	// They are frozen tech-debt: this rule fails only on a NEW _total gauge. v1.190's
+	// only new metric (counters_population_phase) is correctly NOT named _total.
+	legacyTotalGauges := map[string]bool{
+		"nftban_nft_rules_total":      true,
+		"nftban_cidr_current_total":   true,
+		"nftban_cidr_filter_total":    true,
+		"nftban_permanent_bans_total": true,
+		"nftban_schema_errors_total":  true,
+		"nftban_firewall_rules_total": true, // DEPRECATED alias (lazy-registered; here if present on a live scrape)
+		"nftban_suricata_rules_total": true, // distinct Suricata SID gauge (lazy-registered)
+	}
+	for name, mf := range parsed {
+		if !strings.HasPrefix(name, "nftban_") {
+			continue // scope the rule to our namespace (skip go_/process_/promhttp_)
+		}
+		switch mf.GetType() {
+		case dto.MetricType_COUNTER:
+			if !strings.HasSuffix(name, "_total") {
+				t.Errorf("counter %s must end in _total", name)
+			}
+		case dto.MetricType_GAUGE:
+			if strings.HasSuffix(name, "_total") && !legacyTotalGauges[name] {
+				t.Errorf("gauge %s must NOT be named _total (new metric); only legacy nft/firewall/suricata_rules_total are exempt", name)
+			}
+		}
+	}
+}
+
+// (7) JSON↔Prometheus mutual consistency: the JSON mapper stamps
+// counters_phase="contract" at the same time the Prometheus phase gauge reads 0.
+// The two observability surfaces must agree (a consumer reading either must reach
+// the same "population pending" conclusion).
+func TestOpenMetrics_JSONPromMutualConsistency(t *testing.T) {
+	h := validator.MapToHealthOutput(&validator.ValidationResult{})
+	if h.CountersPhase != "contract" {
+		t.Errorf("JSON counters_phase = %q; want \"contract\"", h.CountersPhase)
+	}
+	if h.SchemaVersion != "1.84.0" {
+		t.Errorf("JSON schema_version = %q; want 1.84.0", h.SchemaVersion)
+	}
+	if h.Counters != nil || h.NFT != nil {
+		t.Errorf("JSON counters/nft must be ABSENT in contract phase; got counters=%v nft=%v", h.Counters, h.NFT)
+	}
+	parsed := gatherAndRoundTrip(t)
+	mf := parsed["nftban_counters_population_phase"]
+	if mf == nil || len(mf.Metric) != 1 || mf.Metric[0].GetGauge().GetValue() != 0 {
+		t.Fatalf("Prometheus phase gauge must be 0 to mutually agree with JSON contract phase; got %v", mf)
 	}
 }

--- a/internal/metricscontract/openmetrics_v190_test.go
+++ b/internal/metricscontract/openmetrics_v190_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="openmetrics_v190_test"
+// meta:type="test"
+// meta:version="1.190.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.190.0 SOS-4 OpenMetrics scrape-contract validation (hermetic). Gathers the default Prometheus registry (with the real metric registrants imported), encodes it to text exposition with expfmt, and re-parses it — proving: (1) the exposition is PARSER-VALID and round-trips (HELP/TYPE valid, no duplicate HELP/TYPE conflicts, no duplicate metric family — Gather() + TextToMetricFamilies enforce this); (2) anti-false-zero gate nftban_counters_population_phase exists, is a GAUGE, is NOT named _total, and equals 0 in the contract phase; (3) NO dedicated nftban_nft_anchor_* family is emitted (SOS-2 anchors only via nft_named_counter_*); (4) the existing nft_named_counter_* family, if present, keeps labels {family,counter} and family values stay raw ip/ip6 — NEVER ipv4/ipv6 (SOS-3 Prometheus compat preserved); (5) NO new v1.190 BotScan/BotGuard/Whitelist/FCrDNS counter series are registered (false-zero-free). Alias-mirror (firewall_rules_total==nft_rules_total) + suricata distinctness register lazily at runtime → covered by the lab-first promtool scrape, not this init-time gather."
+// meta:inventory.files="internal/metricscontract/openmetrics_v190_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package metricscontract
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	// Import the REAL metric registrants so their package-level promauto vars
+	// register on the default registry before we gather (init-time registration).
+	_ "github.com/itcmsgr/nftban/internal/metrics"
+	_ "github.com/itcmsgr/nftban/internal/watchdog"
+)
+
+// gatherAndRoundTrip gathers the default registry, encodes every family to text
+// exposition (expfmt), and re-parses it. A non-nil error from Gather() or from
+// the parser means the scrape surface is NOT contract-valid (duplicate family,
+// type conflict, bad HELP/TYPE, invalid label/sample). Returns the re-parsed
+// family map (keyed by metric name) for invariant assertions.
+func gatherAndRoundTrip(t *testing.T) map[string]*dto.MetricFamily {
+	t.Helper()
+	fams, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("SOS-4: registry Gather() failed — scrape surface inconsistent: %v", err)
+	}
+	var buf bytes.Buffer
+	for _, mf := range fams {
+		if _, err := expfmt.MetricFamilyToText(&buf, mf); err != nil {
+			t.Fatalf("SOS-4: MetricFamilyToText(%s) failed: %v", mf.GetName(), err)
+		}
+	}
+	// LegacyValidation = classic Prometheus metric/label names (all nftban_* metrics
+	// satisfy it); the scheme must be set explicitly or the parser panics on "unset".
+	p := expfmt.NewTextParser(model.LegacyValidation)
+	parsed, err := p.TextToMetricFamilies(strings.NewReader(buf.String()))
+	if err != nil {
+		t.Fatalf("SOS-4: emitted /metrics text did NOT parse (format invalid): %v", err)
+	}
+	return parsed
+}
+
+// (1) The exposition must parse cleanly (format validity + no dup HELP/TYPE).
+func TestOpenMetrics_ScrapeParsesClean(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	if len(parsed) == 0 {
+		t.Fatalf("SOS-4: no metric families gathered — registrant import did not register")
+	}
+}
+
+// (2) Anti-false-zero gate: counters_population_phase present, GAUGE, !_total, ==0.
+func TestOpenMetrics_PhaseGaugeIsZeroContract(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	const name = "nftban_counters_population_phase"
+	mf, ok := parsed[name]
+	if !ok {
+		t.Fatalf("SOS-4: %s MUST be present (anti-false-zero gate)", name)
+	}
+	if mf.GetType() != dto.MetricType_GAUGE {
+		t.Errorf("%s must be a GAUGE; got %s", name, mf.GetType())
+	}
+	if strings.HasSuffix(name, "_total") {
+		t.Errorf("%s must NOT be named _total (it is a phase gauge, not a counter)", name)
+	}
+	if len(mf.Metric) != 1 || mf.Metric[0].GetGauge().GetValue() != 0 {
+		t.Errorf("%s must equal 0 in the v1.190.0 contract phase; got %+v", name, mf.Metric)
+	}
+}
+
+// (3) Canonical rule-count present; (SOS-2) NO dedicated anchor metric family.
+func TestOpenMetrics_RuleCountAndNoAnchorMetric(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	if _, ok := parsed["nftban_nft_rules_total"]; !ok {
+		t.Errorf("SOS-4: canonical nftban_nft_rules_total missing from scrape")
+	}
+	for name := range parsed {
+		if strings.Contains(name, "nft_anchor") {
+			t.Errorf("SOS-2 violation: dedicated anchor metric emitted: %s (anchors must reuse nft_named_counter_*)", name)
+		}
+	}
+}
+
+// (4) SOS-3 Prometheus compat: named-counter family stays {family,counter} with
+// raw ip/ip6 — never ipv4/ipv6 (no relabel of the existing shipped surface).
+func TestOpenMetrics_NamedCounterFamilyLabelsCompat(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	for _, name := range []string{"nftban_nft_named_counter_packets_total", "nftban_nft_named_counter_bytes_total"} {
+		mf, ok := parsed[name]
+		if !ok {
+			continue // empty GaugeVec (no children at init) → family absent; nothing to relabel
+		}
+		for _, m := range mf.Metric {
+			var hasFamily, hasCounter bool
+			for _, lp := range m.Label {
+				switch lp.GetName() {
+				case "family":
+					hasFamily = true
+					if v := lp.GetValue(); v == "ipv4" || v == "ipv6" {
+						t.Errorf("SOS-3 violation: %s relabeled family to %q (must stay raw ip/ip6 for compat)", name, v)
+					}
+				case "counter":
+					hasCounter = true
+				}
+			}
+			if !hasFamily || !hasCounter {
+				t.Errorf("%s must keep {family,counter} labels; got %+v", name, m.Label)
+			}
+		}
+	}
+}
+
+// (5) False-zero-free: NO new v1.190 BotScan/BotGuard/Whitelist/FCrDNS counter
+// series are registered (those are v1.191 population, not contract phase).
+func TestOpenMetrics_NoNewCounterSeriesInContract(t *testing.T) {
+	parsed := gatherAndRoundTrip(t)
+	// substrings that would indicate a v1.191 population metric leaked into v1.190
+	forbidden := []string{
+		"botscan_scanned", "botscan_matched", "botscan_signals", "botscan_bans",
+		"botscan_crawler_verify", "botguard_decisions", "botguard_eventbus",
+		"whitelist_changes", "fcrdns_",
+	}
+	for name := range parsed {
+		for _, f := range forbidden {
+			if strings.Contains(name, f) {
+				t.Errorf("false-zero risk: new v1.190 counter series registered before population: %s (matches %q)", name, f)
+			}
+		}
+	}
+}

--- a/internal/validator/counters_contract_v190_test.go
+++ b/internal/validator/counters_contract_v190_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="counters_contract_v190_test"
+// meta:type="test"
+// meta:version="1.190.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.190.0 SCHEMA-UNFREEZE counters CONTRACT guard. Asserts: (1) schema bumped 1.83.0->1.84.0; (2) counters_phase='contract' present (anti-false-zero gate); (3) 'counters' object ABSENT in contract phase (no false-zero); (4) populated container round-trips incl. IP-family (FamilyCounts ipv4/ipv6) per DESIGN_AMENDMENT_V1_190_IP_FAMILY; (5) old-consumer compatibility (pre-1.84 struct still parses); (6) family-aware shape — IP-backed counters carry ipv4/ipv6, non-IP-backed (files_deferred/eventbus_drops) do NOT."
+// meta:inventory.files="internal/validator/counters_contract_v190_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package validator
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// (1) deliberate bump
+func TestSchemaVersion_v190_Is_1_84_0(t *testing.T) {
+	if SchemaVersionCurrent != "1.84.0" {
+		t.Fatalf("SchemaVersionCurrent = %q; v1.190.0 SCHEMA-UNFREEZE requires 1.84.0", SchemaVersionCurrent)
+	}
+	if CountersPhaseContract != "contract" || CountersPhasePopulated != "populated" {
+		t.Fatalf("phase constants drifted: %q/%q", CountersPhaseContract, CountersPhasePopulated)
+	}
+}
+
+// (2)(3) contract phase: phase="contract" present, counters object ABSENT (no false-zero)
+func TestCountersContract_Phase_And_AbsentCounters(t *testing.T) {
+	h := HealthOutput{SchemaVersion: SchemaVersionCurrent, CountersPhase: CountersPhaseContract}
+	b, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"counters_phase":"contract"`) {
+		t.Errorf("counters_phase must be present and 'contract' in v1.190.0; got: %s", s)
+	}
+	if strings.Contains(s, `"counters"`) {
+		t.Errorf("counters object MUST be ABSENT in contract phase (no false-zero); got: %s", s)
+	}
+	if !strings.Contains(s, `"schema_version":"1.84.0"`) {
+		t.Errorf("schema_version must be 1.84.0; got: %s", s)
+	}
+}
+
+// (4) populated shape (v1.191): counters object present + correctly typed
+func TestCountersContract_PopulatedShape(t *testing.T) {
+	h := HealthOutput{
+		SchemaVersion: SchemaVersionCurrent,
+		CountersPhase: CountersPhasePopulated,
+		Counters: &CountersJSON{
+			// IP-family split per DESIGN_AMENDMENT_V1_190_IP_FAMILY: bans v4+v6 independent.
+			BotScan:   &BotScanCountersJSON{Bans: FamilyCounts{IPv4: 5, IPv6: 2}, FilesDeferred: 7},
+			BotGuard:  &BotGuardCountersJSON{Decisions: FamilyCounts{IPv4: 3}, EventbusDrops: 1},
+			Whitelist: &WhitelistCountersJSON{Changes: FamilyCounts{IPv6: 4}},
+		},
+	}
+	b, _ := json.Marshal(h)
+	s := string(b)
+	// family present + independent in JSON
+	if !strings.Contains(s, `"bans":{"ipv4":5,"ipv6":2}`) {
+		t.Errorf("bans must split by family (ipv4/ipv6) independently; got: %s", s)
+	}
+	// non-IP-backed counters carry NO family (plain int)
+	if !strings.Contains(s, `"files_deferred":7`) || !strings.Contains(s, `"eventbus_drops":1`) {
+		t.Errorf("non-IP-backed counters must be plain (no family); got: %s", s)
+	}
+	var rt HealthOutput
+	if err := json.Unmarshal(b, &rt); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if rt.CountersPhase != "populated" || rt.Counters == nil || rt.Counters.BotScan == nil ||
+		rt.Counters.BotScan.Bans.IPv4 != 5 || rt.Counters.BotScan.Bans.IPv6 != 2 ||
+		rt.Counters.BotScan.FilesDeferred != 7 || rt.Counters.BotGuard.Decisions.IPv4 != 3 ||
+		rt.Counters.BotGuard.EventbusDrops != 1 || rt.Counters.Whitelist.Changes.IPv6 != 4 {
+		t.Errorf("populated family-aware counters did not round-trip: %+v", rt.Counters)
+	}
+}
+
+// (5) old-consumer compat: a consumer that predates the counters fields still parses 1.84.0
+func TestCountersContract_OldConsumerCompat(t *testing.T) {
+	// emit current (1.84.0) output WITHOUT counters (contract phase)
+	cur, _ := json.Marshal(HealthOutput{SchemaVersion: SchemaVersionCurrent, Status: "protected", CountersPhase: CountersPhaseContract})
+	// a pre-unfreeze consumer struct (no counters_phase / counters fields)
+	type oldHealth struct {
+		SchemaVersion string `json:"schema_version"`
+		Status        string `json:"status"`
+	}
+	var old oldHealth
+	if err := json.Unmarshal(cur, &old); err != nil {
+		t.Fatalf("old consumer must still parse 1.84.0 output: %v", err)
+	}
+	if old.SchemaVersion != "1.84.0" || old.Status != "protected" {
+		t.Errorf("old consumer parsed wrong values: %+v", old)
+	}
+}

--- a/internal/validator/counters_contract_v190_test.go
+++ b/internal/validator/counters_contract_v190_test.go
@@ -165,3 +165,16 @@ func TestCountersContract_OldConsumerCompat(t *testing.T) {
 		t.Errorf("old consumer parsed wrong values: %+v", old)
 	}
 }
+
+// (8) ToJSONLegacy backward-compat path must still serialize valid JSON in 1.84.0
+// (rebuild safety checks parse the raw ValidationResult via this path).
+func TestToJSONLegacy_StillWorks(t *testing.T) {
+	b, err := (&ValidationResult{}).ToJSONLegacy()
+	if err != nil {
+		t.Fatalf("ToJSONLegacy must still work: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("ToJSONLegacy emitted invalid JSON: %v", err)
+	}
+}

--- a/internal/validator/counters_contract_v190_test.go
+++ b/internal/validator/counters_contract_v190_test.go
@@ -83,11 +83,76 @@ func TestCountersContract_PopulatedShape(t *testing.T) {
 	}
 }
 
+// (6) nft.anchors[] contract: ABSENT in contract phase (no false-zero), present+typed when populated.
+func TestNFTAnchorsContract_AbsentThenPopulated(t *testing.T) {
+	// contract phase: "nft" object MUST be absent (omitempty, NFT==nil)
+	cb, _ := json.Marshal(HealthOutput{SchemaVersion: SchemaVersionCurrent, CountersPhase: CountersPhaseContract})
+	if strings.Contains(string(cb), `"nft"`) {
+		t.Errorf("nft object MUST be ABSENT in contract phase (no false-zero anchors); got: %s", cb)
+	}
+	// populated (v1.191) shape: anchors carry NORMALIZED family ipv4/ipv6
+	h := HealthOutput{
+		SchemaVersion: SchemaVersionCurrent,
+		CountersPhase: CountersPhasePopulated,
+		NFT: &NFTCountersJSON{Anchors: []NFTAnchorJSON{
+			{Family: FamilyIPv4, Anchor: "anchor_hygiene", Packets: 10, Bytes: 800},
+			{Family: FamilyIPv6, Anchor: "anchor_final", Packets: 2, Bytes: 96},
+		}},
+	}
+	b, _ := json.Marshal(h)
+	s := string(b)
+	if !strings.Contains(s, `"family":"ipv4"`) || !strings.Contains(s, `"family":"ipv6"`) {
+		t.Errorf("nft.anchors[] must use normalized ipv4/ipv6; got: %s", s)
+	}
+	if !strings.Contains(s, `"anchor":"anchor_hygiene"`) || !strings.Contains(s, `"anchor":"anchor_final"`) {
+		t.Errorf("nft.anchors[] must carry anchor name; got: %s", s)
+	}
+	// SOS-3: JSON must NEVER emit raw nft family ip/ip6
+	if strings.Contains(s, `"family":"ip"`) || strings.Contains(s, `"family":"ip6"`) {
+		t.Errorf("SOS-3 violation: JSON must NOT emit raw nft family ip/ip6; got: %s", s)
+	}
+	var rt HealthOutput
+	if err := json.Unmarshal(b, &rt); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if rt.NFT == nil || len(rt.NFT.Anchors) != 2 || rt.NFT.Anchors[0].Family != FamilyIPv4 ||
+		rt.NFT.Anchors[0].Packets != 10 || rt.NFT.Anchors[1].Family != FamilyIPv6 {
+		t.Errorf("nft.anchors[] did not round-trip: %+v", rt.NFT)
+	}
+}
+
+// (7) SOS-3 family normalization: nft ip→ipv4, ip6→ipv6; one JSON vocabulary.
+func TestNormalizeNFTFamily_SOS3(t *testing.T) {
+	cases := map[string]string{
+		"ip":    FamilyIPv4,    // nft IPv4 table → JSON ipv4 (bridges Prometheus family="ip")
+		"ipv4":  FamilyIPv4,    // already-normalized passthrough
+		"ip6":   FamilyIPv6,    // nft IPv6 table → JSON ipv6 (bridges Prometheus family="ip6")
+		"ipv6":  FamilyIPv6,    // already-normalized passthrough
+		"inet":  FamilyInet,    // genuinely table-level; never fake-split
+		"":      FamilyUnknown, // missing → unknown (defect signal on per-IP/anchor counters)
+		"bogus": FamilyUnknown,
+	}
+	for in, want := range cases {
+		if got := NormalizeNFTFamily(in); got != want {
+			t.Errorf("NormalizeNFTFamily(%q) = %q; want %q", in, got, want)
+		}
+	}
+	// the JSON vocabulary must be exactly {ipv4,ipv6,inet,unknown}
+	if FamilyIPv4 != "ipv4" || FamilyIPv6 != "ipv6" || FamilyInet != "inet" || FamilyUnknown != "unknown" {
+		t.Fatalf("JSON family vocabulary drifted: %q/%q/%q/%q", FamilyIPv4, FamilyIPv6, FamilyInet, FamilyUnknown)
+	}
+}
+
 // (5) old-consumer compat: a consumer that predates the counters fields still parses 1.84.0
 func TestCountersContract_OldConsumerCompat(t *testing.T) {
-	// emit current (1.84.0) output WITHOUT counters (contract phase)
-	cur, _ := json.Marshal(HealthOutput{SchemaVersion: SchemaVersionCurrent, Status: "protected", CountersPhase: CountersPhaseContract})
-	// a pre-unfreeze consumer struct (no counters_phase / counters fields)
+	// emit FULLY-POPULATED (v1.191-shape) 1.84.0 output incl. counters + nft.anchors[]
+	// to prove a pre-unfreeze consumer ignores ALL added fields (additive compat).
+	cur, _ := json.Marshal(HealthOutput{
+		SchemaVersion: SchemaVersionCurrent, Status: "protected", CountersPhase: CountersPhasePopulated,
+		Counters: &CountersJSON{BotScan: &BotScanCountersJSON{Bans: FamilyCounts{IPv4: 1}}},
+		NFT:      &NFTCountersJSON{Anchors: []NFTAnchorJSON{{Family: FamilyIPv4, Anchor: "anchor_ban", Packets: 1}}},
+	})
+	// a pre-unfreeze consumer struct (no counters_phase / counters / nft fields)
 	type oldHealth struct {
 		SchemaVersion string `json:"schema_version"`
 		Status        string `json:"status"`

--- a/internal/validator/health_mapper.go
+++ b/internal/validator/health_mapper.go
@@ -31,6 +31,7 @@ package validator
 func MapToHealthOutput(r *ValidationResult) HealthOutput {
 	h := HealthOutput{
 		SchemaVersion: SchemaVersionCurrent,
+		CountersPhase: CountersPhaseContract, // v1.190.0: contract only; v1.191.0 → populated
 		Status:        string(r.Status),
 		Timestamp:     r.Timestamp.UTC().Format("2006-01-02T15:04:05Z"),
 		ServiceState: ServiceStateJSON{

--- a/internal/validator/health_mapper_test.go
+++ b/internal/validator/health_mapper_test.go
@@ -29,8 +29,8 @@ func TestMapToHealthOutput_SchemaVersion(t *testing.T) {
 		Timestamp: time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC),
 	}
 	h := MapToHealthOutput(r)
-	if h.SchemaVersion != "1.83.0" {
-		t.Errorf("schema_version = %s, want 1.83.0", h.SchemaVersion)
+	if h.SchemaVersion != "1.84.0" {
+		t.Errorf("schema_version = %s, want 1.84.0", h.SchemaVersion)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestFullOutput_ValidJSON(t *testing.T) {
 	jsonStr := string(data)
 
 	// Schema version present
-	if h.SchemaVersion != "1.83.0" {
+	if h.SchemaVersion != "1.84.0" {
 		t.Errorf("schema_version missing or wrong")
 	}
 

--- a/internal/validator/health_output.go
+++ b/internal/validator/health_output.go
@@ -38,6 +38,59 @@ type HealthOutput struct {
 	Findings      []FindingJSON    `json:"findings"`
 	ChainCounts   ChainCounts      `json:"chain_counts"`
 	Summary       SummaryCounts    `json:"summary"`
+	// v1.84 SCHEMA-UNFREEZE counters contract (additive).
+	CountersPhase string        `json:"counters_phase"`     // "contract" (v1.190.0) | "populated" (v1.191.0); the anti-false-zero gate
+	Counters      *CountersJSON `json:"counters,omitempty"` // nil/ABSENT until v1.191.0 populates — absent ≠ zero (no false-zero dashboards)
+}
+
+// CountersJSON is the v1.84 counters CONTRACT. In v1.190.0 the pointer is always
+// nil → the "counters" object is ABSENT from JSON (omitempty). The contract exists
+// in the type system / schema; population begins v1.191.0 (which also flips
+// counters_phase → "populated"). Absent is deliberately NOT zero so consumers do
+// not read "nothing happened" from contract-only output.
+type CountersJSON struct {
+	BotScan   *BotScanCountersJSON   `json:"botscan,omitempty"`
+	BotGuard  *BotGuardCountersJSON  `json:"botguard,omitempty"`
+	Whitelist *WhitelistCountersJSON `json:"whitelist,omitempty"`
+}
+
+// FamilyCounts is an IP-backed counter split by address family (v1.84 contract;
+// DESIGN_AMENDMENT_V1_190_IP_FAMILY). In Prometheus this is the low-cardinality
+// label family="ipv4|ipv6|inet|unknown"; in JSON it is these omitempty sub-fields.
+// Semantics:
+//   - PER-IP counters (bans/signals/crawler_verify/etc.): use ipv4 / ipv6 only.
+//     `unknown` here signals a classification BUG (a banned IP is always v4 or v6);
+//     `inet` is NOT valid for per-IP counters.
+//   - TABLE-LEVEL counters (nft forward/output from an inet chain): use `inet`.
+// Never fake-split a genuinely-inet rule into ipv4/ipv6. omitempty → absent in the
+// contract phase (no false-zero) and zero families omitted once populated.
+type FamilyCounts struct {
+	IPv4    uint64 `json:"ipv4,omitempty"`
+	IPv6    uint64 `json:"ipv6,omitempty"`
+	Inet    uint64 `json:"inet,omitempty"`    // table-level only (e.g. inet-chain forward/output)
+	Unknown uint64 `json:"unknown,omitempty"` // last-resort; on per-IP counters indicates a classification gap
+}
+
+// BotScanCountersJSON — populated v1.191.0 (BotScan processor state).
+// IP-backed counters carry family; files_deferred is per-FILE (no IP → no family).
+type BotScanCountersJSON struct {
+	ScannedEntries FamilyCounts `json:"scanned_entries"`
+	Matched        FamilyCounts `json:"matched"`        // also by category in Prometheus
+	Signals        FamilyCounts `json:"signals"`        // also ban vs grey in Prometheus
+	Bans           FamilyCounts `json:"bans"`           // also by reason/category in Prometheus
+	CrawlerVerify  FamilyCounts `json:"crawler_verify"` // also ok/bad/timeout/cachehit in Prometheus
+	FilesDeferred  uint64       `json:"files_deferred"` // per-file rotation/budget — NOT IP-backed, no family
+}
+
+// BotGuardCountersJSON — populated v1.191.0 (counters absent in BotGuard today).
+type BotGuardCountersJSON struct {
+	Decisions     FamilyCounts `json:"decisions"`      // IP-backed (also by decision in Prometheus)
+	EventbusDrops uint64       `json:"eventbus_drops"` // not IP-backed → no family
+}
+
+// WhitelistCountersJSON — populated v1.191.0 (today only gauges exist).
+type WhitelistCountersJSON struct {
+	Changes FamilyCounts `json:"changes"` // IP-backed (also by op add/remove/expire in Prometheus)
 }
 
 // ServiceStateJSON is the JSON representation of daemon and timer state.

--- a/internal/validator/health_output.go
+++ b/internal/validator/health_output.go
@@ -41,6 +41,65 @@ type HealthOutput struct {
 	// v1.84 SCHEMA-UNFREEZE counters contract (additive).
 	CountersPhase string        `json:"counters_phase"`     // "contract" (v1.190.0) | "populated" (v1.191.0); the anti-false-zero gate
 	Counters      *CountersJSON `json:"counters,omitempty"` // nil/ABSENT until v1.191.0 populates — absent ≠ zero (no false-zero dashboards)
+	// v1.84 NFT counting-model contract view (additive; nil/ABSENT until v1.191.0).
+	NFT *NFTCountersJSON `json:"nft,omitempty"` // interpreted JSON VIEW over existing nft named counters — NOT a new Prometheus family (SOS-2 Option A)
+}
+
+// NFTCountersJSON is the v1.84 NFT counting-model JSON view. It is an INTERPRETED
+// projection over the EXISTING nft named counters (Prometheus
+// nftban_nft_named_counter_packets_total{family,counter} / _bytes_total) — it does
+// NOT introduce a parallel Prometheus metric (SOS-2 Option A: no double-count). In
+// v1.190.0 the pointer is always nil → the "nft" object is ABSENT (omitempty);
+// population begins v1.191.0 from the same named-counter / nft-JSON source.
+type NFTCountersJSON struct {
+	Anchors []NFTAnchorJSON `json:"anchors,omitempty"` // phase-boundary view; see NFTAnchorJSON
+}
+
+// NFTAnchorJSON is one anchor phase-boundary counter (v1.84 contract).
+// Anchors (anchor_hygiene→…→anchor_final, both ip + ip6 tables, comment
+// NFTBAN_ANCHOR:*) are PHASE-BOUNDARY / pipeline-continuity counters — they answer
+// "did traffic reach this firewall phase?" They are NOT accept/drop verdict counters
+// and MUST NOT be summed into total_input_accept / total_input_drop. They do not
+// change health status in v1.190.0.
+//
+// Family is NORMALIZED per SOS-3 (OPTION_1_NORMALIZE_JSON_KEEP_PROMETHEUS_COMPAT):
+// the kernel/Prometheus family "ip"/"ip6" is mapped to JSON "ipv4"/"ipv6" so the
+// entire 1.84.0 JSON contract speaks ONE vocabulary (ipv4|ipv6|inet|unknown). The
+// Prometheus label nft_named_counter_*{family="ip"|"ip6"} is left UNCHANGED for
+// compatibility; the bridge is documented: Prometheus ip == JSON ipv4, ip6 == ipv6.
+type NFTAnchorJSON struct {
+	Family  string `json:"family"`  // ipv4|ipv6 (normalized from nft ip/ip6); anchors never inet/unknown — unknown ⇒ collection defect
+	Anchor  string `json:"anchor"`  // anchor_hygiene|anchor_trusted|anchor_ban|anchor_established|anchor_detect|anchor_service|anchor_final
+	Packets uint64 `json:"packets"` // from the named counter (real value once populated v1.191.0)
+	Bytes   uint64 `json:"bytes"`   // from the named counter
+}
+
+// NFT family-vocabulary constants — the SINGLE JSON vocabulary (SOS-3).
+// JSON output uses ONLY these; raw nft table families "ip"/"ip6" never appear in JSON.
+const (
+	FamilyIPv4    = "ipv4" // JSON; bridges Prometheus family="ip"
+	FamilyIPv6    = "ipv6" // JSON; bridges Prometheus family="ip6"
+	FamilyInet    = "inet" // table-level only (genuinely-inet rules); never fake-split
+	FamilyUnknown = "unknown"
+)
+
+// NormalizeNFTFamily maps a raw nftables table family to the canonical JSON family
+// vocabulary (SOS-3 OPTION_1). nft "ip"→"ipv4", "ip6"→"ipv6", "inet"→"inet";
+// anything else (incl. empty) → "unknown". This is the ONLY bridge between the
+// Prometheus named-counter label space (ip/ip6, unchanged for compat) and the JSON
+// 1.84.0 contract (ipv4/ipv6/inet/unknown). For per-IP/anchor counters a result of
+// "unknown" signals a classification/collection defect (v1.191 tests assert absence).
+func NormalizeNFTFamily(nftFamily string) string {
+	switch nftFamily {
+	case "ip", "ipv4":
+		return FamilyIPv4
+	case "ip6", "ipv6":
+		return FamilyIPv6
+	case "inet":
+		return FamilyInet
+	default:
+		return FamilyUnknown
+	}
 }
 
 // CountersJSON is the v1.84 counters CONTRACT. In v1.190.0 the pointer is always
@@ -62,6 +121,7 @@ type CountersJSON struct {
 //     `unknown` here signals a classification BUG (a banned IP is always v4 or v6);
 //     `inet` is NOT valid for per-IP counters.
 //   - TABLE-LEVEL counters (nft forward/output from an inet chain): use `inet`.
+//
 // Never fake-split a genuinely-inet rule into ipv4/ipv6. omitempty → absent in the
 // contract phase (no false-zero) and zero families omitted once populated.
 type FamilyCounts struct {

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -809,7 +809,7 @@ func TestReadConfigBoolMissing(t *testing.T) {
 // =============================================================================
 
 func TestSchemaVersion(t *testing.T) {
-	if SchemaVersionCurrent != "1.83.0" {
-		t.Errorf("schema version = %s, want 1.83.0", SchemaVersionCurrent)
+	if SchemaVersionCurrent != "1.84.0" {
+		t.Errorf("schema version = %s, want 1.84.0", SchemaVersionCurrent)
 	}
 }

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -62,9 +62,22 @@ type ValidationResult struct {
 	SetElementCounts map[string]int   `json:"-"` // "family:set" → element count
 }
 
-// SchemaVersionCurrent is the frozen schema version per M81-6.
+// SchemaVersionCurrent is the output/IPC schema version per M81-6.
 // v1.83: bumped for timer_count addition to service_state.
-const SchemaVersionCurrent = "1.83.0"
+// v1.190.0 SCHEMA-UNFREEZE: deliberate bump 1.83.0 → 1.84.0 — adds the counters
+// CONTRACT (additive, omitempty/absent until populated in v1.191.0) + the
+// counters_phase marker. Coordinated with the freeze-guard tests in
+// internal/{blacklist,whitelist,installer/render,validator}. Additive-only:
+// existing fields/types unchanged so old consumers keep parsing.
+const SchemaVersionCurrent = "1.84.0"
+
+// CountersPhaseContract / CountersPhasePopulated are the counters_phase values.
+// v1.190.0 emits "contract" (schema/fields defined, NOT populated → consumers must
+// NOT read absent/zero as real). v1.191.0 will emit "populated" once live counters move.
+const (
+	CountersPhaseContract  = "contract"
+	CountersPhasePopulated = "populated"
+)
 
 // =============================================================================
 // =============================================================================

--- a/internal/watchdog/metrics.go
+++ b/internal/watchdog/metrics.go
@@ -218,6 +218,17 @@ var (
 		Help:      "Whether nftables rules have counters (1=yes, 0=no)",
 	})
 
+	// v1.190.0 SCHEMA-UNFREEZE — counters population phase (anti-false-zero gate).
+	// 0 = contract only (schema 1.84.0 defines the counter fields/metrics but they
+	// are NOT populated; consumers must NOT read absent/zero as real). 1 = populated
+	// (v1.191.0, when live BotScan/BotGuard/whitelist/FCrDNS counters move).
+	// Initialized to 0 in init(); v1.191.0 will Set(1).
+	countersPopulationPhase = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "nftban",
+		Name:      "counters_population_phase",
+		Help:      "Counters contract phase: 0=contract-only (population pending), 1=populated",
+	})
+
 	// ==========================================================================
 	// Cost Metrics
 	// ==========================================================================
@@ -302,6 +313,13 @@ var (
 		Help:      "Cumulative OOM-kill events (per /proc/vmstat oom_kill)",
 	})
 )
+
+// v1.190.0 SCHEMA-UNFREEZE: pin the counters phase to contract-only (0). v1.191.0
+// flips this to 1 (populated) when live counters move. Set here so the gauge always
+// has a defined value (never an absent/implicit reading).
+func init() {
+	countersPopulationPhase.Set(0)
+}
 
 // MetricsExporter updates Prometheus metrics from watchdog data
 type MetricsExporter struct {

--- a/internal/whitelist/schema_freeze_test.go
+++ b/internal/whitelist/schema_freeze_test.go
@@ -49,7 +49,7 @@ import (
 // to the typed-loader changes makes drift-detection blast radius local
 // (mirrors v1.119's adjacency at internal/blacklist/schema_freeze_test.go).
 func TestSchemaVersionUnchangedByV120OperatorSessionWhitelist(t *testing.T) {
-	const expectedSchema = "1.83.0"
+	const expectedSchema = "1.84.0"
 	if validator.SchemaVersionCurrent != expectedSchema {
 		t.Fatalf("SchemaVersionCurrent = %q, want %q — V120 Operator Temp Whitelist Guard MUST NOT "+
 			"bump schema (per V120_OPERATOR_TEMP_WHITELIST_SCHEMA_IMPACT_DECISION.md verdict "+

--- a/scripts/lab/openmetrics_scrape_validate_v190.sh
+++ b/scripts/lab/openmetrics_scrape_validate_v190.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.190 — SOS-4 lab-first OpenMetrics scrape-contract validation
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="openmetrics_scrape_validate_v190"
+# meta:type="tool"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="Operator-run lab-first validation of the LIVE NFTBan Prometheus/OpenMetrics scrape against the v1.190.0 contract (SOS-4). Captures /metrics from the daemon HTTP endpoint (default http://127.0.0.1:9580/metrics, localhost-only) or a node_exporter textfile, validates the exposition with promtool if available (else a strict grep parser), and asserts the v1.190 contract invariants: parser-valid; nftban_counters_population_phase present == 0 (anti-false-zero gate); canonical nftban_nft_rules_total present; DEPRECATED alias nftban_firewall_rules_total mirrors nft_rules_total when both present; nftban_suricata_rules_total distinct (if Suricata enabled); NO dedicated nftban_nft_anchor_* metric (anchors only via nft_named_counter_*); named-counter family labels stay raw ip/ip6 (NOT relabeled ipv4/ipv6); NO new v1.190 BotScan/BotGuard/Whitelist/FCrDNS counter series (false-zero-free); and nftban health --json reports schema 1.84.0. Read-only: scrapes + reads; mutates nothing."
+# meta:input="live /metrics scrape (HTTP or textfile) + nftban health --json"
+# meta:output="pass/fail report; exit 0 all-pass, 1 on any contract violation"
+# meta:depends="bash,curl-or-cat,grep,awk; promtool optional; jq optional"
+# meta:inventory.files="/var/lib/node_exporter/textfile_collector/nftban.prom"
+# meta:inventory.binaries="curl,grep,awk,promtool(optional),jq(optional),nftban"
+# meta:inventory.env_vars="NFTBAN_METRICS_URL,NFTBAN_METRICS_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftband.service"
+# meta:inventory.network="127.0.0.1:9580/tcp (read-only scrape)"
+# meta:inventory.privileges="none (root only if reading a 0600 textfile)"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$' \t\n'
+
+URL="${NFTBAN_METRICS_URL:-http://127.0.0.1:9580/metrics}"
+TEXTFILE="${NFTBAN_METRICS_FILE:-/var/lib/node_exporter/textfile_collector/nftban.prom}"
+TMP="$(mktemp)"; trap 'rm -f "$TMP"' EXIT
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "=== v1.190 SOS-4 lab OpenMetrics scrape validation ==="
+
+# ---- 1. capture the scrape (HTTP preferred; textfile fallback; explicit arg wins)
+SRC=""
+if [[ "${1:-}" == http* ]]; then URL="$1"; fi
+if [[ "${1:-}" == /* && -f "${1:-}" ]]; then TEXTFILE="$1"; fi
+if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 5 "$URL" -o "$TMP" 2>/dev/null && [[ -s "$TMP" ]]; then
+    SRC="HTTP $URL"
+elif [[ -r "$TEXTFILE" ]]; then
+    cp "$TEXTFILE" "$TMP"; SRC="textfile $TEXTFILE"
+elif command -v nftban >/dev/null 2>&1 && nftban metrics export -o "$TMP" >/dev/null 2>&1 && [[ -s "$TMP" ]]; then
+    SRC="nftban metrics export"
+else
+    no "could not capture a /metrics scrape (tried HTTP $URL, textfile $TEXTFILE, nftban metrics export)"
+    echo "=== RESULT: $PASS passed, $FAIL failed ==="; exit 1
+fi
+ok "captured scrape via: $SRC ($(wc -l < "$TMP") lines)"
+
+# ---- 2. format validity (promtool preferred; else strict HELP/TYPE structural check)
+if command -v promtool >/dev/null 2>&1; then
+    if promtool check metrics < "$TMP" >/dev/null 2>&1; then
+        ok "promtool check metrics: exposition is parser-valid"
+    else
+        no "promtool check metrics FAILED" "$(promtool check metrics < "$TMP" 2>&1 | head -3 | tr '\n' ' ')"
+    fi
+else
+    # Fallback: every HELP must precede its TYPE; one TYPE per family; no dup TYPE.
+    DUPTYPE="$(grep '^# TYPE ' "$TMP" | awk '{print $3}' | sort | uniq -d || true)"
+    if [[ -z "$DUPTYPE" ]]; then
+        ok "no duplicate # TYPE family declarations (promtool unavailable — structural check)"
+    else
+        no "duplicate # TYPE declarations" "$(echo "$DUPTYPE" | tr '\n' ' ')"
+    fi
+fi
+
+val(){ awk -v m="$1" '$1==m {print $2; exit}' "$TMP"; }       # value of a no-label series
+has(){ grep -qE "$1" "$TMP"; }
+
+# ---- 3. anti-false-zero gate: counters_population_phase present AND == 0
+PHASE="$(val nftban_counters_population_phase)"
+if [[ "$PHASE" == "0" ]]; then
+    ok "nftban_counters_population_phase = 0 (contract phase, anti-false-zero)"
+elif [[ -z "$PHASE" ]]; then
+    no "nftban_counters_population_phase MISSING (must be present == 0 in v1.190.0)"
+else
+    no "nftban_counters_population_phase != 0 (population must not be live in v1.190.0)" "got=$PHASE"
+fi
+
+# ---- 4. canonical rule-count present
+if has '^nftban_nft_rules_total '; then ok "nftban_nft_rules_total present (canonical rule-count)"
+else no "nftban_nft_rules_total MISSING"; fi
+
+# ---- 5. alias mirrors canonical (only assert when BOTH present on this surface)
+RT="$(val nftban_nft_rules_total)"; FW="$(val nftban_firewall_rules_total)"
+if [[ -n "$RT" && -n "$FW" ]]; then
+    if [[ "$RT" == "$FW" ]]; then ok "nftban_firewall_rules_total ($FW) mirrors nftban_nft_rules_total ($RT)"
+    else no "alias mismatch: firewall_rules_total=$FW != nft_rules_total=$RT"; fi
+else
+    ok "alias-mirror skipped (firewall_rules_total not on this surface: alias='$FW' canonical='$RT')"
+fi
+
+# ---- 6. suricata distinct (only if present / enabled)
+if has '^nftban_suricata_rules_total '; then ok "nftban_suricata_rules_total present + distinct (Suricata SID count)"
+else ok "nftban_suricata_rules_total absent (Suricata not enabled on this host) — distinctness N/A"; fi
+
+# ---- 7. SOS-2: NO dedicated anchor metric
+if has 'nftban_nft_anchor'; then no "SOS-2 violation: dedicated nftban_nft_anchor_* metric present (double-count)"
+else ok "no nftban_nft_anchor_* metric (anchors only via nft_named_counter_*)"; fi
+
+# ---- 8. SOS-3 compat: named-counter family stays ip/ip6 (never relabeled ipv4/ipv6)
+if grep -E '^nftban_nft_named_counter_(packets|bytes)_total\{' "$TMP" | grep -qE 'family="(ipv4|ipv6)"'; then
+    no "SOS-3 violation: named-counter family relabeled to ipv4/ipv6 (must stay raw ip/ip6)"
+else
+    ok "named-counter family stays raw ip/ip6 (SOS-3 Prometheus compat preserved)"
+fi
+
+# ---- 9. false-zero-free: NO new v1.190 population counter series
+LEAK="$(grep -oE 'nftban_(botscan_(scanned|matched|signals|bans|crawler_verify)|botguard_(decisions|eventbus)|whitelist_changes|fcrdns_)[a-z_]*' "$TMP" | sort -u || true)"
+if [[ -z "$LEAK" ]]; then ok "no new v1.190 BotScan/BotGuard/Whitelist/FCrDNS counter series (false-zero-free)"
+else no "false-zero risk: new counter series present before population" "$(echo "$LEAK" | tr '\n' ' ')"; fi
+
+# ---- 10. health JSON schema 1.84.0 parses
+if command -v nftban >/dev/null 2>&1; then
+    HJ="$(nftban health --json 2>/dev/null || true)"
+    if command -v jq >/dev/null 2>&1; then
+        SV="$(printf '%s' "$HJ" | jq -r '.schema_version // empty' 2>/dev/null || true)"
+    else
+        SV="$(printf '%s' "$HJ" | grep -oE '"schema_version":"[^"]*"' | head -1 | cut -d'"' -f4)"
+    fi
+    if [[ "$SV" == "1.84.0" ]]; then ok "nftban health --json schema_version = 1.84.0"
+    else no "health --json schema_version != 1.84.0" "got='$SV'"; fi
+else
+    ok "health --json schema check skipped (nftban CLI not on PATH)"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/lab/openmetrics_scrape_validate_v190.sh
+++ b/scripts/lab/openmetrics_scrape_validate_v190.sh
@@ -21,7 +21,9 @@
 # meta:inventory.privileges="none (root only if reading a 0600 textfile)"
 # =============================================================================
 set -Eeuo pipefail
-IFS=$' \t\n'
+# NOTE: IFS is intentionally left at the shell default (space/tab/newline). An
+# earlier global `IFS=$' \t\n'` was redundant (it re-set the default) and tripped
+# Semgrep bash.lang.security.ifs-tampering; no IFS-dependent splitting is used here.
 
 URL="${NFTBAN_METRICS_URL:-http://127.0.0.1:9580/metrics}"
 TEXTFILE="${NFTBAN_METRICS_FILE:-/var/lib/node_exporter/textfile_collector/nftban.prom}"


### PR DESCRIPTION
**First lane that deliberately breaks the byte-identical/schema freeze** after the v1.187–189 BotScan train. **CONTRACT/SCAFFOLDING ONLY** — no live counter population (reserved v1.191.0). **Daemon-Go: hash moves off `c63d8822`** (expected). Scope  + .

## Schema bump (coordinated, one commit)
`SchemaVersionCurrent` 1.83.0→1.84.0 (validator/types.go) + freeze-guard tests (blacklist/whitelist/installer-render/validator×2) + installer fixtures.

## Counters contract (additive; ABSENT until populated — no false-zero)
- `counters_phase` = "contract" + `counters` *omitempty* (absent in v1.190.0).
- Prometheus `nftban_counters_population_phase` = 0 (anti-false-zero gate; v1.191 → 1).
- **IP-family (operator amendment):** IP-backed counters carry `FamilyCounts{ipv4,ipv6,inet,unknown}` (Prom label `family`); per-IP use ipv4/ipv6 (unknown=bug-signal, inet invalid); table-level use inet; never fake-split inet rules. Non-IP-backed (files_deferred, eventbus_drops) stay plain.

## Name-drift (G-12)
Canonical `nftban_nft_rules_total` now single-owned by watchdog promauto (collector.go raw dup dropped); `firewall_rules_total` DEPRECATED→alias (2-minor window); `nftban_suricata_rules_total` untouched (distinct SID count).

## Validation
`counters_contract_v190_test` PASS (schema 1.84.0; phase=contract; counters absent; family-aware round-trip ipv4/ipv6 independent + non-IP plain; old-consumer compat). `go build` + `go test ./internal/...` green. **Lab-first mandatory** (daemon hash moves): binary-swap lab2+RPM lab4 → scrape /metrics (phase=0, no false-zero series, aliases mirror, no dup), `health --json` schema 1.84.0, old-consumer parse, daemon NRestarts=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)