### PR TITLE
feat(v1.200): LoginMon source-visibility R2 — actionable + ack-able starved-source advisories

### DIFF
--- a/etc/nftban/conf.d/login/main.conf
+++ b/etc/nftban/conf.d/login/main.conf
@@ -250,5 +250,21 @@ LOGIN_LOG_FILE="/var/log/nftban/login-monitor.log"
 # LOGIN_LOG_SUCCESSFUL="false"
 
 # =============================================================================
+# Source-visibility acknowledgement (v1.200 / VAL-LOGINMON-002)
+# =============================================================================
+# A LoginMon source that is "present but produced no readable logs" is reported
+# as an actionable WARN in `nftban health` (e.g. Roundcube installed but
+# log_logins is off, or a web/FTP auth log path NFTBan cannot read). If a stack
+# is starved BY DESIGN on this host (e.g. you intentionally do not collect
+# Roundcube login logs), acknowledge it here: an acked source is reported as INFO
+# ("operator-acked") instead of WARN. The finding stays VISIBLE — it is never
+# silently hidden. Unacknowledged starved sources REMAIN WARN.
+#
+# Space-separated source names: webauth ftpauth roundcube
+# Default (empty) = nothing acked = normal WARN behavior.
+# Override per host in main.conf.local (no-clobber).
+# LOGINMON_SOURCE_ACK=""
+
+# =============================================================================
 # END OF MAIN CONFIGURATION
 # =============================================================================

