### PR TITLE
v1.216.0: sysctl safe default and visibility

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -234,6 +234,53 @@ _collect_system() {
     _support_log OK "OOM-kill evidence"
 }
 
+# v1.216.0 (OPEN_UNIFIED_PROFILE_SYSCTL_SAFE_DEFAULT): sysctl / conntrack evidence.
+# READ-ONLY — collects the shipped + operator sysctl files, the live kernel readback for
+# the NFTBan-relevant keys, conntrack utilization, and the registry risk scan.
+_collect_sysctl() {
+    local bundle_dir="$1"
+    local d="$bundle_dir/sysctl"
+    mkdir -p "$d" || return 1
+
+    # shipped + operator override files
+    if [[ -f /etc/sysctl.d/90-nftban.conf ]]; then
+        cp /etc/sysctl.d/90-nftban.conf "$d/90-nftban.conf" 2>/dev/null && _support_log OK "sysctl 90-nftban.conf"
+    fi
+    if [[ -f /etc/sysctl.d/99-local.conf ]]; then
+        cp /etc/sysctl.d/99-local.conf "$d/99-local.conf" 2>/dev/null && _support_log OK "sysctl 99-local.conf (operator)"
+    else
+        echo "(no /etc/sysctl.d/99-local.conf)" > "$d/99-local.conf.absent"
+    fi
+
+    # live kernel readback for NFTBan-relevant keys + conntrack utilization
+    {
+        echo "# Live sysctl (NFTBan-relevant) — $(date -Iseconds 2>/dev/null)"
+        for k in net.netfilter.nf_conntrack_tcp_timeout_established \
+                 net.netfilter.nf_conntrack_tcp_timeout_time_wait \
+                 net.netfilter.nf_conntrack_tcp_timeout_syn_sent \
+                 net.netfilter.nf_conntrack_tcp_timeout_syn_recv \
+                 net.netfilter.nf_conntrack_max \
+                 net.netfilter.nf_conntrack_count \
+                 net.ipv4.tcp_keepalive_time net.ipv4.tcp_retries2; do
+            printf '%-56s = %s\n' "$k" "$(sysctl -n "$k" 2>/dev/null || echo 'n/a')"
+        done
+    } > "$d/live-sysctl.txt" 2>/dev/null && _support_log OK "live sysctl readback"
+
+    # registry + read-only risk scan
+    local reg="${NFTBAN_LIB_DIR:-/usr/lib/nftban/lib}/nftban_sysctl_registry.sh"
+    [[ -f "$reg" ]] || reg="$(dirname "${BASH_SOURCE[0]}")/../lib/nftban_sysctl_registry.sh"
+    if [[ -f "$reg" ]]; then
+        # Source + emit in SUBSHELLS so the library's `set -Eeuo pipefail` / double-load
+        # guard cannot leak into the support-bundle shell state.
+        # shellcheck source=/dev/null
+        ( source "$reg" 2>/dev/null && nftban_sysctl_registry ) > "$d/registry.txt" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        if ( source "$reg" 2>/dev/null && nftban_sysctl_risk_scan ) > "$d/risk-scan.txt" 2>/dev/null; then
+            _support_log OK "sysctl risk scan"
+        fi
+    fi
+}
+
 _collect_nftables() {
     local bundle_dir="$1"
     local nft_dir="$bundle_dir/nftables"
@@ -1651,6 +1698,7 @@ _cmd_support_bundle() {
     # Always collect these - Core diagnostics
     _collect_version "$bundle_dir"
     _collect_system "$bundle_dir"
+    _collect_sysctl "$bundle_dir"
     _collect_install_info "$bundle_dir"
     _collect_binaries "$bundle_dir"
     _collect_distro_config "$bundle_dir"

--- a/cli/lib/nftban/core/nftban_watchdog_checks.sh
+++ b/cli/lib/nftban/core/nftban_watchdog_checks.sh
@@ -425,6 +425,35 @@ nftban_watchdog_check_conntrack() {
         WATCHDOG_RESULTS[conntrack_status]="OK"
     fi
 
+    # v1.216.0 (OPEN_UNIFIED_PROFILE_SYSCTL_SAFE_DEFAULT): READ-ONLY sysctl-risk advisory.
+    # Surfaces the conntrack established-timeout / keepalive / DB-pool / file-vs-live drift /
+    # module-load-race risk. NEVER writes the kernel or a file. Elevates OK->WARNING only when
+    # the incident precondition (dead-socket risk) is present, so status can't read fully green
+    # while the risk is live.
+    if [[ "${NFTBAN_WATCHDOG_SYSCTL_RISK_ENABLED:-true}" == "true" ]]; then
+        local _reg_lib="${NFTBAN_LIB_DIR:-/usr/lib/nftban/lib}/nftban_sysctl_registry.sh"
+        [[ -f "$_reg_lib" ]] || _reg_lib="$(dirname "${BASH_SOURCE[0]}")/../lib/nftban_sysctl_registry.sh"
+        if [[ -f "$_reg_lib" ]]; then
+            # Source + scan in a SUBSHELL so the library's `set -Eeuo pipefail` and
+            # double-load guard cannot leak into the watchdog's shell state.
+            local _risk _warns
+            # shellcheck source=/dev/null
+            _risk=$( source "$_reg_lib" 2>/dev/null && nftban_sysctl_risk_scan 2>/dev/null )
+            _warns=$(printf '%s\n' "$_risk" | grep -c '^WARN|' || true)
+            case "$_warns" in ''|*[!0-9]*) _warns=0 ;; esac
+            WATCHDOG_RESULTS[sysctl_risk_warnings]="$_warns"
+            if printf '%s\n' "$_risk" | grep -q 'dead-socket risk'; then
+                if watchdog_should_alert "sysctl_conntrack"; then
+                    watchdog_alert "WARNING" "$(printf '%s\n' "$_risk" | grep 'dead-socket risk' | head -1 | cut -d'|' -f3)"
+                fi
+                [[ $status -eq $WATCHDOG_OK ]] && status=$WATCHDOG_WARNING
+                WATCHDOG_RESULTS[sysctl_risk_status]="WARNING"
+            else
+                WATCHDOG_RESULTS[sysctl_risk_status]="OK"
+            fi
+        fi
+    fi
+
     return $status
 }
 

--- a/cli/lib/nftban/lib/nftban_sysctl_registry.sh
+++ b/cli/lib/nftban/lib/nftban_sysctl_registry.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — Declarative sysctl registry + read-only risk scan
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="nftban-sysctl-registry"
+# meta:type="library"
+# meta:header="Sysctl Registry (read-only)"
+# meta:version="1.215.0"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Minimal declarative registry of NFTBan-relevant kernel sysctls (v1.216.0, OPEN_UNIFIED_PROFILE_SYSCTL_SAFE_DEFAULT) + a READ-ONLY risk scan. This library NEVER writes the live kernel or any file — it only reads /proc/sys, the shipped 90-nftban.conf, and 99-local.conf, and emits advisory findings for health/watchdog/support/CLI."
+# meta:inventory.files="cli/lib/nftban/lib/nftban_sysctl_registry.sh"
+# meta:inventory.binaries="sysctl,ss,grep,sed"
+# meta:inventory.config_files="/etc/sysctl.d/90-nftban.conf,/etc/sysctl.d/99-local.conf"
+# meta:inventory.env_vars="NFTBAN_SYSCTL_FILE,NFTBAN_SYSCTL_LOCAL"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none (read-only)"
+# meta:created_date="2026-07-03"
+# meta:updated_date="2026-07-03"
+# =============================================================================
+set -Eeuo pipefail
+
+# Double-load prevention (sourced library)
+[[ -n "${_NFTBAN_SYSCTL_REGISTRY_LOADED:-}" ]] && return 0 2>/dev/null || true
+readonly _NFTBAN_SYSCTL_REGISTRY_LOADED=1
+
+# READ-ONLY. No function here writes the kernel, a file, or nftables.
+
+NFTBAN_SYSCTL_FILE="${NFTBAN_SYSCTL_FILE:-/etc/sysctl.d/90-nftban.conf}"
+NFTBAN_SYSCTL_LOCAL="${NFTBAN_SYSCTL_LOCAL:-/etc/sysctl.d/99-local.conf}"
+
+# nftban_sysctl_registry — emit the declarative registry, one record per line:
+#   key|owner_class|package_default|override_path|risk_rule|rollback
+nftban_sysctl_registry() {
+    cat <<'REG'
+net.netfilter.nf_conntrack_tcp_timeout_established|read-only-observed|kernel-default(432000)|/etc/sysctl.d/99-local.conf|warn if live value < net.ipv4.tcp_keepalive_time AND a local idle TCP DB pool exists (dead-socket precondition)|not set by NFTBan as of v1.216.0; remove any 99-local override; kernel default applies on reboot
+net.netfilter.nf_conntrack_max|nftban-owned-default|262144|/etc/sysctl.d/99-local.conf|informational: large value uses more kernel memory on small hosts|revert 90-nftban.conf / package downgrade
+REG
+}
+
+_nftban_is_uint() { case "${1:-}" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+# _nftban_sysctl_live KEY -> live value (read-only). Test hook: NFTBAN_TEST_LIVE_<key with . -> _>
+_nftban_sysctl_live() {
+    local key="$1" tv
+    tv="NFTBAN_TEST_LIVE_${key//./_}"
+    if [ -n "${!tv:-}" ]; then printf '%s' "${!tv}"; return 0; fi
+    sysctl -n "$key" 2>/dev/null | tr -d '[:space:]' || true
+}
+
+# _nftban_sysctl_file_value KEY FILE -> value assigned in FILE (last wins) or empty
+_nftban_sysctl_file_value() {
+    local key="$1" file="$2" k
+    [ -f "$file" ] || return 0
+    k="${key//./\\.}"
+    grep -E "^[[:space:]]*${k}[[:space:]]*=" "$file" 2>/dev/null | tail -1 | sed -E 's/^[^=]*=[[:space:]]*//' | tr -d '[:space:]' || true
+}
+
+# _nftban_local_db_pool -> yes|no : any local idle TCP connection to a DB port. Test hook: NFTBAN_TEST_DB_POOL
+_nftban_local_db_pool() {
+    if [ -n "${NFTBAN_TEST_DB_POOL:-}" ]; then printf '%s' "$NFTBAN_TEST_DB_POOL"; return 0; fi
+    local n=0
+    if command -v ss >/dev/null 2>&1; then
+        n=$(ss -tnH state established 2>/dev/null | grep -cE '(127\.0\.0\.1|\[?::1\]?):(5432|3306|6379|27017)([^0-9]|$)') || n=0
+    fi
+    _nftban_is_uint "$n" || n=0
+    [ "$n" -gt 0 ] && echo "yes" || echo "no"
+}
+
+# nftban_sysctl_risk_scan — emit findings "SEVERITY|key|message" (SEVERITY = INFO|WARN). READ-ONLY.
+nftban_sysctl_risk_scan() {
+    local est="net.netfilter.nf_conntrack_tcp_timeout_established"
+    local live_est file_est local_est keepalive dbpool
+    live_est=$(_nftban_sysctl_live "$est")
+    file_est=$(_nftban_sysctl_file_value "$est" "$NFTBAN_SYSCTL_FILE")
+    local_est=$(_nftban_sysctl_file_value "$est" "$NFTBAN_SYSCTL_LOCAL")
+    keepalive=$(_nftban_sysctl_live "net.ipv4.tcp_keepalive_time")
+    _nftban_is_uint "$keepalive" || keepalive=7200
+    dbpool=$(_nftban_local_db_pool)
+
+    # (e) operator override present -> INFO
+    [ -n "$local_est" ] && echo "INFO|$est|operator override present in ${NFTBAN_SYSCTL_LOCAL} = ${local_est}s"
+    # (b) legacy static 600 still in the shipped file (should be gone as of v1.216.0)
+    [ "$file_est" = "600" ] && echo "WARN|$est|legacy established=600 present in ${NFTBAN_SYSCTL_FILE} (pre-v1.216.0 default) — remove it or override in 99-local.conf"
+    # (c) file-vs-live drift
+    if [ -n "$file_est" ] && [ -n "$live_est" ] && [ "$file_est" != "$live_est" ]; then
+        echo "WARN|$est|file value (${file_est}) != live value (${live_est}) — not applied (pending reboot or module-load race)"
+    fi
+    # (d) module-load race: file configures a non-default value but live is the kernel default
+    if [ -n "$file_est" ] && [ "$file_est" != "432000" ] && [ "$live_est" = "432000" ]; then
+        echo "WARN|$est|configured ${file_est} but live is kernel-default 432000 — nf_conntrack not loaded when sysctl was applied (module-load race)"
+    fi
+    # (a) the incident precondition: live established < keepalive AND a local idle TCP DB pool
+    if _nftban_is_uint "$live_est" && [ "$live_est" -lt "$keepalive" ]; then
+        if [ "$dbpool" = "yes" ]; then
+            echo "WARN|$est|live established timeout (${live_est}s) < tcp_keepalive_time (${keepalive}s) with a local idle TCP DB pool — idle DB connections can be conntrack-evicted before keepalive probes (dead-socket risk)"
+        else
+            echo "INFO|$est|established timeout (${live_est}s) < tcp_keepalive_time (${keepalive}s) — no local DB pool detected, low risk"
+        fi
+    fi
+    return 0
+}

--- a/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
+++ b/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Test - Sysctl Safe-Default + Registry + Risk Scan (v1.216.0, PR-1/2/3)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="sysctl-safe-default-v216-test"
+# meta:type="test"
+# meta:header="Sysctl Safe-Default v1.216.0"
+# meta:version="1.215.0"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Verify v1.216.0 sysctl safe-default: established=600 no longer shipped + transitional hardening kept + rationale/override comments (PR-1); DEB conffile parity + RPM %config(noreplace) (PR-2); declarative registry + read-only risk scan logic (dead-socket precondition, drift, module-load race, operator override) + support collection, no writes (PR-3)."
+# meta:inventory.files="install/sysctl/90-nftban.conf,packaging/build_nftban.sh,cli/lib/nftban/lib/nftban_sysctl_registry.sh,cli/lib/nftban/cli/cmd_support.sh,cli/lib/nftban/core/nftban_watchdog_checks.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_SYSCTL_FILE,NFTBAN_SYSCTL_LOCAL"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:created_date="2026-07-03"
+# meta:updated_date="2026-07-03"
+# =============================================================================
+set -Eeuo pipefail
+SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT=$(cd "$SD/../../../.." && pwd)
+CONF="$ROOT/install/sysctl/90-nftban.conf"
+BUILD="$ROOT/packaging/build_nftban.sh"
+REG="$ROOT/cli/lib/nftban/lib/nftban_sysctl_registry.sh"
+SUP="$ROOT/cli/lib/nftban/cli/cmd_support.sh"
+WD="$ROOT/cli/lib/nftban/core/nftban_watchdog_checks.sh"
+P=0; F=0
+ok(){ echo "PASS $1"; P=$((P+1)); }
+no(){ echo "FAIL $1"; F=$((F+1)); }
+
+# ---- PR-1: sysctl file policy ----
+grep -qE '^\s*net\.netfilter\.nf_conntrack_tcp_timeout_established\s*=' "$CONF" && no "PR1 established=600 removed" || ok "PR1 established timeout no longer set (kernel default)"
+grep -qE '^\s*net\.netfilter\.nf_conntrack_tcp_timeout_time_wait\s*=\s*30' "$CONF" && ok "PR1 time_wait=30 kept" || no "PR1 time_wait"
+grep -qE '^\s*net\.netfilter\.nf_conntrack_tcp_timeout_syn_sent\s*=\s*30' "$CONF" && ok "PR1 syn_sent=30 kept" || no "PR1 syn_sent"
+grep -qE '^\s*net\.netfilter\.nf_conntrack_tcp_timeout_syn_recv\s*=\s*15' "$CONF" && ok "PR1 syn_recv=15 kept" || no "PR1 syn_recv"
+grep -q '99-local.conf' "$CONF" && ok "PR1 99-local override documented" || no "PR1 99-local comment"
+grep -qiE 'keepalive|dead socket|dead-socket' "$CONF" && ok "PR1 rationale comment present" || no "PR1 rationale"
+grep -qiE 'NO automatic live-kernel|no automatic live' "$CONF" && ok "PR1 no-auto-write note" || no "PR1 no-auto-write note"
+
+# ---- PR-2: packaging parity ----
+grep -qxF '/etc/sysctl.d/90-nftban.conf' <(sed -n '/DEBIAN\/conffiles/,/CONFFILES_EOF/p' "$BUILD") && ok "PR2 DEB conffiles declares sysctl" || no "PR2 DEB conffile"
+grep -qE '%config\(noreplace\)\s+/etc/sysctl.d/90-nftban.conf' "$BUILD" && ok "PR2 RPM %config(noreplace) kept" || no "PR2 RPM noreplace"
+
+# ---- PR-3: registry + risk scan ----
+# shellcheck source=/dev/null
+source "$REG"
+reg=$(nftban_sysctl_registry)
+grep -q 'nf_conntrack_tcp_timeout_established|' <<<"$reg" && ok "PR3 registry has established key" || no "PR3 reg est"
+grep -q 'nf_conntrack_max|nftban-owned-default|262144' <<<"$reg" && ok "PR3 registry has conntrack_max" || no "PR3 reg max"
+grep -q '99-local.conf' <<<"$reg" && ok "PR3 registry override path" || no "PR3 reg override"
+
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+export NFTBAN_SYSCTL_FILE="$WORK/90.conf" NFTBAN_SYSCTL_LOCAL="$WORK/99.conf"
+: > "$NFTBAN_SYSCTL_FILE"
+E=net.netfilter.nf_conntrack_tcp_timeout_established
+
+# (a) incident precondition: live 600 < keepalive 7200 + DB pool -> WARN dead-socket
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 \
+    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_DB_POOL=yes nftban_sysctl_risk_scan)
+grep -q "^WARN|$E|.*dead-socket risk" <<<"$r" && ok "PR3 dead-socket WARN (est<keepalive + DB pool)" || no "PR3 dead-socket"
+# (a') same but no DB pool -> INFO low risk, not a dead-socket WARN
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 \
+    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+{ grep -q "^INFO|$E|.*low risk" <<<"$r" && ! grep -q 'dead-socket risk' <<<"$r"; } && ok "PR3 no-DB-pool -> INFO low-risk only" || no "PR3 no-DB-pool"
+# (b) legacy 600 present in file -> WARN
+printf '%s = 600\n' "$E" > "$NFTBAN_SYSCTL_FILE"
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+grep -q "^WARN|$E|.*legacy established=600" <<<"$r" && ok "PR3 legacy 600-in-file WARN" || no "PR3 legacy600"
+# (c)+(d) file=600 but live=432000 -> drift WARN + module-load-race WARN
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=432000 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+grep -q "^WARN|$E|.*!= live value" <<<"$r" && ok "PR3 file-vs-live drift WARN" || no "PR3 drift"
+grep -q "^WARN|$E|.*module-load race" <<<"$r" && ok "PR3 module-load-race WARN" || no "PR3 modrace"
+# (e) operator override in 99-local -> INFO
+: > "$NFTBAN_SYSCTL_FILE"; printf '%s = 300\n' "$E" > "$NFTBAN_SYSCTL_LOCAL"
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=300 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+grep -q "^INFO|$E|operator override" <<<"$r" && ok "PR3 operator override INFO" || no "PR3 override"
+
+# no writes: the registry lib must not write kernel/files (no sysctl -w, no > to /proc or sysctl.d)
+grep -qE 'sysctl\s+-w|>\s*/proc/sys|>\s*/etc/sysctl' "$REG" && no "PR3 registry must not write" || ok "PR3 registry is read-only (no writes)"
+
+# ---- PR-3 wiring: support + watchdog ----
+grep -q '_collect_sysctl()' "$SUP" && grep -q '_collect_sysctl "\$bundle_dir"' "$SUP" && ok "PR3 support _collect_sysctl defined+called" || no "PR3 support wire"
+grep -q 'nftban_sysctl_risk_scan' "$WD" && ok "PR3 watchdog wires risk scan" || no "PR3 watchdog wire"
+
+echo "=== sysctl_safe_default_v216: PASS=$P FAIL=$F ==="
+[ "$F" -eq 0 ]

--- a/install/sysctl/90-nftban.conf
+++ b/install/sysctl/90-nftban.conf
@@ -36,9 +36,19 @@
 # Default is typically 65536; 262144 handles ~250K simultaneous connections.
 net.netfilter.nf_conntrack_max = 262144
 
-# Reduce established connection timeout from 5 days to 10 minutes.
-# Frees conntrack entries faster on firewalls that see many short-lived connections.
-net.netfilter.nf_conntrack_tcp_timeout_established = 600
+# Established-flow timeout: NFTBan deliberately does NOT set
+# net.netfilter.nf_conntrack_tcp_timeout_established — the kernel default (432000s)
+# applies. (v1.216.0 safe-default correction, OPEN_UNIFIED_PROFILE_SYSCTL_SAFE_DEFAULT.)
+#   Why removed: a short established timeout (the old 600s) could evict idle-but-live
+#   local TCP flows (e.g. a persistent app->DB pool) BEFORE TCP keepalive
+#   (net.ipv4.tcp_keepalive_time, default 7200s) ever probes them, turning them into
+#   dead sockets -- a precondition contributor to the monitor Zabbix/PostgreSQL hang.
+#   NFTBan owns TRANSITIONAL attack-surface timeouts (SYN/TIME_WAIT below), where the
+#   DDoS rationale is clear; it does not own long-lived established-flow semantics.
+#   Operators who still want an aggressive established timeout may set it in
+#   /etc/sysctl.d/99-local.conf (>= net.ipv4.tcp_keepalive_time is strongly advised).
+#   NFTBan performs NO automatic live-kernel write -- this file applies on boot /
+#   `sysctl --system` only.
 
 # Reduce TIME_WAIT conntrack entries (default 120s). Faster cleanup under flood.
 net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1805,6 +1805,7 @@ PRERM
 /etc/nftban/conf.d/persistent.conf
 /etc/nftban/conf.d/watchdog.conf
 /etc/nftban/conf.d/community_stats.conf.default
+/etc/sysctl.d/90-nftban.conf
 CONFFILES_EOF
 }
 


