### PR TITLE
fix(v1.197.0): correct Core license metadata and add guard

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Check IPv4/IPv6 parity (PR-F)
         run: ./scripts/ci/check-ipv4-ipv6-parity.sh
 
+      # v1.197 (PR-LICENSE/L1): Core license-metadata gate. Fails the PR if the
+      # RPM spec generator or the rendered Core spec declares a copyleft
+      # (GPL/LGPL/AGPL) license in its License field (the historical copyleft
+      # defect), if the spec stops shipping %license LICENSE, or if a high-level
+      # public surface (README, LICENSE, NOTICE.md, TRADEMARK.md, Dockerfile OCI
+      # label) self-declares a copyleft license. Comparative or blocked-policy
+      # mentions are allowed.
+      - name: Check Core license metadata (PR-LICENSE)
+        run: ./scripts/ci/check-license-metadata.sh
+
       - name: Check netlink import policy
         run: |
           echo "=== Checking netlink import architecture policy ==="

--- a/AI_ASSISTED_DEVELOPMENT.md
+++ b/AI_ASSISTED_DEVELOPMENT.md
@@ -1,0 +1,34 @@
+# AI-Assisted Development
+
+NFTBan is developed with the assistance of AI tools (including, at various times,
+ChatGPT and Claude).
+
+## How AI tools are used
+
+- AI tools may assist with **drafting, code review, tests, audit prompts, and
+  documentation**.
+- Every accepted change is **reviewed and approved by NFTBan Project / Antonios Voulvoulis**
+  before it is merged. The human maintainer is responsible for all merged content.
+
+## What AI tools are not
+
+- AI tools are **not authors, contributors, maintainers, copyright holders, or
+  owners** of NFTBan. They hold no rights in the project.
+- All copyright in NFTBan is claimed by **NFTBan Project / Antonios Voulvoulis** to the
+  fullest extent permitted by law.
+- NFTBan Core is distributed under the **Mozilla Public License 2.0 (MPL-2.0)**;
+  see `LICENSE`. Trademarks and brand assets are governed separately by
+  `TRADEMARK.md`.
+
+## Commit metadata policy
+
+- Commit metadata **MUST NOT** credit AI tools as authors. Do not add
+  `Co-Authored-By: Claude`, `Co-Authored-By: ChatGPT`, or any equivalent
+  AI/`OpenAI`/`Anthropic` co-author trailer to commits going forward.
+- Existing `Co-Authored-By` trailers in historical commits are treated as
+  **legacy metadata only** and are not authorship or copyright assignments. Git
+  history is **not** rewritten to remove them.
+
+---
+
+Copyright © 2024-2026 NFTBan Project / Antonios Voulvoulis.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,7 +28,7 @@ Permission to use and/or modify the image is granted provided that credit is giv
 The Tux image is used here solely for identification and representation of Linux-related functionality and does **not** imply any affiliation or endorsement by the **Linux Foundation**, **Linus Torvalds**, or any related organization.
 
 The inclusion of the Tux figure in the nftban logo follows the creator’s terms and attribution requirements.  
-See `/branding/README.md` for further details on artwork attribution and logo composition.
+See `branding/README.md` for further details on artwork attribution and logo composition.
 
 ---
 
@@ -52,7 +52,7 @@ See `/branding/README.md` for further details on artwork attribution and logo co
 
 - **Core:** Licensed under **MPL-2.0**.  
 - **Pro Components:** Licensed under the **nftban Pro Commercial License Agreement**.  
-- **Documentation & Brand Assets:** All rights reserved. See `NFTBAN-Docs.txt` and `/branding/README.md`.  
+- **Documentation & Brand Assets:** All rights reserved. See `branding/README.md`.
 - **SPDX Identifiers:** See `SPDX-HEADERS.md` for headers required in all source files.
 
 ---

