### PR TITLE
v1.216.3: fix validator journal grep line cap

### DIFF
--- a/internal/validator/journal.go
+++ b/internal/validator/journal.go
@@ -26,10 +26,16 @@
 // - Silent: no impact on validator status, findings, or exit code
 //
 // Command shape:
-//   journalctl -u nftband --since "-15m" --no-pager -o cat -r -n 200
 //
-// Pattern matching is done in Go (substring), not journalctl --grep.
-// This avoids repeated subprocess cost and keeps matching deterministic.
+//	journalctl -u nftband --since "-15m" --no-pager -o cat -r [-g REGEX] -n 200
+//
+// v1.216.3: pattern queries are scoped SERVER-SIDE with `-g <regex>` (a
+// regexp.QuoteMeta-escaped OR of the literal patterns) so the `-n` line cap
+// bounds MATCHING lines, not all unit lines. Without this, a high-volume
+// journal (e.g. a host under auth attack emitting hundreds of [EVENT]/[BAN]
+// lines per minute) evicts low-rate evidence — the LoginMon 5-minute
+// heartbeat — from the returned window, reintroducing a false VAL-LOGINMON-001.
+// The Go-side substring scan is retained as first-match confirmation.
 // =============================================================================
 package validator
 
@@ -37,6 +43,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -80,11 +87,42 @@ type JournalReader interface {
 // SystemdJournalReader is the production implementation using journalctl.
 type SystemdJournalReader struct{}
 
+// buildJournalArgs constructs the journalctl argv for a bounded query.
+//
+// v1.216.3: when Patterns are present, a server-side `-g <regex>` is added — a
+// regexp.QuoteMeta-escaped OR of the literal patterns — placed before `-n` so the
+// line cap bounds MATCHING lines, not all unit lines. This is the fix for busy-host
+// eviction: previously `-n 200` capped total output before the Go-side match, so a
+// high-volume journal could hide low-rate evidence (the LoginMon 5m heartbeat).
+//
+// Security: every pattern is a compile-time internal constant, each is escaped with
+// regexp.QuoteMeta (so e.g. "[botguard] loaded" is a literal, not a character class),
+// and args are passed as argv to exec.Command — no shell, no injection, no overmatch.
+// Callers still get idempotent defaulting, so this is safe to unit-test standalone.
+func buildJournalArgs(q JournalQuery) []string {
+	applyDefaults(&q) // q is a value copy; local defaulting only
+	args := []string{
+		"-u", q.Unit,
+		"--since", fmt.Sprintf("-%dm", int(q.Since.Minutes())),
+		"--no-pager",
+		"-o", "cat",
+		"-r",
+	}
+	if len(q.Patterns) > 0 {
+		escaped := make([]string, len(q.Patterns))
+		for i, p := range q.Patterns {
+			escaped[i] = regexp.QuoteMeta(p)
+		}
+		args = append(args, "-g", strings.Join(escaped, "|"))
+	}
+	args = append(args, "-n", fmt.Sprintf("%d", q.MaxLines))
+	return args
+}
+
 // Query executes a bounded journalctl query and matches patterns in Go.
 //
-// Strategy: fetch bounded output once with -o cat -r -n N, then scan
-// lines for substring matches. No --grep, no shell pipes, no repeated
-// subprocess calls.
+// Strategy: fetch server-side pattern-scoped output (-g, v1.216.3) bounded by
+// -o cat -r -n N, then scan lines for substring matches (first match wins).
 func (SystemdJournalReader) Query(ctx context.Context, q JournalQuery) JournalEvidence {
 	applyDefaults(&q)
 
@@ -92,32 +130,63 @@ func (SystemdJournalReader) Query(ctx context.Context, q JournalQuery) JournalEv
 	ctx, cancel := context.WithTimeout(ctx, q.Timeout)
 	defer cancel()
 
-	// Build command: journalctl -u UNIT --since "-Xm" --no-pager -o cat -r -n N
-	sinceArg := fmt.Sprintf("-%dm", int(q.Since.Minutes()))
-	cmd := exec.CommandContext(ctx, "journalctl", // #nosec G204 -- args are bounded, not user-controlled
-		"-u", q.Unit,
-		"--since", sinceArg,
-		"--no-pager",
-		"-o", "cat",
-		"-r",
-		"-n", fmt.Sprintf("%d", q.MaxLines),
-	)
+	// Fixed binary "journalctl"; buildJournalArgs returns bounded internal constants,
+	// each pattern regexp.QuoteMeta-escaped, passed as argv (no shell, no tainted input).
+	cmd := exec.CommandContext(ctx, "journalctl", buildJournalArgs(q)...) // #nosec G204 -- args are bounded internal constants, escaped, argv-only (no shell)
 
 	out, err := cmd.Output()
+	return parseJournalResult(q, out, err, ctx.Err())
+}
+
+// parseJournalResult maps a journalctl invocation (stdout, exec error, and the
+// context error) to structured evidence. Pure and unit-testable without a live journal.
+//
+// v1.216.3 CRITICAL semantics with server-side -g: journalctl exits 1 with empty output
+// when nothing matches (grep convention, verified on systemd 252/255). For a PATTERN
+// query that is a definitive "evidence absent" result — returned as ErrNone/Found=false
+// so callers still emit their "no evidence" finding (e.g. VAL-LOGINMON-001 must still
+// fire when a module is genuinely unbound/dead). If this were classified ErrEmpty, the
+// callers' `ErrKind == ErrNone` guard would suppress the finding entirely. Real failures
+// (timeout, exec-not-found, other non-zero exit) still classify as errors so the caller
+// fails safe (no emit) rather than asserting absence it could not determine.
+func parseJournalResult(q JournalQuery, out []byte, err error, ctxErr error) JournalEvidence {
+	hasPatterns := len(q.Patterns) > 0
 	if err != nil {
-		return classifyError(ctx, err)
+		if ctxErr != nil {
+			return JournalEvidence{ErrKind: ErrTimeout, Err: err}
+		}
+		if _, ok := err.(*exec.Error); ok {
+			return JournalEvidence{ErrKind: ErrExec, Err: err} // binary missing / perm denied
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ExitCode() == 1 {
+				// exit 1 = grep-style "no match". For a pattern query this is a
+				// successful absence, not a failure.
+				if hasPatterns {
+					return JournalEvidence{ErrKind: ErrNone, Found: false}
+				}
+				return JournalEvidence{ErrKind: ErrEmpty}
+			}
+			return JournalEvidence{ErrKind: ErrNonZero, Err: err}
+		}
+		return JournalEvidence{ErrKind: ErrExec, Err: err}
 	}
 
 	raw := strings.TrimSpace(string(out))
 	if raw == "" {
+		// Ran clean (exit 0) but no output. For a pattern query (-g) that is a
+		// definitive no-match; treat as ErrNone/Found=false (absent), same as exit 1.
+		if hasPatterns {
+			return JournalEvidence{ErrKind: ErrNone, Found: false}
+		}
 		return JournalEvidence{ErrKind: ErrEmpty}
 	}
 
 	lines := strings.Split(raw, "\n")
 	truncated := len(lines) >= q.MaxLines
 
-	// Scan for patterns (substring match, case-sensitive, first match wins)
-	if len(q.Patterns) > 0 {
+	// Scan for patterns (substring match, case-sensitive, first match wins).
+	if hasPatterns {
 		for i, line := range lines {
 			for _, pattern := range q.Patterns {
 				if strings.Contains(line, pattern) {
@@ -133,31 +202,12 @@ func (SystemdJournalReader) Query(ctx context.Context, q JournalQuery) JournalEv
 		}
 	}
 
-	// No pattern match (or no patterns specified)
+	// No pattern match (or no patterns specified).
 	return JournalEvidence{
 		Found:     false,
 		LinesRead: len(lines),
 		Truncated: truncated,
 	}
-}
-
-// classifyError maps exec errors to structured ErrKind.
-func classifyError(ctx context.Context, err error) JournalEvidence {
-	if ctx.Err() != nil {
-		return JournalEvidence{ErrKind: ErrTimeout, Err: err}
-	}
-	if _, ok := err.(*exec.Error); ok {
-		// Binary not found / permission denied
-		return JournalEvidence{ErrKind: ErrExec, Err: err}
-	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		// journalctl exits 1 on no matches with some configurations
-		if exitErr.ExitCode() == 1 {
-			return JournalEvidence{ErrKind: ErrEmpty}
-		}
-		return JournalEvidence{ErrKind: ErrNonZero, Err: err}
-	}
-	return JournalEvidence{ErrKind: ErrExec, Err: err}
 }
 
 // applyDefaults sets safe defaults for zero-value query fields.

--- a/internal/validator/journal_args_test.go
+++ b/internal/validator/journal_args_test.go
@@ -1,0 +1,190 @@
+// =============================================================================
+// NFTBan v1.216.3 - Journal Query Arg Construction Tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="journal_args_test"
+// meta:type="test"
+// meta:version="1.216.3"
+// meta:owner="NFTBan Project / Antonios Voulvoulis"
+// meta:description="Command-construction guards for buildJournalArgs: pattern queries use server-side -g (regexp.QuoteMeta-escaped OR) placed before -n so the line cap bounds MATCHING lines, not all unit lines (busy-host heartbeat eviction fix); non-pattern queries stay unscoped; regex metacharacters are escaped (no overmatch, no injection); bounds/format flags retained."
+// meta:inventory.files="internal/validator/journal_args_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+package validator
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// exit1Err returns a genuine *exec.ExitError with exit code 1 and empty output,
+// mirroring `journalctl -g <pattern>` when nothing matches (grep convention).
+func exit1Err(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("false").Run() // exits 1, no output
+	if _, ok := err.(*exec.ExitError); !ok {
+		t.Fatalf("expected *exec.ExitError from `false`, got %T (%v)", err, err)
+	}
+	return err
+}
+
+// v1.216.3 CRITICAL: with server-side -g, a PATTERN query that matches nothing exits 1
+// (empty). That must be reported as ErrNone/Found=false (a definitive absence), NOT
+// ErrEmpty — otherwise callers whose guard is `ErrKind == ErrNone` would stop emitting
+// VAL-LOGINMON-001 / VAL-BOTGUARD-001 for a genuinely unbound/dead module.
+func TestParseJournalResult_PatternNoMatchExit1IsAbsentNotError(t *testing.T) {
+	ev := parseJournalResult(JournalQuery{Patterns: []string{"loginmon_source_binding_heartbeat"}}, nil, exit1Err(t), nil)
+	if ev.ErrKind != ErrNone {
+		t.Errorf("pattern no-match (exit 1) must be ErrNone (absent), got %q", ev.ErrKind)
+	}
+	if ev.Found {
+		t.Error("pattern no-match must have Found=false")
+	}
+}
+
+// Exit-0 with empty output for a pattern query is likewise a clean no-match → absent.
+func TestParseJournalResult_PatternEmptyExit0IsAbsent(t *testing.T) {
+	ev := parseJournalResult(JournalQuery{Patterns: []string{"x"}}, []byte("  \n"), nil, nil)
+	if ev.ErrKind != ErrNone || ev.Found {
+		t.Errorf("pattern empty exit0 must be ErrNone/absent, got %+v", ev)
+	}
+}
+
+// A match is Found=true, first-match-wins.
+func TestParseJournalResult_Match(t *testing.T) {
+	out := []byte("noise\n[LOGINMON] loginmon_source_binding_heartbeat resolved_by=heartbeat sources=4 state=running\n")
+	ev := parseJournalResult(JournalQuery{Patterns: []string{"loginmon_source_binding_heartbeat"}}, out, nil, nil)
+	if !ev.Found || ev.ErrKind != ErrNone {
+		t.Errorf("expected Found=true/ErrNone, got %+v", ev)
+	}
+}
+
+// A real query failure (timeout / exec-not-found) must NOT be reported as absence —
+// callers fail safe (no emit) rather than asserting an absence they couldn't determine.
+func TestParseJournalResult_HardFailuresAreErrors(t *testing.T) {
+	// timeout: ctxErr set
+	if ev := parseJournalResult(JournalQuery{Patterns: []string{"x"}}, nil, exit1Err(t), context.DeadlineExceeded); ev.ErrKind != ErrTimeout {
+		t.Errorf("ctxErr set must be ErrTimeout, got %q", ev.ErrKind)
+	}
+	// binary missing: *exec.Error
+	if ev := parseJournalResult(JournalQuery{Patterns: []string{"x"}}, nil, &exec.Error{Name: "journalctl", Err: exec.ErrNotFound}, nil); ev.ErrKind != ErrExec {
+		t.Errorf("exec.Error must be ErrExec, got %q", ev.ErrKind)
+	}
+}
+
+// argIndex returns the index of flag in args, or -1.
+func argIndex(args []string, flag string) int {
+	for i, a := range args {
+		if a == flag {
+			return i
+		}
+	}
+	return -1
+}
+
+// argValue returns the value immediately following flag, or "".
+func argValue(args []string, flag string) string {
+	i := argIndex(args, flag)
+	if i < 0 || i+1 >= len(args) {
+		return ""
+	}
+	return args[i+1]
+}
+
+// The core fix: a pattern query must scope server-side with -g, and -g must come
+// BEFORE -n so journalctl's line cap bounds MATCHING lines (not all unit lines).
+func TestBuildJournalArgs_PatternQueryUsesGrepBeforeCap(t *testing.T) {
+	args := buildJournalArgs(JournalQuery{
+		Unit:     "nftband",
+		Patterns: []string{"module_start: loginmon", "loginmon_source_binding_heartbeat"},
+	})
+	gi := argIndex(args, "-g")
+	ni := argIndex(args, "-n")
+	if gi < 0 {
+		t.Fatalf("pattern query must include -g; args=%v", args)
+	}
+	if ni < 0 {
+		t.Fatalf("query must retain -n; args=%v", args)
+	}
+	if gi > ni {
+		t.Errorf("-g (%d) must precede -n (%d) so the cap bounds matching lines; args=%v", gi, ni, args)
+	}
+	got := argValue(args, "-g")
+	want := regexp.QuoteMeta("module_start: loginmon") + "|" + regexp.QuoteMeta("loginmon_source_binding_heartbeat")
+	if got != want {
+		t.Errorf("-g value = %q, want escaped OR %q", got, want)
+	}
+}
+
+// Non-pattern queries keep the original unscoped bounded behavior (no -g).
+func TestBuildJournalArgs_NonPatternQueryNoGrep(t *testing.T) {
+	args := buildJournalArgs(JournalQuery{Unit: "nftband"})
+	if argIndex(args, "-g") != -1 {
+		t.Errorf("non-pattern query must NOT include -g; args=%v", args)
+	}
+	if argIndex(args, "-n") == -1 {
+		t.Errorf("non-pattern query must retain -n; args=%v", args)
+	}
+}
+
+// Regex metacharacters in a literal pattern must be escaped so -g does not
+// overmatch. "[botguard] loaded" must become a literal, not a character class.
+func TestBuildJournalArgs_RegexEscapeNoOvermatch(t *testing.T) {
+	args := buildJournalArgs(JournalQuery{
+		Unit:     "nftband",
+		Patterns: []string{"[botguard] loaded"},
+	})
+	g := argValue(args, "-g")
+	if g != `\[botguard\] loaded` {
+		t.Errorf("-g value = %q, want escaped literal %q", g, `\[botguard\] loaded`)
+	}
+	// Compile as a regex and prove it matches the literal but NOT a single class char.
+	re := regexp.MustCompile(g)
+	if re.MatchString("b") {
+		t.Error("escaped pattern overmatches 'b' — [botguard] was treated as a character class")
+	}
+	if !re.MatchString("2026 xx [botguard] loaded 3 crawlers") {
+		t.Error("escaped pattern should still match the literal line")
+	}
+}
+
+// Bounds and output format flags are retained (deterministic newest-first, cat, since, unit, cap).
+func TestBuildJournalArgs_RetainsBounds(t *testing.T) {
+	args := buildJournalArgs(JournalQuery{
+		Unit:     "nftband",
+		Patterns: []string{"resolved_by="},
+		Since:    15 * time.Minute,
+		MaxLines: 200,
+	})
+	if argValue(args, "-u") != "nftband" {
+		t.Errorf("missing/incorrect -u: %v", args)
+	}
+	if argValue(args, "--since") != "-15m" {
+		t.Errorf("--since = %q, want -15m; args=%v", argValue(args, "--since"), args)
+	}
+	if argValue(args, "-n") != "200" {
+		t.Errorf("-n = %q, want 200; args=%v", argValue(args, "-n"), args)
+	}
+	if argValue(args, "-o") != "cat" {
+		t.Errorf("-o = %q, want cat; args=%v", argValue(args, "-o"), args)
+	}
+	if argIndex(args, "-r") == -1 {
+		t.Errorf("missing -r (newest-first); args=%v", args)
+	}
+}
+
+// Defaults apply when zero-valued (self-contained, so the helper is testable standalone).
+func TestBuildJournalArgs_AppliesDefaults(t *testing.T) {
+	args := buildJournalArgs(JournalQuery{Unit: "nftband", Patterns: []string{"x"}})
+	if argValue(args, "--since") == "" || argValue(args, "-n") == "" {
+		t.Errorf("defaults for --since/-n not applied; args=%v", args)
+	}
+}

--- a/internal/validator/module_health_test.go
+++ b/internal/validator/module_health_test.go
@@ -653,6 +653,36 @@ func TestLoginMonHeartbeatUnboundStillFlags(t *testing.T) {
 	}
 }
 
+// v1.216.3 end-to-end: startup evidence aged out, high volume of unrelated [EVENT]/[BAN]
+// lines, but the bound heartbeat is within the window → no VAL-LOGINMON-001. The busy-host
+// EVICTION fix itself is a command-semantics property guarded in journal_args_test.go
+// (pattern queries use server-side -g before -n); this test confirms the evaluator verdict
+// once the reader surfaces the heartbeat alongside noise, without any startup line present.
+func TestLoginMonHighVolumeHeartbeatFound(t *testing.T) {
+	cleanup := setupTestConfig(t, map[string]string{
+		"conf.d/login_alert.conf.local": `NFTBAN_LOGIN_ALERT_ENABLED="true"`,
+	})
+	defer cleanup()
+	lines := []string{
+		"[LOGINMON] loginmon_source_binding_heartbeat resolved_by=heartbeat sources=4 state=running",
+	}
+	for i := 0; i < 500; i++ {
+		lines = append(lines, "[EVENT] login_failed: loginmon ip=203.0.113.7 user=root ssh_preauth_disconnect")
+		lines = append(lines, "[BAN] REFUSED (never-ban exempt): 198.51.100.9")
+	}
+	SetJournalReader(mockJournalReader{lines: lines})
+	defer SetJournalReader(SystemdJournalReader{})
+
+	moduleFindings = nil
+	evaluateLoginMon(ServiceState{Nftband: RuntimeRunning})
+
+	for _, f := range moduleFindings {
+		if f.Code == CodeLoginMonNoEvidence {
+			t.Error("should NOT emit VAL-LOGINMON-001 when a bound heartbeat is present amid high-volume noise")
+		}
+	}
+}
+
 func TestLoginMonJournalNoEvidence(t *testing.T) {
 	// Running but no LoginMon evidence → info finding
 	cleanup := setupTestConfig(t, map[string]string{


### PR DESCRIPTION
## v1.216.3 — fix validator journal grep line cap

Narrow follow-up to **v1.216.2 (published but NOT fleet-approved)**. v1.216.2 fixed the *quiet-host* LoginMon false `VAL-LOGINMON-001`, but package-native validation **failed on lab2 (busy DEB host)** and its **fleet rollout is blocked**.

### Root cause
The validator journal reader (`internal/validator/journal.go`) ran `journalctl -u nftband --since -15m -o cat -r **-n 200**` and matched patterns **client-side in Go** — so the `-n 200` cap is applied *before* matching. On a busy host (lab2 under real SSH-attack traffic, ~488 nftband lines/min of `[EVENT]`/`[BAN]`) the 5-minute heartbeat (2 lines/15m) is evicted from the returned 200-line window → `VAL-LOGINMON-001` still fires. Universal under high log volume; hermetic tests missed it because the mock reader bypasses `-n`.

### Fix (`journal.go` only)
- Extract pure **`buildJournalArgs(q) []string`**. When `Patterns` present, add server-side **`-g <regex>`** — a `regexp.QuoteMeta`-escaped OR of the literal patterns, joined with `|`, passed as **argv** (not a shell string), placed **before `-n`** — so **`-n 200` now bounds *matching* lines**, not all unit lines. `--since`, `-o cat`, `-r`, `-n`, timeout retained; non-pattern queries keep the original no-`-g` behavior.
- **`[botguard] loaded` is escaped to a literal**, not a regex character class (proven in test).
- Extract pure **`parseJournalResult(q,out,err,ctxErr)`**. **Critical no-match semantics:** server-side `-g` makes journalctl **exit 1 / empty on no-match** (grep convention, verified on systemd 252/255). For a pattern query that is a **definitive absence** → returned as **`ErrNone`/`Found=false`** so callers still emit their missing-evidence finding (a genuinely unbound/dead module must still trip). Classifying it as a query error would have **silently suppressed** the finding (callers guard on `ErrKind == ErrNone`). Real failures (timeout / exec-not-found / other non-zero) stay errors → caller fails safe.

### Scope
- **LoginMon producer unchanged**; **BotGuard producer unchanged.** No IPC redesign, no suppress-only band-aid.
- **Bonus:** the shared journal reader also fixes the same line-cap eviction for the BotGuard validator evidence query.
- **Daemon/tool re-baseline: YES** (`nftban-validate` changes; `nftband` relinks `internal/validator`). **Schema unchanged 1.84.0.** **VERSION unchanged** (1.216.2; release-prep separate). No sysctl/nft/conntrack/package change. No fleet mutation.

### Tests
`journal_args_test.go` — `buildJournalArgs`: `-g` present + escaped-OR value + **`-g` before `-n`** (key command-semantics guard), regex-escape no-overmatch, non-pattern no `-g`, bounds retained, defaults; `parseJournalResult`: **exit-1-no-match → `ErrNone`/absent** (real `*exec.ExitError`), exit-0-empty → absent, match → Found, timeout/exec → errors. `module_health_test.go` — `TestLoginMonHighVolumeHeartbeatFound` (heartbeat amid 1000 noise lines → no finding). Existing `journal_test.go` T1–T9 + LoginMon/heartbeat/BotGuard tests green. `go test ./...` + `go vet ./...` + gofmt clean.

### Post-merge ladder
release-prep v1.216.3 → tag/publish → **lab2 DEB first** (must now show `VAL-LOGINMON-001` absent under load) → lab4 RPM → srv4 canary → serial fleet.
