### PR TITLE
v1.216.1: refine sysctl dead-socket observability

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -278,6 +278,10 @@ _collect_sysctl() {
         if ( source "$reg" 2>/dev/null && nftban_sysctl_risk_scan ) > "$d/risk-scan.txt" 2>/dev/null; then
             _support_log OK "sysctl risk scan"
         fi
+        # v1.216.1: explicit idle-age observability source (procfs on RHEL / conntrack-tool on Debian-Ubuntu / none)
+        # so operators can see WHY dead-socket classification is CLEAN/INFO/WARN/UNKNOWN on this host.
+        # shellcheck source=/dev/null
+        ( source "$reg" 2>/dev/null && printf 'idle_age_source=%s\n' "$(_nftban_db_idle_source)" ) > "$d/idle-age-source.txt" 2>/dev/null || true
     fi
 }
 

--- a/cli/lib/nftban/lib/nftban_sysctl_registry.sh
+++ b/cli/lib/nftban/lib/nftban_sysctl_registry.sh
@@ -37,7 +37,7 @@ NFTBAN_SYSCTL_LOCAL="${NFTBAN_SYSCTL_LOCAL:-/etc/sysctl.d/99-local.conf}"
 #   key|owner_class|package_default|override_path|risk_rule|rollback
 nftban_sysctl_registry() {
     cat <<'REG'
-net.netfilter.nf_conntrack_tcp_timeout_established|read-only-observed|kernel-default(432000)|/etc/sysctl.d/99-local.conf|warn if live value < net.ipv4.tcp_keepalive_time AND a local idle TCP DB pool exists (dead-socket precondition)|not set by NFTBan as of v1.216.0; remove any 99-local override; kernel default applies on reboot
+net.netfilter.nf_conntrack_tcp_timeout_established|read-only-observed|kernel-default(432000)|/etc/sysctl.d/99-local.conf|warn if live value < net.ipv4.tcp_keepalive_time AND a local TCP DB session is LONG-IDLE (idle age approaching the established timeout); actively-refreshed monitoring sessions are INFO; unmeasurable idle age is UNKNOWN (v1.216.1 idle-age-aware)|not set by NFTBan as of v1.216.0; remove any 99-local override; kernel default applies on reboot
 net.netfilter.nf_conntrack_max|nftban-owned-default|262144|/etc/sysctl.d/99-local.conf|informational: large value uses more kernel memory on small hosts|revert 90-nftban.conf / package downgrade
 REG
 }
@@ -60,27 +60,87 @@ _nftban_sysctl_file_value() {
     grep -E "^[[:space:]]*${k}[[:space:]]*=" "$file" 2>/dev/null | tail -1 | sed -E 's/^[^=]*=[[:space:]]*//' | tr -d '[:space:]' || true
 }
 
