### PR TITLE
v1.211.0 health-truth: prevent LoginMon watcher and nft-read false-green states

### DIFF
--- a/internal/loginmon/journal_watcher_respawn_v211_test.go
+++ b/internal/loginmon/journal_watcher_respawn_v211_test.go
@@ -1,0 +1,131 @@
+// =============================================================================
+// NFTBan v1.211 — LOGINMON-JOURNAL-NO-RESPAWN regression tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="loginmon-journal-watcher-respawn-v211-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Locks v1.211 LOGINMON-JOURNAL-NO-RESPAWN: the journal watcher (journalctl -f) is now SUPERVISED like the file watcher — a child that ends (EOF/error) is respawned with bounded backoff so the auth/authpriv/ftp journal detection sources never go silently dark, and the 'journal' input-source state is observable: OK while healthy, WATCHER_DEGRADED on a transient restart, WATCHER_DOWN after repeated short failures, back to OK on recovery; respawns STOP cleanly on ctx cancel (no leak, no tight loop). Hermetic: injected fast-exit (true) / long-lived (sleep) children, no root, no journalctl; run under -race."
+// meta:inventory.files="internal/loginmon/module.go"
+// meta:inventory.binaries="true,sleep"
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package loginmon
+
+import (
+	"context"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// journalState returns the recorded "journal" input-source state ("" if none).
+func journalState(m *Module) string {
+	return m.inputStateSnapshot()["journal"]
+}
+
+// waitForJournalState polls until the "journal" input-state equals want, or fails.
+func waitForJournalState(t *testing.T, m *Module, want string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if journalState(m) == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("journal input-state = %q, want %q within %s", journalState(m), want, d)
+}
+
+// Core: a journalctl child that keeps ending is RESPAWNED while ctx is alive
+// (detection does NOT go dark), the input-state degrades to WATCHER_DEGRADED then
+// WATCHER_DOWN, and respawns STOP cleanly on ctx cancel (no tight loop, no leak).
+func TestJournalWatcherRespawnsAndDegrades(t *testing.T) {
+	m := newTestModule() // backoff 2ms..8ms, healthyReset=1h (runs never "healthy")
+
+	var spawns int64
+	m.newJournalCmd = func(ctx context.Context) *exec.Cmd {
+		atomic.AddInt64(&spawns, 1)
+		return exec.CommandContext(ctx, "true") // exits immediately → drives respawn
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go m.runJournalWatcher(ctx)
+
+	// Respawn proof: the supervisor must invoke the builder repeatedly.
+	deadline := time.Now().Add(3 * time.Second)
+	for atomic.LoadInt64(&spawns) < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&spawns); got < 3 {
+		t.Fatalf("journal watcher did not respawn: only %d spawns (want >=3) — detection would go dark", got)
+	}
+
+	// After repeated short-lived failures the input-state must read WATCHER_DOWN
+	// (not OK) — an enabled-but-dark journal source must never look healthy.
+	waitForJournalState(t, m, inputStateWatcherDown, 3*time.Second)
+
+	// Clean shutdown: after cancel, spawns must stop increasing (no tight loop).
+	cancel()
+	time.Sleep(60 * time.Millisecond)
+	c1 := atomic.LoadInt64(&spawns)
+	time.Sleep(80 * time.Millisecond)
+	c2 := atomic.LoadInt64(&spawns)
+	if c2 != c1 {
+		t.Fatalf("journal watcher kept respawning after ctx cancel: %d -> %d (clean shutdown broken)", c1, c2)
+	}
+}
+
+// A transient single restart shows WATCHER_DEGRADED (not yet DOWN) before the
+// repeated-failure threshold escalates it.
+func TestJournalWatcherTransientIsDegraded(t *testing.T) {
+	m := newTestModule()
+	m.watcherBackoffMin = 40 * time.Millisecond // slow the loop so DEGRADED is observable pre-DOWN
+	m.watcherBackoffMax = 80 * time.Millisecond
+
+	m.newJournalCmd = func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "true")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.runJournalWatcher(ctx)
+
+	// First short failure → WATCHER_DEGRADED (consecutiveShortFails == 1).
+	waitForJournalState(t, m, inputStateWatcherDegraded, 2*time.Second)
+}
+
+// Recovery: a watcher that was DOWN comes back to OK once a respawned run survives
+// to the healthy-reset threshold.
+func TestJournalWatcherRecoversToOK(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not available")
+	}
+	m := newTestModule()
+	m.watcherBackoffMin = 2 * time.Millisecond
+	m.watcherBackoffMax = 8 * time.Millisecond
+	m.watcherHealthyReset = 40 * time.Millisecond
+
+	var healthy int64 // 0 = fail fast, 1 = long-lived child
+	m.newJournalCmd = func(ctx context.Context) *exec.Cmd {
+		if atomic.LoadInt64(&healthy) == 1 {
+			return exec.CommandContext(ctx, "sleep", "3600") // survives past healthyReset
+		}
+		return exec.CommandContext(ctx, "true") // fail fast
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.runJournalWatcher(ctx)
+
+	// Drive it DOWN first.
+	waitForJournalState(t, m, inputStateWatcherDown, 3*time.Second)
+
+	// Flip to a healthy child: the next respawn must survive and recover to OK.
+	atomic.StoreInt64(&healthy, 1)
+	waitForJournalState(t, m, inputStateOK, 3*time.Second)
+}

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -148,7 +148,12 @@ type Module struct {
 	// child (tail -F) that dies while ctx is alive is respawned with bounded
 	// exponential backoff so a detection source never silently goes dark.
 	// newWatcherCmd is overridable in tests; nil → the default tail -F builder.
-	newWatcherCmd       func(ctx context.Context, logPath string) *exec.Cmd
+	newWatcherCmd func(ctx context.Context, logPath string) *exec.Cmd
+	// v1.211 LOGINMON-JOURNAL-NO-RESPAWN: journal watcher is now supervised with
+	// the same bounded-backoff respawn loop as the file watcher (it previously ran
+	// `journalctl -f` once and went dark on EOF/error). newJournalCmd is overridable
+	// in tests; nil → the default `journalctl -f` builder.
+	newJournalCmd       func(ctx context.Context) *exec.Cmd
 	watcherBackoffMin   time.Duration
 	watcherBackoffMax   time.Duration
 	watcherHealthyReset time.Duration // a run lasting ≥ this resets backoff to min
@@ -443,9 +448,14 @@ func (m *Module) Stop() error {
 		}
 	}
 
