### PR TITLE
v1.209.1 BotScan Go matcher — restore broken prefilter + fix srv3 collector OOM (helper-first)

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -91,6 +91,7 @@ jobs:
           mkdir -p bin
           go build -trimpath -o bin/nftban-core ./cmd/nftban-core
           go build -trimpath -o bin/nftband ./cmd/nftband
+          go build -trimpath -o bin/nftban-botscan-matcher ./cmd/nftban-botscan-matcher
           go build -trimpath -o bin/nftban-validate ./cmd/nftban-validate
 
       - name: Verify binaries

--- a/build.sh
+++ b/build.sh
@@ -248,6 +248,19 @@ build_validator() {
     chmod +x "$BIN_DIR/nftban-detect-ssh-ports"
     ok "Built: $BIN_DIR/nftban-detect-ssh-ports"
 
+    # v1.209.1: BotScan candidate prefilter helper — pure Go, bounded Aho-Corasick + RE2,
+    # replaces the fragile `grep -E -f` prefilter that GNU grep rejects wholesale on the
+    # |-delimiter-mis-split patterns. Shell-invoked (one process per scan file).
+    CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH \
+        go build -trimpath -o "$BIN_DIR/nftban-botscan-matcher" \
+        -ldflags="$LDFLAGS" \
+        ./cmd/nftban-botscan-matcher || {
+        error "Failed to build nftban-botscan-matcher"
+        return 1
+    }
+    chmod +x "$BIN_DIR/nftban-botscan-matcher"
+    ok "Built: $BIN_DIR/nftban-botscan-matcher"
+
     cd "$SCRIPT_DIR"
     return 0
 }

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -1379,6 +1379,25 @@ nftban_botscan_process_logs() {
         _pf="$(mktemp 2>/dev/null)" || _pf=""
         [[ -n "$_pf" ]] && { nftban_botscan_build_prefilter "$_pf" || { rm -f "$_pf"; _pf=""; }; }
     fi
+    # v1.209.1 — resolve the prefilter ENGINE once. The legacy `grep -E -f "$_pf"` is rejected
+    # WHOLESALE by GNU grep (rc=2) when any pattern mis-splits on the '|' field delimiter (3 such
+    # alternation patterns ship today) → with `2>/dev/null || true` the prefilter silently returns
+    # EMPTY → process_entry never runs → pattern-based detection is dead. The bounded Go helper
+    # skips those broken patterns visibly and runs the valid corpus. Selection is fail-SAFE: any
+    # helper problem falls through to unfiltered pass-through (detection preserved), NEVER empty.
+    local _bs_pf_bin=""
+    if [[ -n "$_pf" ]]; then
+        local _cand; _cand="$(command -v nftban-botscan-matcher 2>/dev/null)"
+        [[ -z "$_cand" ]] && _cand="${NFTBAN_BIN_DIR:-/usr/lib/nftban/bin}/nftban-botscan-matcher"
+        local _chk
+        if [[ -x "$_cand" ]] && _chk="$("$_cand" --check "$_pf" 2>&1)"; then
+            _bs_pf_bin="$_cand"
+            # Visible once per cycle: usable/skipped counts (skipped = the |-delimiter-broken patterns).
+            echo "[botscan] prefilter engine: Go matcher — ${_chk##*matcher: }" >&2
+        else
+            echo "[botscan] WARN: Go prefilter helper unavailable/invalid — unfiltered pass-through (detection preserved; slower). Install nftban-botscan-matcher." >&2
+        fi
+    fi
     # Anti-starvation rotation: persist where the last cycle stopped so a host whose
     # backlog exceeds one budget still scans EVERY file over successive cycles instead
     # of always draining the first files and starving the tail.
@@ -1410,7 +1429,7 @@ nftban_botscan_process_logs() {
                 if [[ -n "$log_file" ]]; then tail -1000 -- "$f" 2>/dev/null
                 elif declare -F nftban_http_read_incremental >/dev/null 2>&1; then nftban_http_read_incremental "$f"
                 else tail -1000 -- "$f" 2>/dev/null; fi
-            } | { if [[ -n "$_pf" ]]; then LC_ALL=C grep -E -f "$_pf" 2>/dev/null || true; else cat; fi; }
+            } | { if [[ -n "$_bs_pf_bin" ]]; then "$_bs_pf_bin" --filter "$_pf" 2>/dev/null || cat; else cat; fi; }
         )
         files_done=$((files_done + 1))
     done