### PR DESCRIPTION
## v1.216.0 — sysctl safe default and visibility

Implements the **v1.216.0 slice of the design train** (`NFTBAN_ROADMAP/OPEN_UNIFIED_PROFILE_SYSCTL_SAFE_DEFAULT_V216_DESIGN_TRAIN.md`) — **not** the full profile redesign. The design artifact defines v1.216.0 as safe-default + packaging parity + read-only visibility only, **daemon byte-identical**.

- **Shell/packaging + read-only diagnostics.** No Go/daemon change (byte-identical). Schema unchanged **1.84.0**. VERSION unchanged (bump at release-prep). **No live sysctl writes.** Fleet untouched. Registers not closed. Loopback lane stays separate (v1.217.0+).

### PR-1 — safe default (`install/sysctl/90-nftban.conf`)
- **Drops the unconditional `net.netfilter.nf_conntrack_tcp_timeout_established = 600`** → the kernel default (432000s) owns established-flow lifetime. A short established timeout could conntrack-evict idle-but-live local TCP flows (e.g. a persistent app→DB pool) **before** `tcp_keepalive_time` (7200s) probes them → dead sockets — the precondition contributor to the monitor Zabbix/PostgreSQL hang.
- **Preserves transitional conntrack hardening** (the clearer DDoS lever): `time_wait=30`, `syn_sent=30`, `syn_recv=15`.
- Adds rationale + `/etc/sysctl.d/99-local.conf` override guidance (≥ keepalive advised) + a no-auto-write note.

