### PR TITLE
fix(v1.193.0): firewall/ops hygiene — rebuild whitelist re-merge (PR-A) + table-absent log-noise (PR-B)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2410,6 +2410,23 @@ _firewall_rebuild_core() {
     [[ "$quiet" == "false" ]] && echo "  [6/12] Re-syncing system whitelist..."
     nftban whitelist sync >/dev/null 2>&1 || true
 
+    # Step 6b (v1.193.0 BUG-REBUILD-DROPS-MANUAL-WHITELIST): the atomic load above
+    # recreated the whitelist_* sets and `nftban whitelist sync` re-applies only
+    # auto-detected SYSTEM IPs — NOT the durable manual whitelist.d entries
+    # (operator `--static` admin IPs, e.g. 99-manual.conf) or manual blacklist
+    # entries. Without this, an explicit `firewall rebuild` dropped manual
+    # whitelist.d IPs from the live set until the next periodic sync (a transient
+    # lockout window that breaks the WL-STATIC durability promise). Reconcile them
+    # now via the daemon LoadWhitelists/LoadBlacklists path — the SAME core
+    # `sync --quick` (whitelist/blacklist only, no feeds/geoban) that firewall_reload
+    # uses (Step 3b), so rebuild and reload converge. No-op if the core binary is
+    # unavailable. Does NOT touch system/trust whitelist behaviour or feed/geoban.
+    local _rb_reconcile="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core"
+    if [[ -x "$_rb_reconcile" ]]; then
+        [[ "$quiet" == "false" ]] && echo "    Reconciling durable whitelist.d/blacklist.d entries..."
+        "$_rb_reconcile" sync --quick >/dev/null 2>&1 || true
+    fi
+
     # Step 7: Restore blacklist from backup (BUG FIX: R74 - blacklist was never restored)
     [[ "$quiet" == "false" ]] && echo "  [7/12] Restoring blacklist from backup..."
     local restored_count=0

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -80,6 +80,28 @@ log() {
     echo "$msg" | sed -r 's/\x1B\[[0-9;]*[A-Za-z]//g' >> "$LOGFILE"
 }
 
+# v1.193.0 PR-B (table-absent maintenance-log noise): a single 'no-table' sample
+# from nftban_ssh_apply_state can be a TRANSIENT firewall transition window
+# (a rebuild/reload re-applying the schema) rather than a genuine absence. Before
+# emitting the noisy "table absent" WARN, re-probe the LIVE nftban table a few
+# times over a short bounded grace. If it reappears → transient → caller logs a
+# quiet INFO instead. If still absent across the grace → GENUINE table-absent
+# (e.g. while install_state COMMITTED) → caller logs the WARN (real failure kept).
+# This ONLY changes the maintenance LOG path; it does not touch the FW-transition
+# harm counter (table_absent_while_committed_count), firewall load/rebuild
+# semantics, install_state, or any set. Returns 0 = genuinely absent, 1 = transient.
+_maint_table_absent_confirmed() {
+    local _tbl="${1:-${NFTBAN_TABLE_IPV4:-ip nftban}}" _i
+    for _i in 1 2 3; do
+        sleep "${_MAINT_TABLE_RECHECK_SLEEP:-0.4}"
+        # shellcheck disable=SC2086  # $_tbl is "ip nftban" — intentional 2-token split
+        if nft list table $_tbl >/dev/null 2>&1; then
+            return 1   # reappeared → transient transition window, not a genuine absence
+        fi
+    done
+    return 0   # absent across the whole grace window → genuine
+}
+
 # =============================================================================
 # LOCKING (Prevent concurrent runs)
 # =============================================================================
@@ -176,7 +198,12 @@ main() {
                     echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
                     ;;
                 no-table)
-                    log "WARN" "nftban firewall table absent — SSH-port enforcement skipped this run (state NOT advanced). Run: nftban firewall reload"
+                    # v1.193.0 PR-B: suppress transient transition-window noise; keep genuine absence.
+                    if _maint_table_absent_confirmed "${NFTBAN_TABLE_IPV4}"; then
+                        log "WARN" "nftban firewall table absent — SSH-port enforcement skipped this run (state NOT advanced). Run: nftban firewall reload"
+                    else
+                        log "INFO" "nftban table briefly unavailable during a firewall transition (re-sample shows it present) — SSH-port enforcement deferred to next run; no action needed."
+                    fi
                     ;;
                 no-sets)
                     log "WARN" "nftban set-driven schema (tcp_ports_in/ssh_ports) not loaded — SSH-port enforcement skipped (state NOT advanced). Run: nftban firewall reload"
