### PR TITLE
fix(opqueue): truth-bearing replace_set apply result (L2b)

### DIFF
--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -914,12 +914,13 @@ func (d *Daemon) handleQueueStatusRequest() SocketResponse {
 	return SocketResponse{
 		Success: true,
 		Data: map[string]any{
-			"pending_count":   stats.PendingCount,
-			"total_queued":    stats.TotalQueued,
-			"total_applied":   stats.TotalApplied,
-			"total_dropped":   stats.TotalDropped,
-			"last_flush_time": stats.LastFlushTime.Format(time.RFC3339),
-			"queue_depth":     d.opQueue.QueueDepth(),
+			"pending_count":            stats.PendingCount,
+			"total_queued":             stats.TotalQueued,
+			"total_applied":            stats.TotalApplied,
+			"total_dropped":            stats.TotalDropped,
+			"replace_partial_failures": stats.ReplacePartialFailures,
+			"last_flush_time":          stats.LastFlushTime.Format(time.RFC3339),
+			"queue_depth":              d.opQueue.QueueDepth(),
 		},
 	}
 }

--- a/internal/botguard/guard_batchsignal_decisioncache_test.go
+++ b/internal/botguard/guard_batchsignal_decisioncache_test.go
@@ -260,13 +260,13 @@ type recBackend struct {
 }
 
 func (b *recBackend) FlushSet(table, set string) error { return nil }
-func (b *recBackend) AddElements(table, set string, els []opqueue.SetElement) error {
+func (b *recBackend) AddElements(table, set string, els []opqueue.SetElement) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, e := range els {
 		b.adds[set] = append(b.adds[set], e.Value)
 	}
-	return nil
+	return len(els), nil
 }
 func (b *recBackend) DeleteElements(table, set string, els []opqueue.SetElement) error { return nil }
 func (b *recBackend) GetSetElements(table, set string) ([]string, error)               { return nil, nil }

