### PR TITLE
fix(flush): blacklist flush/count truth — include manual sets used by botscan/admin bans

### DIFF
--- a/cli/lib/nftban/cli/cmd_flush.sh
+++ b/cli/lib/nftban/cli/cmd_flush.sh
@@ -80,7 +80,9 @@ USAGE:
     nftban flush <target> [options]
 
 TARGETS:
-    blacklist           Flush ALL IPs from blacklist_ipv4/ipv6 sets
+    blacklist [SCOPE]   Flush blacklist bans. SCOPE: all (default; feed+GeoBan AND
+                        manual+botscan) | feeds (blacklist_ipv4/ipv6) | manual
+                        (blacklist_manual_ipv4/ipv6). Whitelist preserved.
     whitelist           Flush whitelist sets (system whitelist auto-restored)
     feeds               Flush only feed-sourced IPs from blacklist
     geoban              Flush only geoban-sourced IPs from blacklist
@@ -355,64 +357,102 @@ _apply_file_via_ipc() {
 # =============================================================================
 
 # Flush entire blacklist sets
+# Count kernel elements in one set (grep 'N elements' header, fallback to comma-split).
+_flush_setcount() {
+    local table="$1" set="$2" c
+    c=$(timeout 10s nft list set "$table" "$set" 2>/dev/null | grep -oP '\d+(?= elements)' | head -1 || echo "")
+    if [[ -z "$c" ]]; then
+        c=$(timeout 10s nft list set "$table" "$set" 2>/dev/null | tr ',' '\n' | grep -cE '^[[:space:]]*[0-9a-fA-F]' || true)
+    fi
+    echo "${c:-0}"
+}
+
+# v1.218.10 BLACKLIST_FLUSH_TRUTH: bare `flush blacklist` clears ALL 4 real blacklist
+# sets, not just the feed interval sets. Scope ∈ {all(default),feeds,manual}.
+#   feeds  = blacklist_ipv4/ipv6      (feed + GeoBan interval CIDRs — shared set)
+#   manual = blacklist_manual_ipv4/ipv6 (admin + botscan + portscan/login/ddos-escalated)
+#   all    = both (what "blacklist flush" means to an operator)
+# No new sets. Whitelist/port-allow sets untouched. Kernel-only (blacklist.d re-adds on reconcile).
 _flush_blacklist() {
     local skip_confirm="${1:-false}"
     local dry_run="${2:-false}"
+    local scope="${3:-all}"
+    [[ -z "$scope" ]] && scope="all"
+    case "$scope" in
+        feeds|manual|all) ;;
+        *) echo "Unknown blacklist flush scope: '$scope' (valid: feeds | manual | all)"; return 2 ;;
+    esac
 
-    echo "Flush target: blacklist (blacklist_ipv4 + blacklist_ipv6)"
+    # Count all four real blacklist sets by authority.
+    local fc4 fc6 mc4 mc6
+    fc4=$(_flush_setcount "$NFTBAN_TABLE_IPV4" blacklist_ipv4)
+    fc6=$(_flush_setcount "$NFTBAN_TABLE_IPV6" blacklist_ipv6)
+    mc4=$(_flush_setcount "$NFTBAN_TABLE_IPV4" blacklist_manual_ipv4)
+    mc6=$(_flush_setcount "$NFTBAN_TABLE_IPV6" blacklist_manual_ipv6)
+    local feed_total=$((fc4 + fc6)) manual_total=$((mc4 + mc6))
+    local grand=$((feed_total + manual_total)) removed=0
+
+    echo "Flush target: blacklist (scope: $scope)"
+    echo ""
+    echo "Current blacklist (kernel sets):"
+    echo "  Feed + GeoBan     IPv4: $fc4   IPv6: $fc6   (blacklist_ipv4/ipv6 — interval CIDRs)"
+    echo "  Manual + BotScan  IPv4: $mc4   IPv6: $mc6   (blacklist_manual_ipv4/ipv6 — incl. portscan/login/ddos-escalated)"
+    echo "  Total kernel:     $grand"
     echo ""
 
