### PR TITLE
fix(comms): route remaining shell alerts through central mail authority (A1)

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -1839,24 +1839,13 @@ EOF
                     echo "    cat $output_file | base64 > bundle.b64"
                 fi
             else
-                # Fallback: try mutt or mail with attachment
-                if command -v mutt &>/dev/null; then
-                    echo "$email_body" | mutt -s "[NFTBan] Support Bundle - $hostname_val" \
-                        -a "$output_file" -- "$email_recipient" 2>/dev/null && \
-                        _support_log OK "Bundle sent via mutt to: $email_recipient" || \
-                        _support_log WARN "mutt failed - bundle saved locally"
-                elif command -v mail &>/dev/null; then
-                    # Some mail implementations support -A for attachments
-                    echo "$email_body" | mail -s "[NFTBan] Support Bundle - $hostname_val" \
-                        -A "$output_file" "$email_recipient" 2>/dev/null && \
-                        _support_log OK "Bundle sent via mail to: $email_recipient" || \
-                        _support_log WARN "mail attachment failed - bundle saved locally"
-                else
-                    _support_log WARN "No mail client available - bundle saved locally"
-                    echo ""
-                    echo "  Transfer manually using:"
-                    echo "    scp $output_file user@remote:/path/"
-                fi
+                # A1 central-comms: no direct mutt/mail side channel. If the central mail
+                # authority is unavailable, the bundle is saved locally and the operator is
+                # shown a manual transfer path.
+                _support_log WARN "Central mail authority unavailable - bundle saved locally (no direct fallback)"
+                echo ""
+                echo "  Transfer manually using:"
+                echo "    scp $output_file user@remote:/path/"
             fi
             echo ""
         fi

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -2466,44 +2466,22 @@ To rollback:
         source "$mail_lib" 2>/dev/null || true
     fi
 
-    # Try to send email using nftban mail module
-    if declare -f nftban_mail_send &>/dev/null; then
-        # Use plain text for update notifications
+    # A1 central-comms: send via the central authority's spool/retry variant. On failure the
+    # notice is SPOOLED for later delivery — there is NO direct sendmail/mail side channel.
+    if declare -f nftban_mail_send_with_retry &>/dev/null; then
         local old_html="${NFTBAN_MAIL_USE_HTML:-}"
         NFTBAN_MAIL_USE_HTML="NO"
-
-        echo "$body" | nftban_mail_send "$body" "$recipient" 2>/dev/null && {
+        if nftban_mail_send_with_retry "$body" "$recipient" "$subject" 2>/dev/null; then
             _update_log INFO "Notification sent to: $recipient"
             NFTBAN_MAIL_USE_HTML="$old_html"
             return 0
-        }
+        fi
         NFTBAN_MAIL_USE_HTML="$old_html"
+        _update_log WARN "Central mail send failed for $recipient — spooled for retry (no direct fallback)"
+        return 0
     fi
 
