### PR TITLE
v1.216.2: fix LoginMon health evidence heartbeat

### DIFF
--- a/internal/loginmon/heartbeat_test.go
+++ b/internal/loginmon/heartbeat_test.go
@@ -1,0 +1,75 @@
+// =============================================================================
+// NFTBan v1.216.2 - LoginMon Source-Binding Heartbeat Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="loginmon_heartbeat_test"
+// meta:type="test"
+// meta:version="1.216.2"
+// meta:owner="NFTBan Project / Antonios Voulvoulis"
+// meta:description="Producer-side guarantees for the v1.216.2 LoginMon source-binding heartbeat: bound line carries registration marker + resolved_by=, unbound (sources=0) omits resolved_by= so genuine-unbound stays flagged, interval below the validator 15m journal window, and no secrets leak."
+// meta:inventory.files="internal/loginmon/heartbeat_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package loginmon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// v1.216.2 health-truth hotfix — producer-side guarantees for the source-binding
+// heartbeat that keeps VAL-LOGINMON-001 honest on quiet, long-running hosts.
+
+// A bound heartbeat (sources>0) must carry the registration marker AND resolved_by= so
+// the validator's registration + binding evidence both refresh from one line.
+func TestBindingHeartbeatLineBound(t *testing.T) {
+	line := bindingHeartbeatLine(3)
+	for _, want := range []string{"loginmon_source_binding_heartbeat", "resolved_by=", "sources=3", "state=running"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("bound heartbeat missing %q: %q", want, line)
+		}
+	}
+}
+
+// An unbound heartbeat (sources=0) must include the marker but NOT resolved_by=, so a
+// genuinely running-but-unbound module still trips the validator's binding AND-condition.
+func TestBindingHeartbeatLineUnbound(t *testing.T) {
+	line := bindingHeartbeatLine(0)
+	if !strings.Contains(line, "loginmon_source_binding_heartbeat") {
+		t.Errorf("unbound heartbeat missing registration marker: %q", line)
+	}
+	if strings.Contains(line, "resolved_by=") {
+		t.Errorf("unbound heartbeat (sources=0) must NOT carry resolved_by=: %q", line)
+	}
+	if !strings.Contains(line, "sources=0") {
+		t.Errorf("unbound heartbeat missing sources=0: %q", line)
+	}
+}
+
+// The heartbeat must fire well inside the validator's bounded journal window (15m,
+// internal/validator/journal.go) — otherwise the evidence ages out and the false INFO
+// returns. This guards against future interval drift.
+func TestBindingHeartbeatIntervalBelowJournalWindow(t *testing.T) {
+	const journalWindow = 15 * time.Minute
+	if bindingHeartbeatInterval >= journalWindow {
+		t.Fatalf("heartbeat interval %s must be < validator journal window %s", bindingHeartbeatInterval, journalWindow)
+	}
+}
+
+// The heartbeat must never leak secrets — only a source count and state vocabulary.
+func TestBindingHeartbeatLineNoSecrets(t *testing.T) {
+	for _, n := range []int{0, 1, 9} {
+		line := strings.ToLower(bindingHeartbeatLine(n))
+		for _, bad := range []string{"password", "passwd", "token", "secret", "smtp_pass", "key="} {
+			if strings.Contains(line, bad) {
+				t.Errorf("heartbeat line leaks %q: %q", bad, bindingHeartbeatLine(n))
+			}
+		}
+	}
+}

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -386,6 +386,50 @@ func (m *Module) startPipelineSnapshot(ctx context.Context) {
 	}
 }
 
