### PR TITLE
v1.208.0 BotScan trend-history / reporting-truth (shell-only)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -558,7 +558,7 @@ nftban_health_cmd_rbl() {
 nftban_health_cmd_botscan() {
     # v1.208 — `nftban health botscan --history` summarizes the durable trend.
     case "${1:-}" in
-        --history|history)
+        --history)
             if ! declare -F nftban_botscan_history >/dev/null 2>&1; then
                 # shellcheck source=/dev/null
                 source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_botscan_adaptive.sh" 2>/dev/null || true

--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -556,6 +556,19 @@ nftban_health_cmd_rbl() {
 # v1.207 — BotScan health (reads the adaptive run-state; never reports 0-clean when
 # input was not scanned). rc: 0=OK/DISABLED, 1=WARN/DEGRADED, 2=ERROR.
 nftban_health_cmd_botscan() {
+    # v1.208 — `nftban health botscan --history` summarizes the durable trend.
+    case "${1:-}" in
+        --history|history)
+            if ! declare -F nftban_botscan_history >/dev/null 2>&1; then
+                # shellcheck source=/dev/null
+                source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_botscan_adaptive.sh" 2>/dev/null || true
+            fi
+            if declare -F nftban_botscan_history >/dev/null 2>&1; then
+                echo ""; nftban_botscan_history; return 0
+            fi
+            echo "BotScan history unavailable (adaptive module not loaded)."; return 1
+            ;;
+    esac
     local rs="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json"
     echo ""
     echo "BotScan Health"

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -1289,6 +1289,14 @@ nftban_botscan_process_logs() {
             echo "ERROR: No access log found" >&2
             echo "  Hint: run 'nftban botscan logs --detect' to see candidate paths and panel detection." >&2
             echo "  Or set BOTSCAN_LOG_PATHS in /etc/nftban/conf.d/botscan/main.conf to your access-log glob(s)." >&2
+            # v1.208 — enabled but no web access logs discovered (common on non-web hosts).
+            # Record NO_INPUT_DISCOVERED (informational, NOT clean, NOT a failure) instead of
+            # leaving a perpetual NO_RUN_YET / absent run-state.
+            if declare -F nftban_botscan_record_runstate >/dev/null 2>&1; then
+                nftban_botscan_record_runstate ts="$(date +%s)" health_state="NO_INPUT_DISCOVERED" \
+                    pressure_state="NORMAL" scan_mode="NONE" backlog_state="STABLE" \
+                    disabled_reason="no access logs discovered on this host"
+            fi
             return 1
         fi
     fi
@@ -1441,7 +1449,7 @@ nftban_botscan_process_logs() {
             budget_hit="$deadline_hit" backlog_bytes="${_BS_BYTES:-0}" \
             vhosts_scanned="$files_done" vhosts_deferred="$(( n - files_done ))" \
             bans="$banned" pressure_state="$_BS_PRESSURE" scan_mode="$_BS_MODE" \
-            backlog_state="$_BS_BACKLOG" health_state="$_health"
+            backlog_state="$_BS_BACKLOG" health_state="$_health" load_ratio="${_lr:-0}"
     fi
 
     return 0

--- a/cli/lib/nftban/core/nftban_botscan_adaptive.sh
+++ b/cli/lib/nftban/core/nftban_botscan_adaptive.sh
@@ -30,6 +30,11 @@ readonly NFTBAN_BOTSCAN_ADAPTIVE_LOADED=1
 readonly _BS_RUNSTATE="${NFTBAN_DATA_DIR}/botscan/runstate.json"
 readonly _BS_OFFSET_DIR="${NFTBAN_DATA_DIR}/botscan/proc-offsets"
 readonly _BS_WATCHDOG_TREND="${NFTBAN_DATA_DIR}/watchdog/trend_hourly.json"
+# v1.208 — durable BotScan pressure/mode trend (append-only, bounded). REUSES the
+# watchdog trend for host load/mem/iowait; this file holds only BotScan's own
+# per-run decision + the cheap load_ratio. NO duplicate host-vitals store.
+readonly _BS_TREND="${NFTBAN_DATA_DIR}/botscan/trend.jsonl"
+: "${BOTSCAN_TREND_RETENTION:=500}"   # keep last N records (bounded)
 
 # --- cheap live load ratio (load1 / nproc) ----------------------------------
 nftban_botscan_load_ratio() {
@@ -172,6 +177,61 @@ nftban_botscan_record_runstate() {
 }
 EOF
     mv -f "${_BS_RUNSTATE}.tmp" "$_BS_RUNSTATE" 2>/dev/null || rm -f "${_BS_RUNSTATE}.tmp"
+    # v1.208 — append one durable trend record (gated by should_record above).
+    nftban_botscan_trend_append v
+    return 0
+}
+
+# --- v1.208 durable trend append (append-only, bounded, dedupe-aware) --------
+# Args: name of the assoc array `v` populated in record_runstate (passed by name).
+nftban_botscan_trend_append() {
+    local -n _v="$1" 2>/dev/null || return 0
+    local hs="${_v[health_state]:-OK_SCANNED_NO_BOTS}"
+    mkdir -p "${_BS_TREND%/*}" 2>/dev/null || true
+    # Dedupe: a no-web host re-emits NO_INPUT_DISCOVERED every cycle — do NOT fill
+    # the trend with identical no-input records. Skip the append when this record
+    # is NO_INPUT_DISCOVERED AND the last trend line was also NO_INPUT_DISCOVERED.
+    if [[ "$hs" == "NO_INPUT_DISCOVERED" && -s "$_BS_TREND" ]]; then
+        local _last; _last=$(tail -1 "$_BS_TREND" 2>/dev/null)
+        [[ "$_last" == *'"health_state":"NO_INPUT_DISCOVERED"'* ]] && return 0
+    fi
+    local _host; _host=$(hostname -s 2>/dev/null || echo unknown)
+    local rec
+    rec=$(printf '{"ts":%s,"host":"%s","source":"botscan","health_state":"%s","pressure_state":"%s","scan_mode":"%s","backlog_state":"%s","last_duration_sec":%s,"budget_hit":%s,"lines_scanned":%s,"bans_emitted":%s,"vhosts_scanned":%s,"vhosts_deferred":%s,"backlog_bytes":%s,"load_ratio":"%s"}' \
+        "${_v[ts]:-0}" "$_host" "$hs" "${_v[pressure_state]:-NORMAL}" "${_v[scan_mode]:-FULL}" "${_v[backlog_state]:-STABLE}" \
+        "${_v[dur]:-0}" "${_v[budget_hit]:-0}" "${_v[lines_scanned]:-0}" "${_v[bans]:-0}" \
+        "${_v[vhosts_scanned]:-0}" "${_v[vhosts_deferred]:-0}" "${_v[backlog_bytes]:-0}" "${_v[load_ratio]:-0}")
+    # atomic append under flock (processor is single-instance, but guard anyway)
+    {
+        flock -w 2 9 2>/dev/null || true
+        printf '%s\n' "$rec" >> "$_BS_TREND"
+        # bounded retention: trim to last N
+        local _n; _n=$(wc -l < "$_BS_TREND" 2>/dev/null || echo 0)
+        if [[ "${_n:-0}" -gt "${BOTSCAN_TREND_RETENTION:-500}" ]]; then
+            tail -n "${BOTSCAN_TREND_RETENTION:-500}" "$_BS_TREND" > "${_BS_TREND}.tmp" 2>/dev/null \
+                && mv -f "${_BS_TREND}.tmp" "$_BS_TREND" 2>/dev/null || rm -f "${_BS_TREND}.tmp"
+        fi
+    } 9>>"$_BS_TREND" 2>/dev/null || true
+    return 0
+}
+
+# --- v1.208 trend history summary (answers the operator questions) ----------
+nftban_botscan_history() {
+    if [[ ! -s "$_BS_TREND" ]]; then echo "No BotScan trend history yet ($_BS_TREND absent/empty)."; return 0; fi
+    command -v jq >/dev/null 2>&1 || { echo "(jq unavailable — raw tail:)"; tail -10 "$_BS_TREND"; return 0; }
+    local total; total=$(wc -l < "$_BS_TREND" 2>/dev/null)
+    echo "BotScan trend history — $total records ($_BS_TREND)"
+    echo "─────────────────────────────────────────"
+    echo "  Scan modes:"
+    jq -r '.scan_mode' "$_BS_TREND" 2>/dev/null | sort | uniq -c | awk '{printf "    %-12s %s\n", $2, $1}'
+    echo "  Health states:"
+    jq -r '.health_state' "$_BS_TREND" 2>/dev/null | sort | uniq -c | awk '{printf "    %-26s %s\n", $2, $1}'
+    local bh; bh=$(jq -r 'select(.budget_hit==1)|.host' "$_BS_TREND" 2>/dev/null | sort | uniq -c | awk '{printf "%s(%s) ", $2, $1}')
+    echo "  Budget-hit by host: ${bh:-none}"
+    local grow; grow=$(jq -r 'select(.backlog_state=="GROWING")|.host' "$_BS_TREND" 2>/dev/null | sort -u | tr '\n' ' ')
+    echo "  Backlog GROWING (any record): ${grow:-none}"
+    echo "  Last OK scan:       $(jq -rc 'select(.health_state|startswith("OK_"))|"\(.ts) \(.host) \(.scan_mode) scanned=\(.lines_scanned)"' "$_BS_TREND" 2>/dev/null | tail -1 || echo none)"
+    echo "  Last DEGRADED scan: $(jq -rc 'select(.health_state|startswith("DEGRADED_"))|"\(.ts) \(.host) \(.health_state) backlog=\(.backlog_state)"' "$_BS_TREND" 2>/dev/null | tail -1 || echo none)"
     return 0
 }
 
@@ -186,6 +246,7 @@ nftban_botscan_advisory() {
         WARN_PARTIAL_PROGRESS|DEGRADED_PRESSURE_THROTTLED) echo "BotScan: WARN — $hs (mode=$mode, pressure=$pr); coverage reduced but VISIBLE (not clean)." ;;
         DEGRADED_*)                echo "BotScan: DEGRADED — $hs (mode=$mode, pressure=$pr); NOT clean." ;;
         DISABLED_BY_CONFIG)        echo "BotScan: DISABLED (by config)." ;;
+        NO_INPUT_DISCOVERED)       echo "BotScan: NO INPUT — no web access logs found on this host (not scanning; not 'clean'). Informational on a non-web host." ;;
         *)                         echo "BotScan: $hs (mode=$mode)." ;;
     esac
     [[ "$pr" == "HIGH" || "$pr" == "CRITICAL" ]] && echo "Host pressure: $pr — primary load may be the web/db stack; consider web-layer mitigation."

