### PR TITLE
fix(botscan): EXP_REVSLIDER false-positive that could ban legitimate visitors loading RevSlider static assets

### DIFF
--- a/cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh
+++ b/cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.218.10 EXP_REVSLIDER false-positive narrowing
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_revslider_fp_v218_10_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-08"
+# meta:description="Verifies the v1.218.10 fix to the EXP_REVSLIDER botscan signature. The old pattern matched the bare substring 'revslider' (url-any), so legitimate WordPress pages loading RevSlider static assets (/wp-content/plugins/revslider/.../rs6.min.js, rbtools.min.js, *.css) tripped the 3/60s threshold and banned real visitors. The narrowed pattern matches only exploit-specific action/client_action tokens (revslider_show_image LFI, client_action=get_captions_css LFI, client_action=update_plugin RCE). Asserts: the record still parses via the anchored (|-bearing pattern) parse into exactly 8 fields with match_type/threshold/window/ban/enabled intact; the pattern is no longer the bare 'revslider'; legit asset URLs do NOT match; real exploit probe URLs DO match; threshold/window/ban/enabled unchanged (3/60/3600/true)."
+# meta:input="None (reads the shipped exploit.patterns)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="etc/nftban/patterns.d/botscan/exploit.patterns"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PATTERNS="$REPO_ROOT/etc/nftban/patterns.d/botscan/exploit.patterns"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=== v1.218.10 EXP_REVSLIDER false-positive narrowing ==="
+
+# Grab the EXP_REVSLIDER record line.
+line=$(grep -E '^EXP_REVSLIDER\|' "$PATTERNS" | head -1)
+[[ -n "$line" ]] && ok "EXP_REVSLIDER record present" || { no "EXP_REVSLIDER record present"; }
+
+# Anchored parse (mirrors nftban_botscan.sh: peel NAME off front, 6 fields off back;
+# the middle is the legally |-bearing pattern).
+name="${line%%|*}"; rest="${line#*|}"
+rest="${rest%|*}"                          # drop description (last field; unused here)
+enabled="${rest##*|}";   rest="${rest%|*}"
+ban="${rest##*|}";       rest="${rest%|*}"
+window="${rest##*|}";    rest="${rest%|*}"
+threshold="${rest##*|}"; rest="${rest%|*}"
+match_type="${rest##*|}";rest="${rest%|*}"
+pattern="$rest"
+
+# >= 7 pipes (8 fields; a |-alternation pattern only adds more).
+pipes="${line//[!|]/}"
+[[ "${#pipes}" -ge 7 ]] && ok "record has >= 7 pipes (parseable into 8 fields)" || no "record has >= 7 pipes"
+
+[[ "$name" == "EXP_REVSLIDER" ]] && ok "name field = EXP_REVSLIDER" || no "name field ($name)"
+[[ "$match_type" == "url-any" ]] && ok "match_type field intact = url-any" || no "match_type ($match_type)"
+[[ "$threshold" == "3" ]] && ok "threshold unchanged = 3" || no "threshold ($threshold)"
+[[ "$window" == "60" ]] && ok "window unchanged = 60" || no "window ($window)"
+[[ "$ban" == "3600" ]] && ok "ban unchanged = 3600" || no "ban ($ban)"
+[[ "$enabled" == "true" ]] && ok "enabled unchanged = true" || no "enabled ($enabled)"
+
+# The regression guard: pattern must NOT be the bare product token.
+[[ "$pattern" != "revslider" ]] && ok "pattern narrowed (no longer bare 'revslider')" || no "pattern still bare 'revslider' — FALSE-POSITIVE REGRESSION"
+[[ "$pattern" == *revslider_show_image* ]] && ok "pattern includes exploit indicator revslider_show_image" || no "missing revslider_show_image"
+
+# Behavioural: legit RevSlider asset URLs must NOT match (the FP source).
+legit_ok=true
+for u in \
+  '/wp-content/plugins/revslider/public/assets/js/rbtools.min.js' \
+  '/wp-content/plugins/revslider/public/assets/js/rs6.min.js' \
+  '/wp-content/plugins/revslider/public/assets/css/rs6.css' \
+  '/wp-content/plugins/revslider/public/assets/fonts/revicons.woff' ; do
+  if printf '%s' "$u" | grep -qE "$pattern"; then legit_ok=false; echo "        matched (bad): $u"; fi
+done
+$legit_ok && ok "legit RevSlider asset URLs do NOT match (visitors not banned)" || no "legit asset URL matched — FALSE POSITIVE"
+
+# Behavioural: real RevSlider exploit probes must still match.
+exploit_ok=true
+for u in \
+  '/wp-admin/admin-ajax.php?action=revslider_show_image&img=../../../wp-config.php' \
+  '/wp-admin/admin-ajax.php?action=revslider_ajax_action&client_action=get_captions_css&data=..' \
+  '/wp-admin/admin-ajax.php?action=revslider_ajax_action&client_action=update_plugin' ; do
+  if ! printf '%s' "$u" | grep -qE "$pattern"; then exploit_ok=false; echo "        missed (bad): $u"; fi
+done
+$exploit_ok && ok "real RevSlider exploit probes still match (detection preserved)" || no "exploit probe missed — detection regression"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/etc/nftban/patterns.d/botscan/exploit.patterns
+++ b/etc/nftban/patterns.d/botscan/exploit.patterns
@@ -27,7 +27,7 @@ EXP_WPREST|/wp-json/wp/v2/users|url-get|5|300|1800|true|WP user enumeration
 EXP_WPCRON|/wp-cron\.php\?doing_wp_cron|url-get|20|60|1800|true|WP cron abuse
 EXP_WPUPGRADE|/wp-admin/includes/upgrade\.php|url-any|2|60|3600|true|WP upgrade exploit
 EXP_TIMTHUMB|timthumb\.php|url-any|2|60|3600|true|TimThumb exploit
