### PR TITLE
fix(debug): scrub debug config and env with shared redaction authority

### DIFF
--- a/cli/lib/nftban/cli/cmd_debug.sh
+++ b/cli/lib/nftban/cli/cmd_debug.sh
@@ -47,6 +47,17 @@ fi
 [[ -n "${CMD_DEBUG_LOADED:-}" ]] && return 0
 readonly CMD_DEBUG_LOADED=1
 
+# SEC-P1-2 (duplicate-redactor retirement, P-retire-1): scrub secrets from debug output through the
+# SHARED redaction authority, not a local sed. The previous raw sed matched PASSWORD but not PASS
+# (leaking NFTBAN_SMTP_PASS / connector *_PASS) and matched bare KEY (over-redacting KAFKA_PARTITION_KEY).
+_debug_scrub_stream() {
+    if ! declare -F nftban_redact_stream >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
+    fi
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then nftban_redact_stream; else cat; fi
+}
+
 # =============================================================================
 # COMMAND HANDLER
 # =============================================================================
@@ -461,17 +472,17 @@ nftban_debug_dump() {
         config)
             echo "=== Configuration ==="
             if [[ -f "${NFTBAN_CONFIG_DIR}/nftban.conf" ]]; then
-                # v1.19.0: Filter secrets from debug output (R42)
+                # Filter secrets from debug output via the shared redaction authority (R42).
                 grep -v '^#' "${NFTBAN_CONFIG_DIR}/nftban.conf" | grep -v '^$' \
-                    | sed -E 's/(TOKEN|PASSWORD|SECRET|KEY|APIKEY|API_KEY)=.*/\1=***REDACTED***/i'
+                    | _debug_scrub_stream
             fi
             ;;
 
         env)
             echo "=== Environment Variables ==="
-            # v1.19.0: Filter secret-like env vars from debug output (R42)
+            # Filter secret-like env vars from debug output via the shared redaction authority (R42).
             env | grep -E '^NFTBAN_' | sort \
-                | sed -E 's/(TOKEN|PASSWORD|SECRET|KEY|APIKEY|API_KEY)=.*/\1=***REDACTED***/i'
+                | _debug_scrub_stream
             ;;
 
         services)

--- a/cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Duplicate-redactor retirement P-retire-1: nftban debug uses the shared authority
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_redact_debug_p_retire1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="SEC-P1-2 duplicate-redactor retirement P-retire-1: nftban debug config/env output is scrubbed through the SHARED redaction authority (_debug_scrub_stream -> nftban_redact_stream), not a divergent local sed. Closes the *_PASS leak (NFTBAN_SMTP_PASS + connector *_PASS were printed cleartext because the old sed matched PASSWORD but not PASS) and the bare-KEY over-redaction (KAFKA_PARTITION_KEY was wrongly redacted). Asserts the leak is closed, benign keys survive, and cmd_debug no longer carries a raw redaction sed. Hermetic: extracted fn, no real mail, no network, non-secret markers."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,sed,awk"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+DEBUG="$REPO/cli/lib/nftban/cli/cmd_debug.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== duplicate-redactor retirement P-retire-1: nftban debug shared-authority scrub ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+M="LEAKMARK"
+
+# extract _debug_scrub_stream (it sources the shared lib on-demand via NFTBAN_LIB_DIR)
+FN="$WORK/scrub.sh"; awk '/^_debug_scrub_stream\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$DEBUG" > "$FN"
+grep -q '_debug_scrub_stream' "$FN" && ok "extracted _debug_scrub_stream" || no "extract failed"
+
+# drive a debug-config-like block through it
+scrub() { bash -c "export NFTBAN_LIB_DIR='$REPO/cli/lib/nftban'; source '$FN' >/dev/null 2>&1; _debug_scrub_stream"; }
+
+INPUT=$(printf '%s\n' \
+  "NFTBAN_SMTP_PASS=${M}-smtp" \
+  "NFTBAN_CONNECTOR_KAFKA_SASL_PASS=${M}-sasl" \
+  "NFTBAN_CONNECTOR_WEBHOOK_PASSWORD=${M}-pw" \
+  "NFTBAN_CONNECTOR_WEBHOOK_SECRET=${M}-sec" \
+  "NFTBAN_CONNECTOR_WEBHOOK_TOKEN=${M}-tok" \
+  "NFTBAN_CONNECTOR_ES_API_KEY=${M}-api" \
+  "NFTBAN_CONNECTOR_WEBHOOK_AUTH=${M}-auth" \
+  "NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-keep" \
+  "bypass=5" \
+  "surpass=1" \
+  "NFTBAN_RBL_ENABLED=YES")
+OUT=$(printf '%s' "$INPUT" | scrub)
+
+# leak closed: NO secret marker survives (the *_PASS class the old sed leaked)
+printf '%s' "$OUT" | grep -q "$M" && no "debug scrub LEAKED: $(printf '%s' "$OUT"|grep "$M"|head -1)" || ok "debug scrub: all secret markers redacted (incl *_PASS)"
+# specifically prove the SMTP_PASS line the old sed missed is now redacted
+echo "$OUT" | grep -qE 'NFTBAN_SMTP_PASS=.*(REDACTED|\[)' && ! echo "$OUT" | grep -q "${M}-smtp" && ok "NFTBAN_SMTP_PASS redacted (old sed leaked it)" || no "SMTP_PASS not redacted: $(echo "$OUT"|grep SMTP_PASS)"
+
+# benign survival (the bare-KEY over-redaction is gone)
+echo "$OUT" | grep -q 'NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-keep' && ok "KAFKA_PARTITION_KEY survives (over-redaction fixed)" || no "PARTITION_KEY over-redacted: $(echo "$OUT"|grep PARTITION)"
+echo "$OUT" | grep -q 'bypass=5' && echo "$OUT" | grep -q 'surpass=1' && echo "$OUT" | grep -q 'NFTBAN_RBL_ENABLED=YES' && ok "benign keys survive (bypass/surpass/RBL_ENABLED)" || no "benign over-redacted"
+
+# reviewer rule: cmd_debug no longer carries a raw redaction sed in config/env, and uses the shared authority
+grep -qE "sed -E 's/\(TOKEN\|PASSWORD\|SECRET\|KEY" "$DEBUG" && no "cmd_debug STILL has the raw redaction sed" || ok "cmd_debug: raw redaction sed removed"
+grep -q '_debug_scrub_stream' "$DEBUG" && grep -q 'nftban_redact_stream' "$DEBUG" && ok "cmd_debug uses the shared authority (_debug_scrub_stream -> nftban_redact_stream)" || no "cmd_debug not wired to shared authority"
+
+# idempotency
+r1=$(printf '%s' "$INPUT" | scrub); r2=$(printf '%s' "$r1" | scrub)
+[[ "$r1" == "$r2" ]] && ok "idempotent" || no "not idempotent"
+
+# regressions: the shared authority + SEC-P1-2 suites stay green
+for t in comms_redact_p2a_noleak comms_redact_p2b1; do
+  ( cd "$REPO" && bash "cli/lib/nftban/tests/${t}_test.sh" >/dev/null 2>&1 ) && ok "${t} still passes" || no "${t} regressed"
+done
+out=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 )
+echo "$out" | grep -q '0/4 DEBT' && echo "$out" | grep -q 'PASS' && ok "A0 guard still 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## P-retire-1 — migrate `nftban debug` redaction to the shared authority