--- a/cmd/nftban-botscan-matcher/main.go
+++ b/cmd/nftban-botscan-matcher/main.go
@@ -1,0 +1,160 @@
+// =============================================================================
+// NFTBan v1.209.1 - nftban-botscan-matcher (BotScan candidate prefilter helper)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Purpose: Bounded-memory replacement for `grep -E -f <patternfile>` in the BotScan
+//          shell scan loop. Reads candidate-prefilter patterns (one ERE per line, the
+//          $_pf file build_prefilter writes), streams stdin, and emits the lines grep
+//          would keep. The shell `match_url_g` bash matcher stays authoritative for
+//          attribution; this helper only fixes the prefilter's CPU/memory cost
+//          (srv3 256 MiB cgroup OOM). Does NOT own ban policy / write nft / write
+//          source_index / change thresholds.
+//
+//   nftban-botscan-matcher --filter <patternfile>   < lines  > matching-lines
+//   nftban-botscan-matcher --selftest               (CI smoke; exits 0/non-0)
+//   nftban-botscan-matcher --version
+//
+// Exit codes: 0 ok; 2 usage; 3 pattern load/compile failure (caller should fall back to
+// grep -E -f, never silently drop lines).
+//
+// meta:name="nftban-botscan-matcher" meta:type="binary" meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:inventory.files="main.go"
+// meta:inventory.binaries="nftban-botscan-matcher"
+// meta:inventory.env_vars="NFTBAN_BIN_DIR"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/botscanmatch"
+)
+
+const version = "1.0.0"
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		usage()
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "--version", "-v":
+		fmt.Println(version)
+	case "--selftest":
+		os.Exit(selftest())
+	case "--check":
+		// Validate the pattern file compiles to >=1 usable pattern WITHOUT touching stdin, so the
+		// shell can pick helper-vs-passthrough once per cycle. Exit 0 = usable; 3 = unusable.
+		if len(args) < 2 {
+			usage()
+			os.Exit(2)
+		}
+		os.Exit(runCheck(args[1]))
+	case "--filter":
+		if len(args) < 2 {
+			usage()
+			os.Exit(2)
+		}
+		os.Exit(runFilter(args[1]))
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: nftban-botscan-matcher --filter <patternfile> | --check <patternfile> | --selftest | --version")
+}
+
+// runCheck loads+compiles patterns and reports usability (no stdin). Exit 0 if >=1 usable.
+func runCheck(patternFile string) int {
+	patterns, err := loadPatterns(patternFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: read patterns %q: %v\n", patternFile, err)
+		return 3
+	}
+	m, err := botscanmatch.Compile(patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: compile patterns: %v\n", err)
+		return 3
+	}
+	fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: %d usable, %d skipped\n", len(patterns)-len(m.Skipped()), len(m.Skipped()))
+	return 0
+}
+
+// runFilter loads patterns and streams stdin → stdout, emitting matching lines.
+func runFilter(patternFile string) int {
+	patterns, err := loadPatterns(patternFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: read patterns %q: %v\n", patternFile, err)
+		return 3
+	}
+	m, err := botscanmatch.Compile(patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: compile patterns: %v\n", err)
+		return 3
+	}
+	if sk := m.Skipped(); len(sk) > 0 {
+		// Visible, non-fatal: these are pre-existing RE2-incompatible (|-delimiter mis-split)
+		// patterns, also dead in the shell matcher. Surfaced so they are not silent.
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: skipped %d RE2-incompatible pattern(s): %v\n", len(sk), sk)
+	}
+	if err := m.Filter(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "nftban-botscan-matcher: filter: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func loadPatterns(path string) ([]string, error) {
+	f, err := os.Open(path) // #nosec G304 -- operator-owned prefilter file from build_prefilter
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 16*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r\n")
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out, sc.Err()
+}
+
+// selftest is a hermetic CI smoke: a known pattern set keeps the right lines.
+func selftest() int {
+	m, err := botscanmatch.Compile([]string{`c99\.php`, `shell[0-9]*\.php`, ` 404 `})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "selftest: compile:", err)
+		return 1
+	}
+	keep := []string{`GET /x/c99.php HTTP/1.1`, `GET /shell12.php`, `"GET /a" 404 12`}
+	drop := []string{`GET /index.html`, `POST /wp-login.php 200`, `GET /shell.txt`}
+	for _, l := range keep {
+		if !m.MatchLine([]byte(l)) {
+			fmt.Fprintf(os.Stderr, "selftest: expected KEEP: %q\n", l)
+			return 1
+		}
+	}
+	for _, l := range drop {
+		if m.MatchLine([]byte(l)) {
+			fmt.Fprintf(os.Stderr, "selftest: expected DROP: %q\n", l)
+			return 1
+		}
+	}
+	return 0
+}

