### PR TITLE
docs: correct CLI registry truth and build status

### DIFF
--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -318,14 +318,7 @@ validate:
   has_json: true
   examples:
     - "nftban validate"
-    - "nftban validate all"
-    - "nftban validate firewall"
     - "nftban validate --json"
-  subcommands:
-    - all
-    - firewall
-    - config
-    - permissions
 
 sync:
   category: setup_discovery
@@ -496,10 +489,10 @@ check:
 
 search:
   category: immediate_action
-  description: "Search for IP across all sets and logs"
+  description: "Search for an IP across nftables sets, threat feeds, ports and GeoIP (does not search logs)"
   risk: core
   audience: [cli, auditor, panel]
-  capability: logs_read
+  capability: status_read
   mutates: false
   supports_dry_run: false
   requires_root: false
@@ -1529,7 +1522,7 @@ firewall:
       description: "Validate nftables structure"
     check:
       mutates: false
-      description: "Check if IP or port is blocked/allowed"
+      description: "Check if IP or port is blocked/allowed (alias of the top-level 'nftban check')"
     stats:
       mutates: false
       description: "Show firewall statistics"

--- a/docs/BUILD_STATUS.md
+++ b/docs/BUILD_STATUS.md
@@ -3,8 +3,8 @@
 > **Policy:** Main branch is always green. Failed CI blocks merge.
 > No exceptions, no manual overrides for truth-critical checks.
 
-**Current version:** v1.88.0
-**Last audit:** 2026-04-16
+**Current version:** see [`/VERSION`](../VERSION) — sourced per commit, not hardcoded here.
+**Last audit:** see the [CHANGELOG](../CHANGELOG.md) and GitHub release notes for the current release.
 
 ---
 


### PR DESCRIPTION
## docs: correct CLI registry truth and build status

R2a CLI/docs truth corrections (`OPEN_DOCS_TRUTH_CLI_SCHEMA_FOLLOWUP` lane R2a). Registry/docs metadata only; no runtime behavior change; daemon byte-identical.

- **`nftban search` no longer claims log search** — description corrected from "Search for IP across all sets and logs" to "Search for an IP across nftables sets, threat feeds, ports and GeoIP (does not search logs)"; capability `logs_read` → `status_read`. Code truth: `cmd_search.sh` searches nft sets/feeds/CIDR/ports/GeoIP — there is no journal/log search helper.
- **`nftban validate` no longer advertises phantom subcommands** — removed the `all`/`firewall`/`config`/`permissions` examples and the `subcommands:` block. Code truth: `cmd_validate.sh` accepts only `--json`/`--help` and runs a single `validate_structure`; any other argument ERRORs. The real examples (`nftban validate`, `nftban validate --json`) are kept.
- **`nftban firewall check` documented as an alias** of the top-level `nftban check` (both call `check_ip_or_port`).
- **`docs/BUILD_STATUS.md` no longer hardcodes stale status** — dropped "Current version: v1.88.0" / "Last audit: 2026-04-16"; now references `/VERSION` and the CHANGELOG.

**Guard:** the separate developer command "Validate registry files" (a different, real command) is untouched.

**Validation:** YAML parses; `scripts/lint-registry-parity.sh` PASS; CLI doc-drift test 16/0.

**Scope discipline:** 2 files (`commands.registry.yml`, `docs/BUILD_STATUS.md`); **no** code / nft / schema / metrics / wiki / README / SECURITY / THREAT_MODEL / operator-doc change. No version bump (metadata/docs). No private fleet details. **R2b** (operator docs) and **R2c** (wiki) remain deferred.