-# _nftban_local_db_pool -> yes|no : any local idle TCP connection to a DB port. Test hook: NFTBAN_TEST_DB_POOL
-_nftban_local_db_pool() {
-    if [ -n "${NFTBAN_TEST_DB_POOL:-}" ]; then printf '%s' "$NFTBAN_TEST_DB_POOL"; return 0; fi
+# v1.216.1: idle-age-aware dead-socket classification (read-only, credential-free, NO DB queries).
+# The dead-socket risk is a local TCP DB session left IDLE longer than the conntrack established
+# timeout (so conntrack evicts it before tcp_keepalive_time probes). A short-idle, actively-polled
+# monitoring session (e.g. zabbix-agent2, idle ~60s) is NOT that risk. Idle age is derived host-only
+# from the conntrack REMAINING timeout (idle ≈ established_timeout - remaining), with a cross-scan
+# ss-stability fallback and an explicit UNKNOWN when idle age cannot be measured (never silent-CLEAN).
+NFTBAN_SYSCTL_IDLE_WARN_PCT="${NFTBAN_SYSCTL_IDLE_WARN_PCT:-50}"   # WARN if max idle >= this % of established timeout
+NFTBAN_SYSCTL_SAMPLE_SECS="${NFTBAN_SYSCTL_SAMPLE_SECS:-2}"        # cross-scan fallback window
+
+# _nftban_db_pool_count -> count of established local TCP connections to DB ports. Hook: NFTBAN_TEST_POOL_COUNT
+_nftban_db_pool_count() {
+    if [ -n "${NFTBAN_TEST_POOL_COUNT:-}" ]; then printf '%s' "$NFTBAN_TEST_POOL_COUNT"; return 0; fi
     local n=0
-    if command -v ss >/dev/null 2>&1; then
-        n=$(ss -tnH state established 2>/dev/null | grep -cE '(127\.0\.0\.1|\[?::1\]?):(5432|3306|6379|27017)([^0-9]|$)') || n=0
-    fi
+    command -v ss >/dev/null 2>&1 && n=$(ss -tnH state established 2>/dev/null | grep -cE '(127\.0\.0\.1|\[?::1\]?):(5432|3306|6379|27017)([^0-9]|$)' || true)
     _nftban_is_uint "$n" || n=0
-    [ "$n" -gt 0 ] && echo "yes" || echo "no"
+    printf '%s' "$n"
+}
+
+# _nftban_db_conntrack_maxidle EST -> max idle seconds across local DB-port conntrack entries, or "UNKNOWN".
+# Hook: NFTBAN_TEST_MAXIDLE (integer or "UNKNOWN"). Uses /proc/net/nf_conntrack (remaining timeout field
+# immediately precedes "ESTABLISHED"); idle = est - remaining. No conntrack visibility -> UNKNOWN.
+_nftban_db_conntrack_maxidle() {
+    local est="$1" src=""
+    if [ -n "${NFTBAN_TEST_MAXIDLE:-}" ]; then printf '%s' "$NFTBAN_TEST_MAXIDLE"; return 0; fi
+    _nftban_is_uint "$est" || { echo "UNKNOWN"; return 0; }
+    if [ -r /proc/net/nf_conntrack ]; then
+        src=$(grep -E 'ESTABLISHED' /proc/net/nf_conntrack 2>/dev/null | grep -E '(sport|dport)=(5432|3306|6379|27017)([^0-9]|$)' | grep -E '127\.0\.0\.1|::1' || true)
+    else echo "UNKNOWN"; return 0; fi
+    [ -z "$src" ] && { echo "UNKNOWN"; return 0; }   # pool exists but no conntrack DB entries -> unmeasurable
+    printf '%s\n' "$src" | awk -v est="$est" 'BEGIN{mx=-1} {for(i=1;i<=NF;i++) if($i=="ESTABLISHED"){to=$(i-1)+0; idle=est-to; if(idle<0)idle=0; if(idle>mx)mx=idle}} END{ if(mx<0) print "UNKNOWN"; else printf "%d", mx }'
+}
+
+# _nftban_db_pool_stable -> yes|no : is the DB pool connection-set unchanged across a bounded window?
+# Fallback idle proxy when conntrack is unreadable. Hook: NFTBAN_TEST_SAMPLE_STABLE
+_nftban_db_pool_stable() {
+    if [ -n "${NFTBAN_TEST_SAMPLE_STABLE:-}" ]; then printf '%s' "$NFTBAN_TEST_SAMPLE_STABLE"; return 0; fi
+    command -v ss >/dev/null 2>&1 || { echo "no"; return 0; }
+    local a b
+    a=$(ss -tnH state established 2>/dev/null | grep -E '(127\.0\.0\.1|\[?::1\]?):(5432|3306|6379|27017)([^0-9]|$)' | awk '{print $3"-"$4}' | sort | tr '\n' ',')
+    sleep "${NFTBAN_SYSCTL_SAMPLE_SECS}" 2>/dev/null || true
+    b=$(ss -tnH state established 2>/dev/null | grep -E '(127\.0\.0\.1|\[?::1\]?):(5432|3306|6379|27017)([^0-9]|$)' | awk '{print $3"-"$4}' | sort | tr '\n' ',')
+    [ "$a" = "$b" ] && echo "yes" || echo "no"
+}
+
+# nftban_db_dead_socket_classify EST KEEPALIVE -> "CLASS|pool|maxidle|reason"  (CLASS: CLEAN|INFO|WARN|UNKNOWN)
+nftban_db_dead_socket_classify() {
+    local est="$1" keep="$2" pool mi thr st
+    pool=$(_nftban_db_pool_count); _nftban_is_uint "$pool" || pool=0
+    [ "$pool" -eq 0 ] && { echo "CLEAN|0|0|no local TCP DB pool"; return 0; }
+    # established >= keepalive: keepalive probes before conntrack evicts -> no dead-socket risk regardless of idle
+    if _nftban_is_uint "$est" && [ "$est" -ge "$keep" ]; then
+        echo "INFO|$pool|0|${pool} local TCP DB session(s); established timeout ${est}s >= keepalive ${keep}s (keepalive probes first) — no dead-socket risk"; return 0
+    fi
+    mi=$(_nftban_db_conntrack_maxidle "$est")
+    if [ "$mi" = "UNKNOWN" ]; then
+        st=$(_nftban_db_pool_stable)
+        if [ "$st" = "no" ]; then
+            echo "INFO|$pool|?|${pool} local TCP DB session(s), pool churning across ${NFTBAN_SYSCTL_SAMPLE_SECS}s sample (active) — idle age unmeasurable, low risk"
+        else
+            echo "UNKNOWN|$pool|?|${pool} local TCP DB session(s) stable across sample but idle age UNMEASURABLE (conntrack unreadable) — cannot confirm safe"
+        fi
+        return 0
+    fi
+    _nftban_is_uint "$mi" || mi=0
+    thr=$(( est * NFTBAN_SYSCTL_IDLE_WARN_PCT / 100 ))
+    if [ "$mi" -ge "$thr" ]; then
+        echo "WARN|$pool|$mi|${pool} local TCP DB session(s), max idle ~${mi}s >= ${NFTBAN_SYSCTL_IDLE_WARN_PCT}% of established timeout ${est}s (< keepalive ${keep}s) — long-idle dead-socket risk"
+    else
+        echo "INFO|$pool|$mi|${pool} local TCP DB session(s), actively refreshed (max idle ~${mi}s << established timeout ${est}s) — low risk"
+    fi
 }
 
 # nftban_sysctl_risk_scan — emit findings "SEVERITY|key|message" (SEVERITY = INFO|WARN). READ-ONLY.
 nftban_sysctl_risk_scan() {
     local est="net.netfilter.nf_conntrack_tcp_timeout_established"
-    local live_est file_est local_est keepalive dbpool
+    local live_est file_est local_est keepalive
     live_est=$(_nftban_sysctl_live "$est")
     file_est=$(_nftban_sysctl_file_value "$est" "$NFTBAN_SYSCTL_FILE")
     local_est=$(_nftban_sysctl_file_value "$est" "$NFTBAN_SYSCTL_LOCAL")
     keepalive=$(_nftban_sysctl_live "net.ipv4.tcp_keepalive_time")
     _nftban_is_uint "$keepalive" || keepalive=7200
-    dbpool=$(_nftban_local_db_pool)
 
     # (e) operator override present -> INFO
     [ -n "$local_est" ] && echo "INFO|$est|operator override present in ${NFTBAN_SYSCTL_LOCAL} = ${local_est}s"
@@ -94,13 +154,17 @@ nftban_sysctl_risk_scan() {
     if [ -n "$file_est" ] && [ "$file_est" != "432000" ] && [ "$live_est" = "432000" ]; then
         echo "WARN|$est|configured ${file_est} but live is kernel-default 432000 — nf_conntrack not loaded when sysctl was applied (module-load race)"
     fi
-    # (a) the incident precondition: live established < keepalive AND a local idle TCP DB pool
-    if _nftban_is_uint "$live_est" && [ "$live_est" -lt "$keepalive" ]; then
-        if [ "$dbpool" = "yes" ]; then
-            echo "WARN|$est|live established timeout (${live_est}s) < tcp_keepalive_time (${keepalive}s) with a local idle TCP DB pool — idle DB connections can be conntrack-evicted before keepalive probes (dead-socket risk)"
-        else
-            echo "INFO|$est|established timeout (${live_est}s) < tcp_keepalive_time (${keepalive}s) — no local DB pool detected, low risk"
-        fi
-    fi
+    # (a) dead-socket precondition — v1.216.1 idle-age-aware classification (CLEAN/INFO/WARN/UNKNOWN).
+    # WARN only for genuinely long-idle local TCP DB sessions (idle approaching the established timeout);
+    # actively-refreshed monitoring sessions (short idle) are INFO; unmeasurable idle age is UNKNOWN.
+    local _cls _class _reason
+    _cls=$(nftban_db_dead_socket_classify "${live_est:-}" "${keepalive}")
+    _class="${_cls%%|*}"; _reason="${_cls##*|}"
+    case "$_class" in
+        WARN)    echo "WARN|$est|established ${live_est}s < keepalive ${keepalive}s + ${_reason} (dead-socket risk)" ;;
+        UNKNOWN) echo "UNKNOWN|$est|established ${live_est}s < keepalive ${keepalive}s + ${_reason}" ;;
+        INFO)    echo "INFO|$est|${_reason}" ;;
+        CLEAN)   : ;;  # no local TCP DB pool -> no line
+    esac
     return 0
 }

