### PR TITLE
fix(rbl): surface observe-only reputation state and DNSBL honesty label (A2r)

### DIFF
--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -336,6 +336,10 @@ nftban_cmd_rbl_config() {
     echo "  Cache TTL:      ${NFTBAN_RBL_CACHE_TTL:-24} hours"
     echo "  Alert Email:    ${NFTBAN_RBL_ALERT_EMAIL:-(not set)}"
     echo ""
+    echo "Scope:"
+    echo "  RBL is advisory reputation monitoring (observe-only), not firewall blocking."
+    echo "  A DNSBL check cannot determine a provider-specific Proofpoint/iCloud bounce."
+    echo ""
     echo "To override settings, create/edit: $config_local"
 }
 

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -320,7 +320,7 @@ nftban_health_check_rbl() {
         rbl_issues+=("RBL monitoring disabled (optional)")
         # Not an error - just informational
         NFTBAN_HEALTH_RESULTS["rbl"]=$HEALTH_OK
-        NFTBAN_HEALTH_ISSUES["rbl"]="RBL monitoring disabled (enable in $rbl_config)"
+        NFTBAN_HEALTH_ISSUES["rbl"]="RBL monitoring disabled (optional; advisory reputation monitoring, not blocking)"
         return $HEALTH_OK
     fi
 

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -1369,9 +1369,15 @@ Full Report: nftban rbl check --verbose
 EOF
 )
 
-    # Send via NFTBan unified mail mechanism
-    nftban_mail_send "$body" "$email" 2>/dev/null || \
-        echo "Warning: Failed to send RBL alert email" >&2
+    # A2r: submit to the central authority so the attempt lands in the A2a delivery-log /
+    # last-failure / spool (observable via 'nftban stats comms'). No direct transport.
+    if declare -F nftban_mail_alert >/dev/null 2>&1; then
+        nftban_mail_alert "$subject" "$body" "$email" || \
+            echo "Warning: RBL alert not delivered (spooled/degraded — see 'nftban stats comms')" >&2
+    else
+        nftban_mail_send "$body" "$email" 2>/dev/null || \
+            echo "Warning: Failed to send RBL alert email" >&2
+    fi
 }
 
 nftban_rbl_send_degraded_alert() {
@@ -1438,9 +1444,14 @@ Run manually: nftban rbl check --fresh --verbose
 EOF
 )
 
-    # Send via NFTBan unified mail mechanism
-    nftban_mail_send "$body" "$email" 2>/dev/null || \
-        echo "Warning: Failed to send degraded alert email" >&2
+    # A2r: submit to the central authority (delivery-log / last-failure / spool via A2a).
+    if declare -F nftban_mail_alert >/dev/null 2>&1; then
+        nftban_mail_alert "[NFTBan] RBL monitoring degraded" "$body" "$email" || \
+            echo "Warning: RBL degraded alert not delivered (spooled/degraded)" >&2
+    else
+        nftban_mail_send "$body" "$email" 2>/dev/null || \
+            echo "Warning: Failed to send degraded alert email" >&2
+    fi
 }
 
 # =============================================================================
@@ -1574,6 +1585,9 @@ nftban_rbl_status() {
             echo "  Blacklisted:  0"
         fi
         echo "  Cache:        $cache_count entries (${NFTBAN_RBL_CACHE_TTL}h TTL)"
+        echo ""
+        echo "  Scope:        advisory reputation monitoring (observe-only), not firewall blocking"
+        echo "                a DNSBL check cannot determine a provider-specific Proofpoint/iCloud bounce"
     fi
 }
 

