### PR TITLE
docs: correct public trust claims after v1.217.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,12 @@ nftban health
 # Check validator output directly
 nftban-validate --json
 
-# Enable modules
+# SAFETY FIRST — whitelist your management/SSH IP before enabling enforcement,
+# so a detection rule can never lock you out of your own host:
+nftban whitelist add YOUR.MANAGEMENT.IP        # your admin/SSH source IP
+nftban check YOUR.MANAGEMENT.IP                # confirm it is whitelisted, not banned
+
+# Enable modules (only after your admin IP is whitelisted)
 nftban ddos enable
 nftban portscan enable
 nftban botguard enable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -143,8 +143,8 @@ The `nftband` daemon uses **Unix socket IPC** for CLI communication:
 | Authentication | `SO_PEERCRED` credential verification |
 
 **Security Properties:**
-- **No network listeners:** The daemon does not bind to any network interface
-- **Local-only access:** Communication restricted to local Unix socket
+- **No remote listeners:** The daemon's control/IPC path is a local Unix socket only — it does not accept IPC from any network interface. Its only network binding is a localhost-only HTTP metrics/health endpoint on `127.0.0.1:9580` (loopback; not reachable from remote networks unless explicitly reconfigured).
+- **Local-only access:** IPC restricted to the local Unix socket
 - **Group-based ACL:** Only `nftban` group members can communicate with daemon
 - **Credential verification:** Client UID/GID verified via socket peer credentials
 
@@ -186,10 +186,11 @@ All nftables rule changes are **atomic via nftables transactions**:
 
 ## systemd Service Hardening
 
-All NFTBan services implement comprehensive systemd sandboxing:
+NFTBan services apply a baseline of systemd sandboxing, with additional syscall
+filtering on selected services:
 
 ```ini
-# Applied to all services
+# Baseline directives applied broadly across NFTBan units
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
@@ -201,9 +202,15 @@ RestrictNamespaces=true
 LockPersonality=true
 RestrictSUIDSGID=true
 RestrictRealtime=true
-SystemCallFilter=@system-service
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadWritePaths=/var/lib/nftban /var/log/nftban /var/cache/nftban /run/nftban
+
+# SystemCallFilter is applied to a subset of units (currently the shorter-lived
+# helper services: nftban-core-feeds, nftban-core-geoip, nftban-firewall-init,
+# nftban-firewall-validate). It is NOT currently set on the long-running nftband
+# daemon unit; see the MemoryDenyWriteExecute trade-off note below for why some
+# hardening directives are applied selectively rather than uniformly.
+SystemCallFilter=@system-service   # (selected services only, not nftband.service)
 ```
 
 ### MemoryDenyWriteExecute Trade-off

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -12,7 +12,7 @@ NFTBan is an open-source Linux Intrusion Prevention System (IPS) and firewall ma
 
 - **Login monitoring** - Detects brute-force attacks against SSH, mail, FTP, and web services
 - **Portscan detection** - Identifies network reconnaissance activity
-- **DDoS protection** - Mitigates volumetric and application-layer attacks
+- **Host-level DoS mitigation** - Per-IP SYN/connection rate limiting and syncookies enforced at the nftables layer (host-local); not volumetric DDoS scrubbing or upstream/provider-scale absorption, which require network-capacity mitigation
 - **Threat feed integration** - Blocks known malicious IPs from community and commercial feeds
 - **Geographic blocking** - Country-based access control via GeoIP
 


### PR DESCRIPTION
## docs: correct public trust claims after v1.217.0

Docs-only corrections of four public-trust claims found by the post-v1.217 truth audit (`OPEN_DOCS_TRUTH_CLI_SCHEMA_FOLLOWUP` lane R1). No code or runtime behavior change; daemon byte-identical.

- **SECURITY.md — network listeners (I-1):** the daemon has **no *remote* listeners** (control/IPC is a local Unix socket only), but it **does** bind a **localhost-only HTTP metrics/health endpoint on `127.0.0.1:9580`** (loopback; not reachable remotely unless reconfigured). Replaces the previous, inaccurate "No network listeners: the daemon does not bind to any network interface." No authentication/exposure overclaim added.
- **docs/THREAT_MODEL.md — DoS scope (I-2):** now describes **host-level DoS mitigation** (per-IP SYN/connection rate limiting + syncookies at the nftables layer), **not** volumetric DDoS scrubbing or provider-scale absorption (which require network-capacity mitigation). Replaces "Mitigates volumetric and application-layer attacks."
- **SECURITY.md — SystemCallFilter coverage (I-3):** now states the baseline hardening directives are applied broadly, while **`SystemCallFilter` applies only to the actual subset of services** (nftban-core-feeds, nftban-core-geoip, nftban-firewall-init, nftban-firewall-validate) and is **not** set on the long-running **`nftband.service`**. Replaces the "applied to all services" wording.
- **README.md — Quick-Start safety (I-6):** adds a **whitelist-first** step — whitelist your management/SSH IP (`nftban whitelist add` + `nftban check`) **before** enabling enforcement modules — to prevent operator lockout.

**Scope discipline:** docs-only (3 files: `SECURITY.md`, `docs/THREAT_MODEL.md`, `README.md`); **no** code / nft config / CLI registry / metrics / wiki change. No private fleet hostnames, admin IPs, or internal incident/audit text. R2 (operator/CLI truth cleanup + wiki corrections + new operator docs) remains **deferred**.