-	// Clean up journal command if running
-	if m.journalCmd != nil && m.journalCmd.Process != nil {
-		m.journalCmd.Process.Kill()
+	// Clean up journal command if running. Snapshot under the lock — the journal
+	// supervisor (runJournalWatcherOnce) reassigns m.journalCmd on each respawn.
+	// ctx cancellation already stops respawns; this reaps any child still live.
+	m.mu.Lock()
+	journalCmd := m.journalCmd
+	m.mu.Unlock()
+	if journalCmd != nil && journalCmd.Process != nil {
+		_ = journalCmd.Process.Kill() // best-effort reap at shutdown; ctx already stopped respawns
 	}
 
 	// v1.48.0 / v1.176: Clean up file watcher commands. Snapshot under the lock —
@@ -968,42 +978,133 @@ func (m *Module) detectMode() Mode {
 // LOG_SOURCE_OWNERSHIP_DECLARATION (guarded by TestSourceOwnershipGuard_JournalFacilities).
 var journalAuthFacilities = []string{"4", "10", "11"}
 
-// runJournalWatcher watches journalctl for login failures
+// runJournalWatcher SUPERVISES the journalctl follow watcher: it (re)spawns the
+// child via runJournalWatcherOnce and, if the child dies while ctx is still alive,
+// respawns it with bounded exponential backoff. Without this, a `journalctl -f`
+// child that ends (EOF, abnormal stream end, error) would leave the journal-based
+// detection sources (auth/authpriv/ftp facilities) DARK until daemon restart — a
+// silent detection-availability hole (v1.211 LOGINMON-JOURNAL-NO-RESPAWN; mirrors
+// the v1.176 file-watcher supervisor in runFileWatcher).
+//
+// It also keeps the "journal" input-source state observable + non-stale via
+// recordInputState: OK while a run is healthy, WATCHER_DEGRADED on a transient
+// restart, WATCHER_DOWN after repeated short-lived failures. On ctx cancellation
+// (clean shutdown) it returns without respawning.
 func (m *Module) runJournalWatcher(ctx context.Context) {
-	// Build journalctl command
-	args := []string{
-		"-f",      // Follow mode
-		"-n", "0", // Don't show historical entries
-		"--no-pager",
-		"-o", "short-iso",
-	}
-	for _, f := range journalAuthFacilities {
-		args = append(args, "SYSLOG_FACILITY="+f)
-	}
-	m.journalCmd = exec.CommandContext(ctx, "journalctl", args...)
+	// Record OK initially when the watcher first starts a run (optimistic; the
+	// failure path below flips it to DEGRADED/DOWN, and a healthy run re-affirms OK).
+	m.recordInputState("journal", inputStateOK)
 
-	stdout, err := m.journalCmd.StdoutPipe()
+	backoff := m.watcherBackoffMin
+	consecutiveShortFails := 0
+	for attempt := 0; ; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		start := time.Now()
+		// A run that survives to the healthy-reset threshold is "healthy" → mark OK
+		// from inside the run (so OK only ever appears for a genuinely healthy run,
+		// never flickering on a doomed short respawn).
+		healthyTimer := time.AfterFunc(m.watcherHealthyReset, func() {
+			if ctx.Err() == nil {
+				m.recordInputState("journal", inputStateOK)
+			}
+		})
+		err := m.runJournalWatcherOnce(ctx, attempt)
+		healthyTimer.Stop()
+		// Clean shutdown → do not respawn.
+		if ctx.Err() != nil {
+			return
+		}
+		// A run that lasted long enough is "healthy" → reset backoff + fail streak.
+		if time.Since(start) >= m.watcherHealthyReset {
+			backoff = m.watcherBackoffMin
+			consecutiveShortFails = 0
+		} else {
+			consecutiveShortFails++
+		}
+		// Input-state: transient restart → WATCHER_DEGRADED; repeated short-lived
+		// failures (>=3 runs that never reached healthy-reset) → WATCHER_DOWN.
+		state := inputStateWatcherDegraded
+		if consecutiveShortFails >= 3 {
+			state = inputStateWatcherDown
+		}
+		m.recordInputState("journal", state)
+		m.status.RecordError(fmt.Errorf("journal watcher exited (ran %s): %v — respawning in %s",
+			time.Since(start).Round(time.Millisecond), err, backoff))
+		log.Printf("[LOGINMON] journal: state=%s reason=watcher_respawn ran=%s err=%v",
+			state, time.Since(start).Round(time.Millisecond), err)
+		m.bus.Publish(eventbus.NewEvent(eventbus.EventError, ModuleName).
+			WithMessage(fmt.Sprintf("Journal watcher DOWN (state=%s) — respawning in %s", state, backoff)))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > m.watcherBackoffMax {
+			backoff = m.watcherBackoffMax
+		}
+	}
+}
+
+// runJournalWatcherOnce runs a single `journalctl -f` child and feeds its lines
+// through the detector pipeline until the child dies or ctx is cancelled. Returns
+// the reason the run ended (nil on clean ctx cancellation). The child cmd builder
+// is overridable in tests via m.newJournalCmd.
+func (m *Module) runJournalWatcherOnce(ctx context.Context, attempt int) error {
+	var cmd *exec.Cmd
+	if m.newJournalCmd != nil {
+		cmd = m.newJournalCmd(ctx)
+	} else {
+		// Build journalctl command
+		args := []string{
+			"-f",      // Follow mode
+			"-n", "0", // Don't show historical entries
+			"--no-pager",
+			"-o", "short-iso",
+		}
+		for _, f := range journalAuthFacilities {
+			args = append(args, "SYSLOG_FACILITY="+f)
+		}
+		cmd = exec.CommandContext(ctx, "journalctl", args...)
+	}
+	// Publish the journalctl child reference for Stop() to reap (guarded).
+	m.mu.Lock()
+	m.journalCmd = cmd
+	m.mu.Unlock()
+
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		m.status.RecordError(err)
-		return
+		return fmt.Errorf("pipe: %w", err)
 	}
 	// CRITICAL: Close stdout pipe on exit to prevent FD/memory leak
 	defer stdout.Close()
 
-	if err := m.journalCmd.Start(); err != nil {
-		m.status.RecordError(err)
-		return
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
 	}
+
+	verb := "started"
+	if attempt > 0 {
+		verb = "RESPAWNED"
+	}
+	m.bus.Publish(eventbus.NewEvent(eventbus.EventModuleStart, ModuleName).
+		WithMessage(fmt.Sprintf("Journal watcher %s", verb)))
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 			m.processLine(scanner.Bytes())
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan: %w", err)
+	}
+	_ = cmd.Wait()
+	return fmt.Errorf("journal stream ended (child exited)")
 }
 
 // panelLogPaths maps detected panel services to their log file paths.
