### PR TITLE
fix(v1.198.3): inhibit cadence timers during update binary-swap (BUG-WATCHDOG-TIMER-UPDATE-SWAP-EXEC203-RACE)

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -487,6 +487,15 @@ _cmd_update_main_locked() {
     # only proceed for rpm/deb install types. Reject source/mixed/unknown.
     _update_phase 2 "Install" "package install may take up to 60s"
     local result=0
+    # v1.198.3 PR-A (BUG-WATCHDOG-TIMER-UPDATE-SWAP-EXEC203-RACE): inhibit the
+    # racing cadence timers (watchdog @120s, maintenance @15m) across the binary
+    # swap so they cannot fire mid-swap, hit EXEC-203, and latch a failed unit →
+    # spurious DEGRADED. The scoped INT/TERM trap restores them on interrupt; the
+    # explicit restore after the case covers the normal + handled-failure paths.
+    # NO EXIT trap: cmd_update's lock cleanup is return-based (not trap-based) and
+    # must not be clobbered (scoped trap only, cleared right after restore).
+    _update_inhibit_cadence_timers
+    trap '_update_restore_cadence_timers' INT TERM
     case "$source" in
         github)
             case "$install_type" in
@@ -529,6 +538,11 @@ _cmd_update_main_locked() {
             result=1
             ;;
     esac
+    # v1.198.3 PR-A: binary swap complete — restore exactly the timers we stopped
+    # (covers success AND handled-failure; the failure block below returns AFTER
+    # this) and clear the scoped interrupt trap.
+    _update_restore_cadence_timers
+    trap - INT TERM
 
     if [[ $result -ne 0 ]]; then
         local _update_duration=$(( SECONDS - _update_start_seconds ))
@@ -548,6 +562,12 @@ _cmd_update_main_locked() {
         echo ""
         return $result
     fi
+
+    # v1.198.3 PR-A: confirm the watchdog runs clean on the freshly-installed
+    # binary (a clean run also clears any stale failed-latch). Log-only — a
+    # genuinely-broken watchdog is surfaced by the validator/health machinery and
+    # its next timer cycle; this must not abort an otherwise-successful update.
+    _update_verify_watchdog || true
 
     # Restart services to load new binaries
     echo ""

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -266,3 +266,72 @@ _update_write_history() {
     chmod 0640 "$history_file" 2>/dev/null || true
 }
 
+
+# =============================================================================
+# v1.198.3 PR-A (BUG-WATCHDOG-TIMER-UPDATE-SWAP-EXEC203-RACE)
+# -----------------------------------------------------------------------------
+# Cadence timers (nftban-watchdog.timer @120s, nftban-maintenance.timer @15m)
+# exec /usr/sbin/nftban. If one fires while `nftban update` is replacing /
+# permission/attribute-toggling the binary, systemd hits a transient EXEC-203
+# Permission-denied, latches the .service failed, and the post-install
+# failed-unit assertion marks install_state=DEGRADED on an otherwise-healthy
+# upgrade (reproduced on dns2 2026-06-22 20:23:24Z). These helpers transiently
+# STOP the racing timers for the binary-swap critical section and RESTORE exactly
+# the ones that were active — never mask, never enable a disabled timer.
+# =============================================================================
+
+# Timers that exec the nftban binary on a tight enough cadence to race the swap.
+# watchdog = the proven 120s racer; maintenance = defensive 15m sibling.
+_NFTBAN_UPDATE_CADENCE_TIMERS=("nftban-watchdog.timer" "nftban-maintenance.timer")
+# Records exactly which timers THIS run stopped (so restore only re-starts those).
+_NFTBAN_INHIBITED_TIMERS=""
+
+# _update_inhibit_cadence_timers: stop the racing cadence timers that are
+# currently active; record them for restore. Best-effort — never fail the update.
+_update_inhibit_cadence_timers() {
+    _NFTBAN_INHIBITED_TIMERS=""
+    command -v systemctl >/dev/null 2>&1 || return 0
+    local t
+    for t in "${_NFTBAN_UPDATE_CADENCE_TIMERS[@]}"; do
+        if systemctl is-active --quiet "$t" 2>/dev/null; then
+            if systemctl stop "$t" 2>/dev/null; then
+                _NFTBAN_INHIBITED_TIMERS="${_NFTBAN_INHIBITED_TIMERS:+$_NFTBAN_INHIBITED_TIMERS }$t"
+            fi
+        fi
+    done
+    [[ -n "$_NFTBAN_INHIBITED_TIMERS" ]] && _update_log INFO "Inhibited cadence timer(s) for the install window: ${_NFTBAN_INHIBITED_TIMERS}" || true
+    return 0
+}
+
+# _update_restore_cadence_timers: re-start exactly the timers this run stopped.
+# IDEMPOTENT (empty list = no-op), so it is safe to call from both the normal
+# path and a scoped INT/TERM trap. Never enables a timer that was disabled.
+_update_restore_cadence_timers() {
+    [[ -z "${_NFTBAN_INHIBITED_TIMERS:-}" ]] && return 0
+    command -v systemctl >/dev/null 2>&1 || { _NFTBAN_INHIBITED_TIMERS=""; return 0; }
+    local t
+    for t in $_NFTBAN_INHIBITED_TIMERS; do
+        systemctl start "$t" 2>/dev/null || _update_log WARN "Failed to restart inhibited timer $t — start it manually: systemctl start $t"
+    done
+    _update_log INFO "Restored cadence timer(s): ${_NFTBAN_INHIBITED_TIMERS}"
+    _NFTBAN_INHIBITED_TIMERS=""
+    return 0
+}
+
+# _update_verify_watchdog: after the swap + restore, run the watchdog oneshot
+# ONCE to confirm it is healthy on the new binary. Clears a stale failed-latch
+# only if the fresh run succeeds (never masks a genuinely-broken watchdog).
+# Returns 0 if the post-update watchdog run is clean (or systemctl/unit absent),
+# 1 if the watchdog genuinely still fails.
+_update_verify_watchdog() {
+    command -v systemctl >/dev/null 2>&1 || return 0
+    systemctl cat nftban-watchdog.service >/dev/null 2>&1 || return 0
+    systemctl reset-failed nftban-watchdog.service 2>/dev/null || true
+    systemctl start nftban-watchdog.service 2>/dev/null || true
+    if systemctl is-failed --quiet nftban-watchdog.service 2>/dev/null; then
+        _update_log WARN "post-update watchdog verification FAILED — nftban-watchdog.service still failing after the update (not a transient swap-window race)"
+        return 1
+    fi
+    _update_log OK "post-update watchdog verification passed"
+    return 0
+}

--- a/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
+++ b/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.198.3 - watchdog/update-swap race: cadence-timer inhibit/restore
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="watchdog_update_swap_race_v1983_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-22"
+# meta:description="Hermetic regression for BUG-WATCHDOG-TIMER-UPDATE-SWAP-EXEC203-RACE (v1.198.3 PR-A). systemctl is stubbed: asserts _update_inhibit_cadence_timers stops ONLY the active racing timers, _update_restore_cadence_timers restores EXACTLY those (idempotent; restores on the failure path; never mask; never enable a disabled/inactive timer), _update_verify_watchdog passes on a clean run and fails on a persistently-broken watchdog, and static guards that cmd_update.sh wraps the [2/6] Install phase (inhibit before the case, restore after, scoped INT/TERM trap, NO EXIT trap) and runs the post-update watchdog verification."
+# meta:input="None (systemctl + _update_log stubs)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh,cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer,nftban-watchdog.service"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HELPERS="$REPO_ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+CMDUPD="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1${2:+ — $2}"; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+CALLS="$WORK/calls"; : > "$CALLS"
+declare -A ACTIVE=()      # ACTIVE[unit]=1 when "running"
+WD_FAILS=0                # 1 => stubbed watchdog stays failed after start
+
+# stub systemctl (a function is found by `command -v`); records every call.
+systemctl() {
+    echo "$*" >> "$CALLS"
+    case "${1:-}" in
+        is-active) local u="${*: -1}"; [[ "${ACTIVE[$u]:-0}" = 1 ]] && return 0 || return 1 ;;
+        stop)      ACTIVE[${2:-}]=0; return 0 ;;
+        start)     ACTIVE[${2:-}]=1; return 0 ;;
+        is-failed) [[ "$WD_FAILS" = 1 ]] && return 0 || return 1 ;;
+        reset-failed|cat) return 0 ;;
+        *) return 0 ;;
+    esac
+}
+# quiet logger stub (helpers call _update_log) — but source defines it; override after.
+# shellcheck source=/dev/null
+source "$HELPERS"
+set +e                    # helpers set -Eeuo at source; this test drives non-zero returns
+_update_log(){ :; }       # silence
+
+calls_have(){ grep -qx -- "$1" "$CALLS"; }
+
+echo "== A: inhibit stops ONLY active racing timers; records them =="
+: > "$CALLS"; ACTIVE=( [nftban-watchdog.timer]=1 )   # maintenance INACTIVE
+_update_inhibit_cadence_timers
+calls_have "stop nftban-watchdog.timer" && ok "A stopped active watchdog timer" || no "A watchdog not stopped"
+calls_have "stop nftban-maintenance.timer" && no "A stopped an INACTIVE timer (should not)" || ok "A did NOT stop the inactive maintenance timer"
+[[ "$_NFTBAN_INHIBITED_TIMERS" == "nftban-watchdog.timer" ]] && ok "A recorded exactly the stopped timer" || no "A inhibited-list" "$_NFTBAN_INHIBITED_TIMERS"
+
+echo "== B: restore re-starts EXACTLY those; never enable; idempotent =="
+: > "$CALLS"; _update_restore_cadence_timers
+calls_have "start nftban-watchdog.timer" && ok "B restored the watchdog timer" || no "B watchdog not restored"
+calls_have "start nftban-maintenance.timer" && no "B started a never-stopped timer" || ok "B did NOT start the maintenance timer"
+[[ -z "$_NFTBAN_INHIBITED_TIMERS" ]] && ok "B inhibited-list cleared after restore" || no "B list not cleared"
+: > "$CALLS"; _update_restore_cadence_timers   # idempotent
+[[ ! -s "$CALLS" ]] && ok "B restore is idempotent (no-op when list empty)" || no "B second restore acted" "$(tr '\n' ' ' <"$CALLS")"
+
+echo "== C: never mask, never enable (any case) =="
+: > "$CALLS"; ACTIVE=( [nftban-watchdog.timer]=1 [nftban-maintenance.timer]=1 )
+_update_inhibit_cadence_timers; _update_restore_cadence_timers
+grep -qiE '^(mask|enable|disable) ' "$CALLS" && no "C used mask/enable/disable" "$(grep -iE '^(mask|enable|disable) ' "$CALLS"|tr '\n' ' ')" || ok "C never mask/enable/disable (only stop/start)"
+calls_have "stop nftban-watchdog.timer" && calls_have "stop nftban-maintenance.timer" && ok "C both active timers stopped" || no "C both not stopped"
+calls_have "start nftban-watchdog.timer" && calls_have "start nftban-maintenance.timer" && ok "C both restored" || no "C both not restored"
+
+echo "== D: failure-path restore (timers restored even if install 'fails') =="
+: > "$CALLS"; ACTIVE=( [nftban-watchdog.timer]=1 )
+_update_inhibit_cadence_timers
+false   # simulate a failed install step (handled-failure path)
+_update_restore_cadence_timers   # the explicit restore runs before the failure return
+calls_have "start nftban-watchdog.timer" && ok "D timer restored on the handled-failure path" || no "D not restored on failure"
+
+echo "== E: post-update watchdog verification =="
+WD_FAILS=0; _update_verify_watchdog && ok "E clean watchdog → verify passes (rc0)" || no "E clean verify failed"
+WD_FAILS=1; _update_verify_watchdog && no "E broken watchdog → verify should FAIL" || ok "E persistently-broken watchdog → verify fails (not masked)"
+WD_FAILS=0
+
+echo "== F: static guards on cmd_update.sh (wraps the install phase; scoped trap; no EXIT trap) =="
+awk '/_update_phase 2 "Install"/{i=NR} /^    case "\$source" in/{c=NR} END{exit !(i>0 && c>i && c-i<12)}' "$CMDUPD" && ok "F inhibit sits between phase-2 and the install case" || no "F inhibit placement"
+grep -q "_update_inhibit_cadence_timers" "$CMDUPD" && ok "F cmd_update calls inhibit" || no "F inhibit not wired"
+grep -q "_update_restore_cadence_timers" "$CMDUPD" && ok "F cmd_update calls restore" || no "F restore not wired"
+grep -q "trap '_update_restore_cadence_timers' INT TERM" "$CMDUPD" && ok "F scoped INT/TERM trap present" || no "F scoped trap missing"
+grep -qE "trap '_update_restore_cadence_timers' (INT TERM )?EXIT" "$CMDUPD" && no "F uses an EXIT trap (clobbers lock cleanup)" || ok "F no EXIT trap (lock cleanup not clobbered)"
+grep -q "trap - INT TERM" "$CMDUPD" && ok "F scoped trap cleared after restore" || no "F trap not cleared"
+grep -q "_update_verify_watchdog" "$CMDUPD" && ok "F post-update watchdog verification wired" || no "F verify not wired"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## v1.198.3 — A1 only: cadence-timer inhibit/restore around the update binary-swap

