### PR TITLE
feat(cli): operator-readiness summary in nftban health

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -537,6 +537,14 @@ nftban_health_cmd_truth() {
     printf "  %-14s %s\n" "Overall:" "$(echo "$status" | tr '[:lower:]' '[:upper:]')"
     printf "  %-14s %s\n" "Daemon:" "$nftband_state"
     printf "  %-14s %s\n" "Consistency:" "$consistency"
+
+    # v1.198 R1b-2: top-level operator-readiness verdict (Operational /
+    # Upgrade readiness / Action needed + IDLE explanation), computed shell-side
+    # from the validator JSON + rc already in hand. No install_state in the
+    # health context. Shell-only; daemon byte-identical; --json path unaffected
+    # (returned above). Actionable findings reuse the R1b-1 renderer.
+    nftban_render_operator_readiness "$output" "" "$validator_rc"
+
     echo ""
     echo "  Module       Config     Structure  Runtime    Effective"
     echo "  ───────────  ─────────  ─────────  ─────────  ─────────"

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1268,6 +1268,90 @@ nftban_render_findings() {
 export -f nftban_render_findings 2>/dev/null || true
 
 # =============================================================================
+# OPERATOR-READINESS SUMMARY (v1.198 R1b-2)
+# =============================================================================
+# A concise top-level operator verdict computed ENTIRELY shell-side from the
+# Go validator's already-emitted fields (.status, .findings[].severity) plus
+# optional shell-side inputs (install_state, validator/health rc). It answers
+# the three questions an operator actually has — "is it working / is the
+# upgrade OK / must I act now" — that the raw four-axis/IDLE/DEGRADED output
+# leaves ambiguous (HEALTH-UX-OPERATOR-READINESS-SUMMARY).
+#
+# It adds NO validator JSON field, NO schema change, NO Go change (daemon
+# byte-identical) and is text-mode only (the --json path renders nothing here).
+# Actionable detail reuses the R1b-1 nftban_render_findings helper.
+#
+# Decision table (driven by existing fields):
+#   Operational      : YES if status in {protected,idle,degraded}; else NO.
+#   Upgrade readiness : FAIL if  not-operational  OR status==degraded
+#                              OR max-severity in {error,critical}
+#                              OR install_state==DEGRADED  OR rc>=2;
+#                       PASS_WITH_WARN if max-severity==warn;  else PASS.
+#   Action needed    : FAIL / WARN / NONE mirroring readiness.
+#   IDLE is explained inline ("running, no active bans currently").
+#
+# Usage: nftban_render_operator_readiness "<validator_json>" [install_state] [rc]
+nftban_render_operator_readiness() {
+    local _json="${1:-}"
+    local _install_state="${2:-}"
+    local _rc="${3:-0}"
+
+    local status max_sev
+    status=$(echo "$_json" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+    [[ -z "$status" || "$status" == "null" ]] && status="unknown"
+    # Highest finding severity present (critical>error>warn>info>none).
+    max_sev=$(echo "$_json" | jq -r '
+        [.findings[]?.severity // empty | ascii_downcase] as $s
+        | if   ($s|index("critical")) then "critical"
+          elif ($s|index("error"))    then "error"
+          elif ($s|index("warn"))     then "warn"
+          elif ($s|index("info"))     then "info"
+          else "none" end' 2>/dev/null || echo "none")
+    [[ -z "$max_sev" || "$max_sev" == "null" ]] && max_sev="none"
+
+    local operational readiness action
+    case "$status" in
+        protected|idle|degraded) operational="YES" ;;
+        *)                       operational="NO" ;;
+    esac
+
+    local _rc_fail=0
+    [[ "$_rc" =~ ^[0-9]+$ ]] && (( _rc >= 2 )) && _rc_fail=1
+
+    if [[ "$operational" == "NO" || "$status" == "degraded" \
+          || "$max_sev" == "error" || "$max_sev" == "critical" \
+          || "$_install_state" == "DEGRADED" || "$_rc_fail" -eq 1 ]]; then
+        readiness="FAIL"
+    elif [[ "$max_sev" == "warn" ]]; then
+        readiness="PASS_WITH_WARN"
+    else
+        readiness="PASS"
+    fi
+
+    case "$readiness" in
+        FAIL)           action="FAIL" ;;
+        PASS_WITH_WARN) action="WARN" ;;
+        *)              action="NONE" ;;
+    esac
+
+    local op_line="$operational"
+    [[ "$status" == "idle" ]] && op_line="YES (running, no active bans currently)"
+
+    echo ""
+    echo "  Operator readiness"
+    echo "  ─────────────────────────────────────────"
+    printf "  %-20s %s\n" "Operational:" "$op_line"
+    printf "  %-20s %s\n" "Upgrade readiness:" "$readiness"
+    printf "  %-20s %s\n" "Action needed:" "$action"
+    # When action is needed, show the actionable findings via the shared
+    # R1b-1 renderer (WARN/ERROR/CRITICAL; INFO stays hidden by default).
+    if [[ "$action" != "NONE" ]]; then
+        nftban_render_findings "$_json" false
+    fi
+}
+export -f nftban_render_operator_readiness 2>/dev/null || true
+
+# =============================================================================
 # FOOTER - Debug & Module Info
 # =============================================================================
 