--- a/internal/validator/loginmon_source_ack_v1200_test.go
+++ b/internal/validator/loginmon_source_ack_v1200_test.go
@@ -1,0 +1,117 @@
+// =============================================================================
+// NFTBan v1.200 - LoginMon source-visibility: ack/suppress + per-reason remediation
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="loginmon_source_ack_v1200_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-23"
+// meta:description="v1.200 (VAL-LOGINMON-002 R2): a starved LoginMon source (WARN_NO_LOGS) carries EXACT per-source remediation text and stays WARN unless the operator acks it via LOGINMON_SOURCE_ACK in conf.d/login/main.conf(.local); an acked source becomes INFO but stays VISIBLE (message says operator-acked) — never silently hidden; an absent source stays INFO; a malformed/other-source ack does not hide an unacked starved source. Schema-frozen; validator-only."
+// meta:input="setupTestConfig (temp ConfigDir + login_alert/login configs) + mockJournalReader ([LOGINMON] <src>: state=...) → evaluateLoginMon → moduleFindings"
+// meta:output="t.Error on wrong severity / missing remediation / silent hide / leaked ack"
+// meta:depends="testing,strings"
+// meta:inventory.files="internal/validator/module_health.go,etc/nftban/conf.d/login/main.conf"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="conf.d/login/main.conf,conf.d/login_alert.conf"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validator
+
+import (
+	"strings"
+	"testing"
+)
+
+const rcStarvedLine = "Jun 13 nftband[1]: 2026/06/13 [LOGINMON] roundcube: state=WARN_NO_LOGS resolved_by=discovery files=0 reason=roundcube_present_no_login_logs"
+const modStartLine = "Jun 13 nftband[1]: 2026/06/13 module_start: loginmon"
+
+// helper: run evaluateLoginMon with login enabled + the given ack value + a starved roundcube
+func runLoginMonWithAck(t *testing.T, ack string) {
+	t.Helper()
+	files := map[string]string{"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`}
+	if ack != "__none__" {
+		files["conf.d/login/main.conf"] = "LOGINMON_SOURCE_ACK=\"" + ack + "\"\n"
+	}
+	cleanup := setupTestConfig(t, files)
+	defer cleanup()
+	SetJournalReader(mockJournalReader{lines: []string{rcStarvedLine, modStartLine}})
+	defer SetJournalReader(SystemdJournalReader{})
+	moduleFindings = nil
+	evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+}
+
+// Unacked starved source → WARN with the EXACT remediation (names log_logins for roundcube).
+func TestLoginMonAck_UnackedStarvedWarnWithRemediation(t *testing.T) {
+	runLoginMonWithAck(t, "__none__")
+	f := loginMonInputFinding("roundcube")
+	if f.Severity != SeverityWarn {
+		t.Errorf("unacked starved roundcube severity=%q want WARN (actionable)", f.Severity)
+	}
+	if !strings.Contains(f.Remediation, "log_logins") {
+		t.Errorf("roundcube remediation must name the exact fix (log_logins); got %q", f.Remediation)
+	}
+	if !strings.Contains(f.Remediation, "LOGINMON_SOURCE_ACK") {
+		t.Error("remediation should also point at the ack knob for starved-by-design hosts")
+	}
+}
+
+// Operator-acked starved source → INFO but VISIBLE (message says operator-acked).
+func TestLoginMonAck_AckedStarvedBecomesInfoButVisible(t *testing.T) {
+	runLoginMonWithAck(t, "roundcube")
+	f := loginMonInputFinding("roundcube")
+	if f.Severity != SeverityInfo {
+		t.Errorf("acked starved roundcube severity=%q want INFO", f.Severity)
+	}
+	if !strings.Contains(f.Message, "operator-acked") {
+		t.Errorf("acked finding must remain VISIBLE and say operator-acked; got %q", f.Message)
+	}
+	if f.Code != CodeLoginMonNoInput {
+		t.Errorf("acked finding code=%q want %q (still emitted, not hidden)", f.Code, CodeLoginMonNoInput)
+	}
+}
+
+// Ack lists OTHER/unknown sources → roundcube NOT acked → stays WARN (no silent hide).
+func TestLoginMonAck_OtherSourceAckDoesNotHideRoundcube(t *testing.T) {
+	runLoginMonWithAck(t, "webauth bogus")
+	f := loginMonInputFinding("roundcube")
+	if f.Severity != SeverityWarn {
+		t.Errorf("roundcube not in ack list but severity=%q want WARN (must not be hidden)", f.Severity)
+	}
+}
+
+// Empty/whitespace ack → nothing acked → roundcube stays WARN.
+func TestLoginMonAck_EmptyAckSafe(t *testing.T) {
+	runLoginMonWithAck(t, "   ")
+	f := loginMonInputFinding("roundcube")
+	if f.Severity != SeverityWarn {
+		t.Errorf("empty ack must leave roundcube WARN; got %q", f.Severity)
+	}
+}
+
+// Case-insensitive ack matching (operator may type RoundCube).
+func TestLoginMonAck_CaseInsensitive(t *testing.T) {
+	runLoginMonWithAck(t, "RoundCube")
+	if got := loginMonInputFinding("roundcube").Severity; got != SeverityInfo {
+		t.Errorf("case-insensitive ack: severity=%q want INFO", got)
+	}
+}
+
+// Per-source remediation text is source-specific.
+func TestLoginMonRemediation_SourceSpecific(t *testing.T) {
+	if !strings.Contains(loginMonRemediation("roundcube"), "log_logins") {
+		t.Error("roundcube remediation must name log_logins")
+	}
+	if !strings.Contains(loginMonRemediation("ftpauth"), "FTP") {
+		t.Error("ftpauth remediation must mention the FTP auth log")
+	}
+	if !strings.Contains(loginMonRemediation("webauth"), "web") {
+		t.Error("webauth remediation must mention the web auth log")
+	}
+	if !strings.Contains(loginMonRemediation("somethingelse"), "LOGINMON_SOURCE_ACK") {
+		t.Error("default remediation must still point at the ack knob")
+	}
+}

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -355,13 +355,22 @@ func evaluateLoginMon(svcState ServiceState) *ModuleHealth {
 			switch s.State {
 			case InputWarnNoLogs:
 				// Stack/source present but produced no readable logs → actionable.
-				moduleFindings = append(moduleFindings, Finding{
-					Code:        CodeLoginMonNoInput,
-					Severity:    SeverityWarn,
-					Component:   "module",
-					Message:     "LoginMon " + s.Name + " source present but produced no readable logs" + loginMonReasonSuffix(s.Reason),
-					Remediation: "Confirm the " + s.Name + " log path is present and readable, and that the application is logging auth events",
-				})
+				if loginMonSourceAcked(s.Name) {
+					moduleFindings = append(moduleFindings, Finding{
+						Code:      CodeLoginMonNoInput,
+						Severity:  SeverityInfo,
+						Component: "module",
+						Message:   "LoginMon " + s.Name + " source present but produced no readable logs" + loginMonReasonSuffix(s.Reason) + " — operator-acked via LOGINMON_SOURCE_ACK (starved by design); no action needed",
+					})
+				} else {
+					moduleFindings = append(moduleFindings, Finding{
+						Code:        CodeLoginMonNoInput,
+						Severity:    SeverityWarn,
+						Component:   "module",
+						Message:     "LoginMon " + s.Name + " source present but produced no readable logs" + loginMonReasonSuffix(s.Reason),
+						Remediation: loginMonRemediation(s.Name),
+					})
+				}
 			case InputNoLogs:
 				// Source/stack structurally absent on this host → benign, no action.
 				moduleFindings = append(moduleFindings, Finding{
@@ -414,6 +423,39 @@ func loginMonReasonSuffix(reason string) string {
 		return ""
 	}
 	return " (reason=" + reason + ")"
+}
+
+// loginMonSourceAcked reports whether the operator has acknowledged a
+// starved-by-design LoginMon source via LOGINMON_SOURCE_ACK in the login module
+// config (.local override first). An acked starved source is reported as INFO
+// (still visible in findings), never silently hidden. v1.200 (VAL-LOGINMON-002).
+func loginMonSourceAcked(name string) bool {
+	ack := readKeyFromFile(filepath.Join(ConfigDir, "conf.d/login/main.conf.local"), "LOGINMON_SOURCE_ACK")
+	if ack == "" {
+		ack = readKeyFromFile(filepath.Join(ConfigDir, "conf.d/login/main.conf"), "LOGINMON_SOURCE_ACK")
+	}
+	for _, f := range strings.Fields(ack) {
+		if strings.EqualFold(strings.TrimSpace(f), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// loginMonRemediation returns the EXACT remediation for a starved LoginMon source,
+// keyed by source name. v1.200 (VAL-LOGINMON-002): turns an actionable WARN into a
+// step the operator can follow, and points at the ack knob for starved-by-design hosts.
+func loginMonRemediation(name string) string {
+	switch name {
+	case "roundcube":
+		return "Roundcube is present but login logging is off: set $config['log_logins'] = true; in the Roundcube config (config.inc.php) so credential failures are logged, then reload the webmail PHP worker. If this host intentionally does not collect Roundcube login logs, ack it: add 'roundcube' to LOGINMON_SOURCE_ACK in conf.d/login/main.conf.local."
+	case "webauth":
+		return "The web stack is present but NFTBan reads no auth logs: confirm the web/panel access or auth log exists and is readable and that login attempts are logged there. If web login monitoring is not wanted on this host, ack it: add 'webauth' to LOGINMON_SOURCE_ACK in conf.d/login/main.conf.local."
+	case "ftpauth":
+		return "The FTP stack is present but NFTBan reads no auth logs: confirm the FTP daemon auth log path exists and is readable and that login attempts are logged. If FTP login monitoring is not wanted on this host, ack it: add 'ftpauth' to LOGINMON_SOURCE_ACK in conf.d/login/main.conf.local."
+	default:
+		return "Confirm the " + name + " log path is present and readable and that the application logs auth events; or ack it via LOGINMON_SOURCE_ACK in conf.d/login/main.conf.local if starved by design."
+	}
 }
 
 // parseLoginMonState extracts the input-state token from a "[LOGINMON] <src>: state=<TOK> ..."


### PR DESCRIPTION
## v1.200 — LoginMon source-visibility (R2): VAL-LOGINMON-002

Turns the fleet-wide `PASS_WITH_ACTIONABLE_WARN` LoginMon noise into something **actionable** and **quiet-able**. **Validator-only + config; NFT schema `1.84.0` unchanged; no new JSON axis. The only `.go` change is in `internal/validator` (builds `nftban-validate`, NOT `cmd/nftband`) → `nftband` daemon byte-identical.** No `internal/loginmon`/detector/firewall/BotGuard/stale-oneshot change.

### Fixed
- **Actionable (A):** a starved source (`InputWarnNoLogs` — "present but produced no readable logs") now carries the **exact** remediation: Roundcube → *enable `$config['log_logins'] = true;`*; webauth/ftpauth → the expected auth-log path; default → points at the ack knob.
- **Quiet-able (B):** `LOGINMON_SOURCE_ACK` (in `conf.d/login/main.conf`, `.local` override first) — an acked starved-by-design stack reads **INFO** instead of WARN, but the finding stays **VISIBLE** (message says *operator-acked*). **Never silently hidden;** an unacked starved source stays WARN. Case-insensitive; absent source stays INFO.

### Guarantees / non-goals
- Schema `1.84.0`; no new JSON axis; daemon byte-identical (`internal/validator` → `nftban-validate` only). config(noreplace) → existing hosts unchanged unless they set the knob.
- No detector/ban/firewall behavior change · no BotGuard · **no stale-oneshot/A2/SOAK (that's v1.201)** · no auto-editing third-party (Roundcube/panel/FTP) configs.

### Tests
`loginmon_source_ack_v1200_test.go` — unacked-starved = WARN + `log_logins` remediation; acked = INFO + visible (`operator-acked`, code still emitted); other/empty/malformed ack does **not** hide the WARN; case-insensitive; per-source remediation text. Exercises the real `evaluateLoginMon` path via the existing journal-mock harness.

Next after CI green: lab-first + package-native (validator-only → daemon byte-identical) on a real starved host (Roundcube `log_logins` off) → advisory carries the fix, ack quiets to INFO visibly, un-ack restores WARN.