### PR TITLE
fix(comms): persist delivery truth for central mail visibility (A2a)

### DIFF
--- a/cli/lib/nftban/cli/cmd_validate.sh
+++ b/cli/lib/nftban/cli/cmd_validate.sh
@@ -102,6 +102,22 @@ nftban_cmd_validate() {
 
     # Run validation
     validate_structure "$json_output"
+    local _vrc=$?
+
+    # A2a: communication (central-comms) config validation — produce-side surface. Reported as
+    # its own section; does NOT change the nft-structure validation rc (which this command owns).
+    if [[ "$json_output" != "true" ]]; then
+        if ! declare -F nftban_mail_test_dryrun >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" ]]; then
+            # shellcheck source=/dev/null
+            source "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" 2>/dev/null || true
+        fi
+        if declare -F nftban_mail_test_dryrun >/dev/null 2>&1; then
+            echo ""
+            echo "── Communication (central-comms) ──"
+            nftban_mail_test_dryrun "" || true
+        fi
+    fi
+    return $_vrc
 }
 
 nftban_cmd_validate_help() {

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -270,6 +270,33 @@ nftban_mail_check_status() {
     fi
 
     echo "✓ Mail System: $mta (ready)"
+
+    # A2a: communication truth summary (recipient / spool / last outcome).
+    nftban_mail_status_summary
+    return 0
+}
+
+# A2a: produce-side status summary — recipient state, transport, spool depth + oldest age,
+# last send result / last failure (sanitized). Reads state written by the retry path; sends
+# nothing. Safe to call from mail status and (later) nftban status.
+nftban_mail_status_summary() {
+    local recipient spool_dir spool_depth=0 oldest_age=0 last_succ last_fail_ts last_fail_reason
+    recipient="$(nftban_mail_resolve_recipient "" 2>/dev/null || echo "")"
+    if [[ -n "$recipient" ]]; then echo "  Recipient: ${recipient}"; else echo "  Recipient: (none configured)"; fi
+    spool_dir="${NFTBAN_MAIL_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mailspool}"
+    if [[ -d "$spool_dir" ]]; then
+        spool_depth=$(find "$spool_dir" -name "*.mail" -type f 2>/dev/null | wc -l)
+        local _m; _m=$(find "$spool_dir" -name "*.mail" -type f -printf '%T@\n' 2>/dev/null | sort -n | head -n1)
+        [[ -n "$_m" ]] && oldest_age=$(( $(date +%s) - ${_m%.*} ))
+    fi
+    echo "  Spool: depth=${spool_depth} oldest_age_s=${oldest_age}"
+    last_succ=$(cat "${MAIL_COUNTERS_DIR}/mail_last_success_ts" 2>/dev/null || echo "0")
+    last_fail_ts=$(cat "${MAIL_COUNTERS_DIR}/mail_last_failure_ts" 2>/dev/null || echo "0")
+    last_fail_reason=$(cat "${MAIL_COUNTERS_DIR}/mail_last_failure_reason" 2>/dev/null || echo "")
+    echo "  Last success ts: ${last_succ}"
+    if [[ "${last_fail_ts}" != "0" ]]; then
+        echo "  Last failure: ts=${last_fail_ts} reason=$(_mail_sanitize "${last_fail_reason}")"
+    fi
     return 0
 }
 
@@ -878,7 +905,24 @@ nftban_mail_test_dryrun() {
     elif [[ "$mta" == "curl" ]]; then
         [[ -n "${NFTBAN_SMTP_HOST:-}" ]] || { echo "  ERROR: curl-SMTP selected but NFTBAN_SMTP_HOST is unset"; rc=1; }
         command -v curl >/dev/null 2>&1 || { echo "  ERROR: curl-SMTP selected but curl is not installed"; rc=1; }
+        # SMTP completeness: an SMTP user without a password cannot authenticate.
+        if [[ -n "${NFTBAN_SMTP_USER:-}" && -z "${NFTBAN_SMTP_PASS:-}" ]]; then
+            echo "  ERROR: SMTP incomplete — NFTBAN_SMTP_USER set but NFTBAN_SMTP_PASS is empty"; rc=1
+        fi
+        [[ -n "${NFTBAN_MAIL_FROM:-${NFTBAN_SENDER:-}}" ]] || echo "  WARN: no NFTBAN_MAIL_FROM/NFTBAN_SENDER set (a default will be derived)"
     fi
+    # A2a: a forced method that is not actually available (detect fell back).
+    if [[ -n "${NFTBAN_MAIL_METHOD:-}" ]] && ! _nftban_mail_method_available "${NFTBAN_MAIL_METHOD}"; then
+        echo "  WARN: NFTBAN_MAIL_METHOD='${NFTBAN_MAIL_METHOD}' is not available — auto-detected '${mta}' instead"
+    fi
+    # A2a: fragmented/legacy recipient keys that diverge from the central recipient.
+    local _rk
+    for _rk in NFTBAN_ALERT_EMAIL NFTBAN_TUNNEL_ALERT_EMAIL; do
+        local _v="${!_rk:-}"
+        if [[ -n "$_v" && -n "${NFTBAN_MAIL_RECIPIENT:-}" && "$_v" != "${NFTBAN_MAIL_RECIPIENT}" ]]; then
+            echo "  WARN: legacy recipient key ${_rk} diverges from NFTBAN_MAIL_RECIPIENT (fragmentation)"
+        fi
+    done
     if [[ $rc -eq 0 ]]; then echo "  Result: OK (config valid; nothing was sent)"; else echo "  Result: INVALID (see errors; nothing was sent)"; fi
     return $rc
 }
@@ -1065,6 +1109,19 @@ _mail_write_metrics() {
         spool_depth=$(find "$spool_dir" -name "*.mail" -type f 2>/dev/null | wc -l)
     fi
 
+    # A2a: age (seconds) of the oldest spooled mail, and the currently selected transport.
+    local spool_oldest_age=0
+    if [[ -d "$spool_dir" ]]; then
+        local _oldest_mtime _now
+        _oldest_mtime=$(find "$spool_dir" -name "*.mail" -type f -printf '%T@\n' 2>/dev/null | sort -n | head -n1)
+        if [[ -n "$_oldest_mtime" ]]; then
+            _now=$(date +%s 2>/dev/null || echo 0)
+            spool_oldest_age=$(( _now - ${_oldest_mtime%.*} ))
+            [[ "$spool_oldest_age" -lt 0 ]] && spool_oldest_age=0
+        fi
+    fi
+    local transport_selected; transport_selected="$(nftban_mail_detect_mta 2>/dev/null || echo none)"
+
     cat > "${MAIL_METRICS_FILE}.tmp" <<EOF
 # HELP nftban_mail_send_attempts_total Total mail send attempts
 # TYPE nftban_mail_send_attempts_total counter
@@ -1100,6 +1157,18 @@ nftban_mail_spool_depth $spool_depth
 # HELP nftban_mail_last_success_timestamp Unix timestamp of last successful send
 # TYPE nftban_mail_last_success_timestamp gauge
 nftban_mail_last_success_timestamp $(cat "${MAIL_COUNTERS_DIR}/mail_last_success_ts" 2>/dev/null || echo "0")
+
+# HELP nftban_mail_last_failure_timestamp Unix timestamp of last failed send (A2a)
+# TYPE nftban_mail_last_failure_timestamp gauge
+nftban_mail_last_failure_timestamp $(cat "${MAIL_COUNTERS_DIR}/mail_last_failure_ts" 2>/dev/null || echo "0")
+
+# HELP nftban_mail_spool_oldest_age_seconds Age of the oldest spooled mail in seconds (A2a)
+# TYPE nftban_mail_spool_oldest_age_seconds gauge
+nftban_mail_spool_oldest_age_seconds ${spool_oldest_age}
+
+# HELP nftban_mail_transport_selected Currently selected mail transport (1=selected) (A2a)
+# TYPE nftban_mail_transport_selected gauge
+nftban_mail_transport_selected{transport="${transport_selected}"} 1
 EOF
 
     mv "${MAIL_METRICS_FILE}.tmp" "$MAIL_METRICS_FILE" 2>/dev/null || true
@@ -1119,6 +1188,48 @@ _mail_log() {
 
     mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
     echo "[$timestamp] [$level] $*" >> "$log_file"
+}
+
+# =============================================================================
+# A2a — DELIVERY TRUTH (produce): delivery-log + last-failure state
+# =============================================================================
+
+# Sanitize a short reason/label for a log line: collapse whitespace, strip quotes, bound
+# length. We only ever pass our own short reason codes here; this is defence-in-depth so a
+# secret can never ride into the delivery-log.
+_mail_sanitize() {
+    local s="${1:-}"
+    s="${s//$'\n'/ }"; s="${s//$'\t'/ }"; s="${s//\"/}"; s="${s//\\/}"
+    printf '%s' "${s:0:200}"
+}
+
+# Central delivery-log — ONE JSONL line per send OUTCOME (success|failed|spooled), reusing the
+# A1b sink shape. Recipient is REDACTED to local-part@…; reason is sanitized; NEVER a secret /
+# NFTBAN_SMTP_PASS. Bounded to NFTBAN_MAIL_DELIVERY_LOG_MAX lines (default 500).
+_mail_delivery_log() {
+    local result="${1:-unknown}" transport="${2:-unknown}" recipient="${3:-}" reason="${4:-}"
+    local logf="${NFTBAN_MAIL_DELIVERY_LOG:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mail/delivery.jsonl}"
+    local maxl="${NFTBAN_MAIL_DELIVERY_LOG_MAX:-500}"
+    mkdir -p "$(dirname "$logf")" 2>/dev/null || true
+    local red=""; [[ -n "$recipient" ]] && red="${recipient%%@*}@…"
+    printf '{"ts":"%s","transport":"%s","recipient":"%s","result":"%s","reason":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" \
+        "$(_mail_sanitize "$transport")" "$red" "$(_mail_sanitize "$result")" "$(_mail_sanitize "$reason")" \
+        >> "$logf" 2>/dev/null || true
+    local lines; lines=$(wc -l < "$logf" 2>/dev/null || echo 0)
+    if [[ "${lines:-0}" -gt "$maxl" ]]; then
+        tail -n "$maxl" "$logf" > "${logf}.tmp" 2>/dev/null && mv -f "${logf}.tmp" "$logf" 2>/dev/null || true
+    fi
+    return 0
+}
+
+# Persist last-failure {ts, reason(sanitized)} alongside the existing mail_last_success_ts.
+_mail_record_last_failure() {
+    local reason="${1:-}"
+    mkdir -p "$MAIL_COUNTERS_DIR" 2>/dev/null || true
+    { if type nftban_timestamp_unix &>/dev/null; then nftban_timestamp_unix; else date +%s; fi; } \
+        > "${MAIL_COUNTERS_DIR}/mail_last_failure_ts" 2>/dev/null || true
+    _mail_sanitize "$reason" > "${MAIL_COUNTERS_DIR}/mail_last_failure_reason" 2>/dev/null || true
 }
 
 # =============================================================================
@@ -1149,6 +1260,8 @@ nftban_mail_send_with_retry() {
 
     if [[ "$mta" == "none" ]]; then
         _mail_log "ERROR" "No mail system available, spooling for later"
+        _mail_record_last_failure "no_transport_available"
+        _mail_delivery_log "spooled" "none" "$recipient" "no_transport_available"
         _mail_spool_enqueue "$content_arg" "$recipient" "$subject"
         return 1
     fi
@@ -1174,6 +1287,7 @@ nftban_mail_send_with_retry() {
                 echo "$(date +%s)" > "${MAIL_COUNTERS_DIR}/mail_last_success_ts"
             fi
             _mail_log "INFO" "MAIL_SEND_RESULT task_id=inline status=success transport=$mta attempt=$attempt"
+            _mail_delivery_log "success" "$mta" "$recipient" ""
             _mail_write_metrics
             return 0
         else
@@ -1194,9 +1308,12 @@ nftban_mail_send_with_retry() {
     # All retries exhausted - spool for later
     _mail_counter_inc "failures" "$mta"
     _mail_log "ERROR" "MAIL_SEND_RESULT task_id=inline status=failed transport=$mta retries=$max_retries last_error=$last_error"
+    _mail_record_last_failure "$last_error"
+    _mail_delivery_log "failed" "$mta" "$recipient" "$last_error"
     _mail_write_metrics
 
-    # Enqueue to mail spool (uses queue system)
+    # Enqueue to mail spool (uses queue system) — record the spooled outcome too
+    _mail_delivery_log "spooled" "$mta" "$recipient" "after_${max_retries}_retries"
     _mail_spool_enqueue "$content_arg" "$recipient" "$subject"
 
     return 1

--- a/cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh
+++ b/cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A2a central-comms delivery-truth (produce layer)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a2a_delivery_truth_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="A2a produce layer: emulate send writes a delivery-log success line (redacted recipient, no secret); failed/spooled primitives write their lines + last-failure state; retention cap bounds the log; mail metrics expose spool_oldest_age/last_failure_timestamp/transport_selected; validate comms (dry-run) catches missing recipient + incomplete SMTP and stays truthful; mail status summary shows the new fields; A0 0/4, A0 self-test, A1, A1b all still pass. Hermetic: isolated tempdir, no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,find"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_DELIVERY_LOG,NFTBAN_MAIL_DELIVERY_LOG_MAX,NFTBAN_MAIL_RECIPIENT,NFTBAN_SMTP_PASS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A2a central-comms delivery-truth ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+LEAK_PROBE="nftban-a2a-leakprobe-marker"   # non-secret marker placed in NFTBAN_SMTP_PASS
+
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+EOF
+}
+
+DLOG="$WORK/delivery.jsonl"
+
+# 1) emulate success → delivery-log success line (integration through the retry wrapper)
+bash -c "$(prelude)
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example' NFTBAN_MAIL_DELIVERY_LOG='$DLOG' NFTBAN_SMTP_PASS='$LEAK_PROBE'
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+nftban_mail_send_with_retry 'body' 'rcpt@test.example' 'subj' >/dev/null 2>&1
+" || true
+grep -q '"result":"success"' "$DLOG" 2>/dev/null && ok "emulate success wrote delivery-log success line" || no "no success line"
+# 5) recipient redacted (local-part@…, not full domain)
+grep -q '"recipient":"rcpt@' "$DLOG" 2>/dev/null && ! grep -q 'rcpt@test.example' "$DLOG" 2>/dev/null && ok "recipient redacted in delivery-log" || no "recipient not redacted"
+# 4) no secret in delivery-log
+grep -q "$LEAK_PROBE" "$DLOG" 2>/dev/null && no "secret LEAKED into delivery-log" || ok "no secret in delivery-log"
+
+# 2) failed primitive → failed line + last-failure state ; 3) spooled line
+bash -c "$(prelude)
+export NFTBAN_MAIL_DELIVERY_LOG='$DLOG'
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+_mail_delivery_log 'failed' 'curl' 'rcpt@test.example' 'send_failed_rc_1'
+_mail_record_last_failure 'send_failed_rc_1'
+_mail_delivery_log 'spooled' 'curl' 'rcpt@test.example' 'after_3_retries'
+" || true
+grep -q '"result":"failed"' "$DLOG" 2>/dev/null && ok "failed primitive wrote failed line" || no "no failed line"
+grep -q '"result":"spooled"' "$DLOG" 2>/dev/null && ok "spooled primitive wrote spooled line" || no "no spooled line"
+[[ -s "$WORK/data/metrics/counters/mail_last_failure_ts" ]] && ok "last-failure ts persisted" || no "last-failure ts missing"
+grep -q 'send_failed_rc_1' "$WORK/data/metrics/counters/mail_last_failure_reason" 2>/dev/null && ok "last-failure reason persisted" || no "last-failure reason missing"
+
+# 6) retention cap
+CAP="$WORK/cap.jsonl"
+bash -c "$(prelude)
+export NFTBAN_MAIL_DELIVERY_LOG='$CAP' NFTBAN_MAIL_DELIVERY_LOG_MAX=5
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+for i in \$(seq 1 20); do _mail_delivery_log 'success' 'emulate' 'r@t.example' \"n\$i\"; done
+"
+capn=$(wc -l < "$CAP" 2>/dev/null | tr -d ' ')
+[[ "${capn:-0}" -le 5 ]] && ok "retention cap bounds delivery-log ($capn<=5)" || no "retention cap failed ($capn)"
+
+# 7-9) new metrics present
+MET="$WORK/mail.prom"
+bash -c "$(prelude)
+export NFTBAN_MAIL_METRICS_FILE='$MET' NFTBAN_MAIL_SPOOL_DIR='$WORK/spool'
+mkdir -p '$WORK/spool'; : > '$WORK/spool/old.mail'
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+_mail_write_metrics
+"
+grep -q 'nftban_mail_spool_oldest_age_seconds' "$MET" 2>/dev/null && ok "metric: spool_oldest_age_seconds" || no "missing spool_oldest_age"
+grep -q 'nftban_mail_last_failure_timestamp' "$MET" 2>/dev/null && ok "metric: last_failure_timestamp" || no "missing last_failure_timestamp"
+grep -q 'nftban_mail_transport_selected{transport=' "$MET" 2>/dev/null && ok "metric: transport_selected" || no "missing transport_selected"
+
+# 10-12) validate comms (dry-run) catches
+mrc=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_METHOD=emulate
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+nftban_mail_test_dryrun '' >/dev/null 2>&1; echo \$?")
+[[ "$mrc" != "0" ]] && ok "validate comms catches missing recipient (rc!=0)" || no "missing recipient not caught"
+src=$(bash -c "$(prelude)
+export NFTBAN_MAIL_RECIPIENT='r@t.example' NFTBAN_MAIL_METHOD=curl NFTBAN_SMTP_HOST='smtp.test' NFTBAN_SMTP_USER='u@t' NFTBAN_SMTP_PASS=''
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+nftban_mail_test_dryrun '' 2>/dev/null | grep -c 'SMTP incomplete'")
+[[ "${src:-0}" -ge 1 ]] && ok "validate comms catches incomplete SMTP (user w/o pass)" || no "incomplete SMTP not caught"
+
+# 15) mail status summary shows new fields
+sout=$(bash -c "$(prelude)
+export NFTBAN_MAIL_RECIPIENT='r@t.example'
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+nftban_mail_status_summary 2>/dev/null")
+echo "$sout" | grep -q 'Recipient:' && echo "$sout" | grep -q 'Spool: depth=' && echo "$sout" | grep -q 'Last success ts:' && ok "mail status summary shows new fields" || no "status summary fields missing"
+
+# 16-19) ratchet + prior suites unaffected
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no "A0 guard regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh >/dev/null 2>&1 ) && ok "A0 self-test still passes" || no "A0 self-test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a1_centralization_test.sh >/dev/null 2>&1 ) && ok "A1 test still passes" || no "A1 test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a1b_emulate_test.sh >/dev/null 2>&1 ) && ok "A1b test still passes" || no "A1b test regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Central-comms A2a — delivery-truth (produce layer)

### Problem
- A0+A1+A1b made central-comms **enforced** and **safely testable**.
- A2 needs persistent **produce-side truth** before health/status/stats/RBL/support can consume it.
- The existing retry path had structured logs + counters, but **no durable delivery log, no persisted last-failure state, no oldest-spool metric, and no `validate` comms section**.

### Fix
- **Central delivery log** (JSONL): one line per outcome `success` / `failed` / `spooled`; fields `ts, transport, recipient(redacted local-part@…), result, reason(sanitized)`; **no secrets / `NFTBAN_SMTP_PASS`**; bounded retention via `NFTBAN_MAIL_DELIVERY_LOG_MAX` (default 500).
- **Persisted last-failure state**: `mail_last_failure_ts` + `mail_last_failure_reason` (sanitized), alongside existing `mail_last_success_ts`.
- **Extend `mail.prom`**: `nftban_mail_last_failure_timestamp`, `mail_spool_oldest_age_seconds`, `nftban_mail_transport_selected{transport=...}`; existing success/failure/spool-depth preserved.
- **Extend dry-run/validate comms**: missing recipient · incomplete SMTP (user-without-pass) · forced method unavailable · fragmented legacy recipient keys; **dry-run stays truthful**.
- **Wire validate comms** as its own section in `nftban validate`, **preserving the nft-structure validation rc contract**.
- **Enrich `nftban mail status`**: recipient · transport · spool depth · oldest spool age · last success · last failure.

### Validation
- shellcheck **CLEAN** · `bash -n` clean.
- **A2a test 18/18**: emulate-success delivery-log line · recipient redaction · no secret/`NFTBAN_SMTP_PASS` in log · failed primitive state · spooled primitive state · last-failure persisted · retention cap · new last-failure metric · new oldest-spool metric · new transport-selected metric · validate catches missing recipient · validate catches incomplete SMTP · mail status summary fields · A0 guard **0/4** · A0 self-test **5/5** · A1 **15/15** · A1b **11/11**.
- **lab2 DEB** package-native: daemon active · `nftban validate` rc0 · comms section present · mail status summary present · no new failed units · no real mail · `nftban_mail.sh` restored/pristine.
- **lab4 RPM** package-native: daemon active · `nftban validate` rc0 · comms section present · mail status summary present · no new failed units · no real mail · restored/pristine.

### Scanner note
- Test uses a **GitGuardian-safe non-secret marker**, not fake credential text.

### Schema / daemon
- **shell-only · 0 Go · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes
- A2a delivery-truth produce layer: delivery log · last-failure state · mail metrics additions · validate comms section · mail status summary enrichment.

### Does NOT close
- A2b health/status/stats consume layer · A2r RBL observe-only visibility / honesty label · A2c support-bundle comms/RBL summary · RBLMON · RBL P0 / provider-bounce ingestion · SEC-P1-2 · SEC-P1-3b · A3 docs/wiki/template authority.

### Scope
3 files, shell-only. No Go, no schema/VERSION/docs/wiki/register mutation, no A2b consume, no RBL/support changes, no real mail.