### PR TITLE
v1.204.0 portscan Go-classifier migration

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -693,9 +693,83 @@ nftban_portscan_classic_analyze_all() {
     return 0
 }
 
+# v1.204 PORTSCAN GO-CLASSIFIER: read the live known-open service-port set
+# (tcp_ports_in) so the Go classifier can EXCLUDE those ports from scan scoring.
+# These ports are allowed context, never scan evidence.
+_nftban_portscan_classic_known_open_ports() {
+    local fam_table="${NFTBAN_TABLE_IPV4:-ip nftban}"
+    nft list set ${fam_table} tcp_ports_in 2>/dev/null \
+        | tr ',{}' '\n' | grep -oE '[0-9]+' | sort -un | tr '\n' ' '
+}
+
+# v1.204: obtain the TYPED Go verdict for one IP. Builds the per-IP request JSON
+# (events from the tracked ports/target/timestamps + known-open set + thresholds),
+# pipes it to `nftban-core portscan-classify`, logs the old-vs-new shadow line, and
+# echoes the Go scan_type (empty when action=allow). Pure decision call — the shell
+# (root) remains the log reader; nftban-core does not read logs or write sets.
+_nftban_portscan_classic_go_verdict() {
+    local ip="$1" family="${2:-ipv4}"
+    local core_bin="${NFTBAN_CORE_BIN:-/usr/lib/nftban/bin/nftban-core}"
+    [[ -x "$core_bin" ]] || { echo ""; return 0; }
+
+    local ports="${_PORTSCAN_CLASSIC_IP_PORTS[$ip]:-}"
+    local targets="${_PORTSCAN_CLASSIC_IP_TARGETS[$ip]:-}"
+    local timestamps="${_PORTSCAN_CLASSIC_IP_TIMESTAMPS[$ip]:-}"
+    local one_target; one_target=$(echo "$targets" | tr ' ' '\n' | grep -v '^$' | head -1)
+    local known_open; known_open=$(_nftban_portscan_classic_known_open_ports)
+
+    # Build events[] (pair each port with the IP's first target + a timestamp).
+    local -a parr tarr
+    IFS=$' \t\n' read -ra parr <<< "$ports"
+    IFS=$' \t\n' read -ra tarr <<< "$timestamps"
+    local events="" i=0 sep=""
+    for p in "${parr[@]}"; do
+        [[ "$p" =~ ^[0-9]+$ ]] || continue
+        local ts="${tarr[$i]:-0}"; [[ "$ts" =~ ^[0-9]+$ ]] || ts=0
+        events+="${sep}{\"port\":${p},\"target\":\"${one_target}\",\"ts\":${ts}}"; sep=","
+        i=$((i+1))
+    done
+    local ko_json; ko_json=$(echo "$known_open" | tr ' ' '\n' | grep -E '^[0-9]+$' | paste -sd, -)
+
+    local req
+    req=$(printf '{"ip":"%s","family":"%s","known_open_ports":[%s],"block_range":%s,"vertical_ports":%s,"horizontal_targets":%s,"strobe_ports":%s,"strobe_window_sec":10,"events":[%s]}' \
+        "$ip" "$family" "${ko_json:-}" "${PORTSCAN_CLASSIC_BLOCK_RANGE:-0}" "${PORTSCAN_CLASSIC_VERTICAL_PORTS:-0}" \
+        "${PORTSCAN_CLASSIC_HORIZONTAL_TARGETS:-0}" "${PORTSCAN_CLASSIC_STROBE_PORTS:-0}" "$events")
+
+    local verdict; verdict=$(printf '%s' "$req" | "$core_bin" portscan-classify 2>/dev/null) || { echo ""; return 0; }
+    local scan_type action kc uc
+    scan_type=$(printf '%s' "$verdict" | grep -oE '"scan_type":"[^"]*"' | cut -d'"' -f4)
+    action=$(printf '%s' "$verdict" | grep -oE '"action":"[^"]*"' | cut -d'"' -f4)
+    kc=$(printf '%s' "$verdict" | grep -oE '"known_open_count":[0-9]+' | grep -oE '[0-9]+')
+    uc=$(printf '%s' "$verdict" | grep -oE '"unexpected_count":[0-9]+' | grep -oE '[0-9]+')
+
+    # Shadow line: old shell verdict (total-port-count heuristic) vs new Go verdict.
+    local old_pc; old_pc=$(echo "$ports" | tr ' ' '\n' | grep -v '^$' | sort -u | wc -l)
+    local old_v="none"
+    [[ ${old_pc:-0} -ge ${PORTSCAN_CLASSIC_VERTICAL_PORTS:-99999} || ${old_pc:-0} -ge ${PORTSCAN_CLASSIC_STROBE_PORTS:-99999} ]] && old_v="ban-capable"
+    _nftban_portscan_classic_log "INFO" "PORTSCAN_SHADOW old=${old_v} new=${scan_type:-none} known_open_count=${kc:-0} unexpected_count=${uc:-0} family=${family} src_ip=${ip} action=${action:-allow}"
+
+    [[ "$action" == "ban" ]] && echo "$scan_type" || echo ""
+}
+
 # Detect what type of scan an IP is performing
 nftban_portscan_classic_detect_scan_type() {
     local ip="$1"
+
+    # v1.204 PORTSCAN GO-CLASSIFIER mode gate (default shadow = safe, no behavior
+    # change; 'go' enforces the typed known-open-aware verdict [the FP fix]; 'shell'
+    # = legacy). Shadow/go both emit the old-vs-new shadow audit line.
+    local classifier_mode="${PORTSCAN_CLASSIC_CLASSIFIER:-shadow}"
+    local family="ipv4"; [[ "$ip" == *:* ]] && family="ipv6"
+    if [[ "$classifier_mode" == "go" || "$classifier_mode" == "shadow" ]]; then
+        local go_scan; go_scan=$(_nftban_portscan_classic_go_verdict "$ip" "$family")
+        if [[ "$classifier_mode" == "go" ]]; then
+            # Authoritative: the Go classifier owns the verdict (known-open excluded).
+            [[ -n "$go_scan" ]] && { echo "$go_scan"; return 0; }
+            return 1
+        fi
+        # shadow: comparison logged above; legacy shell logic below still enforces.
+    fi
 
     local ports="${_PORTSCAN_CLASSIC_IP_PORTS[$ip]:-}"
     local targets="${_PORTSCAN_CLASSIC_IP_TARGETS[$ip]:-}"

--- a/cmd/nftban-core/cmd_portscan_classify.go
+++ b/cmd/nftban-core/cmd_portscan_classify.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="cmd_portscan_classify"
+// meta:type="cli-subcommand"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="v1.204 PORTSCAN GO-CLASSIFIER: reads a per-source-IP classification request as JSON on stdin (events + known-open ports + thresholds), runs internal/portscan.Classify (scores only unexpected/closed ports; known-open service ports never accrue scan score), emits the Verdict JSON on stdout. Pure decision function — does NOT read logs or write nft sets; fed pre-parsed events by the existing root log reader (input-authority identity unchanged). CLI-only (nftban-core); does NOT touch the nftband daemon."
+// meta:input="stdin JSON: {ip,family,events:[{port,target,ts}],known_open_ports:[],block_range,vertical_ports,horizontal_targets,strobe_ports,strobe_window_sec}"
+// meta:output="stdout JSON Verdict {scan_type,known_open_count,unexpected_count,target_count,action,family,src_ip}; exit 0=classified, 2=input error"
+// meta:depends="internal/portscan"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/itcmsgr/nftban/internal/portscan"
+)
+
+type portscanClassifyRequest struct {
+	IP                string           `json:"ip"`
+	Family            string           `json:"family"`
+	Events            []portscan.Event `json:"events"`
+	KnownOpenPorts    []int            `json:"known_open_ports"`
+	BlockRange        int              `json:"block_range"`
+	VerticalPorts     int              `json:"vertical_ports"`
+	HorizontalTargets int              `json:"horizontal_targets"`
+	StrobePorts       int              `json:"strobe_ports"`
+	StrobeWindowSec   int64            `json:"strobe_window_sec"`
+}
+
+// cmdPortscanClassify reads a JSON classification request on stdin and writes the
+// Verdict JSON to stdout. Used by the shell classic/suricata classifier to obtain
+// the typed scan verdict (known-open-aware) instead of the old shell scoring.
+func cmdPortscanClassify(args []string) int {
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "portscan-classify: read stdin: %v\n", err)
+		return 2
+	}
+	var req portscanClassifyRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		fmt.Fprintf(os.Stderr, "portscan-classify: bad JSON input: %v\n", err)
+		return 2
+	}
+	v := portscan.Classify(portscan.Input{
+		IP:                req.IP,
+		Family:            req.Family,
+		Events:            req.Events,
+		KnownOpenPorts:    req.KnownOpenPorts,
+		BlockRange:        req.BlockRange,
+		VerticalPorts:     req.VerticalPorts,
+		HorizontalTargets: req.HorizontalTargets,
+		StrobePorts:       req.StrobePorts,
+		StrobeWindowSec:   req.StrobeWindowSec,
+	})
+	out, err := json.Marshal(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "portscan-classify: marshal verdict: %v\n", err)
+		return 2
+	}
+	fmt.Println(string(out))
+	return 0
+}

