### PR TITLE
docs(config): clean recovery.conf comments and inventory header

### DIFF
--- a/cli/etc/nftban/conf.d/recovery.conf
+++ b/cli/etc/nftban/conf.d/recovery.conf
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2024–2026 NFTBAN Project / Antonios Voulvoulis
 #
+# meta:name="recovery.conf"
+# meta:type="config"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Emergency recovery and commit-confirm rollback configuration that prevents permanent SSH lockout after reboot or rule changes"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files="/etc/nftban/conf.d/recovery.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+#
 # This configuration file controls the emergency recovery and rollback system
 # that prevents permanent SSH lockout after server reboot or rule changes.
 #
@@ -209,10 +221,9 @@ NFTBAN_ROLLBACK_FLAG="/run/nftban.rollback.deadline"
 # INTEGRATION WITH OTHER TOOLS
 # =============================================================================
 
-# Integration with fail2ban
-# Fail2ban bans are NOT affected by rollback
+# NFTBan ban sets
+# Manual bans and blacklist entries are NOT affected by rollback
 # They persist in separate nftables sets
-# See: fail2ban.conf
 
 # Integration with threat feeds
 # Feed-based blocks are NOT affected by rollback
@@ -226,7 +237,7 @@ NFTBAN_ROLLBACK_FLAG="/run/nftban.rollback.deadline"
 #   - Custom user rules
 #
 # What DOES NOT get rolled back:
-#   - Fail2ban bans (separate set)
+#   - Manual bans and blacklist entries (separate set)
 #   - Threat feed blocks (separate set)
 #   - Whitelist entries (separate set)
 


### PR DESCRIPTION
## v1.197.0 PR-D — recovery.conf comment + inventory-header cleanup

**Config-comment/header only.** Separate from PR-A VAL-LOGINMON (daemon-Go).

- Removes stale fail2ban wording from `recovery.conf` comments. NFTBan has no fail2ban integration and `fail2ban.conf` does not exist; the comment-only lines are reframed to NFTBan's own ban sets (manual bans + blacklist entries, which already persist in separate nftables sets unaffected by rollback — mirroring the threat-feed/whitelist lines already in the file).
- Adds the required `meta:inventory` header block so the file satisfies the config header contract enforced by `tools/validate-headers.sh`.
- Changes **no** config key/value/default.
- Changes **no** runtime behavior.
- Keeps VERSION `1.196.0`, schema `1.84.0`, daemon byte-identical.
- Separate from PR-A VAL-LOGINMON daemon-Go.
