### PR TITLE
fix(redaction): fail closed when shared redactor is unavailable

### DIFF
--- a/cli/lib/nftban/cli/cmd_debug.sh
+++ b/cli/lib/nftban/cli/cmd_debug.sh
@@ -55,7 +55,16 @@ _debug_scrub_stream() {
         # shellcheck source=/dev/null
         source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
     fi
-    if declare -F nftban_redact_stream >/dev/null 2>&1; then nftban_redact_stream; else cat; fi
+    # SEC-P1-2 P-retire-2: FAIL-CLOSED — never `cat` raw config/env through when the redactor is
+    # unavailable (that was a silent full-leak of debug output). Drain+discard stdin, emit marker.
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then
+        nftban_redact_stream
+    else
+        cat >/dev/null 2>&1
+        printf '%s\n' '[REDACTION-UNAVAILABLE: do not share]'
+        echo '[SECURITY][ERROR] nftban_redact.sh unavailable — redaction skipped, content suppressed' >&2
+    fi
+    return 0
 }
 
 # =============================================================================

--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -53,16 +53,15 @@ source "${NFTBAN_CONFIG_DIR}/nftban.conf" 2>/dev/null || true
 [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]] && \
     source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
 
-# Patterns for secret redaction (LEGACY FALLBACK only — used iff the shared redactor lib
-# above is unavailable; the shared registry is the authoritative, broader set).
-readonly -a SECRET_PATTERNS=(
-    's/([Aa][Pp][Ii][-_]?[Kk][Ee][Yy]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
-    's/([Tt][Oo][Kk][Ee][Nn]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
-    's/([Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
-    's/([Ss][Ee][Cc][Rr][Ee][Tt]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
-    's/(Bearer\s+)[A-Za-z0-9._-]+/\1[REDACTED]/g'
-    's/([Aa][Uu][Tt][Hh]\s*[=:]\s*)["\x27]?[^"\x27\s]+["\x27]?/\1[REDACTED]/g'
-)
+# SEC-P1-2 P-retire-2: FAIL-LOUD when the shared redaction authority is unavailable. The legacy
+# SECRET_PATTERNS fallback (weak keyword sed that missed *_PASS) is RETIRED — a broken/partial
+# install must NEVER silently weak-redact or pass raw content through. Emit an explicit marker to
+# stdout (into the collected artifact) + a loud [SECURITY][ERROR] to stderr; callers all use
+# `… || true` / capture, so returning 0 keeps the bundle generating with clearly-marked sections.
+_redact_unavailable() {
+    printf '%s\n' '[REDACTION-UNAVAILABLE: do not share]'
+    echo '[SECURITY][ERROR] nftban_redact.sh unavailable — redaction skipped, content suppressed' >&2
+}
 
 # =============================================================================
 # HELPER FUNCTIONS
