### PR TITLE
v1.206.0 RBL state and visibility hardening

### DIFF
--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -395,8 +395,13 @@ nftban_health_cmd_rbl() {
 
     local config_dir="${NFTBAN_CONFIG_DIR:-/etc/nftban}"
     local rbl_config="$config_dir/conf.d/rbl/main.conf"
-    local rbl_cache_dir="${NFTBAN_LOG_DIR:-/var/log/nftban}/rbl"
+    # v1.206 (TODO-1): the AUTHORITATIVE RBL state store is the cache dir written
+    # by nftban_rbl_update_state (/var/cache/nftban/rbl), NOT /var/log. The old
+    # /var/log path was a key/state-path drift → health read a non-existent store
+    # and could report PROTECTED while the writer recorded degraded/listed.
+    local rbl_cache_dir="${NFTBAN_RBL_CACHE_DIR:-${NFTBAN_CACHE_DIR:-/var/cache/nftban}/rbl}"
     local last_check_file="$rbl_cache_dir/last_check"
+    local rbl_state_file="$rbl_cache_dir/state.dat"
 
     # Status tracking
     local overall_status="PROTECTED"
@@ -504,6 +509,21 @@ nftban_health_cmd_rbl() {
         fi
     fi
 
+    # 5. v1.206 (TODO-1): read the AUTHORITATIVE state store and surface degraded/
+    # blind RBL results. A degraded entry (resolver-blocked/timeout/error/skipped/
+    # unsupported) means reputation is UNKNOWN — posture must NOT read "fully
+    # protected" while RBL is blind.
+    local rbl_degraded_ips=0 rbl_listed_ips=0
+    if [[ -f "$rbl_state_file" ]]; then
+        rbl_degraded_ips=$(grep -c '=degraded|' "$rbl_state_file" 2>/dev/null || echo 0)
+        rbl_listed_ips=$(grep -c '=listed|' "$rbl_state_file" 2>/dev/null || echo 0)
+    fi
+    if [[ "$rbl_enabled" == "YES" ]] && [[ "${rbl_degraded_ips:-0}" -gt 0 ]] \
+       && [[ "$overall_status" == "PROTECTED" ]]; then
+        overall_status="DEGRADED"
+        status_color="\033[33m"  # Yellow — RBL blind, reputation not fully verified
+    fi
+
     # If RBL is disabled, overall status should still be OK unless there's an error
     if [[ "$rbl_enabled" == "NO" && "$overall_status" == "WARNING" ]]; then
         # Reset to OK if RBL is disabled - warnings only matter when enabled
@@ -516,14 +536,18 @@ nftban_health_cmd_rbl() {
     printf "  Timer Active:    %s\n" "$timer_active"
     printf "  Last Check:      %s\n" "$last_check_status"
     printf "  Cache Dir:       %s\n" "$cache_dir_status"
+    printf "  RBL State:       %s degraded / %s listed (authoritative: %s)\n" \
+        "${rbl_degraded_ips:-0}" "${rbl_listed_ips:-0}" "$rbl_state_file"
+    [[ "${rbl_degraded_ips:-0}" -gt 0 ]] && \
+        printf "  Note: RBL coverage DEGRADED — reputation not fully verified for %s IP(s); not 'fully protected'.\n" "${rbl_degraded_ips}"
     echo ""
     printf "  Status: %b%s%b\n" "$status_color" "$overall_status" "\033[0m"
     echo ""
 
     # Return appropriate exit code
     case "$overall_status" in
-        OK) return 0 ;;
-        WARNING) return 1 ;;
+        OK|PROTECTED) return 0 ;;
+        DEGRADED|WARNING) return 1 ;;
         ERROR) return 2 ;;
         *) return 1 ;;
     esac

