### PR TITLE
feat(config-local): CONFIG_LOCAL_RECOVERY IMPL-2 — read-only `config local` verbs

### DIFF
--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -66,6 +66,12 @@ if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_config_doctor.sh" ]]; then
     source "${NFTBAN_LIB_DIR}/core/nftban_config_doctor.sh" || return 1
 fi
 
+# Load config local (read-only .conf.local diagnostics) module — CONFIG_LOCAL_RECOVERY IMPL-2
+if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_config_local.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${NFTBAN_LIB_DIR}/core/nftban_config_local.sh" || return 1
+fi
+
 # Load IPC library for reload verification
 if [[ -f "${NFTBAN_LIB_DIR}/lib/nft_ipc.sh" ]]; then
     # shellcheck source=/dev/null
@@ -95,6 +101,11 @@ CONFIGURATION COMMANDS:
   reset <module> KEY               Remove single override
   reset-all <module>               Remove all module overrides
 
+LOCAL OVERRIDE DIAGNOSTICS (read-only):
+  local list [--json]              Enumerate *.conf.local (path/base/sha256/size/mtime/syntax)
+  local validate [--json]          bash -n syntax-check each *.conf.local (never sources)
+  local doctor [--json]            Syntax + schema KEY=VALUE lint (OK/UNKNOWN_KEY/DEPRECATED_KEY/BAD_VALUE)
+
 SERVICE COMMANDS:
   apply [module]                   Apply config to running services
   status                           Show config reload status
@@ -113,6 +124,8 @@ EXAMPLES:
   nftban config get portscan --json   # Module config in JSON
   nftban config set portscan PORTSCAN_BAN_THRESHOLD=15
   nftban config apply portscan   # Apply to running service
+  nftban config local list            # List operator *.conf.local overrides
+  nftban config local doctor --json   # Lint overrides against schema (read-only)
 
 EXIT CODES:
   0   Success — command completed and (if applicable) data emitted
@@ -829,6 +842,11 @@ nftban_cmd_config() {
             nftban_cmd_config_doctor "$@"
             ;;
 
+        local)
+            # CONFIG_LOCAL_RECOVERY IMPL-2 — read-only *.conf.local diagnostics
+            nftban_cmd_config_local "$@"
+            ;;
+
         show)
             nftban_cmd_config_show "$@"
             ;;
