### PR TITLE
v1.212.0 botscan: prevent lost batch ban signals

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -1248,11 +1248,38 @@ nftban_botscan_write_signal() {
         conf_json=",\"confidence\":${BOTSCAN_SIGNAL_CONFIDENCE}"
     fi
 
-    # Atomic append (single write, no partial lines)
-    printf '{"ip":"%s","score":%d,"reasons":%s,"action":"%s","ts":%d,"family":"%s","request_class":"%s"%s}\n' \
+    # v1.212 (OPEN_BOTSCAN_LOST_BAN_SIGNAL) — build the JSONL line once, then append it under a
+    # SHARED flock so the Go consumer's atomic rename-then-consume hand-off can never destroy a
+    # signal written in the read->hand-off window. The daemon takes this SAME lock only around its
+    # O(1) rename of the signal file, so an append and the rename are mutually exclusive. The lock
+    # is a STABLE sibling lockfile that is never renamed. Degrade SAFELY when flock is unavailable:
+    # still append (O_APPEND keeps the single write line-atomic; the daemon rename stays the primary
+    # guard) — NEVER silently drop the signal; a write failure is surfaced (return 1).
+    local signal_line
+    printf -v signal_line '{"ip":"%s","score":%d,"reasons":%s,"action":"%s","ts":%d,"family":"%s","request_class":"%s"%s}\n' \
         "${ip//\"/\\\"}" "$score" "$reasons_json" "${action//\"/\\\"}" "$ts" \
-        "$family" "${request_class//\"/\\\"}" "$conf_json" \
-        >> "$signal_file"
+        "$family" "${request_class//\"/\\\"}" "$conf_json"
+
+    local lock_file="${signal_file}.lock"
+    if command -v flock >/dev/null 2>&1; then
+        # Serialize concurrent write_signal callers AND cooperate with the daemon rename. `-w 5`
+        # waits briefly rather than dropping the signal; on timeout / unopenable lockfile the
+        # subshell exits non-zero and we fall through to a safe unlocked append (never a drop).
+        if (
+            flock -w 5 9 || exit 9
+            printf '%s' "$signal_line" >> "$signal_file"
+        ) 9>"$lock_file" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    # flock binary absent, lockfile unopenable, or lock timed out → safe unlocked append. A real
+    # write failure (disk full / perms) is made visible instead of silently lost.
+    if ! printf '%s' "$signal_line" >> "$signal_file"; then
+        echo "[ERROR] botscan: failed to write batch signal for ${ip}" >&2
+        return 1
+    fi
+    return 0
 }
 
 # Ban IP

