### PR TITLE
feat(comms): surface central mail health, status, and stats (A2b)

### DIFF
--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -102,6 +102,23 @@ fi
 # SUBCOMMAND: BRIEF (v1.37.1)
 # =============================================================================
 
+nftban_stats_cmd_comms() {
+    # A2b: central-comms counters from A2a-produced mail.prom (read-only; no new source).
+    local prom="${NFTBAN_MAIL_METRICS_FILE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/metrics/mail.prom}"
+    echo "Communication (central-comms) counters:"
+    if [[ ! -f "$prom" ]]; then
+        echo "  (no mail metrics yet — ${prom} not found)"
+        return 0
+    fi
+    local m
+    for m in nftban_mail_send_success_total nftban_mail_send_failures_total \
+             nftban_mail_spool_depth nftban_mail_spool_oldest_age_seconds \
+             nftban_mail_last_failure_timestamp nftban_mail_transport_selected; do
+        grep -E "^${m}([{ ])" "$prom" 2>/dev/null | sed 's/^/  /' || true
+    done
+    return 0
+}
+
 nftban_stats_cmd_brief() {
     # v1.37.1: One-line stats output for scripts/monitoring
     # Output: "75 banned | 9 whitelisted | 40 dropped | 1463 bans today"
@@ -163,6 +180,10 @@ nftban_cmd_stats() {
             ;;
         --brief|-b)
             nftban_stats_cmd_brief
+            return $?
+            ;;
+        comms)
+            nftban_stats_cmd_comms
             return $?
             ;;
         dashboard|summary|"")
@@ -1314,6 +1335,7 @@ USAGE:
 COMMANDS:
     dashboard | summary    Show comprehensive statistics dashboard (default)
     trend                  Show 7-day trend analysis with averages
+    comms                  Show central-comms delivery counters (read-only)
     top <type> [N]         Show top lists (ips, countries, filters)
     ip <IP>                Show ban history for specific IP
     recent [N]             Show recent ban activity

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1426,6 +1426,22 @@ _status_section_health() {
     echo ""
 }
 
