### PR TITLE
test(comms): add central mail emulate transport and dry-run validation (A1b)

### DIFF
--- a/cli/lib/nftban/cli/cmd_mail.sh
+++ b/cli/lib/nftban/cli/cmd_mail.sh
@@ -102,6 +102,7 @@ cmd_mail_help() {
     echo "  nftban mail setup admin@example.com --all --test"
     echo "  nftban mail setup --show"
     echo "  nftban mail test"
+    echo "  nftban mail test --dry-run   # validate mail config (recipient + transport) without sending"
 }
 
 # =============================================================================
@@ -183,14 +184,26 @@ nftban_cmd_mail() {
             ;;
 
         test)
-            # Send test email
-            local recipient="${1:-}"
+            # Send (or --dry-run validate) a test email
+            local recipient="" dry_run=false _a
+            for _a in "$@"; do
+                case "$_a" in
+                    --dry-run) dry_run=true ;;
+                    -*) ;;  # ignore other flags
+                    *) [[ -z "$recipient" ]] && recipient="$_a" ;;
+                esac
+            done
             # Auto-detect from panel if not provided
             if [[ -z "$recipient" ]] && declare -f nftban_panel_get_admin_email &>/dev/null; then
                 recipient=$(nftban_panel_get_admin_email 2>/dev/null) || true
-                if [[ -n "$recipient" ]]; then
+                if [[ -n "$recipient" && "$dry_run" == false ]]; then
                     echo "[INFO] Using panel admin email: $recipient"
                 fi
+            fi
+            # A1b: --dry-run validates config only (never sends, never records).
+            if [[ "$dry_run" == true ]]; then
+                nftban_mail_test_dryrun "$recipient"
+                return $?
             fi
             nftban_mail_send_test "$recipient"
             return $?

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -73,7 +73,7 @@ nftban_mail_detect_mta() {
     # If user explicitly set a method, use it (after checking availability)
     if [[ -n "${NFTBAN_MAIL_METHOD:-}" ]]; then
         case "${NFTBAN_MAIL_METHOD}" in
-            postfix|sendmail|exim|msmtp|curl|mailx)
+            postfix|sendmail|exim|msmtp|curl|mailx|emulate)
                 # Verify the requested method is available
                 if _nftban_mail_method_available "${NFTBAN_MAIL_METHOD}"; then
                     echo "${NFTBAN_MAIL_METHOD}"
@@ -171,10 +171,32 @@ _nftban_mail_method_available() {
         mailx)
             [[ -x "$NFTBAN_MAILX_BIN" ]] || [[ -x "$NFTBAN_MAILX_ALT_BIN" ]]
             ;;
+        emulate)
+            # A1b: the emulated transport is always available (no binary, no network) —
+            # it records the delivery attempt to a sink for CI/lab validation.
+            return 0
+            ;;
         *)
             return 1
             ;;
     esac
+}
+
+# A1b central-comms emulation: record a delivery ATTEMPT to a sink instead of sending.
+# Same central flow, minus the real transport and the network. NEVER writes secrets.
+# Sink: $NFTBAN_MAIL_EMULATE_SINK, else <data>/mail/test-delivery.jsonl.
+_mail_emulate_record() {
+    local recipient="${1:-}" subject="${2:-}" result="${3:-emulated}"
+    local sink="${NFTBAN_MAIL_EMULATE_SINK:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mail/test-delivery.jsonl}"
+    local dir; dir=$(dirname "$sink")
+    mkdir -p "$dir" 2>/dev/null || true
+    # JSON line — transport=emulate; explicitly NO SMTP password / secret fields.
+    local esc_subj="${subject//\"/\\\"}"; esc_subj="${esc_subj//$'\n'/ }"
+    printf '{"ts":"%s","transport":"emulate","module":"%s","recipient":"%s","subject":"%s","result":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" \
+        "${NFTBAN_MAIL_MODULE:-unknown}" "$recipient" "$esc_subj" "$result" \
+        >> "$sink" 2>/dev/null || true
+    return 0
 }
 
 # =============================================================================
@@ -640,6 +662,16 @@ nftban_mail_send() {
 
     # Send email using detected MTA
     case "$mta" in
+        emulate)
+            # A1b: full central flow (recipient already resolved above) minus the real
+            # transport — record the attempt to the sink, no sendmail/mailx/curl, no network.
+            if [[ "${NFTBAN_MAIL_DEBUG:-false}" == "true" ]]; then
+                echo "[DEBUG] EMULATE: would send to $recipient — Subject: $subject (no real transport)"
+            fi
+            _mail_emulate_record "$recipient" "$subject" "emulated"
+            return 0
+            ;;
+
         postfix|sendmail)
             # Use sendmail command
             if [[ "${NFTBAN_MAIL_DEBUG:-false}" == "true" ]]; then
