### PR TITLE
v1.216.4: classify update warnings and fix timer restore false warn

### DIFF
--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -818,6 +818,9 @@ _cmd_update_main_locked() {
         _summary_warnings=$(tail -n +$((_ilog_before_lines + 1)) "$_ilog_file" 2>/dev/null | grep -c -iE 'WARN|⚠' || true)
         _summary_warnings=${_summary_warnings//[^0-9]/}; _summary_warnings=${_summary_warnings:-0}
     fi
+    # v1.216.4: classify the raw warnings into action / recovered / accepted / external so
+    # the summary and operator-readiness reflect only warnings that actually need action.
+    _update_classify_warnings "$_ilog_file" "$_ilog_before_lines"
 
     case "$_installer_state" in
         COMMITTED)
@@ -842,6 +845,12 @@ _cmd_update_main_locked() {
             # be COMMITTED). One block only — no second/contradictory verdict.
             local _rd_ready="PASS" _rd_action="NONE"
             if [[ "${health_status:-0}" -ne 0 ]]; then _rd_ready="PASS_WITH_WARN"; _rd_action="WARN"; fi
+            # v1.216.4 invariant: "Action needed: NONE" iff there are ZERO warnings requiring
+            # action. Recovered/accepted/external advisories never force an action verdict —
+            # only WARN_REAL (a genuine unresolved warning) does.
+            if [[ "${_NFTBAN_WARN_REAL:-0}" -gt 0 ]]; then
+                _rd_ready="PASS_WITH_WARN"; _rd_action="review ${_NFTBAN_WARN_REAL} warning(s) requiring action"
+            fi
             printf "  %-20s %s\n" "Operational:" "YES"
             printf "  %-20s %s\n" "Upgrade readiness:" "$_rd_ready"
             printf "  %-20s %s\n" "Action needed:" "$_rd_action"

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -90,6 +90,40 @@ _update_start_banner() {
 # Reads the module-global _RUN_ID / FORENSIC_RUN_DIR / UPDATE_LOG_FILE; failed-unit count
 # is read LIVE at summary time. Usage:
 #   _update_final_summary <result> <before_ver> <after_ver> <duration_s> <warnings> <validation>
+
+# _update_classify_warnings: bucket the WARN/⚠ lines in THIS run's installer.log slice
+# into operator-meaningful classes (v1.216.4) so a clean upgrade does not report generic
+# scary warnings. Sets module globals used by _update_final_summary:
+#   _NFTBAN_WARN_REAL      — warnings that require operator action
+#   _NFTBAN_WARN_RECOVERED — transients that self-healed (e.g. a recovered timer restore)
+#   _NFTBAN_WARN_ACCEPTED  — deliberate register-tracked exceptions (tmpfiles firewall-validate, v1.175)
+#   _NFTBAN_WARN_EXTERNAL  — OS/package-manager advisories (needrestart, pending kernel) — not NFTBan
+# W2 (tmpfiles exit 73) + W3 (unsafe path transition) are the SAME tmpfiles event → deduped to
+# ONE accepted exception; needrestart/kernel lines dedup to one external advisory.
+# Usage: _update_classify_warnings <installer_log> <before_line_count>
+_update_classify_warnings() {
+    local ilog="${1:-}" before="${2:-0}"
+    _NFTBAN_WARN_REAL=0; _NFTBAN_WARN_RECOVERED=0; _NFTBAN_WARN_ACCEPTED=0; _NFTBAN_WARN_EXTERNAL=0
+    [[ -f "$ilog" ]] || return 0
+    # Classify by SIGNATURE first (accepted/external lines often lack a WARN tag), skipping
+    # the installer's own meta self-report; only genuinely warn-tagged remainder = REAL.
+    # Order matters: specific signatures are matched before the generic WARN/non-fatal catch.
+    local line _tmpfiles=0 _external=0
+    while IFS= read -r line; do
+        case "$line" in
+            *"recovered — verified active"*)                                             _NFTBAN_WARN_RECOVERED=$((_NFTBAN_WARN_RECOVERED + 1)); continue ;;
+            *"exit 73"*|*"unsafe path transition"*|*"firewall-validate"*)                 _tmpfiles=1; continue ;;                                       # W2/W3 accepted (deduped)
+            *"Pending kernel"*|*needrestart*|*"deferred"*|*"Restarting services"*|*"outdated binaries"*) _external=1; continue ;;                        # W4 external (deduped)
+            *"still inactive after restore"*)                                            _NFTBAN_WARN_REAL=$((_NFTBAN_WARN_REAL + 1)); continue ;;      # W1 real
+            *", with "*"warning"*|*" warning — non-fatal"*|*"non-fatal"*)                 continue ;;                                                    # installer meta self-report — skip
+            *"WARN"*|*"⚠"*)                                                              _NFTBAN_WARN_REAL=$((_NFTBAN_WARN_REAL + 1)); continue ;;      # any other warn-tagged line = real
+        esac
+    done < <(tail -n +$((before + 1)) "$ilog" 2>/dev/null)
+    [[ "$_tmpfiles" -eq 1 ]] && _NFTBAN_WARN_ACCEPTED=1
+    [[ "$_external" -eq 1 ]] && _NFTBAN_WARN_EXTERNAL=1
+    return 0
+}
+
 _update_final_summary() {
     local result="${1:-UNKNOWN}" before="${2:-?}" after="${3:-?}" dur="${4:-?}"
     local warnings="${5:-0}" validation="${6:-unavailable}"
@@ -106,7 +140,13 @@ _update_final_summary() {
     echo "  ┌─ Update summary ─────────────────────────────────────"
     printf '  │ %-16s %s\n' "Result:"          "$result"
     printf '  │ %-16s %s\n' "Version:"         "v${before} → v${after} (${dur}s)"
-    printf '  │ %-16s %s\n' "Warnings:"        "$warnings"
+    # v1.216.4: class-aware warning breakdown so a clean upgrade doesn't show a scary
+    # generic count. Falls back to the plain count if warnings were not classified.
+    if [[ -n "${_NFTBAN_WARN_REAL:-}" ]]; then
+        printf '  │ %-16s %s\n' "Warnings:" "${_NFTBAN_WARN_REAL} action / ${_NFTBAN_WARN_RECOVERED:-0} recovered / ${_NFTBAN_WARN_ACCEPTED:-0} accepted / ${_NFTBAN_WARN_EXTERNAL:-0} external"
+    else
+        printf '  │ %-16s %s\n' "Warnings:" "$warnings"
+    fi
     printf '  │ %-16s %s\n' "Failed units:"    "$failed_units"
     printf '  │ %-16s %s\n' "Validation:"      "$validation"
     printf '  │ %-16s %s\n' "Completed phases:" "${phases_done}/${phases_total}"
@@ -361,11 +401,35 @@ _update_inhibit_cadence_timers() {
 _update_restore_cadence_timers() {
     [[ -z "${_NFTBAN_INHIBITED_TIMERS:-}" ]] && return 0
     command -v systemctl >/dev/null 2>&1 || { _NFTBAN_INHIBITED_TIMERS=""; return 0; }
-    local t
-    for t in $_NFTBAN_INHIBITED_TIMERS; do
-        systemctl start "$t" 2>/dev/null || _update_log WARN "Failed to restart inhibited timer $t — start it manually: systemctl start $t"
+    # v1.216.4 BUG-UPDATE-INHIBITED-TIMER-FALSE-WARN: _NFTBAN_INHIBITED_TIMERS is a
+    # space-joined string, but the update entrypoint sets IFS=$'\n\t' (space excluded),
+    # so a bare `for t in $var` did NOT split it — systemctl was handed both timers as
+    # ONE malformed unit name and always "failed", emitting a false WARN even though the
+    # installer's timer reconciliation left them active. Split on space explicitly (scoped
+    # IFS on the read), start each timer individually, then VERIFY with is-active: warn
+    # ONLY if a timer is genuinely still inactive after restore (a transient start failure
+    # that self-heals is a recovered advisory, not a real warning).
+    local t transient=0
+    local -a _timers_arr=() restored=() still_inactive=()
+    IFS=' ' read -r -a _timers_arr <<< "$_NFTBAN_INHIBITED_TIMERS"
+    for t in "${_timers_arr[@]}"; do
+        [[ -n "$t" ]] || continue
+        systemctl start "$t" 2>/dev/null || transient=1
+        if systemctl is-active --quiet "$t" 2>/dev/null; then
+            restored+=("$t")
+        else
+            still_inactive+=("$t")
+        fi
     done
-    _update_log INFO "Restored cadence timer(s): ${_NFTBAN_INHIBITED_TIMERS}"
+    if [[ ${#still_inactive[@]} -gt 0 ]]; then
+        # WARN_REAL: a cadence timer is actually down after restore — operator action needed.
+        _update_log WARN "cadence timer(s) still inactive after restore: ${still_inactive[*]} — start manually: systemctl start ${still_inactive[*]}"
+    elif [[ "$transient" -eq 1 ]]; then
+        # WARN_RECOVERED: start returned non-zero but is-active confirms recovery (no action).
+        _update_log INFO "Restored cadence timer(s): ${restored[*]} (recovered — verified active after a transient start error)"
+    else
+        _update_log INFO "Restored cadence timer(s): ${restored[*]} (verified active)"
+    fi
     _NFTBAN_INHIBITED_TIMERS=""
     return 0
 }

--- a/cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh
+++ b/cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Test - Update Warning Taxonomy + Timer-Restore Fix (v1.216.4)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="update-warning-taxonomy-v2164-test"
+# meta:type="test"
+# meta:header="Update Warning Taxonomy v1.216.4"
+# meta:version="1.216.3"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Hermetic regression for v1.216.4 lane A. (1) BUG-UPDATE-INHIBITED-TIMER-FALSE-WARN: under the update entrypoint IFS (newline+tab, no space) _update_restore_cadence_timers must still start EACH inhibited timer individually (never as one combined malformed unit) and warn ONLY if a timer is genuinely inactive after restore — a transient start error that self-heals is a recovered advisory, not a WARN. (2) _update_classify_warnings buckets installer-log WARN lines into action/recovered/accepted/external, dedups the tmpfiles firewall-validate exception (W2/W3) and needrestart/kernel advisory (W4), skips the installer meta self-report, and leaves a genuine WARN as REAL. (3) static: Action needed:NONE iff WARN_REAL==0."
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh,cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,systemctl(stub)"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:created_date="2026-07-04"
+# meta:updated_date="2026-07-04"
+# =============================================================================
+set -Eeuo pipefail
+SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT=$(cd "$SD/../../../.." && pwd)
+HELPERS="$ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+CMDUPD="$ROOT/cli/lib/nftban/cli/cmd_update.sh"
+P=0; F=0
+ok(){ echo "PASS $1"; P=$((P+1)); }
+no(){ echo "FAIL $1 ${2:-}"; F=$((F+1)); }
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+CALLS="$WORK/calls"; LOG="$WORK/log"
+
+declare -A ACTIVE=()
+FAIL_TIMER=""   # a timer name whose `start` fails and never becomes active (simulates a real stuck timer)
+systemctl() {
+    local IFS=' '            # record args space-joined regardless of the caller's IFS ($* uses IFS[0])
+    echo "$*" >> "$CALLS"
+    case "${1:-}" in
+        is-active) local u="${*: -1}"; [[ "${ACTIVE[$u]:-0}" = 1 ]] && return 0 || return 1 ;;
+        stop)      ACTIVE[${2:-}]=0; return 0 ;;
+        start)     if [[ "${2:-}" == "$FAIL_TIMER" ]]; then return 1; fi; ACTIVE[${2:-}]=1; return 0 ;;
+        *)         return 0 ;;
+    esac
+}
+# shellcheck source=/dev/null
+source "$HELPERS"
+set +e
+_update_log(){ echo "$1 ${*:2}" >> "$LOG"; }   # capture level+message
+calls_have(){ grep -qx -- "$1" "$CALLS"; }
+
+echo "== W1-A: restore under IFS=\$'\\n\\t' starts EACH timer individually (no combined-arg bug) =="
+: > "$CALLS"; : > "$LOG"; ACTIVE=(); FAIL_TIMER=""
+_NFTBAN_INHIBITED_TIMERS="nftban-watchdog.timer nftban-maintenance.timer"
+OLDIFS=$IFS; IFS=$'\n\t'          # reproduce cmd_update.sh:30 (space NOT in IFS)
+_update_restore_cadence_timers
+IFS=$OLDIFS
+calls_have "start nftban-watchdog.timer"     && ok "W1-A started watchdog.timer individually"   || no "W1-A watchdog not started"
+calls_have "start nftban-maintenance.timer"  && ok "W1-A started maintenance.timer individually" || no "W1-A maintenance not started"
+grep -q "start nftban-watchdog.timer nftban-maintenance.timer" "$CALLS" && no "W1-A combined-arg bug present" || ok "W1-A no combined-arg systemctl call"
+grep -qi 'WARN' "$LOG" && no "W1-A emitted a WARN though both timers active" "$(cat "$LOG")" || ok "W1-A no false WARN (both verified active)"
+[[ -z "$_NFTBAN_INHIBITED_TIMERS" ]] && ok "W1-A inhibited-list cleared" || no "W1-A list not cleared"
+
+echo "== W1-B: WARN_REAL only when a timer stays inactive after restore =="
+: > "$CALLS"; : > "$LOG"; ACTIVE=(); FAIL_TIMER="nftban-maintenance.timer"
+_NFTBAN_INHIBITED_TIMERS="nftban-watchdog.timer nftban-maintenance.timer"
+_update_restore_cadence_timers
+grep -qi 'WARN.*still inactive after restore.*nftban-maintenance.timer' "$LOG" && ok "W1-B real WARN when timer genuinely inactive" || no "W1-B no real WARN emitted" "$(cat "$LOG")"
+
+echo "== W1-C: transient start error that self-heals is recovered, not WARN =="
+# start 'fails' but is-active still reports active (self-heal via installer reconciliation)
+: > "$CALLS"; : > "$LOG"; ACTIVE=( [nftban-watchdog.timer]=1 ); FAIL_TIMER="nftban-watchdog.timer"
+_NFTBAN_INHIBITED_TIMERS="nftban-watchdog.timer"
+_update_restore_cadence_timers
+{ grep -qi 'recovered — verified active' "$LOG" && ! grep -qi 'WARN' "$LOG"; } && ok "W1-C transient→recovered advisory, no WARN" || no "W1-C misclassified" "$(cat "$LOG")"
+
+echo "== W1-D: empty inhibited list is a clean no-op =="
+: > "$CALLS"; : > "$LOG"; _NFTBAN_INHIBITED_TIMERS=""
+_update_restore_cadence_timers
+[[ ! -s "$CALLS" && ! -s "$LOG" ]] && ok "W1-D empty list no-op" || no "W1-D acted on empty list"
+
+echo "== TAX: classify buckets action/recovered/accepted/external, dedups tmpfiles+needrestart, skips meta =="
+ILOG="$WORK/installer.log"
+cat > "$ILOG" <<'LOGEOF'
+[NFTBan WARN] 19:29:56 systemd-tmpfiles --create failed (exit 73) — non-fatal
+Detected unsafe path transition /run/nftban (owned by nftban) -> /run/nftban/firewall-validate (owned by root)
+Pending kernel upgrade!
+  systemctl restart networkd-dispatcher.service (deferred)
+[NFTBan] Restored cadence timer(s): nftban-watchdog.timer (recovered — verified active after a transient start error)
+[NFTBan WARN] 19:30:00 some genuine unresolved problem needs attention
+[NFTBan] Install/upgrade completed (state: COMMITTED, with 1 warning — non-fatal; see log).
+LOGEOF
+_update_classify_warnings "$ILOG" 0
+[[ "${_NFTBAN_WARN_REAL}"      = 1 ]] && ok "TAX real=1 (only the genuine warning)"        || no "TAX real" "$_NFTBAN_WARN_REAL"
+[[ "${_NFTBAN_WARN_RECOVERED}" = 1 ]] && ok "TAX recovered=1 (timer transient)"            || no "TAX recovered" "$_NFTBAN_WARN_RECOVERED"
+[[ "${_NFTBAN_WARN_ACCEPTED}"  = 1 ]] && ok "TAX accepted=1 (tmpfiles W2+W3 deduped)"       || no "TAX accepted" "$_NFTBAN_WARN_ACCEPTED"
+[[ "${_NFTBAN_WARN_EXTERNAL}"  = 1 ]] && ok "TAX external=1 (needrestart+kernel deduped)"   || no "TAX external" "$_NFTBAN_WARN_EXTERNAL"
+
+echo "== TAX-CLEAN: an upgrade with only accepted/external/recovered has WARN_REAL=0 =="
+cat > "$ILOG" <<'LOGEOF'
+[NFTBan WARN] systemd-tmpfiles --create failed (exit 73) — non-fatal
+Pending kernel upgrade!
+[NFTBan] Restored cadence timer(s): nftban-watchdog.timer (recovered — verified active after a transient start error)
+[NFTBan] Install/upgrade completed (state: COMMITTED, with 1 warning — non-fatal; see log).
+LOGEOF
+_update_classify_warnings "$ILOG" 0
+[[ "${_NFTBAN_WARN_REAL}" = 0 ]] && ok "TAX-CLEAN real=0 → Action needed would be NONE" || no "TAX-CLEAN real not 0" "$_NFTBAN_WARN_REAL"
+
+echo "== STATIC: cmd_update.sh ties Action needed to WARN_REAL, and summary is class-aware =="
+grep -q '_update_classify_warnings' "$CMDUPD"      && ok "STATIC cmd_update calls the classifier" || no "STATIC classifier not wired"
+grep -q '_NFTBAN_WARN_REAL' "$CMDUPD"              && ok "STATIC action-needed reads WARN_REAL"   || no "STATIC WARN_REAL not used"
+grep -q 'action / .* recovered / .* accepted / .* external' "$HELPERS" && ok "STATIC summary prints class breakdown" || no "STATIC breakdown missing"
+
+echo ""
+echo "=== update_warning_taxonomy_v2164: PASS=$P FAIL=$F ==="
+[[ "$F" -eq 0 ]]


### PR DESCRIPTION
## v1.216.4: classify update warnings and fix timer restore false warn

Lane A from `OPEN_INSTALL_UPDATE_WARNING_TAXONOMY_AND_DEBT_V216_4_SCOPE.md`. v1.216.3 upgrades are operationally successful (COMMITTED / Validation PASS / Failed units 0), but the warning surface is operator-hostile: recovered, accepted, external, and real warnings are counted together as a generic `Warnings: 3`. **Shell/UX + tests only.**

### W1 — timer-restore false warning (real bug, cosmetic impact)
**Root cause:** the update entrypoint sets `IFS=$'\n\t'` (`cmd_update.sh:30`, space excluded), and `_update_restore_cadence_timers` iterated a **space-joined** timer string with a bare `for t in $_NFTBAN_INHIBITED_TIMERS` → it did **not** split → `systemctl start "nftban-watchdog.timer nftban-maintenance.timer"` (one **malformed combined unit**) always failed → a scary false WARN, even though the installer's timer reconciliation left both timers active (verified on all 11 fleet hosts).

**Fix:** split on space explicitly (`IFS=' ' read -r -a`), **start each timer individually**, then **verify each with `is-active`** — emit a WARN **only** if a timer is genuinely still inactive after restore. A transient start error that self-heals is a **recovered advisory**, not a WARN.

### Warning taxonomy
New `_update_classify_warnings` buckets the installer-log slice into typed classes (replacing the class-blind `grep -c 'WARN|⚠'` at `cmd_update.sh:818`):
- **WARN_REAL** — needs operator action
- **WARN_RECOVERED** — transient that self-healed (e.g. recovered timer restore)
- **WARN_ACCEPTED_SECURITY_EXCEPTION** — tmpfiles `firewall-validate` (W2+W3, **deduped** to one; v1.175)
- **WARN_EXTERNAL_OS_ADVISORY** — needrestart / pending kernel (W4, **deduped**; not NFTBan)

The installer's own "with 1 warning — non-fatal" meta self-report is skipped. Summary now prints, e.g.:
```
│ Warnings:        0 action / 1 recovered / 1 accepted / 1 external
```
**`Action needed: NONE` iff `WARN_REAL == 0`** (else "review N warning(s) requiring action").

### Intentionally unchanged
- **Tmpfiles W2/W3** behavior unchanged — still the accepted security exception; `/run/nftban/firewall-validate` ownership/mode/integrity **not** touched (structural `RuntimeDirectory=` redesign is a later lane).
- **W5 `VAL-LOGINMON-002`** (Roundcube no-readable-logs) stays a **real health-surface WARN** with its action text — not folded into the install-warning count.

### Scope / invariants
Daemon + matcher **byte-identical** (0 Go, source-proven). **Schema unchanged 1.84.0.** **VERSION unchanged 1.216.3** (release-prep separate). No sysctl/nft/conntrack/tmpfiles/package change. No fleet mutation.

### Tests
`update_warning_taxonomy_v2164` **16/0** (W1 fix under real `IFS=$'\n\t'`: individual starts, no combined-arg, verify-before-warn, transient→recovered, empty no-op; taxonomy dedup + meta-skip + `WARN_REAL=0` clean case + Action-needed invariant). `watchdog_update_swap_race_v1983` **20/0** regression. `bash -n` + `shellcheck -x -S warning` clean.
