### PR TITLE
feat(v1.201): cadence-oneshot gated re-verify (A2 + stale-oneshot/SOAK reliability)

### DIFF
--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -408,6 +408,21 @@ func assertFailedUnitsPostInstall(spr SystemdPayloadValidationResult, log *loggi
 				strings.Join(rec, "; "))
 			return r
 		}
+		// v1.201 (A2 + stale-oneshot/SOAK): cadence oneshot(s) whose failed latch
+		// was a transient (the v1.198.3 watchdog/update-swap EXEC-203 class) and
+		// re-ran CLEAN under the host-side gated re-verify — non-fatal, surfaced
+		// honestly. A re-run that still failed would NOT be here (it stays in
+		// FailedUnits → DEGRADED).
+		if len(spr.FailedUnitsTransientRecovered) > 0 {
+			tr := make([]string, 0, len(spr.FailedUnitsTransientRecovered))
+			for _, f := range spr.FailedUnitsTransientRecovered {
+				tr = append(tr, f.Unit+"("+f.Detail+")")
+			}
+			r.Detail = "WARN_TRANSIENT_RECOVERED: cadence oneshot(s) re-ran clean after a transient latch — non-fatal: " + strings.Join(tr, "; ")
+			log.Warn("ASSERT failed_units_postinstall_ok: PASS — WARN_TRANSIENT_RECOVERED (cadence oneshot re-ran clean; gated re-verify): %s",
+				strings.Join(tr, "; "))
+			return r
+		}
 		// v1.135 D-EXPORTER-SETTLE-WINDOW: a failed auxiliary (metrics/
 		// observability) unit does NOT fail this assertion, but it IS
 		// surfaced as a non-fatal warning so operators still see it.