--- a/cli/lib/nftban/lib/nftban_report_data.sh
+++ b/cli/lib/nftban/lib/nftban_report_data.sh
@@ -571,11 +571,11 @@ _collect_rbl_info() {
             _rdata[RBL_LAST_CHECK]="Never"
         fi
 
-        # Activity summary
+        # Activity summary — RBL is advisory reputation monitoring (observe-only), NOT blocking.
         if [[ $listed_count -gt 0 ]]; then
-            _rdata[MODULE_RBL_ACTIVITY]="${listed_count} IPs blacklisted!"
+            _rdata[MODULE_RBL_ACTIVITY]="${listed_count} IP(s) listed on reputation lists (advisory — not blocked)"
         else
-            _rdata[MODULE_RBL_ACTIVITY]="${clean_count} IPs clean"
+            _rdata[MODULE_RBL_ACTIVITY]="${clean_count} IPs clean (advisory reputation monitoring)"
         fi
     else
         _rdata[MODULE_RBL_STATUS]="Disabled"

--- a/cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh
+++ b/cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A2r RBL observe-only visibility + honesty label
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a2r_rbl_visibility_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="A2r: RBL is surfaced observe-only — the DNSBL-only honesty label appears in rbl status + report data (advisory/reputation/not-blocking/cannot-determine-Proofpoint-iCloud-bounce); RBL alerts route through the central authority (nftban_mail_alert) so attempts land in the A2a delivery-log (proven compositionally under A1b emulate); no direct mail transport is introduced (A0 guard 0/4). Re-runs A2a/A2b. Hermetic: isolated tempdir, no real mail, no network, no new RBL probes."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_DELIVERY_LOG,NFTBAN_MAIL_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+RBL="$REPO/cli/lib/nftban/core/nftban_rbl.sh"
+CMD_RBL="$REPO/cli/lib/nftban/cli/cmd_rbl.sh"
+RDATA="$REPO/cli/lib/nftban/lib/nftban_report_data.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A2r RBL observe-only visibility ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# --- DNSBL-only honesty label (status + report) ---
+grep -qi 'advisory reputation monitoring (observe-only), not firewall blocking' "$RBL" "$CMD_RBL" && ok "status: advisory/observe-only/not-blocking wording" || no "status advisory wording missing"
+grep -qi 'cannot determine a provider-specific Proofpoint/iCloud bounce' "$RBL" "$CMD_RBL" && ok "status: DNSBL-only Proofpoint/iCloud honesty label" || no "status DNSBL honesty label missing"
+grep -qi 'advisory — not blocked' "$RDATA" && ok "report: listed = advisory, not blocked" || no "report advisory wording missing"
+
+# --- RBL alerts route through central authority (both send sites) ---
+alerts=$(grep -c 'nftban_mail_alert' "$RBL")
+[[ "${alerts:-0}" -ge 2 ]] && ok "both RBL send sites route via nftban_mail_alert ($alerts)" || no "RBL send sites not routed ($alerts)"
+
+# --- no direct transport introduced in RBL (excluding comments) ---
+send_pat='(\|[[:space:]]*(sendmail|mailx|msmtp))|(\bsendmail[[:space:]]+-t\b)|(\bmail[[:space:]]+-s[[:space:]])|(--mail-rcpt)'
+if grep -nE "$send_pat" "$RBL" | grep -qvE '^[0-9]+:[[:space:]]*#'; then no "RBL introduced a direct transport send"; else ok "RBL has no direct transport send"; fi
+
+# --- compositional: RBL's routing target (nftban_mail_alert) writes A2a delivery truth under emulate ---
+DLOG="$WORK/delivery.jsonl"
+bash -c "
+export NFTBAN_DATA_DIR='$WORK/data' NFTBAN_CONFIG_DIR='$WORK/etc' NFTBAN_RUN_DIR='$WORK/run' NFTBAN_LOG_DIR='$WORK/log' NFTBAN_LIB_DIR='$REPO/cli/lib/nftban'
+mkdir -p \"\$NFTBAN_DATA_DIR\" \"\$NFTBAN_CONFIG_DIR\" \"\$NFTBAN_RUN_DIR\" \"\$NFTBAN_LOG_DIR\"
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example' NFTBAN_MAIL_DELIVERY_LOG='$DLOG'
+source '$MAIL' >/dev/null 2>&1 || true; set +e; set +o pipefail
+nftban_mail_alert '[NFTBAN LISTED] IP reputation' 'RBL advisory body' 'rcpt@test.example' >/dev/null 2>&1
+" || true
+grep -q '\"result\":\"success\"' "$DLOG" 2>/dev/null && ok "RBL alert path (nftban_mail_alert) writes delivery-log under emulate" || no "delivery-log not written by alert path"
+grep -q 'rcpt@test.example' "$DLOG" 2>/dev/null && no "recipient not redacted in delivery-log" || ok "recipient redacted in delivery-log"
+
+# --- RBL computed states remain (clean/listed/degraded) — consume-only, not extended ---
+c=0; for s in clean listed degraded; do grep -qE "_rbl_state=.?${s}" "$CMD_RBL" && c=$((c+1)); done
+[[ "$c" -ge 2 ]] && ok "RBL clean/listed/degraded states preserved ($c/3)" || no "RBL states missing ($c/3)"
+
+# --- ratchet + prior suites ---
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no "A0 guard regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh >/dev/null 2>&1 ) && ok "A2a test still passes" || no "A2a regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh >/dev/null 2>&1 ) && ok "A2b test still passes" || no "A2b regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/check-comms-direct-send.sh
+++ b/scripts/ci/check-comms-direct-send.sh
@@ -44,7 +44,7 @@ COMMS_SEND_PATTERN='(\|[[:space:]]*("?\$\{?mail_cmd\}?|(/usr/s?bin/)?(sendmail|m
 # to the central authority and REMOVED from the allowlist — a future direct send in any of
 # them now fails CI. (cmd_report.sh was already compliant and never allowlisted.)
 # -----------------------------------------------------------------------------
