### PR TITLE
feat(v1.199): lifecycle forensics — per-run records + run-id + JSONL + support all-logs

### DIFF
--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -918,6 +918,14 @@ directories:
       created_by: tmpfiles
       tmpfiles_reconcile: "z"
 
+    - path: /var/log/nftban/update-runs
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "Per-run install/update lifecycle forensic records - JSONL + snapshot, bounded retention (v1.199)"
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
+
     - path: /var/log/nftban/suricata
       mode: "0770"
       owner: suricata

--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -324,6 +324,33 @@ _collect_logs() {
     if [[ -f "$NFTBAN_LOG_DIR/update.log" ]]; then
         cp "$NFTBAN_LOG_DIR/update.log" "$log_dir/update.log" 2>/dev/null || true
     fi
+
+    # v1.199: per-run lifecycle forensic records (update-runs/<run_id>/). Collect
+    # the newest N runs only (bounded bundle), each redacted via _redact_file.
+    local runs_src="$NFTBAN_LOG_DIR/update-runs"
+    if [[ -d "$runs_src" ]]; then
+        local runs_dst="$log_dir/update-runs"
+        local keep="${SUPPORT_UPDATE_RUNS_MAX:-10}"
+        mkdir -p "$runs_dst" 2>/dev/null || true
+        local run_count=0 run_dir
+        # newest-first by mtime; cap at $keep (no silent over-collect)
+        while IFS= read -r run_dir; do
+            [[ -z "$run_dir" ]] && continue
+            [[ $run_count -ge $keep ]] && break
+            local rid; rid=$(basename "$run_dir")
+            mkdir -p "$runs_dst/$rid" 2>/dev/null || continue
+            local f
+            for f in run.jsonl human.log; do
+                [[ -f "$run_dir/$f" ]] && _redact_file "$run_dir/$f" "$runs_dst/$rid/$f" 2>/dev/null || true
+            done
+            run_count=$((run_count + 1))
+        done < <(find "$runs_src" -mindepth 1 -maxdepth 1 -type d -printf '%T@\t%p\n' 2>/dev/null | sort -rn | cut -f2-)
+        if [[ $run_count -gt 0 ]]; then
+            local total; total=$(find "$runs_src" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+            _support_log OK "Per-run forensic records ($run_count of $total collected, newest first, redacted)"
+            [[ $total -gt $run_count ]] && _support_log WARN "Per-run records capped at $keep (SUPPORT_UPDATE_RUNS_MAX); $((total - run_count)) older run(s) omitted"
+        fi
+    fi
 }
 
 _collect_health() {

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -418,9 +418,13 @@ _cmd_update_main_locked() {
 
     _load_config
 
-    local install_type current_version
+    local install_type current_version _RUN_ID
     install_type=$(_detect_install_type)
     current_version=$(_get_current_version)
+
+    # v1.199 lifecycle forensics: mint a run_id + open a per-run record for this update.
+    _RUN_ID=$(_forensic_run_id)
+    _forensic_begin "$_RUN_ID" "$source" "$current_version" "pending"
 
     # v1.174: record the installer.log line count BEFORE the install so the final
     # verdict can detect a WARN_PRE_EXISTING_RECOVERED (a stale pre-existing failed
@@ -494,8 +498,10 @@ _cmd_update_main_locked() {
     # explicit restore after the case covers the normal + handled-failure paths.
     # NO EXIT trap: cmd_update's lock cleanup is return-based (not trap-based) and
     # must not be clobbered (scoped trap only, cleared right after restore).
+    _forensic_snapshot "$_RUN_ID" pre-swap
     _update_inhibit_cadence_timers
     trap '_update_restore_cadence_timers' INT TERM
+    _forensic_event "$_RUN_ID" inhibit "timers=$_NFTBAN_INHIBITED_TIMERS"
     case "$source" in
         github)
             case "$install_type" in
@@ -541,8 +547,10 @@ _cmd_update_main_locked() {
     # v1.198.3 PR-A: binary swap complete — restore exactly the timers we stopped
     # (covers success AND handled-failure; the failure block below returns AFTER
     # this) and clear the scoped interrupt trap.
+    _forensic_event "$_RUN_ID" restore "timers=$_NFTBAN_INHIBITED_TIMERS"
     _update_restore_cadence_timers
     trap - INT TERM
+    _forensic_snapshot "$_RUN_ID" post-swap
 
     if [[ $result -ne 0 ]]; then
         local _update_duration=$(( SECONDS - _update_start_seconds ))
@@ -560,6 +568,7 @@ _cmd_update_main_locked() {
         echo ""
         echo "  Log: $UPDATE_LOG_FILE"
         echo ""
+        _forensic_end "$_RUN_ID" install-fail "$result"
         return $result
     fi
 
@@ -784,6 +793,11 @@ _cmd_update_main_locked() {
     if [[ -f "$_install_state_file" ]]; then
         _installer_state=$(grep -m1 '^INSTALL_STATE=' "$_install_state_file" 2>/dev/null | cut -d= -f2- || echo "COMMITTED")
     fi
+
+    # v1.199 forensics: post-verify snapshot (binary swapped, timers restored,
+    # install_state resolved) + close the per-run record.
+    _forensic_snapshot "$_RUN_ID" post-verify
+    _forensic_event "$_RUN_ID" run_end "state=$_installer_state" "new_version=$new_version" "rc=0"
 
     case "$_installer_state" in
         COMMITTED)

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -335,3 +335,102 @@ _update_verify_watchdog() {
     _update_log OK "post-update watchdog verification passed"
     return 0
 }
+
+# =============================================================================
+# v1.199 Lifecycle Forensics (BUG-INSTALLER-PER-RUN-FORENSIC-LOG-MISSING +
+#                            BUG-INSTALLER-LOG-FORMAT-MIXED-JSON)
+# -----------------------------------------------------------------------------
+# Per-run forensic record under /var/log/nftban/update-runs/<run_id>/: a parseable
+# JSONL event stream (run.jsonl) + a human slice (human.log) + allowlisted
+# lifecycle snapshots at pre-swap / post-swap / post-restore. jq-free; values are
+# redaction-filtered; ONLY an explicit allowlist of fields is emitted (no env, no
+# secrets, no config dump). Bounded retention (keep newest N, prune + log the rest).
+# Forensics ONLY — no reliability/self-heal logic here.
+# =============================================================================
+FORENSIC_RUNS_DIR="${NFTBAN_LOG_DIR:-/var/log/nftban}/update-runs"
+FORENSIC_RETAIN_N="${NFTBAN_FORENSIC_RETAIN:-20}"
+FORENSIC_RUN_DIR=""; FORENSIC_JSONL=""; FORENSIC_HUMAN=""
+
+# deterministic run_id (tests/callers may pin via NFTBAN_RUN_ID)
+_forensic_run_id() { printf '%s' "${NFTBAN_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null)-$$}"; }
+
+# minimal JSON string escaper (no jq dependency)
+_fx_jstr() { local s="${1-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/ }"; s="${s//$'\t'/ }"; s="${s//$'\r'/ }"; printf '%s' "$s"; }
+# secret redaction safety-net (the snapshot is allowlisted, but values pass this too)
+_fx_redact() { sed -E 's/(pass(word)?|secret|token|api[_-]?key|bearer|authorization)([=: ]+)[^ ",]*/\1\3<redacted>/Ig'; }
+
+# _forensic_begin <run_id> <mode> <from> <to>
+_forensic_begin() {
+    local id="$1" mode="${2:-}" from="${3:-}" to="${4:-}"
+    command -v date >/dev/null 2>&1 || return 0
+    FORENSIC_RUN_DIR="$FORENSIC_RUNS_DIR/$id"
+    mkdir -p "$FORENSIC_RUN_DIR" 2>/dev/null || { FORENSIC_RUN_DIR=""; return 0; }
+    chmod 0750 "$FORENSIC_RUN_DIR" 2>/dev/null || true
+    FORENSIC_JSONL="$FORENSIC_RUN_DIR/run.jsonl"; FORENSIC_HUMAN="$FORENSIC_RUN_DIR/human.log"
+    : > "$FORENSIC_JSONL" 2>/dev/null || true; : > "$FORENSIC_HUMAN" 2>/dev/null || true
+    chmod 0640 "$FORENSIC_JSONL" "$FORENSIC_HUMAN" 2>/dev/null || true
+    _forensic_event "$id" run_start "mode=$mode" "from=$from" "to=$to" "pid=$$"
+    _forensic_prune
+}
+
+# _forensic_event <run_id> <event> [key=value ...]  (values redacted; allowlisted callers only)
+_forensic_event() {
+    [ -n "${FORENSIC_JSONL:-}" ] || return 0
+    local id="$1" ev="$2"; shift 2 || true
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf '')
+    local json kv k v
+    json="{\"ts\":\"$(_fx_jstr "$ts")\",\"run_id\":\"$(_fx_jstr "$id")\",\"event\":\"$(_fx_jstr "$ev")\""
+    for kv in "$@"; do
+        k="${kv%%=*}"; v="${kv#*=}"
+        # defense-in-depth: if the KEY is secret-named, redact the whole value;
+        # otherwise run the substring redaction safety-net over the value.
+        if printf '%s' "$k" | grep -qiE '^(pass(word)?|secret|token|api[_-]?key|bearer|authorization)$'; then
+            v="<redacted>"
+        else
+            v=$(printf '%s' "$v" | _fx_redact)
+        fi
+        json="$json,\"$(_fx_jstr "$k")\":\"$(_fx_jstr "$v")\""
+    done
+    json="$json}"
+    printf '%s\n' "$json" >> "$FORENSIC_JSONL" 2>/dev/null || true
+}
+
+# _forensic_snapshot <run_id> <phase>  (allowlisted lifecycle-critical fields ONLY)
+_forensic_snapshot() {
+    [ -n "${FORENSIC_JSONL:-}" ] || return 0
+    local id="$1" ph="$2" bin="${NFTBAN_SBIN:-/usr/sbin/nftban}"
+    local mode mtime xattr ist wd_act wd_next mt_act failed u
+    mode=$(stat -c '%a' "$bin" 2>/dev/null || printf '?'); mtime=$(stat -c '%Y' "$bin" 2>/dev/null || printf '?')
+    xattr=$(lsattr "$bin" 2>/dev/null | awk '{print $1}' || printf '?')
+    ist=$(grep -m1 '^INSTALL_STATE=' "${NFTBAN_DATA_DIR:-/var/lib/nftban}/state/install_state" 2>/dev/null | cut -d= -f2- || printf '?')
+    wd_act=$(systemctl is-active nftban-watchdog.timer 2>/dev/null || printf '?')
+    wd_next=$(systemctl show nftban-watchdog.timer -p NextElapseUSecRealtime --value 2>/dev/null || printf '?')
+    mt_act=$(systemctl is-active nftban-maintenance.timer 2>/dev/null || printf '?')
+    failed=$(systemctl --failed --no-legend 2>/dev/null | grep -iE 'nftban|nftband' | awk '{print $2}' | tr '\n' ',' || printf '')
+    _forensic_event "$id" snapshot "phase=$ph" "bin_mode=$mode" "bin_mtime=$mtime" "bin_xattr=$xattr" \
+        "install_state=$ist" "watchdog_timer=$wd_act" "watchdog_next=$wd_next" "maintenance_timer=$mt_act" "failed_units=$failed"
+    for u in $(systemctl --failed --no-legend 2>/dev/null | grep -iE 'nftban|nftband' | awk '{print $2}'); do
+        _forensic_event "$id" failed_unit "phase=$ph" "unit=$u" \
+            "result=$(systemctl show "$u" -p Result --value 2>/dev/null)" \
+            "exec_status=$(systemctl show "$u" -p ExecMainStatus --value 2>/dev/null)" \
+            "exec_exit=$(systemctl show "$u" -p ExecMainExitTimestamp --value 2>/dev/null)" \
+            "inactive_enter=$(systemctl show "$u" -p InactiveEnterTimestamp --value 2>/dev/null)"
+    done
+}
+
+# _forensic_end <run_id> <state> <rc>
+_forensic_end() { [ -n "${FORENSIC_JSONL:-}" ] || return 0; _forensic_event "$1" run_end "state=${2:-}" "rc=${3:-}"; }
+
+# _forensic_prune — keep newest N run dirs; log what is pruned (no silent cap)
+_forensic_prune() {
+    [ -d "$FORENSIC_RUNS_DIR" ] || return 0
+    # read the env at call time (operator may set NFTBAN_FORENSIC_RETAIN after source)
+    local n="${NFTBAN_FORENSIC_RETAIN:-${FORENSIC_RETAIN_N:-20}}"; [ "$n" -gt 0 ] 2>/dev/null || n=20
+    local total; total=$(find "$FORENSIC_RUNS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+    [ "${total:-0}" -le "$n" ] && return 0
+    local pruned=0 d
+    while IFS= read -r d; do [ -n "$d" ] && rm -rf "$d" 2>/dev/null && pruned=$((pruned+1)); done < <(
+        find "$FORENSIC_RUNS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%T@\t%p\n' 2>/dev/null | sort -n | head -n "$(( total - n ))" | cut -f2-)
+    [ "$pruned" -gt 0 ] && _update_log INFO "forensics: pruned $pruned old run-record(s), retained newest $n (NFTBAN_FORENSIC_RETAIN)" || true
+    return 0
+}

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -158,6 +158,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/botguard"]="0750|nftban|nftban|HTTP Bot Guard logs"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/metrics"]="0750|nftban|nftban|Metrics export logs"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/soak"]="0750|nftban|nftban|Soak validation per-run JSON + cron.log (v1.98.1)"
+    NFTBAN_FHS_DIRECTORIES["/var/log/nftban/update-runs"]="0750|nftban|nftban|Per-run install/update lifecycle forensic records - JSONL + snapshot, bounded retention (v1.199)"
     NFTBAN_FHS_DIRECTORIES["/var/log/nftban/suricata"]="0770|suricata|nftban|Suricata EVE logs (suricata writes, nftban reads)"
 
     # Runtime Directories

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -858,6 +858,14 @@
         "created_by": "tmpfiles"
       },
       {
+        "path": "/var/log/nftban/update-runs",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "Per-run install/update lifecycle forensic records - JSONL + snapshot, bounded retention (v1.199)",
+        "created_by": "tmpfiles"
+      },
+      {
         "path": "/var/log/nftban/suricata",
         "mode": "0770",
         "owner": "suricata",

--- a/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
+++ b/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.199 - Lifecycle forensics: per-run record + JSONL + snapshot
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="lifecycle_forensics_v1199_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-23"
+# meta:description="Hermetic regression for v1.199 lifecycle forensics (BUG-INSTALLER-PER-RUN-FORENSIC-LOG-MISSING + BUG-INSTALLER-LOG-FORMAT-MIXED-JSON). Stubs systemctl/stat/lsattr; asserts run_id is deterministic (NFTBAN_RUN_ID pin), the per-run update-runs/<id>/ dir + run.jsonl/human.log are created, every JSONL line parses and carries run_id, the snapshot emits ONLY allowlisted lifecycle fields (binary mode/mtime/xattr, timer due-time/active, failed-unit detail, install_state) with NO env/secret leakage, secret-bearing values are redacted, and retention keeps newest N + prunes the rest."
+# meta:input="None (systemctl/stat/lsattr + temp log/data dirs stubbed)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,python3,find,sort"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh"
+# meta:inventory.binaries="bash,python3"
+# meta:inventory.env_vars="NFTBAN_RUN_ID,NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_FORENSIC_RETAIN,NFTBAN_SBIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HELPERS="$REPO_ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1${2:+ — $2}"; }
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+export NFTBAN_LOG_DIR="$WORK/log"; export NFTBAN_DATA_DIR="$WORK/data"
+mkdir -p "$NFTBAN_DATA_DIR/state" "$WORK/bin"
+printf 'INSTALL_STATE=COMMITTED\n' > "$NFTBAN_DATA_DIR/state/install_state"
+# a stub "binary" to stat/lsattr
+export NFTBAN_SBIN="$WORK/bin/nftban"; printf '#!/bin/sh\n' > "$NFTBAN_SBIN"; chmod 0750 "$NFTBAN_SBIN"
+
+# stub systemctl + lsattr (PATH shim) so the snapshot is deterministic + offline
+cat > "$WORK/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  is-active) case "$*" in *watchdog*) echo active;; *maintenance*) echo active;; *) echo inactive;; esac ;;
+  show) for a in "$@"; do case "$a" in NextElapseUSecRealtime) echo "Sat 2026-06-23 12:00:00";; Result) echo exit-code;; ExecMainStatus) echo 203;; ExecMainExitTimestamp) echo "Mon 2026-06-22 20:23:24 UTC";; InactiveEnterTimestamp) echo "Mon 2026-06-22 20:23:24 UTC";; esac; done ;;
+  --failed) echo "● nftban-watchdog.service loaded failed failed NFTBan Watchdog" ;;
+esac
+STUB
+cat > "$WORK/bin/lsattr" <<'STUB'
+#!/usr/bin/env bash
+echo "--------------e------- $2"
+STUB
+chmod +x "$WORK/bin/systemctl" "$WORK/bin/lsattr"
+export PATH="$WORK/bin:$PATH"
+
+# shellcheck source=/dev/null
+source "$HELPERS"; set +e
+_update_log(){ :; }
+
+jq_lines_valid(){ python3 - "$1" <<'PY'
+import sys,json
+ok=True
+for i,l in enumerate(open(sys.argv[1]),1):
+    l=l.strip()
+    if not l: continue
+    try: json.loads(l)
+    except Exception as e: print(f"line {i}: {e}"); ok=False
+sys.exit(0 if ok else 1)
+PY
+}
+ev_field(){ python3 - "$1" "$2" "$3" <<'PY'
+import sys,json
+path,ev,field=sys.argv[1],sys.argv[2],sys.argv[3]
+for l in open(path):
+    l=l.strip()
+    if not l: continue
+    o=json.loads(l)
+    if o.get("event")==ev and field in o: print(o[field]); break
+PY
+}
+
+echo "== A: run_id deterministic via NFTBAN_RUN_ID =="
+export NFTBAN_RUN_ID="20260623T120000Z-testpin"
+[ "$(_forensic_run_id)" = "20260623T120000Z-testpin" ] && ok "A run_id honors NFTBAN_RUN_ID pin" || no "A run_id not pinned" "$(_forensic_run_id)"
+unset NFTBAN_RUN_ID; A1=$(_forensic_run_id)
+case "$A1" in *-*[0-9]) ok "A auto run_id has ts-pid shape ($A1)";; *) no "A auto run_id shape" "$A1";; esac
+export NFTBAN_RUN_ID="20260623T120000Z-testpin"
+
+echo "== B: begin creates per-run dir + JSONL/human; run_start logged =="
+RID=$(_forensic_run_id)
+_forensic_begin "$RID" update 1.198.2 1.198.3
+D="$NFTBAN_LOG_DIR/update-runs/$RID"
+[ -d "$D" ] && ok "B per-run dir created ($D)" || no "B dir missing"
+[ -f "$D/run.jsonl" ] && [ -f "$D/human.log" ] && ok "B run.jsonl + human.log created" || no "B files missing"
+grep -q '"event":"run_start"' "$D/run.jsonl" && ok "B run_start event present" || no "B no run_start"
+
+echo "== C: snapshot emits allowlisted fields; JSONL parses; carries run_id =="
+_forensic_snapshot "$RID" pre-swap
+_forensic_event "$RID" inhibit "timers=nftban-watchdog.timer nftban-maintenance.timer"
+_forensic_snapshot "$RID" post-swap
+_forensic_end "$RID" COMMITTED 0
+jq_lines_valid "$D/run.jsonl" && ok "C every JSONL line parses as JSON" || no "C invalid JSONL"
+miss=0; while IFS= read -r l; do [ -z "$l" ] && continue; echo "$l"|grep -q '"run_id":' || miss=1; done < "$D/run.jsonl"
+[ "$miss" = 0 ] && ok "C every event carries run_id" || no "C an event lacks run_id"
+[ "$(ev_field "$D/run.jsonl" snapshot bin_mode)" = "750" ] && ok "C snapshot bin_mode captured (750)" || no "C bin_mode" "$(ev_field "$D/run.jsonl" snapshot bin_mode)"
+echo "$(ev_field "$D/run.jsonl" snapshot bin_xattr)" | grep -q 'e' && ok "C snapshot bin_xattr captured" || no "C bin_xattr missing"
+[ "$(ev_field "$D/run.jsonl" snapshot watchdog_timer)" = "active" ] && ok "C snapshot watchdog_timer active" || no "C watchdog_timer"
+[ -n "$(ev_field "$D/run.jsonl" snapshot watchdog_next)" ] && ok "C snapshot watchdog due-time captured" || no "C watchdog_next missing"
+[ "$(ev_field "$D/run.jsonl" snapshot install_state)" = "COMMITTED" ] && ok "C snapshot install_state captured" || no "C install_state"
+grep -q '"event":"failed_unit"' "$D/run.jsonl" && [ "$(ev_field "$D/run.jsonl" failed_unit exec_status)" = "203" ] && ok "C failed-unit detail (EXEC 203) captured" || no "C failed_unit detail"
+
+echo "== D: allowlist — NO env/secret leakage in the record =="
+export SECRET_TOKEN="hunter2supersecret"; export AWS_SECRET_ACCESS_KEY="leakme123"
+RID2="20260623T120001Z-secrettest"; _forensic_begin "$RID2" update 1 2
+_forensic_event "$RID2" note "password=hunter2 token=abc123 detail=ok"
+_forensic_snapshot "$RID2" pre-swap; _forensic_end "$RID2" COMMITTED 0
+D2="$NFTBAN_LOG_DIR/update-runs/$RID2"
+grep -qi 'hunter2supersecret\|leakme123\|AWS_SECRET\|SECRET_TOKEN' "$D2/run.jsonl" && no "D env secret leaked into record" || ok "D no env secret in record (allowlist only)"
+grep -qi 'hunter2\b\|abc123' "$D2/run.jsonl" && no "D inline secret not redacted" "$(grep -i hunter2 "$D2/run.jsonl"|head -1)" || ok "D inline secret values redacted"
+grep -q '<redacted>' "$D2/run.jsonl" && ok "D redaction marker present" || no "D no redaction applied"
+
+echo "== E: retention keeps newest N, prunes the rest =="
+export NFTBAN_FORENSIC_RETAIN=3
+RDIR="$NFTBAN_LOG_DIR/update-runs"; rm -rf "$RDIR"; mkdir -p "$RDIR"
+for i in 1 2 3 4 5 6; do mkdir -p "$RDIR/run-$i"; touch -d "2026-06-0${i} 00:00:00" "$RDIR/run-$i" 2>/dev/null || touch "$RDIR/run-$i"; sleep 0.02; done
+_forensic_prune
+cnt=$(find "$RDIR" -mindepth 1 -maxdepth 1 -type d | wc -l)
+[ "$cnt" -le 3 ] && ok "E retention pruned to N=3 (now $cnt)" || no "E not pruned" "count=$cnt"
+[ -d "$RDIR/run-6" ] && [ ! -d "$RDIR/run-1" ] && ok "E newest kept (run-6), oldest pruned (run-1)" || no "E wrong dirs kept"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
+++ b/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
@@ -89,7 +89,7 @@ WD_FAILS=1; _update_verify_watchdog && no "E broken watchdog → verify should F
 WD_FAILS=0
 
 echo "== F: static guards on cmd_update.sh (wraps the install phase; scoped trap; no EXIT trap) =="
