### PR TITLE
feat(botscan): endpoint-flood detector — closes advertised xmlrpc/wp-login protection gap

### DIFF
--- a/cli/lib/nftban/cli/cmd_login.sh
+++ b/cli/lib/nftban/cli/cmd_login.sh
@@ -1264,7 +1264,11 @@ MONITORED SERVICES (auto-detected):
       • Dovecot           - IMAP/POP3 login failures
 
     Web/CMS:
-      • WordPress         - wp-login.php + xmlrpc.php attacks (via BotScan access-log scan)
+      • WordPress         - wp-login failed credentials = LoginMon (auth_failure).
+                            xmlrpc.php / wp-login POST-volume floods (incl. HTTP 200) =
+                            BotScan endpoint-flood detector (requires BotScan enabled).
+                            BotGuard handles HTTP burst/concurrency (L3/L4) only — it does
+                            NOT detect low-and-slow L7 floods.
       • Roundcube         - DEFERRED: no runtime watcher yet (advertised key exists; coverage planned v1.178)
 
     FTP:

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -74,6 +74,19 @@ nftban_botscan_load_config() {
     : "${BOTSCAN_404_THRESHOLD:=50}"
     : "${BOTSCAN_404_WINDOW:=300}"
     : "${BOTSCAN_404_BAN:=3600}"
+    # BOTSCAN-ENDPOINT-FLOOD (PROTECTION-CLAIM-MATRIX HIGH) — per-IP/per-endpoint POST
+    # volume to sensitive endpoints (xmlrpc.php / wp-login.php), STATUS-INDEPENDENT (200
+    # counts — WordPress xmlrpc brute/amplification returns 200). Owner: BotScan. NOT
+    # LoginMon (credential-failure only; cannot see the 200-body auth result) and NOT
+    # BotGuard (L3/L4 burst/concurrency only). Counted in the proven 404-tail re-read so it
+    # inherits 404-flood reliability; emitted via the batch-signal path (never the buggy
+    # direct ban_ip --duration branch, BUG-BOTSCAN-DIRECT-BAN-FLAG).
+    : "${BOTSCAN_ENDPOINT_FLOOD_ENABLED:=true}"
+    : "${BOTSCAN_ENDPOINT_FLOOD_METHOD:=POST}"
+    : "${BOTSCAN_ENDPOINT_FLOOD_THRESHOLD:=30}"   # POSTs / window / IP / endpoint (lab-tuned; well above legit Jetpack/pingback)
+    : "${BOTSCAN_ENDPOINT_FLOOD_WINDOW:=60}"
+    : "${BOTSCAN_ENDPOINT_FLOOD_BAN:=3600}"
+    : "${BOTSCAN_ENDPOINT_FLOOD_ENDPOINTS:=xmlrpc.php wp-login.php}"
     # v1.187 Lane A — BOTSCAN-SCAN-THROUGHPUT. Forward-cursor per-file per-cycle window
     # (drains backlog forward instead of the v1.185 64 KiB tail-bias), a C-speed candidate
     # prefilter before the per-line bash matcher, and an independent 404 fixed-tail re-read
@@ -123,6 +136,9 @@ declare -gA _BOTSCAN_IP_404_COUNT      # IP -> 404 count
 declare -gA _BOTSCAN_IP_404_FIRST_SEEN # IP -> 404 first seen timestamp
 declare -gA _BOTSCAN_PATTERNS          # Pattern name -> pattern definition
 declare -gA _BOTSCAN_IP_CRAWLER_CLAIM  # v1.189 FCrDNS: IP -> claimed search-crawler family (UA-claimed; verified at analyze-time)
+declare -gA _BOTSCAN_IP_ENDPOINT_COUNT      # BOTSCAN-ENDPOINT-FLOOD: "ip|endpoint" -> POST count (status-independent)
+declare -gA _BOTSCAN_IP_ENDPOINT_FIRST_SEEN # "ip|endpoint" -> first seen ts (cycle-scoped, reset by count_404_tail)
+declare -ga _BOTSCAN_ENDPOINT_FLOOD_LIST    # parsed endpoint tokens (rebuilt per cycle)
 
 # Initialize state
 nftban_botscan_init_state() {
@@ -133,6 +149,12 @@ nftban_botscan_init_state() {
     _BOTSCAN_IP_404_COUNT=()
     _BOTSCAN_IP_404_FIRST_SEEN=()
     _BOTSCAN_IP_CRAWLER_CLAIM=()
+    _BOTSCAN_IP_ENDPOINT_COUNT=()
+    _BOTSCAN_IP_ENDPOINT_FIRST_SEEN=()
+    _BOTSCAN_ENDPOINT_FLOOD_LIST=()
+    # IFS=' ' is REQUIRED: the module runs under strict IFS=$'\n\t' (no space) → a bare
+    # read -ra would yield ONE token "xmlrpc.php wp-login.php" that never matches (v1.186.1 class).
+    [[ "${BOTSCAN_ENDPOINT_FLOOD_ENABLED:-true}" == "true" ]] && IFS=' ' read -ra _BOTSCAN_ENDPOINT_FLOOD_LIST <<< "${BOTSCAN_ENDPOINT_FLOOD_ENDPOINTS:-}"
 }
 
 # =============================================================================
@@ -823,6 +845,30 @@ nftban_botscan_analyze() {
         done
     fi
 
+    # BOTSCAN-ENDPOINT-FLOOD — per-IP/per-endpoint POST-volume bans (counts populated by
+    # count_404_tail in the same proven tail re-read). Emitted via the BATCH-SIGNAL path
+    # ONLY — never nftban_botscan_ban_ip's direct branch (BUG-BOTSCAN-DIRECT-BAN-FLAG).
+    if [[ "${BOTSCAN_ENDPOINT_FLOOD_ENABLED:-true}" == "true" ]]; then
+        local now_ef _k
+        now_ef=$(date +%s)
+        for _k in "${!_BOTSCAN_IP_ENDPOINT_COUNT[@]}"; do
+            local _cnt="${_BOTSCAN_IP_ENDPOINT_COUNT[$_k]}"
+            local _fs="${_BOTSCAN_IP_ENDPOINT_FIRST_SEEN[$_k]:-$now_ef}"
+            local _el=$(( now_ef - _fs ))
+            [[ "$_cnt" -ge "$BOTSCAN_ENDPOINT_FLOOD_THRESHOLD" && "$_el" -le "$BOTSCAN_ENDPOINT_FLOOD_WINDOW" ]] || continue
+            local _efip="${_k%%|*}" _efep="${_k#*|}"
+            local _efreason="endpoint_flood ${BOTSCAN_ENDPOINT_FLOOD_METHOD} ${_efep}: ${_cnt} in ${_el}s"
+            if [[ "$BOTSCAN_ACTION_MODE" == "alert" ]]; then
+                echo "[ALERT] Would ban ${_efip} for ${BOTSCAN_ENDPOINT_FLOOD_BAN}s: ${_efreason}"
+            else
+                # batch-signal path (mirrors ban_ip's batch branch; NOT the direct branch)
+                nftban_botscan_write_signal "${_efip}" 80 "ban" "botscan-endpoint-flood" "${_efreason}"
+                echo "$(date -Iseconds)|botscan-endpoint-flood|${_efip}|${BOTSCAN_ENDPOINT_FLOOD_BAN}|SIGNAL|${_efreason}" >> "$BOTSCAN_LOG_FILE"
+            fi
+            banned=$((banned + 1))
+        done
+    fi
+
     return $banned
 }
 
@@ -873,7 +919,10 @@ nftban_botscan_build_prefilter() {
 # the (steady-state) freed budget cover the rest across cycles. Honors the whitelists.
 # Args: <start_secs> <budget_secs> -- <file>...
 nftban_botscan_count_404_tail() {
-    [[ "${BOTSCAN_404_TRACKING:-true}" == "true" ]] || return 0
+    # Runs if EITHER 404-flood OR endpoint-flood is on (both ride this proven tail re-read).
+    local _bs_404_on="${BOTSCAN_404_TRACKING:-true}"
+    local _bs_ef_on="${BOTSCAN_ENDPOINT_FLOOD_ENABLED:-true}"
+    [[ "$_bs_404_on" == "true" || "$_bs_ef_on" == "true" ]] || return 0
     local start_secs="${1:-$SECONDS}" budget="${2:-0}"; shift 2
     local now; now=$(nftban_timestamp_unix 2>/dev/null || date +%s)
     local tail_bytes="${BOTSCAN_404_TAIL_BYTES:-2097152}"
@@ -881,6 +930,25 @@ nftban_botscan_count_404_tail() {
     # Reset so the count reflects ONLY this cycle's scanned tails.
     _BOTSCAN_IP_404_COUNT=()
     _BOTSCAN_IP_404_FIRST_SEEN=()
+    # BOTSCAN-ENDPOINT-FLOOD — reset cycle-scoped counts + (re)parse the endpoint token list,
+    # and widen the C-speed tail grep so endpoint POST lines (any status) survive alongside
+    # 404 lines. Without widening, a POST /xmlrpc.php 200 would be filtered out before counting.
+    _BOTSCAN_IP_ENDPOINT_COUNT=()
+    _BOTSCAN_IP_ENDPOINT_FIRST_SEEN=()
+    _BOTSCAN_ENDPOINT_FLOOD_LIST=()
+    # IFS=' ' REQUIRED under strict IFS=$'\n\t' (else one space-joined token; v1.186.1 class).
+    [[ "$_bs_ef_on" == "true" ]] && IFS=' ' read -ra _BOTSCAN_ENDPOINT_FLOOD_LIST <<< "${BOTSCAN_ENDPOINT_FLOOD_ENDPOINTS:-}"
+    local _bs_tail_grep=""
+    [[ "$_bs_404_on" == "true" ]] && _bs_tail_grep='" 404 | 404 '
+    if [[ "$_bs_ef_on" == "true" ]]; then
+        local _ept _eptok
+        for _ept in "${_BOTSCAN_ENDPOINT_FLOOD_LIST[@]}"; do
+            _eptok="${_ept//./\\.}"            # ERE-escape dots
+            [[ -n "$_bs_tail_grep" ]] && _bs_tail_grep+="|"
+            _bs_tail_grep+="$_eptok"
+        done
+    fi
+    [[ -z "$_bs_tail_grep" ]] && return 0
     local files=("$@")
     local n=${#files[@]}
     [[ "$n" -eq 0 ]] && return 0
@@ -903,12 +971,26 @@ nftban_botscan_count_404_tail() {
         consumed=$(( consumed + tail_bytes ))
         while IFS= read -r line; do
             nftban_botscan_parse_line_g "$line" || continue   # v1.187.1 no-fork
-            [[ "$_BS_STATUS" == "404" ]] || continue
             nftban_botscan_is_whitelisted "$_BS_IP" "$_BS_UA" && continue
+            # BOTSCAN-ENDPOINT-FLOOD: STATUS-INDEPENDENT POST volume to sensitive endpoints.
+            # Fork-free (builtin == only); only POSTs enter the tiny endpoint loop.
+            if [[ "$_bs_ef_on" == "true" && "$_BS_METHOD" == "$BOTSCAN_ENDPOINT_FLOOD_METHOD" ]]; then
+                local _efep
+                for _efep in "${_BOTSCAN_ENDPOINT_FLOOD_LIST[@]}"; do
+                    if [[ "$_BS_URL" == *"$_efep"* ]]; then
+                        local _efk="${_BS_IP}|${_efep}"
+                        _BOTSCAN_IP_ENDPOINT_COUNT["$_efk"]=$(( ${_BOTSCAN_IP_ENDPOINT_COUNT[$_efk]:-0} + 1 ))
+                        [[ -z "${_BOTSCAN_IP_ENDPOINT_FIRST_SEEN[$_efk]:-}" ]] && _BOTSCAN_IP_ENDPOINT_FIRST_SEEN["$_efk"]="$now"
+                        break
+                    fi
+                done
+            fi
+            # 404 flood (status-specific)
+            [[ "$_bs_404_on" == "true" && "$_BS_STATUS" == "404" ]] || continue
             nftban_botscan_is_path_whitelisted "$_BS_URL" && continue
             _BOTSCAN_IP_404_COUNT["$_BS_IP"]=$(( ${_BOTSCAN_IP_404_COUNT[$_BS_IP]:-0} + 1 ))
             [[ -z "${_BOTSCAN_IP_404_FIRST_SEEN[$_BS_IP]:-}" ]] && _BOTSCAN_IP_404_FIRST_SEEN["$_BS_IP"]="$now"
-        done < <( tail -c "$tail_bytes" -- "$f" 2>/dev/null | LC_ALL=C grep -E '" 404 | 404 ' 2>/dev/null || true )
+        done < <( tail -c "$tail_bytes" -- "$f" 2>/dev/null | LC_ALL=C grep -E "$_bs_tail_grep" 2>/dev/null || true )
     done
     # Persist rotation: next cycle starts after the last file covered this cycle.
     printf '%s\n' "$(( (rot + covered) % n ))" > "${rot_file}.tmp" 2>/dev/null && mv -f "${rot_file}.tmp" "$rot_file" 2>/dev/null || true

--- a/cli/lib/nftban/tests/botscan_endpoint_flood_test.sh
+++ b/cli/lib/nftban/tests/botscan_endpoint_flood_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - BotScan endpoint-flood detector test (BOTSCAN-ENDPOINT-FLOOD)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_endpoint_flood_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-15"
+# meta:description="Hermetic guard for the BotScan endpoint-flood detector that closes the advertised WordPress/XML-RPC protection gap (PROTECTION-CLAIM-MATRIX HIGH). Proves, with fixture access logs (no ad-hoc tail/cursor injection): (T1/T2) POST /xmlrpc.php and /wp-login.php volume above threshold is counted per-IP/per-endpoint in the proven count_404_tail re-read; (T3) STATUS-INDEPENDENT — 200 AND non-200 POSTs count (not tied to 404); (T4) below-threshold does NOT ban; (T5) non-POST does NOT count; (T6) 404-flood tracker still works and endpoint counting does not interfere; (T7) emission uses the BATCH-SIGNAL path (write_signal JSONL + |SIGNAL| botscan.log line), NEVER the direct ban_ip --duration branch (BUG-BOTSCAN-DIRECT-BAN-FLAG); (T8) an unconfigured endpoint does not count; (T9) per-endpoint keys are independent."
+#
+# meta:inventory.files="botscan_endpoint_flood_test.sh"
+# meta:inventory.binaries="bash,tail,grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_ENDPOINT_FLOOD_THRESHOLD,BOTSCAN_BATCH_SIGNAL_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_PATTERNS_DIR="$tmp/patterns" \
+       BOTSCAN_STATE_FILE="$tmp/s.db" BOTSCAN_LOG_FILE="$tmp/b.log" \
+       BOTSCAN_BATCH_SIGNAL_FILE="$tmp/sig.jsonl" NFTBAN_CONFIG_DIR="$tmp/noetc" \
+       BOTSCAN_ENABLED=true BOTSCAN_404_TRACKING=true BOTSCAN_VERIFY_CRAWLERS=false \
+       BOTSCAN_ENDPOINT_FLOOD_ENABLED=true BOTSCAN_ENDPOINT_FLOOD_THRESHOLD=30 \
+       BOTSCAN_ENDPOINT_FLOOD_WINDOW=60 BOTSCAN_SCAN_PREFILTER=true
+mkdir -p "$NFTBAN_DATA_DIR/botscan" "$BOTSCAN_PATTERNS_DIR" "$tmp/spool"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"; nftban_botscan_load_config
+
+# emit one combined-log line: <ip> <method> <url> <status>
+line() { printf '%s - - [15/Jun/2026:10:00:00 +0000] "%s %s HTTP/1.1" %s 350 "-" "Mozilla/5.0"\n' "$1" "$2" "$3" "$4"; }
+runcycle() { rm -f "$NFTBAN_DATA_DIR/botscan/404-rotate"; nftban_botscan_init_state; nftban_botscan_count_404_tail 0 0 "$1"; }
+
+# --- T1: xmlrpc POST 200 flood (40 > 30) counted per ip|endpoint ---
+f="$tmp/spool/t1.log"; : > "$f"; for i in $(seq 1 40); do line 198.51.100.11 POST /xmlrpc.php 200; done > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.11|xmlrpc.php]:-0}" -eq 40 ]] || fail "T1 xmlrpc count != 40 (got ${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.11|xmlrpc.php]:-0})"
+echo "PASS T1: POST /xmlrpc.php 200 volume counted (40)"
+
+# --- T2: wp-login POST 200 flood counted under its own key ---
+f="$tmp/spool/t2.log"; : > "$f"; for i in $(seq 1 40); do line 198.51.100.12 POST /wp-login.php 200; done > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.12|wp-login.php]:-0}" -eq 40 ]] || fail "T2 wp-login count != 40"
+echo "PASS T2: POST /wp-login.php 200 volume counted (40)"
+
+# --- T3: STATUS-INDEPENDENT — mix 200 + 403 + 500, all count ---
+f="$tmp/spool/t3.log"; : > "$f"; { for i in $(seq 1 20); do line 198.51.100.16 POST /xmlrpc.php 200; done; for i in $(seq 1 12); do line 198.51.100.16 POST /xmlrpc.php 403; done; for i in $(seq 1 8); do line 198.51.100.16 POST /xmlrpc.php 500; done; } > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.16|xmlrpc.php]:-0}" -eq 40 ]] || fail "T3 status-independent count != 40 (got ${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.16|xmlrpc.php]:-0})"
+echo "PASS T3: status-independent (200/403/500 all count = 40)"
+
+# --- T4: below threshold (10 < 30) → no ban on analyze ---
+f="$tmp/spool/t4.log"; : > "$f"; for i in $(seq 1 10); do line 198.51.100.13 POST /xmlrpc.php 200; done > "$f"
+runcycle "$f"; : > "$tmp/sig.jsonl"; : > "$BOTSCAN_LOG_FILE"
+nftban_botscan_analyze >/dev/null 2>&1 || true
+grep -q '198.51.100.13' "$tmp/sig.jsonl" 2>/dev/null && fail "T4 below-threshold IP must NOT be signalled"
+echo "PASS T4: below-threshold (10) does not ban"
+
+# --- T5: non-POST (GET) does NOT count ---
+f="$tmp/spool/t5.log"; : > "$f"; for i in $(seq 1 40); do line 198.51.100.14 GET /xmlrpc.php 200; done > "$f"
+runcycle "$f"
+[[ -z "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.14|xmlrpc.php]:-}" ]] || fail "T5 GET must NOT count as endpoint-flood"
+echo "PASS T5: non-POST (GET) does not count"
+
+# --- T6: 404-flood tracker still works + endpoint counting does not interfere ---
+f="$tmp/spool/t6.log"; : > "$f"; for i in $(seq 1 55); do line 198.51.100.15 GET "/missing-$i.php" 404; done > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_404_COUNT[198.51.100.15]:-0}" -ge 50 ]] || fail "T6 404-flood broken (got ${_BOTSCAN_IP_404_COUNT[198.51.100.15]:-0})"
+[[ -z "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.15|xmlrpc.php]:-}" ]] || fail "T6 404 lines must not count as endpoint-flood"
+echo "PASS T6: 404-flood preserved + no endpoint interference"
+
+# --- T7: emission via BATCH-SIGNAL path (write_signal JSONL + |SIGNAL| log), not direct ban_ip ---
+f="$tmp/spool/t7.log"; : > "$f"; for i in $(seq 1 40); do line 198.51.100.11 POST /xmlrpc.php 200; done > "$f"
+runcycle "$f"; : > "$tmp/sig.jsonl"; : > "$BOTSCAN_LOG_FILE"
+nftban_botscan_analyze >/dev/null 2>&1 || true
+grep -q '"ip":"198.51.100.11"' "$tmp/sig.jsonl" || fail "T7 batch-signal JSONL missing endpoint-flood IP"
+grep -q 'endpoint_flood' "$tmp/sig.jsonl" || fail "T7 batch-signal reason missing endpoint_flood"
+grep -qE '\|botscan-endpoint-flood\|198\.51\.100\.11\|.*\|SIGNAL\|' "$BOTSCAN_LOG_FILE" || fail "T7 botscan.log must record |botscan-endpoint-flood|...|SIGNAL| (batch path, not direct BANNED)"
+grep -q 'BANNED' "$BOTSCAN_LOG_FILE" && fail "T7 must NOT use the direct ban_ip path (no BANNED line for endpoint-flood)"
+echo "PASS T7: emits via batch-signal path (write_signal + |SIGNAL|), avoids direct ban_ip"
+
+# --- T8: an UNCONFIGURED endpoint does not count ---
+f="$tmp/spool/t8.log"; : > "$f"; for i in $(seq 1 40); do line 198.51.100.17 POST /wp-admin/admin-ajax.php 200; done > "$f"
+runcycle "$f"
+for k in "${!_BOTSCAN_IP_ENDPOINT_COUNT[@]}"; do [[ "$k" == 198.51.100.17* ]] && fail "T8 unconfigured endpoint must not count ($k)"; done
+echo "PASS T8: unconfigured endpoint does not count"
+
+# --- T9: per-endpoint keys are independent (xmlrpc vs wp-login from same IP) ---
+f="$tmp/spool/t9.log"; : > "$f"; { for i in $(seq 1 31); do line 198.51.100.18 POST /xmlrpc.php 200; done; for i in $(seq 1 33); do line 198.51.100.18 POST /wp-login.php 200; done; } > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.18|xmlrpc.php]:-0}" -eq 31 && "${_BOTSCAN_IP_ENDPOINT_COUNT[198.51.100.18|wp-login.php]:-0}" -eq 33 ]] || fail "T9 per-endpoint keys not independent"
+echo "PASS T9: per-endpoint keys independent (xmlrpc=31, wp-login=33)"
+
+# --- T10: IPv6 source compatibility (same detector, IPv6 key) ---
+f="$tmp/spool/t10.log"; : > "$f"; for i in $(seq 1 40); do line 2001:db8::dead POST /xmlrpc.php 200; done > "$f"
+runcycle "$f"
+[[ "${_BOTSCAN_IP_ENDPOINT_COUNT[2001:db8::dead|xmlrpc.php]:-0}" -eq 40 ]] || fail "T10 IPv6 endpoint count != 40 (got ${_BOTSCAN_IP_ENDPOINT_COUNT[2001:db8::dead|xmlrpc.php]:-0})"
+# emit path must carry the IPv6 address intact (key split on first '|')
+: > "$tmp/sig.jsonl"; : > "$BOTSCAN_LOG_FILE"; nftban_botscan_analyze >/dev/null 2>&1 || true
+grep -q '"ip":"2001:db8::dead"' "$tmp/sig.jsonl" || fail "T10 IPv6 batch-signal missing/garbled IPv6 address"
+echo "PASS T10: IPv6 source counted + signalled with address intact"
+
+echo "ALL PASS: botscan endpoint-flood detector"