--- a/cli/lib/nftban/core/nftban_botscan_adaptive.sh
+++ b/cli/lib/nftban/core/nftban_botscan_adaptive.sh
@@ -188,12 +188,15 @@ nftban_botscan_trend_append() {
     local -n _v="$1" 2>/dev/null || return 0
     local hs="${_v[health_state]:-OK_SCANNED_NO_BOTS}"
     mkdir -p "${_BS_TREND%/*}" 2>/dev/null || true
-    # Dedupe: a no-web host re-emits NO_INPUT_DISCOVERED every cycle — do NOT fill
-    # the trend with identical no-input records. Skip the append when this record
-    # is NO_INPUT_DISCOVERED AND the last trend line was also NO_INPUT_DISCOVERED.
-    if [[ "$hs" == "NO_INPUT_DISCOVERED" && -s "$_BS_TREND" ]]; then
+    # Dedupe consecutive identical ZERO-PROGRESS records. A no-web host (no logs →
+    # NO_INPUT_DISCOVERED) or an empty-log host (logs found, 0 scanned →
+    # DEGRADED_INPUT_BLIND) re-emits the same state every cycle — do NOT fill the
+    # trend with identical no-progress lines. Any record that scanned > 0 lines is
+    # always recorded (real signal); a state CHANGE is always recorded.
+    local _scanned="${_v[lines_scanned]:-0}"
+    if [[ "${_scanned:-0}" -eq 0 && -s "$_BS_TREND" ]]; then
         local _last; _last=$(tail -1 "$_BS_TREND" 2>/dev/null)
-        [[ "$_last" == *'"health_state":"NO_INPUT_DISCOVERED"'* ]] && return 0
+        [[ "$_last" == *"\"health_state\":\"$hs\""* ]] && return 0
     fi
     local _host; _host=$(hostname -s 2>/dev/null || echo unknown)
     local rec

--- a/cli/lib/nftban/tests/botscan_trend_v208_test.sh
+++ b/cli/lib/nftban/tests/botscan_trend_v208_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.208 BotScan trend-history / reporting-truth
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_trend_v208_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-26"
+# meta:description="Hermetic tests for the v1.208 BotScan durable trend-history (nftban_botscan_trend_append + nftban_botscan_history): one append per recorded run, bounded retention trim, NO_INPUT_DISCOVERED dedupe (no-web host does not fill trend), recording-discipline (disabled+never-run writes no trend), JSON validity, corrupt/partial trend line tolerated by the history summarizer, and that the trend reuses the watchdog host-vitals trend rather than creating a duplicate CPU/RAM store. Self-contained sandbox; no network; no nft."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,awk,mktemp,flock"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,jq,awk,mktemp,flock"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_DATA_DIR,BOTSCAN_ENABLED,BOTSCAN_TREND_RETENTION"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+export NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+export NFTBAN_DATA_DIR="$SANDBOX/data"; mkdir -p "$NFTBAN_DATA_DIR/botscan"
+TREND="$NFTBAN_DATA_DIR/botscan/trend.jsonl"
+SRC="$NFTBAN_LIB_DIR/core/nftban_botscan_adaptive.sh"
+PASS=0; FAIL=0; FAILED=()
+eq(){ [[ "$1" == "$2" ]] && { echo "  [PASS] $3"; PASS=$((PASS+1)); } || { echo "  [FAIL] $3 (want '$2' got '$1')"; FAIL=$((FAIL+1)); FAILED+=("$3"); }; }
+
+# shellcheck source=/dev/null
+source "$SRC"
+echo "================================================="
+echo "v1.208 BotScan trend-history test"
+echo "================================================="
+
+echo "[T1] enabled run → one trend record appended (valid JSON)"
+export BOTSCAN_ENABLED=true
+nftban_botscan_record_runstate ts=100 dur=9 lines_scanned=155 bans=0 health_state=OK_SCANNED_NO_BOTS pressure_state=NORMAL scan_mode=FULL backlog_state=STABLE load_ratio=0.30 >/dev/null 2>&1
+eq "$([[ -s "$TREND" ]] && echo yes || echo no)" "yes" "T1.1 trend.jsonl created"
+eq "$(wc -l < "$TREND" | tr -d ' ')" "1" "T1.2 exactly one record"
+eq "$(jq -r '.scan_mode' "$TREND" 2>/dev/null)" "FULL" "T1.3 valid JSON, scan_mode=FULL"
+eq "$(jq -r '.source' "$TREND" 2>/dev/null)" "botscan" "T1.4 source=botscan"
+
+echo "[T2] disabled + never-run → NO trend record (recording-discipline)"
+rm -f "$TREND" "$NFTBAN_DATA_DIR/botscan/runstate.json"
+export BOTSCAN_ENABLED=false
+nftban_botscan_record_runstate ts=101 health_state=DISABLED_BY_CONFIG >/dev/null 2>&1 || true
+eq "$([[ -f "$TREND" ]] && echo yes || echo no)" "no" "T2.1 disabled+never-run writes NO trend (no noise)"
+
+echo "[T3] NO_INPUT_DISCOVERED dedupe (no-web host doesn't fill trend)"
+export BOTSCAN_ENABLED=true
+nftban_botscan_record_runstate ts=200 health_state=NO_INPUT_DISCOVERED pressure_state=NORMAL scan_mode=NONE backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=201 health_state=NO_INPUT_DISCOVERED pressure_state=NORMAL scan_mode=NONE backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=202 health_state=NO_INPUT_DISCOVERED pressure_state=NORMAL scan_mode=NONE backlog_state=STABLE >/dev/null 2>&1
+eq "$(wc -l < "$TREND" | tr -d ' ')" "1" "T3.1 three consecutive NO_INPUT_DISCOVERED → ONE trend record (deduped)"
+# a real scan after no-input IS recorded (dedupe only collapses consecutive no-input)
+nftban_botscan_record_runstate ts=203 dur=5 lines_scanned=10 health_state=OK_SCANNED_NO_BOTS scan_mode=FULL >/dev/null 2>&1
+eq "$(wc -l < "$TREND" | tr -d ' ')" "2" "T3.2 OK scan after no-input IS appended"
+
+echo "[T4] bounded retention trim"
+rm -f "$TREND"
+export BOTSCAN_TREND_RETENTION=5
+for i in $(seq 1 12); do
+  nftban_botscan_record_runstate ts=$((300+i)) dur=1 lines_scanned=$i health_state=OK_SCANNED_NO_BOTS scan_mode=FULL >/dev/null 2>&1
+done
+eq "$(wc -l < "$TREND" | tr -d ' ')" "5" "T4.1 retention trims to last 5"
+eq "$(jq -r '.ts' "$TREND" 2>/dev/null | tail -1)" "312" "T4.2 newest record retained (ts=312)"
+eq "$(jq -r '.ts' "$TREND" 2>/dev/null | head -1)" "308" "T4.3 oldest retained = 308 (12 written, last 5)"
+export BOTSCAN_TREND_RETENTION=500
+
+echo "[T5] history summarizer (modes, budget-hit hosts, corrupt-line tolerance)"
+rm -f "$TREND"
+nftban_botscan_record_runstate ts=400 dur=9 lines_scanned=100 health_state=OK_SCANNED_NO_BOTS scan_mode=FULL backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=401 dur=67 lines_scanned=30000 health_state=OK_SCANNED_NO_BOTS scan_mode=SURVIVAL pressure_state=CRITICAL backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=402 dur=219 lines_scanned=27000 budget_hit=1 health_state=DEGRADED_BUDGET_HIT scan_mode=FULL backlog_state=GROWING >/dev/null 2>&1
+echo 'THIS IS A CORRUPT NON-JSON LINE' >> "$TREND"   # must be tolerated
+hist=$(nftban_botscan_history 2>&1)
+# scope to the "Scan modes:" section (SURVIVAL also legitimately appears in the Last-OK-scan line)
+eq "$(echo "$hist" | sed -n '/Scan modes:/,/Health states:/p' | grep -c 'SURVIVAL')" "1" "T5.1 history shows SURVIVAL once in mode summary"
+echo "$hist" | grep -q 'DEGRADED_BUDGET_HIT' && eq ok ok "T5.2 history shows DEGRADED_BUDGET_HIT" || eq miss ok "T5.2 history shows DEGRADED_BUDGET_HIT"
+echo "$hist" | grep -qiE 'budget-hit' && eq ok ok "T5.3 history reports budget-hit section" || eq miss ok "T5.3 history reports budget-hit section"
+# corrupt line did not crash the summarizer (we got output)
+eq "$([[ -n "$hist" ]] && echo ok || echo empty)" "ok" "T5.4 corrupt trend line tolerated (no crash)"
+
+echo "[T6] no duplicate host-vitals store (trend record carries decision, not a CPU/RAM trend)"
+# the trend record must NOT contain mem_percent/iowait_percent fields (those live in watchdog trend)
+rm -f "$TREND"
+nftban_botscan_record_runstate ts=500 dur=9 lines_scanned=100 health_state=OK_SCANNED_NO_BOTS scan_mode=FULL load_ratio=0.5 >/dev/null 2>&1
+eq "$(jq -r 'has("mem_percent") or has("iowait_percent")' "$TREND" 2>/dev/null)" "false" "T6.1 no mem/iowait in trend (no dup host-vitals store)"
+eq "$(jq -r 'has("load_ratio")' "$TREND" 2>/dev/null)" "true" "T6.2 carries cheap load_ratio context"
+
+echo
+echo "================================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/botscan_trend_v208_test.sh
+++ b/cli/lib/nftban/tests/botscan_trend_v208_test.sh
@@ -94,6 +94,22 @@ nftban_botscan_record_runstate ts=500 dur=9 lines_scanned=100 health_state=OK_SC
 eq "$(jq -r 'has("mem_percent") or has("iowait_percent")' "$TREND" 2>/dev/null)" "false" "T6.1 no mem/iowait in trend (no dup host-vitals store)"
 eq "$(jq -r 'has("load_ratio")' "$TREND" 2>/dev/null)" "true" "T6.2 carries cheap load_ratio context"
 
+echo "[T7] generalized zero-progress dedupe (DEGRADED_INPUT_BLIND empty-log host)"
+rm -f "$TREND"
+export BOTSCAN_ENABLED=true
+# 3 consecutive empty-log scans (0 lines) → DEGRADED_INPUT_BLIND → collapse to 1
+nftban_botscan_record_runstate ts=600 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=601 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL backlog_state=STABLE >/dev/null 2>&1
+nftban_botscan_record_runstate ts=602 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL backlog_state=STABLE >/dev/null 2>&1
+eq "$(wc -l < "$TREND" | tr -d ' ')" "1" "T7.1 consecutive DEGRADED_INPUT_BLIND(0-scanned) → ONE record (no spam)"
+# a real scan with lines>0 always records (state change / progress)
+nftban_botscan_record_runstate ts=603 dur=9 lines_scanned=120 health_state=OK_SCANNED_NO_BOTS scan_mode=FULL >/dev/null 2>&1
+eq "$(wc -l < "$TREND" | tr -d ' ')" "2" "T7.2 progress scan after blind IS recorded"
+# back to blind → recorded (state change OK→BLIND), then dedupes again
+nftban_botscan_record_runstate ts=604 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL >/dev/null 2>&1
+nftban_botscan_record_runstate ts=605 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL >/dev/null 2>&1
+eq "$(wc -l < "$TREND" | tr -d ' ')" "3" "T7.3 OK→BLIND transition records once, then dedupes"
+
 echo
 echo "================================================="
 echo "Results: $PASS passed, $FAIL failed"

--- a/cli/lib/nftban/tests/botscan_trend_v208_test.sh
+++ b/cli/lib/nftban/tests/botscan_trend_v208_test.sh
@@ -110,6 +110,19 @@ nftban_botscan_record_runstate ts=604 dur=2 lines_scanned=0 health_state=DEGRADE
 nftban_botscan_record_runstate ts=605 dur=2 lines_scanned=0 health_state=DEGRADED_INPUT_BLIND scan_mode=FULL >/dev/null 2>&1
 eq "$(wc -l < "$TREND" | tr -d ' ')" "3" "T7.3 OK→BLIND transition records once, then dedupes"
 
+echo "[T8] integration: process_logs with ZERO discovered logs → NO_INPUT_DISCOVERED (+ dedupe)"
+# authoritative proof of the no-access-log path, independent of any host's log discovery.
+T8=$(NFTBAN_LIB_DIR="$NFTBAN_LIB_DIR" NFTBAN_DATA_DIR="$(mktemp -d)" bash -c '
+  export BOTSCAN_ENABLED=true
+  source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh" >/dev/null 2>&1
+  nftban_botscan_discover_logs() { return 0; }   # zero logs discovered
+  for _ in 1 2 3; do nftban_botscan_process_logs "" >/dev/null 2>&1 || true; done
+  echo "hs=$(jq -r .health_state "$NFTBAN_DATA_DIR/botscan/runstate.json" 2>/dev/null)"
+  echo "trec=$(wc -l < "$NFTBAN_DATA_DIR/botscan/trend.jsonl" 2>/dev/null || echo 0)"
+' 2>/dev/null)
+eq "$(echo "$T8" | grep -oE 'hs=[A-Z_]+' | cut -d= -f2)" "NO_INPUT_DISCOVERED" "T8.1 zero-logs path records NO_INPUT_DISCOVERED (not NO_RUN_YET)"
+eq "$(echo "$T8" | grep -oE 'trec=[0-9]+' | cut -d= -f2)" "1" "T8.2 three consecutive no-logs runs → ONE trend record (deduped)"
+
 echo
 echo "================================================="
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## v1.208.0 — BotScan reporting-truth / trend-history

Scope: `V208_BOTSCAN_PRESSURE_TREND_SCOPE.md` · Report: `V208_BOTSCAN_SMART_ADAPTIVE_IMPL_REPORT.md` (v207) + this lane. **Shell-only — `nftband` byte-identical with v1.207.0; nft schema 1.84.0; no detection/firewall/daemon change.** Updater inhibited-timer fix stays **split** (`cmd_update_helpers.sh` untouched).

### Summary
- **Durable trend** → `/var/lib/nftban/botscan/trend.jsonl`: one JSON record per meaningful run (in `record_runstate`, gated by `should_record`), **bounded retention** (`BOTSCAN_TREND_RETENTION`, default 500) + **flock + atomic trim**, **no duplicate CPU/RAM store** (reuses the watchdog host-vitals trend; carries only BotScan's decision + cheap `load_ratio`).
- **`nftban health botscan --history`** — scan-mode/health-state frequency, budget-hit hosts, backlog-GROWING hosts, last OK / last DEGRADED; tolerates corrupt/partial trend lines.
- **No-input handling + zero-progress dedupe** (avoids trend spam on non-web hosts).

### State classification (preserved)
- **`NO_INPUT_DISCOVERED`** — no log source discovered / no web logs exist (the `nftban_botscan.sh` "No access log found" path).
- **`DEGRADED_INPUT_BLIND`** — a log source exists / path is entered, but the scan makes zero useful progress.
- **Both are NOT clean. Neither is fatal/crash.** Repeated zero-progress states (either kind) **dedupe** to one trend record until the state changes.

### Validation — build 28262735223
- **Hermetic 21/0** (append · retention · disabled-no-noise · NO_INPUT_DISCOVERED + zero-progress dedupe · history summary · corrupt-line tolerance · no-dup-store · **T8 integration: `process_logs` zero-discovery → NO_INPUT_DISCOVERED + dedupe**) + **v207 adaptive regression 29/0** + existing BotScan regressions (nofork-parity, deadline-rotation, request-class incl IPv4/IPv6) PASS.
- **lab2 DEB package-native PASS** — trend accrual ≥2 records, all 16 fields, `source=botscan`, no-dup-store, `--history` view.
- **lab4 RPM package-native PASS** — no-web host → not-clean (DEGRADED_INPUT_BLIND rc1, not crash, not NO_RUN_YET), zero-progress dedupe active, `--history` renders.

### Scope audit
4 shell files · **0 `.go`** · no `cmd/nftband` / `internal/` · schema **1.84.0** · VERSION **1.207.0** (until release-prep) · `nftband` byte-identical · **`cmd_update_helpers.sh` untouched** (no updater-path change) · no detection/ban/firewall-topology change · no RBL/portscan/BotGuard change · no central-comms/email/webhook/auditor · no fleet mutation.