--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -560,23 +560,36 @@ nftban_cmd_rbl_check() {
             # Output results
             echo "$results"
 
-            # Check if listed and send alert if requested
-            if [[ $alert -eq 1 ]] && echo "$results" | grep -q "LISTED"; then
-                any_listed=1
-                # Extract first RBL and reason for alert
-                local first_rbl
-                local first_reason
-                first_rbl=$(echo "$results" | grep "LISTED:" | head -n1 | awk '{print $3}' || true)
-                first_reason=$(echo "$results" | grep "Reason:" | head -n1 | sed 's/.*Reason: //' || true)
+            # v1.206 (TODO-1): 3-way state — listed / degraded / clean. A degraded
+            # result (resolver-blocked, timeout, error, skipped, unsupported) means
+            # the IP's reputation is UNKNOWN and MUST NOT be persisted as "clean".
+            local _rbl_state="clean"
+            if echo "$results" | grep -qE 'LISTED:|"listed": *[1-9]'; then
+                _rbl_state="listed"
+            elif echo "$results" | grep -qE 'RESOLVER_BLOCKED|Degraded total:|"degraded": *[1-9]|"resolver_blocked": *[1-9]|⏱️|SKIPPED \(IPv4-only|UNSUPPORTED \(no IPv6'; then
+                _rbl_state="degraded"
+            fi
 
-                if [[ "${NFTBAN_RBL_ALERT_ON_NEW_LISTING:-YES}" == "YES" ]]; then
-                    if nftban_rbl_check_new_listing "$check_ip" "listed"; then
-                        nftban_rbl_send_alert "$check_ip" "$first_rbl" "$first_reason" "$ip_tag"
+            if [[ "$_rbl_state" == "listed" ]]; then
+                any_listed=1
+                if [[ $alert -eq 1 ]]; then
+                    # Extract first RBL and reason for alert
+                    local first_rbl
+                    local first_reason
+                    first_rbl=$(echo "$results" | grep "LISTED:" | head -n1 | awk '{print $3}' || true)
+                    first_reason=$(echo "$results" | grep "Reason:" | head -n1 | sed 's/.*Reason: //' || true)
+                    if [[ "${NFTBAN_RBL_ALERT_ON_NEW_LISTING:-YES}" == "YES" ]]; then
+                        if nftban_rbl_check_new_listing "$check_ip" "listed"; then
+                            nftban_rbl_send_alert "$check_ip" "$first_rbl" "$first_reason" "$ip_tag"
+                        fi
                     fi
                 fi
-
-                # Update state
                 nftban_rbl_update_state "$check_ip" "listed"
+            elif [[ "$_rbl_state" == "degraded" ]]; then
+                # Persist degraded — NEVER clean. Posture/health must not show
+                # "fully protected" when the lookup could not be completed.
+                [[ $quiet -eq 0 ]] && echo "⚠️  RBL result DEGRADED for $check_ip — reputation NOT fully verified (not marked clean)"
+                nftban_rbl_update_state "$check_ip" "degraded"
             else
                 nftban_rbl_update_state "$check_ip" "clean"
             fi

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -384,6 +384,13 @@ nftban_rbl_check_ip_parallel() {
         [[ "$jobs" -gt 10 ]] && jobs=10
 
         reversed_ip=$(nftban_rbl_reverse_ip "$ip")
+        # v1.206 (TODO-1) IPv6 honesty: detect family + the operator-declared set of
+        # IPv4-only RBL zones (space-separated domains in NFTBAN_RBL_IPV4_ONLY_ZONES).
+        # For an IPv6 target: a zone with no IPv6 reputation must be SKIPPED, and an
+        # un-reversible IPv6 (no python3) is UNSUPPORTED — NEVER a silent CLEAN.
+        local _ip_family="ipv4"
+        [[ "$ip" == *:* ]] && _ip_family="ipv6"
+        local _ipv4_only_zones=" ${NFTBAN_RBL_IPV4_ONLY_ZONES:-} "
         temp_dir=$(mktemp -d)
         # shellcheck disable=SC2064  # Intentional: expand $temp_dir NOW at set time (local var)
         trap "rm -rf '$temp_dir'" EXIT
@@ -418,10 +425,17 @@ nftban_rbl_check_ip_parallel() {
             (
                 local result
                 local txt_record=""
-                result=$(nftban_rbl_dns_lookup "$reversed_ip" "$rbl_domain")
-
-                if [[ "$result" == "LISTED" ]]; then
-                    txt_record=$(nftban_rbl_get_txt_record "$reversed_ip" "$rbl_domain")
+                # v1.206: IPv6 zone-support gating BEFORE any query — distinct
+                # degraded states, never CLEAN.
+                if [[ "$_ip_family" == "ipv6" ]] && [[ -z "$reversed_ip" ]]; then
+                    result="UNSUPPORTED_IPV6_ZONE"
+                elif [[ "$_ip_family" == "ipv6" ]] && [[ "$_ipv4_only_zones" == *" ${rbl_domain} "* ]]; then
+                    result="SKIPPED_IPV4_ONLY_ZONE"
+                else
+                    result=$(nftban_rbl_dns_lookup "$reversed_ip" "$rbl_domain")
+                    if [[ "$result" == "LISTED" ]]; then
+                        txt_record=$(nftban_rbl_get_txt_record "$reversed_ip" "$rbl_domain")
+                    fi
                 fi
 
                 echo "${result}|${rbl_domain}|${rbl_url}|${txt_record}" > "${temp_dir}/${rbl_domain}.result"
@@ -445,6 +459,10 @@ nftban_rbl_check_ip_parallel() {
         local listed_count=0
         local clean_count=0
         local timeout_count=0
+        # v1.206 (TODO-1): degraded sub-counts. NONE of these ever count as clean.
+        local blocked_count=0     # RESOLVER_BLOCKED (Spamhaus block-code / REFUSED)
+        local skipped_count=0     # SKIPPED_IPV4_ONLY_ZONE
+        local unsupported_count=0 # UNSUPPORTED_IPV6_ZONE
 
         if [[ "$format" == "json" ]]; then
             echo "{"
@@ -476,16 +494,21 @@ nftban_rbl_check_ip_parallel() {
                     [[ -n "$txt_record" ]] && echo "   Reason: $txt_record"
                     echo "   Info: $rbl_url"
                 fi
-            elif [[ "$result" == "TIMEOUT" ]] || [[ "$result" == "ERROR" ]] || [[ "$result" == "RATE_LIMITED" ]]; then
+            elif [[ "$result" == "TIMEOUT" ]] || [[ "$result" == "ERROR" ]] || [[ "$result" == "RATE_LIMITED" ]] \
+                 || [[ "$result" == "RESOLVER_BLOCKED" ]] || [[ "$result" == "SKIPPED_IPV4_ONLY_ZONE" ]] \
+                 || [[ "$result" == "UNSUPPORTED_IPV6_ZONE" ]]; then
                 # v1.150 (11.3): ERROR/RATE_LIMITED counted as degraded, never CLEAN.
-                # v1.19.20 FIX
-                ((timeout_count++)) || true
-
+                # v1.206 (TODO-1): RESOLVER_BLOCKED / SKIPPED_IPV4_ONLY_ZONE /
+                # UNSUPPORTED_IPV6_ZONE are ALSO degraded — they mean the IP's
+                # reputation is UNKNOWN, and MUST NEVER increment clean_count.
                 local _status_lc
                 case "$result" in
-                    TIMEOUT)      _status_lc="timeout" ;;
-                    ERROR)        _status_lc="error" ;;
-                    RATE_LIMITED) _status_lc="rate_limited" ;;
+                    TIMEOUT)               _status_lc="timeout";                ((timeout_count++)) || true ;;
+                    ERROR)                 _status_lc="error";                  ((timeout_count++)) || true ;;
+                    RATE_LIMITED)          _status_lc="rate_limited";           ((timeout_count++)) || true ;;
+                    RESOLVER_BLOCKED)      _status_lc="resolver_blocked";       ((blocked_count++)) || true ;;
+                    SKIPPED_IPV4_ONLY_ZONE) _status_lc="skipped_ipv4_only_zone"; ((skipped_count++)) || true ;;
+                    UNSUPPORTED_IPV6_ZONE) _status_lc="unsupported_ipv6_zone";  ((unsupported_count++)) || true ;;
                 esac
 
                 if [[ "$format" == "json" ]]; then