--- a/cmd/nftban-core/main.go
+++ b/cmd/nftban-core/main.go
@@ -170,6 +170,12 @@ func main() {
 		// (reads {baseline,kernel,sessions} JSON on stdin). CLI-only oracle for
 		// `nftban whitelist verify` + the `--static` add live read-back.
 		os.Exit(cmdWhitelistCoverage(os.Args[2:]))
+	case "portscan-classify":
+		// v1.204 PORTSCAN GO-CLASSIFIER: typed scan-type classifier (reads per-IP
+		// {events,known_open_ports,thresholds} JSON on stdin → Verdict JSON). Scores
+		// only unexpected/closed ports; known-open service ports never accrue score.
+		// CLI-only decision function (fed by the existing root log reader).
+		os.Exit(cmdPortscanClassify(os.Args[2:]))
 	case "feeds":
 		if len(os.Args) < 3 {
 			errorWithUsage("feeds", "feeds command requires an action")

--- a/internal/portscan/classify.go
+++ b/internal/portscan/classify.go
@@ -1,0 +1,130 @@
+// =============================================================================
+// NFTBan - Portscan classifier (typed; known-open service-port aware)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="portscan"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="v1.204 PORTSCAN GO-CLASSIFIER: typed portscan scan-type classifier that scores ONLY unexpected/closed destination ports — configured known-open service ports (tcp_ports_in) are allowed context and never accrue scan score. Fixes the false-positive class where a legitimate multi-service client (panel+mail+web+SSH) was classified strobe/vertical. Pure decision function fed pre-parsed per-IP events by the existing root log reader (input-authority identity unchanged); IPv4+IPv6 equivalent."
+// meta:input="Input (per-IP events + known-open port set + thresholds)"
+// meta:output="Verdict (scan type, known_open_count, unexpected_count, action)"
+// meta:depends="none"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package portscan
+
+// Event is one observed connection attempt (one parsed kernel nft-log line),
+// already extracted by the root log reader. Port is the destination port;
+// Target is the destination IP (the protected host, usually one); TS is the
+// event's unix timestamp (seconds).
+type Event struct {
+	Port   int
+	Target string
+	TS     int64
+}
+
+// Input is the per-source-IP classification request. KnownOpenPorts is the
+// configured open-service set (tcp_ports_in / udp_ports_in) — these ports are
+// allowed CONTEXT and never accrue scan score. Family is "ipv4"/"ipv6"; the
+// scoring is identical for both (known-open exclusion is by port number).
+type Input struct {
+	IP             string
+	Family         string
+	Events         []Event
+	KnownOpenPorts []int
+	// Thresholds (from portscan/classic.conf). A threshold <= 0 disables that rule.
+	BlockRange        int   // PORTSCAN_CLASSIC_BLOCK_RANGE
+	VerticalPorts     int   // PORTSCAN_CLASSIC_VERTICAL_PORTS
+	HorizontalTargets int   // PORTSCAN_CLASSIC_HORIZONTAL_TARGETS
+	StrobePorts       int   // PORTSCAN_CLASSIC_STROBE_PORTS
+	StrobeWindowSec   int64 // strobe window (default 10s if <= 0)
+}
+
+// Verdict is the classification result. Action is "allow" or "ban".
+// KnownOpenCount/UnexpectedCount are the distinct-port tallies used for the
+// old-vs-new shadow comparison.
+type Verdict struct {
+	ScanType        string `json:"scan_type"` // "" | block | vertical | horizontal | strobe
+	KnownOpenCount  int    `json:"known_open_count"`
+	UnexpectedCount int    `json:"unexpected_count"`
+	TargetCount     int    `json:"target_count"`
+	Action          string `json:"action"` // allow | ban
+	Family          string `json:"family"`
+	IP              string `json:"src_ip"`
+}
+
+// Classify scores ONLY unexpected (non-known-open) destination ports. Known-open
+// service ports are tallied (for visibility) but never drive a scan verdict, so a
+// legitimate client touching only known-open services yields UnexpectedCount==0 →
+// allow. Genuine diversity across unexpected/closed ports remains ban-capable.
+// IPv4 and IPv6 are treated identically.
+func Classify(in Input) Verdict {
+	known := make(map[int]bool, len(in.KnownOpenPorts))
+	for _, p := range in.KnownOpenPorts {
+		known[p] = true
+	}
+
+	distinctUnexpected := make(map[int]bool)
+	distinctKnown := make(map[int]bool)
+	targets := make(map[string]bool)
+	var minUnexpTS, maxUnexpTS int64
+	haveUnexpTS := false
+
+	for _, e := range in.Events {
+		if known[e.Port] {
+			distinctKnown[e.Port] = true
+			continue // known-open service port → allowed context, NOT scan score
+		}
+		distinctUnexpected[e.Port] = true
+		if e.Target != "" {
+			targets[e.Target] = true
+		}
+		if !haveUnexpTS || e.TS < minUnexpTS {
+			minUnexpTS = e.TS
+		}
+		if !haveUnexpTS || e.TS > maxUnexpTS {
+			maxUnexpTS = e.TS
+		}
+		haveUnexpTS = true
+	}
+
+	v := Verdict{
+		KnownOpenCount:  len(distinctKnown),
+		UnexpectedCount: len(distinctUnexpected),
+		TargetCount:     len(targets),
+		Action:          "allow",
+		Family:          in.Family,
+		IP:              in.IP,
+	}
+	uc := v.UnexpectedCount
+	tc := v.TargetCount
+
+	window := in.StrobeWindowSec
+	if window <= 0 {
+		window = 10
+	}
+
+	switch {
+	case in.BlockRange > 0 && uc >= in.BlockRange:
+		v.ScanType = "block"
+	case in.VerticalPorts > 0 && uc >= in.VerticalPorts && tc <= 1:
+		v.ScanType = "vertical"
+	case in.HorizontalTargets > 0 && tc >= in.HorizontalTargets && uc <= 3 && uc > 0:
+		v.ScanType = "horizontal"
+	case in.StrobePorts > 0 && uc >= in.StrobePorts && (maxUnexpTS-minUnexpTS) < window:
+		v.ScanType = "strobe"
+	}
+	if v.ScanType != "" {
+		v.Action = "ban"
+	}
+	return v
+}

--- a/internal/portscan/classify_test.go
+++ b/internal/portscan/classify_test.go
@@ -1,0 +1,156 @@
+// =============================================================================
+// NFTBan - Tests for the portscan Go classifier (known-open exclusion, v4+v6)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="portscan_classify_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-25"
+// meta:description="Table-driven tests for the v1.204 portscan classifier — known-open exclusion, score-only-unexpected, IPv4+IPv6 parity, strobe window, malformed/empty safety, cross-module non-overlap (classifier never owns DDoS/BotGuard/LoginMon)."
+// meta:input="None"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package portscan
+
+import "testing"
+
+// Standard DA-host known-open service set + thresholds (mirrors classic.conf-ish).
+var knownOpen = []int{22, 25, 80, 110, 143, 443, 465, 587, 993, 995, 2222, 2083, 2096}
+
+func base(family, ip string, ev []Event) Input {
+	return Input{
+		IP: ip, Family: family, Events: ev, KnownOpenPorts: knownOpen,
+		BlockRange: 10, VerticalPorts: 5, HorizontalTargets: 10, StrobePorts: 5, StrobeWindowSec: 10,
+	}
+}
+
+func ev(host string, ts int64, ports ...int) []Event {
+	out := make([]Event, 0, len(ports))
+	for _, p := range ports {
+		out = append(out, Event{Port: p, Target: host, TS: ts})
+	}
+	return out
+}
+
+func TestClassify_KnownOpenOnlyBurst_Allow(t *testing.T) {
+	// Panel+mail+web+SSH+more — 6 known-open services in 1s (the proven FP).
+	in := base("ipv4", "62.38.150.122", ev("203.0.113.10", 1000, 22, 2222, 25, 80, 443, 993))
+	v := Classify(in)
+	if v.Action != "allow" || v.ScanType != "" {
+		t.Fatalf("known-open-only burst must ALLOW, got %+v", v)
+	}
+	if v.UnexpectedCount != 0 || v.KnownOpenCount != 6 {
+		t.Fatalf("expected unexpected=0 known=6, got %+v", v)
+	}
+}
+
+func TestClassify_MultiServiceKnownOpenBurst_Allow(t *testing.T) {
+	in := base("ipv4", "1.2.3.4", ev("203.0.113.10", 1000, 80, 443, 25, 587, 993, 995, 2222))
+	if v := Classify(in); v.Action != "allow" {
+		t.Fatalf("multi-service known-open burst must ALLOW, got %+v", v)
+	}
+}
+
+func TestClassify_UnexpectedClosedPortDiversity_BanCapable(t *testing.T) {
+	// 6 distinct UNEXPECTED ports on one target within 1s → vertical/strobe ban.
+	in := base("ipv4", "9.9.9.9", ev("203.0.113.10", 1000, 1234, 3306, 5432, 6379, 8080, 9000))
+	v := Classify(in)
+	if v.Action != "ban" {
+		t.Fatalf("unexpected-port diversity must be ban-capable, got %+v", v)
+	}
+	if v.UnexpectedCount != 6 {
+		t.Fatalf("expected unexpected=6, got %+v", v)
+	}
+}
+
+func TestClassify_MixedKnownOpenAndUnexpected_ScoreUnexpectedOnly(t *testing.T) {
+	// 4 known-open + 2 unexpected → score = 2 (below vertical=5) → ALLOW.
+	in := base("ipv4", "5.6.7.8", ev("203.0.113.10", 1000, 22, 80, 443, 993, 4444, 5555))
+	v := Classify(in)
+	if v.KnownOpenCount != 4 || v.UnexpectedCount != 2 {
+		t.Fatalf("expected known=4 unexpected=2, got %+v", v)
+	}
+	if v.Action != "allow" {
+		t.Fatalf("2 unexpected (< vertical 5) must ALLOW, got %+v", v)
+	}
+	// add 3 more unexpected → 5 unexpected → ban-capable (known-open still ignored).
+	in2 := base("ipv4", "5.6.7.8", ev("203.0.113.10", 1000, 22, 80, 443, 993, 4444, 5555, 6666, 7777, 8888))
+	if v2 := Classify(in2); v2.Action != "ban" || v2.UnexpectedCount != 5 {
+		t.Fatalf("5 unexpected must ban, got %+v", v2)
+	}
+}
+
+func TestClassify_IPv4KnownOpenOnly_Allow(t *testing.T) {
+	if v := Classify(base("ipv4", "1.1.1.1", ev("203.0.113.10", 1000, 22, 80, 443, 993, 995))); v.Action != "allow" {
+		t.Fatalf("v4 known-open-only must ALLOW, got %+v", v)
+	}
+}
+
+func TestClassify_IPv6KnownOpenOnly_Allow(t *testing.T) {
+	if v := Classify(base("ipv6", "2606:4700::1", ev("2606:4700:4700::1", 1000, 22, 80, 443, 993, 995))); v.Action != "allow" {
+		t.Fatalf("v6 known-open-only must ALLOW, got %+v", v)
+	}
+}
+
+func TestClassify_IPv4UnexpectedDiversity_BanCapable(t *testing.T) {
+	in := base("ipv4", "9.9.9.9", ev("203.0.113.10", 1000, 1111, 3333, 4444, 5555, 6666))
+	if v := Classify(in); v.Action != "ban" {
+		t.Fatalf("v4 unexpected diversity must be ban-capable, got %+v", v)
+	}
+}
+
+func TestClassify_IPv6UnexpectedDiversity_BanCapable(t *testing.T) {
+	in := base("ipv6", "2a01:4f8::99", ev("2606:4700:4700::1", 1000, 1111, 3333, 4444, 5555, 6666))
+	if v := Classify(in); v.Action != "ban" {
+		t.Fatalf("v6 unexpected diversity must be ban-capable, got %+v", v)
+	}
+}
+
+func TestClassify_V4V6Parity_SameInputSameVerdict(t *testing.T) {
+	mk := func(fam string) Verdict {
+		return Classify(base(fam, "x", ev("t", 1000, 1111, 3333, 4444, 5555, 6666)))
+	}
+	a, b := mk("ipv4"), mk("ipv6")
+	if a.Action != b.Action || a.ScanType != b.ScanType || a.UnexpectedCount != b.UnexpectedCount {
+		t.Fatalf("v4/v6 parity broken: %+v vs %+v", a, b)
+	}
+}
+
+func TestClassify_StrobeWindow_OutsideWindowNotStrobe(t *testing.T) {
+	// 5 unexpected ports but spread across 30s (> 10s window), one target →
+	// vertical still fires (vertical has no window). Use 4 unexpected (< vertical 5)
+	// spread wide to confirm strobe needs the window.
+	in := base("ipv4", "8.8.8.8", []Event{
+		{Port: 1111, Target: "t", TS: 1000}, {Port: 2233, Target: "t", TS: 1010},
+		{Port: 3344, Target: "t", TS: 1020}, {Port: 4455, Target: "t", TS: 1030},
+	})
+	v := Classify(in) // 4 unexpected < vertical(5) and spread 30s → no strobe → allow
+	if v.Action != "allow" {
+		t.Fatalf("4 unexpected spread 30s must ALLOW (no strobe), got %+v", v)
+	}
+}
+
+func TestClassify_EmptyInput_NoFalseHealthyOrBan(t *testing.T) {
+	v := Classify(base("ipv4", "1.2.3.4", nil))
+	if v.Action != "allow" || v.ScanType != "" || v.UnexpectedCount != 0 {
+		t.Fatalf("empty input must be allow/no-scan (NOT a ban, NOT a confirmed-healthy assertion), got %+v", v)
+	}
+}
+
+func TestClassify_ThresholdDisabled_NoBan(t *testing.T) {
+	in := base("ipv4", "9.9.9.9", ev("t", 1000, 1111, 3333, 4444, 5555, 6666))
+	in.BlockRange, in.VerticalPorts, in.HorizontalTargets, in.StrobePorts = 0, 0, 0, 0
+	if v := Classify(in); v.Action != "allow" {
+		t.Fatalf("all thresholds disabled must ALLOW, got %+v", v)
+	}
+}


### PR DESCRIPTION
## v1.204.0 — PORTSCAN GO-CLASSIFIER MIGRATION

Moves the classic portscan classifier shell→Go and **fixes the known-open-service-port false-positive class**. Ownership: `LOG_SOURCE_OWNERSHIP_DECLARATION_PORTSCAN.md` → **ACCEPTED**. Impl report: `V204_PORTSCAN_GO_CLASSIFIER_IMPL_REPORT.md`.

### Fix
- Known-open service ports (configured `tcp_ports_in`) **no longer score as scan evidence** — they are allowed context. A legitimate multi-service client (panel+mail+web+SSH ≥5 open ports in <10s) is no longer classified strobe/vertical and temp-banned (proven: admin `192.0.2.122`).
- **Unexpected/closed-port diversity remains ban-capable.** Scoring (block/vertical/horizontal/strobe) is on `unexpected_count`. IPv4 ≡ IPv6.

### Mechanism
- `internal/portscan/classify.go` — typed `Classify()` (+ 12 table-driven tests).
- `nftban-core portscan-classify` — stdin JSON → Verdict JSON; pure decision function (no log read, no nft write).
- `nftban_portscan_classic.sh` — mode gate `PORTSCAN_CLASSIC_CLASSIFIER`: **shadow** (default; logs old-vs-new, **legacy enforcement preserved**), **go** (enforces the fixed behavior), **shell** (legacy). Single ban authority unchanged (shell→daemon IPC→`blacklist_manual_*`).

### Validation
- **lab2 DEB + lab4 RPM package-native PASS** (CI build 28169175734): real `detect_scan_type` integration — go mode known-open burst→allow (v4+v6), unexpected diversity→vertical ban (v4+v6), mixed→scores unexpected only, shadow==shell (legacy preserved); classify makes no nft write; no whitelist/blacklist regression; no ban residue; admin not banned. Both labs restored to v1.203.0.

### Declarations
- **`nftband` daemon RE-BASELINED** (intentional) — `cmd/nftband/daemon_init.go` imports `internal/portscan`, so the daemon links the new package; not byte-identical with v1.203.0.
- **nft `SchemaVersionCurrent` unchanged (1.84.0)** — no set-shape change. **No whitelist/blacklist topology change. No BotGuard change.**
- **No production rollout in this PR.** Production fleet remains v1.203.0; Track-A rollout deferred (HOLD). No VERSION/CHANGELOG/STATUS/FHS in this PR (release-prep is a separate gate).