--- a/cli/lib/nftban/lib/nftban_sysctl_registry.sh
+++ b/cli/lib/nftban/lib/nftban_sysctl_registry.sh
@@ -78,18 +78,32 @@ _nftban_db_pool_count() {
     printf '%s' "$n"
 }
 
-# _nftban_db_conntrack_maxidle EST -> max idle seconds across local DB-port conntrack entries, or "UNKNOWN".
-# Hook: NFTBAN_TEST_MAXIDLE (integer or "UNKNOWN"). Uses /proc/net/nf_conntrack (remaining timeout field
-# immediately precedes "ESTABLISHED"); idle = est - remaining. No conntrack visibility -> UNKNOWN.
+# _nftban_db_idle_source -> which host-only idle-age source is usable: procfs | conntrack-tool | none.
+# v1.216.1 audit: /proc/net/nf_conntrack is present on RHEL-family (procfs=y) but absent on Debian/Ubuntu
+# (procfs=n) — where the `conntrack` userspace tool (conntrack -L) is the fallback. Hook: NFTBAN_TEST_IDLE_SOURCE
+_nftban_db_idle_source() {
+    if [ -n "${NFTBAN_TEST_IDLE_SOURCE:-}" ]; then printf '%s' "$NFTBAN_TEST_IDLE_SOURCE"; return 0; fi
+    if [ -r /proc/net/nf_conntrack ]; then echo "procfs"
+    elif command -v conntrack >/dev/null 2>&1; then echo "conntrack-tool"
+    else echo "none"; fi
+}
+
+# _nftban_db_conntrack_maxidle EST SOURCE -> max idle seconds across local DB-port conntrack entries,
+# "UNKNOWN" (source has no DB entries for this pool), or "UNKNOWN-FORMAT" (output not parseable). Hook: NFTBAN_TEST_MAXIDLE.
+# Source order: procfs (/proc/net/nf_conntrack) -> conntrack-tool (conntrack -L). Idle = est - remaining, where the
+# remaining timeout is the integer field immediately before "ESTABLISHED". Defensive: unrecognized -> UNKNOWN-FORMAT.
 _nftban_db_conntrack_maxidle() {
-    local est="$1" src=""
+    local est="$1" source="$2" raw=""
     if [ -n "${NFTBAN_TEST_MAXIDLE:-}" ]; then printf '%s' "$NFTBAN_TEST_MAXIDLE"; return 0; fi
     _nftban_is_uint "$est" || { echo "UNKNOWN"; return 0; }
-    if [ -r /proc/net/nf_conntrack ]; then
-        src=$(grep -E 'ESTABLISHED' /proc/net/nf_conntrack 2>/dev/null | grep -E '(sport|dport)=(5432|3306|6379|27017)([^0-9]|$)' | grep -E '127\.0\.0\.1|::1' || true)
-    else echo "UNKNOWN"; return 0; fi
-    [ -z "$src" ] && { echo "UNKNOWN"; return 0; }   # pool exists but no conntrack DB entries -> unmeasurable
-    printf '%s\n' "$src" | awk -v est="$est" 'BEGIN{mx=-1} {for(i=1;i<=NF;i++) if($i=="ESTABLISHED"){to=$(i-1)+0; idle=est-to; if(idle<0)idle=0; if(idle>mx)mx=idle}} END{ if(mx<0) print "UNKNOWN"; else printf "%d", mx }'
+    case "$source" in
+        procfs)         raw=$(grep -E 'ESTABLISHED' /proc/net/nf_conntrack 2>/dev/null | grep -E '(sport|dport)=(5432|3306|6379|27017)([^0-9]|$)' | grep -E '127\.0\.0\.1|::1' || true) ;;
+        conntrack-tool) raw=$(conntrack -L -p tcp 2>/dev/null | grep -E 'ESTABLISHED' | grep -E '(sport|dport)=(5432|3306|6379|27017)([^0-9]|$)' | grep -E '127\.0\.0\.1|::1' || true) ;;
+        *)              echo "UNKNOWN"; return 0 ;;
+    esac
+    [ -z "$raw" ] && { echo "UNKNOWN"; return 0; }   # source usable but no DB entries for this pool -> unmeasurable
+    # remaining timeout = the numeric field immediately preceding "ESTABLISHED"; defensive -> UNKNOWN-FORMAT.
+    printf '%s\n' "$raw" | awk -v est="$est" 'BEGIN{mx=-1; seen=0} {for(i=2;i<=NF;i++) if($i=="ESTABLISHED"){v=$(i-1); if(v ~ /^[0-9]+$/){seen=1; to=v+0; idle=est-to; if(idle<0)idle=0; if(idle>mx)mx=idle}}} END{ if(!seen) print "UNKNOWN-FORMAT"; else printf "%d", mx }'
 }
 
 # _nftban_db_pool_stable -> yes|no : is the DB pool connection-set unchanged across a bounded window?
@@ -104,31 +118,34 @@ _nftban_db_pool_stable() {
     [ "$a" = "$b" ] && echo "yes" || echo "no"
 }
 