@@ -493,10 +516,15 @@ nftban_rbl_check_ip_parallel() {
                     nftban_rbl_json_status_obj "$rbl_domain" "$_status_lc" "$rbl_url"
                     first=0
                 else
-                    echo "⏱️  ${result}: $rbl_domain"
+                    case "$result" in
+                        RESOLVER_BLOCKED)       echo "🚫 RESOLVER_BLOCKED: $rbl_domain (reputation UNKNOWN — not clean)" ;;
+                        SKIPPED_IPV4_ONLY_ZONE) echo "⏭️  SKIPPED (IPv4-only zone): $rbl_domain" ;;
+                        UNSUPPORTED_IPV6_ZONE)  echo "⏭️  UNSUPPORTED (no IPv6 reputation): $rbl_domain" ;;
+                        *)                      echo "⏱️  ${result}: $rbl_domain" ;;
+                    esac
                 fi
             else
-                # v1.19.20 FIX
+                # v1.19.20 FIX — reached ONLY by a genuine successful negative lookup.
                 ((clean_count++)) || true
 
                 if [[ "$format" == "text" ]] && [[ "${NFTBAN_RBL_VERBOSE:-NO}" == "YES" ]]; then
@@ -505,13 +533,22 @@ nftban_rbl_check_ip_parallel() {
             fi
         done
 
+        # v1.206: total degraded = every non-LISTED, non-CLEAN outcome. When >0
+        # the IP's reputation is NOT fully verified — callers/posture must not
+        # report "fully protected/clean".
+        local degraded_count=$(( timeout_count + blocked_count + skipped_count + unsupported_count ))
+
         if [[ "$format" == "json" ]]; then
             echo ""
             echo "  ],"
             echo "  \"summary\": {"
             echo "    \"listed\": $listed_count,"
             echo "    \"clean\": $clean_count,"
-            echo "    \"timeout\": $timeout_count"
+            echo "    \"timeout\": $timeout_count,"
+            echo "    \"resolver_blocked\": $blocked_count,"
+            echo "    \"skipped_ipv4_only_zone\": $skipped_count,"
+            echo "    \"unsupported_ipv6_zone\": $unsupported_count,"
+            echo "    \"degraded\": $degraded_count"
             echo "  }"
             echo "}"
         else
@@ -520,10 +557,16 @@ nftban_rbl_check_ip_parallel() {
             echo "  Listed: $listed_count"
             echo "  Clean: $clean_count"
             echo "  Timeout: $timeout_count"
+            [[ $blocked_count -gt 0 ]]     && echo "  Resolver-blocked: $blocked_count (reputation UNKNOWN — not clean)"
+            [[ $skipped_count -gt 0 ]]     && echo "  Skipped (IPv4-only zone): $skipped_count"
+            [[ $unsupported_count -gt 0 ]] && echo "  Unsupported (no IPv6 reputation): $unsupported_count"
+            [[ $degraded_count -gt 0 ]]    && echo "  Degraded total: $degraded_count (RBL coverage incomplete — NOT fully verified)"
         fi
 
-        # Return 1 if any listings found (subshell exit code propagates)
+        # Exit code: 1 = listed; 2 = no listings but degraded (reputation not fully
+        # verified — callers must not treat as a clean all-pass); 0 = all-clean.
         [[ $listed_count -gt 0 ]] && exit 1
+        [[ $degraded_count -gt 0 ]] && exit 2
         exit 0
     )
 }