-    # Count current elements
-    local count_v4 count_v6
-    count_v4=$(timeout 10s nft list set "$NFTBAN_TABLE_IPV4" blacklist_ipv4 2>/dev/null | grep -oP '\d+(?= elements)' || echo "0")
-    count_v6=$(timeout 10s nft list set "$NFTBAN_TABLE_IPV6" blacklist_ipv6 2>/dev/null | grep -oP '\d+(?= elements)' || echo "0")
+    # Sets to flush for this scope (existing sets only — no new sets created).
+    local -a sets=()
+    case "$scope" in
+        feeds)  sets=("$NFTBAN_TABLE_IPV4|blacklist_ipv4" "$NFTBAN_TABLE_IPV6|blacklist_ipv6"); removed=$feed_total ;;
+        manual) sets=("$NFTBAN_TABLE_IPV4|blacklist_manual_ipv4" "$NFTBAN_TABLE_IPV6|blacklist_manual_ipv6"); removed=$manual_total ;;
+        all)    sets=("$NFTBAN_TABLE_IPV4|blacklist_ipv4" "$NFTBAN_TABLE_IPV6|blacklist_ipv6" \
+                      "$NFTBAN_TABLE_IPV4|blacklist_manual_ipv4" "$NFTBAN_TABLE_IPV6|blacklist_manual_ipv6"); removed=$grand ;;
+    esac
 
-    # Fallback count method
-    [[ "$count_v4" == "0" ]] && count_v4=$(timeout 10s nft list set "$NFTBAN_TABLE_IPV4" blacklist_ipv4 2>/dev/null | tr ',' '\n' | grep -cE '^[0-9]' || true)
-    count_v4=${count_v4:-0}
-    [[ "$count_v6" == "0" ]] && count_v6=$(timeout 10s nft list set "$NFTBAN_TABLE_IPV6" blacklist_ipv6 2>/dev/null | tr ',' '\n' | grep -cE '^[0-9a-f]' || true)
-    count_v6=${count_v6:-0}
-
-    echo "Current blacklist:"
-    echo "  IPv4: ~$count_v4 entries"
-    echo "  IPv6: ~$count_v6 entries"
+    echo "This will remove:"
+    [[ "$scope" != manual ]] && echo "  - feed + GeoBan interval blacklist entries (blacklist_ipv4/ipv6)"
+    [[ "$scope" != feeds  ]] && echo "  - manual/admin + botscan blacklist entries (blacklist_manual_ipv4/ipv6)"
+    echo ""
+    echo "WARNING:"
+    echo "  - Flushes KERNEL blacklist sets only; persistent blacklist.d/*.conf entries"
+    echo "    may be re-added on the next reconcile/reload."
+    echo "  - Whitelist and port-allow sets are PRESERVED."
+    [[ "$scope" != manual ]] && echo "  - feeds and GeoBan share the interval set — this also clears GeoBan country blocks (repopulate via feeds/geoban refresh)."
 
     if [[ "$dry_run" == "true" ]]; then
         echo ""
         echo "[DRY-RUN] Would flush:"
-        echo "  - flush set $NFTBAN_TABLE_IPV4 blacklist_ipv4"
-        echo "  - flush set $NFTBAN_TABLE_IPV6 blacklist_ipv6"
+        local s
+        for s in "${sets[@]}"; do echo "  - flush set ${s%%|*} ${s##*|}"; done
         return 0
     fi
 
     # Confirm
-    _confirm_flush "blacklist" "$count_v4" "$count_v6" "$skip_confirm" || return 1
+    if [[ "$skip_confirm" != "true" ]]; then
+        echo ""
+        read -r -p "Proceed? [y/N] " response
+        case "$response" in [yY]|[yY][eE][sS]) ;; *) echo "Aborted."; return 1 ;; esac
+    fi
 
     # v1.19.0: Check daemon or emergency gate (R20)
     _flush_check_daemon || return 1
 
-    # Execute flush via IPC
     echo ""
-    echo "Flushing blacklist sets..."
-
-    if _flush_set_via_ipc "$NFTBAN_TABLE_IPV4" "blacklist_ipv4"; then
-        echo "  [OK] Flushed blacklist_ipv4"
-    else
-        echo "  [WARN] Failed to flush blacklist_ipv4"
-    fi
-
-    if _flush_set_via_ipc "$NFTBAN_TABLE_IPV6" "blacklist_ipv6"; then
-        echo "  [OK] Flushed blacklist_ipv6"
-    else
-        echo "  [WARN] Failed to flush blacklist_ipv6"
-    fi
+    echo "Flushing blacklist sets (scope: $scope)..."
+    local s tbl name
+    for s in "${sets[@]}"; do
+        tbl="${s%%|*}"; name="${s##*|}"
+        if _flush_set_via_ipc "$tbl" "$name"; then
+            echo "  [OK] Flushed $name"
+        else
+            echo "  [WARN] Failed to flush $name"
+        fi
+    done
 
     echo ""
