### PR TITLE
fix(cli): DirectAdmin disable SSH-port wording + 15.14 PAM audit-close

### DIFF
--- a/cli/lib/nftban/lib/nftban_panel_directadmin.sh
+++ b/cli/lib/nftban/lib/nftban_panel_directadmin.sh
@@ -399,8 +399,12 @@ nftban_panel_directadmin_disable() {
         echo ""
         echo "DirectAdmin ports have been removed from firewall."
         echo ""
+        # v1.198 R1a-2 (15.12): don't hardcode SSH on 22 — resolve the safety
+        # port the firewall actually preserves (mirrors the v1.150 help fix), so
+        # the message is correct on hosts that moved SSH off 22.
+        local _da_ssh_port="${NFTBAN_SSH_TEST_PORT:-${SSH_PORT:-22}}"
         echo "Preserved ports from ports.d/:"
-        echo "  • 22 (SSH - safety port)"
+        echo "  • ${_da_ssh_port} (SSH - safety port)"
         echo "  • Any custom ports you configured"
         echo ""
         return 0

--- a/cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh
+++ b/cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1a-2 DirectAdmin help/disable SSH-port + PAM audit
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_da_help_ssh_port_r1a2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-21"
+# meta:description="R1a-2 Part A: DirectAdmin user-facing output (help + disable confirmation) must not hardcode SSH port 22 — it resolves the safety port (NFTBAN_SSH_TEST_PORT/SSH_PORT). Part B audit guard: deprecated nftban-ui appears only in removal/cleanup paths (no live creation/ship)."
+# meta:input="None (greps cmd/lib + install paths)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+DA="${REPO_ROOT}/cli/lib/nftban/lib/nftban_panel_directadmin.sh"
+INSTALL="${REPO_ROOT}/install"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+
+echo "R1a-2 DA SSH-port + PAM audit — tests"
+
+# Part A
+if grep -qE '•[[:space:]]*22[[:space:]]*\(SSH' "$DA"; then bad "Part A: DA output still hardcodes '• 22 (SSH …)'"; else ok "Part A: no hardcoded '• 22 (SSH' in DA user output"; fi
+if grep -qE 'echo "  • \$\{_da_ssh_port\} \(SSH - safety port\)"' "$DA"; then ok "Part A: disable confirmation uses resolved \${_da_ssh_port}"; else bad "Part A: disable confirmation not using resolved port"; fi
+# regression: the v1.150 help fix still resolves the port (not re-hardcoded)
+if grep -qE '\$\{_da_ssh_port\}[[:space:]]+- SSH \(safety port' "$DA"; then ok "Part A: DA help still resolves \${_da_ssh_port} (v1.150 regression)"; else bad "Part A: DA help port resolution regressed"; fi
+# no bare hardcoded 22 in the SSH-safety-port semantic lines
+if grep -qE '(safety port|SSH).*\b22\b' "$DA" | grep -vqE '\$\{|:-22\}' 2>/dev/null; then bad "Part A: a bare 22 lingers in an SSH-safety-port line"; else ok "Part A: SSH-safety-port lines are port-neutral (default :-22 only)"; fi
+
+# Part B audit guard: deprecated nftban-ui only in removal/cleanup context (no live creation)
+if grep -rnE '(^|[^-])nftban-ui' "$INSTALL" --include=*.sh --include=*.inc --include=*.service 2>/dev/null \
+   | grep -vE 'rm |stop|disable|mask|reset-failed|no longer|removed|residue|cleanup|purge|deprecated' \
+   | grep -qvE '#'; then
+    bad "Part B: a non-removal nftban-ui reference exists in install paths (possible live residual)"
+else
+    ok "Part B: nftban-ui appears only in removal/cleanup/comment context (15.14 audit-close)"
+fi
+
+echo "-----------------------------------------------"
+printf 'R1a-2 tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## R1a-2 — DirectAdmin SSH-port wording (15.12) + orphan-PAM audit-close (15.14)

**Baseline:** main `837bc53c`, VERSION `1.197.0`, schema `1.84.0`, BotGuard disabled.

### Part A — 15.12 DA SSH-port (help-text only)
The DirectAdmin **help** already resolved the SSH safety port (fixed v1.150, uses `${_da_ssh_port}`). The residual hardcode was in `nftban_panel_directadmin_disable()`'s post-disable confirmation — `"Preserved ports … • 22 (SSH - safety port)"` — misleading on hosts that moved SSH off 22. Now resolves the same way the help does: `${NFTBAN_SSH_TEST_PORT:-${SSH_PORT:-22}}`. **No runtime / port / behavior change.**

### Part B — 15.14 orphan-PAM → AUDIT-CLOSE (no code)
Read-only audit: deprecated `nftban-ui` (+ `nftban-api.service`) appear **only** in removal/cleanup paths (`prerm`/`preinst`/`preun`/`pre-deprecated` includes purge stale residue) and "no longer shipped" comments — **no live install path creates or ships them.** Existing cleanup covers the concern → audit-close. **No live PAM residual found** (not `R1A2_NO_GO`).

**Observed (separate, NOT 15.14, NOT patched here):** `install/pam.d/nftban-api` is a repo file with **no deb/rpm filelist entry, no installer reference, and no PAM consumer** — a dead/unused orphan file (not a live residual). Flagged for a separate 8.2-class file-cleanup audit (needs its own gate + filelist proof to delete).

### Validation
`bash -n` + shellcheck clean · guard test `nftban_da_help_ssh_port_r1a2_test.sh` **5/5** (no hardcoded `• 22 (SSH`, resolved port used, v1.150 help regression, Part B nftban-ui cleanup-only) · no `.go` changed (daemon byte-identical) · schema `1.84.0` · diff = 1 shell line-group + 1 test.

NON-scope: no installer-Go, no package install/uninstall behavior change, no wiki, no R1a-3/4/5/6, no register status move.