### PR TITLE
feat(comms): sanitized comms + RBL observe-only summary in support bundle (A2c)

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -426,6 +426,58 @@ _collect_status() {
     _safe_cmd "$bundle_dir/status.txt" "NFTBan status" nftban status
 }
 
+# A2c: narrow, LOCAL redaction for the comms summary — SECRET_PATTERNS + comms-specific
+# fields (SMTP user, full recipient local-part). This is intentionally minimal; full
+# support-bundle redaction (SEC-P1-2) remains a separate open lane.
+_redact_comms() {
+    local t; t=$(_redact_secrets "$1")
+    t=$(printf '%s' "$t" | sed -E \
+        -e 's/([Aa]uth [Uu]ser:[[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
+        -e 's/([Ss][Mm][Tt][Pp]_?[Uu][Ss][Ee][Rr][[:space:]]*[=:][[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
+        -e 's/([Nn][Ff][Tt][Bb][Aa][Nn]_[Ss][Mm][Tt][Pp]_[Pp][Aa][Ss][Ss][[:space:]]*[=:][[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
+        -e 's/(Recipient:[[:space:]]*)[^@[:space:]]+@([^[:space:]]+)/\1[redacted]@\2/g')
+    printf '%s' "$t"
+}
+
+# A2c: sanitized central-comms + RBL observe-only summary. Reuses the existing redactor;
+# includes the A2a delivery-log tail (already recipient-redacted, secret-free) and the A2r
+# RBL honesty label. No secrets, no NFTBAN_SMTP_PASS, recipient redacted.
+_collect_communications() {
+    local bundle_dir="$1"
+    local out="$bundle_dir/communications.txt"
+    if ! command -v nftban &>/dev/null; then
+        _support_log SKIP "Communication summary (nftban not in PATH)"
+        return 0
+    fi
+    {
+        echo "=== Communication (central-comms) — sanitized ==="
+        echo "# Collected: $(date -Iseconds)"
+        echo ""
+    } > "$out"
+    _redact_comms "$(nftban mail status 2>&1 || echo '(mail status unavailable)')" >> "$out"
+    echo "" >> "$out"
+
+    echo "=== Delivery-log tail (last 50, sanitized) ===" >> "$out"
+    local dlog="${NFTBAN_MAIL_DELIVERY_LOG:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mail/delivery.jsonl}"
+    if [[ -f "$dlog" ]]; then
+        _redact_comms "$(tail -n 50 "$dlog" 2>/dev/null)" >> "$out"
+    else
+        echo "(no delivery log yet)" >> "$out"
+    fi
+    echo "" >> "$out"
+
+    {
+        echo "=== RBL (observe-only advisory reputation) ==="
+        echo "Note: RBL is advisory reputation monitoring, not firewall blocking."
+        echo "      A DNSBL check cannot determine a provider-specific Proofpoint/iCloud bounce."
+        echo ""
+    } >> "$out"
+    _redact_comms "$(nftban rbl status 2>&1 || echo '(rbl status unavailable)')" >> "$out"
+
+    _support_log OK "Communication + RBL summary (sanitized)"
+    return 0
+}
+
 _collect_update_info() {
     local bundle_dir="$1"
     local update_dir="$bundle_dir/update"
@@ -1714,6 +1766,7 @@ _cmd_support_bundle() {
     _collect_logs "$bundle_dir"
     _collect_health "$bundle_dir"
     _collect_status "$bundle_dir"
+    _collect_communications "$bundle_dir"
     _collect_daemon_status "$bundle_dir"
     _collect_recent_activity "$bundle_dir"
     _collect_update_info "$bundle_dir"

--- a/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
+++ b/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - A2c support-bundle sanitized comms/RBL summary
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_a2c_support_summary_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="A2c: _collect_communications writes a sanitized central-comms + RBL observe-only summary into the support bundle — comms section (transport/recipient/spool/last), delivery-log tail, and RBL section with the DNSBL-only honesty label. Reuses the existing redactor plus a narrow local _redact_comms: NFTBAN_SMTP_PASS / Auth User redacted, recipient local-part redacted, no secret marker. Driven with a nftban stub + fake delivery-log. Re-runs A2a/A2b/A2r. Hermetic: no real mail, no network, full SEC-P1-2 remains open."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars="NFTBAN_MAIL_DELIVERY_LOG,NFTBAN_DATA_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no_fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== A2c support-bundle comms/RBL summary ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+LEAK="LEAKMARK-not-a-real-secret-123"
+
+# nftban stub: mail status leaks a recipient + Auth User + an SMTP pass; rbl status prints state.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/nftban" <<STUB
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "mail status") printf '%s\n' "Mail System: postfix" "  Recipient: alice@example.com" "  Auth User: relayuser@relay.example" "  NFTBAN_SMTP_PASS=$LEAK" "  Spool: depth=0 oldest_age_s=0" ;;
+  "rbl status")  printf '%s\n' "RBL Monitoring Status" "  Enabled:      NO" "  Providers:    24 active" ;;
+  *) echo stub ;;
+esac
+STUB
+chmod +x "$WORK/bin/nftban"
+
+# delivery-log with an A2a-shaped line
+BDIR="$WORK/bundle"; mkdir -p "$BDIR"
+DLOG="$WORK/delivery.jsonl"
+printf '%s\n' '{"ts":"2026-07-07T00:00:00Z","transport":"emulate","recipient":"bob@…","result":"success","reason":""}' > "$DLOG"
+
+# Extract the self-containable functions (sourcing the whole CLI file has heavy load-time deps).
+FN="$WORK/fns.sh"
+{
+  awk '/^readonly -a SECRET_PATTERNS=\(/{f=1} f{print} f&&/^\)/{exit}' "$SUPPORT"
+  awk '/^_redact_secrets\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
+  awk '/^_redact_comms\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
+  awk '/^_collect_communications\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
+  echo '_support_log() { :; }'
+} > "$FN"
+grep -q '_collect_communications' "$FN" && ok "extracted _collect_communications + redactors" || no_fail "extract failed"
+
+# run _collect_communications with the stub in PATH
+bash -c "
+export PATH='$WORK/bin:'\$PATH NFTBAN_MAIL_DELIVERY_LOG='$DLOG' NFTBAN_DATA_DIR='$WORK/data'
+source '$FN' >/dev/null 2>&1 || true
+set +e; set +o pipefail
+_collect_communications '$BDIR'
+" || true
+OUT="$BDIR/communications.txt"
+
+[[ -f "$OUT" ]] && ok "communications.txt written" || no_fail "no communications.txt"
+grep -q 'Communication (central-comms)' "$OUT" 2>/dev/null && ok "comms summary section present" || no_fail "comms section missing"
+grep -q 'RBL (observe-only advisory reputation)' "$OUT" 2>/dev/null && ok "RBL summary section present" || no_fail "RBL section missing"
+grep -q 'cannot determine a provider-specific Proofpoint/iCloud bounce' "$OUT" 2>/dev/null && ok "DNSBL-only honesty label present" || no_fail "honesty label missing"
+grep -q 'not firewall blocking' "$OUT" 2>/dev/null && ok "RBL observe-only/not-blocking wording present" || no_fail "observe-only wording missing"
+grep -q 'Delivery-log tail' "$OUT" 2>/dev/null && ok "delivery-log tail included" || no_fail "delivery-log tail missing"
+grep -q '"transport":"emulate"' "$OUT" 2>/dev/null && ok "delivery-log tail content present" || no_fail "delivery-log content missing"
+# sanitization
+if grep -q "$LEAK" "$OUT" 2>/dev/null; then no_fail "SMTP secret LEAKED into bundle"; else ok "no SMTP secret in bundle"; fi
+if grep -q 'alice@example.com' "$OUT" 2>/dev/null; then no_fail "full recipient leaked"; else ok "recipient local-part redacted"; fi
+if grep -q 'relayuser@relay.example' "$OUT" 2>/dev/null; then no_fail "SMTP Auth User leaked"; else ok "SMTP Auth User redacted"; fi
+
+# ratchet + prior suites
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no_fail "A0 guard regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh >/dev/null 2>&1 ) && ok "A2a test still passes" || no_fail "A2a regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh >/dev/null 2>&1 ) && ok "A2b test still passes" || no_fail "A2b regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh >/dev/null 2>&1 ) && ok "A2r test still passes" || no_fail "A2r regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Central-comms A2c — support-bundle sanitized comms/RBL summary (final A2 slice)