-EXP_REVSLIDER|revslider|url-any|3|60|3600|true|RevSlider exploit
+EXP_REVSLIDER|revslider_show_image|client_action=(get_captions_css|update_plugin)|url-any|3|60|3600|true|RevSlider LFI/RCE exploit probe (narrowed from bare "revslider" so legit /wp-content/plugins/revslider asset loads are not banned)
 EXP_GRAVITYFORMS|/gf_page=preview|url-any|3|60|3600|true|Gravity Forms exploit
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
**Fix BotScan `EXP_REVSLIDER` false-positive that could ban legitimate visitors loading RevSlider static assets.**

## The bug
`etc/nftban/patterns.d/botscan/exploit.patterns`:
```
EXP_REVSLIDER|revslider|url-any|3|60|3600|true|RevSlider exploit
```
The pattern matched the **bare substring `revslider`** anywhere in a URL (`url-any`, 3 hits / 60s). Every normal WordPress page that renders the RevSlider plugin loads several assets whose path contains `revslider`:
- `/wp-content/plugins/revslider/public/assets/js/rbtools.min.js`
- `/wp-content/plugins/revslider/public/assets/js/rs6.min.js`
- `…/assets/css/*.css`

So a **single page view trips 3-in-60s → the visitor is banned for an hour, server-wide across every domain on the host.** To the visitor the site "doesn't load."

## Live evidence (srv2, read-only)
- **133 distinct visitor IPs** flagged by `EXP_REVSLIDER` — dozens of Greek/EU residential (OTE/Vodafone/Wind) addresses.
- A **confirmed mobile phone** (owner-verified) was banned after a normal homepage load ending in `rbtools.min.js` + `rs6.min.js`.
- Structural audit: across all 5 botscan pattern files, `EXP_REVSLIDER` is the **only** enabled `url-any` signature whose pattern is a bare product token — it is the unique offender in this class.

## The fix (surgical — pattern field only)
```
EXP_REVSLIDER|revslider_show_image|client_action=(get_captions_css|update_plugin)|url-any|3|60|3600|true|RevSlider LFI/RCE exploit probe …
```
Matches only **exploit-specific tokens** that never appear in asset paths:
- `revslider_show_image` — classic LFI action
- `client_action=get_captions_css` — LFI via `revslider_ajax_action`
- `client_action=update_plugin` — arbitrary-upload RCE

`threshold/window/ban/enabled` unchanged (3/60/3600/true). The `|`-alternation is safe: the botscan parser uses an anchored parse where the middle field is legally `|`-bearing (see `EXP_CGIBIN|/cgi-bin/.*\.(sh|pl|cgi)`).

## Tests
- New `botscan_revslider_fp_v218_10_test.sh` — **12/12 PASS**: record parses into 8 fields; pattern no longer bare `revslider`; **legit asset URLs do NOT match**; **3 real exploit probe forms still match**; threshold/window/ban/enabled intact.
- Regression: `botscan_pattern_delimiter_v214_test.sh` PASS (shipped set → 140 enabled, 0 skipped — the new multi-pipe record parses).
- `shellcheck -S warning` clean.

## Classification
Pattern/data + test only · **0 Go · no schema change · no nft template change** · no retune of other signatures · not Akrites/telemetry/RBL/webhook/CI-hardening/badge. **Separate from #1054 (management tier) and #1055 (toolchain).** Part of the v1.218.10 release train.

**Does NOT unban existing IPs** — the product fix prevents *new* false bans; targeted cleanup of already-banned asset-loading IPs is a separate read-only-then-targeted step (no bulk unban).

## Not in scope
`SINGLE_DASH` (high-volume but a `useragent` `^-$` empty-UA heuristic, different class → `NEEDS_MORE_EVIDENCE`, audited separately) and all other signatures (exploit-specific paths → real-scanner).

## Hold
No merge without a separate GO. No release-prep / tag / publish / fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)