-# nftban_db_dead_socket_classify EST KEEPALIVE -> "CLASS|pool|maxidle|reason"  (CLASS: CLEAN|INFO|WARN|UNKNOWN)
+# nftban_db_dead_socket_classify EST KEEPALIVE -> "CLASS|pool|maxidle|idle_age_source|reason"
+# CLASS: CLEAN|INFO|WARN|UNKNOWN. idle_age_source: procfs|conntrack-tool|none|unknown-format
 nftban_db_dead_socket_classify() {
-    local est="$1" keep="$2" pool mi thr st
+    local est="$1" keep="$2" pool mi thr st source
     pool=$(_nftban_db_pool_count); _nftban_is_uint "$pool" || pool=0
-    [ "$pool" -eq 0 ] && { echo "CLEAN|0|0|no local TCP DB pool"; return 0; }
+    [ "$pool" -eq 0 ] && { echo "CLEAN|0|0|none|no local TCP DB pool"; return 0; }
+    source=$(_nftban_db_idle_source)
     # established >= keepalive: keepalive probes before conntrack evicts -> no dead-socket risk regardless of idle
     if _nftban_is_uint "$est" && [ "$est" -ge "$keep" ]; then
-        echo "INFO|$pool|0|${pool} local TCP DB session(s); established timeout ${est}s >= keepalive ${keep}s (keepalive probes first) — no dead-socket risk"; return 0
+        echo "INFO|$pool|0|$source|${pool} local TCP DB session(s); established timeout ${est}s >= keepalive ${keep}s (keepalive probes first) — no dead-socket risk [idle_age_source=$source]"; return 0
     fi
-    mi=$(_nftban_db_conntrack_maxidle "$est")
-    if [ "$mi" = "UNKNOWN" ]; then
+    mi=$(_nftban_db_conntrack_maxidle "$est" "$source")
+    if [ "$mi" = "UNKNOWN" ] || [ "$mi" = "UNKNOWN-FORMAT" ]; then
+        [ "$mi" = "UNKNOWN-FORMAT" ] && source="unknown-format"
         st=$(_nftban_db_pool_stable)
         if [ "$st" = "no" ]; then
-            echo "INFO|$pool|?|${pool} local TCP DB session(s), pool churning across ${NFTBAN_SYSCTL_SAMPLE_SECS}s sample (active) — idle age unmeasurable, low risk"
+            echo "INFO|$pool|?|$source|${pool} local TCP DB session(s), pool churning across ${NFTBAN_SYSCTL_SAMPLE_SECS}s sample (active) — idle age unmeasurable, low risk [idle_age_source=$source]"
         else
-            echo "UNKNOWN|$pool|?|${pool} local TCP DB session(s) stable across sample but idle age UNMEASURABLE (conntrack unreadable) — cannot confirm safe"
+            echo "UNKNOWN|$pool|?|$source|${pool} local TCP DB session(s) exists, idle age unmeasurable, cannot confirm safe (no idle-age source; install 'conntrack' on Debian/Ubuntu) [idle_age_source=$source]"
         fi
         return 0
     fi
     _nftban_is_uint "$mi" || mi=0
     thr=$(( est * NFTBAN_SYSCTL_IDLE_WARN_PCT / 100 ))
     if [ "$mi" -ge "$thr" ]; then
-        echo "WARN|$pool|$mi|${pool} local TCP DB session(s), max idle ~${mi}s >= ${NFTBAN_SYSCTL_IDLE_WARN_PCT}% of established timeout ${est}s (< keepalive ${keep}s) — long-idle dead-socket risk"
+        echo "WARN|$pool|$mi|$source|${pool} local TCP DB session(s), max idle ~${mi}s >= ${NFTBAN_SYSCTL_IDLE_WARN_PCT}% of established timeout ${est}s (< keepalive ${keep}s) — long-idle dead-socket risk [idle_age_source=$source]"
     else
-        echo "INFO|$pool|$mi|${pool} local TCP DB session(s), actively refreshed (max idle ~${mi}s << established timeout ${est}s) — low risk"
+        echo "INFO|$pool|$mi|$source|${pool} local TCP DB session(s), actively refreshed (max idle ~${mi}s << established timeout ${est}s) — low risk [idle_age_source=$source]"
     fi
 }
 

--- a/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
+++ b/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Test - Sysctl Risk Guard Idle-Age Refinement (v1.216.1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="sysctl-risk-idle-age-v2161-test"
+# meta:type="test"
+# meta:header="Sysctl Risk Guard Idle-Age v1.216.1"
+# meta:version="1.216.0"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Verify the v1.216.1 idle-age-aware dead-socket classification: CLEAN (no pool), INFO (actively-refreshed short-idle pool, incl the monitor zabbix-agent2 class), WARN (long-idle pool approaching established timeout), UNKNOWN (pool exists but idle age unmeasurable — never silent CLEAN); est>=keepalive => no risk; threshold boundary; credential-free/no-DB-query/no-write."
+# meta:inventory.files="cli/lib/nftban/lib/nftban_sysctl_registry.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_TEST_POOL_COUNT,NFTBAN_TEST_MAXIDLE,NFTBAN_TEST_SAMPLE_STABLE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:created_date="2026-07-04"
+# meta:updated_date="2026-07-04"
+# =============================================================================
+set -Eeuo pipefail
+SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT=$(cd "$SD/../../../.." && pwd)
+REG="$ROOT/cli/lib/nftban/lib/nftban_sysctl_registry.sh"
+P=0; F=0
+ok(){ echo "PASS $1"; P=$((P+1)); }
+no(){ echo "FAIL $1"; F=$((F+1)); }
+# shellcheck source=/dev/null
+source "$REG"
+E=net.netfilter.nf_conntrack_tcp_timeout_established
+# helper: run the classifier directly -> CLASS
+cls(){ nftban_db_dead_socket_classify "$1" "$2" | cut -d'|' -f1; }
+# helper: run full scan with hooks (KEY=VAL ...) -> output (subshell so hooks don't leak)
+scan(){ ( local kv; for kv in "$@"; do export "${kv?}"; done; nftban_sysctl_risk_scan 2>/dev/null ); }
+
+# --- classifier matrix (est=600, keepalive=7200 unless noted) ---
+[ "$(NFTBAN_TEST_POOL_COUNT=0 cls 600 7200)" = CLEAN ] && ok "CLEAN: no pool" || no "CLEAN"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=500 cls 600 7200)" = WARN ] && ok "WARN: long-idle (500>=300)" || no "WARN long-idle"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=59 cls 600 7200)" = INFO ] && ok "INFO: active short-idle (59<<600) [agent2 class]" || no "INFO active"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes cls 600 7200)" = UNKNOWN ] && ok "UNKNOWN: pool stable but idle unmeasurable (not silent CLEAN)" || no "UNKNOWN"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=no cls 600 7200)" = INFO ] && ok "INFO: unmeasurable but churning (active)" || no "INFO churn"
+# est >= keepalive => keepalive probes first => no dead-socket risk even with a pool
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=999999 cls 432000 7200)" = INFO ] && ok "INFO: est(432000)>=keepalive(7200) -> no risk" || no "INFO est>=keep"
+# threshold boundary (est=600 -> 50% = 300)
+[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_MAXIDLE=300 cls 600 7200)" = WARN ] && ok "boundary: idle=300 -> WARN (>=50%)" || no "boundary 300"
+[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_MAXIDLE=299 cls 600 7200)" = INFO ] && ok "boundary: idle=299 -> INFO (<50%)" || no "boundary 299"
+
+# --- full risk_scan integration (message text) ---
+export NFTBAN_SYSCTL_FILE=/nonexistent-90 NFTBAN_SYSCTL_LOCAL=/nonexistent-99
+rA=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=500)
+grep -q "^WARN|$E|.*dead-socket risk" <<<"$rA" && ok "scan WARN carries 'dead-socket risk' (watchdog-compat)" || no "scan WARN text"
+rB=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=59)
+{ grep -q "^INFO|$E|.*low risk" <<<"$rB" && ! grep -q 'dead-socket risk' <<<"$rB"; } && ok "scan INFO active-pool, no dead-socket WARN (agent2 repro)" || no "scan INFO agent2"
+rU=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes)
+{ grep -q "^UNKNOWN|$E|.*UNMEASURABLE" <<<"$rU" && ! grep -q "^WARN.*dead-socket" <<<"$rU"; } && ok "scan UNKNOWN surfaced (not hidden, not WARN)" || no "scan UNKNOWN"
+rC=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=0)
+[ -z "$(grep -E "dead-socket|local TCP DB" <<<"$rC")" ] && ok "scan CLEAN emits no dead-socket line" || no "scan CLEAN"
+
+# --- reason text is explanatory (has est + keepalive + idle) ---
+grep -qE "established .*600.* keepalive .*7200|max idle" <<<"$rA" && ok "reason text explains est/keepalive/idle" || no "reason text"
+
+# --- credential-free / read-only guards ---
+fn=$(declare -f nftban_db_dead_socket_classify _nftban_db_conntrack_maxidle _nftban_db_pool_count _nftban_db_pool_stable)
+grep -qE 'psql|pg_connect|PGPASSWORD|pg_stat|mysql -|redis-cli|mongo ' <<<"$fn" && no "must not query DBs" || ok "no DB queries (credential-free)"
+grep -qE 'sysctl -w|sysctl --system|> */proc/sys|conntrack -[DF]|-w /proc' <<<"$fn" && no "must not write" || ok "read-only (no sysctl/conntrack writes)"
+grep -q '/proc/net/nf_conntrack' <<<"$fn" && ok "idle age from conntrack remaining (host-only)" || no "conntrack source"
+
+echo "=== sysctl_risk_idle_age_v2161: PASS=$P FAIL=$F ==="
+[ "$F" -eq 0 ]

