### PR TITLE
feat(status): v1.218.11 BotScan operator-truth — surface HTTP Exploit Scanner beside HTTP Guard

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -367,8 +367,10 @@ _nftban_botscan_cmd_config() {
         return 0
     fi
 
-    echo "Bot Scanner Configuration"
-    echo "========================="
+    echo "HTTP Exploit Scanner (BotScan) — Configuration"
+    echo "=============================================="
+    echo "  Periodic access-log exploit scanner. INDEPENDENT of BotGuard (HTTP Guard) —"
+    echo "  can enforce bans via the manual blacklist even when BotGuard is disabled."
     echo ""
     echo "  Config File:    $config_file"
     echo "  Override File:  $config_local"
@@ -380,6 +382,7 @@ _nftban_botscan_cmd_config() {
     echo ""
     echo "Settings:"
     echo "  Enabled:        ${BOTSCAN_ENABLED:-false}"
+    echo "  Timer:          $(systemctl is-active nftban-botscan.timer 2>/dev/null || echo inactive) (nftban-botscan.timer)"
     echo "  Action Mode:    ${BOTSCAN_ACTION_MODE:-both}"
     echo "  Threshold:      ${BOTSCAN_DEFAULT_THRESHOLD:-5} hits"
     echo "  Time Window:    ${BOTSCAN_DEFAULT_WINDOW:-60} seconds"

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1070,7 +1070,29 @@ _status_section_protection() {
             botguard_status="ENABLED (sets not loaded)"
         fi
     fi
-    printf "  %-20s %s\n" "Bot Guard..........." "$botguard_status"
+    printf "  %-20s %s\n" "HTTP Guard.........." "$botguard_status"
+
+    # HTTP Exploit Scanner (BotScan) — periodic access-log exploit scanner (v1.218.11 operator-truth).
+    # INDEPENDENT of BotGuard: BotScan can enforce bans via blacklist_manual_* even when BotGuard is OFF.
+    local botscan_status="DISABLED" botscan_enabled="false" botscan_mode="both"
+    if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botscan/main.conf" ]]; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botscan/main.conf" || true
+    fi
+    if [[ -f "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botscan/main.conf.local" ]]; then
+        # shellcheck source=/dev/null
+        _source_local "${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/botscan/main.conf.local"
+    fi
+    botscan_enabled="${BOTSCAN_ENABLED:-false}"
+    botscan_mode="${BOTSCAN_ACTION_MODE:-both}"
+    if [[ "$botscan_enabled" == "true" ]]; then
+        local botscan_timer="stopped"
+        systemctl is-active nftban-botscan.timer &>/dev/null && botscan_timer="active"
+        botscan_status="ENABLED (action=${botscan_mode}, timer ${botscan_timer})"
+    fi
+    printf "  %-20s %s\n" "HTTP Exploit Scan..." "$botscan_status"
+    echo "    (HTTP Guard = BotGuard, live request-time guard; HTTP Exploit Scan = BotScan, periodic"
+    echo "     access-log scanner — can ban via the manual blacklist. BotGuard disabled != BotScan disabled.)"
 
     # Tunnel Suspicion (v1.30.0)
     local tunnel_status="DISABLED"

--- a/cli/lib/nftban/nftban_help.sh
+++ b/cli/lib/nftban/nftban_help.sh
@@ -111,7 +111,10 @@ PROTECTION MODULES:
   ⚡ ddos          DDoS protection (enable/disable/status)
   ⚡ portscan      Port scan detection (enable/disable/status)
   ⚡ login         Login monitor — SSH brute-force protection
-  ⚡ botguard      HTTP bot guard (enable/disable/status/list)
+  ⚡ botguard      HTTP Guard — live request-time HTTP bot guard (enable/disable/status/list)
+  🔍 botscan       HTTP Exploit Scanner — periodic access-log exploit scanner (status/enable/disable)
+                   NOTE: BotScan is independent of BotGuard — it can ban via the manual blacklist
+                   even when BotGuard is disabled.
   ⚡ geoban        Geographic IP blocking (enable/disable/list)
 
 SYSTEM:
@@ -154,7 +157,8 @@ CORE COMMANDS:
 
 PROTECTION MODULES:
   ddos        DDoS protection management
-  botguard    HTTP bot guard management
+  botguard    HTTP Guard — live request-time bot guard management
+  botscan     HTTP Exploit Scanner — periodic access-log exploit scanner (independent of BotGuard)
   portscan    Port scan detection
   geoban      Geographic IP blocking
   geoip       GeoIP database management

--- a/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
+++ b/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.218.11 BotScan operator-truth V1 (shell surfacing)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_operator_truth_v218_11_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-09"
+# meta:description="Verifies the v1.218.11 shell surfacing that makes BotScan (the periodic HTTP-log exploit scanner) first-class alongside BotGuard, after the 2026-07-08 incident where BotGuard showed DISABLED while BotScan was enabled and banning via blacklist_manual_*. Extracts the nftban status BotScan render block and exercises it with enabled/disabled fixtures (asserts HTTP Exploit Scan row, ENABLED with action mode + timer state, DISABLED, and the BotGuard-independence note); asserts nftban help exposes botscan with the HTTP-Guard-vs-HTTP-Exploit-Scanner distinction; asserts nftban botscan status carries the HTTP Exploit Scanner label + timer line. Shell/display only — no Go/schema/pattern change."
+# meta:input="None (extracts + stubs the status render block; greps help/botscan sources)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,systemctl-stub"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_status.sh,cli/lib/nftban/nftban_help.sh,cli/lib/nftban/cli/cmd_botscan.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+STATUS="$REPO/cli/lib/nftban/cli/cmd_status.sh"
+HELP="$REPO/cli/lib/nftban/nftban_help.sh"
+BOTSCAN="$REPO/cli/lib/nftban/cli/cmd_botscan.sh"
+
+SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ printf '%s' "$1" | grep -Fq -- "$2"; }
+
+# Extract the BotScan render block from cmd_status.sh.
+awk '/# HTTP Exploit Scanner \(BotScan\)/{c=1} c{print} /BotGuard disabled != BotScan disabled/{exit}' "$STATUS" > "$SANDBOX/block.sh"
+[[ -s "$SANDBOX/block.sh" ]] && ok "status BotScan render block present" || no "status BotScan render block MISSING"
+
+# Render harness: wrap the block in a function with config + systemctl stubs.
+render() {  # render <enabled> <action_mode> <timer-active:1|0>
+  local en="$1" mode="$2" tmr="$3"
+  mkdir -p "$SANDBOX/conf.d/botscan"
+  printf 'BOTSCAN_ENABLED="%s"\nBOTSCAN_ACTION_MODE="%s"\n' "$en" "$mode" > "$SANDBOX/conf.d/botscan/main.conf"
+  STIMER="$tmr" bash -c '
+    set +e
+    NFTBAN_CONFIG_DIR="'"$SANDBOX"'"
+    _source_local(){ source "$1"; }
+    systemctl(){ [ "${STIMER:-0}" = 1 ] && return 0 || return 1; }
+    render(){
+      '"$(cat "$SANDBOX/block.sh")"'
+    }
+    render
+  '
+}
+
+echo "=== v1.218.11 BotScan operator-truth ==="
+
+out=$(render true ban 1)
+has "$out" "HTTP Exploit Scan" && ok "enabled: HTTP Exploit Scan row rendered" || no "enabled: row"
+has "$out" "ENABLED"           && ok "enabled: shows ENABLED"                   || no "enabled: ENABLED"
+has "$out" "action=ban"        && ok "enabled: shows action mode"              || no "enabled: action mode"
+has "$out" "timer active"      && ok "enabled: shows timer active"             || no "enabled: timer state"
+has "$out" "BotGuard disabled != BotScan disabled" && ok "independence note present" || no "independence note"
+
+out=$(render true ban 0)
+has "$out" "timer stopped" && ok "enabled+timer-off: shows timer stopped" || no "timer stopped"
+
+out=$(render false both 0)
+has "$out" "HTTP Exploit Scan" && has "$out" "DISABLED" && ok "disabled: row shows DISABLED" || no "disabled: row"
+
+# Bot Guard row relabeled to HTTP Guard (display label)
+grep -q 'HTTP Guard' "$STATUS" && ok "status: BotGuard relabeled 'HTTP Guard'" || no "status: HTTP Guard label"
+
+# help exposes botscan + the distinction
+help=$(cat "$HELP")
+has "$help" "botscan" && ok "help: lists botscan" || no "help: botscan"
+has "$help" "HTTP Exploit Scanner" && ok "help: HTTP Exploit Scanner label" || no "help: label"
+grep -qiE 'independent of botguard|BotGuard is disabled' "$HELP" && ok "help: BotGuard-independence stated" || no "help: independence"
+
+# botscan status carries the label + timer line
+bs=$(cat "$BOTSCAN")
+has "$bs" "HTTP Exploit Scanner (BotScan)" && ok "botscan status: HTTP Exploit Scanner label" || no "botscan status: label"
+grep -q 'Timer:.*nftban-botscan.timer' "$BOTSCAN" && ok "botscan status: timer state line" || no "botscan status: timer"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary
Track 2 V1 (shell-only). After the 2026-07-08 RevSlider incident — where `nftban status` showed **`Bot Guard: DISABLED`** while **BotScan was enabled and actively banning** via `blacklist_manual_*` — make BotScan first-class in the operator surfaces so the two independent HTTP subsystems are no longer conflated.

## The two subsystems (now both surfaced)
- **BotGuard = "HTTP Guard"** — live, request-time HTTP bot guard (was disabled fleet-wide).
- **BotScan = "HTTP Exploit Scanner"** — periodic access-log exploit scanner (`nftban-botscan.timer`) that **can enforce bans via the manual blacklist even when BotGuard is off**.

## Changes (shell/display only)
1. **`cmd_status.sh`** — PROTECTION MODULES now shows a **`HTTP Exploit Scan`** (BotScan) row beside **`HTTP Guard`** (BotGuard): enabled/disabled (`BOTSCAN_ENABLED`), **timer state** (`nftban-botscan.timer`), **action mode** (`BOTSCAN_ACTION_MODE`), plus an explicit note: *"BotGuard disabled != BotScan disabled — they are independent."*
2. **`nftban_help.sh`** — exposes `botscan` (ESSENTIAL + CORE) with the HTTP-Guard-vs-HTTP-Exploit-Scanner distinction + independence caveat.
3. **`cmd_botscan.sh`** — `nftban botscan status` gains the **HTTP Exploit Scanner** label + a **timer-state** line (read-only behavior unchanged).

## Classification
**Shell/display only · 0 Go · 0 schema · 0 pattern · 0 workflow · no enablement change · no daemon re-baseline · nft schema 1.84.0 · telemetry off.**

## Excluded (kept for later lanes)
Go health row · `search` kernel-authority/cache-truth (→ v1.218.12) · aliases `http-guard`/`http-exploits` + `botscan test-url` (→ v1.218.13) · pattern/feeds-rc0/phantom-flush/SINGLE_DASH · any unban/cleanup.

## Tests
- New `botscan_operator_truth_v218_11_test.sh` — **14/14** (status BotScan row enabled/disabled/timer/action-mode + independence note; help lists botscan + label + independence; botscan status label + timer).
- `shellcheck -S warning` clean; regressions green: v128 correlation 7/0, cli_hardening 18/0, status_consistency 15/0.

## Hold
No merge without a separate GO. No tag/publish/fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)