### PR TITLE
docs(operator): add recovery, forensics, baseline, and metrics contracts

### DIFF
--- a/docs/operator/BAN_FORENSICS.md
+++ b/docs/operator/BAN_FORENSICS.md
@@ -1,0 +1,127 @@
+# Ban forensics
+
+**Last verified: v1.218.5.**
+
+This page explains how to answer, after the fact, the questions an operator asks about a ban: *is this
+IP actually banned right now, which module banned it, when, why, and in which nftables set?* It covers
+the on-disk log, the query commands, and the kernel-verification commands that prove enforcement.
+
+## Prerequisites
+
+- Root or `nftban` group membership (to read `/var/log/nftban/` and run `nft list set`).
+- NFTBan installed from an official package (FHS layout).
+
+## 1. The ban log
+
+Ban and unban events are written to **`/var/log/nftban/bans.log`**.
+
+The daemon writes pipe-delimited records with up to ten fields:
+
+```
+DATE|TIME|SOURCE|IP|COUNTRY|STATUS|REASON|BAN_ID|TIMEOUT|CLASS
+```
+
+| Field | Meaning |
+|-------|---------|
+| `SOURCE` | which subsystem banned the IP: `manual`, `login`, `portscan`, `ddos`, `feeds`, `suricata` |
+| `STATUS` | `BANNED`, `UNBANNED`, or `RESYNC` (RESYNC = an idempotent re-push of an existing ban, not a new event) |
+| `REASON` | free text; `|` and newlines are sanitized out |
+| `BAN_ID` | links a `BANNED` record to its later `UNBANNED` record (present since v1.41.0; empty before) |
+| `TIMEOUT` | kernel timeout for the ban |
+| `CLASS` | `temp` (kernel TTL, default 15m), `escalated`, `permanent`, `manual`, or `resync` |
+
+Unban events are recorded in the same file with `STATUS=UNBANNED`. There is no separate `unbans.log`
+— a path by that name is referenced in the code but has no writer, so do not look for it.
+
+Example queries:
+
+```bash
+grep '|login|'   /var/log/nftban/bans.log        # everything the login module banned
+grep '203.0.113.5' /var/log/nftban/bans.log      # full history for one IP (BAN + UNBAN share a BAN_ID)
+awk -F'|' '$6=="BANNED"{print $3}' /var/log/nftban/bans.log | sort | uniq -c   # bans per source
+```
+
+## 2. Ask the CLI which set an IP is in
+
+```bash
+nftban search <ip>            # or a port; --json for machine output, --no-interactive to skip prompts
+```
+
+`search` reads the kernel sets in order — `whitelist_<family>`, `blacklist_manual_<family>`,
+`blacklist_<family>` — does CIDR-containment matching, and reports which set the address falls in
+(it relabels `blacklist_manual` as "blacklist (manual)"). It is read-only and never changes state.
+
+```bash
+nftban list banned            # enumerate banned IPs (manual + feed/geoban sets); also: whitelist | all
+nftban list banned --json
+nftban blacklist list         # both feed/geoban and manual entries; blacklist show for detail
+nftban status                 # "Banned IPs" = kernel blacklist_ipv4 + blacklist_manual_ipv4 (+ v6)
+```
+
+## 3. Which set means which origin
+
+The nftables set an IP sits in already tells you how it was banned:
+
+| Set | Holds | Structure |
+|-----|-------|-----------|
+| `whitelist_ipv4` / `whitelist_ipv6` | trusted IPs; bypass all checks | — |
+| `blacklist_manual_ipv4` / `blacklist_manual_ipv6` | manual bans **and** auto-detect bans (login, portscan, ddos) | hash (single IP) |
+| `blacklist_ipv4` / `blacklist_ipv6` | feed and geoban bans | interval / CIDR-aggregated |
+
+So the set distinguishes *manual/auto* (`blacklist_manual_*`) from *feed/geoban* (`blacklist_*`). To
+pin down the **exact module** behind a manual/auto ban, read the `SOURCE` field in `bans.log`
+(`login` / `portscan` / `ddos` / `manual` / `feeds` / `suricata`). Emergency direct bans (see
+[Emergency recovery](EMERGENCY_RECOVERY_AND_ROLLBACK.md)) land in the unified `blacklist_ipv4` /
+`blacklist_ipv6` set.
+
+## 4. Daemon events
+
+For the runtime story of a ban/unban (decision, IPC, errors), read the daemon journal:
+
+```bash
+journalctl -u nftband --since "1 hour ago"
+```
+
+## 5. Kernel truth — prove the ban is enforced
+
+The CLI summaries above are a report layer. The firewall state that actually drops traffic lives in
+the kernel. Confirm it directly:
+
+```bash
+nft list set ip  nftban blacklist_ipv4
+nft list set ip  nftban blacklist_manual_ipv4
+nft list set ip6 nftban blacklist_ipv6
+nft list set ip6 nftban blacklist_manual_ipv6
+nft list tables                              # the nftban tables must be present
+```
+
+If an IP appears in `bans.log` and in `nftban status` but is **not** in the corresponding kernel set,
+the ban is not being enforced — investigate the daemon (`journalctl -u nftband`) and reconcile with
+`nftban blacklist reconcile`.
+
+## 6. Ban counts (metrics)
+
+Aggregate ban counts are cached in the unified stats file at
+`/var/cache/nftban/metrics/stats.json`; the running total is at `.activity.total_bans`:
+
+```bash
+jq .activity.total_bans /var/cache/nftban/metrics/stats.json
+```
+
+See [Metrics truth](METRICS_TRUTH.md) for what the metrics layer does and does not guarantee.
+
+## Failure modes and caveats
+
+- **The log is history; the kernel is state.** An entry in `bans.log` records that an event happened,
+  not that the IP is still banned now. Use `nft list set` for the current state.
+- **RESYNC is not a new ban.** Filter it out when counting distinct ban events.
+- **`RBL` never appears as a ban `SOURCE`.** RBL is DNSBL advisory monitoring (disabled by default);
+  it reports reputation and can send alerts, but it does not write nftables sets or ban anything.
+
+## References
+
+- Ban log writer and format: `internal/banlog/banlog.go`; shell mirror `core/nftban_login_alert.sh`
+- Query commands: `cli/lib/nftban/cli/cmd_search.sh`, `cmd_list.sh`, `cmd_blacklist.sh`, `cmd_status.sh`
+- Set definitions: `install/nftables/nftables.conf.tpl`
+- Stats cache: `cli/lib/nftban/core/nftban_stats.sh`, `nftban_stats_collect.sh`
+- Related: [Emergency recovery](EMERGENCY_RECOVERY_AND_ROLLBACK.md), [Metrics truth](METRICS_TRUTH.md)