--- a/internal/opqueue/bench_netlink_test.go
+++ b/internal/opqueue/bench_netlink_test.go
@@ -79,7 +79,7 @@ func benchmarkNetlinkAddElements(b *testing.B, batchSize int) {
 		_ = backend.FlushSet(table, setName)
 
 		// Measure AddElements
-		if err := backend.AddElements(table, setName, elements); err != nil {
+		if _, err := backend.AddElements(table, setName, elements); err != nil {
 			b.Fatalf("AddElements failed: %v", err)
 		}
 	}
@@ -131,7 +131,7 @@ func benchmarkNetlinkFlushSet(b *testing.B, setSize int) {
 			if end > setSize {
 				end = setSize
 			}
-			_ = backend.AddElements(table, setName, elements[j:end])
+			_, _ = backend.AddElements(table, setName, elements[j:end])
 		}
 		b.StartTimer()
 

--- a/internal/opqueue/buffer.go
+++ b/internal/opqueue/buffer.go
@@ -11,7 +11,7 @@
 package opqueue
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -216,13 +216,15 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceI
 	// 2. Else if flush pending: just flush
 	// 3. Apply pending adds/deletes
 	if replaceOp != nil {
-		result.Applied = buf.applyReplace(backend, table, setName, replaceOp, maxBatchSize)
-		if result.Applied < 0 {
-			result.Err = errors.New("replace_set failed")
-			result.Applied = 0
-		} else {
-			result.WasReplace = true
-			result.Adds = result.Applied
+		// L2b truth-bearing: applied == actually_applied; err set on flush failure OR
+		// partial apply (applied < intended). WasReplace stays true even on partial.
+		applied, intended, replErr := buf.applyReplace(backend, table, setName, replaceOp, maxBatchSize)
+		result.Applied = applied
+		result.Intended = intended
+		result.Adds = applied
+		result.WasReplace = true
+		if replErr != nil {
+			result.Err = replErr
 		}
 	} else if flushPending {
 		if err := backend.FlushSet(table, setName); err != nil {
@@ -245,17 +247,28 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceI
 	return result
 }
 
-// applyReplace applies a replace_set operation: flush + bulk add
-func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string, op *SetOp, maxBatchSize int) int {
+// applyReplace applies a replace_set operation: flush + bulk add.
+//
+// L2b truth-bearing contract. Returns:
+//   - applied:  the count ACTUALLY applied (summed from the backend's real per-batch counts).
+//   - intended: len(op.Elements) — what the replace meant to apply.
+//   - err:      non-nil on flush failure, or when applied < intended (partial apply).
+//
+// Invariant: reported_applied == actually_applied, and partial_apply != success. A flush that
+// succeeds followed by a lost add batch leaves the set partially populated; we now report that
+// as an error instead of a success-shaped short count. We do NOT abort on the first bad batch
+// (later batches still attempt), and we do NOT fail-close the caller — surfacing is the job.
+func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string, op *SetOp, maxBatchSize int) (applied int, intended int, err error) {
 	// Step 1: Flush existing
-	if err := backend.FlushSet(table, setName); err != nil {
-		log.Printf("[opqueue] replace_set flush %s failed: %v", setName, err)
-		return -1
+	if ferr := backend.FlushSet(table, setName); ferr != nil {
+		log.Printf("[opqueue] replace_set flush %s failed: %v", setName, ferr)
+		return 0, 0, fmt.Errorf("replace_set flush %s: %w", setName, ferr)
 	}
 
 	if len(op.Elements) == 0 {
-		return 0
+		return 0, 0, nil
 	}
+	intended = len(op.Elements)
 
 	// Step 2: Bulk add in batches
 	isIPv6 := strings.HasSuffix(setName, "_ipv6")
@@ -268,8 +281,8 @@ func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string
 		})
 	}
 
-	// Batch by maxBatchSize
-	applied := 0
+	// Batch by maxBatchSize — sum the TRUE applied count from each batch.
+	var firstErr error
 	for i := 0; i < len(elements); i += maxBatchSize {
 		end := i + maxBatchSize
 		if end > len(elements) {
@@ -277,15 +290,26 @@ func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string
 		}
 		batch := elements[i:end]
 
-		if err := backend.AddElements(table, setName, batch); err != nil {
-			log.Printf("[opqueue] replace_set add %s batch %d failed: %v", setName, i/maxBatchSize, err)
-		} else {
-			applied += len(batch)
+		n, addErr := backend.AddElements(table, setName, batch)
+		applied += n
+		if addErr != nil {
+			log.Printf("[opqueue] replace_set add %s batch %d failed (%d/%d): %v", setName, i/maxBatchSize, n, len(batch), addErr)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("replace_set add %s batch %d: %w", setName, i/maxBatchSize, addErr)
+			}
 		}
 	}
 
+	if applied < intended {
+		if firstErr == nil {
+			firstErr = fmt.Errorf("replace_set %s: applied %d of %d (partial)", setName, applied, intended)
+		}
+		log.Printf("[opqueue] replace_set %s: PARTIAL apply %d/%d — %v", setName, applied, intended, firstErr)
+		return applied, intended, firstErr
+	}
+
 	log.Printf("[opqueue] replace_set %s: %d elements applied", setName, applied)
-	return applied
+	return applied, intended, nil
 }
 
 // applyPendingCounted applies individual add/delete operations and returns separate counts