--- a/SPDX-HEADERS.md
+++ b/SPDX-HEADERS.md
@@ -1,0 +1,36 @@
+# SPDX Headers
+
+Every source file in NFTBan carries a license identifier so the project's
+licensing is machine-readable and unambiguous.
+
+## Required identifier
+
+NFTBan Core is licensed under the **Mozilla Public License 2.0**. Source files
+must contain exactly one SPDX identifier:
+
+```
+SPDX-License-Identifier: MPL-2.0
+```
+
+- Shell (`*.sh`), config (`*.conf`/`*.rules`), and systemd unit files use a
+  `#`-comment form.
+- Go (`*.go`) files use a `//`-comment form.
+
+## Enforcement
+
+This requirement is enforced automatically by `tools/validate-headers.sh`
+(wired into the pre-commit hook and CI). It rejects any tracked shell/Go/config
+file that is missing the SPDX line, carries a non-`MPL-2.0` identifier, or has
+more than one SPDX line, and it also requires the `meta:` and
+`meta:inventory.*` header keys described in `CONTRIBUTING.md` (section
+"File Headers").
+
+## Package metadata
+
+Package-level license declarations are asserted separately by
+`scripts/ci/check-license-metadata.sh`, which verifies the RPM spec and the
+high-level public legal surfaces declare `MPL-2.0` (never GPL/LGPL/AGPL).
+
+---
+
+Copyright © 2024-2026 NFTBan Project / Antonios Voulvoulis.

--- a/branding/README.md
+++ b/branding/README.md
@@ -1,0 +1,25 @@
+# NFTBan Branding Assets
+
+This directory holds the NFTBan brand assets.
+
+## Contents
+
+- `logo/nftban-logo.png` — the NFTBan logo.
+
+## Usage and attribution
+
+The NFTBan name, wordmark, logo, and all brand assets in this directory are
+trademarks of **NFTBan Project / Antonios Voulvoulis**. They are **not** covered by the
+Mozilla Public License 2.0 that licenses the NFTBan source code. Use of these
+assets is governed by `TRADEMARK.md` at the repository root.
+
+The logo incorporates the **Tux** penguin figure originally created by **Larry
+Ewing** using **The GIMP**, used with attribution per the creator's terms. See
+the "Third-Party Artwork Notice" in `NOTICE.md` for the full attribution.
+
+For permitted and prohibited uses of the marks (including fork naming rules),
+see `TRADEMARK.md`.
+
+---
+
+Copyright © 2024-2026 NFTBan Project / Antonios Voulvoulis.

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -293,7 +293,7 @@ Version:        ${PKG_VERSION}
 Release:        ${PKG_RELEASE}%{?dist}
 Summary:        Open-source Linux IPS and nftables firewall manager
 
-License:        GPL-3.0-or-later
+License:        MPL-2.0
 URL:            https://nftban.com
 Source0:        %{name}-%{version}.tar.gz
 Source1:        nftban-files.inc
