### PR TITLE
fix: preserve timed bans across firewall rebuild

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2095,6 +2095,74 @@ _rebuild_snapshot_full() {
     echo "$snapshot_dir"
 }
 
+# _fw_restore_timed_set — restore a blacklist set from a `nft list set` dump,
+# preserving REMAINING ttl (expires) for timeout-bearing elements. Multiline-safe.
+# Skips expired/unparseable elements with a WARN rather than emitting invalid nft.
+# Args: $1=dump_file  $2=table_family ("ip nftban"|"ip6 nftban")  $3=set_name  $4=quiet
+# Echoes: "<restored> <skipped> <expired>"
+_fw_restore_timed_set() {
+    local dump_file="$1" table_family="$2" set_name="$3" quiet="${4:-true}"
+    local restored=0 skipped=0 expired=0
+    [[ -f "$dump_file" ]] || { echo "0 0 0"; return 0; }
+
+    # Flatten newlines/tabs, then extract the single `elements = { ... }` block.
+    # The block has no nested braces, so [^}]+ is safe once flattened — this is the
+    # fix for the pre-L2a per-line grep that silently dropped wrapped nft output.
+    local blob
+    blob=$(tr '\n\t' '  ' < "$dump_file" 2>/dev/null | grep -oP 'elements = \{\s*\K[^}]+' || true)
+    [[ -z "${blob// /}" ]] && { echo "0 0 0"; return 0; }
+
+    local -a re_add=()
+    local raw addr rest expires
+    local old_ifs="$IFS"
+    IFS=','
+    for raw in $blob; do
+        raw="${raw#"${raw%%[![:space:]]*}"}"   # ltrim
+        raw="${raw%"${raw##*[![:space:]]}"}"    # rtrim
+        [[ -z "$raw" ]] && continue
+        addr="${raw%% *}"                        # first token = ip / ip6 / cidr
+        if ! [[ "$addr" =~ ^[0-9a-fA-F:.]+(/[0-9]{1,3})?$ ]]; then
+            skipped=$((skipped + 1))
+            [[ "$quiet" == "false" ]] && echo "      WARN: $set_name: skip unparseable element '$raw'" >&2
+            continue
+        fi
+        if [[ "$raw" == *" expires "* ]]; then
+            # timeout-bearing → re-apply with REMAINING ttl (expires), not original timeout
+            rest="${raw##* expires }"
+            expires="${rest%% *}"                # drop any trailing comment "..."
+            if [[ -z "$expires" || "$expires" == "0s" || "$expires" == "expired" ]]; then
+                expired=$((expired + 1)); continue
+            fi
+            re_add+=("$addr timeout $expires")
+        else
+            re_add+=("$addr")                    # permanent (no timeout) element
+        fi
+        restored=$((restored + 1))
+    done
+    IFS="$old_ifs"
+
+    if [[ ${#re_add[@]} -gt 0 ]]; then
+        local joined
+        joined=$(IFS=','; echo "${re_add[*]}")
+        # one batched add; on failure fall back per-element so a single bad element
+        # cannot drop the whole set
+        # shellcheck disable=SC2086  # table_family is intentionally two words
+        if ! nft add element $table_family "$set_name" "{ $joined }" 2>/dev/null; then
+            restored=0
+            local e
+            for e in "${re_add[@]}"; do
+                # shellcheck disable=SC2086
+                if nft add element $table_family "$set_name" "{ $e }" 2>/dev/null; then
+                    restored=$((restored + 1))
+                else
+                    skipped=$((skipped + 1))
+                fi
+            done
+        fi
+    fi
+    echo "$restored $skipped $expired"
+}
+
 _rebuild_rollback() {
     # Restore from snapshot
     # Args: $1 = snapshot directory
@@ -2494,41 +2562,29 @@ _firewall_rebuild_core() {
         "$_rb_reconcile" sync --quick >/dev/null 2>&1 || true
     fi
 
-    # Step 7: Restore blacklist from backup (BUG FIX: R74 - blacklist was never restored)
-    [[ "$quiet" == "false" ]] && echo "  [7/12] Restoring blacklist from backup..."
-    local restored_count=0
-    for backup_file in "$backup_dir/blacklist_ipv4_$timestamp.txt" "$backup_dir/blacklist_ipv6_$timestamp.txt"; do
-        [[ -f "$backup_file" ]] || continue
-        # Extract elements from backup (format: elements = { ip1, ip2, ... })
-        local elements
-        # v1.19.20 FIX: Prevent pipefail exit 1 when grep finds no match
-        elements=$(grep -oP 'elements = \{ \K[^}]+' "$backup_file" 2>/dev/null | tr -d '\n\t' | sed 's/  */ /g' || true)
-        [[ -z "$elements" ]] && continue
-
-        # v1.19.27 SECURITY: Validate elements contain only safe characters (defense-in-depth)
-        # Allow: digits, dots, colons (IPv6), slashes (CIDR), commas, spaces, 'timeout', 's/m/h/d'
-        if [[ ! "$elements" =~ ^[0-9a-fA-F.:,/[:space:]timeouts]+$ ]]; then
-            [[ "$quiet" == "false" ]] && echo "    WARNING: Skipping backup with invalid characters: $backup_file"
-            continue
-        fi
-
-        # Determine table and set from filename
-        local table_family set_name
-        if [[ "$backup_file" == *ipv4* ]]; then
-            table_family="ip nftban"
-            set_name="blacklist_ipv4"
-        else
-            table_family="ip6 nftban"
-            set_name="blacklist_ipv6"
-        fi
-        # Add elements back to set
-        if nft add element $table_family $set_name "{ $elements }" 2>/dev/null; then
-            # v1.19.20 FIX
-            ((restored_count++)) || true
-            [[ "$quiet" == "false" ]] && echo "    Restored: $set_name" || true
-        fi
+    # Step 7 (L2a): Restore blacklist + blacklist_manual from the pre-rebuild snapshot,
+    # preserving remaining TTL. blacklist_manual_* holds detector TTL bans
+    # (LoginMon/Portscan/DDoS/Suricata + manual) — it was previously never backed up or
+    # restored, so every rebuild silently dropped active timed bans. We consume the
+    # per-set snapshot that _rebuild_snapshot_full already wrote (no second backup
+    # mechanism) and re-apply with the REMAINING ttl (expires), fixing the old parser's
+    # per-line/wrapped-output and timeout/expires-rejection defects at the same time.
+    [[ "$quiet" == "false" ]] && echo "  [7/12] Restoring blacklist + manual bans from snapshot (TTL-preserving)..."
+    local _rs_total=0 _rs_skip=0 _rs_exp=0
+    local _set _fam _dump _counts _r _s _e
+    for _set in blacklist_ipv4 blacklist_ipv6 blacklist_manual_ipv4 blacklist_manual_ipv6; do
+        case "$_set" in
+            *_ipv4) _fam="ip nftban" ;;
+            *_ipv6) _fam="ip6 nftban" ;;
+            *) continue ;;
+        esac
+        _dump="$snapshot_dir/sets/${_set}.nft"
+        _counts=$(_fw_restore_timed_set "$_dump" "$_fam" "$_set" "$quiet")
+        IFS=' ' read -r _r _s _e <<<"$_counts"
+        _rs_total=$((_rs_total + _r)); _rs_skip=$((_rs_skip + _s)); _rs_exp=$((_rs_exp + _e))
+        [[ "$quiet" == "false" && "$_r" -gt 0 ]] && echo "    Restored $_r into $_set (skipped=$_s expired=$_e)"
     done
-    [[ "$quiet" == "false" && "$restored_count" -eq 0 ]] && echo "    No blacklist entries to restore"
+    [[ "$quiet" == "false" ]] && echo "    Blacklist restore: $_rs_total restored, $_rs_skip skipped, $_rs_exp expired"
 
     # Step 8 (v1.50.1): Re-apply DDoS protection if enabled
     # Preflight: module re-enable requires daemon IPC. If daemon is down

--- a/cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh
+++ b/cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - L2a rebuild timed-ban preservation + restore-parser correctness
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="fw_rebuild_preserve_timed_bans_l2a_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Hermetic test for the L2a firewall-rebuild fix: extracts the REAL _fw_restore_timed_set() from cmd_firewall.sh and verifies it (1) parses wrapped/multiline nft set dumps, (2) re-applies timeout-bearing elements with their REMAINING ttl (expires), never the original timeout, (3) skips expired (expires 0s) elements, (4) restores permanent and CIDR (feed) elements, (5) skips unparseable elements without emitting invalid nft. Uses a mock nft to capture emitted add-element payloads. No host/nft/IPC/daemon."
+# meta:input="None (self-contained; extracts function verbatim from source)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,awk,grep,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+SRC="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+[[ -f "$SRC" ]] || { echo "FATAL: source not found: $SRC" >&2; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+CAP="$WORK/nft_capture.txt"; : > "$CAP"
+
+# Extract the REAL _fw_restore_timed_set() verbatim from the shipped source.
+FN="$WORK/fn.sh"
+awk '/^_fw_restore_timed_set\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SRC" > "$FN"
+if grep -q '_fw_restore_timed_set()' "$FN"; then ok "extracted _fw_restore_timed_set() from cmd_firewall.sh"; else no "could not extract _fw_restore_timed_set() from source"; fi
+
+# Mock nft: record every add-element invocation, succeed.
+nft() { echo "$*" >> "$CAP"; return 0; }
+export -f nft 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$FN"
+
+# Fixture 1: blacklist_manual_ipv4 — wrapped/multiline, timeout+expires, one expired.
+D1="$WORK/blacklist_manual_ipv4.nft"
+cat > "$D1" <<'EOF'
+table ip nftban {
+	set blacklist_manual_ipv4 {
+		type ipv4_addr
+		flags interval,timeout
+		elements = { 1.2.3.4 timeout 1h expires 59m30s,
+			5.6.7.8 timeout 30m expires 0s,
+			9.10.11.12 timeout 2h expires 1h58m }
+	}
+}
+EOF
+
+out1="$(_fw_restore_timed_set "$D1" "ip nftban" "blacklist_manual_ipv4" false || true)"
+IFS=' ' read -r r1 s1 e1 <<<"$out1"
+
+# TTL preserved (remaining expires, NOT the original timeout)
+grep -q '1.2.3.4 timeout 59m30s' "$CAP"  && ok "timed ban re-applied with REMAINING ttl (59m30s), not original (1h)" \
+                                        || no "remaining-ttl not used for 1.2.3.4" "$(tr '\n' '|' <"$CAP")"
+grep -q '9.10.11.12 timeout 1h58m' "$CAP" && ok "second timed ban re-applied with remaining ttl (1h58m)" \
+                                          || no "remaining-ttl not used for 9.10.11.12"
+# Original full timeout must NOT be emitted
+grep -q '1.2.3.4 timeout 1h[^0-9]' "$CAP" && no "original timeout (1h) was emitted for 1.2.3.4 (ttl reset bug)" \
+                                          || ok "original full timeout (1h) not emitted (no TTL reset)"
+# Expired element skipped
+grep -q '5.6.7.8' "$CAP" && no "expired element (expires 0s) was restored" \
+                         || ok "expired element (expires 0s) skipped"
+# Counts
+[[ "$r1" == "2" && "$e1" == "1" ]] && ok "counts: restored=2 expired=1" || no "counts wrong" "restored=$r1 skipped=$s1 expired=$e1"
+
+# Fixture 2: feed blacklist_ipv4 — permanent + CIDR (no timeout).
+: > "$CAP"
+D2="$WORK/blacklist_ipv4.nft"
+cat > "$D2" <<'EOF'
+table ip nftban {
+	set blacklist_ipv4 {
+		type ipv4_addr
+		flags interval
+		elements = { 10.0.0.0/8, 192.168.1.5 }
+	}
+}
+EOF
+out2="$(_fw_restore_timed_set "$D2" "ip nftban" "blacklist_ipv4" false || true)"
+IFS=' ' read -r r2 _ _ <<<"$out2"
+grep -q '10.0.0.0/8' "$CAP" && grep -q '192.168.1.5' "$CAP" && ok "feed blacklist restore works (CIDR + host, permanent)" \
+                                                            || no "feed blacklist restore failed" "$(tr '\n' '|' <"$CAP")"
+grep -q 'timeout' "$CAP" && no "permanent feed elements were given a timeout" || ok "permanent feed elements restored without timeout"
+[[ "$r2" == "2" ]] && ok "feed counts: restored=2" || no "feed counts wrong" "restored=$r2"
+
+# Fixture 3: unparseable element skipped (no invalid nft emitted).
+: > "$CAP"
+D3="$WORK/blacklist_manual_ipv6.nft"
+cat > "$D3" <<'EOF'
+	set blacklist_manual_ipv6 {
+		elements = { 2001:db8::1 timeout 1h expires 55m, not-an-ip timeout 1h expires 40m }
+	}
+EOF
+out3="$(_fw_restore_timed_set "$D3" "ip6 nftban" "blacklist_manual_ipv6" false || true)"
+IFS=' ' read -r r3 s3 _ <<<"$out3"
+grep -q '2001:db8::1 timeout 55m' "$CAP" && ok "valid ipv6 timed ban restored (remaining ttl)" || no "ipv6 timed ban not restored"
+grep -q 'not-an-ip' "$CAP" && no "unparseable element emitted to nft" || ok "unparseable element skipped (no invalid nft)"
+[[ "$r3" == "1" && "$s3" == "1" ]] && ok "mixed valid/invalid counts: restored=1 skipped=1" || no "mixed counts wrong" "restored=$r3 skipped=$s3"
+
+# Fixture 4: missing dump file → no-op, zero counts.
+out4="$(_fw_restore_timed_set "$WORK/does_not_exist.nft" "ip nftban" "blacklist_ipv4" true || true)"
+[[ "$out4" == "0 0 0" ]] && ok "missing snapshot file → 0 0 0 (safe no-op)" || no "missing file not handled" "$out4"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

`nftban firewall rebuild` silently dropped active timed bans on every run.

- The rebuild restore path **did not consume the per-set snapshots for `blacklist_manual_*`** — Step-1 backup covered only `blacklist_ipv4/6`.
- **`blacklist_manual_*` contains detector TTL bans (LoginMon / Portscan / DDoS / Suricata), not just manual bans** (`internal/opqueue/types.go`).
- The existing Step-7 parser was **defective**: a per-line `grep -oP` broke on nft's **wrapped/multi-line** `elements = { ... }` output, and the char-class validation **rejected any `expires`-bearing timed element** (`x`/`p`/`r` not in the class) — so even timed feed bans never restored.

## Fix (shell-only, daemon byte-identical)

- Consume the per-set snapshot that `_rebuild_snapshot_full()` already writes (which includes `blacklist_manual_*`) — **no second backup mechanism**.
- New `_fw_restore_timed_set()`: flattens newlines then extracts the elements block (**multiline-safe**), and **re-applies timed elements using the remaining TTL from `expires`, not the original `timeout`** (no TTL reset).
- **Expired (`expires 0s`) and unparseable elements are skipped with WARN**; batched add falls back per-element so one bad element can't drop the whole set.
- Step 7 now restores `blacklist_ipv4/6` **and** `blacklist_manual_ipv4/6`, logging honest restored/skipped/expired counts.
- Adds a **hermetic parser guard** (`fw_rebuild_preserve_timed_bans_l2a_test.sh`, 13 assertions) extracting the real function.

## Scope / properties

- **Shell-only. Daemon byte-identical.** No Go, no schema bump, no metrics/exporter, no docs/wiki/register, no release/tag/fleet.
- Changed files: `cli/lib/nftban/cli/cmd_firewall.sh`, `cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh`.

## Validation

- `bash -n` OK; ShellCheck clean; **L2a hermetic guard 13/13 PASS**.
- Related firewall tests pass: `firewall_transition_health_*`, `rebuild_no_syn_drop_v192`, `whitelist_rebuild_remerge_v1930`.
- Three sandbox failures are **pre-existing** (reproduce on pristine `main`, caused by running as root in CI-less sandbox), **not** caused by this change: `cmd_firewall_takeover` T6.1 non-root, `cmd_firewall_trust_remerge`, `cmd_firewall_whitelist_session`.

## ⚠️ Required before merge: lab rebuild validation (NOT optional)

This changes firewall **rebuild** behavior and must be proven with real `nft`/`CAP_NET_ADMIN` before merging — preferred **lab2 (DEB) + lab4 (RPM)**, minimum one package-native lab host:

1. add a timed ban (`nftban ban <ip> --timeout <n>` or into `blacklist_manual_ipv4`)
2. capture TTL/`expires` before rebuild
3. run `nftban firewall rebuild`
4. confirm the element still exists after rebuild
5. confirm the TTL did **not** reset upward to the original timeout
6. confirm `nftban validate` / health remains clean

Record host, package type, command summary, before/after TTL, and result. **Do not merge until this lab check passes.**