### PR TITLE
v1.205.0 CLI surface parity fix

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -88,6 +88,13 @@ jobs:
       - name: Check Core license metadata (PR-LICENSE)
         run: ./scripts/ci/check-license-metadata.sh
 
+      # v1.205 CLI surface parity: registry ↔ bash-completion ↔ dispatch (authority
+      # = shell dispatch). Classifies MISSING/STALE/RETIRED/ALIAS_NOT_MARKED/etc.;
+      # fails on real drift (e.g. retired 'gui' resurfacing in completion, a real
+      # dispatch command missing from the registry, an unmarked alias/deprecated verb).
+      - name: Check CLI surface parity (registry/completion/dispatch)
+        run: ./scripts/ci/check-cli-surface-parity.sh
+
       - name: Check netlink import policy
         run: |
           echo "=== Checking netlink import architecture policy ==="

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1332,7 +1332,8 @@ tunnel:
 
 trust:
   category: active_protection
-  description: "Trusted provider IP ranges (CDN, cloud)"
+  aliases: ["cloudflare"]
+  description: "Trusted provider IP ranges (CDN, cloud). NOTE: 'cloudflare' is a legacy top-level alias of 'trust' (sbin/nftban dispatch); kept for discovery/back-compat."
   risk: advanced
   audience: [cli]
   capability: policy_change
@@ -1473,7 +1474,8 @@ geoban:
         --json: {type: bool, description: "Output in JSON format"}
     update:
       mutates: true
-      description: "Update all active countries"
+      aliases: [refresh]
+      description: "Update all active countries ('refresh' is an alias — same dispatch arm/handler)"
     config:
       mutates: false
       description: "Show GeoBan configuration"
@@ -1535,6 +1537,42 @@ firewall:
       mutates: true
       requires_root: true
       description: "Reload nftables ruleset"
+    status:
+      mutates: false
+      description: "Show firewall structure/authority status"
+    rebuild:
+      mutates: true
+      requires_root: true
+      capability: enforcement
+      description: "Atomically rebuild the live nftables ruleset from rendered config (single nft -f transaction)"
+    reset:
+      mutates: true
+      requires_root: true
+      capability: enforcement
+      description: "Reset the nftban firewall to a clean baseline (DESTRUCTIVE to current live ruleset state)"
+    conflicts:
+      mutates: false
+      description: "Detect conflicting external firewalls (fail2ban, ufw, firewalld, csf) — delegates to health conflicts"
+    restore:
+      mutates: true
+      requires_root: true
+      capability: enforcement
+      description: "Re-arm a previously-disarmed external firewall (reverse of takeover). Target required."
+      examples:
+        - "nftban firewall restore csf"
+        - "nftban firewall restore fail2ban"
+        - "nftban firewall restore firewalld"
+        - "nftban firewall restore ufw"
+      arguments:
+        target:
+          type: enum
+          values: [csf, fail2ban, firewalld, ufw]
+          required: true
+          description: "External firewall to re-arm/unmask (the takeover target)"
+    record:
+      mutates: true
+      requires_root: true
+      description: "Record/refresh the firewall ruleset fingerprint baseline (SEC-RULEFP)"
     transition-health:
       mutates: conditional
       requires_root: conditional
@@ -1855,6 +1893,10 @@ port:
       notes:
         - "Shows which ports are listening and which are allowed in firewall"
         - "Compares active listeners against nftables whitelist rules"
+    list:
+      mutates: false
+      deprecated: true
+      description: "DEPRECATED alias of 'status' (dispatch arm 'status|list' maps to the same handler)"
     detailed:
       mutates: false
       description: "Show detailed status with BIND address and PROCESS columns"
@@ -3264,6 +3306,23 @@ module:
     - "nftban module status"
     - "nftban module --json"
 
+export:
+  category: intelligence_reporting
+  aliases: ["stats-export"]
+  description: "Export a stats snapshot — convenience top-level alias of 'nftban stats export' (sbin dispatch)."
+  risk: core
+  audience: [cli]
+  capability: report_read
+  mutates: false
+  supports_dry_run: false
+  requires_root: false
+  panel_expose: false
+  output_modes: [json, text]
+  has_json: true
+  examples:
+    - "nftban export"
+    - "nftban export --json"
+
 fhs:
   category: developer_sysadmin
   description: "Filesystem Hierarchy Standard compliance check"
