### PR TITLE
fix(v1.199): export NFTBAN_RUN_ID so installer.log/update.log correlate with the per-run record

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -424,7 +424,13 @@ _cmd_update_main_locked() {
 
     # v1.199 lifecycle forensics: mint a run_id + open a per-run record for this update.
     _RUN_ID=$(_forensic_run_id)
+    # EXPORT so the Go nftban-installer (invoked via the package %post during the
+    # install phase) inherits the SAME run_id and stamps it into installer.log's RUN
+    # header — correlating installer.log + update.log + update-runs/<run_id>/.
+    export NFTBAN_RUN_ID="$_RUN_ID"
     _forensic_begin "$_RUN_ID" "$source" "$current_version" "pending"
+    # stamp the shared update.log with the run_id (clear correlation delimiter).
+    _update_log INFO "lifecycle run_id=$_RUN_ID (per-run forensic record: ${FORENSIC_RUN_DIR:-n/a})"
 
     # v1.174: record the installer.log line count BEFORE the install so the final
     # verdict can detect a WARN_PRE_EXISTING_RECOVERED (a stale pre-existing failed

--- a/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
+++ b/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
@@ -126,6 +126,13 @@ cnt=$(find "$RDIR" -mindepth 1 -maxdepth 1 -type d | wc -l)
 [ "$cnt" -le 3 ] && ok "E retention pruned to N=3 (now $cnt)" || no "E not pruned" "count=$cnt"
 [ -d "$RDIR/run-6" ] && [ ! -d "$RDIR/run-1" ] && ok "E newest kept (run-6), oldest pruned (run-1)" || no "E wrong dirs kept"
 
+echo "== F: run_id correlation wiring in cmd_update.sh (installer.log + update.log) =="
+CMDUPD="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+grep -qE 'export NFTBAN_RUN_ID="\$_RUN_ID"' "$CMDUPD" && ok "F exports NFTBAN_RUN_ID (Go installer inherits → installer.log correlates)" || no "F NFTBAN_RUN_ID not exported (installer.log would not correlate)"
+grep -qE '_update_log INFO "lifecycle run_id=\$_RUN_ID' "$CMDUPD" && ok "F stamps run_id into update.log (correlation delimiter)" || no "F update.log run_id stamp missing"
+# export must precede the install case (so the %post installer inherits it)
+awk '/export NFTBAN_RUN_ID/{e=NR} /^    case "\$source" in/{c=NR} END{exit !(e>0 && c>e)}' "$CMDUPD" && ok "F export precedes the install case" || no "F export after install case"
+
 echo ""
 echo "=== RESULT: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Stage-B prep finding (pre-publish): `cmd_update.sh` minted `_RUN_ID` for `update-runs/<run_id>/` but did **not** export `NFTBAN_RUN_ID`, so the Go `nftban-installer` (invoked via the package `%post`) generated its **own** run_id → `installer.log` and the shell per-run record did **not** correlate, failing the v1.199 Stage-B correlation requirement.

**Fix (shell-only, zero `.go`, schema 1.84.0, forensics-only):**
- `export NFTBAN_RUN_ID="$_RUN_ID"` before the install case → the Go installer (which reads `NFTBAN_RUN_ID`, landed in #927) inherits the **same** run_id → `installer.log` RUN header correlates.
- Stamp `run_id` into `update.log` as a clear correlation delimiter.

Tests: `lifecycle_forensics_v1199_test.sh` **21/0** (+3 correlation static guards: export present, update.log stamp, export precedes the install case). Enables the v1.199 Stage-B `installer.log/update.log correlate with run_id` checks.