@@ -1369,6 +1470,11 @@ const (
 	inputStateOK         = "OK"
 	inputStateWarnNoLogs = "WARN_NO_LOGS"
 	inputStateNoLogs     = "NO_LOGS"
+	// v1.211 LOGINMON-JOURNAL-NO-RESPAWN: watcher-supervision states for a
+	// detection source whose child watcher is being respawned. healthy=OK,
+	// transient restart=WATCHER_DEGRADED, repeated-failure/dead=WATCHER_DOWN.
+	inputStateWatcherDegraded = "WATCHER_DEGRADED"
+	inputStateWatcherDown     = "WATCHER_DOWN"
 )
 
 // recordInputState stores the input-state of a detection source (v1.182

--- a/internal/validator/health_unknown_v211_test.go
+++ b/internal/validator/health_unknown_v211_test.go
@@ -1,0 +1,284 @@
+// =============================================================================
+// NFTBan v1.211 — HEALTH-FALSE-ZERO regression tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="health-unknown-v211-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Locks v1.211 HEALTH-FALSE-ZERO: a FAILED enforcement-set read (countSetElementsState unknown=true — exec error / malformed JSON / permission-denied) degrades module health to a SeverityWarn finding and an UNSET Effective axis (never a false 'idle'/'enforcing'), while a genuinely EMPTY or CONFIRMED-ABSENT set on an enabled module stays neutral (idle, no WARN), a populated set still reports enforcing/observing, and a disabled module stays quiet. Hermetic: drives the countSetElementsStateFunc seam; no nft, no root."
+// meta:inventory.files="internal/validator/module_health.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files="conf.d/botguard/main.conf,conf.d/botguard/main.conf.local"
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package validator
+
+import "testing"
+
+// botGuardSets is the structural set list BotGuard requires (IPv4 only here; the
+// ip6 nftban table is not present in buildDoc, so v6 is not required).
+var botGuardSets = []string{"http_bot_suspect", "http_bot_pending", "http_bot_allow",
+	"http_bot_grey", "http_bot_ban", "http_bot_emergency"}
+
+// withBotGuardEnabled stands up an enabled+present+running BotGuard so the
+// evaluator reaches the Effective set-read loop, with journal evidence present
+// (so VAL-BOTGUARD-001 is not in play). Returns the evaluated health.
+func withBotGuardEnabled(t *testing.T, stateFn func(family, name string) (int, bool, bool)) *ModuleHealth {
+	t.Helper()
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="true"`,
+	})
+	defer cleanup()
+
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = stateFn
+	defer func() { countSetElementsStateFunc = old }()
+
+	SetJournalReader(mockJournalReader{lines: []string{"module_start: botguard"}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil // reset for this evaluation
+	doc := buildDoc([]string{"http_bot_guard"}, botGuardSets)
+	return evaluateBotGuard(doc, ServiceState{Nftband: RuntimeRunning})
+}
+
+func hasDegradedFinding(t *testing.T) bool {
+	t.Helper()
+	for _, f := range moduleFindings {
+		if f.Code == CodeModuleDegraded && f.Severity == SeverityWarn {
+			return true
+		}
+	}
+	return false
+}
+
+// A FAILED read (exec error / timeout) → unknown → module degraded, NOT idle.
+func TestBotGuardSetReadUnknownDegrades(t *testing.T) {
+	h := withBotGuardEnabled(t, func(_, _ string) (int, bool, bool) {
+		return 0, false, true // read failed: cannot prove empty
+	})
+
+	if h.Effective == EffectiveIdle {
+		t.Errorf("effective = %q, want UNSET (a failed set read must NOT render false idle)", h.Effective)
+	}
+	if h.Effective == EffectiveEnforcing || h.Effective == EffectiveObserving {
+		t.Errorf("effective = %q, want UNSET (a failed read must NOT claim active enforcement)", h.Effective)
+	}
+	if h.Effective != "" {
+		t.Errorf("effective = %q, want \"\" (omitted on unknown)", h.Effective)
+	}
+	if !hasDegradedFinding(t) {
+		t.Error("want a SeverityWarn VAL-MODULE-001 finding on a failed enforcement-set read (degraded visibility)")
+	}
+}
+
+// Malformed-JSON and permission-denied both surface through the seam as unknown=true;
+// the verdict path is the same (degrade, not idle). This locks both error classes.
+func TestBotGuardSetReadUnknownVariantsDegrade(t *testing.T) {
+	for _, name := range []string{"malformed-json", "permission-denied"} {
+		t.Run(name, func(t *testing.T) {
+			h := withBotGuardEnabled(t, func(_, _ string) (int, bool, bool) {
+				return 0, false, true
+			})
+			if h.Effective == EffectiveIdle {
+				t.Errorf("%s: effective rendered idle on a failed read", name)
+			}
+			if !hasDegradedFinding(t) {
+				t.Errorf("%s: want degraded WARN finding", name)
+			}
+		})
+	}
+}
+
+// A genuinely EMPTY set (present, 0 elements) on an enabled module → idle/neutral,
+// NOT a false WARN. This preserves the "zero = NEUTRAL" rule (BUG-3 lesson).
+func TestBotGuardEmptySetIsNeutralIdle(t *testing.T) {
+	h := withBotGuardEnabled(t, func(_, _ string) (int, bool, bool) {
+		return 0, true, false // present + empty
+	})
+	if h.Effective != EffectiveIdle {
+		t.Errorf("effective = %q, want idle (empty set is neutral, not degraded)", h.Effective)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("empty set must NOT emit a degraded WARN finding (zero = NEUTRAL)")
+	}
+}
+
+// A CONFIRMED-ABSENT set (exists=false, unknown=false) is also neutral → idle,
+// never a false WARN.
+func TestBotGuardConfirmedAbsentSetIsNeutralIdle(t *testing.T) {
+	h := withBotGuardEnabled(t, func(_, _ string) (int, bool, bool) {
+		return 0, false, false // confirmed absent
+	})
+	if h.Effective != EffectiveIdle {
+		t.Errorf("effective = %q, want idle (confirmed-absent set is neutral)", h.Effective)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("confirmed-absent set must NOT emit a degraded WARN finding")
+	}
+}
+
+// A populated enforcement set still reports enforcing (unchanged behavior).
+func TestBotGuardPopulatedSetEnforcingUnchanged(t *testing.T) {
+	h := withBotGuardEnabled(t, func(_, name string) (int, bool, bool) {
+		if name == "http_bot_ban" {
+			return 3, true, false
+		}
+		return 0, true, false
+	})
+	if h.Effective != EffectiveEnforcing {
+		t.Errorf("effective = %q, want enforcing (ban set populated)", h.Effective)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("a clean populated read must NOT emit a degraded finding")
+	}
+}
+
+// A populated observation set still reports observing (unchanged behavior).
+func TestBotGuardPopulatedObservationUnchanged(t *testing.T) {
+	h := withBotGuardEnabled(t, func(_, name string) (int, bool, bool) {
+		if name == "http_bot_suspect" {
+			return 5, true, false
+		}
+		return 0, true, false
+	})
+	if h.Effective != EffectiveObserving {
+		t.Errorf("effective = %q, want observing (suspect set populated, ban empty)", h.Effective)
+	}
+}
+
+// A disabled module never reads sets and stays quiet — a failing seam must not be
+// reached, and no degraded finding is emitted.
+func TestBotGuardDisabledStaysQuietOnReadFailure(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="false"`,
+	})
+	defer cleanup()
+
+	called := false
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) {
+		called = true
+		return 0, false, true
+	}
+	defer func() { countSetElementsStateFunc = old }()
+
+	moduleFindings = nil
+	doc := buildDoc([]string{"http_bot_guard"}, botGuardSets)
+	h := evaluateBotGuard(doc, ServiceState{Nftband: RuntimeRunning})
+
+	if called {
+		t.Error("disabled BotGuard must NOT read kernel sets")
+	}
+	if h.Config != ConfigDisabled {
+		t.Errorf("config = %q, want disabled", h.Config)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("disabled module must stay quiet (no degraded finding)")
+	}
+}
+
+// =============================================================================
+// Blacklist (manual) — THE enforcement set. v1.211 HEALTH-FALSE-ZERO closes the
+// last legacy 0-on-error reader: a FAILED manual-set read must degrade (unknown)
+// instead of collapsing to a false "idle" ("no bans").
+// =============================================================================
+
+// withBlacklistManual mocks the 3-valued set reader and disables geoban/feeds so
+// evaluateBlacklist's Manual sub-health is deterministic. stateFn is keyed by
+// (family, setName) — switch on setName to fail only the manual set if desired.
+func withBlacklistManual(t *testing.T, doc *RulesetDocument, stateFn func(family, name string) (int, bool, bool)) *BlacklistHealth {
+	t.Helper()
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="false"`,
+	})
+	defer cleanup()
+
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = stateFn
+	defer func() { countSetElementsStateFunc = old }()
+
+	moduleFindings = nil // reset for this evaluation
+	return evaluateBlacklist(doc)
+}
+
+// A FAILED read on either family of blacklist_manual → "unknown", NOT a false idle,
+// and a SeverityWarn CodeModuleDegraded finding is surfaced.
+func TestBlacklistManualReadUnknownDegrades(t *testing.T) {
+	for _, failSet := range []string{"blacklist_manual_ipv4", "blacklist_manual_ipv6"} {
+		t.Run(failSet, func(t *testing.T) {
+			bh := withBlacklistManual(t, buildDoc(nil, nil), func(_, name string) (int, bool, bool) {
+				if name == failSet {
+					return 0, false, true // read failed: cannot prove empty
+				}
+				return 0, true, false // other family present + empty
+			})
+			if bh.Manual.State == "idle" {
+				t.Error("manual rendered false idle on a failed enforcement-set read")
+			}
+			if bh.Manual.State == "primed" || bh.Manual.State == "enforcing" {
+				t.Errorf("manual state = %q, want unknown (a failed read must NOT claim bans loaded)", bh.Manual.State)
+			}
+			if bh.Manual.State != "unknown" {
+				t.Errorf("manual state = %q, want unknown", bh.Manual.State)
+			}
+			if !hasDegradedFinding(t) {
+				t.Error("want a SeverityWarn CodeModuleDegraded finding on a failed blacklist_manual read")
+			}
+		})
+	}
+}
+
+// Both families present + empty (count 0) → idle/neutral, no spurious WARN.
+// Preserves the zero = NEUTRAL rule.
+func TestBlacklistManualEmptyIsNeutralIdle(t *testing.T) {
+	bh := withBlacklistManual(t, buildDoc(nil, nil), func(_, _ string) (int, bool, bool) {
+		return 0, true, false // present + empty
+	})
+	if bh.Manual.State != "idle" {
+		t.Errorf("manual state = %q, want idle (both families empty is neutral)", bh.Manual.State)
+	}
+	if bh.Manual.Entries != 0 {
+		t.Errorf("manual entries = %d, want 0", bh.Manual.Entries)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("a confirmed-empty manual set must NOT emit a degraded WARN finding (zero = NEUTRAL)")
+	}
+}
+
+// Populated manual set + drops > 0 → enforcing (unchanged). Sum counts only from
+// successful reads (4 per family → 8 total).
+func TestBlacklistManualPopulatedEnforcingUnchanged(t *testing.T) {
+	objects := []NftObject{
+		{Table: &NftTable{Family: "ip", Name: "nftban"}},
+		{Counter: &NftCounter{Family: "ip", Table: "nftban", Name: "input_blacklist_manual_drop", Packets: 7}},
+	}
+	doc := ParseRuleset(&NftRuleset{Nftables: objects})
+	bh := withBlacklistManual(t, doc, func(_, _ string) (int, bool, bool) {
+		return 4, true, false // populated, present
+	})
+	if bh.Manual.State != "enforcing" {
+		t.Errorf("manual state = %q, want enforcing (populated + drops)", bh.Manual.State)
+	}
+	if bh.Manual.Entries != 8 {
+		t.Errorf("manual entries = %d, want 8 (4 ipv4 + 4 ipv6)", bh.Manual.Entries)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("a clean populated read must NOT emit a degraded finding")
+	}
+}
+
+// Populated manual set, no drops → primed (unchanged).
+func TestBlacklistManualPopulatedPrimedUnchanged(t *testing.T) {
+	bh := withBlacklistManual(t, buildDoc(nil, nil), func(_, _ string) (int, bool, bool) {
+		return 2, true, false // populated, present, no drop counter in empty doc
+	})
+	if bh.Manual.State != "primed" {
+		t.Errorf("manual state = %q, want primed (populated, no drops)", bh.Manual.State)
+	}
+	if hasDegradedFinding(t) {
+		t.Error("a clean populated read must NOT emit a degraded finding")
+	}
+}

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -154,10 +154,20 @@ func evaluateBotGuard(doc *RulesetDocument, svcState ServiceState) *ModuleHealth
 		return h
 	}
 
+	// v1.211 HEALTH-FALSE-ZERO: read enforcement-relevant sets with the 3-valued
+	// reader. A FAILED read (unknown) must NOT collapse to a false "idle"/"enforcing":
+	// a populated/empty set proves state, but a failed query proves nothing.
+	readUnknown := false
+
 	// Check enforcement sets (ban, grey, emergency)
 	enforcementSets := []string{"http_bot_ban", "http_bot_grey", "http_bot_emergency"}
 	for _, s := range enforcementSets {
-		if countSetElements("ip", s) > 0 {
+		count, _, unknown := countSetElementsState("ip", s)
+		if unknown {
+			readUnknown = true
+			continue
+		}
+		if count > 0 {
 			h.Effective = EffectiveEnforcing
 			return h
 		}
@@ -166,13 +176,26 @@ func evaluateBotGuard(doc *RulesetDocument, svcState ServiceState) *ModuleHealth
 	// Check observation sets (suspect, pending)
 	observationSets := []string{"http_bot_suspect", "http_bot_pending"}
 	for _, s := range observationSets {
-		if countSetElements("ip", s) > 0 {
+		count, _, unknown := countSetElementsState("ip", s)
+		if unknown {
+			readUnknown = true
+			continue
+		}
+		if count > 0 {
 			h.Effective = EffectiveObserving
 			return h
 		}
 	}
 
-	// All sets empty → idle (valid per BUG-3 lesson)
+	// A set read FAILED and no live set proved enforcing/observing → we cannot
+	// prove "empty". Degrade (WARN) instead of rendering a false idle/clean.
+	if readUnknown {
+		markEnforcementUnknown(h, "botguard")
+		return h
+	}
+
+	// All sets confirmed empty/absent → idle (valid per BUG-3 lesson; empty set on
+	// an enabled module is NEUTRAL, not noisy).
 	h.Effective = EffectiveIdle
 	return h
 }
@@ -528,12 +551,36 @@ func evaluateBlacklist(doc *RulesetDocument) *BlacklistHealth {
 	// elements > 0 + drops = 0 = PRIMED (rules loaded, no matches yet)
 	// elements = 0 = IDLE
 	// v1.85 GAP-185-9: Count both IPv4 and IPv6 manual blacklist elements.
-	manualElements := countSetElements("ip", "blacklist_manual_ipv4")
-	manualElements += countSetElements("ip6", "blacklist_manual_ipv6")
+	// v1.211 HEALTH-FALSE-ZERO: blacklist_manual is THE enforcement set. Read it with
+	// the 3-valued reader (countSetElementsState) so a FAILED read (permission/timeout/
+	// malformed) degrades to "unknown" instead of collapsing to a false "idle" ("no
+	// bans"). Sum counts ONLY from successful reads; a confirmed-empty set on both
+	// families stays neutral (idle), exactly as before.
+	mv4, _, unknownV4 := countSetElementsState("ip", "blacklist_manual_ipv4")
+	mv6, _, unknownV6 := countSetElementsState("ip6", "blacklist_manual_ipv6")
+	manualElements := 0
+	if !unknownV4 {
+		manualElements += mv4
+	}
+	if !unknownV6 {
+		manualElements += mv6
+	}
 	// Counter: check both families
 	manualDrops := doc.GetCounter("ip", "nftban", "input_blacklist_manual_drop")
 	manualDrops += doc.GetCounter("ip6", "nftban", "input_blacklist_manual_drop")
-	if manualElements > 0 && manualDrops > 0 {
+	if unknownV4 || unknownV6 {
+		// EITHER family read FAILED on THE enforcement set: we cannot prove "no bans".
+		// Degrade (WARN) instead of rendering a false idle/primed/enforcing. Mirrors the
+		// markEnforcementUnknown mechanism used for BotGuard (CodeModuleDegraded /
+		// SeverityWarn finding is the schema-safe surface; State carries "unknown").
+		bh.Manual = BlacklistSubHealth{State: "unknown", Entries: manualElements}
+		moduleFindings = append(moduleFindings, Finding{
+			Code:      CodeModuleDegraded,
+			Severity:  SeverityWarn,
+			Component: "module",
+			Message:   "blacklist_manual set read failed — enforcement state unknown (kernel set query failed; cannot confirm bans loaded vs empty)",
+		})
+	} else if manualElements > 0 && manualDrops > 0 {
 		bh.Manual = BlacklistSubHealth{State: "enforcing", Entries: manualElements, Drops: manualDrops}
 	} else if manualElements > 0 {
 		bh.Manual = BlacklistSubHealth{State: "primed", Entries: manualElements}
@@ -758,4 +805,75 @@ func countSetElementsReal(family, setName string) int {
 		}
 	}
 	return 0
+}
+
+// countSetElementsState is the 3-valued sibling of countSetElements (v1.211
+// HEALTH-FALSE-ZERO). It distinguishes a FAILED read (unknown — cannot prove
+// state) from a genuinely EMPTY set and from a CONFIRMED-ABSENT set, so a set
+// read failure on an enforcement-relevant set degrades the verdict instead of
+// rendering a false idle/clean. It mirrors internal/metrics
+// evidence_sets.go:countSetElementsJSON's contract WITHOUT importing
+// internal/metrics (that would create a package cycle).
+//
+// Returns (count, exists, unknown):
+//
+//	count>0, exists=true,  unknown=false → set present with elements
+//	count=0, exists=true,  unknown=false → set present, empty (NEUTRAL — idle ok)
+//	count=0, exists=false, unknown=false → set confirmed absent (NEUTRAL — idle ok)
+//	count=0, exists=false, unknown=true  → read failed (enforcement state UNKNOWN)
+//
+// countSetElementsStateFunc is the test seam (same indirection pattern as
+// countSetElementsFunc above).
+var countSetElementsStateFunc = countSetElementsStateReal
+
+func countSetElementsState(family, setName string) (count int, exists bool, unknown bool) {
+	return countSetElementsStateFunc(family, setName)
+}
+
+func countSetElementsStateReal(family, setName string) (count int, exists bool, unknown bool) {
+	table := "nftban"
+	out, err := exec.Command("nft", "-j", "list", "set", family, table, setName).Output()
+	if err != nil {
+		// Command failure: could be a missing set, but also a timeout/permission/
+		// exec error. Mark unknown so callers never treat failure as confirmed empty.
+		return 0, false, true
+	}
+
+	// Parse JSON: {"nftables": [{"metainfo":...}, {"set": {..., "elem": [...]}}]}
+	var result struct {
+		Nftables []struct {
+			Set *struct {
+				Elem []interface{} `json:"elem"`
+			} `json:"set,omitempty"`
+		} `json:"nftables"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return 0, false, true
+	}
+
+	for _, obj := range result.Nftables {
+		if obj.Set != nil {
+			return len(obj.Set.Elem), true, false
+		}
+	}
+	// Valid JSON, no set object for this name → confirmed absent (NEUTRAL).
+	return 0, false, false
+}
+
+// markEnforcementUnknown records that a set read FAILED for an enforcement-relevant
+// module (v1.211 HEALTH-FALSE-ZERO). The verdict MUST NOT render idle/enforcing as
+// if the set were empty, so the module's Effective axis is left UNSET (omitted from
+// the frozen M81-6 JSON via omitempty — never the false-idle "idle" token) and a
+// SeverityWarn finding is appended. The finding is the schema-safe surface that
+// makes the degraded state visible in `--json` (result.Findings) and the human
+// verdict, the same mechanism used for CodeLoginMonNoInput (see the ModuleHealth
+// note in types.go). This avoids extending the frozen ModuleHealth JSON schema.
+func markEnforcementUnknown(h *ModuleHealth, module string) {
+	h.Effective = "" // never false-idle / false-enforcing on a failed read
+	moduleFindings = append(moduleFindings, Finding{
+		Code:      CodeModuleDegraded,
+		Severity:  SeverityWarn,
+		Component: "module",
+		Message:   module + ": set read failed — enforcement state unknown (kernel set query failed; cannot confirm enforcing vs empty)",
+	})
 }

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -86,9 +86,9 @@ func TestBotGuardEnabledPresentIdle(t *testing.T) {
 	})
 	defer cleanup()
 	// Mock: all sets empty → idle (per BUG-3 lesson)
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 0 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 0, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 	// Mock journal: BotGuard startup evidence present
 	SetJournalReader(mockJournalReader{lines: []string{"module_start: botguard"}})
 	defer SetJournalReader(SystemdJournalReader{})
