### PR TITLE
v1.207.0 BotScan smart-adaptive (pressure/backlog/mode/health, shell-only)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -247,6 +247,9 @@ nftban_cmd_health() {
         rbl)
             nftban_health_cmd_rbl "${clean_args[@]}"
             ;;
+        botscan)
+            nftban_health_cmd_botscan "${clean_args[@]}"
+            ;;
         botguard)
             nftban_health_cmd_botguard "${clean_args[@]}"
             ;;

--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -553,6 +553,39 @@ nftban_health_cmd_rbl() {
     esac
 }
 
+# v1.207 — BotScan health (reads the adaptive run-state; never reports 0-clean when
+# input was not scanned). rc: 0=OK/DISABLED, 1=WARN/DEGRADED, 2=ERROR.
+nftban_health_cmd_botscan() {
+    local rs="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json"
+    echo ""
+    echo "BotScan Health"
+    echo "─────────────────────────────────────────"
+    if [[ ! -f "$rs" ]]; then
+        # No run-state: either never enabled+run (recording-discipline), or first boot.
+        local en="${BOTSCAN_ENABLED:-true}"
+        if [[ "$en" != "true" ]]; then
+            printf "  %-16s %s\n" "State:" "DISABLED_BY_CONFIG (not scanning; not 'clean')"
+            return 0
+        fi
+        printf "  %-16s %s\n" "State:" "NO_RUN_YET (enabled; awaiting first scan)"
+        return 1
+    fi
+    if ! command -v jq &>/dev/null; then printf "  %-16s %s\n" "State:" "(jq unavailable)"; return 1; fi
+    local hs mode pr bl scan bans dur bh
+    IFS=' ' read -r hs mode pr bl scan bans dur bh < <(jq -r '"\(.health_state//"?") \(.scan_mode//"?") \(.pressure_state//"?") \(.backlog_state//"?") \(.lines_scanned_total//0) \(.bans_emitted_total//0) \(.last_duration_sec//0) \(.last_budget_hit//0)"' "$rs" 2>/dev/null)
+    printf "  %-16s %s\n" "Health:" "$hs"
+    printf "  %-16s %s\n" "Scan mode:" "$mode"
+    printf "  %-16s %s\n" "Host pressure:" "$pr"
+    printf "  %-16s %s\n" "Backlog:" "$bl"
+    printf "  %-16s scanned=%s bans=%s last=%ss budget_hit=%s\n" "Counters:" "$scan" "$bans" "$dur" "$bh"
+    if declare -F nftban_botscan_advisory >/dev/null 2>&1; then echo ""; echo "  $(nftban_botscan_advisory)"; fi
+    case "$hs" in
+        OK_*|DISABLED_BY_CONFIG) return 0 ;;
+        ERROR_*) return 2 ;;
+        *) return 1 ;;   # WARN_*/DEGRADED_* are visible non-clean states
+    esac
+}
+
 # =============================================================================
 # COMMAND: posture
 # =============================================================================
