### PR TITLE
feat(whitelist): v1.218.10 durable management-IP tier (99-management.conf) — Scenario-A lockout fix

### DIFF
--- a/cli/lib/nftban/cli/cmd_whitelist.sh
+++ b/cli/lib/nftban/cli/cmd_whitelist.sh
@@ -21,7 +21,7 @@
 # meta:inventory.privileges="root"
 #
 # meta:created_date="2025-11-05"
-# meta:updated_date="2026-02-23"
+# meta:updated_date="2026-07-08"
 
 
 # =============================================================================
@@ -153,6 +153,20 @@ nftban_cmd_whitelist() {
             # v1.163.0 (SEC-WL-VERIFY): READ-ONLY anomaly report comparing the
             # live kernel whitelist sets against the durable whitelist.d baseline.
             nftban_whitelist_verify "$@"
+            ;;
+        management|mgmt)
+            # v1.218.10 (WL-MANAGEMENT / Scenario-A): durable, never-expiring,
+            # never-pruned lockout-critical operator IPs in 99-management.conf.
+            local _mgmt_sub="${1:-help}"; shift 2>/dev/null || true
+            case "$_mgmt_sub" in
+                add)                  nftban_whitelist_mgmt_add_ip "${1:-}" ;;
+                remove|rm|del|delete) nftban_whitelist_mgmt_remove_ip "${1:-}" ;;
+                list|show)            nftban_whitelist_mgmt_list ;;
+                status)               nftban_whitelist_mgmt_status ;;
+                help|-h|--help|"")    nftban_whitelist_mgmt_usage ;;
+                *) echo "ERROR: Unknown 'whitelist management' subcommand: $_mgmt_sub" >&2
+                   nftban_whitelist_mgmt_usage; return 1 ;;
+            esac
             ;;
         sync|whitelistme)
             # Pass to whitelist-system for these commands
