### PR TITLE
fix(v1.198.1): alert-handler /dev/log robustness (PR-A) + official install_state recommit path (PR-B)

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -922,6 +922,43 @@ _cmd_update_main_locked() {
     esac
 }
 
+_cmd_update_recommit() {
+    # v1.198.1 PR-B (D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): official,
+    # restart-free recompute of a stale DEGRADED install_state. Delegates to
+    # `nftban-installer --revalidate`, which re-runs ONLY the live post-install
+    # assertions and re-writes install_state — no package install, no firewall
+    # render, no daemon restart. install_state goes COMMITTED only when every
+    # live assertion passes; a real remaining failure leaves it DEGRADED (no
+    # masking). This is the supported way to clear a stale DEGRADED marker once
+    # the underlying cause (e.g. a pre-existing systemd failed-state latch) is
+    # resolved — replacing manual edits of the machine-written state file.
+    _update_banner
+    echo ""
+
+    if [[ $EUID -ne 0 ]]; then
+        _update_log ERROR "PolicyKit/polkit authorization failed or insufficient privileges"
+        _update_log INFO "Hint: update recommit requires elevated privileges; members of the nftban group are authorized via PolicyKit/polkit rules."
+        return 1
+    fi
+
+    local installer="/usr/lib/nftban/bin/nftban-installer"
+    if [[ ! -x "$installer" ]]; then
+        _update_log ERROR "nftban-installer not found at $installer — cannot recommit"
+        return 1
+    fi
+
+    _update_log INFO "Recomputing install_state from live post-install assertions (no install, no daemon restart)..."
+    "$installer" --revalidate
+    local rc=$?
+    case $rc in
+        0) _update_log OK "install_state recommitted: COMMITTED" ;;
+        1) _update_log WARN "install_state remains DEGRADED — live assertions still failing (see above); not masking a real failure" ;;
+        5) _update_log INFO "Nothing to recommit (state is not DEGRADED, version mismatch, or no state file) — see above" ;;
+        *) _update_log ERROR "recommit failed (installer exit $rc)" ;;
+    esac
+    return $rc
+}
+
 _cmd_update_repair() {
     # Repair a broken nftban installation
     # This is the nuclear option - fixes dpkg, removes immutable flags,
@@ -1581,6 +1618,8 @@ COMMANDS:
     force               Force reinstall/update (fixes dpkg, removes immutable flags)
     rollback            Restore previous version from backup (fixes dpkg first)
     repair              Fix broken install (dpkg state, immutable flags, restore backup)
+    recommit            Recompute a stale DEGRADED install_state from live post-install
+                        assertions (no install/restart); → COMMITTED only if all pass
     list                List available backups
     history             Show update history (last 9 updates, --json supported)
     auto [ACTION]       Manage auto-update timer (enable|disable|status)
@@ -2558,6 +2597,11 @@ nftban_cmd_update() {
             ;;
         repair|--repair|fix)
             _cmd_update_repair
+            ;;
+        recommit|--recommit|revalidate)
+            # v1.198.1 PR-B: restart-free recompute of a stale DEGRADED
+            # install_state → COMMITTED via nftban-installer --revalidate.
+            _cmd_update_recommit
             ;;
         rollback|--rollback|-r)
             # v1.139.2: pass "$@" so _do_rollback's help-guard sees --help/-h/help.

