### PR TITLE
fix(validator): classify LoginMon absent sources as benign and honor geoban data dir

### DIFF
--- a/internal/validator/geoban_path_test.go
+++ b/internal/validator/geoban_path_test.go
@@ -1,0 +1,109 @@
+// =============================================================================
+// NFTBan v1.197.0 - Validator geoban GeoIP DB path resolution tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="validator_geoban_path_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-21"
+// meta:description="Tests for the v1.197 PR-A rider: the geoban health check must resolve the GeoIP database at ${NFTBAN_DATA_DIR}/geoip/dbip-country-lite.mmdb (DataDir) instead of a hardcoded /var/lib/nftban path, matching the shell geoip sync writer. Proves a DB under a configured DataDir reads loaded (no missing finding), an absent DB under that DataDir reads stale + emits CodeGeobanDBMissing, and resolveDataDir falls back deterministically to the canonical default."
+//
+// meta:inventory.files="geoban_path_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_DATA_DIR"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package validator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withDataDir overrides the package DataDir for a test and restores it after.
+func withDataDir(t *testing.T, dir string) func() {
+	t.Helper()
+	old := DataDir
+	DataDir = dir
+	return func() { DataDir = old }
+}
+
+func geobanFindingPresent() bool {
+	for _, f := range moduleFindings {
+		if f.Code == CodeGeobanDBMissing {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGeobanDBPath_HonorsDataDir: a GeoIP DB placed under a configured DataDir
+// (not /var/lib/nftban) must be found → geoban reads loaded, no missing finding.
+func TestGeobanDBPath_HonorsDataDir(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	tmp := t.TempDir()
+	restore := withDataDir(t, tmp)
+	defer restore()
+
+	dbPath := filepath.Join(tmp, "geoip", "dbip-country-lite.mmdb")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dbPath, []byte("mmdb-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moduleFindings = nil
+	bh := evaluateBlacklist(buildDoc(nil, nil))
+	if bh.Geoban.State != "loaded" {
+		t.Errorf("geoban state=%q want loaded (DB under configured DataDir must be found)", bh.Geoban.State)
+	}
+	if geobanFindingPresent() {
+		t.Error("did not expect CodeGeobanDBMissing when the DB exists under DataDir")
+	}
+}
+
+// TestGeobanDBPath_FallbackMissing: with the DB absent under DataDir, geoban reads
+// stale and emits CodeGeobanDBMissing — deterministic, path-driven fallback.
+func TestGeobanDBPath_FallbackMissing(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	restore := withDataDir(t, t.TempDir()) // empty: no geoip/ dir
+	defer restore()
+
+	moduleFindings = nil
+	bh := evaluateBlacklist(buildDoc(nil, nil))
+	if bh.Geoban.State != "stale" {
+		t.Errorf("geoban state=%q want stale (DB missing under DataDir)", bh.Geoban.State)
+	}
+	if !geobanFindingPresent() {
+		t.Error("expected CodeGeobanDBMissing when the DB is absent under DataDir")
+	}
+}
+
+// TestResolveDataDir_Fallback: resolveDataDir honors NFTBAN_DATA_DIR when set and
+// falls back to the canonical default otherwise.
+func TestResolveDataDir_Fallback(t *testing.T) {
+	t.Setenv("NFTBAN_DATA_DIR", "/srv/custom/nftban-data")
+	if got := resolveDataDir(); got != "/srv/custom/nftban-data" {
+		t.Errorf("resolveDataDir()=%q want the configured NFTBAN_DATA_DIR", got)
+	}
+	t.Setenv("NFTBAN_DATA_DIR", "")
+	if got := resolveDataDir(); got != "/var/lib/nftban" {
+		t.Errorf("resolveDataDir()=%q want the canonical default /var/lib/nftban", got)
+	}
+}

--- a/internal/validator/loginmon_input_axis_test.go
+++ b/internal/validator/loginmon_input_axis_test.go
@@ -21,7 +21,10 @@
 
 package validator
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseLoginMonState(t *testing.T) {
 	cases := map[string]InputState{
@@ -34,6 +37,20 @@ func TestParseLoginMonState(t *testing.T) {
 	for line, want := range cases {
 		if got := parseLoginMonState(line); got != want {
 			t.Errorf("parseLoginMonState(%q)=%q want %q", line, got, want)
+		}
+	}
+}
+
+func TestParseLoginMonReason(t *testing.T) {
+	cases := map[string]string{
+		"[LOGINMON] webauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=web_stack_present_no_access_logs": "web_stack_present_no_access_logs",
+		"[LOGINMON] roundcube: state=NO_LOGS resolved_by=discovery files=0 reason=no_roundcube":                        "no_roundcube",
+		"[LOGINMON] webauth: state=OK resolved_by=discovery files=3":                                                   "", // no reason token
+		"no marker here": "",
+	}
+	for line, want := range cases {
+		if got := parseLoginMonReason(line); got != want {
+			t.Errorf("parseLoginMonReason(%q)=%q want %q", line, got, want)
 		}
 	}
 }
@@ -53,10 +70,22 @@ func TestWorseInputState(t *testing.T) {
 	}
 }
 
-// TestLoginMonInputAxis_Starved drives evaluateLoginMon with an enabled config + a
-// journal that reports webauth NO_LOGS → Input axis = no_logs + a CodeLoginMonNoInput
-// finding (enabled-but-starved is now visible, not healthy).
-func TestLoginMonInputAxis_Starved(t *testing.T) {
+// loginMonInputFinding returns the CodeLoginMonNoInput finding whose message names
+// the given source, or a zero Finding if none.
+func loginMonInputFinding(source string) Finding {
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoInput && strings.Contains(f.Message, source) {
+			return f
+		}
+	}
+	return Finding{}
+}
+
+// TestLoginMonInputAxis_BenignAbsent: VAL-LOGINMON-002-UX. webauth NO_LOGS with
+// reason=no_web_stack means the web stack is simply not present on this host. That
+// is benign — it must surface as INFO (not a warning) and preserve the reason so an
+// operator can see "not installed here", not "installed but unreadable".
+func TestLoginMonInputAxis_BenignAbsent(t *testing.T) {
 	cleanup := setupTestConfig(t, map[string]string{
 		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
 	})
@@ -65,7 +94,6 @@ func TestLoginMonInputAxis_Starved(t *testing.T) {
 	SetJournalReader(mockJournalReader{lines: []string{
 		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] webauth: state=NO_LOGS resolved_by=discovery files=0 reason=no_web_stack",
 		"Jun 13 nftband[1]: 2026/06/13 module_start: loginmon",
-		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] exim: maillog=/var/log/exim/mainlog resolved_by=distroconf",
 	}})
 	defer SetJournalReader(SystemdJournalReader{})
 
@@ -74,14 +102,92 @@ func TestLoginMonInputAxis_Starved(t *testing.T) {
 	if h.Input != InputNoLogs {
 		t.Fatalf("Input=%q want %q", h.Input, InputNoLogs)
 	}
-	found := false
-	for _, f := range moduleFindings {
-		if f.Code == CodeLoginMonNoInput {
-			found = true
-		}
+	f := loginMonInputFinding("webauth")
+	if f.Code != CodeLoginMonNoInput {
+		t.Fatal("expected a CodeLoginMonNoInput finding naming webauth")
 	}
-	if !found {
-		t.Errorf("expected a CodeLoginMonNoInput finding for an enabled-but-starved source")
+	if f.Severity != SeverityInfo {
+		t.Errorf("benign-absent webauth severity=%q want %q (must not warn)", f.Severity, SeverityInfo)
+	}
+	if !strings.Contains(f.Message, "no_web_stack") {
+		t.Errorf("finding must preserve reason; message=%q", f.Message)
+	}
+}
+
+// TestLoginMonInputAxis_NoRoundcubeBenign: no Roundcube present → INFO, not a warning.
+func TestLoginMonInputAxis_NoRoundcubeBenign(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	SetJournalReader(mockJournalReader{lines: []string{
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] roundcube: state=NO_LOGS resolved_by=discovery files=0 reason=no_roundcube",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	_ = evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+	f := loginMonInputFinding("roundcube")
+	if f.Severity != SeverityInfo {
+		t.Errorf("no-Roundcube severity=%q want %q (benign)", f.Severity, SeverityInfo)
+	}
+}
+
+// TestLoginMonInputAxis_Starved: webauth WARN_NO_LOGS reason=web_stack_present_no_access_logs
+// means the stack IS present but NFTBan sees no readable logs. That is actionable and
+// must stay WARN, with the source + reason preserved.
+func TestLoginMonInputAxis_Starved(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	SetJournalReader(mockJournalReader{lines: []string{
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] webauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=web_stack_present_no_access_logs",
+		"Jun 13 nftband[1]: 2026/06/13 module_start: loginmon",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	h := evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+	if h.Input != InputWarnNoLogs {
+		t.Fatalf("Input=%q want %q", h.Input, InputWarnNoLogs)
+	}
+	f := loginMonInputFinding("webauth")
+	if f.Code != CodeLoginMonNoInput {
+		t.Fatal("expected a CodeLoginMonNoInput finding naming webauth")
+	}
+	if f.Severity != SeverityWarn {
+		t.Errorf("starved webauth severity=%q want %q (actionable)", f.Severity, SeverityWarn)
+	}
+	if !strings.Contains(f.Message, "web_stack_present_no_access_logs") {
+		t.Errorf("finding must preserve reason; message=%q", f.Message)
+	}
+}
+
+// TestLoginMonInputAxis_MixedSources: a starved webauth (WARN) and an absent roundcube
+// (INFO) must each emit their own correctly-classified finding — proving classification
+// is per-source and not collapsed to one worst-of message.
+func TestLoginMonInputAxis_MixedSources(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	SetJournalReader(mockJournalReader{lines: []string{
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] webauth: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=web_stack_present_no_access_logs",
+		"Jun 13 nftband[1]: 2026/06/13 [LOGINMON] roundcube: state=NO_LOGS resolved_by=discovery files=0 reason=no_roundcube",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	_ = evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+	if got := loginMonInputFinding("webauth").Severity; got != SeverityWarn {
+		t.Errorf("webauth (starved) severity=%q want warn", got)
+	}
+	if got := loginMonInputFinding("roundcube").Severity; got != SeverityInfo {
+		t.Errorf("roundcube (absent) severity=%q want info", got)
 	}
 }
 

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -34,6 +34,21 @@ import (
 // ConfigDir is the base config directory. Overridable for testing.
 var ConfigDir = "/etc/nftban"
 
+// DataDir is the base data directory (project NFTBAN_DATA_DIR). Resolved from the
+// environment with the project-canonical default; overridable for testing.
+// Mirrors the shell rule `${NFTBAN_DATA_DIR:-/var/lib/nftban}` used by
+// cmd_geoip.sh / cmd_selftest.sh so the validator looks for the GeoIP DB in the
+// same place the geoip sync writes it (instead of a hardcoded /var/lib/nftban).
+var DataDir = resolveDataDir()
+
+// resolveDataDir honors NFTBAN_DATA_DIR when set, else the canonical default.
+func resolveDataDir() string {
+	if d := os.Getenv("NFTBAN_DATA_DIR"); d != "" {
+		return d
+	}
+	return "/var/lib/nftban"
+}
+
 // evaluateModuleHealth evaluates all modules and returns the health map.
 // Called from ValidateKernel after structural + runtime checks.
 // evaluateModuleHealth evaluates all modules and returns the health map.
@@ -323,35 +338,82 @@ func evaluateLoginMon(svcState ServiceState) *ModuleHealth {
 	// v1.180 ftpauth). The daemon is the authority on its own watchers; the kernel-truth
 	// validator reads it from the journal it already queries. An enabled-but-starved
 	// source now surfaces in `nftban health` instead of reading healthy.
-	h.Input = loginMonInputState(context.Background())
-	if h.Config == ConfigEnabled && (h.Input == InputNoLogs || h.Input == InputWarnNoLogs) {
-		moduleFindings = append(moduleFindings, Finding{
-			Code:      CodeLoginMonNoInput,
-			Severity:  SeverityWarn,
-			Component: "module",
-			Message:   "LoginMon enabled but a detection source reports no input (" + string(h.Input) + ")",
-		})
+	// VAL-LOGINMON-002-UX: classify per-source, distinguishing a benign absent
+	// input (no stack/source on this host) from real starvation (stack present
+	// but no readable logs). The daemon already separates these — NO_LOGS carries
+	// reason=no_<stack> (absent), WARN_NO_LOGS carries reason=<stack>_present_...
+	// (starved). Collapsing both into one WARN made every non-web/non-FTP host
+	// read as a warning; now an absent source is INFO (no action) while a starved
+	// source stays WARN (actionable), and the source + reason are preserved.
+	srcs := loginMonSourceStates(context.Background())
+	h.Input = InputUnknown
+	for _, s := range srcs {
+		h.Input = worseInputState(h.Input, s.State)
+	}
+	if h.Config == ConfigEnabled {
+		for _, s := range srcs {
+			switch s.State {
+			case InputWarnNoLogs:
+				// Stack/source present but produced no readable logs → actionable.
+				moduleFindings = append(moduleFindings, Finding{
+					Code:        CodeLoginMonNoInput,
+					Severity:    SeverityWarn,
+					Component:   "module",
+					Message:     "LoginMon " + s.Name + " source present but produced no readable logs" + loginMonReasonSuffix(s.Reason),
+					Remediation: "Confirm the " + s.Name + " log path is present and readable, and that the application is logging auth events",
+				})
+			case InputNoLogs:
+				// Source/stack structurally absent on this host → benign, no action.
+				moduleFindings = append(moduleFindings, Finding{
+					Code:      CodeLoginMonNoInput,
+					Severity:  SeverityInfo,
+					Component: "module",
+					Message:   "LoginMon " + s.Name + " source not present on this host" + loginMonReasonSuffix(s.Reason) + "; no action needed",
+				})
+			}
+		}
 	}
 
 	return h
 }
 
-// loginMonInputState derives the worst-case input readability across LoginMon's
-// discovered sources from the daemon's "[LOGINMON] <src>: state=..." journal lines.
-// Precedence (worst wins): no_logs > warn_no_logs > ok > unknown.
-func loginMonInputState(ctx context.Context) InputState {
-	worst := InputUnknown
-	for _, src := range []string{"webauth", "ftpauth"} {
+// loginMonSource is a per-source input-state observation parsed from a daemon
+// "[LOGINMON] <src>: state=<TOK> ... reason=<reason>" journal line.
+type loginMonSource struct {
+	Name   string
+	State  InputState
+	Reason string
+}
+
+// loginMonSourceStates returns the per-source input-state observations for
+// LoginMon's discovered sources from the daemon's "[LOGINMON] <src>: state=..."
+// journal lines. The daemon is the authority on its own watchers; the validator
+// only reads what it already emits. Sources with no journal evidence are omitted.
+func loginMonSourceStates(ctx context.Context) []loginMonSource {
+	var out []loginMonSource
+	for _, name := range []string{"webauth", "ftpauth", "roundcube"} {
 		ev := queryJournal(ctx, JournalQuery{
-			Patterns: []string{"[LOGINMON] " + src + ": state="},
+			Patterns: []string{"[LOGINMON] " + name + ": state="},
 			Since:    15 * time.Minute,
 		})
 		if ev.ErrKind != ErrNone || !ev.Found {
 			continue
 		}
-		worst = worseInputState(worst, parseLoginMonState(ev.MatchedLine))
+		out = append(out, loginMonSource{
+			Name:   name,
+			State:  parseLoginMonState(ev.MatchedLine),
+			Reason: parseLoginMonReason(ev.MatchedLine),
+		})
 	}
-	return worst
+	return out
+}
+
+// loginMonReasonSuffix renders a " (reason=<r>)" suffix, or empty when absent.
+func loginMonReasonSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return " (reason=" + reason + ")"
 }
 
 // parseLoginMonState extracts the input-state token from a "[LOGINMON] <src>: state=<TOK> ..."
@@ -376,6 +438,23 @@ func parseLoginMonState(line string) InputState {
 	default:
 		return InputUnknown
 	}
+}
+
+// parseLoginMonReason extracts the reason token from a
+// "[LOGINMON] <src>: state=<TOK> ... reason=<reason>" line, or "" if absent.
+// The reason (e.g. no_web_stack vs web_stack_present_no_access_logs) is what
+// lets an operator tell "not installed here" from "installed but unreadable".
+func parseLoginMonReason(line string) string {
+	const marker = "reason="
+	i := strings.Index(line, marker)
+	if i < 0 {
+		return ""
+	}
+	tok := line[i+len(marker):]
+	if j := strings.IndexAny(tok, " \t\r\n"); j >= 0 {
+		tok = tok[:j]
+	}
+	return tok
 }
 
 // worseInputState returns the higher-severity of two input states
@@ -451,8 +530,10 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 		// and emits a finding for visibility. "degraded" is not in the blacklist
 		// sub-state enum (enforcing|primed|idle|loaded|stale|disabled).
 		// Canonical path: ${NFTBAN_DATA_DIR}/geoip/dbip-country-lite.mmdb
-		// Downloaded by nftban-core-geoip.timer → nftban geoip sync
-		dbPath := "/var/lib/nftban/geoip/dbip-country-lite.mmdb"
+		// Downloaded by nftban-core-geoip.timer → nftban geoip sync.
+		// Honor NFTBAN_DATA_DIR (via DataDir) instead of hardcoding /var/lib/nftban,
+		// matching the shell sync writer; DataDir falls back to the canonical default.
+		dbPath := filepath.Join(DataDir, "geoip", "dbip-country-lite.mmdb")
 		info, err := os.Stat(dbPath)
 		if err != nil || info.Size() == 0 {
 			bh.Geoban = BlacklistSubHealth{State: "stale"} // missing DB = stale data


### PR DESCRIPTION
## v1.197.0 PR-A — LoginMon benign-absent classification + geoban data-dir

This is **v1.197 PR-A**, the final implementation lane before release-prep. It is **daemon-Go and intentionally moves the daemon hash** (`internal/validator` links into `nftband`). It changes **validator/health reporting only** — no detector/log-source ownership change, no new watcher/parser, no ban-behavior change, no nftables template/rule change, no installer/package change. Schema `1.84.0` and VERSION `1.196.0` preserved.

### Primary fix — VAL-LOGINMON-002-UX
LoginMon collapsed "source absent" and "source present but starved" into a single WARN, so every non-web/non-FTP host read as a warning. Now classified per-source, preserving the daemon's source+reason:
- **`NO_LOGS`** with a benign-absence reason (`no_<stack>`) → **INFO / non-actionable**: "source not present on this host … no action needed".
- **`WARN_NO_LOGS`** with a present-but-starved reason → **WARN / actionable**: "stack/source present but produced no readable logs".
- Per-source reason/source detail is preserved (added `parseLoginMonReason`); `roundcube` added to checked sources.
- The collapsed generic worst-of message is removed.
- Overall **PROTECTED/DEGRADED rollup semantics are unchanged** (`evaluateOverallStatus` only escalates on Critical/Error; Info/Warn never degrade).

### Rider fix — geoban DB path
- `module_health.go` no longer hardcodes `/var/lib/nftban/geoip/dbip-country-lite.mmdb`.
- Resolves via `filepath.Join(DataDir, "geoip", "dbip-country-lite.mmdb")`, honoring `NFTBAN_DATA_DIR` with an explicit, tested `/var/lib/nftban` fallback — aligning with the shell GeoIP writer (`cmd_geoip.sh`).

### Lab-first validation (both restored cleanly)
- **lab2 DEB/Plesk (Ubuntu 24.04):** PASS — candidate live, active/0-failed/2-tables/validate-rc0/PROTECTED; starved ftpauth→WARN, absent roundcube→no WARN, webauth OK→no finding, geoban loaded. Restored clean.
- **lab4 RPM/cPanel (AlmaLinux 9.8):** PASS — candidate live, active/0-failed/COMMITTED/PROTECTED; absent ftpauth+roundcube→INFO "not present on this host… no action needed", geoban loaded. Restored clean.

### Daemon hash
Moves as expected (same-flags isolation): `fa16c561…` → `d535db3e…`.

Changed files: `internal/validator/module_health.go`, `internal/validator/loginmon_input_axis_test.go`, `internal/validator/geoban_path_test.go`.