@@ -651,8 +694,14 @@ nftban_rbl_check_ip() {
     local listed_count=0
     local clean_count=0
     local timeout_count=0
+    # v1.206 (TODO-1) degraded sub-counts — never count as clean.
+    local blocked_count=0 skipped_count=0 unsupported_count=0
 
     reversed_ip=$(nftban_rbl_reverse_ip "$ip")
+    # v1.206 IPv6 honesty (parity with parallel path)
+    local _ip_family="ipv4"
+    [[ "$ip" == *:* ]] && _ip_family="ipv6"
+    local _ipv4_only_zones=" ${NFTBAN_RBL_IPV4_ONLY_ZONES:-} "
 
     if [[ "$format" == "json" ]]; then
         echo "{"
@@ -668,7 +717,14 @@ nftban_rbl_check_ip() {
         local result
         local txt_record
 
-        result=$(nftban_rbl_dns_lookup "$reversed_ip" "$rbl_domain")
+        # v1.206: IPv6 zone-support gating before any query (never silent CLEAN).
+        if [[ "$_ip_family" == "ipv6" ]] && [[ -z "$reversed_ip" ]]; then
+            result="UNSUPPORTED_IPV6_ZONE"
+        elif [[ "$_ip_family" == "ipv6" ]] && [[ "$_ipv4_only_zones" == *" ${rbl_domain} "* ]]; then
+            result="SKIPPED_IPV4_ONLY_ZONE"
+        else
+            result=$(nftban_rbl_dns_lookup "$reversed_ip" "$rbl_domain")
+        fi
 
         if [[ "$result" == "LISTED" ]]; then
             txt_record=$(nftban_rbl_get_txt_record "$reversed_ip" "$rbl_domain")
@@ -685,17 +741,19 @@ nftban_rbl_check_ip() {
                 [[ -n "$txt_record" ]] && echo "   Reason: $txt_record"
                 echo "   Info: $rbl_url"
             fi
-        elif [[ "$result" == "TIMEOUT" ]] || [[ "$result" == "ERROR" ]] || [[ "$result" == "RATE_LIMITED" ]]; then
-            # v1.150 (11.3): ERROR/RATE_LIMITED are non-clean unknowns — count
-            # them with timeouts (degraded) rather than silently as CLEAN.
-            # v1.19.20 FIX
-            ((timeout_count++)) || true
-
+        elif [[ "$result" == "TIMEOUT" ]] || [[ "$result" == "ERROR" ]] || [[ "$result" == "RATE_LIMITED" ]] \
+             || [[ "$result" == "RESOLVER_BLOCKED" ]] || [[ "$result" == "SKIPPED_IPV4_ONLY_ZONE" ]] \
+             || [[ "$result" == "UNSUPPORTED_IPV6_ZONE" ]]; then
+            # v1.150 (11.3) + v1.206 (TODO-1): all of these are non-clean unknowns
+            # (degraded) — MUST NEVER count as CLEAN.
             local _status_lc
             case "$result" in
-                TIMEOUT)      _status_lc="timeout" ;;
-                ERROR)        _status_lc="error" ;;
-                RATE_LIMITED) _status_lc="rate_limited" ;;
+                TIMEOUT)                _status_lc="timeout";                 ((timeout_count++)) || true ;;
+                ERROR)                  _status_lc="error";                   ((timeout_count++)) || true ;;
+                RATE_LIMITED)           _status_lc="rate_limited";            ((timeout_count++)) || true ;;
+                RESOLVER_BLOCKED)       _status_lc="resolver_blocked";        ((blocked_count++)) || true ;;
+                SKIPPED_IPV4_ONLY_ZONE) _status_lc="skipped_ipv4_only_zone";  ((skipped_count++)) || true ;;
+                UNSUPPORTED_IPV6_ZONE)  _status_lc="unsupported_ipv6_zone";   ((unsupported_count++)) || true ;;
             esac
 
             if [[ "$format" == "json" ]]; then
@@ -703,10 +761,15 @@ nftban_rbl_check_ip() {
                 nftban_rbl_json_status_obj "$rbl_domain" "$_status_lc" "$rbl_url"
                 first=0
             else
-                echo "⏱️  ${result}: $rbl_domain"
+                case "$result" in
+                    RESOLVER_BLOCKED)       echo "🚫 RESOLVER_BLOCKED: $rbl_domain (reputation UNKNOWN — not clean)" ;;
+                    SKIPPED_IPV4_ONLY_ZONE) echo "⏭️  SKIPPED (IPv4-only zone): $rbl_domain" ;;
+                    UNSUPPORTED_IPV6_ZONE)  echo "⏭️  UNSUPPORTED (no IPv6 reputation): $rbl_domain" ;;
+                    *)                      echo "⏱️  ${result}: $rbl_domain" ;;
+                esac
             fi
         else
-            # v1.19.20 FIX
+            # v1.19.20 FIX — reached ONLY by a genuine successful negative lookup.
             ((clean_count++)) || true
 
             if [[ "$format" == "text" ]] && [[ "${NFTBAN_RBL_VERBOSE:-NO}" == "YES" ]]; then
