### PR TITLE
v1.214.0 botscan: fix pattern-delimiter (anchored parse + \x1f internal rep + guard)

### DIFF
--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -181,6 +181,85 @@ nftban_botscan_init_state() {
 # PATTERN MANAGEMENT
 # =============================================================================
 
+# v1.214.0 OPEN_BOTSCAN_PATTERN_DELIMITER_FIX — record-parse constants.
+# The 8-field .patterns record NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION
+# is '|'-delimited, but the PATTERN field legally contains regex alternation '|'. A naive
+# `IFS='|' read` mis-splits any '|'-bearing pattern (3 shipped: EXP_CGIBIN/EXP_SQLBACKUP/
+# SCAN_BACKUP_SQL) → truncated regex → RE2 skips it (dead). The parser below peels the record
+# from both ends so the pattern (the middle) is preserved intact, and the INTERNAL
+# _BOTSCAN_PATTERNS representation is joined/split on ASCII Unit Separator (\x1f) — which a
+# regex can never contain — so the hot-path/threshold/prefilter re-splits never re-corrupt it.
+readonly _BS_US=$'\x1f'                                        # internal '|'-safe field delimiter
+readonly _BS_VALID_MATCH_TYPES=" url-404 url-any url-get url-post useragent "  # supported set (matcher case at match_url_g)
+
+# _botscan_parse_record <record-line> — anchored parse of ONE shipped/operator .patterns
+# record. Peels NAME from the FRONT (first '|') and the 6 constrained trailing fields from
+# the BACK (description,enabled,ban,window,threshold,match_type via repeated '##*|'/'%|*');
+# whatever remains in the middle is the pattern (may legally contain '|'). Strips CRLF '\r'.
+# On success sets globals _BSREC_{name,pattern,match_type,threshold,window,ban,enabled,
+# description} and returns 0. Returns 1 for a blank/comment line (skip silently). Returns 2
+# for a malformed record (too few fields, or a peeled constrained field fails validation —
+# e.g. a stray '|' in the free-text description shifted the trailing fields): emits a VISIBLE
+# WARN (stderr + logger) and the caller MUST skip it — NEVER store a corrupted record.
+_botscan_parse_record() {
+    local line="${1-}"
+    line="${line%$'\r'}"                                   # strip trailing CR (CRLF files)
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && return 1
+
+    # A valid record has >= 7 '|' (8 fields; a '|'-alternation pattern only adds more). Fewer
+    # => the record cannot be peeled into 8 fields → malformed.
+    local _pipes="${line//[!|]/}"
+    if [[ "${#_pipes}" -lt 7 ]]; then
+        _botscan_warn_bad_record "${line%%|*}" "too few fields (< 8)"
+        return 2
+    fi
+
+    local rest description enabled ban window threshold match_type pattern
+    _BSREC_name="${line%%|*}"; rest="${line#*|}"
+    description="${rest##*|}"; rest="${rest%|*}"
+    enabled="${rest##*|}";     rest="${rest%|*}"
+    ban="${rest##*|}";         rest="${rest%|*}"
+    window="${rest##*|}";      rest="${rest%|*}"
+    threshold="${rest##*|}";   rest="${rest%|*}"
+    match_type="${rest##*|}";  rest="${rest%|*}"
+    pattern="$rest"                                        # the middle — legally '|'-bearing
+
+    # Constrained-field validation: a stray '|' in the description would shift the trailing
+    # fields, so validate them (and a non-empty pattern) → a shifted record fails VISIBLY
+    # instead of being silently stored corrupted.
+    local why=""
+    if   [[ -z "$pattern" ]]; then why="empty pattern"
+    elif [[ "$_BS_VALID_MATCH_TYPES" != *" $match_type "* ]]; then why="unknown match_type '$match_type'"
+    elif [[ ! "$threshold" =~ ^[0-9]+$ ]]; then why="non-integer threshold '$threshold'"
+    elif [[ ! "$window"    =~ ^[0-9]+$ ]]; then why="non-integer window '$window'"
+    elif [[ ! "$ban"       =~ ^[0-9]+$ ]]; then why="non-integer ban '$ban'"
+    elif [[ "$enabled" != "true" && "$enabled" != "false" ]]; then why="non-boolean enabled '$enabled'"
+    fi
+    if [[ -n "$why" ]]; then
+        _botscan_warn_bad_record "$_BSREC_name" "$why"
+        return 2
+    fi
+
+    _BSREC_pattern="$pattern"
+    _BSREC_match_type="$match_type"
+    _BSREC_threshold="$threshold"
+    _BSREC_window="$window"
+    _BSREC_ban="$ban"
+    _BSREC_enabled="$enabled"
+    _BSREC_description="$description"
+    return 0
+}
+
+# Visible malformed-record warning (stderr + syslog, non-fatal).
+_botscan_warn_bad_record() {
+    local name="${1:-?}" why="${2:-invalid}"
+    printf "[WARN] botscan: malformed pattern record '%s' — skipped (%s)\n" "$name" "$why" >&2
+    if command -v logger >/dev/null 2>&1; then
+        logger -t nftban-botscan -p user.warning "malformed pattern record '$name' skipped ($why)" 2>/dev/null || true
+    fi
+    return 0
+}
+
 # Load patterns from file
 # Format: NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION
 nftban_botscan_load_patterns() {
@@ -209,16 +288,19 @@ nftban_botscan_load_patterns() {
     for pattern_file in "$patterns_dir"/*.patterns; do
         [[ -f "$pattern_file" ]] || continue
 
-        while IFS='|' read -r name pattern match_type threshold window ban enabled description; do
-            # Skip comments and empty lines
-            [[ -z "$name" || "$name" =~ ^# ]] && continue
+        local _bs_line
+        while IFS= read -r _bs_line || [[ -n "$_bs_line" ]]; do
+            # v1.214.0 anchored parse (rc1=blank/comment skip, rc2=malformed WARN+skip).
+            _botscan_parse_record "$_bs_line" || continue
 
             # override.local wins over the shipped ENABLED column (no-clobber).
-            local eff_enabled="${_override[$name]:-$enabled}"
+            local eff_enabled="${_override[$_BSREC_name]:-$_BSREC_enabled}"
             [[ "$eff_enabled" != "true" ]] && continue
 
-            # Store pattern: name -> "pattern|match_type|threshold|window|ban|description"
-            _BOTSCAN_PATTERNS["$name"]="${pattern}|${match_type}|${threshold}|${window}|${ban}|${description}"
+            # v1.214.0 — store name -> "pattern<US>match_type<US>threshold<US>window<US>ban<US>description"
+            # with an ASCII Unit Separator join so the pattern's own '|' survives every downstream
+            # re-split (hot-path :755, threshold :906, prefilter build :1004).
+            _BOTSCAN_PATTERNS["$_BSREC_name"]="${_BSREC_pattern}${_BS_US}${_BSREC_match_type}${_BS_US}${_BSREC_threshold}${_BS_US}${_BSREC_window}${_BS_US}${_BSREC_ban}${_BS_US}${_BSREC_description}"
             pattern_count=$((pattern_count + 1))
 
         done < "$pattern_file"
@@ -246,17 +328,18 @@ nftban_botscan_list_patterns() {
             [[ "$file_category" != "$category" ]] && continue
         fi
 
-        while IFS='|' read -r name pattern match_type threshold window ban enabled description; do
-            [[ -z "$name" || "$name" =~ ^# ]] && continue
+        local _bs_line
+        while IFS= read -r _bs_line || [[ -n "$_bs_line" ]]; do
+            _botscan_parse_record "$_bs_line" || continue
 
             # Filter
             case "$filter" in
-                enabled)  [[ "$enabled" != "true" ]] && continue ;;
-                disabled) [[ "$enabled" == "true" ]] && continue ;;
+                enabled)  [[ "$_BSREC_enabled" != "true" ]] && continue ;;
+                disabled) [[ "$_BSREC_enabled" == "true" ]] && continue ;;
             esac
 
             printf "%-20s %-8s %-10s %-6s %-6s %-6s %s\n" \
-                "$name" "$enabled" "$match_type" "$threshold" "$window" "$ban" "${description:0:40}"
+                "$_BSREC_name" "$_BSREC_enabled" "$_BSREC_match_type" "$_BSREC_threshold" "$_BSREC_window" "$_BSREC_ban" "${_BSREC_description:0:40}"
 
         done < "$pattern_file"
     done
@@ -359,8 +442,10 @@ nftban_botscan_resolve_name() {
     local f name pattern lc_name lc_pat
     for f in "${BOTSCAN_PATTERNS_DIR}"/*.patterns; do
         [[ -f "$f" ]] || continue
-        while IFS='|' read -r name pattern _; do
-            [[ -z "$name" || "$name" =~ ^# ]] && continue
+        local _bs_line
+        while IFS= read -r _bs_line || [[ -n "$_bs_line" ]]; do
+            _botscan_parse_record "$_bs_line" || continue
+            name="$_BSREC_name"; pattern="$_BSREC_pattern"
             lc_name=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
             lc_pat=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
             if [[ "$q" == "$lc_name" || "$q" == "$lc_pat" ]]; then
@@ -444,20 +529,21 @@ nftban_botscan_bots() {
     fi
     printf "%-22s %-9s %-9s %-10s %s\n" "NAME" "CATEGORY" "EFFECTIVE" "MATCH" "DESCRIPTION"
     printf '%s\n' "$(printf '=%.0s' {1..92})"
-    local f cat name pattern match_type threshold window ban enabled description eff
+    local f cat eff
     for f in "${BOTSCAN_PATTERNS_DIR}"/*.patterns; do
         [[ -f "$f" ]] || continue
         cat=$(basename "$f" .patterns)
         [[ -n "$category" && "$cat" != "$category" ]] && continue
-        while IFS='|' read -r name pattern match_type threshold window ban enabled description; do
-            [[ -z "$name" || "$name" =~ ^# ]] && continue
-            eff="${_ov[$name]:-$enabled}"
+        local _bs_line
+        while IFS= read -r _bs_line || [[ -n "$_bs_line" ]]; do
+            _botscan_parse_record "$_bs_line" || continue
+            eff="${_ov[$_BSREC_name]:-$_BSREC_enabled}"
             case "$filter" in
                 enabled)  [[ "$eff" != "true" ]] && continue ;;
                 disabled) [[ "$eff" == "true" ]] && continue ;;
             esac
-            local mark="$eff"; [[ -n "${_ov[$name]:-}" ]] && mark="${eff}*"
-            printf "%-22s %-9s %-9s %-10s %s\n" "$name" "$cat" "$mark" "$match_type" "${description:0:38}"
+            local mark="$eff"; [[ -n "${_ov[$_BSREC_name]:-}" ]] && mark="${eff}*"
+            printf "%-22s %-9s %-9s %-10s %s\n" "$_BSREC_name" "$cat" "$mark" "$_BSREC_match_type" "${_BSREC_description:0:38}"
         done < "$f"
     done
     echo ""
@@ -752,7 +838,7 @@ nftban_botscan_match_url_g() {
     for name in "${!_BOTSCAN_PATTERNS[@]}"; do
         def="${_BOTSCAN_PATTERNS[$name]}"
 
-        IFS='|' read -r pattern match_type _ _ _ _ <<< "$def"
+        IFS="$_BS_US" read -r pattern match_type _ _ _ _ <<< "$def"  # v1.214.0 '|'-safe internal split
 
         # Check match type
         case "$match_type" in
@@ -903,7 +989,7 @@ nftban_botscan_analyze() {
             [[ -z "$def" ]] && continue
 
             local p_threshold p_window p_ban
-            IFS='|' read -r _ _ p_threshold p_window p_ban _ <<< "$def"
+            IFS="$_BS_US" read -r _ _ p_threshold p_window p_ban _ <<< "$def"  # v1.214.0 '|'-safe internal split
 
             # Use lowest threshold (most sensitive)
             [[ "$p_threshold" -lt "$threshold" ]] && threshold="$p_threshold"
@@ -1001,7 +1087,7 @@ nftban_botscan_build_prefilter() {
     local n=0 name def pat
     for name in "${!_BOTSCAN_PATTERNS[@]}"; do
         def="${_BOTSCAN_PATTERNS[$name]}"
-        IFS='|' read -r pat _ _ _ _ _ <<< "$def"
+        IFS="$_BS_US" read -r pat _ _ _ _ _ <<< "$def"  # v1.214.0 '|'-safe internal split → intact regex to Go matcher
         [[ -z "$pat" ]] && continue
         pat="${pat#^}"; pat="${pat%\$}"   # strip line-anchors → match the field within the line
         [[ -z "$pat" ]] && continue
@@ -1575,10 +1661,11 @@ nftban_botscan_status() {
     local total=0 enabled=0
     for pattern_file in "$BOTSCAN_PATTERNS_DIR"/*.patterns; do
         [[ -f "$pattern_file" ]] || continue
-        while IFS='|' read -r name _ _ _ _ _ is_enabled _; do
-            [[ -z "$name" || "$name" =~ ^# ]] && continue
+        local _bs_line
+        while IFS= read -r _bs_line || [[ -n "$_bs_line" ]]; do
+            _botscan_parse_record "$_bs_line" || continue
             total=$((total + 1))
-            [[ "$is_enabled" == "true" ]] && enabled=$((enabled + 1))
+            [[ "$_BSREC_enabled" == "true" ]] && enabled=$((enabled + 1))
         done < "$pattern_file"
     done
 

--- a/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
+++ b/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
@@ -65,13 +65,17 @@ echo "PASS P: parse_line_g globals == parse_line echo across all formats + expli
 # ----------------------------------------------------------------------------
 # (M) match_url: echo API vs no-fork _g, every match_type + no-match
 # ----------------------------------------------------------------------------
-# def format: pattern|match_type|threshold|window|ban|desc
+# def format: pattern<US>match_type<US>threshold<US>window<US>ban<US>desc
+# v1.214.0 OPEN_BOTSCAN_PATTERN_DELIMITER_FIX — the internal _BOTSCAN_PATTERNS join/split
+# moved from '|' to ASCII Unit Separator (\x1f) so a pattern's own '|' alternation survives
+# the downstream re-splits. Build the defs with the module's _BS_US delimiter accordingly.
+_us="${_BS_US:-$'\x1f'}"
 _BOTSCAN_PATTERNS=(
-  [WP_LOGIN]='wp-login|url-404|2|60|3600|wp'
-  [XMLRPC]='xmlrpc|url-post|2|60|3600|xr'
-  [GITCFG]='\.git/config|url-get|1|60|86400|git'
-  [ANYEVIL]='/evil|url-any|1|60|3600|any'
-  [BADUA]='evilbot|useragent|1|60|3600|ua'
+  [WP_LOGIN]="wp-login${_us}url-404${_us}2${_us}60${_us}3600${_us}wp"
+  [XMLRPC]="xmlrpc${_us}url-post${_us}2${_us}60${_us}3600${_us}xr"
+  [GITCFG]="\\.git/config${_us}url-get${_us}1${_us}60${_us}86400${_us}git"
+  [ANYEVIL]="/evil${_us}url-any${_us}1${_us}60${_us}3600${_us}any"
+  [BADUA]="evilbot${_us}useragent${_us}1${_us}60${_us}3600${_us}ua"
 )
 # cases: url method status ua  -> expected match name ("" = no match)
 m_cases=(

--- a/cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.214.0 - BotScan pattern-delimiter fix test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="botscan_pattern_delimiter_v214_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-02"
+# meta:description="v1.214.0 OPEN_BOTSCAN_PATTERN_DELIMITER_FIX. BotScan .patterns records are NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION (8 fields, |-delimited), and the PATTERN field legally contains regex alternation |. The old naive IFS='|' read mis-split any |-bearing pattern (EXP_CGIBIN/EXP_SQLBACKUP/SCAN_BACKUP_SQL) → truncated regex → RE2 skipped it (dead). This proves: (A) the anchored _botscan_parse_record peels name from the front + 6 constrained trailing fields from the back so the |-bearing pattern (the middle) survives; (B) the internal _BOTSCAN_PATTERNS join/split uses ASCII Unit Separator \\x1f so the downstream re-splits (hot path :755, threshold :906, prefilter build :1004 that feeds the Go matcher) do NOT re-corrupt the |; (C) the 3 shipped |-patterns + an operator |-body pattern parse+match; (D) negatives do not overmatch; (E) the constrained-field validation guard emits a visible WARN and skips malformed/|-in-description/bad-field records; (F) the never-ban guards (loopback/private/exempt-list/WP-admin session) still gate; (G) active/skipped counts (real shipped copy → 140 enabled, 3 formerly-dead now intact); (H) CRLF + blank/comment lines."
+#
+# meta:inventory.files="botscan_pattern_delimiter_v214_test.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_DATA_DIR,BOTSCAN_PATTERNS_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges=""
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; export NFTBAN_LIB_DIR
+REPO_ROOT="$(cd "$NFTBAN_LIB_DIR/../../.." && pwd)"
+SHIPPED_PATTERNS="$REPO_ROOT/etc/nftban/patterns.d/botscan"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+US=$'\x1f'   # internal '|'-safe delimiter (must match _BS_US in the module)
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export NFTBAN_DATA_DIR="$tmp/data" BOTSCAN_PATTERNS_DIR="$tmp/patterns" \
+       BOTSCAN_STATE_FILE="$tmp/s.db" BOTSCAN_LOG_FILE="$tmp/b.log" \
+       NFTBAN_CONFIG_DIR="$tmp/noetc" BOTSCAN_ENABLED=true \
+       BOTSCAN_EXEMPT_FILE="$tmp/exempt.list"
+mkdir -p "$NFTBAN_DATA_DIR" "$BOTSCAN_PATTERNS_DIR"
+
+# shellcheck source=/dev/null
+source "$NFTBAN_LIB_DIR/core/nftban_botscan.sh"; nftban_botscan_load_config
+
+# The 3 shipped |-alternation patterns (verbatim; kept literal for parity).
+CGIBIN_RE='/cgi-bin/.*\.(sh|pl|cgi)'
+SQLBK_RE='\.(sql|sql\.gz|sql\.zip)$'
+SCANSQL_RE='\.(sql|sql\.gz)$'
+
+# ----------------------------------------------------------------------------
+# Fixture: a controlled patterns dir (the 3 |-patterns + clean + malformed).
+# ----------------------------------------------------------------------------
+write_fixture() {
+    : > "$BOTSCAN_PATTERNS_DIR/exploit.patterns"
+    {
+        echo "# Format: NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION"
+        echo ""
+        echo "EXP_CGIBIN|${CGIBIN_RE}|url-404|3|60|3600|true|CGI script probe"
+        echo "EXP_SQLBACKUP|${SQLBK_RE}|url-404|3|60|3600|true|SQL backup probe"
+        echo "WP_LOGIN|wp-login\\.php|url-404|3|60|3600|true|clean pattern no pipe"
+        echo "UA_EVIL|evilbot|useragent|1|60|3600|true|UA pattern"
+        echo "DISABLED_ONE|/x\\.php|url-any|3|60|3600|false|disabled record"
+    } > "$BOTSCAN_PATTERNS_DIR/exploit.patterns"
+
+    : > "$BOTSCAN_PATTERNS_DIR/scanner.patterns"
+    {
+        echo "SCAN_BACKUP_SQL|${SCANSQL_RE}|url-404|3|60|3600|true|SQL backup probe"
+    } > "$BOTSCAN_PATTERNS_DIR/scanner.patterns"
+
+    # Operator custom.patterns with a |-alternation body.
+    : > "$BOTSCAN_PATTERNS_DIR/custom.patterns"
+    {
+        echo "# operator custom"
+        echo "CUSTOM_ALT|/x/(a|b|c)\\.php|url-any|2|60|3600|true|custom alternation"
+    } > "$BOTSCAN_PATTERNS_DIR/custom.patterns"
+}
+write_fixture
+
+# ============================================================================
+# (A) Anchored parse — the |-bearing pattern (middle) survives intact.
+# ============================================================================
+nftban_botscan_load_patterns 2>"$tmp/warn_load.txt"
+
+assert_stored() {
+    local key="$1" want_pat="$2" want_mt="$3" want_thr="$4" want_win="$5" want_ban="$6" want_desc="$7"
+    local def="${_BOTSCAN_PATTERNS[$key]:-}"
+    [[ -n "$def" ]] || fail "A: $key not loaded"
+    local f_pat f_mt f_thr f_win f_ban f_desc
+    IFS="$US" read -r f_pat f_mt f_thr f_win f_ban f_desc <<< "$def"
+    [[ "$f_pat"  == "$want_pat"  ]] || fail "A: $key pattern re-split MANGLED: got [$f_pat] want [$want_pat]"
+    [[ "$f_mt"   == "$want_mt"   ]] || fail "A: $key match_type: got [$f_mt] want [$want_mt]"
+    [[ "$f_thr"  == "$want_thr"  ]] || fail "A: $key threshold: got [$f_thr] want [$want_thr]"
+    [[ "$f_win"  == "$want_win"  ]] || fail "A: $key window: got [$f_win] want [$want_win]"
+    [[ "$f_ban"  == "$want_ban"  ]] || fail "A: $key ban: got [$f_ban] want [$want_ban]"
+    [[ "$f_desc" == "$want_desc" ]] || fail "A: $key description: got [$f_desc] want [$want_desc]"
+    # The '|' must be preserved in the pattern (the whole point).
+    [[ "$f_pat" == *"|"* ]] || fail "A: $key lost its '|' alternation"
+}
+assert_stored EXP_CGIBIN     "$CGIBIN_RE"  url-404 3 60 3600 "CGI script probe"
+assert_stored EXP_SQLBACKUP  "$SQLBK_RE"   url-404 3 60 3600 "SQL backup probe"
+assert_stored SCAN_BACKUP_SQL "$SCANSQL_RE" url-404 3 60 3600 "SQL backup probe"
+assert_stored CUSTOM_ALT     '/x/(a|b|c)\.php' url-any 2 60 3600 "custom alternation"
+[[ -z "${_BOTSCAN_PATTERNS[DISABLED_ONE]:-}" ]] || fail "A: disabled record must not be loaded"
+echo "PASS A: anchored parse + \\x1f internal store — |-patterns intact end to end (store→re-split)"
+
+# ============================================================================
+# (B) Downstream re-split proof — hot path (:755) + threshold (:906) intact.
+# ============================================================================
+# Hot path: match_url_g re-splits _BOTSCAN_PATTERNS[def] on \x1f, then [[ =~ pattern ]].
+for u in '/cgi-bin/x.sh' '/cgi-bin/x.pl' '/cgi-bin/x.cgi'; do
+    nftban_botscan_match_url_g "$u" GET 404 "-" || fail "B: EXP_CGIBIN did not match $u (hot-path re-split broke the |)"
+    [[ "$_BS_MATCHED" == "EXP_CGIBIN" ]] || fail "B: expected EXP_CGIBIN for $u got [$_BS_MATCHED]"
+done
+for u in '/db.sql' '/db.sql.gz' '/db.sql.zip'; do
+    nftban_botscan_match_url_g "$u" GET 404 "-" || fail "B: EXP_SQLBACKUP did not match $u"
+done
+for u in '/db.sql' '/db.sql.gz'; do
+    nftban_botscan_match_url_g "$u" GET 404 "-" || fail "B: SCAN_BACKUP_SQL/EXP_SQLBACKUP did not match $u"
+done
+nftban_botscan_match_url_g '/x/b.php' GET 200 "-" || fail "B: operator CUSTOM_ALT did not match /x/b.php"
+[[ "$_BS_MATCHED" == "CUSTOM_ALT" ]] || fail "B: expected CUSTOM_ALT got [$_BS_MATCHED]"
+
+# Threshold field (:906 idiom) reads correctly from the \x1f store.
+_thr=""; _win=""; _ban=""
+IFS="$US" read -r _ _ _thr _win _ban _ <<< "${_BOTSCAN_PATTERNS[EXP_CGIBIN]}"
+[[ "$_thr" == "3" && "$_win" == "60" && "$_ban" == "3600" ]] \
+    || fail "B: threshold re-split (:906 idiom) MANGLED thr=$_thr win=$_win ban=$_ban"
+echo "PASS B: downstream re-splits (hot-path :755, threshold :906) preserve the |"
+
+# ============================================================================
+# (C) Prefilter build (:1004) → Go-matcher input is the INTACT regex.
+# ============================================================================
+pf="$tmp/prefilter.txt"
+nftban_botscan_build_prefilter "$pf" || fail "C: build_prefilter returned non-zero"
+grep -qF "$CGIBIN_RE" "$pf"                 || fail "C: prefilter missing intact EXP_CGIBIN regex"
+grep -qF '\.(sql|sql\.gz|sql\.zip)' "$pf"   || fail "C: prefilter missing intact EXP_SQLBACKUP regex (anchors stripped)"
+grep -qF '\.(sql|sql\.gz)' "$pf"            || fail "C: prefilter missing intact SCAN_BACKUP_SQL regex"
+grep -qF '/x/(a|b|c)\.php' "$pf"            || fail "C: prefilter missing intact operator CUSTOM_ALT regex"
+# Every emitted pattern line compiles as an ERE (RE2 would too → skipped=0, not 3).
+# grep rc: 0=match, 1=no-match (both fine); 2=invalid regex (would be RE2-skipped).
+while IFS= read -r _pfl; do
+    [[ -z "$_pfl" ]] && continue
+    _grc=0
+    printf '\n' | grep -E -- "$_pfl" >/dev/null 2>&1 || _grc=$?
+    [[ "$_grc" -le 1 ]] || fail "C: prefilter emitted a non-compiling regex: [$_pfl]"
+done < "$pf"
+echo "PASS C: prefilter build feeds the Go matcher the intact |-regex (skipped 3 -> 0 conceptually)"
+
+# ============================================================================
+# (D) Negative fixtures — no overmatch on legit paths.
+# ============================================================================
+neg_nomatch() {  # url method status  -> expect NO match
+    local url="$1" m="$2" st="$3"
+    if nftban_botscan_match_url_g "$url" "$m" "$st" "-"; then
+        fail "D: OVERMATCH — $url ($m $st) matched [$_BS_MATCHED]"
+    fi
+}
+neg_nomatch '/cgi-bin/legit.html' GET 404   # not .sh/.pl/.cgi
+neg_nomatch '/report.sqlite'       GET 404   # $-anchor: not .sql/.sql.gz end
+neg_nomatch '/notes.sql.txt'       GET 404   # .sql not at end
+neg_nomatch '/docs/guide.html'     GET 404   # unrelated static doc, 404
+neg_nomatch '/data.sql'            GET 200   # .sql but status 200 (url-404 gate)
+echo "PASS D: negatives do not overmatch (regex bodies + status gate intact)"
+
+# ============================================================================
+# (E) Validation guard — visible WARN + skip on malformed / |-in-description.
+# ============================================================================
+guard_check() {  # record  reason-substring
+    local rec="$1" why="$2"
+    : > "$BOTSCAN_PATTERNS_DIR/badcase.patterns"
+    printf '%s\n' "$rec" > "$BOTSCAN_PATTERNS_DIR/badcase.patterns"
+    local warn="$tmp/warn_case.txt"; : > "$warn"
+    nftban_botscan_load_patterns 2>"$warn"
+    local name="${rec%%|*}"
+    [[ -z "${_BOTSCAN_PATTERNS[$name]:-}" ]] || fail "E: malformed [$name] was STORED (should skip): $why"
+    grep -q "malformed pattern record" "$warn" || fail "E: no visible WARN for [$name] ($why)"
+    grep -q "$name" "$warn" || fail "E: WARN missing record name [$name]"
+}
+guard_check 'BADDESC|foo\.php|url-404|3|60|3600|true|desc with | pipe'  "| in description shifts trailing fields"
+guard_check 'BADMT|foo\.php|url-bogus|3|60|3600|true|desc'             "unknown match_type"
+guard_check 'BADTHR|foo\.php|url-404|x|60|3600|true|desc'             "non-integer threshold"
+guard_check 'BADWIN|foo\.php|url-404|3|y|3600|true|desc'             "non-integer window"
+guard_check 'BADBAN|foo\.php|url-404|3|60|z|true|desc'               "non-integer ban"
+guard_check 'BADEN|foo\.php|url-404|3|60|3600|maybe|desc'            "non-boolean enabled"
+guard_check 'BADEMPTY||url-404|3|60|3600|true|desc'                  "empty pattern"
+guard_check 'TOOFEW|foo|url-404|3|60'                                "too few fields"
+rm -f "$BOTSCAN_PATTERNS_DIR/badcase.patterns"
+echo "PASS E: validation guard — WARN+skip on |-in-description / bad field / empty / too-few (never silent-corrupt)"
+
+# ============================================================================
+# (F) Never-ban invariants preserved with the re-enabled patterns.
+# ============================================================================
+write_fixture
+nftban_botscan_load_patterns 2>/dev/null
+
+# loopback (:672) — a re-enabled cgi-bin 404 from 127.0.0.1 must NOT be tracked.
+nftban_botscan_init_state
+nftban_botscan_process_entry "127.0.0.1" "/cgi-bin/x.sh" "GET" "404" "-"
+[[ -z "${_BOTSCAN_IP_HITS[127.0.0.1]:-}" ]] || fail "F: loopback 127.0.0.1 was tracked (never-ban :672 broken)"
+
+# private (:675-679)
+nftban_botscan_init_state
+nftban_botscan_process_entry "10.1.2.3" "/cgi-bin/x.sh" "GET" "404" "-"
+[[ -z "${_BOTSCAN_IP_HITS[10.1.2.3]:-}" ]] || fail "F: private 10.x tracked (never-ban broken)"
+
+# exempt-list (:681-690)
+printf '%s\n' "203.0.113.20" > "$BOTSCAN_EXEMPT_FILE"
+nftban_botscan_init_state
+nftban_botscan_process_entry "203.0.113.20" "/cgi-bin/x.sh" "GET" "404" "-"
+[[ -z "${_BOTSCAN_IP_HITS[203.0.113.20]:-}" ]] || fail "F: exempt-list IP tracked (never-ban :681 broken)"
+: > "$BOTSCAN_EXEMPT_FILE"
+
+# NON-exempt DOC IP IS tracked (re-enabled pattern is live end-to-end).
+nftban_botscan_init_state
+nftban_botscan_process_entry "203.0.113.10" "/cgi-bin/x.sh" "GET" "404" "-"
+[[ "${_BOTSCAN_IP_HITS[203.0.113.10]:-0}" == "1" ]] || fail "F: DOC IP not tracked — re-enabled EXP_CGIBIN not live"
+[[ "${_BOTSCAN_IP_PATTERNS[203.0.113.10]:-}" == *EXP_CGIBIN* ]] || fail "F: DOC IP hit not attributed to EXP_CGIBIN"
+
+# WP-admin context marker (:816) — a proven login (POST login_path -> 302) is recorded.
+nftban_botscan_init_state
+nftban_botscan_process_entry "203.0.113.30" "/wp-login.php" "POST" "302" "-"
+[[ "${_BOTSCAN_IP_ADMIN_SESSION[203.0.113.30]:-}" == "1" ]] || fail "F: WP-admin session gate (:816) not set"
+echo "PASS F: never-ban guards (loopback/private/exempt/WP-admin) preserved; re-enabled pattern live for non-exempt"
+
+# ============================================================================
+# (G) Real shipped copy — active/skipped counts (140 enabled, 3 now intact).
+# ============================================================================
+if [[ -d "$SHIPPED_PATTERNS" ]]; then
+    ship="$tmp/shipped"; mkdir -p "$ship"
+    cp "$SHIPPED_PATTERNS"/*.patterns "$ship"/
+    BOTSCAN_PATTERNS_DIR="$ship" nftban_botscan_load_patterns 2>"$tmp/warn_ship.txt"
+    # No shipped record is malformed (the 3 |-patterns now parse cleanly).
+    if grep -q "malformed pattern record" "$tmp/warn_ship.txt"; then
+        fail "G: shipped patterns produced a malformed WARN: $(cat "$tmp/warn_ship.txt")"
+    fi
+    loaded="${#_BOTSCAN_PATTERNS[@]}"
+    [[ "$loaded" == "140" ]] || fail "G: expected 140 enabled shipped patterns loaded, got $loaded"
+    for k in EXP_CGIBIN EXP_SQLBACKUP SCAN_BACKUP_SQL; do
+        [[ -n "${_BOTSCAN_PATTERNS[$k]:-}" ]] || fail "G: formerly-dead $k not loaded from shipped set"
+        [[ "${_BOTSCAN_PATTERNS[$k]}" == *"|"* ]] || fail "G: shipped $k lost its | alternation"
+    done
+    echo "PASS G: shipped set → 140 enabled, 3 formerly-dead |-patterns now intact (skipped 0)"
+    # restore fixture dir for any later use
+    write_fixture
+else
+    echo "SKIP G: shipped patterns dir not found at $SHIPPED_PATTERNS (non-repo run)"
+fi
+
+# ============================================================================
+# (H) CRLF + blank/comment handling.
+# ============================================================================
+: > "$BOTSCAN_PATTERNS_DIR/crlf.patterns"
+printf 'CRLF_PAT|/y/(a|b)\\.php|url-any|2|60|3600|true|crlf record\r\n' > "$BOTSCAN_PATTERNS_DIR/crlf.patterns"
+printf '\r\n' >> "$BOTSCAN_PATTERNS_DIR/crlf.patterns"
+printf '   # a comment\r\n' >> "$BOTSCAN_PATTERNS_DIR/crlf.patterns"
+nftban_botscan_load_patterns 2>"$tmp/warn_crlf.txt"
+def="${_BOTSCAN_PATTERNS[CRLF_PAT]:-}"
+[[ -n "$def" ]] || fail "H: CRLF record not loaded"
+IFS="$US" read -r c_pat c_mt _ _ c_ban c_desc <<< "$def"
+[[ "$c_pat" == '/y/(a|b)\.php' ]] || fail "H: CRLF pattern mangled: [$c_pat]"
+[[ "$c_mt"  == 'url-any' ]] || fail "H: CRLF match_type mangled: [$c_mt]"
+[[ "$c_ban" == '3600' ]] || fail "H: CRLF ban mangled (trailing \\r not stripped?): [$c_ban]"
+[[ "$c_desc" == 'crlf record' ]] || fail "H: CRLF description mangled (trailing \\r not stripped?): [$c_desc]"
+grep -q "malformed" "$tmp/warn_crlf.txt" && fail "H: CRLF/blank/comment produced a spurious WARN"
+rm -f "$BOTSCAN_PATTERNS_DIR/crlf.patterns"
+echo "PASS H: CRLF stripped; blank + comment lines ignored"
+
+echo "PASS: botscan pattern-delimiter fix (v1.214.0) — parse + \\x1f internal rep + guard + never-ban"


### PR DESCRIPTION
## v1.214.0 — BotScan pattern-delimiter fix (anchored parse + `\x1f` internal rep + validation guard)

Closes **`OPEN_BOTSCAN_PATTERN_DELIMITER_FIX`**. **SHELL-ONLY** (`nftban_botscan.sh` + tests). **Daemon re-baseline: NO** — `nftband` + `nftban-botscan-matcher` binaries are **byte-identical** (0 Go change). **nft schema 1.84.0 unchanged. BotGuard disabled by default.**

### The bug
BotScan `.patterns` records are `NAME|PATTERN|MATCH_TYPE|THRESHOLD|WINDOW|BAN|ENABLED|DESCRIPTION` (8 `|`-fields). The **pattern field can legally contain regex alternation `|`**. The old loader `IFS='|' read` mis-split any such record, and — the **hostile-challenge finding** — even a loader-only fix was insufficient because `_BOTSCAN_PATTERNS` stored the record as a re-`|`-joined `$def` that was **re-split downstream** (hot path, threshold analyze, and the prefilter build that feeds the Go matcher). Three shipped patterns were dead since v1.209.1:
- `EXP_CGIBIN` (`/cgi-bin/.*\.(sh|pl|cgi)`), `EXP_SQLBACKUP` (`\.(sql|sql\.gz|sql\.zip)$`), `SCAN_BACKUP_SQL` (`\.(sql|sql\.gz)$`).

### The fix
- **Anchored file parser** `_botscan_parse_record` — peel `name` from the front + the 6 constrained trailing fields from the back; the middle is `pattern` (keeps its `|`). CRLF-strip.
- **`\x1f`-safe internal representation** — `_BOTSCAN_PATTERNS` joins/splits on ASCII Unit Separator (`_BS_US`) instead of `|`, so the pattern's `|` survives the downstream re-splits (`:755` hot path, `:906` threshold, `:1004` prefilter→matcher). A URL/regex can't contain `\x1f`.
- **Validation guard** — `match_type ∈ {url-404,url-any,url-get,url-post,useragent}`, integer `threshold/window/ban`, `enabled ∈ {true,false}`, non-empty pattern → on failure visible `[WARN] … malformed pattern record … — skipped` + skip (never silent-corrupt). (`useragent` covers 44 shipped records — validated against real data.)

### Before / after
- active **137** / skipped **3** → active **140** / skipped **0** (matcher `--check`: `3 usable, 0 skipped`; full shipped prefilter `142 usable, 0 skipped`).

### Validation
- BotScan suite **18/18**; new `botscan_pattern_delimiter_v214_test.sh` (parity + **downstream re-split intact** gate + validation-guard WARN+skip + operator-`|`-pattern + negatives + never-ban + active/skipped 3→0 + CRLF). shellcheck `-x -S warning` clean.
- **Package-native lab2 DEB PASS + lab4 RPM PASS:** matcher skipped 3→0; parity `/cgi-bin/x.{sh,pl,cgi}` + `db.sql{,.gz,.zip}` MATCH; negatives `/cgi-bin/legit.html` + `report.sqlite` + `notes.sql.txt` NO MATCH; validation-guard WARN+skip; never-ban invariant preserved; **admin never banned**; resource bounds intact (256M/50); **daemon + matcher sha256 byte-identical**; schema 1.84.0.

### Scope
No shipped `.patterns` format change; no Go/daemon/matcher change; no VERSION bump (release-prep separate); no schema/metrics/log-UX/profile-sysctl/SET_APPLY/CSF/loopback/RBL/portal/wiki. One existing test (`botscan_nofork_parity_v1871`) realigned to the `\x1f` internal contract (forced by the internal-rep change).

**srv4 canary required after publish** — active detection changes (cgi-bin + SQL-backup probes on 404 become bannable), even though the daemon binary is byte-identical.

Full report: `NFTBAN_ROADMAP/OPEN_BOTSCAN_PATTERN_DELIMITER_FIX_V214_IMPL_REPORT.md`.
