### PR TITLE
fix(v1.201): cadence re-verify authoritative — override v1.174 pre-existing-recovered (no-mask)

### DIFF
--- a/internal/installer/validate/cadence_oneshot_reverify_v1201_test.go
+++ b/internal/installer/validate/cadence_oneshot_reverify_v1201_test.go
@@ -134,3 +134,55 @@ func TestV1201BotscanPreWindowStaleClearUnchanged(t *testing.T) {
 		t.Error("botscan must NOT use the v1.201 transient bucket")
 	}
 }
+
+// Lab4 RPM regression (no-mask override): a PRE-window cadence oneshot with CLEAN
+// live health whose re-verify FAILED must DEGRADE — the v1.201 re-verify is
+// authoritative and overrides the v1.174 pre-existing+clean-health recovery. Before
+// the fix this ended COMMITTED (masked) on lab4.
+func TestV1201NoMaskOverridesPreExistingRecoveredWhenHealthClean(t *testing.T) {
+	window := time.Date(2026, 6, 23, 20, 0, 0, 0, time.UTC)
+	in := SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{{
+			Unit: "nftban-watchdog.service", Active: "failed", Sub: "failed", Detail: "exit-code 203",
+			FailureTime: window.Add(-time.Hour), FailureTimeKnown: true, // PRE-window
+			OwnedWindowReverifyDone: true, OwnedWindowReverifyClean: false, // re-run STILL failed
+		}},
+		InstallWindowStart: window, InstallWindowStartKnown: true,
+		LiveHealthClean: true, LiveHealthKnown: true, // clean health would have recovered it under v1.174
+	}
+	r := ValidateInstalledSystemdPayload(in)
+	if r.FailedUnitsOK() {
+		t.Fatal("pre-window cadence + clean health + FAILED re-verify must DEGRADE (v1.201 overrides v1.174) — no-mask")
+	}
+	if len(r.FailedUnitsPreExistingRecovered) != 0 {
+		t.Error("a failed-re-verify cadence oneshot must NOT be WARN_PRE_EXISTING_RECOVERED")
+	}
+	if len(r.FailedUnits) != 1 {
+		t.Errorf("FailedUnits=%d want 1 (fatal)", len(r.FailedUnits))
+	}
+}
+
+// Positive override: a PRE-window cadence oneshot with CLEAN live health whose
+// re-verify ran CLEAN is tolerated as WARN_TRANSIENT_RECOVERED (not PreExisting).
+func TestV1201PreWindowCadenceCleanReverifyTolerated(t *testing.T) {
+	window := time.Date(2026, 6, 23, 20, 0, 0, 0, time.UTC)
+	in := SystemdPayloadInputs{
+		FailedNftbanUnits: []FailedUnitFinding{{
+			Unit: "nftban-soak.service", Active: "failed", Sub: "failed", Detail: "stale",
+			FailureTime: window.Add(-time.Hour), FailureTimeKnown: true,
+			OwnedWindowReverifyDone: true, OwnedWindowReverifyClean: true,
+		}},
+		InstallWindowStart: window, InstallWindowStartKnown: true,
+		LiveHealthClean: true, LiveHealthKnown: true,
+	}
+	r := ValidateInstalledSystemdPayload(in)
+	if !r.FailedUnitsOK() {
+		t.Fatal("clean re-verify must tolerate (COMMITTED)")
+	}
+	if len(r.FailedUnitsTransientRecovered) != 1 {
+		t.Errorf("want TransientRecovered=1, got %d", len(r.FailedUnitsTransientRecovered))
+	}
+	if len(r.FailedUnitsPreExistingRecovered) != 0 {
+		t.Error("clean cadence reverify must be Transient, not PreExisting")
+	}
+}

--- a/internal/installer/validate/systemd_payload.go
+++ b/internal/installer/validate/systemd_payload.go
@@ -541,22 +541,28 @@ func ValidateInstalledSystemdPayload(in SystemdPayloadInputs) SystemdPayloadVali
 		if preExisting && isStaleClearableOneshot(f.Unit) {
 			recovered = true
 		}
