### PR TITLE
ci(comms): add no-direct-send guard for central communication authority (A0)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -56,6 +56,12 @@ jobs:
           # Explicit: NEVER use --warn-all in CI (would disable enforcement)
           WARN_ALL: "0"
 
+      # Central-comms Lane A0 ratchet: mail transport primitives only inside
+      # core/nftban_mail.sh; current known bypasses are allowlisted as DEBT (A1
+      # burns them down). Any NEW direct send fails the PR.
+      - name: Check comms no-direct-send policy
+        run: ./scripts/ci/check-comms-direct-send.sh
+
       # v1.192 transition-atomicity class (D-NFTBAN-SOAK-...-DROP-WINDOW + F-FEED/F-GEO):
       # forbid flush/delete-then-repopulate in a separate transaction on the live
       # nftban table (V-NFT-REBUILD-ATOMICITY) or shared sets (V-NFT-SET-REFRESH-ATOMICITY).

--- a/cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh
+++ b/cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A0 no-direct-send CI ratchet: guard self-test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_no_direct_send_guard_a0_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="Validates scripts/ci/check-comms-direct-send.sh (central-comms A0 ratchet): the clean repo passes (current bypasses allowlisted), a planted un-allowlisted direct send (sendmail -t / mail -s / curl --mail-rcpt) FAILS the guard, and capability probes (command -v) are NOT false positives. Hermetic: builds a sandbox tree; no host/nft/mail."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+GUARD="$REPO/scripts/ci/check-comms-direct-send.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+[[ -x "$GUARD" || -f "$GUARD" ]] || { echo "FATAL: guard not found: $GUARD" >&2; exit 2; }
+
+echo "=== A0 no-direct-send guard self-test ==="
+
+# 1) The real repo passes (current bypasses allowlisted).
+if ( cd "$REPO" && bash "$GUARD" >/dev/null 2>&1 ); then ok "clean repo passes (allowlist covers current debt)"; else no "clean repo unexpectedly failed"; fi
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/cli/lib/nftban/core"
+
+# 2) Planted un-allowlisted direct sendmail → FAIL.
+printf 'send() {\n  echo "$body" | sendmail -t\n}\n' > "$WORK/cli/lib/nftban/core/evil_sendmail.sh"
+if ( cd "$WORK" && bash "$GUARD" >/dev/null 2>&1 ); then no "planted 'sendmail -t' NOT caught"; else ok "planted 'sendmail -t' caught (guard fails)"; fi
+rm -f "$WORK/cli/lib/nftban/core/evil_sendmail.sh"
+
+# 3) Planted un-allowlisted 'mail -s' → FAIL.
+printf 'notify() {\n  echo x | mail -s "[NFTBan] hi" root\n}\n' > "$WORK/cli/lib/nftban/core/evil_mail.sh"
+if ( cd "$WORK" && bash "$GUARD" >/dev/null 2>&1 ); then no "planted 'mail -s' NOT caught"; else ok "planted 'mail -s' caught (guard fails)"; fi
+rm -f "$WORK/cli/lib/nftban/core/evil_mail.sh"
+
+# 4) Planted un-allowlisted curl SMTP → FAIL.
+printf 'send() {\n  curl --url smtp://h --mail-from a --mail-rcpt b -T x\n}\n' > "$WORK/cli/lib/nftban/core/evil_curl.sh"
+if ( cd "$WORK" && bash "$GUARD" >/dev/null 2>&1 ); then no "planted curl '--mail-rcpt' NOT caught"; else ok "planted curl SMTP caught (guard fails)"; fi
+rm -f "$WORK/cli/lib/nftban/core/evil_curl.sh"
+
+# 5) Capability probe is NOT a false positive.
+printf 'if command -v sendmail >/dev/null 2>&1; then have=1; fi\nfor mta in postfix sendmail exim4 msmtp mailx; do :; done\nmail_cmd="sendmail"\n' > "$WORK/cli/lib/nftban/core/probe_only.sh"
+if ( cd "$WORK" && bash "$GUARD" >/dev/null 2>&1 ); then ok "capability probes / assignments NOT flagged"; else no "probe/assignment false-positive"; fi
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/check-comms-direct-send.sh
+++ b/scripts/ci/check-comms-direct-send.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan - CI Gate: no-direct-send (central communication authority)
+# =============================================================================
+# meta:name="check-comms-direct-send"
+# meta:type="script"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Enforce that mail transport primitives (sendmail/mail -s/mailx/msmtp/curl-SMTP) are invoked ONLY inside the central authority core/nftban_mail.sh. Modules must submit alert payloads to nftban_mail_send(); direct sends bypass validation/spool/retry/dedup/metrics/audit and the daemonless curl-SMTP path. Central-comms Lane A0 RATCHET: the current known bypasses are allowlisted as DEBT so CI passes today; A1 removes each entry as its bypass is closed, and any NEW direct send fails immediately. Model: check-nft-writes.sh."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Exit codes: 0 = no un-allowlisted direct sends; 1 = violation (PR must not merge)
+# =============================================================================
+
+set -Eeuo pipefail
+
+# -----------------------------------------------------------------------------
+# SEND-INVOCATION PATTERN — real transport calls only (NOT capability probes,
+# assignments, labels, or comments). Matches:
+#   | sendmail | mailx | msmtp | $mail_cmd   (pipe into a transport)
+#   sendmail -t                              (sendmail send)
+#   mail -s <subject>                        (mail send)
+#   --mail-rcpt                              (curl SMTP send)
+# -----------------------------------------------------------------------------
+COMMS_SEND_PATTERN='(\|[[:space:]]*("?\$\{?mail_cmd\}?|(/usr/s?bin/)?(sendmail|mailx|msmtp)([[:space:]]|$)))|(\bsendmail[[:space:]]+-t\b)|(\bmail[[:space:]]+-s[[:space:]])|(--mail-rcpt)'
+
+# -----------------------------------------------------------------------------
+# ALLOWED — the central authority + annotated A0 DEBT allowlist (A1 removes each).
+#   AUTHORITY:
+#     core/nftban_mail.sh        — the sole intended transport owner (nftban_mail_send)
+#   DEBT (A1 closes → route through nftban_mail_send_with_retry, then delete entry):
+#     core/nftban_tunnel.sh      — Tunnel direct `sendmail` (CENTRAL_COMMS_BYPASS_TUNNEL)
+#     cron/maintenance.sh        — IP-change `mail -s … root` (CENTRAL_COMMS_BYPASS_MAINTENANCE_CRON)
+#     cli/cmd_update.sh          — update notify direct fallback (sendmail/mail)
+#     cli/cmd_support.sh         — support-bundle direct `mail -s`
+#   (NOTE: cmd_report.sh is COMPLIANT — sends via nftban_mail_send; the audit's
+#    'report direct fallback' was empirically disproven by this guard.)
+#   TEST-ONLY:
+#     tests/selftest.sh          — self-test report send (never production)
+# -----------------------------------------------------------------------------
+# TEST-ONLY / this gate itself: scripts/ci/ (the gate carries the pattern string) and
+# the A0 self-test (carries planted-violation fixtures) are not runtime senders.
+ALLOWED_REGEX='^(cli/lib/nftban/core/nftban_mail\.sh|cli/lib/nftban/core/nftban_tunnel\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/cli/cmd_update\.sh|cli/lib/nftban/cli/cmd_support\.sh|cli/lib/nftban/tests/selftest\.sh|cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test\.sh|scripts/ci/)'
+
+# Files in the DEBT allowlist that A1 must burn down (excludes AUTHORITY + TEST).
+DEBT_REGEX='nftban_tunnel\.sh|maintenance\.sh|cmd_update\.sh|cmd_support\.sh'
+
+echo "========================================"
+echo "NFTBan Comms Check: no-direct-send"
+echo "========================================"
+echo "Policy: mail transport primitives only inside core/nftban_mail.sh."
+echo ""
+
+VIO=$(mktemp); trap 'rm -f "$VIO"' EXIT
+
+grep -rnE "$COMMS_SEND_PATTERN" --include="*.sh" cli/ scripts/ install/ 2>/dev/null \
+  | grep -vE "$ALLOWED_REGEX" \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+  | grep -vE 'command -v|nftban_have_cmd|type -t|for [a-zA-Z_]+ in' \
+  >> "$VIO" || true
+
+if [[ -s "$VIO" ]]; then
+  echo "❌ FAIL: direct mail send outside core/nftban_mail.sh (and not allowlisted):"
+  echo ""
+  cat "$VIO"
+  echo ""
+  echo "Fix: submit the alert payload to nftban_mail_send()/nftban_mail_send_with_retry()."
+  echo "If this is a legitimate transport probe (command -v ...), it should not match; refine the call site."
+  exit 1
+fi
+
+# Burndown: how many DEBT files still carry a direct send (A1 target). The {…|| true}
+# guards against set -e when nothing matches (e.g. an empty sandbox in the self-test).
+debt_remaining=$( { grep -rlE "$COMMS_SEND_PATTERN" --include="*.sh" cli/ 2>/dev/null \
+  | grep -E "$DEBT_REGEX" || true; } | sort -u | wc -l | tr -d ' ')
+echo "✅ PASS: no un-allowlisted direct mail sends."
+echo "   A0 ratchet: $debt_remaining/4 DEBT bypass files remaining (A1 burns these down)."
+exit 0