### PR DESCRIPTION
Closes the HIGH PROTECTION-CLAIM-MATRIX gap: POST /xmlrpc.php (and /wp-login.php) 200-volume floods were advertised as protected but had no runtime owner (unbanned fleet-wide).

**Owner = BotScan** (LOG_SOURCE_OWNERSHIP_ACCEPTED). Per-IP×endpoint×window POST-volume, **status-independent** (200 counts), volume-thresholded (no false-ban of legit Jetpack/pingback). Hooks the proven count_404_tail re-read (fork-free, widened grep); emits via the **batch-signal** path only (never the buggy direct ban_ip --duration branch). 404 behavior unchanged.

Fixed an IFS strict-mode parse bug (IFS=' ' read -ra; v1.186.1 class). Claim fix cmd_login.sh:1267.

**Shell-only; daemon byte-identical 351d35df.** No counters (→v1.191). No BotGuard L7 bridge. No LoginMon xmlrpc ownership. Dead Go knobs = separate daemon-Go follow-up.

Tests: botscan_endpoint_flood_test.sh 10/10 (incl. IPv6 T10). Regression: 404-tail/nofork/fcrdns/pattern-ifs/deadline all pass. **Lab-first PASS lab2 DEB + lab4 RPM** (hermetic + live batch-signal integration, reversible, 0 failed units). NFT ruleset/schema UNCHANGED (enforcement reuses existing blacklist/http_bot_ban sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)