--- a/internal/installer/validate/cadence_oneshot_reverify_v1201_test.go
+++ b/internal/installer/validate/cadence_oneshot_reverify_v1201_test.go
@@ -1,0 +1,136 @@
+// =============================================================================
+// NFTBan v1.201 - cadence-oneshot gated re-verify classification tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cadence_oneshot_reverify_v1201_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-23"
+// meta:description="v1.201 (A2 + stale-oneshot/SOAK): the failed-unit classifier tolerates a cadence oneshot (watchdog/soak/maintenance) latch as non-fatal WARN_TRANSIENT_RECOVERED ONLY when the host-side gated re-verify ran CLEAN (OwnedWindowReverifyDone && Clean) — in-window OR pre-window; a re-verify that did not clean, or was not attempted, stays FATAL (no-mask). Non-cadence units and the existing botscan/alert@ pre-window stale-clear are unaffected."
+// meta:input="SystemdPayloadInputs with FailedUnitFinding{OwnedWindowReverify*} → ValidateInstalledSystemdPayload"
+// meta:output="t.Error on wrong bucket / FailedUnitsOK / masked persistent failure"
+// meta:depends="testing,time"
+// meta:inventory.files="internal/installer/validate/systemd_payload.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftban-watchdog.service,nftban-soak.service,nftban-maintenance.service"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validate
+
+import (
+	"testing"
+	"time"
+)
+
+func TestV1201CadenceReverifyClassification(t *testing.T) {
+	window := time.Date(2026, 6, 23, 20, 0, 0, 0, time.UTC)
+	// inWindow = failed during the owned update window; preWindow = stale latch from before this run
+	inWindow := window.Add(2 * time.Minute)
+	preWindow := window.Add(-2 * time.Hour)
+
+	mk := func(unit string, ft time.Time, rvDone, rvClean bool) FailedUnitFinding {
+		return FailedUnitFinding{
+			Unit: unit, Active: "failed", Sub: "failed", Detail: "exit-code 203",
+			FailureTime: ft, FailureTimeKnown: true,
+			OwnedWindowReverifyDone: rvDone, OwnedWindowReverifyClean: rvClean,
+		}
+	}
+	base := func(f FailedUnitFinding) SystemdPayloadInputs {
+		return SystemdPayloadInputs{
+			FailedNftbanUnits:       []FailedUnitFinding{f},
+			InstallWindowStart:      window,
+			InstallWindowStartKnown: true,
+			LiveHealthClean:         false, // worst case; cadence tolerance must NOT rely on live-health
+			LiveHealthKnown:         true,
+		}
+	}
+
+	cases := []struct {
+		name          string
+		in            SystemdPayloadInputs
+		wantOK        bool
+		wantFatal     int
+		wantTransient int
+		wantPreExist  int
+	}{
+		{"watchdog_in_window_reverify_clean_tolerated",
+			base(mk("nftban-watchdog.service", inWindow, true, true)), true, 0, 1, 0},
+		{"watchdog_in_window_reverify_not_clean_DEGRADES",
+			base(mk("nftban-watchdog.service", inWindow, true, false)), false, 1, 0, 0},
+		{"watchdog_in_window_no_reverify_DEGRADES",
+			base(mk("nftban-watchdog.service", inWindow, false, false)), false, 1, 0, 0},
+		{"soak_pre_window_reverify_clean_tolerated",
+			base(mk("nftban-soak.service", preWindow, true, true)), true, 0, 1, 0},
+		{"maintenance_in_window_reverify_clean_tolerated",
+			base(mk("nftban-maintenance.service", inWindow, true, true)), true, 0, 1, 0},
+		{"non_cadence_in_window_even_with_reverify_flags_DEGRADES",
+			base(mk("nftban-health.service", inWindow, true, true)), false, 1, 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := ValidateInstalledSystemdPayload(c.in)
+			if r.FailedUnitsOK() != c.wantOK {
+				t.Errorf("FailedUnitsOK()=%v want %v (fatal=%d transient=%d)", r.FailedUnitsOK(), c.wantOK, len(r.FailedUnits), len(r.FailedUnitsTransientRecovered))
+			}
+			if len(r.FailedUnits) != c.wantFatal {
+				t.Errorf("FailedUnits=%d want %d", len(r.FailedUnits), c.wantFatal)
+			}
+			if len(r.FailedUnitsTransientRecovered) != c.wantTransient {
+				t.Errorf("FailedUnitsTransientRecovered=%d want %d", len(r.FailedUnitsTransientRecovered), c.wantTransient)
+			}
+			if len(r.FailedUnitsPreExistingRecovered) != c.wantPreExist {
+				t.Errorf("FailedUnitsPreExistingRecovered=%d want %d", len(r.FailedUnitsPreExistingRecovered), c.wantPreExist)
+			}
+		})
+	}
+}
+
+// No-mask invariant: a persistent (re-run-failed) cadence oneshot is NEVER cleared.
+func TestV1201NoMaskPersistentCadenceFailure(t *testing.T) {
+	window := time.Date(2026, 6, 23, 20, 0, 0, 0, time.UTC)
+	in := SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{{
+			Unit: "nftban-watchdog.service", Active: "failed", Sub: "failed", Detail: "exit-code 203",
+			FailureTime: window.Add(time.Minute), FailureTimeKnown: true,
+			OwnedWindowReverifyDone: true, OwnedWindowReverifyClean: false, // re-run STILL failed
+		}},
+		InstallWindowStart: window, InstallWindowStartKnown: true,
+		LiveHealthClean: true, LiveHealthKnown: true, // even with clean health, a failed re-run stays fatal
+	}
+	r := ValidateInstalledSystemdPayload(in)
+	if r.FailedUnitsOK() {
+		t.Fatal("persistent cadence re-run failure must NOT pass FailedUnitsOK (no-mask)")
+	}
+	if len(r.FailedUnitsTransientRecovered) != 0 {
+		t.Error("a re-run-failed cadence oneshot must never land in TransientRecovered")
+	}
+}
+
+// Regression: the existing botscan pre-window stale-clear path is unchanged
+// (unconditional recovery, no re-verify required).
+func TestV1201BotscanPreWindowStaleClearUnchanged(t *testing.T) {
+	window := time.Date(2026, 6, 23, 20, 0, 0, 0, time.UTC)
+	in := SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{{
+			Unit: "nftban-botscan.service", Active: "failed", Sub: "failed", Detail: "timeout",
+			FailureTime: window.Add(-time.Hour), FailureTimeKnown: true,
+			// no re-verify flags — botscan uses the unconditional pre-window path
+		}},
+		InstallWindowStart: window, InstallWindowStartKnown: true,
+		LiveHealthClean: false, LiveHealthKnown: true, // botscan recovers even with unclean live health
+	}
+	r := ValidateInstalledSystemdPayload(in)
+	if !r.FailedUnitsOK() {
+		t.Fatal("botscan pre-window stale-clear regressed (should still recover, FailedUnitsOK)")
+	}
+	if len(r.FailedUnitsPreExistingRecovered) != 1 {
+		t.Errorf("botscan should be PreExistingRecovered=1, got %d", len(r.FailedUnitsPreExistingRecovered))
+	}
+	if len(r.FailedUnitsTransientRecovered) != 0 {
+		t.Error("botscan must NOT use the v1.201 transient bucket")
+	}
+}

