### PR TITLE
feat(comms): add remediation guidance for new-user communication setup

### DIFF
--- a/cli/lib/nftban/cli/cmd_stats.sh
+++ b/cli/lib/nftban/cli/cmd_stats.sh
@@ -106,8 +106,41 @@ nftban_stats_cmd_comms() {
     # A2b: central-comms counters from A2a-produced mail.prom (read-only; no new source).
     local prom="${NFTBAN_MAIL_METRICS_FILE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/metrics/mail.prom}"
     echo "Communication (central-comms) counters:"
+
+    # New-user remediation UX: always show recipient/transport state so the no-metrics path is
+    # not a dead end. Resolve via the central authority (no recipient VALUE is printed). Each
+    # resolution runs in an ISOLATED subshell so sourcing the mail lib (which enables
+    # `set -Eeuo pipefail`) cannot contaminate this function's shell or leak a non-zero exit.
+    local _mail_lib="${NFTBAN_LIB_DIR:-/usr/lib/nftban}/core/nftban_mail.sh"
+    local _recipient _transport
+    _recipient=$(
+        set +e +o pipefail
+        declare -F nftban_mail_resolve_recipient >/dev/null 2>&1 || \
+            { [[ -r "$_mail_lib" ]] && { # shellcheck source=/dev/null
+                source "$_mail_lib" >/dev/null 2>&1; }; }
+        set +e +o pipefail
+        declare -F nftban_mail_resolve_recipient >/dev/null 2>&1 && nftban_mail_resolve_recipient "" 2>/dev/null || true
+    )
+    _transport=$(
+        set +e +o pipefail
+        declare -F nftban_mail_detect_mta >/dev/null 2>&1 || \
+            { [[ -r "$_mail_lib" ]] && { # shellcheck source=/dev/null
+                source "$_mail_lib" >/dev/null 2>&1; }; }
+        set +e +o pipefail
+        declare -F nftban_mail_detect_mta >/dev/null 2>&1 && nftban_mail_detect_mta 2>/dev/null || true
+    )
+    [[ -z "$_transport" ]] && _transport="none"
+    if [[ -n "$_recipient" ]]; then
+        echo "  Recipient: configured"
+    else
+        echo "  Recipient: not configured"
+        echo "  Fix:       nftban mail setup <your-email>"
+        echo "  Verify:    nftban mail test   then   nftban health"
+    fi
+    echo "  Transport: ${_transport}"
+
     if [[ ! -f "$prom" ]]; then
-        echo "  (no mail metrics yet — ${prom} not found)"
+        echo "  (no delivery metrics yet — ${prom} not found; counters appear after the first send attempt)"
         return 0
     fi
     local m

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -746,7 +746,23 @@ nftban_health_check_communication() {
     # (a path that generates outbound notifications). Otherwise it is INFO/NOT CONFIGURED —
     # declared, never a false critical, and never fails firewall/security posture.
     local producers=()
-    [[ -d "${NFTBAN_DATA_DIR:-/var/lib/nftban}/reports" ]] && producers+=("auto-reports")
+    # auto-reports counts as an EMAIL producer only when reports are actually configured to be
+    # EMAILED — NOT merely written to disk. The default scheduled report service ExecStart is
+    # disk-only (`nftban report run <freq>`, no --email), so the reports directory or an enabled
+    # timer alone must NOT create a false Communication WARN. Signal: an explicit report email
+    # recipient, or a report timer whose service ExecStart carries --email.
+    local _reports_email=0
+    [[ -n "${NFTBAN_MAIL_REPORT_RECIPIENT:-}" ]] && _reports_email=1
+    if [[ "$_reports_email" -eq 0 ]] && command -v systemctl >/dev/null 2>&1; then
+        local _rt
+        for _rt in daily weekly monthly; do
+            systemctl is-enabled "nftban-report-${_rt}.timer" >/dev/null 2>&1 || continue
+            if systemctl cat "nftban-report-${_rt}.service" 2>/dev/null | grep -qE '^ExecStart=.*--email'; then
+                _reports_email=1; break
+            fi
+        done
+    fi
+    [[ "$_reports_email" -eq 1 ]] && producers+=("auto-reports")
     local _rbl_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf"
     [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null && producers+=("rbl-alerts")
     [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]] && producers+=("tunnel-alerts")
@@ -846,6 +862,30 @@ _health_eval_communication_component() {
     else
         _out_line=$(printf "  %-20s %s" "Communication:" "$_state")
     fi
+    # New-user remediation UX: every WARN/ERROR must give an immediate fix + verify path; an
+    # INFO state (no producer needs email) states an explicit no-action-required outcome. Wording
+    # only — no recipient/secret is ever printed.
+    local _rl
+    case "$_state" in
+        WARN|ERROR)
+            if [[ "$_reason" == *"MISSING_RECIPIENT"* || "$_reason" == *"TRANSPORT_UNAVAILABLE"* ]]; then
+                _rl=$(printf "  %-20s %s" "" "Impact: alert notifications are generated but cannot be delivered.")
+                _out_line+=$'\n'"$_rl"
+                _rl=$(printf "  %-20s %s" "" "Fix:    nftban mail setup <your-email>")
+                _out_line+=$'\n'"$_rl"
+                _rl=$(printf "  %-20s %s" "" "Verify: nftban mail test   then   nftban health")
+                _out_line+=$'\n'"$_rl"
+                if [[ "$_reason" == *"TRANSPORT_UNAVAILABLE"* ]]; then
+                    _rl=$(printf "  %-20s %s" "" "Note:   no local mail transport — 'mail setup' can use SMTP (curl); no local MTA required.")
+                    _out_line+=$'\n'"$_rl"
+                fi
+            fi
+            ;;
+        INFO)
+            _rl=$(printf "  %-20s %s" "" "(no action required — no enabled alert producer needs email delivery)")
+            _out_line+=$'\n'"$_rl"
+            ;;
+    esac
 }
 
 export -f nftban_health_check_communication _health_eval_communication_component

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -1375,7 +1375,7 @@ nftban_render_operator_readiness() {
         printf "  %-20s %s\n" "" "→ firewall-transition alarm: see 'Firewall Transition' below (clear: nftban firewall rebuild)"
     fi
     if [[ "$_comms_alarm" -eq 1 ]]; then
-        printf "  %-20s %s\n" "" "→ communication degraded: see the Communication component below ('nftban stats comms')"
+        printf "  %-20s %s\n" "" "→ communication needs setup: see the Communication component below (fix: nftban mail setup <email>)"
     fi
     if [[ "$action" != "NONE" && ( "$max_sev" == "warn" || "$max_sev" == "error" || "$max_sev" == "critical" ) ]]; then
         printf "  %-20s %s\n" "" "→ see the Findings section below for the actionable item(s)"

--- a/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
+++ b/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
@@ -97,7 +97,7 @@ c=0; for m in nftban_mail_send_success_total nftban_mail_send_failures_total nft
 [[ "$c" -eq 6 ]] && ok "stats comms shows all 6 counters" || no "stats comms only $c/6 counters"
 # stats comms: graceful when mail.prom missing
 sm=$(bash -c "source '$SFN'; NFTBAN_MAIL_METRICS_FILE='$WORK/nope.prom' nftban_stats_cmd_comms 2>/dev/null")
-echo "$sm" | grep -q 'no mail metrics yet' && ok "stats comms graceful on missing mail.prom" || no "stats comms not graceful: $sm"
+echo "$sm" | grep -qE 'no (mail|delivery) metrics yet' && ok "stats comms graceful on missing mail.prom" || no "stats comms not graceful: $sm"
 
 # render: communication surfaces in the OPTIONAL FEATURES terminal render (live path via
 # cmd_health_core.sh) when a result is set.

--- a/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
+++ b/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
@@ -49,7 +49,7 @@ r0=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JS
 echo "$r0" | grep -qE 'Upgrade readiness:[[:space:]]+PASS$' && ok "clean comms -> readiness PASS" || no_fail "clean comms not PASS: $(echo "$r0"|grep -i readiness)"
 r1=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JSON' '' 0 '' 1")
 echo "$r1" | grep -qE 'Upgrade readiness:[[:space:]]+PASS_WITH_WARN' && ok "comms WARN raises verdict -> PASS_WITH_WARN" || no_fail "comms WARN did not raise: $(echo "$r1"|grep -i readiness)"
-echo "$r1" | grep -q 'communication degraded' && ok "comms degraded pointer emitted" || no_fail "comms pointer missing"
+echo "$r1" | grep -qE 'communication (degraded|needs setup)' && ok "comms pointer emitted" || no_fail "comms pointer missing"
 # never forces FAIL from comms (comms ERROR on an otherwise-clean run stays PASS_WITH_WARN, not FAIL)
 r2=$(bash -c "source '$RFN'; set +e; nftban_render_operator_readiness '$CLEAN_JSON' '' 0 '' 2")
 echo "$r2" | grep -qE 'Upgrade readiness:[[:space:]]+PASS_WITH_WARN' && ok "comms ERROR does not force FAIL (advisory)" || no_fail "comms ERROR wrongly changed verdict: $(echo "$r2"|grep -i readiness)"
@@ -87,15 +87,30 @@ _health_eval_communication_component c l r
 echo \"CODE=\$c\"; echo \"LINE=\$l\"")
 echo "$ev_info" | grep -q 'CODE=0' && echo "$ev_info" | grep -qi 'Communication:.*INFO' && echo "$ev_info" | grep -q 'NOT CONFIGURED' && ok "eval: no config + no producer -> INFO/NOT CONFIGURED (code0, no verdict raise)" || no_fail "eval info wrong: $ev_info"
 