--- a/cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh
+++ b/cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.198.1 PR-A: alert handler survives /dev/log denied under sandbox
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="alert_logger_devlog_sandbox_v1981_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-22"
+# meta:description="D-NFTBAN-ALERT-LOGGER-DEVLOG-PERMISSION: under the nftban-alert@ sandbox (PrivateDevices=yes + User=nftban) `logger` hits /dev/log EACCES. PR-A makes log_alert deliver to the journal (stderr, the unit's StandardError=journal) + the file log and treat `logger` as best-effort, so the OnFailure oneshot exits 0 instead of latching failed (which tripped the post-install failed-unit assertion → install_state DEGRADED). Hermetic: a failing `logger` stub on PATH simulates the EACCES; no host, no real systemd."
+# meta:input="None (failing logger stub + temp dirs)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/sbin/nftban-service-alert"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_CONFIG_DIR,NFTBAN_LIB_DIR,NFTBAN_MAIL_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-alert@.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+ALERT="$REPO_ROOT/cli/sbin/nftban-service-alert"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+[[ -f "$ALERT" ]] || { echo "alert script not found: $ALERT"; exit 1; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# A `logger` stub that fails exactly like the sandbox does: EACCES on /dev/log.
+FAKEBIN="$WORK/fakebin"; mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/logger" <<'STUB'
+#!/usr/bin/env bash
+# Drop a sentinel proving we ran, then fail like the sandbox /dev/log EACCES.
+# (PR-A pipes our stderr to /dev/null, so a sentinel — not stderr — proves it fired.)
+d="$(dirname "$0")"; : > "$d/fired" 2>/dev/null || true
+echo "logger: socket /dev/log: Permission denied" >&2
+exit 1
+STUB
+chmod +x "$FAKEBIN/logger"
+
+# run_alert_failing_logger -> sets RC, LOG, ERROUT (stderr captured)
+run_alert_failing_logger() {
+  local logdir="$WORK/log.$RANDOM"; mkdir -p "$logdir"
+  local datadir="$WORK/data.$RANDOM"; mkdir -p "$datadir"
+  ERRFILE="$logdir/stderr.txt"
+  set +e
+  PATH="$FAKEBIN:$PATH" \
+  NFTBAN_LOG_DIR="$logdir" \
+  NFTBAN_DATA_DIR="$datadir" \
+  NFTBAN_CONFIG_DIR="$WORK/noconfig" \
+  NFTBAN_LIB_DIR="$WORK/nolib" \
+  NFTBAN_MAIL_RECIPIENT="" \
+    bash "$ALERT" nftband.service >/dev/null 2>"$ERRFILE"
+  RC=$?
+  set -e
+  LOG="$logdir/service-alerts.log"
+  ERROUT="$(cat "$ERRFILE" 2>/dev/null || true)"
+}
+
+echo "== Test A: logger fails (/dev/log EACCES) => alert oneshot STILL exits 0 (PR-A) =="
+run_alert_failing_logger
+[[ "$RC" -eq 0 ]] && ok "A exit 0 despite logger /dev/log EACCES (RC=$RC)" \
+  || no "A exit 0 under failing logger" "got RC=$RC — log_alert's unguarded logger latched the unit failed (pre-PR-A regression)"
+
+echo "== Test B: the failing logger DID run (sentinel proves the EACCES path was exercised; PR-A pipes its stderr to /dev/null) =="
+if [[ -f "$FAKEBIN/fired" ]]; then ok "B logger stub fired (EACCES path exercised; its stderr correctly suppressed by PR-A)"; else no "B logger stub fired" "sentinel not created — logger was not invoked"; fi
+
+echo "== Test C: alert still DELIVERED to the file log (durable sink) =="
+if [[ -f "$LOG" ]] && grep -q "Service failure detected: nftband.service" "$LOG"; then ok "C alert persisted to file log"; else no "C file-log delivery" "ALERT line missing in $LOG"; fi
+
+echo "== Test D: alert ALSO delivered to the journal path (stderr; unit StandardError=journal) =="
+# PR-A prints '[ts] [LEVEL] msg' to stderr so it reaches the journal WITHOUT /dev/log.
+if grep -q "\[ALERT\] Service failure detected: nftband.service" <<<"$ERROUT"; then ok "D alert on stderr (journal-native) without /dev/log"; else no "D journal-native delivery" "ALERT line missing on stderr"; fi
+
+echo "== Test E: source guard — log_alert is journal-safe (best-effort logger + return 0) =="
+if grep -Eq 'logger -t nftban-alert .* 2>/dev/null \|\| true' "$ALERT"; then ok "E logger call is best-effort (2>/dev/null || true)"; else no "E best-effort logger" "unguarded logger remains in $ALERT"; fi
+if awk '/^log_alert\(\)/{f=1} f&&/^}/{print last; exit} f{last=$0}' "$ALERT" | grep -q 'return 0'; then ok "E log_alert returns 0 (never propagates logger failure)"; else no "E log_alert return 0" "log_alert does not end with 'return 0'"; fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/sbin/nftban-service-alert
+++ b/cli/sbin/nftban-service-alert
@@ -64,8 +64,23 @@ log_alert() {
     local level="$1"
     shift
     mkdir -p "$(dirname "$ALERT_LOG")" 2>/dev/null || true
-    echo "[$TIMESTAMP] [$level] $*" >> "$ALERT_LOG"
-    logger -t nftban-alert -p "user.${level,,}" "$*"
+    echo "[$TIMESTAMP] [$level] $*" >> "$ALERT_LOG" 2>/dev/null || true
+    # v1.198.1 PR-A (D-NFTBAN-ALERT-LOGGER-DEVLOG-PERMISSION): deliver to the journal
+    # via stderr — the unit sets StandardError=journal + SyslogIdentifier=nftban-alert,
+    # so this reaches the journal WITHOUT the /dev/log socket, which is EACCES under the
+    # unit sandbox (PrivateDevices=yes + User=nftban: `logger` → "socket /dev/log:
+    # Permission denied"). stderr (not stdout) avoids polluting any caller's command
+    # substitution; with the file log above it is the durable sink for this handler.
+    printf '[%s] [%s] %s\n' "$TIMESTAMP" "$level" "$*" >&2
+    # Best-effort syslog: under the sandbox `logger` fails with EACCES on /dev/log. That
+    # must NEVER fail or latch the OnFailure oneshot (it is the last command in this
+    # function, so an unguarded non-zero would become the script's exit code → the unit
+    # latches "failed" → the post-install failed-unit assertion trips → install_state
+    # DEGRADED). The journal + file sinks above already delivered the alert.
+    # cf. nftban_login.sh:412 (same /dev/log-in-sandbox suppression). This does NOT hide
+    # a real alert-DELIVERY failure: email delivery keeps its own rc contract in main().
+    logger -t nftban-alert -p "user.${level,,}" "$*" 2>/dev/null || true
+    return 0
 }
 
 # =============================================================================

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -31,23 +31,24 @@ import (
 
 // config holds parsed CLI flags and environment variable overrides.
 type config struct {
-	mode        string // "install" or "upgrade"
-	rpm         bool   // called from RPM %post
-	deb         bool   // called from DEB postinst
-	repair      bool   // resume from last failed phase
-	force         bool // re-run all phases ignoring state (V125 R-4 + V126 Lane A: requires --allow-recommit when state IN {COMMITTED, DEGRADED})
-	allowRecommit bool // V125 R-4 + V126 Lane A: companion to --force; explicit operator confirmation for re-running phases on a completed install state (COMMITTED or DEGRADED)
-	takeover    bool   // approve takeover of conflicting firewalls
-	dryRun      bool   // show what would happen without changes
-	verbose     bool   // full diagnostic logging
-	quiet       bool   // minimal output
-	jsonOutput  bool   // machine-readable JSON output
-	stateDir    string // override state directory
-	logPath     string // override log file path
-	showVersion bool   // print version and exit
-	lifecycle   bool   // v1.98: use canonized lifecycle flow (feature flag)
-	source      bool   // v1.98.x PR-14-pre: source install (stage payload + users from repo tree)
-	sourceDir   string // v1.98.x PR-14-pre: source tree root for --source (resolved in parseFlags)
+	mode          string // "install" or "upgrade"
+	rpm           bool   // called from RPM %post
+	deb           bool   // called from DEB postinst
+	repair        bool   // resume from last failed phase
+	force         bool   // re-run all phases ignoring state (V125 R-4 + V126 Lane A: requires --allow-recommit when state IN {COMMITTED, DEGRADED})
+	allowRecommit bool   // V125 R-4 + V126 Lane A: companion to --force; explicit operator confirmation for re-running phases on a completed install state (COMMITTED or DEGRADED)
+	revalidate    bool   // v1.198.1 PR-B (D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): recompute install_state from LIVE post-install assertions only — no install, no daemon restart. DEGRADED→COMMITTED only if all live assertions pass; never masks a real failure.
+	takeover      bool   // approve takeover of conflicting firewalls
+	dryRun        bool   // show what would happen without changes
+	verbose       bool   // full diagnostic logging
+	quiet         bool   // minimal output
+	jsonOutput    bool   // machine-readable JSON output
+	stateDir      string // override state directory
+	logPath       string // override log file path
+	showVersion   bool   // print version and exit
+	lifecycle     bool   // v1.98: use canonized lifecycle flow (feature flag)
+	source        bool   // v1.98.x PR-14-pre: source install (stage payload + users from repo tree)
+	sourceDir     string // v1.98.x PR-14-pre: source tree root for --source (resolved in parseFlags)
 	// v1.100 PR-22: uninstall scaffold flags. All plan-only in PR-22 —
 	// no mutation code consumes these; they only influence the rendered
 	// release plan.
@@ -107,6 +108,7 @@ func parseFlags() *config {
 	flag.BoolVar(&cfg.rpm, "rpm", false, "Called from RPM %post")
 	flag.BoolVar(&cfg.deb, "deb", false, "Called from DEB postinst")
 	flag.BoolVar(&cfg.repair, "repair", false, "Resume from last failed phase")
+	flag.BoolVar(&cfg.revalidate, "revalidate", false, "Recompute install_state from LIVE post-install assertions only (no install, no daemon restart). Transitions a stale DEGRADED → COMMITTED only when every live assertion passes (version match, validate clean, 0 failed nftban units, ip/ip6 tables, daemon active); otherwise leaves DEGRADED with the current live reason. Does not mask real failures.")
 	flag.BoolVar(&cfg.force, "force", false, "Re-run all phases ignoring state")
 	// V125 R-4 + V126 Lane A: companion safety flag for --force on a completed
 	// install. When install_state is COMMITTED or DEGRADED, --force alone is
@@ -210,7 +212,7 @@ func parseFlags() *config {
 		os.Exit(state.ExitFatal)
 	}
 
-	if !cfg.showVersion && !cfg.repair {
+	if !cfg.showVersion && !cfg.repair && !cfg.revalidate {
 		// v1.100 PR-24: --mode=restore — authority restoration policy
 		// decision engine (pure, no mutation). Validation rules here
 		// exist to keep the invocation surface tight per seed §2: the

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -232,6 +232,14 @@ func systemIdentity() (hostname, osInfo string) {
 
 // run is the top-level orchestrator. Returns a process exit code.
 func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *config, log *logging.Logger) int {
+	// v1.198.1 PR-B (D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): restart-free
+	// recompute of a stale DEGRADED install_state. Dispatched before every
+	// install/upgrade/repair path because it neither installs nor restarts the
+	// daemon — it only re-runs the LIVE post-install assertions and re-writes
+	// install_state. Never marks COMMITTED unless every live assertion passes.
+	if cfg.revalidate {
+		return runRevalidate(ctx, exec, sf, cfg, log)
+	}
 	if cfg.repair {
 		return runRepair(ctx, exec, sf, log)
 	}

--- a/cmd/nftban-installer/revalidate.go
+++ b/cmd/nftban-installer/revalidate.go
@@ -1,0 +1,131 @@
+// =============================================================================
+// NFTBan v1.198.1 - nftban-installer - --revalidate (restart-free recommit)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-revalidate"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-22"
+// meta:description="v1.198.1 PR-B (D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): restart-free recompute of a stale DEGRADED install_state from the live post-install assertion suite only — no install, no daemon restart. DEGRADED→COMMITTED only when every live assertion passes; never masks a real failure."
+// meta:inventory.files="cmd/nftban-installer/revalidate.go"
+// meta:inventory.binaries="nftban-installer"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/fhs"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/installer/validate"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+// runRevalidate implements `nftban-installer --revalidate` — the v1.198.1 PR-B
+// official, non-manual, restart-free recompute of a stale DEGRADED install_state
+// (D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH).
+//
+// It does NOT install packages, render the firewall, or restart the daemon. It
+// re-runs ONLY the live post-install assertion suite (validate.RunAssertionsWithOpts,
+// the same suite the VALIDATE phase uses — which performs the v1.174/v1.185.1
+// stale-latched-oneshot recovery, now incl. the nftban-alert@ template via PR-B's
+// staleClearableOneshotStems entry) and rewrites install_state via the official
+// StateFile.Transition writer.
+//
+// Safety contract (MUST NOT mask a real failure):
+//   - Acts only on a DEGRADED state. COMMITTED → no-op. Any other / FAILED_* state
+//     → refuse (use --repair or re-run the upgrade).
+//   - Refuses when the recorded install version != the running binary version.
+//   - Transitions to COMMITTED ONLY when validate.AllPassed over the LIVE suite is
+//     true; otherwise re-writes DEGRADED with the current live failure reason. A
+//     genuinely-still-failed unit, a non-zero validator, a missing table, an
+//     inactive daemon, etc. all keep it DEGRADED (the assertions fail closed).
+func runRevalidate(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *config, log *logging.Logger) int {
+	// Read the on-disk record authoritatively: main() already overwrote
+	// sf.Version with the running binary version, so re-read for the recorded
+	// version/ssh-port/mode/state.
+	cur := state.NewStateFile(cfg.stateDir)
+	if err := cur.Read(); err != nil {
+		log.Error("revalidate: cannot read install_state at %s: %v", cur.Path(), err)
+		log.Info("revalidate recomputes an EXISTING install_state; none is present — nothing to do")
+		return state.ExitRefused
+	}
+
+	if err := ctx.Err(); err != nil {
+		log.Error("revalidate: context cancelled before start: %v", err)
+		return state.ExitFatal
+	}
+
+	switch cur.State {
+	case state.StateCommitted:
+		log.Info("revalidate: install_state already COMMITTED — nothing to recommit")
+		return state.ExitCommitted
+	case state.StateDegraded:
+		// the one recoverable terminal — proceed
+	default:
+		log.Error("revalidate: install_state=%s is not DEGRADED — recommit only recomputes a DEGRADED record", cur.State)
+		log.Info("revalidate: for a failed install use 'nftban update repair' or re-run the upgrade; revalidate will not touch %s", cur.State)
+		return state.ExitRefused
+	}
+
+	// Version guard: the DEGRADED record must belong to the currently installed
+	// version. A mismatch means the marker is from a different install; stamping
+	// COMMITTED onto it would be dishonest.
+	if cur.Version != "" && cur.Version != version.Version {
+		log.Error("revalidate: install_state version %q != running nftban-installer version %q — refusing to recommit a mismatched record", cur.Version, version.Version)
+		log.Info("revalidate: re-run the upgrade to %s, then recommit if needed", version.Version)
+		return state.ExitRefused
+	}
+
+	sshPort := cur.SSHPort
+	if sshPort <= 0 {
+		sshPort = 22
+		log.Warn("revalidate: install_state carries no SSH_PORT; assuming %d for the SSH-in-set assertion", sshPort)
+	}
+
+	log.Info("revalidate: recomputing install_state from LIVE post-install assertions (version=%s ssh_port=%d) — no install, no daemon restart", version.Version, sshPort)
+
+	policy := panelfw.DefaultPolicy()
+	policy.OperatorDisabled = cfg.noPanel
+	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
+	results := validate.RunAssertionsWithOpts(exec, sshPort, log, opts)
+
+	// Preserve recorded identity the Transition writer re-emits. main() blanked
+	// sf.Mode to the (empty) --mode for a revalidate run; restore it so the
+	// rewritten record stays faithful. sf already carries the file's
+	// Authority/Panel/SchemaVersion/SSHPort from main()'s earlier Read().
+	if sf.Mode == "" {
+		sf.Mode = cur.Mode
+	}
+	if sf.SSHPort == 0 {
+		sf.SSHPort = cur.SSHPort
+	}
+
+	if validate.AllPassed(results) {
+		log.Info("revalidate: all live post-install assertions passed — recommitting install_state COMMITTED")
+		_ = exec.Remove(fhs.InstallFailedMarker)
+		if err := sf.Transition(state.StateCommitted, state.PhaseValidate, ""); err != nil {
+			log.Error("revalidate: failed to persist COMMITTED state: %v", err)
+			return state.ExitFatal
+		}
+		return state.ExitCommitted
+	}
+
+	failed := validate.FailedNames(results)
+	reason := "revalidate: live post-install assertions still failing: " + strings.Join(failed, ", ")
+	log.Warn("revalidate: %d assertion(s) still failing (%s) — leaving install_state DEGRADED (no masking)", len(failed), strings.Join(failed, ", "))
+	if err := sf.Transition(state.StateDegraded, state.PhaseValidate, reason); err != nil {
+		log.Error("revalidate: failed to persist DEGRADED state: %v", err)
+		return state.ExitFatal
+	}
+	return state.ExitDegraded
+}

--- a/cmd/nftban-installer/revalidate_test.go
+++ b/cmd/nftban-installer/revalidate_test.go
@@ -1,0 +1,123 @@
+// =============================================================================
+// NFTBan v1.198.1 - nftban-installer - --revalidate guard/no-mask tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-revalidate-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-22"
+// meta:description="v1.198.1 PR-B: runRevalidate guards (no state / COMMITTED no-op / non-DEGRADED refuse / version-mismatch refuse) + the no-mask contract (failing live assertions leave install_state DEGRADED, never COMMITTED)."
+// meta:inventory.files="cmd/nftban-installer/revalidate_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+func writeRevalState(t *testing.T, dir string, st state.InstallState, ver string) {
+	t.Helper()
+	sf := state.NewStateFile(dir)
+	sf.State = st
+	sf.Version = ver
+	sf.Mode = "upgrade"
+	sf.SSHPort = 22
+	if err := sf.WriteAtomic(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+}
+
+// newRevalSF mimics main()'s setup before run(): read the on-disk record, then
+// overwrite Version with the running binary version and blank Mode to the empty
+// --mode that a --revalidate invocation carries.
+func newRevalSF(dir string) *state.StateFile {
+	sf := state.NewStateFile(dir)
+	_ = sf.Read()
+	sf.Version = version.Version
+	sf.Mode = ""
+	sf.DryRun = false
+	return sf
+}
+
+func TestRunRevalidate_Guards(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no_state_file_refused", func(t *testing.T) {
+		dir := t.TempDir()
+		log := logging.New(dir+"/installer.log", false)
+		sf := state.NewStateFile(dir) // never written
+		cfg := &config{stateDir: dir, revalidate: true}
+		if rc := runRevalidate(ctx, executor.NewMockExecutor(), sf, cfg, log); rc != state.ExitRefused {
+			t.Errorf("no state file: rc=%d want ExitRefused(%d)", rc, state.ExitRefused)
+		}
+	})
+
+	t.Run("committed_is_noop", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRevalState(t, dir, state.StateCommitted, version.Version)
+		log := logging.New(dir+"/installer.log", false)
+		cfg := &config{stateDir: dir, revalidate: true}
+		if rc := runRevalidate(ctx, executor.NewMockExecutor(), newRevalSF(dir), cfg, log); rc != state.ExitCommitted {
+			t.Errorf("committed no-op: rc=%d want ExitCommitted(%d)", rc, state.ExitCommitted)
+		}
+	})
+
+	t.Run("non_degraded_terminal_refused", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRevalState(t, dir, state.StateFailedRebuild, version.Version)
+		log := logging.New(dir+"/installer.log", false)
+		cfg := &config{stateDir: dir, revalidate: true}
+		if rc := runRevalidate(ctx, executor.NewMockExecutor(), newRevalSF(dir), cfg, log); rc != state.ExitRefused {
+			t.Errorf("failed-state refuse: rc=%d want ExitRefused(%d)", rc, state.ExitRefused)
+		}
+		got := state.NewStateFile(dir)
+		_ = got.Read()
+		if got.State != state.StateFailedRebuild {
+			t.Errorf("refuse must NOT change state; got %s", got.State)
+		}
+	})
+
+	t.Run("version_mismatch_refused_no_mask", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRevalState(t, dir, state.StateDegraded, "0.0.0-different")
+		log := logging.New(dir+"/installer.log", false)
+		cfg := &config{stateDir: dir, revalidate: true}
+		if rc := runRevalidate(ctx, executor.NewMockExecutor(), newRevalSF(dir), cfg, log); rc != state.ExitRefused {
+			t.Errorf("version mismatch: rc=%d want ExitRefused(%d)", rc, state.ExitRefused)
+		}
+		got := state.NewStateFile(dir)
+		_ = got.Read()
+		if got.State != state.StateDegraded {
+			t.Errorf("version mismatch must NOT flip to COMMITTED; got %s", got.State)
+		}
+	})
+
+	t.Run("degraded_failing_assertions_stays_degraded_no_mask", func(t *testing.T) {
+		dir := t.TempDir()
+		writeRevalState(t, dir, state.StateDegraded, version.Version)
+		log := logging.New(dir+"/installer.log", false)
+		cfg := &config{stateDir: dir, revalidate: true}
+		// A bare MockExecutor reports no nft tables / inactive services, so the
+		// live assertion suite fails → recommit MUST leave DEGRADED (no masking).
+		if rc := runRevalidate(ctx, executor.NewMockExecutor(), newRevalSF(dir), cfg, log); rc != state.ExitDegraded {
+			t.Errorf("failing assertions: rc=%d want ExitDegraded(%d)", rc, state.ExitDegraded)
+		}
+		got := state.NewStateFile(dir)
+		_ = got.Read()
+		if got.State != state.StateDegraded {
+			t.Errorf("NO-MASK: failing live assertions must leave DEGRADED; got %s", got.State)
+		}
+	})
+}

--- a/internal/installer/validate/systemd_payload.go
+++ b/internal/installer/validate/systemd_payload.go
@@ -130,6 +130,17 @@ func IsAuxiliaryUnit(basename string) bool {
 // upgrade and neither the upgrade nor --repair could clear it).
 var staleClearableOneshotStems = map[string]bool{
 	"nftban-botscan": true,
+	// v1.198.1 PR-B (D-NFTBAN-ALERT-LOGGER-DEVLOG-PERMISSION /
+	// D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): the OnFailure service-failure
+	// alert is Type=oneshot and latches `failed` from a past nftband restart
+	// (before PR-A made its logger sandbox-safe, the alert exited non-zero every
+	// time it fired). Its latch pre-dating the install window cannot have been
+	// caused by this upgrade, and it can itself make the live-health probe read
+	// unclean — the same circular block v1.185.1 fixed for nftban-botscan — so
+	// recover it without the live-health gate. The stem is the TEMPLATE form
+	// ("nftban-alert@"); isStaleClearableOneshot reduces instance stems
+	// ("nftban-alert@nftband.service") to it.
+	"nftban-alert@": true,
 }
 
 // isStaleClearableOneshot reports whether an nftban unit basename is a
@@ -144,7 +155,15 @@ func isStaleClearableOneshot(basename string) bool {
 	if dot <= 0 {
 		return false
 	}
-	return staleClearableOneshotStems[basename[:dot]]
+	stem := basename[:dot]
+	// v1.198.1 PR-B: a template-instance unit (nftban-alert@<instance>.service)
+	// carries an instance-specific stem (e.g. "nftban-alert@nftband.service").
+	// Reduce it to the template stem ("nftban-alert@") so one map entry matches
+	// every instance. Non-template stems are unchanged.
+	if at := strings.IndexByte(stem, '@'); at >= 0 {
+		stem = stem[:at+1]
+	}
+	return staleClearableOneshotStems[stem]
 }
 
 // ParsedUnit is the minimum subset of a systemd unit file needed for

--- a/internal/installer/validate/systemd_payload_v174_test.go
+++ b/internal/installer/validate/systemd_payload_v174_test.go
@@ -342,13 +342,23 @@ func TestMonitorAlertUnitV174(t *testing.T) {
 		t.Fatalf("in-window alert@: failed_units_postinstall_ok must FAIL (stays DEGRADED)")
 	}
 
-	// 3) pre-existing but live health NOT clean -> DEGRADED (fail-safe).
+	// 3) pre-existing + live health NOT clean.
+	// v1.198.1 PR-B (D-NFTBAN-ALERT-LOGGER-DEVLOG-PERMISSION /
+	// D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH): nftban-alert@ is now a
+	// stale-clearable oneshot (staleClearableOneshotStems), so a latch strictly
+	// BEFORE the install window recovers WITHOUT the live-health gate — the alert
+	// latch itself can make the live-health probe read unclean (the same circular
+	// block v1.185.1 fixed for nftban-botscan, and the exact srv4 v1.198.0 case).
+	// This SUPERSEDES the original v1.174 fail-safe-to-DEGRADED expectation for
+	// this pre-existing case. An IN-WINDOW alert failure still DEGRADES (case 2),
+	// so real current failures are never masked.
 	r3 := ValidateInstalledSystemdPayload(SystemdPayloadInputs{
 		FailedNftbanUnits: []FailedUnitFinding{mk(preExisting)}, InstallWindowStart: windowStart,
 		InstallWindowStartKnown: true, LiveHealthClean: false, LiveHealthKnown: true,
 	})
-	if r3.FailedUnitsOK() {
-		t.Fatalf("pre-existing alert@ + unhealthy live health must stay DEGRADED")
+	if !r3.FailedUnitsOK() || len(r3.FailedUnitsPreExistingRecovered) != 1 || len(r3.FailedUnits) != 0 {
+		t.Fatalf("v1.198.1 PR-B: pre-existing alert@ recovers without the live-health gate; got OK=%v recovered=%d fatal=%d",
+			r3.FailedUnitsOK(), len(r3.FailedUnitsPreExistingRecovered), len(r3.FailedUnits))
 	}
 }
 

--- a/internal/installer/validate/systemd_payload_v1981_test.go
+++ b/internal/installer/validate/systemd_payload_v1981_test.go
@@ -1,0 +1,132 @@
+// =============================================================================
+// NFTBan v1.198.1 - Alert-template stale-clearable oneshot classification (PR-B)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-validate-systemd-payload-v1981-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-22"
+// meta:description="PR-B: nftban-alert@<svc>.service (OnFailure oneshot TEMPLATE) pre-existing failed-state recovers WITHOUT the live-health gate; real in-window failures still DEGRADE. Reproduces the srv4 v1.198.0 stuck-DEGRADED case."
+// meta:inventory.files="internal/installer/validate/systemd_payload_v1981_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-alert@nftband.service.service"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validate
+
+import (
+	"testing"
+	"time"
+)
+
+func v1981AlertUnit(t time.Time, known bool) FailedUnitFinding {
+	return FailedUnitFinding{
+		Unit:             "nftban-alert@nftband.service.service",
+		Active:           "failed",
+		Sub:              "failed",
+		Detail:           "exit-code", // logger: socket /dev/log: Permission denied → exit 1
+		FailureTime:      t,
+		FailureTimeKnown: known,
+	}
+}
+
+// TestAlertTemplateStaleClearableClassification — v1.198.1 PR-B.
+// The srv4 case: nftban-alert@nftband.service.service (OnFailure oneshot template)
+// latched `failed` at 2026-06-21 23:26 (before PR-A made its logger sandbox-safe),
+// ~14.5h BEFORE the v1.198.0 install window. Like nftban-botscan (v1.185.1), the
+// latch can itself make the live-health probe read unclean (circular), so it must
+// recover WITHOUT the live-health gate. A real in-window alert failure still
+// DEGRADES (no masking).
+func TestAlertTemplateStaleClearableClassification(t *testing.T) {
+	window := time.Date(2026, 6, 22, 13, 59, 0, 0, time.UTC)
+	preExisting := window.Add(-870 * time.Minute) // 2026-06-21 23:29-ish — the srv4 latch
+	inWindow := window.Add(1 * time.Minute)
+
+	cases := []struct {
+		name             string
+		in               SystemdPayloadInputs
+		wantOK           bool
+		wantFatalLen     int
+		wantRecoveredLen int
+	}{
+		{
+			// The exact srv4 scenario: pre-existing alert latch, live health reads
+			// NOT clean (the latch itself), yet must RECOVER.
+			name: "alert_template_pre_existing_live_not_clean_recovers",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v1981AlertUnit(preExisting, true)},
+				InstallWindowStart:      window,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         false,
+				LiveHealthKnown:         true,
+			},
+			wantOK:           true,
+			wantFatalLen:     0,
+			wantRecoveredLen: 1,
+		},
+		{
+			// A REAL in-window alert failure must still DEGRADE.
+			name: "alert_template_in_window_still_degrades",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v1981AlertUnit(inWindow, true)},
+				InstallWindowStart:      window,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         true, // even clean: in-window stays fatal
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+		{
+			// Unknown failure time → cannot prove pre-existing → fail safe DEGRADE.
+			name: "alert_template_unknown_failure_time_degrades",
+			in: SystemdPayloadInputs{
+				FailedNftbanUnits:       []FailedUnitFinding{v1981AlertUnit(preExisting, false)},
+				InstallWindowStart:      window,
+				InstallWindowStartKnown: true,
+				LiveHealthClean:         false,
+				LiveHealthKnown:         true,
+			},
+			wantOK:       false,
+			wantFatalLen: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := ValidateInstalledSystemdPayload(tc.in)
+			if res.FailedUnitsOK() != tc.wantOK {
+				t.Errorf("FailedUnitsOK=%v want %v (fatal=%d recovered=%d)",
+					res.FailedUnitsOK(), tc.wantOK,
+					len(res.FailedUnits), len(res.FailedUnitsPreExistingRecovered))
+			}
+			if len(res.FailedUnits) != tc.wantFatalLen {
+				t.Errorf("len(FailedUnits)=%d want %d", len(res.FailedUnits), tc.wantFatalLen)
+			}
+			if len(res.FailedUnitsPreExistingRecovered) != tc.wantRecoveredLen {
+				t.Errorf("len(FailedUnitsPreExistingRecovered)=%d want %d",
+					len(res.FailedUnitsPreExistingRecovered), tc.wantRecoveredLen)
+			}
+		})
+	}
+}
+
+// TestIsStaleClearableOneshotAlertTemplate pins the template membership: any
+// instance of nftban-alert@ is stale-clearable; lookalikes are not.
+func TestIsStaleClearableOneshotAlertTemplate(t *testing.T) {
+	if !isStaleClearableOneshot("nftban-alert@nftband.service.service") {
+		t.Error("nftban-alert@nftband.service.service must be stale-clearable (PR-B)")
+	}
+	if !isStaleClearableOneshot("nftban-alert@nftban-queue.service.service") {
+		t.Error("nftban-alert@<any-instance>.service must be stale-clearable (template generalizes)")
+	}
+	if isStaleClearableOneshot("nftban-alertmanager.service") {
+		t.Error("nftban-alertmanager.service must NOT match the nftban-alert@ template stem")
+	}
+	if isStaleClearableOneshot("nftband.service") {
+		t.Error("nftband.service (protection daemon) must NOT be stale-clearable")
+	}
+}


