### PR TITLE
fix: record blacklist-empty rebuild transitions

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2163,6 +2163,19 @@ _fw_restore_timed_set() {
     echo "$restored $skipped $expired"
 }
 
+# _fw_count_dump_elems <nft-set-dump-file> — count elements in a `nft list set`
+# dump (multiline-safe). Echoes an integer (0 if file missing/empty). Used by the
+# L2c blacklist-empty-during-refresh fail-open detector.
+_fw_count_dump_elems() {
+    local f="$1" blob commas
+    [[ -f "$f" ]] || { echo 0; return 0; }
+    blob=$(tr '\n\t' '  ' < "$f" 2>/dev/null | grep -oP 'elements = \{\s*\K[^}]+' || true)
+    blob="${blob// /}"
+    [[ -z "$blob" ]] && { echo 0; return 0; }
+    commas="${blob//[^,]/}"
+    echo $(( ${#commas} + 1 ))
+}
+
 _rebuild_rollback() {
     # Restore from snapshot
     # Args: $1 = snapshot directory
@@ -2570,7 +2583,7 @@ _firewall_rebuild_core() {
     # mechanism) and re-apply with the REMAINING ttl (expires), fixing the old parser's
     # per-line/wrapped-output and timeout/expires-rejection defects at the same time.
     [[ "$quiet" == "false" ]] && echo "  [7/12] Restoring blacklist + manual bans from snapshot (TTL-preserving)..."
-    local _rs_total=0 _rs_skip=0 _rs_exp=0
+    local _rs_total=0 _rs_skip=0 _rs_exp=0 _bl_before=0
     local _set _fam _dump _counts _r _s _e
     for _set in blacklist_ipv4 blacklist_ipv6 blacklist_manual_ipv4 blacklist_manual_ipv6; do
         case "$_set" in
@@ -2579,12 +2592,29 @@ _firewall_rebuild_core() {
             *) continue ;;
         esac
         _dump="$snapshot_dir/sets/${_set}.nft"
+        # L2c: pre-rebuild element count (from the snapshot) = "had bans before"
+        _bl_before=$((_bl_before + $(_fw_count_dump_elems "$_dump")))
         _counts=$(_fw_restore_timed_set "$_dump" "$_fam" "$_set" "$quiet")
         IFS=' ' read -r _r _s _e <<<"$_counts"
         _rs_total=$((_rs_total + _r)); _rs_skip=$((_rs_skip + _s)); _rs_exp=$((_rs_exp + _e))
         [[ "$quiet" == "false" && "$_r" -gt 0 ]] && echo "    Restored $_r into $_set (skipped=$_s expired=$_e)"
     done
     [[ "$quiet" == "false" ]] && echo "    Blacklist restore: $_rs_total restored, $_rs_skip skipped, $_rs_exp expired"
+
+    # L2c (TRANSITION-FAIL-OPEN-UNOBSERVED): if the blacklist held bans before the
+    # rebuild but is completely empty after restore, a fail-open window persisted —
+    # record it as a harm-keyed CRITICAL in the transition-health counter (the
+    # function self-guards before>0). With L2a working this should never fire; it is
+    # a regression detector for any future break of the snapshot-restore path.
+    if [[ "$_bl_before" -gt 0 && "$_rs_total" -eq 0 ]]; then
+        local _fth_helper="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_firewall_transition_health.sh"
+        if [[ -f "$_fth_helper" ]]; then
+            # shellcheck source=/dev/null
+            source "$_fth_helper" 2>/dev/null || true
+            declare -f fth_note_blacklist_empty >/dev/null 2>&1 && fth_note_blacklist_empty "$_bl_before" || true
+        fi
+        [[ "$quiet" == "false" ]] && echo "    WARNING: blacklist empty after rebuild (had $_bl_before before) — recorded transition-health CRITICAL"
+    fi
 
     # Step 8 (v1.50.1): Re-apply DDoS protection if enabled
     # Preflight: module re-enable requires daemon IPC. If daemon is down
@@ -2728,9 +2758,12 @@ _firewall_rebuild_core() {
         fi
 
         # BotGuard: check for botguard helper chain
-        # Actual chain name: botguard_filter
+        # L2d: the real rendered chain is http_bot_guard (BOTGUARD_NFT_CHAIN override,
+        # nft_fragment.sh:1641); the previous `botguard_filter` name never exists, so
+        # this check always downgraded an enabled BotGuard to INCOMPLETE.
+        local _bg_chain="${BOTGUARD_NFT_CHAIN:-http_bot_guard}"
         if _firewall_botguard_is_enabled 2>/dev/null && [[ "$_REBUILD_MODULE_BOTGUARD" == "$MR_OK" ]]; then
-            if nft list chain ip nftban botguard_filter &>/dev/null; then
+            if nft list chain ip nftban "$_bg_chain" &>/dev/null; then
                 [[ "$quiet" == "false" ]] && echo "    BotGuard: chain verified (Level 1+2)"
             else
                 _rebuild_classify_module_result "botguard" "$MR_INCOMPLETE"

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2170,7 +2170,11 @@ _fw_count_dump_elems() {
     local f="$1" blob commas
     [[ -f "$f" ]] || { echo 0; return 0; }
     blob=$(tr '\n\t' '  ' < "$f" 2>/dev/null | grep -oP 'elements = \{\s*\K[^}]+' || true)
+    # Ignore nft element comments (may contain commas) BEFORE stripping spaces,
+    # so `comment "a,b,c"` is not miscounted as 3 elements.
+    blob=$(printf '%s' "$blob" | sed 's/comment "[^"]*"//g')
     blob="${blob// /}"
+    blob="${blob%,}"                       # tolerate a trailing comma
     [[ -z "$blob" ]] && { echo 0; return 0; }
     commas="${blob//[^,]/}"
     echo $(( ${#commas} + 1 ))

--- a/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
+++ b/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
@@ -58,17 +58,29 @@ grep -q '_fw_count_dump_elems()' "$FN" && ok "extracted _fw_count_dump_elems()" 
 # shellcheck source=/dev/null
 source "$FN"
 
-D="$WORK/set.nft"
-printf 'table ip nftban {\n\tset blacklist_manual_ipv4 {\n\t\telements = { 1.2.3.4 timeout 1h expires 59m,\n\t\t\t5.6.7.8 timeout 2h expires 1h,\n\t\t\t9.9.9.9 timeout 30m expires 5m }\n\t}\n}\n' > "$D"
-c=$(_fw_count_dump_elems "$D")
-[[ "$c" == "3" ]] && ok "counts 3 elements in a wrapped/multiline dump" || no "wrong element count" "got=$c want=3"
+# cnt <label> <expected> <printf-body> — count the dumped elements block and assert.
+cnt() { local lbl="$1" exp="$2" body="$3" got; printf '%b' "$body" > "$WORK/c.nft"; got=$(_fw_count_dump_elems "$WORK/c.nft"); [[ "$got" == "$exp" ]] && ok "count: $lbl = $exp" || no "count: $lbl" "got=$got want=$exp"; }
 
-printf 'table ip nftban {\n\tset blacklist_ipv4 {\n\t\telements = { 10.0.0.0/8 }\n\t}\n}\n' > "$WORK/one.nft"
-[[ "$(_fw_count_dump_elems "$WORK/one.nft")" == "1" ]] && ok "counts 1 (single CIDR)" || no "single-element count wrong"
-
-printf 'table ip nftban {\n\tset blacklist_ipv4 {\n\t\ttype ipv4_addr\n\t}\n}\n' > "$WORK/empty.nft"
-[[ "$(_fw_count_dump_elems "$WORK/empty.nft")" == "0" ]] && ok "counts 0 (no elements block)" || no "empty-set count wrong"
-[[ "$(_fw_count_dump_elems "$WORK/missing.nft")" == "0" ]] && ok "counts 0 (missing file)" || no "missing-file count wrong"
+# IPv4
+cnt "IPv4 host single-line x3"   3 'elements = { 1.2.3.4, 5.6.7.8, 9.9.9.9 }'
+cnt "IPv4 wrapped/multiline x3"  3 'elements = { 1.2.3.4 timeout 1h expires 59m,\n\t5.6.7.8 timeout 2h expires 1h,\n\t9.9.9.9 timeout 30m expires 5m }'
+cnt "IPv4 CIDR/interval x1"      1 'elements = { 10.0.0.0/8 }'
+# IPv6 (was the coverage gap)
+cnt "IPv6 host x2"               2 'elements = { 2001:db8::1, 2001:db8::2 }'
+cnt "IPv6 CIDR/interval x2"      2 'elements = { 2001:db8::/32, fe80::/10 }'
+cnt "IPv6 timeout+expires x2"    2 'elements = { 2001:db8::1 timeout 1h expires 55m,\n\tfd00::5 timeout 30m expires 12m }'
+cnt "IPv6 range (dash) x1"       1 'elements = { 2001:db8::1-2001:db8::ff }'
+cnt "mixed v4+v6 x3"             3 'elements = { 1.2.3.4, 2001:db8::1, 10.0.0.0/8 }'
+# empty / missing
+cnt "empty braces { }"          0 'elements = { }'
+cnt "empty braces {}"           0 'elements = {}'
+cnt "no elements block"         0 'type ipv4_addr\n\tflags interval,timeout'
+[[ "$(_fw_count_dump_elems "$WORK/does_not_exist.nft")" == "0" ]] && ok "count: missing file = 0" || no "count: missing file"
+# hardening: comments (may hold commas) + trailing comma must not inflate the count
+cnt "comment with comma x1"     1 'elements = { 1.2.3.4 comment "a,b,c" }'
+cnt "comment no comma x1"       1 'elements = { 1.2.3.4 comment "loginmon" }'
+cnt "timed elem + comment x2"   2 'elements = { 1.2.3.4 timeout 1h expires 5m comment "x,y", 5.6.7.8 }'
+cnt "trailing comma tolerated"  2 'elements = { 1.2.3.4, 5.6.7.8, }'
 
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
+++ b/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - L2c+L2d guard: transition fail-open counter wiring + BotGuard chain name
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="fw_l2cd_transition_counter_botguard_chain_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Guards the L2c+L2d shell fixes. L2c: the firewall rebuild wires the existing transition-health blacklist-empty fail-open counter (fth_note_blacklist_empty) — fires only when the blacklist held bans before the rebuild but is empty after restore; also unit-tests the _fw_count_dump_elems element counter (multiline-safe). L2d: the BotGuard rebuild check uses the real chain name (http_bot_guard / BOTGUARD_NFT_CHAIN), not the nonexistent botguard_filter. Hermetic: greps the shipped source + extracts one function; no host/nft/IPC/daemon."
+# meta:input="None (self-contained)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+FW="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+no() { FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+[[ -f "$FW" ]] || { echo "FATAL: $FW not found" >&2; exit 2; }
+
+# ---- L2d: BotGuard chain-name drift ----
+grep -qE 'nft list chain ip nftban botguard_filter' "$FW" \
+  && no "L2d: stale botguard_filter chain check still present" \
+  || ok "L2d: stale botguard_filter chain check removed"
+grep -qE 'BOTGUARD_NFT_CHAIN:-http_bot_guard' "$FW" \
+  && ok "L2d: BotGuard check uses real chain (BOTGUARD_NFT_CHAIN:-http_bot_guard)" \
+  || no "L2d: real BotGuard chain name not referenced in rebuild check"
+
+# ---- L2c: fail-open counter wiring ----
+grep -qE 'fth_note_blacklist_empty "\$_bl_before"' "$FW" \
+  && ok "L2c: fth_note_blacklist_empty wired into rebuild" \
+  || no "L2c: fth_note_blacklist_empty not called from rebuild"
+# fires only on had-bans-before AND empty-after (not 'currently empty')
+grep -qE '\$_bl_before" -gt 0 && "\$_rs_total" -eq 0' "$FW" \
+  && ok "L2c: guard is (before>0 && restored==0) — harm-keyed, not 'currently empty'" \
+  || no "L2c: fail-open condition not (before>0 && restored==0)"
+
+# ---- L2c: _fw_count_dump_elems correctness (extract + run) ----
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+FN="$WORK/fn.sh"
+awk '/^_fw_count_dump_elems\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$FW" > "$FN"
+grep -q '_fw_count_dump_elems()' "$FN" && ok "extracted _fw_count_dump_elems()" || no "could not extract _fw_count_dump_elems()"
+# shellcheck source=/dev/null
+source "$FN"
+
+D="$WORK/set.nft"
+printf 'table ip nftban {\n\tset blacklist_manual_ipv4 {\n\t\telements = { 1.2.3.4 timeout 1h expires 59m,\n\t\t\t5.6.7.8 timeout 2h expires 1h,\n\t\t\t9.9.9.9 timeout 30m expires 5m }\n\t}\n}\n' > "$D"
+c=$(_fw_count_dump_elems "$D")
+[[ "$c" == "3" ]] && ok "counts 3 elements in a wrapped/multiline dump" || no "wrong element count" "got=$c want=3"
+
+printf 'table ip nftban {\n\tset blacklist_ipv4 {\n\t\telements = { 10.0.0.0/8 }\n\t}\n}\n' > "$WORK/one.nft"
+[[ "$(_fw_count_dump_elems "$WORK/one.nft")" == "1" ]] && ok "counts 1 (single CIDR)" || no "single-element count wrong"
+
+printf 'table ip nftban {\n\tset blacklist_ipv4 {\n\t\ttype ipv4_addr\n\t}\n}\n' > "$WORK/empty.nft"
+[[ "$(_fw_count_dump_elems "$WORK/empty.nft")" == "0" ]] && ok "counts 0 (no elements block)" || no "empty-set count wrong"
+[[ "$(_fw_count_dump_elems "$WORK/missing.nft")" == "0" ]] && ok "counts 0 (missing file)" || no "missing-file count wrong"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Two small, shell-only rebuild/transition-safety fixes.

### L2c — wire the transition-health blacklist-empty fail-open counter
`fth_note_blacklist_empty` (increments `blacklist_empty_during_refresh_count`, CRITICAL) already existed but had **no rebuild caller**. This wires it in:

- Records **only the harmful case**: the blacklist held elements **before** the rebuild **and** the restore produced **zero** restored elements (`_bl_before > 0 && _rs_total == 0`).
- **Does not fire** on hosts with no bans before rebuild.
- It is an **observability / regression detector** for rebuild fail-open — **not a new enforcement path**. With the L2a snapshot-restore working it should never fire; it catches any future break of that path.
- Reuses the existing **fth-1 JSON counter surface → no schema bump**.

### L2d — correct the BotGuard rebuild chain-name drift
The rebuild post-check looked for a chain named `botguard_filter`, which is never rendered, so it always downgraded an enabled BotGuard to INCOMPLETE. It now checks the real `${BOTGUARD_NFT_CHAIN:-http_bot_guard}` (`nft_fragment.sh:1641`). **BotGuard remains default-off; no enablement or runtime policy change.**

### Counting helper hardening (per a counting audit)
`_fw_count_dump_elems` now **ignores nft element comments** (may contain commas) and **tolerates a trailing comma** — neither form is emitted by real `nft list set`, so there is no behavior change on real output; this just makes the helper spec-correct.

## Test coverage
Guard expanded to **21 assertions**: IPv4, **IPv6** (host/CIDR/range/timeout+expires), timeout/expires, multiline/wrapped, empty `{ }`/`{}`, missing file, comment-with-comma, trailing-comma.

## Scope / properties
- **Shell-only. Daemon byte-identical.** No Go, **no schema bump**, no docs/wiki/register, no release/tag/fleet.
- Changed files: `cli/lib/nftban/cli/cmd_firewall.sh`, `cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh`.

## Validation
- L2cd guard 21/21; L2a guard 13/13; `firewall_transition_health_*`, `rebuild_no_syn_drop_v192`, `whitelist_rebuild_remerge_v1930` PASS; ShellCheck clean; `bash -n` OK.
- Unlike L2a (which changed the ban data-path and required a lab rebuild), this slice is a read-only `nft list chain` check + additive observability, so the hermetic guards + CI are sufficient.