### PR TITLE
fix(config-local-recovery IMPL-1 completion): migrate variable-indirected .local sources + strengthen guard

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -147,6 +147,8 @@ _firewall_substitute_placeholders() {
     # shellcheck disable=SC1090  # dynamic config path
     [[ -f "$_ddos_conf" ]] && source "$_ddos_conf" 2>/dev/null || true
     # shellcheck disable=SC1090  # dynamic config path
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$_ddos_local"
     # Use DDoS limits if defined, keeping base defaults as fallback
     [[ -n "${DDOS_CLASSIC_SSH_CONN_LIMIT:-}" ]] && _ct_ssh="$DDOS_CLASSIC_SSH_CONN_LIMIT"

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -147,7 +147,7 @@ _firewall_substitute_placeholders() {
     # shellcheck disable=SC1090  # dynamic config path
     [[ -f "$_ddos_conf" ]] && source "$_ddos_conf" 2>/dev/null || true
     # shellcheck disable=SC1090  # dynamic config path
-    [[ -f "$_ddos_local" ]] && source "$_ddos_local" 2>/dev/null || true
+    _source_local "$_ddos_local"
     # Use DDoS limits if defined, keeping base defaults as fallback
     [[ -n "${DDOS_CLASSIC_SSH_CONN_LIMIT:-}" ]] && _ct_ssh="$DDOS_CLASSIC_SSH_CONN_LIMIT"
     [[ -n "${DDOS_CLASSIC_HTTP_CONN_LIMIT:-}" ]] && _ct_http="$DDOS_CLASSIC_HTTP_CONN_LIMIT"

--- a/cli/lib/nftban/cli/cmd_geoban.sh
+++ b/cli/lib/nftban/cli/cmd_geoban.sh
@@ -405,7 +405,7 @@ nftban_geoban_config() {
     # shellcheck source=/dev/null
     source "$config_file" 2>/dev/null || true
     # shellcheck source=/dev/null
-    source "$config_local" 2>/dev/null || true
+    _source_local "$config_local"
 
     # Count configured countries
     local banned_count=0

--- a/cli/lib/nftban/cli/cmd_geoban.sh
+++ b/cli/lib/nftban/cli/cmd_geoban.sh
@@ -405,6 +405,8 @@ nftban_geoban_config() {
     # shellcheck source=/dev/null
     source "$config_file" 2>/dev/null || true
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$config_local"
 
     # Count configured countries

--- a/cli/lib/nftban/cli/cmd_geoip.sh
+++ b/cli/lib/nftban/cli/cmd_geoip.sh
@@ -589,6 +589,8 @@ nftban_geoip_cmd_config() {
 
             # Load config
             source "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf" 2>/dev/null || true
+            # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+            declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
             _source_local "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local"
 
             local test_url=""

--- a/cli/lib/nftban/cli/cmd_mail.sh
+++ b/cli/lib/nftban/cli/cmd_mail.sh
@@ -119,7 +119,7 @@ _mail_setup_show() {
     # shellcheck source=/dev/null
     [[ -f "$mail_conf" ]] && source "$mail_conf" 2>/dev/null || true
     # shellcheck source=/dev/null
-    [[ -f "$mail_conf_local" ]] && source "$mail_conf_local" 2>/dev/null || true
+    _source_local "$mail_conf_local"
 
     echo "Email Configuration Status"
     echo "=========================="
@@ -303,7 +303,7 @@ NFTBAN_MAIL_ON_LOGIN_ALERT=\"YES\""
                 echo "Sending test email..."
                 # Re-source config to pick up new settings
                 # shellcheck source=/dev/null
-                source "$conf_local" 2>/dev/null || true
+                _source_local "$conf_local"
                 nftban_mail_send_test "$email"
             fi
 

--- a/cli/lib/nftban/cli/cmd_mail.sh
+++ b/cli/lib/nftban/cli/cmd_mail.sh
@@ -119,6 +119,8 @@ _mail_setup_show() {
     # shellcheck source=/dev/null
     [[ -f "$mail_conf" ]] && source "$mail_conf" 2>/dev/null || true
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$mail_conf_local"
 
     echo "Email Configuration Status"

--- a/cli/lib/nftban/cli/cmd_report.sh
+++ b/cli/lib/nftban/cli/cmd_report.sh
@@ -991,7 +991,7 @@ nftban_report_cmd_run() {
         local login_config="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/login_alert.conf"
         local login_config_local="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/login_alert.conf.local"
         source "$login_config" 2>/dev/null || true
-        source "$login_config_local" 2>/dev/null || true
+        _source_local "$login_config_local"
 
         local alert_mode="${NFTBAN_LOGIN_ALERT_MODE:-realtime}"
         if [[ "$alert_mode" == "digest" ]] || [[ "$alert_mode" == "both" ]]; then
@@ -1053,13 +1053,13 @@ nftban_report_cmd_status() {
     local mail_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/mail.conf"
     local mail_local="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/mail.conf.local"
     [[ -f "$mail_conf" ]] && source "$mail_conf" 2>/dev/null || true
-    [[ -f "$mail_local" ]] && source "$mail_local" 2>/dev/null || true
+    _source_local "$mail_local"
 
     # Source stats config if available
     local stats_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/stats.conf"
     local stats_local="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/stats.conf.local"
     [[ -f "$stats_conf" ]] && source "$stats_conf" 2>/dev/null || true
-    [[ -f "$stats_local" ]] && source "$stats_local" 2>/dev/null || true
+    _source_local "$stats_local"
 
     if [[ $json_mode -eq 1 ]]; then
         _report_status_json

--- a/cli/lib/nftban/cli/cmd_report.sh
+++ b/cli/lib/nftban/cli/cmd_report.sh
@@ -991,6 +991,8 @@ nftban_report_cmd_run() {
         local login_config="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/login_alert.conf"
         local login_config_local="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/login_alert.conf.local"
         source "$login_config" 2>/dev/null || true
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$login_config_local"
 
         local alert_mode="${NFTBAN_LOGIN_ALERT_MODE:-realtime}"

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1127,7 +1127,7 @@ _status_section_protection() {
     local zabbix_conf="${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf"
     local zabbix_local="${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
     [[ -f "$zabbix_conf" ]] && source "$zabbix_conf" 2>/dev/null || true
-    [[ -f "$zabbix_local" ]] && source "$zabbix_local" 2>/dev/null || true
+    _source_local "$zabbix_local"
 
     if [[ "${NFTBAN_ZABBIX_ENABLED:-false}" =~ ^([Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|1|[Oo][Nn])$ ]]; then
         if _unit_is_active nftban-unified-exporter.timer; then
@@ -1149,7 +1149,7 @@ _status_section_protection() {
     local connectors_conf="${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf"
     local connectors_local="${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf.local"
     [[ -f "$connectors_conf" ]] && source "$connectors_conf" 2>/dev/null || true
-    [[ -f "$connectors_local" ]] && source "$connectors_local" 2>/dev/null || true
+    _source_local "$connectors_local"
 
     if [[ "${NFTBAN_CONNECTOR_ENABLED:-false}" == "true" ]]; then
         local connector_count=0

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -620,6 +620,8 @@ _status_section_firewall() {
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${NFTBAN_CONFIG_DIR}/conf.d/services.conf.local"
         master_enabled="${NFTBAN_ENABLED:-true}"
     fi

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1895,6 +1895,8 @@ _update_auto_enable() {
 
     # Load update config
     source "$config_file" 2>/dev/null || true
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$config_local"
 
     # Load mail config for global recipient

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -1895,11 +1895,11 @@ _update_auto_enable() {
 
     # Load update config
     source "$config_file" 2>/dev/null || true
-    source "$config_local" 2>/dev/null || true
+    _source_local "$config_local"
 
     # Load mail config for global recipient
     source "$mail_config" 2>/dev/null || true
-    source "$mail_config_local" 2>/dev/null || true
+    _source_local "$mail_config_local"
 
     # Email resolution: override -> update config -> global mail recipient
     local notify_email="${email_override:-${NFTBAN_UPDATE_NOTIFY_EMAIL:-${NFTBAN_MAIL_RECIPIENT:-}}}"
@@ -2081,7 +2081,7 @@ _update_auto_status() {
         source "$config_file" || true
     fi
     if [[ -f "$config_local" ]]; then
-        source "$config_local" || true
+        _source_local "$config_local"
     fi
 
     # Load mail config for global recipient fallback
@@ -2091,7 +2091,7 @@ _update_auto_status() {
         global_mail_recipient="${NFTBAN_MAIL_RECIPIENT:-}"
     fi
     if [[ -f "$mail_config_local" ]]; then
-        source "$mail_config_local" || true
+        _source_local "$mail_config_local"
         global_mail_recipient="${NFTBAN_MAIL_RECIPIENT:-$global_mail_recipient}"
     fi
 
@@ -2221,11 +2221,11 @@ _cmd_update_auto_run() {
 
     # Load update config
     source "$config_file" 2>/dev/null || true
-    source "$config_local" 2>/dev/null || true
+    _source_local "$config_local"
 
     # Load mail config for global email fallback
     source "$mail_config" 2>/dev/null || true
-    source "$mail_config_local" 2>/dev/null || true
+    _source_local "$mail_config_local"
 
     log_file="${NFTBAN_UPDATE_LOG_FILE:-$log_file}"
 

--- a/cli/lib/nftban/cli/cmd_zabbix.sh
+++ b/cli/lib/nftban/cli/cmd_zabbix.sh
@@ -42,6 +42,8 @@ source "${NFTBAN_CONFIG_DIR}/nftban.conf" 2>/dev/null || true
 source "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf" 2>/dev/null || true
 
 # Load zabbix user overrides
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
 
 # Load metrics config (needed to detect NFTBAN_METRICS_ENABLED correctly)

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -132,6 +132,8 @@ nftban_botscan_load_config() {
     # shellcheck source=/dev/null
     source "$config_file" 2>/dev/null || true
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$config_local"
     return 0
 }

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -132,7 +132,7 @@ nftban_botscan_load_config() {
     # shellcheck source=/dev/null
     source "$config_file" 2>/dev/null || true
     # shellcheck source=/dev/null
-    source "$config_local" 2>/dev/null || true
+    _source_local "$config_local"
     return 0
 }
 

--- a/cli/lib/nftban/core/nftban_ddos.sh
+++ b/cli/lib/nftban/core/nftban_ddos.sh
@@ -129,7 +129,7 @@ _nftban_ddos_load_config() {
     # Load user overrides (takes precedence)
     if [[ -f "$main_local" ]]; then
         # shellcheck source=/dev/null
-        source "$main_local" || true
+        _source_local "$main_local"
     fi
 
     # Set defaults

--- a/cli/lib/nftban/core/nftban_ddos.sh
+++ b/cli/lib/nftban/core/nftban_ddos.sh
@@ -129,6 +129,8 @@ _nftban_ddos_load_config() {
     # Load user overrides (takes precedence)
     if [[ -f "$main_local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$main_local"
     fi
 

--- a/cli/lib/nftban/core/nftban_ddos_classic.sh
+++ b/cli/lib/nftban/core/nftban_ddos_classic.sh
@@ -71,7 +71,7 @@ _nftban_ddos_classic_load_config() {
     # Load local overrides (BUG-003 fix: was missing .local support)
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
-        source "$local_config" || true
+        _source_local "$local_config"
     fi
 
     # Set defaults if not configured

--- a/cli/lib/nftban/core/nftban_ddos_classic.sh
+++ b/cli/lib/nftban/core/nftban_ddos_classic.sh
@@ -71,6 +71,8 @@ _nftban_ddos_classic_load_config() {
     # Load local overrides (BUG-003 fix: was missing .local support)
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$local_config"
     fi
 

--- a/cli/lib/nftban/core/nftban_geoip_download.sh
+++ b/cli/lib/nftban/core/nftban_geoip_download.sh
@@ -69,6 +69,8 @@ if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf" ]]; then
 fi
 if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local" ]]; then
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "${NFTBAN_CONFIG_DIR}/conf.d/geoip/main.conf.local"
 fi
 

--- a/cli/lib/nftban/core/nftban_health.sh
+++ b/cli/lib/nftban/core/nftban_health.sh
@@ -76,6 +76,8 @@ fi
 # shellcheck source=/dev/null
 [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" ]] && source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" 2>/dev/null || true
 # shellcheck source=/dev/null
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local"
 
 # Metrics endpoint defaults (fallbacks if not set in config)

--- a/cli/lib/nftban/core/nftban_health_checks_integrations.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_integrations.sh
@@ -193,7 +193,7 @@ nftban_health_check_metrics() {
     local metrics_conf="${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf"
     local metrics_local="${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local"
     [[ -f "$metrics_conf" ]] && source "$metrics_conf" 2>/dev/null || true
-    [[ -f "$metrics_local" ]] && source "$metrics_local" 2>/dev/null || true
+    _source_local "$metrics_local"
 
     # PROMETHEUS EXPORT CHECK (OPTIONAL - only if enabled)
     # Note: Prometheus export is OPTIONAL. NFTBan's default is nc-based unified export.
@@ -383,7 +383,7 @@ nftban_health_check_zabbix() {
     local zabbix_conf="${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf"
     local zabbix_local="${NFTBAN_CONFIG_DIR}/conf.d/zabbix.conf.local"
     [[ -f "$zabbix_conf" ]] && source "$zabbix_conf" 2>/dev/null || true
-    [[ -f "$zabbix_local" ]] && source "$zabbix_local" 2>/dev/null || true
+    _source_local "$zabbix_local"
 
     # Check if Zabbix export is enabled
     if [[ "${NFTBAN_ZABBIX_ENABLED:-false}" != "true" ]]; then
@@ -510,7 +510,7 @@ nftban_health_check_connectors() {
     local connectors_conf="${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf"
     local connectors_local="${NFTBAN_CONFIG_DIR}/conf.d/connectors.conf.local"
     [[ -f "$connectors_conf" ]] && source "$connectors_conf" 2>/dev/null || true
-    [[ -f "$connectors_local" ]] && source "$connectors_local" 2>/dev/null || true
+    _source_local "$connectors_local"
 
     # Check if connector framework is enabled
     if [[ "${NFTBAN_CONNECTOR_ENABLED:-false}" != "true" ]]; then

--- a/cli/lib/nftban/core/nftban_health_checks_integrations.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_integrations.sh
@@ -193,6 +193,8 @@ nftban_health_check_metrics() {
     local metrics_conf="${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf"
     local metrics_local="${NFTBAN_CONFIG_DIR}/conf.d/metrics.conf.local"
     [[ -f "$metrics_conf" ]] && source "$metrics_conf" 2>/dev/null || true
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "$metrics_local"
 
     # PROMETHEUS EXPORT CHECK (OPTIONAL - only if enabled)

--- a/cli/lib/nftban/core/nftban_login.sh
+++ b/cli/lib/nftban/core/nftban_login.sh
@@ -62,6 +62,8 @@ if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     # shellcheck source=/etc/nftban/nftban.conf
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # =============================================================================

--- a/cli/lib/nftban/core/nftban_login.sh
+++ b/cli/lib/nftban/core/nftban_login.sh
@@ -113,7 +113,7 @@ nftban_login_load_config() {
 
     if [[ -f "$main_local" ]]; then
         # shellcheck source=/dev/null
-        source "$main_local" || true
+        _source_local "$main_local"
     fi
 
     # Set defaults
@@ -144,14 +144,14 @@ nftban_login_load_mode_config() {
             local classic_local="${config_dir}/classic.conf.local"
 
             source "$classic_config" 2>/dev/null || true
-            source "$classic_local" 2>/dev/null || true
+            _source_local "$classic_local"
             ;;
         suricata)
             local suricata_config="${config_dir}/suricata.conf"
             local suricata_local="${config_dir}/suricata.conf.local"
 
             source "$suricata_config" 2>/dev/null || true
-            source "$suricata_local" 2>/dev/null || true
+            _source_local "$suricata_local"
             ;;
         hybrid)
             # Load both
@@ -165,7 +165,7 @@ nftban_login_load_mode_config() {
     local services_local="${config_dir}/services.conf.local"
 
     source "$services_config" 2>/dev/null || true
-    source "$services_local" 2>/dev/null || true
+    _source_local "$services_local"
 
     return 0
 }

--- a/cli/lib/nftban/core/nftban_login_alert.sh
+++ b/cli/lib/nftban/core/nftban_login_alert.sh
@@ -40,6 +40,8 @@ if [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf" ]]; then
     # shellcheck source=/etc/nftban/nftban.conf
     source "${NFTBAN_CONFIG_DIR}/nftban.conf" || true
 fi
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # Load strict mode library

--- a/cli/lib/nftban/core/nftban_portscan.sh
+++ b/cli/lib/nftban/core/nftban_portscan.sh
@@ -123,7 +123,7 @@ nftban_portscan_load_config() {
 
     if [[ -f "$main_local" ]]; then
         # shellcheck source=/dev/null
-        source "$main_local" || true
+        _source_local "$main_local"
     fi
 
     # Set defaults

--- a/cli/lib/nftban/core/nftban_portscan.sh
+++ b/cli/lib/nftban/core/nftban_portscan.sh
@@ -55,6 +55,8 @@ readonly PORTSCAN_MODULE_DESCRIPTION="Port Scan Detection Module (Dual-Mode)"
 # Source central config for canonical paths (NO HARDCODED FALLBACKS)
 # shellcheck source=/etc/nftban/nftban.conf
 source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" 2>/dev/null || true
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 readonly NFTBAN_PORTSCAN_CONFIG_DIR="${NFTBAN_CONFIG_DIR}/conf.d/portscan"

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -66,6 +66,8 @@ nftban_portscan_classic_load_config() {
     # Load local overrides
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$local_config"
     fi
 

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -66,7 +66,7 @@ nftban_portscan_classic_load_config() {
     # Load local overrides
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
-        source "$local_config" || true
+        _source_local "$local_config"
     fi
 
     # Set defaults

--- a/cli/lib/nftban/core/nftban_portscan_suricata.sh
+++ b/cli/lib/nftban/core/nftban_portscan_suricata.sh
@@ -62,7 +62,7 @@ nftban_portscan_suricata_load_config() {
     # Load local overrides
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
-        source "$local_config" || true
+        _source_local "$local_config"
     fi
 
     # Set defaults

--- a/cli/lib/nftban/core/nftban_portscan_suricata.sh
+++ b/cli/lib/nftban/core/nftban_portscan_suricata.sh
@@ -62,6 +62,8 @@ nftban_portscan_suricata_load_config() {
     # Load local overrides
     if [[ -f "$local_config" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$local_config"
     fi
 

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -74,6 +74,8 @@ fi
 # Load user overrides (takes precedence over defaults)
 if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/rbl/main.conf.local" ]]; then
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "${NFTBAN_CONFIG_DIR}/conf.d/rbl/main.conf.local"
 fi
 

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -30,6 +30,8 @@ set -Eeuo pipefail
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # Prevent double-loading

--- a/cli/lib/nftban/core/nftban_report_services.sh
+++ b/cli/lib/nftban/core/nftban_report_services.sh
@@ -25,6 +25,8 @@ umask 027
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" ]]; then
     source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf" || true
 fi
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 
 # =============================================================================

--- a/cli/lib/nftban/core/nftban_tunnel.sh
+++ b/cli/lib/nftban/core/nftban_tunnel.sh
@@ -56,6 +56,8 @@ nftban_tunnel_load_config() {
     # .local override
     # shellcheck source=/dev/null
     if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local" ]]; then
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/tunnel/main.conf.local"
     fi
 }

--- a/cli/lib/nftban/core/nftban_watchdog.sh
+++ b/cli/lib/nftban/core/nftban_watchdog.sh
@@ -61,6 +61,8 @@ fi
 # v1.19.0: Source .local override (user customizations survive package updates)
 if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local" ]]; then
     # shellcheck source=/dev/null
+    # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+    declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
     _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/nftban.conf.local"
 fi
 

--- a/cli/lib/nftban/lib/cmd_common.sh
+++ b/cli/lib/nftban/lib/cmd_common.sh
@@ -551,6 +551,8 @@ cmd_load_module_config() {
     # Load local overrides if they exist
     if [[ -f "${config_base}/main.conf.local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${config_base}/main.conf.local"
     fi
 }

--- a/cli/lib/nftban/lib/nftban_panel_cpanel.sh
+++ b/cli/lib/nftban/lib/nftban_panel_cpanel.sh
@@ -564,6 +564,8 @@ nftban_panel_cpanel_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf.local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/cpanel/main.conf" ]]; then

--- a/cli/lib/nftban/lib/nftban_panel_directadmin.sh
+++ b/cli/lib/nftban/lib/nftban_panel_directadmin.sh
@@ -557,6 +557,8 @@ nftban_panel_directadmin_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf.local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/directadmin/main.conf" ]]; then

--- a/cli/lib/nftban/lib/nftban_panel_plesk.sh
+++ b/cli/lib/nftban/lib/nftban_panel_plesk.sh
@@ -514,6 +514,8 @@ nftban_panel_plesk_report() {
     # v1.19.0: Source .local override (user customizations survive package updates)
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf.local" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf.local"
     fi
     if [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/panels/plesk/main.conf" ]]; then

--- a/cli/lib/nftban/lib/nftban_pipeline_validation.sh
+++ b/cli/lib/nftban/lib/nftban_pipeline_validation.sh
@@ -31,6 +31,8 @@ fi
 # shellcheck source=/dev/null
 source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf" 2>/dev/null || true
 # shellcheck source=/dev/null
+# IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
 _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/metrics.conf.local"
 
 # Pipeline defaults (fallbacks if not set in config)

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -38,7 +38,7 @@ _nftban_load_services_config() {
     # Load local overrides
     if [[ -f "$NFTBAN_SERVICES_LOCAL" ]]; then
         # shellcheck source=/dev/null
-        source "$NFTBAN_SERVICES_LOCAL" || true
+        _source_local "$NFTBAN_SERVICES_LOCAL"
     fi
 }
 
@@ -107,7 +107,7 @@ nftban_service_is_enabled() {
             fi
             if [[ -f "$login_local" ]]; then
                 # shellcheck source=/dev/null
-                source "$login_local" || true
+                _source_local "$login_local"
                 enabled="${NFTBAN_LOGIN_ALERT_ENABLED:-$enabled}"
             fi
             [[ "$enabled" == "true" ]]

--- a/cli/lib/nftban/lib/service_control.sh
+++ b/cli/lib/nftban/lib/service_control.sh
@@ -38,6 +38,8 @@ _nftban_load_services_config() {
     # Load local overrides
     if [[ -f "$NFTBAN_SERVICES_LOCAL" ]]; then
         # shellcheck source=/dev/null
+        # IMPL-1: ensure _source_local is defined wherever this file is loaded (env.sh idempotent)
+        declare -F _source_local >/dev/null 2>&1 || source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/env.sh" 2>/dev/null || true
         _source_local "$NFTBAN_SERVICES_LOCAL"
     fi
 }

--- a/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
+++ b/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
@@ -60,11 +60,34 @@ echo "== bypass: NFTBAN_IGNORE_LOCAL_CONFIG=1 skips all .local =="
 MYVAR="base"; NFTBAN_IGNORE_LOCAL_CONFIG=1 _source_local "$NFTBAN_CONFIG_DIR/conf.d/g.conf.local"
 [ "$MYVAR" = "base" ] && ok "bypass: good .local NOT sourced under NFTBAN_IGNORE_LOCAL_CONFIG=1" || no "bypass failed (MYVAR='$MYVAR')"
 
-echo "== MIGRATION GUARD: no direct 'source *.conf.local ... || true' sites remain (outside helper/tests) =="
+echo "== MIGRATION GUARD A: no LITERAL 'source .../*.conf.local' sites remain (outside helper/tests) =="
 stray="$(grep -rnE 'source[[:space:]].*\.conf\.local' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/|lib/env\.sh:|_source_local|^\s*#|meta:' || true)"
-if [ -z "$stray" ]; then ok "0 direct source-.local call sites remain (all routed through _source_local)"; else no "stray direct source-.local sites:"; echo "$stray"; fi
+if [ -z "$stray" ]; then ok "0 literal source-.local sites remain (all routed through _source_local)"; else no "stray literal source-.local sites:"; echo "$stray"; fi
 
-rm -rf "$_tmproot" /tmp/cl_w1 /tmp/cl_w2 2>/dev/null || true
+echo "== MIGRATION GUARD B: no VARIABLE-INDIRECT 'source \"\$VAR\"' where VAR is a .local path (completion regression) =="
+# Closes the IMPL-1 false-pass blind spot: a var assigned a *.local path that is bare-sourced
+# (e.g. service_control.sh: source \"\$NFTBAN_SERVICES_LOCAL\"; cmd_update.sh: config_local=\"\${config_file}.local\").
+strayv=0
+while IFS= read -r f; do
+    # vars whose assignment RHS ends in .local (covers x.conf.local AND \${base}.local)
+    vars="$(grep -oE '^[[:space:]]*(local |readonly |export )?[A-Za-z_][A-Za-z0-9_]*=.*\.local"?[[:space:]]*$' "$f" 2>/dev/null \
+            | sed -E 's/^[[:space:]]*(local |readonly |export )?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/' | sort -u || true)"
+    for v in $vars; do
+        if grep -qE "(^|[[:space:]]|&&)[[:space:]]*(source|\.)[[:space:]]+\"\\\$\{?${v}\}?\"" "$f" 2>/dev/null; then
+            strayv=$((strayv+1)); echo "    STRAY: ${f#"$REPO_LIB"/} bare-sources \$$v (a .local-holding var) — must use _source_local"
+        fi
+    done
+done < <(grep -rlE 'source[[:space:]]|\. "\$' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/')
+[ "$strayv" -eq 0 ] && ok "0 variable-indirected .local source sites remain (all routed through _source_local)" || no "$strayv variable-indirected .local source site(s) still bare"
+
+echo "== REGRESSION: broken .local via VARIABLE indirection — skipped whole, no leak (the false-pass class) =="
+printf 'NFTBAN_ENABLED="false"\n((( broken\n' > "$NFTBAN_CONFIG_DIR/conf.d/svc.conf.local"
+NFTBAN_ENABLED="base"; _svc_local="$NFTBAN_CONFIG_DIR/conf.d/svc.conf.local"   # var holds the .local path
+_source_local "$_svc_local" 2>/tmp/cl_w3
+[ "$NFTBAN_ENABLED" = "base" ] && ok "variable-indirected broken .local skipped whole — NFTBAN_ENABLED=false did NOT leak" || no "var-indirect partial-apply leaked (NFTBAN_ENABLED='$NFTBAN_ENABLED')"
+grep -q "skipping malformed" /tmp/cl_w3 && ok "WARN emitted for var-indirected broken .local" || no "no WARN (var-indirect)"
+
+rm -rf "$_tmproot" /tmp/cl_w1 /tmp/cl_w2 /tmp/cl_w3 2>/dev/null || true
 echo "-----------------------------------------------"
 echo "CONFIG_LOCAL IMPL-1 tests: $P passed, $F failed"
 [ "$F" -eq 0 ]


### PR DESCRIPTION
## IMPL-1 completion (package-native validation found the merged migration incomplete)

Validation on lab2 caught that merged IMPL-1 migrated only **literal** `source ".../x.conf.local"` sites; a second class via **variable indirection** — `source "$VAR"` where `$VAR` holds a `.local` path — was missed by **both** the migration and the guard (same blind spot). `service_control.sh` (`source "$NFTBAN_SERVICES_LOCAL"`) sourced a broken `services.conf.local` → line-1 `NFTBAN_ENABLED=false` partial-applied → status DISABLED, no WARN.

### Changes
- Migrated **30 variable-indirected `.local` source sites / 13 files** → `_source_local "$VAR"`. Detection = any var whose assignment RHS ends in `.local` (covers `x.conf.local` **and** `${base}.local` suffix forms, e.g. `cmd_update.sh` `config_local="${config_file}.local"`). **Base-conf vars deliberately NOT migrated** (`$NFTBAN_SERVICES_CONF`, `$services_config`, …).
- **Strengthened the CI guard**: GUARD A (literal) + **GUARD B (variable-indirect** — vars assigned a `.local` path must not be bare-sourced) → the false-pass blind spot cannot recur. + regression: broken `.local` via variable indirection skipped whole, no leak, WARN.
- Test now **13/13**.

### Boundary
Completes **IMPL-1 only**. Shell-only · `nftband` daemon byte-identical (no `.go`) · schema 1.84.0 · no config-schema/recovery.conf/registry change · no IMPL-2/3/4 · BotGuard disabled.

### Release gate
After merge + post-merge CI: re-run package-native lab2(DEB)+lab4(RPM) — the broken-`services.conf.local` (line-1 `NFTBAN_ENABLED=false` + syntax error) must NOT make `nftban status` DISABLED (no partial-apply), WARN emitted, bypass works, `.local` survives upgrade. Only then release-prep.