### PR TITLE
test(v1.197.0): add dual-family coverage for parity guard exemptions

### DIFF
--- a/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
+++ b/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
@@ -20,10 +20,6 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
-# PARITY-GUARD-EXEMPT: ipv4-only test coverage. The FCrDNS resolver/cache is
-# family-aware at runtime (keyed src_ip+family; bans route to blacklist_ipv4 /
-# blacklist_ipv6, both of which exist). Dual-family TEST coverage (an IPv6
-# crawler/spoofer case) is recorded debt for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
 CORE="$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
@@ -42,6 +38,10 @@ case "$*" in
   *"-t PTR 66.249.66.9"*) echo "9.66.249.66.in-addr.arpa domain name pointer crawler-x.googlebot.com." ;;
   *"crawler-x.googlebot.com"*) echo "crawler-x.googlebot.com has address 8.8.8.8" ;;                # forward mismatch
   *"-t PTR 5.5.5.5"*) sleep 5 ;;                                                                     # timeout
+  # IPv6 parity: real Googlebot v6 (ip6.arpa PTR -> googlebot suffix, AAAA forward-confirms)
+  *"-t PTR 2001:4860:4801:1::1"*) echo "1.0.0.0.1.0.0.0.1.0.8.4.0.6.8.4.1.0.0.2.ip6.arpa domain name pointer crawler-ipv6.googlebot.com." ;;
+  *"crawler-ipv6.googlebot.com"*) echo "crawler-ipv6.googlebot.com has IPv6 address 2001:4860:4801:1::1" ;;
+  *"-t PTR 2001:db8::bad"*) echo "d.a.b.0.ip6.arpa domain name pointer evil6.example.com." ;;          # IPv6 bad suffix
   *) exit 1 ;;                                                                                       # NXDOMAIN
 esac
 HOST
@@ -66,7 +66,10 @@ nftban_botscan_verify_crawler 1.2.3.4 googlebot     && fail "V2: suffix-mismatch
 nftban_botscan_verify_crawler 66.249.66.9 googlebot && fail "V3: forward-mismatch must fail closed"
 nftban_botscan_verify_crawler 5.5.5.5 googlebot     && fail "V4: timeout must fail closed"
 nftban_botscan_verify_crawler 9.9.9.9 googlebot     && fail "V5: NXDOMAIN must fail closed"
-echo "PASS V: verify OK for real crawler; fail-closed on suffix/forward/timeout/NXDOMAIN"
+# IPv4/IPv6 parity: same FCrDNS logic for an IPv6 crawler (ip6.arpa reverse + AAAA forward-confirm)
+nftban_botscan_verify_crawler 2001:4860:4801:1::1 googlebot || fail "V6: real IPv6 Googlebot must verify OK (ip6.arpa PTR + AAAA forward-confirm)"
+nftban_botscan_verify_crawler 2001:db8::bad googlebot       && fail "V7: IPv6 suffix-mismatch spoofer must fail closed"
+echo "PASS V: verify OK for real IPv4 + IPv6 crawler; fail-closed on suffix/forward/timeout/NXDOMAIN (both families)"
 
 # ---- cache: 2nd lookup must NOT call the resolver (count host invocations) ----
 calls_before=$(wc -c < "$HOSTCALLS")

--- a/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
@@ -20,10 +20,6 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
-# PARITY-GUARD-EXEMPT: ipv4-only test coverage. BotScan URL-pattern matching is
-# family-agnostic at runtime (keys on the source IP from the access log regardless
-# of family; bans route to blacklist_ipv4 / blacklist_ipv6, both of which exist).
-# Dual-family TEST coverage is recorded debt for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -49,6 +45,11 @@ mkdir -p "$NFTBAN_DATA_DIR/botguard" "$BOTSCAN_SPOOL_DIR" "$BOTSCAN_PATTERNS_DIR
 {
   printf '198.51.100.10 - - [14/Jun/2026:10:00:00 +0000] "GET /a HTTP/1.1" 200 9 "-" "BadCrawler/1.0"\n'
   printf '198.51.100.11 - - [14/Jun/2026:10:00:00 +0000] "GET /wp-login HTTP/1.1" 404 9 "-" "Mozilla/5.0"\n'
+  # IPv4/IPv6 parity: the same UA + url-404 patterns from IPv6 source addresses
+  # (Apache/nginx log an IPv6 client as the first field). Proves BotScan's per-line
+  # source-IP extraction + pattern ban are family-neutral.
+  printf '2001:db8::10 - - [14/Jun/2026:10:00:00 +0000] "GET /a HTTP/1.1" 200 9 "-" "BadCrawler/1.0"\n'
+  printf '2001:db8::11 - - [14/Jun/2026:10:00:00 +0000] "GET /wp-login HTTP/1.1" 404 9 "-" "Mozilla/5.0"\n'
 } > "$BOTSCAN_SPOOL_DIR/a.log"
 
 # shellcheck source=/dev/null