Closes the concrete **`nftban debug` `*_PASS` leak** found during the duplicate-redactor retirement scope, and fixes over-redaction of benign routing keys like `KAFKA_PARTITION_KEY`.

### Problem
`nftban debug config` and `nftban debug env` scrubbed secrets with a **divergent raw sed** — `s/(TOKEN|PASSWORD|SECRET|KEY|APIKEY|API_KEY)=.*/…/i` — that was **both**:
- **UNDER-redacts (LEAK):** matched `PASSWORD` but not `PASS`, so `NFTBAN_SMTP_PASS` / connector `*_PASS` / `*_SASL_PASS` were printed in cleartext (the same `*_PASS` class SEC-P1-2 P2a closed for support bundles); also missed Bearer, URL credentials, netrc, Auth-User.
- **OVER-redacts:** matched bare `KEY`, redacting benign routing keys like `KAFKA_PARTITION_KEY`.

### Fix
Both debug output paths now scrub through the **shared redaction authority** via a small `_debug_scrub_stream` helper (on-demand-sources `lib/nftban_redact.sh`, then pipes through `nftban_redact_stream`). **No local/raw secret sed remains** in the debug config/env path. Coverage grows to the authority's set (`*_PASS`/`*_PASSWORD`/`*_SECRET`/`*_TOKEN`/`*_API_KEY`/`*_AUTH`, Bearer, URL credentials, netrc, Auth-User).

**Reviewer rule (provable in the diff):** both `sed -E 's/(TOKEN|PASSWORD|SECRET|KEY…)…'` lines are **removed** and replaced by `_debug_scrub_stream` → `nftban_redact_stream`. A stronger local sed would not be acceptable — this uses the shared authority.

### Validation
- **New `comms_redact_debug_p_retire1` test 11/11**: `NFTBAN_SMTP_PASS=leakmark123` **redacted**; connector `*_PASS`/`*_PASSWORD`/`*_SECRET`/`*_TOKEN`/`*_API_KEY`/`*_AUTH` **redacted**; `KAFKA_PARTITION_KEY` / `bypass=` / `surpass=` **survive**; debug path has **no raw sed** and uses the shared authority; idempotent.
- **P2a 30/30 · P2b-1 18/18 · producer_signal_accuracy 9/9 · v2181 17/17 · UX 13/13 · A2b 16/16 · A2c 15/15 · A2r 11/11 · A2a 18/18 · no-direct-send guard 0/4** · shellcheck + `bash -n` clean.

### Scope / status
2 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no release-prep/tag/fleet.** **This is P-retire-1 only.**

**P-retire-2 remains `HOLD_AFTER_P_RETIRE_1`** (separate lane): dead `SECRET_PATTERNS` / wrapper fallback-sed deletion · fail-loud lib-missing behaviour (`[REDACTION-UNAVAILABLE: do not share]`) · `verify_installation.sh` guard for `lib/nftban_redact.sh`. None of that is in this PR.

If merged, this is **unreleased-on-main** and joins `PRODUCER_SIGNAL_ACCURACY` above **v1.218.2**. The fleet remains on v1.218.2 until a future release-prep/tag/rollout gate.