-# v1.218.1 policy: NOT configured but an alert PRODUCER is enabled -> WARN
+# v1.218.1 policy: NOT configured but an alert PRODUCER is enabled -> WARN.
+# UX slice: auto-reports is a producer only when configured for EMAIL delivery
+# (NFTBAN_MAIL_REPORT_RECIPIENT set), NOT merely because the reports dir exists.
 ev_warn_prod=$(bash -c "$(prelude)
 rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/metrics\"
 unset NFTBAN_MAIL_RECIPIENT
-mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+export NFTBAN_MAIL_REPORT_RECIPIENT='reports@test.example'
 nftban_mail_detect_mta() { echo none; }
 _health_eval_communication_component c l r
 echo \"CODE=\$c\"; echo \"LINE=\$l\"")
 echo "$ev_warn_prod" | grep -q 'CODE=1' && echo "$ev_warn_prod" | grep -qi 'Communication:.*WARN' && echo "$ev_warn_prod" | grep -qE 'MISSING_RECIPIENT|TRANSPORT_UNAVAILABLE' && echo "$ev_warn_prod" | grep -q 'auto-reports' && ok "eval: not-configured + producer enabled -> WARN (names the producer)" || no_fail "eval warn-producer wrong: $ev_warn_prod"
+# UX slice: the WARN must carry an actionable Fix/Verify remediation
+echo "$ev_warn_prod" | grep -q 'nftban mail setup' && echo "$ev_warn_prod" | grep -q 'Verify: nftban mail test' && ok "eval: WARN carries Fix/Verify remediation" || no_fail "no remediation in WARN: $ev_warn_prod"
+
+# UX slice: DISK-ONLY reports (reports dir exists, NO email config) must NOT WARN -> INFO
+ev_disk=$(bash -c "$(prelude)
+rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/metrics\"
+unset NFTBAN_MAIL_RECIPIENT NFTBAN_MAIL_REPORT_RECIPIENT
+mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+systemctl() { return 1; }   # no report-email timer
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r
+echo \"CODE=\$c\"; echo \"LINE=\$l\"")
+echo "$ev_disk" | grep -q 'CODE=0' && echo "$ev_disk" | grep -qi 'Communication:.*INFO' && echo "$ev_disk" | grep -q 'no action required' && ok "eval: disk-only reports -> INFO/no-action (no false WARN)" || no_fail "disk-only reports wrongly WARNed: $ev_disk"
 
 # --- prior suites unaffected ---
 out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )

