### PR TITLE
fix(whitelist): durable apply reconcile + range-aware verify (WHITELIST_DURABLE_APPLY_RECONCILE)

### DIFF
--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -379,6 +379,30 @@ MANUAL_HEADER_EOF
 
 # Add a permanent (no-expiry) entry to 99-manual.conf + apply live. Idempotent
 # (refresh: a prior line for the same IP is dropped before re-append).
+# Read-back: is `$1` (IP/CIDR) actually covered by the LIVE kernel whitelist set
+# (either family), range-aware via the oracle? rc: 0=live, 1=not-live, 2=cannot-determine.
+_nftban_wl_static_is_live() {
+    local ip="$1" core_bin="${NFTBAN_CORE_BIN:-/usr/lib/nftban/bin/nftban-core}"
+    local k4 k6 t; local -a ktoks=()
+    k4="$(_nftban_wl_read_kernel_set "ip nftban" "whitelist_ipv4" 2>/dev/null)" || true
+    k6="$(_nftban_wl_read_kernel_set "ip6 nftban" "whitelist_ipv6" 2>/dev/null)" || true
+    while IFS= read -r t; do [[ -n "$t" ]] && ktoks+=("$t"); done <<< "$k4"
+    while IFS= read -r t; do [[ -n "$t" ]] && ktoks+=("$t"); done <<< "$k6"
+    if [[ -x "$core_bin" ]]; then
+        local req out nmiss
+        req="{\"baseline\":$(_nftban_wl_json_arr "$ip"),\"kernel\":$(_nftban_wl_json_arr "${ktoks[@]}"),\"sessions\":[]}"
+        out="$(printf '%s' "$req" | "$core_bin" whitelist-coverage 2>/dev/null)"
+        if printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+            nmiss="$(printf '%s' "$out" | jq -r '.missing_from_kernel | length' 2>/dev/null)"
+            [[ "$nmiss" == "0" ]] && return 0 || return 1
+        fi
+    fi
+    # Oracle unavailable → best-effort exact membership (cannot resolve CIDR coverage).
+    local kk
+    for kk in "${ktoks[@]}"; do [[ "$kk" == "$ip" ]] && return 0; done
+    return 2
+}
+
 nftban_whitelist_add_static_ip() {
     local ip="$1"
 
@@ -410,17 +434,31 @@ nftban_whitelist_add_static_ip() {
     chmod 0640 "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
     chown root:nftban "$_NFTBAN_MANUAL_WHITELIST_PATH" 2>/dev/null || true
 
-    echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) and applied it live — durable: survives firewall reload, daemon restart, and reboot."
-
-    # Apply live immediately via a FULL sync. `nftban sync` runs the daemon
-    # whitelist loader (LoadWhitelists → reconciles whitelist.d/*.conf, incl. this
-    # file, into the live nft set). `firewall reload` alone does NOT apply it — its
-    # whitelist step is system-IP auto-detection, not the whitelist.d loader
-    # (lab-proven on v1.148.0). Fall back to reload if `sync` is unavailable.
+    # Durable file write succeeded. Now apply live via a FULL sync, then READ BACK
+    # the live kernel set to confirm the element is actually present — no false
+    # "applied live" success (WHITELIST_DURABLE_APPLY_RECONCILE Step 3).
     if command -v nftban >/dev/null 2>&1; then
         nftban sync >/dev/null 2>&1 || nftban firewall reload >/dev/null 2>&1 || true
     fi
-    return 0
+
+    _nftban_wl_static_is_live "$ip"
+    case $? in
+        0)
+            echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) and confirmed it is LIVE in the kernel whitelist set — durable: survives firewall reload, daemon restart, and reboot."
+            return 0
+            ;;
+        2)
+            # Could not verify (oracle unavailable + not an exact literal match).
+            echo "Added $ip to the PERMANENT whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH). Durable entry written; LIVE application could NOT be verified (coverage oracle unavailable). Run 'nftban whitelist verify' to confirm." >&2
+            return 0
+            ;;
+        *)
+            echo "ERROR: $ip was written to the durable whitelist ($_NFTBAN_MANUAL_WHITELIST_PATH) but is NOT present in the live kernel whitelist set after sync." >&2
+            echo "       The durable entry persists (survives rebuild), but LIVE protection is NOT active — this IP can still be banned now." >&2
+            echo "       Whitelist apply/reconcile drift: see 'nftban whitelist verify'. (WHITELIST_DURABLE_APPLY_RECONCILE)" >&2
+            return 3
+            ;;
+    esac
 }
 
 # Remove a permanent entry from 99-manual.conf AND the live set, so a rebuild
