### PR TITLE
refactor(cli): share health findings renderer

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -571,43 +571,14 @@ nftban_health_cmd_truth() {
         printf "  %-11s  %-9s  %s\n" "$sub" "$state" "$entries"
     done
 
-    # Render findings (V127 UX-1 item 1.2: filter by severity).
-    #
-    # Default (verbose_mode=false): emit only WARN / ERROR findings. If zero remain,
-    # print "Findings: none" instead of an alarming "Findings (1):" header. If INFO
-    # findings exist, mention the count + how to surface them (--verbose). This makes
-    # `nftban health` usable as a fleet-wide signal on healthy idle hosts where the
-    # INFO-only state was reading as "something is wrong" pre-V127.
-    #
-    # Verbose (verbose_mode=true OR called from json|--json branch): emit all findings
-    # regardless of severity. JSON consumers always see the full array.
-    local total_count info_count visible_count
-    total_count=$(echo "$output" | jq '.findings | length' 2>/dev/null || echo "0")
-    info_count=$(echo "$output" | jq '[.findings[] | select(.severity == "info" or .severity == "INFO")] | length' 2>/dev/null || echo "0")
-    if [[ "$verbose_mode" == "true" ]]; then
-        visible_count="$total_count"
-    else
-        visible_count=$((total_count - info_count))
-    fi
-
-    echo ""
-    if [[ "$visible_count" -gt 0 ]]; then
-        echo "  Findings ($visible_count):"
-        if [[ "$verbose_mode" == "true" ]]; then
-            echo "$output" | jq -r '.findings[] | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
-        else
-            echo "$output" | jq -r '.findings[] | select(.severity != "info" and .severity != "INFO") | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
-        fi
-        if [[ "$verbose_mode" != "true" && "$info_count" -gt 0 ]]; then
-            echo "    (${info_count} INFO finding(s) hidden — use --verbose to show)"
-        fi
-    else
-        if [[ "$info_count" -gt 0 ]]; then
-            echo "  Findings: none (${info_count} INFO finding(s) hidden — use --verbose to show)"
-        else
-            echo "  Findings: none"
-        fi
-    fi
+    # Render findings via the shared helper (v1.198 R1b-1). Behavior is
+    # unchanged from the inline V127 UX-1 item 1.2 block: default hides INFO
+    # (footer with hidden count + "--verbose to show"), --verbose shows all,
+    # zero-visible prints "Findings: none". Extracted to
+    # core/nftban_output.sh::nftban_render_findings so the classification is
+    # single-sourced and the R1b-2 operator-readiness summary can reuse it.
+    # (JSON mode returns above — this is the text path only.)
+    nftban_render_findings "$output" "$verbose_mode"
 
     # v1.192.1 PR-B: harm-keyed firewall transition health as a finding (text
     # mode only; JSON returned above). Prints ONLY when anomalous — a healthy

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1214,6 +1214,60 @@ nftban_kv() {
 export -f nftban_kv 2>/dev/null || true
 
 # =============================================================================
+# SHARED VALIDATOR FINDINGS RENDERER (v1.198 R1b-1)
+# =============================================================================
+# Renders the human findings block for report-style surfaces from the Go
+# validator's --json output. Extracted verbatim from the V127 UX-1 item 1.2
+# block in cmd_health.sh::nftban_health_cmd_truth so the classification lives
+# in one place (and the R1b-2 operator-readiness summary can reuse it). Pure
+# presentation — consumes only already-emitted fields (.findings[].severity /
+# .code / .message); no new validator field, no schema change, daemon
+# byte-identical.
+#
+# Behavior (unchanged from the inline original):
+#   - Default (verbose=false): show only non-INFO findings; if INFO findings
+#     exist, append a footer with the hidden count + "use --verbose to show".
+#   - verbose=true: show ALL findings regardless of severity (no footer).
+#   - Zero visible: "Findings: none" (+ hidden-INFO footer if any INFO exist).
+# Emits a leading blank line, matching the original block's placement.
+#
+# Usage: nftban_render_findings "<validator_json>" [verbose]   # verbose: true|false (default false)
+# JSON-mode callers MUST NOT use this (the --json path passes the validator
+# output through unfiltered upstream; this renderer is text-mode only).
+nftban_render_findings() {
+    local _json="${1:-}"
+    local _verbose="${2:-false}"
+    local total_count info_count visible_count
+    total_count=$(echo "$_json" | jq '.findings | length' 2>/dev/null || echo "0")
+    info_count=$(echo "$_json" | jq '[.findings[] | select(.severity == "info" or .severity == "INFO")] | length' 2>/dev/null || echo "0")
+    if [[ "$_verbose" == "true" ]]; then
+        visible_count="$total_count"
+    else
+        visible_count=$((total_count - info_count))
+    fi
+
+    echo ""
+    if [[ "$visible_count" -gt 0 ]]; then
+        echo "  Findings ($visible_count):"
+        if [[ "$_verbose" == "true" ]]; then
+            echo "$_json" | jq -r '.findings[] | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
+        else
+            echo "$_json" | jq -r '.findings[] | select(.severity != "info" and .severity != "INFO") | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
+        fi
+        if [[ "$_verbose" != "true" && "$info_count" -gt 0 ]]; then
+            echo "    (${info_count} INFO finding(s) hidden — use --verbose to show)"
+        fi
+    else
+        if [[ "$info_count" -gt 0 ]]; then
+            echo "  Findings: none (${info_count} INFO finding(s) hidden — use --verbose to show)"
+        else
+            echo "  Findings: none"
+        fi
+    fi
+}
+export -f nftban_render_findings 2>/dev/null || true
+
+# =============================================================================
 # FOOTER - Debug & Module Info
 # =============================================================================
 

--- a/cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh
+++ b/cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1b-1 shared findings renderer
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_render_findings_r1b1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-21"
+# meta:description="Hermetic tests for core/nftban_output.sh::nftban_render_findings extracted from cmd_health.sh (R1b-1). Proves behavior-equivalence: INFO hidden by default, --verbose shows all, severity filtering, footer hidden-count; plus byte-identical equivalence vs the original inline logic and the non-orphan adopter guard."
+# meta:input="None (canned validator JSON, self-contained)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+
+# Source ONLY the output core module (proves the helper is reachable exactly
+# where cmd_health.sh sources it — core/nftban_output.sh — with no other deps).
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/core/nftban_output.sh"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+assert_contains()     { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3 (missing: $2)"; fi; }
+assert_not_contains() { if grep -qF -- "$2" <<<"$1"; then bad "$3 (unexpected: $2)"; else ok "$3"; fi; }
+
+# Reference = the ORIGINAL inline logic from cmd_health.sh (pre-R1b-1), used to
+# prove the extracted helper is byte-identical.
+_reference_render() {
+    local output="$1" verbose_mode="${2:-false}"
+    local total_count info_count visible_count
+    total_count=$(echo "$output" | jq '.findings | length' 2>/dev/null || echo "0")
+    info_count=$(echo "$output" | jq '[.findings[] | select(.severity == "info" or .severity == "INFO")] | length' 2>/dev/null || echo "0")
+    if [[ "$verbose_mode" == "true" ]]; then visible_count="$total_count"; else visible_count=$((total_count - info_count)); fi
+    echo ""
+    if [[ "$visible_count" -gt 0 ]]; then
+        echo "  Findings ($visible_count):"
+        if [[ "$verbose_mode" == "true" ]]; then
+            echo "$output" | jq -r '.findings[] | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
+        else
+            echo "$output" | jq -r '.findings[] | select(.severity != "info" and .severity != "INFO") | "    [\(.severity | ascii_upcase)] \(.code): \(.message)"' 2>/dev/null
+        fi
+        if [[ "$verbose_mode" != "true" && "$info_count" -gt 0 ]]; then
+            echo "    (${info_count} INFO finding(s) hidden — use --verbose to show)"
+        fi
+    else
+        if [[ "$info_count" -gt 0 ]]; then
+            echo "  Findings: none (${info_count} INFO finding(s) hidden — use --verbose to show)"
+        else
+            echo "  Findings: none"
+        fi
+    fi
+}
+
+# ---- Fixtures (canned validator --json shapes; only .findings[] matters here) ----
+J_INFO_ONLY='{"findings":[{"severity":"info","code":"VAL-LOGINMON-002","message":"roundcube source reports no input (no_roundcube)"}]}'
+J_MIXED='{"findings":[
+  {"severity":"info","code":"VAL-LOGINMON-002","message":"benign absent source"},
+  {"severity":"warn","code":"VAL-LOGINMON-002","message":"webauth present but starved"},
+  {"severity":"error","code":"VAL-CHAIN-001","message":"chain missing"},
+  {"severity":"critical","code":"VAL-ANCHOR-003","message":"final guard absent"}
+]}'
+J_EMPTY='{"findings":[]}'
+
+echo "R1b-1 shared findings renderer — hermetic tests"
+
+# T1: INFO-only hidden by default
+OUT=$(nftban_render_findings "$J_INFO_ONLY" false)
+assert_contains "$OUT" "Findings: none (1 INFO finding(s) hidden — use --verbose to show)" "T1 INFO-only hidden by default (footer with count)"
+assert_not_contains "$OUT" "[INFO]" "T1 INFO line not shown by default"
+
+# T2: INFO visible with --verbose
+OUT=$(nftban_render_findings "$J_INFO_ONLY" true)
+assert_contains "$OUT" "[INFO] VAL-LOGINMON-002:" "T2 INFO shown with --verbose"
+assert_not_contains "$OUT" "hidden — use --verbose" "T2 no hidden-footer in verbose"
+
+# T3: WARN/ERROR/CRITICAL visible by default, INFO hidden + footer
+OUT=$(nftban_render_findings "$J_MIXED" false)
+assert_contains "$OUT" "Findings (3):" "T3 header counts only the 3 visible (INFO excluded)"
+assert_contains "$OUT" "[WARN] VAL-LOGINMON-002:" "T3 WARN visible by default"
+assert_contains "$OUT" "[ERROR] VAL-CHAIN-001:" "T3 ERROR visible by default"
+assert_contains "$OUT" "[CRITICAL] VAL-ANCHOR-003:" "T3 CRITICAL visible by default"
+assert_not_contains "$OUT" "[INFO]" "T3 INFO hidden by default"
+assert_contains "$OUT" "(1 INFO finding(s) hidden — use --verbose to show)" "T3 hidden-INFO footer"
+
+# T4: --verbose shows ALL incl INFO, no footer
+OUT=$(nftban_render_findings "$J_MIXED" true)
+assert_contains "$OUT" "Findings (4):" "T4 header counts all 4 in verbose"
+assert_contains "$OUT" "[INFO] VAL-LOGINMON-002:" "T4 INFO shown in verbose"
+assert_not_contains "$OUT" "hidden — use --verbose" "T4 no hidden-footer in verbose"
+
+# T5: no findings
+OUT=$(nftban_render_findings "$J_EMPTY" false)
+assert_contains "$OUT" "Findings: none" "T5 zero findings -> 'Findings: none'"
+assert_not_contains "$OUT" "hidden" "T5 no hidden-footer when no INFO"
+
+# T6: BYTE-IDENTICAL equivalence vs the original inline logic, every fixture x mode
+t6_fail=0
+for fx in "$J_INFO_ONLY" "$J_MIXED" "$J_EMPTY"; do
+    for vb in false true; do
+        a=$(nftban_render_findings "$fx" "$vb"); b=$(_reference_render "$fx" "$vb")
+        if [[ "$a" != "$b" ]]; then t6_fail=1; printf '    diff (verbose=%s):\n--- helper\n%s\n--- reference\n%s\n' "$vb" "$a" "$b"; fi
+    done
+done
+if [[ "$t6_fail" -eq 0 ]]; then ok "T6 helper output byte-identical to original inline logic (3 fixtures x 2 modes)"; else bad "T6 helper output diverges from original"; fi
+
+# T7: non-orphan adopter guard — cmd_health.sh calls the helper
+if grep -qE 'nftban_render_findings "\$output" "\$verbose_mode"' "${NFTBAN_LIB_DIR}/cli/cmd_health.sh"; then
+    ok "T7 adopter present: cmd_health.sh calls nftban_render_findings (not orphaned)"
+else
+    bad "T7 cmd_health.sh does not call the helper (orphan/regression)"
+fi
+
+# T8: --json path is unaffected — the JSON branch guard + unfiltered passthrough remain
+if grep -qF '"$json_mode" == "true"' "${NFTBAN_LIB_DIR}/cli/cmd_health.sh" \
+   && grep -qF 'schema_version, status, service_state, modules, consistency, counters_phase' "${NFTBAN_LIB_DIR}/cli/cmd_health.sh"; then
+    ok "T8 --json passthrough branch intact (unfiltered, renderer is text-only)"
+else
+    bad "T8 --json passthrough branch changed unexpectedly"
+fi
+
+# T9: helper is exported (available to subshell function calls like the real CLI)
+if declare -F nftban_render_findings >/dev/null 2>&1; then ok "T9 nftban_render_findings defined+sourced from nftban_output.sh"; else bad "T9 helper not defined"; fi
+
+echo "-----------------------------------------------"
+printf 'R1b-1 renderer tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## R1b-1 — shared health findings renderer (behavior-preserving)