--- a/cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh
+++ b/cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.212.0 - BotScan write_signal flock-guarded append test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_signal_flock_v212_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-01"
+# meta:description="OPEN_BOTSCAN_LOST_BAN_SIGNAL (v1.212) producer guard: nftban_botscan_write_signal appends the batch signal under a SHARED flock on a stable sibling lockfile so it cooperates with the Go consumer's atomic rename-then-consume hand-off. (A) concurrent writers never corrupt/interleave/lose JSONL lines and the lockfile is created (lock is used). (B) when the flock binary is ABSENT the append still happens (safe degrade, O_APPEND line-atomic) and no lockfile is created. (C) a real write failure (missing dir) is VISIBLE (rc!=0 + stderr ERROR), never silently dropped. Deterministic; shellcheck-clean."
+#
+# meta:inventory.files="botscan_signal_flock_v212_test.sh"
+# meta:inventory.binaries="bash,flock,date,grep,wc"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_BATCH_SIGNAL_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+fail() { echo "FAIL: $*" >&2; exit 1; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+export NFTBAN_DATA_DIR="$tmp/data"
+mkdir -p "$NFTBAN_DATA_DIR/botguard"
+signal_file="$NFTBAN_DATA_DIR/botguard/batch_signals.jsonl"
+export BOTSCAN_BATCH_SIGNAL_FILE="$signal_file"
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"
+
+# --- (A) concurrent writers: no corruption / no interleave / no loss + lock used ---
+command -v flock >/dev/null 2>&1 || { echo "SKIP A: flock binary not present on this host"; }
+if command -v flock >/dev/null 2>&1; then
+    rm -f "$signal_file" "${signal_file}.lock"
+    N=40
+    for i in $(seq 1 "$N"); do
+        ( nftban_botscan_write_signal "10.0.0.$i" 80 ban "testsrc" "reason_$i" ) &
+    done
+    wait
+
+    total="$(wc -l < "$signal_file")"
+    [[ "$total" -eq "$N" ]] || fail "A: expected $N lines, got $total (loss/corruption under concurrency)"
+
+    # every line must be a complete, well-formed JSONL record (no partial/interleaved lines).
+    valid="$(grep -cE '^\{"ip":"10\.0\.0\.[0-9]+","score":80,"reasons":\[.*\],"action":"ban","ts":[0-9]+,"family":"ipv4","request_class":".*"\}$' "$signal_file" || true)"
+    [[ "$valid" -eq "$N" ]] || fail "A: only $valid/$N lines well-formed (corruption/interleave)"
+
+    # every writer's unique IP present exactly once (no lost writes).
+    for i in $(seq 1 "$N"); do
+        c="$(grep -cF "\"ip\":\"10.0.0.$i\"" "$signal_file" || true)"
+        [[ "$c" -eq 1 ]] || fail "A: ip 10.0.0.$i appears $c times (want 1)"
+    done
+
+    [[ -f "${signal_file}.lock" ]] || fail "A: sibling lockfile ${signal_file}.lock was not created (lock not used)"
+    echo "PASS A: $N concurrent writers → $N intact JSONL lines, no interleave/loss, lock used"
+fi
+
+# --- (B) flock binary ABSENT → safe degrade: append still happens, no lockfile created ---
+# Restrict PATH to a fake bin dir that has `date` (the only external tool write_signal needs
+# before the flock branch) but NOT flock → `command -v flock` fails → the unlocked-append path.
+fakebin="$tmp/fakebin"; mkdir -p "$fakebin"
+ln -s "$(command -v date)" "$fakebin/date"
+rm -f "$signal_file" "${signal_file}.lock"
+( export PATH="$fakebin"; nftban_botscan_write_signal "10.9.9.9" 80 ban "testsrc" "noflock" )
+[[ -s "$signal_file" ]] || fail "B: append must still happen when flock is absent (safe degrade)"
+grep -qF '"ip":"10.9.9.9"' "$signal_file" || fail "B: absent-flock append missing the signal"
+[[ ! -e "${signal_file}.lock" ]] || fail "B: no lockfile should be created on the absent-flock path"
+echo "PASS B: flock absent → append still made (safe degrade), no lockfile created"
+
+# --- (C) write failure is VISIBLE (rc!=0 + stderr ERROR), never a silent drop ---
+export BOTSCAN_BATCH_SIGNAL_FILE="$tmp/does_not_exist_dir/sig.jsonl"  # parent dir missing → append fails
+set +e
+err="$(nftban_botscan_write_signal "10.8.8.8" 80 ban "testsrc" "willfail" 2>&1 >/dev/null)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "C: a write failure must return non-zero (got rc=$rc)"
+[[ "$err" == *ERROR* ]] || fail "C: a write failure must be visible on stderr (got: '$err')"
+echo "PASS C: write failure surfaced (rc=$rc, stderr has ERROR), never silently dropped"
+
+echo "PASS: botscan write_signal flock-guarded append (concurrency-safe + lock used + safe degrade + visible failure)"

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -43,6 +43,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/botguard/decisioncache"
@@ -318,12 +319,16 @@ type BotGuardStatusExtra struct {
 	BatchSignalsMalformed     int64 `json:"batch_signals_malformed"`
 	BatchConsumerRuns         int64 `json:"batch_consumer_runs"`
 	BatchConsumerStaleBacklog bool  `json:"batch_consumer_stale_backlog"`
+	// v1.212 — lost-ban-signal handoff health (additive, omitempty → schema-safe; a nonzero
+	// value lets health WARN/DEGRADE the module instead of a false PROTECTED).
+	BatchHandoffErrors           int64 `json:"batch_handoff_errors,omitempty"`
+	BatchStaleConsumingRecovered int64 `json:"batch_stale_consuming_recovered,omitempty"`
 }
 
 // ToExtraInfo serializes the typed struct into the module.ExtraInfo
 // map[string]any contract expected by module.Status.Extra.
 func (e BotGuardStatusExtra) ToExtraInfo() module.ExtraInfo {
-	return module.ExtraInfo{
+	info := module.ExtraInfo{
 		"loop_interval":           e.LoopInterval,
 		"pressure_mode":           e.PressureMode,
 		"tracked_ips":             e.TrackedIPs,
@@ -346,6 +351,16 @@ func (e BotGuardStatusExtra) ToExtraInfo() module.ExtraInfo {
 		"batch_consumer_runs":          e.BatchConsumerRuns,
 		"batch_consumer_stale_backlog": e.BatchConsumerStaleBacklog,
 	}
+	// v1.212 — additive, omitempty: only surface the hand-off health counters when NONZERO, so a
+	// healthy consumer keeps the existing map shape and a broken hand-off becomes visible (>0 →
+	// health can WARN/DEGRADE instead of a false PROTECTED).
+	if e.BatchHandoffErrors != 0 {
+		info["batch_handoff_errors"] = e.BatchHandoffErrors
+	}
+	if e.BatchStaleConsumingRecovered != 0 {
+		info["batch_stale_consuming_recovered"] = e.BatchStaleConsumingRecovered
+	}
+	return info
 }
 
 // Status returns the current module status.
@@ -377,6 +392,9 @@ func (m *Module) Status() module.Status {
 		BatchSignalsMalformed:     m.stats.BatchSignalsMalformed,
 		BatchConsumerRuns:         m.stats.BatchConsumerRuns,
 		BatchConsumerStaleBacklog: m.stats.BatchConsumerStaleBacklog,
+
+		BatchHandoffErrors:           m.stats.BatchHandoffErrors,
+		BatchStaleConsumingRecovered: m.stats.BatchStaleConsumingRecovered,
 	}
 	m.status.Extra = extra.ToExtraInfo()
 
@@ -689,38 +707,148 @@ const (
 	botscanManualGreyTTLSec uint32 = 1 * 3600
 )
 
-// processBatchSignals reads a BOUNDED TAIL of batch_signals.jsonl (Clock-3 shell botscan), applies
-// only FRESH signals (within WarmupMaxAge), and truncates the file. STALE signals (older than the
-// cutoff) and any backlog beyond the tail window are QUARANTINED — discarded + counted, NEVER
-// applied — so a multi-day unconsumed backlog cannot flood-apply. Bounded by WarmupMaxBytes/Lines/
-// Accepted (never slurps the whole file → no OOM on a 24MB queue).
+// batchSignalConsumingSuffix is appended to the signal file to form the private, consumer-owned
+// hand-off file. Producers (nftban_botscan.sh) NEVER touch this path — only the daemon renames
+// the live signal file to it, processes it, and removes it.
+const batchSignalConsumingSuffix = ".consuming"
+
+// processBatchSignals drains BotScan batch signals (Clock-3 shell botscan) using a flock-guarded
+// ATOMIC RENAME-THEN-CONSUME hand-off (v1.212, OPEN_BOTSCAN_LOST_BAN_SIGNAL). The pre-v1.212 code
+// read the LIVE file and then truncated it to empty in place — destroying any signal the producer
+// appended in the open->truncate window (lost ban, with no counter).
 //
-// Routing: when BotGuard is ENABLED, applies via the existing BotGuard path (http_bot_ban, which is
-// drop-wired then). When BotGuard is DISABLED, routes BotScan bans to the durable, drop-enforced
-// blacklist_manual_{v4,v6} sets (http_bot_ban is NOT drop-wired when BotGuard is off). Single
-// owner: the BotGuard tick when enabled, the standalone consumer when disabled — never both.
+// New model:
+//  1. STALE .consuming recovery: if a prior crash left a `.consuming` (rename done, processing not),
+//     process + remove it FIRST so it is never orphaned; count BatchStaleConsumingRecovered. If it
+//     cannot be cleared (persists across cycles) that is a hand-off error → count + return.
+//  2. ATOMIC HAND-OFF: take a shared flock on a STABLE sibling lockfile (the producer takes the
+//     SAME lock around its append) ONLY around the O(1) os.Rename(signalFile → .consuming), then
+//     release. Append-vs-rename are now mutually exclusive: a producer append lands either in the
+//     renamed file (processed this cycle) or in a fresh signalFile (processed next cycle) — never
+//     destroyed in a gap. No truncate of a live file.
+//  3. CONSUME OUTSIDE THE LOCK: apply the `.consuming` file with the UNCHANGED bounded-tail /
+//     WarmupMaxAge / WarmupMaxLines / WarmupMaxBytes / WarmupMaxAccepted quarantine, then remove it
+//     only after a successful drain. Lock/rename/remove failures increment BatchHandoffErrors so
+//     health can WARN/DEGRADE (never a false PROTECTED when the hand-off is broken).
+//
+// Routing is unchanged: BotGuard ENABLED → http_bot_ban (drop-wired then); BotGuard DISABLED →
+// durable, drop-enforced blacklist_manual_{v4,v6}. Single owner (tick or standalone, never both).
 func (m *Module) processBatchSignals() {
 	signalFile := m.config.BatchSignalFile
 	if signalFile == "" {
 		return
 	}
-	f, err := os.Open(filepath.Clean(signalFile)) // #nosec G304 -- path from nftbanconf (trusted)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("[botguard] batch signal read error: %v", err)
+	consumingFile := signalFile + batchSignalConsumingSuffix
+
+	// BatchConsumerRuns counts once per cycle regardless of which drains run below.
+	m.mu.Lock()
+	m.stats.BatchConsumerRuns++
+	m.mu.Unlock()
+
+	// Step 1 — STALE .consuming recovery (prior-crash residue). Process it FIRST so a crashed
+	// hand-off is never orphaned or lost. The .consuming path is private to the consumer (the
+	// producer only ever appends to signalFile), so processing it outside the lock is safe.
+	if _, err := os.Stat(consumingFile); err == nil {
+		m.mu.Lock()
+		m.stats.BatchStaleConsumingRecovered++
+		m.mu.Unlock()
+		if perr := m.consumeSignalFile(consumingFile); perr != nil {
+			// Could not clear the stale .consuming (it persists across cycles) → hand-off error.
+			// Do NOT rename over it (that would risk clobbering an un-consumed hand-off); surface
+			// the broken hand-off via the counter and retry next cycle.
+			m.mu.Lock()
+			m.stats.BatchHandoffErrors++
+			m.mu.Unlock()
+			log.Printf("[botguard] batch stale .consuming recovery failed (persists): %v", perr)
+			return
 		}
-		return // missing → normal
+	}
+
+	// Step 2 — atomic hand-off: flock ONLY around the O(1) rename.
+	renamed, err := m.renameSignalForConsume(signalFile, consumingFile)
+	if err != nil {
+		m.mu.Lock()
+		m.stats.BatchHandoffErrors++
+		m.mu.Unlock()
+		log.Printf("[botguard] batch signal hand-off (lock/rename) error: %v", err)
+		return
+	}
+	if !renamed {
+		return // missing/empty source → nothing to consume this cycle (normal)
+	}
+
+	// Step 3 — process the renamed file OUTSIDE the lock (slow read/apply); remove on success.
+	if perr := m.consumeSignalFile(consumingFile); perr != nil {
+		m.mu.Lock()
+		m.stats.BatchHandoffErrors++
+		m.mu.Unlock()
+		log.Printf("[botguard] batch signal consume/cleanup error: %v", perr)
+	}
+}
+
+// renameSignalForConsume takes a shared flock on a STABLE sibling lockfile (`signalFile+".lock"`,
+// which is NEVER renamed) and, while holding it, atomically renames a NON-EMPTY signalFile to
+// consumingFile, then releases the lock. The producer (nftban_botscan.sh) takes the SAME lock
+// around its append, so an append and this rename are mutually exclusive → zero signal loss.
+// Flocking signalFile's own fd would be unsafe: the rename replaces the inode, so a producer that
+// opened the new inode would not be excluded (mirrors internal/persistence/blacklistd.go). Returns
+// (true,nil) if a file was renamed for consumption, (false,nil) if there was nothing to consume,
+// and (false,err) on a lock/stat/rename failure (a broken hand-off).
+func (m *Module) renameSignalForConsume(signalFile, consumingFile string) (bool, error) {
+	lockPath := signalFile + ".lock"
+	lockF, err := os.OpenFile(filepath.Clean(lockPath), os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return false, fmt.Errorf("open lock %s: %w", lockPath, err)
+	}
+	defer func() { _ = lockF.Close() }()
+	if err := syscall.Flock(int(lockF.Fd()), syscall.LOCK_EX); err != nil { // #nosec G115 -- fd fits in int
+		return false, fmt.Errorf("flock %s: %w", lockPath, err)
+	}
+	defer func() { _ = syscall.Flock(int(lockF.Fd()), syscall.LOCK_UN) }() // #nosec G115 -- fd fits in int
+
+	fi, err := os.Stat(signalFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // nothing produced this cycle
+		}
+		return false, fmt.Errorf("stat %s: %w", signalFile, err)
+	}
+	if fi.Size() == 0 {
+		return false, nil // empty → nothing to consume
+	}
+	if err := os.Rename(signalFile, consumingFile); err != nil {
+		return false, fmt.Errorf("rename %s -> %s: %w", signalFile, consumingFile, err)
+	}
+	return true, nil
+}
+
+// consumeSignalFile applies a captured `.consuming` hand-off file using the UNCHANGED bounded-tail
+// + age-cutoff quarantine (WarmupMaxBytes/MaxAge/MaxLines/MaxAccepted), then removes it. It reads a
+// BOUNDED TAIL (never slurps the whole file → no OOM on a multi-MiB backlog); STALE signals (older
+// than WarmupMaxAge) and any backlog beyond the tail window are QUARANTINED (counted, never
+// applied). It runs OUTSIDE the flock — producers append to a fresh signalFile meanwhile. A non-nil
+// return means the file could not be cleared after a successful drain (a broken hand-off).
+func (m *Module) consumeSignalFile(path string) error {
+	f, err := os.Open(filepath.Clean(path)) // #nosec G304 -- consumer-private .consuming of a trusted nftbanconf path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // already gone → nothing to do
+		}
+		return fmt.Errorf("open %s: %w", path, err)
 	}
 	fi, err := f.Stat()
