### PR TITLE
fix(health): render Communication in live health readiness output

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -563,7 +563,19 @@ nftban_health_cmd_truth() {
     # computed shell-side from the validator JSON + rc, now FW-transition-aware
     # (4th arg = fth severity code). Shell-only; daemon byte-identical; --json
     # path unaffected (returned above).
-    nftban_render_operator_readiness "$output" "" "$validator_rc" "$_fth_code"
+    # v1.218.1: evaluate the central-comms component (A2b shell check) so it surfaces as a
+    # NAMED component in this live four-axis output AND folds into the readiness verdict
+    # (5th arg, raise-only). The validator JSON does not carry comms; this is shell-side.
+    local _comms_code=0 _comms_line="" _comms_reason=""
+    if ! declare -F _health_eval_communication_component >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        [[ -r "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health_checks_modules.sh" ]] && \
+            source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health_checks_modules.sh" 2>/dev/null || true
+    fi
+    if declare -F _health_eval_communication_component >/dev/null 2>&1; then
+        _health_eval_communication_component _comms_code _comms_line _comms_reason
+    fi
+    nftban_render_operator_readiness "$output" "" "$validator_rc" "$_fth_code" "$_comms_code"
 
     echo ""
     echo "  Module       Config     Structure  Runtime    Effective"
@@ -607,6 +619,15 @@ nftban_health_cmd_truth() {
     # single-sourced and the R1b-2 operator-readiness summary can reuse it.
     # (JSON mode returns above — this is the text path only.)
     nftban_render_findings "$output" "$verbose_mode"
+
+    # v1.218.1: named Communication component line (shell A2b check; not in the validator
+    # JSON four-axis). CLEAN/WARN/ERROR/UNKNOWN + COMMUNICATION_* reason; no secrets/recipient.
+    if [[ -n "$_comms_line" ]]; then
+        echo ""
+        echo "  Communication (central-comms)"
+        echo "  ─────────────────────────────────────────"
+        printf '%s\n' "$_comms_line"
+    fi
 
     # v1.192.1 PR-B: harm-keyed firewall transition health detail (text mode
     # only; JSON returned above). v1.198.2: reuse the single fth eval computed

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -739,24 +739,22 @@ nftban_health_check_communication() {
     declare -F nftban_mail_resolve_recipient >/dev/null 2>&1 && \
         recipient="$(nftban_mail_resolve_recipient "" 2>/dev/null || echo "")"
 
-    # Alerting considered enabled if a recipient is configured OR a mail.conf exists.
-    if [[ -z "$recipient" && ! -f "$mail_conf" ]]; then
-        NFTBAN_HEALTH_RESULTS["communication"]=$HEALTH_OK
-        NFTBAN_HEALTH_ISSUES["communication"]="Communication alerting not configured (optional)"
-        return $HEALTH_OK
-    fi
-
-    if [[ -z "$recipient" ]]; then
-        issues+=("COMMUNICATION_CONFIG_MISSING_RECIPIENT: alerting configured but no recipient resolves")
-        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
-    fi
-
     local transport="none"
     declare -F nftban_mail_detect_mta >/dev/null 2>&1 && transport="$(nftban_mail_detect_mta 2>/dev/null || echo none)"
-    if [[ "$transport" == "none" ]]; then
-        issues+=("COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport")
-        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
-    fi
+
+    # v1.218.1 policy: missing comms config is only WARN when an alert PRODUCER is enabled
+    # (a path that generates outbound notifications). Otherwise it is INFO/NOT CONFIGURED —
+    # declared, never a false critical, and never fails firewall/security posture.
+    local producers=()
+    [[ -d "${NFTBAN_DATA_DIR:-/var/lib/nftban}/reports" ]] && producers+=("auto-reports")
+    local _rbl_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf"
+    [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null && producers+=("rbl-alerts")
+    [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]] && producers+=("tunnel-alerts")
+    [[ -f "$mail_conf" ]] && grep -q 'MAIL_ENABLED=true' "$mail_conf" 2>/dev/null && producers+=("mail-enabled")
+    local producer_enabled=0; [[ ${#producers[@]} -gt 0 ]] && producer_enabled=1
+
+    local comms_usable=1
+    [[ -z "$recipient" || "$transport" == "none" ]] && comms_usable=0
 
     local spool_dir="${NFTBAN_MAIL_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mailspool}"
     local depth=0 oldest_age=0
@@ -784,6 +782,24 @@ nftban_health_check_communication() {
         fi
     fi
 
+    # v1.218.1: producer-aware config/usability verdict. A degraded/backlogged delivery state
+    # (spool / last-failure, gathered above) is always WARN/ERROR. An UNUSABLE comms config is
+    # WARN only if an alert producer is enabled; if nothing needs it and there is no delivery
+    # evidence, declare INFO/NOT CONFIGURED (severity OK, but named — not silent).
+    if [[ "$comms_usable" -eq 0 ]]; then
+        local _why=""
+        [[ -z "$recipient" ]] && _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
+        [[ "$transport" == "none" ]] && _why="${_why:+$_why; }COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
+        if [[ "$producer_enabled" -eq 1 ]]; then
+            issues+=("${_why} (alert producers enabled: ${producers[*]}; notifications generated but not deliverable)")
+            [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+        elif [[ ${#issues[@]} -eq 0 ]]; then
+            NFTBAN_HEALTH_RESULTS["communication"]=$HEALTH_OK
+            NFTBAN_HEALTH_ISSUES["communication"]="NOT CONFIGURED — no outbound alert transport configured; no enabled alert producer currently requires it"
+            return $HEALTH_OK
+        fi
+    fi
+
     NFTBAN_HEALTH_RESULTS["communication"]=$status
     if [[ ${#issues[@]} -gt 0 ]]; then
         local _joined; printf -v _joined '%s; ' "${issues[@]}"; _joined="${_joined%; }"
@@ -795,7 +811,44 @@ nftban_health_check_communication() {
     return $status
 }
 
-export -f nftban_health_check_communication
+# v1.218.1: evaluate the communication component for the LIVE health render. The
+# `nftban health check` four-axis table is validator-JSON-driven and does not include
+# central-comms; this runs the A2b shell check and returns, via namerefs, a severity code
+# (0=CLEAN,1=WARN,2=ERROR) and a named "Communication: STATE (reason)" display line so the
+# check surfaces as a named operator-visible component AND can raise the readiness verdict.
+# Reason is the COMMUNICATION_* issue text (no secrets, no recipient). Shell-only.
+_health_eval_communication_component() {
+    local -n _out_code="$1" _out_line="$2" _out_reason="$3"
+    if ! declare -F nftban_health_check_communication >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        [[ -r "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health.sh" ]] && \
+            source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        [[ -r "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health_checks_modules.sh" ]] && \
+            source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_health_checks_modules.sh" 2>/dev/null || true
+    fi
+    declare -p NFTBAN_HEALTH_RESULTS >/dev/null 2>&1 || declare -gA NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES
+    declare -p NFTBAN_HEALTH_ERRORS  >/dev/null 2>&1 || declare -ga NFTBAN_HEALTH_ERRORS
+    : "${HEALTH_OK:=0}" "${HEALTH_WARNING:=1}" "${HEALTH_ERROR:=2}"
+    declare -F nftban_health_check_communication >/dev/null 2>&1 && \
+        nftban_health_check_communication >/dev/null 2>&1 || true
+    local _res="${NFTBAN_HEALTH_RESULTS[communication]:-}" _reason="${NFTBAN_HEALTH_ISSUES[communication]:-}" _state
+    case "$_res" in
+        0)   if [[ "$_reason" == *"NOT CONFIGURED"* ]]; then _state="INFO"; else _state="CLEAN"; fi ;;
+        1)   _state="WARN"  ;;
+        2|3) _state="ERROR" ;;
+        *)   _state="UNKNOWN"; _res=0 ;;
+    esac
+    _out_code="$_res"
+    _out_reason="$_reason"
+    if [[ -n "$_reason" && "$_state" != "CLEAN" ]]; then
+        _out_line=$(printf "  %-20s %s  (%s)" "Communication:" "$_state" "$_reason")
+    else
+        _out_line=$(printf "  %-20s %s" "Communication:" "$_state")
+    fi
+}
+
+export -f nftban_health_check_communication _health_eval_communication_component
 export -f nftban_health_check_modules nftban_health_check_geoip
 export -f nftban_health_check_geoban nftban_health_check_databases
 export -f nftban_health_check_rbl nftban_health_check_portscan_prefix

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1341,6 +1341,15 @@ nftban_render_operator_readiness() {
         [[ "$readiness" == "PASS" ]] && readiness="PASS_WITH_WARN"
     fi
 
+    # v1.218.1: 5th arg = communication component severity (0=CLEAN,1=WARN,2=ERROR). A degraded
+    # comms state RAISES the verdict (PASS -> PASS_WITH_WARN) — never masks an existing FAIL, and
+    # never forces FAIL (comms is advisory; A2b: offline/unconfigured mail is not a false critical).
+    local _comms_sev="${5:-}" _comms_alarm=0
+    if [[ "$_comms_sev" =~ ^[0-9]+$ ]] && (( _comms_sev >= 1 )); then
+        _comms_alarm=1
+        [[ "$readiness" == "PASS" ]] && readiness="PASS_WITH_WARN"
+    fi
+
     case "$readiness" in
         FAIL)           action="FAIL" ;;
         PASS_WITH_WARN) action="WARN" ;;
@@ -1364,6 +1373,9 @@ nftban_render_operator_readiness() {
     # emits a one-line pointer so the operator knows where the detail is.
     if [[ "$_fth_alarm" -eq 1 ]]; then
         printf "  %-20s %s\n" "" "→ firewall-transition alarm: see 'Firewall Transition' below (clear: nftban firewall rebuild)"
+    fi
+    if [[ "$_comms_alarm" -eq 1 ]]; then
+        printf "  %-20s %s\n" "" "→ communication degraded: see the Communication component below ('nftban stats comms')"
     fi
     if [[ "$action" != "NONE" && ( "$max_sev" == "warn" || "$max_sev" == "error" || "$max_sev" == "critical" ) ]]; then
         printf "  %-20s %s\n" "" "→ see the Findings section below for the actionable item(s)"

--- a/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
+++ b/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
@@ -62,12 +62,13 @@ echo \"RC=\$rc ISSUE=\${NFTBAN_HEALTH_ISSUES[communication]:-}\""; }
 # health: CLEAN when recipient + emulate transport
 r=$(hprobe "export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'")
 echo "$r" | grep -q '^RC=0 ' && ok "health CLEAN (recipient + transport)" || no "health not clean: $r"
-# health: missing recipient while alerting enabled (mail.conf present)
-r=$(hprobe "unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_METHOD=emulate; : > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"")
-echo "$r" | grep -q 'COMMUNICATION_CONFIG_MISSING_RECIPIENT' && [[ "$r" != RC=0* ]] && ok "health WARN: missing recipient" || no "missing recipient not flagged: $r"
-# health: transport unavailable while enabled
-r=$(hprobe "export NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; $NONE_BINS")
-echo "$r" | grep -q 'COMMUNICATION_TRANSPORT_UNAVAILABLE' && ok "health WARN: transport unavailable" || no "transport-unavailable not flagged: $r"
+# health: missing recipient while an ALERT PRODUCER is enabled (v1.218.1 policy → WARN).
+# (mail.conf with MAIL_ENABLED=true is a producer; without a producer this is INFO, tested in the v1.218.1 suite.)
+r=$(hprobe "unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_METHOD=emulate; printf 'MAIL_ENABLED=true\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"")
+echo "$r" | grep -q 'COMMUNICATION_CONFIG_MISSING_RECIPIENT' && [[ "$r" != RC=0* ]] && ok "health WARN: missing recipient (producer enabled)" || no "missing recipient not flagged: $r"
+# health: transport unavailable while an alert producer is enabled → WARN
+r=$(hprobe "export NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; printf 'MAIL_ENABLED=true\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"; $NONE_BINS")
+echo "$r" | grep -q 'COMMUNICATION_TRANSPORT_UNAVAILABLE' && ok "health WARN: transport unavailable (producer enabled)" || no "transport-unavailable not flagged: $r"
 # health: spool backlog
 r=$(hprobe "export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'; mkdir -p \"\$NFTBAN_DATA_DIR/mailspool\"; : > \"\$NFTBAN_DATA_DIR/mailspool/x.mail\"")
 echo "$r" | grep -q 'COMMUNICATION_SPOOL_BACKLOG' && ok "health WARN: spool backlog" || no "spool backlog not flagged: $r"

--- a/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
+++ b/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.218.1 Communication health-render patch
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_health_render_v2181_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="v1.218.1: nftban health (four-axis) now surfaces Communication as a NAMED component and its severity RAISES the readiness verdict. Tests: _health_eval_communication_component returns CLEAN/code0 on a healthy comms state and WARN/code1 with a COMMUNICATION_SPOOL_BACKLOG reason on a forced spool backlog; nftban_render_operator_readiness raises PASS->PASS_WITH_WARN on comms_sev>=1 (never forces FAIL) and emits the comms pointer; clean comms leaves PASS. Re-runs A2a/A2b/A2r/A2c + guard. Hermetic: isolated tempdir, no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,jq"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+OUTPUT="$REPO/cli/lib/nftban/core/nftban_output.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no_fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== v1.218.1 Communication health-render ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# Extract the render verdict fn + the two shell fns (files have load-time deps).
+RFN="$WORK/render.sh"; awk '/^nftban_render_operator_readiness\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$OUTPUT" > "$RFN"
+CFN="$WORK/comps.sh"
+awk '/^nftban_health_check_communication\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >  "$CFN"
+awk '/^_health_eval_communication_component\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >> "$CFN"
+grep -q 'nftban_render_operator_readiness' "$RFN" && ok "extracted render_operator_readiness" || no_fail "extract render"
+grep -q '_health_eval_communication_component' "$CFN" && ok "extracted comms eval fns" || no_fail "extract eval"
+
+CLEAN_JSON='{"status":"protected","findings":[]}'
+
+# --- verdict raise: comms_sev>=1 -> PASS_WITH_WARN + pointer; comms_sev=0 -> PASS ---
+r0=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JSON' '' 0 '' 0")
+echo "$r0" | grep -qE 'Upgrade readiness:[[:space:]]+PASS$' && ok "clean comms -> readiness PASS" || no_fail "clean comms not PASS: $(echo "$r0"|grep -i readiness)"
+r1=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JSON' '' 0 '' 1")
+echo "$r1" | grep -qE 'Upgrade readiness:[[:space:]]+PASS_WITH_WARN' && ok "comms WARN raises verdict -> PASS_WITH_WARN" || no_fail "comms WARN did not raise: $(echo "$r1"|grep -i readiness)"
+echo "$r1" | grep -q 'communication degraded' && ok "comms degraded pointer emitted" || no_fail "comms pointer missing"
+# never forces FAIL from comms (comms ERROR on an otherwise-clean run stays PASS_WITH_WARN, not FAIL)
+r2=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JSON' '' 0 '' 2")
+echo "$r2" | grep -qE 'Upgrade readiness:[[:space:]]+PASS_WITH_WARN' && ok "comms ERROR does not force FAIL (advisory)" || no_fail "comms ERROR wrongly changed verdict: $(echo "$r2"|grep -i readiness)"
+
+# --- eval component: CLEAN on healthy, WARN on forced spool backlog ---
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+export NFTBAN_MAIL_METHOD=emulate NFTBAN_MAIL_RECIPIENT='rcpt@test.example'
+source "$MAIL" >/dev/null 2>&1 || true
+source "$CFN" >/dev/null 2>&1 || true
+set +e; set +o pipefail
+EOF
+}
+ev_clean=$(bash -c "$(prelude)
+_health_eval_communication_component c l r
+echo \"CODE=\$c\"; echo \"LINE=\$l\"")
+echo "$ev_clean" | grep -q 'CODE=0' && echo "$ev_clean" | grep -qi 'Communication:.*CLEAN' && ok "eval: healthy comms -> CLEAN/code0 named line" || no_fail "eval clean wrong: $ev_clean"
+
+ev_warn=$(bash -c "$(prelude)
+mkdir -p \"\$NFTBAN_DATA_DIR/mailspool\"; : > \"\$NFTBAN_DATA_DIR/mailspool/probe.mail\"
+_health_eval_communication_component c l r
+echo \"CODE=\$c\"; echo \"LINE=\$l\"")
+echo "$ev_warn" | grep -q 'CODE=1' && echo "$ev_warn" | grep -qi 'Communication:.*WARN' && echo "$ev_warn" | grep -q 'COMMUNICATION_SPOOL_BACKLOG' && ok "eval: spool backlog -> WARN/code1 + COMMUNICATION_SPOOL_BACKLOG reason" || no_fail "eval warn wrong: $ev_warn"
+
+# v1.218.1 policy: NOT configured + NO alert producer + no evidence -> INFO (declared, not WARN)
+ev_info=$(bash -c "$(prelude)
+rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/reports\" \"\$NFTBAN_DATA_DIR/metrics\"
+unset NFTBAN_MAIL_RECIPIENT
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r
+echo \"CODE=\$c\"; echo \"LINE=\$l\"")
+echo "$ev_info" | grep -q 'CODE=0' && echo "$ev_info" | grep -qi 'Communication:.*INFO' && echo "$ev_info" | grep -q 'NOT CONFIGURED' && ok "eval: no config + no producer -> INFO/NOT CONFIGURED (code0, no verdict raise)" || no_fail "eval info wrong: $ev_info"
+
+# v1.218.1 policy: NOT configured but an alert PRODUCER is enabled -> WARN
+ev_warn_prod=$(bash -c "$(prelude)
+rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/metrics\"
+unset NFTBAN_MAIL_RECIPIENT
+mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r
+echo \"CODE=\$c\"; echo \"LINE=\$l\"")
+echo "$ev_warn_prod" | grep -q 'CODE=1' && echo "$ev_warn_prod" | grep -qi 'Communication:.*WARN' && echo "$ev_warn_prod" | grep -qE 'MISSING_RECIPIENT|TRANSPORT_UNAVAILABLE' && echo "$ev_warn_prod" | grep -q 'auto-reports' && ok "eval: not-configured + producer enabled -> WARN (names the producer)" || no_fail "eval warn-producer wrong: $ev_warn_prod"
+
+# --- prior suites unaffected ---
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4 PASS" || no_fail "A0 guard regressed"
+for t in comms_a2a_delivery_truth comms_a2b_operator_surfacing comms_a2r_rbl_visibility comms_a2c_support_summary; do
+  ( cd "$REPO" && bash "cli/lib/nftban/tests/${t}"*.sh >/dev/null 2>&1 ) && ok "${t} still passes" || no_fail "${t} regressed"
+done
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## v1.218.1 — Communication in the live `nftban health` render (producer-aware)

### Root cause
`nftban health` / `health check` render the **Go validator's four-axis truth table** (config/structural/runtime/effective) — validator-JSON-driven — and did **not** display shell optional-feature checks by name (`metrics`/`watchdog`/`communication` were all absent). The A2b communication check contributed to the shell health arrays but was **not operator-visible as a named line** in the command operators run. v1.218.0 is functionally valid, but the release story ("observable through health/status/stats") was only satisfied indirectly, so fleet rollout was held.

### Fix (shell-only, daemon byte-identical)
- New `_health_eval_communication_component`: runs the A2b check, maps it to `CLEAN/WARN/ERROR/INFO/UNKNOWN` + a named display line + severity code (reason = `COMMUNICATION_*` keys; **no secrets, no recipient**).
- `nftban_render_operator_readiness` gains a **5th arg** = comms severity: a degraded comms state **raises** the readiness verdict (`PASS → PASS_WITH_WARN`) + emits a pointer — **never masks a FAIL, never forces FAIL**. Backward-compatible (cmd_update caller unaffected).
- `cmd_health` check path: evaluate comms before the verdict (mirrors the `fth` alarm), pass the 5th arg, render a named **`Communication (central-comms)`** component after the findings.

### Severity policy (producer-aware — locked)
Missing email config is **not** automatically critical:
- **CLEAN** — alerts disabled, or recipient + usable transport, and no failure/backlog.
- **INFO / NOT CONFIGURED** — no transport configured **and no enabled alert producer requires it** (declared, not silent, no verdict raise).
- **WARN** — an alert **producer** is enabled (auto-reports, RBL, tunnel, `MAIL_ENABLED=true`) but delivery isn't configured; or spool backlog; or recent send failure.
- **ERROR** — spool oldest-age beyond threshold (existing).
- **NEVER** — never hard-fails firewall/security posture or blocks the daemon solely because email is absent; never a false CRITICAL.

The communication check already affected the verdict counts; this makes it a **named operator-visible line** and applies the producer-aware severity.

### Validation
- **v2181 test 15/15**: verdict raise (clean→PASS, WARN→PASS_WITH_WARN + pointer, ERROR→not-FAIL); eval CLEAN/code0; spool→WARN/code1 + `COMMUNICATION_SPOOL_BACKLOG`; **no config + no producer → INFO/NOT CONFIGURED (code0)**; **not-configured + producer → WARN (names the producer)**; A0 guard 0/4; A2a/A2b/A2r/A2c green (A2b test updated to the producer-aware policy).
- shellcheck **CLEAN** · `bash -n` clean · **no secret/recipient leak**.
- **lab2 DEB + lab4 RPM** (patch overlaid on official v1.218.0): `nftban health check` shows the named **Communication** component; both hosts have **auto-reports enabled → WARN `COMMUNICATION_CONFIG_MISSING_RECIPIENT`** (truthful — the dns4 scenario), naming the producer; forced spool backlog → `PASS_WITH_WARN`; `nftban status`/`stats comms`/`rbl status` remain green; support bundle unchanged; daemon active; `nftban validate` rc0; 0 new failed units.
- CLEAN and INFO paths proven hermetically (a live host with a recipient+transport shows `CLEAN`; a host with no producer shows `INFO/NOT CONFIGURED`).

### Scope / boundaries
- **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump** (v1.218.1 release-prep is a later gate).
- No broad health-architecture redesign; no RBLMON; no SEC-P1-2; no fleet rollout until v1.218.1 official packages validate.
- 5 files: `cmd_health.sh`, `nftban_health_checks_modules.sh`, `nftban_output.sh`, + 2 tests (new v2181 + A2b policy update).

Fleet is held on v1.217.0; v1.218.0 is published but not fleet-rolled. After this merges: v1.218.1 release-prep → tag/publish → lab2/lab4 official-package validation (named Communication line) → fleet.