**Baseline:** v1.197.0 (published + closed), schema **1.84.0**, BotGuard disabled fleet-wide.

### Scope
Behavior-preserving **shell extraction**: the existing `cmd_health.sh` findings-list block (V127 UX-1 item 1.2 — hide-INFO by default, `--verbose` shows all, hidden-count footer, "Findings: none") is moved verbatim into a shared helper `nftban_render_findings` in `core/nftban_output.sh`, and `cmd_health.sh` now calls it. Single-sources the classification so the R1b-2 operator-readiness summary can reuse it.

- **Current adopter:** `cmd_health.sh` **only** (the sole current findings-list renderer).
- **Planned future consumer:** R1b-2 operator-readiness summary.

### Explicit NON-scope
- No R1b-2 operator-readiness summary.
- No findings-list output added to `cmd_status.sh` / `cmd_health_components.sh` / `cmd_health_analysis.sh` (they render no findings list; `cmd_status.sh`'s semantic `.findings[]` usage is reviewed in R1b-2).
- No Go files. No schema change. No detector/parser/watcher/log-source change. No ban-behavior change.
- No host mutation. No tag/release. No register status move.

### Validation
- `bash -n` clean on all touched files.
- `shellcheck` clean (test `-S warning`; core/cli `-S error`).
- Hermetic test `nftban_render_findings_r1b1_test.sh`: **19/19 PASS** — incl. byte-identical equivalence vs the original inline logic (3 fixtures × 2 modes) + non-orphan adopter guard.
- `--json` path remains **unfiltered** (the JSON branch returns before the text render; renderer is text-mode only).
- **Daemon byte-identical:** no `.go` files changed.
- **Schema unchanged:** `SchemaVersionCurrent = "1.84.0"` untouched.
- Roadmap docs amended to match implementation reality: `V198_R1B0_RECON.md` + `V198_R1_SCOPE.md` (R1b-1 = shared renderer, adopter = `cmd_health.sh` only).

Files: `core/nftban_output.sh` (+helper), `cli/cmd_health.sh` (call), `tests/nftban_render_findings_r1b1_test.sh` (new).
