### PR TITLE
fix(daemon): enforce never-ban on the generic add_element path (L3a)

### DIFF
--- a/cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh
+++ b/cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - L3a never-ban add_element guard (regression / reachability)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="l3a_never_ban_add_element_guard_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Regression guard for L3a: the never-ban invariant is enforced on the generic add path, not only the ban verb. Asserts (1) backend.AddElement calls the exempt guard (exemptAddRejection) as defense-in-depth, (2) ErrNeverBanExempt exists, (3) IsEnforcementSet covers the blacklist/ddos drop sets and excludes whitelist/port sets, (4) handleAddElementRequest pre-checks IsEnforcementSet+IsExempt, (5) backend.Ban still guards via IsExempt (regression), and (6) the opqueue EnqueueBan path is documented as the separate L3b lane (out of scope here). Hermetic: greps shipped source."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+BACKEND="$REPO/internal/nftbackend/backend.go"
+HANDLER="$REPO/cmd/nftband/daemon_handlers_elements.go"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1${2:+ — $2}"; }
+
+echo "=== L3a never-ban add_element guard ==="
+
+# 1) backend.AddElement enforces the guard (defense-in-depth backstop for ALL callers).
+if grep -q 'exemptAddRejection(req.Set, req.Element)' "$BACKEND"; then ok "backend.AddElement calls exemptAddRejection"; else bad "backend.AddElement does NOT call the exempt guard"; fi
+
+# 2) sentinel error exists.
+if grep -q 'ErrNeverBanExempt = errors.New' "$BACKEND"; then ok "ErrNeverBanExempt defined"; else bad "ErrNeverBanExempt missing"; fi
+
+# 3) enforcement-set classifier covers ALL add_element-reachable drop sets + defense-in-depth.
+for s in blacklist_manual_ipv4 blacklist_manual_ipv6 blacklist_ipv4 blacklist_ipv6 ddos_blocked \
+         geoban_ipv4 geoban_ipv6 persistent_offenders_ipv4 persistent_offenders_ipv6 bogon_ipv4 bogon_ipv6 \
+         http_bot_ban http_bot_emergency; do
+  if grep -q "\"$s\": *true" "$BACKEND"; then ok "IsEnforcementSet covers $s"; else bad "IsEnforcementSet missing $s"; fi
+done
+ES_BLOCK=$(awk '/enforcementSets = map\[string\]bool\{/{f=1} f{print} f&&/^}/{exit}' "$BACKEND")
+if printf '%s' "$ES_BLOCK" | grep -qE '"(whitelist_ipv4|whitelist_ipv6|ssh_ports|tcp_ports_in)"'; then bad "whitelist/port set wrongly in enforcementSets"; else ok "whitelist/port sets NOT in enforcementSets"; fi
+
+# 4) handler pre-check (clear operator feedback).
+if grep -q 'IsEnforcementSet(set)' "$HANDLER" && grep -q 'd.backend.IsExempt(element)' "$HANDLER"; then ok "handleAddElementRequest pre-checks IsEnforcementSet + IsExempt"; else bad "handler pre-check missing"; fi
+
+# 5) backend.Ban still guards (regression).
+if grep -q 'b.exempt.IsExempt(req.IP)' "$BACKEND"; then ok "backend.Ban still guards via IsExempt"; else bad "backend.Ban guard regressed"; fi
+
+# 6) L3b boundary: EnqueueBan (opqueue) is explicitly the next lane, not silently guarded here.
+if grep -q 'L3b' "$BACKEND"; then ok "L3b (opqueue EnqueueBan) documented as separate lane"; else bad "L3b boundary note missing"; fi
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/cmd/nftband/daemon_handlers_elements.go
+++ b/cmd/nftband/daemon_handlers_elements.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,16 @@ func (d *Daemon) handleAddElementRequest(params map[string]any) SocketResponse {
 	}
 	if !validNFTBanSet(set) {
 		return SocketResponse{Success: false, Error: "invalid set: " + set}
+	}
+
+	// L3a — never-ban invariant on the generic add path (handler-level reject for clear
+	// operator/API feedback). The backend enforces the same as defense-in-depth, so this
+	// is a UX layer, not the sole guard. Enforcement sets + single exempt IP only.
+	if nftbackend.IsEnforcementSet(set) {
+		if exempt, reason := d.backend.IsExempt(element); exempt {
+			log.Printf("[ADD_ELEMENT] REFUSED (never-ban exempt: %s) set=%s ip=%s — protected IP NOT added to enforcement set", reason, set, element)
+			return SocketResponse{Success: false, Error: fmt.Sprintf("refused: never-ban exempt (%s) — %s not added to enforcement set %s", reason, element, set)}
+		}
 	}
 
 	timeout := 0