--- a/cmd/nftban-botscan-matcher/main.go
+++ b/cmd/nftban-botscan-matcher/main.go
@@ -34,6 +34,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/itcmsgr/nftban/internal/botscanmatch"
@@ -117,7 +118,7 @@ func runFilter(patternFile string) int {
 }
 
 func loadPatterns(path string) ([]string, error) {
-	f, err := os.Open(path) // #nosec G304 -- operator-owned prefilter file from build_prefilter
+	f, err := os.Open(filepath.Clean(path)) // #nosec G304 -- operator-owned prefilter file from build_prefilter
 	if err != nil {
 		return nil, err
 	}

--- a/internal/botscanmatch/ahocorasick.go
+++ b/internal/botscanmatch/ahocorasick.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="botscanmatch_ahocorasick" meta:type="package" meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:inventory.files="ahocorasick.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+//
+// Compact byte-level Aho-Corasick automaton: match all literal anchors in a single pass
+// over each line. Internal implementation — no external dependency. Bounded memory: one
+// node per distinct anchor prefix-byte; goto via per-node child maps; fail links via BFS.
+
+package botscanmatch
+
+import "errors"
+
+var errNoUsablePatterns = errors.New("botscanmatch: no usable patterns")
+
+type acNode struct {
+	children map[byte]int // byte -> node index
+	fail     int          // fail link (node index)
+	output   []int        // pattern ids whose anchor ENDS at this node
+}
+
+type ahoCorasick struct {
+	nodes []acNode
+}
+
+func newAhoCorasick() *ahoCorasick {
+	return &ahoCorasick{nodes: []acNode{{children: map[byte]int{}}}} // node 0 = root
+}
+
+// add inserts a literal anchor mapped to a pattern id.
+func (a *ahoCorasick) add(anchor string, id int) {
+	cur := 0
+	for i := 0; i < len(anchor); i++ {
+		b := anchor[i]
+		nx, ok := a.nodes[cur].children[b]
+		if !ok {
+			nx = len(a.nodes)
+			a.nodes = append(a.nodes, acNode{children: map[byte]int{}})
+			a.nodes[cur].children[b] = nx
+		}
+		cur = nx
+	}
+	a.nodes[cur].output = append(a.nodes[cur].output, id)
+}
+
+// build computes fail links and merges outputs along fail chains (BFS).
+func (a *ahoCorasick) build() {
+	queue := make([]int, 0, len(a.nodes))
+	for _, nx := range a.nodes[0].children {
+		a.nodes[nx].fail = 0
+		queue = append(queue, nx)
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for b, nx := range a.nodes[cur].children {
+			// fail link for child nx
+			f := a.nodes[cur].fail
+			for f != 0 {
+				if _, ok := a.nodes[f].children[b]; ok {
+					break
+				}
+				f = a.nodes[f].fail
+			}
+			if fc, ok := a.nodes[f].children[b]; ok && fc != nx {
+				a.nodes[nx].fail = fc
+			} else {
+				a.nodes[nx].fail = 0
+			}
+			// merge outputs from fail target (so a suffix-anchor also reports)
+			a.nodes[nx].output = append(a.nodes[nx].output, a.nodes[a.nodes[nx].fail].output...)
+			queue = append(queue, nx)
+		}
+	}
+}
+
+// scan runs the automaton over text. For each anchor occurrence, visit(id) is called for every
+// pattern id at that node; if visit returns false, scanning stops early.
+func (a *ahoCorasick) scan(text []byte, visit func(id int) bool) {
+	cur := 0
+	for i := 0; i < len(text); i++ {
+		b := text[i]
+		for {
+			if nx, ok := a.nodes[cur].children[b]; ok {
+				cur = nx
+				break
+			}
+			if cur == 0 {
+				break
+			}
+			cur = a.nodes[cur].fail
+		}
+		for _, id := range a.nodes[cur].output {
+			if !visit(id) {
+				return
+			}
+		}
+	}
+}

--- a/internal/botscanmatch/matcher.go
+++ b/internal/botscanmatch/matcher.go
@@ -120,15 +120,21 @@ func (m *Matcher) Filter(r io.Reader, w io.Writer) error {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 64*1024), 4*1024*1024) // bounded line buffer (4 MiB max line)
 	bw := bufio.NewWriter(w)