-    echo "Blacklist flush complete:"
-    echo "  - Removed ~$count_v4 IPv4 entries"
-    echo "  - Removed ~$count_v6 IPv6 entries"
-    echo "  - System whitelist: preserved (in whitelist set)"
-
+    echo "Blacklist flush complete (scope: $scope):"
+    echo "  - Removed ~$removed kernel entries (feed+geoban: $feed_total, manual+botscan: $manual_total)"
+    echo "  - Whitelist: preserved"
     return 0
 }
 
@@ -781,10 +821,11 @@ _flush_all() {
     echo "=========================================="
     echo ""
     echo "WARNING: This will flush:"
-    echo "  - blacklist_ipv4 / blacklist_ipv6"
+    echo "  - blacklist_ipv4 / blacklist_ipv6 (feed + GeoBan)"
+    echo "  - blacklist_manual_ipv4 / blacklist_manual_ipv6 (manual + botscan)"
     echo "  - whitelist_ipv4 / whitelist_ipv6 (then restored)"
-    echo "  - ddos_blocked (if exists)"
-    echo "  - portscan_blocked (if exists)"
+    echo "  - ddos_blocked / portscan_blocked (if present)"
+    echo "  NOTE: persistent blacklist.d/*.conf entries re-add on reconcile/reload."
     echo ""
     echo "System whitelist will be IMMEDIATELY restored after flush."
     echo ""
@@ -811,6 +852,10 @@ _flush_all() {
     # v1.19.0: Flush all sets via IPC (batched sequential requests)
     _flush_set_via_ipc "$NFTBAN_TABLE_IPV4" "blacklist_ipv4" && echo "[OK] Flushed blacklist_ipv4"
     _flush_set_via_ipc "$NFTBAN_TABLE_IPV6" "blacklist_ipv6" && echo "[OK] Flushed blacklist_ipv6"
+
+    # v1.218.10: manual/botscan bans live here — MUST be flushed by "all" too.
+    _flush_set_via_ipc "$NFTBAN_TABLE_IPV4" "blacklist_manual_ipv4" && echo "[OK] Flushed blacklist_manual_ipv4"
+    _flush_set_via_ipc "$NFTBAN_TABLE_IPV6" "blacklist_manual_ipv6" && echo "[OK] Flushed blacklist_manual_ipv6"
 
     # Flush whitelist
     _flush_set_via_ipc "$NFTBAN_TABLE_IPV4" "whitelist_ipv4" && echo "[OK] Flushed whitelist_ipv4"
@@ -852,6 +897,7 @@ nftban_cmd_flush() {
     # Parse options
     local skip_confirm=false
     local dry_run=false
+    local subtarget=""   # optional scope for 'blacklist' (feeds|manual|all)
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -866,9 +912,14 @@ nftban_cmd_flush() {
                 return 0
                 ;;
             *)
-                echo "Unknown option: $1"
-                _nftban_flush_help
-                return 2
+                # First bare positional = subtarget (e.g. `flush blacklist manual`).
+                if [[ -z "$subtarget" ]]; then
+                    subtarget="$1"
+                else
+                    echo "Unknown option: $1"
+                    _nftban_flush_help
+                    return 2
+                fi
                 ;;
         esac
         shift
@@ -876,7 +927,7 @@ nftban_cmd_flush() {
 
     case "$target" in
         blacklist)
-            _flush_blacklist "$skip_confirm" "$dry_run"
+            _flush_blacklist "$skip_confirm" "$dry_run" "$subtarget"
             ;;
         whitelist)
             _flush_whitelist "$skip_confirm" "$dry_run"

--- a/cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh
+++ b/cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.218.10 blacklist flush/count manual-set truth hotfix
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="blacklist_flush_manual_truth_v218_10_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-08"
+# meta:description="Verifies the v1.218.10 fix where `nftban blacklist flush` and `nftban flush all` omitted the manual blacklist sets (blacklist_manual_ipv4/ipv6) where botscan/admin/portscan/login/ddos-escalated bans live — so an emergency flush left hundreds of bans active while wiping feed protection. Asserts: bare blacklist flush (scope all) targets all 4 blacklist sets; scope feeds targets only interval sets; scope manual targets only manual sets; invalid scope errors; flush all now includes the manual sets; whitelist is never in the blacklist-flush set list; the prompt shows the feed+GeoBan / manual+botscan breakdown and the persistent-blacklist.d + whitelist-preserved warnings. No new nft sets are created; existing sets only."
+# meta:input="None (self-contained; extracts + stubs the flush functions)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,awk,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_flush.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+SRC="$REPO_ROOT/cli/lib/nftban/cli/cmd_flush.sh"
+
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+CALLS="$SANDBOX/calls"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ printf '%s' "$1" | grep -Fq -- "$2"; }
+
+# Extract the two contiguous function blocks under test.
+{
+  awk '/^# Count kernel elements in one set/{c=1} /^# Flush whitelist sets/{c=0} c{print}' "$SRC"
+  awk '/^_flush_all\(\)/{c=1} c{print} /^}$/{if(c)exit}' "$SRC"
+} > "$SANDBOX/funcs.sh"
+
+# Harness: stubs (defined before the extracted funcs are sourced).
+run() {  # run <flush_fn-with-args...>; echoes stdout; records flushed sets in $CALLS
+  : > "$CALLS"
+  bash -c '
+    set +e
+    NFTBAN_TABLE_IPV4="ip nftban"; NFTBAN_TABLE_IPV6="ip6 nftban"
+    CALLS="'"$CALLS"'"
+    nft(){ echo "set x { type ipv4_addr; elements = { 1.2.3.4, 5.6.7.8 } }"; }
+    timeout(){ shift; "$@"; }
+    _flush_check_daemon(){ return 0; }
+    _flush_set_via_ipc(){ echo "$2" >> "$CALLS"; return 0; }
+    _restore_system_whitelist(){ :; }
+    _nftban_flush_help(){ :; }
+    source "'"$SANDBOX"'/funcs.sh"
+    "$@"
+  ' _ "$@"
+}
+
+echo "=== v1.218.10 blacklist flush/count manual-set truth ==="
+
+# T1 — bare scope=all flushes ALL FOUR blacklist sets
+rc=0; out=$(run _flush_blacklist true false all) || rc=$?
+for s in blacklist_ipv4 blacklist_ipv6 blacklist_manual_ipv4 blacklist_manual_ipv6; do
+  grep -qx "$s" "$CALLS" && ok "all: flushed $s" || no "all: did NOT flush $s"
+done
+grep -qx whitelist_ipv4 "$CALLS" && no "all: WHITELIST flushed (must not)" || ok "all: whitelist NOT flushed"
+
+# T2 — scope=feeds flushes only interval sets
+run _flush_blacklist true false feeds >/dev/null
+grep -qx blacklist_ipv4 "$CALLS" && grep -qx blacklist_ipv6 "$CALLS" && ok "feeds: flushed interval sets" || no "feeds: interval sets"
+grep -qx blacklist_manual_ipv4 "$CALLS" && no "feeds: manual flushed (must not)" || ok "feeds: manual NOT flushed"
+
+# T3 — scope=manual flushes only manual sets
+run _flush_blacklist true false manual >/dev/null
+grep -qx blacklist_manual_ipv4 "$CALLS" && grep -qx blacklist_manual_ipv6 "$CALLS" && ok "manual: flushed manual sets" || no "manual: manual sets"
+grep -qx blacklist_ipv4 "$CALLS" && no "manual: feed flushed (must not)" || ok "manual: feed NOT flushed"
+
+# T4 — invalid scope errors (rc 2), flushes nothing
+rc=0; out=$(run _flush_blacklist true false bogus) || rc=$?
+[[ "$rc" == 2 ]] && ok "invalid scope -> rc2" || no "invalid scope rc ($rc)"
+[[ ! -s "$CALLS" ]] && ok "invalid scope flushed nothing" || no "invalid scope flushed sets"
+
+# T5 — flush all now includes the manual sets
+run _flush_all true false >/dev/null
+grep -qx blacklist_manual_ipv4 "$CALLS" && grep -qx blacklist_manual_ipv6 "$CALLS" && ok "flush all: includes manual sets" || no "flush all: manual sets MISSING"
+grep -qx blacklist_ipv4 "$CALLS" && ok "flush all: still flushes feed sets" || no "flush all: feed sets"
+
+# T6 — dry-run shows the authority breakdown + warnings, lists all 4 sets
+out=$(run _flush_blacklist false true all)
+has "$out" "Feed + GeoBan"      && ok "prompt: feed+GeoBan label"      || no "prompt: feed+GeoBan label"
+has "$out" "Manual + BotScan"   && ok "prompt: manual+botscan label"  || no "prompt: manual+botscan label"
+has "$out" "blacklist.d"        && ok "prompt: persistent blacklist.d warning" || no "prompt: persistent warning"
+has "$out" "PRESERVED"          && ok "prompt: whitelist preserved note" || no "prompt: whitelist preserved"
+has "$out" "blacklist_manual_ipv4" && ok "dry-run: lists manual set" || no "dry-run: manual set"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary
**Fix blacklist flush truth bug: `nftban blacklist flush` (and `flush all`) now include the manual blacklist sets, preventing false "0 bans removed" recovery during false-positive incidents.**

## The bug (found during the EXP_REVSLIDER incident)
`_flush_blacklist` and `_flush_all` targeted only the **feed** interval sets (`blacklist_ipv4/ipv6`) and silently ignored the **manual** sets (`blacklist_manual_ipv4/ipv6`) — where **botscan + admin + portscan/login/ddos-escalated** bans live. On srv2 an operator's `nftban blacklist flush` reported *"removed ~0"* while **487 bans survived**, and it **wiped the useful threat-feed protection** instead. The opposite of what the operator intended, during a live incident.

## Enforcement-set audit (why the fix is shaped this way)
Real ban sets in the schema: `blacklist_ipv4/ipv6` (**feeds + GeoBan**, interval CIDRs) · `blacklist_manual_ipv4/ipv6` (**manual + botscan**; portscan/login/ddos-escalated single-IP bans land here) · `http_bot_ban` (BotGuard, disabled). **GeoBan/DDoS/PortScan have no dedicated sets** — `ddos_blocked`/`portscan_blocked`/`geoban_v4/6` referenced by the flush code **don't exist** (phantom no-ops). So fixing the manual-set omission also correctly covers portscan/login/ddos bans.

## The fix (no new nft sets; existing sets only)
- **`nftban blacklist flush`** [bare] now flushes **all 4 blacklist sets**.
- **Explicit scopes:** `blacklist flush feeds | manual | all`
  - `feeds` = `blacklist_ipv4/ipv6` · `manual` = `blacklist_manual_ipv4/ipv6` · `all` = both
- **Authority-breakdown prompt:** Feed+GeoBan / Manual+BotScan / total, with warnings that kernel-flush ≠ persistent (`blacklist.d/*.conf` re-adds on reconcile), that **whitelist + port-allow sets are preserved**, and that feeds+GeoBan share the interval set.
- **`nftban flush all`** now includes the manual sets too.

## Deliberately left as-is (per "keep working behavior; minimal emergency fix")
- Phantom `ddos_blocked`/`portscan_blocked`/`geoban_v4/6` flush targets — no-op today; **separate follow-up** `OPEN_FLUSH_PHANTOM_SET_TRUTH_CLEANUP`.
- `nftban blacklist count` — **unchanged** (already counts feed+manual, V119 D2).
- Whitelist/port-allow/BotGuard/GeoBan-feed model — untouched.

## Tests
- New `blacklist_flush_manual_truth_v218_10_test.sh` — **18/18**: scope all→4 sets; feeds→interval only; manual→manual only; invalid→rc2/no-op; `flush all`→manual included; whitelist never flushed; breakdown + warnings present.
- `shellcheck -S warning` clean.

## Classification
**Shell-only · 0 Go · nft schema 1.84.0 · no new sets · whitelist preserved.** Separate from #1054 (management tier) and #1056 (EXP_REVSLIDER pattern). Part of the v1.218.10 emergency/safety train. Not bundled with opqueue/Akrites/update-path/RBL/telemetry/webhook/CI-hardening/badge/docs-wiki.

## Hold
No merge without a separate GO. No release-prep / tag / publish / fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)