-awk '/_update_phase 2 "Install"/{i=NR} /^    case "\$source" in/{c=NR} END{exit !(i>0 && c>i && c-i<12)}' "$CMDUPD" && ok "F inhibit sits between phase-2 and the install case" || no "F inhibit placement"
+awk '/_update_phase 2 "Install"/{i=NR} /_update_inhibit_cadence_timers/&&!h{h=NR} /^    case "\$source" in/{c=NR} END{exit !(i>0 && h>i && c>h)}' "$CMDUPD" && ok "F inhibit sits between phase-2 and the install case (order)" || no "F inhibit placement"
 grep -q "_update_inhibit_cadence_timers" "$CMDUPD" && ok "F cmd_update calls inhibit" || no "F inhibit not wired"
 grep -q "_update_restore_cadence_timers" "$CMDUPD" && ok "F cmd_update calls restore" || no "F restore not wired"
 grep -q "trap '_update_restore_cadence_timers' INT TERM" "$CMDUPD" && ok "F scoped INT/TERM trap present" || no "F scoped trap missing"

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -114,6 +114,7 @@ d /var/log/nftban/rbl 0750 nftban nftban -
 d /var/log/nftban/botguard 0750 nftban nftban -
 d /var/log/nftban/metrics 0750 nftban nftban -
 d /var/log/nftban/soak 0750 nftban nftban -
