### PR TITLE
v1.215.0: install/update observability summary

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -432,6 +432,11 @@ _cmd_update_main_locked() {
     # stamp the shared update.log with the run_id (clear correlation delimiter).
     _update_log INFO "lifecycle run_id=$_RUN_ID (per-run forensic record: ${FORENSIC_RUN_DIR:-n/a})"
 
+    # v1.215.0 (OPEN_INSTALL_UPDATE_OBSERVABILITY, PR-1): up-front progress contract —
+    # announce total phases + run_id + per-run log dir so the operator knows what to expect
+    # (identical for RPM and DEB; both flow through the same phases below).
+    _update_start_banner
+
     # v1.174: record the installer.log line count BEFORE the install so the final
     # verdict can detect a WARN_PRE_EXISTING_RECOVERED (a stale pre-existing failed
     # nftban unit cleared during THIS run) scoped to this update only — not a marker
@@ -805,6 +810,15 @@ _cmd_update_main_locked() {
     _forensic_snapshot "$_RUN_ID" post-verify
     _forensic_event "$_RUN_ID" run_end "state=$_installer_state" "new_version=$new_version" "rc=0"
 
+    # v1.215.0 (OPEN_INSTALL_UPDATE_OBSERVABILITY, PR-1): warnings in THIS run's
+    # installer.log slice, for the structured final summary (read once; passed to
+    # _update_final_summary in each terminal arm below).
+    local _summary_warnings=0
+    if [[ -f "$_ilog_file" ]]; then
+        _summary_warnings=$(tail -n +$((_ilog_before_lines + 1)) "$_ilog_file" 2>/dev/null | grep -c -iE 'WARN|⚠' || true)
+        _summary_warnings=${_summary_warnings//[^0-9]/}; _summary_warnings=${_summary_warnings:-0}
+    fi
+
     case "$_installer_state" in
         COMMITTED)
             # Clean success path — emit the green block (existing behavior)
@@ -854,6 +868,7 @@ _cmd_update_main_locked() {
             echo "  Log: $UPDATE_LOG_FILE"
             echo "  History: nftban update history"
             echo ""
+            _update_final_summary "COMMITTED" "$current_version" "$new_version" "$_update_duration" "$_summary_warnings" "$([[ "${health_status:-0}" -eq 0 ]] && echo "PASS" || echo "PASS_WITH_WARN")"
             return 0
             ;;
 
@@ -908,6 +923,7 @@ _cmd_update_main_locked() {
             echo "  Log: $UPDATE_LOG_FILE"
             echo "  History: nftban update history"
             echo ""
+            _update_final_summary "DEGRADED" "$current_version" "$new_version" "$_update_duration" "$_summary_warnings" "DEGRADED"
             return 1
             ;;
 
@@ -938,6 +954,7 @@ _cmd_update_main_locked() {
             echo "  Log: $UPDATE_LOG_FILE"
             echo "  History: nftban update history"
             echo ""
+            _update_final_summary "FAILED" "$current_version" "$new_version" "$_update_duration" "$_summary_warnings" "FAILED"
             return 2
             ;;
 
@@ -957,6 +974,7 @@ _cmd_update_main_locked() {
             echo "  Log: $UPDATE_LOG_FILE"
             echo "  History: nftban update history"
             echo ""
+            _update_final_summary "COMMITTED" "$current_version" "$new_version" "$_update_duration" "$_summary_warnings" "UNKNOWN"
             return 0
             ;;
     esac

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -60,9 +60,61 @@ _update_log() {
 # and NO dynamic state machine; it does not change update logic, ordering, or
 # the rc contract. The total is a fixed phase count for a full run.
 _NFTBAN_UPDATE_PHASE_TOTAL="${_NFTBAN_UPDATE_PHASE_TOTAL:-6}"
+_NFTBAN_UPDATE_PHASE_DONE=0   # v1.215.0: last phase reached (for the final "Completed phases: N/M")
 _update_phase() {
     local n="$1" name="$2" hint="${3:-}"
+    _NFTBAN_UPDATE_PHASE_DONE="$n"   # side-effect only; the emitted marker string is unchanged
     _update_log INFO "[${n}/${_NFTBAN_UPDATE_PHASE_TOTAL}] ${name}${hint:+ — ${hint}}"
+}
+
+# v1.215.0 (OPEN_INSTALL_UPDATE_OBSERVABILITY, PR-1): the up-front progress contract —
+# announce the total phase count + run_id + per-run log dir at the START of the run so the
+# operator knows how many phases to expect and where the full record lives. Presentation
+# only; identical for RPM and DEB (both flow through the same _cmd_update_main phases).
+# Usage: _update_start_banner  (reads module-global _RUN_ID / FORENSIC_RUN_DIR)
+_update_start_banner() {
+    local run_id="${_RUN_ID:-${NFTBAN_RUN_ID:-n/a}}"
+    local log_dir="${FORENSIC_RUN_DIR:-n/a}"
+    echo ""
+    echo "  NFTBan update started — ${_NFTBAN_UPDATE_PHASE_TOTAL} phases expected"
+    echo "    run_id: ${run_id}"
+    echo "    Logs:   ${log_dir}"
+    echo ""
+}
+
+# v1.215.0 (OPEN_INSTALL_UPDATE_OBSERVABILITY, PR-1): one structured final operator
+# summary, emitted on every terminal update path (COMMITTED/DEGRADED/FAILED/fallback).
+# PRESENTATION ONLY — additive to the existing verdict blocks; does NOT change update
+# logic, the rc contract, the per-run run.jsonl (untouched, machine-only), or the legacy
+# "Updated: vX → vY" line. No lifecycle JSON is emitted here (v1.199 invariant preserved).
+# Reads the module-global _RUN_ID / FORENSIC_RUN_DIR / UPDATE_LOG_FILE; failed-unit count
+# is read LIVE at summary time. Usage:
+#   _update_final_summary <result> <before_ver> <after_ver> <duration_s> <warnings> <validation>
+_update_final_summary() {
+    local result="${1:-UNKNOWN}" before="${2:-?}" after="${3:-?}" dur="${4:-?}"
+    local warnings="${5:-0}" validation="${6:-unavailable}"
+    local run_id="${_RUN_ID:-${NFTBAN_RUN_ID:-n/a}}"
+    local log_dir="${FORENSIC_RUN_DIR:-n/a}"
+    local log_path="${UPDATE_LOG_FILE:-/var/log/nftban/update.log}"
+    local failed_units
+    failed_units=$(systemctl --failed --no-legend 2>/dev/null | grep -c -i 'nftban' || true)
+    failed_units=${failed_units//[^0-9]/}; failed_units=${failed_units:-0}
+    [[ "$warnings" =~ ^[0-9]+$ ]] || warnings=0
+    local phases_done="${_NFTBAN_UPDATE_PHASE_DONE:-0}" phases_total="${_NFTBAN_UPDATE_PHASE_TOTAL:-6}"
+
+    echo ""
+    echo "  ┌─ Update summary ─────────────────────────────────────"
+    printf '  │ %-16s %s\n' "Result:"          "$result"
+    printf '  │ %-16s %s\n' "Version:"         "v${before} → v${after} (${dur}s)"
+    printf '  │ %-16s %s\n' "Warnings:"        "$warnings"
+    printf '  │ %-16s %s\n' "Failed units:"    "$failed_units"
+    printf '  │ %-16s %s\n' "Validation:"      "$validation"
+    printf '  │ %-16s %s\n' "Completed phases:" "${phases_done}/${phases_total}"
+    printf '  │ %-16s %s\n' "Run ID:"          "$run_id"
+    printf '  │ %-16s %s\n' "Log dir:"         "$log_dir"
+    printf '  │ %-16s %s\n' "Log:"             "$log_path"
+    echo "  └──────────────────────────────────────────────────────"
+    echo ""
 }
 
 _update_banner() {

--- a/cli/lib/nftban/tests/install_update_observability_v215_test.sh
+++ b/cli/lib/nftban/tests/install_update_observability_v215_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Test - Install/Update Observability (v1.215.0, PR-1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="install-update-observability-v215-test"
+# meta:type="test"
+# meta:header="Install/Update Observability v1.215.0 PR-1"
+# meta:version="1.214.0"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Verify the structured final update summary (_update_final_summary) on success/degraded/failed paths + the 4 wired call sites + legacy line preserved + no JSON on console + run.jsonl untouched."
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh,cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LOG_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:created_date="2026-07-03"
+# meta:updated_date="2026-07-03"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HELPERS="$REPO_ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+CMD_UPDATE="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+PASS=0; FAIL=0
+ok(){ echo "PASS $1"; PASS=$((PASS+1)); }
+no(){ echo "FAIL $1"; FAIL=$((FAIL+1)); }
+
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+# stub systemctl so failed_units is deterministic (0 failed)
+mkdir -p "$WORK/bin"; printf '#!/usr/bin/env bash\nexit 0\n' > "$WORK/bin/systemctl"; chmod +x "$WORK/bin/systemctl"
+export PATH="$WORK/bin:$PATH"
+
+# source only the renderer (extract it to avoid pulling the whole update flow)
+# — but the function is self-contained, so source the helpers file in a guarded subshell.
+# shellcheck disable=SC1090
+if ! source "$HELPERS" 2>/dev/null; then
+    # fallback: extract the function body if full-source has unmet deps
+    sed -n '/^_update_final_summary()/,/^}/p' "$HELPERS" > "$WORK/fn.sh"; source "$WORK/fn.sh"
+fi
+
+export _RUN_ID="20260703T101010Z-4242"
+export FORENSIC_RUN_DIR="/var/log/nftban/update-runs/$_RUN_ID"
+export UPDATE_LOG_FILE="/var/log/nftban/update.log"
+
+# --- A: success path (validation passed explicitly as the arg the caller would compute) ---
+outA=$(_update_final_summary "COMMITTED" "1.214.0" "1.215.0" "42" "0" "PASS")
+grep -q "Result:.*COMMITTED"                 <<<"$outA" && ok "A result COMMITTED"           || no "A result"
+grep -q "Version:.*v1.214.0 → v1.215.0 (42s)" <<<"$outA" && ok "A version before→after+dur"   || no "A version"
+grep -q "Warnings:.*0"                        <<<"$outA" && ok "A warnings"                    || no "A warnings"
+grep -q "Failed units:.*0"                    <<<"$outA" && ok "A failed-units"                || no "A failed-units"
+grep -q "Validation:.*PASS"                   <<<"$outA" && ok "A validation"                 || no "A validation"
+grep -q "Run ID:.*$_RUN_ID"                   <<<"$outA" && ok "A run_id shown"               || no "A run_id"
+grep -q "Log dir:.*update-runs/$_RUN_ID"      <<<"$outA" && ok "A per-run log dir"            || no "A log dir"
+grep -q "Log:.*update.log"                    <<<"$outA" && ok "A update.log path"            || no "A log path"
+grep -q "{" <<<"$outA" && no "A NO JSON on console" || ok "A no JSON on console"
+
+# --- B: degraded path ---
+outB=$(_update_final_summary "DEGRADED" "1.214.0" "1.215.0" "9" "3" "DEGRADED")
+grep -q "Result:.*DEGRADED" <<<"$outB" && ok "B result DEGRADED" || no "B result"
+grep -q "Warnings:.*3"      <<<"$outB" && ok "B warnings=3"      || no "B warnings"
+grep -q "Run ID:.*$_RUN_ID" <<<"$outB" && ok "B run_id shown"   || no "B run_id"
+grep -q "Log:.*update.log"  <<<"$outB" && ok "B log path"       || no "B log path"
+
+# --- C: failed path ---
+outC=$(_update_final_summary "FAILED" "1.214.0" "1.215.0" "3" "1" "FAILED")
+grep -q "Result:.*FAILED"   <<<"$outC" && ok "C result FAILED"  || no "C result"
+grep -q "Log dir:.*update-runs" <<<"$outC" && ok "C log dir"    || no "C log dir"
+
+# --- D: static — 4 call sites wired (COMMITTED/DEGRADED/FAILED/UNKNOWN) + legacy line preserved ---
+grep -q '_update_final_summary "COMMITTED"' "$CMD_UPDATE" && ok "D COMMITTED call wired"  || no "D COMMITTED call"
+grep -q '_update_final_summary "DEGRADED"'  "$CMD_UPDATE" && ok "D DEGRADED call wired"   || no "D DEGRADED call"
+grep -q '_update_final_summary "FAILED"'    "$CMD_UPDATE" && ok "D FAILED call wired"     || no "D FAILED call"
+grep -q '_update_final_summary "COMMITTED" .* "UNKNOWN"' "$CMD_UPDATE" && ok "D fallback call wired" || no "D fallback call"
+grep -q 'Updated: v\$current_version → v\$new_version' "$CMD_UPDATE" && ok "D legacy 'Updated: vX → vY' preserved" || no "D legacy line"
+
+# --- E: renderer emits no lifecycle-JSON routing (does not touch run.jsonl / FORENSIC_JSONL) ---
+grep -q 'FORENSIC_JSONL\|run.jsonl' <<<"$(declare -f _update_final_summary)" && no "E summary must not touch run.jsonl" || ok "E run.jsonl untouched by summary"
+
+# --- F: start banner (up-front progress contract: total phases + run_id + logs) ---
+outF=$(_update_start_banner)
+grep -q "6 phases expected"          <<<"$outF" && ok "F start banner shows total phases" || no "F total phases"
+grep -q "run_id: *$_RUN_ID"          <<<"$outF" && ok "F start banner shows run_id"        || no "F run_id"
+grep -q "Logs: *.*update-runs/$_RUN_ID" <<<"$outF" && ok "F start banner shows per-run log dir" || no "F logs dir"
+grep -q "{" <<<"$outF" && no "F no JSON in start banner" || ok "F no JSON in start banner"
+
+# --- G: completed-phases in summary (6/6 on a full run; N/6 on partial) ---
+_NFTBAN_UPDATE_PHASE_DONE=6
+grep -q "Completed phases:.*6/6" <<<"$(_update_final_summary "COMMITTED" "1.214.0" "1.215.0" "42" "0" "PASS")" && ok "G completed phases 6/6 on success" || no "G 6/6"
+_NFTBAN_UPDATE_PHASE_DONE=4
+grep -q "Completed phases:.*4/6" <<<"$(_update_final_summary "FAILED" "1.214.0" "1.215.0" "9" "1" "FAILED")" && ok "G completed phases 4/6 on partial/fail" || no "G 4/6"
+_NFTBAN_UPDATE_PHASE_DONE=6
+
+# --- H: RPM + DEB share the SAME phase flow (alignment) + start banner wired ---
+grep -q '_update_start_banner' "$CMD_UPDATE" && ok "H start banner wired" || no "H start banner wired"
+# phase 2 wraps both package managers (RPM+DEB aligned): both calls exist between phase 2 and phase 3
+p2=$(grep -n '_update_phase 2 "Install"' "$CMD_UPDATE" | head -1 | cut -d: -f1)
+p3=$(grep -n '_update_phase 3 "Restart services"' "$CMD_UPDATE" | head -1 | cut -d: -f1)
+rpm=$(grep -n '_update_via_rpm' "$CMD_UPDATE" | head -1 | cut -d: -f1)
+deb=$(grep -n '_update_via_deb' "$CMD_UPDATE" | head -1 | cut -d: -f1)
+if [ -n "$p2" ] && [ -n "$p3" ] && [ "$rpm" -gt "$p2" ] && [ "$rpm" -lt "$p3" ] && [ "$deb" -gt "$p2" ] && [ "$deb" -lt "$p3" ]; then
+    ok "H RPM+DEB both inside the shared phase-2..3 flow (aligned)"
+else
+    no "H RPM+DEB phase alignment (rpm=$rpm deb=$deb p2=$p2 p3=$p3)"
+fi
+# all 6 ordered phase markers wired (belt-and-suspenders with r1b3)
+for _pn in 1 2 3 4 5 6; do grep -q "_update_phase $_pn " "$CMD_UPDATE" && ok "H phase $_pn wired" || no "H phase $_pn"; done
+
+echo "=== install_update_observability_v215: PASS=$PASS FAIL=$FAIL ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## v1.215.0 — install/update observability summary (PR-1)

Operator observability for the `nftban update`/install flow: **progress visibility during the run + a structured terminal summary** — no logging redesign. `OPEN_INSTALL_UPDATE_OBSERVABILITY`.

- **shell-only** (`cmd_update.sh`, `cmd_update_helpers.sh` + one test) · **daemon byte-identical** (re-baseline NO) · **nft schema unchanged 1.84.0** · **run.jsonl unchanged** (machine-only; format untouched) · **VERSION unchanged** (1.214.0; release-prep separate) · **fleet untouched** · **registers untouched**
- **v1.214.1 intentionally SKIPPED** (the "unbounded log / global→index redesign" premise was false per code: installer.log/update.log are already logrotate-bounded, run.jsonl + retention + support-bundle already exist). **PR-2 (human.log enrich) + PR-3 (failed-run retention) excluded.**

### What it adds
- **Start banner** (up-front progress contract): `NFTBan update started — 6 phases expected` + `run_id` + per-run log dir.
- **6 ordered `[N/6]` phase markers** already existed — **names UNCHANGED** (Backup / Install / Restart services / Health check / Post-update verification / Finalize; `nftban_update_progress_r1b3_test` locks them). `_update_phase` now also records the last phase reached (**side-effect only** — the emitted marker string is byte-identical).
- **Final structured summary** on every terminal path (COMMITTED/DEGRADED/FAILED/fallback) — log path + run_id now shown on **success** too (previously failure only).
- **No progress bar, no percentage, no fake ETA** — phase count + current phase + elapsed only.
- **Legacy `Updated: vX → vY` preserved verbatim** (the 9 global-log parsers unaffected).
- **RPM and DEB share the same phase/banner/summary flow** (both `_update_via_rpm`/`_update_via_deb` run inside the shared phase-2 `case`; asserted structurally).

### Terminal summary format
```
  NFTBan update started — 6 phases expected
    run_id: 20260703-abc123
    Logs:   /var/log/nftban/update-runs/20260703-abc123
  [1/6] Backup
  [2/6] Install — package install may take up to 60s
  ... (phases 3-5) ...
  [6/6] Finalize
  ┌─ Update summary ─────────────────────────────────────
  │ Result:           COMMITTED
  │ Version:          v1.214.0 → v1.215.0 (47s)
  │ Warnings:         0
  │ Failed units:     0
  │ Validation:       PASS
  │ Completed phases: 6/6
  │ Run ID:           20260703-abc123
  │ Log dir:          /var/log/nftban/update-runs/20260703-abc123
  │ Log:              /var/log/nftban/update.log
  └──────────────────────────────────────────────────────
```
(Result → DEGRADED/FAILED on those paths; Completed phases shows N/6 on a partial run.)

### Tests
- `install_update_observability_v215_test.sh` — **35/35 PASS** (start banner, phase ordering, Completed-phases 6/6 & 4/6, failure/degraded shows completed-count + log path, legacy line preserved, no JSON on console, run.jsonl untouched, RPM+DEB shared-flow)
- `nftban_update_progress_r1b3_test` — **22/22** (phase names/markers unbroken)
- `lifecycle_forensics_v1199_test` — **21/21** (run.jsonl/forensics untouched; no JSON on console)
- `shellcheck -x -S warning` clean; `bash -n` clean

### Rollback
Revert the shell changes → prior ad-hoc output restored; no schema/daemon/forensic-format rollback needed (run.jsonl/logrotate/Go-logger all untouched).