-	if err != nil || fi.Size() == 0 {
+	if err != nil {
 		_ = f.Close()
-		return
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if fi.Size() == 0 {
+		_ = f.Close()
+		return os.Remove(path) // empty hand-off → just clear it
 	}
 	size := fi.Size()
 
 	// Bounded TAIL: newest signals are appended at the end. Seek to the last maxBytes so we never
-	// read a multi-MiB backlog into memory; the un-read head is discarded by the truncate below
-	// (it is the stale backlog — intended quarantine).
+	// read a multi-MiB backlog into memory; the un-read head is the stale backlog (quarantined).
 	maxBytes := m.config.WarmupMaxBytes
 	var startOff int64
 	staleBeyondWindow := false
@@ -730,13 +858,13 @@ func (m *Module) processBatchSignals() {
 	}
 	if _, err := f.Seek(startOff, io.SeekStart); err != nil {
 		_ = f.Close()
-		return
+		return fmt.Errorf("seek %s: %w", path, err)
 	}
 	reader := bufio.NewReader(f)
 	if startOff > 0 {
 		if _, err := reader.ReadString('\n'); err != nil { // drop the partial first line
 			_ = f.Close()
-			return
+			return fmt.Errorf("read %s: %w", path, err)
 		}
 	}
 
@@ -777,11 +905,6 @@ func (m *Module) processBatchSignals() {
 	_ = scanner.Err()
 	_ = f.Close()
 
-	// Truncate AFTER reading (atomic empty write). Drops the un-read stale head — the quarantine.
-	if err := os.WriteFile(signalFile, nil, 0600); err != nil { // #nosec G306 -- truncate to empty
-		log.Printf("[botguard] batch signal truncate error: %v", err)
-	}
-
 	toManual := !m.config.Enabled
 	applied := 0
 	for i := range fresh {
@@ -800,7 +923,6 @@ func (m *Module) processBatchSignals() {
 	m.stats.BatchSignalsApplied += int64(applied)
 	m.stats.BatchSignalsExpired += int64(expired)
 	m.stats.BatchSignalsMalformed += int64(malformed)
-	m.stats.BatchConsumerRuns++
 	m.stats.BatchConsumerStaleBacklog = staleBeyondWindow || expired > 0
 	m.mu.Unlock()
 
@@ -808,6 +930,12 @@ func (m *Module) processBatchSignals() {
 		m.logger.LogEvent("INFO", fmt.Sprintf("batch consumer: applied=%d expired=%d malformed=%d scanned=%d stale_backlog=%v to_manual=%v",
 			applied, expired, malformed, scanned, staleBeyondWindow, toManual))
 	}
+
+	// Remove only AFTER a successful drain. Failure = the hand-off file persists (broken hand-off).
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	return nil
 }
 
 // applyBotscanBanSignal enforces a FRESH BotScan batch signal to the DURABLE, drop-enforced

--- a/internal/botguard/guard_lost_signal_v212_test.go
+++ b/internal/botguard/guard_lost_signal_v212_test.go
@@ -1,0 +1,288 @@
+// =============================================================================
+// NFTBan v1.212.0 - BotScan lost-ban-signal hand-off (flock-guarded rename-then-consume) tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: botguard
+// Purpose: Prove the v1.212 fix for OPEN_BOTSCAN_LOST_BAN_SIGNAL — the consumer no longer
+//          truncates a LIVE file (which destroyed any signal appended in the read->truncate
+//          window). Instead it flock-guards an ATOMIC rename of the live signal file to a private
+//          `.consuming` hand-off, processes that OUTSIDE the lock, and removes it on success. An
+//          append is therefore either in the renamed file (processed now) or in a fresh file
+//          (processed next cycle) — never lost. A crashed hand-off (stale `.consuming`) is
+//          recovered + counted; lock/rename/remove failures increment BatchHandoffErrors so health
+//          can WARN/DEGRADE instead of a false PROTECTED. Bounded-tail/age quarantine, malformed
+//          handling and idempotent apply are unchanged.
+//
+// meta:name="botguard_guard_lost_signal_v212_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:package="botguard"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-07-01"
+// meta:description="Tests for the v1.212 flock-guarded rename-then-consume BotScan signal hand-off (zero-loss + stale-recovery + hand-off counters)"
+// meta:inventory.files="guard_lost_signal_v212_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package botguard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// freshBanLine builds one BotScan ban JSONL line with a current timestamp (passes the age cutoff).
+func freshBanLine(ip string) string {
+	return fmt.Sprintf(`{"ip":%q,"score":80,"action":"ban","request_class":"scanner","family":"ipv4","ts":%d,"reasons":["scanner"]}`+"\n",
+		ip, time.Now().Unix())
+}
+
+// appendLine appends a raw line to a file (models the shell producer's O_APPEND write).
+func appendLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("append open %s: %v", path, err)
+	}
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("append write %s: %v", path, err)
+	}
+	_ = f.Close()
+}
+
+// newDisabledConsumer wires an enforcing module in the BotGuard-DISABLED consumer mode and points
+// BatchSignalFile at a fresh temp path.
+func newDisabledConsumer(t *testing.T) (*Module, *recBackend, string) {
+	t.Helper()
+	m, b := newEnforcingModule(t)
+	m.config.Enabled = false
+	qf := filepath.Join(t.TempDir(), "batch_signals.jsonl")
+	m.config.BatchSignalFile = qf
+	return m, b, qf
+}
+
+// TestV212_APPEND_BEFORE_RENAME_PROCESSED — a signal appended before the hand-off is captured in the
+// renamed file and applied (the ordinary path).
+func TestV212_APPEND_BEFORE_RENAME_PROCESSED(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	const ip = "45.140.17.10"
+	appendLine(t, qf, freshBanLine(ip))
+
+	m.processBatchSignals()
+
+	if !waitBanned(b, "blacklist_manual_ipv4", ip) {
+		t.Fatalf("signal appended before rename must be applied; sets=%v", b.adds)
+	}
+	// live file renamed+consumed → neither the live nor the .consuming file should remain.
+	if _, err := os.Stat(qf); !os.IsNotExist(err) {
+		t.Fatalf("live signal file must not remain after consume (err=%v)", err)
+	}
+	if _, err := os.Stat(qf + ".consuming"); !os.IsNotExist(err) {
+		t.Fatalf(".consuming must be removed after a successful drain (err=%v)", err)
+	}
+}
+
+// TestV212_FORCED_INTERLEAVE_ZERO_LOSS — the core proof: a producer that appends BETWEEN the
+// consumer's rename and its processing writes into a FRESH file and is applied next cycle; the
+// signal captured by the rename is applied now. Nothing is lost. (Pre-v1.212 the truncate of the
+// live file destroyed the interleaved append.)
+func TestV212_FORCED_INTERLEAVE_ZERO_LOSS(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	const ipEarly = "45.140.17.21" // appended before the rename → captured in .consuming
+	const ipRace = "45.140.17.22"  // appended AFTER the rename, before processing → fresh file
+
+	appendLine(t, qf, freshBanLine(ipEarly))
+
+	// Step A — take the hand-off exactly as the consumer does (flock + atomic rename).
+	consuming := qf + ".consuming"
+	renamed, err := m.renameSignalForConsume(qf, consuming)
+	if err != nil || !renamed {
+		t.Fatalf("rename hand-off should succeed: renamed=%v err=%v", renamed, err)
+	}
+
+	// Step B — INTERLEAVE: a producer appends AFTER the rename. It lands in a brand-new live file,
+	// NOT in the renamed .consuming the consumer is about to read.
+	appendLine(t, qf, freshBanLine(ipRace))
+
+	// Step C — consume the captured file (outside the lock). Only ipEarly is here.
+	if perr := m.consumeSignalFile(consuming); perr != nil {
+		t.Fatalf("consume captured file: %v", perr)
+	}
+	if !waitBanned(b, "blacklist_manual_ipv4", ipEarly) {
+		t.Fatalf("early signal must be applied from the captured file; sets=%v", b.adds)
+	}
+
+	// Step D — the interleaved signal survives in the fresh file and is applied next cycle.
+	m.processBatchSignals()
+	if !waitBanned(b, "blacklist_manual_ipv4", ipRace) {
+		t.Fatalf("ZERO-LOSS VIOLATED: signal appended after the rename was lost; sets=%v", b.adds)
+	}
+}
+
+// TestV212_STALE_CONSUMING_RECOVERED — a `.consuming` left by a prior crash (rename done, processing
+// not) is processed FIRST and counted, never orphaned.
+func TestV212_STALE_CONSUMING_RECOVERED(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	const ip = "45.140.17.33"
+	// Simulate crash residue: a populated .consuming with NO live signal file.
+	consuming := qf + ".consuming"
+	if err := os.WriteFile(consuming, []byte(freshBanLine(ip)), 0o600); err != nil {
+		t.Fatalf("seed stale .consuming: %v", err)
+	}
+
+	m.processBatchSignals()
+
+	if !waitBanned(b, "blacklist_manual_ipv4", ip) {
+		t.Fatalf("stale .consuming signal must be recovered+applied; sets=%v", b.adds)
+	}
+	if m.stats.BatchStaleConsumingRecovered != 1 {
+		t.Fatalf("BatchStaleConsumingRecovered = %d, want 1", m.stats.BatchStaleConsumingRecovered)
+	}
+	if _, err := os.Stat(consuming); !os.IsNotExist(err) {
+		t.Fatalf("stale .consuming must be removed after recovery (err=%v)", err)
+	}
+	if m.stats.BatchHandoffErrors != 0 {
+		t.Fatalf("clean recovery must not count a hand-off error, got %d", m.stats.BatchHandoffErrors)
+	}
+}
+
+// TestV212_HANDOFF_ERROR_COUNTED_AND_DEGRADABLE — a lock/rename failure increments BatchHandoffErrors
+// (so health can WARN/DEGRADE) and does NOT consume/destroy the live file. Forced by making the
+// sibling lockfile path un-openable (a directory sits where the lockfile must be created).
+func TestV212_HANDOFF_ERROR_COUNTED_AND_DEGRADABLE(t *testing.T) {
+	m, _, qf := newDisabledConsumer(t)
+	const ip = "45.140.17.44"
+	appendLine(t, qf, freshBanLine(ip))
+
+	// Make signalFile+".lock" un-openable: create a DIRECTORY at that exact path.
+	if err := os.Mkdir(qf+".lock", 0o755); err != nil {
+		t.Fatalf("seed lock-path directory: %v", err)
+	}
+
+	m.processBatchSignals()
+
+	if m.stats.BatchHandoffErrors != 1 {
+		t.Fatalf("BatchHandoffErrors = %d, want 1 (lock/rename failure must be visible to health)",
+			m.stats.BatchHandoffErrors)
+	}
+	// The live signal must NOT be destroyed by a broken hand-off — it stays for a later cycle.
+	if _, err := os.Stat(qf); err != nil {
+		t.Fatalf("live signal file must survive a broken hand-off, got err=%v", err)
+	}
+	// Health-degradability contract: a nonzero counter is surfaced in the typed status Extra.
+	ex := BotGuardStatusExtra{BatchHandoffErrors: m.stats.BatchHandoffErrors}.ToExtraInfo()
+	if v, ok := ex["batch_handoff_errors"].(int64); !ok || v != 1 {
+		t.Fatalf("batch_handoff_errors not surfaced in status Extra: %v", ex["batch_handoff_errors"])
+	}
+}
+
+// TestV212_MALFORMED_AND_EXPIRED_UNCHANGED — malformed lines are counted+skipped and stale (past the
+// age cutoff) signals are quarantined (counted, never applied), exactly as before.
+func TestV212_MALFORMED_AND_EXPIRED_UNCHANGED(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	const freshIP = "45.141.84.11"
+	const staleIP = "45.141.84.21"
+	staleTS := time.Now().Add(-10 * 24 * time.Hour).Unix() // 10 days old → well past the 45m cutoff
+
+	lines := freshBanLine(freshIP) +
+		fmt.Sprintf(`{"ip":%q,"score":80,"action":"ban","request_class":"scanner","family":"ipv4","ts":%d,"reasons":["scanner"]}`+"\n", staleIP, staleTS) +
+		"this is a malformed line\n"
+	if err := os.WriteFile(qf, []byte(lines), 0o600); err != nil {
+		t.Fatalf("write queue: %v", err)
+	}
+
+	m.processBatchSignals()
+
+	if !waitBanned(b, "blacklist_manual_ipv4", freshIP) {
+		t.Fatalf("fresh signal must be applied; sets=%v", b.adds)
+	}
+	if b.has("blacklist_manual_ipv4", staleIP) {
+		t.Fatalf("stale signal must be quarantined, never applied; sets=%v", b.adds)
+	}
+	if m.stats.BatchSignalsExpired < 1 {
+		t.Fatalf("expected >=1 expired, got %d", m.stats.BatchSignalsExpired)
+	}
+	if m.stats.BatchSignalsMalformed < 1 {
+		t.Fatalf("expected >=1 malformed, got %d", m.stats.BatchSignalsMalformed)
+	}
+}
+
+// TestV212_DUPLICATE_IDEMPOTENT — the same IP delivered across two cycles stays banned (idempotent
+// apply, same blacklist_manual element; no error/panic).
+func TestV212_DUPLICATE_IDEMPOTENT(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	const ip = "45.141.84.55"
+
+	appendLine(t, qf, freshBanLine(ip))
+	m.processBatchSignals()
+	if !waitBanned(b, "blacklist_manual_ipv4", ip) {
+		t.Fatalf("first cycle must ban %s; sets=%v", ip, b.adds)
+	}
+
+	appendLine(t, qf, freshBanLine(ip)) // same IP again next cycle
+	m.processBatchSignals()
+	if !b.has("blacklist_manual_ipv4", ip) {
+		t.Fatalf("duplicate apply must keep %s banned; sets=%v", ip, b.adds)
+	}
+}
+
+// TestV212_BOUNDED_TAIL_PRESERVED — a signal file larger than WarmupMaxBytes reads only the bounded
+// TAIL; the stale head beyond the window is quarantined (flagged), and the file does not grow
+// unbounded (it is consumed away each cycle).
+func TestV212_BOUNDED_TAIL_PRESERVED(t *testing.T) {
+	m, b, qf := newDisabledConsumer(t)
+	m.config.WarmupMaxBytes = 512 // tiny window forces a bounded tail read
+
+	var sb strings.Builder
+	// Head: many fresh-but-old-position lines that overflow the window (must be quarantined as head).
+	for i := 0; i < 200; i++ {
+		sb.WriteString(freshBanLine(fmt.Sprintf("203.0.113.%d", i%254+1)))
+	}
+	const tailIP = "45.141.84.99"
+	sb.WriteString(freshBanLine(tailIP)) // newest line at the very end → inside the tail window
+	if err := os.WriteFile(qf, []byte(sb.String()), 0o600); err != nil {
+		t.Fatalf("write big queue: %v", err)
+	}
+	sizeBefore, _ := os.Stat(qf)
+
+	m.processBatchSignals()
+
+	if !waitBanned(b, "blacklist_manual_ipv4", tailIP) {
+		t.Fatalf("newest (tail) signal must be applied; sets=%v", b.adds)
+	}
+	if !m.stats.BatchConsumerStaleBacklog {
+		t.Fatalf("head beyond the tail window must flag BatchConsumerStaleBacklog")
+	}
+	// No unbounded growth: the live file is renamed+removed, never left to accumulate.
+	if _, err := os.Stat(qf); !os.IsNotExist(err) {
+		t.Fatalf("consumed live file must not remain (no unbounded growth); sizeBefore=%v", sizeBefore)
+	}
+}
+
+// TestV212_NO_LIVE_FILE_TRUNCATE_IN_SOURCE — regression guard: the consumer path must NOT reintroduce
+// the truncate-of-a-live-file (os.WriteFile(signalFile, nil, ...)) and MUST hand off via os.Rename.
+func TestV212_NO_LIVE_FILE_TRUNCATE_IN_SOURCE(t *testing.T) {
+	src, err := os.ReadFile("guard.go")
+	if err != nil {
+		t.Fatalf("read guard.go: %v", err)
+	}
+	s := string(src)
+	if strings.Contains(s, "os.WriteFile(signalFile, nil") {
+		t.Fatal("REGRESSION: os.WriteFile(signalFile, nil ...) truncate-of-live-file reintroduced in the batch consumer path")
+	}
+	if !strings.Contains(s, "os.Rename(signalFile, consumingFile)") {
+		t.Fatal("consumer must hand off via os.Rename(signalFile, consumingFile)")
+	}
+	if !strings.Contains(s, "syscall.Flock(") {
+		t.Fatal("consumer hand-off must be flock-guarded (syscall.Flock)")
+	}
+}

--- a/internal/botguard/types.go
+++ b/internal/botguard/types.go
@@ -195,6 +195,10 @@ type GuardStats struct {
 	BatchSignalsMalformed     int64 // malformed batch signals skipped
 	BatchConsumerRuns         int64 // batch-signal drain invocations
 	BatchConsumerStaleBacklog bool  // last drain saw a stale backlog (quarantined)
+	// v1.212 — lost-ban-signal handoff observability (flock-guarded rename-then-consume). These
+	// let health WARN/DEGRADE on a broken signal handoff instead of reading a false PROTECTED.
+	BatchHandoffErrors           int64 // lock/rename/remove handoff failures (health-degradable)
+	BatchStaleConsumingRecovered int64 // leftover .consuming files processed after a prior crash
 }
 
 // BatchSignal represents a signal from the shell botscan (Clock 3).


### PR DESCRIPTION
## v1.212.0 — BotScan lost-ban-signal fix (flock-guarded rename-then-consume)

Closes the **BotScan lost-ban-signal P0** (OPEN Part 1). **Daemon RE-BASELINE: yes** (Go, `internal/botguard`). **nft schema unchanged: 1.84.0.** **VERSION unchanged: 1.211.1** in this implementation PR (release-prep → 1.212.0 is a separate gate). **BotGuard remains disabled by default.**

### The old race
- Producer `nftban_botscan_write_signal()` did a **bare `printf … >> batch_signals.jsonl`** (no lock).
- Daemon consumer `processBatchSignals()` did `os.Open` → read → **`os.WriteFile(signalFile, nil)` truncate of the LIVE file**.
- A ban signal appended in the **open→truncate window was destroyed** — silently lost, with no counter (real enforcement loss; live on the whole fleet via the BotGuard-disabled standalone consumer).

### Producer fix
- Appends under a shared **`flock -w 5` on `${signal_file}.lock`** (stable sibling lockfile).
- Safe degrade if `flock` is absent (still line-atomic `O_APPEND`; the daemon rename is the primary guard) — **never a silent drop**; a real write failure is **visible / returns nonzero**.

### Consumer fix
- **No truncate of the live `batch_signals.jsonl`.**
- Under the SAME flock (held only around the O(1) op): **atomic `os.Rename` → `.consuming`**, then release the lock.
- **Process `.consuming` OUTSIDE the lock** (bounded-tail / max-age / max-lines quarantine + malformed + expired + idempotent apply unchanged), remove on success.
- **Stale `.consuming` recovery**: a prior-crash `.consuming` is processed first each cycle + counted.
- Zero loss: an append is either before the rename (in `.consuming` → processed) or after (in a fresh file → next cycle). The flock forbids append-during-rename.

### Health visibility
- New counters **`BatchHandoffErrors`** + **`BatchStaleConsumingRecovered`** (omitempty in status Extra).
- **WARN/DEGRADE** path when the handoff breaks (lock/rename/remove failure, or a persistent stale `.consuming`) — never a false PROTECTED.

### Validation
- **Go hermetic 8/8 PASS** (forced-interleave zero-loss, append-before/after-rename, stale-consuming recovery, handoff-error-counted, malformed/expired unchanged, duplicate idempotent, bounded-tail preserved).
- **`go test -race` PASS** (no data race).
- **Shell hermetic PASS** (40 concurrent writers no corruption + lock used; flock-absent safe degrade; write failure visible).
- **shellcheck PASS.**
- **`NO_LIVE_FILE_TRUNCATE` regression guard** (asserts no `os.WriteFile(signalFile, nil` remains; handoff via `os.Rename` under `syscall.Flock`).
- **Package-native lab2 DEB PASS** + **lab4 RPM PASS** (rebuilt daemon carries the fix; version 1.211.1; schema 1.84.0; validate rc0; failed units 0; BotGuard disabled).
- **Functional signal injection PASS** (fresh signal → `blacklist_manual_ipv4`, source=botscan, both distros).
- **Concurrent-append proof PASS** (two signals straddling cycles → **both applied, neither lost**, no orphan `.consuming`, 0 handoff errors — both distros).

### Explicit non-scope
`SET_APPLY_SINGLE_WRITER`, pattern-delimiter, BotGuard production re-enable, Aho-Corasick, MalwareGuard, whitelist-drift, opqueue, SCDV, RBL/Suricata, portal/pro.nftban.com, Dependabot publish-path bumps.
