### PR TITLE
fix(firewall): make nftables transitions atomic

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -55,6 +55,12 @@ jobs:
           # Explicit: NEVER use --warn-all in CI (would disable enforcement)
           WARN_ALL: "0"
 
+      # v1.192 transition-atomicity class (D-NFTBAN-SOAK-...-DROP-WINDOW + F-FEED/F-GEO):
+      # forbid flush/delete-then-repopulate in a separate transaction on the live
+      # nftban table (V-NFT-REBUILD-ATOMICITY) or shared sets (V-NFT-SET-REFRESH-ATOMICITY).
+      - name: Check nft transition atomicity
+        run: ./scripts/ci/check-nft-atomicity.sh
+
       - name: Check netlink import policy
         run: |
           echo "=== Checking netlink import architecture policy ==="

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2230,10 +2230,19 @@ _firewall_rebuild_core() {
         esac
     done <<< "$ALL_TABLES"
 
-    # Step 5: Flush + load (safe — we validated above)
-    [[ "$quiet" == "false" ]] && echo "  [5/12] Flushing and loading new schema..."
-    nft flush table ip nftban 2>/dev/null || true
-    nft flush table ip6 nftban 2>/dev/null || true
+    # Step 5: Atomic load (safe — we validated above).
+    # V-NFT-REBUILD-ATOMICITY: the rendered $load_conf self-resets within a
+    # SINGLE transaction — it begins with `table ip/ip6 nftban { }` (idempotent
+    # create) then `delete table ip/ip6 nftban` (clears any orphan chains/sets)
+    # then the full table definition. `nft -f` applies the whole file as ONE
+    # atomic transaction, so packets never observe an empty/partial active
+    # ruleset. The prior standalone `nft flush table ip/ip6 nftban` here emptied
+    # the live table in a SEPARATE transaction before this reload, opening a
+    # fail-CLOSED drop window (D-NFTBAN-REBUILD-FLUSH-WINDOW: input chain
+    # collapsed to policy-drop with no accepts, 19→1 rules, until the reload
+    # completed). Do NOT reintroduce a standalone flush/delete of the active
+    # nftban table before this load — see scripts/ci/check-nft-atomicity.sh.
+    [[ "$quiet" == "false" ]] && echo "  [5/12] Loading new schema (atomic single transaction)..."
 
     if ! nft -f "$load_conf" 2>&1; then
         echo "ERROR: Failed to load NFTBan schema from $load_conf" >&2

--- a/cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh
+++ b/cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.192.0 - Blacklist refresh no-fail-open runtime test (F-FEED / F-GEO)
+# =============================================================================
+# meta:name="blacklist_refresh_no_failopen_v192_test"
+# meta:type="test"
+# meta:version="1.192.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Lab-first: a shared-set refresh must never leave blacklist_* empty/partial (no fail-open window)"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,nft"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="root"
+# =============================================================================
+# F-FEED / F-GEO (D-NFTBAN-{FEED,GEOBAN}-REFRESH-FAILOPEN) runtime regression.
+#
+# The DETERMINISTIC, CI-enforced proof is the setsync Go unit test
+# (renderSetReplaceScript: flush is the single FIRST statement, every other
+# statement is an add → one nft -f transaction). This shell test demonstrates
+# the property at the kernel level on a lab host (root + nft): it tight-loops a
+# reader over a test set while the atomic flush+add replace runs, and asserts
+# the set element count NEVER drops to 0 (no fail-open empty window). It also
+# proves the test discriminates: the OLD non-atomic pattern (standalone flush,
+# then a separate add) CAN be observed empty.
+#
+# Skips cleanly (exit 0) without root / nft.
+# =============================================================================
+
+set -Eeuo pipefail
+
+PASS=0; FAIL=0
+ok()  { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad() { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+echo "=== blacklist_refresh_no_failopen_v192 (F-FEED/F-GEO) ==="
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]] || ! command -v nft >/dev/null 2>&1; then
+    echo "  [SKIP] needs root + nft (lab-first); deterministic proof is the"
+    echo "         setsync renderSetReplaceScript Go unit test."
+    exit 0
+fi
+
+T="nftban_failopen_test_$$"
+ELEMS="10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 203.0.113.0/24, 198.51.100.0/24"
+cleanup() { nft delete table ip "$T" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Throwaway, NON-HOOKED table+set — cannot affect host networking.
+nft -f - <<EOF
+table ip $T {
+    set blacklist_ipv4 {
+        type ipv4_addr
+        flags interval
+        elements = { $ELEMS }
+    }
+}
+EOF
+
+count() { nft list set ip "$T" blacklist_ipv4 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' | wc -l | tr -d ' '; }
+
+# Tight reader loop in background; records the MINIMUM element count seen.
+reader() {
+    local min=999 c
+    local mark="/tmp/${T}_min"
+    for _ in $(seq 1 4000); do
+        c="$(count)"
+        [[ -n "$c" && "$c" -lt "$min" ]] && min="$c"
+    done
+    echo "$min" > "$mark"
+}
+
+# --- Atomic path (the v1.192 fix): flush + add in ONE nft -f -----------------
+reader & R=$!
+sleep 0.02
+for _ in $(seq 1 60); do
+    printf 'flush set ip %s blacklist_ipv4\nadd element ip %s blacklist_ipv4 { %s }\n' "$T" "$T" "$ELEMS" | nft -f -
+done
+wait "$R" 2>/dev/null || true
+MIN_ATOMIC="$(cat "/tmp/${T}_min" 2>/dev/null || echo 0)"; rm -f "/tmp/${T}_min"
+echo "  [INFO] atomic replace: minimum element count observed = $MIN_ATOMIC (expect 5)"
+if [[ "$MIN_ATOMIC" -ge 5 ]]; then
+    ok "atomic flush+add: blacklist never observed empty/partial (min=$MIN_ATOMIC)"
+else
+    bad "atomic flush+add: blacklist dipped to $MIN_ATOMIC (fail-open window!)"
+fi
+
+# --- Discriminator: OLD non-atomic pattern CAN be seen empty -----------------
+# (standalone flush, then a SEPARATE add — the pre-fix shape). We don't fail the
+# test on this; we just confirm the harness can detect an empty window so the
+# atomic PASS above is meaningful.
+reader & R=$!
+sleep 0.02
+saw_empty=0
+for _ in $(seq 1 60); do
+    nft flush set ip "$T" blacklist_ipv4 2>/dev/null || true
+    nft add element ip "$T" blacklist_ipv4 "{ $ELEMS }" 2>/dev/null || true
+done
+wait "$R" 2>/dev/null || true
+MIN_OLD="$(cat "/tmp/${T}_min" 2>/dev/null || echo 0)"; rm -f "/tmp/${T}_min"
+[[ "$MIN_OLD" -lt 5 ]] && saw_empty=1
+echo "  [INFO] non-atomic (pre-fix) pattern: minimum observed = $MIN_OLD (discriminator; <5 expected if window is detectable)"
+if [[ "$saw_empty" -eq 1 ]]; then
+    ok "harness can detect the pre-fix fail-open window (discriminator valid)"
+else
+    echo "  [INFO] window not observed this run (timing); atomic PASS above still holds"
+fi
+
+echo ""
+echo "=== blacklist_refresh_no_failopen_v192: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh
+++ b/cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.192.0 - Rebuild atomicity / no-SYN-drop runtime test (F-RB)
+# =============================================================================
+# meta:name="rebuild_no_syn_drop_v192_test"
+# meta:type="test"
+# meta:version="1.192.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Lab-first: nftban firewall rebuild loop must not drop a SYN to an accepted port, and post-rebuild management-floor accepts must be present"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,nft,nftban"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network="loopback test listener"
+# meta:inventory.privileges="root"
+# =============================================================================
+# F-RB / D-NFTBAN-REBUILD-FLUSH-WINDOW runtime regression.
+#
+# The DETERMINISTIC, CI-enforced proofs of rebuild atomicity are:
+#   * scripts/ci/check-nft-atomicity.sh  (V-NFT-REBUILD-ATOMICITY static guard)
+#   * the rendered template's single-transaction reset (table{}/delete/recreate)
+#
+# This runtime probe needs root + nft + a live nftban install + a real hooked
+# input chain, so it is LAB-FIRST. In a plain CI / dev box (no root / no nft /
+# no nftban) it SKIPS cleanly (exit 0). The sub-window is short (~10ms), so the
+# loopback probe is best-effort for the drop, but the POST-REBUILD INVARIANT
+# assertions below are deterministic and always meaningful on a lab host.
+# =============================================================================
+
+set -Eeuo pipefail
+
+PASS=0; FAIL=0
+ok()   { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad()  { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+echo "=== rebuild_no_syn_drop_v192 (F-RB) ==="
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]] || ! command -v nft >/dev/null 2>&1 \
+   || ! command -v nftban >/dev/null 2>&1; then
+    echo "  [SKIP] needs root + nft + nftban (lab-first); deterministic proof is"
+    echo "         scripts/ci/check-nft-atomicity.sh + the setsync Go unit test."
+    exit 0
+fi
+
+# --- Probe: SYNs to an accepted port across a rebuild loop -------------------
+PORT=53999
+# Background listener on loopback (accepted by base 'lo accept' rule).
+( while true; do printf 'ok' | timeout 1 nc -l -p "$PORT" >/dev/null 2>&1 || sleep 0.05; done ) &
+LISTENER=$!
+cleanup() { kill "$LISTENER" 2>/dev/null || true; }
+trap cleanup EXIT
+sleep 0.3
+
+drops=0; tries=0
+probe() {
+    for _ in $(seq 1 25); do
+        tries=$((tries+1))
+        if ! timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" 2>/dev/null; then
+            drops=$((drops+1))
+        fi
+        exec 3>&- 2>/dev/null || true
+        sleep 0.02
+    done
+}
+
+# Run probe concurrently with a rebuild loop.
+probe &
+PROBE=$!
+for _ in $(seq 1 20); do
+    nftban firewall rebuild --quiet >/dev/null 2>&1 || true
+done
+wait "$PROBE" 2>/dev/null || true
+
+# Loopback probe is best-effort (window ~10ms); report, don't hard-fail on it,
+# because TCP retransmit can mask the loopback drop. A nonzero count is a strong
+# positive signal that the window exists.
+echo "  [INFO] loopback probe: $drops/$tries connects failed across rebuild loop"
+if [[ "$drops" -eq 0 ]]; then
+    ok "no observed loopback connect failures across 20 rebuilds"
+else
+    echo "  [WARN] observed $drops loopback failures — indicates a drop window (investigate)"
+fi
+
+# --- Deterministic post-rebuild invariants (management floor present) --------
+nftban firewall rebuild --quiet >/dev/null 2>&1 || true
+RS="$(nft list table ip nftban 2>/dev/null || true)"
+RS6="$(nft list table ip6 nftban 2>/dev/null || true)"
+
+[[ -n "$RS" ]] && ok "ip nftban table present after rebuild"  || bad "ip nftban table ABSENT after rebuild"
+[[ -n "$RS6" ]] && ok "ip6 nftban table present after rebuild" || bad "ip6 nftban table ABSENT after rebuild"
+
+grep -qiE 'iif(name)? *(\")?lo' <<<"$RS"        && ok "loopback accept present (v4)"        || bad "loopback accept MISSING (v4)"
+grep -qiE 'ct state .*established' <<<"$RS"      && ok "established/related accept present (v4)" || bad "established accept MISSING (v4)"
+# SSH management port accept (port number is env-substituted; just assert a dport accept exists)
+grep -qiE 'tcp dport .*accept' <<<"$RS"          && ok "service/SSH dport accept present (v4)" || bad "no tcp dport accept (v4)"
+
+echo ""
+echo "=== rebuild_no_syn_drop_v192: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/internal/setsync/nft_cli.go
+++ b/internal/setsync/nft_cli.go
@@ -26,6 +26,7 @@ package setsync
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -140,10 +141,74 @@ func nftDeleteElement(family, table, setName, elements string) error {
 	return runNftIgnoring([]string{ErrElementNotExist, ErrNoSuchFile}, args...)
 }
 
-// nftFlushSet flushes all elements from a set
-func nftFlushSet(family, table, setName string) error {
-	_, err := runNft("flush", "set", family, table, setName)
-	return err
+// replaceSetElementsViaFile atomically replaces the full contents of a set by
+// emitting `flush set` followed by batched `add element` into ONE `nft -f`
+// transaction. The flush is the FIRST statement inside the loaded file — never a
+// standalone `nft flush set` call — so the kernel commits flush+repopulate as a
+// single transaction and readers never observe the set empty or partial.
+//
+// This closes the F-FEED / F-GEO fail-open window on the shared blacklist_*
+// sets (a standalone `nft flush set` followed by a separate `nft -f` add left
+// the set transiently EMPTY, admitting banned IPs during feed/geoban refresh),
+// and the same-class window in the interval split/refresh paths
+// (V-NFT-SET-REFRESH-ATOMICITY).
+//
+// On `nft -f` failure the whole transaction rolls back, so the set retains its
+// prior (blocked) contents — fail-CLOSED, never fail-open. Elements must already
+// be canonicalized / non-overlapping by the caller.
+func replaceSetElementsViaFile(family, table, setName string, elements []string) error {
+	tmpfile, err := os.CreateTemp("", "nftban-setrepl-*.nft")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	defer tmpfile.Close()
+
+	if _, err := tmpfile.WriteString(renderSetReplaceScript(family, table, setName, elements)); err != nil {
+		return fmt.Errorf("failed to write set-replace script: %w", err)
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if _, err := runNftFile(tmpfile.Name()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// renderSetReplaceScript builds the `nft -f` script that atomically replaces a
+// set's contents: a SINGLE `flush set` first, then batched `add element` lines.
+// Kept pure (no I/O) so the flush-before-add ordering — the core of the
+// atomicity guarantee — is unit-testable without nft or root. The adds are
+// batched (10k per `add element`) to bound line length on large feed sets.
+func renderSetReplaceScript(family, table, setName string, elements []string) string {
+	var script strings.Builder
+
+	// Flush FIRST, inside the same script → one atomic transaction with the adds.
+	script.WriteString(fmt.Sprintf("flush set %s %s %s\n", family, table, setName))
+
+	const batchSize = 10000
+	for batchStart := 0; batchStart < len(elements); batchStart += batchSize {
+		batchEnd := batchStart + batchSize
+		if batchEnd > len(elements) {
+			batchEnd = len(elements)
+		}
+
+		var builder strings.Builder
+		for i, e := range elements[batchStart:batchEnd] {
+			if i > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(e)
+		}
+
+		script.WriteString(fmt.Sprintf("add element %s %s %s { %s }\n", family, table, setName, builder.String()))
+	}
+
+	return script.String()
 }
 
 // NftListSet lists elements of a set (exported for emulate command)
@@ -228,4 +293,3 @@ func nftFamily(ipv4 bool) string {
 	}
 	return "ip6"
 }
-

--- a/internal/setsync/nft_elements.go
+++ b/internal/setsync/nft_elements.go
@@ -468,50 +468,15 @@ func (m *NFTManager) AddCIDRElementsWithStats(set *nftables.Set, cidrs []string)
 		stats.ReductionPct = float64(stats.OverlapsMerged) / float64(inputCount) * 100.0
 	}
 
-	// Flush the set first using nft CLI to avoid netlink stale connection issues
-	if err := nftFlushSet(family, set.Table.Name, set.Name); err != nil {
-		return nil, fmt.Errorf("failed to flush set: %w", err)
-	}
-
-	// Create temporary file for nft command
-	tmpfile, err := os.CreateTemp("", "nftban-cidr-*.nft")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer os.Remove(tmpfile.Name())
-	defer tmpfile.Close()
-
-	// Write nft commands to file in batches to avoid memory issues
-	// For large datasets, split into multiple add element commands (10k per batch)
-	// Format: add element ip nftban blacklist_ipv4 { 10.0.0.0/8, 192.168.0.0/16, ... }
-
-	const batchSize = 10000
-	for batchStart := 0; batchStart < len(canonicalCIDRs); batchStart += batchSize {
-		batchEnd := batchStart + batchSize
-		if batchEnd > len(canonicalCIDRs) {
-			batchEnd = len(canonicalCIDRs)
-		}
-
-		batch := canonicalCIDRs[batchStart:batchEnd]
-
-		// Use strings.Builder for efficient string concatenation
-		var builder strings.Builder
-		for i, cidr := range batch {
-			if i > 0 {
-				builder.WriteString(", ")
-			}
-			builder.WriteString(cidr)
-		}
-
-		nftCmd := fmt.Sprintf("add element %s %s %s { %s }\n", family, set.Table.Name, set.Name, builder.String())
-		if _, err := tmpfile.WriteString(nftCmd); err != nil {
-			return nil, fmt.Errorf("failed to write to temp file: %w", err)
-		}
-	}
-	tmpfile.Close()
-
-	// Execute nft -f <file> using centralized helper
-	if _, err := runNftFile(tmpfile.Name()); err != nil {
+	// Atomically replace the set contents: flush + add in ONE `nft -f`
+	// transaction (V-NFT-SET-REFRESH-ATOMICITY). Previously this flushed via a
+	// standalone `nft flush set` and repopulated in a SEPARATE `nft -f`, leaving
+	// the shared blacklist_* set transiently EMPTY between transactions — the
+	// F-FEED / F-GEO fail-open window where banned IPs were admitted during the
+	// daily feed / weekly geoban refresh. The single-transaction replace closes
+	// it; on nft failure the transaction rolls back and the prior (blocked)
+	// contents are retained (fail-CLOSED).
+	if err := replaceSetElementsViaFile(family, set.Table.Name, set.Name, canonicalCIDRs); err != nil {
 		return nil, err
 	}
 

--- a/internal/setsync/nft_interval.go
+++ b/internal/setsync/nft_interval.go
@@ -22,7 +22,6 @@ package setsync
 import (
 	"fmt"
 	"net"
-	"os"
 	"regexp"
 	"strings"
 
@@ -333,10 +332,6 @@ func (m *NFTManager) fullSetRefreshExcludingIP6(set *nftables.Set, family, exclu
 		}
 	}
 
-	if err := nftFlushSet(family, set.Table.Name, set.Name); err != nil {
-		return fmt.Errorf("failed to flush set: %w", err)
-	}
-
 	cleanElements := make([]string, 0, len(filteredElements))
 	for _, elem := range filteredElements {
 		elem = strings.TrimSpace(elem)
@@ -345,12 +340,12 @@ func (m *NFTManager) fullSetRefreshExcludingIP6(set *nftables.Set, family, exclu
 		}
 	}
 
-	if len(cleanElements) == 0 {
-		return nil
-	}
-
-	if err := nftAddElementsBatch(family, set.Table.Name, set.Name, cleanElements, 500); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: batch add partial failure: %v\n", err)
+	// Atomic flush+repopulate in one `nft -f` (V-NFT-SET-REFRESH-ATOMICITY): the
+	// shared set is never observed empty between flush and re-add. An empty
+	// cleanElements slice still flushes (the set legitimately becomes empty)
+	// atomically. On failure the transaction rolls back (fail-CLOSED).
+	if err := replaceSetElementsViaFile(family, set.Table.Name, set.Name, cleanElements); err != nil {
+		return fmt.Errorf("failed to refresh set: %w", err)
 	}
 
 	return nil
@@ -518,13 +513,7 @@ func (m *NFTManager) fullSetRefreshExcludingIP(set *nftables.Set, family, exclud
 		}
 	}
 
-	// Step 4: Flush the set
-	if err := nftFlushSet(family, set.Table.Name, set.Name); err != nil {
-		return fmt.Errorf("failed to flush set: %w", err)
-	}
-
-	// Step 5: Re-add filtered elements in batches
-	// First, filter out any empty strings that may have crept in
+	// Step 4: Filter out any empty strings that may have crept in.
 	cleanElements := make([]string, 0, len(filteredElements)) // Pre-allocate
 	for _, elem := range filteredElements {
 		elem = strings.TrimSpace(elem)
@@ -533,14 +522,12 @@ func (m *NFTManager) fullSetRefreshExcludingIP(set *nftables.Set, family, exclud
 		}
 	}
 
-	if len(cleanElements) == 0 {
-		return nil // Nothing to add back
-	}
-
-	// Use centralized batch add (500 elements per batch for safety)
-	if err := nftAddElementsBatch(family, set.Table.Name, set.Name, cleanElements, 500); err != nil {
-		// Log but continue - partial success is better than full failure
-		fmt.Fprintf(os.Stderr, "Warning: batch add partial failure: %v\n", err)
+	// Step 5: Atomic flush+repopulate in one `nft -f`
+	// (V-NFT-SET-REFRESH-ATOMICITY): the set is never observed empty between
+	// flush and re-add (closes the same-class fail-open window). On failure the
+	// transaction rolls back and prior contents are retained (fail-CLOSED).
+	if err := replaceSetElementsViaFile(family, set.Table.Name, set.Name, cleanElements); err != nil {
+		return fmt.Errorf("failed to refresh set: %w", err)
 	}
 
 	return nil

--- a/internal/setsync/nft_set_refresh_atomicity_v192_test.go
+++ b/internal/setsync/nft_set_refresh_atomicity_v192_test.go
@@ -1,0 +1,137 @@
+// =============================================================================
+// NFTBan - v1.192 set-refresh atomicity test (F-FEED / F-GEO)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nft_set_refresh_atomicity_v192_test"
+// meta:type="test"
+// meta:version="1.192.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Asserts shared-set refresh emits flush+add as ONE nft -f transaction (no fail-open empty window)"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// V-NFT-SET-REFRESH-ATOMICITY (hermetic): the blacklist refresh path must
+// replace a set's contents via a SINGLE `nft -f` transaction whose FIRST
+// statement is `flush set` and whose remaining statements are `add element`.
+// That ordering is what guarantees the shared blacklist_* set is never observed
+// empty/partial between transactions (the F-FEED / F-GEO fail-open window where
+// banned IPs were admitted during the daily feed / weekly geoban refresh).
+//
+// These tests assert the rendered script directly — no nft / root / kernel.
+
+package setsync
+
+import (
+	"strings"
+	"testing"
+)
+
+func scriptLines(t *testing.T, s string) []string {
+	t.Helper()
+	out := make([]string, 0, 8)
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.TrimSpace(ln) != "" {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
+func TestSetRefresh_FlushIsFirstStatement(t *testing.T) {
+	script := renderSetReplaceScript("ip", "nftban", "blacklist_ipv4",
+		[]string{"10.0.0.0/8", "192.168.0.0/16", "203.0.113.0/24"})
+	lines := scriptLines(t, script)
+	if len(lines) == 0 {
+		t.Fatal("empty script")
+	}
+	// The FIRST non-blank statement MUST be the flush.
+	if !strings.HasPrefix(lines[0], "flush set ip nftban blacklist_ipv4") {
+		t.Fatalf("first statement is not the flush set: %q", lines[0])
+	}
+	// Exactly ONE flush — never a second flush that could re-empty mid-script.
+	if n := strings.Count(script, "flush set "); n != 1 {
+		t.Fatalf("expected exactly 1 flush set, got %d", n)
+	}
+	// Every other statement is an add element (no standalone delete/flush after).
+	for _, ln := range lines[1:] {
+		if !strings.HasPrefix(ln, "add element ip nftban blacklist_ipv4") {
+			t.Fatalf("non-add statement after flush: %q", ln)
+		}
+	}
+}
+
+func TestSetRefresh_FlushPrecedesEveryAdd(t *testing.T) {
+	script := renderSetReplaceScript("ip6", "nftban", "blacklist_ipv6",
+		[]string{"2001:db8::/32", "2001:db8:1::/48"})
+	flushIdx := strings.Index(script, "flush set ")
+	addIdx := strings.Index(script, "add element ")
+	if flushIdx < 0 {
+		t.Fatal("no flush set in script")
+	}
+	if addIdx < 0 {
+		t.Fatal("no add element in script")
+	}
+	if flushIdx > addIdx {
+		t.Fatalf("flush set (idx %d) must precede the first add element (idx %d) so flush+add commit as one transaction", flushIdx, addIdx)
+	}
+}
+
+func TestSetRefresh_EmptyElementsFlushOnly(t *testing.T) {
+	// An empty replacement legitimately empties the set, but still in ONE flush
+	// transaction (no separate add) — never an orphaned standalone flush call.
+	script := renderSetReplaceScript("ip", "nftban", "blacklist_ipv4", nil)
+	lines := scriptLines(t, script)
+	if len(lines) != 1 || !strings.HasPrefix(lines[0], "flush set ip nftban blacklist_ipv4") {
+		t.Fatalf("empty replace should be a single flush statement, got: %v", lines)
+	}
+	if strings.Contains(script, "add element") {
+		t.Fatalf("empty replace must not emit add element: %q", script)
+	}
+}
+
+func TestSetRefresh_LargeSetBatchesAllAfterSingleFlush(t *testing.T) {
+	// > batchSize elements: still exactly one flush, first, then N add batches.
+	elems := make([]string, 0, 25000)
+	for i := 0; i < 25000; i++ {
+		// vary octets to keep distinct, valid-looking CIDR strings
+		elems = append(elems, formatTestCIDR(i))
+	}
+	script := renderSetReplaceScript("ip", "nftban", "blacklist_ipv4", elems)
+	if n := strings.Count(script, "flush set "); n != 1 {
+		t.Fatalf("large set: expected exactly 1 flush, got %d", n)
+	}
+	// 25000 / 10000 = 3 add-element batches.
+	if n := strings.Count(script, "add element "); n != 3 {
+		t.Fatalf("large set: expected 3 add-element batches, got %d", n)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(script), "flush set ") {
+		t.Fatalf("large set: flush must be first")
+	}
+}
+
+func formatTestCIDR(i int) string {
+	a := (i / 65536) % 256
+	b := (i / 256) % 256
+	c := i % 256
+	return strings.NewReplacer(
+		"A", itoa(a), "B", itoa(b), "C", itoa(c),
+	).Replace("A.B.C.0/24")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}

--- a/scripts/ci/check-nft-atomicity.sh
+++ b/scripts/ci/check-nft-atomicity.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.192.0 - CI Gate: nftables Transition Atomicity
+# =============================================================================
+# meta:name="check-nft-atomicity"
+# meta:type="script"
+# meta:version="1.192.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Forbid flush/delete-then-repopulate-in-a-separate-transaction on live nftban tables and shared sets"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Closes the v1.192 transition-atomicity class
+# (D-NFTBAN-SOAK-NONATOMIC-FIREWALL-REBUILD-DROP-WINDOW and siblings F-FEED/
+# F-GEO). Two guards:
+#
+#   V-NFT-REBUILD-ATOMICITY
+#     A PRODUCTION firewall path must NOT flush/delete the live `nftban` table
+#     in a standalone `nft` call and then load the replacement in a separate
+#     `nft -f`. The rebuild must reset the table INSIDE the loaded file so
+#     `nft -f` applies it as one transaction (no fail-CLOSED drop window).
+#     Recovery/reset/rollback/restore funcs are EXEMPT (operator/by-design).
+#
+#   V-NFT-SET-REFRESH-ATOMICITY
+#     A PRODUCTION set-refresh path must NOT flush a live shared set in a
+#     standalone call and repopulate it in a separate transaction (the F-FEED/
+#     F-GEO fail-OPEN window on blacklist_*). Flush + add must go in one
+#     `nft -f` (see internal/setsync renderSetReplaceScript).
+#
+# Exit codes: 0 = clean · 1 = violation (PR must not merge)
+# =============================================================================
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FAIL=0
+echo "========================================"
+echo "NFTBan Architecture Check: nft Transition Atomicity"
+echo "========================================"
+echo ""
+
+# -----------------------------------------------------------------------------
+# V-NFT-REBUILD-ATOMICITY
+# -----------------------------------------------------------------------------
+# Scan cmd_firewall.sh: any literal `nft (flush|delete) table (ip|ip6|inet)
+# nftban` that lives OUTSIDE an exempt recovery function is a violation.
+# (The ghost-table cleanup uses a `$TABLE_SPEC` variable, not literal `nftban`,
+# so it is not matched.)
+FW="cli/lib/nftban/cli/cmd_firewall.sh"
+echo "[V-NFT-REBUILD-ATOMICITY] scanning $FW ..."
+
+if [[ ! -f "$FW" ]]; then
+    echo "::error::$FW not found"; exit 1
+fi
+
+# Recovery/operator funcs allowed to flush/delete the live table by design.
+REBUILD_EXEMPT='_rebuild_rollback firewall_reset _restore_from_file _restore_previous_firewall'
+
+REBUILD_VIOLATIONS="$(
+    awk -v exempt="$REBUILD_EXEMPT" '
+        BEGIN { split(exempt, e, " "); for (i in e) ex[e[i]] = 1; fn = "(top-level)" }
+        # Track the current top-level function (name() at column 0).
+        /^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{?[[:space:]]*$/ {
+            f = $0; sub(/\(\).*/, "", f); fn = f; next
+        }
+        # Match a real (non-comment) standalone flush/delete of the live table.
+        /nft[[:space:]]+(flush|delete)[[:space:]]+table[[:space:]]+(ip|ip6|inet)[[:space:]]+nftban/ {
+            line = $0; sub(/^[[:space:]]+/, "", line)
+            if (line ~ /^#/) next
+            if (!(fn in ex)) printf "  %s:%d  [in %s()]  %s\n", FILENAME, NR, fn, line
+        }
+    ' "$FW"
+)"
+
+if [[ -n "$REBUILD_VIOLATIONS" ]]; then
+    echo "::error::V-NFT-REBUILD-ATOMICITY violation — standalone flush/delete of the live nftban table in a production path:"
+    echo "$REBUILD_VIOLATIONS"
+    echo "  Fix: reset the table INSIDE the loaded \$load_conf (it already begins with"
+    echo "       'table ... { }' + 'delete table ...'), so 'nft -f' applies it atomically."
+    FAIL=1
+else
+    echo "  PASS — no standalone live-table flush/delete outside recovery funcs."
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# V-NFT-SET-REFRESH-ATOMICITY
+# -----------------------------------------------------------------------------
+# In internal/setsync, a shared-set replace must NOT use a standalone set flush
+# followed by a separate add. Two negative checks + one positive wiring check.
+echo "[V-NFT-SET-REFRESH-ATOMICITY] scanning internal/setsync ..."
+
+# (a) No standalone set-flush helper callsites (helper removed in v1.192).
+NFTFLUSH_HITS="$(grep -rnE '\bnftFlushSet[[:space:]]*\(' --include='*.go' internal/setsync 2>/dev/null \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' || true)"
+if [[ -n "$NFTFLUSH_HITS" ]]; then
+    echo "::error::V-NFT-SET-REFRESH-ATOMICITY violation — standalone nftFlushSet() callsite (flush in a separate transaction from the add):"
+    echo "$NFTFLUSH_HITS"
+    echo "  Fix: replace contents via replaceSetElementsViaFile() — flush+add in ONE nft -f."
+    FAIL=1
+fi
+
+# (b) No direct standalone `nft flush set` exec/runNft in setsync.
+DIRECT_FLUSH_HITS="$(grep -rnE '(runNft[A-Za-z]*\(|exec\.Command\("nft"[^)]*)[^)]*"flush"[[:space:]]*,[[:space:]]*"set"' \
+    --include='*.go' internal/setsync 2>/dev/null \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' || true)"
+if [[ -n "$DIRECT_FLUSH_HITS" ]]; then
+    echo "::error::V-NFT-SET-REFRESH-ATOMICITY violation — direct standalone 'nft flush set' in setsync:"
+    echo "$DIRECT_FLUSH_HITS"
+    echo "  Fix: emit 'flush set' as the first line of the nft -f script (renderSetReplaceScript)."
+    FAIL=1
+fi
+
+# (c) Positive wiring: the atomic replace path must exist and emit an in-file flush.
+if ! grep -q 'func renderSetReplaceScript' internal/setsync/nft_cli.go 2>/dev/null; then
+    echo "::error::V-NFT-SET-REFRESH-ATOMICITY: renderSetReplaceScript missing (atomic replace path absent)."
+    FAIL=1
+elif ! grep -qE '"flush set %s %s %s' internal/setsync/nft_cli.go 2>/dev/null; then
+    echo "::error::V-NFT-SET-REFRESH-ATOMICITY: renderSetReplaceScript does not emit an in-file 'flush set'."
+    FAIL=1
+fi
+if ! grep -q 'replaceSetElementsViaFile(' internal/setsync/nft_elements.go 2>/dev/null; then
+    echo "::error::V-NFT-SET-REFRESH-ATOMICITY: AddCIDRElementsWithStats no longer routes through replaceSetElementsViaFile."
+    FAIL=1
+fi
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "  PASS — set refresh flushes+adds atomically (single nft -f), no standalone flush callsites."
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+echo "========================================"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "RESULT: PASS — transition atomicity invariants hold"
+    exit 0
+fi
+echo "RESULT: FAIL — transition atomicity violation (see ::error:: above)"
+exit 1

--- a/scripts/ci/check-nft-writes.sh
+++ b/scripts/ci/check-nft-writes.sh
@@ -84,8 +84,12 @@ NFT_READ_PATTERN='nft[[:space:]]+(list|get)[[:space:]]'
 #     scripts/test_server_cleanup.sh — lab teardown (nft delete table)
 #     nft_writer_authority_v150_test.sh — asserts ON this policy (contains nft-write
 #                                   text in descriptions/patterns; never runs in production)
+#     blacklist_refresh_no_failopen_v192_test.sh — v1.192 set-refresh atomicity
+#                                   harness: raw nft writes target a THROWAWAY test
+#                                   table (nftban_failopen_test_$$), never production;
+#                                   lab/root-only, skips without root/nft.
 # REMOVED v1.150 AUTH-4: nftban_geoban.sh (0 direct nft writes — routes via nft_ipc_apply_ruleset).
-ALLOWED_REGEX='^(cmd/nftband/|internal/nftbackend/|internal/setsync/|scripts/ci/|scripts/test_server_cleanup\.sh|cli/lib/nftban/tests/nft_writer_authority_v150_test\.sh|cli/sbin/nftban-apply|cli/sbin/nftban-rollback|cli/lib/nftban/lib/nft_ipc\.sh|cli/lib/nftban/core/nftban_health_fixes\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/helpers/autoheal\.sh|cli/lib/nftban/lib/nft_fragment\.sh|install/helpers/firewall-init-with-delay\.sh|cli/lib/nftban/cli/cmd_firewall\.sh|cli/lib/nftban/cli/cmd_flush\.sh|cli/lib/nftban/core/nftban_ddos_classic\.sh|cli/lib/nftban/core/nftban_firewall_conflicts\.sh|cli/lib/nftban/core/nftban_health_checks_security\.sh|cli/lib/nftban/cli/cmd_whitelist\.sh|cli/lib/nftban/cli/cmd_zabbix\.sh|cli/lib/nftban/cli/cmd_health_core\.sh|cli/lib/nftban/cli/cmd_firewall_logs\.sh|cli/lib/nftban/lib/service_control\.sh|cli/lib/nftban/core/nftban_system_ip\.sh)'
+ALLOWED_REGEX='^(cmd/nftband/|internal/nftbackend/|internal/setsync/|scripts/ci/|scripts/test_server_cleanup\.sh|cli/lib/nftban/tests/nft_writer_authority_v150_test\.sh|cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test\.sh|cli/sbin/nftban-apply|cli/sbin/nftban-rollback|cli/lib/nftban/lib/nft_ipc\.sh|cli/lib/nftban/core/nftban_health_fixes\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/helpers/autoheal\.sh|cli/lib/nftban/lib/nft_fragment\.sh|install/helpers/firewall-init-with-delay\.sh|cli/lib/nftban/cli/cmd_firewall\.sh|cli/lib/nftban/cli/cmd_flush\.sh|cli/lib/nftban/core/nftban_ddos_classic\.sh|cli/lib/nftban/core/nftban_firewall_conflicts\.sh|cli/lib/nftban/core/nftban_health_checks_security\.sh|cli/lib/nftban/cli/cmd_whitelist\.sh|cli/lib/nftban/cli/cmd_zabbix\.sh|cli/lib/nftban/cli/cmd_health_core\.sh|cli/lib/nftban/cli/cmd_firewall_logs\.sh|cli/lib/nftban/lib/service_control\.sh|cli/lib/nftban/core/nftban_system_ip\.sh)'
 
 # =============================================================================
 # MAIN


### PR DESCRIPTION
## v1.192 PR-A — close the nftables transition-atomicity class

Closes three same-class blockers, all reducing to one root cause: **flush + repopulate in SEPARATE transactions instead of one `nft -f`**. The fix makes every production live-object transition a single atomic transaction, so packets never observe an empty/partial state.

| ID | Class | Window |
|---|---|---|
| **F-RB** (`D-NFTBAN-REBUILD-FLUSH-WINDOW`) | fail-**CLOSED** | rebuild flushed the live `nftban` table before a separate `nft -f`, collapsing the input chain to policy-drop with no accepts |
| **F-FEED** (`D-NFTBAN-FEED-REFRESH-FAILOPEN`) | fail-**OPEN** | daily feed refresh flushed the shared `blacklist_*` set then repopulated separately → banned IPs admitted during the window |
| **F-GEO** (`D-NFTBAN-GEOBAN-REFRESH-FAILOPEN`) | fail-**OPEN** | weekly geoban refresh hit the same shared set-writer |

### Fix
- **F-RB** (`cli/lib/nftban/cli/cmd_firewall.sh`): removed the standalone `nft flush table ip/ip6 nftban` in `_firewall_rebuild_core` Step 5. The rendered `$load_conf` already self-resets in one transaction (`table{}` create → `delete table` → full recreate), so `nft -f` alone is the atomic replace.
- **F-FEED / F-GEO** (`internal/setsync`): new `replaceSetElementsViaFile` / `renderSetReplaceScript` emit `flush set` as the **first statement of the same `nft -f` script**, so flush+add commit atomically (on failure the txn rolls back → prior blocked contents retained, fail-CLOSED). `AddCIDRElementsWithStats` and the two `nft_interval.go` split/refresh paths route through it; standalone `nftFlushSet` removed.

### Guards & tests
- **Static (CI):** `scripts/ci/check-nft-atomicity.sh` — `V-NFT-REBUILD-ATOMICITY` + `V-NFT-SET-REFRESH-ATOMICITY`, wired into `ci-architecture.yml`. **Function-scoped / structural** (not file-level allowlisting), **verified to FAIL on the reconstructed pre-fix tree and PASS on the fix**.
- **Hermetic Go unit test** (`internal/setsync/nft_set_refresh_atomicity_v192_test.go`): flush is the single first statement, precedes every add, batched at scale — no root/nft required.
- **Lab-first runtime tests** (`rebuild_no_syn_drop_v192_test.sh`, `blacklist_refresh_no_failopen_v192_test.sh`): self-skip without root/nft.

### Lab-first validation (reversible source+daemon deploy; restored clean to v1.190.3)
- **lab2 (DEB, Ubuntu 24.04)** + **lab4 (RPM, AlmaLinux 9.8)**.
- Pre-fix repro: input chain collapsed **19 → 1** during rebuild (distro-independent fail-closed window).
- Post-fix F-RB: management floor (loopback **AND** established **AND** SSH/service dport) present in **every** sample during rebuild — breach **0/600** (lab2), **0/500** (lab4); collapse-to-1 **eliminated**. Residual 19↔24 count fluctuation = benign post-load dynamic whitelist re-sync atop a complete floor, not a fail-closed window.
- F-FEED/F-GEO: shipped kernel test — atomic replace **never empty** (min=5); discriminator confirms the pre-fix pattern does hit 0.

### Statements
- **Daemon binary CHANGED** — the F-FEED/F-GEO fix is Go (`internal/setsync`, linked into `nftband`). Future shell/data-only lanes must re-baseline off the post-PR-A daemon.
- **Schema UNCHANGED** — `SchemaVersionCurrent = "1.84.0"`; **MergeStats / IPC contracts unchanged**.

### Scope boundaries
- **PR-B (harm-keyed health observability)** is **separate** — not in this PR.
- **Deferred:** F-OPQ (build-then-swap), F-DDOS (operator chain rebuild), F-LOCK (rebuild lock), `nftban_base` defense-in-depth.
- **Exempt by design:** recovery/reset/rollback/restore/stop paths.
- Residual to exercise at rollout: a **live populated** feed/geoban refresh (labs had empty `blacklist_ipv4`; daemon path proven via hermetic test + guard + kernel test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)