+// bindingHeartbeatInterval is how often the source-binding heartbeat is emitted.
+// It MUST stay below the health validator's bounded journal-evidence window
+// (internal/validator/journal.go: 15 minutes) so the evidence never ages out on a
+// quiet, long-running host. v1.216.2 health-truth hotfix.
+const bindingHeartbeatInterval = 5 * time.Minute
+
+// bindingHeartbeatLine builds the periodic heartbeat log payload. Extracted (pure,
+// no receiver state beyond the count) so it is unit-testable without a running module.
+// When sources are bound (n>0) it includes "resolved_by=" so the validator's binding
+// evidence refreshes alongside the "loginmon_source_binding_heartbeat" registration
+// marker; when n==0 it deliberately omits "resolved_by=" so a genuinely unbound module
+// still trips VAL-LOGINMON-001's binding-evidence AND-condition. Never logs secrets —
+// only a source count and running state.
+func bindingHeartbeatLine(n int) string {
+	if n > 0 {
+		return fmt.Sprintf("loginmon_source_binding_heartbeat resolved_by=heartbeat sources=%d state=running", n)
+	}
+	return "loginmon_source_binding_heartbeat sources=0 state=running"
+}
+
+// startBindingHeartbeat periodically emits the source-binding heartbeat to journald so
+// the health validator (VAL-LOGINMON-001) can confirm a quiet, long-running LoginMon is
+// still running and bound. LoginMon logs its registration ("module_start: loginmon") and
+// per-source binding ("resolved_by=...") lines only once, at Start/discovery; on a quiet
+// host they age out of the validator's bounded 15-minute journal window (guaranteed on
+// volatile-journald hosts), producing a benign-but-recurring INFO. This heartbeat keeps
+// the evidence fresh. It changes no ban behavior and performs no source discovery — it
+// only reflects the already-captured bound-source count. v1.216.2.
+func (m *Module) startBindingHeartbeat(ctx context.Context) {
+	ticker := time.NewTicker(bindingHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.mu.RLock()
+			n := len(m.inputSources)
+			m.mu.RUnlock()
+			log.Printf("[LOGINMON] %s", bindingHeartbeatLine(n))
+		}
+	}
+}
+
 // Start begins the module's background work
 func (m *Module) Start(ctx context.Context) error {
 	ctx, m.cancel = context.WithCancel(ctx)
@@ -431,6 +475,11 @@ func (m *Module) Start(ctx context.Context) error {
 
 	// Start cleanup goroutine
 	go m.runCleanup(ctx)
+
+	// v1.216.2 health-truth: periodic source-binding heartbeat so the health
+	// validator can confirm a quiet, long-running LoginMon is still running+bound
+	// without depending on one-shot startup lines aging out of its 15m journal window.
+	go m.startBindingHeartbeat(ctx)
 
 	return nil
 }

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -326,8 +326,15 @@ func evaluateLoginMon(svcState ServiceState) *ModuleHealth {
 		// Both must be present — module_start alone proves the module loaded,
 		// but sources must be bound for LoginMon to actually process events.
 		// Two separate queries with AND semantics (not OR).
+		// v1.216.2 health-truth: also accept the periodic source-binding heartbeat
+		// ("loginmon_source_binding_heartbeat", emitted every 5m while running) as
+		// registration evidence. The one-shot "module_start: loginmon" line ages out
+		// of this bounded 15m window on quiet/long-running (and volatile-journald)
+		// hosts; the heartbeat keeps a healthy running+bound module from tripping a
+		// false VAL-LOGINMON-001. When sources are bound the heartbeat also carries
+		// "resolved_by=", so the binding query below refreshes from the same line.
 		regEvidence := queryJournal(context.Background(), JournalQuery{
-			Patterns: []string{"module_start: loginmon"},
+			Patterns: []string{"module_start: loginmon", "loginmon_source_binding_heartbeat"},
 			Since:    15 * time.Minute,
 		})
 		bindEvidence := queryJournal(context.Background(), JournalQuery{

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -601,6 +601,58 @@ func TestLoginMonJournalOnlyRegistration(t *testing.T) {
 	}
 }
 
+// v1.216.2 health-truth: the periodic source-binding heartbeat keeps a healthy,
+// long-running LoginMon from tripping VAL-LOGINMON-001 once the one-shot startup lines
+// ("module_start: loginmon") age out of the bounded 15m window. The bound heartbeat
+// carries BOTH the registration marker and resolved_by=, so a single fresh line proves
+// running+bound.
+func TestLoginMonHeartbeatSatisfiesEvidence(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+	// No "module_start: loginmon" (aged out) — only the heartbeat.
+	SetJournalReader(mockJournalReader{lines: []string{
+		"[LOGINMON] loginmon_source_binding_heartbeat resolved_by=heartbeat sources=3 state=running",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoEvidence {
+			t.Error("should NOT emit VAL-LOGINMON-001 when a bound-source heartbeat is fresh (startup lines aged out)")
+		}
+	}
+}
+
+// v1.216.2: an unbound heartbeat (sources=0, no resolved_by=) must STILL leave the genuine
+// running-but-unbound case flagged — the fix refreshes evidence, it does not blanket-suppress.
+func TestLoginMonHeartbeatUnboundStillFlags(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+	SetJournalReader(mockJournalReader{lines: []string{
+		"[LOGINMON] loginmon_source_binding_heartbeat sources=0 state=running",
+	}})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+
+	found := false
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoEvidence {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected VAL-LOGINMON-001 when heartbeat shows sources=0 (running but unbound, no resolved_by=)")
+	}
+}
+
 func TestLoginMonJournalNoEvidence(t *testing.T) {
 	// Running but no LoginMon evidence → info finding
 	cleanup := setupTestConfig(t, map[string]string{
@@ -772,7 +824,7 @@ func TestBlacklistManualPrimedZeroDrops(t *testing.T) {
 func TestReadConfigBoolLocalOverride(t *testing.T) {
 	cleanup := setupTestConfig(t, map[string]string{
 		"conf.d/botguard/main.conf":       `HTTP_BOTGUARD_ENABLED="false"`,
-		"conf.d/botguard/main.conf.local":  `HTTP_BOTGUARD_ENABLED="true"`,
+		"conf.d/botguard/main.conf.local": `HTTP_BOTGUARD_ENABLED="true"`,
 	})
 	defer cleanup()
 


### PR DESCRIPTION
## v1.216.2 — fix LoginMon health evidence heartbeat

Fixes a recurring benign **`[INFO] VAL-LOGINMON-001: no recent LoginMon runtime + source-binding evidence in journal (last 15m)`** on a **healthy, long-running LoginMon** (observed on srv4: Overall PROTECTED, Daemon RUNNING, LoginMon Runtime=running).

### Root cause
The validator proves "running + bound" by searching a **decaying 15-minute journal window** for **one-shot** startup/discovery lines — `module_start: loginmon` and `resolved_by=` — which LoginMon logs **once** at Start/source-discovery and never refreshes (`internal/validator/module_health.go` ANDs two 15m journal queries). On quiet long-running hosts the evidence ages out and the INFO fires forever (worse on srv3/srv4 with volatile in-memory journald). **Health-truth debt: an event log used as a state store.** Not a LoginMon failure.

### Fix (scope Option 1 — smallest safe)
- **`internal/loginmon/module.go`** — new always-on `startBindingHeartbeat` goroutine (launched from `Start()`, all modes) emitting, every **5 min** (< the 15m validator window):
  `[LOGINMON] loginmon_source_binding_heartbeat resolved_by=heartbeat sources=N state=running`
  Extracted `bindingHeartbeatLine(n)` + `bindingHeartbeatInterval` const for testability. **Logs only a source count (`sources=N`) — no source paths, no secrets.** No ban-logic change, no discovery change.
- **Real unbound case still emits:** when `sources=0` (running but nothing bound) the line **omits `resolved_by=`**, so the validator's binding AND-condition still (correctly) trips VAL-LOGINMON-001.
- **`internal/validator/module_health.go`** — registration-evidence query also accepts `loginmon_source_binding_heartbeat`; binding evidence remains satisfied by `resolved_by=`. A single fresh bound heartbeat refreshes both. Genuine missing/starved paths intact.

### Scope / constraints
- **BotGuard sibling deferred** — `VAL-BOTGUARD-001` uses the identical pattern but is default-OFF; registered as open debt `OPEN_HEALTH_TRUTH_BOTGUARD_JOURNAL_WINDOW_FALSE_INFO`. **Not** in this PR.
- **Daemon re-baseline: YES** (`nftband` + `nftban-validate` Go change) — not a shell-only lane.
- **Schema unchanged 1.84.0.** **VERSION unchanged** (1.216.1; release-prep separate). No sysctl/nft/conntrack change, no loopback, no profile-registry, no fleet mutation. No IPC redesign, no suppress-the-INFO band-aid.

### Tests
`go test ./internal/loginmon ./internal/validator` green, incl. `TestLoginMonHeartbeatSatisfiesEvidence`, `TestLoginMonHeartbeatUnboundStillFlags`, `TestBindingHeartbeatLine{Bound,Unbound,NoSecrets}`, `TestBindingHeartbeatIntervalBelowJournalWindow`, plus existing journal/validator tests. `go test ./...`, `go vet ./...`, gofmt on changed files all clean.
