### PR TITLE
fix(rbl): harden observe-only enable-readiness checks

### DIFF
--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -607,6 +607,13 @@ nftban_cmd_rbl_check() {
     # Prune expired cache entries (v1.46.0 — prevent unbounded cache growth)
     nftban_rbl_cache_purge --expired 2>/dev/null || true
 
+    # v1.218.5 (§4.2): bound state.dat by AGE — drop lines not refreshed within the state-retention
+    # TTL. Age-based (not set-membership), so it never removes a currently-monitored IP (its timestamp
+    # is refreshed above via nftban_rbl_update_state) and a transiently-absent IP survives until it has
+    # been gone for the full TTL. Safe on any path — a single-IP check leaves other IPs' fresh lines
+    # untouched — so no monitored-set and no full-scan guard are needed.
+    nftban_rbl_prune_state 2>/dev/null || true
+
     # Return exit code based on listings
     return $any_listed
 }

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -324,6 +324,27 @@ nftban_health_check_rbl() {
         return $HEALTH_OK
     fi
 
+    # v1.218.5 (§4.3): RBL is ENABLED but may have NO effective watch targets — that must surface as a
+    # config advisory, not a silent effective-CLEAN. Determination is CONFIG-ONLY (no discovery run, no
+    # DNSBL/network, no mail): auto-discovery supplies the server's own IPs at runtime, so only when it
+    # is OFF do explicit targets (NFTBAN_RBL_CRITICAL_IPS or a non-empty watchlist file) matter.
+    local _rbl_autodisc _rbl_critical _rbl_watchlist
+    # grep fallbacks use `|| echo ""` so a no-match under `set -o pipefail` yields empty (never aborts
+    # the function mid-body) — matching the line-316 idiom.
+    _rbl_autodisc="${NFTBAN_RBL_AUTO_DISCOVER_IPS:-}"
+    [[ -z "$_rbl_autodisc" && -f "$rbl_config" ]] && _rbl_autodisc=$(grep -E "^NFTBAN_RBL_AUTO_DISCOVER_IPS=" "$rbl_config" 2>/dev/null | cut -d'"' -f2 || echo "")
+    _rbl_autodisc="${_rbl_autodisc:-YES}"
+    _rbl_critical="${NFTBAN_RBL_CRITICAL_IPS:-}"
+    [[ -z "$_rbl_critical" && -f "$rbl_config" ]] && _rbl_critical=$(grep -E "^NFTBAN_RBL_CRITICAL_IPS=" "$rbl_config" 2>/dev/null | cut -d'"' -f2 || echo "")
+    _rbl_watchlist="${NFTBAN_RBL_WATCHLIST_FILE:-}"
+    [[ -z "$_rbl_watchlist" && -f "$rbl_config" ]] && _rbl_watchlist=$(grep -E "^NFTBAN_RBL_WATCHLIST_FILE=" "$rbl_config" 2>/dev/null | cut -d'"' -f2 || echo "")
+    local _rbl_watchlist_has=0
+    [[ -n "$_rbl_watchlist" && -f "$_rbl_watchlist" ]] && grep -qvE '^[[:space:]]*(#|$)' "$_rbl_watchlist" 2>/dev/null && _rbl_watchlist_has=1
+    if [[ "$_rbl_autodisc" != "YES" && -z "$_rbl_critical" && "$_rbl_watchlist_has" -eq 0 ]]; then
+        rbl_issues+=("RBL enabled but no watch targets configured — nothing is being monitored (advisory reputation monitoring, not firewall blocking; set NFTBAN_RBL_CRITICAL_IPS, add a watchlist, or enable auto-discovery)")
+        [[ $status -lt $HEALTH_WARNING ]] && status=$HEALTH_WARNING
+    fi
+
     # Check last check time
     local last_check_file="${rbl_cache_dir}/last_check"
     if [[ -f "$last_check_file" ]]; then

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -1215,6 +1215,58 @@ nftban_rbl_update_state() {
     _nftban_rbl_state_to_json > "$state_json"
 }
 
+nftban_rbl_prune_state() {
+    # v1.218.5 (§4.2, AGE-BASED): remove state.dat lines whose last-update timestamp is older than the
+    # state-retention TTL. This is NOT based on the current enumerated IP set — so it is immune to
+    # transient enumeration misses, floating/VRRP movement, DHCP renewal, IPv6 privacy-address
+    # rotation, and scheduled-vs-server path mismatch. A currently-monitored IP has its timestamp
+    # refreshed by nftban_rbl_update_state at least every cache-TTL (default 24h — on cache expiry;
+    # cache-served scans do not rewrite state.dat), far inside the retention window, so it is
+    # effectively always fresh and can NEVER be pruned; a transiently-absent IP keeps its transition
+    # baseline until it has been absent for the FULL TTL.
+    # RISK GUARDS:
+    #   - A line whose timestamp is UNPARSEABLE is KEPT (never prune on ambiguity).
+    #   - A non-numeric / zero TTL disables pruning entirely (fail-safe: keep everything).
+    #   - The effective TTL is FLOORED to max(48h, 2x cache-TTL): a sub-floor override can never prune a
+    #     live cache-served IP, so "a live IP is never pruned" holds unconditionally, not just at default.
+    #   - Retained lines are copied VERBATIM (transition baseline byte-identical — no alert-once reset).
+    #   - Comments/blank lines kept. Pure file op — no network, no DNSBL, no alert, no enumeration.
+    # State retention default = 30d, internal (NFTBAN_RBL_STATE_TTL override; NOT in the conf template).
+    # The RBL cache TTL (24h, result freshness) is intentionally NOT reused as the window — too short.
+    local state_file="${NFTBAN_RBL_CACHE_DIR}/state.dat"
+    [[ -f "$state_file" ]] || return 0
+    local _ttl="${NFTBAN_RBL_STATE_TTL:-2592000}"
+    [[ "$_ttl" =~ ^[0-9]+$ ]] && [[ "$_ttl" -gt 0 ]] || return 0
+    # Floor the window so a mis-set tiny TTL can never prune a still-live (cache-served) IP.
+    local _cache_ttl_h="${NFTBAN_RBL_CACHE_TTL:-24}"
+    [[ "$_cache_ttl_h" =~ ^[0-9]+$ ]] && [[ "$_cache_ttl_h" -gt 0 ]] || _cache_ttl_h=24
+    local _min_ttl=$(( _cache_ttl_h * 7200 ))         # 2x cache-TTL, in seconds
+    [[ "$_min_ttl" -lt 172800 ]] && _min_ttl=172800   # hard floor 48h
+    [[ "$_ttl" -lt "$_min_ttl" ]] && _ttl="$_min_ttl"
+    local _now _cutoff
+    _now=$(date +%s 2>/dev/null) || return 0
+    [[ "$_now" =~ ^[0-9]+$ ]] || return 0
+    _cutoff=$(( _now - _ttl ))
+    local _tmp="${state_file}.prune.$$"
+    : > "$_tmp" || return 0
+    local _line _ts _ts_epoch
+    while IFS= read -r _line || [[ -n "$_line" ]]; do
+        if [[ -z "$_line" || "$_line" == \#* ]]; then printf '%s\n' "$_line" >> "$_tmp"; continue; fi
+        # format: IP=status|timestamp|prev_status|prev_timestamp — extract field-2 (last-update ts).
+        _ts="${_line#*=}"; _ts="${_ts#*|}"; _ts="${_ts%%|*}"
+        _ts_epoch=$(date -d "$_ts" +%s 2>/dev/null || echo "")
+        if [[ -z "$_ts_epoch" || ! "$_ts_epoch" =~ ^[0-9]+$ ]]; then
+            # unparseable timestamp -> KEEP (never prune on ambiguity)
+            printf '%s\n' "$_line" >> "$_tmp"; continue
+        fi
+        # keep if within retention window (fresh); prune only if strictly older than the cutoff.
+        [[ "$_ts_epoch" -ge "$_cutoff" ]] && printf '%s\n' "$_line" >> "$_tmp"
+    done < "$state_file"
+    mv "$_tmp" "$state_file" 2>/dev/null || { rm -f "$_tmp"; return 0; }
+    _nftban_rbl_state_to_json > "${NFTBAN_RBL_CACHE_DIR}/state.json" 2>/dev/null || true
+    return 0
+}
+
 _nftban_rbl_state_to_json() {
     # Convert state.dat to state.json for API compatibility
     local state_file="${NFTBAN_RBL_CACHE_DIR}/state.dat"
@@ -1690,6 +1742,7 @@ export -f nftban_rbl_send_degraded_alert
 export -f nftban_rbl_check_new_listing
 export -f nftban_rbl_check_delisting
 export -f nftban_rbl_update_state
+export -f nftban_rbl_prune_state
 export -f nftban_rbl_get_state
 export -f nftban_rbl_watchlist_get
 export -f nftban_rbl_watchlist_add

--- a/cli/lib/nftban/tests/rbl_enable_readiness_test.sh
+++ b/cli/lib/nftban/tests/rbl_enable_readiness_test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - RBLMON enable-readiness hardening (§4.2 state.dat prune + §4.3 advisory)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_enable_readiness_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-08"
+# meta:description="§4.2 nftban_rbl_prune_state bounds state.dat to the live monitored IP set — stale IPs removed, still-monitored IPs retained VERBATIM (transition baseline preserved), empty set is a NO-OP, comments kept. §4.3 nftban_health_check_rbl surfaces a config advisory (WARN) when RBL is ENABLED but has no effective watch targets (auto-discover OFF + no critical IPs + empty watchlist), config-only, observe-only wording, never a silent CLEAN, never a firewall hard-fail. Hermetic: extracted fns, no DNSBL/network, no real mail, no nft writes."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk"
+# meta:inventory.env_vars="NFTBAN_RBL_CACHE_DIR,NFTBAN_RBL_AUTO_DISCOVER_IPS,NFTBAN_RBL_CRITICAL_IPS,NFTBAN_RBL_WATCHLIST_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$TEST_DIR/../../../.." && pwd)"
+RBL="$REPO/cli/lib/nftban/core/nftban_rbl.sh"
+MODULES="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+no() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+
+echo "=== RBLMON enable-readiness (§4.2 prune + §4.3 advisory) ==="
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# ------------------------------------------------------------------ §4.2 age-based prune
+PFN="$WORK/prune.sh"
+awk '/^nftban_rbl_prune_state\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$RBL" > "$PFN"
+
+prune_run() {  # $1 = state.dat contents ; $2 = TTL seconds (default 30d)
+  local content="$1" ttl="${2:-2592000}"
+  bash -c '
+    set +e
+    export NFTBAN_RBL_CACHE_DIR="'"$WORK"'/cache"; mkdir -p "$NFTBAN_RBL_CACHE_DIR"
+    export NFTBAN_RBL_STATE_TTL="'"$ttl"'"
+    _nftban_rbl_state_to_json() { :; }   # stub: json regen not under test
+    printf '"'"'%s'"'"' "'"$content"'" > "$NFTBAN_RBL_CACHE_DIR/state.dat"
+    source "'"$PFN"'"
+    nftban_rbl_prune_state
+    cat "$NFTBAN_RBL_CACHE_DIR/state.dat"
+  '
+}
+
+# real timestamps: FRESH = now (refreshed this scan), STALE = 40d ago (past the 30d retention)
+NOW=$(date -Iseconds); OLD=$(date -Iseconds -d '40 days ago'); MID=$(date -Iseconds -d '5 days ago')
+SD=$'# rbl state\n'"A=listed|$NOW|clean|$OLD"$'\n'"B=clean|$OLD|clean|$OLD"$'\n'"C=clean|$MID||"$'\n'
+
+# 1. fresh line retained, stale line pruned (age-based core)
+r=$(prune_run "$SD")
+echo "$r" | grep -q '^A=' && ! echo "$r" | grep -q '^B=' && ok "§4.2 fresh(A) retained, stale-40d(B) pruned" || no "4.2-1: $r"
+
+# 2. currently-refreshed IP line preserved VERBATIM (transition baseline byte-identical)
+r=$(prune_run "$SD")
+echo "$r" | grep -qxF "A=listed|$NOW|clean|$OLD" && ok "§4.2 refreshed A line byte-identical (baseline not reset)" || no "4.2-2: $r"
+
+# 3. transiently-missing-but-not-expired IP (C, 5d old, absent from any 'set') RETAINED
+r=$(prune_run "$SD")
+echo "$r" | grep -q '^C=' && ok "§4.2 transiently-absent-but-fresh(C 5d) retained (age-based, not set-membership)" || no "4.2-3: $r"
+
+# 4. malformed timestamp -> KEEP (never prune on ambiguity)
+r=$(prune_run $'X=listed|not-a-date|clean|t0\n')
+echo "$r" | grep -q '^X=' && ok "§4.2 unparseable timestamp -> line KEPT (no prune on ambiguity)" || no "4.2-4: $r"
+
+# 5. comments/blank kept verbatim
+r=$(prune_run "$SD")
+echo "$r" | grep -qxF '# rbl state' && ok "§4.2 comment line kept verbatim" || no "4.2-5: $r"
+
+# 6. non-numeric / zero TTL -> keep everything (fail-safe, no pruning)
+r=$(prune_run "$SD" 0)
+echo "$r" | grep -q '^A=' && echo "$r" | grep -q '^B=' && echo "$r" | grep -q '^C=' && ok "§4.2 TTL=0 disables pruning (fail-safe keep-all)" || no "4.2-6: $r"
+r=$(prune_run "$SD" abc)
+echo "$r" | grep -q '^B=' && ok "§4.2 non-numeric TTL disables pruning (fail-safe keep-all)" || no "4.2-6b: $r"
+
+# 7. NO set-membership behaviour remains: passing IP args must NOT change the outcome (age-based only)
+awk_args=$(grep -c '_keep\|for _ip in' "$PFN" || true)
+[[ "$awk_args" -eq 0 ]] && ok "§4.2 no set-membership code remains (no _keep / IP-arg loop)" || no "4.2-7: set-membership residue ($awk_args)"
+
+# 8. empty current enumeration does NOT wipe state.dat (age-based ignores enumeration entirely)
+r=$(prune_run $'A=listed|'"$NOW"'|clean|'"$OLD"$'\n')
+echo "$r" | grep -q '^A=' && ok "§4.2 fresh entry survives regardless of enumeration (no set input)" || no "4.2-8: $r"
+
+# 9. no transition-baseline reset: a just-updated IP (now) is never pruned even at tiny TTL=1s
+r=$(prune_run $'A=listed|'"$NOW"'|clean|'"$OLD"$'\n' 1)
+echo "$r" | grep -qxF "A=listed|$NOW|clean|$OLD" && ok "§4.2 just-refreshed IP survives even at TTL=1s (fresh never pruned)" || no "4.2-9: $r"
+
+# 10. TTL FLOOR: a mis-set tiny TTL (1h) must NOT prune a still-live cache-served IP (~20h old);
+#     the floor (max 48h, 2x cache-TTL) clamps the window up so live cache-served IPs survive.
+H20=$(date -Iseconds -d '20 hours ago')
+r=$(prune_run $'A=listed|'"$H20"'|clean|'"$OLD"$'\n' 3600)
+echo "$r" | grep -q '^A=' && ok "§4.2 TTL floor: 20h-old live IP retained under mis-set 1h TTL (floor≥48h)" || no "4.2-10: $r"
+
+# 11. floor still prunes GENUINE staleness: a 40d entry is older than the 48h floor -> pruned
+r=$(prune_run $'B=clean|'"$OLD"'|clean|'"$OLD"$'\n' 3600)
+! echo "$r" | grep -q '^B=' && ok "§4.2 floor still prunes genuinely-stale 40d entry (>48h)" || no "4.2-11: $r"
+
+# ------------------------------------------------------------------ §4.3 advisory
+HFN="$WORK/hrbl.sh"
+awk '/^nftban_health_check_rbl\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$MODULES" > "$HFN"
+
+hrbl() {  # env-var assignments as $1 (conf lines), returns "CODE=n" + issue text
+  bash -c '
+    set +e
+    export NFTBAN_CONFIG_DIR="'"$WORK"'/etc" NFTBAN_LOG_DIR="'"$WORK"'/log"
+    mkdir -p "$NFTBAN_CONFIG_DIR/conf.d/rbl" "$NFTBAN_LOG_DIR/rbl"
+    HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+    declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+    systemctl() { return 1; }   # skip timer sub-check (is-enabled fails)
+    date -Iseconds > "$NFTBAN_LOG_DIR/rbl/last_check"   # recent -> no stale WARN
+    unset NFTBAN_RBL_AUTO_DISCOVER_IPS NFTBAN_RBL_CRITICAL_IPS NFTBAN_RBL_WATCHLIST_FILE
+    '"$1"'
+    source "'"$HFN"'"
+    nftban_health_check_rbl; c=$?; echo "CODE=$c"; printf "%s\n" "${NFTBAN_HEALTH_ISSUES[rbl]}"
+  '
+}
+
+CONF='printf "NFTBAN_RBL_ENABLED=\"YES\"\n" > "$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf"'
+
+# A. enabled + auto-discover OFF + no critical + no watchlist -> WARN advisory
+r=$(hrbl "$CONF; printf 'NFTBAN_RBL_AUTO_DISCOVER_IPS=\"NO\"\n' >> \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'no watch targets' && ok "§4.3 enabled + no effective targets -> WARN advisory (not silent CLEAN)" || no "4.3-A: $r"
+
+# A-wording. observe-only framing preserved, not firewall-failure
+echo "$r" | grep -q 'not firewall blocking' && ok "§4.3 advisory preserves observe-only wording" || no "4.3-Aw: $r"
+
+# A-severity. WARN not ERROR (never hard-fail posture)
+echo "$r" | grep -q 'CODE=1' && ! echo "$r" | grep -q 'CODE=2' && ok "§4.3 severity is WARN, never ERROR" || no "4.3-Asev: $r"
+
+# B. enabled + auto-discover YES (default) -> no empty-watchlist advisory
+r=$(hrbl "$CONF")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'no watch targets' && ok "§4.3 enabled + auto-discover YES -> no empty-watchlist WARN" || no "4.3-B: $r"
+
+# C. enabled + auto-discover OFF + CRITICAL_IPS set -> no advisory
+r=$(hrbl "$CONF; printf 'NFTBAN_RBL_AUTO_DISCOVER_IPS=\"NO\"\nNFTBAN_RBL_CRITICAL_IPS=\"203.0.113.5\"\n' >> \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'no watch targets' && ok "§4.3 auto-discover OFF but CRITICAL_IPS set -> no advisory" || no "4.3-C: $r"
+
+# D. enabled + auto-discover OFF + non-empty watchlist file -> no advisory
+r=$(hrbl "printf '203.0.113.9\n' > \"\$NFTBAN_LOG_DIR/wl.txt\"; $CONF; printf 'NFTBAN_RBL_AUTO_DISCOVER_IPS=\"NO\"\nNFTBAN_RBL_WATCHLIST_FILE=\"'\"\$NFTBAN_LOG_DIR\"'/wl.txt\"\n' >> \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"")
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'no watch targets' && ok "§4.3 auto-discover OFF but non-empty watchlist -> no advisory" || no "4.3-D: $r"
+
+# E. disabled -> OK, no advisory (early return)
+r=$(hrbl 'printf "NFTBAN_RBL_ENABLED=\"NO\"\n" > "$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf"')
+echo "$r" | grep -q 'CODE=0' && ! echo "$r" | grep -q 'no watch targets' && ok "§4.3 disabled -> OK, no empty-watchlist WARN" || no "4.3-E: $r"
+
+# F. auto-discover OFF + watchlist file present but comments-only -> WARN (empty effective)
+r=$(hrbl "printf '# only a comment\n' > \"\$NFTBAN_LOG_DIR/wl.txt\"; $CONF; printf 'NFTBAN_RBL_AUTO_DISCOVER_IPS=\"NO\"\nNFTBAN_RBL_WATCHLIST_FILE=\"'\"\$NFTBAN_LOG_DIR\"'/wl.txt\"\n' >> \"\$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf\"")
+echo "$r" | grep -q 'CODE=1' && echo "$r" | grep -q 'no watch targets' && ok "§4.3 comments-only watchlist counts as empty -> WARN" || no "4.3-F: $r"
+
+# G. STRICT MODE (set -eEuo pipefail, NO `|| true` caller wrap): enabled + no env vars, main.conf has
+#    no watchlist line → the grep fallbacks must NOT abort the function mid-body (deputy-2 finding).
+r=$(bash -c '
+  set -eEuo pipefail
+  export NFTBAN_CONFIG_DIR="'"$WORK"'/etcs" NFTBAN_LOG_DIR="'"$WORK"'/logs"
+  mkdir -p "$NFTBAN_CONFIG_DIR/conf.d/rbl" "$NFTBAN_LOG_DIR/rbl"
+  HEALTH_OK=0; HEALTH_WARNING=1; HEALTH_ERROR=2
+  declare -A NFTBAN_HEALTH_RESULTS NFTBAN_HEALTH_ISSUES; declare -a NFTBAN_HEALTH_ERRORS
+  systemctl() { return 1; }
+  date -Iseconds > "$NFTBAN_LOG_DIR/rbl/last_check"
+  printf "NFTBAN_RBL_ENABLED=\"YES\"\n" > "$NFTBAN_CONFIG_DIR/conf.d/rbl/main.conf"
+  source "'"$HFN"'"
+  nftban_health_check_rbl; c=$?
+  echo "DONE=$c RESULT=${NFTBAN_HEALTH_RESULTS[rbl]:-UNSET}"
+' 2>&1 || echo "ABORTED")
+echo "$r" | grep -q 'DONE=' && echo "$r" | grep -q 'RESULT=0' && ! echo "$r" | grep -q 'ABORTED' && ok "§4.3 completes under strict mode without || true (grep fallbacks guarded)" || no "4.3-G strict: $r"
+
+# ------------------------------------------------------------------ regressions
+o=$( cd "$REPO" && bash scripts/ci/check-comms-direct-send.sh 2>&1 ); echo "$o" | grep -q '0/4 DEBT' && ok "A0 guard 0/4" || no "A0 guard regressed"
+echo "  RBL nft/ban writes: $(grep -cE 'nft add|nftban_ban|add element' "$RBL")  (want 0)"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## RBLMON enable-readiness hardening (§4.2 + §4.3)

Completes the RBLMON enable-readiness bundle. **RBLMON substrate is already shipped and disabled-by-default — this PR does not build RBLMON.** It implements only §4.2 + §4.3 hardening so the observe-only monitor is enable-ready without false health truth.

- **§4.1 producer-recipient accuracy is already merged separately** (PR #1042 → `1dbdd0cd`).
- **§4.4 degraded-persistence remains HOLD.**
- **RBL P0** (Proofpoint/iCloud/provider-bounce ingestion) remains a separate lane.
- **Fleet remains v1.218.4** until a later release-prep/tag/rollout gate. RBL stays observe-only and disabled by default.

### §4.2 — age-based `state.dat` retention
Rejects unsafe **set-membership** pruning (an earlier adversarial review showed it could reset a still-monitored IP's baseline on a transient enumeration miss — floating/VRRP, DHCP renewal, IPv6 privacy-address rotation, scheduled-vs-server mismatch — and re-fire a "new listing" alert). New `nftban_rbl_prune_state()`:
- prunes only lines whose **last-update timestamp** is older than the retention TTL (default **30d**, internal `NFTBAN_RBL_STATE_TTL`; the 24h cache TTL is intentionally not reused as the window);
- a monitored IP is refreshed at least every cache-TTL (~24h) → always fresh → **never pruned**; a transiently-absent IP keeps its baseline until absent the **full TTL**;
- **risk guards:** unparseable timestamp → KEPT; non-numeric/zero TTL → keep-all; effective TTL **floored to `max(48h, 2×cache-TTL)`** so a mis-set tiny override can never prune a live cache-served IP; retained lines **verbatim**; pure file op (no network/DNSBL/alert/enumeration). Mirrors the existing `nftban_rbl_cache_purge --expired` precedent.

### §4.3 — enabled-empty-watchlist advisory
`nftban_health_check_rbl` renders a **config-only WARN** (never ERROR, never hard-fails firewall posture, observe-only wording) when RBL is enabled but has no effective watch targets (auto-discover OFF **and** no `NFTBAN_RBL_CRITICAL_IPS` **and** empty/absent watchlist). No discovery run, no DNSBL/network, no mail. strict-mode `grep|cut` fallbacks guarded.

### Reviewer rule (provable in the diff)
Age-based retention only · **0 set-membership residue** (no `_keep`/IP-arg loop) · no RBL enablement · no nft writes/bans · no provider-bounce/MailGuard logic · **§4.1 `_rbl_rcpt`/`_tunnel_rcpt` mapping untouched** (0 diff lines). `nftban_rbl.sh` gains only the observe-only prune (0 nft/ban).

### Validation
- **New `rbl_enable_readiness` test 22/22**: 11 §4.2 age cases (incl. **TTL-floor retains 20h live IP** + **floor still prunes 40d stale**, unparseable-kept, TTL-0/non-numeric fail-safe, no set-membership residue, no baseline reset at TTL=1s) + 8 §4.3 advisory cases + strict-mode + guard.
- **rbl/tunnel producer-recipient 14/14 · producer_signal_accuracy 9/9 · A2a 18/18 · A2b 16/16 · A2c 15/15 · A2r 11/11 · v2181 17/17 · no-direct-send guard 0/4** · shellcheck + `bash -n` clean · **RBL nft/ban writes 0** · no real mail · no DNSBL network queries.
- Two adversarial-deputy passes on §4.2 (set-membership rejected → age-based verified SAFE at default + floored).

### Scope / rules
4 files, **shell-only · 0 Go · daemon byte-identical · nft schema 1.84.0 · no VERSION bump · no release-prep/tag/fleet · no RBL enablement · no RBLMON rebuild · no RBL P0 · no nft writes/bans · no MailGuard/inbound blocking · §4.4 HOLD.**