### PR TITLE
test(v1.196.0): add IPv4 IPv6 parity guard

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Check protection-claim matrix (8C)
         run: ./scripts/ci/check-protection-claim-matrix.sh
 
+      # v1.196 (PR-F): IPv4/IPv6 parity. Fails if a family-keyed nft set/check
+      # exists for one family without the other (both ip+ip6 nftban tables; every
+      # *_ipv4 has *_ipv6 and the canonical set inventories of the two tables match),
+      # or if a family-sensitive matrix fixture silently covers only one family
+      # (without a PARITY-GUARD-EXEMPT marker).
+      - name: Check IPv4/IPv6 parity (PR-F)
+        run: ./scripts/ci/check-ipv4-ipv6-parity.sh
+
       - name: Check netlink import policy
         run: |
           echo "=== Checking netlink import architecture policy ==="

--- a/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
+++ b/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
@@ -20,6 +20,10 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
+# PARITY-GUARD-EXEMPT: ipv4-only test coverage. The FCrDNS resolver/cache is
+# family-aware at runtime (keyed src_ip+family; bans route to blacklist_ipv4 /
+# blacklist_ipv6, both of which exist). Dual-family TEST coverage (an IPv6
+# crawler/spoofer case) is recorded debt for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
 CORE="$NFTBAN_LIB_DIR/core/nftban_botscan.sh"

--- a/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
@@ -20,6 +20,10 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
+# PARITY-GUARD-EXEMPT: ipv4-only test coverage. BotScan URL-pattern matching is
+# family-agnostic at runtime (keys on the source IP from the access log regardless
+# of family; bans route to blacklist_ipv4 / blacklist_ipv6, both of which exist).
+# Dual-family TEST coverage is recorded debt for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
+++ b/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
@@ -19,6 +19,10 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
+# PARITY-GUARD-EXEMPT: ipv4-only test coverage. The WP-admin authenticated-context
+# gate is family-agnostic at runtime (per-source-IP, regardless of family).
+# Dual-family TEST coverage (an authenticated IPv6 editor case) is recorded debt
+# for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
+++ b/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
@@ -27,6 +27,10 @@
 # =============================================================================
 
 set -Eeuo pipefail