@@ -510,6 +524,227 @@ nftban_whitelist_remove_static_ip() {
     else
         echo "INFO: $ip not found in $_NFTBAN_MANUAL_WHITELIST_PATH (also removed from live set if present)."
     fi
+    return 0
+}
+
+# =============================================================================
+# v1.218.10 — PERMANENT MANAGEMENT whitelist tier (WL-MANAGEMENT / Scenario-A)
+# =============================================================================
+# Lockout-critical operator IPs live in whitelist.d/99-management.conf with NO
+# EXPIRES_AT. Consumed AUTOMATICALLY by the existing whitelist.d/*.conf glob
+# (internal/whitelist/loader.go) AND the never-ban exemption resolver
+# (internal/nftbackend/exemption.go) — so this tier needs NO daemon/loader/schema
+# change, only a CLI writer for the durable file. Unlike 00-session.conf these
+# entries never expire, and unlike anything the session reaper touches (it is
+# 00-session-scoped) they are never pruned — closing the Scenario-A lockout where
+# an expired session whitelist + absent permanent entry can lock out a management
+# IP. Stronger validation than --static: a whole-internet /0 is refused.
+_NFTBAN_MGMT_WHITELIST_PATH="/etc/nftban/whitelist.d/99-management.conf"
+
+# Refuse the whole-internet catch-all — a management whitelist must never be /0
+# (that would exempt every source from banning). rc 0 = ok, 1 = over-broad.
+_nftban_wl_reject_overbroad() {
+    local ip="$1"
+    case "$ip" in
+        0.0.0.0/0|::/0|*/0)
+            echo "ERROR: refusing over-broad management entry '$ip' — a /0 (whole-internet) whitelist would exempt every source from banning." >&2
+            return 1 ;;
+    esac
+    return 0
+}
+
+# Ensure 99-management.conf exists with a header on FIRST creation only. Never
+# clobbers an existing file (may carry hand-written operator entries).
+_nftban_whitelist_mgmt_ensure_header() {
+    [[ -f "$_NFTBAN_MGMT_WHITELIST_PATH" ]] && return 0
+    mkdir -p "$(dirname "$_NFTBAN_MGMT_WHITELIST_PATH")"
+    cat > "$_NFTBAN_MGMT_WHITELIST_PATH" <<'MGMT_HEADER_EOF'
+# =============================================================================
+# NFTBan Permanent MANAGEMENT Whitelist (99-management.conf)
+# =============================================================================
+#
+# Lockout-critical operator/management IPs — NO expiry, NEVER pruned. Loaded on
+# every firewall rebuild and exempted from banning at the durable apply boundary
+# (never-ban resolver). Use for the fixed IP(s)/CIDR(s) you administer this host
+# from, so an expired session whitelist can never lock you out (Scenario-A).
+#
+#   nftban whitelist management add <ip|cidr>      # persist here (permanent)
+#   nftban whitelist management remove <ip|cidr>   # remove from here + live set
+#   nftban whitelist management list               # show configured entries
+#   nftban whitelist management status             # drift report (present/missing)
+#
+# One IP or CIDR per line; '#' starts a comment. A /0 (whole-internet) entry is
+# refused. Safe to hand-edit.
+# =============================================================================
+
+MGMT_HEADER_EOF
+    chmod 0640 "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+}
+
+# Add a permanent (no-expiry) management entry + apply live. Idempotent refresh.
+nftban_whitelist_mgmt_add_ip() {
+    local ip="$1"
+    if [[ -z "$ip" ]]; then
+        echo "Usage: nftban whitelist management add <IP|CIDR>" >&2; return 1
+    fi
+    if ! nftban_validate_ip "$ip" && ! nftban_validate_cidr "$ip"; then
+        echo "ERROR: Invalid IP/CIDR format: $ip" >&2; return 1
+    fi
+    _nftban_wl_reject_overbroad "$ip" || return 1
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: writing $_NFTBAN_MGMT_WHITELIST_PATH requires root (permanent management whitelist)." >&2
+        return 1
+    fi
+
+    _nftban_whitelist_mgmt_ensure_header
+
+    local tmp
+    tmp=$(mktemp "${_NFTBAN_MGMT_WHITELIST_PATH}.XXXXXX") || { echo "ERROR: mktemp failed" >&2; return 1; }
+    # Drop any prior line whose first token == ip (idempotent refresh).
+    # shellcheck disable=SC2016
+    awk -v ip="$ip" '
+        { t=$0; gsub(/^[ \t]+/,"",t)
+          if (t=="" || substr(t,1,1)=="#") { print; next }
+          split(t,a,"#"); n=split(a[1],b,/[ \t]+/)
+          if (n>=1 && b[1]==ip) next
+          print }
+    ' "$_NFTBAN_MGMT_WHITELIST_PATH" > "$tmp"
+    printf '%s  # REASON=management ADDED_BY=nftban-whitelist-management\n' "$ip" >> "$tmp"
+    mv "$tmp" "$_NFTBAN_MGMT_WHITELIST_PATH"
+    chmod 0640 "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+    chown root:nftban "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+
+    if command -v nftban >/dev/null 2>&1; then
+        nftban sync >/dev/null 2>&1 || nftban firewall reload >/dev/null 2>&1 || true
+    fi
+
+    _nftban_wl_static_is_live "$ip"
+    case $? in
+        0) echo "Added $ip to the PERMANENT MANAGEMENT whitelist ($_NFTBAN_MGMT_WHITELIST_PATH) and confirmed it is LIVE — never expires, never pruned; an expired session can no longer lock this IP out."
+           return 0 ;;
+        2) echo "Added $ip to the PERMANENT MANAGEMENT whitelist ($_NFTBAN_MGMT_WHITELIST_PATH). Durable entry written; LIVE application could NOT be verified (coverage oracle unavailable). Run 'nftban whitelist management status'." >&2
+           return 0 ;;
+        *) echo "ERROR: $ip was written to the durable management whitelist ($_NFTBAN_MGMT_WHITELIST_PATH) but is NOT present in the live kernel whitelist set after sync — durable, but LIVE protection is not active. See 'nftban whitelist verify'." >&2
+           return 3 ;;
+    esac
+}
+
+# Remove a management entry from 99-management.conf AND the live set.
+nftban_whitelist_mgmt_remove_ip() {
+    local ip="$1"
+    if [[ -z "$ip" ]]; then
+        echo "Usage: nftban whitelist management remove <IP|CIDR>" >&2; return 1
+    fi
+    if ! nftban_validate_ip "$ip" && ! nftban_validate_cidr "$ip"; then
+        echo "ERROR: Invalid IP/CIDR format: $ip" >&2; return 1
+    fi
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: editing $_NFTBAN_MGMT_WHITELIST_PATH requires root." >&2; return 1
+    fi
+
+    local removed="false"
+    if [[ -f "$_NFTBAN_MGMT_WHITELIST_PATH" ]]; then
+        local tmp
+        tmp=$(mktemp "${_NFTBAN_MGMT_WHITELIST_PATH}.XXXXXX") || { echo "ERROR: mktemp failed" >&2; return 1; }
+        # shellcheck disable=SC2016
+        if awk -v ip="$ip" '
+            { t=$0; gsub(/^[ \t]+/,"",t)
+              if (t=="" || substr(t,1,1)=="#") { print; next }
+              split(t,a,"#"); n=split(a[1],b,/[ \t]+/)
+              if (n>=1 && b[1]==ip) { dropped=1; next }
+              print }
+            END { exit (dropped?0:1) }
+        ' "$_NFTBAN_MGMT_WHITELIST_PATH" > "$tmp"; then
+            mv "$tmp" "$_NFTBAN_MGMT_WHITELIST_PATH"
+            chmod 0640 "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+            chown root:nftban "$_NFTBAN_MGMT_WHITELIST_PATH" 2>/dev/null || true
+            removed="true"
+        else
+            rm -f "$tmp"
+        fi
+    fi
+
+    nftban_whitelist_remove_ip "$ip" >/dev/null 2>&1 || true
+    if command -v nftban >/dev/null 2>&1; then
+        nftban sync >/dev/null 2>&1 || true
+    fi
+
+    if [[ "$removed" == "true" ]]; then
+        echo "Removed $ip from the PERMANENT MANAGEMENT whitelist ($_NFTBAN_MGMT_WHITELIST_PATH) + live set."
+    else
+        echo "INFO: $ip not found in $_NFTBAN_MGMT_WHITELIST_PATH (also removed from live set if present)."
+    fi
+    return 0
+}
+
+# List configured management entries (first token per non-comment line).
+nftban_whitelist_mgmt_list() {
+    if [[ ! -f "$_NFTBAN_MGMT_WHITELIST_PATH" ]]; then
+        echo "No management whitelist configured ($_NFTBAN_MGMT_WHITELIST_PATH absent)."
+        echo "Add lockout-critical IPs with: nftban whitelist management add <ip|cidr>"
+        return 0
+    fi
+    echo "Permanent management whitelist ($_NFTBAN_MGMT_WHITELIST_PATH):"
+    local any="false" line t tok
+    while IFS= read -r line; do
+        t="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$t" || "${t:0:1}" == "#" ]] && continue
+        tok="${t%%[[:space:]]*}"; tok="${tok%%#*}"
+        [[ -z "$tok" ]] && continue
+        echo "  $tok"; any="true"
+    done < "$_NFTBAN_MGMT_WHITELIST_PATH"
+    [[ "$any" == "false" ]] && echo "  (none configured yet)"
+    return 0
+}
+
+# Drift report: is each configured management entry LIVE in the kernel whitelist?
+# Surfaces the Scenario-A risk (configured-but-not-effective). rc 1 if any MISSING.
+nftban_whitelist_mgmt_status() {
+    if [[ ! -f "$_NFTBAN_MGMT_WHITELIST_PATH" ]]; then
+        echo "Management whitelist: NOT CONFIGURED ($_NFTBAN_MGMT_WHITELIST_PATH absent)."
+        echo "  Recommendation: add the fixed IP(s) you administer this host from —"
+        echo "  'nftban whitelist management add <ip|cidr>' — to prevent session-expiry lockout."
+        return 0
+    fi
+    echo "Management whitelist drift ($_NFTBAN_MGMT_WHITELIST_PATH):"
+    local any="false" missing=0 undet=0 line t tok
+    while IFS= read -r line; do
+        t="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$t" || "${t:0:1}" == "#" ]] && continue
+        tok="${t%%[[:space:]]*}"; tok="${tok%%#*}"
+        [[ -z "$tok" ]] && continue
+        any="true"
+        _nftban_wl_static_is_live "$tok"
+        case $? in
+            0) echo "  PRESENT  $tok" ;;
+            2) echo "  UNKNOWN  $tok (coverage oracle unavailable)"; undet=$((undet+1)) ;;
+            *) echo "  MISSING  $tok  <-- configured but NOT live: lockout risk"; missing=$((missing+1)) ;;
+        esac
+    done < "$_NFTBAN_MGMT_WHITELIST_PATH"
+    [[ "$any" == "false" ]] && { echo "  (none configured yet)"; return 0; }
+    if [[ "$missing" -gt 0 ]]; then
+        echo "DRIFT: $missing management entry(ies) configured but not live — run 'nftban sync' or 'nftban firewall reload'." >&2
+        return 1
+    fi
+    echo "OK: all management entries are live in the kernel whitelist."
+    return 0
+}
+
+nftban_whitelist_mgmt_usage() {
+    cat >&2 <<'MGMT_USAGE_EOF'
+Usage: nftban whitelist management <add|remove|list|status> [IP|CIDR]
+
+  add <ip|cidr>      Add a PERMANENT, never-expiring, never-pruned management IP
+  remove <ip|cidr>   Remove a management entry (file + live set)
+  list               List configured management entries
+  status             Drift report — which entries are live vs missing
+
+Permanent management IPs live in /etc/nftban/whitelist.d/99-management.conf and are
+exempt from banning at the durable apply boundary. Use for the fixed addresses you
+administer this host from, so an expired session whitelist can never lock you out.
+A /0 (whole-internet) entry is refused.
+MGMT_USAGE_EOF
     return 0
 }
 