--- a/internal/installer/validate/systemd_payload.go
+++ b/internal/installer/validate/systemd_payload.go
@@ -166,6 +166,36 @@ func isStaleClearableOneshot(basename string) bool {
 	return staleClearableOneshotStems[stem]
 }
 
+// cadenceReverifiableOneshotStems lists nftban cadence-driven oneshot unit stems
+// whose `failed` state — whether pre-existing OR inside the owned update window —
+// is recoverable ONLY through a live re-verify (reset-failed + a fresh, clean run),
+// NEVER unconditionally. v1.201 (A2 + stale-oneshot/SOAK): the v1.198.3 watchdog/
+// update-swap race (nftban-watchdog firing EXEC-203 while the binary was mid-swap,
+// reproduced on dns2) is the canonical case — by post-install the binary is
+// executable again and the unit re-runs clean, so the in-window latch is transient,
+// not a real break. nftban-maintenance/nftban-soak share the cadence-oneshot shape.
+// DISTINCT from staleClearableOneshotStems (botscan/alert@), which clear
+// unconditionally for PRE-window latches; these clear ONLY on a proven clean re-run
+// (the gate is enforced host-side in the gatherer; the classifier consults its result).
+var cadenceReverifiableOneshotStems = map[string]bool{
+	"nftban-watchdog":    true,
+	"nftban-soak":        true,
+	"nftban-maintenance": true,
+}
+
+// isCadenceReverifiableOneshot reports whether an nftban unit basename is a
+// cadence oneshot that may be recovered ONLY via a live re-verify. v1.201.
+func isCadenceReverifiableOneshot(basename string) bool {
+	if !IsNftbanUnit(basename) {
+		return false
+	}
+	dot := strings.LastIndexByte(basename, '.')
+	if dot <= 0 {
+		return false
+	}
+	return cadenceReverifiableOneshotStems[basename[:dot]]
+}
+
 // ParsedUnit is the minimum subset of a systemd unit file needed for
 // PR26.1 validation. Constructed by the host-side gatherer or by
 // tests directly.
@@ -230,6 +260,18 @@ type FailedUnitFinding struct {
 	// (fail closed) — an unparseable timestamp can never be classified as
 	// pre-existing/recovered.
 	FailureTimeKnown bool
+
+	// OwnedWindowReverifyDone / OwnedWindowReverifyClean carry the result of
+	// the v1.201 host-side gated re-verify, performed ONLY for
+	// isCadenceReverifiableOneshot units (watchdog/soak/maintenance). The
+	// gatherer reset-failed the unit and issued a fresh `systemctl start`;
+	// Clean is true ONLY when that re-run succeeded and the unit is no longer
+	// failed. The classifier consults these to tolerate a transient
+	// (re-verified-clean) cadence-oneshot latch as non-fatal; an absent or
+	// false result keeps the unit FATAL (no-mask: a persistent failure that
+	// re-fails its run is never cleared). Zero value = no re-verify attempted.
+	OwnedWindowReverifyDone  bool
+	OwnedWindowReverifyClean bool
 }
 
 // PayloadInventory describes which paths are considered known after
