### PR TITLE
fix(daemon): fence legacy replace_set IPC from atomic-owned interval sets (L2e)

### DIFF
--- a/cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh
+++ b/cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - L2e replace_set legacy-IPC reachability guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="l2e_replace_set_reachability_guard_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Locks the L2e reachability invariants proven in the scope: the non-atomic opqueue replace_set path stays fenced. Asserts (1) OpReplaceSet is constructed only by EnqueueReplace, (2) EnqueueReplace is called only by handleReplaceSetRequest, (3) EnqueueReplaceFromFile has no caller (dead), (4) no shipped feeds/geoban/trust/detector shell module calls nft_ipc_replace_set, (5) feeds/geoban/trust use nft_ipc_sync_or_apply (FULL sync), and (6) the daemon reject-guard denies replace_set for blacklist_ipv4/blacklist_ipv6. Hermetic: greps shipped source; no host/nft/daemon."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+# NOTE: the counting pipelines below use `|| true` because a `grep -v` that filters out
+# every line legitimately exits non-zero, which pipefail would otherwise treat as a
+# failure. The captured stdout (the count) is still correct; the test's real exit status
+# is the final FAIL==0 check.
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+SYNC_GO="$REPO/cmd/nftband/daemon_handlers_sync.go"
+FEEDS="$REPO/cli/lib/nftban/core/nftban_feeds.sh"
+GEOBAN="$REPO/cli/lib/nftban/core/nftban_geoban.sh"
+TRUST="$REPO/cli/lib/nftban/core/nftban_trust.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1${2:+ — $2}"; }
+
+echo "=== L2e replace_set reachability guard ==="
+
+# 1) Only EnqueueReplace constructs OpReplaceSet (single producer).
+n=$(grep -rn 'Type:[[:space:]]*OpReplaceSet' "$REPO/cmd" "$REPO/internal" 2>/dev/null | grep -v '_test.go' | wc -l || true)
+[[ "$n" -eq 1 ]] && ok "OpReplaceSet constructed in exactly 1 place (EnqueueReplace)" \
+                 || bad "OpReplaceSet constructed in $n places (want 1)"
+
+# 2) EnqueueReplace is called only by handleReplaceSetRequest.
+callers=$(grep -rn '\.EnqueueReplace(' "$REPO/cmd" "$REPO/internal" 2>/dev/null | grep -v '_test.go' | grep -v 'func ' | wc -l || true)
+[[ "$callers" -eq 1 ]] && ok "EnqueueReplace has exactly 1 caller (handleReplaceSetRequest)" \
+                       || bad "EnqueueReplace has $callers callers (want 1)"
+grep -q 'EnqueueReplace(setName, result.Elements, source)' "$SYNC_GO" \
+  && ok "the one EnqueueReplace caller is handleReplaceSetRequest" \
+  || bad "EnqueueReplace caller is not handleReplaceSetRequest"
+
+# 3) EnqueueReplaceFromFile is dead (no caller).
+efc=$(grep -rn 'EnqueueReplaceFromFile(' "$REPO/cmd" "$REPO/internal" "$REPO/cli" 2>/dev/null | grep -v 'func (q' | grep -v '_test.go' | wc -l || true)
+[[ "$efc" -eq 0 ]] && ok "EnqueueReplaceFromFile has no caller (dead)" \
+                   || bad "EnqueueReplaceFromFile has $efc caller(s) (expected dead)"
+
+# 4) No shipped feeds/geoban/trust shell module calls the legacy nft_ipc_replace_set.
+for f in "$FEEDS" "$GEOBAN" "$TRUST"; do
+  base=$(basename "$f")
+  if grep -q 'nft_ipc_replace_set' "$f" 2>/dev/null; then bad "$base calls nft_ipc_replace_set"; else ok "$base does not call nft_ipc_replace_set"; fi
+done
+
+# 5) feeds/geoban/trust use the FULL-sync apply helper (atomic path).
+for f in "$FEEDS" "$GEOBAN" "$TRUST"; do
+  base=$(basename "$f")
+  if grep -q 'nft_ipc_sync_or_apply' "$f" 2>/dev/null; then ok "$base uses nft_ipc_sync_or_apply (FULL sync)"; else bad "$base does not use nft_ipc_sync_or_apply"; fi
+done
+
+# 6) Daemon reject-guard denies replace_set for the atomic-owned interval sets.
+grep -q 'intervalSetsOwnedByAtomicSync' "$SYNC_GO" \
+  && ok "reject-guard set intervalSetsOwnedByAtomicSync present" \
+  || bad "reject-guard set missing"
+grep -Pzoq '"blacklist_ipv4":\s*true,\s*\n?\s*"blacklist_ipv6":\s*true' "$SYNC_GO" 2>/dev/null \
+  && ok "guard set contains blacklist_ipv4 + blacklist_ipv6" \
+  || { grep -q '"blacklist_ipv4": true' "$SYNC_GO" && grep -q '"blacklist_ipv6": true' "$SYNC_GO" && ok "guard set contains blacklist_ipv4 + blacklist_ipv6" || bad "guard set missing interval sets"; }
+grep -q 'blocked for interval/protection set' "$SYNC_GO" \
+  && ok "reject returns explicit blocked error" \
+  || bad "reject error message missing"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -774,8 +774,25 @@ func partitionCIDRTokens(items []string) (singles, cidrs []string) {
 	return singles, cidrs
 }
 