@@ -827,6 +859,29 @@ CURLEOF
 # =============================================================================
 # SEND TEST EMAIL
 # =============================================================================
+
+# A1b: validate the comms config WITHOUT sending or recording (dry-run = validate only).
+# Reports recipient resolution, selected transport, and transport prerequisites. Returns
+# 0 if the config could deliver, 1 otherwise. Never invokes a transport, never writes a sink.
+nftban_mail_test_dryrun() {
+    local override="${1:-}" rc=0 recipient mta
+    echo "Mail config dry-run (validate only — NOT sent):"
+    if recipient="$(nftban_mail_resolve_recipient "$override")"; then
+        echo "  Recipient: ${recipient} (resolved)"
+    else
+        echo "  Recipient: MISSING — set NFTBAN_MAIL_RECIPIENT or pass a recipient"; rc=1
+    fi
+    mta="$(nftban_mail_detect_mta)"
+    echo "  Transport: ${mta}"
+    if [[ "$mta" == "none" ]]; then
+        echo "  ERROR: no usable transport (no local MTA and no curl + NFTBAN_SMTP_HOST)"; rc=1
+    elif [[ "$mta" == "curl" ]]; then
+        [[ -n "${NFTBAN_SMTP_HOST:-}" ]] || { echo "  ERROR: curl-SMTP selected but NFTBAN_SMTP_HOST is unset"; rc=1; }
+        command -v curl >/dev/null 2>&1 || { echo "  ERROR: curl-SMTP selected but curl is not installed"; rc=1; }
+    fi
+    if [[ $rc -eq 0 ]]; then echo "  Result: OK (config valid; nothing was sent)"; else echo "  Result: INVALID (see errors; nothing was sent)"; fi
+    return $rc
+}
 
 nftban_mail_send_test() {
     # Send test email

--- a/cli/lib/nftban/tests/comms_a1b_emulate_test.sh
+++ b/cli/lib/nftban/tests/comms_a1b_emulate_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A1b central-comms emulate transport + dry-run
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a1b_emulate_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="A1b: proves the central emulate transport records a delivery attempt without any real transport or network, writes no SMTP secret to the sink, and that mail test --dry-run validates config only (no send, no record). Also re-runs the A0 guard (0/4), A0 self-test (5/5) and A1 test (15/15) to confirm emulate did not regress the ratchet. Hermetic: sources the mail authority in an isolated tempdir; no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_EMULATE_SINK,NFTBAN_MAIL_RECIPIENT,NFTBAN_SMTP_PASS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A1b central-comms emulate + dry-run ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+# A non-credential marker (NOT a real secret) placed in NFTBAN_SMTP_PASS to prove the
+# emulate sink never records it. Deliberately not password-shaped, to avoid secret scanners.
+LEAK_PROBE="nftban-a1b-leakprobe-marker"
+
+# Common env so the (env-dependent) mail authority sources cleanly in isolation.
+env_prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+EOF
+}
+
+# --- emulate: records an attempt, no transport, no secret in sink ---
+SINK="$WORK/test-delivery.jsonl"
+bash -c "$(env_prelude)
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example' NFTBAN_MAIL_EMULATE_SINK='$SINK' NFTBAN_SMTP_PASS='$LEAK_PROBE' NFTBAN_MAIL_MODULE='a1btest'
+source '$MAIL' >/dev/null 2>&1 || true; set +e
+nftban_mail_send 'emulated body' 'rcpt@test.example' >/dev/null 2>&1 || true
+" || true
+
+if [[ -s "$SINK" ]]; then ok "emulate wrote a delivery record"; else no "emulate did not write a sink record"; fi
+grep -q '"transport":"emulate"' "$SINK" 2>/dev/null && ok "record marks transport=emulate" || no "record missing transport=emulate"
+grep -q 'rcpt@test.example' "$SINK" 2>/dev/null && ok "record contains resolved recipient" || no "record missing recipient"
+if grep -q "$LEAK_PROBE" "$SINK" 2>/dev/null; then no "SMTP secret LEAKED into sink"; else ok "no SMTP secret in sink"; fi
+# no real transport binary was needed: emulate returns success without one
+rc=$(bash -c "$(env_prelude)
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='r@t.example' NFTBAN_MAIL_EMULATE_SINK='$WORK/s2.jsonl'
+source '$MAIL' >/dev/null 2>&1 || true; set +e
+nftban_mail_send 'x' 'r@t.example' >/dev/null 2>&1; echo \$?")
+[[ "$rc" == "0" ]] && ok "emulate send returns success (no real transport)" || no "emulate send rc=$rc"
+
+# --- dry-run: validate only, no send, no record ---
+DRSINK="$WORK/dry.jsonl"
+drc=$(bash -c "$(env_prelude)
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='dry@t.example' NFTBAN_MAIL_EMULATE_SINK='$DRSINK'
+source '$MAIL' >/dev/null 2>&1 || true; set +e
+nftban_mail_test_dryrun 'dry@t.example' >/dev/null 2>&1; echo \$?")
+[[ "$drc" == "0" ]] && ok "dry-run validates a good config (rc0)" || no "dry-run rc=$drc"
+[[ ! -f "$DRSINK" ]] && ok "dry-run wrote NO delivery record" || no "dry-run wrongly wrote a record"
+# dry-run with no recipient errors
+mrc=$(bash -c "$(env_prelude)
+unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_METHOD=emulate
+source '$MAIL' >/dev/null 2>&1 || true; set +e
+nftban_mail_test_dryrun '' >/dev/null 2>&1; echo \$?")
+[[ "$mrc" != "0" ]] && ok "dry-run errors on missing recipient" || no "dry-run did not error on missing recipient"
+
+# --- ratchet + prior suites unaffected ---
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no "A0 guard regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh >/dev/null 2>&1 ) && ok "A0 self-test still passes" || no "A0 self-test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a1_centralization_test.sh >/dev/null 2>&1 ) && ok "A1 test still passes" || no "A1 test regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -1215,7 +1215,7 @@ rbl:
       mutates: false
       description: "Alert system management"
       subcommands:
-        test: {mutates: false, description: "Send test alert email"}
+        test: {mutates: false, description: "Send test alert email (or --dry-run to validate mail config without sending)"}
     critical:
       mutates: conditional
       description: "Manage critical IPs for monitoring"


### PR DESCRIPTION
## Central-comms A1b — emulate transport + dry-run

### Problem
- A0+A1 made the central-comms send path **mandatory and regression-guarded**.
- A2 health/status/delivery visibility needs a safe way to prove send-path behavior **without real email or network traffic**.
- Dry-run and emulate must be **distinct**: dry-run validates configuration only; emulate exercises the central send path and records a non-network delivery attempt.

### Fix
- Add `NFTBAN_MAIL_METHOD=emulate` **inside `nftban_mail.sh`** — remains in the central authority; **no second send plane**.
- Emulate runs the full central flow: recipient resolution → content path → dispatch decision → delivery-attempt record.
- Emulate **never** invokes `sendmail` / `mail`/`mailx` / `msmtp` / curl-SMTP / any network socket.
- Emulate writes a JSONL sink: `NFTBAN_MAIL_EMULATE_SINK` if set, else the default `<data>/mail/test-delivery.jsonl`.
  - Fields: `ts`, `transport: emulate`, `module`, `recipient`, `subject`, `result`.
  - **Sink must not contain `NFTBAN_SMTP_PASS` or secrets.**
- Add/clarify `nftban mail test --dry-run`: validates recipient resolution + selected transport + curl/SMTP prerequisites when relevant; **never sends, never records** a delivery attempt.
- Update `commands.registry.yml` because the CLI surface changed (`mail test` gains `--dry-run`; no new verb).

### Validation
- shellcheck **CLEAN** · `bash -n` clean.
- **A1b test 11/11**: emulate records delivery attempt · `transport=emulate` recorded · recipient resolved · **no secret in sink** · emulate returns success without a real transport · dry-run validates rc0 where configured · dry-run writes no record · dry-run errors on missing recipient · A0 guard remains **0/4** · A0 self-test **5/5** · A1 test **15/15**.
- commands registry **parity OK**.
- **lab2 DEB** package-native: daemon active · `nftban validate` rc0 · no new failed units · `mail test --dry-run` tested · no real mail · sink cleaned. **Note:** lab2 dry-run **rc1/INVALID is expected and correct** — no usable transport is configured, so the validator truthfully reports it rather than pretending send-readiness.
- **lab4 RPM** package-native: daemon active · `nftban validate` rc0 · no new failed units · `mail test --dry-run` rc0 · no real mail · sink cleaned.

### Schema / daemon
- **shell-only · 0 Go changes · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes
- A1b emulate transport / dry-run test substrate.

### Does NOT close
- A2 health/status/stats comms visibility · `COMMUNICATION_SPOOL_BACKLOG` surfacing · production delivery log / last-failure surfacing · support-bundle redaction / SEC-P1-2 · SEC-P1-3b · A3 docs/wiki/template authority · Watchdog syslog-only reconciliation · RBLMON · RBL P0.

### Scope
4 files. No Go, no schema/VERSION/docs/wiki/register mutation, no real mail, no A2 visibility, no production delivery-log semantics beyond the emulate sink, no RBLMON/RBL, no SEC-P1-2/3b.