@@ -715,13 +778,19 @@ nftban_rbl_check_ip() {
         fi
     done < <(nftban_rbl_load_providers)
 
+    local degraded_count=$(( timeout_count + blocked_count + skipped_count + unsupported_count ))
+
     if [[ "$format" == "json" ]]; then
         echo ""
         echo "  ],"
         echo "  \"summary\": {"
         echo "    \"listed\": $listed_count,"
         echo "    \"clean\": $clean_count,"
-        echo "    \"timeout\": $timeout_count"
+        echo "    \"timeout\": $timeout_count,"
+        echo "    \"resolver_blocked\": $blocked_count,"
+        echo "    \"skipped_ipv4_only_zone\": $skipped_count,"
+        echo "    \"unsupported_ipv6_zone\": $unsupported_count,"
+        echo "    \"degraded\": $degraded_count"
         echo "  }"
         echo "}"
     else
@@ -730,7 +799,16 @@ nftban_rbl_check_ip() {
         echo "  Listed: $listed_count"
         echo "  Clean: $clean_count"
         echo "  Timeout: $timeout_count"
+        [[ $blocked_count -gt 0 ]]     && echo "  Resolver-blocked: $blocked_count (reputation UNKNOWN — not clean)"
+        [[ $skipped_count -gt 0 ]]     && echo "  Skipped (IPv4-only zone): $skipped_count"
+        [[ $unsupported_count -gt 0 ]] && echo "  Unsupported (no IPv6 reputation): $unsupported_count"
+        [[ $degraded_count -gt 0 ]]    && echo "  Degraded total: $degraded_count (RBL coverage incomplete — NOT fully verified)"
     fi
+
+    # Exit code parity with the parallel path: 1=listed, 2=degraded-only, 0=all-clean.
+    [[ $listed_count -gt 0 ]] && return 1
+    [[ $degraded_count -gt 0 ]] && return 2
+    return 0
 }
 
 # v1.150 (11.1): resolver-binary selection. `host` is preferred (its output
@@ -751,19 +829,29 @@ nftban_rbl_resolver() {
 }
 
 nftban_rbl_dns_lookup() {
-    # Perform DNS A record lookup for RBL
+    # Perform DNS A record lookup for RBL.
     # Args: $1 = reversed IP (4.3.2.1)
     #       $2 = RBL domain (zen.spamhaus.org)
-    # Output: LISTED, CLEAN, TIMEOUT, or ERROR
+    # Output (v1.206 7-state model): LISTED, CLEAN, ERROR, RESOLVER_BLOCKED,
+    #        TIMEOUT, RATE_LIMITED  (zone-skip states SKIPPED_IPV4_ONLY_ZONE /
+    #        UNSUPPORTED_IPV6_ZONE are decided by the caller before this query).
     #
-    # v1.150 (11.1/11.3): capture the resolver's real exit code (no `|| true`,
-    # which used to mask rc and make the TIMEOUT branch dead) and never collapse
-    # a resolver failure / missing binary into CLEAN.
-    #   rc==124        → TIMEOUT (the `timeout` SIGTERM exit)
-    #   rc!=0 (other)  → ERROR   (resolver failed — NOT a clean verdict)
-    #   rc==0 + empty  → CLEAN   (NXDOMAIN / not listed)
-    #   rc==0 + 127/8  → LISTED  (RFC 5782 valid response)
-    #   rc==0 + other  → CLEAN   (non-127/8 response is invalid per RFC 5782)
+    # INVARIANT (v1.206 TODO-1): CLEAN means ONLY a successful negative lookup
+    # (authoritative NXDOMAIN / RFC5782 not-listed). A resolver/provider failure
+    # or a provider block-code must NEVER collapse into CLEAN.
+    #
+    # v1.150 (11.1/11.3): capture the resolver's real rc (no `|| true`).
+    #   rc==124              → TIMEOUT
+    #   rc!=0 (other)        → ERROR (resolver/network failure — NOT clean)
+    # v1.206 classification (rc==0):
+    #   answer 127.255.255.252/.253/.254 → RESOLVER_BLOCKED (Spamhaus query-blocked
+    #        / volume-limit / wrong-query — NOT listed and NOT clean) — carved out
+    #        BEFORE the blanket 127/8 listed check.
+    #   dig status REFUSED   → RESOLVER_BLOCKED (the resolver refused the zone)
+    #   dig status SERVFAIL  → ERROR (authority/delegation failure — NOT clean)
+    #   dig status NXDOMAIN / empty 127/8-absent → CLEAN (authoritative negative)
+    #   other 127/8 answer   → LISTED (RFC 5782 valid hit)
+    #   non-127/8 answer     → CLEAN (invalid per RFC 5782)
 
     local reversed_ip="$1"
     local rbl_domain="$2"
@@ -786,23 +874,26 @@ nftban_rbl_dns_lookup() {
         return 0
     fi
 
-    # Perform DNS lookup with timeout. Capture rc WITHOUT `|| true` (which would
-    # force rc=0 and resurrect the dead-TIMEOUT bug). Use `|| rc=$?`, which is
-    # set -e-safe AND preserves the resolver's real exit code (rc==124 for the
-    # `timeout` SIGTERM, rc==1 for host NXDOMAIN/failure, etc).
-    # NOTE: `if ! cmd; then rc=$?` does NOT work here — inside the `then` branch
-    # $? reflects the negated `! cmd` result (0), not cmd's exit code.
-    local dns_result="" rc=0
+    # Perform DNS lookup with timeout. Capture rc WITHOUT `|| true` (preserves the
+    # real rc: 124 for timeout SIGTERM, etc). For dig we ALSO capture the response
+    # status (REFUSED/SERVFAIL/NXDOMAIN/NOERROR) so resolver-block and authority
+    # failures are classified honestly instead of looking empty/CLEAN.
+    local dns_result="" rc=0 dns_status=""
     case "$resolver" in
         host)
             dns_result=$(timeout "$timeout" host -t A "$lookup_host" 2>/dev/null) || rc=$?
             ;;
         dig)
-            # dig +short emits one address per line (or empty for NXDOMAIN).
-            dns_result=$(timeout "$timeout" dig +short A "$lookup_host" 2>/dev/null) || rc=$?
+            # +noall +answer +comments → answer records AND the "status:" line in
+            # one query (no extra round-trip), so REFUSED/SERVFAIL are visible.
+            local dig_full=""
+            dig_full=$(timeout "$timeout" dig +noall +answer +comments A "$lookup_host" 2>/dev/null) || rc=$?
+            dns_status=$(printf '%s\n' "$dig_full" | grep -oP 'status:\s*\K[A-Z]+' | head -1)
+            dns_result=$(printf '%s\n' "$dig_full" | awk '!/^;/ && NF {print $NF}' | grep -E '^[0-9.]+$')
             ;;
         nslookup)
             dns_result=$(timeout "$timeout" nslookup -type=A "$lookup_host" 2>/dev/null) || rc=$?
+            dns_status=$(printf '%s\n' "$dns_result" | grep -oiP '\b(REFUSED|SERVFAIL|NXDOMAIN)\b' | head -1 | tr '[:lower:]' '[:upper:]')
             ;;
     esac
 