--- a/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
+++ b/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1b-2 operator-readiness summary
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_operator_readiness_r1b2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-21"
+# meta:description="Hermetic tests for core/nftban_output.sh::nftban_render_operator_readiness (R1b-2): shell-side Operational/Upgrade-readiness/Action-needed verdict + IDLE explanation, computed from canned validator JSON + mocked install_state/rc. Plus guards that cmd_health.sh wires it text-only (--json unaffected) and cmd_status.sh semantic findings usage is untouched."
+# meta:input="None (canned validator JSON, self-contained)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/core/nftban_output.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+# regex matcher (whitespace-tolerant for padded summary lines)
+ar()  { if grep -qE -- "$2" <<<"$1"; then ok "$3"; else bad "$3 (no match: $2)"; fi; }
+nr()  { if grep -qE -- "$2" <<<"$1"; then bad "$3 (unexpected: $2)"; else ok "$3"; fi; }
+# fixed-string matcher (for literal finding lines)
+af()  { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3 (missing: $2)"; fi; }
+nf()  { if grep -qF -- "$2" <<<"$1"; then bad "$3 (unexpected: $2)"; else ok "$3"; fi; }
+
+echo "R1b-2 operator-readiness summary — hermetic tests"
+
+# T1: protected + info-only -> YES / PASS / NONE, no findings block
+OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[{"severity":"info","code":"X","message":"benign"}]}' "" 0)
+ar "$OUT" "Operational:[[:space:]]+YES$"            "T1 protected -> Operational YES"
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS$"     "T1 protected -> readiness PASS"
+ar "$OUT" "Action needed:[[:space:]]+NONE$"         "T1 protected -> action NONE"
+nf "$OUT" "Findings"                                "T1 no actionable findings block when NONE"
+
+# T2: idle + clean -> YES + IDLE explanation / PASS
+OUT=$(nftban_render_operator_readiness '{"status":"idle","findings":[]}' "" 0)
+af "$OUT" "YES (running, no active bans currently)" "T2 idle -> IDLE explanation"
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS$"     "T2 idle -> readiness PASS"
+
+# T3: idle + WARN -> YES / PASS_WITH_WARN / WARN (+ finding shown via R1b-1 helper)
+OUT=$(nftban_render_operator_readiness '{"status":"idle","findings":[{"severity":"warn","code":"VAL-LOGINMON-002","message":"webauth present but starved"}]}' "" 0)
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS_WITH_WARN$" "T3 WARN -> readiness PASS_WITH_WARN"
+ar "$OUT" "Action needed:[[:space:]]+WARN$"         "T3 WARN -> action WARN"
+af "$OUT" "[WARN] VAL-LOGINMON-002:"                "T3 actionable WARN finding rendered (R1b-1 helper)"
+
+# T4a: degraded status -> FAIL
+OUT=$(nftban_render_operator_readiness '{"status":"degraded","findings":[{"severity":"warn","code":"VAL-TIMER-001","message":"x"}]}' "" 0)
+ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T4a degraded -> readiness FAIL"
+ar "$OUT" "Action needed:[[:space:]]+FAIL$"         "T4a degraded -> action FAIL"
+
+# T4b: error-severity finding (status protected) -> FAIL + finding shown
+OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[{"severity":"error","code":"VAL-CHAIN-001","message":"chain missing"}]}' "" 0)
+ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T4b error finding -> readiness FAIL"
+af "$OUT" "[ERROR] VAL-CHAIN-001:"                  "T4b error finding rendered"
+
+# T5: install_state DEGRADED (update path) -> NOT PASS even when protected+clean
+OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[]}' "DEGRADED" 0)
+nr "$OUT" "Upgrade readiness:[[:space:]]+PASS"      "T5 install_state DEGRADED -> readiness not PASS/PASS_WITH_WARN"
+ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T5 install_state DEGRADED -> readiness FAIL"
+
+# T5b: down status -> Operational NO / FAIL
+OUT=$(nftban_render_operator_readiness '{"status":"down","findings":[]}' "" 2)
+ar "$OUT" "Operational:[[:space:]]+NO$"             "T5b down -> Operational NO"
+ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T5b down -> readiness FAIL"
+
+# T6: cmd_health.sh wires the summary in the TEXT path; --json passthrough intact
+HC="${NFTBAN_LIB_DIR}/cli/cmd_health.sh"
+if grep -qF 'nftban_render_operator_readiness "$output" "" "$validator_rc"' "$HC"; then ok "T6 cmd_health.sh calls the readiness helper (text path)"; else bad "T6 cmd_health.sh does not wire the helper"; fi
+if grep -qF 'schema_version, status, service_state, modules, consistency, counters_phase' "$HC"; then ok "T6 --json passthrough branch intact (unfiltered)"; else bad "T6 --json passthrough changed"; fi
+
+# T7: cmd_status.sh semantic findings usage intact; no forced renderer block added
+ST="${NFTBAN_LIB_DIR}/cli/cmd_status.sh"
+if grep -qF '.findings[0].code' "$ST" && grep -qF 'select(.code == "VAL-CONS-001")' "$ST"; then ok "T7 cmd_status.sh semantic .findings[] usage intact"; else bad "T7 cmd_status.sh semantic findings usage changed"; fi
+if grep -qE 'nftban_render_(findings|operator_readiness)' "$ST"; then bad "T7 cmd_status.sh got a forced renderer block (out of R1b-2 scope)"; else ok "T7 cmd_status.sh NOT given a forced renderer block"; fi
+
+# T8: helper defined+exported
+if declare -F nftban_render_operator_readiness >/dev/null 2>&1; then ok "T8 nftban_render_operator_readiness defined+sourced"; else bad "T8 helper not defined"; fi
+
+echo "-----------------------------------------------"
+printf 'R1b-2 readiness tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## R1b-2 — shell operator-readiness summary in `nftban health`