--- a/internal/nftbackend/backend.go
+++ b/internal/nftbackend/backend.go
@@ -96,7 +96,10 @@ type Stats struct {
 	Syncs       int64
 	Errors      int64
 	ExemptSkips int64 // bans refused because the IP is never-ban exempt (F2 guard)
-	LastError   string
+	// L3a: add_element requests refused because a single exempt IP targeted an
+	// enforcement set (never-ban invariant enforced on the generic add path too).
+	AddElementExemptSkips int64
+	LastError             string
 }
 
 // EnableExemptionGuard wires the authoritative never-ban exemption guard. configDir is
@@ -512,9 +515,79 @@ func isPortSet(setName string) bool { return portSets[setName] }
 
 // AddElement adds an element to any set
 // This is the ONLY authorized add element implementation
+// ErrNeverBanExempt is returned by AddElement when a single exempt IP is refused entry
+// into an enforcement (drop) set. Callers can errors.Is() it to give a clear message.
+var ErrNeverBanExempt = errors.New("never-ban exempt: refused add to enforcement set")
+
+// enforcementSets are the drop/block sets where inserting a single exempt IP would
+// violate the never-ban invariant. Never-ban is a target-set + element property, so this
+// must cover EVERY add_element-reachable enforcement/drop set — not only the sets named in
+// the original L3a scope. Whitelist/port/metadata sets are intentionally excluded (adding
+// an admin IP to whitelist/ssh_ports is correct).
+//
+// add_element-reachable (validNFTBanSet) drop sets: blacklist_ipv4/6, geoban_ipv4/6,
+// persistent_offenders_ipv4/6, bogon_ipv4/6, and the BotGuard drop states
+// http_bot_ban{,6}/http_bot_emergency{,6}. blacklist_manual_* and ddos_blocked are NOT
+// add_element-reachable today but are kept as backend defense-in-depth. The live opqueue
+// EnqueueBan path that writes the BotGuard sets is a separate lane (L3b).
+var enforcementSets = map[string]bool{
+	"blacklist_ipv4":            true,
+	"blacklist_ipv6":            true,
+	"geoban_ipv4":               true,
+	"geoban_ipv6":               true,
+	"persistent_offenders_ipv4": true,
+	"persistent_offenders_ipv6": true,
+	"bogon_ipv4":                true,
+	"bogon_ipv6":                true,
+	"http_bot_ban":              true,
+	"http_bot_ban6":             true,
+	"http_bot_emergency":        true,
+	"http_bot_emergency6":       true,
+	// defense-in-depth (not add_element-reachable via validNFTBanSet today):
+	"blacklist_manual_ipv4": true,
+	"blacklist_manual_ipv6": true,
+	"ddos_blocked":          true,
+}
+
+// IsEnforcementSet reports whether set is a drop/block set subject to the never-ban
+// invariant on element add. Never-ban is a target-set + element property, not a verb
+// property — so the generic add path must consult this, not only the ban verb.
+func IsEnforcementSet(set string) bool { return enforcementSets[set] }
+
+// IsExempt reports whether ip must never be banned (admin/management/whitelist/system/
+// live-SSH), delegating to the authoritative resolver. Nil-safe: no resolver → not exempt
+// (fail-safe; never blocks a legitimate operation). Exposed so handlers can pre-check.
+func (b *Backend) IsExempt(ip string) (bool, string) {
+	if b.exempt == nil {
+		return false, ""
+	}
+	return b.exempt.IsExempt(ip)
+}
+
+// exemptAddRejection reports whether adding element to set must be refused by the
+// never-ban invariant: enforcement set AND a single exempt IP. Pure (no nft I/O), so the
+// decision is unit-testable without netlink/root. IsExempt returns false for CIDR/range
+// and non-single-IP inputs, so feed/interval CIDR adds are naturally unaffected.
+func (b *Backend) exemptAddRejection(set, element string) (bool, string) {
+	if b.exempt == nil || !IsEnforcementSet(set) {
+		return false, ""
+	}
+	return b.exempt.IsExempt(element)
+}
+
 func (b *Backend) AddElement(ctx context.Context, req AddElementRequest) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	// L3a — AUTHORITATIVE never-ban guard on the GENERIC add path (defense-in-depth).