@@ -811,27 +902,54 @@ nftban_rbl_dns_lookup() {
         return 0
     fi
 
+    # v1.206: resolver-status classification (when the resolver surfaced one).
+    # REFUSED = the resolver/provider refused to answer the zone → blocked, not clean.
+    # SERVFAIL = authority/delegation failure → ERROR, never clean.
+    case "$dns_status" in
+        REFUSED)  echo "RESOLVER_BLOCKED"; return 0 ;;
+        SERVFAIL) echo "ERROR";            return 0 ;;
+    esac
+
     if [[ $rc -ne 0 ]]; then
         # host returns rc=1 on NXDOMAIN (not listed); dig/nslookup return rc=0
         # with empty output. For `host`, distinguish "not found" (= CLEAN) from
-        # a genuine resolver/network failure (= ERROR).
+        # a genuine resolver/network failure (= ERROR). dig REFUSED/SERVFAIL were
+        # already handled above via dns_status.
         if [[ "$resolver" == "host" ]] && \
            printf '%s' "$dns_result" | grep -qi "not found\|NXDOMAIN\|has no .* record"; then
             echo "CLEAN"
+        elif [[ "$resolver" == "host" ]] && \
+             printf '%s' "$dns_result" | grep -qi "REFUSED"; then
+            echo "RESOLVER_BLOCKED"
         else
             echo "ERROR"
         fi
         return 0
     fi
 
+    # rc==0 + authoritative negative → CLEAN.
+    if [[ "$dns_status" == "NXDOMAIN" ]]; then
+        echo "CLEAN"
+        return 0
+    fi
     if [[ -z "$dns_result" ]] || printf '%s' "$dns_result" | grep -qi "not found\|NXDOMAIN"; then
         echo "CLEAN"
         return 0
     fi
 
-    # v1.19.0: RFC 5782 validation - responses must be in 127.0.0.0/8 (R23)
+    # v1.19.0: RFC 5782 validation - responses must be in 127.0.0.0/8 (R23).
     local response_ip
     response_ip=$(printf '%s' "$dns_result" | grep -oP '\d+\.\d+\.\d+\.\d+' | head -1)
+    # v1.206 (TODO-1): carve out Spamhaus resolver/provider BLOCK codes BEFORE the
+    # blanket 127/8 listed check — these answers do NOT mean "listed", they mean
+    # the query was blocked (open-resolver / volume-limit / use DQS) and the IP's
+    # true reputation is UNKNOWN. Must classify RESOLVER_BLOCKED, never LISTED/CLEAN.
+    case "$response_ip" in
+        127.255.255.252|127.255.255.253|127.255.255.254)
+            echo "RESOLVER_BLOCKED"
+            return 0
+            ;;
+    esac
     if [[ -n "$response_ip" ]] && [[ "$response_ip" =~ ^127\. ]]; then
         echo "LISTED"
     elif [[ -n "$response_ip" ]]; then

--- a/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
+++ b/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
@@ -22,6 +22,11 @@
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'
+# This harness shadows resolver/provider leaf functions (nftban_rbl_resolver,
+# dig, timeout, nftban_rbl_dns_lookup, nftban_rbl_load_providers, …) which are
+# invoked INDIRECTLY by name from the sourced module under test — shellcheck's
+# SC2329 ("never invoked") cannot see that. Disabled file-wide for the harness.
+# shellcheck disable=SC2329
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)

--- a/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
+++ b/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
@@ -20,13 +20,13 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # =============================================================================
-set -Eeuo pipefail
-IFS=$'\n\t'
 # This harness shadows resolver/provider leaf functions (nftban_rbl_resolver,
 # dig, timeout, nftban_rbl_dns_lookup, nftban_rbl_load_providers, …) which are
 # invoked INDIRECTLY by name from the sourced module under test — shellcheck's
 # SC2329 ("never invoked") cannot see that. Disabled file-wide for the harness.
 # shellcheck disable=SC2329
+set -Eeuo pipefail
+IFS=$'\n\t'
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)