@@ -59,5 +60,7 @@ nftban_botscan_process_logs "" 60 >/dev/null 2>&1 || fail "process_logs rc!=0"
 
 banned_has "198.51.100.10" || fail "useragent pattern ban did not fire under runtime IFS (IFS word-split defect)"
 banned_has "198.51.100.11" || fail "url-404 pattern ban did not fire under runtime IFS (IFS word-split defect)"
+banned_has "2001:db8::10" || fail "IPv6 useragent pattern ban did not fire (BotScan source-IP extraction must be family-neutral)"
+banned_has "2001:db8::11" || fail "IPv6 url-404 pattern ban did not fire (BotScan source-IP extraction must be family-neutral)"
 
-echo "PASS: BotScan pattern bans (useragent + url-404) fire under the lib's runtime IFS"
+echo "PASS: BotScan pattern bans (useragent + url-404) fire for IPv4 AND IPv6 under the lib's runtime IFS"

--- a/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
+++ b/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
@@ -19,10 +19,6 @@
 # meta:inventory.privileges=""
 # =============================================================================
 set -Eeuo pipefail
-# PARITY-GUARD-EXEMPT: ipv4-only test coverage. The WP-admin authenticated-context
-# gate is family-agnostic at runtime (per-source-IP, regardless of family).
-# Dual-family TEST coverage (an authenticated IPv6 editor case) is recorded debt
-# for v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -76,6 +72,14 @@ pe 198.51.100.5 "/wp-admin/admin-ajax.php?f=skin.php" GET 200 "Mozilla/5.0 (Mac)
 pe 198.51.100.6 "/wp-admin/admin-ajax.php" POST 200 "Mozilla/5.0 (Mac) Chrome/148"
 # G = empty-UA scanner doing EXP_WPREST x5, no auth -> bans
 for _ in 1 2 3 4 5; do pe 198.51.100.7 "/wp-json/wp/v2/users" GET 200 "-"; done
+# IPv4/IPv6 parity: the per-IP context gate keys on the source IP, so it must behave
+# identically for IPv6 clients.
+# H = IPv6 AUTHENTICATED admin: 302 login + EXP_WPREST x5 + WS_WPADMIN -> suppressed -> no ban
+pe 2001:db8::1 "/wp-login.php?redirect_to=/wp-admin/" POST 302 "Mozilla/5.0 (Mac) Chrome/148"
+for _ in 1 2 3 4 5; do pe 2001:db8::1 "/wp-json/wp/v2/users/?who=authors" GET 200 "Mozilla/5.0 (Mac) Chrome/148"; done
+pe 2001:db8::1 "/wp-admin/admin-ajax.php?f=skin.php" GET 200 "Mozilla/5.0 (Mac) Chrome/148"
+# I = IPv6 UNAUTHENTICATED WS_WPADMIN (threshold 1), no login -> must ban
+pe 2001:db8::2 "/wp-admin/load.php?x=shell.php" GET 404 "Mozilla/5.0 (Mac) Chrome/148"
 analyze
 
 echo "=== gate ENABLED ==="
@@ -86,6 +90,8 @@ banned 198.51.100.4 && ok "D WS_WPADMIN no-auth STILL bans (stable UA never auto
 banned 198.51.100.5 && bad "E authenticated WS_WPADMIN-only BANNED" || ok "E authenticated admin (WS_WPADMIN only) NOT banned"
 banned 198.51.100.6 && bad "F normal admin-ajax BANNED" || ok "F normal admin-ajax (no scanner pattern) NOT banned"
 banned 198.51.100.7 && ok "G empty-UA scanner STILL bans" || bad "G empty-UA scanner not banned"
+banned 2001:db8::1 && bad "H IPv6 authenticated admin BANNED (context gate not family-neutral)" || ok "H IPv6 authenticated admin NOT banned (gate suppresses for IPv6 too)"
+banned 2001:db8::2 && ok "I IPv6 no-auth WS_WPADMIN STILL bans (enforcement family-neutral)" || bad "I IPv6 no-auth scanner not banned"
 
 # ---- discriminator: gate DISABLED -> case A bans (proves the gate is what suppresses) ----
 export BOTSCAN_WPADMIN_CONTEXT_GATE=false