### PR DESCRIPTION
## v1.198.1 surgical hotfix — srv4 rollout blocker

Two coupled defects found during the v1.198.0 Track-A rollout (srv4 upgraded functionally but stuck `install_state=DEGRADED`). Scope: `V1_198_1_HOTFIX_SCOPE_ALERT_HANDLER_AND_RECOMMIT.md`. **Schema unchanged (1.84.0).** Internally split:

### PR-A — `D-NFTBAN-ALERT-LOGGER-DEVLOG-PERMISSION` (`55776786`)
`cli/sbin/nftban-service-alert`: the OnFailure alert oneshot runs under `nftban-alert@.service` (`PrivateDevices=yes` + `User=nftban`), where `logger`→`/dev/log` is EACCES. The unguarded `logger` was the **last** command in `log_alert()`, so its non-zero exit latched the unit `failed` → post-install failed-unit assertion tripped → `install_state=DEGRADED`, and real failures went **unalerted**.
- `log_alert()` now delivers to the **journal via stderr** (the unit's `StandardError=journal` + `SyslogIdentifier=nftban-alert` reach the journal **without** `/dev/log`), keeps the file log, makes `logger` **best-effort** (`2>/dev/null || true`), and `return 0`.
- Email **delivery** keeps its own rc contract (real delivery failures still fail the unit) — **no masking**.
- Hermetic test `alert_logger_devlog_sandbox_v1981_test.sh` (6/6).

### PR-B — `D-V198-STICKY-DEGRADED-NO-RECOMMIT-PATH` (`13adb943`)
Once DEGRADED, no official command recomputed it to COMMITTED on the same version (`--force`/`--repair` re-echo the stale record; `reset-failed` is defeated by the alert re-firing on the update restart) → forced manual edits.
- **Classification:** add the `nftban-alert@` **template** to `staleClearableOneshotStems` (`isStaleClearableOneshot` reduces instance stems → template stem). A pre-existing alert latch now recovers **without** the live-health gate — the same circular block v1.185.1 fixed for `nftban-botscan`. **In-window failures still DEGRADE** (no masking).
- **New `nftban-installer --revalidate`** (shell verb **`nftban update recommit`**): restart-free recompute — re-runs **only** the live post-install assertion suite and rewrites `install_state` via the official `StateFile.Transition`. **No install, no daemon restart.** → COMMITTED only when `AllPassed`; refuses on non-DEGRADED / version-mismatch / missing-state-file; stays DEGRADED with the live reason otherwise. Replaces hand-editing the machine-written state file.
- Tests: `systemd_payload_v1981_test.go` (alert@ template recovery + in-window degrade + membership), `revalidate_test.go` (guards + **no-mask**: failing assertions leave DEGRADED, never COMMITTED); `TestMonitorAlertUnitV174` case 3 updated for the superseded behavior.

### Guarantees
- **No firewall/ban/detector behavior change · no BotGuard re-enable · no schema/counter change (1.84.0).**
- Does **not** mask the alert unit; does **not** hand-edit `install_state`; does **not** weaken service-failure visibility (PR-A *improves* it).
- Local: `go build ./cmd/...` OK · `go test -race ./cmd/nftban-installer/... ./internal/installer/validate/... ./internal/installer/state/...` PASS · gofmt clean (changed files) · shellcheck clean · existing alert/update shell tests pass.

Next after CI green: lab-first lab2 (DEB) + lab4 (RPM), then release-prep v1.198.1, then srv4 recommit → Track-A rollout closure.