Surgical, **shell-only** lifecycle/update-window reliability hotfix. **Zero `.go` → daemon byte-identical to v1.198.2. NFT schema `1.84.0` unchanged. No systemd-unit, no firewall/nftables behavior, no A2 assertion-tolerance, no v1.199 forensic-log work.** Scope: `V1_198_3_SCOPE_WATCHDOG_UPDATE_RACE.md`.

### Defect — `BUG-WATCHDOG-TIMER-UPDATE-SWAP-EXEC203-RACE`
`nftban-watchdog.timer` (`OnUnitActiveSec=120s`, `ExecStart=/usr/sbin/nftban watchdog run`) can fire while `nftban update` is replacing / permission-/attribute-toggling `/usr/sbin/nftban`. systemd then hits a transient `EXEC 203 Permission denied`, latches `nftban-watchdog.service` failed, and the post-install `failed_units_postinstall_ok` assertion marks `install_state=DEGRADED` on an otherwise-healthy upgrade. **Class:** lifecycle/update-race. **Severity:** MED (reliability/lifecycle-truth) — **not** a firewall/ban/protection failure, **not** a v1.198.2 regression.

### dns2 incident (reproduced in prod)
During the v1.198.2 fleet resume, **dns2** landed `DEGRADED` + `failed=1` = `nftban-watchdog.service` `Failed at step EXEC spawning /usr/sbin/nftban: Permission denied` at **2026-06-22 20:23:24Z — inside the update window**. Live state was healthy (v1.198.2, validate rc0, daemon active, floor_breach=0; `/usr/sbin/nftban` `0750 root:nftban`; watchdog re-runs clean). **dns2 recovered to COMMITTED via the official `nftban update recommit`** (v1.198.1 path). monitor + dns1 passed clean; dns4/srv1/srv2/srv3 each ~30-40% likely to hit the same race → fleet held.