@@ -731,6 +769,39 @@ _nftban_wl_read_sessions() {
 # family via the named-by-convention globals below (bash can't return ints >255
 # cleanly, and we want a precise count). Sets _NFTBAN_WL_VERIFY_ANOM.
 # $1 = family label (IPv4/IPv6), $2 = "4"/"6", $3 = table words, $4 = set name.
+# Exact string-match fallback (used ONLY when the range-aware oracle binary is
+# absent). Args: anom-counter var name, kernel array name, baseline array name,
+# sessions array name (passed by name for namerefs).
+_nftban_wl_verify_family_exact() {
+    local -n _anom="$1" _kernel="$2" _baseline="$3" _sessions="$4"
+    local b kk found is_session
+    for kk in "${_kernel[@]}"; do
+        found=false
+        for b in "${_baseline[@]}"; do [[ "$kk" == "$b" ]] && { found=true; break; }; done
+        [[ "$found" == "true" ]] && continue
+        is_session=false
+        for b in "${_sessions[@]}"; do [[ "$kk" == "$b" ]] && { is_session=true; break; }; done
+        if [[ "$is_session" == "true" ]]; then
+            echo "    [info]    $kk — active session whitelist (unexpired); not an anomaly"
+        else
+            echo "    [ANOMALY] $kk — IN-KERNEL-NOT-IN-BASELINE (present in live set, not in durable whitelist.d; possible injection)"
+            _anom=$(( _anom + 1 ))
+        fi
+    done
+    for b in "${_baseline[@]}"; do
+        found=false
+        for kk in "${_kernel[@]}"; do [[ "$b" == "$kk" ]] && { found=true; break; }; done
+        [[ "$found" == "false" ]] && { echo "    [ANOMALY] $b — IN-BASELINE-NOT-IN-KERNEL (durable whitelist.d entry not applied to live set; drift)"; _anom=$(( _anom + 1 )); }
+    done
+}
+
+# Build a JSON array from shell args (IP/CIDR/interval tokens are quote-safe).
+_nftban_wl_json_arr() {
+    local first=1 x; printf '['
+    for x in "$@"; do [[ $first -eq 1 ]] && first=0 || printf ','; printf '"%s"' "$x"; done
+    printf ']'
+}
+
 _nftban_wl_verify_family() {
     local label="$1" fam="$2" table="$3" set_name="$4"
     local -a kernel=() baseline=() sessions=()
@@ -752,36 +823,38 @@ _nftban_wl_verify_family() {
     while IFS= read -r k; do [[ -n "$k" ]] && sessions+=("$k"); done < <(_nftban_wl_read_sessions "$fam")
 
     local anom=0 b kk found
+    local core_bin="${NFTBAN_CORE_BIN:-/usr/lib/nftban/bin/nftban-core}"
 
     echo "  ${label} (set ${set_name}):"
 
-    # IN-KERNEL-NOT-IN-BASELINE: kernel keys absent from durable baseline.
-    for kk in "${kernel[@]}"; do
-        found=false
-        for b in "${baseline[@]}"; do [[ "$kk" == "$b" ]] && { found=true; break; }; done
-        if [[ "$found" == "true" ]]; then continue; fi
-        # Not baseline — is it a current session? (informational, not anomaly)
-        local is_session=false
-        for b in "${sessions[@]}"; do [[ "$kk" == "$b" ]] && { is_session=true; break; }; done
-        if [[ "$is_session" == "true" ]]; then
-            echo "    [info]    $kk — active session whitelist (unexpired 00-session.conf); not an anomaly"
+    if [[ -x "$core_bin" ]]; then
+        # Range-aware oracle (CIDR<->interval coverage). nft coalesces adjacent
+        # CIDRs into intervals; compare COVERAGE, not strings, so e.g.
+        # 104.16.0.0/13 + 104.24.0.0/14 == 104.16.0.0-104.27.255.255 is NOT drift.
+        local req out m
+        req="{\"baseline\":$(_nftban_wl_json_arr "${baseline[@]}"),\"kernel\":$(_nftban_wl_json_arr "${kernel[@]}"),\"sessions\":$(_nftban_wl_json_arr "${sessions[@]}")}"
+        out="$(printf '%s' "$req" | "$core_bin" whitelist-coverage 2>/dev/null)"
+        if [[ -n "$out" ]] && printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+            while IFS= read -r m; do
+                [[ -z "$m" ]] && continue
+                echo "    [ANOMALY] $m — IN-BASELINE-NOT-IN-KERNEL (durable whitelist.d entry not covered by live set; drift)"
+                anom=$(( anom + 1 ))
+            done < <(printf '%s' "$out" | jq -r '.missing_from_kernel[]?' 2>/dev/null)
+            while IFS= read -r m; do
+                [[ -z "$m" ]] && continue
+                echo "    [ANOMALY] $m — IN-KERNEL-NOT-IN-BASELINE (present in live set, not in durable whitelist.d/sessions; possible injection)"
+                anom=$(( anom + 1 ))
+            done < <(printf '%s' "$out" | jq -r '.extra_in_kernel[]?' 2>/dev/null)
+            while IFS= read -r m; do [[ -n "$m" ]] && echo "    [info]    unparseable kernel token (ignored): $m"; done < <(printf '%s' "$out" | jq -r '.bad_kernel[]?' 2>/dev/null)
         else
-            echo "    [ANOMALY] $kk — IN-KERNEL-NOT-IN-BASELINE (present in live set, not in durable whitelist.d; possible injection)"
-            anom=$(( anom + 1 ))
+            echo "    [warn] range-aware oracle unavailable — falling back to exact-match (may over-report CIDR/interval)"
+            _nftban_wl_verify_family_exact anom kernel baseline sessions
         fi
-    done
+    else
+        _nftban_wl_verify_family_exact anom kernel baseline sessions
+    fi
 
-    # IN-BASELINE-NOT-IN-KERNEL: durable baseline keys missing from the kernel.
-    for b in "${baseline[@]}"; do
-        found=false
-        for kk in "${kernel[@]}"; do [[ "$b" == "$kk" ]] && { found=true; break; }; done
-        if [[ "$found" == "false" ]]; then
-            echo "    [ANOMALY] $b — IN-BASELINE-NOT-IN-KERNEL (durable whitelist.d entry not applied to live set; drift)"
-            anom=$(( anom + 1 ))
-        fi
-    done
-
-    [[ "$anom" -eq 0 ]] && echo "    OK — kernel matches durable baseline (sessions informational)."
+    [[ "$anom" -eq 0 ]] && echo "    OK — kernel matches durable baseline (range-aware; sessions informational)."
 
     _NFTBAN_WL_VERIFY_ANOM=$(( ${_NFTBAN_WL_VERIFY_ANOM:-0} + anom ))
     return 0

--- a/cmd/nftban-core/cmd_whitelist_coverage.go
+++ b/cmd/nftban-core/cmd_whitelist_coverage.go
@@ -1,0 +1,83 @@
+// =============================================================================
+// NFTBan core — whitelist-coverage (range-aware verify oracle)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="cmd_whitelist_coverage"
+// meta:type="cli-subcommand"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Range-aware whitelist coverage diff. Reads JSON {baseline,kernel,sessions} of IP/CIDR/interval tokens on stdin, emits JSON {missing_from_kernel,extra_in_kernel,bad_baseline,bad_kernel} using netutil.CoverageDiff (coverage, not strings — so coalesced kernel intervals do not read as drift). CLI-only (cmd/nftban-core); does NOT touch the nftband daemon."
+// meta:input="stdin JSON: {baseline:[],kernel:[],sessions:[]}"
+// meta:output="stdout JSON: {missing_from_kernel:[],extra_in_kernel:[],bad_baseline:[],bad_kernel:[]}; exit 0=clean, 1=real anomalies, 2=input error"
+// meta:depends="internal/netutil"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/itcmsgr/nftban/internal/netutil"
+)
+
+type coverageInput struct {
+	Baseline []string `json:"baseline"`
+	Kernel   []string `json:"kernel"`
+	Sessions []string `json:"sessions"`
+}
+
+type coverageOutput struct {
+	MissingFromKernel []string `json:"missing_from_kernel"`
+	ExtraInKernel     []string `json:"extra_in_kernel"`
+	BadBaseline       []string `json:"bad_baseline"`
+	BadKernel         []string `json:"bad_kernel"`
+}
+
+func nilToEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+// cmdWhitelistCoverage reads a coverage request on stdin and prints the
+// range-aware diff. Exit: 0 = no real drift, 1 = real anomalies, 2 = input error.
+func cmdWhitelistCoverage(_ []string) int {
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "whitelist-coverage: read stdin: %v\n", err)
+		return 2
+	}
+	var in coverageInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		fmt.Fprintf(os.Stderr, "whitelist-coverage: parse json: %v\n", err)
+		return 2
+	}
+	res := netutil.CoverageDiff(in.Baseline, in.Kernel, in.Sessions)
+	out := coverageOutput{
+		MissingFromKernel: nilToEmpty(res.MissingFromKernel),
+		ExtraInKernel:     nilToEmpty(res.ExtraInKernel),
+		BadBaseline:       nilToEmpty(res.BadBaseline),
+		BadKernel:         nilToEmpty(res.BadKernel),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "whitelist-coverage: encode: %v\n", err)
+		return 2
+	}
+	if len(out.MissingFromKernel) > 0 || len(out.ExtraInKernel) > 0 {
+		return 1
+	}
+	return 0
+}

