### PR TITLE
test(v1.195.0): validate wp-login LoginMon claim in protection matrix

### DIFF
--- a/cli/lib/nftban/tests/protection_claim_matrix_v194.tsv
+++ b/cli/lib/nftban/tests/protection_claim_matrix_v194.tsv
@@ -16,7 +16,7 @@
 SSH-SU-SUDO-AUTHFAIL|auth_failure|auth-log+journal-sshd-su-sudo|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|health-visible|lab-validated-prior|ban|validated
 MAIL-AUTHFAIL|auth_failure|exim-dovecot-postfix-logs+journal|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|health-visible|lab-validated-prior|ban|validated
 FTP-AUTHFAIL|auth_failure|vsftpd-proftpd-files+pureftpd-journal|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|health-visible|lab-validated-v1180|ban|validated
-WPLOGIN-AUTHFAIL|auth_failure|web-access-logs|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|WARN_NO_LOGS|read-only-fleet-G3|ban|unproven
+WPLOGIN-AUTHFAIL|auth_failure|web-access-logs|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|WARN_NO_LOGS|internal/loginmon/detector/webauth_test.go|ban|validated
 HTTP-BASICAUTH-401-403|auth_failure|web-access-logs|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|WARN_NO_LOGS|read-only-fleet|ban|unproven
 ROUNDCUBE-AUTHFAIL-DA|auth_failure|var-log-roundcube-userlogins|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|health-visible|lab-validated-v1186-DA-only|ban|validated
 DIRECTADMIN-AUTHFAIL|auth_failure|DA-login-log|LoginMon|root-daemon-CAP_DAC_OVERRIDE|IPC-blacklist|enforce|health-visible|read-only-fleet|ban|unproven


### PR DESCRIPTION
## v1.195.0 (8D) — validate the wp-login LoginMon claim in the Protection-Claim Matrix

This is **v1.195.0, 8D only** — a **data-only** matrix update (no product code). A read-only fleet proof validated `WPLOGIN-AUTHFAIL` **live** on **srv1 / srv2 / srv3 / srv4**: failed `POST /wp-login.php` (HTTP 200) credential attempts are banned by the **Go LoginMon WebAuth detector** (reason `wordpress_wp_login`, temp 900s, IPv4 + IPv6), so the claim is flipped from `unproven` to `validated` rather than writing any LoginMon fix.

### Matrix row change (single line)
- `classification`: **unproven → validated**
- `fixture`: **read-only-fleet-G3 → `internal/loginmon/detector/webauth_test.go`**
- owner (LoginMon), event class (auth_failure), ban authority (IPC-blacklist) unchanged.

### The existing WebAuth Go test already covers
- `POST /wp-login.php` + `200` → `ReasonWordPressWPLogin` (IPv4 **and** IPv6)
- `302` success → no verdict
- `xmlrpc` / `GET` → not owned (web_abuse stays BotScan→BotGuard)

(That test is unchanged by this PR and runs in `ci-go`.)

### Discipline
- **No product behavior change** — no LoginMon/detector/parser/daemon/CLI code touched.
- **No schema change** (1.84.0). **VERSION stays 1.194.0** (release-prep is separate).
- No BotScan context-gate change · no BotGuard work · no 8E (cPanel/Plesk) · no 8G (dead-knob deletion) · no counters/CSF/installer.
- **Track A fleet rollout remains deferred** until after v1.195.0 publishes (one direct hop v1.192.2 → v1.195.0).

Repo diff = one line in `cli/lib/nftban/tests/protection_claim_matrix_v194.tsv`.
