### PR TITLE
fix(v1.198.2): FW-transition health truth — sticky-counter reset + verdict aggregation + double-render

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -282,6 +282,66 @@ _firewall_record_transition_health() {
     return 0
 }
 
+# _firewall_reset_transition_health [reason]
+# v1.198.2 PR-A (BUG-FW-TRANSITION-HEALTH-COUNTER-STICKY-NO-RESET): after a CLEAN
+# rebuild (post_status protected|idle, all checks passed ⇒ floor intact + atomic
+# + tables present + baseline re-recorded), clear any STALE cumulative
+# transition-health counters via the gated official reset. fth_reset_transition_health
+# self-verifies there is NO CURRENT breach before zeroing (no masking) and touches
+# ONLY the state JSON (no ban/nft mutation, no reset --force). Best effort — must
+# NEVER fail or slow the firewall path.
+_firewall_reset_transition_health() {
+    local reason="${1:-firewall rebuild: clean re-baseline}"
+    local helper="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_firewall_transition_health.sh"
+    [[ -r "$helper" ]] || return 0
+    # shellcheck source=/dev/null
+    source "$helper" 2>/dev/null || return 0
+    declare -f fth_reset_transition_health >/dev/null 2>&1 || return 0
+    fth_reset_transition_health "$reason" >/dev/null 2>&1 || true
+    return 0
+}
+
+# _firewall_transition_health_cmd [status|ack|reset]
+# v1.198.2 PR-A: operator surface for the firewall-transition health alarm.
+#   status (default) — print the current CODE|reason from fth_eval_health.
+#   ack|reset        — clear a RESOLVED alarm via the gated fth_reset (refuses if a
+#                      CURRENT breach remains — no masking; state-JSON only, no ban loss).
+_firewall_transition_health_cmd() {
+    local action="${1:-status}"
+    local helper="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_firewall_transition_health.sh"
+    if [[ ! -r "$helper" ]]; then echo "ERROR: transition-health module not found" >&2; return 1; fi
+    # shellcheck source=/dev/null
+    source "$helper" 2>/dev/null || { echo "ERROR: cannot load transition-health module" >&2; return 1; }
+    case "$action" in
+        status|"")
+            local res code reason
+            res=$(fth_eval_health 2>/dev/null || echo "0|"); code="${res%%|*}"; reason="${res#*|}"
+            case "$code" in
+                0) echo "Firewall transition health: OK" ;;
+                1) echo "Firewall transition health: WARNING — ${reason}" ;;
+                2) echo "Firewall transition health: ERROR — ${reason}" ;;
+                3) echo "Firewall transition health: CRITICAL — ${reason}" ;;
+                *) echo "Firewall transition health: unknown" ;;
+            esac
+            ;;
+        ack|reset|clear)
+            if ! declare -f fth_reset_transition_health >/dev/null 2>&1; then
+                echo "ERROR: reset path unavailable in this build" >&2; return 1
+            fi
+            fth_reset_transition_health "operator ack via 'nftban firewall transition-health $action'"
+            local rc=$?
+            case "$rc" in
+                0) echo "✓ Firewall-transition health alarm cleared (counters reset; live floor verified intact; audit history preserved)." ;;
+                2) echo "✗ Refused: a CURRENT firewall-transition breach still exists — restore the floor first with 'nftban firewall rebuild', then retry." >&2; return 2 ;;
+                *) echo "✗ Reset failed (state-write error)." >&2; return 1 ;;
+            esac
+            ;;
+        *)
+            echo "Usage: nftban firewall transition-health [status|ack]" >&2; return 1 ;;
+    esac
+    return 0
+}
+
 # =============================================================================
 # MAIN COMMAND HANDLER
 # =============================================================================
@@ -387,6 +447,11 @@ nftban_cmd_firewall() {
         record)
             shift
             firewall_record "$@"
+            ;;
+        transition-health|fw-transition-health)
+            # v1.198.2 PR-A: report or ACK/reset the firewall-transition health alarm.
+            shift
+            _firewall_transition_health_cmd "$@"
             ;;
         takeover)
             shift