@@ -1033,5 +1066,6 @@ nftban_health_cmd_botguard() {
 export -f nftban_health_cmd_conflicts
 export -f nftban_health_cmd_config
 export -f nftban_health_cmd_rbl
+export -f nftban_health_cmd_botscan
 export -f nftban_health_cmd_botguard
 export -f nftban_health_cmd_posture

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -43,6 +43,9 @@ source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_file_utils.sh" 2>/dev/null
 # v1.177: shared panel-aware HTTP access-log discovery (DirectAdmin/cPanel/Plesk).
 # shellcheck source=/dev/null
 source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_http_logs.sh" 2>/dev/null || true
+# v1.207 — smart-adaptive controller (pressure/backlog/mode/health/recording-discipline).
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_botscan_adaptive.sh" 2>/dev/null || true
 
 # =============================================================================
 # CONFIGURATION
@@ -1265,6 +1268,12 @@ nftban_botscan_process_logs() {
 
     [[ "$BOTSCAN_ENABLED" != "true" ]] && {
         echo "Bot scanner is disabled"
+        # v1.207 recording-discipline: a disabled module records DISABLED_BY_CONFIG
+        # ONLY if it has a prior meaningful run-state; a disabled+never-run module
+        # writes NOTHING (no counters/noise, and never a fake "0 clean").
+        if declare -F nftban_botscan_record_runstate >/dev/null 2>&1; then
+            nftban_botscan_record_runstate ts="$(date +%s)" health_state="DISABLED_BY_CONFIG" disabled_reason="BOTSCAN_ENABLED!=true"
+        fi
         return 0
     }
 
@@ -1290,6 +1299,30 @@ nftban_botscan_process_logs() {
 
     echo "Processing: ${#logs[@]} access log(s)"
     echo "Patterns loaded: ${#_BOTSCAN_PATTERNS[@]}"
+
+    # v1.207 SMART-ADAPTIVE controller — derive pressure + scan_mode from EXISTING
+    # signals (watchdog trend + /proc/loadavg + forward-cursor backlog) and modulate
+    # the EXISTING per-file cap. REUSE only; no new collectors; no schema change.
+    local _BS_PRESSURE="NORMAL" _BS_BACKLOG="STABLE" _BS_MODE="FULL" _BS_BYTES=0
+    if declare -F nftban_botscan_select_mode >/dev/null 2>&1; then
+        local _lr _l5 _mem _io _behind _rr=0 _bh=0 _prev=0
+        _lr=$(nftban_botscan_load_ratio)
+        IFS=' ' read -r _l5 _mem _io < <(nftban_botscan_watchdog_pressure)
+        IFS=' ' read -r _BS_BYTES _behind < <(nftban_botscan_backlog "${logs[@]}")
+        if [[ -f "${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json" ]] && command -v jq &>/dev/null; then
+            local _ld; IFS=' ' read -r _ld _bh _prev < <(jq -r '"\(.last_duration_sec//0) \(.last_budget_hit//0) \(.backlog_bytes//0)"' "${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json" 2>/dev/null)
+            local _bud="${BOTSCAN_SCAN_BUDGET_SECS:-180}"; [[ "$_bud" -ge 1 ]] || _bud=180
+            _rr=$(awk -v d="${_ld:-0}" -v b="$_bud" 'BEGIN{printf "%.2f",(b>0?d/b:0)}')
+        fi
+        _BS_PRESSURE=$(nftban_botscan_pressure_state "$_lr" "$_rr" "${_bh:-0}" "${_mem:-0}" "${_io:-0}")
+        _BS_BACKLOG=$(nftban_botscan_backlog_state "${_BS_BYTES:-0}" "${_prev:-0}")
+        _BS_MODE=$(nftban_botscan_select_mode "$_BS_PRESSURE" "$_BS_BACKLOG")
+        case "$_BS_MODE" in
+            FAIR_SHARE) export BOTSCAN_SCAN_MAX_BYTES_PER_FILE=$(( ${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-262144} / 2 )) ;;
+            SURVIVAL)   export BOTSCAN_SCAN_MAX_BYTES_PER_FILE=$(( ${BOTSCAN_SCAN_MAX_BYTES_PER_FILE:-262144} / 4 )); export BOTSCAN_SCAN_PREFILTER=true ;;
+        esac
+        echo "Adaptive: pressure=$_BS_PRESSURE backlog=$_BS_BACKLOG mode=$_BS_MODE (load_ratio=$_lr)"
+    fi
 
     # v1.185 CORE-BOTSCAN-PROCESSOR-TIMEOUT-AT-SCALE — DEADLINE-AWARE SELF-BOUND.
     # Fleet-proven failure: on high-ENTRY-VOLUME hosts (srv2 120 logs 0/53, srv4 17 logs
@@ -1395,6 +1428,21 @@ nftban_botscan_process_logs() {
     local banned
     banned=$(nftban_botscan_analyze) || banned=0
     echo "Banned: $banned IPs"
+
+    # v1.207 — record run-state + health (recording-discipline honored in the writer).
+    # INVARIANT: 0 scanned is NEVER "clean" — a host with input (n>0) but 0 processed
+    # is DEGRADED_INPUT_BLIND; budget-hit / growing-backlog are DEGRADED + visible.
+    if declare -F nftban_botscan_record_runstate >/dev/null 2>&1; then
+        local _dur=$(( SECONDS - start_secs )) _hasin=0 _health
+        [[ "$n" -gt 0 ]] && _hasin=1
+        _health=$(nftban_botscan_health_state "${BOTSCAN_ENABLED:-true}" "$processed" "$banned" "$deadline_hit" "$_BS_BACKLOG" "$_hasin" 0)
+        nftban_botscan_record_runstate \
+            ts="$(date +%s)" dur="$_dur" lines_seen="$processed" lines_scanned="$processed" \
+            budget_hit="$deadline_hit" backlog_bytes="${_BS_BYTES:-0}" \
+            vhosts_scanned="$files_done" vhosts_deferred="$(( n - files_done ))" \
+            bans="$banned" pressure_state="$_BS_PRESSURE" scan_mode="$_BS_MODE" \
+            backlog_state="$_BS_BACKLOG" health_state="$_health"
+    fi
 
     return 0
 }

--- a/cli/lib/nftban/core/nftban_botscan_adaptive.sh
+++ b/cli/lib/nftban/core/nftban_botscan_adaptive.sh
@@ -21,7 +21,8 @@
 # meta:inventory.privileges="root:read-metrics"
 # =============================================================================
 set -Eeuo pipefail
-IFS=$'\n\t'
+# IFS intentionally NOT set globally (codebase convention; avoids ifs-tampering).
+# Every field-splitting read sets IFS locally per-read (e.g. `IFS=' ' read ...`).
 [[ -n "${NFTBAN_BOTSCAN_ADAPTIVE_LOADED:-}" ]] && return 0
 readonly NFTBAN_BOTSCAN_ADAPTIVE_LOADED=1
 

--- a/cli/lib/nftban/core/nftban_botscan_adaptive.sh
+++ b/cli/lib/nftban/core/nftban_botscan_adaptive.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - BotScan smart-adaptive controller (v1.207) — pressure/backlog/health
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_botscan_adaptive"
+# meta:type="core"
+# meta:header="BotScan smart-adaptive control loop"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-26"
+# meta:description="v1.207 BotScan smart-adaptive controller. Pure-shell control loop that REUSES existing signals (watchdog pressure trend /var/lib/nftban/watchdog/trend_hourly.json + live /proc/loadavg + BotScan forward-cursor proc-offsets backlog) to derive a deterministic pressure_state (NORMAL/ELEVATED/HIGH/CRITICAL), backlog_state (DRAINING/STABLE/GROWING/STARVED) and scan_mode (FULL/PREFILTERED/FAIR_SHARE/SURVIVAL) that MODULATE the existing prefilter/budget/rotation; an additive run-state/counters file (botscan/runstate.json) + a health model that NEVER reports 0-clean when input was not scanned (disabled!=clean, blind!=clean, throttled visible); and a RECORDING-DISCIPLINE guard (a disabled+never-run module emits NO scan counters/noise). Reads existing CPU/RAM/load trend — does NOT create a duplicate host-vitals store. No nft schema change; no daemon."
+# meta:input="watchdog trend_hourly.json, /proc/loadavg, BotScan proc-offsets, BOTSCAN_ENABLED"
+# meta:output="botscan/runstate.json (additive); pressure_state/scan_mode/health_state strings"
+# meta:depends="nftban_botscan.sh,nftban_watchdog.sh"
+# meta:inventory.files="/var/lib/nftban/botscan/runstate.json"
+# meta:inventory.binaries="awk,jq"
+# meta:inventory.env_vars="BOTSCAN_ENABLED,BOTSCAN_SCAN_BUDGET_SECS,NFTBAN_DATA_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="none"
+# meta:inventory.network="none"
+# meta:inventory.privileges="root:read-metrics"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+[[ -n "${NFTBAN_BOTSCAN_ADAPTIVE_LOADED:-}" ]] && return 0
+readonly NFTBAN_BOTSCAN_ADAPTIVE_LOADED=1
+
+: "${NFTBAN_DATA_DIR:=/var/lib/nftban}"
+readonly _BS_RUNSTATE="${NFTBAN_DATA_DIR}/botscan/runstate.json"
+readonly _BS_OFFSET_DIR="${NFTBAN_DATA_DIR}/botscan/proc-offsets"
+readonly _BS_WATCHDOG_TREND="${NFTBAN_DATA_DIR}/watchdog/trend_hourly.json"
+
+# --- cheap live load ratio (load1 / nproc) ----------------------------------
+nftban_botscan_load_ratio() {
+    local load1 _ rest ncpu
+    if ! IFS=' ' read -r load1 _ rest < /proc/loadavg 2>/dev/null; then echo "0"; return 0; fi
+    ncpu=$(nproc 2>/dev/null || echo 1); [[ "$ncpu" -ge 1 ]] || ncpu=1
+    awk -v l="$load1" -v c="$ncpu" 'BEGIN{ if(c<1)c=1; printf "%.2f", l/c }'
+}
+
+# --- smoothed pressure inputs from the EXISTING watchdog trend (no new store) -
+# Echoes "load5 mem_pct iowait_pct" (best-effort; "0 0 0" if trend absent).
+nftban_botscan_watchdog_pressure() {
+    if [[ -f "$_BS_WATCHDOG_TREND" ]] && command -v jq &>/dev/null; then
+        jq -r '(.samples // []) | (last // {}) | "\(.load_5m // 0) \(.mem_percent // 0) \(.iowait_percent // 0)"' \
+            "$_BS_WATCHDOG_TREND" 2>/dev/null || echo "0 0 0"
+    else
+        echo "0 0 0"
+    fi
+}
+
+# --- per-vhost backlog from the EXISTING forward cursor (file_size - offset) --
+# Args: log files. Echoes "backlog_bytes vhosts_behind".
+nftban_botscan_backlog() {
+    local bytes=0 behind=0 f base off sz
+    for f in "$@"; do
+        [[ -f "$f" ]] || continue
+        sz=$(stat -c %s "$f" 2>/dev/null || echo 0)
+        base=$(printf '%s' "$f" | tr '/' '_')
+        off=0
+        [[ -r "$_BS_OFFSET_DIR/$base" ]] && IFS= read -r off < "$_BS_OFFSET_DIR/$base" 2>/dev/null
+        [[ "$off" =~ ^[0-9]+$ ]] || off=0
+        if [[ "$sz" -gt "$off" ]]; then bytes=$(( bytes + sz - off )); behind=$(( behind + 1 )); fi
+    done
+    echo "$bytes $behind"
+}
+
+# --- deterministic pressure_state ------------------------------------------
+# Args: load_ratio runtime_ratio budget_hit_recent(0/1) mem_pct iowait_pct
+nftban_botscan_pressure_state() {
+    local lr="${1:-0}" rr="${2:-0}" bh="${3:-0}" mem="${4:-0}" io="${5:-0}"
+    awk -v lr="$lr" -v rr="$rr" -v bh="$bh" -v mem="$mem" -v io="$io" 'BEGIN{
+        st="NORMAL"
+        if (lr>=1.0 || rr>=0.5 || mem>=80 || io>=20) st="ELEVATED"
+        if (lr>=2.0 || rr>=0.7 || mem>=90 || io>=35) st="HIGH"
+        if (lr>=4.0 || rr>=0.9 || bh==1)             st="CRITICAL"
+        print st
+    }'
+}
+
+# --- backlog_state ----------------------------------------------------------
+# Args: backlog_bytes prev_backlog_bytes
+nftban_botscan_backlog_state() {
+    local now="${1:-0}" prev="${2:-0}"
+    [[ "$now" =~ ^[0-9]+$ ]] || now=0; [[ "$prev" =~ ^[0-9]+$ ]] || prev=0
+    if   [[ "$now" -eq 0 ]]; then echo "DRAINING"
+    elif [[ "$now" -gt $(( prev + prev/4 + 1 )) ]]; then echo "GROWING"
+    elif [[ "$now" -lt $(( prev - prev/4 )) ]]; then echo "DRAINING"
+    elif [[ "$now" -gt 67108864 ]]; then echo "STARVED"   # >64MiB behind = starved
+    else echo "STABLE"; fi
+}
+
+# --- scan_mode from pressure + backlog --------------------------------------
+nftban_botscan_select_mode() {
+    local pressure="${1:-NORMAL}" backlog="${2:-STABLE}"
+    case "$pressure" in
+        CRITICAL) echo "SURVIVAL" ;;
+        HIGH)     echo "FAIR_SHARE" ;;
+        ELEVATED) [[ "$backlog" == "STARVED" || "$backlog" == "GROWING" ]] && echo "FAIR_SHARE" || echo "PREFILTERED" ;;
+        *)        [[ "$backlog" == "STARVED" ]] && echo "FAIR_SHARE" || echo "FULL" ;;
+    esac
+}
+
+# --- health_state (INVARIANT: 0-clean only if input was actually scanned) ----
+# Args: enabled(true/false) lines_scanned bots_found budget_hit backlog_state has_input(0/1) error(0/1)
+nftban_botscan_health_state() {
+    local en="${1:-true}" scanned="${2:-0}" bots="${3:-0}" bh="${4:-0}" bl="${5:-STABLE}" hasin="${6:-0}" err="${7:-0}"
+    [[ "$err" == "1" ]] && { echo "ERROR_RUNTIME_FAILURE"; return; }
+    [[ "$en" != "true" ]] && { echo "DISABLED_BY_CONFIG"; return; }      # disabled != clean
+    [[ "$bh" == "1" ]] && { echo "DEGRADED_BUDGET_HIT"; return; }
+    [[ "$bl" == "GROWING" || "$bl" == "STARVED" ]] && { echo "DEGRADED_BACKLOG_GROWING"; return; }
+    if [[ "${scanned:-0}" -eq 0 ]]; then
+        # zero scanned: blind if there WAS input, throttled is caller-set; NEVER clean
+        [[ "$hasin" == "1" ]] && { echo "DEGRADED_INPUT_BLIND"; return; }
+        echo "DEGRADED_INPUT_BLIND"; return
+    fi
+    [[ "${bots:-0}" -gt 0 ]] && { echo "OK_SCANNED_BOTS_FOUND"; return; }
+    echo "OK_SCANNED_NO_BOTS"
+}
+
+# --- RECORDING DISCIPLINE: should we record this run at all? -----------------
+# Returns 0 (record) only if BotScan is enabled OR a meaningful prior run-state
+# exists. A disabled+never-run module records nothing (no counters/noise).
+nftban_botscan_should_record() {
+    [[ "${BOTSCAN_ENABLED:-true}" == "true" ]] && return 0
+    [[ -f "$_BS_RUNSTATE" ]] && return 0   # previously ran → preserve/mark disabled
+    return 1                                # disabled + never ran → no record
+}
+
+# --- write additive run-state/counters (schema-free) ------------------------
+# Reads prior counters to accumulate *_total. Honors recording discipline.
+nftban_botscan_record_runstate() {
+    # k=v pairs on argv: ts dur lines_seen lines_scanned lines_prefiltered
+    #   lines_skipped_pressure backlog_bytes backlog_lines vhosts_scanned
+    #   vhosts_deferred signals bans already_banned_skipped pressure_state
+    #   scan_mode backlog_state health_state disabled_reason
+    local -A v=(); local kv
+    for kv in "$@"; do v["${kv%%=*}"]="${kv#*=}"; done
+    if ! nftban_botscan_should_record; then return 0; fi
+    mkdir -p "${_BS_RUNSTATE%/*}" 2>/dev/null || true
+    # accumulate totals from prior file
+    local p_bh=0 p_seen=0 p_scan=0 p_pf=0 p_skip=0 p_sig=0 p_ban=0 p_abs=0
+    if [[ -f "$_BS_RUNSTATE" ]] && command -v jq &>/dev/null; then
+        IFS=' ' read -r p_bh p_seen p_scan p_pf p_skip p_sig p_ban p_abs < <(
+            jq -r '"\(.budget_hit_total//0) \(.lines_seen_total//0) \(.lines_scanned_total//0) \(.lines_prefiltered_total//0) \(.lines_skipped_pressure_total//0) \(.signals_emitted_total//0) \(.bans_emitted_total//0) \(.already_banned_skipped_total//0)"' "$_BS_RUNSTATE" 2>/dev/null) || true
+    fi
+    local en="${BOTSCAN_ENABLED:-true}"
+    cat > "${_BS_RUNSTATE}.tmp" <<EOF
+{
+  "enabled": ${en/true/true},
+  "last_run_ts": ${v[ts]:-0},
+  "last_duration_sec": ${v[dur]:-0},
+  "budget_hit_total": $(( p_bh + ${v[budget_hit]:-0} )),
+  "lines_seen_total": $(( p_seen + ${v[lines_seen]:-0} )),
+  "lines_scanned_total": $(( p_scan + ${v[lines_scanned]:-0} )),
+  "lines_prefiltered_total": $(( p_pf + ${v[lines_prefiltered]:-0} )),
+  "lines_skipped_pressure_total": $(( p_skip + ${v[lines_skipped_pressure]:-0} )),
+  "backlog_bytes": ${v[backlog_bytes]:-0},
+  "backlog_lines": ${v[backlog_lines]:-0},
+  "vhosts_scanned": ${v[vhosts_scanned]:-0},
+  "vhosts_deferred": ${v[vhosts_deferred]:-0},
+  "signals_emitted_total": $(( p_sig + ${v[signals]:-0} )),
+  "bans_emitted_total": $(( p_ban + ${v[bans]:-0} )),
+  "already_banned_skipped_total": $(( p_abs + ${v[already_banned_skipped]:-0} )),
+  "last_budget_hit": ${v[budget_hit]:-0},
+  "pressure_state": "${v[pressure_state]:-NORMAL}",
+  "scan_mode": "${v[scan_mode]:-FULL}",
+  "backlog_state": "${v[backlog_state]:-STABLE}",
+  "health_state": "${v[health_state]:-OK_SCANNED_NO_BOTS}",
+  "disabled_reason": "${v[disabled_reason]:-}"
+}
+EOF
+    mv -f "${_BS_RUNSTATE}.tmp" "$_BS_RUNSTATE" 2>/dev/null || rm -f "${_BS_RUNSTATE}.tmp"
+    return 0
+}
+
+# --- one-line operator advisory from the run-state --------------------------
+nftban_botscan_advisory() {
+    [[ "${BOTSCAN_ENABLED:-true}" != "true" ]] && { echo "BotScan: DISABLED (by config) — not scanning; not 'clean'."; return; }
+    [[ -f "$_BS_RUNSTATE" ]] && command -v jq &>/dev/null || { echo "BotScan: no run recorded yet."; return; }
+    local hs mode pr scan bans dur bl
+    IFS=' ' read -r hs mode pr scan bans dur bl < <(jq -r '"\(.health_state) \(.scan_mode) \(.pressure_state) \(.lines_scanned_total) \(.bans_emitted_total) \(.last_duration_sec) \(.backlog_state)"' "$_BS_RUNSTATE" 2>/dev/null)
+    case "$hs" in
+        OK_SCANNED_*)              echo "BotScan: OK — mode=$mode, scanned ${scan} lines, ${bans} bans, backlog ${bl,,}." ;;
+        WARN_PARTIAL_PROGRESS|DEGRADED_PRESSURE_THROTTLED) echo "BotScan: WARN — $hs (mode=$mode, pressure=$pr); coverage reduced but VISIBLE (not clean)." ;;
+        DEGRADED_*)                echo "BotScan: DEGRADED — $hs (mode=$mode, pressure=$pr); NOT clean." ;;
+        DISABLED_BY_CONFIG)        echo "BotScan: DISABLED (by config)." ;;
+        *)                         echo "BotScan: $hs (mode=$mode)." ;;
+    esac
+    [[ "$pr" == "HIGH" || "$pr" == "CRITICAL" ]] && echo "Host pressure: $pr — primary load may be the web/db stack; consider web-layer mitigation."
+}