--- a/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
+++ b/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# NFTBan Test - Sysctl Risk Guard Idle-Age Refinement (v1.216.1)
+# NFTBan Test - Sysctl Risk Guard Idle-Age Refinement + conntrack fallback (v1.216.1)
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 #
@@ -11,10 +11,10 @@
 # meta:owner="NFTBan Project / Antonios Voulvoulis"
 # meta:homepage="https://nftban.com"
 #
-# meta:description="Verify the v1.216.1 idle-age-aware dead-socket classification: CLEAN (no pool), INFO (actively-refreshed short-idle pool, incl the monitor zabbix-agent2 class), WARN (long-idle pool approaching established timeout), UNKNOWN (pool exists but idle age unmeasurable — never silent CLEAN); est>=keepalive => no risk; threshold boundary; credential-free/no-DB-query/no-write."
+# meta:description="Verify v1.216.1 idle-age-aware dead-socket classification (CLEAN/INFO/WARN/UNKNOWN by idle age vs established timeout, incl the monitor zabbix-agent2 active class), the optional conntrack-tool fallback (procfs -> conntrack -L -> none), IPv4/IPv6 loopback parsing, UNKNOWN-FORMAT defensiveness, the idle_age_source field, and credential-free/no-DB-query/no-write guarantees."
 # meta:inventory.files="cli/lib/nftban/lib/nftban_sysctl_registry.sh"
-# meta:inventory.binaries="bash,grep"
-# meta:inventory.env_vars="NFTBAN_TEST_POOL_COUNT,NFTBAN_TEST_MAXIDLE,NFTBAN_TEST_SAMPLE_STABLE"
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_TEST_POOL_COUNT,NFTBAN_TEST_MAXIDLE,NFTBAN_TEST_IDLE_SOURCE,NFTBAN_TEST_SAMPLE_STABLE"
 # meta:inventory.config_files=""
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
@@ -29,45 +29,66 @@ REG="$ROOT/cli/lib/nftban/lib/nftban_sysctl_registry.sh"
 P=0; F=0
 ok(){ echo "PASS $1"; P=$((P+1)); }
 no(){ echo "FAIL $1"; F=$((F+1)); }
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+# mock `conntrack` (PATH shim) emitting MOCK_CONNTRACK_OUT — for the conntrack-tool fallback path
+mkdir -p "$WORK/bin"; printf '#!/usr/bin/env bash\nprintf "%%s\\n" "${MOCK_CONNTRACK_OUT:-}"\n' > "$WORK/bin/conntrack"; chmod +x "$WORK/bin/conntrack"
+export PATH="$WORK/bin:$PATH"
 # shellcheck source=/dev/null
 source "$REG"
 E=net.netfilter.nf_conntrack_tcp_timeout_established
-# helper: run the classifier directly -> CLASS
-cls(){ nftban_db_dead_socket_classify "$1" "$2" | cut -d'|' -f1; }
-# helper: run full scan with hooks (KEY=VAL ...) -> output (subshell so hooks don't leak)
+cls(){ nftban_db_dead_socket_classify "$1" "$2" | cut -d'|' -f1; }        # CLASS
+src(){ nftban_db_dead_socket_classify "$1" "$2" | cut -d'|' -f4; }        # idle_age_source
 scan(){ ( local kv; for kv in "$@"; do export "${kv?}"; done; nftban_sysctl_risk_scan 2>/dev/null ); }
 
-# --- classifier matrix (est=600, keepalive=7200 unless noted) ---
+# ---- classifier matrix (hook-driven, est=600 keepalive=7200) ----
 [ "$(NFTBAN_TEST_POOL_COUNT=0 cls 600 7200)" = CLEAN ] && ok "CLEAN: no pool" || no "CLEAN"
-[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=500 cls 600 7200)" = WARN ] && ok "WARN: long-idle (500>=300)" || no "WARN long-idle"
-[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=59 cls 600 7200)" = INFO ] && ok "INFO: active short-idle (59<<600) [agent2 class]" || no "INFO active"
-[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes cls 600 7200)" = UNKNOWN ] && ok "UNKNOWN: pool stable but idle unmeasurable (not silent CLEAN)" || no "UNKNOWN"
-[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=no cls 600 7200)" = INFO ] && ok "INFO: unmeasurable but churning (active)" || no "INFO churn"
-# est >= keepalive => keepalive probes first => no dead-socket risk even with a pool
-[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=999999 cls 432000 7200)" = INFO ] && ok "INFO: est(432000)>=keepalive(7200) -> no risk" || no "INFO est>=keep"
-# threshold boundary (est=600 -> 50% = 300)
-[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_MAXIDLE=300 cls 600 7200)" = WARN ] && ok "boundary: idle=300 -> WARN (>=50%)" || no "boundary 300"
-[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_MAXIDLE=299 cls 600 7200)" = INFO ] && ok "boundary: idle=299 -> INFO (<50%)" || no "boundary 299"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=500 cls 600 7200)" = WARN ] && ok "WARN: long-idle (500>=300)" || no "WARN long-idle"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=59 cls 600 7200)" = INFO ] && ok "INFO: active short-idle (59<<600) [agent2 class]" || no "INFO active"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=none NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes cls 600 7200)" = UNKNOWN ] && ok "UNKNOWN: no source + stable pool (not silent CLEAN)" || no "UNKNOWN"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=none NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=no cls 600 7200)" = INFO ] && ok "INFO: unmeasurable but churning (active)" || no "INFO churn"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=999999 cls 432000 7200)" = INFO ] && ok "INFO: est(432000)>=keepalive -> no risk" || no "INFO est>=keep"
+[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=300 cls 600 7200)" = WARN ] && ok "boundary idle=300 -> WARN" || no "boundary 300"
+[ "$(NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=299 cls 600 7200)" = INFO ] && ok "boundary idle=299 -> INFO" || no "boundary 299"
 