@@ -118,14 +118,14 @@ func TestBotGuardEnabledEnforcing(t *testing.T) {
 	})
 	defer cleanup()
 	// Mock: ban set has elements → enforcing
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, name string) int {
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, name string) (int, bool, bool) {
 		if name == "http_bot_ban" {
-			return 3
+			return 3, true, false
 		}
-		return 0
+		return 0, true, false
 	}
-	defer func() { countSetElementsFunc = old }()
+	defer func() { countSetElementsStateFunc = old }()
 	SetJournalReader(mockJournalReader{lines: []string{"module_start: botguard"}})
 	defer SetJournalReader(SystemdJournalReader{})
 
@@ -145,14 +145,14 @@ func TestBotGuardEnabledObserving(t *testing.T) {
 	})
 	defer cleanup()
 	// Mock: suspect set has elements, ban set empty → observing
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, name string) int {
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, name string) (int, bool, bool) {
 		if name == "http_bot_suspect" {
-			return 5
+			return 5, true, false
 		}
-		return 0
+		return 0, true, false
 	}
-	defer func() { countSetElementsFunc = old }()
+	defer func() { countSetElementsStateFunc = old }()
 	SetJournalReader(mockJournalReader{lines: []string{"module_start: botguard"}})
 	defer SetJournalReader(SystemdJournalReader{})
 