@@ -383,6 +425,16 @@ type SystemdPayloadValidationResult struct {
 	// stays in FailedUnits (fatal) — fail safe toward DEGRADED.
 	FailedUnitsPreExistingRecovered []FailedUnitPostInstall
 
+	// FailedUnitsTransientRecovered holds cadence-oneshot nftban units
+	// (isCadenceReverifiableOneshot: watchdog/soak/maintenance) whose failed
+	// latch was recovered by the v1.201 host-side gated re-verify — the unit
+	// was reset-failed and a fresh `systemctl start` ran CLEAN, proving the
+	// latch was transient (the v1.198.3 watchdog/update-swap EXEC-203 class).
+	// Surfaced as WARN_TRANSIENT_RECOVERED and does NOT fail
+	// FAILED-UNIT-POSTINSTALL-001. A cadence-oneshot whose re-run still fails
+	// (or was never re-verified) stays in FailedUnits (fatal) — no-mask.
+	FailedUnitsTransientRecovered []FailedUnitPostInstall
+
 	// FailedUnitQueryError mirrors SystemdPayloadInputs.FailedUnitQueryError
 	// for the assertion-side detail message. When non-empty,
 	// FAILED-UNIT-POSTINSTALL-001 fails closed regardless of
@@ -492,6 +544,19 @@ func ValidateInstalledSystemdPayload(in SystemdPayloadInputs) SystemdPayloadVali
 		if recovered {
 			entry.Classification = "WARN_PRE_EXISTING_RECOVERED"
 			res.FailedUnitsPreExistingRecovered = append(res.FailedUnitsPreExistingRecovered, entry)
+			continue
+		}
+		// v1.201 (A2 + stale-oneshot/SOAK): a cadence oneshot (watchdog/soak/
+		// maintenance) recovered by the host-side GATED re-verify — the gatherer
+		// reset-failed it and a fresh `systemctl start` ran CLEAN — is a transient
+		// latch (the v1.198.3 watchdog/update-swap EXEC-203 class), non-fatal.
+		// Strict no-mask: requires the re-verify to have been DONE and CLEAN; a
+		// cadence oneshot whose re-run still fails (or was not re-verified) falls
+		// through to FATAL below. Applies in-window AND pre-window (a stale soak
+		// latch that re-runs clean is recoverable; one that re-fails DEGRADES).
+		if isCadenceReverifiableOneshot(f.Unit) && f.OwnedWindowReverifyDone && f.OwnedWindowReverifyClean {
+			entry.Classification = "WARN_TRANSIENT_RECOVERED"
+			res.FailedUnitsTransientRecovered = append(res.FailedUnitsTransientRecovered, entry)
 			continue
 		}
 		if preExisting {

--- a/internal/installer/validate/systemd_payload_gather.go
+++ b/internal/installer/validate/systemd_payload_gather.go
@@ -386,9 +386,42 @@ func queryFailedNftbanUnitsOnce(exec executor.Executor, log *logging.Logger) (fi
 		// pre-existing vs in-window. Parse error => FailureTimeKnown stays
 		// false (fail closed → fatal).
 		finding.FailureTime, finding.FailureTimeKnown = queryUnitFailureTime(exec, unit, log)
+		// v1.201 (A2 + stale-oneshot/SOAK): for a cadence oneshot
+		// (watchdog/soak/maintenance) attempt the GATED live re-verify — clear the
+		// latch and run once; the latch is recoverable ONLY if that fresh run is
+		// clean (no-mask). The classifier consults OwnedWindowReverify{Done,Clean}.
+		if isCadenceReverifiableOneshot(unit) {
+			finding.OwnedWindowReverifyDone, finding.OwnedWindowReverifyClean = reverifyCadenceOneshot(exec, unit, log)
+		}
 		findings = append(findings, finding)
 	}
 	return findings, ""
+}
+
+// reverifyCadenceOneshot performs the v1.201 GATED re-verify for a cadence
+// oneshot in a failed latch: reset the failed-state, issue one fresh
+// `systemctl start`, and report clean ONLY when that run succeeds AND the unit
+// is no longer failed. This is the no-mask gate — a unit whose re-run still
+// fails returns clean=false and stays FATAL (DEGRADED). The reset-failed +
+// start are bounded to exactly the cadence-oneshot stems and are the only
+// side-effects; nothing is hidden on assumption. done=true always (attempted).
+func reverifyCadenceOneshot(exec executor.Executor, unit string, log *logging.Logger) (done, clean bool) {
+	_ = exec.ServiceResetFailed(unit) // clear the latch so the start is not blocked; non-fatal
+	startErr := exec.ServiceStart(unit)
+	// `systemctl is-failed <unit>` exits 0 when the unit is in failed state.
+	stillFailed := false
+	if r := exec.Run("systemctl", "is-failed", unit); r.ExitCode == 0 {
+		stillFailed = true
+	}
+	clean = startErr == nil && !stillFailed
+	if log != nil {
+		if clean {
+			log.Info("v1.201 re-verify: %s cadence oneshot re-ran CLEAN — transient latch recovered (reset-failed + fresh start ok)", unit)
+		} else {
+			log.Warn("v1.201 re-verify: %s cadence oneshot re-run did NOT clean (start_err=%v still_failed=%v) — keeping FATAL (no-mask)", unit, startErr, stillFailed)
+		}
+	}
+	return true, clean
 }
 
 // queryUnitFailureTime asks systemd for a unit's last-failure timestamp via


### PR DESCRIPTION
## v1.201 — stale-oneshot / SOAK / A2 assertion-tolerance reliability

A transient, re-verifiable nftban oneshot latch no longer latches `install_state=DEGRADED`; a **persistent** one still does. **Installer-confined Go** (`internal/installer/validate` → `nftban-installer`, NOT `cmd/nftband`) → **`nftband` daemon byte-identical**. Schema `1.84.0`. Scope: `V1_201_STALE_ONESHOT_SOAK_A2_SCOPE.md`.

### Mechanism (strict no-mask gate)
- **New gated class** `cadenceReverifiableOneshotStems` = `{nftban-watchdog, nftban-soak, nftban-maintenance}` — recoverable **only** via a live re-verify, never unconditionally. DISTINCT from the existing `staleClearableOneshotStems` (botscan/alert@, unconditional pre-window clear — unchanged).
- **Host-side gated re-verify** (`reverifyCadenceOneshot`, gatherer): `reset-failed` + one fresh `systemctl start` + `is-failed` recheck → **clean only when the run succeeds AND the unit is no longer failed**. (The v1.198.3 watchdog/update-swap EXEC-203 class re-runs clean by post-install; a genuinely-broken unit re-fails.)
- **Classifier:** a cadence oneshot is bucketed `WARN_TRANSIENT_RECOVERED` (non-fatal) **only** when `OwnedWindowReverifyDone && OwnedWindowReverifyClean` (in-window OR pre-window). Otherwise → FATAL (`FailedUnits`) → DEGRADED. Covers **A2** (in-window), **B** (the stems), **C** (stale soak re-verified).
- **Assertion:** surfaces `WARN_TRANSIENT_RECOVERED` as PASS-non-fatal, honest (like `WARN_PRE_EXISTING_RECOVERED`).
- **D (forensics):** the tolerate/DEGRADE decision is recorded via `installer.log` (run_id-correlated, v1.199) + the `update-runs/<run_id>/` post-verify snapshot's `install_state`.

### Hard non-goals honored
No masking / no unconditional allowlist (re-verify gate mandatory) · no `systemctl mask` · no hand-edited install_state · no LoginMon/R2 change · no schema/counter/metrics · no BotGuard · no firewall/nftables/detector/ban-path change · no `nftband` daemon change.

### Tests
`cadence_oneshot_reverify_v1201_test.go`: in-window watchdog reverify-clean → tolerated/COMMITTED · reverify-not-clean or not-done → DEGRADED · pre-window soak reverify-clean → tolerated · non-cadence in-window → DEGRADED · **no-mask: persistent re-run failure never cleared** · botscan pre-window stale-clear regression intact.

Next after CI green: lab-first package-native (lab2 DEB + lab4 RPM) — induce a transient cadence-oneshot failure (clean re-run → COMMITTED) + a persistent one (→ DEGRADED), confirm the v1.199 update-runs record captures the decision, daemon byte-identity, schema 1.84.0, BotGuard disabled, no LoginMon/R2 change.