### PR TITLE
v1.206.1 stats manual attribution hotfix

### DIFF
--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -54,15 +54,22 @@ readonly NFTBAN_STATS_FORMAT_LOADED=1
 nftban_stats_manual_provenance() {
     local total="${1:-0}"
     local bd="${NFTBAN_CONFIG_DIR:-/etc/nftban}/blacklist.d"
+    # Extract the leading IP token per non-comment line (drops inline comments),
+    # deduped. IP-SET based (not raw line counts) so precedence + no-double-count
+    # are real: an IP listed in BOTH files counts ONCE, as operator (99-manual wins).
+    local op_ips per_ips
+    # awk: skip comment/blank lines, print the FIRST token (the IP; drops inline
+    # comments), then keep only IP-shaped tokens, dedup. (Avoids tr -d which would
+    # collapse newlines and mash all IPs onto one line.)
+    op_ips=$(awk '!/^[[:space:]]*#/ && NF {print $1}' "$bd/99-manual.conf" 2>/dev/null | grep -E '^[0-9A-Fa-f.:]+$' | sort -u || true)
+    per_ips=$(awk '!/^[[:space:]]*#/ && NF {print $1}' "$bd/30-persistent-offenders.conf" 2>/dev/null | grep -E '^[0-9A-Fa-f.:]+$' | sort -u || true)
     local op per adopted
-    # grep -c always prints a count; `|| true` swallows its exit-1 (no matches)
-    # without appending a second line (the `|| echo 0` form printed "0\n0").
-    op=$(grep -cvE '^[[:space:]]*#|^[[:space:]]*$' "$bd/99-manual.conf" 2>/dev/null || true)
-    per=$(grep -cvE '^[[:space:]]*#|^[[:space:]]*$' "$bd/30-persistent-offenders.conf" 2>/dev/null || true)
+    op=$(printf '%s\n' "$op_ips" | grep -c . || true)
+    # persistent EXCLUDING any IP already attributed to operator (precedence)
+    per=$(comm -23 <(printf '%s\n' "$per_ips" | sort -u) <(printf '%s\n' "$op_ips" | sort -u) 2>/dev/null | grep -c . || true)
     op=${op:-0}; per=${per:-0}
     [[ "$op" =~ ^[0-9]+$ ]] || op=0; [[ "$per" =~ ^[0-9]+$ ]] || per=0
-    # Precedence: an IP in 99-manual is operator-manual even if also persistent
-    # (operator intent wins); adopted = live manual-set members in neither file.
+    # adopted = live manual-set members in neither file (clamped >=0).
     adopted=$(( total - op - per ))
     [ "$adopted" -lt 0 ] && adopted=0
     printf '%s %s %s' "$op" "$per" "$adopted"

--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -44,6 +44,30 @@ readonly NFTBAN_STATS_FORMAT_LOADED=1
 # DASHBOARD GENERATION
 # =============================================================================
 
+# v1.206.1 (BUG-STATS-MANUAL-MISATTRIBUTION): split the live manual-hash-set
+# population by PROVENANCE using the authoritative blacklist.d files, so LoginMon
+# / persistent-offender DURABLE bans are not displayed as operator "Manual".
+# Since v1.203.0 (INC2) single-IP blacklist.d entries (incl. 30-persistent-
+# offenders.conf, written by LoginMon for >=N bans/window) are routed into the
+# blacklist_manual_* hash set; the set NAME is a backend label, NOT provenance.
+# Echoes: "<operator_manual> <persistent_loginmon> <adopted_unknown>".
+nftban_stats_manual_provenance() {
+    local total="${1:-0}"
+    local bd="${NFTBAN_CONFIG_DIR:-/etc/nftban}/blacklist.d"
+    local op per adopted
+    # grep -c always prints a count; `|| true` swallows its exit-1 (no matches)
+    # without appending a second line (the `|| echo 0` form printed "0\n0").
+    op=$(grep -cvE '^[[:space:]]*#|^[[:space:]]*$' "$bd/99-manual.conf" 2>/dev/null || true)
+    per=$(grep -cvE '^[[:space:]]*#|^[[:space:]]*$' "$bd/30-persistent-offenders.conf" 2>/dev/null || true)
+    op=${op:-0}; per=${per:-0}
+    [[ "$op" =~ ^[0-9]+$ ]] || op=0; [[ "$per" =~ ^[0-9]+$ ]] || per=0
+    # Precedence: an IP in 99-manual is operator-manual even if also persistent
+    # (operator intent wins); adopted = live manual-set members in neither file.
+    adopted=$(( total - op - per ))
+    [ "$adopted" -lt 0 ] && adopted=0
+    printf '%s %s %s' "$op" "$per" "$adopted"
+}
+
 nftban_stats_generate_dashboard() {
     # Generate comprehensive terminal dashboard - Clean v1.0 layout
     # Usage: nftban_stats_generate_dashboard [since] [until]
@@ -200,8 +224,17 @@ nftban_stats_generate_dashboard() {
     # split on every path); `manual` is a SUBSET of total (decision: subset-of-total),
     # so it is labelled "incl. manual" to read as included-within, not additive.
     echo "  Direct Bans (nftables):"
-    printf "      %-16s %'d (perm: %'d, temp: %'d; incl. manual: %'d)\n" "IPv4............" "$black_v4" "$black_v4_perm" "$black_v4_temp" "$manual_v4"
-    printf "      %-16s %'d (perm: %'d, temp: %'d; incl. manual: %'d)\n" "IPv6............" "$black_v6" "$black_v6_perm" "$black_v6_temp" "$manual_v6"
+    printf "      %-16s %'d (perm: %'d, temp: %'d; incl. manual-set: %'d)\n" "IPv4............" "$black_v4" "$black_v4_perm" "$black_v4_temp" "$manual_v4"
+    printf "      %-16s %'d (perm: %'d, temp: %'d; incl. manual-set: %'d)\n" "IPv6............" "$black_v6" "$black_v6_perm" "$black_v6_temp" "$manual_v6"
+    # v1.206.1: provenance split of the manual-hash-set so persistent/LoginMon
+    # durable bans are not read as operator "Manual".
+    local _manual_total=$(( manual_v4 + manual_v6 ))
+    if [[ $_manual_total -gt 0 ]]; then
+        local _m_op _m_per _m_ad
+        IFS=" " read -r _m_op _m_per _m_ad <<< "$(nftban_stats_manual_provenance "$_manual_total")"
+        printf "      %-16s operator-manual: %'d · persistent/loginmon: %'d · adopted: %'d\n" "Manual-set by:" "$_m_op" "$_m_per" "$_m_ad"
+        echo "        (manual-set = blacklist_manual hash; LoginMon persistent-offenders live here too — NOT operator manual)"
+    fi
 
     # Count feeds (SINGLE SOURCE OF TRUTH from unified cache)
     local feeds_ipv4_total=0 feeds_ipv6_total=0
@@ -289,8 +322,11 @@ nftban_stats_generate_dashboard() {
     # ─────────────────────────────────────────────────────────────────────
     echo "ACTIVITY HISTORY"
     echo "───────────────────────────────────────────────────────────"
-    printf "  %-20s %s\n" "New bans (period)..." "$total_bans"
+    printf "  %-20s %s\n" "New ban events......" "$total_bans"
     printf "  %-20s %s\n" "Unique IPs banned..." "$unique_ips"
+    # v1.206.1 (BUG-STATS-COUNT-DIVERGENCE): label count semantics so operators do
+    # not expect events, unique IPs, per-source, and live-set counts to sum.
+    echo "    (ban EVENTS in period, incl. re-bans of the same IP; not the live-set size)"
 
     # Source breakdown (SINGLE SOURCE OF TRUTH via nftban_stats_ban_sources)
     local sources
@@ -304,7 +340,7 @@ nftban_stats_generate_dashboard() {
         feeds=$(echo "$sources" | jq -r '.feeds // 0')
         suricata_bans=$(echo "$sources" | jq -r '.suricata // 0')
 
-        echo "  Modules:"
+        echo "  By source (ban events, this period):"
         printf "      %-14s %s\n" "Login..........." "$login_bans"
         printf "      %-14s %s\n" "Port Scan......." "$portscan_bans"
         printf "      %-14s %s\n" "DDoS............" "$ddos_bans"
@@ -514,6 +550,11 @@ nftban_stats_generate_dashboard() {
     printf "  %-18s %'d IPs\n" "DDOS" "$ddos_count"
     printf "  %-18s %'d IPs\n" "MANUAL" "$manual_count"
     [[ "$suricata_count" -gt 0 ]] && printf "  %-18s %'d IPs\n" "SURICATA" "$suricata_count"
+    # v1.206.1: "MANUAL" here = ban events sourced manual/cli (cumulative cache).
+    # Durable LoginMon/persistent-offenders live in the manual hash SET but are
+    # shown by provenance under PROTECTION BREAKDOWN ("Manual-set by:"), not as
+    # operator manual — see that line to distinguish operator vs persistent.
+    echo "  (operator-manual vs persistent/loginmon provenance: see PROTECTION BREAKDOWN above)"
     echo ""
 
     # ─────────────────────────────────────────────────────────────────────
@@ -522,10 +563,20 @@ nftban_stats_generate_dashboard() {
     if [[ $total_black -gt 0 ]]; then
         echo "CURRENT ACTIVE BANS (sample)"
         echo "───────────────────────────────────────────────────────────"
-        if timeout 10s nft list set "${NFTBAN_TABLE_IPV4}" blacklist_ipv4 &>/dev/null 2>&1; then
-            timeout 10s nft list set "${NFTBAN_TABLE_IPV4}" blacklist_ipv4 2>/dev/null | \
-                grep -oP '\d+\.\d+\.\d+\.\d+(/\d+)?' | \
-                awk 'NR<=5 {print "  " $1}' 2>/dev/null || true
+        # v1.206.1 (BUG-STATS-COUNT-DIVERGENCE): sample BOTH the interval set
+        # (blacklist_ipv4: feed/geoban) AND the manual hash set
+        # (blacklist_manual_ipv4: single-IP durable incl. persistent-offenders).
+        # Previously only the interval set was sampled, so a host whose only live
+        # bans are in the manual set (e.g. a LoginMon persistent-offender, no
+        # feeds) rendered an EMPTY sample despite Blocked IPs (live) > 0.
+        local _sample
+        _sample=$( { for _s in blacklist_ipv4 blacklist_manual_ipv4; do
+                        timeout 10s nft list set "${NFTBAN_TABLE_IPV4}" "$_s" 2>/dev/null
+                     done; } | grep -oP '\d+\.\d+\.\d+\.\d+(/\d+)?' | awk 'NF' | sort -u | head -5 )
+        if [[ -n "$_sample" ]]; then
+            printf '  %s\n' $_sample
+        else
+            echo "  (sample unavailable — live bans may be IPv6-only or set read timed out)"
         fi
         echo ""
     fi

--- a/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
+++ b/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.206.1 stats manual-ban provenance attribution (hotfix)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="stats_manual_provenance_v206_1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-25"
+# meta:description="Tests the v1.206.1 stats hotfix for BUG-STATS-MANUAL-MISATTRIBUTION + BUG-STATS-COUNT-DIVERGENCE. Asserts nftban_stats_manual_provenance() splits the live manual-hash-set total into operator-manual (99-manual.conf), persistent/loginmon (30-persistent-offenders.conf) and adopted/unknown (remainder); that a persistent-offender IP is NOT attributed to operator manual; that operator-manual is reserved for 99-manual.conf; that adopted is clamped >=0 when files exceed the total; and that the dashboard renderer carries the new count-semantics labels (manual-set, persistent/loginmon provenance, ban EVENTS, By source). Self-contained; no network; no nft."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+SRC="$NFTBAN_LIB_DIR/core/nftban_stats_format.sh"
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_CONFIG_DIR="$SANDBOX/etc"
+mkdir -p "$NFTBAN_CONFIG_DIR/blacklist.d"
+BD="$NFTBAN_CONFIG_DIR/blacklist.d"
+
+PASS=0; FAIL=0; FAILED=()
+aeq(){ if [[ "$1" == "$2" ]]; then printf "  [PASS] %s\n" "$3"; PASS=$((PASS+1)); else printf "  [FAIL] %s (want '%s' got '%s')\n" "$3" "$2" "$1"; FAIL=$((FAIL+1)); FAILED+=("$3"); fi; }
+
+# shellcheck source=/dev/null
+source "$SRC"
+
+echo "==============================================="
+echo "v1.206.1 stats manual provenance test suite"
+echo "==============================================="
+
+# 5 operator-manual + 3 persistent(loginmon); live manual-set total = 10 → adopted 2
+printf '%s\n' '1.1.1.1' '1.1.1.2' '1.1.1.3' '1.1.1.4 # note' '1.1.1.5' > "$BD/99-manual.conf"
+printf '%s\n' '# header comment' '2.2.2.1  # >=10 bans in 24h from loginmon' '2.2.2.2' '2.2.2.3' > "$BD/30-persistent-offenders.conf"
+
+IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 10)"
+echo "[T1] split of total=10 with op=5 per=3 → $OP/$PER/$AD"
+aeq "$OP"  "5" "T1.1 operator-manual = 99-manual.conf non-comment lines"
+aeq "$PER" "3" "T1.2 persistent/loginmon = 30-persistent-offenders.conf non-comment lines"
+aeq "$AD"  "2" "T1.3 adopted = total - operator - persistent"
+
+# persistent-only: total 3, op 0 → persistent 3, adopted 0 (NOT counted as operator manual)
+: > "$BD/99-manual.conf"
+IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 3)"
+aeq "$OP"  "0" "T2.1 no operator manual when 99-manual.conf empty"
+aeq "$PER" "3" "T2.2 persistent-offenders attributed to persistent (NOT operator)"
+aeq "$AD"  "0" "T2.3 adopted 0"
+
+# files exceed total (stale) → adopted clamped to 0, never negative
+IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 1)"
+aeq "$AD" "0" "T3 adopted clamped >=0 when files exceed live total"
+
+# zero total with empty files → all zero (true-empty case; renderer only shows
+# provenance when manual_total>0, so this is the meaningful zero path)
+: > "$BD/99-manual.conf"; : > "$BD/30-persistent-offenders.conf"
+IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 0)"
+aeq "$OP/$PER/$AD" "0/0/0" "T4 zero total + empty files → 0/0/0"
+
+echo "[T5] renderer carries the new count-semantics + provenance labels"
+grep -q 'incl. manual-set:' "$SRC"                       && { echo "  [PASS] T5.1 Direct Bans relabeled 'incl. manual-set'"; PASS=$((PASS+1)); } || { echo "  [FAIL] T5.1"; FAIL=$((FAIL+1)); FAILED+=("T5.1"); }
+grep -q 'persistent/loginmon' "$SRC"                     && { echo "  [PASS] T5.2 provenance split rendered"; PASS=$((PASS+1)); } || { echo "  [FAIL] T5.2"; FAIL=$((FAIL+1)); FAILED+=("T5.2"); }
+grep -q 'New ban events' "$SRC"                          && { echo "  [PASS] T5.3 'New ban events' label"; PASS=$((PASS+1)); } || { echo "  [FAIL] T5.3"; FAIL=$((FAIL+1)); FAILED+=("T5.3"); }
+grep -q 'By source (ban events, this period)' "$SRC"     && { echo "  [PASS] T5.4 'By source' window label"; PASS=$((PASS+1)); } || { echo "  [FAIL] T5.4"; FAIL=$((FAIL+1)); FAILED+=("T5.4"); }
+grep -q 'sample unavailable' "$SRC" && { echo "  [PASS] T5.5 empty-sample reason"; PASS=$((PASS+1)); } || { echo "  [FAIL] T5.5"; FAIL=$((FAIL+1)); FAILED+=("T5.5"); }
+
+echo
+echo "==============================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
+++ b/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
@@ -62,6 +62,17 @@ aeq "$OP"  "0" "T2.1 no operator manual when 99-manual.conf empty"
 aeq "$PER" "3" "T2.2 persistent-offenders attributed to persistent (NOT operator)"
 aeq "$AD"  "0" "T2.3 adopted 0"
 
+# precedence + no-double-count: IP in BOTH files counts once, as operator
+printf '%s\n' '7.7.7.7' '8.8.8.8' > "$BD/99-manual.conf"          # 2 operator
+printf '%s\n' '7.7.7.7  # also persistent' '9.9.9.9' > "$BD/30-persistent-offenders.conf"  # 7.7.7.7 dup, 9.9.9.9 new
+IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 3)"
+aeq "$OP"  "2" "T3a operator = 2 (7.7.7.7, 8.8.8.8)"
+aeq "$PER" "1" "T3a persistent = 1 (9.9.9.9 only; 7.7.7.7 deduped to operator)"
+aeq "$AD"  "0" "T3a adopted = 0 (3 total = 2 op + 1 per, no double-count)"
+# restore the T1/T2 fixture for the clamp test below
+printf '%s\n' '1.1.1.1' '1.1.1.2' '1.1.1.3' '1.1.1.4 # note' '1.1.1.5' > "$BD/99-manual.conf"
+printf '%s\n' '# header comment' '2.2.2.1' '2.2.2.2' '2.2.2.3' > "$BD/30-persistent-offenders.conf"
+
 # files exceed total (stale) → adopted clamped to 0, never negative
 IFS=" " read -r OP PER AD <<< "$(nftban_stats_manual_provenance 1)"
 aeq "$AD" "0" "T3 adopted clamped >=0 when files exceed live total"


### PR DESCRIPTION
## v1.206.1 — STATS MANUAL-ATTRIBUTION + COUNT-CLARITY HOTFIX

**Reporting/stats-only.** Evidence: `V206_FLEET_STATS_MANUAL_ATTRIBUTION_FINDINGS.md` · Report: `V206_1_STATS_ATTRIBUTION_HOTFIX_IMPL_REPORT.md`.

### Problem
Since v1.203.0 (INC2) single-IP `blacklist.d` entries (incl. LoginMon persistent-offenders from `30-persistent-offenders.conf`) route into the `blacklist_manual_*` hash set; `source_index` tags adopted entries `"unknown"`; `nftban stats` then displayed them as operator **"Manual"** → operator panic ("I didn't make any manual"). Counts also diverged without labels; the active-bans sample rendered empty when the only live bans were in the manual hash set.

### Fix (one stats formatter + one test)
- New `nftban_stats_manual_provenance()` — IP-set split of the live manual-hash-set into **operator-manual** (`99-manual.conf`) · **persistent/loginmon** (`30-persistent-offenders.conf`) · **adopted/unknown** (remainder, clamped ≥0). Precedence: 99-manual wins; **no double-count**.
- PROTECTION BREAKDOWN: `incl. manual` → `incl. manual-set` + provenance line so persistent-offenders are NOT shown as operator manual.
- ACTIVITY: `New bans (period)` → `New ban events` + semantics note; `Modules:` → `By source (ban events, this period)`. BANS-BY-MODULE note → provenance line.
- CURRENT ACTIVE BANS sample reads both interval + manual hash sets; explicit "sample unavailable" reason.

### Validation — build 28194777988
- **lab2 DEB PASS · lab4 RPM PASS** (attribution matrix, precedence/no-double-count, labels, regression, restore to v1.206.0). Hermetic 16/0.
- **Live smoke (real data):** lab2 `operator-manual: 0 · persistent/loginmon: 386 · adopted: 20`; lab4 `0 · 133 · 0`. **→ LoginMon persistent-offenders no longer display as operator "Manual"; the operator panic is resolved.**

### Scope / non-scope
Reporting/stats-only. **v1.203 blacklist topology remains intact; `source_index.jsonl` is NOT rewritten; the updater inhibited-timer warning is NOT touched** (parked separately). No `.go`/daemon change (`nftband` NOT re-baselined); nft schema **1.84.0** unchanged; VERSION stays 1.206.0 (release-prep bumps to 1.206.1). No firewall/ban/LoginMon-threshold/RBL/portscan/CLI-parity/central-comms change; no fleet rollout.