### PR TITLE
docs(config): CONFIG/RHG cosmetic comment cleanup (D-RHG-1)

### DIFF
--- a/cli/etc/nftban/conf.d/login_alert.conf
+++ b/cli/etc/nftban/conf.d/login_alert.conf
@@ -1,15 +1,21 @@
 # =============================================================================
-# NFTBan v1.0.0 - Login Alert Configuration
+# NFTBan - Login Alert Configuration
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 # File: /etc/nftban/conf.d/login_alert.conf
 # Purpose: Configure login monitoring and alerting
 #
-# meta:name=login_alert.conf
-# meta:type=config
-# meta:version=1.0.0
+# meta:name="login_alert.conf"
+# meta:type="config"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
-# meta:homepage=https://nftban.com
+# meta:description="Configure login monitoring and alerting"
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files="/etc/nftban/conf.d/login_alert.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
 #
 # NOTE: Email recipient is configured globally in /etc/nftban/conf.d/mail.conf
 #       using NFTBAN_MAIL_RECIPIENT - no need to configure email here!

--- a/cli/etc/nftban/conf.d/services.conf
+++ b/cli/etc/nftban/conf.d/services.conf
@@ -1,5 +1,5 @@
 # =============================================================================
-# NFTBan v1.0.0 - Services Control Configuration
+# NFTBan - Services Control Configuration
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 # File: /etc/nftban/conf.d/services.conf

