### PR TITLE
fix(config-local-recovery IMPL-1): migrate cli/sbin/nftban entry-script .local sources + broaden guard

### DIFF
--- a/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
+++ b/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
@@ -25,6 +25,9 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_LIB="$(cd "$SCRIPT_DIR/.." && pwd)"   # .../cli/lib/nftban
 export NFTBAN_LIB_DIR="$REPO_LIB"
+# Guards scan the WHOLE cli/ tree (lib + sbin/bin entry scripts), not just cli/lib/nftban —
+# the original IMPL-1 miss was cli/sbin/nftban (the dispatcher), outside cli/lib/nftban.
+SCAN_ROOT="$(cd "$REPO_LIB/../.." && pwd)"   # .../cli
 _tmproot="$(mktemp -d)"
 export NFTBAN_CONFIG_DIR="$_tmproot/etc/nftban"
 mkdir -p "$NFTBAN_CONFIG_DIR/conf.d"
@@ -61,7 +64,7 @@ MYVAR="base"; NFTBAN_IGNORE_LOCAL_CONFIG=1 _source_local "$NFTBAN_CONFIG_DIR/con
 [ "$MYVAR" = "base" ] && ok "bypass: good .local NOT sourced under NFTBAN_IGNORE_LOCAL_CONFIG=1" || no "bypass failed (MYVAR='$MYVAR')"
 
 echo "== MIGRATION GUARD A: no LITERAL 'source .../*.conf.local' sites remain (outside helper/tests) =="
-stray="$(grep -rnE 'source[[:space:]].*\.conf\.local' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/|lib/env\.sh:|_source_local|^\s*#|meta:' || true)"
+stray="$(grep -rnE 'source[[:space:]].*\.conf\.local' "$SCAN_ROOT" 2>/dev/null | grep -vE '/tests/|lib/env\.sh:|_source_local|^\s*#|meta:' || true)"
 if [ -z "$stray" ]; then ok "0 literal source-.local sites remain (all routed through _source_local)"; else no "stray literal source-.local sites:"; echo "$stray"; fi
 
 echo "== MIGRATION GUARD B: no VARIABLE-INDIRECT 'source \"\$VAR\"' where VAR is a .local path (completion regression) =="
@@ -77,7 +80,7 @@ while IFS= read -r f; do
             strayv=$((strayv+1)); echo "    STRAY: ${f#"$REPO_LIB"/} bare-sources \$$v (a .local-holding var) — must use _source_local"
         fi
     done
-done < <(grep -rlE 'source[[:space:]]|\. "\$' "$REPO_LIB" 2>/dev/null | grep -vE '/tests/')
+done < <(grep -rlE 'source[[:space:]]|\. "$' "$SCAN_ROOT" 2>/dev/null | grep -vE '/tests/')
 [ "$strayv" -eq 0 ] && ok "0 variable-indirected .local source sites remain (all routed through _source_local)" || no "$strayv variable-indirected .local source site(s) still bare"
 
 echo "== REGRESSION: broken .local via VARIABLE indirection — skipped whole, no leak (the false-pass class) =="

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -133,7 +133,7 @@ if [[ -d "${NFTBAN_CONFIG_DIR}/conf.d" ]]; then
                 # Skip if INI-style
                 if ! grep -q '^\[' "$local_override" 2>/dev/null; then
                     # shellcheck source=/dev/null
-                    source "$local_override"
+                    _source_local "$local_override"
                 fi
             fi
         fi
@@ -143,7 +143,7 @@ fi
 # Load user overrides (highest priority) if exists
 if [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf.local" ]]; then
     # shellcheck source=/dev/null
-    source "${NFTBAN_CONFIG_DIR}/nftban.conf.local"
+    _source_local "${NFTBAN_CONFIG_DIR}/nftban.conf.local"
 fi
 
 # =============================================================================


### PR DESCRIPTION
Package-native validation found the leak persisted via the **dispatcher entry script** `cli/sbin/nftban` — **outside `cli/lib/nftban`**, so never in any prior migration pass or guard scan. It bare-sourced `services.conf.local` via a loop var (`source "$local_override"` over `conf.d/*.conf.local`) + literal `nftban.conf.local` → broken `.local` partial-applied `NFTBAN_ENABLED=false` → status DISABLED, no WARN.

- `cli/sbin/nftban:136` `source "$local_override"` → `_source_local` (kept `grep '^\['` INI-skip; env.sh already at sbin:41).
- `cli/sbin/nftban:146` literal `nftban.conf.local` → `_source_local`.
- **Guard now scans the whole `cli/` tree** (entry scripts included) — the scope fix that would've caught this pre-merge. Repo-wide re-scan = **0** remaining.

Shell-only · daemon byte-identical (no `.go`) · schema 1.84.0 · test 13/13 · shellcheck clean. Completes IMPL-1.