--- a/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
+++ b/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.207 BotScan smart-adaptive controller
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_adaptive_v207_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-26"
+# meta:description="Hermetic tests for the v1.207 BotScan smart-adaptive controller (nftban_botscan_adaptive.sh): deterministic pressure_state transitions (load/runtime/mem/iowait), backlog_state, scan_mode selection (FULL/PREFILTERED/FAIR_SHARE/SURVIVAL), the health model invariant that 0-scanned is NEVER clean (disabled!=clean, blind!=clean, budget-hit/backlog-growing visible), and the RECORDING-DISCIPLINE guard (a disabled+never-run module writes NO run-state; a disabled module with a prior run records DISABLED_BY_CONFIG; counters accumulate as *_total). Self-contained sandbox; no network; no nft; reads no real host state."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,awk,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq,awk,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_DATA_DIR,BOTSCAN_ENABLED"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+export NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_DATA_DIR="$SANDBOX/data"; mkdir -p "$NFTBAN_DATA_DIR/botscan"
+SRC="$NFTBAN_LIB_DIR/core/nftban_botscan_adaptive.sh"
+PASS=0; FAIL=0; FAILED=()
+eq(){ [[ "$1" == "$2" ]] && { echo "  [PASS] $3"; PASS=$((PASS+1)); } || { echo "  [FAIL] $3 (want '$2' got '$1')"; FAIL=$((FAIL+1)); FAILED+=("$3"); }; }
+
+# shellcheck source=/dev/null
+source "$SRC"
+echo "================================================="
+echo "v1.207 BotScan smart-adaptive controller test"
+echo "================================================="
+
+echo "[T1] pressure_state transitions (load_ratio, runtime_ratio, mem, iowait)"
+eq "$(nftban_botscan_pressure_state 0.3 0.1 0 10 5)"  "NORMAL"   "T1.1 idle → NORMAL"
+eq "$(nftban_botscan_pressure_state 1.2 0.2 0 50 10)" "ELEVATED" "T1.2 load 1.2x → ELEVATED"
+eq "$(nftban_botscan_pressure_state 2.5 0.3 0 60 10)" "HIGH"     "T1.3 load 2.5x → HIGH"
+eq "$(nftban_botscan_pressure_state 4.1 0.3 0 60 10)" "CRITICAL" "T1.4 load 4.1x → CRITICAL"
+eq "$(nftban_botscan_pressure_state 0.3 0.95 0 10 5)" "CRITICAL" "T1.5 runtime 95% of budget → CRITICAL"
+eq "$(nftban_botscan_pressure_state 0.3 0.3 1 10 5)"  "CRITICAL" "T1.6 last-run budget-hit → CRITICAL"
+eq "$(nftban_botscan_pressure_state 0.3 0.3 0 92 5)"  "HIGH"     "T1.7 mem 92% → HIGH"
+
+echo "[T2] scan_mode selection"
+eq "$(nftban_botscan_select_mode NORMAL STABLE)"     "FULL"        "T2.1 NORMAL → FULL"
+eq "$(nftban_botscan_select_mode ELEVATED STABLE)"   "PREFILTERED" "T2.2 ELEVATED → PREFILTERED"
+eq "$(nftban_botscan_select_mode ELEVATED GROWING)"  "FAIR_SHARE"  "T2.3 ELEVATED+GROWING → FAIR_SHARE"
+eq "$(nftban_botscan_select_mode HIGH STABLE)"       "FAIR_SHARE"  "T2.4 HIGH → FAIR_SHARE"
+eq "$(nftban_botscan_select_mode CRITICAL STABLE)"   "SURVIVAL"    "T2.5 CRITICAL → SURVIVAL"
+eq "$(nftban_botscan_select_mode NORMAL STARVED)"    "FAIR_SHARE"  "T2.6 NORMAL+STARVED → FAIR_SHARE"
+
+echo "[T3] backlog_state"
+eq "$(nftban_botscan_backlog_state 0 1000)"        "DRAINING" "T3.1 0 backlog → DRAINING"
+eq "$(nftban_botscan_backlog_state 2000 1000)"     "GROWING"  "T3.2 2x prior → GROWING"
+eq "$(nftban_botscan_backlog_state 100000000 100000000)" "STARVED" "T3.3 >64MiB → STARVED"
+
+echo "[T4] health model — 0-scanned is NEVER clean"
+eq "$(nftban_botscan_health_state true 0 0 0 STABLE 1 0)"   "DEGRADED_INPUT_BLIND"   "T4.1 enabled, input present, 0 scanned → BLIND (not clean)"
+eq "$(nftban_botscan_health_state false 0 0 0 STABLE 0 0)"  "DISABLED_BY_CONFIG"     "T4.2 disabled → DISABLED (not clean)"
+eq "$(nftban_botscan_health_state true 5000 0 1 STABLE 1 0)" "DEGRADED_BUDGET_HIT"   "T4.3 budget hit → DEGRADED"
+eq "$(nftban_botscan_health_state true 5000 0 0 GROWING 1 0)" "DEGRADED_BACKLOG_GROWING" "T4.4 backlog growing → DEGRADED"
+eq "$(nftban_botscan_health_state true 5000 3 0 STABLE 1 0)" "OK_SCANNED_BOTS_FOUND" "T4.5 scanned + bots → OK_BOTS"
+eq "$(nftban_botscan_health_state true 5000 0 0 STABLE 1 0)" "OK_SCANNED_NO_BOTS"   "T4.6 scanned, no bots → OK_NO_BOTS (clean ONLY because scanned)"
+eq "$(nftban_botscan_health_state true 0 0 0 STABLE 1 1)"   "ERROR_RUNTIME_FAILURE" "T4.7 error flag → ERROR"
+
+echo "[T5] recording-discipline guard"
+BOTSCAN_ENABLED=false
+nftban_botscan_record_runstate ts=1 health_state=DISABLED_BY_CONFIG >/dev/null 2>&1 || true
+eq "$([[ -f "$NFTBAN_DATA_DIR/botscan/runstate.json" ]] && echo yes || echo no)" "no" "T5.1 disabled + never-run → NO run-state file written"
+BOTSCAN_ENABLED=true
+nftban_botscan_record_runstate ts=2 dur=10 lines_scanned=1000 bans=2 health_state=OK_SCANNED_BOTS_FOUND pressure_state=NORMAL scan_mode=FULL >/dev/null 2>&1
+eq "$([[ -f "$NFTBAN_DATA_DIR/botscan/runstate.json" ]] && echo yes || echo no)" "yes" "T5.2 enabled run → run-state written"
+eq "$(jq -r '.bans_emitted_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "2" "T5.3 bans_total recorded"
+BOTSCAN_ENABLED=false
+nftban_botscan_record_runstate ts=3 health_state=DISABLED_BY_CONFIG disabled_reason="off" >/dev/null 2>&1
+eq "$(jq -r '.health_state' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "DISABLED_BY_CONFIG" "T5.4 disabled WITH prior run → records DISABLED (not clean)"
+
+echo "[T6] counters accumulate (*_total)"
+BOTSCAN_ENABLED=true
+nftban_botscan_record_runstate ts=4 lines_scanned=500 bans=3 health_state=OK_SCANNED_BOTS_FOUND >/dev/null 2>&1
+eq "$(jq -r '.bans_emitted_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "5" "T6.1 bans_total accumulates (2+3)"
+eq "$(jq -r '.lines_scanned_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "1500" "T6.2 lines_scanned_total accumulates (1000+500)"
+
+echo
+echo "================================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
+++ b/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
@@ -70,19 +70,19 @@ eq "$(nftban_botscan_health_state true 5000 0 0 STABLE 1 0)" "OK_SCANNED_NO_BOTS
 eq "$(nftban_botscan_health_state true 0 0 0 STABLE 1 1)"   "ERROR_RUNTIME_FAILURE" "T4.7 error flag → ERROR"
 
 echo "[T5] recording-discipline guard"