--- a/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
+++ b/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
@@ -27,10 +27,6 @@
 # =============================================================================
 
 set -Eeuo pipefail
-# PARITY-GUARD-EXEMPT: ipv4-only test coverage. Port-scan detection is kernel-inline
-# nft and present in BOTH table ip nftban and table ip6 nftban; this test corroborates
-# the family-neutral classifier logic. Dual-family TEST coverage is recorded debt for
-# v1.197. See scripts/ci/check-ipv4-ipv6-parity.sh.
 IFS=$'\n\t'
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -164,6 +160,15 @@ assert_not_contains "$T8" "BAN_CALLED" "T8.1 generic-observe is never banned (AC
 echo; echo "[T9] handle_detection(generic) bans (corroborated path intact)"
 T9=$(handle 9.9.9.9 "generic")
 assert_contains "$T9" "BAN_CALLED 9.9.9.9" "T9.1 corroborated generic still bans"
+
+# T10: IPv4/IPv6 parity. The classifier + handler are family-neutral (they key on the
+# source-IP string + port/target counts, never parse the address), so an IPv6 source
+# classifies + bans identically to the IPv4 corroborated-generic path (mirrors T2/T9).
+echo; echo "[T10] IPv6 source — corroborated generic classifies + bans (family parity)"
+T10C=$(classify 2001:db8::99 "1 2 3 4 5 6 7 8 9 10 11 12" "2001:db8::1 2001:db8::2" "$TS_SLOW")
+assert_eq "$T10C" "generic" "T10.1 IPv6 corroborated generic classifies (parity with T2)"
+T10H=$(handle 2001:db8::99 "generic")
+assert_contains "$T10H" "BAN_CALLED 2001:db8::99" "T10.2 IPv6 corroborated generic bans (parity with T9)"
 
 echo; echo "================================================="
 echo "Results: PASS=$PASS  FAIL=$FAIL"


### PR DESCRIPTION
## v1.197.0 PR-C — Dual-family IPv4/IPv6 test coverage

**Test-only.** Closes the four v1.196 PR-F `# PARITY-GUARD-EXEMPT` fixtures by giving each one real IPv6 coverage, then removing the exemption markers so the IPv4/IPv6 parity guard counts them as dual-family.

### Scope
- PR-C is **test-only** — no daemon-Go, runtime, nftables-template, schema, VERSION, installer, or package behavior change.
- It **closes the four v1.196 PR-F `# PARITY-GUARD-EXEMPT` fixtures**; all four exemption markers were removed.
- Existing **IPv4 assertions remain intact** (unchanged); only IPv6 cases were added.
- New **IPv6 assertions pass against unchanged runtime**.
- **No runtime family gap was found** — `verify_crawler`, the portscan classifier/handler, the per-line source-IP extraction, and the per-IP WP-admin context gate are already family-neutral.
- The **PR-F parity guard now reports 6 dual-family fixtures and 0 exempt** for this set.
- **8C matrix guard and harness pass.**
- **Daemon remains byte-identical.**

### Per-fixture IPv6 coverage
| Fixture | Added IPv6 coverage |
|---|---|
| `portscan_generic_corroborate_v149_test.sh` | IPv6 corroborated-generic **classifies + bans** (parity with the IPv4 T2/T9 path) |
| `botscan_pattern_ban_ifs_v1861_test.sh` | IPv6 UA + url-404 **pattern bans** fire under the lib's runtime IFS |
| `botscan_wpadmin_context_gate_v1922_test.sh` | IPv6 authenticated-admin **suppressed** (FP); IPv6 no-auth WS_WPADMIN **still bans** |
| `botscan_fcrdns_v189_test.sh` | Real IPv6 Googlebot **verifies** via `ip6.arpa` PTR + `AAAA` forward-confirm; IPv6 suffix-mismatch spoofer **fails closed** |

### Validation
- `bash -n` + `shellcheck -x -S warning` clean on all four fixtures; each runs with IPv4 + IPv6 cases at rc=0.
- PR-F parity guard PASS (6 dual-family, 0 exempt); 8C guard PASS; 8C harness 10/0 (21 rows).
- **Negative control:** each new IPv6 assertion was mutated in place → rc=1 on that specific assertion → restored.

VERSION `1.196.0` · schema `1.84.0` · daemon byte-identical · product behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