@@ -334,11 +358,12 @@ func (buf *SetBuffer) applyPendingCounted(backend NetlinkBackend, table, setName
 		if end > len(toAdd) {
 			end = len(toAdd)
 		}
-		if err := backend.AddElements(table, setName, toAdd[i:end]); err != nil {
-			log.Printf("[opqueue] add %s batch failed: %v", setName, err)
+		n, addErr := backend.AddElements(table, setName, toAdd[i:end])
+		adds += n // L2b: true applied count (n), not the batch size
+		if addErr != nil {
+			log.Printf("[opqueue] add %s batch failed (%d/%d): %v", setName, n, end-i, addErr)
 		} else {
-			adds += end - i
-			// v1.209 — record provenance ONLY after the nft add succeeded (apply boundary).
+			// v1.209 — record provenance ONLY after the nft add fully succeeded (apply boundary).
 			// Without a source we leave the reconcile path's "unknown" fallback untouched.
 			if recordProv {
 				now := time.Now().Unix()

--- a/internal/opqueue/nftbackend_wrapper.go
+++ b/internal/opqueue/nftbackend_wrapper.go
@@ -114,27 +114,41 @@ func (w *NFTBackendWrapper) FlushSet(tableName, setName string) error {
 	return w.nft.FlushSet(set)
 }
 
-// AddElements adds elements to a set (batched)
-func (w *NFTBackendWrapper) AddElements(tableName, setName string, elements []SetElement) error {
+// AddElements adds elements to a set (batched). L2b (OPQUEUE_PER_ELEMENT_APPLY_RESULT):
+// truth-bearing — returns the count ACTUALLY applied and, if any element failed, a
+// non-nil error carrying the applied/total shortfall + the first failure. Previously this
+// swallowed per-element failures and returned nil (success-shaped), which hid partial
+// replace_set applies from the caller. It still continues past a single bad element (so one
+// bad IP does not abort the whole batch), but no longer reports that as full success.
+func (w *NFTBackendWrapper) AddElements(tableName, setName string, elements []SetElement) (int, error) {
 	if len(elements) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	set, err := w.getSet(setName)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Convert to string IPs for NFTManager
+	applied := 0
+	var firstErr error
 	for _, elem := range elements {
 		timeout := time.Duration(elem.TTL) * time.Second
 		if err := w.nft.AddIPWithTimeout(set, elem.Value, timeout); err != nil {
-			// Log but continue - don't fail batch for individual errors
+			// Continue past a single bad element, but remember the first failure.
+			if firstErr == nil {
+				firstErr = fmt.Errorf("add %q to %s: %w", elem.Value, setName, err)
+			}
 			continue
 		}
+		applied++
 	}
 
-	return nil
+	if applied < len(elements) {
+		return applied, fmt.Errorf("applied %d of %d to %s: %w", applied, len(elements), setName, firstErr)
+	}
+	return applied, nil
 }
 
 // DeleteElements removes elements from a set (batched)

--- a/internal/opqueue/queue.go
+++ b/internal/opqueue/queue.go
@@ -262,7 +262,8 @@ func (s *Scheduler) applyFastBatch(batch []FastOp) {
 				}
 				// R75: Use retry with exponential backoff (v1.19.12)
 				if s.retryWithBackoff("fast add "+setName, func() error {
-					return s.backend.AddElements(table, setName, []SetElement{elem})
+					_, addErr := s.backend.AddElements(table, setName, []SetElement{elem})
+					return addErr
 				}) {
 					applied++
 				}
@@ -390,10 +391,10 @@ func (s *Scheduler) processBulkJob(ctx context.Context, job BulkJob) {
 			})
 		}
 
-		if err := s.backend.AddElements(table, setName, batch); err != nil {
-			log.Printf("[scheduler] bulk add %s batch %d failed: %v", setName, i/s.config.MaxBatchSize, err)
-		} else {
-			applied += len(batch)
+		n, addErr := s.backend.AddElements(table, setName, batch)
+		applied += n // L2b: true applied count
+		if addErr != nil {
+			log.Printf("[scheduler] bulk add %s batch %d failed (%d/%d): %v", setName, i/s.config.MaxBatchSize, n, len(batch), addErr)
 		}
 	}
 
@@ -462,10 +463,10 @@ func (s *Scheduler) processBulkJobDirect(job BulkJob) {
 			})
 		}
 
-		if err := s.backend.AddElements(table, setName, batch); err != nil {
-			log.Printf("[scheduler] bulk add %s batch %d failed: %v", setName, i/s.config.MaxBatchSize, err)
-		} else {
-			applied += len(batch)
+		n, addErr := s.backend.AddElements(table, setName, batch)
+		applied += n // L2b: true applied count
+		if addErr != nil {
+			log.Printf("[scheduler] bulk add %s batch %d failed (%d/%d): %v", setName, i/s.config.MaxBatchSize, n, len(batch), addErr)
 		}
 	}
 
@@ -535,11 +536,11 @@ func (s *Scheduler) EnqueueBulkFromFile(ctx context.Context, setName, filePath, 
 		}
 
 		// Add batch to set
-		if err := s.backend.AddElements(table, setName, elements); err != nil {
-			log.Printf("[scheduler] streaming bulk %s batch %d failed: %v", setName, batchNum, err)
+		n, addErr := s.backend.AddElements(table, setName, elements)
+		totalApplied += n // L2b: true applied count
+		if addErr != nil {
+			log.Printf("[scheduler] streaming bulk %s batch %d failed (%d/%d): %v", setName, batchNum, n, len(elements), addErr)
 			// Continue with other batches
-		} else {
-			totalApplied += len(elements)
 		}
 		return nil
 	})
