### PR TITLE
feat(cli): nftban update progress markers + readiness verdict

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -472,6 +472,7 @@ _cmd_update_main_locked() {
     echo ""
 
     # Create backup (H14 fix: abort if backup fails unless --force)
+    _update_phase 1 "Backup"
     if ! _create_backup; then
         if [[ "$_NFTBAN_UPDATE_FORCE" -eq 1 ]]; then
             _update_log WARN "Backup failed but continuing (--force mode)"
@@ -484,6 +485,7 @@ _cmd_update_main_locked() {
     # Execute update based on source
     # V108 Item 6: when source resolves to "github" (direct package-manager path),
     # only proceed for rpm/deb install types. Reject source/mixed/unknown.
+    _update_phase 2 "Install" "package install may take up to 60s"
     local result=0
     case "$source" in
         github)
@@ -549,7 +551,7 @@ _cmd_update_main_locked() {
 
     # Restart services to load new binaries
     echo ""
-    _update_log INFO "Restarting NFTBan services..."
+    _update_phase 3 "Restart services"
     local _svc_restart_failed=0
     for _svc in nftband.service nftban-core.service; do
         if systemctl is-active --quiet "$_svc" 2>/dev/null; then
@@ -569,7 +571,7 @@ _cmd_update_main_locked() {
     echo ""
     # Invalidate stale health cache from previous version
     rm -f "${NFTBAN_CACHE_DIR:-/var/cache/nftban}/health/health_status.cache" 2>/dev/null || true
-    _update_log INFO "Running health check..."
+    _update_phase 4 "Health check"
     local health_output health_status
     health_output=$(nftban health check --auto-heal --cache-status 2>&1) || health_status=$?
     health_status="${health_status:-0}"
@@ -588,7 +590,7 @@ _cmd_update_main_locked() {
     local new_version
     new_version=$(_get_current_version)
     echo ""
-    _update_log INFO "Running post-update verification..."
+    _update_phase 5 "Post-update verification"
     local _verify_fail=0
 
     # V1: nftables authority — nftban table must exist
@@ -756,6 +758,7 @@ _cmd_update_main_locked() {
     # ("Go installer is the single source of truth on non-clean exits") from
     # the postinst path to the nftban update path.
     # (Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md UX-1 item 1.6)
+    _update_phase 6 "Finalize"
     local _install_state_file="${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/install_state"
     local _installer_state="COMMITTED"  # default: green if state file absent (older installs)
     if [[ -f "$_install_state_file" ]]; then
@@ -773,6 +776,21 @@ _cmd_update_main_locked() {
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
             echo "  Updated: v$current_version → v$new_version (${_update_duration}s)"
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+
+            # v1.198 R1b-3: explicit operator-readiness line, consistent with the
+            # consolidated install_state verdict (COMMITTED = success). PASS unless
+            # the post-update health check reported issues (then PASS_WITH_WARN);
+            # never FAIL on this path (DEGRADED/FAILED emit their own blocks).
+            # Derived from the update's OWN adjudicated signals — NOT the generic
+            # nftban_render_operator_readiness helper, whose status==degraded→FAIL
+            # rule would contradict a COMMITTED verdict (non-structural degraded can
+            # be COMMITTED). One block only — no second/contradictory verdict.
+            local _rd_ready="PASS" _rd_action="NONE"
+            if [[ "${health_status:-0}" -ne 0 ]]; then _rd_ready="PASS_WITH_WARN"; _rd_action="WARN"; fi
+            printf "  %-20s %s\n" "Operational:" "YES"
+            printf "  %-20s %s\n" "Upgrade readiness:" "$_rd_ready"
+            printf "  %-20s %s\n" "Action needed:" "$_rd_action"
             echo ""
 
             # v1.174 transparency: if this run auto-recovered a PRE-EXISTING failed
@@ -816,6 +834,12 @@ _cmd_update_main_locked() {
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
             echo "  Update completed in DEGRADED state: v$current_version → v$new_version"
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            # v1.198 R1b-3: readiness line consistent with the DEGRADED verdict
+            # (install_state authoritative). Augments the single consolidated block.
+            printf "  %-20s %s\n" "Operational:" "YES (kernel firewall may be active)"
+            printf "  %-20s %s\n" "Upgrade readiness:" "FAIL"
+            printf "  %-20s %s\n" "Action needed:" "review / repair (below)"
             echo ""
             if [[ -n "$_failure_reason" ]]; then
                 echo "  Reason: $_failure_reason"

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -54,6 +54,17 @@ _update_log() {
     esac
 }
 
+# v1.198 R1b-3: fixed-phase progress marker for the full `nftban update` run.
+# Emits "[n/total] <phase>[ — <hint>]" through _update_log (timestamped in the
+# log, prefixed on the terminal). Presentation only — there is NO progress bar
+# and NO dynamic state machine; it does not change update logic, ordering, or
+# the rc contract. The total is a fixed phase count for a full run.
+_NFTBAN_UPDATE_PHASE_TOTAL="${_NFTBAN_UPDATE_PHASE_TOTAL:-6}"
+_update_phase() {
+    local n="$1" name="$2" hint="${3:-}"
+    _update_log INFO "[${n}/${_NFTBAN_UPDATE_PHASE_TOTAL}] ${name}${hint:+ — ${hint}}"
+}
+
 _update_banner() {
     local current_ver
     current_ver=$(_get_current_version 2>/dev/null || echo "unknown")

--- a/cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh
+++ b/cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1b-3 update progress UX + readiness reconciliation
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_update_progress_r1b3_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-21"
+# meta:description="Unit test for cmd_update_helpers.sh::_update_phase ([n/total] markers) + structural assertions that cmd_update.sh wires ordered phase banners and an operator-readiness line consistent with the existing consolidated install_state verdict (no second/contradictory verdict, rc contract preserved). Full _cmd_update_main_locked execution is exercised by CI's Update Canonization Gate."
+# meta:input="None (sources cmd_update_helpers.sh in a sandbox; greps cmd_update.sh)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,UPDATE_LOG_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+CU="${NFTBAN_LIB_DIR}/cli/cmd_update.sh"
+
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+export UPDATE_LOG_FILE="$SANDBOX/update.log"
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/cli/cmd_update_helpers.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+ar()  { if grep -qE -- "$2" <<<"$1"; then ok "$3"; else bad "$3 (no match: $2)"; fi; }
+gf()  { if grep -qF -- "$1" "$CU"; then ok "$2"; else bad "$2 (missing in cmd_update.sh: $1)"; fi; }
+
+echo "R1b-3 update progress + readiness — tests"
+
+# T1 (unit): _update_phase format + default total
+OUT=$(_update_phase 1 "Backup")
+ar "$OUT" '\[1/6\] Backup$'                         "T1 phase marker format [1/6] Backup"
+OUT=$(_update_phase 2 "Install" "package install may take up to 60s")
+ar "$OUT" '\[2/6\] Install — package install may take up to 60s$' "T1 phase marker with long-step hint"
+
+# T2: ordered fixed-phase markers wired in cmd_update.sh (success path)
+gf '_update_phase 1 "Backup"'                       "T2 phase 1 Backup wired"
+gf '_update_phase 2 "Install"'                      "T2 phase 2 Install wired"
+gf '_update_phase 3 "Restart services"'             "T2 phase 3 Restart wired"
+gf '_update_phase 4 "Health check"'                 "T2 phase 4 Health wired"
+gf '_update_phase 5 "Post-update verification"'     "T2 phase 5 Post-verify wired"
+gf '_update_phase 6 "Finalize"'                     "T2 phase 6 Finalize wired"
+
+# T3: COMMITTED (protected/idle clean) readiness defaults to PASS (not DEGRADED/FAIL)
+gf 'local _rd_ready="PASS" _rd_action="NONE"'       "T3 COMMITTED readiness default PASS/NONE"
+# T4: WARN (health reported issues) -> PASS_WITH_WARN, success path NOT failed
+gf '_rd_ready="PASS_WITH_WARN"; _rd_action="WARN"'  "T4 health-issues -> PASS_WITH_WARN/WARN"
+
+# T5: install_state DEGRADED -> readiness FAIL (not fully ready)
+if grep -Pzoq 'DEGRADED\)(.|\n)*?Upgrade readiness:" "FAIL"(.|\n)*?return 1' "$CU" 2>/dev/null; then
+    ok "T5 DEGRADED block -> readiness FAIL + return 1"
+else
+    # portable fallback: both tokens present and DEGRADED returns 1
+    if grep -qF 'printf "  %-20s %s\n" "Upgrade readiness:" "FAIL"' "$CU"; then ok "T5 DEGRADED readiness FAIL line present"; else bad "T5 DEGRADED readiness FAIL line missing"; fi
+fi
+
+# T6: structural-vs-non-structural degraded distinction in the update verdict preserved (V6)
+gf '_has_structural=true'                           "T6 structural-degraded detection preserved"
+gf 'non-structural degradation'                     "T6 non-structural warning path preserved"
+
+# T7: no duplicate/conflicting readiness verdict — single consolidated case; generic helper NOT called here
+if [[ "$(grep -c 'case "\$_installer_state" in' "$CU")" -eq 1 ]]; then ok "T7 single consolidated install_state verdict (one case)"; else bad "T7 unexpected number of verdict case blocks"; fi
+# the helper may be NAMED in a comment ("NOT the generic helper…") but must never be CALLED here
+if grep 'nftban_render_operator_readiness' "$CU" | grep -qvE '^[[:space:]]*#'; then bad "T7 generic readiness helper CALLED (non-comment) in update (contradiction risk)"; else ok "T7 generic readiness helper NOT called in cmd_update.sh (no contradiction)"; fi
+
+# T7b: rc contract preserved across verdict branches
+gf 'return 0'  "T7b COMMITTED/unknown return 0 preserved"
+gf 'return 1'  "T7b DEGRADED return 1 preserved"
+gf 'return 2'  "T7b FAILED return 2 preserved"
+gf 'return $result' "T7b install-failure preserves source rc"
+
+# T8: --json cache path (update check) intact + not polluted by human-only progress text
+if grep -qF -- '--json|-j)' "$CU"; then ok "T8 update --json flag handling intact"; else bad "T8 --json flag handling missing"; fi
+# the json cache writer block must not contain phase/readiness human text
+if awk '/update_available\.json/{c++} END{exit (c>0)?0:1}' "$CU"; then ok "T8 update_available.json cache path present"; else bad "T8 json cache path missing"; fi
+
+# T9: helper defined+available
+if declare -F _update_phase >/dev/null 2>&1; then ok "T9 _update_phase defined (cmd_update_helpers.sh)"; else bad "T9 _update_phase not defined"; fi
+
+echo "-----------------------------------------------"
+printf 'R1b-3 progress tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## R1b-3 — `nftban update` progress markers + readiness reconciliation

**Baseline:** main `8ed90112` (R1b-1+R1b-2 merged), VERSION `1.197.0`, schema **1.84.0**, BotGuard disabled.

### Scope
1. **Fixed-phase progress UX:** `[n/6]` markers for the full update run via `cmd_update_helpers.sh::_update_phase` — Backup → Install → Restart services → Health check → Post-update verification → Finalize, with a long-step hint on Install ("package install may take up to 60s"). **No progress bar, no state machine**, no change to update logic or rc.
2. **R1b-2 readiness reconciliation (the deferred slice):** the operator-readiness verdict is folded **into the existing consolidated install_state verdict block** (V127 item 1.6) — COMMITTED → `Operational: YES · Upgrade readiness: PASS|PASS_WITH_WARN · Action needed: NONE|WARN` (PASS_WITH_WARN when the post-update health check reported issues); DEGRADED → `FAIL`. Derived from the update's **own adjudicated signals** (`install_state` + health rc).

### Why NOT the generic helper here
Calling `nftban_render_operator_readiness` in the update path would print a **contradictory second verdict**: its `status==degraded → FAIL` rule fires even when the installer committed a non-structural-degraded state (a COMMITTED success). That is exactly the double-verdict V127 1.6 fixed. So readiness is rendered inline, consistent-by-construction with the single consolidated block.

### Preserved
Structural-vs-non-structural degraded distinction (V6); all verdict rc codes (COMMITTED 0 / DEGRADED 1 / FAILED 2 / install-fail `$result`); `update check --json` cache path; `cmd_status.sh` untouched.

### Explicit NON-scope
No Go (daemon byte-identical); no `nftban-installer` Go-installer output (its progress stays split out); no schema/counter/detector/ban-behavior/BotGuard/CSF/host/tag/release/register change; no R1b-4 message audit; no R1a.

### Validation
- `bash -n` clean; shellcheck clean (test `-S warning`; core/cli `-S error`).
- Hermetic test `nftban_update_progress_r1b3_test.sh`: **22/22** — unit `_update_phase` format + hint; ordered phase wiring [1/6]–[6/6]; COMMITTED PASS/PASS_WITH_WARN logic; DEGRADED FAIL+return 1; structural/non-structural preserved; single consolidated verdict; generic helper NOT called (no contradiction); rc contract; `--json` intact.
- **Full update flow exercised by CI's Update Canonization Gate** (real install/update in containers).
- R1b-1 + R1b-2 tests still pass (regression). No `.go` changed; `SchemaVersionCurrent = "1.84.0"` untouched.

Files: `cli/cmd_update.sh`, `cli/cmd_update_helpers.sh` (+`_update_phase`), `tests/nftban_update_progress_r1b3_test.sh` (new).
