### PR TITLE
v1.209.0 BotScan signal-consumer un-gate + enforced/provenanced ban path (daemon-Go)

### DIFF
--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -479,6 +479,14 @@ func (d *Daemon) initOpQueue() error {
 		log.Printf("[OpQueue] Warning: failed to load source index: %v", err)
 	}
 
+	// v1.209 — wire SourceIndex to the bot guard module so consumer-applied BotScan bans record
+	// provenance source=botscan (created here, AFTER InitEnforcer's earlier module wiring).
+	if bgMod, ok := d.registry.Get(botguard.ModuleName); ok {
+		if bg, ok := bgMod.(*botguard.Module); ok {
+			bg.InitSourceIndex(d.sourceIndex)
+		}
+	}
+
 	// Start async workers
 	d.opQueue.Start(d.ctx)
 	go d.sourceIndex.StartBackgroundSaver(d.ctx)

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -479,13 +479,10 @@ func (d *Daemon) initOpQueue() error {
 		log.Printf("[OpQueue] Warning: failed to load source index: %v", err)
 	}
 
-	// v1.209 — wire SourceIndex to the bot guard module so consumer-applied BotScan bans record
-	// provenance source=botscan (created here, AFTER InitEnforcer's earlier module wiring).
-	if bgMod, ok := d.registry.Get(botguard.ModuleName); ok {
-		if bg, ok := bgMod.(*botguard.Module); ok {
-			bg.InitSourceIndex(d.sourceIndex)
-		}
-	}
+	// v1.209 — wire SourceIndex into the OpQueue so the apply boundary records provenance for
+	// EVERY producer's bans (source=botscan/manual/...). Set BEFORE opQueue.Start (below) so no
+	// flush ever runs without it — lifecycle-race-free, no per-module wiring.
+	d.opQueue.SetSourceIndexer(d.sourceIndex)
 
 	// Start async workers
 	d.opQueue.Start(d.ctx)

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -86,6 +86,9 @@ type Module struct {
 	// route BotScan bans to the DURABLE, drop-enforced blacklist_manual_{v4,v6} sets when
 	// BotGuard classification is disabled (http_bot_ban is unenforced then). Set in InitEnforcer.
 	opQueue *opqueue.OpQueue
+	// v1.209 — daemon SourceIndex so consumer-applied BotScan bans record provenance source=botscan
+	// (EnqueueBan's Source field does NOT reach source_index; the reconcile path would tag "unknown").
+	sourceIndex *opqueue.SourceIndex
 
 	// State map: tracked IPs and their classification
 	ips   map[netip.Addr]*IPRecord
@@ -206,6 +209,12 @@ func (m *Module) Init(bus *eventbus.Bus) error {
 func (m *Module) InitEnforcer(queue *opqueue.OpQueue) {
 	m.enforcer = NewEnforcer(queue, m.config)
 	m.opQueue = queue // v1.209: BotScan bans → blacklist_manual via the queue when BotGuard disabled
+}
+
+// InitSourceIndex wires the daemon's SourceIndex so consumer-applied BotScan bans record
+// provenance source=botscan (v1.209). Called by the daemon after the SourceIndex is created.
+func (m *Module) InitSourceIndex(si *opqueue.SourceIndex) {
+	m.sourceIndex = si
 }
 
 // Start begins the classification loop.
@@ -853,6 +862,11 @@ func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
 	if err := m.opQueue.EnqueueBan(setName, ip.String(), ttlSec, botscanProvenanceSrc, reason); err != nil {
 		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
 		return false
+	}
+	// v1.209 — record provenance source=botscan (EnqueueBan's Source does NOT reach source_index;
+	// without this the reconcile path tags the element "unknown"). blacklist_manual is a persisted set.
+	if m.sourceIndex != nil {
+		m.sourceIndex.AddWithExpiry(setName, ip.String(), botscanProvenanceSrc, time.Now().Add(ttl).Unix())
 	}
 	m.mu.Lock()
 	m.stats.BanCount++

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -86,9 +86,6 @@ type Module struct {
 	// route BotScan bans to the DURABLE, drop-enforced blacklist_manual_{v4,v6} sets when
 	// BotGuard classification is disabled (http_bot_ban is unenforced then). Set in InitEnforcer.
 	opQueue *opqueue.OpQueue
-	// v1.209 — daemon SourceIndex so consumer-applied BotScan bans record provenance source=botscan
-	// (EnqueueBan's Source field does NOT reach source_index; the reconcile path would tag "unknown").
-	sourceIndex *opqueue.SourceIndex
 
 	// State map: tracked IPs and their classification
 	ips   map[netip.Addr]*IPRecord
@@ -209,12 +206,6 @@ func (m *Module) Init(bus *eventbus.Bus) error {
 func (m *Module) InitEnforcer(queue *opqueue.OpQueue) {
 	m.enforcer = NewEnforcer(queue, m.config)
 	m.opQueue = queue // v1.209: BotScan bans → blacklist_manual via the queue when BotGuard disabled
-}
-
-// InitSourceIndex wires the daemon's SourceIndex so consumer-applied BotScan bans record
-// provenance source=botscan (v1.209). Called by the daemon after the SourceIndex is created.
-func (m *Module) InitSourceIndex(si *opqueue.SourceIndex) {
-	m.sourceIndex = si
 }
 
 // Start begins the classification loop.
@@ -863,11 +854,6 @@ func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
 		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
 		return false
 	}
-	// v1.209 — record provenance source=botscan (EnqueueBan's Source does NOT reach source_index;
-	// without this the reconcile path tags the element "unknown"). blacklist_manual is a persisted set.
-	if m.sourceIndex != nil {
-		m.sourceIndex.AddWithExpiry(setName, ip.String(), botscanProvenanceSrc, time.Now().Add(ttl).Unix())
-	}
 	m.mu.Lock()
 	m.stats.BanCount++
 	m.mu.Unlock()
@@ -886,18 +872,9 @@ func (m *Module) runBatchSignalConsumer(ctx context.Context) {
 	if interval <= 0 {
 		interval = 60 * time.Second
 	}
-	// Brief settle before the FIRST drain: module Start() (and this goroutine) runs in daemon init
-	// BEFORE the daemon creates + wires the SourceIndex (InitSourceIndex) and starts the OpQueue.
-	// Draining immediately would apply bans with m.sourceIndex==nil → provenance recorded as
-	// "unknown". A short wait lets init finish wiring; the ticker cadence is unaffected.
-	select {
-	case <-ctx.Done():
-		return
-	case <-time.After(3 * time.Second):
-	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-	m.processBatchSignals() // first drain (SourceIndex + OpQueue wired by now)
+	m.processBatchSignals() // prompt first drain on start (provenance recorded at OpQueue flush boundary)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -36,6 +36,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/netip"
 	"os"
@@ -80,6 +81,11 @@ type Module struct {
 	verifier   *FCrDNSVerifier
 	classifier *Classifier
 	logger     *Logger
+
+	// v1.209 — direct OpQueue handle so the standalone BotScan batch-signal consumer can
+	// route BotScan bans to the DURABLE, drop-enforced blacklist_manual_{v4,v6} sets when
+	// BotGuard classification is disabled (http_bot_ban is unenforced then). Set in InitEnforcer.
+	opQueue *opqueue.OpQueue
 
 	// State map: tracked IPs and their classification
 	ips   map[netip.Addr]*IPRecord
@@ -199,12 +205,24 @@ func (m *Module) Init(bus *eventbus.Bus) error {
 // Called after daemon creates the OpQueue.
 func (m *Module) InitEnforcer(queue *opqueue.OpQueue) {
 	m.enforcer = NewEnforcer(queue, m.config)
+	m.opQueue = queue // v1.209: BotScan bans → blacklist_manual via the queue when BotGuard disabled
 }
 
 // Start begins the classification loop.
 func (m *Module) Start(ctx context.Context) error {
 	if !m.config.Enabled {
 		log.Printf("[botguard] Module disabled in config")
+		// v1.209 — BotScan (Clock-3 shell) writes ban signals to batch_signals.jsonl. Its only
+		// consumer used to live in the classifier tick, which never ran when BotGuard was
+		// disabled → BotScan bans were inert fleet-wide. Run a STANDALONE, bounded, age-filtered
+		// consumer that routes BotScan bans to the durable, drop-enforced blacklist_manual_{v4,v6}
+		// sets — WITHOUT enabling BotGuard classification (no suspect-read / FCrDNS / classifier).
+		// Requires the OpQueue (set unconditionally in InitEnforcer).
+		if m.config.BatchSignalFile != "" && m.opQueue != nil {
+			ctx, m.cancel = context.WithCancel(ctx)
+			go m.runBatchSignalConsumer(ctx)
+			log.Printf("[botguard] BotScan batch-signal consumer started (classification disabled; bans → blacklist_manual)")
+		}
 		return nil
 	}
 
@@ -294,6 +312,12 @@ type BotGuardStatusExtra struct {
 	VerifyVerified        int64  `json:"verify_verified"`
 	VerifyFailed          int64  `json:"verify_failed"`
 	BatchSignalsProcessed int64  `json:"batch_signals_processed"`
+	// v1.209 — BotScan signal-consumer (un-gate) observability.
+	BatchSignalsApplied       int64 `json:"batch_signals_applied"`
+	BatchSignalsExpired       int64 `json:"batch_signals_expired"`
+	BatchSignalsMalformed     int64 `json:"batch_signals_malformed"`
+	BatchConsumerRuns         int64 `json:"batch_consumer_runs"`
+	BatchConsumerStaleBacklog bool  `json:"batch_consumer_stale_backlog"`
 }
 
 // ToExtraInfo serializes the typed struct into the module.ExtraInfo
@@ -315,7 +339,12 @@ func (e BotGuardStatusExtra) ToExtraInfo() module.ExtraInfo {
 		"verify_completed":        e.VerifyCompleted,
 		"verify_verified":         e.VerifyVerified,
 		"verify_failed":           e.VerifyFailed,
-		"batch_signals_processed": e.BatchSignalsProcessed,
+		"batch_signals_processed":      e.BatchSignalsProcessed,
+		"batch_signals_applied":        e.BatchSignalsApplied,
+		"batch_signals_expired":        e.BatchSignalsExpired,
+		"batch_signals_malformed":      e.BatchSignalsMalformed,
+		"batch_consumer_runs":          e.BatchConsumerRuns,
+		"batch_consumer_stale_backlog": e.BatchConsumerStaleBacklog,
 	}
 }
 
@@ -342,6 +371,12 @@ func (m *Module) Status() module.Status {
 		VerifyVerified:        m.stats.VerifyVerified,
 		VerifyFailed:          m.stats.VerifyFailed,
 		BatchSignalsProcessed: m.stats.BatchSignalsProcessed,
+
+		BatchSignalsApplied:       m.stats.BatchSignalsApplied,
+		BatchSignalsExpired:       m.stats.BatchSignalsExpired,
+		BatchSignalsMalformed:     m.stats.BatchSignalsMalformed,
+		BatchConsumerRuns:         m.stats.BatchConsumerRuns,
+		BatchConsumerStaleBacklog: m.stats.BatchConsumerStaleBacklog,
 	}
 	m.status.Extra = extra.ToExtraInfo()
 
@@ -645,66 +680,208 @@ func (m *Module) pruneExpired() {
 	}
 }
 
-// processBatchSignals reads and processes batch_signals.jsonl from Clock 3 (shell botscan).
-// Reads all lines, applies each signal as a classification input, then truncates the file.
-// Thread-safe: only called from the classification loop goroutine.
+// v1.209 — BotScan batch-signal consumer constants.
+const (
+	botscanManualSetV4   = "blacklist_manual_ipv4" // durable, drop-enforced (independent of BotGuard)
+	botscanManualSetV6   = "blacklist_manual_ipv6"
+	botscanProvenanceSrc = "botscan"
+	botscanManualBanTTL  = 24 * time.Hour // BotScan-originated blacklist_manual ban TTL (behavioral; re-confirmable)
+	botscanManualGreyTTL = 1 * time.Hour
+)
+
+// processBatchSignals reads a BOUNDED TAIL of batch_signals.jsonl (Clock-3 shell botscan), applies
+// only FRESH signals (within WarmupMaxAge), and truncates the file. STALE signals (older than the
+// cutoff) and any backlog beyond the tail window are QUARANTINED — discarded + counted, NEVER
+// applied — so a multi-day unconsumed backlog cannot flood-apply. Bounded by WarmupMaxBytes/Lines/
+// Accepted (never slurps the whole file → no OOM on a 24MB queue).
+//
+// Routing: when BotGuard is ENABLED, applies via the existing BotGuard path (http_bot_ban, which is
+// drop-wired then). When BotGuard is DISABLED, routes BotScan bans to the durable, drop-enforced
+// blacklist_manual_{v4,v6} sets (http_bot_ban is NOT drop-wired when BotGuard is off). Single
+// owner: the BotGuard tick when enabled, the standalone consumer when disabled — never both.
 func (m *Module) processBatchSignals() {
 	signalFile := m.config.BatchSignalFile
 	if signalFile == "" {
 		return
 	}
-
-	// Open the file for reading
 	f, err := os.Open(filepath.Clean(signalFile)) // #nosec G304 -- path from nftbanconf (trusted)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return // No signals yet — normal
+		if !os.IsNotExist(err) {
+			log.Printf("[botguard] batch signal read error: %v", err)
 		}
-		log.Printf("[botguard] batch signal read error: %v", err)
+		return // missing → normal
+	}
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		_ = f.Close()
 		return
 	}
+	size := fi.Size()
 
-	var signals []BatchSignal
-	scanner := bufio.NewScanner(f)
+	// Bounded TAIL: newest signals are appended at the end. Seek to the last maxBytes so we never
+	// read a multi-MiB backlog into memory; the un-read head is discarded by the truncate below
+	// (it is the stale backlog — intended quarantine).
+	maxBytes := m.config.WarmupMaxBytes
+	var startOff int64
+	staleBeyondWindow := false
+	if maxBytes > 0 && size > maxBytes {
+		startOff = size - maxBytes
+		staleBeyondWindow = true
+	}
+	if _, err := f.Seek(startOff, io.SeekStart); err != nil {
+		_ = f.Close()
+		return
+	}
+	reader := bufio.NewReader(f)
+	if startOff > 0 {
+		if _, err := reader.ReadString('\n'); err != nil { // drop the partial first line
+			_ = f.Close()
+			return
+		}
+	}
+
+	var cutoff int64
+	if m.config.WarmupMaxAge > 0 {
+		cutoff = time.Now().Add(-m.config.WarmupMaxAge).Unix()
+	}
+	maxLines := m.config.WarmupMaxLines
+	maxAccepted := m.config.WarmupMaxAccepted
+
+	var fresh []BatchSignal
+	var scanned, expired, malformed int
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64<<10), 256<<10)
 	for scanner.Scan() {
+		if maxLines > 0 && scanned >= maxLines {
+			break
+		}
 		line := scanner.Bytes()
+		scanned++
 		if len(line) == 0 {
 			continue
 		}
 		var sig BatchSignal
-		if err := json.Unmarshal(line, &sig); err != nil {
-			log.Printf("[botguard] batch signal parse error: %v", err)
+		if err := json.Unmarshal(line, &sig); err != nil || sig.IP == "" {
+			malformed++
 			continue
 		}
-		signals = append(signals, sig)
+		if cutoff > 0 && sig.TS != 0 && sig.TS < cutoff {
+			expired++ // STALE → quarantine, never apply
+			continue
+		}
+		fresh = append(fresh, sig)
+		if maxAccepted > 0 && len(fresh) >= maxAccepted {
+			break
+		}
 	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("[botguard] batch signal scanner error: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		log.Printf("[botguard] batch signal file close error: %v", err)
-	}
+	_ = scanner.Err()
+	_ = f.Close()
 
-	if len(signals) == 0 {
-		return
-	}
-
-	// Truncate the file after reading (atomic: write empty file)
+	// Truncate AFTER reading (atomic empty write). Drops the un-read stale head — the quarantine.
 	if err := os.WriteFile(signalFile, nil, 0600); err != nil { // #nosec G306 -- truncate to empty
 		log.Printf("[botguard] batch signal truncate error: %v", err)
 	}
 
-	// Process each signal
-	for i := range signals {
-		m.applyBatchSignal(&signals[i])
+	toManual := !m.config.Enabled
+	applied := 0
+	for i := range fresh {
+		if toManual {
+			if m.applyBotscanBanSignal(&fresh[i]) {
+				applied++
+			}
+		} else {
+			m.applyBatchSignal(&fresh[i]) // existing BotGuard path (http_bot_ban, drop-wired when enabled)
+			applied++
+		}
 	}
 
 	m.mu.Lock()
-	m.stats.BatchSignalsProcessed += int64(len(signals))
+	m.stats.BatchSignalsProcessed += int64(scanned)
+	m.stats.BatchSignalsApplied += int64(applied)
+	m.stats.BatchSignalsExpired += int64(expired)
+	m.stats.BatchSignalsMalformed += int64(malformed)
+	m.stats.BatchConsumerRuns++
+	m.stats.BatchConsumerStaleBacklog = staleBeyondWindow || expired > 0
 	m.mu.Unlock()
 
+	if (applied > 0 || expired > 0) && m.logger != nil {
+		m.logger.LogEvent("INFO", fmt.Sprintf("batch consumer: applied=%d expired=%d malformed=%d scanned=%d stale_backlog=%v to_manual=%v",
+			applied, expired, malformed, scanned, staleBeyondWindow, toManual))
+	}
+}
+
+// applyBotscanBanSignal enforces a FRESH BotScan batch signal to the DURABLE, drop-enforced
+// blacklist_manual_{v4,v6} set (NOT http_bot_ban, which is unenforced when BotGuard is disabled).
+// Used by the standalone consumer when BotGuard classification is off. Browser-like/static/admin
+// classes are suppressed (never ban from class alone). Whitelist/admin/session safety is preserved
+// by firewall RULE ORDER (the whitelist `accept` precedes the blacklist_manual `drop`, exactly as
+// for every feed/manual ban). Provenance: source=botscan. Returns true if a ban was enqueued.
+func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
+	if m.opQueue == nil {
+		return false
+	}
+	ip, err := netip.ParseAddr(sig.IP)
+	if err != nil {
+		return false
+	}
+	if sig.Action != "ban" && sig.Action != "grey" {
+		return false // only ban/grey actions enforce; allow_demote/extend are no-ops here
+	}
+	// keep decision-cache observability consistent (harmless; never durable)
+	m.recordDecisionTransition(sig, ip)
+	// browser-like / static / e-shop / admin fan-out → never ban from class alone (fail-safe)
+	if m.suppressBrowserLikeBatchBan(sig) {
+		if m.config.LogDecisions {
+			log.Printf("[botguard] botscan: suppressed_browser_like %s class=%s action=%s",
+				ip, sig.NormalizedRequestClass(), sig.Action)
+		}
+		return false
+	}
+	setName := botscanManualSetV4
+	if ip.Is6() {
+		setName = botscanManualSetV6
+	}
+	ttl := botscanManualBanTTL
+	if sig.Action == "grey" {
+		ttl = botscanManualGreyTTL
+	}
+	reason := botscanProvenanceSrc
+	if len(sig.Reasons) > 0 {
+		reason = botscanProvenanceSrc + ":" + sig.Reasons[0]
+	}
+	ttlSec := uint32(ttl / time.Second) // #nosec G115 -- bounded constant (<= 24h), fits uint32
+	if err := m.opQueue.EnqueueBan(setName, ip.String(), ttlSec, botscanProvenanceSrc, reason); err != nil {
+		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
+		return false
+	}
+	m.mu.Lock()
+	m.stats.BanCount++
+	m.mu.Unlock()
 	if m.logger != nil {
-		m.logger.LogEvent("INFO", fmt.Sprintf("Processed %d batch signals from Clock 3", len(signals)))
+		m.logger.LogEvent("INFO", fmt.Sprintf("botscan ban → %s ip=%s ttl=%ds reason=%s", setName, ip, ttlSec, reason))
+	}
+	return true
+}
+
+// runBatchSignalConsumer drains BotScan batch signals on a ticker, INDEPENDENT of the BotGuard
+// classifier loop. Used only when BotGuard classification is disabled but BotScan (Clock-3) is
+// producing ban signals — so BotScan bans apply without enabling BotGuard. No suspect-read, no
+// FCrDNS, no classifier; only the bounded + age-filtered processBatchSignals drain.
+func (m *Module) runBatchSignalConsumer(ctx context.Context) {
+	interval := m.config.LoopInterval
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	m.processBatchSignals() // prompt first drain on start
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.processBatchSignals()
+		}
 	}
 }
 

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -886,9 +886,18 @@ func (m *Module) runBatchSignalConsumer(ctx context.Context) {
 	if interval <= 0 {
 		interval = 60 * time.Second
 	}
+	// Brief settle before the FIRST drain: module Start() (and this goroutine) runs in daemon init
+	// BEFORE the daemon creates + wires the SourceIndex (InitSourceIndex) and starts the OpQueue.
+	// Draining immediately would apply bans with m.sourceIndex==nil → provenance recorded as
+	// "unknown". A short wait lets init finish wiring; the ticker cadence is unaffected.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(3 * time.Second):
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-	m.processBatchSignals() // prompt first drain on start
+	m.processBatchSignals() // first drain (SourceIndex + OpQueue wired by now)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -685,8 +685,8 @@ const (
 	botscanManualSetV4   = "blacklist_manual_ipv4" // durable, drop-enforced (independent of BotGuard)
 	botscanManualSetV6   = "blacklist_manual_ipv6"
 	botscanProvenanceSrc = "botscan"
-	botscanManualBanTTL  = 24 * time.Hour // BotScan-originated blacklist_manual ban TTL (behavioral; re-confirmable)
-	botscanManualGreyTTL = 1 * time.Hour
+	botscanManualBanTTLSec  uint32 = 24 * 3600 // BotScan blacklist_manual ban TTL seconds (behavioral; re-confirmable)
+	botscanManualGreyTTLSec uint32 = 1 * 3600
 )
 
 // processBatchSignals reads a BOUNDED TAIL of batch_signals.jsonl (Clock-3 shell botscan), applies
@@ -841,15 +841,14 @@ func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
 	if ip.Is6() {
 		setName = botscanManualSetV6
 	}
-	ttl := botscanManualBanTTL
+	ttlSec := botscanManualBanTTLSec
 	if sig.Action == "grey" {
-		ttl = botscanManualGreyTTL
+		ttlSec = botscanManualGreyTTLSec
 	}
 	reason := botscanProvenanceSrc
 	if len(sig.Reasons) > 0 {
 		reason = botscanProvenanceSrc + ":" + sig.Reasons[0]
 	}
-	ttlSec := uint32(ttl / time.Second) // #nosec G115 -- bounded constant (<= 24h), fits uint32
 	if err := m.opQueue.EnqueueBan(setName, ip.String(), ttlSec, botscanProvenanceSrc, reason); err != nil {
 		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
 		return false

--- a/internal/botguard/guard_botscan_consumer_ungate_v209_test.go
+++ b/internal/botguard/guard_botscan_consumer_ungate_v209_test.go
@@ -32,9 +32,60 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
+
+// fakeSourceIndexer satisfies opqueue.SourceIndexer and records provenance writes so a test can
+// assert the OpQueue apply boundary recorded source=botscan for a consumer-applied ban.
+type fakeSourceIndexer struct {
+	mu   sync.Mutex
+	adds map[string][]string // set -> ["ip|source", ...]
+}
+
+func (f *fakeSourceIndexer) AddWithExpiry(setName, element, source string, _ int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.adds == nil {
+		f.adds = map[string][]string{}
+	}
+	f.adds[setName] = append(f.adds[setName], element+"|"+source)
+}
+
+func (f *fakeSourceIndexer) hasSource(set, ip, source string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.adds[set] {
+		if e == ip+"|"+source {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBOTSCAN_BAN_RECORDS_SOURCE_INDEX_BOTSCAN — the apply boundary records source=botscan for a
+// consumer-applied ban (the v1.209 provenance contract fix; race-free, no module init wiring).
+func TestBOTSCAN_BAN_RECORDS_SOURCE_INDEX_BOTSCAN(t *testing.T) {
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+	fsi := &fakeSourceIndexer{}
+	m.opQueue.SetSourceIndexer(fsi)
+	const ip = "45.140.17.99"
+	if !m.applyBotscanBanSignal(freshSig(ip, "scanner", "ban")) {
+		t.Fatalf("ban should enqueue")
+	}
+	if !waitBanned(b, "blacklist_manual_ipv4", ip) {
+		t.Fatalf("ban not applied to blacklist_manual_ipv4")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !fsi.hasSource("blacklist_manual_ipv4", ip, "botscan") {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !fsi.hasSource("blacklist_manual_ipv4", ip, "botscan") {
+		t.Fatalf("source_index provenance not recorded as botscan; adds=%v", fsi.adds)
+	}
+}
 
 // freshSig builds a BotScan ban signal with a current timestamp (passes the age cutoff).
 func freshSig(ip, class, action string) *BatchSignal {

--- a/internal/botguard/guard_botscan_consumer_ungate_v209_test.go
+++ b/internal/botguard/guard_botscan_consumer_ungate_v209_test.go
@@ -1,0 +1,145 @@
+// =============================================================================
+// NFTBan v1.209.0 - BotScan batch-signal consumer un-gate (Option A) tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: botguard
+// Purpose: Prove the v1.209 fix — when BotGuard classification is DISABLED, BotScan (Clock-3)
+//          ban signals are still consumed and routed to the DURABLE, drop-enforced
+//          blacklist_manual_{v4,v6} sets (NOT http_bot_ban, which is unenforced when BotGuard
+//          is off), with a MANDATORY stale-backlog quarantine (age-cutoff + bounded drain) so a
+//          multi-day backlog cannot flood-apply. Browser-like classes stay suppressed; IPv4/IPv6
+//          parity; malformed/stale signals are safely discarded.
+//
+// meta:name="botguard_guard_botscan_consumer_ungate_v209_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:package="botguard"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-27"
+// meta:description="Tests for BotScan batch-signal consumer un-gate routing to blacklist_manual + stale quarantine (v1.209 Option A)"
+// meta:inventory.files="guard_botscan_consumer_ungate_v209_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package botguard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// freshSig builds a BotScan ban signal with a current timestamp (passes the age cutoff).
+func freshSig(ip, class, action string) *BatchSignal {
+	s := mkSig(ip, class, action, class)
+	s.TS = time.Now().Unix()
+	s.Family = ""
+	return s
+}
+
+// TestBOTSCAN_BAN_ROUTES_TO_BLACKLIST_MANUAL_V4 — a fresh scanner ban (BotGuard disabled) lands
+// in blacklist_manual_ipv4 (drop-enforced), NOT http_bot_ban.
+func TestBOTSCAN_BAN_ROUTES_TO_BLACKLIST_MANUAL_V4(t *testing.T) {
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+	const ip = "45.140.17.9"
+	if !m.applyBotscanBanSignal(freshSig(ip, "scanner", "ban")) {
+		t.Fatalf("applyBotscanBanSignal should return true (enqueued) for a scanner ban")
+	}
+	if !waitBanned(b, "blacklist_manual_ipv4", ip) {
+		t.Fatalf("%s must be banned in blacklist_manual_ipv4; sets=%v", ip, b.adds)
+	}
+	if b.has("http_bot_ban", ip) {
+		t.Fatalf("%s must NOT be in http_bot_ban (unenforced when BotGuard disabled)", ip)
+	}
+}
+
+// TestBOTSCAN_BAN_ROUTES_TO_BLACKLIST_MANUAL_V6 — IPv6 parity.
+func TestBOTSCAN_BAN_ROUTES_TO_BLACKLIST_MANUAL_V6(t *testing.T) {
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+	const ip = "2001:db8::dead:beef"
+	if !m.applyBotscanBanSignal(freshSig(ip, "scanner", "ban")) {
+		t.Fatalf("applyBotscanBanSignal should enqueue an IPv6 scanner ban")
+	}
+	if !waitBanned(b, "blacklist_manual_ipv6", ip) {
+		t.Fatalf("%s must be banned in blacklist_manual_ipv6; sets=%v", ip, b.adds)
+	}
+}
+
+// TestBOTSCAN_BROWSER_LIKE_SUPPRESSED — a browser/static class ban is suppressed (never enqueued).
+func TestBOTSCAN_BROWSER_LIKE_SUPPRESSED(t *testing.T) {
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+	const ip = "203.0.113.77"
+	if m.applyBotscanBanSignal(freshSig(ip, "static", "ban")) {
+		t.Fatalf("browser-like (static) ban must be suppressed, not enqueued")
+	}
+	assertNotBanned(t, b, "blacklist_manual_ipv4", ip)
+}
+
+// TestBOTSCAN_CONSUMER_STALE_QUARANTINE — processBatchSignals applies only FRESH signals and
+// quarantines (expires, never applies) stale ones, even with a mixed queue.
+func TestBOTSCAN_CONSUMER_STALE_QUARANTINE(t *testing.T) {
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+
+	dir := t.TempDir()
+	qf := filepath.Join(dir, "batch_signals.jsonl")
+	m.config.BatchSignalFile = qf
+
+	const freshIP = "45.141.84.10"
+	const staleIP = "45.141.84.20"
+	now := time.Now().Unix()
+	staleTS := time.Now().Add(-10 * 24 * time.Hour).Unix() // 10 days old → far past the 45m cutoff
+
+	lines := fmt.Sprintf(
+		`{"ip":%q,"score":80,"action":"ban","request_class":"scanner","family":"ipv4","ts":%d,"reasons":["scanner"]}`+"\n"+
+			`{"ip":%q,"score":80,"action":"ban","request_class":"scanner","family":"ipv4","ts":%d,"reasons":["scanner"]}`+"\n"+
+			`this is a malformed line`+"\n",
+		freshIP, now, staleIP, staleTS)
+	if err := os.WriteFile(qf, []byte(lines), 0o600); err != nil {
+		t.Fatalf("write queue: %v", err)
+	}
+
+	m.processBatchSignals()
+
+	if !waitBanned(b, "blacklist_manual_ipv4", freshIP) {
+		t.Fatalf("fresh signal %s must be applied to blacklist_manual_ipv4; sets=%v", freshIP, b.adds)
+	}
+	if b.has("blacklist_manual_ipv4", staleIP) {
+		t.Fatalf("STALE signal %s must be QUARANTINED, never applied; sets=%v", staleIP, b.adds)
+	}
+	if m.stats.BatchSignalsExpired < 1 {
+		t.Fatalf("expected >=1 expired (stale quarantined), got %d", m.stats.BatchSignalsExpired)
+	}
+	if m.stats.BatchSignalsMalformed < 1 {
+		t.Fatalf("expected >=1 malformed counted, got %d", m.stats.BatchSignalsMalformed)
+	}
+	if m.stats.BatchConsumerRuns < 1 {
+		t.Fatalf("expected consumer-run counted")
+	}
+	// The queue file must be truncated after a successful drain.
+	if fi, err := os.Stat(qf); err == nil && fi.Size() != 0 {
+		t.Fatalf("queue file must be truncated after drain, size=%d", fi.Size())
+	}
+}
+
+// TestBOTSCAN_CONSUMER_EMPTY_AND_MISSING_SAFE — empty/missing queue is a no-op, no panic.
+func TestBOTSCAN_CONSUMER_EMPTY_AND_MISSING_SAFE(t *testing.T) {
+	m, _ := newEnforcingModule(t)
+	m.config.Enabled = false
+	m.config.BatchSignalFile = filepath.Join(t.TempDir(), "absent.jsonl")
+	m.processBatchSignals() // missing → no-op
+	empty := filepath.Join(t.TempDir(), "empty.jsonl")
+	_ = os.WriteFile(empty, nil, 0o600)
+	m.config.BatchSignalFile = empty
+	m.processBatchSignals() // empty → no-op
+}

--- a/internal/botguard/guard_test.go
+++ b/internal/botguard/guard_test.go
@@ -69,12 +69,18 @@ func TestBotGuardStatusExtra_ToExtraInfo(t *testing.T) {
 		"verify_verified":         int64(8),
 		"verify_failed":           int64(2),
 		"batch_signals_processed": int64(250),
+		// v1.209 — BotScan signal-consumer observability counters (default 0/false in this fixture).
+		"batch_signals_applied":        int64(0),
+		"batch_signals_expired":        int64(0),
+		"batch_signals_malformed":      int64(0),
+		"batch_consumer_runs":          int64(0),
+		"batch_consumer_stale_backlog": false,
 	}
 	got := extra.ToExtraInfo()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ToExtraInfo() = %v, want %v", got, want)
 	}
-	if len(got) != 16 {
-		t.Errorf("ToExtraInfo() key count = %d, want 16", len(got))
+	if len(got) != 21 {
+		t.Errorf("ToExtraInfo() key count = %d, want 21", len(got))
 	}
 }

--- a/internal/botguard/types.go
+++ b/internal/botguard/types.go
@@ -189,6 +189,12 @@ type GuardStats struct {
 	VerifyVerified        int64         // IPs that passed FCrDNS
 	VerifyFailed          int64         // IPs that failed FCrDNS
 	BatchSignalsProcessed int64         // Batch signals consumed from Clock 3
+	// v1.209 — BotScan signal-consumer (un-gate) counters.
+	BatchSignalsApplied       int64 // fresh batch signals enforced
+	BatchSignalsExpired       int64 // stale batch signals quarantined (older than cutoff)
+	BatchSignalsMalformed     int64 // malformed batch signals skipped
+	BatchConsumerRuns         int64 // batch-signal drain invocations
+	BatchConsumerStaleBacklog bool  // last drain saw a stale backlog (quarantined)
 }
 
 // BatchSignal represents a signal from the shell botscan (Clock 3).

--- a/internal/opqueue/buffer.go
+++ b/internal/opqueue/buffer.go
@@ -178,7 +178,7 @@ func (buf *SetBuffer) countLocked() int {
 
 // flush extracts and applies pending ops, returns post-barrier ops for re-enqueue
 // This is called by the worker goroutine
-func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int) FlushResult {
+func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceIndexer) FlushResult {
 	buf.mu.Lock()
 
 	// Snapshot all state
@@ -236,7 +236,7 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int) FlushResul
 
 	// Apply pending individual ops
 	if len(pending) > 0 {
-		adds, deletes := buf.applyPendingCounted(backend, table, setName, pending, maxBatchSize)
+		adds, deletes := buf.applyPendingCounted(backend, table, setName, pending, maxBatchSize, si)
 		result.Applied += adds + deletes
 		result.Adds += adds
 		result.Deletes += deletes
@@ -289,10 +289,14 @@ func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string
 }
 
 // applyPendingCounted applies individual add/delete operations and returns separate counts
-func (buf *SetBuffer) applyPendingCounted(backend NetlinkBackend, table, setName string, pending map[string]*PendingOp, maxBatchSize int) (adds, deletes int) {
+func (buf *SetBuffer) applyPendingCounted(backend NetlinkBackend, table, setName string, pending map[string]*PendingOp, maxBatchSize int, si SourceIndexer) (adds, deletes int) {
 	isIPv6 := strings.HasSuffix(setName, "_ipv6")
 
 	var toAdd, toDelete []SetElement
+	// v1.209 — keep the PendingOps parallel to toAdd so provenance (op.Source) can be recorded
+	// at the apply boundary after a successful add. Provenance only for persisted blacklist sets.
+	recordProv := si != nil && IsPersistedSet(setName)
+	var toAddOps []*PendingOp
 
 	for _, op := range pending {
 		elem := SetElement{
@@ -303,6 +307,9 @@ func (buf *SetBuffer) applyPendingCounted(backend NetlinkBackend, table, setName
 		switch op.Type {
 		case OpAdd:
 			toAdd = append(toAdd, elem)
+			if recordProv {
+				toAddOps = append(toAddOps, op)
+			}
 		case OpDelete:
 			toDelete = append(toDelete, elem)
 		}
@@ -331,6 +338,21 @@ func (buf *SetBuffer) applyPendingCounted(backend NetlinkBackend, table, setName
 			log.Printf("[opqueue] add %s batch failed: %v", setName, err)
 		} else {
 			adds += end - i
+			// v1.209 — record provenance ONLY after the nft add succeeded (apply boundary).
+			// Without a source we leave the reconcile path's "unknown" fallback untouched.
+			if recordProv {
+				now := time.Now().Unix()
+				for _, pop := range toAddOps[i:end] {
+					if pop.Source == "" {
+						continue
+					}
+					var exp int64
+					if pop.TTL > 0 {
+						exp = now + int64(pop.TTL)
+					}
+					si.AddWithExpiry(setName, pop.Element, pop.Source, exp)
+				}
+			}
 		}
 	}
 

--- a/internal/opqueue/queue.go
+++ b/internal/opqueue/queue.go
@@ -595,8 +595,35 @@ type OpQueue struct {
 	// Last flush time
 	lastFlushTime atomic.Value // time.Time
 
+	// v1.209 — provenance recorder, injected once at daemon init (before Start). The apply
+	// boundary records source_index from the op's Source so every producer's bans get correct
+	// provenance (no per-module wiring, no lifecycle race). nil = no provenance recording.
+	sourceIndexer SourceIndexer
+
 	// Running state
 	running atomic.Bool
+}
+
+// SourceIndexer records element provenance at the durable apply boundary (v1.209). The OpQueue
+// depends on this interface — not on any producing module — so wiring is lifecycle-race-free.
+// *SourceIndex satisfies it.
+type SourceIndexer interface {
+	AddWithExpiry(setName, element, source string, expiresAt int64)
+}
+
+// SetSourceIndexer wires the provenance recorder. MUST be called during daemon init BEFORE
+// Start()/any flush so every apply records provenance.
+func (q *OpQueue) SetSourceIndexer(si SourceIndexer) {
+	q.mu.Lock()
+	q.sourceIndexer = si
+	q.mu.Unlock()
+}
+
+// getSourceIndexer returns the wired recorder (race-safe).
+func (q *OpQueue) getSourceIndexer() SourceIndexer {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.sourceIndexer
 }
 
 // NewOpQueue creates a new operation queue
@@ -721,7 +748,7 @@ func (q *OpQueue) EnqueueReplaceFromFile(setName, filePath, source string, batch
 	countBefore := buf.count()
 	if countBefore > 0 {
 		// Flush pending ops first (they'll be discarded by replace anyway)
-		result := buf.flush(q.backend, q.config.MaxBatchSize)
+		result := buf.flush(q.backend, q.config.MaxBatchSize, q.getSourceIndexer())
 		q.pendingCount.Add(-int64(countBefore))
 		q.totalApplied.Add(safeconv.ToUint64OrZero(result.Applied))
 		metrics.RecordEventsApplied("fast", result.Applied)
@@ -869,7 +896,7 @@ func (q *OpQueue) flushSetWithReenqueue(setName string) {
 	}
 
 	// Flush returns post-barrier ops to re-enqueue
-	result := buf.flush(q.backend, q.config.MaxBatchSize)
+	result := buf.flush(q.backend, q.config.MaxBatchSize, q.getSourceIndexer())
 
 	// Release lock after kernel operations
 	if nftLock != nil {

--- a/internal/opqueue/source_index.go
+++ b/internal/opqueue/source_index.go
@@ -37,6 +37,10 @@ var persistSets = map[string]bool{
 	"blacklist_manual_ipv6": true,
 }
 
+// IsPersistedSet reports whether a set's element provenance is tracked/persisted (v1.209).
+// The OpQueue apply boundary uses this to decide whether to record source_index provenance.
+func IsPersistedSet(setName string) bool { return persistSets[setName] }
+
 // IndexEntry represents a persisted index entry
 type IndexEntry struct {
 	Set       string   `json:"set"`


### PR DESCRIPTION
## v1.209.0 — restore BotScan's ban path when BotGuard is disabled

One coherent failure domain: **make BotScan's bans actually apply, with correct enforcement target and provenance, without enabling BotGuard.** No CPU-engine/Aho-Corasick, no decision-cache accumulation, no MalwareGuard. Daemon re-baseline (Go); **nft schema 1.84.0 unchanged.**

### Root cause
BotScan (Clock-3 shell) produces real batch ban signals to `batch_signals.jsonl`, but the only consumer (`processBatchSignals`) lived inside BotGuard's `tick()`, which never runs when BotGuard is disabled (`Start()` returns early). **BotGuard is disabled fleet-wide → signals accumulated unconsumed → BotScan bans never applied.**

### Safety finding (stale backlog)
The fleet had a **~10-day, tens-of-thousands-of-line** unconsumed backlog (dns1 121k, srv2 65k). A naïve un-gate would flood-apply stale bans. Fix adds a **mandatory max-age cutoff + bounded tail-drain** (reuses Warmup limits): stale signals are **expired/quarantined, never applied**; the daemon never slurps the whole file.

### Routing finding
`http_bot_ban` is part of the BotGuard chain and is **not drop-wired when BotGuard is disabled**. So BotScan bans must route to the durable, drop-enforced **`blacklist_manual_{v4,v6}`** sets (enabled path unchanged — still `http_bot_ban`).

### Provenance finding (fixed at the contract boundary)
`OpQueue.EnqueueBan(source=...)` carried the source but the persisted-set apply path dropped it → reconcile tagged elements `"unknown"`. **Fix:** a `SourceIndexer` interface on the OpQueue, wired **once at daemon init before `opQueue.Start`** (lifecycle-race-free, no module timing, no import cycle); `buffer.applyPendingCounted` records `AddWithExpiry(set, ip, op.Source, expiry)` after a successful nft add, for persisted blacklist sets with a non-empty source. **This fixes provenance for every producer, not just BotScan.** An earlier module-init-wiring attempt hit a daemon init-order race and was reverted — **no sleep/settle workaround remains.**

### Validation
- **lab2 DEB + lab4 RPM package-native PASS** (build 28281075864): consumer runs with BotGuard disabled (classifier off); fresh signal → `blacklist_manual_ipv4` + kernel drop + **`source_index source=botscan`**; NOT in `http_bot_ban`; stale → quarantined/not-applied; mixed queue (malformed safe); browser-like suppressed; idempotent; integrity (VERSION 1.208.0, schema 1.84.0, validate rc0, BotGuard disabled, failed 0); admin safe; restored to v1.208.0.
- **Go build + vet + `go test ./internal/opqueue ./internal/botguard` green** on lab2 + lab4 + CI build-packages — incl `TestBOTSCAN_BAN_RECORDS_SOURCE_INDEX_BOTSCAN` (apply boundary records botscan), routing v4/v6, stale-quarantine, suppression, and existing regressions (`TestEXISTING_BOTSCAN_BAN_ACTION_STILL_REACHES_HTTP_BOT_BAN` — enabled path preserved; golden status map updated 16→21 keys).

### Scope audit
8 Go files (opqueue + botguard + daemon_init); **0 shell · 0 schema change · VERSION 1.208.0 · no validator-JSON change · no BotGuard default flip · no firewall-topology change · no queue-path rename · no Aho-Corasick / MalwareGuard / decision-cache · no sleep workaround.**