### PR DESCRIPTION
## Central-comms A0 — no-direct-send CI ratchet

### Problem
- NFTBan **already has** a central communication authority: `nftban_mail_send()` (`core/nftban_mail.sh`) — it owns transport selection (incl. daemonless curl-SMTP), SMTP creds, recipient validation, retry/spool, and metrics.
- **Most modules already use it.** The remaining risk is a **bounded set of direct-send legacy differentials**.
- Without a CI ratchet, new direct `sendmail`/`mail`/`curl-SMTP` side channels can reappear.

### Fix
- Add `scripts/ci/check-comms-direct-send.sh`; wire it into CI **after `check-nft-writes`** (`ci-architecture.yml`).
- Guard rejects direct `sendmail` / `mail -s` / `mailx` / `msmtp` / `curl --mail-rcpt` / `$mail_cmd` **outside `core/nftban_mail.sh`**.
- Current known bypasses are allowlisted **only as temporary A1 debt**.
- Capability probes (`command -v`, `for mta in …`) / assignments / labels are **not** false positives.
- **No runtime behavior change. No test-mail. No bypass removed in A0.**

### Empirical correction (the ratchet doubles as the completeness proof)
The guard establishes the **true direct-send debt = 4 files**:
- `core/nftban_tunnel.sh` · `cron/maintenance.sh` · `cli/cmd_update.sh` · `cli/cmd_support.sh`