@@ -2695,6 +2760,11 @@ _firewall_rebuild_core() {
             declare -f _rebuild_marker_clear &>/dev/null && _rebuild_marker_clear
             # v1.192.1 PR-B: record transition health (harm-keyed; never cadence).
             _firewall_record_transition_health rebuild "$_fth_t0"
+            # v1.198.2 PR-A: a clean rebuild restored the floor + re-recorded the
+            # baseline atomically — clear any STALE cumulative transition-health
+            # alarm. Gated: fth_reset refuses if a CURRENT breach remains (no mask),
+            # touches only the state JSON (no ban loss).
+            _firewall_reset_transition_health "firewall rebuild: clean re-baseline (floor intact, atomic, baseline re-recorded)"
             return 0
             ;;
         degraded)
@@ -3522,6 +3592,8 @@ Validation & Diagnostics:
   logs          View and filter firewall logs
   record        Snapshot current nft schema to JSON for audit/comparison
   ssh-audit     Report sshd listeners vs ssh_ports vs declared external admin ports
+  transition-health  Report (status) or acknowledge (ack) the firewall-transition
+                health alarm; 'ack' clears a RESOLVED alarm (refuses if breached)
 
 Operations:
   init          Initialize firewall tables (alias for rebuild)
@@ -3549,6 +3621,10 @@ Examples:
 
   # SSH admin-port audit (external :55000->:22 redirect class)
   nftban firewall ssh-audit            # sshd listeners vs ssh_ports vs declared