@@ -591,6 +592,10 @@ type OpQueue struct {
 	totalQueued  atomic.Uint64
 	totalApplied atomic.Uint64
 	totalDropped atomic.Uint64
+	// L2b: count of replace_set operations that flushed then applied fewer elements than
+	// intended (partial/fail-open apply). A non-zero value is a degraded signal — the set
+	// is short of what was requested. Surfaced via QueueStats / sync-status JSON.
+	replacePartialFailures atomic.Uint64
 
 	// Last flush time
 	lastFlushTime atomic.Value // time.Time
@@ -675,11 +680,12 @@ func (q *OpQueue) QueueDepth() int64 {
 func (q *OpQueue) Stats() QueueStats {
 	lastFlush, _ := q.lastFlushTime.Load().(time.Time)
 	return QueueStats{
-		PendingCount:  q.pendingCount.Load(),
-		TotalQueued:   q.totalQueued.Load(),
-		TotalApplied:  q.totalApplied.Load(),
-		TotalDropped:  q.totalDropped.Load(),
-		LastFlushTime: lastFlush,
+		PendingCount:           q.pendingCount.Load(),
+		TotalQueued:            q.totalQueued.Load(),
+		TotalApplied:           q.totalApplied.Load(),
+		TotalDropped:           q.totalDropped.Load(),
+		ReplacePartialFailures: q.replacePartialFailures.Load(),
+		LastFlushTime:          lastFlush,
 	}
 }
 
@@ -765,6 +771,8 @@ func (q *OpQueue) EnqueueReplaceFromFile(setName, filePath, source string, batch
 	// Step 2: Stream elements from file and add in batches
 	isIPv6 := isIPv6Set(setName)
 	totalApplied := 0
+	totalIntended := 0
+	var partialErr error // L2b: first per-batch failure in this streaming replace
 
 	err = reader.StreamElements(func(batch []string, batchNum int) error {
 		// Convert to SetElement
@@ -777,18 +785,30 @@ func (q *OpQueue) EnqueueReplaceFromFile(setName, filePath, source string, batch
 			}
 		}
 
-		// Add batch to set
-		if err := q.backend.AddElements(table, setName, elements); err != nil {
-			log.Printf("[opqueue] streaming replace_set %s batch %d failed: %v", setName, batchNum, err)
-			// Continue with other batches
-		} else {
-			totalApplied += len(elements)
+		// Add batch to set — L2b: sum the TRUE applied count and remember shortfall.
+		totalIntended += len(elements)
+		n, addErr := q.backend.AddElements(table, setName, elements)
+		totalApplied += n
+		if addErr != nil {
+			log.Printf("[opqueue] streaming replace_set %s batch %d failed (%d/%d): %v", setName, batchNum, n, len(elements), addErr)
+			if partialErr == nil {
+				partialErr = addErr
+			}
+			// Continue with other batches (do not fail-close the sync)
 		}
 		return nil
 	})
 
 	if err != nil {
 		return totalApplied, err
+	}
+
+	// L2b: a streaming replace that flushed then lost elements is a partial (fail-open)
+	// window — surface it as a degraded counter + log, without fail-closing the caller.
+	if partialErr != nil || totalApplied < totalIntended {
+		q.replacePartialFailures.Add(1)
+		log.Printf("[opqueue] streaming replace_set %s: PARTIAL apply %d/%d (degraded, fail-open) — %v",
+			setName, totalApplied, totalIntended, partialErr)
 	}
 
 	// Update stats
@@ -936,6 +956,14 @@ func (q *OpQueue) flushSetWithReenqueue(setName string) {
 
 	if result.Err != nil {
 		log.Printf("[opqueue] Flush %s failed: %v", setName, result.Err)
+		// L2b: a replace that flushed then applied fewer than intended is a degraded
+		// (fail-open) apply — record it so health/status can see it. The success onFlush
+		// callback above is guarded by result.Err == nil, so it did NOT fire with the
+		// wrong short count.
+		if result.WasReplace && (result.Intended == 0 || result.Applied < result.Intended) {
+			q.replacePartialFailures.Add(1)
+			log.Printf("[opqueue] replace_set %s degraded: applied %d of %d (fail-open)", setName, result.Applied, result.Intended)
+		}
 	}
 }
 

--- a/internal/opqueue/replace_apply_truth_l2b_test.go
+++ b/internal/opqueue/replace_apply_truth_l2b_test.go
@@ -1,0 +1,223 @@
+// =============================================================================
+// NFTBan - L2b replace_set apply-truth (REPLACE-PARTIAL-SILENT + OPQUEUE_PER_ELEMENT_APPLY_RESULT)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="opqueue/replace_apply_truth_l2b_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="L2b: proves the replace_set apply result is truth-bearing — reported_applied == actually_applied and partial_apply != success. Mocks NetlinkBackend to force a mid-replace shortfall and asserts FlushResult.Err is set, Applied is the true count, Intended is preserved, WasReplace stays true, the success onFlush callback does not fire, and QueueStats.ReplacePartialFailures increments. Hermetic; no real nft/netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+//
+// Invariant under test (the whole point of L2b):
+//
+//	reported_applied == actually_applied     // the count returned is the count really added
+//	reported_success == (applied == intended) // success only when everything applied
+//	partial_apply     != success              // a flushed-then-short replace is an ERROR, not success
+//
+// Before L2b, applyReplace/AddElements swallowed per-element/batch failures and returned a
+// success-shaped partial count with a nil error, hiding a fail-open (blocklist short of intended).
+// =============================================================================
+
+package opqueue
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// mockPartialBackend is a truth-bearing NetlinkBackend that accepts at most acceptLimit
+// elements total (acceptLimit < 0 = accept all) and reports the REAL applied count + an
+// error on any shortfall — exactly the contract the real wrapper now honors.
+type mockPartialBackend struct {
+	acceptLimit int // total elements it will accept across all AddElements calls; <0 = unlimited
+	flushErr    error
+	accepted    int      // elements actually accepted (ground truth)
+	added       []string // values actually accepted
+	flushed     bool
+}
+
+func (m *mockPartialBackend) FlushSet(table, set string) error {
+	if m.flushErr != nil {
+		return m.flushErr
+	}
+	m.flushed = true
+	return nil
+}
+
+func (m *mockPartialBackend) AddElements(table, set string, els []SetElement) (int, error) {
+	applied := 0
+	var firstErr error
+	for _, e := range els {
+		if m.acceptLimit >= 0 && m.accepted >= m.acceptLimit {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("simulated add failure for %s", e.Value)
+			}
+			continue
+		}
+		m.accepted++
+		m.added = append(m.added, e.Value)
+		applied++
+	}
+	if applied < len(els) {
+		return applied, fmt.Errorf("mock applied %d of %d: %w", applied, len(els), firstErr)
+	}
+	return applied, nil
+}
+
+func (m *mockPartialBackend) DeleteElements(table, set string, els []SetElement) error { return nil }
+func (m *mockPartialBackend) GetSetElements(table, set string) ([]string, error)        { return nil, nil }
+
+func replaceElements(n int) []string {
+	els := make([]string, n)
+	for i := 0; i < n; i++ {
+		// TEST-NET-3 (203.0.113.0/24) space, unique via a second octet.
+		els[i] = fmt.Sprintf("203.0.113.%d/32", i%254+1)
+	}
+	return els
+}
+
+func flushReplace(backend NetlinkBackend, setName string, n, batchSize int) FlushResult {
+	buf := newSetBuffer(setName)
+	buf.replaceOp = &SetOp{Type: OpReplaceSet, Elements: replaceElements(n)}
+	return buf.flush(backend, batchSize, nil)
+}
+
+// --- Invariant 1: reported_applied == actually_applied (on a partial) ---
+func TestReplaceApplyTruth_ReportedAppliedEqualsActuallyApplied(t *testing.T) {
+	m := &mockPartialBackend{acceptLimit: 150}
+	res := flushReplace(m, "blacklist_ipv4", 250, 100)
+
+	if res.Applied != m.accepted {
+		t.Fatalf("reported_applied(%d) != actually_applied(%d)", res.Applied, m.accepted)
+	}
+	if res.Applied != len(m.added) {
+		t.Fatalf("reported_applied(%d) != len(added)(%d)", res.Applied, len(m.added))
+	}
+	if res.Applied != 150 {
+		t.Fatalf("expected 150 actually applied, got %d", res.Applied)
+	}
+}
+
+// --- Invariant 2: partial_apply != success ---
+func TestReplaceApplyTruth_PartialApplyIsNotSuccess(t *testing.T) {
+	m := &mockPartialBackend{acceptLimit: 150}
+	res := flushReplace(m, "blacklist_ipv4", 250, 100)
+
+	if res.Err == nil {
+		t.Fatal("partial apply reported success (Err == nil) — this is the L2b fail-open bug")
+	}
+	if res.Intended != 250 {
+		t.Fatalf("Intended=%d, want 250", res.Intended)
+	}
+	if res.Applied >= res.Intended {
+		t.Fatalf("Applied(%d) should be < Intended(%d) on a partial", res.Applied, res.Intended)
+	}
+	if !res.WasReplace {
+		t.Fatal("WasReplace must stay true even on a partial replace")
+	}
+}
+
+// --- Invariant 3: full success is unchanged (Err nil, applied == intended) ---
+func TestReplaceApplyTruth_FullSuccessUnchanged(t *testing.T) {
+	m := &mockPartialBackend{acceptLimit: -1} // accept all
+	res := flushReplace(m, "blacklist_ipv6", 250, 100)
+
+	if res.Err != nil {
+		t.Fatalf("full success must have nil Err, got %v", res.Err)
+	}
+	if res.Applied != 250 || res.Intended != 250 {
+		t.Fatalf("full success: Applied=%d Intended=%d, want 250/250", res.Applied, res.Intended)
+	}
+	if !res.WasReplace {
+		t.Fatal("WasReplace must be true")
+	}
+	if res.Applied != m.accepted {
+		t.Fatalf("reported_applied(%d) != actually_applied(%d)", res.Applied, m.accepted)
+	}
+}
+
+// --- Invariant 3b: zero-applied is degraded, not success-shaped ---
+func TestReplaceApplyTruth_ZeroAppliedIsDegradedNotSuccess(t *testing.T) {
+	m := &mockPartialBackend{acceptLimit: 0} // flush ok, every add fails
+	res := flushReplace(m, "blacklist_ipv4", 100, 50)
+
+	if res.Applied != 0 {
+		t.Fatalf("Applied=%d, want 0", res.Applied)
+	}
+	if res.Err == nil {
+		t.Fatal("zero-applied replace must be degraded (Err != nil), not success")
+	}
+	if res.Intended != 100 {
+		t.Fatalf("Intended=%d, want 100", res.Intended)
+	}
+}
+
+// --- Flush failure keeps failing (old -1 sentinel folded into an error) ---
+func TestReplaceApplyTruth_FlushFailureSurfaced(t *testing.T) {
+	m := &mockPartialBackend{flushErr: errors.New("flush boom")}
+	res := flushReplace(m, "blacklist_ipv4", 100, 50)
+
+	if res.Err == nil {
+		t.Fatal("flush failure must surface as Err")
+	}
+	if res.Applied != 0 {
+		t.Fatalf("Applied=%d, want 0 on flush failure", res.Applied)
+	}
+}
+
+// --- AddElements contract: reports the real shortfall instead of nil success ---
+func TestAddElementsContract_ReportsPerElementShortfall(t *testing.T) {
+	m := &mockPartialBackend{acceptLimit: 2}
+	applied, err := m.AddElements("nftban", "blacklist_ipv4", []SetElement{
+		{Value: "203.0.113.1"}, {Value: "203.0.113.2"}, {Value: "203.0.113.3"},
+	})
+	if applied != 2 {
+		t.Fatalf("applied=%d, want 2 (actually accepted)", applied)
+	}
+	if err == nil {
+		t.Fatal("AddElements must return an error when applied < len(elements)")
+	}
+}
+
+// --- Counter + no-success-callback: a partial replace increments ReplacePartialFailures
+//     and does NOT fire the success onFlush callback with the wrong short count. ---
+func TestReplaceApplyTruth_CounterIncrementsAndNoSuccessCallback(t *testing.T) {
+	cfg := DefaultQueueConfig()
+	cfg.MaxBatchSize = 100
+
+	// Partial replace → counter increments, success callback must NOT fire.
+	mPartial := &mockPartialBackend{acceptLimit: 150}
+	qp := NewOpQueue(mPartial, cfg)
+	var partialCallbackFired bool
+	qp.SetOnFlush(func(setName string, applied int, opType string) { partialCallbackFired = true })
+	bufP := qp.getOrCreateBuffer("blacklist_ipv4")
+	bufP.replaceOp = &SetOp{Type: OpReplaceSet, Elements: replaceElements(250)}
+	qp.flushSetWithReenqueue("blacklist_ipv4")
+
+	if got := qp.Stats().ReplacePartialFailures; got != 1 {
+		t.Fatalf("ReplacePartialFailures=%d, want 1 after a partial replace", got)
+	}
+	if partialCallbackFired {
+		t.Fatal("success onFlush callback fired for a PARTIAL replace (would report the wrong short count)")
+	}
+
+	// Full success → counter stays 0, success callback fires.
+	mFull := &mockPartialBackend{acceptLimit: -1}
+	qf := NewOpQueue(mFull, cfg)
+	var fullCallbackFired bool
+	qf.SetOnFlush(func(setName string, applied int, opType string) { fullCallbackFired = true })
+	bufF := qf.getOrCreateBuffer("blacklist_ipv4")
+	bufF.replaceOp = &SetOp{Type: OpReplaceSet, Elements: replaceElements(250)}
+	qf.flushSetWithReenqueue("blacklist_ipv4")
+
+	if got := qf.Stats().ReplacePartialFailures; got != 0 {
+		t.Fatalf("ReplacePartialFailures=%d, want 0 on full success", got)
+	}
+	if !fullCallbackFired {
+		t.Fatal("success onFlush callback must fire on a full replace")
+	}
+}

--- a/internal/opqueue/types.go
+++ b/internal/opqueue/types.go
@@ -108,19 +108,25 @@ type QueueStats struct {
 	TotalQueued   uint64
 	TotalApplied  uint64
 	TotalDropped  uint64
-	LastFlushTime time.Time
+	// L2b: number of replace_set applies that flushed then applied fewer elements than
+	// intended (partial/fail-open). Non-zero = degraded; the set is short of requested.
+	ReplacePartialFailures uint64
+	LastFlushTime          time.Time
 }
 
 // FlushResult contains the outcome of a buffer flush
 type FlushResult struct {
 	SetName     string
-	Applied     int
+	Applied     int      // TRUE count of elements actually applied (== actually_applied)
+	Intended    int      // L2b: elements the replace/flush intended to apply (diagnostic; 0 if N/A)
 	Adds        int      // Count of add operations applied (v1.32.0)
 	Deletes     int      // Count of delete operations applied (v1.32.0)
 	WasReplace  bool     // True if this was a replace_set operation (v1.32.0)
 	WasFlush    bool     // True if this was a flush_set operation (v1.32.0)
 	PostBarrier []*SetOp // Ops to re-enqueue after flush
-	Err         error
+	// Err is set when the operation did not fully succeed. L2b invariant:
+	// a partial replace (Applied < Intended) is NOT success — Err is non-nil.
+	Err error
 }
 
 // SetElement represents an element to add/delete from nftables
@@ -135,8 +141,11 @@ type NetlinkBackend interface {
 	// FlushSet clears all elements from a set
 	FlushSet(table, set string) error
 
-	// AddElements adds elements to a set (batched)
-	AddElements(table, set string, elements []SetElement) error
+	// AddElements adds elements to a set (batched). L2b: truth-bearing contract —
+	// returns the count ACTUALLY applied and a non-nil error if any element failed
+	// (applied < len(elements)). The returned count MUST equal what was really applied;
+	// callers rely on partial_apply != success.
+	AddElements(table, set string, elements []SetElement) (applied int, err error)
 
 	// DeleteElements removes elements from a set (batched)
 	DeleteElements(table, set string, elements []SetElement) error


### PR DESCRIPTION
## This is apply-truth, not "more logging"

The invariant this PR enforces:

```
reported_applied == actually_applied
reported_success == intended_applied
partial_apply     != success
```

## 1. Problem
A `replace_set` that flushed the set then lost an add batch could become **success-shaped**: it returned a smaller applied count with a **nil error**, so a feed/geoban blocklist ended up **short of intended (fail-open)** while reporting success — invisible to health. Root cause: the apply layer swallowed failures — `NetlinkBackend.AddElements` `continue`d past per-element errors and `return nil`, so `applyReplace` could only ever see a whole-set lookup failure, never an element/batch shortfall. Pure `buffer.go` handling was therefore unreachable; the apply **return contract** had to change.

## 2. Fix (Option A — truth-bearing result)
- `NetlinkBackend.AddElements` now returns `(applied int, err error)` — the **real** applied count and a non-nil error on any shortfall. The wrapper still continues past one bad element, but never reports a partial as full success.
- `applyReplace` returns `(applied, intended, err)`; `flush()` maps it to `FlushResult{Applied=true-applied, Intended, Err set on partial, WasReplace preserved}`.
- The success `onFlush` callback is **not fired on a partial** (guarded by `Err == nil`), so the set counter is never updated to the wrong short value.
- New `QueueStats.ReplacePartialFailures` counter, incremented on a partial replace (buffered and streaming paths), exposed in sync-status JSON as `replace_partial_failures`.
- Does **not** fail-close the sync path; does **not** touch atomicity.

## 3. Rows closed
- `REPLACE-PARTIAL-SILENT`
- `OPQUEUE_PER_ELEMENT_APPLY_RESULT`

## 4. Rows explicitly still open (not addressed here)
- opqueue `replace_set` atomicity (flush-then-add window remains)
- `D-DAEMON-RULESET-SKEW-WINDOW`
- `BOOT-SNAPSHOT-NO-WRITER`
- `COMMIT-CONFIRM-ORPHAN`
- `D-UPDATE-INTERACTIVE-NO-AUTO-ROLLBACK`
- `SEC-P1-3`
- GUI-config-remnant

## 5. Validation evidence (built + tested on lab hosts, not locally)
**lab2 — Ubuntu 24.04 / DEB:** `go build ./...` OK · `go vet` OK · **full `go test ./...` rc=0** · L2b suite **7/7 PASS** · daemon active · `nftban validate` rc0 · 0 failed units · happy-path replace preserved · no replace-partial logs.

**lab4 — AlmaLinux 9.8 / RPM:** `go build` OK · L2b `opqueue` suite PASS · daemon active · `nftban validate` rc0 · 0 **new** failed units (`cpgreylistd` pre-existing, unrelated cPanel daemon) · blacklist preserved **351 == 351** across the replace · no replace-partial logs.

Partial-failure behavior is proven by the **unit tests** (a mock forces a mid-replace shortfall); the labs prove packaging/daemon safety + the feed/geoban happy path.

## 6. Daemon re-baseline
**Required and done.** `nftband` is a Go change → no longer byte-identical to v1.217.0's daemon during validation. Rebuilt via `./build.sh` (version-stamped) on both labs, then the **released daemon was restored** afterward — final live daemon md5 **identical on both labs**: `155b564752ec…`.

## 7. Schema
nft schema remains **1.84.0**. `QueueStats` is a daemon API/status surface, not an nft-schema field. No Prometheus/schema-unfreeze metric added.

## 8. Risk: MEDIUM
Apply-path contract changed in the single-writer opqueue. Mitigated by the negative partial-failure tests, the success-regression test (full replace unchanged), the counter/no-success-callback test, package-native daemon safety on DEB+RPM, and no fleet mutation.

## Scope
8 Go files only. No atomic-replace refactor, no schema bump, no tag/release-prep/fleet, no L3/Cluster-D/whitelist/docs/wiki/GUI side work.