### PR TITLE
Fix blacklist.d feed-reload fail-open topology

### DIFF
--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -217,18 +217,27 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 			log.Printf("[SYNC] Warning: blacklist.d IPv6 %s -> manual hash set: %v", ip, err)
 		}
 	}
-	// The feed/geoban-owned interval sets receive ONLY blacklist.d CIDRs now (single
-	// IPs are repointed above); CIDR ownership is the next checkpoint.
-	blacklistIPv4 = blacklistIPv4CIDR
-	blacklistIPv6 = blacklistIPv6CIDR
+	// INC3 (BLACKLIST_TOPOLOGY_CLEANUP, Option A): blacklist.d CIDRs are folded into the
+	// SAME canonical replace as feeds + geoban (below) so the flush-first replace OWNS
+	// them and they survive feed reload. The interval blacklist sets are therefore NOT
+	// synced via FullSync's string diff anymore (nil below) — replaceSetElementsViaFile
+	// is the SOLE writer of blacklist_ipv4/_ipv6. Combining all CIDR sources into ONE
+	// replace also closes a pre-existing feed-vs-geoban clobber (two sequential pure
+	// replaces → last source wins). Single IPs were already repointed to the hash sets
+	// above. IPv4+IPv6.
+	_ = blacklistIPv4 // single IPs handled above; CIDRs flow through the unified replace
+	_ = blacklistIPv6
+	unifiedBlacklistV4 := append([]string(nil), blacklistIPv4CIDR...)
+	unifiedBlacklistV6 := append([]string(nil), blacklistIPv6CIDR...)
 
-	// Perform full sync
+	// Perform full sync — WHITELIST ONLY here. The interval blacklist sets are owned by
+	// the unified CIDR replace below; the manual hash sets by AddIPWithTimeout above.
 	result, err := nftsync.FullSync(
 		nft,
 		whitelistIPv4Set, whitelistIPv6Set,
-		blacklistIPv4Set, blacklistIPv6Set,
+		nil, nil,
 		whitelistIPv4, whitelistIPv6,
-		blacklistIPv4, blacklistIPv6,
+		nil, nil,
 		whitelistExpiry,
 	)
 
