### PR TITLE
chore(deps): bump Go toolchain 1.25.11 → 1.25.12 (OSV security: os.Root + crypto/tls ECH)

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -96,9 +96,9 @@ jobs:
     needs: validate-dependencies
     name: Build Go binaries
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11); this job
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); this job
     # only runs ./build.sh (go build of our module), so GOTOOLCHAIN=local avoids
-    # a redundant toolchain re-download. Compiler version unchanged (1.25.11),
+    # a redundant toolchain re-download. Compiler version unchanged (1.25.12),
     # so binary output stays byte-reproducible.
     env:
       GOTOOLCHAIN: local
@@ -111,8 +111,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
-          go-version: '1.25.11'
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
+          go-version: '1.25.12'
 
       - name: Build binaries
         run: |

--- a/.github/workflows/ci-empty-env-smoke.yml
+++ b/.github/workflows/ci-empty-env-smoke.yml
@@ -46,7 +46,7 @@ jobs:
   empty-env-smoke:
     name: Empty-Env Smoke Guard (H4)
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11); a single
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); a single
     # unconditional setup-go feeds every go command in this job, so
     # GOTOOLCHAIN=local safely avoids a redundant toolchain re-download.
     env:
@@ -58,8 +58,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
-          go-version: '1.25.11'
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
+          go-version: '1.25.12'
 
       # ------------------------------------------------------------------
       # H4.1 — CLI empty-env smoke (shell). Hermetic test: runs the CLI

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -32,7 +32,7 @@ jobs:
   go-build-test:
     name: Build & Test
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11) on the
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12) on the
     # runner, so GOTOOLCHAIN=local prevents a redundant toolchain re-download
     # (and its TLS-handshake flake) mid-build. Safe: requested == go.mod patch.
     env:
@@ -42,9 +42,9 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`) so the
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`) so the
           # toolchain patch never moves under us mid-build.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.3.0

--- a/.github/workflows/ci-install-canonization.yml
+++ b/.github/workflows/ci-install-canonization.yml
@@ -73,10 +73,10 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set here: the RPM matrix legs
           # build with dnf-installed Go (not this step), whose patch may differ.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Build nftban-installer
         shell: bash

--- a/.github/workflows/ci-restore-canonization.yml
+++ b/.github/workflows/ci-restore-canonization.yml
@@ -86,10 +86,10 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set here: the RPM matrix legs
           # build with dnf-installed Go (not this step), whose patch may differ.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       # ------------------------------------------------------------------
       # G4-RESTORE-NO-IMPLICIT-EXEC — static scan of the restore package

--- a/.github/workflows/ci-runtime-truth.yml
+++ b/.github/workflows/ci-runtime-truth.yml
@@ -81,10 +81,10 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set here: the RPM matrix legs
           # build with dnf-installed Go (not this step), whose patch may differ.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Build binaries
         shell: bash

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -31,7 +31,7 @@ jobs:
   smoke:
     name: CLI Smoke Test
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11); a single
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); a single
     # unconditional setup-go feeds every go command in this job, so
     # GOTOOLCHAIN=local safely avoids a redundant toolchain re-download.
     env:
@@ -43,8 +43,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
-          go-version: '1.25.11'
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
+          go-version: '1.25.12'
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/ci-uninstall-canonization.yml
+++ b/.github/workflows/ci-uninstall-canonization.yml
@@ -72,10 +72,10 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set here: the RPM matrix legs
           # build with dnf-installed Go (not this step), whose patch may differ.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       # ------------------------------------------------------------------
       # G3-UN-NO-MUTATION — structural grep on the uninstall package +

--- a/.github/workflows/ci-update-canonization.yml
+++ b/.github/workflows/ci-update-canonization.yml
@@ -76,10 +76,10 @@ jobs:
         if: matrix.label == 'ubuntu-24.04'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set here: the RPM matrix legs
           # build with dnf-installed Go (not this step), whose patch may differ.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       # ------------------------------------------------------------------
       # Unit tests — close G3-U2 (version detection) + G3-U4 (preflight)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set: CodeQL drives its own Go
           # autobuild; forcing local could interfere with its build resolution.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.3.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,7 +38,7 @@ jobs:
   fuzz:
     name: Fuzz Tests
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11); a single
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); a single
     # unconditional setup-go feeds every go command in this job, so
     # GOTOOLCHAIN=local safely avoids a redundant toolchain re-download.
     env:
@@ -48,8 +48,8 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
-          go-version: '1.25.11'
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
+          go-version: '1.25.12'
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.3.0

--- a/.github/workflows/ossra-remediation.yml
+++ b/.github/workflows/ossra-remediation.yml
@@ -36,8 +36,8 @@ concurrency:
 
 env:
   # v1.157 PR-C: pin exact patch (was the moving "1.25.x" range; matches
-  # go.mod `go 1.25.11`) so the toolchain patch never moves mid-build.
-  GO_VERSION: "1.25.11"
+  # go.mod `go 1.25.12`) so the toolchain patch never moves mid-build.
+  GO_VERSION: "1.25.12"
 
 jobs:
   license-compliance:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set: this job installs the
           # third-party osv-scanner tool, whose go directive may require a
           # newer toolchain; local would block that auto-fetch.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install OSV-Scanner
         run: |