**Baseline:** main `606453b6` (R1b-1 merged), VERSION `1.197.0`, schema **1.84.0**, BotGuard disabled fleet-wide.

### Scope
Adds a top-level operator verdict to the `nftban health` four-axis table, computed **entirely shell-side** from the validator's already-emitted fields (`.status`, `.findings[].severity`) + shell rc. **No new validator field, no schema change, no Go change (daemon byte-identical).**

New shared helper `core/nftban_output.sh::nftban_render_operator_readiness`:
- `Operational: YES/NO` · `Upgrade readiness: PASS / PASS_WITH_WARN / FAIL` · `Action needed: NONE / WARN / FAIL` · IDLE explained (“running, no active bans currently”).
- Accepts optional `install_state` + `rc` (for the update path later); actionable findings reuse the **R1b-1** `nftban_render_findings` helper.

Wired into `cmd_health.sh` (full validator JSON). The `--json` branch returns before the text render → **JSON output unchanged/unfiltered**.

### Explicit NON-scope
- `cmd_update.sh` post-update wiring **deferred to R1b-3** (which owns the update summary and already captures the validator JSON) — so the readiness verdict is reconciled with the update's structural-vs-non-structural degraded logic instead of printing a contradictory second verdict.
- `cmd_status.sh` untouched — its semantic `.findings[]` usage (degraded-reason / `VAL-CONS-001`) is preserved; no findings-list/readiness block forced there.
- No R1b-3 update-progress UX; no R1b-4 message audit.
- Does not implement the REP-D attention-axis engine; forensic TODO-24/30/31/32 stay OPEN.
- No Go / schema / detector / parser / watcher / log-source / ban-behavior / installer-Go / BotGuard / CSF / host / tag / release / register changes.

### Validation
- `bash -n` clean; `shellcheck` clean (test `-S warning`; core/cli `-S error`).
- Hermetic test `nftban_operator_readiness_r1b2_test.sh`: **22/22** — protected→PASS/NONE; idle→PASS+IDLE-explanation; WARN→PASS_WITH_WARN/WARN(+finding); degraded→FAIL; error→FAIL(+finding); `install_state=DEGRADED`→FAIL; down→Operational NO/FAIL; `--json` passthrough intact; `cmd_status.sh` semantic findings intact + no forced renderer.
- R1b-1 test still passes (regression).
- No `.go` files changed; `SchemaVersionCurrent = "1.84.0"` untouched.

Files: `core/nftban_output.sh` (+helper), `cli/cmd_health.sh` (wire), `tests/nftban_operator_readiness_r1b2_test.sh` (new).