@@ -917,6 +1152,7 @@ COMMANDS:
   add --ttl <dur> <IP>   Add IP to a TIMED session whitelist (00-session.conf; auto-expires)
   remove <IP>            Remove IP from the runtime whitelist (live set only)
   remove --static <IP>   Remove IP from the permanent whitelist (99-manual.conf) + live set
+  management <sub> [IP]  Durable MANAGEMENT tier (add|remove|list|status) — lockout-critical, never-pruned (99-management.conf)
   list                   Show all whitelisted IPs
   verify                 Read-only: compare live kernel sets vs durable whitelist.d baseline (reports anomalies)
   sync                   Auto-detect and whitelist system IPs
@@ -926,6 +1162,7 @@ WHITELIST TIERS:
   runtime   (default add)  live nft set only; DROPPED on the next firewall rebuild/reload/restart.
   timed     (--ttl <dur>)  written to 00-session.conf with an expiry; auto-pruned after the TTL.
   permanent (--static)     written to 99-manual.conf (no expiry); applied live; survives firewall reload/restart/reboot.
+  management               written to 99-management.conf (no expiry, NEVER pruned); lockout-critical operator IPs — refuses a /0.
 
 EXAMPLES:
   nftban whitelist add 192.168.1.100              # runtime only (temporary)