+d /var/log/nftban/update-runs 0750 nftban nftban -
 z /var/log/nftban 0750 nftban nftban -
 z /var/log/nftban/watchdog 0750 nftban nftban -
 z /var/log/nftban/reports 0750 nftban nftban -
@@ -121,6 +122,7 @@ z /var/log/nftban/rbl 0750 nftban nftban -
 z /var/log/nftban/botguard 0750 nftban nftban -
 z /var/log/nftban/metrics 0750 nftban nftban -
 z /var/log/nftban/soak 0750 nftban nftban -
+z /var/log/nftban/update-runs 0750 nftban nftban -
 
 # Cache and runtime directories
 d /var/cache/nftban 0755 nftban nftban -

--- a/internal/installer/logging/logger.go
+++ b/internal/installer/logging/logger.go
@@ -40,6 +40,7 @@ type Logger struct {
 	runStart   time.Time
 	phaseStart time.Time
 	logPath    string
+	runID      string // v1.199: correlates installer.log with the shell per-run record (update-runs/<run_id>/)
 
 	// v1.160 PR-A (warning truth-accounting): tally non-fatal warnings so the
 	// final operator summary can report them honestly. Before v1.160, Warn()
@@ -70,6 +71,13 @@ func New(logPath string, verbose bool) *Logger {
 		logPath:  logPath,
 	}
 
+	// v1.199: run-id from NFTBAN_RUN_ID (shared with the shell update path when
+	// invoked under `nftban update`), else generated <UTC compact>-<pid>.
+	l.runID = os.Getenv("NFTBAN_RUN_ID")
+	if l.runID == "" {
+		l.runID = fmt.Sprintf("%s-%d", l.runStart.UTC().Format("20060102T150405Z"), os.Getpid())
+	}
+
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(logPath), 0750); err == nil {
 		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
@@ -91,6 +99,12 @@ func (l *Logger) Close() {
 // LogPath returns the path to the log file being written.
 func (l *Logger) LogPath() string {
 	return l.logPath
+}
+
+// RunID returns the run-id correlating this installer run with the shell
+// per-run forensic record (update-runs/<run_id>/). v1.199.
+func (l *Logger) RunID() string {
+	return l.runID
 }
 
 // FileWriter returns the open log-file handle as an io.Writer, or nil if no log
@@ -120,7 +134,7 @@ func (l *Logger) RunHeader(version, mode, hostname, osInfo string) {
 	l.writeFile("", sep)
 	l.writeFile("RUN", fmt.Sprintf("nftban-installer %s — %s", version, mode))
 	l.writeFile("RUN", fmt.Sprintf("host=%s os=%s", hostname, osInfo))
-	l.writeFile("RUN", fmt.Sprintf("started=%s pid=%d", l.runStart.Format(time.RFC3339), os.Getpid()))
+	l.writeFile("RUN", fmt.Sprintf("started=%s pid=%d run_id=%s", l.runStart.Format(time.RFC3339), os.Getpid(), l.runID))
 	l.writeFile("", sep)
 }
 

--- a/internal/installer/logging/logger_runid_test.go
+++ b/internal/installer/logging/logger_runid_test.go
@@ -1,0 +1,67 @@
+// =============================================================================
+// NFTBan v1.199 - Installer Logger run-id correlation tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="logger_runid_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-23"
+// meta:description="v1.199 lifecycle forensics: verifies the installer Logger carries a run-id that (a) honors NFTBAN_RUN_ID so it matches the shell update path's per-run record id, (b) is generated <UTC compact>-<pid> when the env is unset, and (c) is stamped into the RUN header block written to installer.log."
+// meta:input="Logger.New()/RunID()/RunHeader() over a t.TempDir() log file with NFTBAN_RUN_ID set/unset"
+// meta:output="t.Error on missing/wrong run-id or missing header stamp"
+// meta:depends="testing,os,path/filepath,strings"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_RUN_ID"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunIDHonorsEnv(t *testing.T) {
+	t.Setenv("NFTBAN_RUN_ID", "20260623T120000Z-pinned")
+	l := New(filepath.Join(t.TempDir(), "installer.log"), false)
+	t.Cleanup(l.Close)
+	if got := l.RunID(); got != "20260623T120000Z-pinned" {
+		t.Errorf("RunID() = %q, want the pinned NFTBAN_RUN_ID", got)
+	}
+}
+
+func TestRunIDGeneratedWhenEnvUnset(t *testing.T) {
+	t.Setenv("NFTBAN_RUN_ID", "")
+	l := New(filepath.Join(t.TempDir(), "installer.log"), false)
+	t.Cleanup(l.Close)
+	got := l.RunID()
+	if got == "" {
+		t.Fatal("RunID() empty when NFTBAN_RUN_ID unset; want generated id")
+	}
+	// shape: <UTC compact ts>T...Z-<pid>
+	if !strings.Contains(got, "Z-") {
+		t.Errorf("generated RunID() = %q, want <UTC compact>-<pid> shape", got)
+	}
+}
+
+func TestRunHeaderStampsRunID(t *testing.T) {
+	t.Setenv("NFTBAN_RUN_ID", "20260623T120000Z-hdr")
+	p := filepath.Join(t.TempDir(), "installer.log")
+	l := New(p, false)
+	l.RunHeader("v1.199.0", "update", "host1", "linux")
+	l.Close()
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read installer.log: %v", err)
+	}
+	if !strings.Contains(string(data), "run_id=20260623T120000Z-hdr") {
+		t.Errorf("RUN header missing run_id stamp; log:\n%s", data)
+	}
+}