--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -165,6 +165,11 @@ func main() {
 		// compare to the captured baseline (--capture re-captures from the live
 		// ruleset). Custom exit codes: OK/BASELINE_MISSING=0, MISMATCH=2, NFT_UNAVAILABLE=3.
 		os.Exit(cmdVerifyRules(os.Args[2:]))
+	case "whitelist-coverage":
+		// WHITELIST_DURABLE_APPLY_RECONCILE: range-aware whitelist coverage diff
+		// (reads {baseline,kernel,sessions} JSON on stdin). CLI-only oracle for
+		// `nftban whitelist verify` + the `--static` add live read-back.
+		os.Exit(cmdWhitelistCoverage(os.Args[2:]))
 	case "feeds":
 		if len(os.Args) < 3 {
 			errorWithUsage("feeds", "feeds command requires an action")

--- a/internal/netutil/coverage.go
+++ b/internal/netutil/coverage.go
@@ -230,24 +230,3 @@ func CoverageDiff(baseline, kernel, sessions []string) CoverageResult {
 	}
 	return res
 }
-
-// IsTokenCoveredBy reports whether `needle` (IP/CIDR/interval) is fully covered
-// by the union of `haystack` tokens. Used by the --static add live read-back to
-// confirm a durable entry is actually present in the live kernel set.
-func IsTokenCoveredBy(needle string, haystack []string) (bool, error) {
-	r, err := ParseRangeToken(needle)
-	if err != nil {
-		return false, err
-	}
-	hP, _ := parseAll(haystack)
-	var hr []*IPRange
-	for _, p := range hP {
-		hr = append(hr, p.r)
-	}
-	h4, h6 := splitFamilies(hr)
-	m := h4
-	if r.V6 {
-		m = h6
-	}
-	return covered(r, m), nil
-}

--- a/internal/netutil/coverage.go
+++ b/internal/netutil/coverage.go
@@ -90,7 +90,12 @@ func ParseRangeToken(tok string) (*IPRange, error) {
 		}
 		ones, bits := ipnet.Mask.Size()
 		hostBits := bits - ones
-		size := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+		// ParseCIDR guarantees 0 <= ones <= bits, so hostBits is in [0,128]; guard
+		// the lower bound explicitly so the uint conversion cannot underflow.
+		if hostBits < 0 || hostBits > 128 {
+			return nil, fmt.Errorf("invalid CIDR mask for %q", tok)
+		}
+		size := new(big.Int).Lsh(big.NewInt(1), uint(hostBits)) //#nosec G115 -- hostBits guarded to [0,128] above
 		end := new(big.Int).Add(start, size)
 		end.Sub(end, big.NewInt(1))
 		return &IPRange{Start: start, End: end, V6: v6}, nil

--- a/internal/netutil/coverage.go
+++ b/internal/netutil/coverage.go
@@ -1,0 +1,253 @@
+// =============================================================================
+// NFTBan - Whitelist range-coverage oracle
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="coverage"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Range-aware whitelist coverage oracle: single IP / CIDR / nft interval normalized to [start,end] big.Int ranges (IPv4+IPv6) and compared by COVERAGE not strings, so coalesced kernel intervals (e.g. 104.16.0.0/13 + 104.24.0.0/14 == 104.16.0.0-104.27.255.255) are not reported as drift. CLI-only (internal/netutil); does not touch the nftband daemon."
+// meta:depends="net,math/big"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package netutil
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"sort"
+	"strings"
+)
+
+// IPRange is an inclusive [Start,End] address range within one family (V6 flag).
+type IPRange struct {
+	Start *big.Int
+	End   *big.Int
+	V6    bool
+}
+
+// ipToBig converts a net.IP to a big.Int (4-byte for IPv4, 16-byte for IPv6).
+func ipToBig(ip net.IP) (*big.Int, bool, bool) {
+	if ip == nil {
+		return nil, false, false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return new(big.Int).SetBytes(v4), false, true
+	}
+	if v16 := ip.To16(); v16 != nil {
+		return new(big.Int).SetBytes(v16), true, true
+	}
+	return nil, false, false
+}
+
+// ParseRangeToken parses a single IP, a CIDR, or an nft interval ("a-b") into an
+// inclusive IPRange. Trailing nft decorations (comment/timeout) must be stripped
+// by the caller. Returns an error on anything unparseable.
+func ParseRangeToken(tok string) (*IPRange, error) {
+	tok = strings.TrimSpace(tok)
+	if tok == "" {
+		return nil, fmt.Errorf("empty token")
+	}
+	// Interval "a-b" (nft coalesced form). Guard against IPv6 "::" by requiring
+	// no "/" and a '-' that separates two parseable IPs.
+	if !strings.Contains(tok, "/") {
+		if i := strings.IndexByte(tok, '-'); i > 0 {
+			aStr := strings.TrimSpace(tok[:i])
+			bStr := strings.TrimSpace(tok[i+1:])
+			a := net.ParseIP(aStr)
+			b := net.ParseIP(bStr)
+			if a != nil && b != nil {
+				as, av6, ok1 := ipToBig(a)
+				bs, bv6, ok2 := ipToBig(b)
+				if !ok1 || !ok2 || av6 != bv6 {
+					return nil, fmt.Errorf("interval family mismatch: %q", tok)
+				}
+				if as.Cmp(bs) > 0 {
+					as, bs = bs, as
+				}
+				return &IPRange{Start: as, End: bs, V6: av6}, nil
+			}
+		}
+	}
+	// CIDR
+	if strings.Contains(tok, "/") {
+		_, ipnet, err := net.ParseCIDR(tok)
+		if err != nil {
+			return nil, err
+		}
+		start, v6, ok := ipToBig(ipnet.IP)
+		if !ok {
+			return nil, fmt.Errorf("bad CIDR base: %q", tok)
+		}
+		ones, bits := ipnet.Mask.Size()
+		hostBits := bits - ones
+		size := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+		end := new(big.Int).Add(start, size)
+		end.Sub(end, big.NewInt(1))
+		return &IPRange{Start: start, End: end, V6: v6}, nil
+	}
+	// Single IP
+	ip := net.ParseIP(tok)
+	if ip == nil {
+		return nil, fmt.Errorf("bad IP: %q", tok)
+	}
+	s, v6, ok := ipToBig(ip)
+	if !ok {
+		return nil, fmt.Errorf("bad IP: %q", tok)
+	}
+	return &IPRange{Start: s, End: new(big.Int).Set(s), V6: v6}, nil
+}
+
+// mergeFamily sorts and coalesces overlapping/adjacent ranges of ONE family.
+func mergeFamily(rs []*IPRange) []*IPRange {
+	if len(rs) == 0 {
+		return nil
+	}
+	sort.Slice(rs, func(i, j int) bool { return rs[i].Start.Cmp(rs[j].Start) < 0 })
+	out := []*IPRange{{Start: new(big.Int).Set(rs[0].Start), End: new(big.Int).Set(rs[0].End), V6: rs[0].V6}}
+	one := big.NewInt(1)
+	for _, r := range rs[1:] {
+		last := out[len(out)-1]
+		// adjacent or overlapping if r.Start <= last.End + 1
+		thresh := new(big.Int).Add(last.End, one)
+		if r.Start.Cmp(thresh) <= 0 {
+			if r.End.Cmp(last.End) > 0 {
+				last.End.Set(r.End)
+			}
+		} else {
+			out = append(out, &IPRange{Start: new(big.Int).Set(r.Start), End: new(big.Int).Set(r.End), V6: r.V6})
+		}
+	}
+	return out
+}
+
+// splitFamilies merges ranges per family and returns (v4merged, v6merged).
+func splitFamilies(rs []*IPRange) ([]*IPRange, []*IPRange) {
+	var v4, v6 []*IPRange
+	for _, r := range rs {
+		if r.V6 {
+			v6 = append(v6, r)
+		} else {
+			v4 = append(v4, r)
+		}
+	}
+	return mergeFamily(v4), mergeFamily(v6)
+}
+
+// covered reports whether r is fully contained in the union represented by the
+// pre-merged family slice `merged`.
+func covered(r *IPRange, merged []*IPRange) bool {
+	for _, m := range merged {
+		if m.Start.Cmp(r.Start) <= 0 && m.End.Cmp(r.End) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// CoverageResult holds the real (range-aware) drift between baseline and kernel.
+type CoverageResult struct {
+	MissingFromKernel []string // baseline tokens whose coverage is NOT in the kernel union
+	ExtraInKernel     []string // kernel tokens whose coverage is NOT in baseline∪sessions union
+	BadBaseline       []string // unparseable baseline tokens (surfaced, not silently dropped)
+	BadKernel         []string // unparseable kernel tokens
+}
+
+type parsed struct {
+	tok string
+	r   *IPRange
+}
+
+func parseAll(toks []string) ([]parsed, []string) {
+	var ok []parsed
+	var bad []string
+	for _, t := range toks {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		r, err := ParseRangeToken(t)
+		if err != nil {
+			bad = append(bad, t)
+			continue
+		}
+		ok = append(ok, parsed{tok: t, r: r})
+	}
+	return ok, bad
+}
+
+// CoverageDiff compares the durable baseline against the live kernel set using
+// range coverage. A kernel element is "extra" only if it is covered by neither
+// the durable baseline NOR the (allowed) session/runtime entries. CIDR<->interval
+// representation differences are NOT reported (coverage-equivalent == match).
+func CoverageDiff(baseline, kernel, sessions []string) CoverageResult {
+	bP, bBad := parseAll(baseline)
+	kP, kBad := parseAll(kernel)
+	sP, _ := parseAll(sessions)
+
+	var bRanges, kRanges, sRanges []*IPRange
+	for _, p := range bP {
+		bRanges = append(bRanges, p.r)
+	}
+	for _, p := range kP {
+		kRanges = append(kRanges, p.r)
+	}
+	for _, p := range sP {
+		sRanges = append(sRanges, p.r)
+	}
+
+	k4, k6 := splitFamilies(kRanges)
+	// baseline∪sessions for the "extra" direction
+	bs4, bs6 := splitFamilies(append(append([]*IPRange{}, bRanges...), sRanges...))
+
+	res := CoverageResult{BadBaseline: bBad, BadKernel: kBad}
+	for _, p := range bP {
+		m := k4
+		if p.r.V6 {
+			m = k6
+		}
+		if !covered(p.r, m) {
+			res.MissingFromKernel = append(res.MissingFromKernel, p.tok)
+		}
+	}
+	for _, p := range kP {
+		m := bs4
+		if p.r.V6 {
+			m = bs6
+		}
+		if !covered(p.r, m) {
+			res.ExtraInKernel = append(res.ExtraInKernel, p.tok)
+		}
+	}
+	return res
+}
+
+// IsTokenCoveredBy reports whether `needle` (IP/CIDR/interval) is fully covered
+// by the union of `haystack` tokens. Used by the --static add live read-back to
+// confirm a durable entry is actually present in the live kernel set.
+func IsTokenCoveredBy(needle string, haystack []string) (bool, error) {
+	r, err := ParseRangeToken(needle)
+	if err != nil {
+		return false, err
+	}
+	hP, _ := parseAll(haystack)
+	var hr []*IPRange
+	for _, p := range hP {
+		hr = append(hr, p.r)
+	}
+	h4, h6 := splitFamilies(hr)
+	m := h4
+	if r.V6 {
+		m = h6
+	}
+	return covered(r, m), nil
+}

--- a/internal/netutil/coverage_test.go
+++ b/internal/netutil/coverage_test.go
@@ -105,30 +105,6 @@ func TestCoverage_AdminIPMissingThenLive(t *testing.T) {
 	}
 }
 
-func TestIsTokenCoveredBy(t *testing.T) {
-	cases := []struct {
-		needle   string
-		hay      []string
-		want     bool
-	}{
-		{"62.38.150.122", []string{"62.38.150.122"}, true},
-		{"62.38.150.122", []string{"46.224.164.50"}, false},
-		{"1.2.3.4", []string{"1.2.3.0/24"}, true},
-		{"104.20.0.0/16", []string{"104.16.0.0-104.27.255.255"}, true}, // sub-range of interval
-		{"2606:4700::1", []string{"2606:4700::/32"}, true},
-		{"9.9.9.9", []string{"1.2.3.0/24", "10.0.0.0/8"}, false},
-	}
-	for _, c := range cases {
-		got, err := IsTokenCoveredBy(c.needle, c.hay)
-		if err != nil {
-			t.Fatalf("IsTokenCoveredBy(%q) err: %v", c.needle, err)
-		}
-		if got != c.want {
-			t.Fatalf("IsTokenCoveredBy(%q, %v) = %v, want %v", c.needle, c.hay, got, c.want)
-		}
-	}
-}
-
 func TestParseRangeToken_BadInput(t *testing.T) {
 	for _, bad := range []string{"", "not-an-ip", "1.2.3.4/99", "garbage-text"} {
 		if _, err := ParseRangeToken(bad); err == nil {

--- a/internal/netutil/coverage_test.go
+++ b/internal/netutil/coverage_test.go
@@ -1,0 +1,145 @@
+// =============================================================================
+// NFTBan - Tests for range-aware coverage oracle
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="netutil_coverage_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Tests for range-aware coverage oracle"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package netutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCoverage_CloudflareCIDRIntervalEquivalence(t *testing.T) {
+	// Baseline holds two adjacent CIDRs; kernel coalesced them into one interval.
+	baseline := []string{"104.16.0.0/13", "104.24.0.0/14"}
+	kernel := []string{"104.16.0.0-104.27.255.255"}
+	res := CoverageDiff(baseline, kernel, nil)
+	if len(res.MissingFromKernel) != 0 || len(res.ExtraInKernel) != 0 {
+		t.Fatalf("expected 0 phantom anomalies, got missing=%v extra=%v", res.MissingFromKernel, res.ExtraInKernel)
+	}
+}
+
+func TestCoverage_RealMissingDurableRange(t *testing.T) {
+	baseline := []string{"1.2.3.4", "10.0.0.0/24"}
+	kernel := []string{"1.2.3.4"} // 10.0.0.0/24 missing from kernel
+	res := CoverageDiff(baseline, kernel, nil)
+	if len(res.MissingFromKernel) != 1 || res.MissingFromKernel[0] != "10.0.0.0/24" {
+		t.Fatalf("expected 10.0.0.0/24 missing, got %v", res.MissingFromKernel)
+	}
+	if len(res.ExtraInKernel) != 0 {
+		t.Fatalf("unexpected extra: %v", res.ExtraInKernel)
+	}
+}
+
+func TestCoverage_RealExtraInKernel(t *testing.T) {
+	baseline := []string{"1.2.3.4"}
+	kernel := []string{"1.2.3.4", "9.9.9.9"} // 9.9.9.9 injected, no baseline/session source
+	res := CoverageDiff(baseline, kernel, nil)
+	if len(res.ExtraInKernel) != 1 || res.ExtraInKernel[0] != "9.9.9.9" {
+		t.Fatalf("expected 9.9.9.9 extra, got %v", res.ExtraInKernel)
+	}
+}
+
+func TestCoverage_SessionAllowance(t *testing.T) {
+	baseline := []string{"1.2.3.4"}
+	kernel := []string{"1.2.3.4", "5.6.7.8"}
+	sessions := []string{"5.6.7.8"} // 5.6.7.8 is a legit session entry, not "extra"
+	res := CoverageDiff(baseline, kernel, sessions)
+	if len(res.ExtraInKernel) != 0 {
+		t.Fatalf("session entry should not be extra, got %v", res.ExtraInKernel)
+	}
+}
+
+func TestCoverage_SingleIPCoveredByCIDR(t *testing.T) {
+	// Baseline lists a single IP; kernel covers it via a CIDR → not missing.
+	baseline := []string{"1.2.3.4"}
+	kernel := []string{"1.2.3.0/24"}
+	res := CoverageDiff(baseline, kernel, nil)
+	if len(res.MissingFromKernel) != 0 {
+		t.Fatalf("single IP should be covered by CIDR, got missing=%v", res.MissingFromKernel)
+	}
+}
+
+func TestCoverage_IPv6(t *testing.T) {
+	baseline := []string{"2606:4700::/32", "2a01:4f8:c014:f4da::1"}
+	kernel := []string{"2606:4700::/32", "2a01:4f8:c014:f4da::1"}
+	res := CoverageDiff(baseline, kernel, nil)
+	if len(res.MissingFromKernel) != 0 || len(res.ExtraInKernel) != 0 {
+		t.Fatalf("v6 exact match expected clean, got missing=%v extra=%v", res.MissingFromKernel, res.ExtraInKernel)
+	}
+	// v6 missing
+	res2 := CoverageDiff([]string{"2606:4700::/32"}, []string{"2a01:4f8::1"}, nil)
+	if len(res2.MissingFromKernel) != 1 {
+		t.Fatalf("expected v6 missing, got %v", res2.MissingFromKernel)
+	}
+}
+
+func TestCoverage_AdminIPMissingThenLive(t *testing.T) {
+	// The srv3 scenario: durable single IP absent from live kernel set.
+	res := CoverageDiff([]string{"62.38.150.122"}, []string{"46.224.164.50"}, nil)
+	if len(res.MissingFromKernel) != 1 || res.MissingFromKernel[0] != "62.38.150.122" {
+		t.Fatalf("expected admin IP missing, got %v", res.MissingFromKernel)
+	}
+	// after it is live:
+	res2 := CoverageDiff([]string{"62.38.150.122"}, []string{"46.224.164.50", "62.38.150.122"}, nil)
+	if len(res2.MissingFromKernel) != 0 {
+		t.Fatalf("admin IP should be covered now, got %v", res2.MissingFromKernel)
+	}
+}
+
+func TestIsTokenCoveredBy(t *testing.T) {
+	cases := []struct {
+		needle   string
+		hay      []string
+		want     bool
+	}{
+		{"62.38.150.122", []string{"62.38.150.122"}, true},
+		{"62.38.150.122", []string{"46.224.164.50"}, false},
+		{"1.2.3.4", []string{"1.2.3.0/24"}, true},
+		{"104.20.0.0/16", []string{"104.16.0.0-104.27.255.255"}, true}, // sub-range of interval
+		{"2606:4700::1", []string{"2606:4700::/32"}, true},
+		{"9.9.9.9", []string{"1.2.3.0/24", "10.0.0.0/8"}, false},
+	}
+	for _, c := range cases {
+		got, err := IsTokenCoveredBy(c.needle, c.hay)
+		if err != nil {
+			t.Fatalf("IsTokenCoveredBy(%q) err: %v", c.needle, err)
+		}
+		if got != c.want {
+			t.Fatalf("IsTokenCoveredBy(%q, %v) = %v, want %v", c.needle, c.hay, got, c.want)
+		}
+	}
+}
+
+func TestParseRangeToken_BadInput(t *testing.T) {
+	for _, bad := range []string{"", "not-an-ip", "1.2.3.4/99", "garbage-text"} {
+		if _, err := ParseRangeToken(bad); err == nil {
+			t.Fatalf("expected error for %q", bad)
+		}
+	}
+}
+
+func TestCoverage_BadTokensSurfaced(t *testing.T) {
+	res := CoverageDiff([]string{"1.2.3.4", "JUNK"}, []string{"1.2.3.4"}, nil)
+	if len(res.BadBaseline) != 1 || !strings.Contains(res.BadBaseline[0], "JUNK") {
+		t.Fatalf("expected JUNK surfaced as bad baseline, got %v", res.BadBaseline)
+	}
+}

--- a/internal/setsync/diff.go
+++ b/internal/setsync/diff.go
@@ -27,8 +27,39 @@ import (
 	"time"
 
 	"github.com/google/nftables"
+	"github.com/itcmsgr/nftban/internal/netutil"
 	"github.com/itcmsgr/nftban/internal/util"
 )
+
+// computeWhitelistRangeDiff produces a RANGE-AWARE add/remove plan for the
+// whitelist interval set (WHITELIST_DURABLE_APPLY_RECONCILE Step 4). Unlike the
+// string ComputeDiff: a desired CIDR COVERED by an existing kernel interval is
+// "unchanged" (not re-added), and a kernel interval covered by the desired set is
+// "unchanged" (not removed) — so a stable Cloudflare/trust config yields 0 churn.
+// currentRanges MUST come from GetSetElementsRanges (range-preserving). Unparseable
+// desired tokens fall back to exact membership so nothing is silently dropped.
+func computeWhitelistRangeDiff(desiredIPs, currentRanges []string) *DiffResult {
+	res := netutil.CoverageDiff(desiredIPs, currentRanges, nil)
+	d := &DiffResult{ToAdd: make([]string, 0), ToRemove: make([]string, 0)}
+	d.ToAdd = append(d.ToAdd, res.MissingFromKernel...)
+	d.ToRemove = append(d.ToRemove, res.ExtraInKernel...)
+	if len(res.BadBaseline) > 0 {
+		cur := make(map[string]struct{}, len(currentRanges))
+		for _, c := range currentRanges {
+			cur[c] = struct{}{}
+		}
+		for _, b := range res.BadBaseline {
+			if _, ok := cur[b]; !ok {
+				d.ToAdd = append(d.ToAdd, b)
+			}
+		}
+	}
+	d.Unchanged = len(desiredIPs) - len(d.ToAdd)
+	if d.Unchanged < 0 {
+		d.Unchanged = 0
+	}
+	return d
+}
 
 // DiffResult is a type alias for the generic util.DiffResult[string]
 // This maintains backwards compatibility while using the optimized generic implementation
@@ -88,15 +119,19 @@ func SyncWhitelistSetToNFT(nft *NFTManager, set *nftables.Set, desiredIPs []stri
 		TotalDesired: len(desiredIPs),
 	}
 
-	currentIPs, err := nft.GetSetElements(set)
+	// Range-preserving read: the whitelist set is an auto-merge INTERVAL set, so
+	// GetSetElements would return only interval starts as bare IPs (losing the
+	// range) → a string diff would churn CIDR<->interval forever. Use the
+	// range-aware reader + diff instead (compare COVERAGE, not text).
+	currentRanges, err := nft.GetSetElementsRanges(set)
 	if err != nil {
 		stats.Error = fmt.Errorf("failed to get current elements: %w", err)
 		stats.Duration = time.Since(startTime)
 		return stats, stats.Error
 	}
-	stats.TotalCurrent = len(currentIPs)
+	stats.TotalCurrent = len(currentRanges)
 
-	diff := ComputeDiff(desiredIPs, currentIPs)
+	diff := computeWhitelistRangeDiff(desiredIPs, currentRanges)
 	stats.IPsAdded = len(diff.ToAdd)
 	stats.IPsRemoved = len(diff.ToRemove)
 	stats.IPsUnchanged = diff.Unchanged
@@ -132,6 +167,25 @@ func SyncWhitelistSetToNFT(nft *NFTManager, set *nftables.Set, desiredIPs []stri
 			stats.Error = fmt.Errorf("failed to remove elements: %w", err)
 			stats.Duration = time.Since(startTime)
 			return stats, stats.Error
+		}
+	}
+
+	// Post-apply durable-coverage verification: every PERMANENT desired entry must
+	// now be covered by the live set. If any is still absent the reconcile silently
+	// failed (the srv3 symptom) — fail LOUD instead of reporting success.
+	permanentDesired := make([]string, 0, len(desiredIPs))
+	for _, ip := range desiredIPs {
+		if _, timed := remainingTimeout(expiry, ip, now); !timed {
+			permanentDesired = append(permanentDesired, ip)
+		}
+	}
+	if len(permanentDesired) > 0 {
+		if after, rerr := nft.GetSetElementsRanges(set); rerr == nil {
+			if v := netutil.CoverageDiff(permanentDesired, after, nil); len(v.MissingFromKernel) > 0 {
+				stats.Error = fmt.Errorf("durable whitelist entries NOT live after sync (reconcile failed): %v", v.MissingFromKernel)
+				stats.Duration = time.Since(startTime)
+				return stats, stats.Error
+			}
 		}
 	}
 

--- a/internal/setsync/nft_ranges_test.go
+++ b/internal/setsync/nft_ranges_test.go
@@ -1,0 +1,139 @@
+// =============================================================================
+// NFTBan - Tests for nftables interval range reconstruction
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="setsync_nft_ranges_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Tests for nftables interval range reconstruction"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package setsync
+
+import (
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/google/nftables"
+)
+
+// el builds a SetElement with the family-correct key length.
+func el(ip string, end bool) nftables.SetElement {
+	p := net.ParseIP(ip)
+	var k []byte
+	if v4 := p.To4(); v4 != nil {
+		k = v4
+	} else {
+		k = p.To16()
+	}
+	return nftables.SetElement{Key: k, IntervalEnd: end}
+}
+
+// TestReconstructIntervalRanges_ObservedStructure pins the EXACT element stream
+// observed from google/nftables on lab2 (NFTABLES_INTERVAL_ELEMENT_MODEL):
+//   - each logical entry = a START (IntervalEnd=false) + an EXCLUSIVE END (=last+1)
+//   - the END precedes its START in the stream
+//   - singletons get a paired end (X → X+1)
+//   - a trailing orphan wraparound end (0.0.0.0) is present
+// Set: { 8.8.8.8, 9.9.9.9, 62.38.150.122, 65.21.157.15, 104.16.0.0-104.27.255.255, 127.0.0.1 }
+func TestReconstructIntervalRanges_ObservedStructure(t *testing.T) {
+	elems := []nftables.SetElement{
+		el("127.0.0.2", true), el("127.0.0.1", false),
+		el("104.28.0.0", true), el("104.16.0.0", false),
+		el("65.21.157.16", true), el("65.21.157.15", false),
+		el("62.38.150.123", true), el("62.38.150.122", false),
+		el("9.9.9.10", true), el("9.9.9.9", false),
+		el("8.8.8.9", true), el("8.8.8.8", false),
+		el("0.0.0.0", true), // orphan wraparound end
+	}
+	got := reconstructIntervalRanges(elems)
+	want := []string{
+		"8.8.8.8", "9.9.9.9", "62.38.150.122", "65.21.157.15",
+		"104.16.0.0-104.27.255.255", "127.0.0.1",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !sortedEq(got, want) {
+		t.Fatalf("reconstructIntervalRanges mismatch:\n got=%v\nwant=%v", got, want)
+	}
+	// Guard against the prior bug: NO backwards range (start > end) must ever appear.
+	for _, tok := range got {
+		if i := indexByte(tok, '-'); i > 0 {
+			a := net.ParseIP(tok[:i])
+			b := net.ParseIP(tok[i+1:])
+			if a == nil || b == nil {
+				t.Fatalf("unparseable reconstructed range %q", tok)
+			}
+			if compareIP(a, b) > 0 {
+				t.Fatalf("BACKWARDS range produced: %q", tok)
+			}
+		}
+	}
+}
+
+func TestReconstructIntervalRanges_SingletonAndOrphanOnly(t *testing.T) {
+	// One singleton + the orphan end only.
+	got := reconstructIntervalRanges([]nftables.SetElement{
+		el("9.9.9.10", true), el("9.9.9.9", false), el("0.0.0.0", true),
+	})
+	if len(got) != 1 || got[0] != "9.9.9.9" {
+		t.Fatalf("got %v want [9.9.9.9]", got)
+	}
+}
+
+func TestReconstructIntervalRanges_IPv6(t *testing.T) {
+	// 2606:4700::/32 → start 2606:4700:: , exclusive end 2606:4701::
+	got := reconstructIntervalRanges([]nftables.SetElement{
+		el("2606:4701::", true), el("2606:4700::", false), el("::", true),
+	})
+	want := "2606:4700::-2606:4700:ffff:ffff:ffff:ffff:ffff:ffff"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("got %v want [%s]", got, want)
+	}
+}
+
+func TestReconstructIntervalRanges_HashSetNoEnds(t *testing.T) {
+	// Plain (non-interval) set: no IntervalEnd markers → each element is single IP.
+	got := reconstructIntervalRanges([]nftables.SetElement{
+		el("1.2.3.4", false), el("5.6.7.8", false),
+	})
+	sort.Strings(got)
+	if !sortedEq(got, []string{"1.2.3.4", "5.6.7.8"}) {
+		t.Fatalf("hash-set got %v", got)
+	}
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func compareIP(a, b net.IP) int {
+	a16, b16 := a.To16(), b.To16()
+	for i := 0; i < 16; i++ {
+		if a16[i] != b16[i] {
+			if a16[i] < b16[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/setsync/nft_ranges_test.go
+++ b/internal/setsync/nft_ranges_test.go
@@ -48,6 +48,7 @@ func el(ip string, end bool) nftables.SetElement {
 //   - the END precedes its START in the stream
 //   - singletons get a paired end (X → X+1)
 //   - a trailing orphan wraparound end (0.0.0.0) is present
+//
 // Set: { 8.8.8.8, 9.9.9.9, 62.38.150.122, 65.21.157.15, 104.16.0.0-104.27.255.255, 127.0.0.1 }
 func TestReconstructIntervalRanges_ObservedStructure(t *testing.T) {
 	elems := []nftables.SetElement{

--- a/internal/setsync/nft_sets.go
+++ b/internal/setsync/nft_sets.go
@@ -20,8 +20,10 @@
 package setsync
 
 import (
+	"bytes"
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/google/nftables"
 )
@@ -178,6 +180,92 @@ func (m *NFTManager) GetSetElements(set *nftables.Set) ([]string, error) {
 	}
 
 	return ips, nil
+}
+
+// decrementIP returns ip-1 (big-endian byte arithmetic). nftables interval END
+// markers are EXCLUSIVE (last_ip + 1), so the inclusive end is endKey - 1.
+func decrementIP(ip net.IP) net.IP {
+	b := make(net.IP, len(ip))
+	copy(b, ip)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] > 0 {
+			b[i]--
+			break
+		}
+		b[i] = 0xff
+	}
+	return b
+}
+
+// GetSetElementsRanges returns one token per set entry, reconstructing interval
+// ranges as "start-end" (or a single IP when start==end). Unlike GetSetElements
+// — which returns only interval STARTS as bare IPs and drops the range — this
+// preserves CIDR/range COVERAGE so a range-aware diff can compare coverage, not
+// strings (WHITELIST_DURABLE_APPLY_RECONCILE Step 4). nftables stores an interval
+// [a,b] as a start element (a) + an interval-end marker (b+1, exclusive).
+func (m *NFTManager) GetSetElementsRanges(set *nftables.Set) ([]string, error) {
+	elements, err := m.conn.GetSetElements(set)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get set elements: %w", err)
+	}
+	return reconstructIntervalRanges(elements), nil
+}
+
+// reconstructIntervalRanges is the PURE (unit-testable) range reconstruction,
+// separated from the netlink fetch. Empirically pinned model (lab2 probe,
+// NFTABLES_INTERVAL_ELEMENT_MODEL): nftables interval sets emit, per logical
+// entry, a START (IntervalEnd=false) and an EXCLUSIVE END (IntervalEnd=true, =
+// last+1); singletons get a paired end (X → X+1); the END precedes its START in
+// the stream; and there is a trailing orphan wraparound end (0.0.0.0). Intervals
+// are disjoint (auto-merge), so we sort starts+ends and, for each start, take the
+// smallest end strictly greater than it — which skips the orphan and never
+// produces a backwards range.
+func reconstructIntervalRanges(elements []nftables.SetElement) []string {
+	var starts, ends [][]byte
+	for _, elem := range elements {
+		k := append([]byte(nil), elem.Key...)
+		if elem.IntervalEnd {
+			ends = append(ends, k)
+		} else {
+			starts = append(starts, k)
+		}
+	}
+	// Plain (non-interval) set: no end markers → each element is a single IP.
+	if len(ends) == 0 {
+		out := make([]string, 0, len(starts))
+		for _, s := range starts {
+			out = append(out, net.IP(s).String())
+		}
+		return out
+	}
+	// nftables emits interval END markers (exclusive) and STARTs not necessarily
+	// adjacent, plus a trailing wraparound end (0.0.0.0). Intervals are disjoint,
+	// so: sort both ascending and, for each start, take the SMALLEST end strictly
+	// greater than it (two-pointer). This skips the orphan wraparound end and
+	// reconstructs each [start, end-1] correctly regardless of stream order.
+	sort.Slice(starts, func(i, j int) bool { return bytes.Compare(starts[i], starts[j]) < 0 })
+	sort.Slice(ends, func(i, j int) bool { return bytes.Compare(ends[i], ends[j]) < 0 })
+	out := make([]string, 0, len(starts))
+	ei := 0
+	for _, s := range starts {
+		for ei < len(ends) && bytes.Compare(ends[ei], s) <= 0 {
+			ei++ // skip ends at/below this start (incl. the wraparound 0.0.0.0)
+		}
+		if ei >= len(ends) {
+			// No end above this start — treat as a single IP (defensive).
+			out = append(out, net.IP(s).String())
+			continue
+		}
+		startIP := net.IP(s)
+		endIncl := decrementIP(net.IP(ends[ei]))
+		ei++
+		if startIP.Equal(endIncl) {
+			out = append(out, startIP.String())
+		} else {
+			out = append(out, startIP.String()+"-"+endIncl.String())
+		}
+	}
+	return out
 }
 
 // AddSetElements adds IPs to a set (batch operation with chunking)

--- a/internal/setsync/range_diff_test.go
+++ b/internal/setsync/range_diff_test.go
@@ -1,0 +1,110 @@
+// =============================================================================
+// NFTBan - Tests for range-aware whitelist diff
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="setsync_range_diff_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Tests for range-aware whitelist diff"
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package setsync
+
+import (
+	"net"
+	"sort"
+	"testing"
+)
+
+func sortedEq(a, b []string) bool {
+	sort.Strings(a)
+	sort.Strings(b)
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestComputeWhitelistRangeDiff_CloudflareNoChurn(t *testing.T) {
+	// Desired = adjacent CIDRs; kernel = coalesced interval (from GetSetElementsRanges).
+	desired := []string{"104.16.0.0/13", "104.24.0.0/14"}
+	current := []string{"104.16.0.0-104.27.255.255"}
+	d := computeWhitelistRangeDiff(desired, current)
+	if len(d.ToAdd) != 0 || len(d.ToRemove) != 0 {
+		t.Fatalf("expected 0 churn, got ToAdd=%v ToRemove=%v", d.ToAdd, d.ToRemove)
+	}
+}
+
+func TestComputeWhitelistRangeDiff_NewSingleIPOnCIDRHost(t *testing.T) {
+	desired := []string{"104.16.0.0/13", "104.24.0.0/14", "62.38.150.122"}
+	current := []string{"104.16.0.0-104.27.255.255"}
+	d := computeWhitelistRangeDiff(desired, current)
+	if !sortedEq(d.ToAdd, []string{"62.38.150.122"}) {
+		t.Fatalf("expected ToAdd=[62.38.150.122], got %v", d.ToAdd)
+	}
+	if len(d.ToRemove) != 0 {
+		t.Fatalf("expected no removals, got %v", d.ToRemove)
+	}
+}
+
+func TestComputeWhitelistRangeDiff_RealExtraRemoved(t *testing.T) {
+	desired := []string{"1.2.3.4"}
+	current := []string{"1.2.3.4", "9.9.9.9"}
+	d := computeWhitelistRangeDiff(desired, current)
+	if len(d.ToAdd) != 0 {
+		t.Fatalf("expected no adds, got %v", d.ToAdd)
+	}
+	if !sortedEq(d.ToRemove, []string{"9.9.9.9"}) {
+		t.Fatalf("expected ToRemove=[9.9.9.9], got %v", d.ToRemove)
+	}
+}
+
+func TestComputeWhitelistRangeDiff_IPCoveredByKernelInterval(t *testing.T) {
+	// A desired single IP already covered by a live interval → not re-added.
+	desired := []string{"104.20.0.5"}
+	current := []string{"104.16.0.0-104.27.255.255"}
+	d := computeWhitelistRangeDiff(desired, current)
+	if len(d.ToAdd) != 0 {
+		t.Fatalf("covered IP must not be re-added, got %v", d.ToAdd)
+	}
+}
+
+func TestComputeWhitelistRangeDiff_IPv6(t *testing.T) {
+	desired := []string{"2606:4700::/32"}
+	current := []string{"2606:4700::-2606:4700:ffff:ffff:ffff:ffff:ffff:ffff"}
+	d := computeWhitelistRangeDiff(desired, current)
+	if len(d.ToAdd) != 0 || len(d.ToRemove) != 0 {
+		t.Fatalf("v6 coverage-equivalent expected 0 churn, got ToAdd=%v ToRemove=%v", d.ToAdd, d.ToRemove)
+	}
+}
+
+func TestDecrementIP(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"104.28.0.0", "104.27.255.255"},
+		{"1.2.3.5", "1.2.3.4"},
+		{"10.0.0.0", "9.255.255.255"},
+	}
+	for _, c := range cases {
+		got := decrementIP(net.ParseIP(c.in).To4())
+		if got.String() != c.want {
+			t.Fatalf("decrementIP(%s)=%s want %s", c.in, got.String(), c.want)
+		}
+	}
+}


### PR DESCRIPTION
## WHITELIST_DURABLE_APPLY_RECONCILE — trusted-must-be-live invariant

Closes the P1/P2 invariant: a durable `whitelist.d` entry must be **live in the kernel whitelist set**. Audited: `WHITELIST_DURABLE_APPLY_RECONCILE_INDEPENDENT_AUDIT.md` → **PASS_WITH_WARNINGS_READY_FOR_PR_MERGE** (warnings cleared).

### Root cause
The whitelist set is an `interval, auto-merge` set; the kernel coalesces adjacent CIDRs (`104.16.0.0/13 + 104.24.0.0/14 → 104.16.0.0-104.27.255.255`). The daemon's `setsync` used a **string** `ComputeDiff` against the coalesced interval → spurious `+2/-1` churn every sync that could drop genuinely-new durable entries (the srv3 admin-IP-not-live symptom). The same mismatch made `whitelist verify` report phantom Cloudflare drift.

### Fix (range coverage, not strings)
- `internal/netutil/coverage.go` — range-aware coverage oracle (IPv4+IPv6; IP/CIDR/nft-interval; CIDR ≡ coalesced interval).
- `cmd/nftban-core` `whitelist-coverage` subcommand; `nftban whitelist verify` rewired → **phantom anomalies eliminated**.
- `cmd_whitelist.sh` — `--static` add **live read-back / loud-fail** (rc≠0, no false "applied live").
- `internal/setsync` — `GetSetElementsRanges` range-preserving reader (`reconstructIntervalRanges`, two-pointer; nftables element model **pinned by unit test** `NFTABLES_INTERVAL_ELEMENT_MODEL.md`) + `computeWhitelistRangeDiff` (**0 churn** on stable CIDR sets) + **post-apply durable-coverage verification** (FullSync fails loud if a permanent durable entry isn't live).

### Declarations
- **`nftband` daemon RE-BASELINED** — `internal/setsync` links into the daemon → the `nftband` hash **changes** (do **not** assert byte-identity). This is intentional and matches `WHITELIST_DURABLE_RECONCILE_DAEMON_IMPACT_DECLARATION.md`.
- **nft `SchemaVersionCurrent` stays 1.84.0** (no set-shape/schema change).
- **No release-prep files** · no portscan / BotGuard / detector changes · no srv3 rebuild / fleet mutation.

### Validation
- Commit lineage: `e17871d3` (impl) + `aa95ae4f` (pre-PR cleanup: drop orphan `IsTokenCoveredBy` + gofmt).
- netutil + setsync unit tests (incl. `TestReconstructIntervalRanges_ObservedStructure` against the exact probed nftables stream) · go vet · builds — all green (lab2).
- **Package-native lab2 (DEB) 19/0 + lab4 (RPM) 19/0** — 0-churn / clean-interval / new-`--static`-IP-lands / loud-fail / manual+trust+system tier reconcile / session-preserved / health / labs restored clean.

Docs: `..._SCOPE.md`, `..._FINDINGS.md` (srv3), `..._DAEMON_IMPACT_DECLARATION.md`, `NFTABLES_INTERVAL_ELEMENT_MODEL.md`, `..._INDEPENDENT_AUDIT.md`.