### PR TITLE
fix: prevent duplicate runtime goroutines metric emission

### DIFF
--- a/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
+++ b/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh
@@ -528,9 +528,17 @@ collect_all_metrics() {
             if [[ -f "$daemon_stats" ]]; then
                 goroutines=$(jq -r '.goroutines // 0' "$daemon_stats" 2>/dev/null || echo "0")
             fi
-            # Fallback: use thread count as approximation if goroutines not available
+            # Fallback: use thread count as approximation if goroutines not available.
+            # NOTE: this value feeds the JSON stats cache further below (the
+            # "goroutines" field), NOT the Prometheus .prom output.
             [[ "$goroutines" == "0" || -z "$goroutines" ]] && goroutines=$threads
-            metrics+="nftban_runtime_goroutines $goroutines $timestamp\n"
+            # L1 fix (2026-07-06, EXPORTER-GOROUTINES-DUP): nftban_runtime_goroutines is
+            # emitted EXACTLY ONCE, from the authoritative live-IPC path below
+            # (`nftban watchdog stats --json` -> .runtime.goroutines). It is deliberately
+            # NOT emitted here — on a healthy daemon this proc/stats-file path and the
+            # live-IPC path both fired into the same .prom, producing a duplicate series
+            # that node_exporter/promtool reject (blanking all NFTBan metrics).
+            # nftban_threads (emitted above) already covers the thread-count use case.
 
             # --- Memory Leak Detection Metrics ---
             # Calculate memory growth rate (MB/hour) for leak detection

--- a/cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh
+++ b/cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - L1 EXPORTER-GOROUTINES-DUP regression guard (NEW-01 / MX-1 / FAB-01)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="exporter_no_duplicate_goroutines_emit_v217_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Regression lock for the L1 P0 observability fix: the shell unified exporter must emit nftban_runtime_goroutines EXACTLY ONCE (from the authoritative live-IPC path, using \$d_goroutines), never twice. Two emissions on a healthy daemon produced a duplicate .prom series that node_exporter/promtool reject, blanking all NFTBan metrics. Also asserts nftban_threads is still emitted (covers the thread-count use case) and the JSON stats-cache goroutines field is intact. Hermetic: greps the shipped exporter source; no host/nft/IPC/daemon."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+SRC="$REPO_ROOT/cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$SRC" ]] || { echo "FATAL: exporter source not found: $SRC" >&2; exit 2; }
+
+# 1) nftban_runtime_goroutines must be emitted by EXACTLY ONE metrics+= line.
+emit_count="$(grep -cE 'metrics\+="nftban_runtime_goroutines ' "$SRC" || true)"
+if [[ "$emit_count" == "1" ]]; then
+    ok "nftban_runtime_goroutines emitted exactly once (was 2 → duplicate .prom series)"
+else
+    no "nftban_runtime_goroutines emitted $emit_count time(s), expected exactly 1" \
+       "$(grep -nE 'metrics\+="nftban_runtime_goroutines ' "$SRC" | tr '\n' '|')"
+fi
+
+# 2) The surviving emission must be the authoritative live-IPC path ($d_goroutines),
+#    not the removed proc/stats-file fallback path ($goroutines).
+if grep -qE 'metrics\+="nftban_runtime_goroutines \$d_goroutines ' "$SRC"; then
+    ok "surviving emission is the authoritative live-IPC path (\$d_goroutines)"
+else
+    no "surviving nftban_runtime_goroutines emission is not the live-IPC (\$d_goroutines) path"
+fi
+if grep -qE 'metrics\+="nftban_runtime_goroutines \$goroutines ' "$SRC"; then
+    no "the removed proc/stats-file emission (\$goroutines) is back — regression"
+else
+    ok "removed proc/stats-file emission (\$goroutines) is absent"
+fi
+
+# 3) nftban_threads must still be emitted (covers the thread-count use case).
+if grep -qE 'metrics\+="nftban_threads ' "$SRC"; then
+    ok "nftban_threads still emitted (thread-count use case preserved)"
+else
+    no "nftban_threads emission missing — thread-count use case lost"
+fi
+
+# 4) The JSON stats-cache goroutines field must remain intact (the fallback var still feeds it).
+if grep -qE '"goroutines":[[:space:]]*\$\{goroutines' "$SRC"; then
+    ok "JSON stats-cache goroutines field intact (fallback var still consumed)"
+else
+    no "JSON stats-cache goroutines field missing — fallback removal broke the cache"
+fi
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

`nftban_runtime_goroutines` was emitted **twice** by the shell unified exporter during a single collection cycle:

- a proc/stats-file fallback path (value `$goroutines`), and
- the authoritative live-IPC path (value `$d_goroutines`, from `nftban watchdog stats --json` → `.runtime.goroutines`).

On a healthy daemon both guards pass, so both fired into the same `nftban.prom`, producing a **duplicate metric series**. node_exporter's textfile collector / `promtool` **reject the whole file**, which can blank all NFTBan fleet metrics (P0 observability).

## Fix

- Removed the earlier **proc/stats-file `.prom` emission**.
- Kept the **authoritative live-IPC emission** as the single source.
- `nftban_threads` remains **unchanged** (already covers the thread-count use case).
- The **JSON stats-cache `goroutines` field** remains intact — the fallback variable still feeds it (only the duplicate Prometheus emission was removed).
- Added a hermetic **regression guard** (`exporter_no_duplicate_goroutines_emit_v217_test.sh`) asserting exactly one emission, from the live-IPC path, with `nftban_threads` and the JSON cache preserved.

## Scope / properties

- **Shell / exporter only. Daemon byte-identical.** No Go change, **no schema bump**, no release/tag/fleet activity.
- Changed files: `cli/lib/nftban/exporters/nftban_unified_exporter_collect.sh`, `cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh`.

## Validation

- New dup guard: 5/5 PASS. Existing exporter tests pass. ShellCheck clean.
- **Recommended CI/lab follow-up:** a `promtool check metrics` / node_exporter textfile scrape end-to-end check — `promtool`/`node_exporter` are not present on the dev box, so the deterministic source-level guard is used locally and the scrape is the meaningful CI/lab confirmation of the exact failure mode.