### PR TITLE
docs: correct :9580 HTTP binding security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,13 @@ These invariants are enforced by validation logic and CI gates.
 
 ## Metrics and Observability
 
-The daemon exposes runtime metrics on `http://127.0.0.1:9580/metrics`
-(localhost only, Prometheus text exposition format). This is the canonical
-runtime metrics surface. As of v1.89, the evidence layer reads all kernel
-data from the validator — no duplicate nft queries.
+The daemon serves runtime metrics at `http://127.0.0.1:9580/metrics`
+(the `/metrics` endpoint is loopback-restricted; Prometheus text exposition
+format). This is the canonical runtime metrics surface. Note that the daemon's
+`:9580` listener binds all interfaces and its `/health` and `/api/v1/*`
+endpoints are not loopback-restricted — firewall `:9580` to trusted sources.
+As of v1.89, the evidence layer reads all kernel data from the validator — no
+duplicate nft queries.
 
 The watchdog subsystem provides adaptive resource control. It monitors
 process, Go runtime, and kernel metrics, and adjusts operating mode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -143,7 +143,8 @@ The `nftband` daemon uses **Unix socket IPC** for CLI communication:
 | Authentication | `SO_PEERCRED` credential verification |
 
 **Security Properties:**
-- **No remote listeners:** The daemon's control/IPC path is a local Unix socket only — it does not accept IPC from any network interface. Its only network binding is a localhost-only HTTP metrics/health endpoint on `127.0.0.1:9580` (loopback; not reachable from remote networks unless explicitly reconfigured).
+- **IPC is local-only:** The daemon's control/IPC path is a local Unix socket (`SO_PEERCRED`, `root:nftban` `0660`) — it does not accept IPC from any network interface.
+- **HTTP surface (`:9580`) is network-reachable — hardening tracked:** The daemon also serves an HTTP metrics/health/status surface that, by default, **binds `:9580` on all interfaces** (not loopback-only). The `/metrics` endpoint enforces a loopback source check (localhost only), but **`/health`, `/api/v1/status`, and `/api/v1/modules` are unauthenticated and reachable from remote networks** (information disclosure). Binding this surface to loopback and/or adding authentication is a planned hardening item; **until it ships, operators should firewall `:9580` to trusted sources** (e.g. allow only the local monitoring host).
 - **Local-only access:** IPC restricted to the local Unix socket
 - **Group-based ACL:** Only `nftban` group members can communicate with daemon
 - **Credential verification:** Client UID/GID verified via socket peer credentials

--- a/docs/architecture/PUBLIC_API_BOUNDARY.md
+++ b/docs/architecture/PUBLIC_API_BOUNDARY.md
@@ -32,7 +32,7 @@ Direct import of engine packages (nftbackend, botguard, suricata, etc.) would by
 
 1. **Go programs**: Use `pkg/ipc` to communicate with the daemon
 2. **Shell scripts**: Use the `nftban` CLI commands
-3. **HTTP clients**: Use the daemon's HTTP API at `127.0.0.1:9580/api/`
+3. **HTTP clients**: The daemon serves an HTTP API on `:9580` (binds all interfaces by default). Note: `/health`, `/api/v1/status`, and `/api/v1/modules` are currently **unauthenticated** — do not expose `:9580` to untrusted networks; loopback/auth hardening is planned. `/metrics` is loopback-restricted.
 4. **Monitoring**: Use the Prometheus exporter or Zabbix integration
 
 ## Decision History


### PR DESCRIPTION
## What

Corrects a public documentation trust-boundary error introduced by an earlier docs pass (#1011). The prior wording described the daemon's HTTP surface as **localhost-only / not reachable from remote networks**, which is inaccurate.

## Code truth

- The daemon HTTP surface **listens on `:9580` and binds all interfaces** unless explicitly reconfigured (`internal/nftbanconf/loader.go:639` sets the effective `APIAddr=":9580"`; the `127.0.0.1:9580` constant at `cmd/nftband/daemon_types.go:57` is a dead fallback).
- **`/metrics` is loopback-gated** (`cmd/nftband/daemon_http.go:48-51`).
- **`/health`, `/api/v1/status`, and `/api/v1/modules` are unauthenticated** and reachable from remote networks — they **must not be exposed to untrusted networks**. Operators should firewall `:9580` to trusted sources.

## Scope

- **Documentation only.** No code, wiki, CLI registry, metrics/exporter, release, tag, fleet, or schema change.
- Files: `SECURITY.md`, `docs/architecture/PUBLIC_API_BOUNDARY.md`, `README.md`.
- The **runtime bind/authentication hardening remains separately tracked and is NOT closed by this docs PR** — this change only aligns the docs with today's code.
- No private fleet details or internal register tokens included.