### PR TITLE
fix(cli): correct stale GeoIP country-IP help path

### DIFF
--- a/cli/lib/nftban/cli/cmd_geoban.sh
+++ b/cli/lib/nftban/cli/cmd_geoban.sh
@@ -620,7 +620,7 @@ Features:
 Notes:
   • GeoBan uses the nftban-geoip Go binary for performance
   • Changes are applied atomically to running firewall
-  • Country IP lists are cached in /var/cache/nftban/geoban/
+  • Country IP lists are stored in /var/lib/nftban/geoip/
   • Configuration files stored in /etc/nftban/geoban.d/
 
 EOF

--- a/cli/lib/nftban/cli/cmd_geoip.sh
+++ b/cli/lib/nftban/cli/cmd_geoip.sh
@@ -787,7 +787,7 @@ FILES AND LOCATIONS:
     GeoBan config:   /etc/nftban/conf.d/geoban/main.conf
     User overrides:  *.conf.local files in same directories
     GeoBan files:    /etc/nftban/geoban.d/
-    Country IPs:     /var/cache/nftban/geoban/
+    Country IPs:     /var/lib/nftban/geoip/
     Tracking:        /var/lib/nftban/geoban/tracking/
     Logs:            ${NFTBAN_LOG_DIR}/geoip.log
 

--- a/cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh
+++ b/cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1a-1 GeoIP help-path correction
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_geoip_help_path_r1a1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-21"
+# meta:description="Guard for R1a-1: cmd_geoip.sh / cmd_geoban.sh help text must not advertise the stale /var/cache/nftban/geoban country-IP path and must use the real runtime path /var/lib/nftban/geoip/ (authority: nftban_geoip_download.sh + Go GeoIPDir = DataDir/geoip)."
+# meta:input="None (greps the two CLI help files)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+LIB="${REPO_ROOT}/cli/lib/nftban"
+GEOIP="${LIB}/cli/cmd_geoip.sh"
+GEOBAN="${LIB}/cli/cmd_geoban.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+
+echo "R1a-1 GeoIP help-path — guard tests"
+
+# 1. stale country-IP cache path must be gone from both surfaces
+if grep -qF '/var/cache/nftban/geoban' "$GEOIP"; then bad "cmd_geoip.sh still advertises stale /var/cache/nftban/geoban"; else ok "cmd_geoip.sh: no stale /var/cache/nftban/geoban"; fi
+if grep -qF '/var/cache/nftban/geoban' "$GEOBAN"; then bad "cmd_geoban.sh still advertises stale /var/cache/nftban/geoban"; else ok "cmd_geoban.sh: no stale /var/cache/nftban/geoban"; fi
+
+# 2. corrected surfaces reference the real runtime path
+if grep -qF '/var/lib/nftban/geoip/' "$GEOIP"; then ok "cmd_geoip.sh references /var/lib/nftban/geoip/"; else bad "cmd_geoip.sh missing /var/lib/nftban/geoip/"; fi
+if grep -qF '/var/lib/nftban/geoip/' "$GEOBAN"; then ok "cmd_geoban.sh references /var/lib/nftban/geoip/"; else bad "cmd_geoban.sh missing /var/lib/nftban/geoip/"; fi
+
+# 3. the corrected "Country IP" lines specifically use the geoip dir
+if grep -qE 'Country IP.*/var/lib/nftban/geoip/' "$GEOIP"; then ok "cmd_geoip.sh 'Country IPs' line uses geoip dir"; else bad "cmd_geoip.sh 'Country IPs' line not corrected"; fi
+if grep -qE 'Country IP lists.*/var/lib/nftban/geoip/' "$GEOBAN"; then ok "cmd_geoban.sh 'Country IP lists' line uses geoip dir"; else bad "cmd_geoban.sh 'Country IP lists' line not corrected"; fi
+
+# 4. authority sanity: the runtime path matches the downloader/Go target (not a new invention)
+if grep -qF '${NFTBAN_DATA_DIR:-/var/lib/nftban}/geoip' "${LIB}/core/nftban_geoip_download.sh"; then ok "authority: downloader target is DataDir/geoip (matches corrected help)"; else bad "authority: downloader target unexpected — re-verify path"; fi
+
+echo "-----------------------------------------------"
+printf 'R1a-1 help-path tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## R1a-1 — GeoIP help-path correction (help-text only)

**Baseline:** main `fcd9c8e7`, VERSION `1.197.0`, schema `1.84.0`, BotGuard disabled.

`nftban geoip` / `nftban geoban` help advertised the obsolete country-IP location `/var/cache/nftban/geoban/`. The **real runtime path is `/var/lib/nftban/geoip/`** — verified authority (not invented):
- downloader `core/nftban_geoip_download.sh:204` writes `${NFTBAN_DATA_DIR:-/var/lib/nftban}/geoip`
- Go `nftbanconf/loader.go:671` `GeoIPDir: cfg.DataDir + "/geoip"`; `GeoIPFile("GR.zone") → /var/lib/nftban/geoip/GR.zone`
- `cmd_geoip.sh:785` already prints `/var/lib/nftban/geoip/` for the DB
- `/var/cache/nftban/geoban/` has **no writer/reader anywhere** (repo-wide grep) — purely stale text.

### Change (2 help lines)
- `cmd_geoip.sh` `Country IPs:` → `/var/lib/nftban/geoip/`
- `cmd_geoban.sh` `Country IP lists are stored in /var/lib/nftban/geoip/`

### NON-scope / preserved
No runtime path / config default / downloader / GeoIP / geoban behavior change. The separate `Tracking: /var/lib/nftban/geoban/tracking/` line is untouched. RBL 11.4 / TODO-23 untouched. No Go (daemon byte-identical); schema `1.84.0`; no wiki; no other R1a items.

### Validation
`bash -n` + shellcheck clean · guard test `nftban_geoip_help_path_r1a1_test.sh` 7/7 (stale path gone, real path present, authority sanity) · no `.go` changed · diff = 2 help lines + 1 test.