--- a/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
+++ b/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Central-comms new-user remediation UX
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_new_user_remediation_ux_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="Central-comms new-user remediation UX: every Communication WARN/ERROR in nftban health renders an actionable Fix (nftban mail setup <email>) + Verify path; the no-local-MTA case adds the SMTP note; an INFO state (no producer) states an explicit no-action-required outcome. The auto-reports producer heuristic no longer fires on a disk-only reports directory (only when report email delivery is configured). nftban stats comms no-metrics path shows recipient/transport state + remediation instead of a dead end, and keeps counters when mail.prom exists. The readiness pointer points to the fix. Hermetic: isolated tempdir, no real mail, no network."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_MAIL_RECIPIENT,NFTBAN_MAIL_REPORT_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+STATS="$REPO/cli/lib/nftban/cli/cmd_stats.sh"
+OUTPUT="$REPO/cli/lib/nftban/core/nftban_output.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== central-comms new-user remediation UX ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+CFN="$WORK/comps.sh"
+awk '/^nftban_health_check_communication\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >  "$CFN"
+awk '/^_health_eval_communication_component\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >> "$CFN"
+SFN="$WORK/stats.sh"; awk '/^nftban_stats_cmd_comms\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$STATS" > "$SFN"
+
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR/conf.d" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+source "$MAIL" >/dev/null 2>&1 || true
+source "$CFN" >/dev/null 2>&1 || true
+systemctl() { return 1; }   # no report-email timer in the hermetic env
+set +e; set +o pipefail
+EOF
+}
+
+# 1. missing recipient + local MTA present (transport ok) -> WARN + Fix/Verify, NO no-MTA note
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'MISSING_RECIPIENT' && echo "$r" | grep -q 'Fix:    nftban mail setup' && echo "$r" | grep -q 'Verify: nftban mail test' && ok "missing recipient + local MTA -> WARN with Fix/Verify" || no "case1: $r"
+echo "$r" | grep -q 'no local mail transport' && no "case1 wrongly showed no-MTA note (MTA present)" || ok "missing recipient + MTA present -> no spurious no-MTA note"
+
+# 2. missing recipient + NO transport -> WARN + no-MTA SMTP note
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r; printf '%s\n' \"\$l\"")
+echo "$r" | grep -qE 'MISSING_RECIPIENT|TRANSPORT_UNAVAILABLE' && echo "$r" | grep -q 'nftban mail setup' && echo "$r" | grep -q 'no local mail transport' && ok "missing recipient + no transport -> WARN with no-MTA SMTP note" || no "case2: $r"
+
+# 3. disk-only reports (dir exists, NO email config) -> INFO/no-action (NO false WARN)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT NFTBAN_MAIL_REPORT_RECIPIENT
+mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=0' && echo "$r" | grep -qi 'INFO' && echo "$r" | grep -q 'no action required' && ok "disk-only reports -> INFO/no-action (false-positive WARN removed)" || no "case3: $r"
+
+# 4. real email producer (REPORT_RECIPIENT) + missing recipient -> WARN (names auto-reports)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'auto-reports' && ok "report email configured -> WARN names auto-reports producer" || no "case4: $r"
+
+# 5. CLEAN comms -> no remediation noise
+r=$(bash -c "$(prelude)
+export NFTBAN_MAIL_RECIPIENT='ok@test.example'
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'mail setup' && ok "CLEAN comms -> no remediation noise" || no "case5: $r"
+
+# 6. stats comms: no-metrics path shows recipient state + remediation (not a dead end)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT
+source \"$SFN\" >/dev/null 2>&1 || true
+nftban_mail_detect_mta() { echo none; }
+nftban_stats_cmd_comms")
+echo "$r" | grep -q 'Recipient: not configured' && echo "$r" | grep -q 'nftban mail setup' && echo "$r" | grep -q 'no delivery metrics yet' && ok "stats comms no-metrics -> recipient state + remediation" || no "case6: $r"
+
+# 7. stats comms: metrics present -> counters preserved + recipient state
+r=$(bash -c "$(prelude)
+export NFTBAN_MAIL_RECIPIENT='ok@test.example'
+mkdir -p \"\$NFTBAN_DATA_DIR/metrics\"
+printf 'nftban_mail_send_success_total 5\n' > \"\$NFTBAN_DATA_DIR/metrics/mail.prom\"
+source \"$SFN\" >/dev/null 2>&1 || true
+nftban_mail_detect_mta() { echo sendmail; }
+nftban_stats_cmd_comms")
+echo "$r" | grep -q 'Recipient: configured' && echo "$r" | grep -q 'nftban_mail_send_success_total 5' && ok "stats comms with metrics -> recipient state + counters preserved" || no "case7: $r"
+
+# 8. readiness pointer points to the fix command (not just 'nftban stats comms')
+RFN="$WORK/render.sh"; awk '/^nftban_render_operator_readiness\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$OUTPUT" > "$RFN"
+r=$(bash -c "source '$RFN' >/dev/null 2>&1; set +e +o pipefail
+nftban_render_operator_readiness '{\"status\":\"protected\",\"findings\":[]}' '' 0 0 1 2>&1")
+echo "$r" | grep -q 'nftban mail setup' && ok "readiness pointer -> nftban mail setup" || no "case8: $r"
+
+# --- regressions ---
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_health_render_v2181_test.sh >/dev/null 2>&1 ) && ok "v2181 still passes" || no "v2181 regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh >/dev/null 2>&1 ) && ok "A2b still passes" || no "A2b regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2c_support_summary_test.sh >/dev/null 2>&1 ) && ok "A2c still passes" || no "A2c regressed"
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/docs/operator/NOTIFICATIONS_SETUP.md
+++ b/docs/operator/NOTIFICATIONS_SETUP.md
@@ -1,0 +1,75 @@
+# Notifications setup (email alerts)
+
+As of v1.218.1, `nftban health` reports a named **Communication (central-comms)** component. This
+page explains the one warning a first-time operator is most likely to see there and how to resolve
+it.
+
+## Why the warning appears
+
+`nftban health` may show:
+
+```
+  Communication:       WARN  (COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves ...)
+                       Impact: alert notifications are generated but cannot be delivered.
+                       Fix:    nftban mail setup <your-email>
+                       Verify: nftban mail test   then   nftban health
+```
+
+This means an alert producer is enabled (for example email-delivered scheduled reports, RBL
+reputation alerts, tunnel alerts, or `MAIL_ENABLED=true`) but **no recipient address resolves**, so
+NFTBan has nowhere to send the notifications it generates.
+
+The warning never fails firewall or security posture — bans and rules are unaffected. It only
+reports that outbound notifications cannot be delivered.
+
+## One-command setup
+
+```
+nftban mail setup you@example.com
+```
+
+This writes the recipient to `mail.conf.local` (your durable override). Add `--all` to route all
+alert categories to that address, and `--test` to send a test message as part of setup:
+
+```
+nftban mail setup you@example.com --all --test
+```
+
+To review the current mail configuration without changing it:
+
+```
+nftban mail setup --show
+```
+
+## Verification
+
+```
+nftban mail test      # attempt a delivery and report the outcome
+nftban health         # the Communication component should now read CLEAN
+```
+
+## No local mail server?
+
+A local MTA (Postfix/Exim/Sendmail) is **not required**. If `nftban health` adds:
+
+```
+                       Note:   no local mail transport — 'mail setup' can use SMTP (curl); no local MTA required.
+```
+
+then configure an SMTP relay in `mail.conf.local` (host, port, credentials). NFTBan sends over SMTP
+directly with `curl`; no mail daemon needs to run on the host.
+
+## Disk-only reports — no action required
+
+If you generate reports only to disk (the default scheduled report writes to
+`<data>/reports` and does **not** email), the Communication component reports:
+
+```
+  Communication:       INFO  (NOT CONFIGURED — no outbound alert transport configured; ...)
+                       (no action required — no enabled alert producer needs email delivery)
+```
+
+This is the expected state when nothing is configured to send email. No recipient is needed, and no
+setup is required. A report becomes an email producer only when it is configured for email delivery
+(an explicit report recipient, or a report timer whose service runs with `--email`) — generating
+reports to disk alone does not.


### PR DESCRIPTION
## Central-comms new-user remediation UX

### Purpose
Improve first-operator remediation UX for central communications after v1.218.1. The system already renders a named **Communication (central-comms)** health component; this patch makes its **WARN/ERROR actionable** and removes a **false WARN** for disk-only report setups. It does not reopen the closed central-comms A2 architecture — it improves operator guidance on top of the shipped, fleet-live v1.218.1 baseline.

### Changes
1. **`nftban health`** — Communication WARN/ERROR now shows **Impact**, **`Fix: nftban mail setup <email>`**, **`Verify: nftban mail test` then `nftban health`**; adds a **daemonless note** when no local transport exists (*no local MTA required; SMTP via curl is supported*). **INFO** explicitly states *no action required*.
2. **`nftban stats comms`** — the no-metrics path is no longer a dead end: prints **Recipient** (configured / not configured), **Transport**, and the **Fix/Verify** remediation when the recipient is missing; **counters preserved** when `mail.prom` exists. Mail-lib resolution is **isolated in subshells** to avoid `set -e` / `pipefail` contamination of the caller.
3. **Readiness pointer** points to the remediation action, not only `nftban stats comms`.
4. **Producer detection fix** — auto-reports count as an email producer **only when configured for email delivery** (an explicit report recipient, or a report timer whose service ExecStart includes `--email`). The shipped scheduled report is **disk-only**, so disk-only scheduled reports no longer create a Communication WARN; disk-only hosts correctly render **INFO / no action**.
5. **Docs** — `docs/operator/NOTIFICATIONS_SETUP.md` (why the warning appears, one-command setup, verification, the no-MTA case, the disk-only no-action case). States the **daemonless/curl-SMTP** option; does **not** imply Postfix/Exim/Sendmail are required.

### Validation
- **New UX test 13/13**: WARN Fix/Verify **with** local transport, WARN Fix/Verify **without** local MTA, **disk-only reports → INFO / no action**, real email producer → WARN, `stats comms` no-metrics path (recipient/transport/remediation), `stats comms` metrics path preserved, readiness pointer.
- Full comms suite green: **v2181 17/17 · A2b 16/16 · A2c 15/15 · A2r 11/11 · A2a 18/18** · **A0 guard 0/4** · shellcheck **clean**. (v2181/A2b assertions updated for the improved wording.)
- **lab2 DEB** overlay: WARN renders Fix/Verify, `stats comms` remediation visible, disk-only host INFO, daemon active, `nftban validate` rc0, 0 new failed units, no real mail.
- **lab4 RPM** overlay: same matrix PASS.

### Does NOT close
SEC-P1-2 P2b-2 privacy mode · `nftban support --privacy` · webhook transport · RBLMON · RBL P0 · ADR/A3 docs · telemetry/Zabbix/exporter · generic event router.

### Scope / rules
7 files, **shell/docs-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no real mail in tests · no fleet mutation · no release-prep · no reopen of the central-comms A2 closure · no change to firewall/security posture semantics.** Note: this changes fleet health *output* (disk-only hosts: WARN→INFO) — advisory only, never affects firewall/security posture.