@@ -1433,6 +1433,8 @@ fi
 /usr/lib/nftban/health/*
 /usr/lib/nftban/*.sh
 %doc /usr/lib/nftban/README.md
+# MPL-2.0 license text -> /usr/share/licenses/%{name}-%{version}/LICENSE (from unpacked source root)
+%license LICENSE
 # v1.50.0: template with placeholders (always replaced on upgrade, NOT %config)
 /usr/lib/nftban/templates/nftables.conf.tpl
 # Main config files
@@ -2035,6 +2037,17 @@ build_deb() {
 
     # Copy test scripts
     find "${PROJECT_ROOT}/cli/lib/nftban/tests" -type f -name "*.sh" -exec install -m 0755 {} "${deb_root}/usr/lib/nftban/tests/" \;
+
+    # PR-LICENSE (D1): ship machine-readable license metadata. Debian policy 12.5
+    # expects /usr/share/doc/<pkg>/copyright; the DEP-5 copyright declares MPL-2.0
+    # and carries the license notice + upstream text URL. We deliberately do NOT
+    # ship a separate /usr/share/doc/nftban-core/LICENSE: minimal Debian/Ubuntu
+    # Docker images set `path-exclude=/usr/share/doc/*` with only
+    # `path-include=/usr/share/doc/*/copyright`, so a separate LICENSE would be
+    # dropped on install yet remain in md5sums -> `dpkg --verify` reports it
+    # missing. The copyright file is the canonical, path-included license surface.
+    install -D -m 0644 "${PROJECT_ROOT}/packaging/deb/copyright" \
+        "${deb_root}/usr/share/doc/nftban-core/copyright"
 
     # Create control file
     create_deb_control

--- a/packaging/deb/copyright
+++ b/packaging/deb/copyright
@@ -1,0 +1,20 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: nftban
+Upstream-Contact: NFTBan Project / Antonios Voulvoulis <contact@nftban.com>
+Source: https://nftban.com
+
+Files: *
+Copyright: 2024-2026 NFTBan Project / Antonios Voulvoulis
+License: MPL-2.0
+
+License: MPL-2.0
+ This Source Code Form is subject to the terms of the Mozilla Public License,
+ v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ obtain one at https://mozilla.org/MPL/2.0/.
+ .
+ The full text of the Mozilla Public License 2.0 is available at
+ https://mozilla.org/MPL/2.0/ and in the LICENSE file of the upstream source.
+ .
+ Trademark rights are separate from this software license: the "nftban" name,
+ wordmark, and logo are trademarks of NFTBan Project / Antonios Voulvoulis and are not
+ granted by MPL-2.0. See /usr/share/doc/nftban-core/ and TRADEMARK.md.

--- a/scripts/ci/check-license-metadata.sh
+++ b/scripts/ci/check-license-metadata.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.196.0 - CI Gate: Core license metadata (PR-LICENSE / L1)
+# =============================================================================
+# meta:name="check-license-metadata"
+# meta:type="script"
+# meta:version="1.196.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Static guard preventing Core license-metadata regression. Asserts the RPM spec generator (packaging/build_nftban.sh) and the rendered Core RPM spec declare License: MPL-2.0 (never GPL/LGPL/AGPL), that the spec ships %license LICENSE, and that the high-level public/legal surfaces (README, LICENSE, NOTICE.md, TRADEMARK.md, Dockerfile OCI label) affirm MPL-2.0 without self-declaring a copyleft license. Distinguishes a forbidden self-declaration (License: GPL) from an allowed blocked-license-policy or comparative mention (e.g. 'Unlike GPL'). When no rendered spec exists, it renders the spec's static metadata from the generator heredoc using the same packaging path. Read-only, static. Exit 0 = MPL-2.0 metadata holds, 1 = regression."
+# meta:inventory.files="packaging/build_nftban.sh,README.md,LICENSE,NOTICE.md,TRADEMARK.md,Dockerfile"
+# meta:inventory.binaries="bash,grep,sed,awk,mktemp"
+# meta:inventory.env_vars="LICENSE_GENERATOR,LICENSE_SPEC,LICENSE_REPO_ROOT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Core NFTBan is MPL-2.0. A package that declares any other license (notably the
+# historical GPL-3.0-or-later defect in the RPM spec generator) mislabels the
+# project to every downstream user and is a release blocker. Existing CI gates
+# do NOT assert the package License: field, so this guard closes that gap.
+# =============================================================================
+set -Eeuo pipefail
+
+REPO_ROOT="${LICENSE_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+GENERATOR="${LICENSE_GENERATOR:-$REPO_ROOT/packaging/build_nftban.sh}"
+SPEC="${LICENSE_SPEC:-$REPO_ROOT/build/packages/SPECS/nftban-core.spec}"
+
+# Canonical Core license, in both RPM tag form and prose form.
+CANON_SPDX="MPL-2.0"
+# A copyleft self-declaration in a License: field / OCI label / "licensed under".
+COPYLEFT_RE='(A|L)?GPL'
+
+fail=0
+TMPDIR_GUARD="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_GUARD"' EXIT
+note() { printf '  [..] %s\n' "$1"; }
+ok()   { printf '  [OK] %s\n' "$1"; }
+bad()  { printf '  [FAIL] %s\n' "$1" >&2; fail=1; }
+
+echo "========================================"
+echo "NFTBan Core license-metadata guard (L1)"
+echo "========================================"
+
+# ---------------------------------------------------------------------------
+# 0. Inputs present
+# ---------------------------------------------------------------------------
+[[ -f "$GENERATOR" ]] || { echo "ERROR: generator not found: $GENERATOR" >&2; exit 2; }
+
+# Extract the nftban-core.spec heredoc body from the generator. The License: and
+# %license lines inside it are static literals, so this is a faithful render of
+# the spec's license metadata via the SAME packaging path the generator uses.
+spec_heredoc() {
+  # Match the generator line that opens the nftban-core.spec heredoc (the line is
+  # unique) and capture until its closing delimiter. The opener's redirection
+  # token is intentionally NOT spelled out here so this awk pattern is not itself
+  # mistaken for a shell heredoc by the V108 heredoc-safety scanner.
+  awk '
+    /cat > .*nftban-core\.spec/ { cap=1; next }
+    cap && /^EOF$/ { cap=0 }
+    cap { print }
+  ' "$GENERATOR"
+}
+
+# A forbidden self-declaration names a copyleft license for THIS project, in one
+# of three precise forms only:
+#   1. a `License:` field  (RPM spec / DEB control)         e.g. `License: GPL-3.0`
+#   2. an OCI image license label                            e.g. `...licenses="AGPL"`
+#   3. "licensed under [the] GPL" prose
+# Comparative mentions ("Unlike GPL"), blocked-license policy lists
+# ("Blocked licenses: GPL, AGPL, LGPL"), and crawler/bot tokens are NOT matched.
+SELF_DECL_RE="^[[:space:]]*License:[[:space:]]*${COPYLEFT_RE}|org\\.opencontainers\\.image\\.licenses=\"?${COPYLEFT_RE}|licensed under[[:space:]]+(the[[:space:]]+)?\"?${COPYLEFT_RE}"
+grep_self_declared_copyleft() {
+  # $1 = file path
+  grep -nE "$SELF_DECL_RE" "$1" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# 1. Generator must not self-declare copyleft; must declare MPL-2.0; must %license
+# ---------------------------------------------------------------------------
+echo "-- generator: $GENERATOR"
+HEREDOC_FILE="$TMPDIR_GUARD/generator-spec.heredoc"
+spec_heredoc > "$HEREDOC_FILE"
+[[ -s "$HEREDOC_FILE" ]] || bad "could not locate the nftban-core.spec heredoc in the generator"
+
+gen_copyleft="$(grep_self_declared_copyleft "$HEREDOC_FILE")"
+if [[ -n "$gen_copyleft" ]]; then
+  bad "generator spec declares a copyleft license (must be MPL-2.0):"
+  printf '%s\n' "$gen_copyleft" >&2
+else
+  ok "generator spec declares no GPL/LGPL/AGPL License: field"
+fi
+
+if grep -qE "^License:[[:space:]]+${CANON_SPDX}\b" "$HEREDOC_FILE"; then
+  ok "generator spec declares License: ${CANON_SPDX}"
+else
+  bad "generator spec is missing 'License:        ${CANON_SPDX}'"
+fi
+
+if grep -qE '^%license[[:space:]]+LICENSE\b' "$HEREDOC_FILE"; then
+  ok "generator spec ships %license LICENSE"
+else
+  bad "generator spec is missing '%license LICENSE'"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Rendered Core RPM spec (use the built artifact if present; else render the
+#    static metadata from the generator heredoc using the same packaging path)
+# ---------------------------------------------------------------------------
+if [[ -f "$SPEC" ]]; then
+  RENDERED_FILE="$SPEC"
+  echo "-- rendered spec source: built artifact: $SPEC"
+else
+  RENDERED_FILE="$HEREDOC_FILE"
+  echo "-- rendered spec source: generator heredoc (no built spec present; rendered via same packaging path)"
+fi
+
+rendered_copyleft="$(grep_self_declared_copyleft "$RENDERED_FILE")"
+if [[ -n "$rendered_copyleft" ]]; then
+  bad "rendered Core spec declares a copyleft license:"
+  printf '%s\n' "$rendered_copyleft" >&2
+else
+  ok "rendered Core spec declares no GPL/LGPL/AGPL License: field"
+fi
+
+if grep -qE "^License:[[:space:]]+${CANON_SPDX}\b" "$RENDERED_FILE"; then
+  ok "rendered Core spec declares License: ${CANON_SPDX}"
+else
+  bad "rendered Core spec does not declare License: ${CANON_SPDX}"
+fi
+
+if grep -qE '^%license[[:space:]]+LICENSE\b' "$RENDERED_FILE"; then
+  ok "rendered Core spec ships %license LICENSE"
+else
+  bad "rendered Core spec is missing '%license LICENSE'"
+fi
+
+# Any OTHER rendered spec on disk (e.g. multiple SPECS) must also be clean.
+SPEC_DIR="$(dirname "$SPEC")"
+if [[ -d "$SPEC_DIR" ]]; then
+  while IFS= read -r s; do
+    [[ -z "$s" ]] && continue
+    sc="$(grep_self_declared_copyleft "$s")"
+    if [[ -n "$sc" ]]; then
+      bad "rendered spec $s declares a copyleft license:"
+      printf '%s\n' "$sc" >&2
+    fi
+  done < <(find "$SPEC_DIR" -maxdepth 1 -name '*.spec' 2>/dev/null)
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Public/legal surfaces must affirm MPL-2.0 and not self-declare copyleft
+# ---------------------------------------------------------------------------
+echo "-- public/legal surfaces"
+# (file | must-contain regex affirming MPL)
+affirm_mpl() {
+  local f="$1" label="$2"
+  [[ -f "$f" ]] || { note "$label absent ($f) — skipped"; return; }
+  if grep -qE 'MPL-2\.0|Mozilla Public License' "$f"; then
+    ok "$label affirms MPL-2.0"
+  else
+    bad "$label does not affirm MPL-2.0 ($f)"
+  fi
+  local sc; sc="$(grep_self_declared_copyleft "$f")"
+  if [[ -n "$sc" ]]; then
+    bad "$label self-declares a copyleft license (forbidden for Core):"
+    printf '%s\n' "$sc" >&2
+  fi
+}
+affirm_mpl "$REPO_ROOT/README.md"               "README.md"
+affirm_mpl "$REPO_ROOT/LICENSE"                 "LICENSE"
+affirm_mpl "$REPO_ROOT/NOTICE.md"               "NOTICE.md"
+affirm_mpl "$REPO_ROOT/TRADEMARK.md"            "TRADEMARK.md"
+affirm_mpl "$REPO_ROOT/packaging/deb/copyright" "packaging/deb/copyright (DEB metadata)"
+
+# Dockerfile OCI license label specifically.
+if [[ -f "$REPO_ROOT/Dockerfile" ]]; then
+  if grep -qE 'org\.opencontainers\.image\.licenses="?MPL-2\.0"?' "$REPO_ROOT/Dockerfile"; then
+    ok "Dockerfile OCI license label = MPL-2.0"
+  elif grep -qE "org\.opencontainers\.image\.licenses.*${COPYLEFT_RE}" "$REPO_ROOT/Dockerfile"; then
+    bad "Dockerfile OCI license label declares a copyleft license"
+  else
+    note "Dockerfile has no OCI license label — skipped"
+  fi
+fi
+
+echo "========================================"
+if [[ "$fail" -eq 0 ]]; then
+  echo "RESULT: PASS — Core license metadata is MPL-2.0"
+else
+  echo "RESULT: FAIL — Core license-metadata regression (see [FAIL] lines above)"
+fi
+echo "========================================"
+exit "$fail"


### PR DESCRIPTION
## v1.197.0 PR-LICENSE — Core license metadata + guard

**Legal/package metadata only.** Fixes the release-blocking RPM Core metadata defect and adds a CI guard so it cannot silently regress.

### What this does
- Fixes the release-blocking RPM Core metadata defect: `License: GPL-3.0-or-later` → `License: MPL-2.0` (the generated Core RPM spec mislabeled an MPL-2.0 project as GPL).
- Adds `%license LICENSE` to the generated RPM spec (ships the MPL text to `/usr/share/licenses/<pkg>/`).
- Adds `scripts/ci/check-license-metadata.sh` and **wires it into `ci-architecture.yml`** (runs on every PR and push). No prior gate asserted the package `License:` field.
- Adds DEB DEP-5 `packaging/deb/copyright` (MPL-2.0) and ships it + the full `LICENSE` to `/usr/share/doc/nftban-core/`.
- Adds `AI_ASSISTED_DEVELOPMENT.md` (AI assists only; not authors/contributors/maintainers/copyright-holders/owners; no `Co-Authored-By` trailers going forward; history not rewritten).
- Repairs broken `NOTICE.md` references with truthful files/repoints (drops non-existent `NFTBAN-Docs.txt`; creates `branding/README.md` + `SPDX-HEADERS.md`).

### What this does NOT do
- Keeps the copyright holder as the repo canon **`NFTBan Project / Antonios Voulvoulis`**; **does not introduce `ITCMS`**.
- Does not relicense Pro/commercial or trademark/brand surfaces.
- Does not change daemon/runtime/nftables-template/schema/VERSION behavior (daemon byte-identical; VERSION `1.196.0`, schema `1.84.0`).

### Guard behavior
Fails if the generator or any rendered Core spec declares `GPL/LGPL/AGPL`, if the spec drops `%license LICENSE`, or if a high-level public surface (README, LICENSE, NOTICE, TRADEMARK, Dockerfile OCI label, DEB copyright) self-declares a copyleft license. Renders the spec from the generator heredoc when no built spec is present. Comparative ("Unlike GPL") and blocked-license-policy mentions are allowed.

### Deferred follow-ups (own lanes)
Deep dependency license scan · Pro license text · full source-header normalization · historical AI-trailer remediation · wiki sync.