--- a/docs/operator/EMERGENCY_RECOVERY_AND_ROLLBACK.md
+++ b/docs/operator/EMERGENCY_RECOVERY_AND_ROLLBACK.md
@@ -1,0 +1,186 @@
+# Emergency recovery and rollback
+
+**Last verified: v1.218.5.**
+
+This page is the operator reference for recovering an NFTBan host after a failed update, a broken
+firewall reload, an unresponsive daemon, or an accidental self-lockout. Every command and path below
+is taken from the shipped code; where a `--help` string or a referenced path is stale, this page says
+so and gives the real value.
+
+## Prerequisites
+
+- Root (or a shell that can run `nft`, `systemctl`, and the `nftban` CLI).
+- NFTBan installed from an official package. The recovery paths below assume the FHS layout
+  (`/usr/lib/nftban/`, `/etc/nftban/`, `/var/lib/nftban/`, `/var/log/nftban/`).
+- Keep a second way into the box (console, or a second SSH session on a known-good port) before you
+  start recovery work.
+
+## 1. Roll back a failed update
+
+`nftban update` takes a backup as its first phase, before it installs anything. If the backup step
+fails, the update aborts unless you pass `--force`.
+
+- **What is captured:** a single `tar -czf` archive of whichever of `usr/lib/nftban`,
+  `usr/sbin/nftban`, and `etc/nftban` exist.
+- **Where it is written:** `/var/lib/nftban/update-backups/`, as
+  `nftban-<version>-<YYYYMMDD-HHMMSS>.tar.gz`.
+  (Note: the `nftban rollback --help` text prints an older path, `/var/lib/nftban/update/backups/`.
+  That string is stale — the real directory is `/var/lib/nftban/update-backups/`.)
+- **Retention:** the newest `NFTBAN_UPDATE_BACKUP_COUNT` archives are kept (default 3); older ones are
+  pruned.
+
+Inspect backups without changing anything:
+
+```bash
+nftban update list        # list available backups
+nftban update history     # update history
+```
+
+Roll back to the most recent backup:
+
+```bash
+nftban update rollback    # alias: nftban rollback
+```
+
+Rollback selects the newest `nftban-*.tar.gz`, repairs broken package state if needed, clears any
+immutable flags, and extracts the archive over `/`. On a `.deb` system it re-runs
+`dpkg --configure -a` afterwards. **This is destructive and has no undo** — it overwrites the current
+install with the backup.
+
+Related recovery verbs (printed by the update-failure message):
+
+```bash
+nftban update repair      # fix broken package state, clear immutable flags, optional backup restore
+nftban update force       # re-run the update ignoring the abort guard
+nftban update recommit    # re-validate the current install without a restart (nftban-installer --revalidate)
+```
+
+### What the update checks before it declares success
+
+Any of these failing tells you to roll back:
+
+- the `nftban` nftables table is present in the kernel,
+- every detected SSH port is present both in the live kernel set and in durable config (lockout
+  guard),
+- `nftband` is active, the installed VERSION matches, and the Go validator passes.
+
+## 2. Rebuild the firewall schema
+
+The command is **`nftban firewall rebuild`**. (The bare `nftban rebuild` is an inert stub in this
+build — it only prints that rebuild is handled by the distro package. Use the `firewall` form.)
+
+Rebuild is safe to run for recovery because it validates before it applies:
+
+1. renders the ruleset to a temporary file,
+2. dry-run validates it with `nft -c -f`,
+3. only on success does it atomically `mv` the file into place and load it in a single `nft -f`
+   transaction.
+
+If validation fails, the existing firewall is left untouched. The rendered ruleset does its
+create/delete/define inside one transaction, so packets never see an empty ruleset. Before the
+rebuild, NFTBan snapshots the full ruleset to `/var/lib/nftban/backup/rebuild_<timestamp>/` and backs
+up the whitelist and blacklist sets (v4 and v6), so existing bans and whitelist entries are preserved
+across the rebuild. If the load fails, the CLI advises `nftban firewall reset --force`.
+
+Verify after a rebuild:
+
+```bash
+nft list tables            # must include: table ip nftban  and  table ip6 nftban
+nftban health
+```
+
+## 3. Recover an unresponsive daemon
+
+The runtime daemon is **`nftband.service`** (with `nftband.socket`). It owns IPC and ban/unban
+execution.
+
+```bash
+systemctl start nftband        # or: systemctl restart nftband
+nftban services                # report unit status (alias: nftban service)
+nftban services fix            # auto-start stopped NFTBan services
+```
+
+Confirm recovery:
+
+```bash
+systemctl is-active nftband
+nft list tables                # nftban tables present
+nftban health
+```
+
+### Emergency mode (daemon down, you still need to ban/unban)
+
+When the daemon cannot be started, NFTBan can talk to nftables directly. This is a break-glass path —
+every use logs a warning:
+
+- enable with `export NFTBAN_EMERGENCY_MODE=1`, **or** `touch /run/nftban/.emergency_unlock`,
+- then `nftban ban <ip>` / `nftban unban <ip>` operate directly on the `blacklist_ipv4` /
+  `blacklist_ipv6` sets.
+
+The normal ban path always tries the daemon IPC first and only falls back to the direct path when
+emergency mode is enabled.
+
+## 4. Emergency flush
+
+```bash
+nftban flush all               # EMERGENCY: flush everything
+nftban flush blacklist         # or: whitelist | feeds | geoban | ddos
+```
+
+`flush all` supports `--dry-run` and `--yes`. The system whitelist is automatically restored even
+after `flush all`, so a flush does not strip your trusted-IP protection. Do not interrupt a flush
+mid-run.
+
+## 5. Recover from a self-lockout
+
+The kernel ruleset evaluates the whitelist **before** the blacklist: `@whitelist_ipv4 … accept`
+precedes the `@blacklist_manual_ipv4 … drop` and `@blacklist_ipv4 … drop` rules (and the same for
+IPv6). A whitelisted address bypasses every ban check.
+
+To recover trusted access durably:
+
+```bash
+nftban whitelist add --static <your-ip>    # writes whitelist.d/99-manual.conf; survives rebuild
+```
+
+A plain `nftban whitelist add <ip>` is runtime-only and is lost on the next rebuild — use `--static`
+for recovery.
+
+For an SSH-port lockout: NFTBan's update verification treats an SSH port that is missing from the live
+kernel `tcp_ports_in` set as an error ("lockout risk"). The durable SSH port lives in
+`/etc/nftban/nftban.conf.local` (`SSH_PORT=` / `TCP_PORTS_IN=`). See
+[Changing the SSH port safely](../SSH-PORT-LIFECYCLE.md) for the full lifecycle.
+
+## 6. Uninstall and reinstall
+
+`./uninstall.sh` performs a complete removal: it stops and disables the units and (on `.deb`)
+`dpkg --purge nftban-core`.
+
+- **Without `--purge`:** `/etc/nftban` and `/var/lib/nftban` are preserved (configuration and data
+  survive), so a reinstall picks up your existing config.
+- **With `--purge`:** those directories are removed.
+
+Reinstall from the official package for your distro, then confirm with `nftban health` and
+`nft list tables`.
+
+## Failure modes and caveats
+
+- **Rollback is destructive.** It overwrites the current install with the newest backup and cannot be
+  undone. Read `nftban update list` first.
+- **CLI output is a report, not proof.** After any recovery, confirm kernel state with `nft list set`
+  / `nft list tables`, not the CLI summary alone.
+- **Emergency mode is break-glass.** It bypasses the daemon and logs a warning on every operation;
+  return to the normal daemon path as soon as `nftband` is healthy.
+- **`unbans.log` does not exist.** Unban events are recorded in `bans.log` with `STATUS=UNBANNED` (see
+  [Ban forensics](BAN_FORENSICS.md)).
+
+## References
+
+- Update / rollback / repair: `cli/lib/nftban/cli/cmd_update.sh`, `cmd_update_backup.sh`
+- Firewall rebuild / atomic apply: `cli/lib/nftban/cli/cmd_firewall.sh`
+- Emergency IPC path: `cli/lib/nftban/lib/nft_ipc.sh`
+- Flush: `cli/lib/nftban/cli/cmd_flush.sh`
+- Whitelist (durable `--static`): `cli/lib/nftban/cli/cmd_whitelist.sh`
+- Services: `cli/lib/nftban/cli/cmd_services.sh`
+- Ruleset template (whitelist-before-blacklist ordering): `install/nftables/nftables.conf.tpl`
+- Related: [Ban forensics](BAN_FORENSICS.md), [Production baseline](PRODUCTION_BASELINE.md)