-# --- full risk_scan integration (message text) ---
+# ---- idle_age_source field ----
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=59 src 600 7200)" = procfs ] && ok "source=procfs surfaced" || no "source procfs"
+[ "$(NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=none NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes src 600 7200)" = none ] && ok "source=none surfaced (UNKNOWN)" || no "source none"
+
+# ---- REAL conntrack-tool fallback via mock (no NFTBAN_TEST_MAXIDLE -> exercises conntrack -L + parser) ----
+CT_IDLE='tcp      6 100 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=54321 dport=5432 src=127.0.0.1 dst=127.0.0.1 sport=5432 dport=54321 [ASSURED] mark=0 use=1'
+CT_ACT='tcp      6 580 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=54322 dport=5432 [ASSURED]'
+CT_V6='tcp      6 120 ESTABLISHED src=::1 dst=::1 sport=54323 dport=5432 [ASSURED]'
+CT_BAD='tcp SOMEGARBAGE ESTABLISHED src=127.0.0.1 dport=5432'
+r=$(MOCK_CONNTRACK_OUT="$CT_IDLE" NFTBAN_TEST_POOL_COUNT=3 NFTBAN_TEST_IDLE_SOURCE=conntrack-tool cls 600 7200); [ "$r" = WARN ] && ok "conntrack-tool fallback: remaining=100 -> idle=500 -> WARN" || no "ct-tool WARN ($r)"
+r=$(MOCK_CONNTRACK_OUT="$CT_ACT" NFTBAN_TEST_POOL_COUNT=3 NFTBAN_TEST_IDLE_SOURCE=conntrack-tool cls 600 7200); [ "$r" = INFO ] && ok "conntrack-tool fallback: remaining=580 -> idle=20 -> INFO" || no "ct-tool INFO ($r)"
+r=$(MOCK_CONNTRACK_OUT="$CT_V6" NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_IDLE_SOURCE=conntrack-tool cls 600 7200); [ "$r" = WARN ] && ok "conntrack-tool fallback: IPv6 ::1 loopback parsed (idle=480 -> WARN)" || no "ct-tool v6 ($r)"
+r=$(MOCK_CONNTRACK_OUT="$CT_BAD" NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_IDLE_SOURCE=conntrack-tool src 600 7200); [ "$r" = unknown-format ] && ok "malformed conntrack output -> UNKNOWN-FORMAT (defensive, not CLEAN)" || no "ct-tool malformed ($r)"
+r=$(MOCK_CONNTRACK_OUT="" NFTBAN_TEST_POOL_COUNT=1 NFTBAN_TEST_IDLE_SOURCE=conntrack-tool cls 600 7200); [ "$r" = UNKNOWN ] && ok "conntrack-tool present but no DB entries -> UNKNOWN" || no "ct-tool empty ($r)"
+
+# ---- full risk_scan integration (message text + watchdog compat + no-hidden-unknown) ----
 export NFTBAN_SYSCTL_FILE=/nonexistent-90 NFTBAN_SYSCTL_LOCAL=/nonexistent-99
-rA=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=500)
-grep -q "^WARN|$E|.*dead-socket risk" <<<"$rA" && ok "scan WARN carries 'dead-socket risk' (watchdog-compat)" || no "scan WARN text"
-rB=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=59)
-{ grep -q "^INFO|$E|.*low risk" <<<"$rB" && ! grep -q 'dead-socket risk' <<<"$rB"; } && ok "scan INFO active-pool, no dead-socket WARN (agent2 repro)" || no "scan INFO agent2"
-rU=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes)
-{ grep -q "^UNKNOWN|$E|.*UNMEASURABLE" <<<"$rU" && ! grep -q "^WARN.*dead-socket" <<<"$rU"; } && ok "scan UNKNOWN surfaced (not hidden, not WARN)" || no "scan UNKNOWN"
+rA=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=500)
+{ grep -q "^WARN|$E|.*dead-socket risk" <<<"$rA" && grep -q 'idle_age_source=procfs' <<<"$rA"; } && ok "scan WARN carries 'dead-socket risk' + idle_age_source" || no "scan WARN"
+rB=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=procfs NFTBAN_TEST_MAXIDLE=59)
+{ grep -q "^INFO|$E|.*low risk" <<<"$rB" && ! grep -q 'dead-socket risk' <<<"$rB"; } && ok "scan INFO active pool, no dead-socket WARN (agent2 repro)" || no "scan INFO agent2"
+rU=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_IDLE_SOURCE=none NFTBAN_TEST_MAXIDLE=UNKNOWN NFTBAN_TEST_SAMPLE_STABLE=yes)
+{ grep -q "^UNKNOWN|$E|.*unmeasurable" <<<"$rU" && grep -qi 'cannot confirm safe' <<<"$rU" && ! grep -q "dead-socket risk" <<<"$rU"; } && ok "scan UNKNOWN surfaced (not hidden, not WARN, mentions conntrack)" || no "scan UNKNOWN"
+grep -qi "install 'conntrack'" <<<"$rU" && ok "UNKNOWN advises installing conntrack (DEB)" || no "UNKNOWN advice"
 rC=$(scan NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=0)
 [ -z "$(grep -E "dead-socket|local TCP DB" <<<"$rC")" ] && ok "scan CLEAN emits no dead-socket line" || no "scan CLEAN"
 
-# --- reason text is explanatory (has est + keepalive + idle) ---
-grep -qE "established .*600.* keepalive .*7200|max idle" <<<"$rA" && ok "reason text explains est/keepalive/idle" || no "reason text"
-
-# --- credential-free / read-only guards ---
-fn=$(declare -f nftban_db_dead_socket_classify _nftban_db_conntrack_maxidle _nftban_db_pool_count _nftban_db_pool_stable)
+# ---- credential-free / read-only guards ----
+fn=$(declare -f nftban_db_dead_socket_classify _nftban_db_conntrack_maxidle _nftban_db_pool_count _nftban_db_pool_stable _nftban_db_idle_source)
 grep -qE 'psql|pg_connect|PGPASSWORD|pg_stat|mysql -|redis-cli|mongo ' <<<"$fn" && no "must not query DBs" || ok "no DB queries (credential-free)"