--- a/.github/workflows/project-health.yml
+++ b/.github/workflows/project-health.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set: this job runs a mixed
           # health/lint script; left unset to avoid constraining its tooling.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install linters & tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
   build-binaries:
     name: Build Go binaries
     runs-on: ubuntu-latest
-    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.11); a single
+    # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); a single
     # unconditional setup-go feeds the build, so GOTOOLCHAIN=local avoids a
-    # redundant toolchain re-download. Compiler version is unchanged (1.25.11),
+    # redundant toolchain re-download. Compiler version is unchanged (1.25.12),
     # so binary output stays byte-reproducible.
     env:
       GOTOOLCHAIN: local
@@ -63,8 +63,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
-          go-version: '1.25.11'
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
+          go-version: '1.25.12'
 
       - name: Build binaries
         run: |

--- a/.github/workflows/secure-go.yml
+++ b/.github/workflows/secure-go.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:
-          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`).
+          # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`).
           # GOTOOLCHAIN=local intentionally NOT set: this job `go install`s
           # third-party tools (staticcheck, gosec) whose own go directive may
           # require a newer toolchain; local would block that auto-fetch.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Cache Go build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.3.0

--- a/.github/workflows/slsa-go-releaser.yml
+++ b/.github/workflows/slsa-go-releaser.yml
@@ -78,10 +78,10 @@ jobs:
       actions: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
-      # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.11`) so the SLSA
+      # v1.157 PR-C: pin exact patch (matches go.mod `go 1.25.12`) so the SLSA
       # builder selects the same toolchain patch. GOTOOLCHAIN cannot be injected
       # into this third-party reusable workflow, so it is left to the builder.
-      go-version: "1.25.11"
+      go-version: "1.25.12"
       # Config file specifies build parameters
       config-file: .github/slsa/nftban-core.yml
       evaluated-envs: "VERSION:${{ needs.get-tag.outputs.tag }}"

--- a/.github/workflows/socket-supplychain.yml
+++ b/.github/workflows/socket-supplychain.yml
@@ -34,8 +34,8 @@ concurrency:
 
 env:
   # v1.157 PR-C: pin exact patch (was the moving "1.25.x" range; matches
-  # go.mod `go 1.25.11`) so the toolchain patch never moves mid-build.
-  GO_VERSION: "1.25.11"
+  # go.mod `go 1.25.12`) so the toolchain patch never moves mid-build.
+  GO_VERSION: "1.25.12"
 
 jobs:
   socket-scan:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/itcmsgr/nftban
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/coreos/go-systemd/v22 v22.7.0


### PR DESCRIPTION
## What & why
Closes the **OSV Vulnerability Scan** failure now surfacing on unrelated PRs (e.g. #1054). The scan reports **2 Go stdlib advisories** against the `go 1.25.11` directive, both **fixed in go1.25.12**:

| Advisory | CVE | stdlib pkg | Summary |
|---|---|---|---|
| GO-2026-4970 | CVE-2026-39822 | `os` | `os.Root` follows a symlink outside the root when the final component is a symlink and the path ends `/` (sandbox escape) |
| GO-2026-5856 | CVE-2026-42505 | `crypto/tls` | ECH handshakes de-anonymizable by a passive observer (PSK identity in cleartext ClientHello) |

These are **pre-existing** — `go.mod` was untouched by the PRs that tripped the check; they fail `main` identically. The OSV database published these since the last green run. **Honest fix = toolchain bump, not suppression** (the builder at 1.25.11 is genuinely unpatched).

## Change (mechanical, bounded)
- `go.mod`: `go 1.25.11` → `go 1.25.12`.
- Every `setup-go` `go-version` / `GO_VERSION` pin across **18 workflows** → `1.25.12` (+ the live `# matches go.mod 1.25.11` comments).
- **No new OSV suppressions.** **No dependency bump** — `golang.org/x/net` is already at the clean `v0.55.0` (the `0.52.0` alerts were stale); `x/sys`/`x/sync` unchanged (no cascade).
- **Not touched:** `CHANGELOG.md` / `STATUS.md` (historical `1.25.11` references preserved), `docs/*`, any Go source, schema, CLI.

## Validation
- **Local `osv-scanner v2.3.3` (repo `osv-scanner.toml`) against the bumped `go.mod`: `0 vulnerabilities`** (was 2). ✅
- 18 changed workflows valid YAML.
- 0 Go source / schema / cli changed.
- CI on this PR verifies the full Go suite + OSV green under 1.25.12.

## Classification
Toolchain/security bump · **CI/workflow change** · **0 Go source change** · nft schema **1.84.0** unchanged · telemetry untouched · not Akrites. **Recompiles the shipped Go binaries under go1.25.12 → daemon binary re-baseline (Go source identical).**

## Sequence (deps-first)
1. Merge this PR → `main` OSV green.
2. Rebase **#1054** (management-whitelist tier) onto green `main` → its OSV re-runs green → merge #1054 clean.
3. v1.218.10 release-prep with honest wording: management tier is 0-Go / Go-source-identical; **binaries recompiled under go1.25.12 (this separate security lane)**.

**Not bundled** with #1054 (management whitelist), Akrites, signing, update-path, telemetry, RBL, webhook, docs/wiki, or badge.

## Hold
Do not merge without a separate GO. No release-prep / tag / publish / fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)