### PR TITLE
fix(botscan): never-ban exemption guard at the durable apply boundary (F2)

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -678,6 +678,17 @@ nftban_botscan_is_whitelisted() {
     [[ "$ip" =~ ^[Ff][CcDd] ]] && return 0
     [[ "$ip" =~ ^[Ff][Ee]80: ]] && return 0
 
+    # v1.209.x F2: daemon-published never-ban exemption list (admin/management/whitelist/
+    # system/live-SSH). Cheap EXACT-match — no nft read needed, so it works under the
+    # unprivileged scanner (which cannot query the nft whitelist set on most hosts). This
+    # is early signal-suppression / defense-in-depth ONLY; range-aware coverage and the
+    # authoritative never-ban invariant are enforced by the daemon at the ban-apply
+    # boundary (Backend.Ban), independent of this gate.
+    local _exempt_file="${BOTSCAN_EXEMPT_FILE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/exempt.list}"
+    if [[ -r "$_exempt_file" ]] && grep -qxF "$ip" "$_exempt_file" 2>/dev/null; then
+        return 0
+    fi
+
     # Check global whitelist
     if [[ "$BOTSCAN_USE_GLOBAL_WHITELIST" == "true" ]]; then
         if type -t nftban_is_whitelisted &>/dev/null; then

--- a/cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh
+++ b/cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - BotScan admin/management-IP exemption (F2) — scanner-gate tests
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_admin_ip_exemption_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-06-29"
+# meta:description="Locks the F2 admin/management-IP exemption SCANNER gate: nftban_botscan_is_whitelisted consults the daemon-published never-ban exempt list (BOTSCAN_EXEMPT_FILE) via a cheap EXACT match that needs no nft read (works under the unprivileged scanner). Exempt IPs are suppressed (never signaled); non-exempt IPs are NOT suppressed (still bannable). The AUTHORITATIVE range-aware never-ban invariant is enforced daemon-side at Backend.Ban (Go test internal/nftbackend/exemption_test.go) — this covers the shell defense-in-depth half."
+# meta:inventory.files="cli/lib/nftban/core/nftban_botscan.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,BOTSCAN_EXEMPT_FILE,BOTSCAN_USE_GLOBAL_WHITELIST"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+CORE="$REPO/cli/lib/nftban/core/nftban_botscan.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+EXEMPT="$WORK/exempt.list"
+printf '# generated\n203.0.113.7\n62.38.150.122\n2001:db8::1\n' > "$EXEMPT"
+
+echo "=== F2 BotScan scanner exemption gate ==="
+# shellcheck source=/dev/null
+( export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_EXEMPT_FILE="$EXEMPT" BOTSCAN_USE_GLOBAL_WHITELIST=false
+  source "$CORE" >/dev/null 2>&1
+
+  # T1: exact-listed exempt IP (the F2 admin IP) → suppressed (rc0 = whitelisted/exempt)
+  if nftban_botscan_is_whitelisted "62.38.150.122" ""; then echo T1ok; fi
+  # T2: another exact-listed exempt IP → suppressed
+  if nftban_botscan_is_whitelisted "203.0.113.7" ""; then echo T2ok; fi
+  # T3: exempt v6 → suppressed
+  if nftban_botscan_is_whitelisted "2001:db8::1" ""; then echo T3ok; fi
+  # T4: NON-exempt IP → NOT suppressed (must remain bannable)
+  if nftban_botscan_is_whitelisted "198.51.100.9" ""; then echo T4bad; else echo T4ok; fi
+  # T5: partial/substring must NOT match (exact-line only)
+  if nftban_botscan_is_whitelisted "62.38.150.12" ""; then echo T5bad; else echo T5ok; fi
+) > "$WORK/out" 2>&1
+
+grep -q T1ok "$WORK/out" && ok "T1 exempt admin IP suppressed" || no "T1"
+grep -q T2ok "$WORK/out" && ok "T2 exempt IP suppressed" || no "T2"
+grep -q T3ok "$WORK/out" && ok "T3 exempt v6 suppressed" || no "T3"
+grep -q T4ok "$WORK/out" && ok "T4 non-exempt IP NOT suppressed (still bannable)" || no "T4" "$(cat "$WORK/out")"
+grep -q T5ok "$WORK/out" && ok "T5 substring does NOT match (exact-line only)" || no "T5"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -154,16 +154,21 @@ func (d *Daemon) Run() error {
 		}
 
 		// Execute the ban via nftables backend
-		_, err := d.backend.Ban(d.ctx, nftbackend.BanRequest{
+		result, err := d.backend.Ban(d.ctx, nftbackend.BanRequest{
 			IP:      e.IP,
 			Timeout: timeout,
 			Reason:  reason,
 			Source:  e.Source,
 		})
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Printf("[BAN] Failed to ban %s: %v", e.IP, err)
 			metrics.RecordBanError(e.Source, "nft_error")
-		} else {
+		case result != nil && result.Exempt:
+			// v1.209.x F2: the never-ban guard refused this ban (admin/management/
+			// whitelist/system/live-SSH IP). Not an error, not a ban — log honestly.
+			log.Printf("[BAN] Exempt (not banned) %s (source=%s): %s", e.IP, e.Source, result.Message)
+		default:
 			log.Printf("[BAN] Successfully banned %s (timeout=%ds, source=%s)", e.IP, timeout, e.Source)
 			// Record in stats collector
 			d.stats.RecordBan()

--- a/cmd/nftband/main.go
+++ b/cmd/nftband/main.go
@@ -60,7 +60,7 @@ func main() {
 	log.Printf("Safety: %s", safety.GetProfileDescription())
 
 	// Create daemon
-	_, configDir, _, _ := getDaemonPaths()
+	_, configDir, dataDir, _ := getDaemonPaths()
 	d := &Daemon{
 		bus:       eventbus.New(),
 		registry:  module.NewRegistry(),
@@ -70,6 +70,12 @@ func main() {
 		connSem:   make(chan struct{}, MaxConcurrentIPCConns),
 		startedAt: time.Now(),
 	}
+
+	// v1.209.x F2: wire the AUTHORITATIVE never-ban exemption guard at the durable apply
+	// boundary (Backend.Ban). Establishes the never-ban invariant for admin/management/
+	// whitelist/system/live-SSH IPs across ALL ban paths, and publishes the resolved
+	// exempt list for the unprivileged BotScan scanner to suppress signals cheaply.
+	d.backend.EnableExemptionGuard(configDir, dataDir+"/botscan/exempt.list")
 
 	// Initialize dynamic watchdog
 	if err := d.initWatchdog(); err != nil {

--- a/internal/nftbackend/backend.go
+++ b/internal/nftbackend/backend.go
@@ -80,17 +80,37 @@ type Backend struct {
 	tableIPv4Str string
 	tableIPv6Str string
 
+	// v1.209.x F2: authoritative never-ban exemption guard (admin/management/whitelist/
+	// system/live-SSH). Consulted by Ban() before any drop-set write. nil = disabled
+	// (guard not wired) → bans proceed unguarded (pre-existing rule-order behavior).
+	exempt *exemptResolver
+
 	// Statistics
 	stats Stats
 }
 
 // Stats tracks operation counts
 type Stats struct {
-	Bans      int64
-	Unbans    int64
-	Syncs     int64
-	Errors    int64
-	LastError string
+	Bans        int64
+	Unbans      int64
+	Syncs       int64
+	Errors      int64
+	ExemptSkips int64 // bans refused because the IP is never-ban exempt (F2 guard)
+	LastError   string
+}
+
+// EnableExemptionGuard wires the authoritative never-ban exemption guard. configDir is
+// the nftban config dir (for whitelist.d); scannerFile is the path the resolved exempt
+// list is published to for the unprivileged BotScan scanner ("" to skip publishing).
+// Safe to call once at daemon init. Idempotent.
+func (b *Backend) EnableExemptionGuard(configDir, scannerFile string) {
+	r := newExemptResolver(configDir, scannerFile)
+	b.mu.Lock()
+	b.exempt = r
+	b.mu.Unlock()
+	// Warm the snapshot OFF the caller's (daemon startup) path. Refresh must never
+	// block the daemon reaching READY; IsExempt lazily refreshes too.
+	go r.Refresh()
 }
 
 // New creates a new nftables backend with netlink connection
@@ -249,6 +269,7 @@ type BanResult struct {
 	IP      string
 	Set     string
 	Message string
+	Exempt  bool // true if the ban was REFUSED because the IP is never-ban exempt (F2 guard)
 }
 
 // Ban adds an IP to the appropriate blacklist set
@@ -267,6 +288,27 @@ func (b *Backend) Ban(ctx context.Context, req BanRequest) (*BanResult, error) {
 			b.stats.Errors++
 			b.stats.LastError = "invalid IP: " + req.IP
 			return nil, fmt.Errorf("invalid IP address: %s", req.IP)
+		}
+	}
+
+	// v1.209.x F2 — AUTHORITATIVE never-ban exemption guard. This is the durable apply
+	// boundary: EVERY ban path (BotScan batch-signal consumer, EventBus module bans,
+	// persistent escalation, manual CLI, BotGuard enforcer) funnels through Ban(), so
+	// enforcing the exemption HERE establishes the never-ban invariant universally —
+	// admin/management/whitelist/system/live-SSH IPs are never written to a drop set,
+	// instead of relying on firewall rule order (the pre-v1.209.x ordering-only model).
+	// Range-aware, v4+v6. Fail-safe: a nil/empty resolver never blocks a legitimate ban.
+	// Exemption ≠ accept: this only prevents a DROP of protected IPs; it adds no allow.
+	if b.exempt != nil {
+		if ok, reason := b.exempt.IsExempt(req.IP); ok {
+			b.stats.ExemptSkips++
+			log.Printf("[BAN] REFUSED (never-ban exempt: %s) ip=%s source=%s — protected admin/management/whitelist/system/live-SSH IP NOT added to blacklist", reason, req.IP, req.Source)
+			return &BanResult{
+				Success: true,
+				IP:      req.IP,
+				Exempt:  true,
+				Message: fmt.Sprintf("not banned: never-ban exempt (%s)", reason),
+			}, nil
 		}
 	}
 

--- a/internal/nftbackend/exemption.go
+++ b/internal/nftbackend/exemption.go
@@ -1,0 +1,357 @@
+// NFTBan - durable apply-boundary never-ban exemption guard
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="nftbackend_exemption"
+// meta:type="core"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-06-29"
+// meta:description="Authoritative never-ban exemption resolver consulted by Backend.Ban() before any IP is written to a drop set. Establishes the never-ban invariant for admin/management/whitelist/system/live-SSH IPs at the durable apply boundary (NOT relying on firewall rule order or the unprivileged shell scanner gate). Range-aware (CIDR), v4+v6 parity, fail-safe (a resolver failure NEVER blocks a legitimate ban — it falls back to no-exemption + rule-order). Sources: whitelist.d (operator 99-manual / session 00-session / system 00-system, CIDR-aware via internal/whitelist), DetectSystemIPs (server/gateway/dns/loopback/current-SSH), live established SSH peers (/proc/net/tcp{,6}), and an optional NFTBAN_MANAGEMENT_IPS env. Also publishes the resolved exempt list to a scanner-readable file so the unprivileged BotScan scanner can suppress signals cheaply (no nft read)."
+// meta:inventory.files="/etc/nftban/whitelist.d/*.conf,/proc/net/tcp,/proc/net/tcp6,/etc/ssh/sshd_config"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_MANAGEMENT_IPS"
+// meta:inventory.config_files="/etc/nftban/whitelist.d/*.conf"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+// =============================================================================
+
+package nftbackend
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/safety"
+	"github.com/itcmsgr/nftban/internal/whitelist"
+)
+
+// exemptResolver holds the never-ban exemption snapshot and refreshes it on a TTL.
+// IsExempt reads the snapshot under an RLock; a stale snapshot triggers one refresh.
+// Fail-safe: on any source error a previously-good snapshot is kept; if nothing has
+// ever loaded the snapshot is simply empty (so bans proceed — a broken resolver must
+// NEVER block legitimate bans; admin safety then degrades to the pre-existing rule
+// order, not worse than before).
+type exemptResolver struct {
+	mu          sync.RWMutex
+	configDir   string
+	scannerFile string
+	ttl         time.Duration
+
+	loaded   bool
+	loadedAt time.Time
+	exact    map[string]struct{} // canonical single-IP strings
+	prefixes []netip.Prefix      // CIDR ranges (incl. loopback)
+}
+
+func newExemptResolver(configDir, scannerFile string) *exemptResolver {
+	// NOTE: does NOT Refresh here — the initial load must stay OFF the daemon startup
+	// path (Refresh touches /proc, files, and host detection; it must never gate the
+	// daemon reaching READY). EnableExemptionGuard warms it in a goroutine; IsExempt
+	// also lazily refreshes on first use. Until first load, IsExempt returns
+	// NOT-exempt (fail-safe: bans proceed; rule order still protects).
+	return &exemptResolver{
+		configDir:   configDir,
+		scannerFile: scannerFile,
+		ttl:         30 * time.Second,
+		exact:       map[string]struct{}{},
+	}
+}
+
+// IsExempt reports whether ipStr (a single IP literal) must never be banned, plus a
+// short reason. Returns false for non-single-IP inputs (CIDR ban requests are not the
+// admin/session class this guard protects). Range-aware, v4+v6.
+func (r *exemptResolver) IsExempt(ipStr string) (bool, string) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(ipStr))
+	if err != nil {
+		return false, ""
+	}
+	r.maybeRefresh()
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if _, ok := r.exact[addr.String()]; ok {
+		return true, "exact"
+	}
+	for _, p := range r.prefixes {
+		if p.Contains(addr) {
+			return true, "cidr"
+		}
+	}
+	return false, ""
+}
+
+func (r *exemptResolver) maybeRefresh() {
+	r.mu.RLock()
+	fresh := r.loaded && time.Since(r.loadedAt) <= r.ttl
+	r.mu.RUnlock()
+	if !fresh {
+		r.Refresh()
+	}
+}
+
+// Refresh rebuilds the exemption snapshot from all sources. Each source is best-effort;
+// a source error contributes nothing and never aborts the rebuild. The snapshot is
+// swapped atomically; the scanner file is then published best-effort.
+func (r *exemptResolver) Refresh() {
+	exact := make(map[string]struct{})
+	var prefixes []netip.Prefix
+
+	addIP := func(ip net.IP) {
+		if ip == nil {
+			return
+		}
+		if a, ok := netip.AddrFromSlice(ip); ok {
+			exact[a.Unmap().String()] = struct{}{}
+		}
+	}
+	addEntry := func(value string, isCIDR bool) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if isCIDR || strings.Contains(value, "/") {
+			if p, err := netip.ParsePrefix(value); err == nil {
+				prefixes = append(prefixes, p)
+			}
+			return
+		}
+		if a, err := netip.ParseAddr(value); err == nil {
+			exact[a.Unmap().String()] = struct{}{}
+		}
+	}
+
+	// 1. whitelist.d (operator 99-manual, live-session 00-session, system 00-system) — CIDR-aware.
+	if r.configDir != "" {
+		if v4, v6, err := whitelist.LoadAllWhitelistsTyped(r.configDir); err == nil {
+			for _, m := range []map[string]whitelist.WhitelistEntry{v4, v6} {
+				for _, e := range m {
+					addEntry(e.Value, e.IsCIDR)
+				}
+			}
+		}
+	}
+
+	// 2. System IPs that must never be blocked (server/gateway/dns/loopback/current-SSH).
+	if sys, err := safety.DetectSystemIPs(); err == nil && sys != nil {
+		for _, ip := range sys.ServerIPs {
+			addIP(ip)
+		}
+		for _, ip := range sys.GatewayIPs {
+			addIP(ip)
+		}
+		for _, ip := range sys.DNSServers {
+			addIP(ip)
+		}
+		addIP(sys.CurrentUserIP)
+		for i := range sys.LoopbackCIDRs {
+			c := sys.LoopbackCIDRs[i]
+			if p, err := netip.ParsePrefix(c.String()); err == nil {
+				prefixes = append(prefixes, p)
+			}
+		}
+	}
+
+	// 3. Live established inbound SSH peers — protects whoever is connected right now,
+	//    even if not whitelisted (the strongest lockout guard).
+	for _, ip := range detectActiveSSHPeers() {
+		if a, err := netip.ParseAddr(ip); err == nil {
+			exact[a.Unmap().String()] = struct{}{}
+		}
+	}
+
+	// 4. Optional explicit operator management IPs/CIDRs.
+	for _, tok := range strings.FieldsFunc(os.Getenv("NFTBAN_MANAGEMENT_IPS"), func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		addEntry(tok, strings.Contains(tok, "/"))
+	}
+
+	r.mu.Lock()
+	// Fail-safe: only overwrite a good snapshot if we resolved at least something OR we
+	// never loaded before. (An all-empty rebuild after a previously-populated snapshot
+	// likely means a transient source failure — keep the last good set so admin
+	// protection doesn't silently vanish.)
+	if len(exact) > 0 || len(prefixes) > 0 || !r.loaded {
+		r.exact = exact
+		r.prefixes = prefixes
+		r.loaded = true
+		r.loadedAt = time.Now()
+	} else {
+		r.loadedAt = time.Now() // defer next retry by ttl; keep old snapshot
+	}
+	snapExact := r.exact
+	snapPrefixes := r.prefixes
+	r.mu.Unlock()
+
+	r.writeScannerFile(snapExact, snapPrefixes)
+}
+
+// writeScannerFile publishes the resolved exempt list (one CIDR/IP per line) to a
+// 0640 nftban-readable file so the unprivileged BotScan scanner can suppress signals
+// without needing nft read. Best-effort; never fatal.
+func (r *exemptResolver) writeScannerFile(exact map[string]struct{}, prefixes []netip.Prefix) {
+	if r.scannerFile == "" {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("# NFTBan never-ban exemption list (generated by nftband; do not edit)\n")
+	for ip := range exact {
+		b.WriteString(ip)
+		b.WriteByte('\n')
+	}
+	for _, p := range prefixes {
+		b.WriteString(p.String())
+		b.WriteByte('\n')
+	}
+	// safety.SafeWriteFile is the project durability idiom (atomic temp+fsync+rename;
+	// also satisfies the FSYNC-RESIDUAL guard). perm 0644 so the unprivileged BotScan
+	// scanner (User=nftban) can read this as "other": the daemon runs as root WITHOUT
+	// CAP_CHOWN (CapabilityBoundingSet = CAP_NET_ADMIN,CAP_DAC_OVERRIDE) so it cannot
+	// chown to nftban. The parent dir /var/lib/nftban/botscan is 0750 nftban:nftban,
+	// which already gates access to nftban+root only — no other local user can traverse
+	// in — so 0644 here does NOT expose the (non-secret, whitelist/admin) IP list
+	// further. Best-effort; the daemon guard is the authority regardless.
+	_ = safety.SafeWriteFile(r.scannerFile, []byte(b.String()), 0o644)
+}
+
+// detectActiveSSHPeers returns the remote IPs of currently-ESTABLISHED inbound
+// connections whose local port is an SSH listening port. Pure-Go via /proc/net/tcp{,6}
+// (root-readable); returns nil on any error.
+func detectActiveSSHPeers() []string {
+	ports := sshListenPorts()
+	if len(ports) == 0 {
+		return nil
+	}
+	var peers []string
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		peers = append(peers, parseProcNetTCP(path, ports)...)
+	}
+	return peers
+}
+
+// sshListenPorts returns the set of SSH ports (default 22 + any `Port` in sshd_config
+// and sshd_config.d/*.conf). Match blocks/Include subtleties are ignored — over-
+// inclusion only widens exemption (safe; never widens accept).
+func sshListenPorts() map[uint16]struct{} {
+	ports := map[uint16]struct{}{22: {}}
+	files := []string{"/etc/ssh/sshd_config"}
+	if extra, err := filepath.Glob("/etc/ssh/sshd_config.d/*.conf"); err == nil {
+		files = append(files, extra...)
+	}
+	for _, f := range files {
+		fh, err := os.Open(filepath.Clean(f)) // #nosec G304 -- fixed sshd config paths
+		if err != nil {
+			continue
+		}
+		sc := bufio.NewScanner(fh)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if len(line) < 5 || line[0] == '#' {
+				continue
+			}
+			if !strings.HasPrefix(strings.ToLower(line), "port") {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && strings.EqualFold(fields[0], "Port") {
+				if p, err := strconv.ParseUint(fields[1], 10, 16); err == nil && p > 0 {
+					ports[uint16(p)] = struct{}{}
+				}
+			}
+		}
+		_ = fh.Close()
+	}
+	return ports
+}
+
+// parseProcNetTCP parses /proc/net/tcp{,6} and returns remote IPs of ESTABLISHED
+// connections (st==01) whose local port is in ports.
+func parseProcNetTCP(path string, ports map[uint16]struct{}) []string {
+	fh, err := os.Open(filepath.Clean(path)) // #nosec G304 -- fixed /proc paths
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = fh.Close() }()
+
+	var out []string
+	sc := bufio.NewScanner(fh)
+	first := true
+	for sc.Scan() {
+		if first { // header
+			first = false
+			continue
+		}
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		if fields[3] != "01" { // 01 = TCP_ESTABLISHED
+			continue
+		}
+		localPort, ok := hexPort(fields[1])
+		if !ok {
+			continue
+		}
+		if _, want := ports[localPort]; !want {
+			continue
+		}
+		if remIP, ok := hexAddrIP(fields[2]); ok {
+			out = append(out, remIP)
+		}
+	}
+	return out
+}
+
+// hexPort parses the "ADDR:PORT" hex local/remote field's port part.
+func hexPort(field string) (uint16, bool) {
+	i := strings.LastIndexByte(field, ':')
+	if i < 0 {
+		return 0, false
+	}
+	p, err := strconv.ParseUint(field[i+1:], 16, 16)
+	if err != nil {
+		return 0, false
+	}
+	return uint16(p), true
+}
+
+// hexAddrIP parses the "ADDR:PORT" hex address part into a canonical IP string.
+// IPv4 addr is 8 hex chars (little-endian); IPv6 is 32 hex chars (4 LE words).
+func hexAddrIP(field string) (string, bool) {
+	i := strings.LastIndexByte(field, ':')
+	if i < 0 {
+		return "", false
+	}
+	raw := field[:i]
+	b, err := hex.DecodeString(raw)
+	if err != nil {
+		return "", false
+	}
+	switch len(b) {
+	case 4: // IPv4 stored little-endian → network-order IP is the reversed bytes
+		ip := net.IPv4(b[3], b[2], b[1], b[0])
+		if a, ok := netip.AddrFromSlice(ip.To4()); ok {
+			return a.String(), true
+		}
+	case 16: // IPv6, four little-endian 32-bit words
+		ipb := make([]byte, 16)
+		for w := 0; w < 4; w++ {
+			word := binary.LittleEndian.Uint32(b[w*4 : w*4+4])
+			binary.BigEndian.PutUint32(ipb[w*4:w*4+4], word)
+		}
+		if a, ok := netip.AddrFromSlice(ipb); ok {
+			return a.Unmap().String(), true
+		}
+	}
+	return "", false
+}