@@ -307,35 +316,20 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 				feedsMemNeeded = estimatedFeedBytes
 				// Skip feeds but continue with sync - don't fail entirely
 			} else {
-			// v2.1: Load feeds into unified blacklist_ipv4/ipv6 sets (CIDR aggregated)
-			// All ban sources now use the same blacklist - daemon tracks source in DB
+			// INC3: queue feed CIDRs for the unified canonical replace (feeds + geoban +
+			// blacklist.d CIDRs in ONE flush-first replace; replaceSetElementsViaFile is
+			// the sole writer of the shared blacklist_ipv4/_ipv6 interval sets).
 			if len(ipv4CIDRs) > 0 {
-				feedSetV4, err := nft.GetOrCreateIntervalSet(tableIPv4, "blacklist_ipv4", true)
-				if err != nil {
-					log.Printf("[SYNC] Warning: Failed to get blacklist_ipv4 set: %v", err)
-				} else {
-					if stats, err := nft.AddCIDRElementsWithStats(feedSetV4, ipv4CIDRs); err != nil {
-						log.Printf("[SYNC] Warning: Failed to load feeds IPv4: %v", err)
-					} else if stats != nil {
-						feedsIPv4Loaded = stats.OutputRanges
-						log.Printf("[SYNC] Feeds IPv4: loaded %d ranges (from %d input CIDRs)", stats.OutputRanges, stats.InputCIDRs)
-					}
-				}
+				unifiedBlacklistV4 = append(unifiedBlacklistV4, ipv4CIDRs...)
+				feedsIPv4Loaded = len(ipv4CIDRs)
+				log.Printf("[SYNC] Feeds IPv4: %d input CIDRs queued for unified replace", len(ipv4CIDRs))
 			}
 
-			// Load IPv6 feeds into unified blacklist_ipv6 set
+			// IPv6 feeds → unified replace
 			if len(ipv6CIDRs) > 0 {
-				feedSetV6, err := nft.GetOrCreateIntervalSet(tableIPv6, "blacklist_ipv6", false)
-				if err != nil {
-					log.Printf("[SYNC] Warning: Failed to get blacklist_ipv6 set: %v", err)
-				} else {
-					if stats, err := nft.AddCIDRElementsWithStats(feedSetV6, ipv6CIDRs); err != nil {
-						log.Printf("[SYNC] Warning: Failed to load feeds IPv6: %v", err)
-					} else if stats != nil {
-						feedsIPv6Loaded = stats.OutputRanges
-						log.Printf("[SYNC] Feeds IPv6: loaded %d ranges (from %d input CIDRs)", stats.OutputRanges, stats.InputCIDRs)
-					}
-				}
+				unifiedBlacklistV6 = append(unifiedBlacklistV6, ipv6CIDRs...)
+				feedsIPv6Loaded = len(ipv6CIDRs)
+				log.Printf("[SYNC] Feeds IPv6: %d input CIDRs queued for unified replace", len(ipv6CIDRs))
 			}
 			// Memory cleanup: clear CIDR slices after loading to nftables
 			// These slices can hold 100-200MB that's no longer needed
@@ -394,35 +388,21 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 					geobanMemNeeded = estimatedGeoBytes
 					// Skip geoban but continue with sync - don't fail entirely
 				} else {
-				// v2.1: Load geoban CIDRs into unified blacklist_ipv4/ipv6 sets
-				// All ban sources now use the same blacklist - CIDR aggregation prevents duplicates
+				// INC3: queue geoban CIDRs for the unified canonical replace (feeds +
+				// geoban + blacklist.d CIDRs in ONE flush-first replace — closes the
+				// pre-existing feed-vs-geoban clobber where the second replace wiped the
+				// first). All ban sources share blacklist_ipv4/_ipv6.
 				if len(geobanData.IPv4) > 0 {
-					geoSetV4, err := nft.GetOrCreateIntervalSet(tableIPv4, "blacklist_ipv4", true)
-					if err != nil {
-						log.Printf("[SYNC] Warning: Failed to get blacklist_ipv4 set: %v", err)
-					} else {
-						if stats, err := nft.AddCIDRElementsWithStats(geoSetV4, geobanData.IPv4); err != nil {
-							log.Printf("[SYNC] Warning: Failed to load geoban IPv4: %v", err)
-						} else if stats != nil {
-							geobanIPv4Loaded = stats.OutputRanges
-							log.Printf("[SYNC] Geoban IPv4: loaded %d ranges (from %d input CIDRs)", stats.OutputRanges, stats.InputCIDRs)
-						}
-					}
+					unifiedBlacklistV4 = append(unifiedBlacklistV4, geobanData.IPv4...)
+					geobanIPv4Loaded = len(geobanData.IPv4)
+					log.Printf("[SYNC] Geoban IPv4: %d input CIDRs queued for unified replace", len(geobanData.IPv4))
 				}
 
-				// Load IPv6 geoban CIDRs into unified blacklist_ipv6 set
+				// IPv6 geoban → unified replace
 				if len(geobanData.IPv6) > 0 {
-					geoSetV6, err := nft.GetOrCreateIntervalSet(tableIPv6, "blacklist_ipv6", false)
-					if err != nil {
-						log.Printf("[SYNC] Warning: Failed to get blacklist_ipv6 set: %v", err)
-					} else {
-						if stats, err := nft.AddCIDRElementsWithStats(geoSetV6, geobanData.IPv6); err != nil {
-							log.Printf("[SYNC] Warning: Failed to load geoban IPv6: %v", err)
-						} else if stats != nil {
-							geobanIPv6Loaded = stats.OutputRanges
-							log.Printf("[SYNC] Geoban IPv6: loaded %d ranges (from %d input CIDRs)", stats.OutputRanges, stats.InputCIDRs)
-						}
-					}
+					unifiedBlacklistV6 = append(unifiedBlacklistV6, geobanData.IPv6...)
+					geobanIPv6Loaded = len(geobanData.IPv6)
+					log.Printf("[SYNC] Geoban IPv6: %d input CIDRs queued for unified replace", len(geobanData.IPv6))
 				}
 				// Memory cleanup: clear geoban data to allow garbage collection
 				// Geoban can hold 200-400MB that's no longer needed after loading
@@ -435,6 +415,30 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 		}
 		} // end else ShouldSkipGeoban
 	} // end if !quickMode (geoban)
