### PR TITLE
feat(config-local-recovery IMPL-1): central _source_local helper + migrate all .conf.local sites

### DIFF
--- a/cli/lib/nftban/cli/cmd_geoip.sh
+++ b/cli/lib/nftban/cli/cmd_geoip.sh
@@ -589,7 +589,7 @@ nftban_geoip_cmd_config() {
 
             # Load config
             source "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf" 2>/dev/null || true
-            source "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local" 2>/dev/null || true
+            _source_local "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local"
 
             local test_url=""
             local current_month

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -620,7 +620,7 @@ _status_section_firewall() {
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local" 2>/dev/null || true
+        _source_local "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local"
         master_enabled="${NFTBAN_ENABLED:-true}"
     fi
 
@@ -995,7 +995,7 @@ _status_section_protection() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf.local"
     fi
     if [[ "${NFTBAN_RBL_ENABLED:-NO}" == "YES" ]]; then
         rbl_status="ENABLED"
@@ -1036,7 +1036,7 @@ _status_section_protection() {
     # Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botguard/main.conf.local"
     fi
     botguard_enabled="${HTTP_BOTGUARD_ENABLED:-false}"
     if [[ "$botguard_enabled" == "true" ]]; then
@@ -1067,7 +1067,7 @@ _status_section_protection() {
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local"
     fi
     if [[ "${NFTBAN_TUNNEL_ENABLED:-NO}" == "YES" ]]; then
         local tunnel_high=0 tunnel_med=0
@@ -1866,7 +1866,7 @@ output_json() {
     local master_enabled="true"
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local" 2>/dev/null || true
+        _source_local "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local"
         master_enabled="${NFTBAN_ENABLED:-true}"
     fi
     if grep -q 'nftban=disabled' /proc/cmdline 2>/dev/null; then

--- a/cli/lib/nftban/cli/cmd_zabbix.sh
+++ b/cli/lib/nftban/cli/cmd_zabbix.sh
@@ -42,14 +42,14 @@ source "${NFTBAN_CONFIG_DIR}/nftban.conf" 2>/dev/null || true
 source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf" 2>/dev/null || true
 
 # Load zabbix user overrides
-source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
 
 # Load metrics config (needed to detect NFTBAN_METRICS_ENABLED correctly)
 source "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local"
 
 # Load global user overrides LAST (highest priority - written by nftban config set)
-source "${NFTBAN_CONFIG_DIR}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/nftban.conf.local"
 
 # Set bash defaults for any unset variables
 : "${NFTBAN_ZABBIX_ENABLED:=false}"
@@ -1129,7 +1129,7 @@ _cmd_zabbix_reload() {
 
     # Re-source config files to pick up changes
     source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf" 2>/dev/null || true
-    source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local" 2>/dev/null || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
 
     local enabled server
     enabled=$(_zabbix_config_get "NFTBAN_ZABBIX_ENABLED" "false")

--- a/cli/lib/nftban/core/nftban_geoban.sh
+++ b/cli/lib/nftban/core/nftban_geoban.sh
@@ -94,10 +94,10 @@ nftban_warn() {
 
 # Load configuration (new standard paths)
 source "${NFTBAN_CONFIG_DIR}/conf.d/geoban/main.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/geoban/main.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/geoban/main.conf.local"
 # Legacy path support (deprecated - will be removed in v2.0)
 source "${NFTBAN_CONFIG_DIR}/conf.d/nftban-go.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/nftban-go.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/nftban-go.conf.local"
 
 # =============================================================================
 # CONFIGURATION DEFAULTS (uses central config paths)

--- a/cli/lib/nftban/core/nftban_geoip_download.sh
+++ b/cli/lib/nftban/core/nftban_geoip_download.sh
@@ -69,7 +69,7 @@ if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf" ]]; then
 fi
 if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local" ]]; then
     # shellcheck source=/dev/null
-    source "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local" || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local"
 fi
 
 # Load output module

--- a/cli/lib/nftban/core/nftban_health.sh
+++ b/cli/lib/nftban/core/nftban_health.sh
@@ -76,7 +76,7 @@ fi
 # shellcheck source=/dev/null
 [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" ]] && source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" 2>/dev/null || true
 # shellcheck source=/dev/null
-[[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local" ]] && source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local"
 
 # Metrics endpoint defaults (fallbacks if not set in config)
 : "${NFTBAN_METRICS_PROMETHEUS_ADDR:=localhost:9090}"

--- a/cli/lib/nftban/core/nftban_login.sh
+++ b/cli/lib/nftban/core/nftban_login.sh
@@ -62,7 +62,7 @@ if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     # shellcheck source=/etc/nftban/nftban.conf
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # =============================================================================
 # FHS COMPLIANT PATHS (uses central config from nftban.conf)

--- a/cli/lib/nftban/core/nftban_login_alert.sh
+++ b/cli/lib/nftban/core/nftban_login_alert.sh
@@ -40,7 +40,7 @@ if [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf" ]]; then
     # shellcheck source=/etc/nftban/nftban.conf
     source "${NFTBAN_CONFIG_DIR}/nftban.conf" || true
 fi
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # Load strict mode library
 # shellcheck source=/usr/lib/nftban/lib/strict.sh
@@ -82,7 +82,7 @@ fi
 
 # Load local overrides (user customizations)
 if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/login_alert.conf.local" ]]; then
-    source "${NFTBAN_CONFIG_DIR}/conf.d/login_alert.conf.local" || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/login_alert.conf.local"
 fi
 
 # Load global mail module for centralized email

--- a/cli/lib/nftban/core/nftban_portscan.sh
+++ b/cli/lib/nftban/core/nftban_portscan.sh
@@ -55,7 +55,7 @@ readonly PORTSCAN_MODULE_DESCRIPTION="Port Scan Detection Module (Dual-Mode)"
 # Source central config for canonical paths (NO HARDCODED FALLBACKS)
 # shellcheck source=/etc/nftban/nftban.conf
 source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 readonly NFTBAN_PORTSCAN_CONFIG_DIR="${NFTBAN_CONFIG_DIR}/conf.d/portscan"
 readonly NFTBAN_PORTSCAN_DATA_DIR="${PORTSCAN_DATA_DIR:-${NFTBAN_DATA_DIR}/portscan}"

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -74,7 +74,7 @@ fi
 # Load user overrides (takes precedence over defaults)
 if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/rbl/main.conf.local" ]]; then
     # shellcheck source=/dev/null
-    source "${NFTBAN_CONFIG_DIR}/conf.d/rbl/main.conf.local" || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/rbl/main.conf.local"
 fi
 
 # Set defaults if not configured

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -30,7 +30,7 @@ set -Eeuo pipefail
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # Prevent double-loading
 [[ -n "${NFTBAN_REPORT_EMAIL_LOADED:-}" ]] && return 0

--- a/cli/lib/nftban/core/nftban_report_services.sh
+++ b/cli/lib/nftban/core/nftban_report_services.sh
@@ -25,7 +25,7 @@ umask 027
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # =============================================================================
 # GLOBALS

--- a/cli/lib/nftban/core/nftban_tunnel.sh
+++ b/cli/lib/nftban/core/nftban_tunnel.sh
@@ -56,7 +56,7 @@ nftban_tunnel_load_config() {
     # .local override
     # shellcheck source=/dev/null
     if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local" ]]; then
-        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local"
     fi
 }
 

--- a/cli/lib/nftban/core/nftban_watchdog.sh
+++ b/cli/lib/nftban/core/nftban_watchdog.sh
@@ -61,7 +61,7 @@ fi
 # v1.19.0: Source .local override (user customizations survive package updates)
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" ]]; then
     # shellcheck source=/dev/null
-    source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" || true
+    _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 fi
 
 # Load watchdog-specific config (+ .local override)
@@ -71,7 +71,7 @@ if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/watchdog/main.conf" ]]; then
 fi
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/watchdog/main.conf.local" ]]; then
     # shellcheck source=/dev/null
-    source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/watchdog/main.conf.local" || true
+    _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/watchdog/main.conf.local"
 fi
 
 # Watchdog defaults (can be overridden in conf.d/watchdog/main.conf.local)

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -56,7 +56,9 @@ umask 027
 # shellcheck source=/etc/nftban/nftban.conf
 source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" 2>/dev/null || true
 # v1.19.0: Source .local override (user customizations survive package updates)
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+# IMPL-1: ensure _source_local helper is defined (env.sh is idempotent)
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # NFTables table names (must match nft_schema.sh)
 : "${NFTBAN_TABLE_IPV4:=ip nftban}"
@@ -783,7 +785,7 @@ EOF
         source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf" 2>/dev/null || true
     # shellcheck source=/dev/null
     [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf.local" ]] && \
-        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf.local" 2>/dev/null || true
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan/main.conf.local"
     _ps_enabled="${PORTSCAN_ENABLED:-false}"
 
     if [[ "$_ps_enabled" != "true" ]]; then

--- a/cli/lib/nftban/exporters/nftban_unified_exporter.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter.sh
@@ -77,19 +77,21 @@ fi
 
 # Load metrics configuration (unified collector settings)
 source "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local" 2>/dev/null || true
+# IMPL-1: ensure _source_local helper is defined (env.sh is idempotent)
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local"
 
 # Load Zabbix configuration (for export_zabbix)
 source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
 
 # Load Connectors configuration (for export_connectors)
 source "${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf.local"
 
 # Load Portal configuration (for export_portal to pro.nftban.com)
 source "${NFTBAN_CONFIG_DIR}/conf.d/portal.conf" 2>/dev/null || true
-source "${NFTBAN_CONFIG_DIR}/conf.d/portal.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR}/conf.d/portal.conf.local"
 
 # =============================================================================
 # CONFIGURATION DEFAULTS (from metrics.conf, with fallbacks)

--- a/cli/lib/nftban/helpers/suricata_effective_config.sh
+++ b/cli/lib/nftban/helpers/suricata_effective_config.sh
@@ -218,15 +218,17 @@ _suricata_generate_module_overlap_disables() {
 
     # Source main config
     source "${NFTBAN_CONFIG_DIR}/nftban.conf" 2>/dev/null || true
-    source "${NFTBAN_CONFIG_DIR}/nftban.conf.local" 2>/dev/null || true
+    # IMPL-1: ensure _source_local helper is defined (env.sh is idempotent)
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
+    _source_local "${NFTBAN_CONFIG_DIR}/nftban.conf.local"
 
     # Source module configs
     source "${NFTBAN_CONFIG_DIR}/conf.d/login/main.conf" 2>/dev/null || true
-    source "${NFTBAN_CONFIG_DIR}/conf.d/login/main.conf.local" 2>/dev/null || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/login/main.conf.local"
     source "${NFTBAN_CONFIG_DIR}/conf.d/portscan/main.conf" 2>/dev/null || true
-    source "${NFTBAN_CONFIG_DIR}/conf.d/portscan/main.conf.local" 2>/dev/null || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/portscan/main.conf.local"
     source "${NFTBAN_CONFIG_DIR}/conf.d/ddos/main.conf" 2>/dev/null || true
-    source "${NFTBAN_CONFIG_DIR}/conf.d/ddos/main.conf.local" 2>/dev/null || true
+    _source_local "${NFTBAN_CONFIG_DIR}/conf.d/ddos/main.conf.local"
 
     # Map to variables
     login_enabled="${NFTBAN_LOGIN_ENABLED:-$login_enabled}"

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -551,7 +551,7 @@ cmd_load_module_config() {
     # Load local overrides if they exist
     if [[ -f "${config_base}/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${config_base}/main.conf.local" || true
+        _source_local "${config_base}/main.conf.local"
     fi
 }
 

--- a/cli/lib/nftban/lib/env.sh
+++ b/cli/lib/nftban/lib/env.sh
@@ -32,6 +32,38 @@ NFTBAN_ENV_LOADED="true"
 [[ -z "${NFTBAN_DATA_DIR:-}" ]] && export NFTBAN_DATA_DIR="/var/lib/nftban"
 
 # =============================================================================
+# CONFIG-LOCAL OVERRIDE LOADER (v1.201.x CONFIG_LOCAL_RECOVERY IMPL-1)
+# =============================================================================
+# _source_local <abs_path_to_.conf.local> — the SINGLE authority for sourcing
+# operator *.conf.local override files. Replaces ~41 scattered, inconsistently-
+# guarded `source X 2>/dev/null || true` sites. Behavior:
+#   - NFTBAN_IGNORE_LOCAL_CONFIG=1 -> skip ALL .local (break-glass bypass)
+#   - missing / unreadable file    -> silent success (return 0)
+#   - present + `bash -n` clean     -> source it (KEY=value assignments land in
+#                                      the global scope, preserving today's
+#                                      semantics for good .local files)
+#   - present + `bash -n` FAILS     -> do NOT source (no partial-apply), emit ONE
+#                                      actionable WARN, continue non-fatal (the
+#                                      caller proceeds on base defaults)
+# Always returns 0 (non-fatal) so callers need no `|| true` and set -e is safe.
+declare -A _NFTBAN_LOCAL_WARNED 2>/dev/null || true
+_source_local() {
+    local _sl_file="$1"
+    [[ -n "${NFTBAN_IGNORE_LOCAL_CONFIG:-}" ]] && return 0
+    [[ -f "$_sl_file" && -r "$_sl_file" ]] || return 0
+    if bash -n "$_sl_file" 2>/dev/null; then
+        # shellcheck source=/dev/null
+        source "$_sl_file"
+        return 0
+    fi
+    if [[ -z "${_NFTBAN_LOCAL_WARNED[$_sl_file]:-}" ]]; then
+        _NFTBAN_LOCAL_WARNED[$_sl_file]=1
+        printf 'nftban: WARNING: skipping malformed config override %s (bash -n failed) — using defaults. Fix it, or run with NFTBAN_IGNORE_LOCAL_CONFIG=1.\n' "$_sl_file" >&2
+    fi
+    return 0
+}
+
+# =============================================================================
 # LOAD CONFIG (if not already loaded by main CLI)
 # =============================================================================
 # Only load config if the main nftban script hasn't already done it
@@ -42,11 +74,8 @@ if [[ -z "${NFTBAN_CONFIG_LOADED:-}" ]]; then
         # shellcheck source=/dev/null
         source "${NFTBAN_CONFIG_DIR}/nftban.conf" || true
     fi
-    # v1.19.0: Source .local override (user customizations survive package updates)
-    # v1.19.26: Also check -r (readable) to prevent crash when running as nftban user
-    if [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf.local" ]] && [[ -r "${NFTBAN_CONFIG_DIR}/nftban.conf.local" ]]; then
-        # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/nftban.conf.local" || true
-    fi
+    # v1.19.0: Source .local override (user customizations survive package updates).
+    # v1.201.x IMPL-1: routed through _source_local (bash -n gate + bypass-aware).
+    _source_local "${NFTBAN_CONFIG_DIR}/nftban.conf.local"
     export NFTBAN_CONFIG_LOADED="true"
 fi

--- a/cli/lib/nftban/lib/nftban_panel_cpanel.sh
+++ b/cli/lib/nftban/lib/nftban_panel_cpanel.sh
@@ -564,7 +564,7 @@ nftban_panel_cpanel_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf" ]]; then
 

--- a/cli/lib/nftban/lib/nftban_panel_directadmin.sh
+++ b/cli/lib/nftban/lib/nftban_panel_directadmin.sh
@@ -557,7 +557,7 @@ nftban_panel_directadmin_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf" ]]; then
         echo "   TCP INPUT:  ${NFTBAN_DIRECTADMIN_TCP_IN:-Not configured}"

--- a/cli/lib/nftban/lib/nftban_panel_plesk.sh
+++ b/cli/lib/nftban/lib/nftban_panel_plesk.sh
@@ -514,7 +514,7 @@ nftban_panel_plesk_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf.local" ]]; then
         # shellcheck source=/dev/null
-        source "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf.local" || true
+        _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf" ]]; then
         echo "   TCP INPUT:  ${NFTBAN_PLESK_TCP_IN:-Not configured}"

--- a/cli/lib/nftban/lib/nftban_pipeline_validation.sh
+++ b/cli/lib/nftban/lib/nftban_pipeline_validation.sh
@@ -31,7 +31,7 @@ fi
 # shellcheck source=/dev/null
 source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" 2>/dev/null || true
 # shellcheck source=/dev/null
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local"
 
 # Pipeline defaults (fallbacks if not set in config)
 : "${NFTBAN_METRICS_PROM_FILE:=/var/lib/node_exporter/textfile_collector/nftban.prom}"

--- a/cli/lib/nftban/setup/install_vmagent.sh
+++ b/cli/lib/nftban/setup/install_vmagent.sh
@@ -38,7 +38,9 @@ if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
 # v1.19.0: Source .local override (user customizations survive package updates)
-source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" 2>/dev/null || true
+# IMPL-1: ensure _source_local helper is defined (env.sh is idempotent)
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
+_source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # =============================================================================
 # HELPER FUNCTIONS

--- a/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
+++ b/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan CONFIG_LOCAL_RECOVERY IMPL-1 — _source_local helper + migration guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="config_local_source_helper_impl1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-24"
+# meta:description="IMPL-1: central _source_local (bash -n gate, bypass, no partial-apply, warn-once) + guard that no direct 'source *.conf.local || true' call sites remain outside the helper."
+# meta:input="env.sh _source_local + repo grep"
+# meta:output="PASS/FAIL per assertion; nonzero exit on any FAIL"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/lib/env.sh"
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CONFIG_DIR,NFTBAN_IGNORE_LOCAL_CONFIG"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$(cd "$SCRIPT_DIR/.." && pwd)"   # .../cli/lib/nftban
+REPO_ROOT="$(cd "$REPO_LIB/../../.." && pwd)"
+export NFTBAN_LIB_DIR="$REPO_LIB"
+export NFTBAN_CONFIG_DIR="$(mktemp -d)/etc/nftban"; mkdir -p "$NFTBAN_CONFIG_DIR/conf.d"
+P=0; F=0
+ok(){ P=$((P+1)); echo "  PASS: $1"; }
+no(){ F=$((F+1)); echo "  FAIL: $1"; }
+
+# Load the helper (preset NFTBAN_CONFIG_LOADED so env.sh skips its own config read).
+NFTBAN_CONFIG_LOADED=pretend source "$NFTBAN_LIB_DIR/lib/env.sh"
+type _source_local >/dev/null 2>&1 && ok "_source_local helper defined by env.sh" || { no "_source_local NOT defined"; echo "RESULT: $P passed, $((F)) failed"; exit 1; }
+
+echo "== missing .local => silent success, no change =="
+BASEVAR=base; _source_local "$NFTBAN_CONFIG_DIR/conf.d/none.conf.local"; rc=$?
+{ [ "$BASEVAR" = base ] && [ "$rc" -eq 0 ]; } && ok "missing .local: silent, return 0" || no "missing .local"
+
+echo "== good .local overrides base (semantics preserved) =="
+printf 'MYVAR="from_local"\n' > "$NFTBAN_CONFIG_DIR/conf.d/g.conf.local"
+MYVAR="base"; _source_local "$NFTBAN_CONFIG_DIR/conf.d/g.conf.local"
+[ "$MYVAR" = "from_local" ] && ok "good .local overrides base" || no "good .local override (got '$MYVAR')"
+
+echo "== broken .local: NOT sourced, NO partial-apply, warn ONCE, non-fatal =="
+printf 'BEFORE="leaked"\nthis is a (((syntax error\nAFTER="applied"\n' > "$NFTBAN_CONFIG_DIR/conf.d/b.conf.local"
+BEFORE="orig"; AFTER="orig"
+_source_local "$NFTBAN_CONFIG_DIR/conf.d/b.conf.local" 2>/tmp/cl_w1; rc=$?
+[ "$rc" -eq 0 ] && ok "broken .local returns 0 (non-fatal)" || no "broken .local non-zero"
+[ "$BEFORE" = "orig" ] && ok "no partial-apply: var before error not leaked" || no "PARTIAL-APPLY: BEFORE='$BEFORE'"
+[ "$AFTER" = "orig" ] && ok "var after error not applied" || no "AFTER applied"
+grep -q "WARNING: skipping malformed" /tmp/cl_w1 && ok "one actionable WARN emitted" || no "no WARN emitted"
+_source_local "$NFTBAN_CONFIG_DIR/conf.d/b.conf.local" 2>/tmp/cl_w2
+[ ! -s /tmp/cl_w2 ] && ok "warn-once (2nd inline call silent)" || no "warned more than once"
+
+echo "== bypass: NFTBAN_IGNORE_LOCAL_CONFIG=1 skips all .local =="
+MYVAR="base"; NFTBAN_IGNORE_LOCAL_CONFIG=1 _source_local "$NFTBAN_CONFIG_DIR/conf.d/g.conf.local"
+[ "$MYVAR" = "base" ] && ok "bypass: good .local NOT sourced under NFTBAN_IGNORE_LOCAL_CONFIG=1" || no "bypass failed (MYVAR='$MYVAR')"
+
+echo "== MIGRATION GUARD: no direct 'source *.conf.local ... || true' sites remain (outside helper/tests) =="
+stray="$(grep -rnE 'source[[:space:]].*\.conf\.local' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/|lib/env\.sh:|_source_local|^\s*#|meta:' || true)"
+if [ -z "$stray" ]; then ok "0 direct source-.local call sites remain (all routed through _source_local)"; else no "stray direct source-.local sites:"; echo "$stray"; fi
+
+rm -rf "$(dirname "$NFTBAN_CONFIG_DIR")" /tmp/cl_w1 /tmp/cl_w2 2>/dev/null || true
+echo "-----------------------------------------------"
+echo "CONFIG_LOCAL IMPL-1 tests: $P passed, $F failed"
+[ "$F" -eq 0 ]

--- a/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
+++ b/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
@@ -24,9 +24,10 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_LIB="$(cd "$SCRIPT_DIR/.." && pwd)"   # .../cli/lib/nftban
-REPO_ROOT="$(cd "$REPO_LIB/../../.." && pwd)"
 export NFTBAN_LIB_DIR="$REPO_LIB"
-export NFTBAN_CONFIG_DIR="$(mktemp -d)/etc/nftban"; mkdir -p "$NFTBAN_CONFIG_DIR/conf.d"
+_tmproot="$(mktemp -d)"
+export NFTBAN_CONFIG_DIR="$_tmproot/etc/nftban"
+mkdir -p "$NFTBAN_CONFIG_DIR/conf.d"
 P=0; F=0
 ok(){ P=$((P+1)); echo "  PASS: $1"; }
 no(){ F=$((F+1)); echo "  FAIL: $1"; }
@@ -63,7 +64,7 @@ echo "== MIGRATION GUARD: no direct 'source *.conf.local ... || true' sites rema
 stray="$(grep -rnE 'source[[:space:]].*\.conf\.local' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/|lib/env\.sh:|_source_local|^\s*#|meta:' || true)"
 if [ -z "$stray" ]; then ok "0 direct source-.local call sites remain (all routed through _source_local)"; else no "stray direct source-.local sites:"; echo "$stray"; fi
 
-rm -rf "$(dirname "$NFTBAN_CONFIG_DIR")" /tmp/cl_w1 /tmp/cl_w2 2>/dev/null || true
+rm -rf "$_tmproot" /tmp/cl_w1 /tmp/cl_w2 2>/dev/null || true
 echo "-----------------------------------------------"
 echo "CONFIG_LOCAL IMPL-1 tests: $P passed, $F failed"
 [ "$F" -eq 0 ]


### PR DESCRIPTION
## CONFIG_LOCAL_RECOVERY — IMPL-1 only

Centralizes the **~41 scattered, inconsistently-guarded** `source *.conf.local || true` sites (26 files) behind a single authority with a **`bash -n` gate** (broken `.local` skipped WHOLE — no partial-apply — one actionable WARN, non-fatal) and a **break-glass bypass**. Design: `CONFIG_LOCAL_RECOVERY_DESIGN.md`.

**Shell-only · `nftband` daemon byte-identical (source-proven: zero `.go`) · schema 1.84.0 · adds NO CLI command → command registry + help text untouched.**

### Changes
- **`lib/env.sh`** — `_source_local <path>`: `NFTBAN_IGNORE_LOCAL_CONFIG=1` bypass · missing/unreadable → silent `return 0` · `bash -n` clean → source (good-`.local` semantics preserved, KEY=value lands global) · `bash -n` fail → **do NOT source (no partial-apply)**, warn-once, `return 0` (non-fatal). env.sh's own `nftban.conf.local` source rewired through it.
- Migrated all direct `source *.conf.local` sites (24 files) → `_source_local`; fixed the **13 no-`2>/dev/null`** inconsistencies; removed one dangling `[[ -f ]] &&` prefix.
- Added idempotent `source env.sh` to the 4 direct-invoked/self-bootstrapping entrypoints (maintenance, unified_exporter, install_vmagent, suricata_effective_config) so the helper is defined on every path (CLI paths get it via `sbin/nftban:41`).
- Test `config_local_source_helper_impl1_test.sh` (**10/10**): missing-silent · good-overrides · broken-not-sourced + **no-partial-apply** + warn-once + non-fatal · bypass · **migration guard** (0 direct source-`.local` sites remain).

### Out of scope (deferred lanes)
`config local list|validate|doctor` (IMPL-2) · quarantine/disable/restore verbs (IMPL-3) · parse-not-execute migration (IMPL-4). No detector/firewall/ban-path/LoginMon/BotGuard change; no auto-mutation of operator config.

### Release gate
Not tag-ready on merge — **package-native lab2(DEB)+lab4(RPM)** required: good `services.conf.local` still overrides base, a broken `.local` no longer partial-applies / doesn't brick status/validate, bypass works, `.local` survives upgrade, COMMITTED/rc0/0-failed, schema 1.84.0, BotGuard disabled, daemon byte-identical.