-// handleReplaceSetRequest handles bulk replace_set operations via file
-// This is for feeds/geoban that need atomic flush+bulk-add
+// intervalSetsOwnedByAtomicSync are the protection-critical interval blacklist sets
+// whose ONLY writer is the atomic FULL-sync path (nftsync.FullSync →
+// replaceSetElementsViaFile, a single `nft -f` flush+add transaction). The legacy,
+// non-atomic opqueue replace_set path (buffer.applyReplace: flush THEN add, separate
+// netlink transactions) would re-introduce a transient empty-set fail-open window on a
+// protection set. L2e fences it here (reject-guard); it is unreachable from the shipped
+// shell today (no nft_ipc_replace_set producer), so this only denies a latent surface.
+var intervalSetsOwnedByAtomicSync = map[string]bool{
+	"blacklist_ipv4": true,
+	"blacklist_ipv6": true,
+}
+
+// handleReplaceSetRequest handles the legacy bulk replace_set IPC verb.
+//
+// NOTE: this is NOT the feed/geoban writer. Since v1.213.0 SET_APPLY_SINGLE_WRITER the
+// interval blacklist sets are written atomically by the FULL-sync path (setsync). This
+// legacy verb is retained only for mixed-version IPC acceptance and has no shipped shell
+// producer; full retirement is SET_APPLY_SINGLE_WRITER phase-2. L2e denies it the
+// atomic-owned protection interval sets so the non-atomic path can never touch them.
 func (d *Daemon) handleReplaceSetRequest(params map[string]any) SocketResponse {
 	if d.opQueue == nil {
 		return SocketResponse{Success: false, Error: "OpQueue not initialized"}
@@ -791,6 +808,11 @@ func (d *Daemon) handleReplaceSetRequest(params map[string]any) SocketResponse {
 	}
 	if !validNFTBanSet(setName) {
 		return SocketResponse{Success: false, Error: "invalid set: " + setName}
+	}
+	// L2e reject-guard: deny the legacy non-atomic replace_set on the atomic-owned
+	// interval sets. These are the sole domain of the FULL-sync atomic writer.
+	if intervalSetsOwnedByAtomicSync[setName] {
+		return SocketResponse{Success: false, Error: "replace_set blocked for interval/protection set " + setName + ": owned by the atomic FULL sync path (setsync) — use sync, not replace_set"}
 	}
 	if filePath == "" {
 		return SocketResponse{Success: false, Error: "missing file parameter"}

--- a/cmd/nftband/replace_set_reject_guard_l2e_test.go
+++ b/cmd/nftband/replace_set_reject_guard_l2e_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftband/replace_set_reject_guard_l2e_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="L2e reject-guard: handleReplaceSetRequest must DENY the legacy non-atomic replace_set IPC for the atomic-owned interval sets (blacklist_ipv4/blacklist_ipv6), which are the sole domain of the FULL-sync atomic writer (setsync). Proves the two protection sets are rejected with an explicit error and that a non-interval set is not blocked by this guard. Hermetic; no nft/netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/opqueue"
+)
+
+// stubReplaceBackend is a no-op NetlinkBackend so we can build a real OpQueue; the
+// L2e guard rejects before the queue is ever used for the protection sets.
+type stubReplaceBackend struct{}
+
+func (stubReplaceBackend) FlushSet(table, set string) error { return nil }
+func (stubReplaceBackend) AddElements(table, set string, e []opqueue.SetElement) (int, error) {
+	return len(e), nil
+}
+func (stubReplaceBackend) DeleteElements(table, set string, e []opqueue.SetElement) error { return nil }
+func (stubReplaceBackend) GetSetElements(table, set string) ([]string, error)             { return nil, nil }
+
+const l2eBlockedMsg = "blocked for interval/protection set"
+
+func newReplaceGuardDaemon() *Daemon {
+	return &Daemon{opQueue: opqueue.NewOpQueue(stubReplaceBackend{}, opqueue.DefaultQueueConfig())}
+}
+
+// The atomic-owned interval sets MUST be rejected: the non-atomic opqueue replace_set
+// path can never touch them (they belong to the FULL-sync atomic writer).
+func TestReplaceSet_RejectsAtomicOwnedIntervalSets(t *testing.T) {
+	d := newReplaceGuardDaemon()
+	for _, set := range []string{"blacklist_ipv4", "blacklist_ipv6"} {
+		resp := d.handleReplaceSetRequest(map[string]any{
+			"set": set, "file": "/nonexistent", "source": "test",
+		})
+		if resp.Success {
+			t.Fatalf("replace_set for %s must be rejected, got Success=true", set)
+		}
+		if !strings.Contains(resp.Error, l2eBlockedMsg) {
+			t.Fatalf("replace_set %s reject error must mention %q; got %q", set, l2eBlockedMsg, resp.Error)
+		}
+	}
+}
+
+// A valid non-interval set must NOT be blocked by the L2e guard (it fails later, at
+// file read, proving the guard is set-specific and did not fire).
+func TestReplaceSet_GuardIsSetSpecific(t *testing.T) {
+	d := newReplaceGuardDaemon()
+	resp := d.handleReplaceSetRequest(map[string]any{
+		"set": "geoban_ipv4", "file": "/nonexistent/file", "source": "test",
+	})
+	if resp.Success {
+		t.Fatal("expected failure at file read for a missing file")
+	}
+	if strings.Contains(resp.Error, l2eBlockedMsg) {
+		t.Fatalf("non-interval set must NOT be blocked by the L2e guard; got %q", resp.Error)
+	}
+}
+
+// The guard set must contain exactly the two atomic-owned interval blacklist sets.
+func TestReplaceSet_GuardSetMembership(t *testing.T) {
+	if !intervalSetsOwnedByAtomicSync["blacklist_ipv4"] || !intervalSetsOwnedByAtomicSync["blacklist_ipv6"] {
+		t.Fatal("both blacklist_ipv4 and blacklist_ipv6 must be in intervalSetsOwnedByAtomicSync")
+	}
+	if intervalSetsOwnedByAtomicSync["blacklist_manual_ipv4"] {
+		t.Fatal("manual hash sets must NOT be in the interval-owned guard set")
+	}
+}


### PR DESCRIPTION
## L2e — replace_set legacy IPC reject-guard

Not Option B (atomic routing) and not full legacy retirement. This is the scoped reject-guard: deny `replace_set` for the atomic-owned interval protection sets, lock the reachability invariants, and downgrade the register row from active-P1 to P2-latent.

### Problem
The old register row described opqueue `replace_set` atomicity as an **active P1 fail-open**. A reachability audit corrected this:
- normal interval-set replace is **already atomic** via FULL sync → setsync `replaceSetElementsViaFile` (`nft -f`);
- **no live protection surface** reaches opqueue `replace_set`;
- the remaining non-atomic path is **legacy IPC-only**;
- `nft_ipc_replace_set` has **no shipped shell caller**;
- `EnqueueReplaceFromFile` is **dead**.

### Fix
- `handleReplaceSetRequest` **rejects** `replace_set` for `blacklist_ipv4` / `blacklist_ipv6`.
- Error explicitly states these sets are owned by the atomic FULL sync path and callers must use `sync`.
- Adds Go reject tests + a shell reachability CI guard.
- Does **not** route through atomic `ReplaceSetElementsViaFile`.
- Does **not** retire the whole legacy verb.
- Does **not** touch normal FULL sync or detector/manual add paths.

### Validation (built + tested on lab hosts, not locally)
**lab2 — Ubuntu 24.04 / DEB:** go build + vet OK · L2e Go reject tests **3/3 PASS** · reachability guard **13/13 PASS**, shellcheck clean · full `go test ./...` **rc=0, 0 FAIL** · build.sh rc=0 · daemon active · `nftban validate` rc0 · 0 failed units · blacklist preserved **5==5** · **live `blacklist_ipv4` replace_set rejected** · feed FULL-sync happy path intact.

**lab4 — AlmaLinux 9.8 / RPM:** go build + vet OK · L2e Go reject tests PASS · reachability guard **13/13 PASS** · build.sh rc=0 · daemon active · `nftban validate` rc0 · **0 new** failed units (`cpgreylistd` pre-existing) · blacklist preserved **351==351** · **live `blacklist_ipv4` replace_set rejected and wrote nothing (351 unchanged)** · feed FULL-sync happy path intact.

**Lab caveat (disclosed plainly):** the lab2 run also sent a `geoban_ipv4` control `replace_set` to prove set-specificity live — a transient lab-only control mutation; the daemon restart reconciled it and I verified **no residue** (geoban_ipv4 clean). lab4 dropped that mutating control and relied on the hermetic Go test. **No production hosts touched.**

### Daemon
- Go change → daemon re-baseline required and done.
- Released daemon restored on both labs; final released-binary md5 identical: `155b564752ec03f3963c5bdb127f1d60`.

### Schema / release
- nft schema remains **1.84.0** · VERSION unchanged at **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes / aligns
- Fences the active fail-open **risk** from opqueue `replace_set` by denying it to protection interval sets.
- Regression-locks single-writer authority.
- Register row should downgrade from **P1 active fail-open → P2-latent legacy IPC fenced**.

### Does NOT close
- full legacy `replace_set` verb retirement · SET_APPLY_SINGLE_WRITER phase-2 · `D-DAEMON-RULESET-SKEW-WINDOW` · `BOOT-SNAPSHOT-NO-WRITER` · `COMMIT-CONFIRM-ORPHAN` · `D-UPDATE-INTERACTIVE-NO-AUTO-ROLLBACK` · SEC-P1-3 · GUI-remnant · L3.

### Scope
3 files only. No register mutation, no scope-doc movement, no opportunistic cleanup.