--- a/docs/operator/METRICS_TRUTH.md
+++ b/docs/operator/METRICS_TRUTH.md
@@ -1,0 +1,120 @@
+# Metrics truth
+
+**Last verified: v1.218.5.**
+
+This page explains what NFTBan's metrics layer is, where its data lives, and — importantly — what it
+does and does not prove. It is a reference for reading metrics correctly, not a tuning guide, and it
+does not change any metrics behavior. Known exporter defects are noted and routed to the metrics lane,
+not fixed here.
+
+## Prerequisites
+
+- Root or `nftban` group membership to read `/var/cache/nftban/metrics/` and query the daemon socket.
+- `jq` for reading the JSON cache.
+
+## 1. The unified stats cache is the source of truth
+
+NFTBan collects metrics into a single JSON cache:
+
+```
+/var/cache/nftban/metrics/stats.json
+```
+
+It is written by the unified exporter (`/usr/lib/nftban/exporters/nftban_unified_exporter.sh`, run by
+`nftban-unified-exporter.timer`). The cache carries a `schema_version`; consumers reject a cache
+without a valid one. Its freshness window is 300 seconds (5 minutes) — a reading older than that is
+considered stale and recollected.
+
+Real field paths (examples):
+
+```bash
+jq .blacklist.total                 /var/cache/nftban/metrics/stats.json
+jq .blacklist.ipv4.permanent        /var/cache/nftban/metrics/stats.json
+jq .activity.total_bans             /var/cache/nftban/metrics/stats.json
+jq .nftables.apply_latency_ms       /var/cache/nftban/metrics/stats.json
+```
+
+## 2. `nftban stats export` vs `nftban metrics`
+
+These are different tools — do not confuse them:
+
+- **`nftban export`** is an alias for **`nftban stats export`**. It emits the stats in **`json`
+  (default) or `csv`**, optionally to `--output FILE`. There is no Prometheus format on this path.
+- **`nftban metrics`** manages the **Prometheus metrics collection integration** (Prometheus /
+  node_exporter). It enables or disables that integration; it is not the exporter itself.
+
+```bash
+nftban stats export --format json                 # or: --format csv
+nftban stats export --format json --output /tmp/stats.json
+```
+
+## 3. Prometheus output
+
+When a node_exporter textfile directory is present, the unified exporter writes a **single** file:
+
+```
+/var/lib/node_exporter/textfile_collector/nftban.prom
+```
+
+(The directory and filename are overridable via `NFTBAN_PROMETHEUS_TEXTFILE_DIR` /
+`NFTBAN_PROMETHEUS_OUTPUT_FILE`.) Prometheus export auto-enables only when that textfile directory
+already exists. There are no per-module `.prom` files — everything is in `nftban.prom`.
+
+## 4. The daemon HTTP endpoint (`:9580`)
+
+The daemon binds an HTTP endpoint on **`127.0.0.1:9580` (loopback) by default**, and the bind is
+**enforced**, not merely defaulted:
+
+- A loopback bind address is accepted as-is.
+- A non-loopback bind address (a routable IP, `0.0.0.0`, `::`, a hostname, or an empty host) is
+  **refused and the daemon falls back to loopback**, unless the operator explicitly sets
+  `NFTBAN_API_ALLOW_INSECURE_BIND=YES` (the SEC-P1-3a escape hatch).
+- The `/metrics` path is additionally restricted to `127.0.0.1` / `::1` and returns HTTP 403 from any
+  other client.
+
+The bind address is configurable via the daemon's `APIAddr` config. Treat `:9580` as a local-only
+endpoint unless you have deliberately opened it.
+
+## 5. Metrics are a report layer — the kernel is the truth
+
+Metrics and CLI summaries describe state; they do not enforce it. Two consequences an operator must
+keep in mind:
+
+- **Enforcement truth is the kernel.** To know an IP is actually banned, read the set:
+  `nft list set ip nftban blacklist_ipv4` (see [Ban forensics](BAN_FORENSICS.md)). The four-axis
+  health view is built on the Go validator precisely so the CLI does not compute health independently.
+- **The daemon's HTTP `/health` is not a posture signal.** It returns a fixed `{"status":"ok"}`
+  regardless of real state. Use `nftban validate` and `nft list tables` to judge protection, not the
+  HTTP health route.
+
+## 6. Known metrics defects — tracked in the metrics lane
+
+These are open items owned by the observability/metrics lane, not by this doc. They are listed here so
+operators reading metrics know the caveats; the fixes are scoped and gated separately.
+
+- **`EXPORTER-PROM-MULTIWRITER` (P1):** the Go collector and the shell exporter can write the same
+  `nftban.prom` without a shared lock. Tracked in the metrics lane
+  (`NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md`, Cluster D).
+- **`DAEMON-HTTP-HEALTH-ALWAYS-OK` (P3):** the daemon `/health` route is hardcoded to `ok`
+  (`cmd/nftband/daemon_http.go`), which is why kernel/validator checks — not HTTP `/health` — are the
+  posture truth. Tracked in the same lane.
+
+Report new metrics-accuracy issues to the metrics lane rather than working around them in
+integrations.
+
+## Failure modes and caveats
+
+- **A 5-minute-old cache is expected.** `stats.json` has a 300s freshness window; a reading is not
+  "live to the second."
+- **`nftban.prom` only appears if node_exporter's textfile directory exists.** No directory, no
+  `.prom` file — that is by design, not a fault.
+- **`:9580` is loopback by default and refuses insecure binds** unless `NFTBAN_API_ALLOW_INSECURE_BIND=YES`
+  is set. If you expect remote scraping and see nothing, that guard is why.
+
+## References
+
+- Unified cache / exporter: `cli/lib/nftban/core/nftban_stats.sh`, `exporters/nftban_unified_exporter.sh`, `exporters/nftban_unified_exporter_export.sh`
+- JSON field compat: `cli/lib/nftban/exporters/nftban_exporter_json_compat.sh`
+- Export / metrics commands: `cli/lib/nftban/cli/cmd_stats.sh`, `cmd_metrics.sh`
+- Daemon HTTP bind rules: `cmd/nftband/daemon_http.go`, `daemon_types.go`
+- Related: [Ban forensics](BAN_FORENSICS.md), [Production baseline](PRODUCTION_BASELINE.md)