-ALLOWED_REGEX='^(cli/lib/nftban/core/nftban_mail\.sh|cli/lib/nftban/tests/selftest\.sh|cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test\.sh|cli/lib/nftban/tests/comms_a1_centralization_test\.sh|scripts/ci/)'
+ALLOWED_REGEX='^(cli/lib/nftban/core/nftban_mail\.sh|cli/lib/nftban/tests/selftest\.sh|cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test\.sh|cli/lib/nftban/tests/comms_a1_centralization_test\.sh|cli/lib/nftban/tests/comms_a2r_rbl_visibility_test\.sh|scripts/ci/)'
 
 # Historical A0 debt files — burndown display only (all migrated in A1; expect 0).
 DEBT_REGEX='nftban_tunnel\.sh|maintenance\.sh|cmd_update\.sh|cmd_support\.sh'


### PR DESCRIPTION
## Central-comms A2r — RBL observe-only visibility + DNSBL honesty label

### Problem
- RBL is **observe-only reputation monitoring**, not a firewall blocking path.
- Operators can misread RBL *listed* state as NFTBan blocking, or as proof of a provider-specific bounce.
- The **dns4 Proofpoint/iCloud incident** exposed the need for explicit **DNSBL-only** honesty wording.
- A2a/A2b now provide central-comms delivery truth + operator visibility, so RBL can consume that substrate safely.

### Fix
- **DNSBL-only honesty label** in `nftban rbl status`: advisory reputation monitoring · observe-only · **not firewall blocking** · *a DNSBL check cannot determine a provider-specific Proofpoint/iCloud bounce*. (Also in `rbl config`.)
- **Report wording aligned:** `"N IP(s) listed on reputation lists (advisory — not blocked)"` — removes the "IPs blacklisted!" block-implying wording.
- **Health wording:** RBL disabled message framed as advisory/not-blocking.
- **Central alert routing:** RBL listed + degraded alert paths now submit via `nftban_mail_alert` → attempts consume A2a delivery-log / last-failure / spool, and are visible via `nftban stats comms`. **No direct transport introduced; A0 guard stays 0/4.**

### Hard boundaries (RBL consumes, never extends)
No RBLMON daemon/timer · no MTA-log ingestion · no bounce ingestion · no Proofpoint/iCloud parser · no new DNSBL probes/zones · no RBL-driven ban · no nft write · no A2c/support · no A3 · no full SEC-P1-2 · no SEC-P1-3b · no Go · no schema/VERSION.

### Validation
- **A2r test 11/11**: honesty label in status · report advisory wording · both RBL send sites route via `nftban_mail_alert` · no direct transport · delivery-log written under emulate (compositional) · recipient redacted · clean/listed/degraded states preserved 3/3 · A0 guard **0/4** · A2a **18/18** · A2b **16/16**.
- shellcheck **CLEAN**.
- **lab2 DEB** package-native: `nftban rbl status` shows advisory + DNSBL honesty label · daemon active · `nftban validate` rc0 · no new failed units · no real mail · restored/pristine.
- **lab4 RPM** package-native: same — advisory + DNSBL label present · daemon active · validate rc0 · no new failed units · no real mail · restored/pristine.

### Honest implementation notes
- RBL's alert **throttle (R07)** can suppress a direct hermetic call, so delivery-truth was proven **compositionally**: RBL routes to `nftban_mail_alert`, and `nftban_mail_alert` writes the A2a delivery-log under emulate.
- The honesty label had to be placed in the actual **status path** (`nftban_rbl.sh`), not only `config` wording.
- The A2r test file is allowlisted in the no-direct-send guard **only** because it carries send-pattern literals for negative testing.

### Schema / daemon
- **shell-only · 0 Go · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes
- A2r RBL observe-only visibility · RBL advisory/report wording alignment · DNSBL-only honesty label · RBL alert consumption of central-comms delivery truth.

### Does NOT close
- A2c support-bundle comms/RBL summary · RBLMON · RBL P0 provider-bounce/Proofpoint ingestion · SEC-P1-2 · SEC-P1-3b · A3 docs/wiki/template authority.

### Scope
6 files (shell/test/report). No Go, no schema/VERSION/docs/wiki/register mutation, no RBL extension, no real mail.