@@ -3277,8 +3336,16 @@ fhs:
   output_modes: [json, text]
   has_json: true
   examples:
-    - "nftban fhs check"
+    - "nftban fhs status"
     - "nftban fhs status --json"
+  subcommands:
+    status:
+      mutates: false
+      description: "Show FHS compliance status (paths/ownership/permissions)"
+    check:
+      mutates: false
+      deprecated: true
+      description: "DEPRECATED alias of 'status' (dispatch maps 'check' → status)"
 
 timers:
   category: developer_sysadmin

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -17,11 +17,11 @@ _nftban() {
     # CORE: status health validate config sync version help
     # FIREWALL: firewall ban unban list check search whitelist whitelist-system profile panel permissions
     # PROTECTION: ddos portscan login feeds trust country cloudflare geoban geoip
-    # MONITORING: gui metrics stats report fhs module services timers mail
+    # MONITORING: metrics stats report fhs module services timers mail
     # DEBUG: debug smoke selftest emulate setup menu
 
     # H28 fix: 'cloudflare' is a legacy alias for 'trust' — still listed for discovery
-    local commands="status health validate config sync version help firewall firewall-logs ban unban protect unprotect cleanup list check search blacklist whitelist whitelist-system profile panel permissions polkit ddos portscan botscan botguard login feeds trust country cloudflare geoban geoip gui metrics stats report queue fhs module services timers mail rbl debug smoke selftest emulate setup menu nftables port system test wizard watchdog flush update support suricata pro connector modes snapshot zabbix preflight export tunnel benchmark rollback scale"
+    local commands="status health validate config sync version help firewall firewall-logs ban unban protect unprotect cleanup list check search blacklist whitelist whitelist-system profile panel permissions polkit ddos portscan botscan botguard login feeds trust country cloudflare geoban geoip metrics stats report queue fhs module services timers mail rbl debug smoke selftest emulate setup menu nftables port system test wizard watchdog flush update support suricata pro connector modes snapshot zabbix preflight export tunnel benchmark rollback scale"
 
     # ==========================================================================
     # SUBCOMMANDS FOR EACH MAIN COMMAND
@@ -63,7 +63,6 @@ _nftban() {
     local geoip_cmds="status update lookup config --json help"
 
     # Monitoring & Reporting
-    local gui_cmds="status enable disable help"
     local metrics_cmds="status enable disable help"
     local stats_cmds="summary dashboard top export monitor cleanup trend --json help"
     local report_cmds="generate run schedule email email-setup list status --json help"
@@ -229,9 +228,6 @@ _nftban() {
                     ;;
 
                 # Monitoring & Reporting
-                gui)
-                    COMPREPLY=($(compgen -W "${gui_cmds}" -- "${cur}"))
-                    ;;
                 metrics)
                     COMPREPLY=($(compgen -W "${metrics_cmds}" -- "${cur}"))
                     ;;

--- a/scripts/ci/check-cli-surface-parity.sh
+++ b/scripts/ci/check-cli-surface-parity.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan CI guard — CLI surface parity (registry ↔ bash-completion ↔ dispatch)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="check-cli-surface-parity"
+# meta:type="ci-guard"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="v1.205 CLI SURFACE PARITY guard. Authority rule: runtime shell dispatch (sbin/nftban + cmd_*.sh) is the source of truth; commands.registry.yml and bash-completion are validated against it. Classifies drift: MISSING_FROM_REGISTRY / STALE_IN_REGISTRY / MISSING_FROM_COMPLETION / RETIRED_IN_COMPLETION / ALIAS_NOT_MARKED / DEPRECATED_NOT_MARKED / INTERNAL_OR_TARGET_ONLY_ALLOWLISTED / PASS. Also: retired-gui completion check + duplicate-handler (grouped case-arm) scan. Fails CI on real drift."
+# meta:inventory.files="commands.registry.yml, install/bash-completion/nftban, cli/sbin/nftban, cli/lib/nftban/cli/cmd_*.sh"
+# meta:inventory.binaries=""
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+REGISTRY="commands.registry.yml"
+COMPLETION="install/bash-completion/nftban"
+SBIN="cli/sbin/nftban"
+
+[ -f "$REGISTRY" ] || { echo "FAIL: $REGISTRY not found"; exit 2; }
+[ -f "$COMPLETION" ] || { echo "FAIL: $COMPLETION not found"; exit 2; }
+
+python3 - "$REGISTRY" "$COMPLETION" "$SBIN" <<'PY'
+import sys, re, glob, os
+reg_path, comp_path, sbin_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# --- registry: top-level commands + aliases + deprecated (lightweight YAML scan; no pyyaml dep) ---
+reg_cmds, reg_alias, reg_deprecated = set(), {}, set()
+cur = None
+with open(reg_path) as f:
+    for line in f:
+        m = re.match(r'^([a-z][a-z0-9_-]*):\s*$', line)
+        if m:
+            cur = m.group(1)
+            if cur not in ("subcommands","options","arguments","examples","notes","values","global_options"):
+                reg_cmds.add(cur)
+            continue
+        # top-level command alias line:  "  aliases: [\"cloudflare\"]" (2-space indent = command-level)
+        a = re.match(r'^  aliases:\s*\[([^\]]*)\]', line)
+        if a and cur:
+            for tok in re.findall(r'[A-Za-z0-9_-]+', a.group(1)):
+                reg_alias.setdefault(cur, set()).add(tok)
+KNOWN_NONCMD = {"global","setup_discovery","global_options","standard_params"}
+reg_cmds -= KNOWN_NONCMD
+
+# --- completion: the top-level $commands="..." list ---
+comp_cmds = set()
+txt = open(comp_path).read()
+m = re.search(r'local commands="([^"]*)"', txt)
+if m:
+    comp_cmds = set(m.group(1).split())
+gui_in_completion = bool(re.search(r'\bgui\b', txt))
+
+# --- intentional aliases (marked in registry) + internal/target-only allowlist ---
+alias_flat = {al for s in reg_alias.values() for al in s}
+ALLOW_INTERNAL = {"firewall-logs","menu","wizard","test","selftest","preflight","benchmark","rollback","scale","modes"}
+# universal meta-verbs handled outside the per-command registry (global dispatch)
+ALLOW_META = {"help"}
+ALLOW_INTERNAL |= ALLOW_META
+
+fails = []
+def emit(cat, item, detail=""):
+    print(f"  {cat}: {item}{(' — '+detail) if detail else ''}")
+    if cat not in ("INTERNAL_OR_TARGET_ONLY_ALLOWLISTED","PASS"):
+        fails.append((cat,item))
+
+print("== top-level: completion vs registry ==")
+# RETIRED_IN_COMPLETION: gui (retired v1.100.1b) must not appear
+if gui_in_completion:
+    emit("RETIRED_IN_COMPLETION", "gui", "retired v1.100.1b/#502 — remove from bash-completion")
+else:
+    print("  PASS: retired 'gui' absent from completion")
+
+for c in sorted(comp_cmds):
+    if c in reg_cmds: continue
+    if c in alias_flat:
+        print(f"  ALIAS_OK: {c} (marked alias in registry)"); continue
+    if c in ALLOW_INTERNAL:
+        emit("INTERNAL_OR_TARGET_ONLY_ALLOWLISTED", c); continue
+    emit("MISSING_FROM_REGISTRY" if c!="gui" else "RETIRED_IN_COMPLETION", c, "in completion, not a registry command/alias")
+
+for c in sorted(reg_cmds):
+    if c in comp_cmds or c in alias_flat: continue
+    if c in ALLOW_INTERNAL: continue
+    emit("MISSING_FROM_COMPLETION", c, "registry command not offered in completion")
+
+print("== required confirmed fixes (v1.205 / FULL_CLI_SURFACE_PARITY_AUDIT) ==")
+def reg_has_subcmd(cmd, sub, flag=None):
+    # scan the registry block for 'cmd:' then its subcommands for 'sub:' (+ optional flag line)
+    block=[]; cap=False
+    for line in open(reg_path):
+        if re.match(rf'^{cmd}:\s*$', line): cap=True; continue
+        if cap and re.match(r'^[a-z][a-z0-9_-]*:\s*$', line): break
+        if cap: block.append(line)
+    body="".join(block)
+    ms=re.search(rf'^    {sub}:\s*$(.*?)(?=^    [a-z]|\Z)', body, re.M|re.S)
+    if not ms: return False
+    if flag and flag not in ms.group(1): return False
+    return True
+checks = [
+  ("firewall rebuild present", reg_has_subcmd("firewall","rebuild")),
+  ("firewall restore present", reg_has_subcmd("firewall","restore")),
+  ("firewall record present",  reg_has_subcmd("firewall","record")),
+  ("trust aliases includes cloudflare", "cloudflare" in reg_alias.get("trust",set())),
+  ("geoban update aliases includes refresh", reg_has_subcmd("geoban","update","refresh")),
+  ("fhs check deprecated", reg_has_subcmd("fhs","check","deprecated: true")),
+  ("port list deprecated", reg_has_subcmd("port","list","deprecated: true")),
+]
+for name,ok in checks:
+    if ok: print(f"  PASS: {name}")
+    else: emit("ALIAS_NOT_MARKED" if "alias" in name or "deprecated" in name else "MISSING_FROM_REGISTRY", name, "expected by audit")
+
+print("== duplicate-handler (grouped case-arm) scan — informational unless unmarked ==")
+dups=0
+for sh in glob.glob("cli/lib/nftban/cli/cmd_*.sh"):
+    for ln in open(sh, errors="ignore"):
+        m=re.match(r'^\s*([a-z][a-z0-9_-]*(?:\|[a-z][a-z0-9_-]*){1,})\)\s*$', ln)
+        if m and "|" in m.group(1):
+            verbs=m.group(1).split("|")
+            if len(verbs)>=2:
+                dups+=1
+                # informational; registry alias/deprecated markers are the resolution
+print(f"  INFO: {dups} grouped case-arms (multiple verbs → one handler) across cmd_*.sh — resolve via registry alias/deprecated markers (guard does not fail on these)")
+
+print()
+if fails:
+    print(f"RESULT: DRIFT_FOUND — {len(fails)} blocking item(s):")
+    for c,i in fails: print(f"  - {c}: {i}")
+    sys.exit(1)
+print("RESULT: PASS — CLI surface parity clean (registry ↔ completion ↔ confirmed fixes)")
+PY


### PR DESCRIPTION
## v1.205.0 — CLI SURFACE PARITY FIX

**Source audit:** `FULL_CLI_SURFACE_PARITY_AUDIT.md` (DRIFT_FOUND). **Impl report:** `V205_CLI_SURFACE_PARITY_FIX_IMPL_REPORT.md`. **Authority:** runtime shell dispatch + `--help` = source of truth; registry/completion validated against it. **Metadata/completion/CI-only — no product behavior change.**

### Registry (`commands.registry.yml`)
- **firewall** (F1): added real dispatch subcommands missing from registry — `status`, `rebuild`, `reset`, `conflicts`, `restore` (target enum csf/fail2ban/firewalld/ufw), `record`.
- **trust** alias `cloudflare` (legacy top-level alias, sbin dispatch).
- **geoban update** alias `refresh` (F4 — same handler / double-verb).
- **fhs check** deprecated → status; **port list** deprecated → status (F5).
- top-level **`export`** (real dispatch arm; alias of `stats export`) — guard-surfaced gap.

### bash-completion (`install/bash-completion/nftban`)
- removed retired **`gui`** (retired v1.100.1b/#502) — was the 5th truth surface still advertising it.

### CI guard (`scripts/ci/check-cli-surface-parity.sh` + `ci-architecture.yml`)
- registry ↔ completion ↔ dispatch parity classification (MISSING_FROM_REGISTRY / STALE_IN_REGISTRY / MISSING_FROM_COMPLETION / RETIRED_IN_COMPLETION / ALIAS_NOT_MARKED / DEPRECATED_NOT_MARKED / INTERNAL_OR_TARGET_ONLY_ALLOWLISTED / PASS) + retired-gui check + duplicate-handler scan. **Guard PASSES.**

### Non-scope
No portscan change · **no daemon change (nftband NOT re-baselined)** · no schema change (1.84.0) · VERSION stays 1.204.0 · no fleet rollout · no RBL/comms/auditor work · no docs/website change (already clean). Release-prep (1.204.0→1.205.0) is a separate gate.