### PR TITLE
v1.206.2 stats count reconciliation hotfix

### DIFF
--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -121,7 +121,16 @@ nftban_stats_generate_dashboard() {
         # v1.167 PR-2 (E): casing-consistency. The two Data source values are
         # siblings; align the cache-hit value to the all-caps convention used
         # by its sibling ("DERIVED ...") and the section headers (SYSTEM, etc.).
-        printf "  %-20s %s\n" "Data source........." "UNIFIED CACHE"
+        # v1.206.2 (BUG-STATS-CACHE-STALENESS): surface the cache snapshot AGE so
+        # operators know counts are a point-in-time snapshot — a ban added since the
+        # last collect (EITHER family) will not appear until the cache regenerates.
+        local _cache_age="?"
+        if [[ -f "${NFTBAN_UNIFIED_CACHE:-}" ]]; then
+            local _ct; _ct=$(stat -c %Y "$NFTBAN_UNIFIED_CACHE" 2>/dev/null || echo "")
+            [[ -n "$_ct" ]] && _cache_age="$(( $(date +%s) - _ct ))s ago"
+        fi
+        printf "  %-20s %s\n" "Data source........." "UNIFIED CACHE (snapshot, collected ${_cache_age})"
+        echo "    (counts are a cached snapshot; a ban added since the last collect may not appear until the next collection)"
     else
         printf "  %-20s %s\n" "Data source........." "DERIVED (cache miss; live aggregation from nftables + bans.log)"
     fi
@@ -348,12 +357,29 @@ nftban_stats_generate_dashboard() {
         suricata_bans=$(echo "$sources" | jq -r '.suricata // 0')
 
         echo "  By source (ban events, this period):"
-        printf "      %-14s %s\n" "Login..........." "$login_bans"
-        printf "      %-14s %s\n" "Port Scan......." "$portscan_bans"
-        printf "      %-14s %s\n" "DDoS............" "$ddos_bans"
-        printf "      %-14s %s\n" "Manual.........." "$manual"
-        printf "      %-14s %s\n" "Feeds..........." "$feeds"
-        [[ "$suricata_bans" != "0" ]] && printf "      %-14s %s\n" "Suricata........" "$suricata_bans"
+        printf "      %-18s %s\n" "Login.........." "$login_bans"
+        printf "      %-18s %s\n" "Port Scan......" "$portscan_bans"
+        printf "      %-18s %s\n" "DDoS..........." "$ddos_bans"
+        # v1.206.2 (BUG-STATS labels): "Manual" here = ban EVENTS whose source was
+        # operator/CLI (manual). It is NOT the manual-hash SET (persistent-offenders
+        # live there too) — see PROTECTION BREAKDOWN "Manual-set by:" for set provenance.
+        printf "      %-18s %s\n" "Operator/CLI..." "$manual"
+        printf "      %-18s %s\n" "Feeds.........." "$feeds"
+        [[ "$suricata_bans" != "0" ]] && printf "      %-18s %s\n" "Suricata......." "$suricata_bans"
+        # v1.206.2 (BUG-STATS-COUNT-DIVERGENCE): reconcile to New ban events. The
+        # by-source breakdown is parsed from bans.log; New ban events is the activity
+        # counter. If the breakdown does not sum to the total, surface the remainder
+        # as Other/Unclassified rather than silently dropping it.
+        if [[ "$total_bans" =~ ^[0-9]+$ ]]; then
+            local _src_sum=$(( login_bans + portscan_bans + ddos_bans + manual + feeds + suricata_bans ))
+            local _other=$(( total_bans - _src_sum ))
+            if [[ $_other -gt 0 ]]; then
+                printf "      %-18s %s\n" "Other/Unclass.." "$_other"
+                echo "      (Other = New ban events − classified-by-source; events whose source token was absent/unrecognised in bans.log this window)"
+            elif [[ $_other -lt 0 ]]; then
+                echo "      (note: by-source total ${_src_sum} exceeds New ban events ${total_bans} — different source/window basis; not additive)"
+            fi
+        fi
 
         if [[ "$login_bans" == "0" ]] && [[ "$portscan_bans" == "0" ]] && [[ "$ddos_bans" == "0" ]] && [[ "$manual" == "0" ]] && [[ "$feeds" == "0" ]] && [[ "$suricata_bans" == "0" ]]; then
             echo ""
@@ -555,13 +581,13 @@ nftban_stats_generate_dashboard() {
     printf "  %-18s %'d IPs\n" "LOGIN" "$login_count"
     printf "  %-18s %'d IPs\n" "PORTSCAN" "$portscan_count"
     printf "  %-18s %'d IPs\n" "DDOS" "$ddos_count"
-    printf "  %-18s %'d IPs\n" "MANUAL" "$manual_count"
+    # v1.206.2 (BUG-STATS labels): rename ambiguous "MANUAL" → "OPERATOR/CLI" — this
+    # is the manual/cli ban SOURCE, NOT the manual-hash SET (persistent-offenders
+    # live in the set but are NOT operator action; see PROTECTION BREAKDOWN provenance).
+    printf "  %-18s %'d IPs\n" "OPERATOR/CLI" "$manual_count"
     [[ "$suricata_count" -gt 0 ]] && printf "  %-18s %'d IPs\n" "SURICATA" "$suricata_count"
-    # v1.206.1: "MANUAL" here = ban events sourced manual/cli (cumulative cache).
-    # Durable LoginMon/persistent-offenders live in the manual hash SET but are
-    # shown by provenance under PROTECTION BREAKDOWN ("Manual-set by:"), not as
-    # operator manual — see that line to distinguish operator vs persistent.
-    echo "  (operator-manual vs persistent/loginmon provenance: see PROTECTION BREAKDOWN above)"
+    echo "  (OPERATOR/CLI = manual/cli ban source; durable persistent-offenders are in the manual-set —"
+    echo "   see PROTECTION BREAKDOWN \"Manual-set by:\" for operator-manual vs persistent/loginmon vs adopted)"
     echo ""
 
     # ─────────────────────────────────────────────────────────────────────
@@ -576,14 +602,28 @@ nftban_stats_generate_dashboard() {
         # Previously only the interval set was sampled, so a host whose only live
         # bans are in the manual set (e.g. a LoginMon persistent-offender, no
         # feeds) rendered an EMPTY sample despite Blocked IPs (live) > 0.
-        local _sample
-        _sample=$( { for _s in blacklist_ipv4 blacklist_manual_ipv4; do
-                        timeout 10s nft list set "${NFTBAN_TABLE_IPV4}" "$_s" 2>/dev/null
-                     done; } | grep -oP '\d+\.\d+\.\d+\.\d+(/\d+)?' | awk 'NF' | sort -u | head -5 )
-        if [[ -n "$_sample" ]]; then
-            printf '  %s\n' $_sample
+        # v1.206.2: gather from BOTH families (interval + manual hash) so IPv6
+        # active bans appear; print "showing X of N" and list ALL when N is small.
+        local _all _v4 _v6 _n _show
+        _v4=$( { for _s in blacklist_ipv4 blacklist_manual_ipv4; do
+                    timeout 10s nft list set "${NFTBAN_TABLE_IPV4}" "$_s" 2>/dev/null
+                 done; } | grep -oP '\d+\.\d+\.\d+\.\d+(/\d+)?' )
+        _v6=$( { for _s in blacklist_ipv6 blacklist_manual_ipv6; do
+                    timeout 10s nft list set "${NFTBAN_TABLE_IPV6:-ip6 nftban}" "$_s" 2>/dev/null
+                 done; } | grep -oiP '[0-9a-f]{0,4}:[0-9a-f:]+(/\d+)?' )
+        _all=$(printf '%s\n%s\n' "$_v4" "$_v6" | awk 'NF' | sort -u)
+        _n=$(printf '%s\n' "$_all" | awk 'NF' | wc -l)
+        if [[ "${_n:-0}" -eq 0 ]]; then
+            echo "  (sample unavailable — set read timed out or live count is in a non-enumerable set)"
         else
-            echo "  (sample unavailable — live bans may be IPv6-only or set read timed out)"
+            # list all when small (<=10); otherwise show first 10 of N
+            local _cap=10
+            if [[ "$_n" -le "$_cap" ]]; then
+                echo "  showing $_n of $_n:"; printf '%s\n' "$_all" | sed 's/^/  /'
+            else
+                _show=$(printf '%s\n' "$_all" | head -"$_cap")
+                echo "  showing $_cap of $_n:"; printf '%s\n' "$_show" | sed 's/^/  /'
+            fi
         fi
         echo ""
     fi

--- a/cli/lib/nftban/core/nftban_stats_format.sh
+++ b/cli/lib/nftban/core/nftban_stats_format.sh
@@ -129,7 +129,10 @@ nftban_stats_generate_dashboard() {
             local _ct; _ct=$(stat -c %Y "$NFTBAN_UNIFIED_CACHE" 2>/dev/null || echo "")
             [[ -n "$_ct" ]] && _cache_age="$(( $(date +%s) - _ct ))s ago"
         fi
-        printf "  %-20s %s\n" "Data source........." "UNIFIED CACHE (snapshot, collected ${_cache_age})"
+        # NOTE: the Data source VALUE stays exactly "UNIFIED CACHE" (v1.167 PR-2
+        # casing-consistency guard); the snapshot age is a SEPARATE sibling line.
+        printf "  %-20s %s\n" "Data source........." "UNIFIED CACHE"
+        printf "  %-20s %s\n" "Snapshot............" "collected ${_cache_age}"
         echo "    (counts are a cached snapshot; a ban added since the last collect may not appear until the next collection)"
     else
         printf "  %-20s %s\n" "Data source........." "DERIVED (cache miss; live aggregation from nftables + bans.log)"

--- a/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
+++ b/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
@@ -43,7 +43,8 @@ echo "v1.206.2 stats count-reconcile / freshness / labels"
 echo "==============================================="
 
 echo "[T1] freshness clarity"
-has "T1.1 UNIFIED CACHE line carries snapshot age" "UNIFIED CACHE (snapshot, collected "
+has "T1.1a Data source value stays exactly UNIFIED CACHE (v1.167 guard)" '"Data source........." "UNIFIED CACHE"'
+has "T1.1b snapshot age on sibling line" '"Snapshot............" "collected '
 has "T1.2 staleness note present" "may not appear until the next collection"
 
 echo "[T2] count reconciliation (Other/Unclass)"

--- a/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
+++ b/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.206.2 stats count-reconcile / freshness / label hotfix
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="stats_count_reconcile_v206_2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-25"
+# meta:description="Tests the v1.206.2 stats reporting hotfix (reporting-only): (1) freshness — the UNIFIED CACHE Data source line carries a snapshot age + a staleness note; (2) count reconciliation — an Other/Unclass bucket reconciles by-source to New ban events; (3) label disambiguation — the ambiguous bare 'Manual' by-source/module labels are replaced by 'Operator/CLI', and operator-manual/persistent/adopted provenance remains separated (no regression of the v1.206.1 nftban_stats_manual_provenance helper); (4) active-bans sample prints 'showing X of N' and reads both IPv4 and IPv6 sets. Self-contained; no network; no nft mutation."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_CONFIG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+SRC="$NFTBAN_LIB_DIR/core/nftban_stats_format.sh"
+
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_CONFIG_DIR="$SANDBOX/etc"; mkdir -p "$NFTBAN_CONFIG_DIR/blacklist.d"; BD="$NFTBAN_CONFIG_DIR/blacklist.d"
+PASS=0; FAIL=0; FAILED=()
+has(){ grep -qF -- "$2" "$SRC" && { echo "  [PASS] $1"; PASS=$((PASS+1)); } || { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }; }
+hasnt(){ grep -qE -- "$2" "$SRC" && { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); FAILED+=("$1"); } || { echo "  [PASS] $1"; PASS=$((PASS+1)); }; }
+aeq(){ [[ "$1" == "$2" ]] && { echo "  [PASS] $3"; PASS=$((PASS+1)); } || { echo "  [FAIL] $3 (want '$2' got '$1')"; FAIL=$((FAIL+1)); FAILED+=("$3"); }; }
+
+# shellcheck source=/dev/null
+source "$SRC"
+echo "==============================================="
+echo "v1.206.2 stats count-reconcile / freshness / labels"
+echo "==============================================="
+
+echo "[T1] freshness clarity"
+has "T1.1 UNIFIED CACHE line carries snapshot age" "UNIFIED CACHE (snapshot, collected "
+has "T1.2 staleness note present" "may not appear until the next collection"
+
+echo "[T2] count reconciliation (Other/Unclass)"
+has "T2.1 Other/Unclass bucket label" "Other/Unclass.."
+has "T2.2 Other = New ban events − classified explanation" "Other = New ban events"
+has "T2.3 over-count different-basis note" "exceeds New ban events"
+
+echo "[T3] label disambiguation"
+has "T3.1 By-source uses Operator/CLI" "Operator/CLI.."
+has "T3.2 BANS BY MODULE uses OPERATOR/CLI" '"OPERATOR/CLI"'
+hasnt "T3.3 no bare 'Manual..........' by-source label remains" '"Manual\.\.\.\.\.\.\.\.\.\." '
+hasnt "T3.4 no bare \"MANUAL\" module label remains" 'IPs\\n" "MANUAL"'
+
+echo "[T4] active-bans sample showing X of N + both families"
+has "T4.1 'showing X of N' wording" "showing "
+has "T4.2 samples IPv6 interval+manual sets" "blacklist_manual_ipv6"
+has "T4.3 samples IPv6 interval set" "blacklist_ipv6"
+
+echo "[T5] v1.206.1 provenance helper — NO regression"
+printf '%s\n' 1.2.3.4 5.6.7.8 > "$BD/99-manual.conf"
+printf '%s\n' '# c' 9.9.9.9 1.2.3.4 > "$BD/30-persistent-offenders.conf"   # 1.2.3.4 dup → operator wins
+IFS=' ' read -r OP PER AD <<< "$(nftban_stats_manual_provenance 4)"
+aeq "$OP" "2" "T5.1 operator-manual=2"
+aeq "$PER" "1" "T5.2 persistent=1 (dup deduped to operator)"
+aeq "$AD" "1" "T5.3 adopted=1 (4-2-1)"
+
+echo "[T6] retraction honored — no false IPv6-producer-omission claim in code"
+hasnt "T6.1 no '.blacklist_manual.ipv6 omitted' assertion added" "producer omits .blacklist_manual.ipv6"
+
+echo
+echo "==============================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"


### PR DESCRIPTION
## v1.206.2 — STATS COUNT-RECONCILE / FRESHNESS / LABELS (reporting-only)

Impl report: `V206_2_STATS_COUNT_RECONCILE_IMPL_REPORT.md`.

### Retraction (carried from the dns3 audit)
The suspected **IPv6 producer omission is RETRACTED** — a valid collect/fresh path shows the IPv6 manual count; the previous `0` was **cache staleness / snapshot timing** (and an earlier read of the wrong file, `metrics.cache` = Prometheus text vs the JSON unified cache). **No `.blacklist_manual.ipv6` producer change.**

### Fix summary (stats/format only)
- **Freshness:** `Data source: UNIFIED CACHE (snapshot, collected Ns ago)` + explicit note that a ban added since the last collect (either family) may not appear until the next collection.
- **Count reconciliation:** by-source reconciles to `New ban events` via an `Other/Unclass` bucket (= total − Σ by-source); over-count prints a different-basis note. No more unexplained `17 vs 9`.
- **Label disambiguation:** bare `Manual` → `Operator/CLI` (By source) and `MANUAL` → `OPERATOR/CLI` (BANS BY MODULE) — the manual/CLI ban *source*, not the manual-hash *set*; operator/persistent/adopted stays in the PROTECTION BREAKDOWN provenance line.
- **Active-bans sample:** `showing X of N`, lists all when N≤10, reads BOTH families (interval + manual hash, IPv4 + IPv6) so IPv6 active bans appear.

### Validation — build 28199925166
- **lab2 DEB PASS · lab4 RPM PASS**: controlled v4+v6 ban → fresh/live path → IPv6 manual-set `0`→`1` VISIBLE (staleness disclosed, not a producer omission), family-correct; freshness age+note; reconcile; Operator/CLI labels (no bare Manual); sample `showing X of N` + v6; provenance no-regression (op2/per1/adopted1); no residue; admin safe; restored to v1.206.1. Hermetic 16/0 + v1.206.1 provenance regression 16/0.

### Scope / non-scope
stats/reporting-only · **no daemon re-baseline** · nft schema **1.84.0** unchanged · VERSION stays 1.206.1 (release-prep → 1.206.2) · no enforcement/topology/ban/`source_index`/LoginMon/RBL/portscan/CLI-parity/updater-timer/central-comms change · no fleet rollout.