@@ -933,6 +1170,8 @@ EXAMPLES:
   nftban whitelist add --static 2001:db8::1        # IPv6 permanent
   nftban whitelist add --ttl 30m 192.168.1.100    # 30-minute session
   nftban whitelist remove --static 192.168.1.100  # remove permanent entry + live
+  nftban whitelist management add 203.0.113.10     # permanent lockout-critical mgmt IP
+  nftban whitelist management status               # which mgmt IPs are live vs missing
   nftban whitelist list
   nftban whitelist verify                          # read-only anomaly check (live set vs baseline)
   nftban whitelist sync

--- a/cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.218.10 whitelist management tier (WL-MANAGEMENT / Scenario-A)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cmd_whitelist_management_v218_10_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-08"
+# meta:description="Tests for v1.218.10 nftban whitelist management permanent tier. Asserts add writes whitelist.d/99-management.conf with NO EXPIRES_AT (durable — survives 00-session expiry because it is a different, never-reaped tier), re-adding refreshes (no dup), remove drops the durable line, invalid IP rejected, over-broad /0 (0.0.0.0/0 and ::/0) refused, v4+v6 parity, ensure-header never clobbers an existing file, list shows entries, and status reports PRESENT/MISSING drift (rc1 on missing). Never-ban exemption + session-reaper non-interference + live-apply are lab integration tests (the resolver/reaper are Go)."
+# meta:input="None (self-contained sandbox)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,awk,sed,mktemp"
+# meta:inventory.files=""
+# meta:inventory.binaries="bash,grep,awk,sed,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-contained sandbox; no host contact; no root required. We extract the
+# v1.218.10 management functions (+ shared helpers) from cmd_whitelist.sh by name,
+# patch out the `[[ $EUID -ne 0 ]]` root guards, redirect $_NFTBAN_MGMT_WHITELIST_PATH
+# to a tempfile, and stub the leaf helpers (validation, runtime remove, live-check).
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_LIB_DIR="${REPO_ROOT}/cli/lib/nftban"
+export NFTBAN_LIB_DIR
+WL_SRC="$NFTBAN_LIB_DIR/cli/cmd_whitelist.sh"
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+MGMT_FILE="$SANDBOX/99-management.conf"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s\n         expected to contain: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="$3"
+    if printf '%s' "$haystack" | grep -F -q -- "$needle"; then
+        printf "  [FAIL] %s\n         did NOT expect: %s\n" "$name" "$needle"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    else
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    fi
+}
+assert_rc() {
+    local rc="$1" expected="$2" name="$3"
+    if [[ "$rc" == "$expected" ]]; then
+        printf "  [PASS] %s\n" "$name"; PASS=$((PASS + 1))
+    else
+        printf "  [FAIL] %s (expected rc %s, got %s)\n" "$name" "$expected" "$rc"
+        FAIL=$((FAIL + 1)); FAILED_TESTS+=("$name")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Harness: load the management functions in a subshell with stubs.
+#   _STUB_LIVE_RC controls the stubbed _nftban_wl_static_is_live return code
+#   (0=live/PRESENT, 1=not-live/MISSING, 2=unknown).
+# ---------------------------------------------------------------------------
+mgmt_env() {
+    local live_rc="${1:-0}"
+    cat <<STUBS
+nftban_validate_ip()   { [[ "\$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}\$ ]] || { [[ "\$1" == *:* && "\$1" =~ ^[0-9a-fA-F:]+\$ ]]; }; }
+nftban_validate_cidr() { [[ "\$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}\$ ]] || { [[ "\$1" == *:* && "\$1" =~ ^[0-9a-fA-F:]+/[0-9]{1,3}\$ ]]; }; }
+nftban_whitelist_remove_ip() { return 0; }
+_nftban_wl_static_is_live() { return ${live_rc}; }
+STUBS
+    # Extract the management block; the shared _NFTBAN_MGMT_WHITELIST_PATH..usage
+    # functions live between the WL-MANAGEMENT banner and "# List whitelisted IPs".
+    awk '/^# v1.218.10 — PERMANENT MANAGEMENT/{c=1} /^# List whitelisted IPs/{c=0} c{print}' "$WL_SRC" \
+        | sed -E 's@\[\[ \$EUID -ne 0 \]\]@[[ 1 -eq 0 ]]@g'
+    printf '_NFTBAN_MGMT_WHITELIST_PATH=%q\n' "$MGMT_FILE"
+}
+
+run_mgmt() {
+    # $1 = live_rc for the stub; rest = args after `run_mgmt <rc> <func> ...`
+    local live_rc="$1"; shift
+    bash -c "$(mgmt_env "$live_rc"); set +e; \"\$@\"" _ "$@"
+}
+
+echo "=== v1.218.10 whitelist management tier tests ==="
+
+# 1. add writes a permanent (no EXPIRES_AT) entry
+rm -f "$MGMT_FILE"
+out=$(run_mgmt 0 nftban_whitelist_mgmt_add_ip 203.0.113.10 2>&1) || true
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "203.0.113.10" "add: entry written to 99-management.conf"
+assert_not_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "EXPIRES_AT" "add: NO EXPIRES_AT (permanent, survives session expiry)"
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "REASON=management" "add: tagged REASON=management"
+
+# 2. idempotent re-add (no duplicate)
+run_mgmt 0 nftban_whitelist_mgmt_add_ip 203.0.113.10 >/dev/null 2>&1 || true
+cnt=$(grep -c '^203\.0\.113\.10' "$MGMT_FILE" 2>/dev/null || echo 0)
+assert_rc "$cnt" "1" "add: idempotent (no duplicate line on re-add)"
+
+# 3. v6 parity
+run_mgmt 0 nftban_whitelist_mgmt_add_ip 2001:db8::1 >/dev/null 2>&1 || true
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "2001:db8::1" "add: IPv6 parity"
+
+# 4. reject over-broad /0
+rc=0; out=$(run_mgmt 0 nftban_whitelist_mgmt_add_ip 0.0.0.0/0 2>&1) || rc=$?
+assert_rc "$rc" "1" "reject: 0.0.0.0/0 refused (rc1)"
+assert_contains "$out" "over-broad" "reject: 0.0.0.0/0 message"
+rc=0; out=$(run_mgmt 0 nftban_whitelist_mgmt_add_ip "::/0" 2>&1) || rc=$?
+assert_rc "$rc" "1" "reject: ::/0 refused (rc1)"
+
+# 5. reject invalid IP
+rc=0; out=$(run_mgmt 0 nftban_whitelist_mgmt_add_ip "not-an-ip" 2>&1) || rc=$?
+assert_rc "$rc" "1" "reject: invalid IP refused (rc1)"
+
+# 6. list shows configured entries
+out=$(run_mgmt 0 nftban_whitelist_mgmt_list 2>&1) || true
+assert_contains "$out" "203.0.113.10" "list: shows v4 entry"
+assert_contains "$out" "2001:db8::1" "list: shows v6 entry"
+
+# 7. status PRESENT when live (stub rc 0)
+rc=0; out=$(run_mgmt 0 nftban_whitelist_mgmt_status 2>&1) || rc=$?
+assert_contains "$out" "PRESENT" "status: PRESENT when live"
+assert_rc "$rc" "0" "status: rc0 when all present"
+
+# 8. status MISSING + rc1 when not live (stub rc 1)
+rc=0; out=$(run_mgmt 1 nftban_whitelist_mgmt_status 2>&1) || rc=$?
+assert_contains "$out" "MISSING" "status: MISSING when not live"
+assert_contains "$out" "DRIFT" "status: DRIFT summary when missing"
+assert_rc "$rc" "1" "status: rc1 on drift (lockout risk surfaced)"
+
+# 9. remove drops the durable line
+run_mgmt 0 nftban_whitelist_mgmt_remove_ip 203.0.113.10 >/dev/null 2>&1 || true
+assert_not_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "203.0.113.10" "remove: durable line dropped"
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "2001:db8::1" "remove: other entries preserved"
+
+# 10. ensure-header never clobbers an existing file
+printf 'PRE-EXISTING-OPERATOR-LINE\n' > "$MGMT_FILE"
+run_mgmt 0 nftban_whitelist_mgmt_add_ip 198.51.100.5 >/dev/null 2>&1 || true
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "PRE-EXISTING-OPERATOR-LINE" "ensure-header: never clobbers existing content"
+assert_contains "$(cat "$MGMT_FILE" 2>/dev/null)" "198.51.100.5" "ensure-header: appends alongside existing content"
+
+# 11. dispatcher routes `whitelist management <sub>`
+disp=$(bash -c '
+  source "'"$WL_SRC"'" 2>/dev/null || true
+  nftban_whitelist_mgmt_add_ip()    { echo "ROUTED:add:$1"; }
+  nftban_whitelist_mgmt_status()    { echo "ROUTED:status"; }
+  nftban_whitelist_mgmt_usage()     { echo "ROUTED:usage"; }
+  nftban_cmd_whitelist management add 10.0.0.9
+  nftban_cmd_whitelist management status
+  nftban_cmd_whitelist management bogus 2>/dev/null || true
+' 2>&1) || true
+assert_contains "$disp" "ROUTED:add:10.0.0.9" "dispatch: management add routes with arg"
+assert_contains "$disp" "ROUTED:status" "dispatch: management status routes"
+assert_contains "$disp" "ROUTED:usage" "dispatch: unknown subcommand -> usage"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+    printf 'FAILED: %s\n' "${FAILED_TESTS[@]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What & why
Closes the **Scenario-A management-IP lockout class** — where an expired `00-session.conf` entry plus an absent permanent/manual whitelist can lock an operator out of their own host (materialized as the dns2 lockout at v1.210.0).

Implements a durable **management whitelist tier** at `/etc/nftban/whitelist.d/99-management.conf`: permanent (no `EXPIRES_AT`), never pruned (the session reaper is `00-session`-scoped), exempted from banning at the durable `Backend.Ban` boundary.

## Design — reuses the existing whitelist.d glob (no Go, no daemon re-baseline)
- The whitelist loader (`internal/whitelist/loader.go` — `os.ReadDir(whitelist.d)`) and the never-ban exemption resolver (`internal/nftbackend/exemption.go` — `whitelist.d/*.conf` glob) already consume **all** `whitelist.d/*.conf`, so the new tier is auto-unioned with **zero Go change**.
- New CLI mirrors the existing `99-manual` durable-writer pattern:
  - `nftban whitelist management add <ip|cidr>`
  - `nftban whitelist management remove <ip|cidr>`
  - `nftban whitelist management list`
  - `nftban whitelist management status`  (drift report — PRESENT/MISSING, rc1 on drift)
- **Rejects the whole-internet `/0`** (`0.0.0.0/0`, `::/0`) and invalid IP/CIDR; v4+v6 parity.

## Classification
- **Shell-only · daemon byte-identical (0 Go) · nft schema 1.84.0 unchanged**
- No render/template change · no systemd/env change · **no schema change** · no README badge
- **No daemon re-baseline**
- Telemetry default-OFF (untouched) · not an Akrites lane

## NOT bundled (each its own future GO)
opqueue atomicity (Item 3) · Akrites Lane 2a/2b/2c · update stale-cache guard · interactive auto-rollback · RBL · telemetry · webhook · CI hardening · badge · docs/wiki truth passes · ports.d-range hardening.

## Tests
- **New unit test** `cmd_whitelist_management_v218_10_test.sh` — **23/23 PASS** (add/permanent-no-EXPIRES_AT/idempotent/v4+v6/reject-`/0`/reject-invalid/list/status-drift-rc1/remove/no-clobber/dispatch).
- **Static regression** `cmd_whitelist_static_v149_test.sh` — 26 pass / 2 fail, **identical to `main`** (the 2 are pre-existing, not introduced here).
- `shellcheck -S warning` clean · `bash -n` clean · v128 help/code correlation **7/0**.

## Lab validation — runtime-resolver (NOT package-native)
> This proves the installed **byte-identical** daemon resolver consumes `99-management.conf`. It is **not** a package-native install/update test — that rides the normal tag/publish → lab2/lab4 → canary → fleet gate once the real v1.218.10 DEB/RPM artifacts exist. (A full local build wasn't possible: `go`/`dpkg-deb` absent on the build host.)

**lab2 (Ubuntu 24.04 DEB) PASS · lab4 (AlmaLinux 9.8 RPM) PASS**, v4 + v6:
- `add` v4+v6 → written, LIVE; `/0` + invalid rejected.
- `99-management.conf` → `root:nftban 0640`, **no `EXPIRES_AT`**; other whitelist.d files untouched.
- `nftban sync` → mgmt IPs **live in kernel `whitelist_ipv4`/`_ipv6`** (resolver consumed the tier).
- **Decisive `Backend.Ban` exemption:** `nftban ban 203.0.113.77` → *"IP is currently whitelisted!"*, IP **absent from `blacklist_manual_ipv4`** (exempted; not dropped).
- Persisted through sync/restart/ban; `remove` works; installed file **restored byte-identical**; `validate` rc0 before/after; daemon active; 0 failed units; telemetry off; labs left pristine.

## Hold
Do not merge / tag / release-prep / publish / canary / fleet-rollout without a separate GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)