-	defer bw.Flush()
 	for sc.Scan() {
 		line := sc.Bytes()
 		if m.MatchLine(line) {
-			bw.Write(line)
-			bw.WriteByte('\n')
+			if _, err := bw.Write(line); err != nil {
+				return err
+			}
+			if err := bw.WriteByte('\n'); err != nil {
+				return err
+			}
 		}
 	}
-	return sc.Err()
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	return bw.Flush()
 }
 
 // longestLiteral returns the longest literal substring guaranteed to appear in every string

--- a/internal/botscanmatch/matcher.go
+++ b/internal/botscanmatch/matcher.go
@@ -1,0 +1,189 @@
+// =============================================================================
+// NFTBan v1.209.1 - BotScan hybrid pattern matcher (Aho-Corasick prefilter + RE2)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: botscanmatch
+// Purpose: Bounded, single-pass replacement for the `grep -E -f <patternfile>`
+//          BotScan candidate prefilter. The shell `match_url_g` bash matcher stays
+//          AUTHORITATIVE for attribution/thresholds; this only reproduces the set of
+//          candidate lines that grep would keep, with bounded memory under the srv3
+//          256 MiB cgroup cap.
+//
+// Design: an Aho-Corasick automaton over each pattern's longest LITERAL anchor
+// rejects the ~99% of clean lines in one pass; for the lines an anchor hits, the
+// pattern's compiled RE2 confirms so output == grep's matching-line set. Patterns
+// with no usable literal anchor fall to a small always-run RE2 residual set.
+//
+// Parity: the BotScan corpus has no backreferences/lookaround, so POSIX ERE (grep -E)
+// and Go RE2 agree for these patterns; build_prefilter strips ^/$ line-anchors, so the
+// patterns are unanchored substring matches == grep substring semantics.
+//
+// meta:name="botscanmatch_matcher" meta:type="package" meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:inventory.files="matcher.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package botscanmatch
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+)
+
+const minAnchorLen = 2 // shorter literal runs are too common to be a useful prefilter
+
+// Matcher reproduces `grep -E -f` over a pattern list with bounded memory.
+type Matcher struct {
+	ac      *ahoCorasick     // literal anchor -> pattern ids that own that anchor
+	res     []*regexp.Regexp // compiled RE2 per kept pattern
+	lit     []bool           // pattern i is a pure literal (anchor == whole pattern → AC hit is a match)
+	always  []int            // pattern ids with no literal anchor → RE2 run on every line
+	skipped []string         // patterns that failed RE2 compile (pre-existing broken/mis-split)
+}
+
+// Skipped returns patterns dropped because they failed RE2 compilation (e.g. the known
+// |-delimiter mis-split alternation patterns). These are also non-functional in the shell
+// matcher, so dropping them is behavior-preserving; the caller may log them for visibility.
+func (m *Matcher) Skipped() []string { return m.skipped }
+
+// Compile builds a Matcher from ERE patterns (one per line, as in build_prefilter's $_pf:
+// line-anchors already stripped). A pattern that fails RE2 compilation is skipped from the
+// confirm step but its literal anchor (if any) still contributes to the prefilter (fail-open
+// to a candidate, never a false negative). Returns an error only if NO pattern is usable.
+func Compile(patterns []string) (*Matcher, error) {
+	m := &Matcher{ac: newAhoCorasick()}
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		re, err := regexp.Compile(p) // RE2
+		if err != nil {
+			// Pre-existing broken pattern (e.g. |-delimiter mis-split alternation). grep -E -f
+			// errors on these too and the shell matcher can't match them, so skipping is
+			// behavior-preserving. Record for visibility; never fail-open to a phantom candidate.
+			m.skipped = append(m.skipped, p)
+			continue
+		}
+		id := len(m.res)
+		m.res = append(m.res, re)
+		anchor, pureLiteral := longestLiteral(p)
+		m.lit = append(m.lit, pureLiteral)
+		if len(anchor) >= minAnchorLen {
+			m.ac.add(anchor, id)
+		} else {
+			// No selective literal anchor → check this pattern's RE2 on every line.
+			// (Audit of the BotScan corpus shows this set is empty/tiny.)
+			m.always = append(m.always, id)
+		}
+	}
+	m.ac.build()
+	if len(m.res) == 0 {
+		return nil, errNoUsablePatterns
+	}
+	return m, nil
+}
+
+// MatchLine reports whether grep -E -f would keep this line (any pattern matches).
+func (m *Matcher) MatchLine(line []byte) bool {
+	// 1) Always-run RE2 residual set (no literal anchor).
+	for _, id := range m.always {
+		if re := m.res[id]; re != nil && re.Match(line) {
+			return true
+		}
+	}
+	// 2) Aho-Corasick single pass → candidate pattern ids; confirm via RE2 (or accept if pure literal).
+	hit := false
+	m.ac.scan(line, func(id int) bool {
+		if m.lit[id] {
+			hit = true
+			return false // stop scan early
+		}
+		if re := m.res[id]; re == nil || re.Match(line) {
+			hit = true
+			return false
+		}
+		return true // keep scanning for another candidate
+	})
+	return hit
+}
+
+// Filter streams lines from r and writes the matching ones to w (drop-in for grep -E -f).
+// Lines are matched without their trailing newline; the newline is preserved on output.
+func (m *Matcher) Filter(r io.Reader, w io.Writer) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024) // bounded line buffer (4 MiB max line)
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+	for sc.Scan() {
+		line := sc.Bytes()
+		if m.MatchLine(line) {
+			bw.Write(line)
+			bw.WriteByte('\n')
+		}
+	}
+	return sc.Err()
+}
+
+// longestLiteral returns the longest literal substring guaranteed to appear in every string
+// the ERE matches, and whether the whole pattern is that literal (no regex metachars at all).
+// Escaped metachars (\.) count as their literal char. Unescaped metachars break the run.
+func longestLiteral(ere string) (string, bool) {
+	var best, cur []byte
+	pure := true
+	flush := func() {
+		if len(cur) > len(best) {
+			best = append(best[:0:0], cur...)
+		}
+		cur = cur[:0]
+	}
+	i := 0
+	for i < len(ere) {
+		c := ere[i]
+		switch c {
+		case '\\':
+			if i+1 < len(ere) {
+				cur = append(cur, ere[i+1]) // \x → literal x (covers \. \/ \- etc.)
+				i += 2
+				continue
+			}
+			i++
+		case '[':
+			// char class: its contents are NOT a literal substring of matches — skip to ']'
+			pure = false
+			flush()
+			i++
+			if i < len(ere) && ere[i] == '^' {
+				i++
+			}
+			if i < len(ere) && ere[i] == ']' { // literal ']' as first class member
+				i++
+			}
+			for i < len(ere) && ere[i] != ']' {
+				if ere[i] == '\\' && i+1 < len(ere) {
+					i += 2
+				} else {
+					i++
+				}
+			}
+			if i < len(ere) {
+				i++ // consume ']'
+			}
+		case ']', '(', ')', '{', '}', '*', '+', '?', '|', '^', '$', '.':
+			pure = false
+			flush()
+			i++
+		default:
+			cur = append(cur, c)
+			i++
+		}
+	}
+	flush()
+	return string(best), pure
+}