@@ -210,9 +210,9 @@ func TestBotGuardJournalEvidencePresent(t *testing.T) {
 		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="true"`,
 	})
 	defer cleanup()
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 0 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 0, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 	SetJournalReader(mockJournalReader{lines: []string{
 		"module_start: botguard",
 	}})
@@ -237,9 +237,9 @@ func TestBotGuardJournalNoEvidence(t *testing.T) {
 		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="true"`,
 	})
 	defer cleanup()
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 0 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 0, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 	// Journal has output but no BotGuard lines
 	SetJournalReader(mockJournalReader{lines: []string{
 		"some other daemon output",
@@ -273,9 +273,9 @@ func TestBotGuardJournalUnavailable(t *testing.T) {
 		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="true"`,
 	})
 	defer cleanup()
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 0 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 0, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 	// Journal exec fails
 	SetJournalReader(mockJournalReader{errKind: ErrExec, err: errors.New("exec failed")})
 	defer SetJournalReader(SystemdJournalReader{})
@@ -660,10 +660,10 @@ func TestBlacklistManualIdle(t *testing.T) {
 		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="false"`,
 	})
 	defer cleanup()
-	// Mock: manual set empty → idle
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 0 }
-	defer func() { countSetElementsFunc = old }()
+	// Mock: manual set empty → idle (present, 0 elements, not unknown)
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 0, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 
 	sets := []string{"blacklist_ipv4", "blacklist_manual_ipv4"}
 	doc := buildDoc(nil, sets)
@@ -689,9 +689,9 @@ func TestBlacklistManualPrimed(t *testing.T) {
 	})
 	defer cleanup()
 	// Mock: manual set has 5 entries per family → 10 total (IPv4+IPv6)
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 5 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 5, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 
 	sets := []string{"blacklist_ipv4", "blacklist_manual_ipv4"}
 	doc := buildDoc(nil, sets)
