### PR TITLE
cleanup(v1.197.0): remove obsolete GOTH GUI group orphan

### DIFF
--- a/install/config/allowed-gui-groups
+++ b/install/config/allowed-gui-groups
@@ -1,2 +1,0 @@
-nftban
-nftban-auditor


### PR DESCRIPTION
## v1.197.0 — remove obsolete GOTH GUI group orphan (orphan-only)

**Orphan-only GOTH/nftban-ui cleanup.** Deletes the one verified tracked orphan left from the GOTH GUI/nftban-ui retirement.

### Change
- **Deleted `install/config/allowed-gui-groups`** (groups `nftban`/`nftban-auditor`) — 1 file, −2 lines.

### Why it's safe
- **Zero consumers found** — no reference anywhere in shell CLI, installer, packaging, polkit, PAM, Go, tests, FHS spec, or manifests (post-deletion grep = 0 files).
- **Not packaged** — no `%files`/install line, no `install/config/*` glob sweeps it. **Not a registered conffile** → no upgrade-removal risk.
- The nftban-ui source/units/`cmd_gui.sh` were already removed by prior GOTH stages; the untracked gitignored `bin/nftban-ui*` ELF leftovers were cleaned locally (not in repo).

### Deliberately retained (operator-confirmed, orphan-only)
- **`ENABLE_GUI=0`** emission in `cmd_wizard.sh` — external `/etc` backward-compat (untouched).
- **GOTH deprecation-cleanup machinery** — prerm/preinst/preun/`.inc`/uninstall purge (untouched).
- **migration-coverage CI gate** + **`cli_no_gui_doc_drift_v144` guard** (untouched; both pass).

### Discipline
- No product behavior change. No schema change (1.84.0). VERSION stays 1.196.0.
- No runtime / daemon-Go / nftables-template / installer / package / release / register / host / fleet change. No `nftban-ui` payload reintroduced.