--- a/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
+++ b/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
@@ -131,7 +131,7 @@ R=$( nftban_rbl_resolver(){ echo ""; }; _NFTBAN_RBL_QUERY_COUNT=0
      nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
 assert_eq "$R" "ERROR" "T9.1 no resolver → ERROR"
 R=$( nftban_rbl_resolver(){ echo dig; }; _NFTBAN_RBL_QUERY_COUNT=999999
-     NFTBAN_RBL_MAX_QUERIES_PER_RUN=1; nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+     export NFTBAN_RBL_MAX_QUERIES_PER_RUN=1; nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
 assert_eq "$R" "RATE_LIMITED" "T9.2 query cap → RATE_LIMITED"
 
 echo

--- a/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
+++ b/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for the v1.206 RBL 7-state result model (TODO-1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_seven_state_v206_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-25"
+# meta:description="Tests the v1.206 RBL 7-state model: LISTED/CLEAN/ERROR/RESOLVER_BLOCKED/TIMEOUT/SKIPPED_IPV4_ONLY_ZONE/UNSUPPORTED_IPV6_ZONE. Asserts Spamhaus block-codes 127.255.255.252/.253/.254 classify RESOLVER_BLOCKED (not LISTED, not CLEAN); dig status REFUSED→RESOLVER_BLOCKED and SERVFAIL→ERROR; authoritative NXDOMAIN→CLEAN; a 127/8 listing→LISTED; that non-CLEAN states NEVER increment clean_count (the P0 false-negative invariant); rbl check --json stays valid JSON and exposes per-state degraded counts; IPv6 un-reversible→UNSUPPORTED_IPV6_ZONE and IPv4-only-zone→SKIPPED_IPV4_ONLY_ZONE; and the v1.150 ERROR/RATE_LIMITED-degraded behavior still holds. Self-contained sandbox; no network."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sed,mktemp,jq"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,sed,mktemp,jq"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_RBL_IPV4_ONLY_ZONES"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+RBL_SRC="$NFTBAN_LIB_DIR/core/nftban_rbl.sh"
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_CONFIG_DIR="$SANDBOX/etc"
+export NFTBAN_LOG_DIR="$SANDBOX/log"
+export NFTBAN_CACHE_DIR="$SANDBOX/cache"
+mkdir -p "$NFTBAN_CONFIG_DIR" "$NFTBAN_LOG_DIR" "$NFTBAN_CACHE_DIR"
+
+PASS=0; FAIL=0; FAILED_TESTS=()
+assert_eq() { local a="$1" e="$2" n="$3"
+    if [[ "$a" == "$e" ]]; then printf "  [PASS] %s\n" "$n"; PASS=$((PASS+1))
+    else printf "  [FAIL] %s (expected '%s', got '%s')\n" "$n" "$e" "$a"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$n"); fi; }
+assert_ok() { if [[ "$1" -eq 0 ]]; then printf "  [PASS] %s\n" "$2"; PASS=$((PASS+1))
+    else printf "  [FAIL] %s  %s\n" "$2" "${3:-}"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$2"); fi; }
+
+# shellcheck source=/dev/null
+source "$RBL_SRC"
+
+echo "================================================="
+echo "v1.206 RBL 7-state model test suite"
+echo "================================================="
+
+# A dig stub emitting a realistic `dig +noall +answer +comments` block. $1=status,
+# $2=answer-ip (optional). The classifier parses the 'status:' line and the answer.
+_dig_block() { local st="$1" ip="${2:-}"
+    echo ";; ->>HEADER<<- opcode: QUERY, status: ${st}, id: 12345"
+    [[ -n "$ip" ]] && echo "4.3.2.1.zen.example.test. 300 IN A ${ip}"; }
+
+echo; echo "[T1] Spamhaus block-codes → RESOLVER_BLOCKED (not LISTED, not CLEAN)"
+for code in 127.255.255.252 127.255.255.253 127.255.255.254; do
+    R=$( nftban_rbl_resolver(){ echo dig; }; timeout(){ shift; "$@"; }
+         dig(){ _dig_block NOERROR "$code"; return 0; }; _NFTBAN_RBL_QUERY_COUNT=0
+         nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+    assert_eq "$R" "RESOLVER_BLOCKED" "T1 $code → RESOLVER_BLOCKED"
+done
+
+echo; echo "[T2] dig status REFUSED → RESOLVER_BLOCKED"
+R=$( nftban_rbl_resolver(){ echo dig; }; timeout(){ shift; "$@"; }
+     dig(){ _dig_block REFUSED; return 0; }; _NFTBAN_RBL_QUERY_COUNT=0
+     nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "RESOLVER_BLOCKED" "T2 REFUSED → RESOLVER_BLOCKED"
+
+echo; echo "[T3] dig status SERVFAIL → ERROR (never CLEAN)"
+R=$( nftban_rbl_resolver(){ echo dig; }; timeout(){ shift; "$@"; }
+     dig(){ _dig_block SERVFAIL; return 0; }; _NFTBAN_RBL_QUERY_COUNT=0
+     nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "ERROR" "T3 SERVFAIL → ERROR"
+
+echo; echo "[T4] authoritative NXDOMAIN → CLEAN"
+R=$( nftban_rbl_resolver(){ echo dig; }; timeout(){ shift; "$@"; }
+     dig(){ _dig_block NXDOMAIN; return 0; }; _NFTBAN_RBL_QUERY_COUNT=0
+     nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "CLEAN" "T4 NXDOMAIN → CLEAN"
+
+echo; echo "[T5] real 127/8 listing → LISTED"
+R=$( nftban_rbl_resolver(){ echo dig; }; timeout(){ shift; "$@"; }
+     dig(){ _dig_block NOERROR 127.0.0.2; return 0; }; _NFTBAN_RBL_QUERY_COUNT=0
+     nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "LISTED" "T5 127.0.0.2 → LISTED"
+
+echo; echo "[T6] aggregation: non-CLEAN NEVER counts clean + valid JSON (the P0 invariant)"
+# 4 providers → listed / resolver_blocked / timeout / clean. clean MUST be 1.
+T6=$(
+    nftban_rbl_load_providers(){ printf '%s\n' "listed.test:u1" "blocked.test:u2" "tmo.test:u3" "clean.test:u4"; }
+    nftban_rbl_dns_lookup(){ case "$2" in
+        listed.test) echo LISTED ;; blocked.test) echo RESOLVER_BLOCKED ;;
+        tmo.test) echo TIMEOUT ;; *) echo CLEAN ;; esac; }
+    nftban_rbl_get_txt_record(){ echo "test"; }
+    nftban_rbl_check_ip "1.2.3.4" "json"
+) || true
+assert_ok "$(echo "$T6" | jq . >/dev/null 2>&1; echo $?)" "T6.1 --json is valid JSON"
+assert_eq "$(echo "$T6" | jq -r '.summary.clean')" "1"            "T6.2 clean count = 1 (degraded NOT folded into clean)"
+assert_eq "$(echo "$T6" | jq -r '.summary.listed')" "1"           "T6.3 listed = 1"
+assert_eq "$(echo "$T6" | jq -r '.summary.resolver_blocked')" "1" "T6.4 resolver_blocked = 1"
+assert_eq "$(echo "$T6" | jq -r '.summary.timeout')" "1"          "T6.5 timeout = 1"
+assert_eq "$(echo "$T6" | jq -r '.summary.degraded')" "2"         "T6.6 degraded total = 2 (blocked+timeout)"
+
+echo; echo "[T7] IPv6 un-reversible (no python3) → UNSUPPORTED_IPV6_ZONE (never CLEAN)"
+T7=$(
+    nftban_rbl_reverse_ip(){ echo ""; }   # simulate no-python3 IPv6 reverse
+    nftban_rbl_load_providers(){ printf '%s\n' "zen.test:u1"; }
+    nftban_rbl_dns_lookup(){ echo "SHOULD_NOT_BE_CALLED"; }
+    nftban_rbl_check_ip "2001:db8::1" "json"
+) || true
+assert_eq "$(echo "$T7" | jq -r '.summary.unsupported_ipv6_zone')" "1" "T7.1 unsupported_ipv6_zone = 1"
+assert_eq "$(echo "$T7" | jq -r '.summary.clean')" "0"                 "T7.2 clean = 0 (not a silent clean)"
+
+echo; echo "[T8] IPv6 + IPv4-only zone → SKIPPED_IPV4_ONLY_ZONE (never CLEAN)"
+T8=$(
+    export NFTBAN_RBL_IPV4_ONLY_ZONES="v4only.test"
+    nftban_rbl_reverse_ip(){ echo "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"; }
+    nftban_rbl_load_providers(){ printf '%s\n' "v4only.test:u1"; }
+    nftban_rbl_dns_lookup(){ echo CLEAN; }   # would falsely say clean if not skipped
+    nftban_rbl_check_ip "2001:db8::1" "json"
+) || true
+assert_eq "$(echo "$T8" | jq -r '.summary.skipped_ipv4_only_zone')" "1" "T8.1 skipped_ipv4_only_zone = 1"
+assert_eq "$(echo "$T8" | jq -r '.summary.clean')" "0"                  "T8.2 clean = 0 (IPv4-only zone not counted clean for IPv6)"
+
+echo; echo "[T9] v1.150 regression: ERROR + RATE_LIMITED still degraded, never CLEAN"
+R=$( nftban_rbl_resolver(){ echo ""; }; _NFTBAN_RBL_QUERY_COUNT=0
+     nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "ERROR" "T9.1 no resolver → ERROR"
+R=$( nftban_rbl_resolver(){ echo dig; }; _NFTBAN_RBL_QUERY_COUNT=999999
+     NFTBAN_RBL_MAX_QUERIES_PER_RUN=1; nftban_rbl_dns_lookup "1.2.3.4" "zen.example.test" )
+assert_eq "$R" "RATE_LIMITED" "T9.2 query cap → RATE_LIMITED"
+
+echo
+echo "================================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED_TESTS[@]}"; exit 1; fi
+echo "ALL PASS"


### PR DESCRIPTION
## v1.206.0 — RBL STATE + VISIBILITY HARDENING (TODO-1 P0 false-negative)

**Scope:** `V206_RBL_STATE_AND_VISIBILITY_SCOPE.md` · **Report:** `V206_RBL_STATE_AND_VISIBILITY_IMPL_REPORT.md`. **Shell-only — no daemon/schema change.**

### Fixed — RBL 7-state result model
`LISTED · CLEAN · ERROR · RESOLVER_BLOCKED · TIMEOUT · SKIPPED_IPV4_ONLY_ZONE · UNSUPPORTED_IPV6_ZONE`.
- **Invariant:** CLEAN = a *successful negative* lookup ONLY; non-CLEAN **never** increments clean count and **never** projects as fully protected (closes the `else→clean` swallow = the P0 false-negative).
- **Spamhaus block-codes `127.255.255.252/.253/.254` → RESOLVER_BLOCKED** (carved out before the blanket 127/8 listed check — not listed, not clean).
- `dig` status captured (`+noall +answer +comments`): **REFUSED → RESOLVER_BLOCKED, SERVFAIL → ERROR, authoritative NXDOMAIN → CLEAN, no-resolver → ERROR**.
- **IPv6 honesty:** un-reversible IPv6 → `UNSUPPORTED_IPV6_ZONE`; operator-declared IPv4-only zones (`NFTBAN_RBL_IPV4_ONLY_ZONES`) → `SKIPPED_IPV4_ONLY_ZONE`; never a silent clean.

### Visibility
- `rbl check` persists 3-way state (listed/degraded/clean) — a degraded check is no longer recorded clean.
- **`nftban health rbl` reads the authoritative `/var/cache/nftban/rbl`** (fixes the stale `/var/log` key/state-path drift) + surfaces **DEGRADED** / "not fully protected" when RBL is blind. No stale `/var/log` reader remains.
- `rbl check --json` exposes per-state counts + a `degraded` total (state, not a clean/listed bool).

### Validation — package-native, build 28185397692
- **lab2 DEB PASS · lab4 RPM PASS** (7-state on the installed module, aggregation invariant clean=1/degraded=2, IPv6 never-clean, health cache-authority + DEGRADED surfacing, no residue, no RBL-timer default-enable flip; both labs restored to v1.205.0). Hermetic suite 19/0 + v1.150 regression 17/0.
- **Validation honesty:** two intermediate false-fails were **harness bugs only** — an artifact-download TLS timeout (ran the old module) and a `dig`-stub/inline-`case` parse issue on lab4's bash. The **product** passed on both lab2 and lab4 once the harness was corrected.

### Non-scope (unchanged)
No daemon change (`nftband` NOT re-baselined) · no nft schema change (1.84.0) · VERSION stays 1.205.0 (release-prep is a separate gate) · no email/webhook/auditor/central-comms · no RBL-timer default-enable flip · no portscan/CLI-parity change · no fleet rollout. Watchlist + mail template untouched.