### PR TITLE
docs(v1.196.0): refresh stale version and architecture references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ emulate, search, list, fhs, botguard, tunnel, sync
 
 ### Current Version
 ```
-v1.56.0 (check /VERSION file for updates)
+v1.195.0 (check /VERSION file for updates)
 ```
 
 ### NOT Supported (Common Hallucinations)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,11 +28,11 @@ NFTBan is an open-source Linux Intrusion Prevention System (IPS) and firewall ma
 
 | Version | Support Status |
 |---------|----------------|
-| 1.190.x | **Current** - Full support (security fixes, bug fixes, features) |
-| 1.189.x | Security fixes only |
-| < 1.189 | **Not supported** - upgrade immediately |
+| 1.195.x | **Current** - Full support (security fixes, bug fixes, features) |
+| 1.194.x | Security fixes only |
+| < 1.194 | **Not supported** - upgrade immediately |
 
-**Recommendation:** Always run the latest stable release (currently v1.190.1) for optimal security and performance.
+**Recommendation:** Always run the latest stable release (currently v1.195.0) for optimal security and performance.
 
 ### Supported Platforms by Tier
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,8 +118,8 @@ Key Principle: Single Writer Architecture
        |                          |------------------------>|                    |
        |                          |                         |                    |
        |                          |                         |  nft add element   |
-       |                          |                         |  inet nftban       |
-       |                          |                         |  blacklist_v4      |
+       |                          |                         |  ip nftban         |
+       |                          |                         |  blacklist_ipv4    |
        |                          |                         |  { 1.2.3.4 }       |
        |                          |                         |------------------->|
        |                          |                         |                    |

--- a/docs/systemd/TIMERS.md
+++ b/docs/systemd/TIMERS.md
@@ -99,9 +99,9 @@ The timer's `WantedBy=timers.target` line is intentionally commented out. Auto-e
 
 ### DEPRECATED Services
 
-| Service | Replaced By | Removal Target |
-|---------|-------------|----------------|
-| `nftban-login-monitor.service` | `nftband` loginmon module (`internal/loginmon`) | v1.23.0 |
+| Service | Replaced By | Status |
+|---------|-------------|--------|
+| ~~`nftban-login-monitor.service`~~ | `nftband` loginmon module (`internal/loginmon`) | Removed — legacy shell service, auto-disabled by package postinst since v1.21.3 |
 
 The shell-based login monitor is superseded by the Go daemon's built-in
 loginmon module. Running both simultaneously causes duplicate ban attempts


### PR DESCRIPTION
## v1.196.0 PR-B — refresh stale version & architecture references (docs-only)

**v1.196.0 PR-B only. Scope = docs/text-only.** No product behavior change.

### Edits
- **SECURITY.md** — supported-versions text refreshed: `1.190.x`/`1.189.x`/`<1.189` → `1.195.x`/`1.194.x`/`<1.194`; "currently v1.190.1" → "currently v1.195.0".
- **docs/ARCHITECTURE.md** — IPC ban-flow diagram fixed to current split-family nftables naming: `inet nftban` → `ip nftban`, `blacklist_v4` → `blacklist_ipv4`.
- **docs/systemd/TIMERS.md** — retired stale timer removal-target wording: `Removal Target | v1.23.0` → `Status | Removed — legacy shell service, auto-disabled by postinst since v1.21.3`.
- **.claude/CLAUDE.md** — Current Version stamp `v1.56.0` → `v1.195.0`.

### Deliberately deferred
- **`cli/etc/nftban/conf.d/recovery.conf`** (fail2ban-comment fix) — **deferred and unchanged**: the file lacks the required `meta:inventory` header block, so changing it requires inventory-header handling beyond docs-only scope. Separate lane.

### Discipline
- No schema change (1.84.0). VERSION stays 1.195.0.
- No runtime, shell-code, Go-code, nftables-template, installer, packaging, workflow, or config key/value change.
- **PR-F (IPv4/IPv6 parity guard) remains a separate test/CI-only lane.** Fleet rollout remains deferred to the final train release (v1.197.0, waved).

Diff = 4 docs/text files.