--- a/internal/botscanmatch/matcher_test.go
+++ b/internal/botscanmatch/matcher_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="botscanmatch_matcher_test" meta:type="test" meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:inventory.files="matcher_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+
+package botscanmatch
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// loadRealPatterns reads the shipped BotScan corpus the way build_prefilter does: field 2 of
+// each `name|pattern|type|...` line, with ^/$ line-anchors stripped (match the field within a line).
+func loadRealPatterns(t *testing.T) []string {
+	t.Helper()
+	dir := filepath.Join("..", "..", "etc", "nftban", "patterns.d", "botscan")
+	files, err := filepath.Glob(filepath.Join(dir, "*.patterns"))
+	if err != nil || len(files) == 0 {
+		t.Skipf("no pattern files under %s (%v)", dir, err)
+	}
+	var out []string
+	for _, fp := range files {
+		f, err := os.Open(fp)
+		if err != nil {
+			t.Fatalf("open %s: %v", fp, err)
+		}
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			cols := strings.Split(line, "|")
+			if len(cols) < 2 {
+				continue
+			}
+			p := strings.TrimPrefix(cols[1], "^")
+			p = strings.TrimSuffix(p, "$")
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+		f.Close()
+	}
+	return out
+}
+
+// naive models `grep -E -f`: any pattern's RE2 matches the line.
+func naive(res []*regexp.Regexp, line string) bool {
+	for _, re := range res {
+		if re != nil && re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// fixtureLines: malicious probes (should match), benign traffic + 404 lines, and lines built by
+// embedding each pattern's literal anchor (AC-hit → RE2-confirm parity stress).
+func fixtureLines(patterns []string) []string {
+	lines := []string{
+		`1.2.3.4 - - [x] "GET /wp-content/c99.php HTTP/1.1" 200 10 "-" "Mozilla"`,
+		`1.2.3.4 - - [x] "GET /shell12.php HTTP/1.1" 404 0 "-" "x"`,
+		`1.2.3.4 - - [x] "GET /index.html HTTP/1.1" 200 1000 "-" "Mozilla/5.0"`,
+		`1.2.3.4 - - [x] "POST /wp-login.php HTTP/1.1" 200 500 "-" "Chrome"`,
+		`1.2.3.4 - - [x] "GET /favicon.ico HTTP/1.1" 404 0 "-" "Safari"`,
+		`1.2.3.4 - - [x] "GET /style.css HTTP/1.1" 200 2000 "-" "-"`,
+		`1.2.3.4 - - [x] "GET /api/v1/users HTTP/1.1" 200 50 "-" "curl/7.1"`,
+	}
+	// Embed each pattern's literal anchor in a synthetic line so the AC fires; parity must hold
+	// whether or not the full RE2 confirms.
+	for _, p := range patterns {
+		anc, _ := longestLiteral(p)
+		if len(anc) >= minAnchorLen {
+			lines = append(lines, `9.9.9.9 - - "GET /x`+anc+`y HTTP/1.1" 404 0 "-" "UA-`+anc+`"`)
+		}
+	}
+	return lines
+}
+
+func TestParity_AgainstNaiveRE2_RealCorpus(t *testing.T) {
+	patterns := loadRealPatterns(t)
+	if len(patterns) == 0 {
+		t.Fatal("no patterns loaded")
+	}
+	t.Logf("loaded %d real BotScan patterns", len(patterns))
+
+	// Audit: classify RE2-incompatible patterns. The only expected ones are the pre-existing
+	// |-delimiter mis-split alternation patterns (broken in the shell too); they must be SKIPPED,
+	// not silently treated as matching. Any OTHER non-compiling pattern is a real regression.
+	res := make([]*regexp.Regexp, len(patterns))
+	var broken []string
+	for i, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			broken = append(broken, p)
+		}
+		res[i] = re
+	}
+	t.Logf("RE2-incompatible (pre-existing mis-split) patterns: %d %v", len(broken), broken)
+
+	m, err := Compile(patterns)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(m.Skipped()) != len(broken) {
+		t.Errorf("matcher skipped %d patterns, audit found %d broken — mismatch", len(m.Skipped()), len(broken))
+	}
+
+	for _, line := range fixtureLines(patterns) {
+		got := m.MatchLine([]byte(line))
+		want := naive(res, line)
+		if got != want {
+			t.Errorf("PARITY MISMATCH got=%v want=%v line=%q", got, want, line)
+		}
+	}
+}
+
+func TestParity_EveryLiteralPatternMatchesItsOwnLine(t *testing.T) {
+	patterns := loadRealPatterns(t)
+	m, err := Compile(patterns)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// For each pure-literal pattern (\. unescaped to .), a line containing that literal must be kept.
+	for _, p := range patterns {
+		anc, pure := longestLiteral(p)
+		if !pure || len(anc) < minAnchorLen {
+			continue
+		}
+		line := "GET /probe/" + anc + " HTTP/1.1"
+		if !m.MatchLine([]byte(line)) {
+			t.Errorf("literal pattern %q: own line not kept: %q", p, line)
+		}
+	}
+}
+
+func TestLongestLiteral(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		pure bool
+	}{
+		{`c99\.php`, "c99.php", true},
+		{`shell[0-9]*\.php`, "shell", false},
+		{`/[a-z]{2}\.php`, ".php", false},
+		{`wso\.php`, "wso.php", true},
+		{`(bak)`, "bak", false},
+		{`abc`, "abc", true},
+		{`[0-9]+`, "", false},
+	}
+	for _, c := range cases {
+		got, pure := longestLiteral(c.in)
+		if got != c.want || pure != c.pure {
+			t.Errorf("longestLiteral(%q) = (%q,%v), want (%q,%v)", c.in, got, pure, c.want, c.pure)
+		}
+	}
+}
+
+func TestAhoCorasick_MultiAnchorSinglePass(t *testing.T) {
+	m, err := Compile([]string{`c99\.php`, `r57\.php`, `wso\.php`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.MatchLine([]byte("GET /a/r57.php?x=1")) {
+		t.Error("suffix anchor r57.php should match")
+	}
+	if m.MatchLine([]byte("GET /a/safe.php")) {
+		t.Error("non-anchor line should not match")
+	}
+}
+
+func TestNoUsablePatterns(t *testing.T) {
+	if _, err := Compile([]string{"", ""}); err == nil {
+		t.Error("expected error for empty pattern set")
+	}
+}

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -409,6 +409,7 @@ mv -f "\${yq_tmp}" yq_linux_amd64
 # Binaries
 install -D -m 0755 bin/nftban-core %{buildroot}/usr/lib/nftban/bin/nftban-core
 install -D -m 0755 bin/nftband %{buildroot}/usr/lib/nftban/bin/nftband
+install -D -m 0755 bin/nftban-botscan-matcher %{buildroot}/usr/lib/nftban/bin/nftban-botscan-matcher
 install -D -m 0755 bin/nftban-validate %{buildroot}/usr/lib/nftban/bin/nftban-validate
 install -D -m 0755 bin/nftban-detect-ssh-ports %{buildroot}/usr/lib/nftban/bin/nftban-detect-ssh-ports
 install -D -m 0755 bin/nftban-installer %{buildroot}/usr/lib/nftban/bin/nftban-installer
@@ -1846,6 +1847,7 @@ build_deb() {
     # Copy binaries
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-core" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftband" "${deb_root}/usr/lib/nftban/bin/"
+    install -m 0755 "${PROJECT_ROOT}/bin/nftban-botscan-matcher" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-validate" "${deb_root}/usr/lib/nftban/bin/"
     install -m 0755 "${PROJECT_ROOT}/bin/nftban-detect-ssh-ports" "${deb_root}/usr/lib/nftban/bin/"
     # NB-5: privileged binaries ship 0750 in .deb payload; postinst converges


### PR DESCRIPTION
## v1.209.1 — BotScan prefilter correctness + bounded matcher (Track-A completion hotfix)

Completes v1.209 Track-A by unblocking srv3 and fixing a **fleet-wide prefilter-correctness defect** the srv3 canary uncovered. Helper-first; **nftband daemon byte-identical**; **nft schema 1.84.0 unchanged**; **no VERSION bump** (release-prep is separate).

### Root cause
The BotScan pattern file uses `|` as its field delimiter, but **3 patterns contain `|` alternation** in field 2 (`EXP_CGIBIN` `/cgi-bin/.*\.(sh|pl|cgi)`, `EXP_SQLBACKUP`, `SCAN_BACKUP_SQL`). The shell `IFS='|' read` mis-splits them into invalid regex (`/cgi-bin/.*\.(sh`), and **GNU grep 3.6 rejects the entire `grep -E -f "$_pf"` file (rc=2)**. The shell ran it as `grep … 2>/dev/null || true`, so the prefilter **silently returned empty** → `process_entry` ran **zero** times → **pattern-based BotScan detection (webshell/exploit/scanner/badbot) has been dead fleet-wide.** (The 404/endpoint-flood path is separate and still produced signals/backlog.) Confirmed live on srv2 (prefilter on by default, patterns installed, grep rc=2).

### Corrected corpus facts
Real corpus = **155 patterns** (earlier 775/137 were worktree-duplicate / wrong-column artifacts): **98 pure-literal + 57 regex-requiring** (char-class/quantifier/anchor; **0 backref/lookaround** → all RE2-compatible). 3 are the `|`-mis-split alternation patterns.

### Implementation
- `internal/botscanmatch/` — **Aho-Corasick literal prefilter** (one anchor/pattern) + **RE2 confirm** so output == grep's matching-line set. Internal impl, **no external dependency**. Bounded memory (streaming, bounded automaton) → fits srv3's `MemoryMax=256M`, no whole-file slurp.
- `cmd/nftban-botscan-matcher` — helper (`--filter`/`--check`/`--selftest`/`--version`). Skips the **3 broken patterns visibly** (`--check` → "152 usable, 3 skipped"; stderr count); runs the **152 valid**.
- Shell wiring: prefilter engine resolved once/cycle via `--check`; replaces `grep -E -f`. build.sh + RPM/DEB install + ci-go build.

### Restored-detection impact (must read)
**v1.209.1 restores intended pattern-based BotScan detection for the 152 valid patterns. This may INCREASE legitimate BotScan bans, because previously-suppressed detections (real webshell/exploit probes) become active.** This is correct/intended, not new behavior — the prefilter is supposed to filter, not error-to-empty.

### Safety / fail-safe
On **any** helper problem (missing binary, zero usable patterns, compile failure), the shell falls through to **unfiltered pass-through** — the authoritative bash `match_url_g` matcher still runs on all lines (detection preserved, slower). It **never silently empties** like the old grep path. Skip count is surfaced once per cycle.

### Package-native validation (lab2 DEB + lab4 RPM — both PASS)
- helper installed+executable; `--version` 1.0.0; `--selftest` rc0; `--check` → **"152 usable, 3 skipped"**.
- **Restoration proof:** `grep -E -f` **rc=2 / kept=0 (broken)** vs helper **kept=4 (restored)**; webshell `c99.php` kept.
- **Parity:** helper == `grep`(valid `$_pf`) **byte-identical**.
- Shell wired; fail-safe pass-through present; validate rc0; failed units 0; schema 1.84.0; BotGuard disabled.
- **Daemon byte-identical:** `go list -deps ./cmd/nftband` does not include `botscanmatch`; no `cmd/nftband` change. (Installed `nftband` sha differs only as a non-reproducible-build artifact — not a re-baseline.)

### Non-scope
No VERSION bump · no schema/validator-JSON · no daemon logic · no source_index/firewall/ban-path/threshold/action change · no BotGuard default flip · no MalwareGuard/decision-cache · no full BotScan-in-daemon migration · **the 3 delimiter-broken patterns are NOT activated** (pattern files unchanged).

### Follow-up
`OPEN_BOTSCAN_PATTERN_DELIMITER_FIX` — fix the pattern-file serialization/loader so `|`-containing patterns aren't mis-split, then re-enable the 3 alternation patterns with parity fixtures. Tracked separately; not in this PR.