--- a/docs/operator/PRODUCTION_BASELINE.md
+++ b/docs/operator/PRODUCTION_BASELINE.md
@@ -1,0 +1,141 @@
+# Production baseline
+
+**Last verified: v1.218.5.**
+
+This page describes what a healthy NFTBan production host looks like on v1.218.5 and the commands an
+operator uses to confirm it. Use it after an install, an update, or an incident to establish that the
+host is back to a known-good state.
+
+## Prerequisites
+
+- Root or `nftban` group membership.
+- NFTBan installed from an official package (FHS layout).
+
+## 1. Version
+
+`VERSION` is the single source of truth. On a baseline v1.218.5 host:
+
+```bash
+nftban version            # Version: 1.218.5  (CLI and Core components report the same version)
+nftband --version         # daemon binary; version is injected at build time
+```
+
+A version mismatch between the CLI and the daemon binary, or against the `/usr/lib/nftban/VERSION`
+file, means the install is inconsistent — see [Emergency recovery](EMERGENCY_RECOVERY_AND_ROLLBACK.md).
+
+## 2. Health
+
+```bash
+nftban health
+```
+
+`nftban health` reports each component with one of: **OK, WARNING, ERROR, CRITICAL, NOT INSTALLED,
+DISABLED**. The overall verdict is derived from the counts: no errors and no warnings → **OK**; no
+errors but some warnings → **WARNING**; any error → **ERROR**.
+
+Two components matter for baseline truth on v1.218.5:
+
+- **Communication (central-comms)** — shown under *optional features*. On a host with no alert
+  producer needing email, it reads **INFO / NOT CONFIGURED** (a healthy state, exit code 0). It warns
+  only when an enabled producer cannot deliver (missing recipient, spool backlog, or an unresolved
+  last-failure). A Communication warning **never** fails firewall posture — the health output states
+  that warnings are about optional features and the firewall protection is unaffected. See
+  [Notifications setup](NOTIFICATIONS_SETUP.md).
+- **RBL** — DNSBL advisory reputation monitoring, **disabled by default**. On a baseline host it reads
+  **OK** with the advisory note *"RBL monitoring disabled (optional; advisory reputation monitoring,
+  not blocking)."* It does not block traffic or write nftables sets.
+
+### Four-axis truth (`nftban health check`)
+
+```bash
+nftban health check
+```
+
+This view is driven by the Go validator (`nftban-validate --json`); the CLI only presents its output.
+It reports **Config, Structure, Runtime, Effective** axes for the `botguard`, `ddos`, `portscan`, and
+`loginmon` modules, plus a `Blacklist` composite. It expects the validator `schema_version` to be
+**1.84.0** and warns on a mismatch. (This `schema_version` is the validator's JSON contract version —
+it is not the `nft(8)` binary version.)
+
+## 3. Status and validate
+
+```bash
+nftban status
+```
+
+`status` renders `SYSTEM`, `FIREWALL`, `AUTHORITY`, `SERVICES`, `PROTECTION MODULES`, and `HEALTH`
+sections, with a one-line summary of the form `<state> | v1.218.5 | N banned | N whitelisted |
+<health>`. The banned/whitelisted counts are read from the kernel sets, not from a cache.
+
+```bash
+nftban validate
+```
+
+`validate` checks the nftables structure and owns the exit code. The contract is: **rc 0 = PROTECTED
+or IDLE** (all structure checks passed; warnings are allowed), rc 1 = DEGRADED, rc 2 = DOWN, rc 3 =
+validator crashed or unreachable. It also prints a *Communication (central-comms)* dry-run block, but
+that block does **not** change the nftables-structure exit code. The structure checks require the
+`ip nftban` and `ip6 nftban` tables, forbid `inet filter` / `ip filter`, require the base sets
+(`whitelist_ipv4`, `blacklist_ipv4`, `tcp_ports_in`, …), and expect chain policies input=drop,
+output=accept.
+
+## 4. Kernel baseline
+
+A baseline host has **two** nftban tables (separate IPv4 and IPv6 families — not `inet`):
+
+```bash
+nft list tables
+# expected: table ip nftban   and   table ip6 nftban
+```
+
+Each table has base chains `input` (policy **drop**), `forward` (drop), and `output` (accept). The
+base sets include `whitelist_ipv4`, `blacklist_ipv4`, `blacklist_manual_ipv4`, the `tcp_ports_*` /
+`udp_ports_*` / `ssh_ports` port sets, and the six `http_bot_*` BotGuard sets (always present, empty
+when BotGuard is disabled), with the IPv6 mirror in `ip6 nftban`. Rule ordering is security-critical:
+loopback accept → conntrack-invalid drop → blacklist drop (before established) → the rest.
+
+## 5. Services and timers
+
+```bash
+nftban services          # unit status (alias: nftban service)
+nftban timers            # timer status
+systemctl is-active nftband
+```
+
+The runtime daemon is `nftband.service` (with `nftband.socket`); it exposes an HTTP endpoint on
+`127.0.0.1:9580` and a Unix socket at `/run/nftban/nftband.sock` (see [Metrics truth](METRICS_TRUTH.md)
+for the endpoint's bind rules). The install ships a set of timers (health, maintenance, watchdog,
+feeds, geoip, the unified metrics exporter, the RBL check, and others). The **RBL check timer is
+present but the RBL module is disabled by default**, so its presence in `nftban timers` is expected
+and does not mean RBL is active.
+
+## 6. Defaults that define the baseline
+
+| Setting | Default | Baseline meaning |
+|---------|---------|------------------|
+| BotGuard (`HTTP_BOTGUARD_ENABLED`) | `false` | disabled; the `http_bot_*` sets exist but are empty |
+| RBL (`NFTBAN_RBL_ENABLED`) | `NO` | observe-only monitoring is off; RBL never blocks or writes nft |
+| GeoBan (`GEOBAN_ENABLED`) | `true` | module enabled, but **blocks nothing by default** |
+
+GeoBan is enabled by default but its default policy is `allow` and the country lists in
+`/etc/nftban/geoban.d/` are empty out of the box, so **GeoBan blocks no countries until you add a
+`blocked.list`.** Do not read "GeoBan enabled" as "countries are being blocked."
+
+## Failure modes and caveats
+
+- **CLI output is a report.** `nftban status` / `health` summarize state; the enforcement truth is the
+  kernel (`nft list set`, `nft list tables`). Confirm there, not from the summary alone.
+- **The daemon's HTTP `/health` is not a posture signal.** It returns a fixed `ok`; use
+  `nftban validate` and `nft list tables` to judge protection state (see
+  [Metrics truth](METRICS_TRUTH.md)).
+- **Optional-feature warnings are not firewall failures.** A Communication or RBL advisory does not
+  degrade the firewall.
+
+## References
+
+- Version: `cli/lib/nftban/lib/version.sh`, `cmd_version.sh`; daemon `cmd/nftband/main.go`
+- Health: `cli/lib/nftban/core/nftban_health.sh`, `nftban_health_render.sh`, `nftban_health_checks_modules.sh`, `cmd_health.sh`
+- Status / validate: `cli/lib/nftban/cli/cmd_status.sh`, `cmd_validate.sh`
+- Schema / sets / chains: `cli/lib/nftban/lib/nft_schema.sh`; daemon allowlist `cmd/nftband/daemon_types.go`
+- Defaults: `etc/nftban/conf.d/botguard/main.conf`, `conf.d/rbl/main.conf`, `conf.d/geoban/main.conf`
+- Related: [Metrics truth](METRICS_TRUTH.md), [Emergency recovery](EMERGENCY_RECOVERY_AND_ROLLBACK.md)