+# PARITY-GUARD-EXEMPT: ipv4-only test coverage. Port-scan detection is kernel-inline
+# nft and present in BOTH table ip nftban and table ip6 nftban; this test corroborates
+# the family-neutral classifier logic. Dual-family TEST coverage is recorded debt for
+# v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 IFS=$'\n\t'
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/scripts/ci/check-ipv4-ipv6-parity.sh
+++ b/scripts/ci/check-ipv4-ipv6-parity.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.196.0 - CI Gate: IPv4 / IPv6 parity (PR-F)
+# =============================================================================
+# meta:name="check-ipv4-ipv6-parity"
+# meta:type="script"
+# meta:version="1.196.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Static guard: every nft set/check that exists for one IP family must exist for the other. Asserts both ip+ip6 nftban tables present, that the canonical set inventory of table ip nftban equals table ip6 nftban (handling _ipv4/_ipv6 + http_bot_X/X6 + unsuffixed service-port conventions), and that family-sensitive matrix fixtures assert both families (or carry an explicit PARITY-GUARD-EXEMPT marker). Read-only, static. Exit 0 = parity holds, 1 = mismatch."
+# meta:inventory.files="install/nftables/nftables.conf,cli/lib/nftban/tests/protection_claim_matrix_v194.tsv"
+# meta:inventory.binaries="bash,awk,grep,sort,comm"
+# meta:inventory.env_vars="PARITY_NFT_CONF,PARITY_MATRIX"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NFTCONF="${PARITY_NFT_CONF:-$REPO_ROOT/install/nftables/nftables.conf}"
+MATRIX="${PARITY_MATRIX:-$REPO_ROOT/cli/lib/nftban/tests/protection_claim_matrix_v194.tsv}"
+FAIL=0
+echo "========================================"
+echo "NFTBan IPv4/IPv6 parity guard (PR-F)"
+echo "========================================"
+[[ -f "$NFTCONF" ]] || { echo "::error::nftables.conf not found: $NFTCONF"; exit 1; }
+
+# --- R1: both family tables present -----------------------------------------
+for fam in ip ip6; do
+    if grep -qE "^table $fam nftban \{" "$NFTCONF"; then
+        echo "  [OK] table $fam nftban present"
+    else
+        echo "::error::missing table: $fam nftban"; FAIL=1
+    fi
+done
+
+# Extract set names from a populated table block. The block opener is the
+# 'table <fam> nftban {' line with nothing after the brace (the empty stubs
+# 'table ip nftban { }' are skipped); the block closes at a column-0 '}'.
+extract_sets() {
+    awk -v want="$1" '
+        $0 ~ ("^table " want " nftban \\{[[:space:]]*$") { intbl=1; next }
+        intbl && /^\}/ { intbl=0 }
+        intbl && /^[[:space:]]*set [a-z0-9_]+ \{/ {
+            line=$0; sub(/^[[:space:]]*set /, "", line); sub(/ \{.*/, "", line); print line
+        }
+    ' "$NFTCONF" | sort -u
+}
+
+# Canonicalize a set name to a family-neutral base, covering all 3 conventions:
+#   *_ipv4 / *_ipv6  -> strip suffix          (blacklist_ipv4 -> blacklist)
+#   http_bot_X / X6  -> strip trailing 6      (http_bot_ban6  -> http_bot_ban)
+#   unsuffixed       -> unchanged             (tcp_ports_in   -> tcp_ports_in)
+canon() {
+    local s b
+    while read -r s; do
+        [[ -z "$s" ]] && continue
+        b="${s%_ipv4}"; b="${b%_ipv6}"
+        case "$b" in http_bot_*) b="${b%6}";; esac
+        printf '%s\n' "$b"
+    done | sort -u
+}
+
+# --- R2a: explicit *_ipv4 <-> *_ipv6 suffix parity --------------------------
+v4suf=$(grep -oE 'set [a-z0-9_]+_ipv4' "$NFTCONF" | sed 's/set //; s/_ipv4$//' | sort -u)
+v6suf=$(grep -oE 'set [a-z0-9_]+_ipv6' "$NFTCONF" | sed 's/set //; s/_ipv6$//' | sort -u)
+if [[ "$v4suf" == "$v6suf" ]]; then
+    echo "  [OK] *_ipv4 <-> *_ipv6 suffix sets balanced ($(echo "$v4suf" | grep -c . ) pairs)"
+else
+    echo "::error::_ipv4/_ipv6 suffix mismatch:"; comm -3 <(echo "$v4suf") <(echo "$v6suf") | sed 's/^/      /'; FAIL=1
+fi
+
+# --- R2b: full table set inventory parity (canonical) -----------------------
+v4canon=$(extract_sets ip  | canon)
+v6canon=$(extract_sets ip6 | canon)
+if [[ "$v4canon" == "$v6canon" ]]; then
+    echo "  [OK] table ip nftban and ip6 nftban have matching canonical set inventories ($(echo "$v4canon" | grep -c .) sets each)"
+else
+    echo "::error::ip/ip6 table set inventory mismatch (canonical):"
+    echo "    only in ip (no ip6 counterpart):";  comm -23 <(echo "$v4canon") <(echo "$v6canon") | sed 's/^/      /'
+    echo "    only in ip6 (no ip counterpart):";  comm -13 <(echo "$v4canon") <(echo "$v6canon") | sed 's/^/      /'
+    FAIL=1
+fi
+
+# --- R3: matrix fixtures must cover BOTH families (or be explicitly exempt) ---
+# A fixture that asserts an IPv4 literal must also assert an IPv6 literal, unless
+# it carries a '# PARITY-GUARD-EXEMPT: ...' marker documenting it is family-agnostic
+# at runtime but single-family in test coverage (recorded debt, never silent).
+if [[ -f "$MATRIX" ]]; then
+    mapfile -t FIX < <(grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$MATRIX" | awk -F'|' '$9 ~ /_test\.(sh|go)$/ {print $9}' | sort -u)
+    fix_ok=0; fix_exempt=0
+    for fx in "${FIX[@]}"; do
+        if [[ "$fx" == *_test.sh ]]; then fp="$REPO_ROOT/cli/lib/nftban/tests/$fx"; else fp="$REPO_ROOT/$fx"; fi
+        [[ -f "$fp" ]] || continue
+        if grep -qE '#[[:space:]]*PARITY-GUARD-EXEMPT' "$fp"; then fix_exempt=$((fix_exempt+1)); continue; fi
+        v4=$(grep -cE '\b[0-9]{1,3}(\.[0-9]{1,3}){3}\b' "$fp" || true)
+        # IPv6 literal: '::' compressed form OR 4+ hex:hex groups (avoids HH:MM:SS timestamps).
+        v6=$(grep -cE '::[0-9a-fA-F]|[0-9a-fA-F]:[0-9a-fA-F]*::|([0-9a-fA-F]{1,4}:){4,}' "$fp" || true)
+        if [[ "$v4" -gt 0 && "$v6" -eq 0 ]]; then
+            echo "::error::fixture $fx asserts IPv4 but has no IPv6 case and no '# PARITY-GUARD-EXEMPT' marker"; FAIL=1
+        else
+            fix_ok=$((fix_ok+1))
+        fi
+    done
+    echo "  [OK] matrix fixtures family-checked: $fix_ok dual-family, $fix_exempt explicitly exempt"
+fi
+
+echo "========================================"
+if [[ "$FAIL" -eq 0 ]]; then echo "RESULT: PASS — IPv4/IPv6 parity holds"; exit 0; fi
+echo "RESULT: FAIL — IPv4/IPv6 parity violation (see ::error:: above)"; exit 1


### PR DESCRIPTION
## v1.196.0 PR-F — IPv4/IPv6 parity guard (static/test/CI-only)

**v1.196.0 PR-F only. Scope = static / test / CI-only.** No product behavior change.

Adds `scripts/ci/check-ipv4-ipv6-parity.sh` and wires it into `ci-architecture.yml`.

### Guard asserts
- Both `table ip nftban` **and** `table ip6 nftban` are present.
- Every `*_ipv4` set has a matching `*_ipv6` sibling **and vice-versa**.
- The **canonical set inventories** of the two table blocks match (handling the `_ipv4`/`_ipv6`, `http_bot_X`/`http_bot_X6`, and unsuffixed service-port conventions).
- Family-sensitive matrix fixtures **either cover both families or carry an explicit `# PARITY-GUARD-EXEMPT` marker** (never silently single-family).

### Negative controls discriminate
- renamed `_ipv6` set → fail; missing `http_bot_ban6` → fail; missing exemption marker → fail; restored tree → pass.

### Findings
- **No runtime parity gap.** The nft data model is already fully dual-family.
- **Four IPv4-only fixture gaps** (fcrdns, pattern-ban-ifs, wpadmin-context-gate, portscan) are **TEST-coverage only** — the runtime is family-agnostic (detectors key on the source IP regardless of family; bans route to `blacklist_ipv4`/`_ipv6`, both present; portscan is kernel-inline in both tables). Recorded as **explicit exemptions, not hidden**; dual-family TEST coverage is a v1.197 follow-up cited in each marker. **Any future runtime parity gap must be escalated to v1.197 / a separate gate — not fixed in this lane.**

### Discipline
- No schema change (1.84.0). VERSION stays 1.195.0. **Matrix TSV unchanged.**
- No runtime, daemon, detector, nftables-template, installer, packaging, matrix-data, release-prep, closure, or register change. Fixture edits are comment-only.

Diff = guard + 1 workflow step + 4 test-fixture comment markers (6 files).
