### PR TITLE
fix(security): migrate remaining secret-bearing outputs to shared redactor

### DIFF
--- a/cli/lib/nftban/cli/cmd_connector.sh
+++ b/cli/lib/nftban/cli/cmd_connector.sh
@@ -571,7 +571,19 @@ _cmd_connector_show() {
     local config_file
     config_file=$(_connector_config_path "$name")
 
-    grep -v "^#" "$config_file" | grep -v "^$"
+    # SEC-P1-2 P2b-1: this printed the RAW connector config — including WEBHOOK_TOKEN/SECRET/
+    # PASS/API_KEY. Route the display through the shared redactor so credentials are masked
+    # (non-secret fields — URL/index/brokers/type — remain visible). Display-only; runtime
+    # unchanged. Falls back to the raw grep only if the shared redactor lib is unavailable.
+    if ! declare -F nftban_redact_stream >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
+    fi
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then
+        grep -v "^#" "$config_file" | grep -v "^$" | nftban_redact_stream
+    else
+        grep -v "^#" "$config_file" | grep -v "^$"
+    fi
     echo ""
 }
 

--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -349,6 +349,14 @@ _collect_configs() {
     fi
 }
 
+# SEC-P1-2 P2b-1: scrub SECRET material (credentials/tokens/keys/Bearer/netrc/URL creds)
+# from a stream. Attacker IPs and usernames are deliberately NOT touched here — they are
+# forensic evidence (identifier-privacy is a separate opt-in mode, P2b-2). Degrades to `cat`
+# if the shared redactor lib is unavailable.
+_support_scrub_stream() {
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then nftban_redact_stream; else cat; fi
+}
+
 _collect_logs() {
     local bundle_dir="$1"
     local log_dir="$bundle_dir/logs"
@@ -357,33 +365,33 @@ _collect_logs() {
     local since_time
     since_time=$(date -d "$SUPPORT_LOG_HOURS hours ago" '+%Y-%m-%d %H:%M' 2>/dev/null || date '+%Y-%m-%d %H:%M')
 
-    # journalctl logs for nftban
+    # journalctl logs for nftban (secret-scrubbed; attacker IPs/usernames preserved)
     if command -v journalctl &>/dev/null; then
         journalctl -u nftban -u nftban-webapi -u nftban-feeds \
-            --since "$since_time" --no-pager \
-            > "$log_dir/journalctl-nftban.txt" 2>&1 || true
-        _support_log OK "Systemd journal logs (last ${SUPPORT_LOG_HOURS}h)"
+            --since "$since_time" --no-pager 2>&1 \
+            | _support_scrub_stream > "$log_dir/journalctl-nftban.txt" || true
+        _support_log OK "Systemd journal logs (last ${SUPPORT_LOG_HOURS}h, secrets redacted)"
     fi
 
-    # File-based logs
+    # File-based logs (secret-scrubbed; identifiers preserved)
     if [[ -d "$NFTBAN_LOG_DIR" ]]; then
         local log_count=0
         while IFS= read -r -d '' log_file; do
             local basename
             basename=$(basename "$log_file")
             # Only get last 500 lines to keep bundle size reasonable
-            tail -500 "$log_file" > "$log_dir/$basename" 2>/dev/null || true
+            tail -500 "$log_file" 2>/dev/null | _support_scrub_stream > "$log_dir/$basename" || true
             log_count=$((log_count + 1))
         done < <(find "$NFTBAN_LOG_DIR" -maxdepth 1 -name "*.log" -type f -print0 2>/dev/null)
 
         if [[ $log_count -gt 0 ]]; then
-            _support_log OK "Log files ($log_count files, last 500 lines each)"
+            _support_log OK "Log files ($log_count files, last 500 lines each, secrets redacted)"
         fi
     fi
 
-    # Update log specifically
+    # Update log specifically (secret-scrubbed)
     if [[ -f "$NFTBAN_LOG_DIR/update.log" ]]; then
-        cp "$NFTBAN_LOG_DIR/update.log" "$log_dir/update.log" 2>/dev/null || true
+        _support_scrub_stream < "$NFTBAN_LOG_DIR/update.log" > "$log_dir/update.log" 2>/dev/null || true
     fi
 
     # v1.199: per-run lifecycle forensic records (update-runs/<run_id>/). Collect

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -473,7 +473,19 @@ _forensic_run_id() { printf '%s' "${NFTBAN_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ 2>/
 # minimal JSON string escaper (no jq dependency)
 _fx_jstr() { local s="${1-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/ }"; s="${s//$'\t'/ }"; s="${s//$'\r'/ }"; printf '%s' "$s"; }
 # secret redaction safety-net (the snapshot is allowlisted, but values pass this too)
-_fx_redact() { sed -E 's/(pass(word)?|secret|token|api[_-]?key|bearer|authorization)([=: ]+)[^ ",]*/\1\3<redacted>/Ig'; }
+_fx_redact() {
+    # SEC-P1-2 P2b-1: delegate to the shared redaction authority (broader coverage: *_PASS,
+    # connector/pro/portal creds, URL creds, netrc). Legacy sed is a fallback only.
+    if ! declare -F nftban_redact_stream >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
+    fi
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then
+        nftban_redact_stream
+    else
+        sed -E 's/(pass(word)?|secret|token|api[_-]?key|bearer|authorization)([=: ]+)[^ ",]*/\1\3<redacted>/Ig'
+    fi
+}
 
 # _forensic_begin <run_id> <mode> <from> <to>
 _forensic_begin() {

--- a/cli/lib/nftban/lib/nftban_redact.sh
+++ b/cli/lib/nftban/lib/nftban_redact.sh
@@ -8,7 +8,7 @@
 # meta:version="1.0.0"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 # meta:created_date="2026-07-07"
-# meta:description="Single source-of-truth redactor for secret material in any operator-facing output (support bundles, comms/delivery logs, forensics, future webhook/RBLMON evidence). Declarative pattern registry covers *_PASS/*_PASSWORD/*_SECRET/*_TOKEN/*_API_KEY/*_AUTH/*_LICENSE_KEY/*_SASL_PASS assignments, Bearer tokens, URL credentials (scheme://user:pass@host), netrc password/login material, SMTP Auth User, and the Recipient: local-part. Word-boundary anchored so benign keys (KAFKA_PARTITION_KEY, bypass=) survive. APIs: nftban_redact_string / nftban_redact_stream / nftban_redact_file. Coverage may only GROW — never weaken a call site when migrating to this lib."
+# meta:description="Single source-of-truth redactor for secret material in any operator-facing output (support bundles, comms/delivery logs, forensics, future webhook/RBLMON evidence). Declarative pattern registry covers *_PASS/*_PASSWORD/*_SECRET/*_TOKEN/*_API_KEY/*_AUTH/*_LICENSE_KEY/*_SASL_PASS assignments, Bearer tokens, URL credentials (scheme://user:pass@host), netrc password material, SMTP Auth User, and the Recipient: local-part. The sensitive key-suffix must be the whole key or a _-delimited segment so benign keys (KAFKA_PARTITION_KEY, bypass=, surpass=) survive; forensic identifiers (attacker IPs, usernames) are never redacted. APIs: nftban_redact_string / nftban_redact_stream / nftban_redact_file. Coverage may only GROW — never weaken a call site when migrating to this lib."
 # meta:inventory.files=""
 # meta:inventory.binaries="sed"
 # meta:inventory.env_vars=""
@@ -28,10 +28,11 @@ readonly _NFTBAN_REDACT_LOADED=1
 # PATTERN REGISTRY — one authoritative set. Each entry is a GNU-sed -E program.
 # The `I` (case-insensitive) flag is used where key names vary in case.
 # Design rules:
-#   * KEY=VALUE / KEY: VALUE — the KEY must END in a sensitive segment AND start
-#     at a token boundary (^|[^A-Za-z0-9_]) so `bypass=` and `KAFKA_PARTITION_KEY=`
-#     do NOT match (bare KEY is intentionally excluded; only API_KEY/APIKEY/
-#     LICENSE_KEY qualify).
+#   * KEY=VALUE / KEY: VALUE — the sensitive word must be the WHOLE key or a
+#     `_`-delimited segment of it (prefix, if any, ends in `_`) AND start at a
+#     token boundary (^|[^A-Za-z0-9_]). So `bypass=`/`surpass=` (…ends in "pass"
+#     but not a `_`-segment) and `KAFKA_PARTITION_KEY=` (bare KEY excluded; only
+#     API_KEY/APIKEY/LICENSE_KEY qualify) do NOT match, while `SMTP_PASS=` does.
 #   * The opening quote (if any) is preserved; the VALUE becomes [REDACTED].
 #   * URL creds redact the password only, keeping scheme://user@host readable.
 #   * Recipient redaction is context-anchored to a "Recipient:" label (won't
@@ -39,15 +40,17 @@ readonly _NFTBAN_REDACT_LOADED=1
 # -----------------------------------------------------------------------------
 # shellcheck disable=SC2016  # single-quoted sed programs are intentional
 readonly -a NFTBAN_REDACT_PATTERNS=(
-    # sensitive KEY = VALUE (token-anchored; key ends in a sensitive segment)
-    's/(^|[^A-Za-z0-9_])([A-Za-z0-9_]*(PASSWORD|PASS|SECRET|TOKEN|API_?KEY|APIKEY|AUTH|LICENSE_KEY|SASL_PASSWORD|SASL_PASS))([[:space:]]*[=:][[:space:]]*["'"'"']?)[^"'"'"'[:space:],]*/\1\2\4[REDACTED]/Ig'
+    # sensitive KEY = VALUE (token-anchored; sensitive word = whole key or a _-delimited segment)
+    's/(^|[^A-Za-z0-9_])([A-Za-z0-9_]*_)?(PASSWORD|PASS|SECRET|TOKEN|API_?KEY|APIKEY|AUTH|LICENSE_KEY|SASL_PASSWORD|SASL_PASS)([[:space:]]*[=:][[:space:]]*["'"'"']?)[^"'"'"'[:space:],]*/\1\2\3\4[REDACTED]/Ig'
     # Bearer <token>
     's/(Bearer[[:space:]]+)[A-Za-z0-9._~+/=-]+/\1[REDACTED]/Ig'
     # URL credentials: scheme://user:PASS@host  ->  scheme://user:[REDACTED]@host
     's|(://[^/:@[:space:]]+:)[^/@[:space:]]+@|\1[REDACTED]@|g'
-    # netrc: "password <x>" and "login <x>"
+    # netrc/keyword: "password <x>" — the netrc secret. (SEC-P1-2 P2b-1: the netrc
+    # "login <x>" pattern is intentionally NOT included — in free-text journals "login"
+    # is followed by a USERNAME [forensic evidence, must survive] or filler text, so
+    # redacting it would destroy identifiers. netrc passwords remain covered here.)
     's/(\bpassword[[:space:]]+)[^[:space:]]+/\1[REDACTED]/Ig'
-    's/(\blogin[[:space:]]+)[^[:space:]]+/\1[REDACTED]/Ig'
     # SMTP "Auth User: <x>"
     's/(Auth User:[[:space:]]*)[^[:space:]]+/\1[REDACTED]/Ig'
     # Recipient: local@domain  ->  [redacted]@domain (context-anchored)

--- a/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
@@ -63,7 +63,7 @@ out=$(red "  Recipient: alice@example.com")
 echo "$out" | grep -q '\[redacted\]@example.com' && ! echo "$out" | grep -q 'alice@example.com' && ok "Recipient local-part redacted (domain kept)" || no "recipient: $out"
 
 # --- benign survival (must NOT be redacted) ---
-for b in "NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-abc" "bypass_count=5" "NFTBAN_RBL_ENABLED=YES" "admin_user_id=42"; do
+for b in "NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-abc" "bypass_count=5" "bypass=5" "surpass=1" "NFTBAN_RBL_ENABLED=YES" "admin_user_id=42"; do
   out=$(red "$b"); v="${b#*=}"
   echo "$out" | grep -q "$v" && ok "benign survives: $b" || no "over-redacted benign: $b → $out"
 done

--- a/cli/lib/nftban/tests/comms_redact_p2b1_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_p2b1_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - SEC-P1-2 P2b-1 remaining secret-coverage (forensics/journal/connector)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_redact_p2b1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="SEC-P1-2 P2b-1: update-forensics _fx_redact delegates to the shared redactor; support-bundle journal/logs are secret-scrubbed; nftban connector show masks credentials. CRITICAL forensic invariant: attacker IPs and usernames SURVIVE by default (identifier-privacy is a separate opt-in mode, P2b-2) while secret values do NOT. Also asserts the netrc 'login <user>' pattern was removed so journal usernames survive. Re-runs P2a/A2c/v2181 + guard. Non-secret LEAKMARK markers; no real secrets."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,sed,awk"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+LIB="$REPO/cli/lib/nftban/lib/nftban_redact.sh"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+CONNECTOR="$REPO/cli/lib/nftban/cli/cmd_connector.sh"
+UPD="$REPO/cli/lib/nftban/cli/cmd_update_helpers.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== SEC-P1-2 P2b-1 remaining secret-coverage ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+M="LEAKMARK"
+red() { bash -c "source '$LIB' >/dev/null 2>&1; nftban_redact_string \"\$1\"" _ "$1"; }
+
+# --- CRITICAL: journal/log surface — secrets scrubbed, IPs + usernames SURVIVE ---
+# Built with printf so every line-break is a REAL newline (sed redacts per line).
+JLINES=$(printf '%s\n' \
+  "2026-07-07 [BAN] banned 203.0.113.45 reason=bruteforce user=attacker99" \
+  "NFTBAN_SMTP_PASS=${M}-jrnl" \
+  "password ${M}-netrc" \
+  "LoginMon: failed login for admin from 198.51.100.7" \
+  "sshd: Accepted publickey for root from 2001:db8::1234" \
+  "Authorization: Bearer ${M}tok.abc")
+jr=$(red "$JLINES")
+printf '%s' "$jr" | grep -q "$M" && no "journal: secret LEAKED" || ok "journal: all secrets scrubbed"
+echo "$jr" | grep -q '203.0.113.45' && ok "journal: attacker IPv4 SURVIVES (forensic)" || no "IPv4 lost: $jr"
+echo "$jr" | grep -q '198.51.100.7'  && echo "$jr" | grep -q '2001:db8::1234' && ok "journal: more IPv4/IPv6 survive" || no "IP lost"
+echo "$jr" | grep -q 'user=attacker99' && ok "journal: username (user=attacker99) SURVIVES" || no "username lost: $jr"
+echo "$jr" | grep -q 'login for admin' && ok "journal: 'login <user>' username SURVIVES (netrc login pattern removed)" || no "login-username lost: $jr"
+echo "$jr" | grep -q 'for root from' && ok "journal: 'root' identifier survives" || no "root lost"
+
+# --- update forensics _fx_redact delegates to shared (functional + wiring) ---
+FX="$WORK/fx.sh"; awk '/^_fx_redact\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$UPD" > "$FX"
+fo=$(bash -c "export NFTBAN_LIB_DIR='$REPO/cli/lib/nftban'; source '$FX' >/dev/null 2>&1; printf '%s\n' 'NFTBAN_CONNECTOR_KAFKA_SASL_PASS=${M}-fx bypass=5' | _fx_redact")
+printf '%s' "$fo" | grep -q "$M" && no "_fx_redact leaked *_PASS" || ok "_fx_redact scrubs *_PASS (shared coverage)"
+echo "$fo" | grep -q 'bypass=5' && ok "_fx_redact: benign survives" || no "_fx_redact over-redacted"
+grep -q 'nftban_redact_stream' "$UPD" && ok "_fx_redact delegates to shared authority" || no "_fx_redact not delegated"
+
+# --- connector show masks credentials, keeps non-secret fields ---
+CONF="$WORK/es.conf"; printf '%s\n' "# comment" "CONNECTOR_TYPE=webhook" "NFTBAN_CONNECTOR_WEBHOOK_TOKEN=${M}-wh" "CONNECTOR_WEBHOOK_SECRET=${M}-hmac" "CONNECTOR_ES_URL=https://es.example:9200" > "$CONF"
+co=$(bash -c "source '$LIB' >/dev/null 2>&1; grep -v '^#' '$CONF' | grep -v '^\$' | nftban_redact_stream")
+printf '%s' "$co" | grep -q "$M" && no "connector show LEAKED credential" || ok "connector show: credentials masked"
+echo "$co" | grep -q 'CONNECTOR_ES_URL=https://es.example:9200' && echo "$co" | grep -q 'CONNECTOR_TYPE=webhook' && ok "connector show: non-secret fields (URL/type) survive" || no "connector show dropped non-secret fields"
+grep -q 'nftban_redact_stream' "$CONNECTOR" && ok "connector show wired to shared redactor" || no "connector show not wired"
+
+# --- support-bundle log wiring ---
+grep -q '_support_scrub_stream' "$SUPPORT" && grep -q 'journalctl .* | _support_scrub_stream\|_support_scrub_stream > ' "$SUPPORT" && ok "_collect_logs scrubs journal/logs (identifiers untouched)" || no "_collect_logs not wired"
+
+# --- idempotency ---
+r1=$(red "$JLINES"); r2=$(red "$r1")
+[[ "$r1" == "$r2" ]] && ok "idempotent" || no "not idempotent"
+
+# --- regressions (coverage never shrinks) ---
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh >/dev/null 2>&1 ) && ok "P2a no-leak still passes" || no "P2a regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2c_support_summary_test.sh >/dev/null 2>&1 ) && ok "A2c support still passes" || no "A2c regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_health_render_v2181_test.sh >/dev/null 2>&1 ) && ok "v2181 still passes" || no "v2181 regressed"
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## SEC-P1-2 P2b-1 — migrate remaining secret-bearing outputs to the shared redactor

### Purpose
P2b-1 completes the **safe** remaining SEC-P1-2 secret-coverage after P2a by migrating remaining secret-bearing output paths to the shared redaction authority (`lib/nftban_redact.sh`), **without changing journal identifier/privacy policy** (attacker IPs and usernames remain forensic evidence, kept by default).

### Changes
1. **Update forensics:** `_fx_redact` now delegates to shared `nftban_redact.sh` (broader coverage incl. `*_PASS`/connector/pro creds). Legacy sed retained only as a safety fallback.
2. **Support-bundle logs:** `_collect_logs` journal / `*.log` / `update.log` surfaces now **secret-scrub** through a shared support stream (`_support_scrub_stream`). Credentials/tokens/API keys/passwords/Bearer/URL creds are scrubbed; **attacker IPs and usernames remain visible by default** for forensic value. Identifier privacy is explicitly deferred to **P2b-2**.
3. **Connector diagnostics:** `nftban connector show` previously printed the **raw** connector config (`WEBHOOK_TOKEN`/`SECRET`/`PASS`/`API_KEY`) to the terminal — now routed through the shared redactor (secret values masked, non-secret fields like URL/type preserved). **Connector runtime unchanged; telemetry/Zabbix plane boundary unchanged.**

### Shared-redactor hardening (found during P2b-1)
- **Removed** the netrc `login <x>` pattern — in free-text journals "login" is followed by a **USERNAME** (forensic, must survive) or filler, so it would destroy identifiers. netrc **password** redaction retained.
- **Sensitive key-suffix must be the whole key or a `_`-delimited segment** — so benign keys such as `bypass=` / `surpass=` (end in "pass" but not a segment) are no longer false-redacted.

### Validation
- **P2b-1 test 18/18**: journal secrets scrubbed · **attacker IPs survive by default** · **usernames survive by default** · `_fx_redact` coverage · connector-show coverage · benign survival · idempotency · **P2a green · A2c green · v2181 green · A0 guard 0/4**.
- shellcheck **clean**.
- **lab2 DEB** planted-log: **0 secret leaks**, IP/user preserved, connector show masked, daemon active, `nftban validate` rc0, 0 new failed units.
- **lab4 RPM** planted-log: **0 secret leaks**, IP/user preserved, connector show masked, daemon active, `nftban validate` rc0, 0 new failed units.
- labs restored to official v1.218.1.

### Does NOT close
P2b-2 journal identifier-privacy mode · `nftban support --privacy` · IP hashing/truncation/redaction · username redaction by default · duplicate-wrapper retirement (separately gated) · webhook transport · RBLMON · ADR/A3 · telemetry/exporter/Zabbix refactor · generic event router.

### Scope / rules
6 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no mail delivery-log migration · no report-path migration · no privacy-mode implementation · no release-prep/tag/fleet.**