+
+  # Firewall-transition health alarm (v1.198.2)
+  nftban firewall transition-health        # show current verdict
+  nftban firewall transition-health ack    # clear a RESOLVED alarm (gated; no ban loss)
 
   # Recovery operations
   nftban firewall rebuild              # Fix corruption

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -538,12 +538,29 @@ nftban_health_cmd_truth() {
     printf "  %-14s %s\n" "Daemon:" "$nftband_state"
     printf "  %-14s %s\n" "Consistency:" "$consistency"
 
-    # v1.198 R1b-2: top-level operator-readiness verdict (Operational /
-    # Upgrade readiness / Action needed + IDLE explanation), computed shell-side
-    # from the validator JSON + rc already in hand. No install_state in the
-    # health context. Shell-only; daemon byte-identical; --json path unaffected
-    # (returned above). Actionable findings reuse the R1b-1 renderer.
-    nftban_render_operator_readiness "$output" "" "$validator_rc"
+    # v1.198.2 PR-B (BUG-HEALTH-VERDICT-IGNORES-FW-TRANSITION-CRITICAL): compute
+    # firewall-transition health ONCE here, BEFORE the readiness verdict, so an
+    # unresolved CRITICAL/ERROR transition alarm flags operator readiness (no
+    # green/clean headline beside a CRITICAL transition line). Reused by the
+    # "Firewall Transition" detail block below (single probe).
+    local _fth_code=0 _fth_reason=""
+    local _fth_helper="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_firewall_transition_health.sh"
+    if [[ -r "$_fth_helper" ]]; then
+        # shellcheck source=/dev/null
+        source "$_fth_helper" 2>/dev/null || true
+        if declare -f fth_eval_health >/dev/null 2>&1; then
+            local _fth_res; _fth_res=$(fth_eval_health 2>/dev/null || echo "0|")
+            _fth_code="${_fth_res%%|*}"; _fth_reason="${_fth_res#*|}"
+            [[ "$_fth_code" =~ ^[0-9]+$ ]] || _fth_code=0
+        fi
+    fi
+
+    # v1.198 R1b-2 / v1.198.2 PR-B: top-level operator-readiness verdict
+    # (Operational / Upgrade readiness / Action needed + IDLE explanation),
+    # computed shell-side from the validator JSON + rc, now FW-transition-aware
+    # (4th arg = fth severity code). Shell-only; daemon byte-identical; --json
+    # path unaffected (returned above).
+    nftban_render_operator_readiness "$output" "" "$validator_rc" "$_fth_code"
 
     echo ""
     echo "  Module       Config     Structure  Runtime    Effective"
@@ -588,24 +605,15 @@ nftban_health_cmd_truth() {
     # (JSON mode returns above — this is the text path only.)
     nftban_render_findings "$output" "$verbose_mode"
 
-    # v1.192.1 PR-B: harm-keyed firewall transition health as a finding (text
-    # mode only; JSON returned above). Prints ONLY when anomalous — a healthy
-    # transition / rebuild cadence emits nothing (no false alarm).
-    local _fth_helper="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_firewall_transition_health.sh"
-    if [[ -r "$_fth_helper" ]]; then
-        # shellcheck source=/dev/null
-        source "$_fth_helper" 2>/dev/null || true
-        if declare -f fth_eval_health >/dev/null 2>&1; then
-            local _fth_res _fth_code _fth_reason _fth_sev
-            _fth_res=$(fth_eval_health 2>/dev/null || echo "0|")
-            _fth_code="${_fth_res%%|*}"; _fth_reason="${_fth_res#*|}"
-            if [[ "$_fth_code" =~ ^[0-9]+$ ]] && (( _fth_code >= 2 )); then
-                if (( _fth_code >= 3 )); then _fth_sev="CRITICAL"; else _fth_sev="WARN"; fi
-                echo ""
-                echo "  Firewall Transition ($_fth_sev):"
-                echo "    [$_fth_sev] FW-TRANSITION-HEALTH: ${_fth_reason}"
-            fi
-        fi
+    # v1.192.1 PR-B: harm-keyed firewall transition health detail (text mode
+    # only; JSON returned above). v1.198.2: reuse the single fth eval computed
+    # above the readiness verdict (no second live probe). Prints ONLY when
+    # anomalous (code>=2) — a healthy transition emits nothing.
+    if [[ "$_fth_code" =~ ^[0-9]+$ ]] && (( _fth_code >= 2 )); then
+        local _fth_sev; if (( _fth_code >= 3 )); then _fth_sev="CRITICAL"; else _fth_sev="WARN"; fi
+        echo ""
+        echo "  Firewall Transition ($_fth_sev):"
+        echo "    [$_fth_sev] FW-TRANSITION-HEALTH: ${_fth_reason}"
     fi
 
     echo ""

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1206,11 +1206,26 @@ _status_section_health() {
     # authoritative posture verdict. Label it "Health" so the authoritative
     # firewall posture is stated once (in the State line), and the health
     # roll-up reads as diagnostics rather than a competing PROTECTED claim.
-    if [[ "$_health_base_state" == "PROTECTED" ]] && [[ "$health_status" == *"ERROR"* || "$health_status" == *"CRITICAL"* ]]; then
-        nftban_kv "Health" "OK (info notices)"
-    else
-        nftban_kv "Health" "$health_status"
+    # v1.198.2 PR-B (BUG-HEALTH-VERDICT-IGNORES-FW-TRANSITION-CRITICAL): read the
+    # transition harm counters BEFORE the Health roll-up so a CRITICAL alarm
+    # qualifies it — the Health line must not read clean/green beside the 🔴
+    # CRITICAL "FW Transition" line below. Cheap persisted read (sed, jq-free).
+    local _fthf="${NFTBAN_STATE_DIR:-/var/lib/nftban/state}/firewall_transition_health.json" _fth_crit=0
+    if [[ -r "$_fthf" ]]; then
+        local _qf _qt _qb
+        _qf=$(sed -n 's/.*"floor_breach_count"[: ]*\([0-9]*\).*/\1/p' "$_fthf" | head -1)
+        _qt=$(sed -n 's/.*"table_absent_while_committed_count"[: ]*\([0-9]*\).*/\1/p' "$_fthf" | head -1)
+        _qb=$(sed -n 's/.*"blacklist_empty_during_refresh_count"[: ]*\([0-9]*\).*/\1/p' "$_fthf" | head -1)
+        (( ${_qf:-0} > 0 || ${_qt:-0} > 0 || ${_qb:-0} > 0 )) && _fth_crit=1
     fi
+    local _health_render
+    if [[ "$_health_base_state" == "PROTECTED" ]] && [[ "$health_status" == *"ERROR"* || "$health_status" == *"CRITICAL"* ]]; then
+        _health_render="OK (info notices)"
+    else
+        _health_render="$health_status"
+    fi
+    (( _fth_crit == 1 )) && _health_render="${_health_render} — ⚠ firewall-transition alarm (see FW Transition)"
+    nftban_kv "Health" "$_health_render"
 
     # v1.192.1 PR-B: firewall transition health (harm-keyed; cadence never alarms).
     # Reads persisted counters only (cheap, no live nft probe here).

--- a/cli/lib/nftban/core/nftban_firewall_transition_health.sh
+++ b/cli/lib/nftban/core/nftban_firewall_transition_health.sh
@@ -312,3 +312,44 @@ fth_eval_health() {
     fi
     echo "${code}|${reason}"
 }
+
+# -----------------------------------------------------------------------------
+# fth_reset_transition_health [reason]
+# v1.198.2 PR-A (BUG-FW-TRANSITION-HEALTH-COUNTER-STICKY-NO-RESET): the official,
+# PROPORTIONATE clear path for a RESOLVED firewall-transition alarm. Zeroes the
+# cumulative harm counters ONLY after a fresh live probe proves there is NO
+# current breach (floor / service-port / table all clean). REFUSES (rc 2) if any
+# current breach remains — it must never mask a live condition. Preserves the
+# prior anomaly timestamp as audit history and records the reset reason.
+#
+# Touches ONLY the state JSON via the product writer (_fth_write_json) — NO nft
+# set/ban mutation, NO `firewall reset --force`, NO manual JSON edit, NO ban loss.
+# Safe-by-design: fth_eval_health re-probes the live state, so even after a reset a
+# genuinely-still-breached floor is immediately re-flagged (the reset cannot hide
+# an ongoing condition; it only clears stale historical counters).
+#
+# Returns: 0 = reset written; 2 = refused (current live breach); 1 = write error.
+# -----------------------------------------------------------------------------
+fth_reset_transition_health() {
+    local ack_reason="${1:-resolved transition alarm acknowledged}"
+    # Fresh live probe — the reset gate MUST see current kernel state regardless
+    # of any caller FTH_SKIP_GATHER optimization.
+    local _saved_skip="${FTH_SKIP_GATHER:-}"
+    FTH_SKIP_GATHER=0
+    _fth_gather
+    _fth_compute_breaches
+    FTH_SKIP_GATHER="$_saved_skip"
+    # No-mask gate: refuse if any CURRENT live breach exists.
+    if (( ${FTH_B_FLOOR:-0} > 0 || ${FTH_B_SVC:-0} > 0 || ${FTH_B_TABLE:-0} > 0 )); then
+        return 2
+    fi
+    # Preserve audit history; annotate the reset.
+    local prev_at prev_reason now note
+    prev_at=$(_fth_json_get last_transition_anomaly_at "")
+    prev_reason=$(_fth_json_get last_transition_anomaly_reason "")
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+    note="reset ${now}: ${ack_reason}"
+    [[ -n "$prev_reason" ]] && note="${note} (prior: ${prev_reason})"
+    # Zero the cumulative counters; keep the prior anomaly timestamp as history.
+    _fth_write_json 0 0 0 0 0 Y reset-ack 0 "${prev_at:-$now}" "$note"
+}

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1328,6 +1328,19 @@ nftban_render_operator_readiness() {
         readiness="PASS"
     fi
 
+    # v1.198.2 PR-B (BUG-HEALTH-VERDICT-IGNORES-FW-TRANSITION-CRITICAL): an
+    # unresolved CRITICAL/ERROR firewall-transition alarm MUST flag operator
+    # readiness even when the runtime validator status is protected/idle — the
+    # headline must never read clean (PASS/NONE) while a CRITICAL transition
+    # finding is printed. $4 is the fth_eval_health severity code (3=CRITICAL,
+    # 2=ERROR, 1=WARN, 0=OK, ""=unknown/absent), passed by cmd_health. Only ever
+    # RAISE the verdict (PASS -> PASS_WITH_WARN); never mask an existing FAIL.
+    local _fth_sev="${4:-}" _fth_alarm=0
+    if [[ "$_fth_sev" == "3" || "$_fth_sev" == "2" ]]; then
+        _fth_alarm=1
+        [[ "$readiness" == "PASS" ]] && readiness="PASS_WITH_WARN"
+    fi
+
     case "$readiness" in
         FAIL)           action="FAIL" ;;
         PASS_WITH_WARN) action="WARN" ;;
@@ -1336,6 +1349,8 @@ nftban_render_operator_readiness() {
 
     local op_line="$operational"
     [[ "$status" == "idle" ]] && op_line="YES (running, no active bans currently)"
+    # PR-B: qualify Operational so a transition alarm is visible on the verdict line.
+    [[ "$_fth_alarm" -eq 1 ]] && op_line="${op_line} — unresolved firewall-transition alarm"
 
     echo ""
     echo "  Operator readiness"
@@ -1343,10 +1358,15 @@ nftban_render_operator_readiness() {
     printf "  %-20s %s\n" "Operational:" "$op_line"
     printf "  %-20s %s\n" "Upgrade readiness:" "$readiness"
     printf "  %-20s %s\n" "Action needed:" "$action"
-    # When action is needed, show the actionable findings via the shared
-    # R1b-1 renderer (WARN/ERROR/CRITICAL; INFO stays hidden by default).
-    if [[ "$action" != "NONE" ]]; then
-        nftban_render_findings "$_json" false
+    # v1.198.2 PR-C (D-V198-HEALTH-FINDINGS-DOUBLE-RENDER): the readiness block is
+    # the VERDICT surface only — it no longer re-renders the per-finding detail
+    # (that duplicated the canonical "Findings:" section in cmd_health). It now
+    # emits a one-line pointer so the operator knows where the detail is.
+    if [[ "$_fth_alarm" -eq 1 ]]; then
+        printf "  %-20s %s\n" "" "→ firewall-transition alarm: see 'Firewall Transition' below (clear: nftban firewall rebuild)"
+    fi
+    if [[ "$action" != "NONE" && ( "$max_sev" == "warn" || "$max_sev" == "error" || "$max_sev" == "critical" ) ]]; then
+        printf "  %-20s %s\n" "" "→ see the Findings section below for the actionable item(s)"
     fi
 }
 export -f nftban_render_operator_readiness 2>/dev/null || true

--- a/cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh
+++ b/cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.198.2 - FW-transition health truth: reset (A) + verdict aggregation (B)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="fw_transition_health_truth_v1982_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-22"
+# meta:description="Hermetic tests for v1.198.2: (A) fth_reset_transition_health zeroes the cumulative counters ONLY when the live probe shows no current breach (refuses otherwise — no masking), preserves anomaly history, and touches only the state JSON (no ban/nft mutation); (B) nftban_render_operator_readiness raises the verdict (PASS->PASS_WITH_WARN, action WARN, + alarm note) when the FW-transition severity is CRITICAL/ERROR and never downgrades an existing FAIL. Live nft probe is stubbed via _fth_gather override."
+# meta:input="None (synthetic fth-1 JSON + stubbed _fth_gather)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,jq,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/core/nftban_firewall_transition_health.sh,cli/lib/nftban/core/nftban_output.sh"
+# meta:inventory.binaries="bash,jq"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_STATE_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"; export NFTBAN_LIB_DIR
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+bad(){ FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1"; }
+ar(){ if grep -qE -- "$2" <<<"$1"; then ok "$3"; else bad "$3 (no match: $2)"; fi; }
+nr(){ if grep -qE -- "$2" <<<"$1"; then bad "$3 (unexpected: $2)"; else ok "$3"; fi; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+export NFTBAN_STATE_DIR="$WORK"
+STATE="$WORK/firewall_transition_health.json"
+export FTH_STATE_FILE="$STATE"
+
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/core/nftban_output.sh"
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR}/core/nftban_firewall_transition_health.sh"
+# Both core modules `set -Eeuo pipefail` at source time; this test DELIBERATELY
+# drives functions that return non-zero (fth_reset refusal = rc 2), so disable
+# errexit here while keeping nounset + pipefail.
+set +e
+
+write_state() { # <floor> [anomaly_at] [reason]
+    local floor="${1:-0}" at="${2:-2026-06-21T23:26:09Z}" reason="${3:-mgmt floor absent (ip)}"
+    printf '{\n  "schema": "fth-1",\n  "service_port_breach_count": 0,\n  "floor_breach_count": %d,\n  "table_absent_while_committed_count": 0,\n  "blacklist_empty_during_refresh_count": 0,\n  "non_atomic_rebuild_count": 0,\n  "last_rebuild_atomic": true,\n  "last_trigger": "rebuild",\n  "last_duration_ms": 0,\n  "last_transition_anomaly_at": "%s",\n  "last_transition_anomaly_reason": "%s"\n}\n' "$floor" "$at" "$reason" > "$STATE"
+}
+floor_count() { grep -oE '"floor_breach_count": *[0-9]+' "$STATE" | grep -oE '[0-9]+$'; }
+
+echo "== B. verdict aggregation (FW-transition CRITICAL/ERROR raises operator readiness) =="
+# B1: clean validator + fth CRITICAL(3) -> NOT PASS/NONE; PASS_WITH_WARN + WARN + alarm note
+OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[]}' "" 0 "3")
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS_WITH_WARN$" "B1 fth CRITICAL -> readiness PASS_WITH_WARN (not clean PASS)"
+ar "$OUT" "Action needed:[[:space:]]+WARN$"               "B1 fth CRITICAL -> action WARN"
+ar "$OUT" "firewall-transition alarm"                     "B1 fth CRITICAL -> alarm note shown"
+# B2: clean validator + fth OK(0) -> PASS / NONE, no alarm
+OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[]}' "" 0 "0")
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS$"           "B2 fth OK -> readiness PASS"
+ar "$OUT" "Action needed:[[:space:]]+NONE$"               "B2 fth OK -> action NONE"
+nr "$OUT" "firewall-transition alarm"                     "B2 fth OK -> no alarm note"
+# B3: fth ERROR(2) also raises
+OUT=$(nftban_render_operator_readiness '{"status":"idle","findings":[]}' "" 0 "2")
+ar "$OUT" "Upgrade readiness:[[:space:]]+PASS_WITH_WARN$" "B3 fth ERROR -> PASS_WITH_WARN"
+# B4: existing FAIL (down) NOT downgraded by fth alarm
+OUT=$(nftban_render_operator_readiness '{"status":"down","findings":[]}' "" 2 "3")
+ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"           "B4 fth CRITICAL never downgrades an existing FAIL"
+
+echo "== A. reset positive (clean live floor -> counters cleared, history kept) =="
+write_state 1
+# stub the live probe to report a CLEAN current state
+# shellcheck disable=SC2034  # FTH_* are read by the sourced _fth_compute_breaches
+_fth_gather() { FTH_FLOOR_4=Y; FTH_FLOOR_6=Y; FTH_TABLE_PRESENT=Y; FTH_COMMITTED=N; FTH_EFF_TCPIN=""; FTH_EFF_TCPOUT=""; FTH_EFF_UDPIN=""; FTH_EFF_UDPOUT=""; }
+fth_reset_transition_health "test: floor restored"; RC=$?
+[[ "$RC" -eq 0 ]] && ok "A+ reset returns 0 on clean live state" || bad "A+ reset rc=$RC (want 0)"
+[[ "$(floor_count)" == "0" ]] && ok "A+ floor_breach_count cleared to 0" || bad "A+ floor_breach_count=$(floor_count) (want 0)"
+grep -q '"last_transition_anomaly_at": "2026-06-21T23:26:09Z"' "$STATE" && ok "A+ prior anomaly timestamp retained as audit history" || bad "A+ anomaly history lost"
+grep -q 'reset .*test: floor restored' "$STATE" && ok "A+ reset reason recorded" || bad "A+ reset reason missing"
+RES=$(fth_eval_health); [[ "${RES%%|*}" == "0" ]] && ok "A+ fth_eval_health now OK (no CRITICAL)" || bad "A+ fth_eval_health=${RES} (want 0)"
+
+echo "== A. reset negative (current live breach -> refuse, no masking) =="
+write_state 1
+# stub the live probe to report a CURRENT floor breach
+# shellcheck disable=SC2034  # FTH_* are read by the sourced _fth_compute_breaches
+_fth_gather() { FTH_FLOOR_4=N; FTH_FLOOR_6=Y; FTH_TABLE_PRESENT=Y; FTH_COMMITTED=N; FTH_EFF_TCPIN=""; FTH_EFF_TCPOUT=""; FTH_EFF_UDPIN=""; FTH_EFF_UDPOUT=""; }
+fth_reset_transition_health "test: should refuse"; RC=$?
+[[ "$RC" -eq 2 ]] && ok "A- reset REFUSES (rc 2) while a current breach exists" || bad "A- reset rc=$RC (want 2)"
+[[ "$(floor_count)" == "1" ]] && ok "A- counters UNCHANGED on refusal (no masking)" || bad "A- floor_breach_count=$(floor_count) (want 1, unchanged)"
+
+echo "== A. no ban loss / no nft mutation (structural) =="
+# fth_reset_transition_health must touch ONLY the state JSON — never nft/ban sets.
+BODY=$(declare -f fth_reset_transition_health)
+if grep -qE 'nft (add|delete|flush)|nft -f|Service|blacklist' <<<"$BODY"; then
+    bad "A no-ban-loss: reset function contains nft/ban mutation"
+else
+    ok "A no-ban-loss: reset touches only state JSON (no nft/ban mutation in function body)"
+fi
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
+++ b/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
@@ -54,21 +54,26 @@ OUT=$(nftban_render_operator_readiness '{"status":"idle","findings":[]}' "" 0)
 af "$OUT" "YES (running, no active bans currently)" "T2 idle -> IDLE explanation"
 ar "$OUT" "Upgrade readiness:[[:space:]]+PASS$"     "T2 idle -> readiness PASS"
 
-# T3: idle + WARN -> YES / PASS_WITH_WARN / WARN (+ finding shown via R1b-1 helper)
+# T3: idle + WARN -> YES / PASS_WITH_WARN / WARN. v1.198.2 PR-C: the readiness
+# block is the VERDICT surface only — it no longer re-renders the per-finding
+# detail (that duplicated the canonical "Findings:" section in cmd_health); it
+# emits a one-line pointer instead.
 OUT=$(nftban_render_operator_readiness '{"status":"idle","findings":[{"severity":"warn","code":"VAL-LOGINMON-002","message":"webauth present but starved"}]}' "" 0)
 ar "$OUT" "Upgrade readiness:[[:space:]]+PASS_WITH_WARN$" "T3 WARN -> readiness PASS_WITH_WARN"
 ar "$OUT" "Action needed:[[:space:]]+WARN$"         "T3 WARN -> action WARN"
-af "$OUT" "[WARN] VAL-LOGINMON-002:"                "T3 actionable WARN finding rendered (R1b-1 helper)"
+nf "$OUT" "[WARN] VAL-LOGINMON-002:"                "T3 PR-C: finding detail NOT re-rendered in readiness block (verdict-only)"
+ar "$OUT" "see the Findings section below"          "T3 PR-C: readiness points to the Findings section instead of duplicating"
 
 # T4a: degraded status -> FAIL
 OUT=$(nftban_render_operator_readiness '{"status":"degraded","findings":[{"severity":"warn","code":"VAL-TIMER-001","message":"x"}]}' "" 0)
 ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T4a degraded -> readiness FAIL"
 ar "$OUT" "Action needed:[[:space:]]+FAIL$"         "T4a degraded -> action FAIL"
 
-# T4b: error-severity finding (status protected) -> FAIL + finding shown
+# T4b: error-severity finding (status protected) -> FAIL. v1.198.2 PR-C: detail
+# rendered once in the canonical Findings section, not duplicated here.
 OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[{"severity":"error","code":"VAL-CHAIN-001","message":"chain missing"}]}' "" 0)
 ar "$OUT" "Upgrade readiness:[[:space:]]+FAIL$"     "T4b error finding -> readiness FAIL"
-af "$OUT" "[ERROR] VAL-CHAIN-001:"                  "T4b error finding rendered"
+nf "$OUT" "[ERROR] VAL-CHAIN-001:"                  "T4b PR-C: error finding detail NOT re-rendered in readiness block"
 
 # T5: install_state DEGRADED (update path) -> NOT PASS even when protected+clean
 OUT=$(nftban_render_operator_readiness '{"status":"protected","findings":[]}' "DEGRADED" 0)

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1535,6 +1535,13 @@ firewall:
       mutates: true
       requires_root: true
       description: "Reload nftables ruleset"
+    transition-health:
+      mutates: conditional
+      requires_root: conditional
+      description: "Report or acknowledge the firewall-transition health alarm. 'status' (default) prints the current verdict; 'ack' clears a RESOLVED alarm via the gated reset (refuses if a current breach remains; touches only state JSON, no ban loss). v1.198.2 PR-A."
+      examples:
+        - "nftban firewall transition-health"
+        - "nftban firewall transition-health ack"
     takeover:
       mutates: true
       requires_root: true

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -35,7 +35,7 @@ _nftban() {
     local sync_cmds="full validate status --dry-run help"
 
     # Firewall & Security commands
-    local firewall_cmds="status stats validate conflicts check logs record init reload rebuild reset restore --json help"
+    local firewall_cmds="status stats validate conflicts check logs record init reload rebuild reset restore transition-health takeover ssh-audit --json help"
     local firewall_logs_cmds="enable disable status show help"
     local ban_cmds="--timeout --reason --source --json help"
     local unban_cmds="--json help"


### PR DESCRIPTION
## v1.198.2 — firewall-transition health truth (surgical, shell-only)

Fixes the operator-truth + clear-path defects exposed on lab2 (sticky `floor_breach=1` CRITICAL while the headline read green). **Zero `.go` change → daemon byte-identical to v1.198.1. Schema `1.84.0` unchanged.** Scope: `V1_198_2_SCOPE_FW_TRANSITION_HEALTH_TRUTH.md`.

### PR-A — `BUG-FW-TRANSITION-HEALTH-COUNTER-STICKY-NO-RESET`
- `nftban_firewall_transition_health.sh`: new **`fth_reset_transition_health`** — zeroes the cumulative harm counters **only** after a fresh live probe proves **no current breach** (refuses rc 2 otherwise — **no masking**), preserves the prior anomaly timestamp as audit history, and touches **only the state JSON** (no nft/ban mutation, no `reset --force`, no manual edit).
- `cmd_firewall.sh`: a **clean** rebuild (post protected|idle) clears a stale alarm via the gated reset; new operator verb **`nftban firewall transition-health [status|ack]`**.

### PR-B — `BUG-HEALTH-VERDICT-IGNORES-FW-TRANSITION-CRITICAL`
- `nftban_output.sh`: operator-readiness now consults the FW-transition severity (4th arg). A CRITICAL/ERROR alarm raises `PASS`→`PASS_WITH_WARN` + `Action: WARN` + an alarm note (**never** downgrades an existing FAIL). `cmd_health.sh` computes it once before the verdict; `cmd_status.sh` qualifies the Health roll-up — **no green/clean headline beside a 🔴 CRITICAL transition line**.

### PR-C — `D-V198-HEALTH-FINDINGS-DOUBLE-RENDER`
- The readiness block is now the **verdict surface only** (one-line pointer); finding detail renders **once** in the canonical Findings section.

### CLI registry (per project rule)
`firewall transition-health` added to **`commands.registry.yml`** + **`show_firewall_help`** + **bash-completion** (also backfilled `takeover`/`ssh-audit` in completion).

### Tests / guarantees
- `fw_transition_health_truth_v1982_test.sh` **16/16** (reset positive/negative + **no-ban-loss** + verdict aggregation incl. no-FAIL-downgrade); `nftban_operator_readiness_r1b2_test.sh` updated for the verdict-only contract **23/0**; `firewall_transition_health_v1921_test.sh` **34/0**, `nftban_render_findings_r1b1_test.sh` **19/0** (no regression). shellcheck clean.
- **No firewall/ban/detector/BotGuard/counter/metrics/schema change.** Deferred: `BUG-INSTALLER-PER-RUN-FORENSIC-LOG-MISSING` (v1.199 lifecycle-forensics lane).

Next: CI green → lab-first **lab2** (the stuck host = the proof: clear the alarm via the official path, bans preserved) + **lab4** (clean regression) → release-prep → publish → resume fleet.