### Fix (A1)
`cmd_update.sh` wraps the `[2/6] Install` (binary-swap) phase:
- `_update_inhibit_cadence_timers` — `systemctl stop` the **active** racing timers (`nftban-watchdog.timer` + defensive `nftban-maintenance.timer`), recording exactly which it stopped.
- `_update_restore_cadence_timers` — restore **exactly those** (idempotent; **never enables a disabled timer; never masks**). Explicit restore after the install case (covers success + handled-failure) + a **scoped `INT/TERM` trap** (interrupt). **No `EXIT` trap** — `cmd_update`'s update-lock cleanup is return-based and must not be clobbered; the trap is cleared right after restore.
- `_update_verify_watchdog` — runs the watchdog once post-swap; **fails only if the RESTORED watchdog still fails** (a clean re-run clears any stale latch; never masks a real failure).

### Trap-safety (reviewed, all hold)
existing traps preserved (none to chain — lock cleanup is return-based) · update.lock cleanup still runs · restore on success/handled-failure/INT-TERM (install is `|| result=$?`-guarded under `set -Eeuo`, no `exit` in-window) · never starts a disabled timer · no mask/enable.

### Stage 1 (source/staged) lab validation
lab2 (DEB) + lab4 (RPM): candidate update path staged on v1.198.1, real `nftban update` (→v1.198.2) → inhibit + restore (watchdog+maintenance) + watchdog verification ran → **COMMITTED, validate rc0, 0 failed units, watchdog.timer active, no failed-latch, no FW-transition CRITICAL**. Ban deltas were **feed-resync lag, not loss** (lab4 `blacklist_ipv4` 743→115→**742 in 45s**; manual=0). **Implementation validated, NOT release-ready.**