+_status_section_communication() {
+    # A2b: read-only central-comms summary from A2a-produced state (sends nothing).
+    if ! declare -F nftban_mail_status_summary >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR}/core/nftban_mail.sh" 2>/dev/null || true
+    fi
+    declare -F nftban_mail_status_summary >/dev/null 2>&1 || return 0
+    local transport; transport="$(nftban_mail_detect_mta 2>/dev/null || echo none)"
+    echo ""
+    echo "COMMUNICATION"
+    printf "  %-21s %s\n" "Transport............" "$transport"
+    # recipient / spool depth+age / last success / last failure (all A2a state, sanitized)
+    nftban_mail_status_summary 2>/dev/null
+    return 0
+}
+
 _status_section_activity() {
     # ─────────────────────────────────────────────────────────────────────
     # RECENT ACTIVITY
@@ -1710,6 +1726,7 @@ output_terminal() {
     _status_section_authority
     _status_section_services
     _status_section_protection "$quiet_mode"
+    _status_section_communication
     _status_section_health "$protection_state" "$quiet_mode"
     _status_section_activity
     _status_section_timers "$quiet_mode"

--- a/cli/lib/nftban/core/nftban_health.sh
+++ b/cli/lib/nftban/core/nftban_health.sh
@@ -551,6 +551,7 @@ nftban_health_check_all() {
     nftban_health_check_geoip 2>/dev/null || true
     nftban_health_check_geoban 2>/dev/null || true
     nftban_health_check_rbl 2>/dev/null || true
+    nftban_health_check_communication 2>/dev/null || true
     nftban_health_check_botguard 2>/dev/null || true
     nftban_health_check_tunnel 2>/dev/null || true
     nftban_health_check_databases 2>/dev/null || true

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -718,6 +718,84 @@ nftban_health_check_tunnel() {
 }
 
 # Export functions
+# A2b: communication (central-comms) health — CONSUME A2a delivery-truth. Reads state only
+# (recipient/transport + spool + last-failure); sends nothing. CLEAN when alerting is not
+# configured OR recipient+transport are valid; WARN on enabled-but-unusable / backlog /
+# unresolved last-failure; ERROR only for a very old spool backlog. Does not harden the
+# overall contract — advisory/offline mail never becomes a false critical.
+nftban_health_check_communication() {
+    local status=$HEALTH_OK
+    local issues=()
+    local spool_warn_depth="${NFTBAN_MAIL_SPOOL_WARN_DEPTH:-1}"
+    local spool_oldest_error="${NFTBAN_MAIL_SPOOL_OLDEST_ERROR_S:-86400}"
+    local lastfail_warn_age="${NFTBAN_MAIL_LASTFAIL_WARN_S:-86400}"
+
+    if ! declare -F nftban_mail_resolve_recipient >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_mail.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_mail.sh" 2>/dev/null || true
+    fi
+
+    local recipient="" mail_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/mail.conf"
+    declare -F nftban_mail_resolve_recipient >/dev/null 2>&1 && \
+        recipient="$(nftban_mail_resolve_recipient "" 2>/dev/null || echo "")"
+
+    # Alerting considered enabled if a recipient is configured OR a mail.conf exists.
+    if [[ -z "$recipient" && ! -f "$mail_conf" ]]; then
+        NFTBAN_HEALTH_RESULTS["communication"]=$HEALTH_OK
+        NFTBAN_HEALTH_ISSUES["communication"]="Communication alerting not configured (optional)"
+        return $HEALTH_OK
+    fi
+
+    if [[ -z "$recipient" ]]; then
+        issues+=("COMMUNICATION_CONFIG_MISSING_RECIPIENT: alerting configured but no recipient resolves")
+        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+    fi
+
+    local transport="none"
+    declare -F nftban_mail_detect_mta >/dev/null 2>&1 && transport="$(nftban_mail_detect_mta 2>/dev/null || echo none)"
+    if [[ "$transport" == "none" ]]; then
+        issues+=("COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport")
+        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+    fi
+
+    local spool_dir="${NFTBAN_MAIL_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mailspool}"
+    local depth=0 oldest_age=0
+    if [[ -d "$spool_dir" ]]; then
+        depth=$(find "$spool_dir" -name "*.mail" -type f 2>/dev/null | wc -l)
+        local _m; _m=$(find "$spool_dir" -name "*.mail" -type f -printf '%T@\n' 2>/dev/null | sort -n | head -n1)
+        [[ -n "$_m" ]] && oldest_age=$(( $(date +%s) - ${_m%.*} ))
+    fi
+    if [[ "${depth:-0}" -ge "$spool_warn_depth" && "${depth:-0}" -gt 0 ]]; then
+        issues+=("COMMUNICATION_SPOOL_BACKLOG: ${depth} spooled, oldest ${oldest_age}s")
+        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+        [[ "$oldest_age" -ge "$spool_oldest_error" ]] && status=$HEALTH_ERROR
+    fi
+
+    local counters="${NFTBAN_DATA_DIR:-/var/lib/nftban}/metrics/counters"
+    local lf_ts ls_ts
+    lf_ts=$(cat "${counters}/mail_last_failure_ts" 2>/dev/null || echo 0)
+    ls_ts=$(cat "${counters}/mail_last_success_ts" 2>/dev/null || echo 0)
+    if [[ "${lf_ts:-0}" -gt 0 && "${lf_ts:-0}" -ge "${ls_ts:-0}" ]]; then
+        local age=$(( $(date +%s) - lf_ts ))
+        if [[ "$age" -le "$lastfail_warn_age" ]]; then
+            issues+=("COMMUNICATION_LAST_SEND_FAILED: last send failed ${age}s ago (unresolved)")
+            issues+=("COMMUNICATION_SEND_FAILURE: see delivery log")
+            [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+        fi
+    fi
+
+    NFTBAN_HEALTH_RESULTS["communication"]=$status
+    if [[ ${#issues[@]} -gt 0 ]]; then
+        local _joined; printf -v _joined '%s; ' "${issues[@]}"; _joined="${_joined%; }"
+        NFTBAN_HEALTH_ISSUES["communication"]="$_joined"
+        [[ $status -eq $HEALTH_ERROR ]] && NFTBAN_HEALTH_ERRORS+=("Communication: ${issues[0]}")
+    else
+        NFTBAN_HEALTH_ISSUES["communication"]="Communication OK (recipient + transport valid)"
+    fi
+    return $status
+}
+
+export -f nftban_health_check_communication
 export -f nftban_health_check_modules nftban_health_check_geoip
 export -f nftban_health_check_geoban nftban_health_check_databases
 export -f nftban_health_check_rbl nftban_health_check_portscan_prefix

--- a/cli/lib/nftban/core/nftban_health_render.sh
+++ b/cli/lib/nftban/core/nftban_health_render.sh
@@ -82,6 +82,7 @@ nftban_health_render_terminal() {
         [boot_safety]="Boot Safety"
         [cli_errors]="CLI Errors"
         [rbl]="RBL"
+        [communication]="Communication"
         [timers]="Timers"
         [fhs]="FHS Layout"
         [nftban_bin]="NFTBan Binary"
@@ -152,7 +153,7 @@ nftban_health_render_terminal() {
     echo "OPTIONAL FEATURES"
     echo "───────────────────────────────────────────────────────────"
 
-    for check in systemd_hardening memory_protection metrics zabbix connectors watchdog gui polkit bash_completion portscan_prefix v030_helpers pro; do
+    for check in systemd_hardening memory_protection metrics zabbix connectors watchdog communication gui polkit bash_completion portscan_prefix v030_helpers pro; do
         if [[ -n "${NFTBAN_HEALTH_RESULTS[$check]:-}" ]]; then
             local status=${NFTBAN_HEALTH_RESULTS[$check]}
             local status_text

--- a/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
+++ b/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A2b central-comms operator surfacing (consume layer)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a2b_operator_surfacing_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-06"
+# meta:description="A2b consume layer: nftban_health_check_communication reads A2a state and reports CLEAN (recipient+transport) / COMMUNICATION_CONFIG_MISSING_RECIPIENT / COMMUNICATION_TRANSPORT_UNAVAILABLE / COMMUNICATION_SPOOL_BACKLOG / COMMUNICATION_LAST_SEND_FAILED; status summary shows transport/recipient/spool/last-failure; stats comms prints the mail.prom counters and degrades gracefully when mail.prom is missing. Re-runs A0/self-test/A1/A1b/A2a. Hermetic: isolated tempdir, no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,find,awk"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_RECIPIENT,NFTBAN_MAIL_METRICS_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+STATS="$REPO/cli/lib/nftban/cli/cmd_stats.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A2b central-comms operator surfacing ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# Extract the two self-containable functions (the full files carry heavier deps).
+HFN="$WORK/hc.sh"; awk '/^nftban_health_check_communication\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" > "$HFN"
+SFN="$WORK/sc.sh"; awk '/^nftban_stats_cmd_comms\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$STATS" > "$SFN"
+grep -q 'nftban_health_check_communication' "$HFN" && ok "extracted health check fn" || no "extract health fn"
+grep -q 'nftban_stats_cmd_comms' "$SFN" && ok "extracted stats comms fn" || no "extract stats fn"
+
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR/conf.d" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR" "\$NFTBAN_DATA_DIR/metrics/counters"
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+source "$MAIL" >/dev/null 2>&1 || true
+source "$HFN" >/dev/null 2>&1 || true
+set +e; set +o pipefail
+EOF
+}
+# Deterministic "no transport": override the detector to none (a host may run a real MTA).
+NONE_BINS='nftban_mail_detect_mta() { echo none; }'
+
+hprobe() { bash -c "$(prelude)
+$1
+nftban_health_check_communication; rc=\$?
+echo \"RC=\$rc ISSUE=\${NFTBAN_HEALTH_ISSUES[communication]:-}\""; }
+
+# health: CLEAN when recipient + emulate transport
+r=$(hprobe "export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'")
+echo "$r" | grep -q '^RC=0 ' && ok "health CLEAN (recipient + transport)" || no "health not clean: $r"
+# health: missing recipient while alerting enabled (mail.conf present)
+r=$(hprobe "unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_METHOD=emulate; : > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"")
+echo "$r" | grep -q 'COMMUNICATION_CONFIG_MISSING_RECIPIENT' && [[ "$r" != RC=0* ]] && ok "health WARN: missing recipient" || no "missing recipient not flagged: $r"
+# health: transport unavailable while enabled
+r=$(hprobe "export NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; $NONE_BINS")
+echo "$r" | grep -q 'COMMUNICATION_TRANSPORT_UNAVAILABLE' && ok "health WARN: transport unavailable" || no "transport-unavailable not flagged: $r"
+# health: spool backlog
+r=$(hprobe "export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; mkdir -p \"\$NFTBAN_DATA_DIR/mailspool\"; : > \"\$NFTBAN_DATA_DIR/mailspool/x.mail\"")
+echo "$r" | grep -q 'COMMUNICATION_SPOOL_BACKLOG' && ok "health WARN: spool backlog" || no "spool backlog not flagged: $r"
+# health: last send failed (failure newer than success)
+r=$(hprobe "export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; echo \$(date +%s) > \"\$NFTBAN_DATA_DIR/metrics/counters/mail_last_failure_ts\"; echo 0 > \"\$NFTBAN_DATA_DIR/metrics/counters/mail_last_success_ts\"")
+echo "$r" | grep -q 'COMMUNICATION_LAST_SEND_FAILED' && echo "$r" | grep -q 'COMMUNICATION_SEND_FAILURE' && ok "health WARN: last send failed + send failure" || no "last-failure not flagged: $r"
+
+# status consume: transport + summary fields
+s=$(bash -c "$(prelude)
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'
+t=\$(nftban_mail_detect_mta 2>/dev/null); echo \"T=\$t\"; nftban_mail_status_summary 2>/dev/null")
+echo "$s" | grep -q 'T=emulate' && echo "$s" | grep -q 'Recipient:' && echo "$s" | grep -q 'Spool: depth=' && echo "$s" | grep -q 'Last success ts:' && ok "status consume shows transport+recipient+spool+last" || no "status consume incomplete: $s"
+
+# stats comms: counters present from a mail.prom carrying the A2a metric names
+PROM="$WORK/mail.prom"
+cat > "$PROM" <<'PROMEOF'
+nftban_mail_send_success_total{transport="curl"} 3
+nftban_mail_send_failures_total{transport="curl"} 1
+nftban_mail_spool_depth 2
+nftban_mail_spool_oldest_age_seconds 120
+nftban_mail_last_failure_timestamp 1700000000
+nftban_mail_transport_selected{transport="curl"} 1
+PROMEOF
+so=$(bash -c "source '$SFN'; NFTBAN_MAIL_METRICS_FILE='$PROM' nftban_stats_cmd_comms 2>/dev/null")
+c=0; for m in nftban_mail_send_success_total nftban_mail_send_failures_total nftban_mail_spool_depth nftban_mail_spool_oldest_age_seconds nftban_mail_last_failure_timestamp nftban_mail_transport_selected; do echo "$so" | grep -q "$m" && c=$((c+1)); done
+[[ "$c" -eq 6 ]] && ok "stats comms shows all 6 counters" || no "stats comms only $c/6 counters"
+# stats comms: graceful when mail.prom missing
+sm=$(bash -c "source '$SFN'; NFTBAN_MAIL_METRICS_FILE='$WORK/nope.prom' nftban_stats_cmd_comms 2>/dev/null")
+echo "$sm" | grep -q 'no mail metrics yet' && ok "stats comms graceful on missing mail.prom" || no "stats comms not graceful: $sm"
+
+# render: communication surfaces in the OPTIONAL FEATURES terminal render (live path via
+# cmd_health_core.sh) when a result is set.
+RENDER="$REPO/cli/lib/nftban/core/nftban_health_render.sh"
+rout=$(bash -c "
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES
+declare -a NFTBAN_HEALTH_ERRORS NFTBAN_HEALTH_WARNINGS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+NFTBAN_HEALTH_RESULTS[communication]=1
+NFTBAN_HEALTH_ISSUES[communication]='COMMUNICATION_SPOOL_BACKLOG: 1 spooled'
+source '$RENDER' >/dev/null 2>&1 || true
+set +e; set +o pipefail
+nftban_health_render_terminal 2>/dev/null | grep -i communication")
+echo "$rout" | grep -qi 'Communication' && ok "health render lists Communication (OPTIONAL FEATURES)" || no "render missing Communication: $rout"
+
+# ratchet + prior suites
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no "A0 guard regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh >/dev/null 2>&1 ) && ok "A0 self-test still passes" || no "A0 self-test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a1_centralization_test.sh >/dev/null 2>&1 ) && ok "A1 test still passes" || no "A1 test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a1b_emulate_test.sh >/dev/null 2>&1 ) && ok "A1b test still passes" || no "A1b test regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh >/dev/null 2>&1 ) && ok "A2a test still passes" || no "A2a test regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -2164,6 +2164,7 @@ stats:
   output_modes: [json, text]
   has_json: true
   subcommands:
+    comms: {mutates: false, description: "Show central-comms delivery counters (success/failures/spool/oldest-age/last-failure/transport)"}
     dashboard:
       mutates: false
       description: "Show dashboard overview"

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -64,7 +64,7 @@ _nftban() {
 
     # Monitoring & Reporting
     local metrics_cmds="status enable disable help"
-    local stats_cmds="summary dashboard top export monitor cleanup trend --json help"
+    local stats_cmds="summary dashboard top export monitor cleanup trend comms --json help"
     local report_cmds="generate run schedule email email-setup list status --json help"
     local fhs_cmds="check status --json help"
     local module_cmds="list status --json help"


### PR DESCRIPTION
## Central-comms A2b — operator surfacing (consume layer)

### Problem
- A2a persists central-comms **delivery truth**, but operators still need to **see** it in `nftban health`/`status`/`stats`.
- RBLMON remains blocked until central-comms is observable.

### Fix
- Add `nftban_health_check_communication`; register it in `nftban_health_check_all` (affects the health verdict).
- 5 status keys: `COMMUNICATION_CONFIG_MISSING_RECIPIENT`, `COMMUNICATION_TRANSPORT_UNAVAILABLE`, `COMMUNICATION_SEND_FAILURE`, `COMMUNICATION_SPOOL_BACKLOG`, `COMMUNICATION_LAST_SEND_FAILED`.
- Render **Communication** in the optional/features health table.
- Add `nftban status` communication section (transport + recipient/spool/last via A2a summary).
- Add `nftban stats comms` section (mail.prom counters; graceful when absent) + registry/completion/help.
- **Reads only A2a-produced state.** No new send paths. No RBL change. No support-bundle change.

### Validation
- **A2b test 16/16**: all 5 health keys (incl. transport-unavailable & spool-backlog) · status communication section · stats comms section · stats graceful when `mail.prom` absent · **health render lists Communication** · A0 guard **0/4** · A0 self-test **5/5** · A1 **15/15** · A1b **11/11** · A2a **18/18**.
- shellcheck **CLEAN** · registry/completion/help **parity OK**.
- **lab2 DEB**: daemon active · `nftban validate` rc0 · no new failed units · status COMMUNICATION present · stats comms present · no real mail · restored/pristine.
- **lab4 RPM**: daemon active · `nftban validate` rc0 · no new failed units · status COMMUNICATION present · stats comms present · no real mail · restored/pristine.

### Honest render note
- The health **check** registration is in `nftban_health_check_all` and **affects the verdict**.
- The optional-features **table rendering** (`nftban_health_render_terminal`) is a **separate live path** (`cmd_health_core.sh:148`); `nftban health check` uses a distinct four-axis render.
- Render wiring was proven **hermetically** in the A2b test (a `render_terminal` call with a communication result → `Communication ... WARNING`) rather than via fragile full-CLI overlay.

### Schema / daemon
- **shell-only · 0 Go · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes
- A2b operator surfacing / consume layer — central-comms is now observable in health/status/stats.
- Gate-wise, RBLMON is unblocked after merge+align (implementation remains a later GO).

### Does NOT close
- A2r RBL observe-only visibility / DNSBL-only honesty label · A2c support-bundle comms/RBL summary · RBLMON implementation · RBL P0 provider-bounce ingestion · SEC-P1-2 · SEC-P1-3b · A3 docs/wiki/template authority.

### Scope
8 files (shell/registry/completion/help/test). No Go, no schema/VERSION/docs/wiki/register mutation, no RBL/support changes, no real mail.