-BOTSCAN_ENABLED=false
+export BOTSCAN_ENABLED=false
 nftban_botscan_record_runstate ts=1 health_state=DISABLED_BY_CONFIG >/dev/null 2>&1 || true
 eq "$([[ -f "$NFTBAN_DATA_DIR/botscan/runstate.json" ]] && echo yes || echo no)" "no" "T5.1 disabled + never-run → NO run-state file written"
-BOTSCAN_ENABLED=true
+export BOTSCAN_ENABLED=true
 nftban_botscan_record_runstate ts=2 dur=10 lines_scanned=1000 bans=2 health_state=OK_SCANNED_BOTS_FOUND pressure_state=NORMAL scan_mode=FULL >/dev/null 2>&1
 eq "$([[ -f "$NFTBAN_DATA_DIR/botscan/runstate.json" ]] && echo yes || echo no)" "yes" "T5.2 enabled run → run-state written"
 eq "$(jq -r '.bans_emitted_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "2" "T5.3 bans_total recorded"
-BOTSCAN_ENABLED=false
+export BOTSCAN_ENABLED=false
 nftban_botscan_record_runstate ts=3 health_state=DISABLED_BY_CONFIG disabled_reason="off" >/dev/null 2>&1
 eq "$(jq -r '.health_state' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "DISABLED_BY_CONFIG" "T5.4 disabled WITH prior run → records DISABLED (not clean)"
 
 echo "[T6] counters accumulate (*_total)"