### PR DESCRIPTION
## v1.199 — Lifecycle forensics (observability only)

Forensics/observability **only** — no reliability self-heal (A2/stale-oneshot/SOAK stay **v1.201**). Closes the evidence gaps the v1.198.x rollout exposed (dns2/srv4 needed live `journalctl`/`stat` archaeology). Scope: `V1_199_LIFECYCLE_FORENSICS_SCOPE.md`. **Schema `1.84.0` unchanged; the only Go change is in `internal/installer/logging` — imported by `nftban-installer`, NOT `cmd/nftband` (daemon byte-identical).**

### A — per-run forensic record (`BUG-INSTALLER-PER-RUN-FORENSIC-LOG-MISSING`)
`cmd_update_helpers.sh` adds `_forensic_run_id`/`_forensic_begin`/`_forensic_event`/`_forensic_snapshot`/`_forensic_end`/`_forensic_prune`. Each `nftban update` mints a **run_id** → `/var/log/nftban/update-runs/<run_id>/{run.jsonl,human.log}`. `cmd_update.sh` wraps the lifecycle: begin → **pre-swap** snapshot → inhibit event → install → restore event → **post-swap** snapshot → **post-verify** snapshot + run_end (and run_end on the install-fail path). **Bounded retention** (newest N, default 20 via `NFTBAN_FORENSIC_RETAIN`); prune **logs what it drops** (no silent cap).