+
+	// INC3: ONE canonical replace of the interval blacklist sets with the UNION of
+	// feeds + geoban + blacklist.d CIDRs. AddCIDRElementsWithStats →
+	// replaceSetElementsViaFile (flush+add in a single nft -f) is the SOLE writer of
+	// blacklist_ipv4/_ipv6 → no feed/geoban/blacklist.d clobber, no string-diff churn,
+	// blacklist.d CIDRs survive feed reload. Skipped if a source was memory-pressure
+	// skipped (the union would be incomplete → don't partial-replace and wipe the
+	// skipped source's prior content) or in quickMode (feeds/geoban deferred). IPv4+IPv6.
+	if !quickMode && !feedsSkipped && !geobanSkipped {
+		if len(unifiedBlacklistV4) > 0 {
+			if _, err := nft.AddCIDRElementsWithStats(blacklistIPv4Set, unifiedBlacklistV4); err != nil {
+				log.Printf("[SYNC] Warning: unified blacklist_ipv4 replace failed: %v", err)
+			} else {
+				log.Printf("[SYNC] Unified blacklist_ipv4 replace: %d input CIDRs (feeds+geoban+blacklist.d)", len(unifiedBlacklistV4))
+			}
+		}
+		if len(unifiedBlacklistV6) > 0 {
+			if _, err := nft.AddCIDRElementsWithStats(blacklistIPv6Set, unifiedBlacklistV6); err != nil {
+				log.Printf("[SYNC] Warning: unified blacklist_ipv6 replace failed: %v", err)
+			} else {
+				log.Printf("[SYNC] Unified blacklist_ipv6 replace: %d input CIDRs (feeds+geoban+blacklist.d)", len(unifiedBlacklistV6))
+			}
+		}
+	}
 
 	// Force garbage collection after large sync to release memory immediately
 	// Without this, ~800MB-1.3GB can remain allocated until next GC cycle
@@ -469,10 +473,14 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 		"whitelist_ipv4_removed": result.WhitelistIPv4.IPsRemoved,
 		"whitelist_ipv6_added":   result.WhitelistIPv6.IPsAdded,
 		"whitelist_ipv6_removed": result.WhitelistIPv6.IPsRemoved,
-		"blacklist_ipv4_added":   result.BlacklistIPv4.IPsAdded,
-		"blacklist_ipv4_removed": result.BlacklistIPv4.IPsRemoved,
-		"blacklist_ipv6_added":   result.BlacklistIPv6.IPsAdded,
-		"blacklist_ipv6_removed": result.BlacklistIPv6.IPsRemoved,
+		// INC3: interval blacklist sets are now replace-based (not string-diff via
+		// FullSync), so there are no per-sync add/removed diff counts here. result
+		// .BlacklistIPv4/IPv6 are nil (FullSync skipped them) — report 0 and rely on
+		// feeds/geoban loaded counts below + the unified replace logs.
+		"blacklist_ipv4_added":   0,
+		"blacklist_ipv4_removed": 0,
+		"blacklist_ipv6_added":   0,
+		"blacklist_ipv6_removed": 0,
 		"feeds_ipv4_loaded":      feedsIPv4Loaded,
 		"feeds_ipv6_loaded":      feedsIPv6Loaded,
 		"geoban_ipv4_loaded":     geobanIPv4Loaded,

--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -195,8 +195,13 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 	// file-backed (operator hand-edited / persist-only) bans stop being enforced once
 	// feeds load (BUG-BLACKLIST-FILE-ENTRY-FAIL-OPEN-ON-FEED-RELOAD). Add single IPs
 	// (add-only, permanent) to the hash sets — the feed replace never touches hash