-BOTSCAN_ENABLED=true
+export BOTSCAN_ENABLED=true
 nftban_botscan_record_runstate ts=4 lines_scanned=500 bans=3 health_state=OK_SCANNED_BOTS_FOUND >/dev/null 2>&1
 eq "$(jq -r '.bans_emitted_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "5" "T6.1 bans_total accumulates (2+3)"
 eq "$(jq -r '.lines_scanned_total' "$NFTBAN_DATA_DIR/botscan/runstate.json")" "1500" "T6.2 lines_scanned_total accumulates (1000+500)"


### PR DESCRIPTION
## v1.207.0 — BotScan smart-adaptive control loop

Scope: `V207_BOTSCAN_SMART_ADAPTIVE_SCOPE.md` · Report: `V207_BOTSCAN_SMART_ADAPTIVE_IMPL_REPORT.md`. **Shell-only — `nftband` NOT re-baselined; nft schema 1.84.0; no enforcement/topology/ban change.**

### What it does (REUSE, not rebuild)
A pure-shell controller (`nftban_botscan_adaptive.sh`) that consumes EXISTING signals — watchdog pressure trend (`nftban_watchdog.sh:703`), `/proc/loadavg`, BotScan forward-cursor backlog (`proc-offsets`), the v1.187 candidate prefilter, the soft budget — to derive `pressure_state` (NORMAL/ELEVATED/HIGH/CRITICAL) + `backlog_state` (DRAINING/STABLE/GROWING/STARVED) → `scan_mode` (FULL/PREFILTERED/FAIR_SHARE/SURVIVAL), modulating the EXISTING per-file cap (FAIR_SHARE halves → 131072, SURVIVAL quarters → 65536). The `grep` prefilter is already C-speed (benchmark: 0.012–0.015s/100k, identical 40024 detections); the bounded cap is the correct throttle for the bash matcher. **No new collectors, no duplicate CPU/RAM store, no schema, no daemon-Go.**

