### PR TITLE
fix(comms): key report producer detection on STATS_EMAIL_ENABLED

### DIFF
--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -746,31 +746,56 @@ nftban_health_check_communication() {
     # (a path that generates outbound notifications). Otherwise it is INFO/NOT CONFIGURED —
     # declared, never a false critical, and never fails firewall/security posture.
     local producers=()
-    # auto-reports counts as an EMAIL producer only when reports are actually configured to be
-    # EMAILED — NOT merely written to disk. The default scheduled report service ExecStart is
-    # disk-only (`nftban report run <freq>`, no --email), so the reports directory or an enabled
-    # timer alone must NOT create a false Communication WARN. Signal: an explicit report email
-    # recipient, or a report timer whose service ExecStart carries --email.
-    local _reports_email=0
-    [[ -n "${NFTBAN_MAIL_REPORT_RECIPIENT:-}" ]] && _reports_email=1
-    if [[ "$_reports_email" -eq 0 ]] && command -v systemctl >/dev/null 2>&1; then
-        local _rt
-        for _rt in daily weekly monthly; do
-            systemctl is-enabled "nftban-report-${_rt}.timer" >/dev/null 2>&1 || continue
-            if systemctl cat "nftban-report-${_rt}.service" 2>/dev/null | grep -qE '^ExecStart=.*--email'; then
-                _reports_email=1; break
-            fi
-        done
+    # auto-reports is an EMAIL producer only when scheduled reports are actually configured to be
+    # EMAILED. The canonical signal is STATS_EMAIL_ENABLED truthy (conf.d/stats.conf, or the
+    # environment) — that is exactly what the default `nftban report run` timer checks before
+    # emailing (cmd_report.sh:984, with NO --email flag), and STATS_EMAIL_RECIPIENTS is the report's
+    # own recipient. Disk-only reports (STATS_EMAIL_ENABLED false/unset) never produce a
+    # Communication WARN. (Supersedes the v1.218.2 NFTBAN_MAIL_REPORT_RECIPIENT / timer-`--email`
+    # gate, which keyed on signals the scheduled report path does not use — NFTBAN_MAIL_REPORT_RECIPIENT
+    # is only a fallback for the on-demand `module/fhs/port` report emails, not a standing producer.)
+    local _stats_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/stats.conf" _stats_email_on=0 _report_rcpt=""
+    if [[ -f "$_stats_conf" ]]; then
+        grep -qiE '^[[:space:]]*STATS_EMAIL_ENABLED="?(yes|true|1|on)"?[[:space:]]*$' "$_stats_conf" 2>/dev/null && _stats_email_on=1
+        _report_rcpt=$(grep -E '^[[:space:]]*STATS_EMAIL_RECIPIENTS=' "$_stats_conf" 2>/dev/null | head -n1 \
+            | sed -E 's/^[[:space:]]*STATS_EMAIL_RECIPIENTS=//; s/^"//; s/"$//')
     fi
-    [[ "$_reports_email" -eq 1 ]] && producers+=("auto-reports")
+    local _se="${STATS_EMAIL_ENABLED:-}"; [[ "${_se,,}" =~ ^(yes|true|1|on)$ ]] && _stats_email_on=1
+    [[ -n "${STATS_EMAIL_RECIPIENTS:-}" ]] && _report_rcpt="${STATS_EMAIL_RECIPIENTS}"
+    [[ "$_stats_email_on" -eq 1 ]] && producers+=("auto-reports")
+    local _general_producer=0
     local _rbl_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf"
-    [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null && producers+=("rbl-alerts")
-    [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]] && producers+=("tunnel-alerts")
-    [[ -f "$mail_conf" ]] && grep -q 'MAIL_ENABLED=true' "$mail_conf" 2>/dev/null && producers+=("mail-enabled")
+    [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null && { producers+=("rbl-alerts"); _general_producer=1; }
+    [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]] && { producers+=("tunnel-alerts"); _general_producer=1; }
+    [[ -f "$mail_conf" ]] && grep -q 'MAIL_ENABLED=true' "$mail_conf" 2>/dev/null && { producers+=("mail-enabled"); _general_producer=1; }
     local producer_enabled=0; [[ ${#producers[@]} -gt 0 ]] && producer_enabled=1
 
-    local comms_usable=1
-    [[ -z "$recipient" || "$transport" == "none" ]] && comms_usable=0
+    # Per-producer deliverability — a producer WARNs when IT SPECIFICALLY cannot deliver, judged by
+    # its OWN recipient. Scheduled reports (auto-reports) deliver ONLY to STATS_EMAIL_RECIPIENTS
+    # (cmd_report.sh:984 has no general fallback), so a general recipient does not make reports
+    # deliverable, and a stray STATS_EMAIL_RECIPIENTS does not make the general producers deliverable.
+    # General producers (rbl/tunnel/mail) deliver via nftban_mail_resolve_recipient = NFTBAN_MAIL_RECIPIENT.
+    local _undeliverable=0 _why=""
+    if [[ "$_stats_email_on" -eq 1 ]]; then
+        if [[ -z "$_report_rcpt" ]]; then
+            # Design choice B: email reports enabled but no report recipient is a MISCONFIGURATION
+            # (nothing sends — cmd_report.sh:984 never fires without STATS_EMAIL_RECIPIENTS), NOT a
+            # delivery failure. Word it so, regardless of any general recipient.
+            _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: email reports enabled but no recipient configured"
+        elif [[ "$transport" == "none" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
+        fi
+    fi
+    if [[ "$_undeliverable" -eq 0 && "$_general_producer" -eq 1 ]]; then
+        if [[ -z "$recipient" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
+        elif [[ "$transport" == "none" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
+        fi
+    fi
+    # Is the general comms path configured at all? (drives the INFO/NOT-CONFIGURED terminal.)
+    local _config_unusable=0
+    [[ -z "$recipient" || "$transport" == "none" ]] && _config_unusable=1
 
     local spool_dir="${NFTBAN_MAIL_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/mailspool}"
     local depth=0 oldest_age=0
@@ -798,22 +823,17 @@ nftban_health_check_communication() {
         fi
     fi
 
-    # v1.218.1: producer-aware config/usability verdict. A degraded/backlogged delivery state
-    # (spool / last-failure, gathered above) is always WARN/ERROR. An UNUSABLE comms config is
-    # WARN only if an alert producer is enabled; if nothing needs it and there is no delivery
-    # evidence, declare INFO/NOT CONFIGURED (severity OK, but named — not silent).
-    if [[ "$comms_usable" -eq 0 ]]; then
-        local _why=""
-        [[ -z "$recipient" ]] && _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
-        [[ "$transport" == "none" ]] && _why="${_why:+$_why; }COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
-        if [[ "$producer_enabled" -eq 1 ]]; then
-            issues+=("${_why} (alert producers enabled: ${producers[*]}; notifications generated but not deliverable)")
-            [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
-        elif [[ ${#issues[@]} -eq 0 ]]; then
-            NFTBAN_HEALTH_RESULTS["communication"]=$HEALTH_OK
-            NFTBAN_HEALTH_ISSUES["communication"]="NOT CONFIGURED — no outbound alert transport configured; no enabled alert producer currently requires it"
-            return $HEALTH_OK
-        fi
+    # Producer-aware verdict. A degraded/backlogged delivery state (spool / last-failure, gathered
+    # above) is always WARN/ERROR. Any enabled producer that cannot deliver (reason computed above)
+    # is WARN. If nothing needs email and the general comms path is not configured — and there is no
+    # other delivery evidence — declare INFO/NOT CONFIGURED (severity OK, but named — not silent).
+    if [[ "$_undeliverable" -eq 1 ]]; then
+        issues+=("${_why} (alert producers enabled: ${producers[*]})")
+        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+    elif [[ "$producer_enabled" -eq 0 && "$_config_unusable" -eq 1 && ${#issues[@]} -eq 0 ]]; then
+        NFTBAN_HEALTH_RESULTS["communication"]=$HEALTH_OK
+        NFTBAN_HEALTH_ISSUES["communication"]="NOT CONFIGURED — no outbound alert transport configured; no enabled alert producer currently requires it"
+        return $HEALTH_OK
     fi
 
     NFTBAN_HEALTH_RESULTS["communication"]=$status

--- a/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
+++ b/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
@@ -89,11 +89,11 @@ echo "$ev_info" | grep -q 'CODE=0' && echo "$ev_info" | grep -qi 'Communication:
 
 # v1.218.1 policy: NOT configured but an alert PRODUCER is enabled -> WARN.
 # UX slice: auto-reports is a producer only when configured for EMAIL delivery
-# (NFTBAN_MAIL_REPORT_RECIPIENT set), NOT merely because the reports dir exists.
+# (STATS_EMAIL_ENABLED=true — the real scheduled-report email signal), NOT the reports dir or NFTBAN_MAIL_REPORT_RECIPIENT.
 ev_warn_prod=$(bash -c "$(prelude)
 rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/metrics\"
 unset NFTBAN_MAIL_RECIPIENT
-export NFTBAN_MAIL_REPORT_RECIPIENT='reports@test.example'
+export STATS_EMAIL_ENABLED=true; unset STATS_EMAIL_RECIPIENTS
 nftban_mail_detect_mta() { echo none; }
 _health_eval_communication_component c l r
 echo \"CODE=\$c\"; echo \"LINE=\$l\"")
@@ -104,7 +104,7 @@ echo "$ev_warn_prod" | grep -q 'nftban mail setup' && echo "$ev_warn_prod" | gre
 # UX slice: DISK-ONLY reports (reports dir exists, NO email config) must NOT WARN -> INFO
 ev_disk=$(bash -c "$(prelude)
 rm -rf \"\$NFTBAN_DATA_DIR/mailspool\" \"\$NFTBAN_DATA_DIR/metrics\"
-unset NFTBAN_MAIL_RECIPIENT NFTBAN_MAIL_REPORT_RECIPIENT
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS
 mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
 systemctl() { return 1; }   # no report-email timer
 nftban_mail_detect_mta() { echo none; }

--- a/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
+++ b/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
@@ -11,7 +11,7 @@
 # meta:description="Central-comms new-user remediation UX: every Communication WARN/ERROR in nftban health renders an actionable Fix (nftban mail setup <email>) + Verify path; the no-local-MTA case adds the SMTP note; an INFO state (no producer) states an explicit no-action-required outcome. The auto-reports producer heuristic no longer fires on a disk-only reports directory (only when report email delivery is configured). nftban stats comms no-metrics path shows recipient/transport state + remediation instead of a dead end, and keeps counters when mail.prom exists. The readiness pointer points to the fix. Hermetic: isolated tempdir, no real mail, no network."
 # meta:inventory.files=""
 # meta:inventory.binaries="bash,grep,awk"
-# meta:inventory.env_vars="NFTBAN_MAIL_RECIPIENT,NFTBAN_MAIL_REPORT_RECIPIENT"
+# meta:inventory.env_vars="NFTBAN_MAIL_RECIPIENT,STATS_EMAIL_ENABLED,STATS_EMAIL_RECIPIENTS"
 # meta:inventory.config_files=""
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
@@ -55,30 +55,30 @@ EOF
 
 # 1. missing recipient + local MTA present (transport ok) -> WARN + Fix/Verify, NO no-MTA note
 r=$(bash -c "$(prelude)
-unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_RECIPIENTS; export STATS_EMAIL_ENABLED=true
 nftban_mail_detect_mta() { echo sendmail; }
 _health_eval_communication_component c l r; printf '%s\n' \"\$l\"")
 echo "$r" | grep -q 'MISSING_RECIPIENT' && echo "$r" | grep -q 'Fix:    nftban mail setup' && echo "$r" | grep -q 'Verify: nftban mail test' && ok "missing recipient + local MTA -> WARN with Fix/Verify" || no "case1: $r"
 echo "$r" | grep -q 'no local mail transport' && no "case1 wrongly showed no-MTA note (MTA present)" || ok "missing recipient + MTA present -> no spurious no-MTA note"
 
-# 2. missing recipient + NO transport -> WARN + no-MTA SMTP note
+# 2. producer WITH a recipient but NO transport -> WARN TRANSPORT_UNAVAILABLE + no-MTA SMTP note
 r=$(bash -c "$(prelude)
-unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+unset NFTBAN_MAIL_RECIPIENT; export STATS_EMAIL_ENABLED=true STATS_EMAIL_RECIPIENTS='r@test.example'
 nftban_mail_detect_mta() { echo none; }
 _health_eval_communication_component c l r; printf '%s\n' \"\$l\"")
-echo "$r" | grep -qE 'MISSING_RECIPIENT|TRANSPORT_UNAVAILABLE' && echo "$r" | grep -q 'nftban mail setup' && echo "$r" | grep -q 'no local mail transport' && ok "missing recipient + no transport -> WARN with no-MTA SMTP note" || no "case2: $r"
+echo "$r" | grep -q 'TRANSPORT_UNAVAILABLE' && echo "$r" | grep -q 'nftban mail setup' && echo "$r" | grep -q 'no local mail transport' && ok "producer + recipient + no transport -> WARN with no-MTA SMTP note" || no "case2: $r"
 
 # 3. disk-only reports (dir exists, NO email config) -> INFO/no-action (NO false WARN)
 r=$(bash -c "$(prelude)
-unset NFTBAN_MAIL_RECIPIENT NFTBAN_MAIL_REPORT_RECIPIENT
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS
 mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
 nftban_mail_detect_mta() { echo none; }
 _health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
 echo "$r" | grep -q 'CODE=0' && echo "$r" | grep -qi 'INFO' && echo "$r" | grep -q 'no action required' && ok "disk-only reports -> INFO/no-action (false-positive WARN removed)" || no "case3: $r"
 
-# 4. real email producer (REPORT_RECIPIENT) + missing recipient -> WARN (names auto-reports)
+# 4. real email producer (STATS_EMAIL_ENABLED) + missing recipient -> WARN (names auto-reports)
 r=$(bash -c "$(prelude)
-unset NFTBAN_MAIL_RECIPIENT; export NFTBAN_MAIL_REPORT_RECIPIENT='r@test.example'
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_RECIPIENTS; export STATS_EMAIL_ENABLED=true
 mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
 nftban_mail_detect_mta() { echo none; }
 _health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")

--- a/cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh
+++ b/cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Central-comms producer-signal accuracy
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_producer_signal_accuracy_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="Central-comms producer-signal accuracy: the auto-reports EMAIL producer is keyed on STATS_EMAIL_ENABLED truthy (from conf.d/stats.conf OR the environment) with STATS_EMAIL_RECIPIENTS as the report recipient. A disk-only reports directory never fires a Communication WARN (v1.218.2 regression guard). A resolvable report recipient is deliverable (never MISSING_RECIPIENT). STATS_EMAIL_ENABLED with no recipient anywhere is a MISCONFIGURATION (misconfig wording, not a delivery-failure wording). The check reads conf.d/stats.conf, not just env, and other producers (mail.conf MAIL_ENABLED) still surface. Hermetic: isolated tempdir, no real mail, no network, non-secret markers only."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_MAIL_RECIPIENT,STATS_EMAIL_ENABLED,STATS_EMAIL_RECIPIENTS"
+# meta:inventory.config_files="conf.d/stats.conf,conf.d/mail.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== central-comms producer-signal accuracy ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+CFN="$WORK/comps.sh"
+awk '/^nftban_health_check_communication\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >  "$CFN"
+awk '/^_health_eval_communication_component\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >> "$CFN"
+
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR/conf.d" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+source "$MAIL" >/dev/null 2>&1 || true
+source "$CFN" >/dev/null 2>&1 || true
+systemctl() { return 1; }   # no report-email timer in the hermetic env
+set +e; set +o pipefail
+EOF
+}
+
+# 1. DISK-ONLY: reports dir exists but STATS_EMAIL disabled + no recipient -> INFO/no-action (CODE=0)
+#    Regression guard for the v1.218.2 disk-only fix: the dir alone must NOT fire a Communication WARN.
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS
+mkdir -p \"\$NFTBAN_DATA_DIR/reports\"
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=0' && echo "$r" | grep -qi 'INFO' && echo "$r" | grep -q 'no action required' \
+  && ok "row1 disk-only reports dir -> CODE=0 INFO no-action-required" || no "row1: $r"
+
+# 2. CLEAN: STATS_EMAIL_ENABLED=true + report recipient + transport present -> CODE=0, NOT WARN, NOT MISSING_RECIPIENT
+#    (deliverable via the report's own recipient even with the general NFTBAN_MAIL_RECIPIENT unset)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT
+export STATS_EMAIL_ENABLED=true STATS_EMAIL_RECIPIENTS='r@test.example'
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'WARN' && ! echo "$r" | grep -q 'MISSING_RECIPIENT' \
+  && ok "row2 report recipient + transport -> CODE=0, not WARN, not MISSING_RECIPIENT" || no "row2: $r"
+
+# 3. WARN transport-none: STATS_EMAIL_ENABLED=true + recipient set + transport none
+#    -> CODE=1 WARN TRANSPORT_UNAVAILABLE + Fix/Verify remediation lines
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT
+export STATS_EMAIL_ENABLED=true STATS_EMAIL_RECIPIENTS='r@test.example'
+nftban_mail_detect_mta() { echo none; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'WARN' && echo "$r" | grep -q 'TRANSPORT_UNAVAILABLE' \
+  && echo "$r" | grep -q 'nftban mail setup' && echo "$r" | grep -q 'nftban mail test' \
+  && ok "row3 transport none -> CODE=1 WARN TRANSPORT_UNAVAILABLE + Fix/Verify" || no "row3: $r"
+
+# 4. WARN misconfig: STATS_EMAIL_ENABLED=true + NO recipient anywhere
+#    -> CODE=1 MISSING_RECIPIENT with misconfig wording (NOT the delivery-failure wording)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_RECIPIENTS
+export STATS_EMAIL_ENABLED=true
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'MISSING_RECIPIENT' \
+  && echo "$r" | grep -q 'email reports enabled but no recipient configured' \
+  && ! echo "$r" | grep -q 'notifications generated but not deliverable' \
+  && ok "row4 enabled + no recipient -> CODE=1 MISSING_RECIPIENT + misconfig wording" || no "row4: $r"
+
+# 5. REPORT-ONLY recipient not mislabeled: report recipient set, general NFTBAN_MAIL_RECIPIENT empty,
+#    transport present -> NOT MISSING_RECIPIENT (assert the negative)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT
+export STATS_EMAIL_ENABLED=true STATS_EMAIL_RECIPIENTS='r@test.example'
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+! echo "$r" | grep -q 'MISSING_RECIPIENT' \
+  && ok "row5 report-only recipient -> not mislabeled MISSING_RECIPIENT" || no "row5: $r"
+
+# 6. CONF-FILE PATH: STATS_EMAIL_ENABLED="true" in conf.d/stats.conf (env unset), no recipient
+#    -> CODE=1 WARN (proves the check reads conf.d/stats.conf, not just env)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS
+printf 'STATS_EMAIL_ENABLED=\"true\"\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/stats.conf\"
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'WARN' \
+  && ok "row6 STATS_EMAIL_ENABLED in conf.d/stats.conf -> CODE=1 WARN" || no "row6: $r"
+
+# 7. OTHER PRODUCERS regression: STATS_EMAIL disabled, MAIL_ENABLED=true in conf.d/mail.conf, no recipient
+#    -> still CODE=1 WARN (other producers unaffected by the re-key)
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS
+printf 'MAIL_ENABLED=true\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'WARN' \
+  && ok "row7 mail.conf MAIL_ENABLED producer -> still CODE=1 WARN" || no "row7: $r"
+
+echo "----"
+# 8. (Deputy-2 ISSUE-1) report producer keyed on its OWN recipient: STATS_EMAIL_ENABLED=true +
+#    empty STATS_EMAIL_RECIPIENTS + a GENERAL recipient set + transport -> WARN misconfig, NOT CLEAN
+#    (the general recipient must NOT mask the missing report recipient; reports self-deliver only).
+r=$(bash -c "$(prelude)
+unset STATS_EMAIL_RECIPIENTS
+export STATS_EMAIL_ENABLED=true NFTBAN_MAIL_RECIPIENT='general@test.example'
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'email reports enabled but no recipient configured' \
+  && ok "row8 report producer + general recipient but no report recipient -> WARN misconfig (not false-CLEAN)" || no "row8: $r"
+
+# 9. (Deputy-3 regression) stray STATS_EMAIL_RECIPIENTS must NOT mask a non-report producer's missing
+#    recipient: RBL producer enabled, general recipient empty, STATS_EMAIL_ENABLED unset (auto-reports
+#    NOT a producer), STATS_EMAIL_RECIPIENTS set, transport present -> WARN (rbl can't deliver), NOT CLEAN.
+r=$(bash -c "$(prelude)
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED
+export STATS_EMAIL_RECIPIENTS='stray@test.example'
+mkdir -p \"\$NFTBAN_CONFIG_DIR/conf.d/rbl\"; printf 'NFTBAN_RBL_ENABLED=\"YES\"\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"
+nftban_mail_detect_mta() { echo sendmail; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'MISSING_RECIPIENT' && echo "$r" | grep -q 'rbl-alerts' \
+  && ok "row9 stray report recipient does NOT mask rbl missing-recipient -> WARN preserved" || no "row9: $r"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## PRODUCER_SIGNAL_ACCURACY — close the v1.218.2 Communication false-green

### Problem
v1.218.2 removed the disk-only false Communication WARN, but keyed the auto-reports producer on `NFTBAN_MAIL_REPORT_RECIPIENT` / a report-timer ExecStart `--email` — **neither is what the scheduled report path uses**. Scheduled reports email when `STATS_EMAIL_ENABLED` is truthy **and** `STATS_EMAIL_RECIPIENTS` is set (`cmd_report.sh:984`), on the default `report run` timer (no `--email`), through the central authority (`nftban_report_email.sh` → `nftban_mail_send`). So a host with `STATS_EMAIL_ENABLED=true` + recipient + no transport was mis-reported **INFO instead of WARN**.

### Fix
- **Re-key auto-reports detection** on `STATS_EMAIL_ENABLED` truthy (from `conf.d/stats.conf` + environment); capture `STATS_EMAIL_RECIPIENTS` as the report recipient. Drop the dead `NFTBAN_MAIL_REPORT_RECIPIENT` / timer-`--email` heuristics from the scheduled-report authority (`NFTBAN_MAIL_REPORT_RECIPIENT` is only a fallback for on-demand `module/fhs/port` report emails, not a standing producer).
- **Per-producer deliverability** (the real correctness boundary): each producer is judged by ITS OWN recipient — auto-reports by `STATS_EMAIL_RECIPIENTS` (no general fallback), general producers (rbl/tunnel/mail) by `NFTBAN_MAIL_RECIPIENT`. A general recipient must NOT mask a missing report recipient, and a stray `STATS_EMAIL_RECIPIENTS` must NOT mask a missing general recipient.
- **Design-B misconfiguration** locked: `STATS_EMAIL_ENABLED=true` + no `STATS_EMAIL_RECIPIENTS` → **WARN**, wording **"email reports enabled but no recipient configured"** (NOT a delivery failure — no email fires without a recipient).
- **Preserve v1.218.2 disk-only behavior**: disk-only reports remain INFO / no action; the reports directory or default timer alone never triggers WARN.
- **Hardening**: anchored truthy match for `STATS_EMAIL_ENABLED`; quote-robust `STATS_EMAIL_RECIPIENTS` extraction.

### Adversarial deputy findings (folded in)
- **Deputy 2 — false-CLEAN ISSUE-1:** a general `NFTBAN_MAIL_RECIPIENT` masked a missing `STATS_EMAIL_RECIPIENTS`, making the Design-B misconfig verdict unreachable. Fixed by per-producer deliverability + **regression row 8**.
- **Deputy 3 — second false-CLEAN:** a stray `STATS_EMAIL_RECIPIENTS` masked a missing general recipient for an enabled RBL producer (reproduced WARN→CLEAN). Fixed by per-producer deliverability + **regression row 9**.
- **Deputy 1** authored the producer-signal test matrix with no production-code divergence.

Neither false-CLEAN was covered by the pre-existing suites — the per-producer refinement is what makes this lane correct rather than merely "recognizes STATS_EMAIL_ENABLED."

### Validation
`comms_producer_signal_accuracy` **9/9** · v2181 **17/0** · UX **13/13** · A2b **16/16** · A2c **15/15** · A2r **11/11** · A2a **18/18** · no-direct-send guard **0/4** · shellcheck + `bash -n` clean.
- **lab2 DEB** (official v1.218.2 + overlay): `STATS_EMAIL_ENABLED=true` + no report recipient → **WARN misconfig**; report recipient + MTA → **CLEAN**; disk-only → **INFO**; daemon active, `nftban validate` rc0, no real mail, restored.
- **lab4 RPM**: same matrix PASS; daemon active, validate rc0, no real mail, restored.

### Scope / status
4 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no finding registry · no privacy mode · no webhook/RBLMON/ADR/A3 · no new send path · no real mail.** Closes only **OPEN_PRODUCER_SIGNAL_ACCURACY**. **Unreleased-on-main after merge** — the fleet remains on **v1.218.2** until a future release-prep/tag/rollout gate.

**Reviewer note:** require the diff to prove **per-producer deliverability** (auto-reports↔`STATS_EMAIL_RECIPIENTS`, general↔`NFTBAN_MAIL_RECIPIENT`, no cross-masking), not just recognition of `STATS_EMAIL_ENABLED` — that is the real correctness boundary.