### PR TITLE
fix(daemon): default HTTP API bind to loopback (SEC-P1-3a)

### DIFF
--- a/cmd/nftband/daemon_http.go
+++ b/cmd/nftband/daemon_http.go
@@ -25,11 +25,61 @@ import (
 	"net"
 	"net/http"
 	nethttpprof "net/http/pprof" // BUG-H4 FIX: explicit import instead of blank import to avoid polluting DefaultServeMux
+	"os"
+	"strings"
 
 	"github.com/itcmsgr/nftban/internal/constants"
 	"github.com/itcmsgr/nftban/pkg/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// isLoopbackAPIBind reports whether addr binds only the loopback interface. An empty
+// host (e.g. ":9580"), "0.0.0.0", "::", a hostname, or a routable IP are all NON-loopback
+// (exposed). "localhost", 127.0.0.0/8, and ::1 are loopback.
+func isLoopbackAPIBind(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr // no port form — evaluate as-is
+	}
+	if host == "" {
+		return false // ":9580" = all interfaces
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false // hostname → conservative: treat as non-loopback
+	}
+	return ip.IsLoopback()
+}
+
+// apiInsecureBindAcked reports whether the operator explicitly acknowledged a non-loopback
+// (unauthenticated) HTTP API bind via NFTBAN_API_ALLOW_INSECURE_BIND. Auth/token is SEC-P1-3b.
+func apiInsecureBindAcked() bool {
+	switch strings.ToUpper(strings.TrimSpace(os.Getenv("NFTBAN_API_ALLOW_INSECURE_BIND"))) {
+	case "YES", "TRUE", "1":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveAPIBind applies the SEC-P1-3a guard: loopback binds pass through; a non-loopback
+// bind is honored ONLY with an explicit ack (loud warning), otherwise it is refused and
+// falls back to the loopback default (loud error) so an unsafe config never exposes the
+// unauthenticated API. Returns the address the daemon will actually bind.
+func resolveAPIBind(addr string) string {
+	if isLoopbackAPIBind(addr) {
+		return addr
+	}
+	if apiInsecureBindAcked() {
+		log.Printf("[SECURITY][WARN] HTTP API is bound non-loopback (%s) without authentication; expose only behind firewall/reverse-proxy. Token/auth is SEC-P1-3b.", addr)
+		return addr
+	}
+	log.Printf("[SECURITY][ERROR] HTTP API configured to bind non-loopback (%s) without NFTBAN_API_ALLOW_INSECURE_BIND=YES — refusing unsafe bind, falling back to loopback %s. Set the ack to expose deliberately (auth is SEC-P1-3b).", addr, DefaultHTTPAddr)
+	return DefaultHTTPAddr
+}
 
 // startHTTP starts the HTTP API server
 func (d *Daemon) startHTTP() error {
@@ -82,7 +132,11 @@ func (d *Daemon) startHTTP() error {
 	// TODO: Mount existing internal/api handlers here
 	// mux.Handle("/api/v1/", api.NewRouter())
 
-	addr := getAPIAddr()
+	// SEC-P1-3a: default is loopback; a non-loopback bind is refused (→ loopback) unless
+	// explicitly acknowledged. This closes the live all-interfaces unauthenticated exposure
+	// and fences the future-mutator amplifier.
+	addr := resolveAPIBind(getAPIAddr())
+	log.Printf("[nftband] HTTP API binding %s (loopback=%t)", addr, isLoopbackAPIBind(addr))
 
 	// v1.52.0: Pre-check if port is available — if not, skip HTTP API gracefully
 	// This prevents noisy errors when Apache/DA/cPanel/nginx is on the same port

--- a/cmd/nftband/http_api_loopback_default_sec_p1_3a_test.go
+++ b/cmd/nftband/http_api_loopback_default_sec_p1_3a_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftband/http_api_loopback_default_sec_p1_3a_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="SEC-P1-3a: the daemon HTTP API defaults to loopback and a non-loopback bind is refused (falls back to loopback) unless explicitly acknowledged via NFTBAN_API_ALLOW_INSECURE_BIND. Covers isLoopbackAPIBind classification (loopback vs all-interfaces/0.0.0.0/::/LAN/public/hostname), resolveAPIBind fallback-vs-honor, the ack env parse, and that the DefaultHTTPAddr fallback is loopback. Hermetic: pure functions, no netlink/daemon."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_API_ALLOW_INSECURE_BIND"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package main
+
+import "testing"
+
+func TestIsLoopbackAPIBind_SEC_P1_3a(t *testing.T) {
+	loopback := []string{"127.0.0.1:9580", "127.0.0.1:6060", "[::1]:9580", "localhost:9580"}
+	exposed := []string{":9580", "0.0.0.0:9580", "[::]:9580", "192.168.1.5:9580", "203.0.113.9:9580", "10.0.0.1:9580", "host.example:9580"}
+	for _, a := range loopback {
+		if !isLoopbackAPIBind(a) {
+			t.Errorf("%q must be loopback", a)
+		}
+	}
+	for _, a := range exposed {
+		if isLoopbackAPIBind(a) {
+			t.Errorf("%q must be NON-loopback (exposed)", a)
+		}
+	}
+}
+
+func TestApiInsecureBindAcked_SEC_P1_3a(t *testing.T) {
+	for _, v := range []string{"YES", "yes", "TRUE", "true", "1"} {
+		t.Setenv("NFTBAN_API_ALLOW_INSECURE_BIND", v)
+		if !apiInsecureBindAcked() {
+			t.Errorf("%q must be an ack", v)
+		}
+	}
+	for _, v := range []string{"", "NO", "no", "0", "false", "maybe"} {
+		t.Setenv("NFTBAN_API_ALLOW_INSECURE_BIND", v)
+		if apiInsecureBindAcked() {
+			t.Errorf("%q must NOT be an ack", v)
+		}
+	}
+}
+
+func TestResolveAPIBind_LoopbackPassThrough_SEC_P1_3a(t *testing.T) {
+	t.Setenv("NFTBAN_API_ALLOW_INSECURE_BIND", "")
+	for _, a := range []string{"127.0.0.1:9580", "[::1]:9580", "localhost:9580"} {
+		if got := resolveAPIBind(a); got != a {
+			t.Errorf("loopback %q must pass through, got %q", a, got)
+		}
+	}
+}
+
+func TestResolveAPIBind_NonLoopbackWithoutAck_FallsBackToLoopback_SEC_P1_3a(t *testing.T) {
+	t.Setenv("NFTBAN_API_ALLOW_INSECURE_BIND", "")
+	for _, a := range []string{":9580", "0.0.0.0:9580", "[::]:9580", "192.168.1.5:9580", "203.0.113.9:9580"} {
+		got := resolveAPIBind(a)
+		if got != DefaultHTTPAddr {
+			t.Errorf("unsafe %q without ack must fall back to %q, got %q", a, DefaultHTTPAddr, got)
+		}
+		if !isLoopbackAPIBind(got) {
+			t.Errorf("fallback %q must be loopback", got)
+		}
+	}
+}
+
+func TestResolveAPIBind_NonLoopbackWithAck_Honored_SEC_P1_3a(t *testing.T) {
+	t.Setenv("NFTBAN_API_ALLOW_INSECURE_BIND", "YES")
+	for _, a := range []string{"0.0.0.0:9580", ":9580", "203.0.113.9:9580"} {
+		if got := resolveAPIBind(a); got != a {
+			t.Errorf("acked non-loopback %q must be honored, got %q", a, got)
+		}
+	}
+}
+
+func TestDefaultHTTPAddr_IsLoopback_SEC_P1_3a(t *testing.T) {
+	if DefaultHTTPAddr != "127.0.0.1:9580" {
+		t.Fatalf("DefaultHTTPAddr=%q, want 127.0.0.1:9580", DefaultHTTPAddr)
+	}
+	if !isLoopbackAPIBind(DefaultHTTPAddr) {
+		t.Fatal("DefaultHTTPAddr must be loopback")
+	}
+}

--- a/install/config/nftban.conf
+++ b/install/config/nftban.conf
@@ -190,6 +190,13 @@ NFTBAN_GUI_ENABLED="false"
 # GUI listen address
 NFTBAN_GUI_ADDR="127.0.0.1:3940"
 
+# Daemon HTTP API listen address (read-only /health, /api/v1/status, /api/v1/modules;
+# /metrics is loopback-only). SEC-P1-3a: defaults to loopback (127.0.0.1:9580) — the API
+# is UNAUTHENTICATED, so a non-loopback bind (0.0.0.0/:9580/LAN/public) is REFUSED and
+# falls back to loopback unless you set NFTBAN_API_ALLOW_INSECURE_BIND=YES and firewall it
+# yourself. Token/auth for a deliberate non-loopback bind is a later lane (SEC-P1-3b).
+#NFTBAN_API_ADDR="127.0.0.1:9580"
+
 # -----------------------------------------------------------------------------
 # SECURITY FEATURES
 # -----------------------------------------------------------------------------

--- a/internal/nftbanconf/loader.go
+++ b/internal/nftbanconf/loader.go
@@ -636,7 +636,7 @@ func defaultConfig() *Config {
 		SuricataEnabled:         false,
 		GUIEnabled:              false,
 		GUIAddr:                 "127.0.0.1:3940",
-		APIAddr:                 ":9580",
+		APIAddr:                 "127.0.0.1:9580", // SEC-P1-3a: loopback by default (was ":9580" = all interfaces, unauthenticated). Non-loopback needs NFTBAN_API_ALLOW_INSECURE_BIND=YES.
 		PortscanEnabled:         false,
 		DDoSEnabled:             false,
 		LoginMonitorEnabled:     false,


### PR DESCRIPTION
## SEC-P1-3a — daemon HTTP API loopback-by-default

### Problem
- Default `APIAddr` was effectively **`":9580"` — binding all interfaces**.
- Exposed **unauthenticated read-only** routes: `/health`, `/api/v1/status`, `/api/v1/modules`.
- Mutating routes remain dead/commented; the nftban CLI uses the **Unix socket**, not the local HTTP API.
- Risk: live information exposure (version, module topology + health) **plus a future-mutator amplifier** (any handler added to the all-interfaces unauthenticated mux would be exposed).

### Fix
- **Default bind → `127.0.0.1:9580`.**
- A non-loopback bind is **refused → falls back to loopback** unless `NFTBAN_API_ALLOW_INSECURE_BIND=YES`.
  - Acknowledged non-loopback → honored, logs **`[SECURITY][WARN]`**.
  - Unacknowledged non-loopback → **`[SECURITY][ERROR]`** + fallback to loopback.
- Actual bind address is logged.
- **Single IPv4 loopback default; IPv6 `::1` dual-stack deferred.**
- `/metrics` loopback gate unchanged; pprof unchanged; Unix socket / SO_PEERCRED mutation path unchanged.
- **No token/auth** — SEC-P1-3b remains open.

### Validation (built + tested on lab hosts, not locally)
**lab2 — Ubuntu 24.04 / DEB:** build + vet OK · SEC-P1-3a `-race` unit tests **6/6 PASS** · full `go test ./...` **rc=0 / 0 FAIL** · daemon active · `nftban validate` rc0 · 0 failed units · **default bind became `127.0.0.1:9580`** · `/health` works on loopback · **external access unreachable** (tested from the host's routable IP).

**lab4 — AlmaLinux 9.8 / RPM:** build + vet OK · SEC-P1-3a tests PASS · daemon active · `nftban validate` rc0 · 0 new failed units (`cpgreylistd` pre-existing) · default bind `127.0.0.1:9580` · **authoritative unsafe-bind proof:** `NFTBAN_API_ADDR=":9580"` without ack was **refused, fell back to `127.0.0.1:9580`, and logged `[SECURITY][ERROR]`**.

**Validation note (lab2 conf.d caveat):** on lab2 the unsafe-bind case was set via `conf.d`, which the daemon config loader does **not** read for this key (the loader reads `/etc/nftban/nftban.conf` + `nftban.conf.local`), so the fallback didn't trigger there. **lab4 is the authoritative live proof** for the unsafe-bind fallback because it used the loader-read `nftban.conf.local` path; the guard logic is also covered by the `-race` unit tests.

**Released binary restored on both labs:** md5 `155b564752ec03f3963c5bdb127f1d60`.

### Schema / release
- nft schema remains **1.84.0** · VERSION remains **1.217.0** · no tag · no release-prep · no fleet rollout.

### Upgrade behavior note
- Hosts with `NFTBAN_API_ADDR` unset move from `*:9580` to `127.0.0.1:9580` after release.
- Any external `:9580` scraping stops unless the operator explicitly sets a non-loopback address **and** `NFTBAN_API_ALLOW_INSECURE_BIND=YES`.
- **No nftban self-function breaks:** CLI uses the socket; metrics are loopback.

### Closes
- SEC-P1-3a live all-interfaces unauthenticated HTTP API exposure.
- Future-mutator amplifier from the default all-interface mux.
- Re-exposure guard for unsafe non-loopback config.

### Does NOT close
- SEC-P1-3b (token/auth for deliberate non-loopback exposure) · SEC-P1-2 (support-bundle token/secret redaction) · central-comms · RBL P0 / RBLMON · IPv6 `::1` dual-stack · GUI-remnant · daemon unit hardening · SO_PEERCRED auth-boundary test lane.

### Scope
4 files. No VERSION/schema/docs/wiki/packaging drift; no token/auth; no SEC-P1-2; no central-comms/RBL.