-    # Fallback: try sendmail directly
-    if command -v sendmail &>/dev/null; then
-        {
-            echo "From: nftban@$hostname_val"
-            echo "To: $recipient"
-            echo "Subject: $subject"
-            echo "Content-Type: text/plain; charset=UTF-8"
-            echo ""
-            echo "$body"
-        } | sendmail -t 2>/dev/null && {
-            _update_log INFO "Notification sent to: $recipient (via sendmail)"
-            return 0
-        }
-    fi
-
-    # Fallback: try mail command
-    if command -v mail &>/dev/null; then
-        echo "$body" | mail -s "$subject" "$recipient" 2>/dev/null && {
-            _update_log INFO "Notification sent to: $recipient (via mail)"
-            return 0
-        }
-    fi
-
-    _update_log WARN "Could not send email notification (no mail system available)"
+    _update_log WARN "Central mail authority unavailable — update notification not sent (no direct fallback)"
     return 1
 }
 

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -86,6 +86,16 @@ nftban_mail_detect_mta() {
         esac
     fi
 
+    # A1 central-comms (prefer-explicit-SMTP): if the operator configured an SMTP relay
+    # (NFTBAN_SMTP_HOST) and did NOT force a method, prefer daemonless curl-SMTP over an
+    # incidentally-present local MTA. This gives predictable delivery via the operator's
+    # chosen relay instead of e.g. a panel's local postfix/greylisting. Explicit
+    # NFTBAN_MAIL_METHOD still wins (handled above). Honors NO_LOCAL_MAIL_DAEMON_REQUIREMENT.
+    if [[ -z "${NFTBAN_MAIL_METHOD:-}" && -n "${NFTBAN_SMTP_HOST:-}" ]] && command -v curl &>/dev/null; then
+        echo "curl"
+        return 0
+    fi
+
     # Auto-detect: Check Postfix (highest priority - local MTA)
     if [[ -x "$NFTBAN_POSTFIX_BIN" ]]; then
         if systemctl is-active postfix &>/dev/null 2>&1 || pgrep -x master &>/dev/null; then
@@ -518,6 +528,36 @@ nftban_mail_template_replace() {
 # SEND EMAIL (MAIN FUNCTION)
 # =============================================================================
 
+# A1 central-comms: single recipient-resolution choke point. Model: module override →
+# global NFTBAN_MAIL_RECIPIENT. Prints the resolved recipient (stdout) and returns 0, or
+# returns 1 with no output when neither is set (missing recipient = explicit error, never a
+# silent no-op). Every module send-path must terminate here.
+nftban_mail_resolve_recipient() {
+    local override="${1:-}"
+    local recip="${override:-${NFTBAN_MAIL_RECIPIENT:-}}"
+    [[ -z "$recip" ]] && return 1
+    printf '%s' "$recip"
+    return 0
+}
+
+# A1 central-comms: the ONLY entry a module should use to emit an alert. Modules submit a
+# payload (subject + body [+ optional recipient override]); central owns recipient
+# resolution, transport, retry, and spool. On a missing recipient or an unavailable central
+# authority it returns non-zero WITHOUT any direct-send side channel (the caller logs a
+# degraded event). Never invokes a transport primitive itself.
+nftban_mail_alert() {
+    local subject="${1:-NFTBan Alert}" body="${2:-}" override="${3:-}"
+    local recipient
+    recipient="$(nftban_mail_resolve_recipient "$override")" || {
+        echo "Error: no mail recipient configured (set NFTBAN_MAIL_RECIPIENT)" >&2
+        return 1
+    }
+    # Prepend a Subject header only if the body doesn't already carry one.
+    local content="$body"
+    [[ "$body" == Subject:* ]] || content=$(printf 'Subject: %s\n\n%s' "$subject" "$body")
+    nftban_mail_send_with_retry "$content" "$recipient" "$subject"
+}
+
 nftban_mail_send() {
     # Send email with content
     # Args: $1 = content (text or file path)
@@ -712,8 +752,15 @@ EOF
             # v1.19.0: Add SMTP auth via netrc file to avoid credential exposure in process args (R23)
             local _smtp_netrc=""
             if [[ -n "${NFTBAN_SMTP_USER:-}" ]]; then
+                # A1: SMTP password lands in a temp netrc (never argv). Harden the lifecycle —
+                # umask 077 so it is created 0600 even before chmod, and a signal-safe trap so
+                # the credential file is removed on EXIT/INT/TERM/HUP/QUIT, not only after curl.
+                local _old_umask; _old_umask=$(umask); umask 077
                 _smtp_netrc=$(mktemp "${NFTBAN_RUN_DIR:-/run/nftban}/nftban-smtp-netrc.XXXXXX")
+                umask "$_old_umask"
                 chmod 600 "$_smtp_netrc"
+                # shellcheck disable=SC2064  # expand path now so the trap cleans this exact file
+                trap "rm -f '$_smtp_netrc' 2>/dev/null || true" EXIT INT TERM HUP QUIT
                 local _smtp_host
                 _smtp_host=$(echo "${NFTBAN_SMTP_SERVER:-localhost}" | cut -d: -f1)
                 echo "machine $_smtp_host login ${NFTBAN_SMTP_USER} password ${NFTBAN_SMTP_PASS:-}" > "$_smtp_netrc"

--- a/cli/lib/nftban/core/nftban_tunnel.sh
+++ b/cli/lib/nftban/core/nftban_tunnel.sh
@@ -667,22 +667,27 @@ _tunnel_maybe_alert() {
     # Record alert time
     echo "$ts" > "${cooldown_file}.tmp" 2>/dev/null && mv -f "${cooldown_file}.tmp" "$cooldown_file" 2>/dev/null || true
 
-    # Try to send alert email
-    local alert_email="${NFTBAN_TUNNEL_ALERT_EMAIL:-}"
-    [[ -z "$alert_email" ]] && alert_email="${NFTBAN_ALERT_EMAIL:-}"
-    if [[ -n "$alert_email" ]]; then
+    # A1 central-comms: submit the alert to the central authority (never a direct sendmail).
+    # Module override NFTBAN_TUNNEL_ALERT_EMAIL → global NFTBAN_MAIL_RECIPIENT. On missing
+    # recipient / unavailable authority the central path no-ops or spools; no side channel.
+    local tun_override="${NFTBAN_TUNNEL_ALERT_EMAIL:-${NFTBAN_ALERT_EMAIL:-}}"
+    if ! declare -F nftban_mail_alert >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" 2>/dev/null || true
+    fi
+    if declare -F nftban_mail_alert >/dev/null 2>&1; then
         local hostname
         hostname=$(hostname -f 2>/dev/null || hostname)
-        {
-            echo "Subject: [NFTBan] DNS Tunnel Suspicion — $high_count HIGH on $hostname"
-            echo ""
-            echo "NFTBan Tunnel Suspicion Module detected $high_count HIGH-suspicion source(s)."
-            echo "This is advisory-only — no IPs have been blocked."
-            echo ""
-            echo "Run 'nftban tunnel top' on $hostname for details."
-            echo ""
-            echo "Time: $(date '+%Y-%m-%d %H:%M:%S')"
-        } | sendmail "$alert_email" 2>/dev/null || true
+        local subject="[NFTBan] DNS Tunnel Suspicion — $high_count HIGH on $hostname"
+        local body
+        body=$(printf '%s\n' \
+            "NFTBan Tunnel Suspicion Module detected $high_count HIGH-suspicion source(s)." \
+            "This is advisory-only — no IPs have been blocked." \
+            "" \
+            "Run 'nftban tunnel top' on $hostname for details." \
+            "" \
+            "Time: $(date '+%Y-%m-%d %H:%M:%S')")
+        nftban_mail_alert "$subject" "$body" "$tun_override" || true
     fi
 }
 

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -92,6 +92,27 @@ log() {
 # This ONLY changes the maintenance LOG path; it does not touch the FW-transition
 # harm counter (table_absent_while_committed_count), firewall load/rebuild
 # semantics, install_state, or any set. Returns 0 = genuinely absent, 1 = transient.
+# A1 central-comms: emit a system IP-change notice through the CENTRAL mail authority
+# instead of a direct root mailer (which silently failed on daemonless/minimal hosts and
+# hardcoded the root recipient). INFO-severity operational notice; recipient terminates at
+# NFTBAN_MAIL_RECIPIENT. No direct transport, no hardcoded recipient.
+_maint_ipchange_alert() {
+    local family="$1" ip="$2"
+    if ! declare -F nftban_mail_alert >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_mail.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_mail.sh" 2>/dev/null || true
+    fi
+    if ! declare -F nftban_mail_alert >/dev/null 2>&1; then
+        log "WARN" "central mail authority unavailable — ${family} change notice not sent (no direct fallback)"
+        return 0
+    fi
+    local host; host=$(hostname 2>/dev/null)
+    nftban_mail_alert \
+        "[NFTBan] ${family} Address Auto-Updated on ${host}" \
+        "NFTBan info (INFO/operational): system ${family} changed to ${ip}, auto-whitelisted and firewall reloaded on ${host} at $(date)." \
+        "" || true
+}
+
 _maint_table_absent_confirmed() {
     local _tbl="${1:-${NFTBAN_TABLE_IPV4:-ip nftban}}" _i
     for _i in 1 2 3; do
@@ -563,11 +584,8 @@ EOF
                 mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
                 echo "$current_ipv4 $(date)" >> "$IP_ALERT_STATE"
 
-                # Send email alert if configured (ONLY ONCE)
-                if command -v mail &>/dev/null && [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/mail.conf" ]]; then
-                    echo "NFTBan Security Alert: System IPv4 changed to $current_ipv4, auto-whitelisted and firewall reloaded on $(hostname) at $(date)" | \
-                        mail -s "[NFTBan] IP Address Auto-Updated on $(hostname)" root 2>/dev/null || true
-                fi
+                # Send IP-change notice via the central mail authority (ONLY ONCE)
+                _maint_ipchange_alert "IPv4" "$current_ipv4"
             fi
         fi
 
@@ -607,11 +625,8 @@ EOF
                 mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
                 echo "$current_ipv6 $(date)" >> "$IP_ALERT_STATE"
 
-                # Email alert
-                if command -v mail &>/dev/null && [[ -f "${NFTBAN_CONFIG_DIR}/conf.d/mail.conf" ]]; then
-                    echo "NFTBan Security Alert: System IPv6 changed to $current_ipv6, auto-whitelisted and firewall reloaded on $(hostname) at $(date)" | \
-                        mail -s "[NFTBan] IPv6 Address Auto-Updated on $(hostname)" root 2>/dev/null || true
-                fi
+                # Send IPv6-change notice via the central mail authority (ONLY ONCE)
+                _maint_ipchange_alert "IPv6" "$current_ipv6"
             fi
         fi
 

--- a/cli/lib/nftban/tests/comms_a1_centralization_test.sh
+++ b/cli/lib/nftban/tests/comms_a1_centralization_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A1 central-comms shell centralization
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a1_centralization_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="A1: proves the 4 direct-send differentials are migrated to the central mail authority and the new helpers behave. Sources nftban_mail.sh to test nftban_mail_resolve_recipient (override→global, missing→error) and prefer-explicit-SMTP transport selection (NFTBAN_SMTP_HOST + no NFTBAN_MAIL_METHOD → curl; explicit method wins). Greps to assert Tunnel/Maintenance/update/support carry NO direct sendmail/mail/mailx transport and route through central; and that the A0 guard now shows 0/4 debt. Hermetic: no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_MAIL_RECIPIENT,NFTBAN_SMTP_HOST,NFTBAN_MAIL_METHOD"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+TUNNEL="$REPO/cli/lib/nftban/core/nftban_tunnel.sh"
+MAINT="$REPO/cli/lib/nftban/cron/maintenance.sh"
+UPDATE="$REPO/cli/lib/nftban/cli/cmd_update.sh"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A1 central-comms centralization ==="
+
+# --- helper behavior: extract the pure resolver (the full lib has env deps) ---
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+FN="$WORK/fn.sh"
+awk '/^nftban_mail_resolve_recipient\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MAIL" > "$FN"
+grep -q 'nftban_mail_resolve_recipient()' "$FN" && ok "extracted nftban_mail_resolve_recipient" || no "could not extract resolver"
+rr() { bash -c "source '$FN'; NFTBAN_MAIL_RECIPIENT='${2:-}'; if out=\$(nftban_mail_resolve_recipient '${1:-}' 2>/dev/null); then printf 'OK:%s' \"\$out\"; else printf ERR; fi"; }
+[[ "$(rr 'mod@x.test' 'glob@y.test')" == "OK:mod@x.test" ]] && ok "resolve: module override wins" || no "resolve: override"
+[[ "$(rr '' 'glob@y.test')" == "OK:glob@y.test" ]] && ok "resolve: falls back to global NFTBAN_MAIL_RECIPIENT" || no "resolve: global"
+[[ "$(rr '' '')" == "ERR" ]] && ok "resolve: missing recipient errors (not silent)" || no "resolve: missing-error"
+
+# --- prefer-explicit-SMTP: assert the curl-first branch exists (executing detect_mta needs
+#     full-lib sourcing + binary probes; the branch is the invariant). ---
+if grep -Eq '\[\[ -z "\$\{NFTBAN_MAIL_METHOD:-\}" && -n "\$\{NFTBAN_SMTP_HOST:-\}" \]\] && command -v curl' "$MAIL"; then
+  ok "prefer-explicit-SMTP: SMTP_HOST + no method → curl branch present (before local MTA)"
+else
+  no "prefer-explicit-SMTP branch missing"
+fi
+
+# --- migrations: NO direct transport in the 4 files; they route through central ---
+send_pat='(\|[[:space:]]*(sendmail|mailx|msmtp))|(\bsendmail[[:space:]]+-t\b)|(\bmail[[:space:]]+-s[[:space:]])|(--mail-rcpt)'
+for f in "$TUNNEL" "$MAINT" "$UPDATE" "$SUPPORT"; do
+  b=$(basename "$f")
+  if grep -nE "$send_pat" "$f" | grep -qvE '^[0-9]+:[[:space:]]*#'; then no "$b still has a direct transport send"; else ok "$b: no direct transport send"; fi
+done
+grep -q 'nftban_mail_alert' "$TUNNEL"  && ok "Tunnel routes through nftban_mail_alert" || no "Tunnel not central"
+grep -q '_maint_ipchange_alert' "$MAINT" && grep -q 'nftban_mail_alert' "$MAINT" && ok "Maintenance routes through central" || no "Maintenance not central"
+grep -q 'nftban_mail_send_with_retry' "$UPDATE" && ok "update uses spool/retry variant" || no "update not on retry variant"
+grep -q 'no direct fallback' "$SUPPORT" && ok "support degraded path (no direct fallback)" || no "support fallback not removed"
+
+# --- A0 guard now shows 0/4 debt and still passes ---
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && ok "A0 guard burndown: 0/4 debt" || no "A0 guard debt not 0/4"
+echo "$out" | grep -q 'PASS' && ok "A0 guard passes clean" || no "A0 guard failed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/check-comms-direct-send.sh
+++ b/scripts/ci/check-comms-direct-send.sh
@@ -32,24 +32,21 @@ set -Eeuo pipefail
 COMMS_SEND_PATTERN='(\|[[:space:]]*("?\$\{?mail_cmd\}?|(/usr/s?bin/)?(sendmail|mailx|msmtp)([[:space:]]|$)))|(\bsendmail[[:space:]]+-t\b)|(\bmail[[:space:]]+-s[[:space:]])|(--mail-rcpt)'
 
 # -----------------------------------------------------------------------------
-# ALLOWED — the central authority + annotated A0 DEBT allowlist (A1 removes each).
+# ALLOWED — the central authority + test-only surfaces.
 #   AUTHORITY:
-#     core/nftban_mail.sh        — the sole intended transport owner (nftban_mail_send)
-#   DEBT (A1 closes → route through nftban_mail_send_with_retry, then delete entry):
-#     core/nftban_tunnel.sh      — Tunnel direct `sendmail` (CENTRAL_COMMS_BYPASS_TUNNEL)
-#     cron/maintenance.sh        — IP-change `mail -s … root` (CENTRAL_COMMS_BYPASS_MAINTENANCE_CRON)
-#     cli/cmd_update.sh          — update notify direct fallback (sendmail/mail)
-#     cli/cmd_support.sh         — support-bundle direct `mail -s`
-#   (NOTE: cmd_report.sh is COMPLIANT — sends via nftban_mail_send; the audit's
-#    'report direct fallback' was empirically disproven by this guard.)
+#     core/nftban_mail.sh        — the sole transport owner (nftban_mail_send / *_with_retry)
 #   TEST-ONLY:
 #     tests/selftest.sh          — self-test report send (never production)
+#     tests/comms_no_direct_send_guard_a0_test.sh — planted-violation fixtures
+#     scripts/ci/                — this gate (carries the pattern string)
+#
+# A1 BURNDOWN COMPLETE (0/4): Tunnel, Maintenance-cron, cmd_update, cmd_support were migrated
+# to the central authority and REMOVED from the allowlist — a future direct send in any of
+# them now fails CI. (cmd_report.sh was already compliant and never allowlisted.)
 # -----------------------------------------------------------------------------
-# TEST-ONLY / this gate itself: scripts/ci/ (the gate carries the pattern string) and
-# the A0 self-test (carries planted-violation fixtures) are not runtime senders.
-ALLOWED_REGEX='^(cli/lib/nftban/core/nftban_mail\.sh|cli/lib/nftban/core/nftban_tunnel\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/cli/cmd_update\.sh|cli/lib/nftban/cli/cmd_support\.sh|cli/lib/nftban/tests/selftest\.sh|cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test\.sh|scripts/ci/)'
+ALLOWED_REGEX='^(cli/lib/nftban/core/nftban_mail\.sh|cli/lib/nftban/tests/selftest\.sh|cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test\.sh|cli/lib/nftban/tests/comms_a1_centralization_test\.sh|scripts/ci/)'
 
-# Files in the DEBT allowlist that A1 must burn down (excludes AUTHORITY + TEST).
+# Historical A0 debt files — burndown display only (all migrated in A1; expect 0).
 DEBT_REGEX='nftban_tunnel\.sh|maintenance\.sh|cmd_update\.sh|cmd_support\.sh'
 
 echo "========================================"
@@ -78,8 +75,9 @@ fi
 
 # Burndown: how many DEBT files still carry a direct send (A1 target). The {…|| true}
 # guards against set -e when nothing matches (e.g. an empty sandbox in the self-test).
-debt_remaining=$( { grep -rlE "$COMMS_SEND_PATTERN" --include="*.sh" cli/ 2>/dev/null \
-  | grep -E "$DEBT_REGEX" || true; } | sort -u | wc -l | tr -d ' ')
+debt_remaining=$( { grep -rnE "$COMMS_SEND_PATTERN" --include="*.sh" cli/ 2>/dev/null \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' | grep -oE '^[^:]+' | grep -E "$DEBT_REGEX" || true; } \
+  | sort -u | wc -l | tr -d ' ')
 echo "✅ PASS: no un-allowlisted direct mail sends."
 echo "   A0 ratchet: $debt_remaining/4 DEBT bypass files remaining (A1 burns these down)."
 exit 0


### PR DESCRIPTION
## Central-comms A1 — shell centralization

### Problem
- The central mail authority `nftban_mail_send()` already exists; **A0** made direct-send detection machine-enforced.
- Remaining A1 debt was exactly **4 files**: **Tunnel**, **Maintenance-cron**, **Update fallback**, **Support fallback** — these bypassed central validation/spool/metrics or retained direct-send side channels.

### Fix
- **Tunnel** direct `sendmail` → central `nftban_mail_alert`.
- **Maintenance** `mail -s … root` → central INFO alert via `_maint_ipchange_alert` (recipient → `NFTBAN_MAIL_RECIPIENT`; no hardcoded root; fixes silent no-delivery on daemonless hosts).
- **Update** direct sendmail/mail fallback **removed** → `nftban_mail_send_with_retry` (central spool path; degraded log, no side channel).
- **Support** direct attachment fallback **removed** → central-only; bundle remains saved locally with a manual transfer path if delivery is unavailable.
- **`cmd_report.sh` unchanged** — A0 proved it compliant.
- **A0 allowlist burned from 4/4 → 0/4.**
- Add `nftban_mail_resolve_recipient(override)`: `override → NFTBAN_MAIL_RECIPIENT`; **missing recipient = explicit error** (never silent).
- Add `nftban_mail_alert(subject, body, [override])` as the module-facing central entry point.
- **Prefer explicit SMTP:** `NFTBAN_SMTP_HOST` set + no `NFTBAN_MAIL_METHOD` → curl-SMTP selected **before** an incidental local MTA; explicit `NFTBAN_MAIL_METHOD` still wins.
- **Harden curl-SMTP netrc temp-file lifecycle:** `umask 077` + safe temp credential file + signal-safe trap cleanup; no SMTP password in argv/logs.

### Validation (labs, no real mail)
- shellcheck **CLEAN** · `bash -n` clean for touched shell files.
- **A0 no-direct-send guard PASS with 0/4 debt** · A0 self-test **5/5**.
- **A1 test 15/15**: resolver override/global/missing · prefer-SMTP branch · all 4 former debt files have **no direct transport** · all 4 route central.
- **lab2 DEB** package-native: daemon active · `nftban validate` rc0 · no new failed units · `mail status` works · **no real mail sent**.
- **lab4 RPM** package-native: daemon active · `nftban validate` rc0 · no new failed units (`cpgreylistd` pre-existing) · `mail status` works · **no real mail sent**.
- Labs restored/pristine after validation.

### Schema / daemon
- **shell-only · 0 Go changes · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Explicit deferral
- The **emulate transport / `nftban mail test --dry-run` validator** was intentionally **NOT** implemented here. A real emulate transport needs a new sink/counter path and shares mechanics with delivery-log visibility, so it belongs in **A1b or A2**. **No CLI verb added → no `commands.registry.yml` change required.**

### Closes
- A1 migration of the 4 direct-send differentials · A0 allowlist debt **4/4 → 0/4** · recipient fragmentation for these paths · no-local-mail-daemon enforcement for Tunnel/Maintenance · update/support direct fallback side channels.

### Does NOT close
- A1b emulate transport / dry-run validator · A2 health/status/stats comms visibility · `COMMUNICATION_SPOOL_BACKLOG` surfacing · delivery log / last-failure surfacing · support-bundle redaction / SEC-P1-2 · SEC-P1-3b · A3 docs/wiki/template authority · Watchdog syslog-only reconciliation · RBLMON · RBL P0.

### Scope
7 files, shell-only. No Go, no schema/VERSION/docs/wiki/register mutation, no real mail, no RBLMON/RBL, no SEC-P1-2/3b.