### PR TITLE
fix(security): add shared redactor authority for support bundles

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -48,7 +48,13 @@ readonly SUPPORT_LOG_HOURS="${NFTBAN_SUPPORT_LOG_HOURS:-24}"
 # Load main config (sets readonly paths)
 source "${NFTBAN_CONFIG_DIR}/nftban.conf" 2>/dev/null || true
 
-# Patterns for secret redaction
+# SEC-P1-2 P2a: shared redaction authority (single source of truth for secret scrubbing).
+# shellcheck source=/dev/null
+[[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]] && \
+    source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
+
+# Patterns for secret redaction (LEGACY FALLBACK only — used iff the shared redactor lib
+# above is unavailable; the shared registry is the authoritative, broader set).
 readonly -a SECRET_PATTERNS=(
     's/([Aa][Pp][Ii][-_]?[Kk][Ee][Yy]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
     's/([Tt][Oo][Kk][Ee][Nn]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
@@ -84,13 +90,17 @@ _support_banner() {
 }
 
 _redact_secrets() {
-    local input="$1"
-    local output="$input"
-
+    # SEC-P1-2 P2a: delegate to the shared redaction authority (broader coverage: *_PASS,
+    # connector/pro/portal creds, Bearer, URL creds, netrc). Legacy SECRET_PATTERNS loop is
+    # kept ONLY as a fallback for when the shared lib is unavailable (coverage never weaker).
+    if declare -F nftban_redact_string >/dev/null 2>&1; then
+        nftban_redact_string "${1:-}"
+        return
+    fi
+    local output="${1:-}"
     for pattern in "${SECRET_PATTERNS[@]}"; do
         output=$(echo "$output" | sed -E "$pattern" 2>/dev/null) || true
     done
-
     echo "$output"
 }
 
@@ -430,6 +440,13 @@ _collect_status() {
 # fields (SMTP user, full recipient local-part). This is intentionally minimal; full
 # support-bundle redaction (SEC-P1-2) remains a separate open lane.
 _redact_comms() {
+    # SEC-P1-2 P2a: the shared registry now covers SMTP Auth User / *_PASS / SMTP_USER and
+    # the Recipient: local-part (A2c behaviour preserved + broadened), so delegate wholesale.
+    if declare -F nftban_redact_string >/dev/null 2>&1; then
+        nftban_redact_string "${1:-}"
+        return
+    fi
+    # Fallback (shared lib unavailable): the original A2c narrow set.
     local t; t=$(_redact_secrets "$1")
     t=$(printf '%s' "$t" | sed -E \
         -e 's/([Aa]uth [Uu]ser:[[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \

--- a/cli/lib/nftban/lib/nftban_redact.sh
+++ b/cli/lib/nftban/lib/nftban_redact.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan - Shared redaction authority (SEC-P1-2 P2a)
+# =============================================================================
+# meta:name="nftban_redact"
+# meta:type="library"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="Single source-of-truth redactor for secret material in any operator-facing output (support bundles, comms/delivery logs, forensics, future webhook/RBLMON evidence). Declarative pattern registry covers *_PASS/*_PASSWORD/*_SECRET/*_TOKEN/*_API_KEY/*_AUTH/*_LICENSE_KEY/*_SASL_PASS assignments, Bearer tokens, URL credentials (scheme://user:pass@host), netrc password/login material, SMTP Auth User, and the Recipient: local-part. Word-boundary anchored so benign keys (KAFKA_PARTITION_KEY, bypass=) survive. APIs: nftban_redact_string / nftban_redact_stream / nftban_redact_file. Coverage may only GROW — never weaken a call site when migrating to this lib."
+# meta:inventory.files=""
+# meta:inventory.binaries="sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+
+# Prevent double-loading
+[[ -n "${_NFTBAN_REDACT_LOADED:-}" ]] && return 0
+readonly _NFTBAN_REDACT_LOADED=1
+
+# -----------------------------------------------------------------------------
+# PATTERN REGISTRY — one authoritative set. Each entry is a GNU-sed -E program.
+# The `I` (case-insensitive) flag is used where key names vary in case.
+# Design rules:
+#   * KEY=VALUE / KEY: VALUE — the KEY must END in a sensitive segment AND start
+#     at a token boundary (^|[^A-Za-z0-9_]) so `bypass=` and `KAFKA_PARTITION_KEY=`
+#     do NOT match (bare KEY is intentionally excluded; only API_KEY/APIKEY/
+#     LICENSE_KEY qualify).
+#   * The opening quote (if any) is preserved; the VALUE becomes [REDACTED].
+#   * URL creds redact the password only, keeping scheme://user@host readable.
+#   * Recipient redaction is context-anchored to a "Recipient:" label (won't
+#     touch arbitrary operational emails elsewhere).
+# -----------------------------------------------------------------------------
+# shellcheck disable=SC2016  # single-quoted sed programs are intentional
+readonly -a NFTBAN_REDACT_PATTERNS=(
+    # sensitive KEY = VALUE (token-anchored; key ends in a sensitive segment)
+    's/(^|[^A-Za-z0-9_])([A-Za-z0-9_]*(PASSWORD|PASS|SECRET|TOKEN|API_?KEY|APIKEY|AUTH|LICENSE_KEY|SASL_PASSWORD|SASL_PASS))([[:space:]]*[=:][[:space:]]*["'"'"']?)[^"'"'"'[:space:],]*/\1\2\4[REDACTED]/Ig'
+    # Bearer <token>
+    's/(Bearer[[:space:]]+)[A-Za-z0-9._~+/=-]+/\1[REDACTED]/Ig'
+    # URL credentials: scheme://user:PASS@host  ->  scheme://user:[REDACTED]@host
+    's|(://[^/:@[:space:]]+:)[^/@[:space:]]+@|\1[REDACTED]@|g'
+    # netrc: "password <x>" and "login <x>"
+    's/(\bpassword[[:space:]]+)[^[:space:]]+/\1[REDACTED]/Ig'
+    's/(\blogin[[:space:]]+)[^[:space:]]+/\1[REDACTED]/Ig'
+    # SMTP "Auth User: <x>"
+    's/(Auth User:[[:space:]]*)[^[:space:]]+/\1[REDACTED]/Ig'
+    # Recipient: local@domain  ->  [redacted]@domain (context-anchored)
+    's/(Recipient:[[:space:]]*)[^@[:space:]]+@([^[:space:]]+)/\1[redacted]@\2/g'
+)
+
+# Precompute the sed -e argument list once.
+_NFTBAN_REDACT_SED_ARGS=()
+for _p in "${NFTBAN_REDACT_PATTERNS[@]}"; do _NFTBAN_REDACT_SED_ARGS+=(-e "$_p"); done
+unset _p
+
+# nftban_redact_stream — stdin -> stdout, fully redacted. Idempotent.
+nftban_redact_stream() {
+    sed -E "${_NFTBAN_REDACT_SED_ARGS[@]}" 2>/dev/null || cat
+}
+
+# nftban_redact_string "<text>" — echo the redacted text (no trailing newline forced
+# beyond sed's own). Value never appears in a child process argv beyond this call.
+nftban_redact_string() {
+    printf '%s' "${1:-}" | nftban_redact_stream
+}
+
+# nftban_redact_file <src> <dst> — redact a file to dst (no-op if src missing).
+nftban_redact_file() {
+    local src="${1:-}" dst="${2:-}"
+    [[ -f "$src" && -n "$dst" ]] || return 0
+    nftban_redact_stream < "$src" > "$dst"
+}
+
+export -f nftban_redact_stream nftban_redact_string nftban_redact_file 2>/dev/null || true

--- a/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - SEC-P1-2 P2a shared redactor no-leak matrix
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_redact_p2a_noleak_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="SEC-P1-2 P2a: the shared redactor (lib/nftban_redact.sh) scrubs every sensitive field class — *_PASS / *_PASSWORD / *_SECRET / *_TOKEN / *_API_KEY / *_AUTH / *_LICENSE_KEY / *_SASL_PASS, Bearer tokens, URL credentials, netrc password+login, SMTP Auth User, Recipient local-part — across string and file (support-bundle) surfaces; benign keys (KAFKA_PARTITION_KEY, bypass=, RBL_ENABLED) survive; redaction is idempotent. Confirms cmd_support delegates its redactors to the shared authority. Re-runs A2a/A2c/v2181 + guard. Uses non-secret LEAKMARK markers; no real secrets."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+LIB="$REPO/cli/lib/nftban/lib/nftban_redact.sh"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== SEC-P1-2 P2a shared redactor no-leak matrix ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+M="LEAKMARK"   # non-secret marker; MUST NOT survive in redacted output
+
+# redact via the shared lib in a clean subshell
+red() { bash -c "source '$LIB' >/dev/null 2>&1 || exit 3; nftban_redact_string \"\$1\"" _ "$1"; }
+
+# --- field-class × string surface ---
+declare -A CASES=(
+  ["SMTP *_PASS"]="NFTBAN_SMTP_PASS=${M}-smtp"
+  ["connector SASL_PASS"]="NFTBAN_CONNECTOR_KAFKA_SASL_PASS=${M}-kafka"
+  ["connector WEBHOOK_TOKEN"]="NFTBAN_CONNECTOR_WEBHOOK_TOKEN='${M}-wh'"
+  ["connector ES_API_KEY"]="NFTBAN_CONNECTOR_ES_API_KEY=\"${M}-es\""
+  ["PRO_TOKEN"]="NFTBAN_PRO_TOKEN=${M}-pro"
+  ["PORTAL_API_KEY"]="NFTBAN_PORTAL_API_KEY=${M}-portal"
+  ["GEOIP_LICENSE_KEY"]="NFTBAN_GEOIP_LICENSE_KEY=${M}-geoip"
+  ["METRICS token"]="NFTBAN_METRICS_REMOTE_WRITE_TOKEN=${M}-metrics"
+  ["generic PASSWORD"]="password: ${M}-pw"
+  ["generic SECRET"]="CONNECTOR_WEBHOOK_SECRET=${M}-hmac"
+  ["Bearer token"]="Authorization: Bearer ${M}abc123.def"
+  ["URL credentials"]="url=https://user:${M}urlpw@example.com/path"
+  ["netrc password"]="machine h login u password ${M}-netrc"
+  ["SMTP Auth User"]="Auth User: ${M}user@relay.example"
+)
+for name in "${!CASES[@]}"; do
+  out=$(red "${CASES[$name]}")
+  if printf '%s' "$out" | grep -q "$M"; then no "$name → LEAK ($out)"; else ok "$name redacted"; fi
+done
+# recipient local-part (context-anchored)
+out=$(red "  Recipient: alice@example.com")
+echo "$out" | grep -q '\[redacted\]@example.com' && ! echo "$out" | grep -q 'alice@example.com' && ok "Recipient local-part redacted (domain kept)" || no "recipient: $out"
+
+# --- benign survival (must NOT be redacted) ---
+for b in "NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-abc" "bypass_count=5" "NFTBAN_RBL_ENABLED=YES" "admin_user_id=42"; do
+  out=$(red "$b"); v="${b#*=}"
+  echo "$out" | grep -q "$v" && ok "benign survives: $b" || no "over-redacted benign: $b → $out"
+done
+
+# --- idempotency ---
+in="NFTBAN_SMTP_PASS=${M}-x https://u:${M}p@h Bearer ${M}tok"
+r1=$(red "$in"); r2=$(red "$r1")
+[[ "$r1" == "$r2" ]] && ! printf '%s' "$r1" | grep -q "$M" && ok "idempotent + no marker after 2 passes" || no "idempotency: $r1 // $r2"
+
+# --- file / support-bundle surface: a collected .conf with all secret families ---
+FIX="$WORK/connector.conf"; OUTF="$WORK/connector.redacted"
+cat > "$FIX" <<CONF
+NFTBAN_SMTP_PASS="${M}-smtp"
+NFTBAN_CONNECTOR_KAFKA_SASL_PASS=${M}-kafka
+NFTBAN_CONNECTOR_WEBHOOK_TOKEN='${M}-wh'
+NFTBAN_CONNECTOR_ES_API_KEY=${M}-es
+NFTBAN_PRO_TOKEN=${M}-pro
+NFTBAN_GEOIP_LICENSE_KEY=${M}-geoip
+NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-keep
+NFTBAN_RBL_ENABLED=YES
+CONF
+bash -c "source '$LIB' >/dev/null 2>&1; nftban_redact_file '$FIX' '$OUTF'"
+if grep -q "$M" "$OUTF" 2>/dev/null; then no "file redaction LEAKED: $(grep "$M" "$OUTF"|head -1)"; else ok "file redaction: no secret marker in output"; fi
+grep -q 'part-keep' "$OUTF" 2>/dev/null && grep -q 'NFTBAN_RBL_ENABLED=YES' "$OUTF" 2>/dev/null && ok "file redaction: benign fields survive" || no "file redaction dropped benign fields"
+
+# --- cmd_support delegates to the shared authority ---
+grep -q 'source .*nftban_redact.sh' "$SUPPORT" && ok "cmd_support sources the shared redactor" || no "cmd_support does not source shared redactor"
+grep -q 'declare -F nftban_redact_string' "$SUPPORT" && ok "_redact_secrets/_redact_comms delegate to shared" || no "no delegation in cmd_support"
+
+# --- regressions ---
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2c_support_summary_test.sh >/dev/null 2>&1 ) && ok "A2c support test still passes" || no "A2c regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh >/dev/null 2>&1 ) && ok "A2a delivery-log test still passes" || no "A2a regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_health_render_v2181_test.sh >/dev/null 2>&1 ) && ok "v2181 health-render test still passes" || no "v2181 regressed"
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## SEC-P1-2 P2a — shared redaction authority + support-bundle rewire

### Problem
Redaction was fragmented across multiple implementations, and the support-bundle path used a **keyword-based** redactor that missed fields like `*_PASS`. Because `_collect_configs` collects **all** `conf.d/*.conf`, SMTP/connector secrets such as `NFTBAN_SMTP_PASS` or `NFTBAN_CONNECTOR_KAFKA_SASL_PASS` **could leak into support bundles**.

### Fix
- **Shared redaction authority:** `cli/lib/nftban/lib/nftban_redact.sh` — one declarative pattern registry, the single source of truth.
- **APIs:** `nftban_redact_string` · `nftban_redact_stream` · `nftban_redact_file`.
- **Covers:** `*_PASS` · `*_PASSWORD` · `*_SECRET` · `*_TOKEN` · `*_API_KEY`/`*_APIKEY` · `*_AUTH` · `*_LICENSE_KEY` · `*_SASL_PASS`/`*_SASL_PASSWORD` · Bearer tokens · URL credentials (`scheme://user:pass@host`) · netrc login/password · SMTP Auth User · Recipient local-part. **Word-boundary anchored** so benign keys (`KAFKA_PARTITION_KEY`, `bypass=`, `RBL_ENABLED`) survive (bare `KEY` intentionally excluded).
- **Support-bundle rewire:** `_redact_secrets` / `_redact_comms` / `_redact_file` delegate to the shared authority; legacy `SECRET_PATTERNS` kept **only as a fallback** so coverage never shrinks.

### Validation
- **P2a no-leak test 28/28**: 14 secret field-classes redacted · recipient local-part redacted · **benign fields survive** (`KAFKA_PARTITION_KEY`, `bypass=`, `RBL_ENABLED`, `admin_user_id`) · idempotency PASS · file/support-bundle surface clean · `cmd_support` delegates to shared redactor · A2a/A2c/v2181 green · A0 guard **0/4**.
- shellcheck **CLEAN** · `bash -n` clean.
- **lab2 DEB** real support bundle with a planted secret `.conf`: **0 leaks**, benign survives, `[REDACTED]` active, daemon active, `nftban validate` rc0, 0 new failed units, restored.
- **lab4 RPM** real support bundle with a planted secret `.conf`: **0 leaks**, benign survives, daemon active, validate rc0, 0 new failed units, restored.

### Closes (this PR)
- P2a shared redactor lib · declarative pattern registry · no-leak harness · support-bundle rewire · the highest-risk support-bundle config-secret leak.

### Does NOT close (P2b + later)
- P2b: `_fx_redact` (update forensics) · mail delivery-log secret-scrub · connector echo · report-path migration · retirement of duplicate redactors beyond the support wrappers. Also out: webhook transport · RBLMON · ADR/A3 docs · telemetry/exporter/Zabbix refactor · generic event router.

### Scope / rules
3 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no connector runtime change · no release-prep/tag/fleet.**