### PR TITLE
v1.213.0 set-apply: route sync-owned writers through full sync

### DIFF
--- a/cli/lib/nftban/core/nftban_feeds.sh
+++ b/cli/lib/nftban/core/nftban_feeds.sh
@@ -1064,8 +1064,13 @@ EOF
         echo "}" >> "$nft_file"
     fi
 
-    # Atomic reload using IPC
-    if nft_ipc_apply_ruleset "$nft_file" 2>&1 | tee -a "$NFTBAN_FEEDS_LOG"; then
+    # v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): the durable per-feed source
+    # (/var/lib/nftban/feeds/*.txt) is already written upstream; trigger a FULL
+    # daemon sync (which reconciles blacklist_ipv4/_ipv6 from those same durable
+    # files) instead of pushing an additive add-element. On IPC failure fall back
+    # to the legacy additive apply of "$nft_file" (mixed-version rollout safety),
+    # emitting a visible WARN. Ordering is write-durable-source-THEN-sync.
+    if nft_ipc_sync_or_apply "feeds" "$nft_file" 2>&1 | tee -a "$NFTBAN_FEEDS_LOG"; then
         nftban_feeds_log INFO "Sync complete: $ipv4_count IPv4, $ipv6_count IPv6 (CIDRs merged)"
     else
         nftban_feeds_log ERROR "Atomic reload failed"