-	// sets, and periodic reconciliation adopts them. Only CIDR blacklist.d entries
-	// continue to the interval path (pending the CIDR-policy checkpoint). IPv4+IPv6.
+	// sets, so these survive feed reload. The hash entries are OWNED by this sync/load
+	// routing (re-added every sync); removal is owned by `nftban unban` (UnpersistBan +
+	// kernel delete) or explicit blacklist.d file-removal handling — NOT by passive
+	// reconciliation (which is record-only and never prunes the kernel set). A removed
+	// file-edit therefore persists until unban (over-ban / fail-closed). Only CIDR
+	// blacklist.d entries continue to the interval path (folded into the unified
+	// replace below). IPv4+IPv6.
 	blacklistIPv4Single, blacklistIPv4CIDR := partitionCIDRTokens(blacklistIPv4)
 	blacklistIPv6Single, blacklistIPv6CIDR := partitionCIDRTokens(blacklistIPv6)
 	manualV4Set, err := nft.GetOrCreateHashSet(tableIPv4, "blacklist_manual_ipv4", true)

--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -188,6 +188,40 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 	whitelistIPv4, whitelistIPv6, whitelistExpiry := state.GetWhitelistSnapshotWithExpiry()
 	blacklistIPv4, blacklistIPv6 := state.GetBlacklistSnapshot()
 
+	// INC2 (BLACKLIST_TOPOLOGY_CLEANUP): blacklist.d single-IP entries belong in the
+	// manual HASH sets (blacklist_manual_*), NOT the feed/geoban-owned interval sets.
+	// Previously they were string-diffed into blacklist_ipv4/_ipv6 via FullSync, then
+	// silently WIPED by the feed/geoban flush-first replace — a fail-open where
+	// file-backed (operator hand-edited / persist-only) bans stop being enforced once
+	// feeds load (BUG-BLACKLIST-FILE-ENTRY-FAIL-OPEN-ON-FEED-RELOAD). Add single IPs
+	// (add-only, permanent) to the hash sets — the feed replace never touches hash
+	// sets, and periodic reconciliation adopts them. Only CIDR blacklist.d entries
+	// continue to the interval path (pending the CIDR-policy checkpoint). IPv4+IPv6.
+	blacklistIPv4Single, blacklistIPv4CIDR := partitionCIDRTokens(blacklistIPv4)
+	blacklistIPv6Single, blacklistIPv6CIDR := partitionCIDRTokens(blacklistIPv6)
+	manualV4Set, err := nft.GetOrCreateHashSet(tableIPv4, "blacklist_manual_ipv4", true)
+	if err != nil {
+		return SocketResponse{Success: false, Error: "failed to get/create blacklist_manual_ipv4 set: " + err.Error()}
+	}
+	manualV6Set, err := nft.GetOrCreateHashSet(tableIPv6, "blacklist_manual_ipv6", false)
+	if err != nil {
+		return SocketResponse{Success: false, Error: "failed to get/create blacklist_manual_ipv6 set: " + err.Error()}
+	}
+	for _, ip := range blacklistIPv4Single {
+		if err := nft.AddIPWithTimeout(manualV4Set, ip, 0); err != nil {
+			log.Printf("[SYNC] Warning: blacklist.d IPv4 %s -> manual hash set: %v", ip, err)
+		}
+	}
+	for _, ip := range blacklistIPv6Single {
+		if err := nft.AddIPWithTimeout(manualV6Set, ip, 0); err != nil {
+			log.Printf("[SYNC] Warning: blacklist.d IPv6 %s -> manual hash set: %v", ip, err)
+		}
+	}
+	// The feed/geoban-owned interval sets receive ONLY blacklist.d CIDRs now (single
+	// IPs are repointed above); CIDR ownership is the next checkpoint.
+	blacklistIPv4 = blacklistIPv4CIDR
+	blacklistIPv6 = blacklistIPv6CIDR
+
 	// Perform full sync
 	result, err := nftsync.FullSync(
 		nft,
@@ -699,6 +733,20 @@ func (d *Daemon) loadCIDRsIntoSets(setType string, ipv4CIDRs, ipv6CIDRs []string
 		Success: true,
 		Data:    data,
 	}
+}
+
+// partitionCIDRTokens splits blacklist tokens into single IPs (no "/") and CIDRs
+// ("/"). Used by the sync handler to route blacklist.d single IPs to the manual
+// hash sets while CIDRs continue to the interval path (BLACKLIST_TOPOLOGY_CLEANUP).
+func partitionCIDRTokens(items []string) (singles, cidrs []string) {
+	for _, it := range items {
+		if strings.Contains(it, "/") {
+			cidrs = append(cidrs, it)
+		} else {
+			singles = append(singles, it)
+		}
+	}
+	return singles, cidrs
 }
 
 // handleReplaceSetRequest handles bulk replace_set operations via file