--- a/internal/nftbackend/exemption_test.go
+++ b/internal/nftbackend/exemption_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="nftbackend_exemption_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Unit tests for the never-ban exemption resolver: IsExempt exact+CIDR (v4/v6), empty-snapshot fail-safe (never blocks bans), /proc/net/tcp hex addr/port parsers, SSH-peer extraction, and scanner-file publish."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package nftbackend
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// snapshot builds a resolver with a fixed, non-stale snapshot so IsExempt tests the
+// matching logic without triggering a live Refresh.
+func snapshot(exact []string, cidrs []string) *exemptResolver {
+	r := &exemptResolver{ttl: time.Hour, loaded: true, loadedAt: time.Now(), exact: map[string]struct{}{}}
+	for _, e := range exact {
+		if a, err := netip.ParseAddr(e); err == nil {
+			r.exact[a.Unmap().String()] = struct{}{}
+		}
+	}
+	for _, c := range cidrs {
+		if p, err := netip.ParsePrefix(c); err == nil {
+			r.prefixes = append(r.prefixes, p)
+		}
+	}
+	return r
+}
+
+func TestIsExempt_ExactAndCIDR_V4V6(t *testing.T) {
+	r := snapshot(
+		[]string{"62.38.150.122", "2001:db8::1"},
+		[]string{"10.0.0.0/8", "2001:db8:abcd::/48"},
+	)
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"62.38.150.122", true},        // exact v4 (the F2 admin IP)
+		{"10.5.6.7", true},             // inside v4 CIDR
+		{"10.0.0.1", true},             // inside v4 CIDR
+		{"2001:db8::1", true},          // exact v6
+		{"2001:db8:abcd::99", true},    // inside v6 CIDR
+		{"8.8.8.8", false},             // not exempt → MUST still be bannable
+		{"203.0.113.5", false},         // not exempt
+		{"2001:db8:ffff::1", false},    // v6 not in CIDR
+		{"not-an-ip", false},           // invalid
+		{"1.2.3.0/24", false},          // CIDR ban request is not the admin/session class
+	}
+	for _, c := range cases {
+		got, _ := r.IsExempt(c.ip)
+		if got != c.want {
+			t.Errorf("IsExempt(%q) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestIsExempt_EmptySnapshotNeverBlocks(t *testing.T) {
+	// Fail-safe: an empty resolver must NOT exempt anything (legitimate bans proceed).
+	r := snapshot(nil, nil)
+	if ok, _ := r.IsExempt("203.0.113.9"); ok {
+		t.Fatal("empty resolver exempted an IP — would block legitimate bans (fail-safe violated)")
+	}
+}
+
+func TestHexPort(t *testing.T) {
+	cases := map[string]uint16{
+		"0100007F:0050": 80,
+		"00000000:D6D8": 55000, // 0xD6D8
+		"00000000:0016": 22,
+	}
+	for field, want := range cases {
+		got, ok := hexPort(field)
+		if !ok || got != want {
+			t.Errorf("hexPort(%q) = %d,%v want %d", field, got, ok, want)
+		}
+	}
+}
+
+func TestHexAddrIP(t *testing.T) {
+	cases := map[string]string{
+		"0100007F:0050": "127.0.0.1",  // little-endian → reversed
+		"0F02000A:0016": "10.0.2.15",  // 0A.00.02.0F
+		"00000000000000000000000001000000:0016": "::1", // v6 ::1 /proc repr
+	}
+	for field, want := range cases {
+		got, ok := hexAddrIP(field)
+		if !ok || got != want {
+			t.Errorf("hexAddrIP(%q) = %q,%v want %q", field, got, ok, want)
+		}
+	}
+}
+
+func TestSSHListenPorts_DefaultPlusConfig(t *testing.T) {
+	// sshListenPorts always includes 22; we can't easily fake /etc/ssh here, so just
+	// assert 22 is present and the function never panics.
+	ports := sshListenPorts()
+	if _, ok := ports[22]; !ok {
+		t.Error("sshListenPorts missing default port 22")
+	}
+}
+
+func TestParseProcNetTCP_EstablishedSSHPeer(t *testing.T) {
+	// Synthetic /proc/net/tcp: one ESTABLISHED (st=01) conn to local port 22 (0016)
+	// from 10.0.2.15 (0F02000A), and one to a non-SSH port that must be ignored.
+	content := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n" +
+		"   0: 0100007F:0016 0F02000A:C001 01 00000000:00000000 00:00000000 00000000     0        0 1 1 ffff\n" +
+		"   1: 0100007F:1F90 0F02000B:C002 01 00000000:00000000 00:00000000 00000000     0        0 1 1 ffff\n" +
+		"   2: 0100007F:0016 0F02000C:C003 06 00000000:00000000 00:00000000 00000000     0        0 1 1 ffff\n" // st=06 TIME_WAIT, ignore
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	peers := parseProcNetTCP(path, map[uint16]struct{}{22: {}})
+	if len(peers) != 1 || peers[0] != "10.0.2.15" {
+		t.Errorf("parseProcNetTCP peers = %v, want [10.0.2.15] (only established SSH-port conn)", peers)
+	}
+}
+
+func TestRefresh_WritesScannerFileAndNoPanic(t *testing.T) {
+	dir := t.TempDir()
+	scanner := filepath.Join(dir, "exempt.list")
+	// Empty configDir → whitelist load is a no-op; DetectSystemIPs/proc run live but
+	// must not panic. We only assert the scanner file is written.
+	r := &exemptResolver{configDir: "", scannerFile: scanner, ttl: time.Hour, exact: map[string]struct{}{}}
+	r.Refresh()
+	if _, err := os.Stat(scanner); err != nil {
+		t.Errorf("Refresh did not write scanner file: %v", err)
+	}
+}


### PR DESCRIPTION
## fix(botscan): never-ban exemption guard at the durable apply boundary (F2)

**F2** (from the post-v1.209.2 health check): BotScan could ban the admin/management IP. Admin/session safety was **firewall rule-ordering only, not a never-ban invariant** — the durable Go ban-apply boundary (`Backend.Ban`) had no whitelist/management guard, so the BotScan/EventBus/escalation/enforcer paths could write the admin IP into `blacklist_manual`. The CIDR-aware pre-ban guard (`whitelist.IsIPInWhitelistFile`) existed but was wired **only** into the manual CLI handler; every automated path bypassed it. The shell scanner gate also fails on most hosts (the unprivileged scanner can't read the nft whitelist set — live-probed 5/6 — and the `whitelist.d` fallback grep is literal-only).

### Fix — DAEMON RE-BASELINE (declared openly; this is a Go change)
- **Authoritative never-ban guard inside `Backend.Ban()`** — the single choke point all ban paths funnel through. Exempt IPs are refused (never written to a drop set), logged, and returned with `BanResult.Exempt`. Range-aware (CIDR), **v4+v6**. Replaces ordering-only with a true never-ban invariant.
- **`internal/nftbackend/exemption.go`** resolver — sources: `whitelist.d` (operator 99-manual / live-session 00-session / system 00-system, CIDR-aware) + `safety.DetectSystemIPs` (server/gateway/dns/loopback/current-SSH) + live established inbound SSH peers (`/proc/net/tcp{,6}`) + optional `NFTBAN_MANAGEMENT_IPS`. TTL-cached. **Fail-safe: a resolver failure never blocks a legitimate ban.**
- **Exemption ≠ accept** (adds no allow rule); firewall rule order kept as defense-in-depth.
- **Scanner-side cheap suppression** — daemon publishes the resolved exempt list to a scanner-readable file; `nftban_botscan_is_whitelisted` consults it via exact match (no nft read). Defense-in-depth only; the daemon guard is the authority.

### Three fixes found during package-native (called out per gate)
1. **Non-blocking exemption refresh** — the initial Refresh ran synchronously before `d.Run()` and blocked the daemon from signaling READY (stuck `activating`). Now warmed in a goroutine; daemon reaches `active` immediately.
2. **`exempt.list` mode 0644** — the daemon runs root **without CAP_CHOWN** (`CAP_NET_ADMIN`+`CAP_DAC_OVERRIDE` only), so it can't chown to nftban. The `0750 nftban:nftban` parent dir already gates access to nftban+root, so 0644 lets the scanner read it without exposing the (non-secret) list further. The CGO/NSS `user.Lookup` was dropped entirely.
3. **`git archive` / clean rebuild** — a `tar` of the working tree shipped a stale `bin/`; `build_nftban.sh` skips the Go rebuild when `bin/` exists → packaged a no-guard binary. Shipping via `git archive` (untracked `bin/` excluded) forces a clean rebuild.

### Package-native proof (commit 6378fac9)
**lab2 DEB + lab4 RPM both PASS:**
- Negative: non-exempt bot reaches `blacklist_manual` **v4 and v6** (drop path intact; source/provenance preserved).
- Positive (backend guard, log-proven REFUSED): mgmt-CIDR **v4 + v6** (v4/v6 parity), whitelisted+session admin, system/server IP — all via paths the CLI whitelist pre-check does NOT consult → proves the **daemon apply-boundary guard is authoritative**.
- Scanner-readable exempt list; firewall rule order (whitelist accept → blacklist drop) intact.
- Anti-regression: BotScan consumer alive; manual ban of exempt refused, of non-exempt works; daemon never crashed (nrestarts=0).
- nftband active, `nftban validate` rc0, failed units 0, BotGuard default unchanged (disabled), **nft schema frozen (1.84.0)**, SELinux clean.

### Scope
**VERSION unchanged** (release-prep decides the bump). No schema bump, no MemoryMax change, no BotGuard default flip, no pattern-delimiter, no spool, no whitelist-drift changes. Bulk feed-replace path unchanged (rule order still protects there).