Adds: a health model where **0-scanned is NEVER clean** (DEGRADED_INPUT_BLIND; disabled→DISABLED_BY_CONFIG; budget-hit/backlog-growing visible); **recording-discipline** (disabled+never-run writes NO run-state/noise; disabled-after-run marks DISABLED, not clean; counters accumulate); `nftban health botscan` + operator advisory (incl. "pressure may be web/db"); additive `botscan/runstate.json`. Wired via 4 `declare -F`-guarded additive seams (no-op if absent). FULL/PREFILTERED preserve shipped detections; only SURVIVAL reduces coverage, explicitly declared, never blind-clean. IPv4/IPv6 parity preserved.

### Validation — build 28252680518
- **lab2 DEB PASS · lab4 RPM PASS**: controller matrix 15/15 (installed module), cap modulation, recording-discipline (disabled+never-run → no noise), `nftban health botscan` live, flood benchmark 40024==40024 (FULL/PREFILTERED equivalence), v4/v6 request-class regression, no FW-CRITICAL, admin safe, restored to v1.206.2. Hermetic 29/0 + existing botscan regressions (nofork/deadline-rotation/request-class) PASS.

### 🚦 Busy-host policy (dns4)
**dns4 is the real-pressure CONFIRMATION host, not a lab validation host.** No branch package install on dns4. Read-only confirm (2026-06-26, dns4 on v1.203.0): load 7.46/4cpu driven by **web+db 143%** (the real source), 30.9k log-lines/15min, but BotScan **bounded** (6/6 runs completed, 0 budget-hit, 0 backlog, enforcement working). v1.207 makes BotScan smarter under this pressure but will NOT remove the PHP/MySQL load — that is web-layer/operational. **After v1.207 publishes, dns4 is rolled LAST or DEFERRED if still under active flood; any dns4 pre-release check is read-only only** (load, BotScan health, runstate/advisory, backlog, timer, web/db pressure, active drops).

### Scope / non-scope
0 `.go`/`cmd/`/`internal/` · nft schema 1.84.0 · VERSION stays 1.206.2 (release-prep → 1.207.0) · no enforcement/topology/ban/RBL/portscan/BotGuard/CLI-parity/updater-timer change · **no central-comms/email/webhook/auditor build** (advisory is local state/journal only) · no website/PHP/MySQL change · no fleet rollout.