### PR DESCRIPTION
## BLACKLIST_TOPOLOGY_CLEANUP — blacklist.d ban ownership / feed-reload fail-open

Commits: `fdefa09b` (INC2 — blacklist.d single IP → `blacklist_manual_*`) · `bc090bdb` (INC3 — blacklist.d CIDR → unified replace).

### Closed
- **`BUG-BLACKLIST-FILE-ENTRY-FAIL-OPEN-ON-FEED-RELOAD`** — file-backed `blacklist.d` bans were silently un-enforced once feeds loaded:
  - blacklist.d **single-IP** file-backed bans wiped by feed reload.
  - blacklist.d **CIDR** file-backed bans wiped by feed reload.
- **Incidental: feed-vs-geoban clobber** — feeds and geoban each did a separate full flush-first replace of `blacklist_ipv4/_ipv6`, so the second source wiped the first.

Root cause: `blacklist_ipv4/_ipv6` are `interval,auto-merge` sets owned by the feed/geoban flush-first replace (`replaceSetElementsViaFile`); the sync ALSO string-diffed `blacklist.d` into them via `FullSync`→`SyncSetToNFT`, and the feed/geoban replace then wiped those entries.

### Key behavior
- blacklist.d **single IPs** route to `blacklist_manual_ipv4/_ipv6` (hash sets; the feed replace never touches them; reconciliation adopts them).
- blacklist.d **CIDRs** fold into the **unified** feed/geoban canonical replace input (one `AddCIDRElementsWithStats`→`replaceSetElementsViaFile` per family).
- `blacklist_ipv4/_ipv6` interval sets now have **one canonical replace writer** (no string-diff path).
- The masked `SyncSetToNFT(blacklist_ipv4/_ipv6, blacklist.d)` is **retargeted** — `FullSync` is passed `nil` for the interval blacklist sets, so it no longer writes them.
- **CLI/IPC `nftban ban` behavior unchanged** (manual hash sets).
- **`unban` clears all relevant live copies** (no stale interval duplicate).
- **IPv4 + IPv6 lock-step** (every change symmetric across families).

### Declarations
- **`nftband` daemon RE-BASELINED** (`cmd/nftband/daemon_handlers_sync.go`) — daemon hash moves; not byte-identical with v1.202.0.
- **nft `SchemaVersionCurrent` stays 1.84.0** (no set-shape/schema change; no new set).
- **No portscan / BotGuard / detector / schema change.** No new CLI command.

### Validation
- **Package-native CI build:** [run 28161680101](https://github.com/itcmsgr/nftban/actions/runs/28161680101).
- **lab2 (DEB) PASS + lab4 (RPM) PASS** on installed packages (not source overlay): INC2 single-IP + INC3 CIDR survive feed reload, coexist with real feeds (lab4 1262 ranges), no clobber, no malformed intervals, CLI/unban OK, COMMITTED/validate rc0/0 failed/schema 1.84.0/BotGuard off/admin preserved, v4+v6. Both labs restored to published v1.202.0 (daemon swapped back — no branch-build leak).
- Docs: `BLACKLIST_INC0_5_LAB_CHARACTERIZATION.md`, `BLACKLIST_FILE_ENTRY_SEVERITY_TRIAGE.md`, `BLACKLIST_TOPOLOGY_CLEANUP_SCOPE.md`, `..._INC2_LAB_SOURCE_DEPLOY_REPORT.md`.

No release-prep in this PR (no VERSION/CHANGELOG/STATUS/FHS edits) — release-prep (~v1.203.0) is a separate later gate.