@@ -90,18 +89,15 @@ _support_banner() {
 }
 
 _redact_secrets() {
-    # SEC-P1-2 P2a: delegate to the shared redaction authority (broader coverage: *_PASS,
-    # connector/pro/portal creds, Bearer, URL creds, netrc). Legacy SECRET_PATTERNS loop is
-    # kept ONLY as a fallback for when the shared lib is unavailable (coverage never weaker).
+    # SEC-P1-2 P2a/P-retire-2: delegate to the shared redaction authority (the ONLY secret-redaction
+    # path). If it is unavailable, FAIL LOUD — return the marker in place of the content, never the
+    # raw string and never a weak fallback.
     if declare -F nftban_redact_string >/dev/null 2>&1; then
         nftban_redact_string "${1:-}"
-        return
+        return 0
     fi
-    local output="${1:-}"
-    for pattern in "${SECRET_PATTERNS[@]}"; do
-        output=$(echo "$output" | sed -E "$pattern" 2>/dev/null) || true
-    done
-    echo "$output"
+    _redact_unavailable
+    return 0
 }
 
 _redact_file() {
@@ -354,7 +350,16 @@ _collect_configs() {
 # forensic evidence (identifier-privacy is a separate opt-in mode, P2b-2). Degrades to `cat`
 # if the shared redactor lib is unavailable.
 _support_scrub_stream() {
-    if declare -F nftban_redact_stream >/dev/null 2>&1; then nftban_redact_stream; else cat; fi
+    # SEC-P1-2 P-retire-2: FAIL-CLOSED — never `cat` raw stdin through when the redactor is
+    # unavailable (that was a silent full-leak of journal/log content). Drain+discard stdin and
+    # emit the marker instead.
+    if declare -F nftban_redact_stream >/dev/null 2>&1; then
+        nftban_redact_stream
+    else
+        cat >/dev/null 2>&1
+        _redact_unavailable
+    fi
+    return 0
 }
 
 _collect_logs() {
@@ -444,24 +449,19 @@ _collect_status() {
     _safe_cmd "$bundle_dir/status.txt" "NFTBan status" nftban status
 }
 
-# A2c: narrow, LOCAL redaction for the comms summary — SECRET_PATTERNS + comms-specific
-# fields (SMTP user, full recipient local-part). This is intentionally minimal; full
-# support-bundle redaction (SEC-P1-2) remains a separate open lane.
+# A2c: sanitized comms summary. `_redact_comms` now delegates wholesale to the shared redaction
+# authority (SMTP Auth User / *_PASS / SMTP_USER / Recipient local-part all covered), and fails
+# closed with [REDACTION-UNAVAILABLE] if the authority is missing (SEC-P1-2 P-retire-2).
 _redact_comms() {
-    # SEC-P1-2 P2a: the shared registry now covers SMTP Auth User / *_PASS / SMTP_USER and
-    # the Recipient: local-part (A2c behaviour preserved + broadened), so delegate wholesale.
+    # SEC-P1-2 P2a/P-retire-2: the shared registry covers SMTP Auth User / *_PASS / SMTP_USER and
+    # the Recipient: local-part, so delegate wholesale. If the authority is unavailable, FAIL LOUD —
+    # never the original narrow sed fallback (which missed the broader field set).
     if declare -F nftban_redact_string >/dev/null 2>&1; then
         nftban_redact_string "${1:-}"
-        return
+        return 0
     fi
-    # Fallback (shared lib unavailable): the original A2c narrow set.
-    local t; t=$(_redact_secrets "$1")
-    t=$(printf '%s' "$t" | sed -E \
-        -e 's/([Aa]uth [Uu]ser:[[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
-        -e 's/([Ss][Mm][Tt][Pp]_?[Uu][Ss][Ee][Rr][[:space:]]*[=:][[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
-        -e 's/([Nn][Ff][Tt][Bb][Aa][Nn]_[Ss][Mm][Tt][Pp]_[Pp][Aa][Ss][Ss][[:space:]]*[=:][[:space:]]*)[^[:space:]]+/\1[REDACTED]/g' \
-        -e 's/(Recipient:[[:space:]]*)[^@[:space:]]+@([^[:space:]]+)/\1[redacted]@\2/g')
-    printf '%s' "$t"
+    _redact_unavailable
+    return 0
 }
 
 # A2c: sanitized central-comms + RBL observe-only summary. Reuses the existing redactor;

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -474,17 +474,21 @@ _forensic_run_id() { printf '%s' "${NFTBAN_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ 2>/
 _fx_jstr() { local s="${1-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/ }"; s="${s//$'\t'/ }"; s="${s//$'\r'/ }"; printf '%s' "$s"; }
 # secret redaction safety-net (the snapshot is allowlisted, but values pass this too)
 _fx_redact() {
-    # SEC-P1-2 P2b-1: delegate to the shared redaction authority (broader coverage: *_PASS,
-    # connector/pro/portal creds, URL creds, netrc). Legacy sed is a fallback only.
+    # SEC-P1-2 P2b-1/P-retire-2: delegate to the shared redaction authority (the ONLY secret path).
     if ! declare -F nftban_redact_stream >/dev/null 2>&1 && [[ -f "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" ]]; then
         # shellcheck source=/dev/null
         source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_redact.sh" 2>/dev/null || true
     fi
+    # FAIL-CLOSED — the legacy weak sed (missed *_PASS) is RETIRED. If the authority is unavailable,
+    # drain+discard stdin and emit the marker; never weak-redact, never raw passthrough.
     if declare -F nftban_redact_stream >/dev/null 2>&1; then
         nftban_redact_stream
     else
-        sed -E 's/(pass(word)?|secret|token|api[_-]?key|bearer|authorization)([=: ]+)[^ ",]*/\1\3<redacted>/Ig'
+        cat >/dev/null 2>&1
+        printf '%s\n' '[REDACTION-UNAVAILABLE: do not share]'
+        echo '[SECURITY][ERROR] nftban_redact.sh unavailable — redaction skipped, content suppressed' >&2
     fi
+    return 0
 }
 
 # _forensic_begin <run_id> <mode> <from> <to>

--- a/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
+++ b/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
@@ -53,7 +53,7 @@ printf '%s\n' '{"ts":"2026-07-07T00:00:00Z","transport":"emulate","recipient":"b
 # Extract the self-containable functions (sourcing the whole CLI file has heavy load-time deps).
 FN="$WORK/fns.sh"
 {
-  awk '/^readonly -a SECRET_PATTERNS=\(/{f=1} f{print} f&&/^\)/{exit}' "$SUPPORT"
+  awk '/^_redact_unavailable\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
   awk '/^_redact_secrets\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
   awk '/^_redact_comms\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
   awk '/^_collect_communications\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SUPPORT"
@@ -64,6 +64,7 @@ grep -q '_collect_communications' "$FN" && ok "extracted _collect_communications
 # run _collect_communications with the stub in PATH
 bash -c "
 export PATH='$WORK/bin:'\$PATH NFTBAN_MAIL_DELIVERY_LOG='$DLOG' NFTBAN_DATA_DIR='$WORK/data'
+source '$REPO/cli/lib/nftban/lib/nftban_redact.sh' >/dev/null 2>&1 || true
 source '$FN' >/dev/null 2>&1 || true
 set +e; set +o pipefail
 _collect_communications '$BDIR'

--- a/cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Duplicate-redactor retirement P-retire-2: fail-loud when the redactor is unavailable
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_redact_failloud_p_retire2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="SEC-P1-2 P-retire-2: the legacy weak/passthrough fallbacks are retired. With the shared redaction authority (lib/nftban_redact.sh) UNAVAILABLE, every secret-redaction wrapper (_redact_secrets/_redact_comms/_support_scrub_stream in cmd_support, _debug_scrub_stream in cmd_debug, _fx_redact in cmd_update_helpers) FAILS LOUD/CLOSED: emits exactly '[REDACTION-UNAVAILABLE: do not share]' to stdout, discards raw stdin (no passthrough), writes a [SECURITY][ERROR] to stderr, and returns 0 — never a raw secret and never the weak SECRET_PATTERNS/sed fallback. Also asserts no 'else cat' passthrough or SECRET_PATTERNS array remains, verify_installation asserts the lib, and coverage does not shrink with the lib present. Hermetic; no real mail; no network; non-secret markers."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,sed"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+DEBUG="$REPO/cli/lib/nftban/cli/cmd_debug.sh"
+UPD="$REPO/cli/lib/nftban/cli/cmd_update_helpers.sh"
+VERIFY="$REPO/install/verify_installation.sh"
+LIB="$REPO/cli/lib/nftban/lib/nftban_redact.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== SEC-P1-2 P-retire-2 fail-loud + fallback retirement ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+M="LEAKMARK"
+MARKER='[REDACTION-UNAVAILABLE: do not share]'
+NOLIB="$WORK/nolib"; mkdir -p "$NOLIB/lib"   # NFTBAN_LIB_DIR with NO nftban_redact.sh
+
+extract() { awk "/^$2\(\) \{/{f=1} f{print} f&&/^\}/{exit}" "$1"; }
+
+# --- cmd_support wrappers (use _redact_unavailable) — force lib unavailable ---
+SFN="$WORK/support_fns.sh"
+extract "$SUPPORT" "_redact_unavailable" >  "$SFN"
+extract "$SUPPORT" "_redact_secrets"     >> "$SFN"
+extract "$SUPPORT" "_redact_comms"       >> "$SFN"
+extract "$SUPPORT" "_support_scrub_stream" >> "$SFN"
+
+# _redact_secrets fail-loud (string)
+out=$(bash -c "source '$SFN'; set +e; _redact_secrets 'NFTBAN_SMTP_PASS=${M}-a'" 2>"$WORK/e1"); rc=$?
+echo "$out" | grep -qF "$MARKER" && ! echo "$out" | grep -q "$M" && [ "$rc" = 0 ] && grep -q 'SECURITY..ERROR. nftban_redact.sh unavailable' "$WORK/e1" \
+  && ok "_redact_secrets fail-loud: marker, no secret, stderr alarm, rc0" || no "_redact_secrets: out='$out' rc=$rc err=$(cat "$WORK/e1")"
+
+# _redact_comms fail-loud (string)
+out=$(bash -c "source '$SFN'; set +e; _redact_comms 'NFTBAN_SMTP_PASS=${M}-b'" 2>/dev/null)
+echo "$out" | grep -qF "$MARKER" && ! echo "$out" | grep -q "$M" && ok "_redact_comms fail-loud: marker, no secret" || no "_redact_comms: $out"
+
+# _support_scrub_stream fail-loud (stream — must DISCARD stdin, not cat)
+out=$(bash -c "source '$SFN'; set +e; printf '%s\n' 'NFTBAN_SMTP_PASS=${M}-c' 'attacker 1.2.3.4' | _support_scrub_stream" 2>/dev/null)
+echo "$out" | grep -qF "$MARKER" && ! echo "$out" | grep -q "$M" && ! echo "$out" | grep -q '1.2.3.4' \
+  && ok "_support_scrub_stream fail-loud: marker, stdin discarded (no passthrough)" || no "_support_scrub_stream: $out"
+
+# --- cmd_debug _debug_scrub_stream (self-sources; point NFTBAN_LIB_DIR at a lib-less dir) ---
+DFN="$WORK/debug_fn.sh"; extract "$DEBUG" "_debug_scrub_stream" > "$DFN"
+out=$(bash -c "export NFTBAN_LIB_DIR='$NOLIB'; source '$DFN'; set +e; printf '%s\n' 'NFTBAN_SMTP_PASS=${M}-d' | _debug_scrub_stream" 2>"$WORK/e2"); rc=$?
+echo "$out" | grep -qF "$MARKER" && ! echo "$out" | grep -q "$M" && [ "$rc" = 0 ] && grep -q 'SECURITY..ERROR' "$WORK/e2" \
+  && ok "_debug_scrub_stream fail-loud: marker, no secret, stderr, rc0 (no else cat)" || no "_debug_scrub_stream: out='$out' rc=$rc"
+
+# --- cmd_update _fx_redact (self-sources; lib-less dir) ---
+FFN="$WORK/fx_fn.sh"; extract "$UPD" "_fx_redact" > "$FFN"
+out=$(bash -c "export NFTBAN_LIB_DIR='$NOLIB'; source '$FFN'; set +e; printf '%s\n' 'NFTBAN_SMTP_PASS=${M}-e' | _fx_redact" 2>/dev/null)
+echo "$out" | grep -qF "$MARKER" && ! echo "$out" | grep -q "$M" && ok "_fx_redact fail-loud: marker, no secret (weak sed retired)" || no "_fx_redact: $out"
+
+# --- source-level retirement assertions ---
+[ "$(grep -c 'else cat' "$SUPPORT" "$DEBUG" "$UPD" 2>/dev/null | awk -F: '{s+=$2}END{print s}')" = 0 ] && ok "no 'else cat' passthrough remains in any wrapper" || no "else cat still present"
+grep -qE '^\s*readonly -a SECRET_PATTERNS' "$SUPPORT" && no "SECRET_PATTERNS array still present" || ok "SECRET_PATTERNS array retired"
+grep -q 'source .*nftban_redact.sh' "$VERIFY" && grep -q 'declare -F nftban_redact_string' "$VERIFY" && ok "verify_installation asserts nftban_redact.sh + API" || no "verify_installation missing redactor assertion"
+
+# --- no coverage shrink WITH the lib present (wrappers still redact via the authority) ---
+out=$(bash -c "source '$LIB'; source '$SFN'; set +e; _redact_secrets 'NFTBAN_SMTP_PASS=${M}-f NFTBAN_CONNECTOR_KAFKA_PARTITION_KEY=part-keep bypass=5'")
+! echo "$out" | grep -q "$M" && echo "$out" | grep -q 'part-keep' && echo "$out" | grep -q 'bypass=5' \
+  && ok "lib present: *_PASS redacted, KAFKA_PARTITION_KEY + bypass= survive (no shrink)" || no "no-shrink: $out"
+
+# --- regressions ---
+for t in comms_redact_p2a_noleak comms_redact_p2b1 comms_redact_debug_p_retire1; do
+  ( cd "$REPO" && bash "cli/lib/nftban/tests/${t}_test.sh" >/dev/null 2>&1 ) && ok "${t} still passes" || no "${t} regressed"
+done
+o=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 ); echo "$o" | grep -q '0/4 DEBT' && echo "$o" | grep -q 'PASS' && ok "A0 guard 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/install/verify_installation.sh
+++ b/install/verify_installation.sh
@@ -82,6 +82,17 @@ echo "Checking NEW Files (2025-11-28)..."
 check_file "/usr/lib/nftban/lib/nftban_metrics.sh"        # NEW: Shared metrics library
 check_file "/usr/lib/nftban/cli/cmd_metrics.sh"           # NEW: Metrics command
 
+# SEC-P1-2: the shared redaction authority MUST be present and usable, otherwise support/debug
+# output fails closed ([REDACTION-UNAVAILABLE]). Assert the file AND that its API is loadable.
+check_file "/usr/lib/nftban/lib/nftban_redact.sh"         # SEC-P1-2: shared redaction authority
+TOTAL=$((TOTAL + 1))
+if bash -c 'source /usr/lib/nftban/lib/nftban_redact.sh >/dev/null 2>&1 && declare -F nftban_redact_string >/dev/null 2>&1'; then
+    PRESENT=$((PRESENT + 1))
+    [[ "$VERBOSE" == true ]] && echo -e "  \033[0;32m✓\033[0m nftban_redact.sh usable (nftban_redact_string defined)"
+else
+    echo -e "  \033[0;31m✖\033[0m nftban_redact.sh NOT usable — redaction authority missing/broken; support/debug will fail closed"
+fi
+
 # ==============================================================================
 # Updated Files - Modified 2025-11-28
 # ==============================================================================


### PR DESCRIPTION
## SEC-P1-2 P-retire-2 — fail-loud redactor durability

Makes the shared redaction authority durable by removing the remaining weak/passthrough fallback redactors and adding install-time verification. **This is P-retire-2 only.**

### The risk this closes
Before this change, if `lib/nftban_redact.sh` failed to load (broken/partial install), the secret-redaction wrappers fell back to either:
- a **weak keyword sed** (`_redact_secrets`/`_fx_redact`/`_redact_comms`) that **missed `*_PASS`**, or
- **`cat` — a silent FULL PASSTHROUGH** of raw journal/log/debug content (`_support_scrub_stream`, `_debug_scrub_stream`).

So a broken install could emit raw secrets in `nftban support` / `nftban debug` with a false sense of redaction.

### Fix
- **Delete legacy fallback authority:** `SECRET_PATTERNS` array + the weak sed fallbacks in `_fx_redact` and `_redact_comms`. **Delete the two `else cat` passthroughs.**
- **All six wrappers** (`_redact_secrets`, `_redact_file`, `_redact_comms`, `_support_scrub_stream`, `_debug_scrub_stream`, `_fx_redact`) delegate to the shared authority when present, else **FAIL LOUD / FAIL CLOSED**: stream wrappers drain+discard stdin; all emit `[REDACTION-UNAVAILABLE: do not share]` to stdout + `[SECURITY][ERROR] nftban_redact.sh unavailable — redaction skipped, content suppressed` to stderr; **return 0** (callers all `… || true`/capture → artifacts still generate with marked sections; no hard crash, **no weak fallback, no raw passthrough**).
- **`install/verify_installation.sh`** now asserts `lib/nftban_redact.sh` exists **and is usable** (sources it, asserts `nftban_redact_string`).
- Thin wrapper *functions* + non-secret sanitizers (shell/sql/html/log, path, mail) unchanged; coverage only grows.

**Reviewer rule (provable in the diff):** no redactor-failure path emits raw content or weak-redacts — **2 `else cat` removed, 5 `SECRET_PATTERNS` lines removed, 7 fail-loud markers added, installer assertion added**; the authority `nftban_redact.sh` is untouched.

### Status
- v1.218.3 is latest published/fleet-live; **this is intended v1.218.4 content** after merge + a later release-prep/tag/rollout gate. Fleet remains **v1.218.3** until then.
- **P2b-2 privacy mode remains separate and decision-gated** — no identifier hashing/truncation here. No webhook/RBLMON/RBL-P0 work.

### Validation
- **New `comms_redact_failloud_p_retire2` test 13/13**: every wrapper emits the marker, no planted secret appears, no raw passthrough, stderr alarm present, wrapper rc0; **no `else cat`, no `SECRET_PATTERNS`**; installer assertion present; **no coverage shrink with lib present** (`*_PASS` redacted; `KAFKA_PARTITION_KEY`/`bypass=`/`surpass=` survive).
- **P2a 30/30 · P2b-1 18/18 · debug-redaction 11/11 · A2a 18/18 · A2b 16/16 · A2c 15/15 · A2r 11/11 · producer_signal_accuracy 9/9 · v2181 17/17 · no-direct-send guard 0/4** · shellcheck + `bash -n` clean.
- **lab2 DEB + lab4 RPM:** fail-loud spot-check emits the marker when forced unavailable; shipped wrappers have 0 `else cat` / 0 `SECRET_PATTERNS`; `verify_installation` passes with the redactor present; daemon active, `nftban validate` rc0, 0 new failed units, no real mail.

### Scope / rules
6 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no release-prep/tag/fleet · no privacy/webhook/RBLMON/RBL-P0/finding-registry/ADR-A3/SEC-P1-3b/Watchdog · no non-secret-sanitizer refactor.**