@@ -275,7 +302,12 @@ EOF
             elif [[ "$_autofix_state" == "no-sets" ]]; then
                 log "WARN" "nftban set-driven schema not loaded (tcp_ports_in/ssh_ports missing) — SSH port whitelisted in config but NOT applied. Run: nftban firewall reload"
             else
-                log "WARN" "nftban firewall table absent — SSH port whitelisted in config but NOT applied. Run: nftban firewall reload"
+                # v1.193.0 PR-B: suppress transient transition-window noise; keep genuine absence.
+                if _maint_table_absent_confirmed "${NFTBAN_TABLE_IPV4}"; then
+                    log "WARN" "nftban firewall table absent — SSH port whitelisted in config but NOT applied. Run: nftban firewall reload"
+                else
+                    log "INFO" "nftban table briefly unavailable during a firewall transition (re-sample shows it present) — SSH-port apply deferred to next run; no action needed."
+                fi
             fi
 
             # Alert-dedup marker (independent of apply outcome — prevents spam).

--- a/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
+++ b/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.193.0 PR-B - maintenance table-absent transient-noise suppression
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="maint_table_absent_noise_v1930_test"
+# meta:type="test"
+# meta:version="1.193.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-17"
+# meta:description="PR-B: maintenance.sh re-probes the live nftban table before logging 'table absent' — a transient firewall-transition window (table reappears) is suppressed (quiet INFO), while a GENUINE persistent absence still WARNs. Tests _maint_table_absent_confirmed (transient→rc1, genuine→rc0, reappear→rc1) + static guard that both WARN sites are gated. Hermetic: stubbed nft/sleep, no root/nft/host."
+# meta:inventory.files="maint_table_absent_noise_v1930_test.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAINT="$SCRIPT_DIR/../cron/maintenance.sh"
+[[ -f "$MAINT" ]] || { echo "FAIL: maintenance.sh not found at $MAINT"; exit 1; }
+PASS=0; FAIL=0
+ok(){ echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# Extract just the helper function (no top-level maintenance side effects).
+HELPER="$(awk '/^_maint_table_absent_confirmed\(\)/{f=1} f{print} f&&/^\}/{exit}' "$MAINT")"
+[[ -n "$HELPER" ]] || { echo "FAIL: _maint_table_absent_confirmed not found"; exit 1; }
+eval "$HELPER"
+sleep(){ :; }                              # fast: no real delay
+export _MAINT_TABLE_RECHECK_SLEEP=0
+# NFTBAN_TABLE_IPV4 left unset → the helper uses its ${NFTBAN_TABLE_IPV4:-ip nftban} fallback.
+
+echo "=== T1: GENUINE absence (table never reappears) → rc0 (caller WARNs) ==="
+nft(){ return 1; }
+if _maint_table_absent_confirmed; then ok "persistent absence → confirmed genuine (rc0 → WARN kept)"; else bad "genuine absence misclassified as transient"; fi
+
+echo "=== T2: table PRESENT on re-probe → rc1 (transient, suppress to INFO) ==="
+nft(){ return 0; }
+if _maint_table_absent_confirmed; then bad "present table classified genuine-absent"; else ok "table present → transient (rc1 → suppress noisy WARN)"; fi
+
+echo "=== T3: table REAPPEARS mid-grace (fail then present) → rc1 (transient) ==="
+_n3=0; nft(){ _n3=$((_n3+1)); [ "$_n3" -ge 2 ] && return 0 || return 1; }
+if _maint_table_absent_confirmed; then bad "reappearing table classified genuine-absent (noise would persist)"; else ok "table reappears within grace → transient (rc1 → suppress)"; fi
+unset -f nft 2>/dev/null || true
+
+echo "=== T4: static guard — BOTH 'table absent' WARN sites are gated by the recheck ==="
+warn_total=$(grep -cE 'log "WARN" "nftban firewall table absent' "$MAINT")
+warn_gated=$(grep -B4 -E 'log "WARN" "nftban firewall table absent' "$MAINT" | grep -cE '_maint_table_absent_confirmed')
+echo "    table-absent WARN sites=$warn_total  gated-by-recheck=$warn_gated"
+[[ "$warn_total" -ge 2 && "$warn_gated" -ge "$warn_total" ]] \
+  && ok "every table-absent WARN ($warn_total) is gated by _maint_table_absent_confirmed" \
+  || bad "ungated table-absent WARN remains (total=$warn_total gated=$warn_gated)"
+
+echo "=== T5: helper present + def count (1 def + ≥2 callers) ==="
+calls=$(grep -cE '_maint_table_absent_confirmed' "$MAINT")
+[[ "$calls" -ge 3 ]] && ok "_maint_table_absent_confirmed defined + called at both sites ($calls refs)" || bad "missing helper def/call ($calls)"
+
+echo "=== T6: no harm-counter / firewall-load semantics touched (noise-only guard) ==="
+# the PR-B edit must NOT reset counters or alter nft -f / install_state in maintenance.sh
+grep -qE 'firewall_transition_health\.json.*>|: > .*firewall_transition_health|table_absent_while_committed_count *=' "$MAINT" \
+  && bad "PR-B touched the FW-transition harm counter (must stay authoritative)" \
+  || ok "PR-B does not reset/modify the FW-transition harm counter"
+
+echo ""
+echo "=== maintenance table-absent noise v1.193.0: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh
+++ b/cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.193.0 - rebuild re-merges manual whitelist.d (BUG-REBUILD-DROPS-MANUAL-WHITELIST)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="whitelist_rebuild_remerge_v1930_test"
+# meta:type="test"
+# meta:version="1.193.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-17"
+# meta:description="Static guard: _firewall_rebuild_core must reconcile durable manual whitelist.d/blacklist.d via the core 'sync --quick' path (same as firewall_reload Step 3b), AFTER the system 'nftban whitelist sync', so an explicit 'firewall rebuild' no longer drops manual --static whitelist IPs from the live set. Hermetic — parses cmd_firewall.sh function bodies; no nft/root (real behaviour proven lab-first)."
+# meta:inventory.files="whitelist_rebuild_remerge_v1930_test.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FW="$SCRIPT_DIR/../cli/cmd_firewall.sh"
+[[ -f "$FW" ]] || { echo "FAIL: cmd_firewall.sh not found at $FW"; exit 1; }
+PASS=0; FAIL=0
+ok(){ echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# Extract a top-level function body by name (name() { ... } at column 0).
+fn_body(){ # $1=func name
+  awk -v fn="$1" '
+    $0 ~ "^"fn"\\(\\)[[:space:]]*\\{?[[:space:]]*$" {inf=1}
+    inf {print}
+    inf && /^\}/ {exit}
+  ' "$FW"
+}
+
+REBUILD="$(fn_body _firewall_rebuild_core)"
+RELOAD="$(fn_body firewall_reload)"
+[[ -n "$REBUILD" ]] || { echo "FAIL: could not extract _firewall_rebuild_core"; exit 1; }
+[[ -n "$RELOAD" ]]  || { echo "FAIL: could not extract firewall_reload"; exit 1; }
+
+echo "=== T1: rebuild reconciles manual whitelist.d via core 'sync --quick' ==="
+printf '%s\n' "$REBUILD" | grep -qE 'sync --quick' \
+  && ok "rebuild invokes core 'sync --quick' (manual whitelist.d/blacklist.d reconcile)" \
+  || bad "rebuild MISSING 'sync --quick' reconcile (manual --static whitelist would be dropped on rebuild)"
+
+echo "=== T2: reconcile is AFTER the system 'nftban whitelist sync' (ordering) ==="
+ln_wlsync=$(printf '%s\n' "$REBUILD" | grep -nE 'nftban whitelist sync' | head -1 | cut -d: -f1)
+ln_recon=$(printf '%s\n' "$REBUILD" | grep -nE 'sync --quick' | head -1 | cut -d: -f1)
+if [[ -n "$ln_wlsync" && -n "$ln_recon" && "$ln_recon" -gt "$ln_wlsync" ]]; then
+  ok "reconcile (line $ln_recon) follows system whitelist sync (line $ln_wlsync)"
+else
+  bad "ordering wrong: whitelist sync=$ln_wlsync reconcile=$ln_recon"
+fi
+
+echo "=== T3: parity — firewall_reload also reconciles via 'sync --quick' ==="
+printf '%s\n' "$RELOAD" | grep -qE 'sync --quick' \
+  && ok "reload invokes core 'sync --quick' (parity established)" \
+  || bad "reload missing 'sync --quick' (parity broken — investigate)"
+
+echo "=== T4: reconcile is guarded by core-binary existence (no hard failure if absent) ==="
+printf '%s\n' "$REBUILD" | grep -qE '\[\[ -x .*nftban-core.* \]\]|if \[\[ -x' \
+  && ok "rebuild reconcile guarded by -x core check" \
+  || bad "rebuild reconcile not guarded (could hard-fail when core binary absent)"
+
+echo "=== T5: --quick keeps it whitelist/blacklist-only (no feeds/geoban pulled into rebuild reconcile) ==="
+# the reconcile call itself must carry --quick (not a bare 'sync' that would do feeds/geoban)
+printf '%s\n' "$REBUILD" | grep -E 'nftban-core.*sync|_rb_reconcile.*sync|"\$.*" sync' | grep -qE 'sync --quick' \
+  && ok "rebuild reconcile uses --quick (whitelist/blacklist only)" \
+  || bad "rebuild reconcile not --quick"
+
+echo ""
+echo "=== whitelist rebuild re-merge v1.193.0: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## v1.193.0 — post-v1.192 firewall/ops hygiene (PR-A + PR-B)

Small, single-domain shell-only release. **Schema unchanged (1.84.0); Go source byte-identical to v1.192.2** (packaged binary hashes move only via the embedded git-commit stamp). No BotGuard, no counters/schema, no CSF, no installer parity. PR-C (monitor MEDs) was closed read-only with evidence — no code.

### PR-A — `BUG-REBUILD-DROPS-MANUAL-WHITELIST` (cmd_firewall.sh)
An explicit `nftban firewall rebuild` dropped manual `/etc/nftban/whitelist.d/*.conf` entries (operator `--static` admin IPs) from the live whitelist set; reload/restart/reboot/maintenance preserved them. Fix: rebuild now reconciles durable manual `whitelist.d`/`blacklist.d` via the same core `sync --quick` path `firewall_reload` uses (Step 6b), so rebuild and reload converge. System/trust whitelist + blacklist/feed/geoban unchanged.

### PR-B — table-absent maintenance-log noise (cron/maintenance.sh)
~60/day `WARN "nftban firewall table absent"` were a sampling artifact when the maintenance run sampled the table mid firewall transition. Fix: `_maint_table_absent_confirmed` re-probes the live table over a short bounded grace before the WARN — transient (reappears) → quiet INFO, **genuine persistent absence → WARN kept**. The FW-transition harm counter `table_absent_while_committed_count` is untouched and remains authoritative. No firewall load/rebuild/install_state change.

### Validation
- Hermetic: `whitelist_rebuild_remerge_v1930_test.sh` 5/5, `maint_table_absent_noise_v1930_test.sh` 6/6 (both discriminate the pre-fix behavior); shellcheck -S warning clean; existing firewall/render/atomicity/botscan green.
- Lab-first lab2 (DEB) + lab4 (RPM): PR-A manual whitelist survives `rebuild`; PR-B transient suppressed / genuine kept (helper vs real nft); FW Transition 🟢 + harm counters 0; restored clean.
- **DEB/RPM package-native validation PASS** (`V193_PR_AB_PACKAGE_NATIVE_PASS_READY_FOR_PR`): packages ship both shell files + tests, RPM≡DEB parity.

### Notes
VERSION bump to 1.193.0 is the separate release-prep gate. Not bundled: v1.192.1 fleet rollout, BotGuard re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)