### B — run-id / JSONL (`BUG-INSTALLER-LOG-FORMAT-MIXED-JSON`)
`run.jsonl` is a parseable one-event-per-line stream, every line carrying `run_id`. `logger.go` stamps the **same** run_id (`NFTBAN_RUN_ID` shared with the shell path, else `<UTC compact>-<pid>`) into `installer.log`'s RUN header → the two correlate (+ `RunID()` accessor).

### C — redaction (strict allowlist)
jq-free. Values pass a secret-pattern safety-net **and** a secret-named-key redaction. The snapshot is an explicit **allowlist** — binary mode/mtime/xattr, timer due-time/active, failed-unit name/`Result`/`ExecMainStatus`/timestamps, install_state. **No env, no secrets, no config dump** (not a "collect everything" dump).

### D — `nftban support` all-logs
`_collect_logs` collects the newest N `update-runs/<run_id>/` (`SUPPORT_UPDATE_RUNS_MAX`, default 10), redacted via `_redact_file`, **size-bounded**; warns when older runs are omitted.

### FHS
`build/fhs-spec.yaml` adds `/var/log/nftban/update-runs` (0750 nftban:nftban, tmpfiles `z`-reconcile); regenerated `fhs_spec.sh` + `fhs_directories.json` + `tmpfiles.d/nftban.conf` (generator `--check` idempotent).

### Tests
`lifecycle_forensics_v1199_test.sh` **18/0** (run_id stability, per-run dir, JSONL parseability + run_id on every line, snapshot allowlist, redaction incl. **env/secret non-leak**, retention pruning) · `logger_runid_test.go` (env-honor / generated / header stamp) · `tmpfiles_zz_v139` **11/0** (regen idempotent) · `watchdog_update_swap_race_v1983` **20/0** (install-phase guard relaxed to order-based). shellcheck clean.

### Hard non-goals honored
No stale-oneshot/A2 assertion-tolerance · no watchdog/SOAK self-heal · no R2/LoginMon · no schema/counter/metrics · no BotGuard · no firewall/nftables/detector change · no `nftband` daemon change.

Next after CI green: lab-first lab2/lab4 + package-native Stage-B (same discipline as v1.198.3) before tag/publish.