@@ -857,7 +875,7 @@ nftban_cmd_config() {
             # full show_usage block — explicit user request, not error.
             _v144_error_with_hint \
                 "Unknown command: $subcommand" \
-                "Valid subcommands: get, set, defaults, overrides, reset, reset-all, audit, validate, doctor, show, diff, status, apply" \
+                "Valid subcommands: get, set, defaults, overrides, reset, reset-all, audit, validate, doctor, local, show, diff, status, apply" \
                 "nftban config help"
             return $?
             ;;

--- a/cli/lib/nftban/core/nftban_config_local.sh
+++ b/cli/lib/nftban/core/nftban_config_local.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — config local (read-only .conf.local diagnostics) — IMPL-2
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2024–2026 NFTBAN Project / Antonios Voulvoulis
+#
+# meta:name="nftban_config_local.sh"
+# meta:type="core"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Read-only diagnostics for operator *.conf.local overrides: list/validate/doctor. Enumerates the .local inventory, bash -n syntax-checks (never sources/executes), and lints KEY=VALUE assignments against config-schema.json (single source of truth). STRICTLY READ-ONLY — no writes, no quarantine, no mutation (CONFIG_LOCAL_RECOVERY IMPL-2)."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq,sha256sum,stat,grep,sed"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR,NFTBAN_LIB_DIR"
+# meta:inventory.config_files="conf.d/*.conf.local,whitelist.d/*.conf.local,blacklist.d/*.conf.local,nftban.conf.local"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+[[ -n "${NFTBAN_CONFIG_LOCAL_LOADED:-}" ]] && return 0
+readonly NFTBAN_CONFIG_LOCAL_LOADED=1
+
+# Enumerate every operator *.conf.local across the standard inventory globs.
+# Read-only; prints existing files only, one per line.
+_config_local_inventory() {
+    local cd="${NFTBAN_CONFIG_DIR:-/etc/nftban}"
+    local f
+    shopt -s nullglob
+    for f in "$cd"/nftban.conf.local \
+             "$cd"/conf.d/*.conf.local \
+             "$cd"/whitelist.d/*.conf.local \
+             "$cd"/blacklist.d/*.conf.local; do
+        if [[ -f "$f" ]]; then printf '%s\n' "$f"; fi
+    done
+    shopt -u nullglob
+    return 0
+}
+
+# bash -n syntax gate (the SAME check _source_local uses). Read-only.
+# echoes "OK" / "MALFORMED:<msg>"; returns 0 if clean, 1 if malformed.
+_config_local_bashn() {
+    local f="$1" err
+    if err=$(bash -n "$f" 2>&1); then printf 'OK'; return 0; fi
+    printf 'MALFORMED:%s' "$(printf '%s' "$err" | head -1)"
+    return 1
+}
+
+# nftban config local list [--json]
+nftban_cmd_config_local_list() {
+    local json=0 a
+    for a in "$@"; do if [[ "$a" == "--json" ]]; then json=1; fi; done
+    local files; files=$(_config_local_inventory)
+    if [[ $json -eq 1 ]]; then
+        local arr="[]" f base sha size mtime st
+        while IFS= read -r f; do
+            if [[ -z "$f" ]]; then continue; fi
+            base="${f%.local}"
+            sha=$(sha256sum "$f" 2>/dev/null | cut -d' ' -f1) || true
+            size=$(stat -c '%s' "$f" 2>/dev/null) || true
+            mtime=$(stat -c '%Y' "$f" 2>/dev/null) || true
+            st=$(_config_local_bashn "$f") || true; st="${st%%:*}"
+            arr=$(jq -c --arg p "$f" --arg b "$base" --arg s "$sha" \
+                --argjson z "${size:-0}" --argjson m "${mtime:-0}" --arg st "$st" \
+                '. + [{path:$p,overrides:$b,sha256:$s,size:$z,mtime:$m,syntax:$st}]' <<<"$arr")
+        done <<<"$files"
+        printf '%s\n' "$arr" | jq .
+        return 0
+    fi
+    if [[ -z "$files" ]]; then
+        echo "No operator *.conf.local overrides found under ${NFTBAN_CONFIG_DIR:-/etc/nftban}."
+        return 0
+    fi
+    printf '%-48s %-9s %-7s %s\n' "FILE" "SYNTAX" "SIZE" "SHA256(12)"
+    local f base sha size st
+    while IFS= read -r f; do
+        if [[ -z "$f" ]]; then continue; fi
+        base="${f%.local}"
+        sha=$(sha256sum "$f" 2>/dev/null | cut -c1-12) || true
+        size=$(stat -c '%s' "$f" 2>/dev/null) || true
+        st=$(_config_local_bashn "$f") || true; st="${st%%:*}"
+        printf '%-48s %-9s %-7s %s\n' "$f" "$st" "${size:-?}" "$sha"
+        printf '    overrides: %s\n' "$base"
+    done <<<"$files"
+    return 0
+}
+
+# nftban config local validate [--json]  — bash -n only; rc≠0 if any SYNTAX_ERROR.
+nftban_cmd_config_local_validate() {
+    local json=0 a; for a in "$@"; do if [[ "$a" == "--json" ]]; then json=1; fi; done
+    local files; files=$(_config_local_inventory)
+    local rc=0 f res status msg arr="[]"
+    while IFS= read -r f; do
+        if [[ -z "$f" ]]; then continue; fi
+        if res=$(_config_local_bashn "$f"); then status="OK"; msg=""
+        else status="SYNTAX_ERROR"; msg="${res#MALFORMED:}"; rc=1; fi
+        if [[ $json -eq 1 ]]; then
+            arr=$(jq -c --arg p "$f" --arg s "$status" --arg m "$msg" \
+                '. + [{path:$p,status:$s,message:$m}]' <<<"$arr")
+        elif [[ "$status" == "OK" ]]; then
+            printf '  OK            %s\n' "$f"
+        else
+            printf '  SYNTAX_ERROR  %s — %s\n' "$f" "$msg"
+        fi
+    done <<<"$files"
+    if [[ $json -eq 1 ]]; then printf '%s\n' "$arr" | jq .
+    elif [[ -z "$files" ]]; then echo "No *.conf.local overrides to validate."; fi
+    return $rc
+}
+
+# Classify one KEY=VALUE against config-schema.json via the canonical validator.
+# echoes "OK|UNKNOWN_KEY|DEPRECATED_KEY|BAD_VALUE<TAB>message"; always returns 0.
+_config_local_classify_kv() {
+    local key="$1" val="$2" msg rc cls prop dep
+    # Honor a property-level deprecated:true flag — the canonical validator only
+    # checks the .deprecated map for keys ABSENT from .properties, so a still-present
+    # deprecated property (e.g. the v1.201.3 recovery keys) would otherwise read OK.
+    prop=$(nftban_schema_get_property "$key" 2>/dev/null) || true
+    if [[ -n "$prop" ]]; then
+        dep=$(printf '%s' "$prop" | jq -r '.deprecated // false' 2>/dev/null) || true
+        if [[ "$dep" == "true" ]]; then printf 'DEPRECATED_KEY\t%s' "deprecated in schema"; return 0; fi
+    fi
+    msg=$(nftban_config_validate_value "$key" "$val" 2>/dev/null) && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then cls="OK"; msg=""
+    elif [[ "$msg" == DEPRECATED* || "$msg" == RENAMED* ]]; then cls="DEPRECATED_KEY"
+    elif [[ "$msg" == UNKNOWN* ]]; then cls="UNKNOWN_KEY"
+    else cls="BAD_VALUE"; fi
+    printf '%s\t%s' "$cls" "$msg"
+    return 0
+}
+
+# nftban config local doctor [--dry-run] [--json]
+# Read-only by design (no mutating mode exists). validate + schema-derived KEY=VALUE lint.
+nftban_cmd_config_local_doctor() {
+    local json=0 a; for a in "$@"; do case "$a" in --json) json=1;; --dry-run) :;; esac; done
+    local files; files=$(_config_local_inventory)
+    local rc=0 f line key val cls msg arr="[]" farr synstat
+    while IFS= read -r f; do
+        if [[ -z "$f" ]]; then continue; fi
+        if _config_local_bashn "$f" >/dev/null; then synstat="OK"; else synstat="SYNTAX_ERROR"; rc=1; fi
+        if [[ $json -eq 0 ]]; then printf '  %s  [syntax:%s]\n' "$f" "$synstat"; fi
+        farr="[]"
+        # parse ONLY simple KEY=VALUE assignments — never source/execute
+        while IFS= read -r line; do
+            if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then continue; fi
+            key="${BASH_REMATCH[1]}"; val="${BASH_REMATCH[2]}"
+            val="${val%%#*}"; val="${val%"${val##*[![:space:]]}"}"   # strip trailing comment/space
+            val="${val#[\"\']}"; val="${val%[\"\']}"                 # strip one layer of quotes
+            IFS=$'\t' read -r cls msg <<<"$(_config_local_classify_kv "$key" "$val")"
+            if [[ "$cls" != "OK" ]]; then rc=1; fi
+            if [[ $json -eq 1 ]]; then
+                farr=$(jq -c --arg k "$key" --arg c "$cls" --arg m "$msg" \
+                    '. + [{key:$k,class:$c,message:$m}]' <<<"$farr")
+            else
+                printf '    %-14s %s%s\n' "$cls" "$key" "${msg:+  ($msg)}"
+            fi
+        done < "$f"
+        if [[ $json -eq 1 ]]; then
+            arr=$(jq -c --arg p "$f" --arg s "$synstat" --argjson keys "$farr" \
+                '. + [{path:$p,syntax:$s,keys:$keys}]' <<<"$arr")
+        fi
+    done <<<"$files"
+    if [[ $json -eq 1 ]]; then printf '%s\n' "$arr" | jq .
+    elif [[ -z "$files" ]]; then echo "No *.conf.local overrides to check."; fi
+    return $rc
+}
+
+# Dispatch: nftban config local <list|validate|doctor> [opts]
+nftban_cmd_config_local() {
+    local sub="${1:-help}"; shift || true
+    case "$sub" in
+        list)
+            case "${1:-}" in -h|--help|help)
+                echo "nftban config local list [--json] — enumerate operator *.conf.local overrides (read-only)"
+                echo "    Per file: path · base .conf it overrides · sha256 · size · mtime · bash -n syntax status"; return 0;; esac
+            nftban_cmd_config_local_list "$@" ;;
+        validate)
+            case "${1:-}" in -h|--help|help)
+                echo "nftban config local validate [--json] — bash -n syntax-check each *.conf.local (read-only; never sources)"
+                echo "    rc=0 if all OK; rc≠0 if any SYNTAX_ERROR"; return 0;; esac
+            nftban_cmd_config_local_validate "$@" ;;
+        doctor)
+            case "${1:-}" in -h|--help|help)
+                echo "nftban config local doctor [--json] — syntax + schema lint of each *.conf.local (READ-ONLY by design)"
+                echo "    Per KEY=VALUE: OK | UNKNOWN_KEY | DEPRECATED_KEY | BAD_VALUE (validated against config-schema.json)"
+                echo "    This command never modifies, quarantines, or disables any file. rc≠0 if any issue is found."; return 0;; esac
+            nftban_cmd_config_local_doctor "$@" ;;
+        help|-h|--help|"")
+            echo "nftban config local <subcommand> — read-only diagnostics for operator *.conf.local overrides"
+            echo ""
+            echo "Subcommands:"
+            echo "    list      [--json]   Enumerate *.conf.local (path/base/sha256/size/mtime/syntax)"
+            echo "    validate  [--json]   bash -n syntax-check each (never sources/executes)"
+            echo "    doctor    [--json]   Syntax + schema KEY=VALUE lint (READ-ONLY by design)"
+            echo ""
+            echo "All subcommands are READ-ONLY: no writes, no quarantine, no disable/reset/restore."
+            return 0 ;;
+        *)
+            echo "ERROR: Unknown 'config local' subcommand: $sub" >&2
+            echo "Valid: list, validate, doctor" >&2
+            return 1 ;;
+    esac
+}
+
+export -f nftban_cmd_config_local
+export -f nftban_cmd_config_local_list nftban_cmd_config_local_validate nftban_cmd_config_local_doctor

--- a/cli/lib/nftban/tests/config_local_impl2_test.sh
+++ b/cli/lib/nftban/tests/config_local_impl2_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — CONFIG_LOCAL_RECOVERY IMPL-2 — read-only `config local` verbs test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="config_local_impl2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-24"
+# meta:description="IMPL-2: nftban config local list/validate/doctor are read-only diagnostics — list enumerates *.conf.local (path/base/sha/size/mtime/syntax), validate bash -n distinguishes OK/SYNTAX_ERROR, doctor lints KEY=VALUE against config-schema.json (OK/UNKNOWN_KEY/DEPRECATED_KEY/BAD_VALUE) with NO mutation/quarantine, registry+help wired, lint is schema-derived (no second key list)."
+# meta:input="nftban_config_local.sh, config-schema.json, commands.registry.yml"
+# meta:output="PASS/FAIL per assertion; nonzero on any FAIL"
+# meta:depends="bash,jq,sha256sum,stat"
+# meta:inventory.files=""
+# meta:inventory.binaries="jq,sha256sum,stat,bash"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+export NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban"
+_tmp="$(mktemp -d)"; export NFTBAN_CONFIG_DIR="$_tmp/etc/nftban"
+mkdir -p "$NFTBAN_CONFIG_DIR/conf.d"
+trap 'rm -rf "$_tmp"' EXIT
+P=0; F=0; ok(){ P=$((P+1)); echo "  PASS: $1"; }; no(){ F=$((F+1)); echo "  FAIL: $1"; }
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/lib/env.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_config_schema.sh"
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_config_local.sh"
+# env.sh / schema set -Eeuo pipefail; this test deliberately exercises verbs that
+# return nonzero (the "issues found" contract), so drop -e here (keep -u + pipefail).
+set +e
+
+# plant fixtures
+printf 'NFTBAN_SSH_TEST_PORT="2222"\n' > "$NFTBAN_CONFIG_DIR/conf.d/recovery.conf.local"          # clean, valid
+printf 'NFTBAN_RECOVERY_ENABLED="true"\nNFTBAN_FAKE_KEY_XYZ="x"\nNFTBAN_SSH_TEST_PORT="nope"\n' > "$NFTBAN_CONFIG_DIR/conf.d/ddos.conf.local"  # deprecated+unknown+badvalue
+printf 'NFTBAN_A="1"\n((( broken\n' > "$NFTBAN_CONFIG_DIR/nftban.conf.local"                       # malformed
+
+echo "== list =="
+out=$(nftban_cmd_config_local_list)
+grep -q 'recovery.conf.local' <<<"$out" && grep -q 'overrides:' <<<"$out" && ok "list enumerates .local + base mapping" || no "list enumerate"
+grep -q 'MALFORMED' <<<"$out" && ok "list flags MALFORMED syntax" || no "list syntax flag"
+nftban_cmd_config_local_list --json | jq -e 'type=="array" and length==3 and (.[0]|has("sha256") and has("size") and has("mtime") and has("syntax"))' >/dev/null && ok "list --json (3 files, sha/size/mtime/syntax)" || no "list --json"
+
+echo "== validate =="
+nftban_cmd_config_local_validate >/dev/null 2>&1; rc=$?
+[ "$rc" -ne 0 ] && ok "validate rc≠0 (malformed present)" || no "validate rc"
+vout=$(nftban_cmd_config_local_validate 2>&1)
+grep -q 'SYNTAX_ERROR.*nftban.conf.local' <<<"$vout" && ok "validate flags SYNTAX_ERROR on malformed" || no "validate syntax_error"
+grep -q 'OK .*recovery.conf.local' <<<"$vout" && ok "validate OK on clean" || no "validate ok"
+
+echo "== doctor classification (schema-derived) =="
+dout=$(nftban_cmd_config_local_doctor 2>&1); drc_out=$(nftban_cmd_config_local_doctor >/dev/null 2>&1; echo $?)
+grep -q 'DEPRECATED_KEY NFTBAN_RECOVERY_ENABLED' <<<"$dout" && ok "doctor: deprecated recovery key → DEPRECATED_KEY" || no "doctor deprecated"
+grep -q 'UNKNOWN_KEY .*NFTBAN_FAKE_KEY_XYZ' <<<"$dout" && ok "doctor: unknown key → UNKNOWN_KEY" || no "doctor unknown"
+grep -q 'BAD_VALUE .*NFTBAN_SSH_TEST_PORT' <<<"$dout" && ok "doctor: bad value → BAD_VALUE" || no "doctor bad_value"
+grep -qE 'OK +NFTBAN_SSH_TEST_PORT' <<<"$dout" && ok "doctor: valid key+value → OK" || no "doctor ok"
+[ "$drc_out" -ne 0 ] && ok "doctor rc≠0 when issues found" || no "doctor rc"
+# capture first — doctor exits nonzero by design (issues found); pipefail would otherwise
+# mask jq's verdict with doctor's rc.
+djson=$(nftban_cmd_config_local_doctor --json 2>/dev/null)
+printf '%s' "$djson" | jq -e '[.[]|select(.path|endswith("ddos.conf.local")).keys[].class] as $c
+  | (["DEPRECATED_KEY","UNKNOWN_KEY","BAD_VALUE"]|all(. as $x|$c|index($x)!=null))' >/dev/null \
+  && ok "doctor --json carries DEPRECATED+UNKNOWN+BAD_VALUE" || no "doctor --json"
+
+echo "== READ-ONLY (no mutation, no quarantine) =="
+pre=$(find "$NFTBAN_CONFIG_DIR" -name '*.local' -exec sha256sum {} \; | sort)
+nftban_cmd_config_local_list >/dev/null 2>&1; nftban_cmd_config_local_validate >/dev/null 2>&1; nftban_cmd_config_local_doctor >/dev/null 2>&1
+post=$(find "$NFTBAN_CONFIG_DIR" -name '*.local' -exec sha256sum {} \; | sort)
+[ "$pre" = "$post" ] && ok ".local files byte-identical after all verbs" || no "files mutated"
+[ ! -d "$_tmp/var/lib/nftban/config-quarantine" ] && [ ! -d "$NFTBAN_CONFIG_DIR/config-quarantine" ] && ok "no config-quarantine dir created" || no "quarantine dir appeared"
+# no mutating verbs leaked into the dispatcher
+for v in disable reset restore quarantine; do
+  nftban_cmd_config_local "$v" >/dev/null 2>&1 && no "mutating verb '$v' is accepted (must not exist in IMPL-2)" || :; done
+ok "no disable/reset/restore/quarantine verbs in 'config local'"
+
+echo "== help + registry contract =="
+nftban_cmd_config_local --help 2>&1 | grep -qi 'read-only' && ok "config local --help present + states read-only" || no "help"
+nftban_cmd_config_local doctor --help 2>&1 | grep -qi 'never modifies' && ok "doctor --help states read-only by design (no future mutate mode implied)" || no "doctor help wording"
+python3 -c "import yaml,sys; d=yaml.safe_load(open('$REPO_ROOT/commands.registry.yml')); s=d['config']['subcommands']['local']; sys.exit(0 if (s.get('mutates') is False and set(s['subcommands'])>={'list','validate','doctor'}) else 1)" \
+  && ok "commands.registry.yml: config.local wired (mutates:false, list/validate/doctor)" || no "registry wiring"
+
+echo "== -e safety (production dispatcher runs set -Eeuo pipefail) =="
+# A malformed .local is present; under -e a verb that returns 0 must still complete
+# fully (no mid-loop [[ ]] && abort). list returns 0 and must emit all 3 files.
+n_listed=$( set -Eeuo pipefail; nftban_cmd_config_local_list 2>/dev/null | grep -c 'overrides:' )
+[ "$n_listed" -eq 3 ] && ok "list completes under -e with malformed fixture present (3 files, no abort)" || no "-e abort: only $n_listed/3 listed"
+
+echo "== single source of truth (no second hardcoded key allowlist) =="
+# the lint must derive keys from config-schema.json via the schema accessor, not an embedded list
+if grep -qE 'nftban_(config_validate_value|schema_get_property)' "$NFTBAN_LIB_DIR/core/nftban_config_local.sh" \
+   && ! grep -qE '^[[:space:]]*(VALID_KEYS|ALLOWED_KEYS|KNOWN_KEYS)=' "$NFTBAN_LIB_DIR/core/nftban_config_local.sh"; then
+  ok "lint is schema-derived (no embedded key allowlist)"
+else no "lint not schema-derived / embedded key list found"; fi
+
+echo "-----------------------------------------------"
+echo "config local IMPL-2 tests: $P passed, $F failed"
+[ "$F" -eq 0 ]

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1798,6 +1798,21 @@ config:
     status:
       mutates: false
       description: "Show config reload status"
+    local:
+      mutates: false
+      capability: config_view
+      introduced_in: "1.201.4"
+      description: "Read-only diagnostics for operator *.conf.local overrides (list/validate/doctor)"
+      subcommands:
+        list:
+          mutates: false
+          description: "Enumerate *.conf.local overrides (path/base/sha256/size/mtime/syntax)"
+        validate:
+          mutates: false
+          description: "bash -n syntax-check each *.conf.local (never sources/executes)"
+        doctor:
+          mutates: false
+          description: "Syntax + schema KEY=VALUE lint (OK/UNKNOWN_KEY/DEPRECATED_KEY/BAD_VALUE); read-only by design"
   allowlist:
     paths:
       - /etc/nftban/nftban.conf


### PR DESCRIPTION
## CONFIG_LOCAL_RECOVERY IMPL-2 — read-only `config local` diagnostics

Adds operator-override diagnostics on top of the IMPL-1 `_source_local` mechanism. **Strictly read-only.**

- `nftban config local list [--json]` — enumerate `*.conf.local` (path · base `.conf` · sha256 · size · mtime · `bash -n` syntax)
- `nftban config local validate [--json]` — `bash -n` each (never sources/executes); rc≠0 on SYNTAX_ERROR
- `nftban config local doctor [--json]` — syntax + schema `KEY=VALUE` lint → `OK`/`UNKNOWN_KEY`/`DEPRECATED_KEY`/`BAD_VALUE`

### Read-only boundary (hard)
No file writes · no quarantine · no `disable`/`reset`/`restore` · no `config-quarantine/` dir · no `.local`/`.conf` mutation · no sourcing during validate/doctor · no change to `_source_local` loading. `doctor` has **no** mutating mode (help states this — no future non-dry-run mode implied).

### Schema-derived lint (single source of truth)
Uses `config-schema.json` via the canonical `nftban_config_validate_value` — **no second key list**. Additionally honors property-level `deprecated:true` (which the canonical validator skips for still-present properties), so the 11 v1.201.3-deprecated recovery keys are flagged `DEPRECATED_KEY`.

### CLI contract
`core/nftban_config_local.sh` (sourced by `cmd_config.sh`) + `local)` dispatch + `show_usage()` + `config local [--help]` + per-verb `--help` + `commands.registry.yml` (`config.subcommands.local`, `mutates:false`, `config_view`, list/validate/doctor).

### Boundary
Shell-only · **no `.go` · `nftband` daemon byte-identical (source-proven) · nft `SchemaVersionCurrent` 1.84.0** (config-schema.json read only) · no daemon IPC · no IMPL-3/IMPL-4. `-e`-safe (runs under the dispatcher's `set -Eeuo pipefail`). Hermetic test **20/20** incl. read-only proof + `-e`-safety proof.

### Release gate
After merge + post-merge CI: package-native lab2(DEB)+lab4(RPM) per the IMPL-2 scope validation plan (behavior + read-only + no-quarantine + registry/help + daemon byte-identical + labs restored clean). No release-prep until both families pass.