-grep -qE 'sysctl -w|sysctl --system|> */proc/sys|conntrack -[DF]|-w /proc' <<<"$fn" && no "must not write" || ok "read-only (no sysctl/conntrack writes)"
-grep -q '/proc/net/nf_conntrack' <<<"$fn" && ok "idle age from conntrack remaining (host-only)" || no "conntrack source"
+grep -qE 'sysctl -w|sysctl --system|> */proc/sys|conntrack -[DFU]' <<<"$fn" && no "must not write / no conntrack mutation" || ok "read-only (conntrack -L only, no -D/-F/-U/writes)"
+grep -q '/proc/net/nf_conntrack' <<<"$fn" && grep -q 'conntrack -L' <<<"$fn" && ok "idle source order procfs -> conntrack -L (host-only)" || no "source order"
+
+# ---- packaging: DEB Recommends conntrack (optional, not Depends); RPM unchanged ----
+BUILD="$ROOT/packaging/build_nftban.sh"
+grep -qE '^Recommends:.*\bconntrack\b' "$BUILD" && ok "DEB Recommends includes conntrack (optional)" || no "DEB Recommends conntrack"
+grep -qE '^Depends:.*\bconntrack\b' "$BUILD" && no "conntrack must NOT be a hard DEB Depends" || ok "conntrack is not a hard DEB dependency"
+# RPM %spec Recommends (the RHEL block) must NOT gain conntrack-tools (procfs already full)
+sed -n '/^Recommends:     acl/,/^Recommends:     newt/p' "$BUILD" | grep -qE 'conntrack' && no "RPM must not add conntrack-tools" || ok "RPM dependency metadata unchanged (procfs full)"
 
 echo "=== sysctl_risk_idle_age_v2161: PASS=$P FAIL=$F ==="
 [ "$F" -eq 0 ]

--- a/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
+++ b/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
@@ -60,25 +60,25 @@ export NFTBAN_SYSCTL_FILE="$WORK/90.conf" NFTBAN_SYSCTL_LOCAL="$WORK/99.conf"
 : > "$NFTBAN_SYSCTL_FILE"
 E=net.netfilter.nf_conntrack_tcp_timeout_established
 
-# (a) incident precondition: live 600 < keepalive 7200 + DB pool -> WARN dead-socket
+# (a) incident precondition: live 600 < keepalive 7200 + LONG-IDLE DB pool -> WARN dead-socket (v1.216.1 idle-age)
 r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 \
-    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_DB_POOL=yes nftban_sysctl_risk_scan)
-grep -q "^WARN|$E|.*dead-socket risk" <<<"$r" && ok "PR3 dead-socket WARN (est<keepalive + DB pool)" || no "PR3 dead-socket"
-# (a') same but no DB pool -> INFO low risk, not a dead-socket WARN
+    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=500 nftban_sysctl_risk_scan)
+grep -q "^WARN|$E|.*dead-socket risk" <<<"$r" && ok "PR3 dead-socket WARN (est<keepalive + LONG-IDLE pool)" || no "PR3 dead-socket"
+# (a') actively-refreshed pool (idle 59s, the agent2 class) -> INFO low risk, NOT a dead-socket WARN
 r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 \
-    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
-{ grep -q "^INFO|$E|.*low risk" <<<"$r" && ! grep -q 'dead-socket risk' <<<"$r"; } && ok "PR3 no-DB-pool -> INFO low-risk only" || no "PR3 no-DB-pool"
-# (b) legacy 600 present in file -> WARN
+    NFTBAN_TEST_LIVE_net_ipv4_tcp_keepalive_time=7200 NFTBAN_TEST_POOL_COUNT=5 NFTBAN_TEST_MAXIDLE=59 nftban_sysctl_risk_scan)
+{ grep -q "^INFO|$E|.*low risk" <<<"$r" && ! grep -q 'dead-socket risk' <<<"$r"; } && ok "PR3 active pool -> INFO low-risk only" || no "PR3 active-pool"
+# (b) legacy 600 present in file -> WARN (no DB pool so dead-socket is CLEAN)
 printf '%s = 600\n' "$E" > "$NFTBAN_SYSCTL_FILE"
-r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=600 NFTBAN_TEST_POOL_COUNT=0 nftban_sysctl_risk_scan)
 grep -q "^WARN|$E|.*legacy established=600" <<<"$r" && ok "PR3 legacy 600-in-file WARN" || no "PR3 legacy600"
 # (c)+(d) file=600 but live=432000 -> drift WARN + module-load-race WARN
-r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=432000 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=432000 NFTBAN_TEST_POOL_COUNT=0 nftban_sysctl_risk_scan)
 grep -q "^WARN|$E|.*!= live value" <<<"$r" && ok "PR3 file-vs-live drift WARN" || no "PR3 drift"
 grep -q "^WARN|$E|.*module-load race" <<<"$r" && ok "PR3 module-load-race WARN" || no "PR3 modrace"
 # (e) operator override in 99-local -> INFO
 : > "$NFTBAN_SYSCTL_FILE"; printf '%s = 300\n' "$E" > "$NFTBAN_SYSCTL_LOCAL"
-r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=300 NFTBAN_TEST_DB_POOL=no nftban_sysctl_risk_scan)
+r=$(NFTBAN_TEST_LIVE_net_netfilter_nf_conntrack_tcp_timeout_established=300 NFTBAN_TEST_POOL_COUNT=0 nftban_sysctl_risk_scan)
 grep -q "^INFO|$E|operator override" <<<"$r" && ok "PR3 operator override INFO" || no "PR3 override"
 
 # no writes: the registry lib must not write kernel/files (no sysctl -w, no > to /proc or sysctl.d)