### PR DESCRIPTION
## R2b — versioned operator-contract pages (docs-only)

Adds four `/docs/operator/` pages per the accepted documentation source-of-truth policy: **`/docs` = versioned code/release contract**, wiki carries human explanation, registers/scopes stay engineering evidence. These four are command / kernel / exit-code / exporter / production **contracts**, not tutorials, so they belong in the repo and are reviewed alongside code. **Candidate content for a v1.218.6 docs release.**

### Files (exactly 4, ~+574 lines)
- `docs/operator/EMERGENCY_RECOVERY_AND_ROLLBACK.md`
- `docs/operator/BAN_FORENSICS.md`
- `docs/operator/PRODUCTION_BASELINE.md`
- `docs/operator/METRICS_TRUTH.md`

### Content
- **Emergency Recovery / Rollback:** `nftban update rollback / repair / recommit`; real backup path `/var/lib/nftban/update-backups/`; `nftban firewall rebuild` atomic validate-before-apply (the bare `nftban rebuild` is an inert stub); emergency mode + flush; daemon recovery; self-lockout recovery (whitelist-before-blacklist, `--static` durable); uninstall.
- **Ban Forensics:** `bans.log` format (`DATE|TIME|SOURCE|IP|COUNTRY|STATUS|REASON|BAN_ID|TIMEOUT|CLASS`); query commands (search/list/blacklist/status); set→origin mapping (`blacklist_manual_*` vs `blacklist_*`); journal evidence; kernel-truth `nft list set` proofs.
- **Production Baseline:** version/health/status/validate baseline; the real **OK/WARNING/ERROR** and **PROTECTED/IDLE/DEGRADED/DOWN** vocabularies; expected tables/chains/sets; defaults — BotGuard off, RBL off, GeoBan enabled-but-IDLE.
- **Metrics Truth:** `stats.json` contract; `nftban stats export` (json/csv) vs `nftban metrics`; single `nftban.prom`; `:9580` loopback-by-default and enforced; CLI-is-a-report caveat; daemon `/health`-always-ok caveat. **Exporter defects are cross-referenced and routed to the metrics lane — not fixed here.**

### Validation
- **Docs-only:** 4 files, 0 code, 0 Go, 0 shell, 0 tests; nft schema **1.84.0** unchanged; **no VERSION bump**.
- Every page stamped **"Last verified: v1.218.5"**; version tokens checked (all v1.218.5 + one historical v1.41.0 BAN_ID note); links resolve.
- **No register/scope/COMPLETED history pasted.** No private hostnames/IPs/tokens/workspace paths; example IPs are **RFC5737** ranges only.
- **No forbidden claims:** no RBL blocking, no provider-bounce/RBL P0 as shipped, no MailGuard as shipped, no GUI dashboard, no cluster/sync, no unverified benchmark numbers.

### Reviewer rule
Docs-only and repo-only. This PR does **not** include: R2c wiki edits, the WK-6/WK-8 register correction, the `ssh_test.go` private-leak scrub, or public-site changes — each is its own separate gated lane.