--- a/cli/lib/nftban/core/nftban_geoban.sh
+++ b/cli/lib/nftban/core/nftban_geoban.sh
@@ -319,7 +319,12 @@ nftban_geoban_apply_to_nftables() {
 
     # =========================================================================
     # 3. Add IPv4 CIDRs to blacklist_ipv4
-    # NOTE: We ADD elements. Set can be flushed on full refresh.
+    # v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): the durable source
+    # (/etc/nftban/geoban.d/50-ban-*.conf) is already written upstream by the
+    # geoip ban/unban command; trigger a FULL daemon sync (reconciles
+    # blacklist_ipv4/_ipv6 from those same conf files — both additions and
+    # country removals) instead of an additive add-element. The fragment is kept
+    # as the legacy IPC-failure fallback (mixed-version rollout safety).
     # =========================================================================
 
     if [[ $cidr_count_v4 -gt 0 ]]; then
@@ -337,7 +342,7 @@ nftban_geoban_apply_to_nftables() {
         element_fragment=$(mktemp "${NFTBAN_RUN_DIR:-/run/nftban}/nftban_geoban_frag_XXXXXX.nft")
         echo "add element $table_v4 $set_v4 { $cidr_list_v4 }" > "$element_fragment"
 
-        if nft_ipc_apply_ruleset "$element_fragment" 2>/dev/null; then
+        if nft_ipc_sync_or_apply "geoban" "$element_fragment" 2>/dev/null; then
             rm -f "$element_fragment" 2>/dev/null
             nftban_success "Added $cidr_count_v4 IPv4 CIDRs to $set_v4"
         else
@@ -366,7 +371,8 @@ nftban_geoban_apply_to_nftables() {
         element_fragment=$(mktemp "${NFTBAN_RUN_DIR:-/run/nftban}/nftban_geoban_frag_XXXXXX.nft")
         echo "add element $table_v6 $set_v6 { $cidr_list_v6 }" > "$element_fragment"
 
-        if nft_ipc_apply_ruleset "$element_fragment" 2>/dev/null; then
+        # v1.213.0: FULL sync (durable geoban.d source) with legacy additive fallback
+        if nft_ipc_sync_or_apply "geoban" "$element_fragment" 2>/dev/null; then
             rm -f "$element_fragment" 2>/dev/null
             nftban_success "Added $cidr_count_v6 IPv6 CIDRs to $set_v6"
         else
@@ -445,7 +451,11 @@ nftban_geoban_remove_from_nftables() {
         delete_fragment=$(mktemp "${NFTBAN_RUN_DIR:-/run/nftban}/nftban_geoban_del_v4_XXXXXX.nft")
         echo "delete element $table_v4 $set_v4 { $cidr_list_v4 }" > "$delete_fragment"
 
-        if nft_ipc_apply_ruleset "$delete_fragment" 2>/dev/null; then
+        # v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): a FULL daemon sync
+        # reconciles blacklist_ipv4/_ipv6 from the current geoban.d source (a
+        # removed country's 50-ban conf is gone → its CIDRs drop out) instead of
+        # an additive delete-element. Legacy delete kept as IPC-failure fallback.
+        if nft_ipc_sync_or_apply "geoban" "$delete_fragment" 2>/dev/null; then
             rm -f "$delete_fragment" 2>/dev/null
             nftban_success "Removed ${#cidrs_v4[@]} IPv4 CIDRs from $set_v4"
         else
@@ -468,7 +478,8 @@ nftban_geoban_remove_from_nftables() {
         delete_fragment=$(mktemp "${NFTBAN_RUN_DIR:-/run/nftban}/nftban_geoban_del_v6_XXXXXX.nft")
         echo "delete element $table_v6 $set_v6 { $cidr_list_v6 }" > "$delete_fragment"
 
-        if nft_ipc_apply_ruleset "$delete_fragment" 2>/dev/null; then
+        # v1.213.0: FULL sync (durable geoban.d source) with legacy delete fallback
+        if nft_ipc_sync_or_apply "geoban" "$delete_fragment" 2>/dev/null; then
             rm -f "$delete_fragment" 2>/dev/null
             nftban_success "Removed ${#cidrs_v6[@]} IPv6 CIDRs from $set_v6"
         else

--- a/cli/lib/nftban/core/nftban_trust.sh
+++ b/cli/lib/nftban/core/nftban_trust.sh
@@ -509,9 +509,15 @@ _trust_apply_to_nft() {
         fi
     fi
 
-    # Apply via IPC if we have elements
+    # v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): the durable source
+    # (/etc/nftban/whitelist.d/30-trust-<provider>.conf) is already written
+    # upstream by _trust_write_whitelist; trigger a FULL daemon sync (which
+    # flush-replaces whitelist_ipv4/_ipv6 from whitelist.d via state.LoadWhitelists)
+    # instead of an additive add-element. The fragment is kept as the legacy
+    # IPC-failure fallback (mixed-version rollout safety). Ordering is
+    # write-durable-source-THEN-sync.
     if [[ -s "$nft_fragment" ]]; then
-        if nft_ipc_apply_ruleset "$nft_fragment" 2>/dev/null; then
+        if nft_ipc_sync_or_apply "trust" "$nft_fragment" 2>/dev/null; then
             _trust_log "INFO" "Applied ${ipv4_count} IPv4 + ${ipv6_count} IPv6 CIDRs to whitelist sets"
             rm -f "$nft_fragment"
             return 0
@@ -570,7 +576,16 @@ _trust_remove_from_nft() {
     fi
 
     if [[ -s "$nft_fragment" ]]; then
-        nft_ipc_apply_ruleset "$nft_fragment" 2>/dev/null || true
+        # v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): removal is reconciled from
+        # the durable source. Remove this provider's whitelist.d conf FIRST
+        # (write-durable-source-THEN-sync ordering) so the FULL daemon sync
+        # flush-replaces whitelist_ipv4/_ipv6 WITHOUT the provider's CIDRs — a
+        # true single-writer removal, not an additive delete-element. The delete
+        # fragment (built from the still-present cache above) is kept as the
+        # legacy IPC-failure fallback (mixed-version rollout safety).
+        # _trust_clear_whitelist (called later in the disable flow) is idempotent.
+        rm -f "$(_trust_get_whitelist_file "$provider")" 2>/dev/null || true
+        nft_ipc_sync_or_apply "trust" "$nft_fragment" 2>/dev/null || true
         _trust_log "INFO" "Removed ${provider} CIDRs from whitelist sets"
     fi
 

--- a/cli/lib/nftban/lib/nft_ipc.sh
+++ b/cli/lib/nftban/lib/nft_ipc.sh
@@ -388,6 +388,7 @@ _nft_ipc_sync_marker() {
 # Trigger a FULL daemon reconcile sync (quick=false), debounced + retried.
 # Usage: nft_ipc_sync [force]   (force=1 bypasses the debounce window)
 # Returns: 0 on success (or coalesced), nonzero if all IPC attempts fail.
+# shellcheck disable=SC2120  # force is an optional arg; callers may omit it (debounce path)
 nft_ipc_sync() {
     local force="${1:-0}"
     local marker

--- a/cli/lib/nftban/lib/nft_ipc.sh
+++ b/cli/lib/nftban/lib/nft_ipc.sh
@@ -354,6 +354,101 @@ nft_ipc_apply_ruleset() {
     fi
 }
 
+# =============================================================================
+# v1.213.0: FULL-SYNC TRIGGER (SET_APPLY_SINGLE_WRITER — Design A)
+# =============================================================================
+# The daemon's full `sync` (handleSyncRequest, quick=false) flush-replaces the
+# interval blacklist_/whitelist_ sets from the SAME durable sources the shell
+# writes (feeds /var/lib/nftban/feeds/*.txt, geoban /etc/nftban/geoban.d/*.conf,
+# trust /etc/nftban/whitelist.d/*.conf). Feeds/geoban/trust therefore write
+# their durable source and then trigger a FULL sync here, instead of pushing an
+# additive add/delete element via apply_ruleset. That makes the daemon full sync
+# the effective SOLE WRITER of those sets (no second additive writer to clobber).
+#
+# CONTRACT (all callers identical):
+#   - FULL sync only (quick=false). A quick sync SKIPS feeds/geoban/whitelist
+#     reconcile and would NOT apply the durable-source change — NEVER send quick.
+#   - Debounced: rapid successive calls inside NFTBAN_SYNC_DEBOUNCE_SECONDS
+#     coalesce into ONE sync (storm avoidance). The existing periodic reconcile
+#     timer is the trailing backstop for any coalesced (pending-marked) request.
+#   - Retries with backoff; returns nonzero if every attempt fails so the caller
+#     can fall back to the legacy additive apply (mixed-version rollout safety).
+#   - Ordering is the caller's responsibility: write the durable source FIRST,
+#     then trigger the sync (never sync-then-write).
+
+# Coalescing / retry knobs (test-overridable)
+NFTBAN_SYNC_DEBOUNCE_SECONDS="${NFTBAN_SYNC_DEBOUNCE_SECONDS:-3}"
+NFTBAN_SYNC_RETRIES="${NFTBAN_SYNC_RETRIES:-3}"
+NFTBAN_SYNC_RETRY_DELAY="${NFTBAN_SYNC_RETRY_DELAY:-1}"
+
+_nft_ipc_sync_marker() {
+    echo "${NFTBAN_RUN_DIR:-/run/nftban}/.sync_last"
+}
+
+# Trigger a FULL daemon reconcile sync (quick=false), debounced + retried.
+# Usage: nft_ipc_sync [force]   (force=1 bypasses the debounce window)
+# Returns: 0 on success (or coalesced), nonzero if all IPC attempts fail.
+nft_ipc_sync() {
+    local force="${1:-0}"
+    local marker
+    marker="$(_nft_ipc_sync_marker)"
+
+    # Debounce: coalesce rapid successive full-sync requests into one.
+    if [[ "$force" != "1" && "${NFTBAN_SYNC_DEBOUNCE_SECONDS}" -gt 0 && -f "$marker" ]]; then
+        local last now
+        last="$(cat "$marker" 2>/dev/null || echo 0)"
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+        now="$(date +%s 2>/dev/null || echo 0)"
+        if [[ "$now" -ge "$last" && $((now - last)) -lt "${NFTBAN_SYNC_DEBOUNCE_SECONDS}" ]]; then
+            # A full sync ran within the debounce window; coalesce this request.
+            # The periodic reconcile timer flushes the pending marker as a backstop.
+            : > "${marker}.pending" 2>/dev/null || true
+            return 0
+        fi
+    fi
+
+    # FULL sync (quick=false). NEVER quick — quick skips feeds/geoban/whitelist.
+    local params='{"quick":false}'
+    local attempt=0 delay="${NFTBAN_SYNC_RETRY_DELAY}" response
+    while [[ "$attempt" -lt "${NFTBAN_SYNC_RETRIES}" ]]; do
+        response="$(nft_ipc_request "sync" "$params")"
+        if nft_ipc_success "$response"; then
+            date +%s > "$marker" 2>/dev/null || true
+            rm -f "${marker}.pending" 2>/dev/null || true
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        if [[ "$attempt" -lt "${NFTBAN_SYNC_RETRIES}" ]]; then
+            sleep "$delay" 2>/dev/null || true
+            delay=$((delay * 2))
+        fi
+    done
+    return 1
+}
+
+# Trigger a FULL sync; on IPC failure fall back to the legacy additive apply so
+# a ban/allow is not lost during the mixed-version rollout window. The daemon
+# still accepts the legacy additive apply (no reject-guard in v1.213.0).
+# Usage: nft_ipc_sync_or_apply <module_name> <fallback_nft_file>
+# Returns: 0 on success (sync OR fallback apply), nonzero on total failure.
+nft_ipc_sync_or_apply() {
+    local module="${1:-nftban}"
+    local fallback_file="${2:-}"
+
+    if nft_ipc_sync; then
+        return 0
+    fi
+
+    echo "[WARN] ${module}: sync IPC failed, fell back to legacy additive apply" >&2
+    logger -t nftban "[WARN] ${module}: sync IPC failed, fell back to legacy additive apply" 2>/dev/null || true
+
+    if [[ -n "$fallback_file" && -f "$fallback_file" ]]; then
+        nft_ipc_apply_ruleset "$fallback_file"
+        return $?
+    fi
+    return 1
+}
+
 # Check if IP is banned
 # Usage: nft_ipc_check <ip>
 # Returns: 0 if banned, 1 if not banned
@@ -626,6 +721,10 @@ nft_ipc_load_ports() {
 export NFTBAN_DAEMON_SOCKET
 export NFTBAN_IPC_TIMEOUT
 export NFTBAN_EMERGENCY_MODE
+# v1.213.0 SET_APPLY_SINGLE_WRITER coalescing/retry knobs
+export NFTBAN_SYNC_DEBOUNCE_SECONDS
+export NFTBAN_SYNC_RETRIES
+export NFTBAN_SYNC_RETRY_DELAY
 
 export -f nft_ipc_is_daemon_running
 export -f nft_ipc_request
@@ -637,6 +736,10 @@ export -f nft_ipc_add_element
 export -f nft_ipc_delete_element
 export -f nft_ipc_flush_set
 export -f nft_ipc_apply_ruleset
+# v1.213.0 SET_APPLY_SINGLE_WRITER (Design A): full-sync trigger + sync-or-apply
+export -f _nft_ipc_sync_marker
+export -f nft_ipc_sync
+export -f nft_ipc_sync_or_apply
 export -f nft_ipc_check
 export -f nft_ipc_status
 export -f nft_smart_ban

--- a/cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh
+++ b/cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.213.0 - SET_APPLY_SINGLE_WRITER (Design A) static grep-guard
+# =============================================================================
+# meta:name="set_apply_single_writer_v213_grep_guard_test"
+# meta:type="test"
+# meta:version="1.213.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Static drift-guard: feeds/geoban/trust normal path routes through nft_ipc_sync_or_apply (FULL sync), no longer invokes nft_ipc_apply_ruleset as the PRIMARY writer (only the shared fallback in nft_ipc.sh does); no quick-sync on that path; no new daemon reject-guard; SchemaVersionCurrent stays 1.84.0; VERSION stays 1.212.0"
+# meta:input="None (reads repo source read-only)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_feeds.sh,cli/lib/nftban/core/nftban_geoban.sh,cli/lib/nftban/core/nftban_trust.sh,cli/lib/nftban/lib/nft_ipc.sh,cmd/nftband/daemon_handlers_sync.go,internal/validator/types.go,VERSION"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+
+FEEDS="$REPO_ROOT/cli/lib/nftban/core/nftban_feeds.sh"
+GEOBAN="$REPO_ROOT/cli/lib/nftban/core/nftban_geoban.sh"
+TRUST="$REPO_ROOT/cli/lib/nftban/core/nftban_trust.sh"
+IPC="$REPO_ROOT/cli/lib/nftban/lib/nft_ipc.sh"
+SYNC_GO="$REPO_ROOT/cmd/nftband/daemon_handlers_sync.go"
+ELEM_GO="$REPO_ROOT/cmd/nftband/daemon_handlers_elements.go"
+TYPES_GO="$REPO_ROOT/internal/validator/types.go"
+VER="$REPO_ROOT/VERSION"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== set_apply_single_writer_v213_grep_guard ==="
+
+# --- shared helper exists + is exported --------------------------------------
+echo "--- nft_ipc.sh: shared FULL-sync helper ---"
+if grep -q '^nft_ipc_sync()' "$IPC"; then ok "nft_ipc_sync defined"; else bad "nft_ipc_sync missing"; fi
+if grep -q '^nft_ipc_sync_or_apply()' "$IPC"; then ok "nft_ipc_sync_or_apply defined"; else bad "nft_ipc_sync_or_apply missing"; fi
+if grep -q 'export -f nft_ipc_sync$' "$IPC" && grep -q 'export -f nft_ipc_sync_or_apply$' "$IPC"; then
+    ok "both helpers exported"
+else
+    bad "helpers not exported"
+fi
+# FULL sync only (quick=false), never quick=true on this path
+if grep -q '"quick":false' "$IPC" && ! grep -q '"quick":true' "$IPC"; then
+    ok "nft_ipc_sync forces quick:false and never quick:true"
+else
+    bad "nft_ipc_sync does not force a FULL (quick:false) sync"
+fi
+# fallback path + visible WARN live inside the shared helper
+if grep -q 'nft_ipc_apply_ruleset "\$fallback_file"' "$IPC" \
+   && grep -qi '\[WARN\] .*sync IPC failed, fell back to legacy additive apply' "$IPC"; then
+    ok "sync-or-apply keeps the legacy additive apply as fallback with a visible WARN"
+else
+    bad "sync-or-apply fallback/WARN missing"
+fi
+
+# --- each module routes through the FULL-sync helper -------------------------
+echo "--- feeds/geoban/trust: normal path uses nft_ipc_sync_or_apply ---"
+for f in "$FEEDS" "$GEOBAN" "$TRUST"; do
+    name="$(basename "$f")"
+    if grep -q 'nft_ipc_sync_or_apply' "$f"; then
+        ok "$name routes normal-path writes through nft_ipc_sync_or_apply"
+    else
+        bad "$name does NOT use nft_ipc_sync_or_apply"
+    fi
+done
+
+# --- no module INVOKES apply_ruleset as the PRIMARY writer -------------------
+# (type -t availability checks and comments are allowed; a primary invocation
+#  passes a file variable: nft_ipc_apply_ruleset "$...")
+echo "--- no primary additive apply in the modules (fallback lives in nft_ipc.sh) ---"
+for f in "$FEEDS" "$GEOBAN" "$TRUST"; do
+    name="$(basename "$f")"
+    if grep -qE 'nft_ipc_apply_ruleset[[:space:]]+"\$' "$f"; then
+        bad "$name still invokes nft_ipc_apply_ruleset as a primary writer"
+    else
+        ok "$name has no primary nft_ipc_apply_ruleset invocation"
+    fi
+done
+
+# --- no quick-sync on the module path ---------------------------------------
+echo "--- no quick sync on the converted path ---"
+for f in "$FEEDS" "$GEOBAN" "$TRUST"; do
+    name="$(basename "$f")"
+    if grep -q '"quick":true' "$f"; then
+        bad "$name sends a quick sync (would skip feeds/geoban/whitelist reconcile)"
+    else
+        ok "$name never requests a quick sync"
+    fi
+done
+
+# --- daemon: comment corrected, NO new reject-guard (mixed-version safe) -----
+echo "--- daemon: phased writer comment + no reject-guard ---"
+if grep -qi 'STILL ACCEPTS the legacy' "$SYNC_GO" \
+   && grep -qi 'DEFERRED to a phased' "$SYNC_GO"; then
+    ok "daemon_handlers_sync.go comment states the phased contract (accepts legacy; reject-guard deferred)"
+else
+    bad "daemon_handlers_sync.go comment not corrected to the phased contract"
+fi
+if [[ -f "$ELEM_GO" ]] && grep -qiE 'reject.*(blacklist|whitelist)_(ipv4|ipv6)|(blacklist|whitelist)_(ipv4|ipv6).*reject' "$ELEM_GO"; then
+    bad "a daemon reject-guard for blacklist/whitelist apply was added (must be deferred)"
+else
+    ok "no daemon blacklist/whitelist reject-guard added"
+fi
+
+# --- schema + version pinned -------------------------------------------------
+echo "--- schema + version pinned ---"
+if grep -q 'SchemaVersionCurrent = "1.84.0"' "$TYPES_GO"; then
+    ok "SchemaVersionCurrent stays 1.84.0"
+else
+    bad "SchemaVersionCurrent changed"
+fi
+if [[ "$(tr -d '[:space:]' < "$VER")" == "1.212.0" ]]; then
+    ok "VERSION stays 1.212.0"
+else
+    bad "VERSION changed (got $(cat "$VER"))"
+fi
+
+echo ""
+echo "=== set_apply_single_writer_v213_grep_guard: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh
+++ b/cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.213.0 - SET_APPLY_SINGLE_WRITER (Design A) behavioral test
+# =============================================================================
+# meta:name="set_apply_single_writer_v213_test"
+# meta:type="test"
+# meta:version="1.213.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Design A: feeds/geoban/trust write durable source then trigger a FULL daemon sync (quick=false) via nft_ipc_sync; debounced; IPC-fail falls back to legacy additive apply with a visible WARN; no quick-sync; no additive push on sync success"
+# meta:input="None (self-contained sandbox; sources real cli/lib/nftban/lib/nft_ipc.sh; stubs nft_ipc_request/apply_ruleset)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp,date"
+# meta:inventory.files="cli/lib/nftban/lib/nft_ipc.sh"
+# meta:inventory.binaries="bash,grep,mktemp,date"
+# meta:inventory.env_vars="NFTBAN_RUN_DIR,NFTBAN_SYNC_DEBOUNCE_SECONDS,NFTBAN_SYNC_RETRIES,NFTBAN_SYNC_RETRY_DELAY"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-contained; no host contact; no root; no live nft/IPC. Sources the REAL
+# nft_ipc.sh single-writer helpers (nft_ipc_sync / nft_ipc_sync_or_apply) and
+# drives them with a recording stub for nft_ipc_request + nft_ipc_apply_ruleset.
+# Every module (feeds, geoban, trust) routes its normal-path writes through
+# nft_ipc_sync_or_apply "<module>" "<fragment>", so the helper contract IS the
+# per-module contract; the companion grep-guard test proves each module is wired
+# to it.
+# =============================================================================
+
+set -Eeuo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+IPC_LIB="$REPO_ROOT/cli/lib/nftban/lib/nft_ipc.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== set_apply_single_writer_v213 (Design A) ==="
+
+if [[ ! -f "$IPC_LIB" ]]; then
+    echo "  [SKIP] nft_ipc.sh not found at $IPC_LIB"
+    exit 0
+fi
+
+SBX="$(mktemp -d)"
+trap 'rm -rf "$SBX"' EXIT
+export NFTBAN_RUN_DIR="$SBX/run"
+mkdir -p "$NFTBAN_RUN_DIR"
+
+STUB_LOG="$SBX/ipc_calls.log"
+: > "$STUB_LOG"
+
+# Stub controls
+SYNC_SHOULD_FAIL=0     # 1 => the daemon "sync" verb reports failure
+ORDER_PROBE=""         # if set, the sync stub records PRESENT/ABSENT of this path
+
+# Source the REAL helper library, then override the transport with a recorder.
+# shellcheck source=/dev/null
+source "$IPC_LIB"
+
+nft_ipc_request() {
+    local method="$1" params="${2:-}"
+    echo "REQUEST method=${method} params=${params}" >> "$STUB_LOG"
+    if [[ "$method" == "sync" ]]; then
+        if [[ -n "$ORDER_PROBE" ]]; then
+            if [[ -e "$ORDER_PROBE" ]]; then
+                echo "SYNC_SAW probe=PRESENT" >> "$STUB_LOG"
+            else
+                echo "SYNC_SAW probe=ABSENT" >> "$STUB_LOG"
+            fi
+        fi
+        if [[ "$SYNC_SHOULD_FAIL" == "1" ]]; then
+            echo '{"success":false,"error":"stub sync fail"}'
+            return 1
+        fi
+        echo '{"success":true}'
+        return 0
+    fi
+    echo '{"success":true}'
+    return 0
+}
+nft_ipc_apply_ruleset() {
+    echo "APPLY file=${1:-}" >> "$STUB_LOG"
+    return 0
+}
+
+reset_log() { : > "$STUB_LOG"; rm -f "$NFTBAN_RUN_DIR/.sync_last" "$NFTBAN_RUN_DIR/.sync_last.pending"; }
+count_sync()  { grep -c 'REQUEST method=sync ' "$STUB_LOG" 2>/dev/null || true; }
+count_apply() { grep -c '^APPLY '            "$STUB_LOG" 2>/dev/null || true; }
+
+# Keep retries cheap + debounce large enough for the coalesce test.
+export NFTBAN_SYNC_RETRIES=2
+export NFTBAN_SYNC_RETRY_DELAY=0
+export NFTBAN_SYNC_DEBOUNCE_SECONDS=30
+
+# ---------------------------------------------------------------------------
+echo "--- helper contract: FULL sync only (never quick) ---"
+reset_log
+rc=0; nft_ipc_sync || rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q 'REQUEST method=sync .*"quick":false' "$STUB_LOG"; then
+    ok "nft_ipc_sync sends the daemon 'sync' verb with quick:false"
+else
+    bad "nft_ipc_sync did not send a FULL (quick:false) sync (rc=$rc)"
+fi
+if ! grep -q 'quick":true' "$STUB_LOG"; then
+    ok "nft_ipc_sync NEVER sends quick=true"
+else
+    bad "nft_ipc_sync sent quick=true (would skip feeds/geoban/whitelist reconcile)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "--- debounce: N rapid full-sync requests coalesce into ONE ---"
+reset_log
+for _ in 1 2 3 4 5; do rc=0; nft_ipc_sync || rc=$?; done
+n="$(count_sync)"
+if [[ "$n" -eq 1 ]]; then
+    ok "5 rapid nft_ipc_sync calls coalesced into 1 sync (debounced)"
+else
+    bad "expected 1 coalesced sync, observed $n"
+fi
+
+# ---------------------------------------------------------------------------
+echo "--- per-module normal path: sync (not additive) on success ---"
+for mod in feeds geoban trust; do
+    reset_log
+    SYNC_SHOULD_FAIL=0
+    frag="$SBX/${mod}.nft"; echo "add element ip nftban x { 1.2.3.4 }" > "$frag"
+    rc=0; nft_ipc_sync_or_apply "$mod" "$frag" || rc=$?
+    if [[ "$rc" -eq 0 ]] && [[ "$(count_sync)" -eq 1 ]] && [[ "$(count_apply)" -eq 0 ]]; then
+        ok "$mod: normal path triggers FULL sync and does NOT additively apply"
+    else
+        bad "$mod: expected 1 sync + 0 apply, got sync=$(count_sync) apply=$(count_apply) rc=$rc"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo "--- per-module IPC-fail fallback: legacy additive apply + visible WARN ---"
+for mod in feeds geoban trust; do
+    reset_log
+    SYNC_SHOULD_FAIL=1
+    frag="$SBX/${mod}_fb.nft"; echo "add element ip nftban x { 5.6.7.8 }" > "$frag"
+    warn="$SBX/${mod}_warn.txt"
+    rc=0; nft_ipc_sync_or_apply "$mod" "$frag" 2>"$warn" || rc=$?
+    SYNC_SHOULD_FAIL=0
+    if grep -q "APPLY file=${frag}" "$STUB_LOG" \
+       && grep -qi "\[WARN\] ${mod}: sync IPC failed, fell back to legacy additive apply" "$warn"; then
+        ok "$mod: sync IPC failure falls back to legacy additive apply with a visible WARN"
+    else
+        bad "$mod: fallback/WARN missing (apply=$(count_apply) warn='$(cat "$warn" 2>/dev/null)')"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo "--- IPC-fail retries before giving up (bounded) ---"
+reset_log
+SYNC_SHOULD_FAIL=1
+rc=0; nft_ipc_sync || rc=$?
+SYNC_SHOULD_FAIL=0
+if [[ "$rc" -ne 0 ]] && [[ "$(count_sync)" -ge 2 ]]; then
+    ok "nft_ipc_sync retries (>=2 attempts) then returns nonzero so caller can fall back"
+else
+    bad "expected nonzero rc + >=2 attempts, got rc=$rc attempts=$(count_sync)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "--- ordering: durable source written BEFORE the sync (add path) ---"
+reset_log
+probe="$SBX/durable_source.conf"
+rm -f "$probe"
+ORDER_PROBE="$probe"
+# emulate the module contract: write durable source, THEN trigger sync
+printf '1.2.3.0/24\n' > "$probe"
+rc=0; nft_ipc_sync || rc=$?
+ORDER_PROBE=""
+if grep -q 'SYNC_SAW probe=PRESENT' "$STUB_LOG"; then
+    ok "add path: durable source present at sync time (write-durable-THEN-sync)"
+else
+    bad "add path: durable source was NOT present when the sync ran"
+fi
+
+# ---------------------------------------------------------------------------
+echo "--- ordering: durable source removed BEFORE the sync (delete path) ---"
+reset_log
+probe="$SBX/durable_source_del.conf"
+printf '9.9.9.0/24\n' > "$probe"
+ORDER_PROBE="$probe"
+# emulate the removal contract: remove durable source, THEN trigger sync
+rm -f "$probe"
+rc=0; nft_ipc_sync || rc=$?
+ORDER_PROBE=""
+if grep -q 'SYNC_SAW probe=ABSENT' "$STUB_LOG"; then
+    ok "delete path: durable source absent at sync time (remove-durable-THEN-sync)"
+else
+    bad "delete path: durable source still present when the sync ran"
+fi
+
+echo ""
+echo "=== set_apply_single_writer_v213: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -226,10 +226,22 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 	// SAME canonical replace as feeds + geoban (below) so the flush-first replace OWNS
 	// them and they survive feed reload. The interval blacklist sets are therefore NOT
 	// synced via FullSync's string diff anymore (nil below) — replaceSetElementsViaFile
-	// is the SOLE writer of blacklist_ipv4/_ipv6. Combining all CIDR sources into ONE
-	// replace also closes a pre-existing feed-vs-geoban clobber (two sequential pure
-	// replaces → last source wins). Single IPs were already repointed to the hash sets
-	// above. IPv4+IPv6.
+	// is the canonical writer of blacklist_ipv4/_ipv6 from the durable sources (feeds
+	// *.txt + geoban.d + blacklist.d CIDRs). Combining all CIDR sources into ONE replace
+	// also closes a pre-existing feed-vs-geoban clobber (two sequential pure replaces →
+	// last source wins). Single IPs were already repointed to the hash sets above.
+	// IPv4+IPv6.
+	//
+	// v1.213.0 SET_APPLY_SINGLE_WRITER (Design A) — phased writer contract:
+	//   - v1.213.0 shell (feeds/geoban/trust) writes its durable source then triggers a
+	//     FULL sync (this handler) instead of pushing an additive add/delete element, so
+	//     this replace is the effective NORMAL-PATH sole writer of the interval sets.
+	//   - For mixed-version rollout safety the daemon STILL ACCEPTS the legacy additive
+	//     apply_ruleset path (handleApplyRulesetRequest); there is intentionally NO hard
+	//     reject-guard here yet. The reject-guard that makes single-writer *enforced* is
+	//     DEFERRED to a phased follow-up after the fleet has fully converged onto the
+	//     v1.213.0 shell. So "sole writer" describes the v1.213 normal path + the target
+	//     end state, not an enforced invariant in this release.
 	_ = blacklistIPv4 // single IPs handled above; CIDRs flow through the unified replace
 	_ = blacklistIPv6
 	unifiedBlacklistV4 := append([]string(nil), blacklistIPv4CIDR...)


### PR DESCRIPTION
## v1.213.0 — SET_APPLY_SINGLE_WRITER: route sync-owned writers through full sync

Closes **SET_APPLY_SINGLE_WRITER**. Converts **feeds + geoban + trust** from normal-path additive `apply_ruleset` to **durable-source write → FULL daemon `sync`**.

### The fix
The daemon `sync` flush-replaces the sync-owned interval sets from durable sources — `blacklist_ipv4/_ipv6` (feeds `/var/lib/nftban/feeds/*.txt` + geoban `/etc/nftban/geoban.d/50-ban-*.conf`) and `whitelist_ipv4/_ipv6` (trust `/etc/nftban/whitelist.d/30-trust-*.conf`) — under `syncMutex`. The shell modules ALSO pushed additive `add/delete element` via IPC `apply_ruleset` under `backend.mu` → two daemon-executed writers under different mutexes → **lost-update/clobber** (a flush-replace to a stale snapshot dropped an element). Not a fail-open empty-set window (both paths atomic/fail-closed).

**Design A** — the daemon full sync becomes the **authoritative writer** for sync-owned interval sets:
- feeds/geoban/trust write their durable source first (unchanged), then trigger a **FULL** sync.
- **Quick sync is NOT used** — quick mode skips feeds/geoban/whitelist reconcile (`daemon_handlers_sync.go:264,360,431`), so it would not apply them.
- New shared shell helpers in `nft_ipc.sh`: `nft_ipc_sync` (sends the `sync` verb, `{"quick":false}`, debounced + retry/backoff) and `nft_ipc_sync_or_apply <module> <fallback>` (on sync-IPC failure → legacy additive `apply_ruleset` + visible `[WARN] … fell back to legacy additive apply`).
- **Legacy additive apply remains as a compatibility fallback only.**
- **Daemon reject-guard is explicitly DEFERRED** to a phased follow-up after fleet convergence — the daemon STILL accepts legacy additive `apply_ruleset` so old-shell↔new-daemon and new-shell↔old-daemon are both safe during rollout.

### Facts
- **nft schema unchanged: 1.84.0.** **VERSION unchanged: 1.212.0** (release-prep separate).
- **Daemon re-baseline: NO** — the only `cmd/nftband` change is a **comment** (0 logic lines, reframing the SOLE-WRITER contract) → daemon binary functionally **byte-identical**; the behavior change is shell-side on the EXISTING daemon `sync` verb.
- `cmd_flush` (operator unban) = documented WATCH; `ddos_suricata`/`cmd_port`/emergency `_bash` = exempt (non-sync-owned sets) — per the writer-surface classification.

### Validation
- Hermetic shell **12/12** + grep-guard **18/18** (FULL-only/never-quick, debounce 5→1, per-module sync-not-additive, IPC-fail fallback+WARN, ordering, no-reject-guard, schema/VERSION pinned); shellcheck clean; `go build`/`go vet` rc0.
- **Package-native lab2 DEB PASS + lab4 RPM PASS** — install COMMITTED, checks 1-8 pass; **no-clobber proven**: Test A (trust→`whitelist_ipv4`) element **survives a 2nd full sync + a daemon restart**, removed on source removal (both distros); feeds/geoban full-sync reconcile counters stable (lab4 live feeds exact +1/−1); IPC-fail fallback WARN fires live; admin IP never banned; validate rc0; no empty-set window.

**srv4 canary required after release publish** because the live ban/allow application path changed (even though the daemon binary is byte-identical).

Full report: `NFTBAN_ROADMAP/OPEN_SET_APPLY_SINGLE_WRITER_V213_IMPL_REPORT.md`.
