### PR TITLE
fix(botguard): enforce never-ban on opqueue EnqueueBan path (L3b)

### DIFF
--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -457,6 +457,17 @@ func (d *Daemon) initOpQueue() error {
 	// Create OpQueue with default config
 	d.opQueue = opqueue.NewOpQueue(wrapper, opqueue.DefaultQueueConfig())
 
+	// L3b — inject the never-ban guard into the opqueue ban path. BotGuard state-set bans
+	// (opqueue.EnqueueBan) bypass backend.Ban and the L3a backend.AddElement guard; this
+	// makes the invariant hold there too. The closure combines the enforcement-set
+	// classifier with the SAME authoritative resolver backend.Ban / L3a use.
+	d.opQueue.SetExemptResolver(func(set, ip string) (bool, string) {
+		if nftbackend.IsEnforcementSet(set) {
+			return d.backend.IsExempt(ip)
+		}
+		return false, ""
+	})
+
 	// v1.32.0: Initialize set element counters for huge set management
 	runDir, _, _, _ := getDaemonPaths()
 	d.setCounters = stats.NewSetCounters(runDir)

--- a/internal/botguard/enforcer.go
+++ b/internal/botguard/enforcer.go
@@ -81,6 +81,16 @@ func (e *Enforcer) Apply(ip netip.Addr, oldState, newState IPState, reason strin
 
 	ttl := e.ttlSeconds(newState)
 
+	// L3b — never-ban pre-check: a BotGuard state-set ban is still a ban. Skip (with a
+	// clear log) before enqueuing an exempt admin/management/whitelist/system/live-SSH IP
+	// into a drop/enforcement set. The opqueue EnqueueBan guard is the backstop.
+	if exempt, why := e.queue.CheckExempt(newSet, ipStr); exempt {
+		if e.config.LogDecisions {
+			log.Printf("[botguard] never-ban exempt (%s): %s NOT added to %s", why, ipStr, newSet)
+		}
+		return nil
+	}
+
 	if err := e.queue.EnqueueBan(newSet, ipStr, ttl, enforcerSource, reason); err != nil {
 		return fmt.Errorf("add %s to %s: %w", ipStr, newSet, err)
 	}

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -977,6 +977,12 @@ func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
 	if len(sig.Reasons) > 0 {
 		reason = botscanProvenanceSrc + ":" + sig.Reasons[0]
 	}
+	// L3b — never-ban pre-check before the opqueue ban (the EnqueueBan guard is the
+	// backstop). Skip an exempt IP with a clear log; not counted as a ban.
+	if exempt, why := m.opQueue.CheckExempt(setName, ip.String()); exempt {
+		log.Printf("[botguard] never-ban exempt (%s): %s NOT added to %s", why, ip, setName)
+		return false
+	}
 	if err := m.opQueue.EnqueueBan(setName, ip.String(), ttlSec, botscanProvenanceSrc, reason); err != nil {
 		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
 		return false

--- a/internal/botguard/never_ban_exempt_l3b_test.go
+++ b/internal/botguard/never_ban_exempt_l3b_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="botguard/never_ban_exempt_l3b_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="L3b caller-side never-ban pre-check: a BotGuard ban signal for an exempt IP must NOT enter any drop/enforcement set (the enforcer/batch-signal path skips before EnqueueBan). Control: a non-exempt IP with the same signal IS banned, proving the skip is specific to the exempt IP and the path is otherwise live. Uses the package recBackend harness; no netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package botguard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/eventbus"
+	"github.com/itcmsgr/nftban/internal/opqueue"
+)
+
+func bannedAnywhere(b *recBackend, ip string) (string, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for set, ips := range b.adds {
+		for _, got := range ips {
+			if got == ip {
+				return set, true
+			}
+		}
+	}
+	return "", false
+}
+
+func TestBATCH_SIGNAL_EXEMPT_IP_NOT_BANNED_L3b(t *testing.T) {
+	b := &recBackend{adds: make(map[string][]string)}
+	qcfg := opqueue.DefaultQueueConfig()
+	qcfg.FlushThreshold = 1
+	qcfg.FlushInterval = 5 * time.Millisecond
+	q := opqueue.NewOpQueue(b, qcfg)
+
+	const exemptIP = "198.51.100.88"
+	const normalIP = "198.51.100.99"
+	// L3b resolver: the exempt IP must never enter a drop/enforcement set.
+	q.SetExemptResolver(func(set, ip string) (bool, string) {
+		if ip == exemptIP {
+			return true, "test-exempt"
+		}
+		return false, ""
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	q.Start(ctx)
+
+	m := New()
+	m.bus = eventbus.New()
+	m.InitEnforcer(q)
+
+	// Control: a normal IP with a ban signal must reach a drop set.
+	m.applyBatchSignal(mkSig(normalIP, "scanner", "ban", "scanner pattern: webshell"))
+	// The exempt IP with the SAME ban signal must be skipped (never-ban).
+	m.applyBatchSignal(mkSig(exemptIP, "scanner", "ban", "scanner pattern: webshell"))
+
+	// Wait until the control IP lands (proves the path is live), then assert the exempt
+	// IP never appears.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := bannedAnywhere(b, normalIP); ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, ok := bannedAnywhere(b, normalIP); !ok {
+		t.Fatalf("control: normal IP %s was not banned — path not exercised (sets: %v)", normalIP, b.adds)
+	}
+	// Small grace for any late async apply, then the exempt IP must be absent.
+	time.Sleep(100 * time.Millisecond)
+	if set, ok := bannedAnywhere(b, exemptIP); ok {
+		t.Fatalf("never-ban violation: exempt IP %s was banned into %s", exemptIP, set)
+	}
+}

--- a/internal/opqueue/enqueue_ban_never_ban_guard_l3b_test.go
+++ b/internal/opqueue/enqueue_ban_never_ban_guard_l3b_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="opqueue/enqueue_ban_never_ban_guard_l3b_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="L3b: the never-ban invariant holds on the opqueue ban path. Proves EnqueueBan refuses (skips) an exempt single IP into an enforcement/drop set (v4+v6) via the injected resolver, increments EnqueueBanExemptSkips, allows normal public IPs, allows exempt IPs into non-enforcement sets, and is fail-safe when no resolver is injected. Also covers CheckExempt (the caller-side pre-check helper). Hermetic: trivial stub backend, no netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package opqueue
+
+import (
+	"context"
+	"testing"
+)
+
+type l3bStubBackend struct{}
+
+func (l3bStubBackend) FlushSet(table, set string) error { return nil }
+func (l3bStubBackend) AddElements(table, set string, e []SetElement) (int, error) {
+	return len(e), nil
+}
+func (l3bStubBackend) DeleteElements(table, set string, e []SetElement) error { return nil }
+func (l3bStubBackend) GetSetElements(table, set string) ([]string, error)     { return nil, nil }
+
+// resolver mirroring the daemon closure: enforcement set + exempt single IP → refuse.
+func l3bResolver(set, ip string) (bool, string) {
+	enforcement := map[string]bool{
+		"http_bot_ban": true, "http_bot_ban6": true, "http_bot_emergency": true,
+		"blacklist_manual_ipv4": true, "blacklist_ipv4": true,
+	}
+	exempt := map[string]bool{"10.0.0.5": true, "2001:db8::9": true}
+	if enforcement[set] && exempt[ip] {
+		return true, "test-exempt"
+	}
+	return false, ""
+}
+
+func newGuardedQueue(t *testing.T) *OpQueue {
+	t.Helper()
+	q := NewOpQueue(l3bStubBackend{}, DefaultQueueConfig())
+	q.SetExemptResolver(l3bResolver)
+	q.Start(context.Background())
+	t.Cleanup(q.Stop)
+	return q
+}
+
+func TestEnqueueBan_RejectsExemptIntoEnforcementSet_L3b(t *testing.T) {
+	q := newGuardedQueue(t)
+	// v4 into a BotGuard drop set
+	if err := q.EnqueueBan("http_bot_ban", "10.0.0.5", 3600, "botguard", "test"); err != nil {
+		t.Fatalf("exempt v4 EnqueueBan must skip (nil err), got %v", err)
+	}
+	// v6 into the v6 BotGuard drop set
+	if err := q.EnqueueBan("http_bot_ban6", "2001:db8::9", 3600, "botguard", "test"); err != nil {
+		t.Fatalf("exempt v6 EnqueueBan must skip (nil err), got %v", err)
+	}
+	// blacklist_manual (the batch-signal path target) also fenced
+	if err := q.EnqueueBan("blacklist_manual_ipv4", "10.0.0.5", 3600, "botscan", "test"); err != nil {
+		t.Fatalf("exempt into blacklist_manual must skip, got %v", err)
+	}
+	if got := q.Stats().EnqueueBanExemptSkips; got != 3 {
+		t.Fatalf("EnqueueBanExemptSkips=%d, want 3", got)
+	}
+}
+
+func TestEnqueueBan_AllowsNormalAndNonEnforcement_L3b(t *testing.T) {
+	q := newGuardedQueue(t)
+	// normal public IP into an enforcement set → allowed (not skipped)
+	if err := q.EnqueueBan("http_bot_ban", "203.0.113.9", 3600, "botguard", "test"); err != nil {
+		t.Fatalf("public IP ban should proceed, got %v", err)
+	}
+	// exempt IP into a NON-enforcement set (allow/grey state) → not fenced
+	if err := q.EnqueueBan("http_bot_allow", "10.0.0.5", 3600, "botguard", "test"); err != nil {
+		t.Fatalf("non-enforcement set add should proceed, got %v", err)
+	}
+	if got := q.Stats().EnqueueBanExemptSkips; got != 0 {
+		t.Fatalf("EnqueueBanExemptSkips=%d, want 0 (nothing fenced)", got)
+	}
+}
+
+func TestEnqueueBan_NilResolver_FailSafe_L3b(t *testing.T) {
+	q := NewOpQueue(l3bStubBackend{}, DefaultQueueConfig()) // no SetExemptResolver
+	q.Start(context.Background())
+	t.Cleanup(q.Stop)
+	// with no resolver, even an "exempt" IP proceeds (fail-safe: never block a legit ban)
+	if err := q.EnqueueBan("http_bot_ban", "10.0.0.5", 3600, "botguard", "test"); err != nil {
+		t.Fatalf("nil resolver must not block, got %v", err)
+	}
+	if got := q.Stats().EnqueueBanExemptSkips; got != 0 {
+		t.Fatalf("EnqueueBanExemptSkips=%d, want 0 with nil resolver", got)
+	}
+}
+
+func TestCheckExempt_L3b(t *testing.T) {
+	q := NewOpQueue(l3bStubBackend{}, DefaultQueueConfig())
+	// nil resolver → not exempt
+	if ex, _ := q.CheckExempt("http_bot_ban", "10.0.0.5"); ex {
+		t.Fatal("nil resolver CheckExempt must return false")
+	}
+	q.SetExemptResolver(l3bResolver)
+	if ex, _ := q.CheckExempt("http_bot_ban", "10.0.0.5"); !ex {
+		t.Fatal("exempt IP into enforcement set must be exempt")
+	}
+	if ex, _ := q.CheckExempt("http_bot_allow", "10.0.0.5"); ex {
+		t.Fatal("non-enforcement set must not be exempt")
+	}
+	if ex, _ := q.CheckExempt("http_bot_ban", "203.0.113.9"); ex {
+		t.Fatal("public IP must not be exempt")
+	}
+}

--- a/internal/opqueue/queue.go
+++ b/internal/opqueue/queue.go
@@ -596,6 +596,12 @@ type OpQueue struct {
 	// intended (partial/fail-open apply). A non-zero value is a degraded signal — the set
 	// is short of what was requested. Surfaced via QueueStats / sync-status JSON.
 	replacePartialFailures atomic.Uint64
+	// L3b: never-ban invariant on the opqueue ban path. exemptCheck (injected by the
+	// daemon) reports whether adding ip to set would violate never-ban (enforcement set +
+	// exempt single IP). nil = no guard (fail-safe: never blocks a legitimate ban).
+	// enqueueBanExemptSkips counts EnqueueBan calls refused for an exempt IP.
+	exemptCheck           func(set, ip string) (bool, string)
+	enqueueBanExemptSkips atomic.Uint64
 
 	// Last flush time
 	lastFlushTime atomic.Value // time.Time
@@ -651,6 +657,24 @@ func (q *OpQueue) SetOnFlush(fn func(setName string, applied int, opType string)
 	q.onFlush = fn
 }
 
+// SetExemptResolver injects the L3b never-ban guard. fn reports (exempt, reason) for
+// adding ip into set; it should combine the enforcement-set classifier with the
+// authoritative IsExempt resolver (same one backend.Ban / L3a use). Safe to call once at
+// daemon init. nil disables the guard (fail-safe).
+func (q *OpQueue) SetExemptResolver(fn func(set, ip string) (bool, string)) {
+	q.exemptCheck = fn
+}
+
+// CheckExempt reports whether adding ip into set would violate the never-ban invariant,
+// using the injected resolver. Nil-safe (no resolver → not exempt). Exposed so ban-path
+// callers (e.g. the BotGuard enforcer) can pre-check and skip with a clear log.
+func (q *OpQueue) CheckExempt(set, ip string) (bool, string) {
+	if q.exemptCheck == nil {
+		return false, ""
+	}
+	return q.exemptCheck(set, ip)
+}
+
 // Start begins the async flush worker
 func (q *OpQueue) Start(ctx context.Context) {
 	if q.running.Load() {
@@ -685,12 +709,22 @@ func (q *OpQueue) Stats() QueueStats {
 		TotalApplied:           q.totalApplied.Load(),
 		TotalDropped:           q.totalDropped.Load(),
 		ReplacePartialFailures: q.replacePartialFailures.Load(),
+		EnqueueBanExemptSkips:  q.enqueueBanExemptSkips.Load(),
 		LastFlushTime:          lastFlush,
 	}
 }
 
 // EnqueueBan adds a ban operation (async, non-blocking)
 func (q *OpQueue) EnqueueBan(setName string, element string, ttl uint32, source, reason string) error {
+	// L3b — never-ban invariant on the opqueue ban path (backstop). BotGuard state-set
+	// bans are still bans: an exempt single IP must never enter a DROP/enforcement set,
+	// regardless of queue path or a caller forgetting to pre-check. Skip (not an error) —
+	// exempt = safe no-op, mirroring backend.Ban. Nil resolver never blocks a legit ban.
+	if exempt, reasonWhy := q.CheckExempt(setName, element); exempt {
+		q.enqueueBanExemptSkips.Add(1)
+		log.Printf("[opqueue] EnqueueBan REFUSED (never-ban exempt: %s) set=%s ip=%s source=%s reason=%s — protected admin/management/whitelist/system/live-SSH IP NOT added to enforcement set", reasonWhy, setName, element, source, reason)
+		return nil
+	}
 	op := &SetOp{
 		Type:    OpAdd,
 		Element: element,

--- a/internal/opqueue/types.go
+++ b/internal/opqueue/types.go
@@ -111,7 +111,10 @@ type QueueStats struct {
 	// L2b: number of replace_set applies that flushed then applied fewer elements than
 	// intended (partial/fail-open). Non-zero = degraded; the set is short of requested.
 	ReplacePartialFailures uint64
-	LastFlushTime          time.Time
+	// L3b: number of EnqueueBan calls refused because a single exempt IP targeted an
+	// enforcement/drop set (never-ban invariant on the opqueue ban path).
+	EnqueueBanExemptSkips uint64
+	LastFlushTime         time.Time
 }
 
 // FlushResult contains the outcome of a buffer flush


### PR DESCRIPTION
## Problem
- GUARD-VERB-SCOPE **L3a** closed `add_element`.
- Remaining **L3b hole**: BotGuard enforcer / batch-signal paths use `opqueue.EnqueueBan`.
- `EnqueueBan` wrote to BotGuard drop/enforcement sets (`http_bot_*`) without the authoritative `IsExempt` resolver.
- This bypasses **both** `backend.Ban` and the L3a `backend.AddElement` guard.
- BotGuard is **default-OFF**, so this is narrow/latent — but real when enabled.

## Fix
- OpQueue gains an injected `SetExemptResolver` / `CheckExempt`.
- `daemon_init` wires the existing authoritative resolver:
  `IsEnforcementSet(set) && backend.IsExempt(ip)`.
- `EnqueueBan` skips exempt single IPs into enforcement sets **before** enqueue (skip, not error — mirrors `backend.Ban`).
- `EnqueueBanExemptSkips` internal `QueueStats` counter added.
- BotGuard enforcer and batch-signal path do a caller-side pre-check and log the never-ban exempt skip.
- Nil resolver does **not** block legitimate bans (fail-safe).
- No `opqueue → nftbackend` import cycle.
- BotGuard state-set model unchanged.
- No `backend.Ban` reroute.

## Validation
**lab2 (DEB):**
- build + vet OK
- L3b `-race` unit tests PASS
- touched packages `-race` clean
- L2b / L2e / L3a regressions PASS
- full `go test ./...` rc=0 / 0 FAIL
- `build.sh` rc0
- daemon active
- `nftban validate` rc0
- 0 failed units
- BotGuard default-off remains disabled, 0 active `http_bot` chains

**lab4 (RPM):**
- build + vet OK
- relevant tests PASS via full/touched run
- `build.sh` rc0
- daemon active
- `nftban validate` rc0
- 0 new failed units
- BotGuard default-off clean

- Released binary restored on both labs: md5 `155b564752ec03f3963c5bdb127f1d60`

## Schema / release
- nft schema remains **1.84.0**
- VERSION remains **1.217.0**
- no tag
- no release-prep
- no fleet rollout

## Closes
- GUARD-VERB-SCOPE **HOLE 2**: `opqueue.EnqueueBan` / BotGuard enforcer never-ban bypass.
- With L3a + L3b, GUARD-VERB-SCOPE can close fully at align.

## Does NOT close
- SEC-P1-3
- `delete_element` / whitelist-removal watch edges
- FullSync-from-`blacklist.d` watch edge
- D-DAEMON-RULESET-SKEW-WINDOW
- BOOT-SNAPSHOT-NO-WRITER
- COMMIT-CONFIRM-ORPHAN
- D-UPDATE-INTERACTIVE-NO-AUTO-ROLLBACK
- GUI-remnant
- central communication authority
- RBLMON / RBL detection lane

## PR rules
- Do not merge yet.
- No register mutation inside the PR.
- No scope-doc movement inside the PR.
- No schema / VERSION / docs / wiki / packaging drift.
- No SEC-P1-3.
- No central-comms / RBL changes.