--- a/docs/SYSCTL_DEAD_SOCKET_OBSERVABILITY.md
+++ b/docs/SYSCTL_DEAD_SOCKET_OBSERVABILITY.md
@@ -1,0 +1,53 @@
+# Sysctl dead-socket risk guard — idle-age observability
+
+As of v1.216.1, NFTBan's read-only sysctl risk guard (surfaced by the watchdog and `nftban support`)
+classifies a local TCP database connection pool by **idle age** relative to the live conntrack
+established timeout, rather than warning on any pool. This avoids false alarms on actively-polled
+monitoring connections (e.g. a local `zabbix-agent2` PostgreSQL plugin) while still catching genuinely
+long-idle sessions that conntrack can evict before TCP keepalive probes.
+
+## Classification
+
+- **CLEAN** — no local TCP DB pool.
+- **INFO** — a pool exists but is safe: either its sessions are actively refreshed (max idle well below
+  the established timeout), or `nf_conntrack_tcp_timeout_established >= tcp_keepalive_time` (keepalive
+  probes before conntrack evicts).
+- **WARN** — one or more sessions are long-idle (max idle at or above ~50% of the established timeout)
+  while `established < keepalive` — the dead-socket precondition. Only WARN elevates the watchdog.
+- **UNKNOWN** — a pool exists but idle age cannot be measured on this host. This is honest, not an error:
+  it is never silently treated as CLEAN, and it does not raise a dead-socket WARN.
+
+## Idle-age source, by distribution
+
+Idle age is read host-only (no database credentials, no queries) from conntrack's remaining-timeout
+(`idle ≈ established_timeout − remaining`). The available source differs by distribution family:
+
+| Family | Source | Result |
+|---|---|---|
+| RHEL family (CentOS Stream / AlmaLinux / Rocky, EL9/EL10) | `/proc/net/nf_conntrack` (kernel `CONFIG_NF_CONNTRACK_PROCFS=y`) | **Full** classification (CLEAN/INFO/WARN) |
+| Debian / Ubuntu (with the `conntrack` package) | `conntrack -L` (userspace tool) | **Full** classification |
+| Debian / Ubuntu (without `conntrack`) | none | **UNKNOWN** when a DB pool is present |
+
+Debian and Ubuntu kernels ship `CONFIG_NF_CONNTRACK_PROCFS=n`, so `/proc/net/nf_conntrack` is absent
+there. NFTBan therefore falls back to the `conntrack` userspace tool when present.
+
+## Recommendation for Debian / Ubuntu
+
+Install the `conntrack` package for full idle-age classification:
+
+```
+apt install conntrack
+```
+
+NFTBan's DEB package lists `conntrack` under **Recommends** (installed by default with apt, and
+removable) — it is recommended, not mandatory. Without it, the guard reports **UNKNOWN** for any local
+TCP DB pool, which is a safe and honest limited-observability state.
+
+## Where the source is reported
+
+`nftban support` records the active source in `sysctl/idle-age-source.txt`
+(`idle_age_source=procfs | conntrack-tool | none | unknown-format`), and the risk-scan lines include an
+`[idle_age_source=…]` tag, so an operator can see why a host classified CLEAN / INFO / WARN / UNKNOWN.
+
+A dependency-free reader (via nfnetlink, so Debian/Ubuntu needs no extra package) is planned as a later
+enhancement.

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1656,7 +1656,7 @@ Section: net
 Priority: optional
 Architecture: amd64
 Depends: nftables (>= 0.9.0), systemd, bash (>= 4.0), bash-completion, jq, curl, tar, gzip, bc, gawk, socat, acl, logrotate, polkitd | policykit-1
-Recommends: dnsutils, mailutils, netmask, whiptail
+Recommends: dnsutils, mailutils, netmask, whiptail, conntrack
 Maintainer: NFTBan Team <noreply@nftban.com>
 Description: Open-source Linux IPS and nftables firewall manager
  NFTBan is an open-source Linux Intrusion Prevention System (IPS) and


### PR DESCRIPTION
## v1.216.1 — refine sysctl dead-socket observability

Refines the v1.216.0 read-only sysctl dead-socket guard so it classifies a local TCP DB pool by **idle age** vs the live conntrack established timeout, instead of warning on *any* pool. Driven by a cross-distro observability audit + a real Ubuntu 24.04 lab proof.

- **Fixes the conservative false-positive** from actively-polled monitoring TCP sockets (the monitor `zabbix-agent2` PostgreSQL plugin, idle ~45–59s ≪ 600s) — no more spurious dead-socket WARN / watchdog elevation.
- **Adds idle-age classification:** CLEAN / INFO / WARN / UNKNOWN.
- **RPM/RHEL-family:** reads `/proc/net/nf_conntrack` (procfs) → full classification.
- **Debian/Ubuntu:** kernels ship `CONFIG_NF_CONNTRACK_PROCFS=n`, so `/proc/net/nf_conntrack` is absent → **optional `conntrack -L` fallback**. DEB package now **`Recommends: conntrack`** (not `Depends` — installed by default via apt, removable). RPM metadata unchanged.
- **UNKNOWN is a first-class, honest limited-observability state** — a DB pool exists but idle age can't be measured (no source): never silently CLEAN, advises `apt install conntrack`.
- **Watchdog elevates on WARN (`dead-socket risk`) only, never UNKNOWN.**
- **`idle_age_source`** (`procfs|conntrack-tool|none|unknown-format`) exposed in `nftban support` (`sysctl/idle-age-source.txt`) and risk-scan lines, so operators see *why* a host classified as it did.
- **No daemon/Go change** (byte-identical) · **schema unchanged 1.84.0** · **VERSION unchanged** (1.216.0; release-prep separate) · **no live sysctl writes** · read-only, credential-free (no DB queries).
- **Future HOLD lane registered:** a dependency-free **nfnetlink** conntrack reader (`OPEN_DEB_CONNTRACK_NFNETLINK_READER_V216_PLUS`) so Debian/Ubuntu eventually needs no extra package.

### Idle-age source order
1. `/proc/net/nf_conntrack` if readable → 2. `conntrack -L` if the tool exists → 3. UNKNOWN. Idle ≈ established_timeout − remaining; IPv4 + IPv6 loopback; DB ports 5432/3306/6379/27017; malformed output → UNKNOWN-FORMAT (never CLEAN).

### Tests
- `sysctl_risk_idle_age_v2161` — **26/26** (CLEAN/INFO/WARN/UNKNOWN matrix + agent2 repro + threshold boundary + **conntrack-tool fallback** [WARN/INFO/IPv6/malformed/empty via mock] + `idle_age_source` + DEB-Recommends/RPM-unchanged packaging asserts + credential-free/read-only/host-only guards)
- `sysctl_safe_default_v216` — **21/21** regression · `shellcheck -x -S warning` clean · `bash -n` clean
- **Real DEB lab proof (lab2, Ubuntu 24.04):** before conntrack → UNKNOWN (source=none); after `apt install conntrack` (1:1.4.8-1ubuntu1) → source=conntrack-tool, real `conntrack -L` parsed a real loopback DB session's remaining timer to a numeric idle. Live sysctl unchanged; synthetic session only.

### Docs
`docs/SYSCTL_DEAD_SOCKET_OBSERVABILITY.md` — observability matrix (RPM=procfs full; DEB=needs `conntrack` else UNKNOWN; UNKNOWN is honest; nfnetlink reader planned).

### Out of scope
Go/nfnetlink reader (HOLD lane); loopback-before-invalid (v1.217.0+); agent2/Zabbix template changes; profile-registry expansion; daemon/schema/VERSION.