+	// backend.Ban guards its verb; without this an exempt admin/session/system/live-SSH
+	// IP could be inserted into a drop set via add_element, bypassing the F2 invariant.
+	// Enforcement sets + single exempt IP only; CIDR/whitelist/port adds pass. Fail-safe.
+	if reject, reason := b.exemptAddRejection(req.Set, req.Element); reject {
+		b.stats.AddElementExemptSkips++
+		log.Printf("[ADDELEMENT] REFUSED (never-ban exempt: %s) set=%s ip=%s — protected admin/management/whitelist/system/live-SSH IP NOT added to enforcement set", reason, req.Set, req.Element)
+		return fmt.Errorf("%w: %s (%s)", ErrNeverBanExempt, req.Element, reason)
+	}
 
 	// Ensure netlink connection
 	if err := b.ensureNetlink(); err != nil {

--- a/internal/nftbackend/never_ban_add_element_l3a_test.go
+++ b/internal/nftbackend/never_ban_add_element_l3a_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftbackend/never_ban_add_element_l3a_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="L3a: never-ban is a target-set + element invariant, not a verb property. Proves backend.AddElement refuses a single exempt IP into an enforcement (drop) set (v4+v6, exact+CIDR-covered), that the AddElementExemptSkips counter increments, that whitelist/port/public-IP/CIDR adds are NOT blocked, and that backend.Ban still refuses exempt IPs (regression). Uses the package snapshot() helper for a fixed exempt set; the reject path returns before any netlink work, so it is hermetic (no nft/root)."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package nftbackend
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestIsEnforcementSet_L3a(t *testing.T) {
+	for _, s := range []string{
+		"blacklist_manual_ipv4", "blacklist_manual_ipv6", "blacklist_ipv4", "blacklist_ipv6",
+		"ddos_blocked", "http_bot_ban", "http_bot_ban6", "http_bot_emergency", "http_bot_emergency6",
+		// add_element-reachable drop sets discovered during implementation:
+		"geoban_ipv4", "geoban_ipv6", "persistent_offenders_ipv4", "persistent_offenders_ipv6",
+		"bogon_ipv4", "bogon_ipv6",
+	} {
+		if !IsEnforcementSet(s) {
+			t.Errorf("%s must be an enforcement set", s)
+		}
+	}
+	for _, s := range []string{"whitelist_ipv4", "whitelist_ipv6", "ssh_ports", "tcp_ports_in", "tcp_ports_out", ""} {
+		if IsEnforcementSet(s) {
+			t.Errorf("%s must NOT be an enforcement set", s)
+		}
+	}
+}
+
+// The core invariant: reject == (enforcement set) AND (single exempt IP). No verb involved.
+func TestExemptAddRejection_L3a(t *testing.T) {
+	b := &Backend{}
+	b.exempt = snapshot([]string{"10.0.0.5"}, []string{"2001:db8::/48"})
+	cases := []struct {
+		set, el string
+		want    bool
+	}{
+		{"blacklist_manual_ipv4", "10.0.0.5", true},   // exact exempt v4 → enforcement: REJECT
+		{"blacklist_manual_ipv6", "2001:db8::9", true}, // cidr-covered exempt v6: REJECT
+		{"blacklist_ipv4", "10.0.0.5", true},           // interval enforcement: REJECT
+		{"ddos_blocked", "10.0.0.5", true},             // ddos drop set: REJECT
+		{"geoban_ipv4", "10.0.0.5", true},              // geoban drop set (add_element-reachable): REJECT
+		{"persistent_offenders_ipv6", "2001:db8::9", true}, // persistent-offenders drop set: REJECT
+		{"bogon_ipv4", "10.0.0.5", true},               // bogon drop set: REJECT
+		{"whitelist_ipv4", "10.0.0.5", false},          // whitelist add of exempt IP: ALLOW
+		{"blacklist_manual_ipv4", "203.0.113.9", false}, // normal public IP: ALLOW
+		{"blacklist_ipv4", "10.0.0.0/8", false},        // CIDR input (IsExempt=false): ALLOW
+		{"ssh_ports", "10.0.0.5", false},               // port set (not enforcement): ALLOW
+	}
+	for _, c := range cases {
+		got, _ := b.exemptAddRejection(c.set, c.el)
+		if got != c.want {
+			t.Errorf("exemptAddRejection(%q,%q)=%v want %v", c.set, c.el, got, c.want)
+		}
+	}
+}
+
+// backend.AddElement refuses exempt IPs into enforcement sets and returns before any
+// netlink work (so the counter increments and no set is mutated).
+func TestAddElement_RejectsExemptBeforeNetlink_L3a(t *testing.T) {
+	b := &Backend{}
+	b.exempt = snapshot([]string{"10.0.0.5"}, []string{"2001:db8::/48"})
+
+	if err := b.AddElement(context.Background(), AddElementRequest{Table: "ip nftban", Set: "blacklist_manual_ipv4", Element: "10.0.0.5"}); !errors.Is(err, ErrNeverBanExempt) {
+		t.Fatalf("v4 exempt add: want ErrNeverBanExempt, got %v", err)
+	}
+	if err := b.AddElement(context.Background(), AddElementRequest{Table: "ip6 nftban", Set: "blacklist_manual_ipv6", Element: "2001:db8::9"}); !errors.Is(err, ErrNeverBanExempt) {
+		t.Fatalf("v6 exempt add: want ErrNeverBanExempt, got %v", err)
+	}
+	if b.stats.AddElementExemptSkips != 2 {
+		t.Fatalf("AddElementExemptSkips=%d, want 2", b.stats.AddElementExemptSkips)
+	}
+}
+
+// Regression: backend.Ban still refuses exempt IPs (the original F2 guard is unchanged).
+func TestBan_StillRejectsExempt_L3a(t *testing.T) {
+	b := &Backend{}
+	b.exempt = snapshot([]string{"10.0.0.5"}, []string{"2001:db8::/48"})
+	for _, ip := range []string{"10.0.0.5", "2001:db8::9"} {
+		res, err := b.Ban(context.Background(), BanRequest{IP: ip, Source: "test"})
+		if err != nil {
+			t.Fatalf("Ban(%s) unexpected err: %v", ip, err)
+		}
+		if res == nil || !res.Exempt {
+			t.Fatalf("Ban(%s) must be refused as exempt", ip)
+		}
+	}
+}


### PR DESCRIPTION
## L3a — never-ban is a target-set + element invariant, not a verb property

L3a closes the `add_element` / `backend.AddElement` never-ban bypass by enforcing the invariant at the **backend `AddElement` boundary**.

The guard rejects exempt single IPs **before netlink** whenever the target is an enforcement/drop set. This includes the originally scoped blacklist/BotGuard/DDoS sets **and** the `add_element`-reachable `geoban`, `persistent_offenders`, and `bogon` drop sets discovered during implementation.

The invariant is intentionally **set-based, not verb-based**:
```
exempt single IP + enforcement set = reject before netlink
```
Whitelist / CIDR / ssh_ports paths are unaffected. Non-exempt public IP additions remain allowed. Nil resolver remains fail-safe. No schema/VERSION change.

## Problem
`backend.Ban` enforced the authoritative F2 never-ban guard, but `add_element → backend.AddElement` had **no** exemption check, and `validNFTBanSet` permits enforcement sets — so an exempt admin/management/whitelist/system/live-SSH single IP could be inserted into a drop set via the generic add path, defeating the invariant.

## Fix (Option C — handler reject + backend defense-in-depth)
- `backend.AddElement` refuses a single exempt IP targeting an enforcement set → `ErrNeverBanExempt` + audit log + `AddElementExemptSkips` counter. Pure decision (`exemptAddRejection`), returns **before** any netlink work.
- `handleAddElementRequest` pre-checks `IsEnforcementSet` + `IsExempt` for a clear operator/API error. The backend guard is the **universal backstop** so no handler (incl. a future HTTP router) can bypass it.
- `IsExempt` returns false for CIDR/range/non-single-IP → feed/interval CIDR + whitelist/port/ssh_ports adds unaffected. Fail-safe: nil resolver never blocks a legitimate add.

## Enforcement sets
`add_element`-reachable drop sets: `blacklist_ipv4/6`, `geoban_ipv4/6`, `persistent_offenders_ipv4/6`, `bogon_ipv4/6`, `http_bot_ban{,6}`, `http_bot_emergency{,6}`. Plus `blacklist_manual_*` and `ddos_blocked` as backend defense-in-depth (not `add_element`-reachable via `validNFTBanSet` today).

## Validation (built + tested on lab hosts, not locally)
| | lab2 (Ubuntu 24.04 / DEB) | lab4 (AlmaLinux 9.8 / RPM) |
|---|---|---|
| build + vet | OK | OK |
| backend L3a tests | PASS (classifier, exemptAddRejection incl. geoban/persistent_offenders/bogon, AddElement-reject v4+v6, Ban regression) | PASS |
| handler L3a test | PASS | PASS |
| shell reachability guard | 19/0, shellcheck clean | 19/0 |
| full `go test ./...` | **rc=0, 0 FAIL** | — |
| daemon / validate / failed units | active / 0 / 0 | active / 0 / 0-new (`cpgreylistd` pre-existing) |
| **A: exempt → `blacklist_ipv4`** | **REJECT, not added** | **REJECT, not added** |
| **A2: exempt → `geoban_ipv4`** (new set) | **REJECT, not added** | **REJECT, not added** |
| B: public IP → `blacklist_ipv4` | allowed | allowed |
| C: normal ban | works | works |
| D: whitelist add | works | works |

Live proof used a **whitelisted test IP** (`203.0.113.50`), not a real SSH IP, to prove the reject with zero lockout risk (the current-SSH exemption path is covered by the resolver's `/proc/net/tcp` source + hermetic tests).

## Daemon / release
Daemon re-baseline required and done; released daemon restored on both labs, md5 identical `155b564752ec…`. nft schema **1.84.0**, VERSION **1.217.0**, no tag / release-prep / fleet.

## Closes / does NOT close
- **Closes:** HOLE 1 — `add_element` / `backend.AddElement` never-ban bypass, for **all currently-known `add_element`-reachable enforcement/drop sets**, plus defense-in-depth non-reachable sets, plus the Suricata-DDoS `add_element` fallback.
- **Does NOT close:** L3b (opqueue `EnqueueBan` / BotGuard) · SEC-P1-3 (amplifier; HTTP mutating router is off) · `D-DAEMON-RULESET-SKEW-WINDOW` · `BOOT-SNAPSHOT-NO-WRITER` · `COMMIT-CONFIRM-ORPHAN` · `D-UPDATE-INTERACTIVE-NO-AUTO-ROLLBACK` · GUI-remnant.

## Scope
5 files. No schema bump, no VERSION bump, no logic redesign beyond the guard, no tag/release/fleet.