### Pre-existing test debt (NOT introduced here)
`cmd_update_lock_cleanup_v135_test.sh :: static_s3_contention_path_does_not_remove_holders_file` is red on **both** clean main `795a2c54` (8 passed, 1 failed) **and** this candidate `16bedeea` (8 passed, 1 failed) — identical. v1.198.3 did not touch that file or the lock-contention path. Labeled **`PRE_EXISTING_TEST_DEBT_STATIC_S3_LOCK_CLEANUP_NOT_INTRODUCED_BY_V1_198_3`** and filed as separate debt (not closed, not in scope).

### Tests
`watchdog_update_swap_race_v1983_test.sh` **20/0** (stops-only-active · restores-exactly · idempotent · failure-path · never mask/enable · verify pos/neg · static install-phase-wiring + no-EXIT-trap guard). All other update tests green. shellcheck clean.

### ⚠️ Release gate
**Release remains BLOCKED until package-native Stage B DEB/RPM validation passes** (`OPEN_V1_198_3_PACKAGE_NATIVE_STAGE_B`): v1.198.3 must be proven as **built packages** through the official package/update path on lab2+lab4, not staged scripts. Merging this PR does **not** authorize tag/publish.

Deferred: A2 assertion-tolerance + broader stale-oneshot/SOAK → v1.201; installer per-run forensic logs + `nftban support` all-logs → v1.199.