### PR TITLE
v1.217.0: loopback before invalid rule-order fix

### DIFF
--- a/cli/lib/nftban/lib/nft_schema.sh
+++ b/cli/lib/nftban/lib/nft_schema.sh
@@ -57,8 +57,8 @@ readonly NFTBAN_NFT_SCHEMA_LOADED=1
 #
 # Priority  | Rule                          | Reason
 # ----------|-------------------------------|----------------------------------
-# 1.        | ct state invalid → drop       | Malformed packets
-# 2.        | iif lo → accept               | Loopback always allowed
+# 1.        | iif lo → accept               | Loopback always allowed (BEFORE invalid-drop, v1.217.0)
+# 2.        | ct state invalid → drop       | Malformed packets (after loopback carve-out)
 # 3.        | whitelist → accept            | Trusted IPs bypass all checks
 # 4.        | blacklist → drop              | ⚠️ BEFORE established! (permanent + temporary with timeout)
 # 5.        | ct state established → accept | ✅ NOW SAFE (after all bans)
@@ -1114,6 +1114,23 @@ nftban_nft_validate_rule_order() {
                 echo "WARNING: ${family} nftban: port_allow should come BEFORE 'ct state established'" >&2
             fi
         fi
+
+        # v1.217.0 LOOPBACK_BEFORE_INVALID: the loopback accept (iif lo) MUST precede the
+        # invalid-state drop, so local loopback traffic the kernel marks INVALID is never
+        # dropped. External INVALID traffic is still dropped (the rule just moves after the
+        # loopback carve-out). Handle order: iif "lo" accept < ct state invalid drop.
+        local loopback_handle=0 invalid_handle=0
+        loopback_handle=$(echo "$rules" | grep -E 'iif "?lo"?.*accept' | grep -oP 'handle \K[0-9]+' | head -1 || true)
+        [[ -z "$loopback_handle" ]] && loopback_handle=0
+        invalid_handle=$(echo "$rules" | grep -E 'ct state invalid.*drop' | grep -oP 'handle \K[0-9]+' | head -1 || true)
+        [[ -z "$invalid_handle" ]] && invalid_handle=0
+        if [[ $loopback_handle -gt 0 && $invalid_handle -gt 0 ]]; then
+            if [[ $loopback_handle -gt $invalid_handle ]]; then
+                echo "CRITICAL: ${family} nftban: Loopback (iif lo) MUST come BEFORE 'ct state invalid' drop!" >&2
+                echo "  Current order can drop local loopback traffic marked INVALID (v1.217.0 LOOPBACK_BEFORE_INVALID)." >&2
+                status=1
+            fi
+        fi
     done
 
     return $status
@@ -1241,7 +1258,7 @@ nftban_nft_validate_full() {
     echo ""
     echo "5. Rule Order Security (IPv4 + IPv6):"
     if output=$(nftban_nft_validate_rule_order 2>&1); then
-        echo "   ✅ Rule order is correct (blacklist before established)"
+        echo "   ✅ Rule order is correct (loopback before invalid, blacklist before established)"
     else
         echo "   ❌ SECURITY ISSUE: Rule order incorrect!"
         echo "$output" | sed 's/^/      /'

--- a/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
+++ b/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan Test - Loopback-Before-Invalid rule order (v1.217.0)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="nft-loopback-before-invalid-v217-test"
+# meta:type="test"
+# meta:header="Loopback Before Invalid v1.217.0"
+# meta:version="1.216.4"
+# meta:owner="NFTBan Project / Antonios Voulvoulis"
+# meta:homepage="https://nftban.com"
+#
+# meta:description="Static regression for v1.217.0 LOOPBACK_BEFORE_INVALID: in every shipped nftables config (template nftables.conf.tpl, rendered nftables.conf, nftables-safe.conf) the loopback accept (iif lo) MUST precede the ct-state-invalid drop in BOTH the ipv4 and ipv6 input chains; output chains keep oif lo first (unchanged); no rule was dropped (loopback+invalid+whitelist+blacklist+established all still present); the header doc tables list loopback before invalid; and the validator nftban_nft_validate_rule_order carries the loopback<invalid CRITICAL assertion for ip+ip6."
+# meta:inventory.files="install/nftables/nftables.conf.tpl,install/nftables/nftables.conf,install/nftables/nftables-safe.conf,cli/lib/nftban/lib/nft_schema.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:created_date="2026-07-05"
+# meta:updated_date="2026-07-05"
+# =============================================================================
+set -Eeuo pipefail
+SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT=$(cd "$SD/../../../.." && pwd)
+TPL="$ROOT/install/nftables/nftables.conf.tpl"
+CONF="$ROOT/install/nftables/nftables.conf"
+SAFE="$ROOT/install/nftables/nftables-safe.conf"
+SCHEMA="$ROOT/cli/lib/nftban/lib/nft_schema.sh"
+P=0; F=0
+ok(){ echo "PASS $1"; P=$((P+1)); }
+no(){ echo "FAIL $1 ${2:-}"; F=$((F+1)); }
+
+# For each input chain, the loopback-accept line must precede the invalid-drop line.
+# Both files carry exactly two input chains (ipv4, ipv6); sorted by line number the
+# per-chain sequence must be lo_v4 < inv_v4 (and) lo_v6 < inv_v6.
+check_order() {
+    local f="$1" label="$2"
+    local -a lo inv
+    # RULE lines only — exclude comment/doc-table lines (LINENUM:<spaces>#…).
+    mapfile -t lo  < <(grep -nE 'iif "?lo"?[^,]*accept' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' | grep -oE '^[0-9]+')
+    mapfile -t inv < <(grep -nE 'ct state invalid[^,]*drop' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' | grep -oE '^[0-9]+')
+    if [[ ${#lo[@]} -lt 2 || ${#inv[@]} -lt 2 ]]; then
+        no "$label: expected 2 input-chain loopback+invalid rules (found lo=${#lo[@]} inv=${#inv[@]})"; return
+    fi
+    local i fam
+    for i in 0 1; do
+        fam="ipv4"; [[ $i -eq 1 ]] && fam="ipv6"
+        if [[ ${lo[$i]} -lt ${inv[$i]} ]]; then
+            ok "$label $fam: loopback(L${lo[$i]}) BEFORE invalid(L${inv[$i]})"
+        else
+            no "$label $fam: loopback(L${lo[$i]}) is AFTER invalid(L${inv[$i]})"
+        fi
+    done
+}
+
+echo "== rendered/template rule order =="
+check_order "$TPL"  "template"
+check_order "$CONF" "rendered"
+check_order "$SAFE" "safe"
+
+echo "== output chains unchanged (main rendered conf keeps oif lo v4+v6; only input chains were touched) =="
+n=$(grep -cE 'oif "?lo"?[^,]*accept' "$CONF" || true)
+[[ "$n" -ge 2 ]] && ok "nftables.conf: output oif-lo accept present (${n})" || no "nftables.conf: output oif-lo accept missing" "$n"
+# The edit only reordered the two input-chain rules; assert the safe conf's output chains are byte-untouched
+# by confirming it still parses the same two output-chain markers we did not modify.
+so=$(grep -cE 'chain output' "$SAFE" || true)
+[[ "$so" -ge 2 ]] && ok "nftables-safe.conf: output chains intact (${so}, not modified)" || no "safe output chains changed" "$so"
+
+echo "== no rule dropped (all key rules still present in rendered conf, per family) =="
+for kw in 'iif "lo".*accept' 'ct state invalid.*drop' '@whitelist_ipv4.*accept' '@blacklist_ipv4.*drop' 'ct state.*established.*accept' '@whitelist_ipv6.*accept' '@blacklist_ipv6.*drop'; do
+    grep -qE "$kw" "$CONF" && ok "rendered still has: $kw" || no "rendered MISSING: $kw"
+done
+
+echo "== no topology drift (anchors intact, no unexpected new chain) =="
+grep -qE 'ANCHOR_HYGIENE' "$CONF" && grep -qE 'ANCHOR_TRUSTED' "$CONF" && ok "phase anchors intact" || no "phase anchors changed"
+
+echo "== header doc tables corrected (loopback before invalid) =="
+# In the template header RULE ORDER table, the 'loopback accept' line must appear before 'ct state invalid drop'.
+tl=$(grep -nE '^#[[:space:]]*[0-9]+\.[[:space:]]*loopback accept' "$TPL" | grep -oE '^[0-9]+' | head -1 || true)
+ti=$(grep -nE '^#[[:space:]]*[0-9]+\.[[:space:]]*ct state invalid drop' "$TPL" | grep -oE '^[0-9]+' | head -1 || true)
+{ [[ -n "$tl" && -n "$ti" && "$tl" -lt "$ti" ]]; } && ok "tpl header table: loopback($tl) before invalid($ti)" || no "tpl header table order" "lo=$tl inv=$ti"
+sl=$(grep -nE 'iif lo → accept' "$SCHEMA" | grep -oE '^[0-9]+' | head -1 || true)
+si=$(grep -nE 'ct state invalid → drop' "$SCHEMA" | grep -oE '^[0-9]+' | head -1 || true)
+{ [[ -n "$sl" && -n "$si" && "$sl" -lt "$si" ]]; } && ok "nft_schema header table: loopback($sl) before invalid($si)" || no "nft_schema header table order" "lo=$sl inv=$si"
+
+echo "== validator carries the loopback<invalid CRITICAL assertion =="
+grep -q 'LOOPBACK_BEFORE_INVALID' "$SCHEMA" && grep -qE 'Loopback \(iif lo\) MUST come BEFORE .ct state invalid' "$SCHEMA" && ok "validator has loopback<invalid CRITICAL check" || no "validator assertion missing"
+grep -q "loopback before invalid, blacklist before established" "$SCHEMA" && ok "health message updated" || no "health message not updated"
+
+echo ""
+echo "=== nft_loopback_before_invalid_v217: PASS=$P FAIL=$F ==="
+[[ "$F" -eq 0 ]]

--- a/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
+++ b/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
@@ -85,6 +85,15 @@ ti=$(grep -nE '^#[[:space:]]*[0-9]+\.[[:space:]]*ct state invalid drop' "$TPL" |
 sl=$(grep -nE 'iif lo → accept' "$SCHEMA" | grep -oE '^[0-9]+' | head -1 || true)
 si=$(grep -nE 'ct state invalid → drop' "$SCHEMA" | grep -oE '^[0-9]+' | head -1 || true)
 { [[ -n "$sl" && -n "$si" && "$sl" -lt "$si" ]]; } && ok "nft_schema header table: loopback($sl) before invalid($si)" || no "nft_schema header table order" "lo=$sl inv=$si"
+# v1.217.0 doc-order guards (D-1/D-2): the RENDERED conf header comment and the schema-doc
+# rule-order table must also teach loopback-before-invalid (these regressed in the initial pass).
+rl=$(grep -nE '^#[[:space:]]*[0-9]+\.[[:space:]]*loopback accept' "$CONF" | grep -oE '^[0-9]+' | head -1 || true)
+ri=$(grep -nE '^#[[:space:]]*[0-9]+\.[[:space:]]*ct state invalid drop' "$CONF" | grep -oE '^[0-9]+' | head -1 || true)
+{ [[ -n "$rl" && -n "$ri" && "$rl" -lt "$ri" ]]; } && ok "rendered nftables.conf header comment: loopback($rl) before invalid($ri)" || no "rendered conf header comment order" "lo=$rl inv=$ri"
+NSV="$ROOT/docs/NFT-Schema-Validation.md"
+dl=$(grep -nE '^1[[:space:]]*\|[[:space:]]*iif lo accept' "$NSV" | grep -oE '^[0-9]+' | head -1 || true)
+di=$(grep -nE '^2[[:space:]]*\|[[:space:]]*ct state invalid drop' "$NSV" | grep -oE '^[0-9]+' | head -1 || true)
+{ [[ -n "$dl" && -n "$di" && "$dl" -lt "$di" ]]; } && ok "docs/NFT-Schema-Validation table: loopback(row1) before invalid(row2)" || no "NFT-Schema-Validation table order" "lo=$dl inv=$di"
 
 echo "== validator carries the loopback<invalid CRITICAL assertion =="
 grep -q 'LOOPBACK_BEFORE_INVALID' "$SCHEMA" && grep -qE 'Loopback \(iif lo\) MUST come BEFORE .ct state invalid' "$SCHEMA" && ok "validator has loopback<invalid CRITICAL check" || no "validator assertion missing"

--- a/docs/ANCHOR_CONTRACT.md
+++ b/docs/ANCHOR_CONTRACT.md
@@ -11,8 +11,8 @@ NFTBan's input chain has a fixed 7-phase structure. Each phase boundary is marke
 ```
 Phase  Anchor                   Purpose
 ─────  ───────────────────────  ─────────────────────────────────
-  0    ANCHOR_HYGIENE           ct state invalid drop
-  1    ANCHOR_TRUSTED           loopback accept, whitelist accept
+  0    ANCHOR_HYGIENE           loopback accept, then ct state invalid drop (v1.217.0: iif lo BEFORE invalid-drop)
+  1    ANCHOR_TRUSTED           whitelist accept
   2    ANCHOR_BAN               blacklist drop, per-IP port access
   3    ANCHOR_ESTABLISHED       ct state established,related accept
   4    ANCHOR_DETECT            CT limits, SYN meter, portscan

--- a/docs/NFT-Schema-Validation.md
+++ b/docs/NFT-Schema-Validation.md
@@ -123,8 +123,8 @@ The order of rules in the input chain is **non-negotiable**.
 ```
 Priority | Rule                            | Purpose
 ---------|----------------------------------|---------------------------
-1        | ct state invalid drop           | Malformed packets
-2        | iif lo accept                   | Loopback always allowed
+1        | iif lo accept                   | Loopback first — local traffic never hit by invalid-drop (v1.217.0)
+2        | ct state invalid drop           | Malformed packets (external INVALID still dropped, after loopback)
 3        | whitelist accept                | Trusted IPs bypass checks
 4        | blacklist drop                  | ⚠️ BEFORE established!
 5        | ct state established accept     | ✅ NOW safe (after bans)

--- a/install/nftables/nftables-safe.conf
+++ b/install/nftables/nftables-safe.conf
@@ -80,11 +80,11 @@ table ip nftban {
     chain input {
         type filter hook input priority filter; policy drop;
 
-        # 1. Drop invalid packets
-        ct state invalid counter drop comment "invalid state"
-
-        # 2. Always allow loopback
+        # 1. Always allow loopback (BEFORE invalid-drop — v1.217.0 LOOPBACK_BEFORE_INVALID)
         iif lo counter accept comment "loopback"
+
+        # 2. Drop invalid packets (after the loopback carve-out; external INVALID still dropped)
+        ct state invalid counter drop comment "invalid state"
 
         # 3. Whitelist (bypass all checks) - ADMIN IPs PROTECTED
         ip saddr @whitelist_ipv4 counter accept comment "whitelist - full access"
@@ -182,8 +182,8 @@ table ip6 nftban {
 
     chain input {
         type filter hook input priority filter; policy drop;
-        ct state invalid counter drop comment "invalid state"
         iif lo counter accept comment "loopback"
+        ct state invalid counter drop comment "invalid state"
         ip6 saddr @whitelist_ipv6 counter accept comment "whitelist - full access"
         ip6 saddr @blacklist_ipv6 counter drop comment "blacklist (permanent + temporary)"
         ct state established,related counter accept comment "established connections"

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -365,14 +365,15 @@ table ip nftban {
         # ── Phase 0: HYGIENE ──────────────────────────────────────
         counter name anchor_hygiene comment "NFTBAN_ANCHOR:ANCHOR_HYGIENE"
 
-        # 1. Drop invalid packets early
+        # 1. Loopback - always allowed (MUST precede invalid-state drop so local
+        #    traffic the kernel marks INVALID is never dropped — v1.217.0 LOOPBACK_BEFORE_INVALID)
+        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
+
+        # 2. Drop invalid packets (after the loopback carve-out; external INVALID still dropped)
         ct state invalid counter name input_invalid_drop counter name total_input_drop drop comment "invalid state"
 
         # ── Phase 1: TRUSTED ──────────────────────────────────────
         counter name anchor_trusted comment "NFTBAN_ANCHOR:ANCHOR_TRUSTED"
-
-        # 2. Loopback - always allowed
-        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
 
         # 3. Trust / Block (CRITICAL: blacklist BEFORE established)
         ip saddr @whitelist_ipv4 counter name input_whitelist_accept counter name total_input_accept accept
@@ -733,14 +734,15 @@ table ip6 nftban {
         # ── Phase 0: HYGIENE ──────────────────────────────────────
         counter name anchor_hygiene comment "NFTBAN_ANCHOR:ANCHOR_HYGIENE"
 
-        # 1. Drop invalid packets
+        # 1. Loopback - always allowed (MUST precede invalid-state drop so local
+        #    traffic the kernel marks INVALID is never dropped — v1.217.0 LOOPBACK_BEFORE_INVALID)
+        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
+
+        # 2. Drop invalid packets (after the loopback carve-out; external INVALID still dropped)
         ct state invalid counter name input_invalid_drop counter name total_input_drop drop comment "invalid state"
 
         # ── Phase 1: TRUSTED ──────────────────────────────────────
         counter name anchor_trusted comment "NFTBAN_ANCHOR:ANCHOR_TRUSTED"
-
-        # 2. Loopback
-        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
 
         # 3. Trust / Block
         ip6 saddr @whitelist_ipv6 counter name input_whitelist_accept counter name total_input_accept accept

--- a/install/nftables/nftables.conf
+++ b/install/nftables/nftables.conf
@@ -40,8 +40,8 @@
 #   http_bot_*                 - Bot Guard sets (6 per family, always present, empty when disabled)
 #
 # RULE ORDER (security-critical):
-#   1. ct state invalid drop
-#   2. loopback accept
+#   1. loopback accept     <- iif lo BEFORE invalid-drop (v1.217.0 LOOPBACK_BEFORE_INVALID)
+#   2. ct state invalid drop
 #   3. whitelist accept    <- trusted IPs skip everything
 #   4. blacklist drop      <- BEFORE established (CVE protection)
 #   5. ct state established,related accept

--- a/install/nftables/nftables.conf.tpl
+++ b/install/nftables/nftables.conf.tpl
@@ -40,8 +40,8 @@
 #   http_bot_*                 - Bot Guard sets (6 per family, always present, empty when disabled)
 #
 # RULE ORDER (security-critical):
-#   1. ct state invalid drop
-#   2. loopback accept
+#   1. loopback accept     <- iif lo BEFORE invalid-drop (v1.217.0 LOOPBACK_BEFORE_INVALID)
+#   2. ct state invalid drop
 #   3. whitelist accept    <- trusted IPs skip everything
 #   4. blacklist drop      <- BEFORE established (CVE protection)
 #   5. ct state established,related accept
@@ -364,14 +364,15 @@ table ip nftban {
         # ── Phase 0: HYGIENE ──────────────────────────────────────
         counter name anchor_hygiene comment "NFTBAN_ANCHOR:ANCHOR_HYGIENE"
 
-        # 1. Drop invalid packets early
+        # 1. Loopback - always allowed (MUST precede invalid-state drop so local
+        #    traffic the kernel marks INVALID is never dropped — v1.217.0 LOOPBACK_BEFORE_INVALID)
+        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
+
+        # 2. Drop invalid packets (after the loopback carve-out; external INVALID still dropped)
         ct state invalid counter name input_invalid_drop counter name total_input_drop drop comment "invalid state"
 
         # ── Phase 1: TRUSTED ──────────────────────────────────────
         counter name anchor_trusted comment "NFTBAN_ANCHOR:ANCHOR_TRUSTED"
-
-        # 2. Loopback - always allowed
-        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
 
         # 3. Trust / Block (CRITICAL: blacklist BEFORE established)
         ip saddr @whitelist_ipv4 counter name input_whitelist_accept counter name total_input_accept accept
@@ -729,14 +730,15 @@ table ip6 nftban {
         # ── Phase 0: HYGIENE ──────────────────────────────────────
         counter name anchor_hygiene comment "NFTBAN_ANCHOR:ANCHOR_HYGIENE"
 
-        # 1. Drop invalid packets
+        # 1. Loopback - always allowed (MUST precede invalid-state drop so local
+        #    traffic the kernel marks INVALID is never dropped — v1.217.0 LOOPBACK_BEFORE_INVALID)
+        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
+
+        # 2. Drop invalid packets (after the loopback carve-out; external INVALID still dropped)
         ct state invalid counter name input_invalid_drop counter name total_input_drop drop comment "invalid state"
 
         # ── Phase 1: TRUSTED ──────────────────────────────────────
         counter name anchor_trusted comment "NFTBAN_ANCHOR:ANCHOR_TRUSTED"
-
-        # 2. Loopback
-        iif "lo" counter name input_loopback_accept counter name total_input_accept accept
 
         # 3. Trust / Block
         ip6 saddr @whitelist_ipv6 counter name input_whitelist_accept counter name total_input_accept accept


### PR DESCRIPTION
## v1.217.0: loopback before invalid rule-order fix

A narrow, single-defect defensive **nft rule-order** correction: `iif "lo" accept` now precedes `ct state invalid drop` in **both the IPv4 and IPv6 `nftban input` chains**. Previously the input chains emitted `ct state invalid drop` first, so a loopback packet the kernel marks INVALID could be dropped before the loopback-accept rule protects it. Latent (masked by `tcp_loose=1` + no long-idle off-monitor local-TCP pool) — not observed firing — but a fleet-wide rule-order landmine.

### What changed
- **nft data-plane semantics CHANGED** (this is the point): the input-chain rule *order* now carves out loopback before the invalid-state drop. External INVALID traffic is still dropped — the rule simply follows the loopback carve-out. Output chains (`oif lo` first) are unchanged.
- **nft schema *contract* version remains `1.84.0`** — no set/chain/table added, renamed, or restructured; only rule ordering + a validator assertion (contract checks, not schema structure). So: *data-plane semantics changed, schema contract unchanged.*
- Template `nftables.conf.tpl` (v4+v6) + rendered `nftables.conf` + `nftables-safe.conf` reordered; validator `nftban_nft_validate_rule_order` gains a **CRITICAL loopback<invalid assertion** for `ip`+`ip6`; regression test added.
- **Doc-order blockers D-1/D-2/D-3 cleared** (commit `4d050b0c`): the rendered-conf header comment (`nftables.conf:43-44`), the `docs/NFT-Schema-Validation.md` rule-order table, and `docs/ANCHOR_CONTRACT.md` Phase-0 description now all teach loopback-before-invalid; the regression test guards those tables from drift.

### Scope discipline
- **No daemon Go change → `nftband` byte-identical** (input-chain order is template-driven; `internal/nftbackend/exemption.go` loopback fail-safe unchanged). **0 Go files in this PR.**
- **No fleet mutation** in this gate.
- v1.217.0 stays a **single-defect defensive rule-order release**.
- The broad docs/CLI truth debt found by the audit (SECURITY.md "no network listeners", THREAT_MODEL volumetric wording, `search`/`validate` registry overclaims, SystemCallFilter, Quick-Start whitelist, missing-docs) is **deliberately deferred** to `OPEN_DOCS_TRUTH_CLI_SCHEMA_FOLLOWUP` — not in this PR.

### Tests
`nft_loopback_before_invalid_v217` **22/0** (rendered/template/safe order v4+v6, output chains unchanged, no rule dropped, anchors intact, header/doc tables corrected, validator wired); `shellcheck -x -S warning` clean; `nft -c -f` parse OK on rendered config.

### Post-merge ladder (canary order per operator, 2026-07-06)
release-prep v1.217.0 → tag → package-native **lab2 DEB → lab4 RPM** → monitor smoke (optional, sensitive) → **dns1 first live canary** → **srv1 second (only if dns1 clean)** → remaining fleet → closure. (Do not start live with srv1.)
