### PR TITLE
fix(comms): credit RBL and Tunnel producer-specific recipients

### DIFF
--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -763,30 +763,57 @@ nftban_health_check_communication() {
     local _se="${STATS_EMAIL_ENABLED:-}"; [[ "${_se,,}" =~ ^(yes|true|1|on)$ ]] && _stats_email_on=1
     [[ -n "${STATS_EMAIL_RECIPIENTS:-}" ]] && _report_rcpt="${STATS_EMAIL_RECIPIENTS}"
     [[ "$_stats_email_on" -eq 1 ]] && producers+=("auto-reports")
-    local _general_producer=0
+    # rbl-alerts and tunnel-alerts have their OWN recipient (with a general fallback), just like
+    # auto-reports — RBL delivers to NFTBAN_RBL_ALERT_EMAIL (else general — nftban_rbl.sh:1303),
+    # tunnel delivers to NFTBAN_TUNNEL_ALERT_EMAIL/NFTBAN_ALERT_EMAIL (else general). Capture each so
+    # the deliverability check credits the producer's own recipient (no false MISSING_RECIPIENT when
+    # only the producer-specific recipient is set).
+    local _rbl_on=0 _rbl_rcpt="" _tunnel_on=0 _tunnel_rcpt="" _mail_on=0
     local _rbl_conf="${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/main.conf"
-    [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null && { producers+=("rbl-alerts"); _general_producer=1; }
-    [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]] && { producers+=("tunnel-alerts"); _general_producer=1; }
-    [[ -f "$mail_conf" ]] && grep -q 'MAIL_ENABLED=true' "$mail_conf" 2>/dev/null && { producers+=("mail-enabled"); _general_producer=1; }
+    if [[ -f "$_rbl_conf" ]] && grep -qE '^[[:space:]]*NFTBAN_RBL_ENABLED="?YES' "$_rbl_conf" 2>/dev/null; then
+        _rbl_on=1; producers+=("rbl-alerts")
+        _rbl_rcpt="${NFTBAN_RBL_ALERT_EMAIL:-}"
+        [[ -z "$_rbl_rcpt" ]] && _rbl_rcpt=$(grep -E '^[[:space:]]*NFTBAN_RBL_ALERT_EMAIL=' "$_rbl_conf" 2>/dev/null | head -n1 \
+            | sed -E 's/^[[:space:]]*NFTBAN_RBL_ALERT_EMAIL=//; s/^"//; s/"$//')
+    fi
+    if [[ -n "${NFTBAN_TUNNEL_ALERT_EMAIL:-}${NFTBAN_ALERT_EMAIL:-}" ]]; then
+        _tunnel_on=1; producers+=("tunnel-alerts"); _tunnel_rcpt="${NFTBAN_TUNNEL_ALERT_EMAIL:-${NFTBAN_ALERT_EMAIL:-}}"
+    fi
+    [[ -f "$mail_conf" ]] && grep -q 'MAIL_ENABLED=true' "$mail_conf" 2>/dev/null && { _mail_on=1; producers+=("mail-enabled"); }
     local producer_enabled=0; [[ ${#producers[@]} -gt 0 ]] && producer_enabled=1
 
     # Per-producer deliverability — a producer WARNs when IT SPECIFICALLY cannot deliver, judged by
-    # its OWN recipient. Scheduled reports (auto-reports) deliver ONLY to STATS_EMAIL_RECIPIENTS
-    # (cmd_report.sh:984 has no general fallback), so a general recipient does not make reports
-    # deliverable, and a stray STATS_EMAIL_RECIPIENTS does not make the general producers deliverable.
-    # General producers (rbl/tunnel/mail) deliver via nftban_mail_resolve_recipient = NFTBAN_MAIL_RECIPIENT.
+    # its OWN recipient (with the general NFTBAN_MAIL_RECIPIENT as a shared fallback). A producer's
+    # own recipient satisfies ONLY that producer (no cross-masking: a stray RBL/tunnel/report recipient
+    # never makes another producer deliverable). Transport-none is undeliverable for any producer.
     local _undeliverable=0 _why=""
+    # auto-reports: delivers ONLY to STATS_EMAIL_RECIPIENTS (cmd_report.sh:984 has NO general fallback);
+    # enabled with no report recipient is a misconfiguration (nothing sends).
     if [[ "$_stats_email_on" -eq 1 ]]; then
         if [[ -z "$_report_rcpt" ]]; then
-            # Design choice B: email reports enabled but no report recipient is a MISCONFIGURATION
-            # (nothing sends — cmd_report.sh:984 never fires without STATS_EMAIL_RECIPIENTS), NOT a
-            # delivery failure. Word it so, regardless of any general recipient.
             _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: email reports enabled but no recipient configured"
         elif [[ "$transport" == "none" ]]; then
             _undeliverable=1; _why="COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
         fi
     fi
-    if [[ "$_undeliverable" -eq 0 && "$_general_producer" -eq 1 ]]; then
+    # rbl-alerts: own recipient NFTBAN_RBL_ALERT_EMAIL, else general.
+    if [[ "$_undeliverable" -eq 0 && "$_rbl_on" -eq 1 ]]; then
+        if [[ -z "$_rbl_rcpt" && -z "$recipient" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
+        elif [[ "$transport" == "none" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
+        fi
+    fi
+    # tunnel-alerts: own recipient NFTBAN_TUNNEL_ALERT_EMAIL/NFTBAN_ALERT_EMAIL, else general.
+    if [[ "$_undeliverable" -eq 0 && "$_tunnel_on" -eq 1 ]]; then
+        if [[ -z "$_tunnel_rcpt" && -z "$recipient" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
+        elif [[ "$transport" == "none" ]]; then
+            _undeliverable=1; _why="COMMUNICATION_TRANSPORT_UNAVAILABLE: no usable mail transport"
+        fi
+    fi
+    # mail-enabled: no own recipient — delivers via the general NFTBAN_MAIL_RECIPIENT only.
+    if [[ "$_undeliverable" -eq 0 && "$_mail_on" -eq 1 ]]; then
         if [[ -z "$recipient" ]]; then
             _undeliverable=1; _why="COMMUNICATION_CONFIG_MISSING_RECIPIENT: no recipient resolves"
         elif [[ "$transport" == "none" ]]; then

--- a/cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh
+++ b/cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - RBL/Tunnel producer-recipient accuracy (central-comms deliverability)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="comms_rbl_tunnel_producer_recipient_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-07"
+# meta:description="Central-comms deliverability now credits each producer's OWN recipient: rbl-alerts↔NFTBAN_RBL_ALERT_EMAIL, tunnel-alerts↔NFTBAN_TUNNEL_ALERT_EMAIL (both fall back to the general NFTBAN_MAIL_RECIPIENT), auto-reports↔STATS_EMAIL_RECIPIENTS, mail-enabled↔general. A producer with its own recipient set is deliverable even when the general recipient is empty (no false COMMUNICATION_CONFIG_MISSING_RECIPIENT); a producer's own recipient satisfies ONLY that producer (no cross-masking). Hermetic: extracted fns, no real mail, no network, no DNSBL queries."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_RBL_ALERT_EMAIL,NFTBAN_TUNNEL_ALERT_EMAIL,NFTBAN_MAIL_RECIPIENT,STATS_EMAIL_RECIPIENTS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+MAIL="$REPO/cli/lib/nftban/core/nftban_mail.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== RBL/Tunnel producer-recipient accuracy ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+CFN="$WORK/comps.sh"
+awk '/^nftban_health_check_communication\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >  "$CFN"
+awk '/^_health_eval_communication_component\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" >> "$CFN"
+
+prelude() {
+  cat <<EOF
+export NFTBAN_DATA_DIR="$WORK/data" NFTBAN_CONFIG_DIR="$WORK/etc" NFTBAN_RUN_DIR="$WORK/run" NFTBAN_LOG_DIR="$WORK/log" NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+mkdir -p "\$NFTBAN_DATA_DIR" "\$NFTBAN_CONFIG_DIR/conf.d/rbl" "\$NFTBAN_RUN_DIR" "\$NFTBAN_LOG_DIR"
+declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+unset NFTBAN_MAIL_RECIPIENT STATS_EMAIL_ENABLED STATS_EMAIL_RECIPIENTS NFTBAN_RBL_ALERT_EMAIL NFTBAN_TUNNEL_ALERT_EMAIL NFTBAN_ALERT_EMAIL
+source "$MAIL" >/dev/null 2>&1 || true
+source "$CFN" >/dev/null 2>&1 || true
+systemctl() { return 1; }
+rbl_on() { printf 'NFTBAN_RBL_ENABLED="YES"\n' > "\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf"; }
+set +e; set +o pipefail
+EOF
+}
+run() { bash -c "$(prelude)
+$1
+nftban_mail_detect_mta() { echo ${2:-sendmail}; }
+_health_eval_communication_component c l r; echo \"CODE=\$c\"; printf '%s\n' \"\$l\""; }
+
+# 1. RBL enabled + RBL_ALERT_EMAIL set + no general + transport -> CLEAN (THE FIX)
+r=$(run "rbl_on; export NFTBAN_RBL_ALERT_EMAIL='rbl@test.example'")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'MISSING_RECIPIENT' && ok "RBL + own recipient + no general -> CLEAN (was false-WARN)" || no "case1: $r"
+
+# 2. RBL enabled + no RBL recipient + general set + transport -> CLEAN
+r=$(run "rbl_on; export NFTBAN_MAIL_RECIPIENT='gen@test.example'")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'MISSING_RECIPIENT' && ok "RBL + no own + general -> CLEAN" || no "case2: $r"
+
+# 3. RBL enabled + no RBL recipient + no general -> WARN
+r=$(run "rbl_on")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'MISSING_RECIPIENT' && echo "$r" | grep -q 'rbl-alerts' && ok "RBL + no own + no general -> WARN MISSING_RECIPIENT" || no "case3: $r"
+
+# 3b. RBL_ALERT_EMAIL read from conf.d/rbl/main.conf (not just env)
+r=$(run "rbl_on; printf 'NFTBAN_RBL_ALERT_EMAIL=\"rblconf@test.example\"\n' >> \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'MISSING_RECIPIENT' && ok "RBL recipient read from conf.d/rbl/main.conf -> CLEAN" || no "case3b: $r"
+
+# 4. Tunnel enabled (own recipient) + no general + transport -> CLEAN (THE FIX)
+r=$(run "export NFTBAN_TUNNEL_ALERT_EMAIL='tun@test.example'")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'MISSING_RECIPIENT' && ok "Tunnel + own recipient + no general -> CLEAN (was false-WARN)" || no "case4: $r"
+
+# 5. Tunnel enabled + transport none -> WARN TRANSPORT
+r=$(run "export NFTBAN_TUNNEL_ALERT_EMAIL='tun@test.example'" none)
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'TRANSPORT_UNAVAILABLE' && ok "Tunnel + own recipient + no transport -> WARN TRANSPORT" || no "case5: $r"
+
+# 6. RBL enabled + RBL_ALERT_EMAIL set + transport none -> WARN TRANSPORT
+r=$(run "rbl_on; export NFTBAN_RBL_ALERT_EMAIL='rbl@test.example'" none)
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'TRANSPORT_UNAVAILABLE' && ok "RBL + own recipient + no transport -> WARN TRANSPORT" || no "case6: $r"
+
+# 7. CROSS-MASK: RBL (no own) + stray STATS_EMAIL_RECIPIENTS (auto-reports NOT enabled) + no general -> WARN
+r=$(run "rbl_on; export STATS_EMAIL_RECIPIENTS='reports@test.example'")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'rbl-alerts' && ok "cross-mask: stray STATS_EMAIL_RECIPIENTS does NOT satisfy RBL -> WARN" || no "case7: $r"
+
+# 8. CROSS-MASK: mail-enabled + RBL_ALERT_EMAIL set + no general -> WARN (RBL email must not satisfy mail-enabled)
+r=$(run "printf 'MAIL_ENABLED=true\n' > \"\$NFTBAN_CONFIG_DIR/conf.d/mail.conf\"; export NFTBAN_RBL_ALERT_EMAIL='rbl@test.example'")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'mail-enabled' && ok "cross-mask: RBL recipient does NOT satisfy mail-enabled -> WARN" || no "case8: $r"
+
+# 9. CROSS-MASK: tunnel own recipient must not satisfy an RBL that lacks its own + no general -> WARN
+r=$(run "rbl_on; export NFTBAN_TUNNEL_ALERT_EMAIL='tun@test.example'")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'rbl-alerts' && ok "cross-mask: tunnel recipient does NOT satisfy RBL -> WARN (RBL undeliverable)" || no "case9: $r"
+
+# --- regressions ---
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh >/dev/null 2>&1 ) && ok "producer_signal_accuracy still passes" || no "producer_signal regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh >/dev/null 2>&1 ) && ok "A2b still passes" || no "A2b regressed"
+( cd "$REPO" && bash cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh >/dev/null 2>&1 ) && ok "A2r still passes" || no "A2r regressed"
+o=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 ); echo "$o" | grep -q '0/4 DEBT' && echo "$o" | grep -q 'PASS' && ok "A0 guard 0/4" || no "A0 guard regressed"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## RBLMON §4.1 — producer-recipient deliverability truth for RBL/Tunnel

Central-comms deliverability judged `rbl-alerts` and `tunnel-alerts` by the general `NFTBAN_MAIL_RECIPIENT`, but at runtime those producers deliver to their **own** recipient. So `NFTBAN_RBL_ENABLED=YES` + `NFTBAN_RBL_ALERT_EMAIL` set + no general recipient falsely WARNed as `COMMUNICATION_CONFIG_MISSING_RECIPIENT` (RBL actually delivers fine); tunnel had the same latent false-WARN. Same producer-recipient class already fixed for auto-reports.

### Context
- **RBLMON observe-only substrate is already shipped and disabled-by-default.**
- **This PR fixes only producer-recipient deliverability truth for RBL/Tunnel.** RBL remains observe-only. RBL remains disabled by default.
- **Fleet remains v1.218.4** until a later release-prep/tag/rollout gate.

### Fix
Central-comms deliverability now credits each producer's own recipient, with the general recipient preserved as fallback:
- **rbl-alerts** ← `NFTBAN_RBL_ALERT_EMAIL` (env or `conf.d/rbl/main.conf`), fallback `NFTBAN_MAIL_RECIPIENT`
- **tunnel-alerts** ← `NFTBAN_TUNNEL_ALERT_EMAIL` / `NFTBAN_ALERT_EMAIL`, fallback `NFTBAN_MAIL_RECIPIENT`
- **auto-reports** ← `STATS_EMAIL_RECIPIENTS` (unchanged)
- **mail-enabled** ← general recipient only

**Correctness rule:** a producer-specific recipient satisfies only that producer; the general recipient remains a shared fallback; **no cross-producer masking**; both own and general unset while a producer is enabled → WARN.

**Reviewer rule (provable in the diff):** producer-recipient truth only — it does **not** rebuild RBLMON, enable RBL, alter RBL core behavior, add nft writes/bans, or touch provider-bounce/MailGuard logic. Only `nftban_health_checks_modules.sh` (deliverability) + a new test change; `nftban_rbl.sh` is untouched.

### Validation
- **New `comms_rbl_tunnel_producer_recipient` test 14/14**: RBL own→CLEAN · RBL general-fallback→CLEAN · RBL neither→WARN · RBL conf-read path · Tunnel own→CLEAN · Tunnel/RBL transport-none→WARN · **cross-masking negatives** (stray `STATS_EMAIL_RECIPIENTS` / `NFTBAN_RBL_ALERT_EMAIL` / `NFTBAN_TUNNEL_ALERT_EMAIL` never satisfy another producer).
- **producer_signal_accuracy 9/9 · A2a 18/18 · A2b 16/16 · A2c 15/15 · A2r 11/11 · v2181 17/17 · UX 13/13 · no-direct-send guard 0/4** · shellcheck + `bash -n` clean.
- **lab2 official v1.218.4 overlay:** RBL enabled + `NFTBAN_RBL_ALERT_EMAIL` set + no general recipient → **Communication CLEAN** (was false-WARN); daemon active, `nftban validate` rc0; restored to RBL disabled.

### Remaining RBL work stays separate
Enable-readiness (`OPEN_RBLMON_ENABLE_READINESS_HARDENING`): `state.dat` bound · enabled-empty-watchlist `CONFIG_ERROR` · optional degraded-persistence decision. **RBL P0** (Proofpoint/iCloud/provider-bounce ingestion) remains its own lane. **Fleet-enable** remains a separate ops gate.

### Scope / rules
2 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no release-prep/tag/fleet · no RBL enablement · no RBLMON rebuild · no RBL P0 · no nft writes/bans · no MailGuard/inbound blocking.**