**`cmd_report.sh` is COMPLIANT** — its fallback IS `nftban_mail_send` (`cmd_report.sh:401`), and its `mail_cmd` usage is **display-only** (`:1123`). It is therefore **not allowlisted** → a future direct send in `cmd_report.sh` now **fails CI**. (The audit had listed report as a bypass; the guard disproved it.)

### Validation
- shellcheck **CLEAN** · guard on clean tree **PASS** (`4/4 DEBT files remaining`).
- Hermetic self-test **5/5**: clean tree passes · planted `sendmail -t` caught · planted `mail -s` caught · planted `curl --mail-rcpt` caught · capability probes/assignments not flagged.
- **lab2 only is sufficient** — this is shell/CI-only with no runtime host behavior change.

### Schema / release
- nft schema **1.84.0** unchanged · VERSION **1.217.0** unchanged · **daemon byte-identical** · no tag · no release-prep · no fleet rollout.

### Closes
- A0 CI ratchet for central-comms direct-send detection.
- Machine-enforced proof of the current bypass set.

### Does NOT close
- A1 migration of the 4 bypasses · central-comms full unification · `COMMUNICATION_SPOOL_BACKLOG` / health/status/stats visibility · delivery log / last-failure surfacing · recipient resolver · prefer-explicit-SMTP · netrc lifecycle hardening · RBLMON · RBL P0 · SEC-P1-2 · SEC-P1-3b.

### Scope
3 files (CI/shell only). No register mutation, no scope-doc movement, no runtime change, no mail sending, no A1 migration.