+		// v1.201 (A2 + stale-oneshot/SOAK): a cadence oneshot (watchdog/soak/
+		// maintenance) is governed by the host-side GATED re-verify, which is
+		// AUTHORITATIVE and consulted BEFORE the generic v1.174 pre-existing+clean-
+		// health recovery. A clean re-run (reset-failed + fresh `systemctl start`
+		// succeeded) → transient latch (the v1.198.3 watchdog/update-swap EXEC-203
+		// class), non-fatal WARN_TRANSIENT_RECOVERED. A re-run that STILL FAILS →
+		// force FATAL (recovered=false) so a demonstrably-broken cadence oneshot can
+		// NEVER be masked by the older recovered branch even when live health reads
+		// clean — the no-mask invariant (lab4 RPM regression: pre-window + clean
+		// health was being recovered despite a failed re-run). Applies in-window AND
+		// pre-window. A cadence oneshot with no re-verify falls through unchanged.
+		if isCadenceReverifiableOneshot(f.Unit) && f.OwnedWindowReverifyDone {
+			if f.OwnedWindowReverifyClean {
+				entry.Classification = "WARN_TRANSIENT_RECOVERED"
+				res.FailedUnitsTransientRecovered = append(res.FailedUnitsTransientRecovered, entry)
+				continue
+			}
+			recovered = false // re-run still failed → never recover via the v1.174 path
+		}
 		if recovered {
 			entry.Classification = "WARN_PRE_EXISTING_RECOVERED"
 			res.FailedUnitsPreExistingRecovered = append(res.FailedUnitsPreExistingRecovered, entry)
-			continue
-		}
-		// v1.201 (A2 + stale-oneshot/SOAK): a cadence oneshot (watchdog/soak/
-		// maintenance) recovered by the host-side GATED re-verify — the gatherer
-		// reset-failed it and a fresh `systemctl start` ran CLEAN — is a transient
-		// latch (the v1.198.3 watchdog/update-swap EXEC-203 class), non-fatal.
-		// Strict no-mask: requires the re-verify to have been DONE and CLEAN; a
-		// cadence oneshot whose re-run still fails (or was not re-verified) falls
-		// through to FATAL below. Applies in-window AND pre-window (a stale soak
-		// latch that re-runs clean is recoverable; one that re-fails DEGRADES).
-		if isCadenceReverifiableOneshot(f.Unit) && f.OwnedWindowReverifyDone && f.OwnedWindowReverifyClean {
-			entry.Classification = "WARN_TRANSIENT_RECOVERED"
-			res.FailedUnitsTransientRecovered = append(res.FailedUnitsTransientRecovered, entry)
 			continue
 		}
 		if preExisting {


### PR DESCRIPTION
Package-native validation (lab4 RPM) found a real no-mask ordering defect: a cadence oneshot that **re-fails** its gated re-verify could still be masked to COMMITTED when the failure is **pre-window + live-health-clean**, because the v1.174 `recovered := preExisting && LiveHealthClean` branch ran **before** the v1.201 cadence gate. lab2 DEB only avoided it because the failed watchdog made live health read unclean there.

**Fix (classifier):** the v1.201 cadence re-verify is **authoritative**, consulted **before** the v1.174 recovered branch — clean re-run → `WARN_TRANSIENT_RECOVERED`; re-run still fails → `recovered=false` → **FATAL/DEGRADED** (overrides v1.174). A demonstrably-broken cadence oneshot can never be masked by the clean-health rule. botscan/alert@ unchanged.

**Scope:** installer-validation Go only (`systemd_payload.go` + tests); **nftband daemon byte-identical**; schema 1.84.0; no LoginMon/R2/BotGuard/firewall/detector change; VERSION unchanged (1.201.0, fix on top of release-prep).

**Tests:** + pre-window cadence + clean health + **reverify-not-clean → DEGRADED** (locks the lab4 condition) + pre-window cadence + clean health + reverify-clean → tolerated; all existing v1.201 cases intact.

After merge: rebuild v1.201.0 from new main + re-run package-native validation on lab2+lab4 — both must show transient→COMMITTED AND persistent→DEGRADED.