### PR TITLE
feat(v1.197.0): expand support diagnostics coverage

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -205,6 +205,33 @@ _collect_system() {
         fi
     } > "$sys_dir/virtualization.txt"
     _support_log OK "Virtualization detection"
+
+    # Journald disk usage (capacity-pressure diagnosis)
+    if command -v journalctl &>/dev/null; then
+        journalctl --disk-usage > "$sys_dir/journald-disk-usage.txt" 2>&1 || true
+        _support_log OK "Journald disk usage"
+    fi
+
+    # OOM-kill evidence (kernel ring buffer + journal; read-only, bounded to last 50 matches)
+    {
+        echo "# OOM-kill / out-of-memory evidence"
+        echo "# Collected: $(date -Iseconds)"
+        echo ""
+        echo "=== journalctl -k (oom matches, last 50) ==="
+        if command -v journalctl &>/dev/null; then
+            journalctl -k --no-pager 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process|oom_reaper' | tail -50 || echo "(none)"
+        else
+            echo "(journalctl not available)"
+        fi
+        echo ""
+        echo "=== dmesg (oom matches, last 50) ==="
+        if command -v dmesg &>/dev/null; then
+            dmesg 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process|oom_reaper' | tail -50 || echo "(none or insufficient privilege)"
+        else
+            echo "(dmesg not available)"
+        fi
+    } > "$sys_dir/oom-evidence.txt"
+    _support_log OK "OOM-kill evidence"
 }
 
 _collect_nftables() {
@@ -377,16 +404,39 @@ _collect_services() {
         return 0
     fi
 
-    # NFTBan-related services
-    for svc in nftban nftban-webapi nftban-feeds nftban-sync nftables; do
-        if systemctl list-unit-files "${svc}.service" &>/dev/null; then
-            systemctl status "$svc" --no-pager > "$svc_dir/${svc}.txt" 2>&1 || true
-        fi
+    # All NFTBan/nftband units (dynamic — services, sockets, timers; not a fixed list).
+    # Covers nftband.service/.socket, nftban-soak, nftban-botscan, etc.
+    local units
+    units=$(systemctl list-unit-files 'nftban*' 'nftband*' 'nftables.service' --no-legend 2>/dev/null \
+            | awk '{print $1}' | grep -E '\.(service|socket|timer)$' | sort -u)
+    local nunits=0
+    for unit in $units; do
+        systemctl status "$unit" --no-pager > "$svc_dir/${unit}.txt" 2>&1 || true
+        nunits=$((nunits + 1))
     done
-    _support_log OK "Systemd service status"
+    _support_log OK "Systemd unit status ($nunits nftban/nftband units)"
+
+    # Failed units (whole-system) — DEGRADED diagnosis
+    systemctl --failed --all --no-pager > "$svc_dir/failed-units.txt" 2>&1 || true
+    _support_log OK "Failed units"
+
+    # Per-unit Result / restart / OOM properties (actionable failure signal)
+    {
+        echo "# Per-unit properties (Result / ExecMainStatus / NRestarts / OOM)"
+        echo "# Collected: $(date -Iseconds)"
+        for unit in $units; do
+            echo ""
+            echo "=== $unit ==="
+            systemctl show "$unit" \
+                -p ActiveState -p SubState -p Result -p ExecMainStatus -p ExecMainCode \
+                -p NRestarts -p OOMPolicy -p MemoryCurrent -p MemoryMax -p ActiveEnterTimestamp \
+                2>/dev/null || echo "(show failed)"
+        done
+    } > "$svc_dir/unit-properties.txt"
+    _support_log OK "Unit Result/OOM properties"
 
     # Timer status
-    systemctl list-timers 'nftban*' --no-pager > "$svc_dir/timers.txt" 2>&1 || true
+    systemctl list-timers 'nftban*' 'nftband*' --all --no-pager > "$svc_dir/timers.txt" 2>&1 || true
 }
 
 _collect_install_info() {
@@ -434,6 +484,22 @@ _collect_install_info() {
 
     } > "$install_dir/install-type.txt"
     _support_log OK "Install type detection"
+
+    # Machine-written install/upgrade state (INSTALL_STATE / INSTALL_VERSION /
+    # PHASE_REACHED / FAILURE_REASON / REBUILD_EXIT_CODE) — DEGRADED/upgrade diagnosis.
+    local state_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/install_state"
+    if [[ -f "$state_file" ]]; then
+        {
+            echo "# install_state (machine-written; do not edit)"
+            echo "# Source: $state_file"
+            echo "# Collected: $(date -Iseconds)"
+            echo ""
+            cat "$state_file"
+        } > "$install_dir/install_state.txt" 2>&1
+        _support_log OK "install_state"
+    else
+        _support_log SKIP "install_state (not present: $state_file)"
+    fi
 }
 
 _collect_binaries() {


### PR DESCRIPTION
## v1.197.0 PR-B — expand support diagnostics coverage (shell-only, read-only)

Enhances the `nftban support` bundle by extending **existing read-only collectors only** — no new orchestration, no behavior change.

### Changes (all read-only collection)
- **`_collect_services`** — replace the fixed 5-unit list with **dynamic enumeration** of every `nftban*` / `nftband*` service, socket, and timer (now captures `nftband.service`, `nftband.socket`, `nftban-soak`, `nftban-botscan`, and other nftban-family units). Add `systemctl --failed --all` → `failed-units.txt`. Add per-unit `Result` / `ExecMainStatus` / `NRestarts` / `OOMPolicy` / `Memory*` → `unit-properties.txt`.
- **`_collect_install_info`** — include `install_state` from `${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/install_state` (INSTALL_STATE / INSTALL_VERSION / PHASE_REACHED / FAILURE_REASON / REBUILD_EXIT_CODE).
- **`_collect_system`** — include `journalctl --disk-usage`; include **bounded** OOM-kill evidence from `journalctl -k` + `dmesg` (last 50 matches).

### Discipline
- **Read-only diagnostics only** — collectors are `systemctl status/show/--failed/list-*`, `journalctl`, `dmesg`, `cat`; output goes only into the support bundle dir. No state-changing `systemctl`, no `nft` mutation, no remediation command, no new dependency.
- No daemon-Go · no runtime/service/unit behavior change · no nftables-template · no installer/packaging · no schema · no VERSION change. **Daemon byte-identical.**

### Validation
- `bash -n` + `shellcheck -x -S warning` clean. Hermetic collector run produced all new files (`install_state.txt` captured `INSTALL_STATE=COMMITTED`, plus `failed-units.txt` / `unit-properties.txt` / `journald-disk-usage.txt` / `oom-evidence.txt`).

Diff = `cli/lib/nftban/cli/cmd_support.sh` only (+73/−7). VERSION 1.196.0; schema 1.84.0.