--- a/cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh
+++ b/cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.198 R1a-6 CONFIG/RHG cosmetic comment cleanup (D-RHG-1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_config_rhg_cosmetic_r1a6_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-22"
+# meta:description="Guards the R1a-6 (D-RHG-1) cosmetic comment cleanup: the two conf.d header comments no longer carry the stale 'NFTBan v1.0.0' version banner, and the four scripts/ci comment blocks no longer embed the /home/commonfolder dev-machine path. Comment-only; no KEY=VALUE/default change."
+# meta:input="None (greps the 6 touched files)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+
+echo "R1a-6 CONFIG/RHG cosmetic (D-RHG-1) — guard tests"
+
+# (1) the two conf.d headers no longer carry the stale 'NFTBan v1.0.0' banner
+for c in conf.d/services.conf conf.d/login_alert.conf; do
+    f="${REPO_ROOT}/cli/etc/nftban/${c}"
+    if grep -qF 'NFTBan v1.0.0' "$f"; then bad "$c still has stale 'NFTBan v1.0.0' header"; else ok "$c: stale 'NFTBan v1.0.0' header removed"; fi
+done
+
+# (2) the four CI scripts no longer embed the /home/commonfolder dev-machine path
+for s in test-heredoc-safety test-systemd-execstart-payload-resolution test-install-method-detection test-immutable-lifecycle-matrix; do
+    f="${REPO_ROOT}/scripts/ci/${s}.sh"
+    if grep -qF '/home/commonfolder' "$f"; then bad "scripts/ci/${s}.sh still embeds /home/commonfolder dev path"; else ok "scripts/ci/${s}.sh: dev-machine path removed"; fi
+    # the audit scope-doc reference is preserved (cleanup, not deletion of the pointer)
+    if grep -qE 'SCOPE\.md' "$f"; then ok "scripts/ci/${s}.sh: scope-doc reference preserved"; else bad "scripts/ci/${s}.sh: lost its scope-doc reference"; fi
+done
+
+echo "-----------------------------------------------"
+printf 'R1a-6 cosmetic tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/test-heredoc-safety.sh
+++ b/scripts/ci/test-heredoc-safety.sh
@@ -17,8 +17,7 @@
 # meta:inventory.privileges="none"
 # =============================================================================
 #
-# Implements V108 Item 3 per scope artifact:
-#   /home/commonfolder/LLMAI4NFTBAN/V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/
+# Implements V108 Item 3 per the project audit scope artifact:
 #   V108_ITEM3_HEREDOC_SAFETY_SCAN_SCOPE.md
 #
 # Motivating defect (v1.107.1 / PR #585 fixup commit da14e182):

--- a/scripts/ci/test-immutable-lifecycle-matrix.sh
+++ b/scripts/ci/test-immutable-lifecycle-matrix.sh
@@ -17,8 +17,7 @@
 # meta:inventory.privileges="none"
 # =============================================================================
 #
-# Implements V108 Item 2 per scope artifact:
-#   /home/commonfolder/LLMAI4NFTBAN/V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/
+# Implements V108 Item 2 per the project audit scope artifact:
 #   V108_ITEM2_IMMUTABLE_LIFECYCLE_MATRIX_SCOPE.md
 #
 # Motivating defect (v1.107.2 / PR #585):

--- a/scripts/ci/test-install-method-detection.sh
+++ b/scripts/ci/test-install-method-detection.sh
@@ -17,8 +17,7 @@
 # meta:inventory.privileges="none"
 # =============================================================================
 #
-# Implements V108 Item 6 per scope artifact:
-#   /home/commonfolder/LLMAI4NFTBAN/V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/
+# Implements V108 Item 6 per the project audit scope artifact:
 #   V108_ITEM6_SOURCE_INSTALL_DETECTION_SCOPE.md
 #
 # Motivating defect (dns2 v1.107.2 rollout):

--- a/scripts/ci/test-systemd-execstart-payload-resolution.sh
+++ b/scripts/ci/test-systemd-execstart-payload-resolution.sh
@@ -17,8 +17,7 @@
 # meta:inventory.privileges="none"
 # =============================================================================
 #
-# Implements V108 Item 1 per scope artifact:
-#   /home/commonfolder/LLMAI4NFTBAN/V1.90_AUDIT_WIKI_CODE/AUDIT_190_LIFECYCLE/
+# Implements V108 Item 1 per the project audit scope artifact:
 #   V108_ITEM1_EXECSTART_PAYLOAD_RESOLUTION_SCOPE.md
 #
 # Compile-time complement to runtime assertion `systemd_execstart_paths_ok`


### PR DESCRIPTION
## R1a-6 — CONFIG/RHG cosmetic comment cleanup (D-RHG-1)

**Baseline:** main `871c92a9`, VERSION `1.197.0`, schema `1.84.0`, BotGuard disabled. **Comment/text-only.**

D-RHG-1 cosmetic drift (open register), the safe comment-only subset:
- **`conf.d/services.conf` + `conf.d/login_alert.conf`** — drop the stale `NFTBan v1.0.0` version banner from the file-header comment → neutral `NFTBan - … Configuration` (matches the v1.190.2 header-neutralization). *(the "stale banner ×2")*
- **`scripts/ci/{test-heredoc-safety, test-systemd-execstart-payload-resolution, test-install-method-detection, test-immutable-lifecycle-matrix}.sh`** — drop the embedded `/home/commonfolder` dev-machine path from each scope-artifact comment block; the audit scope-doc **name** reference is preserved. *(the "CI-comment paths")*

### Note: pre-existing header non-compliance surfaced
Touching `login_alert.conf` tripped the commit hook on a **pre-existing** header-standard violation (unquoted `meta:` lines + missing `meta:inventory.*` block) — unrelated to the banner fix, but the hook blocks any commit of a non-compliant file. Brought its meta header to the **same standard as its compliant sibling `services.conf`** (quote meta, add the 7 inventory lines, drop the stale unrequired `meta:version`/`meta:homepage`). All `# meta:` comment lines.

### Validation
Diff audit: **every changed line is a comment (`#`)** — no `KEY=VALUE`, no default, no schema, no parser-sensitive syntax, no package/filelist change. `bash -n` + shellcheck clean (CI scripts) · config files parse · guard test `nftban_config_rhg_cosmetic_r1a6_test.sh` **10/10** · no `.go` (daemon byte-identical) · schema `1.84.0`.

### Out of scope (NOT touched)
User-facing echo/setup version banners · Go-file headers · accurate "since v1.0" descriptive comments · the `packaging/`-vs-`install/` systemd-split structural note (D-RHG-1 sub-item, not a comment) · R1a-5 file cleanup / `install/pam.d/nftban-api` orphan · wiki.