@@ -712,9 +712,9 @@ func TestBlacklistManualEnforcing(t *testing.T) {
 	})
 	defer cleanup()
 	// Mock: manual set has 3 entries
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 3 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 3, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 
 	// Build doc with manual drop counter > 0
 	objects := []NftObject{
@@ -745,9 +745,9 @@ func TestBlacklistManualPrimedZeroDrops(t *testing.T) {
 		"conf.d/geoban/main.conf": `GEOBAN_ENABLED="false"`,
 	})
 	defer cleanup()
-	old := countSetElementsFunc
-	countSetElementsFunc = func(_, _ string) int { return 2 }
-	defer func() { countSetElementsFunc = old }()
+	old := countSetElementsStateFunc
+	countSetElementsStateFunc = func(_, _ string) (int, bool, bool) { return 2, true, false }
+	defer func() { countSetElementsStateFunc = old }()
 
 	// Counter exists but zero packets
 	objects := []NftObject{


### PR DESCRIPTION
## Scope
Addresses the two P0 "health-truth / lies green" defects (split from the stability train; Items 3/4/5 stay separate lanes):
- **`BUG-LOGINMON-JOURNAL-WATCHER-NO-RESPAWN`** — journal watcher dies silently, detection goes dark while status reads protected.
- **`HEALTH_FALSE_SAFE_FIX`** — nft set read error collapses to 0 → rendered as idle/clean.
- Minimal health/status visibility wiring only.

**Daemon re-baseline: YES** (Go change — `nftband` not byte-identical with v1.210.0; declared openly).
**nft schema:** unchanged **1.84.0**. **VERSION:** unchanged **1.210.0** (release-prep to v1.211.0 is a separate gate).

## What changed
- **LoginMon journal-watcher supervision** (`internal/loginmon/module.go`): `runJournalWatcher` is now a bounded-backoff supervisor mirroring `runFileWatcher` (reuses `watcherBackoffMin/Max`/`watcherHealthyReset`, ctx-aware, returns without respawn on clean cancel); old body → `runJournalWatcherOnce`. The daemon does **not** restart on a watcher death — only the watcher respawns.
- **Runtime input-source state**: `recordInputState("journal", …)` → `OK` (run survives healthy-reset) / `WATCHER_DEGRADED` (transient restart) / `WATCHER_DOWN` (≥3 consecutive short fails); no longer a stale boot snapshot.
- **Validator 3-valued set read** (`internal/validator/module_health.go`): new validator-local `countSetElementsState(family,set) (count, exists, unknown)` (mirrors `internal/metrics/evidence_sets.go` without importing it — avoids a package cycle). Read failure → **unknown**.
- **Unknown → WARN/DEGRADED, not idle/clean**: applied to the BotGuard verdict and the enforcement-critical `blacklist_manual` sub-health (was collapsing to false `idle`). Surfaced via a `SeverityWarn`/`CodeModuleDegraded` Finding (`Effective` unset / `State:"unknown"`). **Empty/disabled modules remain neutral** (the `zero = NEUTRAL` rule is preserved).

## Validation already completed
- Go build / vet / test / `-race` on lab2: **PASS** (independently re-verified).
- **Package-native lab2 DEB + lab4 RPM: PASS** — install COMMITTED 16/16; `nftban validate` rc0; `nftban health` no false-WARN on clean hosts (blacklist_manual reads enforcing/primed, not false-unknown); `nftban status` renders; NFTBan failed units 0; nft schema 1.84.0; VERSION 1.210.0; BotGuard disabled; installed daemon carries the fix (new symbols present).
- **Journal-watcher kill/respawn live simulation: PASS both labs** — daemon NRestarts 0 (no restart), watcher respawned (`WATCHER_DEGRADED → DOWN/respawn-in-1s → RESPAWNED`), exactly one journalctl child after, loginmon axis stayed running, detection recovered.
- Set-read unknown behavior: hermetic/`-race` proven (`health_unknown_v211_test.go`); not safely live-simulatable inside the root daemon.

## Process note
Package-native validation found that `git archive <branch>` ships only committed HEAD — the fix was uncommitted working-tree changes, so an archive build initially produced the **stale** daemon. **This PR commits the implementation before CI/release packaging** so the daemon CI builds carries the fix.

## Explicitly out of scope
Trust-Feeds label · BotScan lost-ban-signal · `SET_APPLY_SINGLE_WRITER` · pattern-delimiter · whitelist-drift · opqueue · SCDV/security-hardening · RBL/auditor/central-comms/Suricata · Aho-Corasick · MalwareGuard · docs/site/wiki · release-prep/VERSION bump.