### PR-2 — DEB/RPM parity (`packaging/build_nftban.sh`)
- Declares `/etc/sysctl.d/90-nftban.conf` in the **DEB conffiles** heredoc → dpkg preserves operator edits on upgrade, matching RPM **`%config(noreplace)`** (preserved).

### PR-3 — read-only visibility / support / minimal registry
- New `cli/lib/nftban/lib/nftban_sysctl_registry.sh`: declarative 2-key registry + **read-only risk scan** (dead-socket precondition [est<keepalive + local idle TCP DB pool], legacy-600-in-file, file-vs-live drift, module-load race, operator-override INFO). **Never writes.**
- Wired read-only into the watchdog conntrack check (OK→WARNING only on the dead-socket precondition; sourced in a subshell so the lib's `set -Eeuo` can't leak).
- Support bundle `_collect_sysctl`: shipped + operator sysctl files, live `/proc/sys/net/netfilter/*` readback, registry, and risk scan (subshell-isolated).

### Out of scope (deferred per design train)
Automatic live-kernel write; `sysctl --system`/modprobe on upgrade; RAM-scaling `nf_conntrack_max`; `NftbanProfile` object / platform expansion; `nftban sysctl apply`; loopback-before-invalid; monitor Zabbix/PostgreSQL changes; BotScan; CSF.

### Tests
- `cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh` — **21/21** (PR-1 file policy; PR-2 conffile parity; PR-3 registry + all risk-scan branches + read-only assertion + support/watchdog wiring)
- `shellcheck -x -S warning` clean; `bash -n` clean
- Regressions: v128 help-correlation 7/0, botguard_diag ALL PASS (both source changed files); watchdog conntrack fn intact

### Rollback
File/package rollback restores the previous shipped defaults; **no live-kernel state to unwind** (no auto-write). Read-only guard/support/registry are inert to remove.