### Problem
- A2a/A2b/A2r made central-comms enforced, observable, and RBL surfaced observe-only.
- The support bundle had no sanitized snapshot of comms delivery state or RBL advisory state for offline triage.

### Fix
- Add `_collect_communications()` to the support bundle, reusing the existing redactor:
  - **Comms summary:** `nftban mail status` (transport / recipient / spool depth+oldest-age / last success / last failure) + the **A2a delivery-log tail** (last 50; already recipient-redacted + secret-free).
  - **RBL summary:** `nftban rbl status` (observe-only state) + the **A2r DNSBL-only honesty label** (advisory reputation monitoring, not firewall blocking; a DNSBL check cannot determine a provider-specific Proofpoint/iCloud bounce).
  - **Redaction:** reuses `_redact_secrets`/`SECRET_PATTERNS` plus a **narrow local `_redact_comms`** that additionally strips `NFTBAN_SMTP_PASS` / SMTP `Auth User` and the recipient local-part. Intentionally minimal — **full support-bundle redaction (SEC-P1-2) remains a separate open lane.**
- No secrets, no `NFTBAN_SMTP_PASS`, recipient redacted. No RBL extension.

### Validation
- **A2c test 15/15**: comms + RBL sections · DNSBL honesty label · observe-only wording · delivery-log tail included + content · **no SMTP secret in bundle** · recipient local-part redacted · SMTP Auth User redacted · A0 guard **0/4** · A2a **18/18** · A2b **16/16** · A2r **11/11**.
- shellcheck **CLEAN** · `bash -n` clean.
- **lab2 DEB + lab4 RPM** package-native: real `nftban support` bundle generates with `communications.txt` (comms section + RBL honesty label + delivery-log tail; **no `NFTBAN_SMTP_PASS` value leaked**) · daemon active · `nftban validate` rc0 · no new failed units · no real mail · restored/pristine.

### Notes
- The hermetic test **extracts** the functions (`cmd_support.sh` has heavy load-time deps that break standalone sourcing); a `nftban` stub + planted secret proves the redaction end-to-end.

### Schema / daemon
- **shell-only · 0 Go · daemon byte-identical** · nft schema **1.84.0** · VERSION **1.217.0** · no tag · no release-prep · no fleet rollout.

### Closes
- A2c support-bundle sanitized comms/RBL summary — **the final implementation slice before the single release tag** (central-comms enforced/testable/observable + RBL advisory surfaced).

### Does NOT close
- RBLMON · RBL P0 provider-bounce/Proofpoint ingestion · SEC-P1-2 (full support-bundle redaction) · SEC-P1-3b · A3 docs/wiki/template authority.

### Scope
2 files (support + test). No Go, no schema/VERSION/docs/wiki/register mutation, no RBL extension, no real mail.