### PR TITLE
feat(botscan): v1.219.0 PR-A — BotScan operator-truth contract (shell/docs, daemon byte-identical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Interpretation rules:
 | Module | Layer | Evidence | Daemon |
 |---|---|---|---|
 | **DDoS Protection** | L3/L4 | 5 dedicated kernel counters | NO |
-| **BotGuard** | L7 HTTP | 6 dedicated kernel sets | YES |
+| **BotGuard** (HTTP Guard) | L7 HTTP | 6 dedicated kernel sets | YES |
+| **BotScan** (HTTP Exploit Scanner) | L7 HTTP | Access-log pattern scan → `blacklist_manual_*` | Timer + daemon consumer |
 | **Portscan Detection** | L3/L4 | Structure only (no counter) | NO |
 | **Login Monitoring** | L2 Auth | Journal + shared sets | YES |
 | **Blacklist & Feeds** | L1 IP | Shared sets + counters | Partial |

--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -85,18 +85,24 @@ COMMANDS:
     help                Show this help message
 
 DESCRIPTION:
-    The bot scanner module identifies malicious bots, web shells, exploit
+    BotScan is the HTTP Exploit Scanner: it identifies web shells, exploit
     probes, and reconnaissance scanners by analyzing HTTP access logs.
 
     Unlike portscan detection which monitors network layer traffic, botscan
     operates at the application layer by parsing Apache/Nginx access logs.
+
+    BotScan vs BotGuard: HTTP Guard (BotGuard) is the live, request-time bot
+    guard; HTTP Exploit Scanner (BotScan) is this periodic access-log scanner.
+    They are INDEPENDENT — BotGuard being disabled does NOT disable BotScan,
+    and BotScan can enforce bans via the manual blacklist on its own.
 
 HOW IT WORKS:
 
     1. Log Monitoring: Parses Apache/Nginx access logs
     2. Pattern Match: Matches URLs against malicious patterns
     3. Threshold: Flags IPs that hit N patterns in M seconds
-    4. Auto-Ban: Automatically bans detected bot scanners
+    4. Action:  With BOTSCAN_ACTION_MODE=ban|both, bans flagged IPs via the
+                manual blacklist; with =alert, DETECT-ONLY (logs, does not ban)
 
 DETECTION CATEGORIES:
 
@@ -145,7 +151,7 @@ CONFIGURATION:
 
     Key settings:
       BOTSCAN_ENABLED           Enable/disable module (true/false)
-      BOTSCAN_ACTION_MODE       alert, ban, or both
+      BOTSCAN_ACTION_MODE       alert = detect-only | ban = enforce | both = enforce
       BOTSCAN_DEFAULT_THRESHOLD Hits before ban (default: 5)
       BOTSCAN_DEFAULT_WINDOW    Time window in seconds (default: 60)
       BOTSCAN_404_TRACKING      Track excessive 404s (true/false)
@@ -191,6 +197,7 @@ LOG FILES:
     State tracking: /var/lib/nftban/botscan-state.db
 
 SEE ALSO:
+    nftban botguard help   - HTTP Guard (live request-time bot guard; independent of BotScan)
     nftban login help      - Login/auth brute-force detection
     nftban portscan help   - Network port scan detection
     nftban ddos help       - DDoS protection

--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -598,6 +598,13 @@ nftban_health_cmd_truth() {
         printf "  %-11s  %-9s  %-9s  %-9s  %s\n" "$mod" "$config" "$structural" "$runtime" "$effective"
     done
 
+    # v1.219.0 — HTTP Exploit Scanner (BotScan) health block. Shell-side, CHEAP-READ ONLY
+    # (config + timer + spool stat + runstate.json). NEVER scans access-log content — see the
+    # log-read-at-init blow-up history (v1.187.1 cycle-timeout, v1.209.3 spool-OOM). BotScan can
+    # ban via blacklist_manual_* independently of BotGuard, so it is surfaced as first-class here.
+    # The Go four-axis module (frozen ModulesJSON) is deferred to v1.220+; handoff-error truth to PR-B.
+    _nftban_health_render_botscan
+
     # Render blacklist (composite)
     echo ""
     echo "  Blacklist    State      Entries"

--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -1088,9 +1088,35 @@ _status_section_protection() {
     if [[ "$botscan_enabled" == "true" ]]; then
         local botscan_timer="stopped"
         systemctl is-active nftban-botscan.timer &>/dev/null && botscan_timer="active"
-        botscan_status="ENABLED (action=${botscan_mode}, timer ${botscan_timer})"
+        # v1.219.0 action-mode honesty: alert = detect-only (no ban); ban == both (enforce).
+        local _bs_mode_note=""
+        case "$botscan_mode" in
+            alert) _bs_mode_note=" — DETECT-ONLY, does not ban" ;;
+            ban|both) _bs_mode_note=" — enforces via blacklist_manual" ;;
+        esac
+        botscan_status="ENABLED (action=${botscan_mode}${_bs_mode_note}, timer ${botscan_timer})"
+        # v1.219.0 operator-truth: a scanner that is enabled but BLIND/DEGRADED is not enforcing.
+        # Cheap read only — runstate.json (health_state / last cycle), NEVER an access-log content scan.
+        local _bs_rs="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json"
+        if [[ -r "$_bs_rs" ]] && command -v jq &>/dev/null; then
+            local _bs_hs _bs_ls _bs_bud _bs_bans _bs_uips
+            IFS='|' read -r _bs_hs _bs_ls _bs_bud _bs_bans _bs_uips < <(jq -r '"\(.health_state//"UNKNOWN")|\(.last_run_ts//0)|\(.budget_hit_total//0)|\(.bans_emitted_total//0)|\(.unique_ips_flagged_last//0)"' "$_bs_rs" 2>/dev/null)
+            if [[ "$_bs_hs" == DEGRADED_* || "$_bs_hs" == NO_INPUT_* ]]; then
+                botscan_status="ENABLED but ${_bs_hs} — NOT currently enforcing (scanner blind/degraded), action=${botscan_mode}, timer ${botscan_timer}"
+            fi
+        fi
     fi
     printf "  %-20s %s\n" "HTTP Exploit Scan..." "$botscan_status"
+    if [[ "$botscan_enabled" == "true" && -r "${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json" ]] && command -v jq &>/dev/null; then
+        local _r="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json"
+        printf "      last scan %ss ago · %ss · bans %s · signals %s · budget-hits %s · %s\n" \
+            "$(( $(date +%s) - $(jq -r '.last_run_ts//0' "$_r" 2>/dev/null) ))" \
+            "$(jq -r '.last_duration_sec//0' "$_r" 2>/dev/null)" \
+            "$(jq -r '.bans_emitted_total//0' "$_r" 2>/dev/null)" \
+            "$(jq -r '.signals_emitted_total//0' "$_r" 2>/dev/null)" \
+            "$(jq -r '.budget_hit_total//0' "$_r" 2>/dev/null)" \
+            "$(jq -r '.health_state//"UNKNOWN"' "$_r" 2>/dev/null)"
+    fi
     echo "    (HTTP Guard = BotGuard, live request-time guard; HTTP Exploit Scan = BotScan, periodic"
     echo "     access-log scanner — can ban via the manual blacklist. BotGuard disabled != BotScan disabled.)"
 

--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -1098,7 +1098,33 @@ _collect_module_status() {
             nftban login status 2>&1 || echo "Command failed"
         } > "$mod_dir/login.txt"
 
-        _support_log OK "Module status (6 modules)"
+        # HTTP Exploit Scanner (BotScan) — v1.219.0: BotScan can ban via blacklist_manual_*,
+        # so its config/timer/runstate/pattern-inventory must be in the bundle for forensics.
+        # Read-only, cheap surfaces only (no access-log content scan). Redaction applies to configs below.
+        {
+            echo "# HTTP Exploit Scanner (BotScan) Status"
+            echo "# Collected: $(date -Iseconds)"
+            echo ""
+            nftban botscan status 2>&1 || echo "Command failed"
+            echo ""
+            echo "## botscan config"
+            nftban botscan config 2>&1 || echo "Command failed"
+            echo ""
+            echo "## runstate.json"
+            cat "${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json" 2>/dev/null || echo "(no runstate.json)"
+            echo ""
+            echo "## pattern inventory (enabled/total per file; names + match_type only, no request data)"
+            for pf in "${NFTBAN_CONFIG_DIR:-/etc/nftban}"/patterns.d/botscan/*.patterns; do
+                [[ -f "$pf" ]] || continue
+                local _en _tot
+                _tot=$(grep -cE '^[A-Za-z]' "$pf" 2>/dev/null || echo 0)
+                _en=$(grep -cE '\|true\|[^|]*$' "$pf" 2>/dev/null || echo 0)
+                echo "$(basename "$pf"): ${_en} enabled / ${_tot} records"
+                awk -F'|' '/^[A-Za-z]/{print "    "$1" ["$(NF-5)"]"}' "$pf" 2>/dev/null | head -60
+            done
+        } > "$mod_dir/botscan.txt"
+
+        _support_log OK "Module status (7 modules incl. BotScan)"
     else
         _support_log SKIP "Module status (nftban not in PATH)"
     fi
@@ -2025,7 +2051,7 @@ OUTPUT:
     - update/             Update check and backup list
     - services/           Systemd service/timer status
     - network/            Network info (if --network)
-    - modules/            Module status (ddos, portscan, geoban, feeds, rbl, login,
+    - modules/            Module status (ddos, portscan, geoban, feeds, rbl, login, botscan,
                           botguard, suricata)
     - mail/               Mail system status and configuration
     - stats-summary.txt   Current statistics and top IPs

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -147,6 +147,7 @@ nftban_botscan_load_config() {
 
 # Associative arrays for tracking
 declare -gA _BOTSCAN_IP_HITS        # IP -> hit count
+declare -gi _BOTSCAN_SIGNALS_EMITTED=0   # v1.219.0 truth-fix: batch signals emitted this cycle
 declare -gA _BOTSCAN_IP_PATTERNS    # IP -> matched patterns
 declare -gA _BOTSCAN_IP_FIRST_SEEN  # IP -> first seen timestamp
 declare -gA _BOTSCAN_IP_LAST_SEEN   # IP -> last seen timestamp
@@ -164,6 +165,7 @@ nftban_botscan_init_state() {
     _BOTSCAN_IP_HITS=()
     _BOTSCAN_IP_PATTERNS=()
     _BOTSCAN_IP_FIRST_SEEN=()
+    _BOTSCAN_SIGNALS_EMITTED=0   # v1.219.0 truth-fix: real per-cycle batch-signal count (was always 0)
     _BOTSCAN_IP_LAST_SEEN=()
     _BOTSCAN_IP_404_COUNT=()
     _BOTSCAN_IP_404_FIRST_SEEN=()
@@ -1304,6 +1306,9 @@ nftban_botscan_write_signal() {
     shift 3
     local reasons=("$@")
 
+    # v1.219.0 truth-fix: count every emitted batch signal for signals_emitted_total.
+    _BOTSCAN_SIGNALS_EMITTED=$(( ${_BOTSCAN_SIGNALS_EMITTED:-0} + 1 ))
+
     local signal_file="${BOTSCAN_BATCH_SIGNAL_FILE:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/botguard/batch_signals.jsonl}"
 
     # Build JSON reasons array
@@ -1632,7 +1637,9 @@ nftban_botscan_process_logs() {
             ts="$(date +%s)" dur="$_dur" lines_seen="$processed" lines_scanned="$processed" \
             budget_hit="$deadline_hit" backlog_bytes="${_BS_BYTES:-0}" \
             vhosts_scanned="$files_done" vhosts_deferred="$(( n - files_done ))" \
-            bans="$banned" pressure_state="$_BS_PRESSURE" scan_mode="$_BS_MODE" \
+            bans="$banned" signals="${_BOTSCAN_SIGNALS_EMITTED:-0}" \
+            unique_ips="${#_BOTSCAN_IP_HITS[@]}" \
+            pressure_state="$_BS_PRESSURE" scan_mode="$_BS_MODE" \
             backlog_state="$_BS_BACKLOG" health_state="$_health" load_ratio="${_lr:-0}"
     fi
 

--- a/cli/lib/nftban/core/nftban_botscan_adaptive.sh
+++ b/cli/lib/nftban/core/nftban_botscan_adaptive.sh
@@ -138,7 +138,7 @@ nftban_botscan_should_record() {
 nftban_botscan_record_runstate() {
     # k=v pairs on argv: ts dur lines_seen lines_scanned lines_prefiltered
     #   lines_skipped_pressure backlog_bytes backlog_lines vhosts_scanned
-    #   vhosts_deferred signals bans already_banned_skipped pressure_state
+    #   vhosts_deferred signals unique_ips bans already_banned_skipped pressure_state
     #   scan_mode backlog_state health_state disabled_reason
     local -A v=(); local kv
     for kv in "$@"; do v["${kv%%=*}"]="${kv#*=}"; done
@@ -160,11 +160,13 @@ nftban_botscan_record_runstate() {
   "lines_seen_total": $(( p_seen + ${v[lines_seen]:-0} )),
   "lines_scanned_total": $(( p_scan + ${v[lines_scanned]:-0} )),
   "lines_prefiltered_total": $(( p_pf + ${v[lines_prefiltered]:-0} )),
+  "lines_prefiltered_status": "RESERVED_NO_PRODUCER",
   "lines_skipped_pressure_total": $(( p_skip + ${v[lines_skipped_pressure]:-0} )),
   "backlog_bytes": ${v[backlog_bytes]:-0},
   "backlog_lines": ${v[backlog_lines]:-0},
   "vhosts_scanned": ${v[vhosts_scanned]:-0},
   "vhosts_deferred": ${v[vhosts_deferred]:-0},
+  "unique_ips_flagged_last": ${v[unique_ips]:-0},
   "signals_emitted_total": $(( p_sig + ${v[signals]:-0} )),
   "bans_emitted_total": $(( p_ban + ${v[bans]:-0} )),
   "already_banned_skipped_total": $(( p_abs + ${v[already_banned_skipped]:-0} )),

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -956,6 +956,90 @@ _health_eval_communication_component() {
     esac
 }
 
+# =============================================================================
+# HTTP EXPLOIT SCANNER (BotScan) — cheap-read health (v1.219.0)
+# =============================================================================
+# CHEAP-READ ONLY: config source, systemctl timer, stat spool dir, jq runstate.json.
+# MUST NOT scan/read access-log CONTENT synchronously (log-read-at-init blow-up guard:
+# v1.187.1 cycle-timeout, v1.209.3 spool-OOM). BotScan can ban via blacklist_manual_*
+# independently of BotGuard. Go four-axis module (frozen ModulesJSON) deferred to v1.220+;
+# consumer handoff-error truth to PR-B.
+_nftban_health_botscan_facts() {
+    # Emits: enabled|mode|timer|health_state|last_ago|bans|spool_state  (all cheap)
+    local cfgdir="${NFTBAN_CONFIG_DIR:-/etc/nftban}" conf
+    conf="$cfgdir/conf.d/botscan/main.conf"
+    local enabled="false" mode="both"
+    if [[ -f "$conf" ]]; then
+        enabled=$(grep -m1 '^BOTSCAN_ENABLED=' "$conf" 2>/dev/null | cut -d= -f2- | tr -d '"' || echo false)
+        mode=$(grep -m1 '^BOTSCAN_ACTION_MODE=' "$conf" 2>/dev/null | cut -d= -f2- | tr -d '"' || echo both)
+        local lconf="$conf.local" le lm
+        if [[ -f "$lconf" ]]; then
+            le=$(grep -m1 '^BOTSCAN_ENABLED=' "$lconf" 2>/dev/null | cut -d= -f2- | tr -d '"'); [[ -n "$le" ]] && enabled="$le"
+            lm=$(grep -m1 '^BOTSCAN_ACTION_MODE=' "$lconf" 2>/dev/null | cut -d= -f2- | tr -d '"'); [[ -n "$lm" ]] && mode="$lm"
+        fi
+    fi
+    local timer="inactive"
+    systemctl is-active nftban-botscan.timer &>/dev/null && timer="active"
+    local rs="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/runstate.json"
+    local hs="UNKNOWN" last="-" bans="-"
+    if [[ -r "$rs" ]] && command -v jq &>/dev/null; then
+        hs=$(jq -r '.health_state//"UNKNOWN"' "$rs" 2>/dev/null)
+        local lt; lt=$(jq -r '.last_run_ts//0' "$rs" 2>/dev/null)
+        [[ "$lt" =~ ^[0-9]+$ && "$lt" -gt 0 ]] && last="$(( $(date +%s) - lt ))s"
+        bans=$(jq -r '.bans_emitted_total//0' "$rs" 2>/dev/null)
+    fi
+    local spool="${BOTSCAN_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/spool}" spool_state="absent"
+    [[ -d "$spool" ]] && { spool_state="present"; [[ -r "$spool" ]] || spool_state="present/UNREADABLE"; }
+    printf '%s|%s|%s|%s|%s|%s|%s\n' "$enabled" "$mode" "$timer" "$hs" "$last" "$bans" "$spool_state"
+}
+
+_nftban_health_render_botscan() {
+    echo ""
+    echo "  HTTP Exploit Scanner (BotScan) — periodic access-log exploit scanner (bans via blacklist_manual)"
+    echo "  ────────────────────────────────────────────────────────────────────────────────────────────"
+    local enabled mode timer hs last bans spool
+    IFS='|' read -r enabled mode timer hs last bans spool < <(_nftban_health_botscan_facts)
+    local mode_note="enforces via blacklist_manual"
+    [[ "$mode" == "alert" ]] && mode_note="DETECT-ONLY (does not ban)"
+    local verdict
+    if [[ "$enabled" != "true" ]]; then
+        verdict="DISABLED (not scanning; no bans)"
+    elif [[ "$hs" == DEGRADED_* || "$hs" == NO_INPUT_* ]]; then
+        verdict="ENABLED but ${hs} — NOT currently enforcing (scanner blind/degraded)"
+    elif [[ "$timer" != "active" ]]; then
+        verdict="ENABLED but timer ${timer} — not scanning on schedule"
+    else
+        verdict="ENABLED + timer active — ${mode_note}"
+    fi
+    printf "  %-11s  %s\n" "State:" "$verdict"
+    printf "  %-11s  enabled=%s · action=%s (%s) · timer=%s\n" "Config:" "$enabled" "$mode" "$mode_note" "$timer"
+    printf "  %-11s  health_state=%s · last_scan=%s · bans_emitted=%s · spool=%s\n" "Runtime:" "$hs" "${last:+${last} ago}" "$bans" "$spool"
+    printf "  %-11s  consumer handoff-error truth not available until v1.219.0 PR-B (daemon status surface)\n" "Handoff:"
+    echo "  (BotGuard disabled does NOT disable BotScan — they are independent. HTTP Guard = BotGuard.)"
+}
+
+# Shell health-check entrypoint (cheap-read; populates NFTBAN_HEALTH_RESULTS like the others).
+nftban_health_check_botscan() {
+    local enabled mode timer hs last bans spool status=$HEALTH_OK
+    IFS='|' read -r enabled mode timer hs last bans spool < <(_nftban_health_botscan_facts)
+    if [[ "$enabled" == "true" ]]; then
+        if [[ "$hs" == DEGRADED_* || "$hs" == NO_INPUT_* ]]; then
+            NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner ENABLED but ${hs} — NOT currently enforcing (blind/degraded)"
+            status=$HEALTH_WARNING
+        elif [[ "$timer" != "active" ]]; then
+            NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner ENABLED but timer ${timer}"
+            status=$HEALTH_WARNING
+        else
+            NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner enabled (action=${mode}, timer active)"
+        fi
+    else
+        NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner installed (disabled)"
+    fi
+    NFTBAN_HEALTH_RESULTS["botscan"]=$status
+    return "$status"
+}
+
+export -f _nftban_health_botscan_facts _nftban_health_render_botscan nftban_health_check_botscan
 export -f nftban_health_check_communication _health_eval_communication_component
 export -f nftban_health_check_modules nftban_health_check_geoip
 export -f nftban_health_check_geoban nftban_health_check_databases

--- a/cli/lib/nftban/lib/nftban_botguard_explain.sh
+++ b/cli/lib/nftban/lib/nftban_botguard_explain.sh
@@ -91,7 +91,7 @@ nftban_botguard_explain_render() {
     data=$(nftban_botguard_explain_json "$ip")
     avail=$(_nftban_botguard_explain_field "$data" '.cache_available' "false")
 
-    echo "BotGuard temporary decision-cache (TEMPORARY — not durable nft/kernel state):"
+    echo "BotGuard decision-cache — CACHE ONLY — not currently enforced (not durable nft/kernel state; the kernel-set verdict above is authoritative):"
     echo "───────────────────────────────────────────────────────────────"
     if [[ "$avail" != "true" ]]; then
         echo "  BotGuard temporary cache: unavailable"
@@ -140,7 +140,7 @@ nftban_botguard_explain_emulate_note() {
     data=$(nftban_botguard_explain_json "$ip")
     avail=$(_nftban_botguard_explain_field "$data" '.cache_available' "false")
 
-    echo "BotGuard temporary decision-cache (read-only; does NOT change the decision above):"
+    echo "BotGuard decision-cache — CACHE ONLY — not currently enforced (read-only; does NOT change the kernel-authoritative verdict above):"
     echo "───────────────────────────────────────────────────────────────"
     if [[ "$avail" != "true" ]]; then
         echo "  BotGuard temporary cache: unavailable (durable decision above is unaffected)"

--- a/cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh
+++ b/cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.219.0 PR-A BotScan operator-truth contract (shell/docs)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_operator_truth_contract_v219_0_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-09"
+# meta:description="v1.219.0 PR-A (shell/docs, daemon byte-identical) BotScan first-class operator-truth contract. Behaviorally exercises the cheap-read nftban health BotScan render across enabled+active, DEGRADED/blind, and alert-mode fixtures (asserts a blind/degraded scanner renders 'NOT currently enforcing', alert renders DETECT-ONLY, and the render/facts NEVER open access-log content — the cheap-read invariant). Source-asserts: counter truth-fix wiring (signals emitted counter reset+increment+passed, unique_ips passed, lines_prefiltered marked RESERVED_NO_PRODUCER), nftban status DEGRADED honesty + action-mode note + runstate read, search cache-only relabelled 'CACHE ONLY — not currently enforced', support bundle collects botscan + pattern inventory, help draws BotGuard-vs-BotScan and drops 'Automatically bans', docs (TIMERS botscan-not-botguard, README BotScan row, BotGuard-vs-BotScan + recovery-drill docs), dead config keys marked non-functional."
+# meta:input="None (extracts + stubs health render; greps sources/docs)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,jq"
+# meta:inventory.files="cli/lib/nftban/core/nftban_botscan.sh,cli/lib/nftban/core/nftban_botscan_adaptive.sh,cli/lib/nftban/cli/cmd_status.sh,cli/lib/nftban/core/nftban_health_checks_modules.sh,cli/lib/nftban/cli/cmd_health.sh,cli/lib/nftban/lib/nftban_botguard_explain.sh,cli/lib/nftban/cli/cmd_support.sh,cli/lib/nftban/cli/cmd_botscan.sh"
+# meta:inventory.binaries="bash,awk,grep,jq"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR,NFTBAN_DATA_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+BOTSCAN="$REPO/cli/lib/nftban/core/nftban_botscan.sh"
+ADAPT="$REPO/cli/lib/nftban/core/nftban_botscan_adaptive.sh"
+STATUS="$REPO/cli/lib/nftban/cli/cmd_status.sh"
+HMOD="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+HEALTH="$REPO/cli/lib/nftban/cli/cmd_health.sh"
+EXPLAIN="$REPO/cli/lib/nftban/lib/nftban_botguard_explain.sh"
+SUPPORT="$REPO/cli/lib/nftban/cli/cmd_support.sh"
+CMD="$REPO/cli/lib/nftban/cli/cmd_botscan.sh"
+
+SB=$(mktemp -d); trap 'rm -rf "$SB"' EXIT
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ [[ "$1" == *"$2"* ]]; }
+hasf(){ grep -Fq -- "$2" "$1"; }
+
+echo "=== v1.219.0 PR-A BotScan operator-truth contract ==="
+
+# ---- Behavioral: extract the cheap-read health render + facts and run with fixtures ----
+awk '/^_nftban_health_botscan_facts\(\)/{c=1} c{print} /^_nftban_health_render_botscan\(\)/{r=1} r&&/^}/{print "";exit}' "$HMOD" > "$SB/render.sh"
+[[ -s "$SB/render.sh" ]] && ok "extracted health facts+render block" || no "extract health render block"
+
+render(){ # render <enabled> <mode> <timer:active|inactive> <health_state>
+  local en="$1" mode="$2" tmr="$3" hs="$4"
+  mkdir -p "$SB/conf.d/botscan" "$SB/data/botscan" "$SB/data/botscan/spool"
+  printf 'BOTSCAN_ENABLED="%s"\nBOTSCAN_ACTION_MODE="%s"\n' "$en" "$mode" > "$SB/conf.d/botscan/main.conf"
+  printf '{"health_state":"%s","last_run_ts":%s,"bans_emitted_total":3}\n' "$hs" "$(date +%s)" > "$SB/data/botscan/runstate.json"
+  NFTBAN_CONFIG_DIR="$SB" NFTBAN_DATA_DIR="$SB/data" STIMER="$tmr" bash -c '
+    set +e
+    systemctl(){ [ "${STIMER:-inactive}" = active ] && return 0 || return 1; }
+    export -f systemctl 2>/dev/null || true
+    source "'"$SB/render.sh"'"
+    _nftban_health_render_botscan
+  '
+}
+
+out=$(render true both active OK_SCANNED_NO_BOTS)
+has "$out" "HTTP Exploit Scanner (BotScan)" && ok "render: BotScan section heading" || no "render heading"
+has "$out" "ENABLED + timer active" && has "$out" "enforces via blacklist_manual" && ok "render enabled+active: enforcing" || no "render enabled+active"
+
+out=$(render true both active DEGRADED_INPUT_BLIND)
+has "$out" "NOT currently enforcing" && ok "render DEGRADED: 'NOT currently enforcing'" || no "render DEGRADED honesty"
+
+out=$(render true alert active OK_SCANNED_NO_BOTS)
+has "$out" "DETECT-ONLY" && ok "render alert-mode: DETECT-ONLY" || no "render alert-mode"
+
+out=$(render false both inactive UNKNOWN)
+has "$out" "DISABLED" && ok "render disabled: DISABLED (no bans)" || no "render disabled"
+
+# ---- Cheap-read invariant: facts/render must never read access-log CONTENT ----
+if grep -nE 'access\.log|access_log|/var/log/(apache|httpd|nginx)|tail .*log|grep .*access' "$SB/render.sh" >/dev/null 2>&1; then
+  no "cheap-read invariant: health render reads access-log content"
+else ok "cheap-read invariant: health render has NO access-log content read"; fi
+# status BotScan row must also be cheap (runstate/jq/systemctl only, no access-log content)
+if awk '/HTTP Exploit Scanner \(BotScan\)/,/BotGuard disabled != BotScan disabled/' "$STATUS" | grep -nE 'access\.log|tail .*/var/log|grep .*access\.log' >/dev/null 2>&1; then
+  no "cheap-read invariant: status row reads access-log content"
+else ok "cheap-read invariant: status row has NO access-log content read"; fi
+
+# ---- Counter truth-fix wiring ----
+grep -q '_BOTSCAN_SIGNALS_EMITTED=0' "$BOTSCAN" && ok "counter: signals counter reset in init_state" || no "counter reset"
+grep -q '_BOTSCAN_SIGNALS_EMITTED=$(( ${_BOTSCAN_SIGNALS_EMITTED:-0} + 1 ))' "$BOTSCAN" && ok "counter: write_signal increments" || no "write_signal increment"
+grep -q 'signals="${_BOTSCAN_SIGNALS_EMITTED:-0}"' "$BOTSCAN" && ok "counter: signals passed to record_runstate" || no "signals passed"
+grep -q 'unique_ips="${#_BOTSCAN_IP_HITS\[@\]}"' "$BOTSCAN" && ok "counter: unique_ips passed to record_runstate" || no "unique_ips passed"
+grep -q 'unique_ips_flagged_last' "$ADAPT" && ok "runstate: unique_ips_flagged_last field" || no "unique_ips field"
+grep -q 'RESERVED_NO_PRODUCER' "$ADAPT" && ok "runstate: lines_prefiltered marked RESERVED (not faked)" || no "lines_prefiltered honesty"
+
+# ---- Status honesty ----
+hasf "$STATUS" "NOT currently enforcing (scanner blind/degraded)" && ok "status: DEGRADED honesty branch" || no "status DEGRADED"
+hasf "$STATUS" "DETECT-ONLY, does not ban" && ok "status: alert-mode note" || no "status alert note"
+hasf "$STATUS" "runstate.json" && ok "status: reads runstate (cheap counters)" || no "status runstate read"
+
+# ---- Search relabel + kernel-authority preserved ----
+hasf "$EXPLAIN" "CACHE ONLY — not currently enforced" && ok "search: cache-only relabelled" || no "search relabel"
+# kernel authority not weakened: top-level STATUS still derived from nft reads (search unchanged)
+grep -q 'nft get element' "$REPO/cli/lib/nftban/cli/cmd_search.sh" && ok "search: top-level still nft/kernel-authoritative" || no "search kernel authority"
+
+# ---- Health wiring ----
+grep -q '_nftban_health_render_botscan' "$HEALTH" && ok "health: BotScan render wired into nftban health" || no "health wiring"
+grep -q 'nftban_health_check_botscan' "$HMOD" && ok "health: nftban_health_check_botscan present" || no "health check fn"
+# must NOT touch the Go four-axis loop (ModulesJSON frozen — deferred v1.220+)
+grep -q 'for mod in botguard ddos portscan loginmon botscan' "$HEALTH" && no "health: botscan wrongly added to Go four-axis loop" || ok "health: Go four-axis loop untouched (ModulesJSON frozen)"
+
+# ---- Support bundle ----
+hasf "$SUPPORT" 'mod_dir/botscan.txt' && ok "support: collects botscan.txt" || no "support botscan.txt"
+hasf "$SUPPORT" 'pattern inventory' && ok "support: pattern inventory collected" || no "support patterns"
+hasf "$SUPPORT" '7 modules incl. BotScan' && ok "support: module count updated" || no "support count"
+
+# ---- Help + config honesty ----
+hasf "$CMD" 'BotScan vs BotGuard' && ok "help: BotGuard-vs-BotScan distinction" || no "help distinction"
+grep -q 'Automatically bans detected bot scanners' "$CMD" && no "help: stale 'Automatically bans' wording remains" || ok "help: 'always bans' wording removed"
+grep -c 'NON-FUNCTIONAL / RESERVED' "$REPO/etc/nftban/conf.d/botscan/main.conf" | grep -q '[34]' && ok "config: dead keys marked non-functional" || no "config dead keys"
+
+# ---- Docs ----
+grep -q '| .nftban-botscan.timer. | Every 10min | botscan |' "$REPO/docs/systemd/TIMERS.md" && ok "docs: TIMERS botscan not attributed to botguard" || no "docs TIMERS"
+grep -qi 'BotScan.*HTTP Exploit Scanner' "$REPO/README.md" && ok "docs: README BotScan row" || no "docs README"
+[[ -f "$REPO/docs/operator/BOTGUARD_VS_BOTSCAN.md" ]] && ok "docs: BotGuard-vs-BotScan contract" || no "docs BotGuard-vs-BotScan"
+[[ -f "$REPO/docs/operator/FALSE_POSITIVE_AND_RECOVERY_DRILL.md" ]] && ok "docs: FP recovery drill runbook" || no "docs recovery drill"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
+++ b/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
@@ -34,7 +34,7 @@ SANDBOX=$(mktemp -d); trap 'rm -rf "$SANDBOX"' EXIT
 PASS=0; FAIL=0; FAILED=()
 ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
 no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
-has(){ printf '%s' "$1" | grep -Fq -- "$2"; }
+has(){ [[ "$1" == *"$2"* ]]; }
 
 # Extract the BotScan render block from cmd_status.sh.
 awk '/# HTTP Exploit Scanner \(BotScan\)/{c=1} c{print} /BotGuard disabled != BotScan disabled/{exit}' "$STATUS" > "$SANDBOX/block.sh"

--- a/cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh
+++ b/cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh
@@ -32,7 +32,7 @@ CMD="$REPO/cli/lib/nftban/cli/cmd_botscan.sh"
 PASS=0; FAIL=0; FAILED=()
 ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
 no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
-has(){ printf '%s' "$1" | grep -Fq -- "$2"; }
+has(){ [[ "$1" == *"$2"* ]]; }
 
 echo "=== v1.218.12 botscan status label/timer hotfix ==="
 

--- a/docs/operator/BOTGUARD_VS_BOTSCAN.md
+++ b/docs/operator/BOTGUARD_VS_BOTSCAN.md
@@ -1,0 +1,40 @@
+# HTTP Guard (BotGuard) vs HTTP Exploit Scanner (BotScan)
+
+*Versioned contract — as of v1.219.0.*
+
+NFTBan has **two independent HTTP protection subsystems.** They are not the same component, and one does not control the other.
+
+| | **HTTP Guard = BotGuard** | **HTTP Exploit Scanner = BotScan** |
+|---|---|---|
+| What it is | Live, request-time HTTP bot guard | Periodic access-log exploit scanner |
+| Trigger | Real-time request evaluation | `nftban-botscan.timer` (default every 10 min) |
+| Config flag | `HTTP_BOTGUARD_ENABLED` | `BOTSCAN_ENABLED` |
+| Patterns | crawler allow/deny lists | `patterns.d/botscan/*.patterns` |
+| Enforces via | `http_bot_ban` / `http_bot_suspect` sets | `blacklist_manual_ipv4` / `blacklist_manual_ipv6` |
+| Fleet default | **disabled** | **enabled** (`action=both`) |
+
+## The one rule to remember
+
+> **BotGuard disabled does NOT mean BotScan disabled.** They are independent.
+
+BotScan can — and by default does — enforce bans through `blacklist_manual_*` even when BotGuard is off. Its ban path (the daemon batch-signal consumer) was ungated from `HTTP_BOTGUARD_ENABLED` in v1.209. So an operator who sees `Bot Guard: DISABLED` in `nftban status` must **not** conclude that HTTP exploit banning is off — check the **HTTP Exploit Scan (BotScan)** row too.
+
+## Action modes (BotScan)
+
+- `alert` — **detect-only**, does not ban.
+- `ban` / `both` — **enforce** (write bans to `blacklist_manual_*`). In the current code `ban` and `both` are equivalent enforcement.
+
+## Where to look
+
+- `nftban status` — shows **HTTP Guard** and **HTTP Exploit Scan** rows independently, with last-scan/health for BotScan.
+- `nftban botscan status` — heads *"HTTP Exploit Scanner (BotScan) Status"* with enabled/timer/action/patterns.
+- `nftban health` — has a dedicated *HTTP Exploit Scanner (BotScan)* block (cheap-read; it never scans access-log content synchronously).
+- `nftban search <ip>` — top-level `BANNED` is **kernel-authoritative** (reads nft sets). A BotGuard decision-cache hit renders as *"CACHE ONLY — not currently enforced"* and never flips the top-level verdict.
+
+## Suricata is optional, not required
+
+BotScan is NFTBan's **native, lightweight web-exploit detector** for the URL/path/query class (e.g. `/.env`, `/.git/config`, `revslider_show_image`, RFI probes). **Suricata is an optional deep IDS** (payload/TLS/protocol) — it is not required for ordinary HTTP exploit-path scanning, and its absence does not degrade BotScan.
+
+## If BotScan false-bans a legitimate visitor
+
+See [`FALSE_POSITIVE_AND_RECOVERY_DRILL.md`](FALSE_POSITIVE_AND_RECOVERY_DRILL.md).

--- a/docs/operator/FALSE_POSITIVE_AND_RECOVERY_DRILL.md
+++ b/docs/operator/FALSE_POSITIVE_AND_RECOVERY_DRILL.md
@@ -1,0 +1,49 @@
+# BotScan False-Positive & Recovery Drill
+
+*Operator runbook — as of v1.219.0. (End-to-end automated drill test is deferred to v1.222.0; this is the manual procedure + the standing gate.)*
+
+BotScan (HTTP Exploit Scanner) can ban a legitimate visitor if a pattern is too broad (e.g. the v1.218.10 EXP_REVSLIDER and v1.218.13 EXP_RFI false positives, where a bare product/URL token matched normal requests). This runbook is the standing recovery path. It applies the maturity principle: **operator truth is security** — a ban you cannot explain and recover from is itself a hazard.
+
+## 0. Confirm it is really a BotScan ban (not admin/feed/geo)
+
+```
+nftban search <ip>
+```
+- Top-level `BANNED` is **kernel-authoritative** (nft-set membership). A `CACHE ONLY — not currently enforced` line is NOT a ban.
+- A BotScan-origin ban lands in `blacklist_manual_*` with `source=botscan` (see `source_index.jsonl`). *(Full per-ban reason + matched URL attribution arrives with v1.219.0 PR-B durable evidence.)*
+
+## 1. Truth: what did BotScan do, and is it still enforcing?
+
+```
+nftban status                 # HTTP Exploit Scan row: enabled? DEGRADED? action mode?
+nftban botscan status         # enabled / timer / action / patterns
+nftban health                 # HTTP Exploit Scanner (BotScan) block
+```
+`ENABLED but DEGRADED … NOT currently enforcing` means the scanner is blind — a ban you see is from a prior cycle, and new bans are not being written.
+
+## 2. Count / list truth
+
+```
+nftban blacklist list | grep <ip>      # confirm kernel membership
+nftban stats                            # BotScan bans_emitted / signals
+```
+
+## 3. Recover the specific IP (targeted, evidence-based — NOT a bulk flush)
+
+```
+nftban whitelist add <ip>     # durable protection so it cannot be re-banned
+nftban unban <ip>             # remove the current ban
+```
+Prefer per-IP recovery with evidence. **Do not** bulk-flush `blacklist_manual_*` to clear one false positive — that drops real bans too.
+
+## 4. Fix the pattern (root cause), not just the symptom
+
+If a pattern is systematically false-positive, narrow it (mirror the EXP_REVSLIDER / EXP_RFI fixes): anchor to exploit-specific tokens, add an **asset-negative fixture** (a real legit URL that must NOT match) and an **exploit-positive fixture** (a probe that must match). Ship it as a pattern-data hotfix. Generalized pattern-quality CI lint + `nftban botscan test-url <url>` land in v1.222.0.
+
+## 5. RPM config-drift caveat
+
+If you ever hand-edit `patterns.d/botscan/*` on an RPM host, `%config(noreplace)` will make future **packaged** pattern security fixes silently skip that host. Verify with `rpm -V nftban-core`; reconcile from the packaged file. (Tracked: `OPEN_RPM_PATTERN_CONFIG_DRIFT_RECONCILE_GUARD`.)
+
+## Standing gate: FALSE_POSITIVE_AND_RECOVERY_DRILL
+
+Every BotScan-touching release must be able to demonstrate: **false-positive → search truth → list/count truth → targeted whitelist+unban → not re-banned**, and that a broken/blind scanner or a cache-only hit never presents as enforced/protected.

--- a/docs/systemd/TIMERS.md
+++ b/docs/systemd/TIMERS.md
@@ -41,7 +41,7 @@ included in core reconciliation.
 
 | Timer | Schedule | Module | Purpose |
 |-------|----------|--------|---------|
-| `nftban-botscan.timer` | Every 10min | botguard | Clock 3: access log pattern matching |
+| `nftban-botscan.timer` | Every 10min | botscan | Clock 3: HTTP Exploit Scanner (BotScan) access-log pattern matching. Runs on `BOTSCAN_ENABLED`, **independent of BotGuard** — not owned by or conditional on the BotGuard module. |
 | `nftban-suricata-update.timer` | Weekly Sun 03:40 | suricata | Suricata rule updates |
 
 ### OPTIONAL Timers (opt-in)
@@ -167,10 +167,11 @@ nftban-core-geoip.timer         ← CORE (weekly)
 nftban-unified-exporter.timer   ← CORE (60s)
 ```
 
-With botguard enabled, also:
+With `BOTSCAN_ENABLED=true` (the default; **independent of BotGuard**), also:
 ```
-nftban-botscan.timer            ← CONDITIONAL (10min)
+nftban-botscan.timer            ← HTTP Exploit Scanner (BotScan), 10min
 ```
+Note: `nftban-botscan.timer` is gated by `BOTSCAN_ENABLED`, NOT by BotGuard. BotGuard being disabled does not disable BotScan.
 
 With suricata enabled, also:
 ```

--- a/etc/nftban/conf.d/botscan/main.conf
+++ b/etc/nftban/conf.d/botscan/main.conf
@@ -26,7 +26,10 @@
 # Enable/disable bot scanner module
 BOTSCAN_ENABLED="true"
 
-# Action mode: alert, ban, both
+# Action mode: alert | ban | both
+#   alert = DETECT-ONLY (logs matches, does NOT ban)
+#   ban   = enforce (write bans to blacklist_manual_*)
+#   both  = enforce (identical to 'ban' in the current engine)
 BOTSCAN_ACTION_MODE="both"
 
 # =============================================================================
@@ -74,8 +77,17 @@ BOTSCAN_PROGRESSIVE_MAX="86400"
 # Pattern directory
 BOTSCAN_PATTERNS_DIR="${NFTBAN_CONFIG_DIR:-/etc/nftban}/patterns.d/botscan"
 
-# Pattern files (loaded in order)
+# Pattern files
+# NON-FUNCTIONAL / RESERVED (v1.219.0): the loader globs ALL patterns.d/botscan/*.patterns;
+# this key is NOT read and does not select files. Left for documentation only.
 BOTSCAN_PATTERN_FILES="webshell.patterns,exploit.patterns,scanner.patterns,custom.patterns"
+
+# --- Scan safety / budget knobs (read by the scanner; document them here) ---
+# BOTSCAN_SCAN_BUDGET_SECS — per-cycle soft deadline in seconds (0 = time-unbounded; the
+#   processor timer path defaults to 180). Lower it on busy hosts to bound cycle time.
+# BOTSCAN_SCAN_MAX_BYTES_PER_FILE / BOTSCAN_404_TAIL_TOTAL_BYTES — per-file / 404-tail read caps
+#   that bound memory (the v1.209.3 spool-OOM class). These gate the exact blow-ups BotScan guards.
+#BOTSCAN_SCAN_BUDGET_SECS="180"
 
 # =============================================================================
 # WHITELIST
@@ -108,10 +120,14 @@ BOTSCAN_DEBUG="false"
 # =============================================================================
 
 # Send to Prometheus metrics
+# NON-FUNCTIONAL / RESERVED (v1.219.0): not read by the scanner. No effect.
 BOTSCAN_PROMETHEUS_ENABLED="true"
 
 # GeoIP enrichment
+# NON-FUNCTIONAL / RESERVED (v1.219.0): not read by the scanner. No effect.
 BOTSCAN_GEOIP_ENABLED="true"
 
 # Alert notifications
+# NON-FUNCTIONAL / RESERVED (v1.219.0): not read by the scanner. Detect-only vs ban is
+# controlled by BOTSCAN_ACTION_MODE (alert/ban/both), not by this key. No effect.
 BOTSCAN_ALERT_ENABLED="true"


### PR DESCRIPTION
## Summary
**PR-A of two** for the v1.219.0 BotScan first-class operator-truth contract. Shell/docs/tests only — **daemon byte-identical, 0 Go, nft schema 1.84.0, `ModulesJSON` untouched.** Substantive, not a status patch: **a blind/degraded scanner or a cache-only hit no longer presents as enforced/protected.** PR-B (Go daemon re-baseline) follows before release-prep.

## A — Truth-fixes
- **`signals_emitted_total` wired** — `_BOTSCAN_SIGNALS_EMITTED` reset in `init_state`, incremented in `write_signal`, passed to `record_runstate` (was always 0).
- **`unique_ips_flagged_last`** recorded into `runstate.json`.
- **`lines_prefiltered` marked `RESERVED_NO_PRODUCER`** — honest, not faked (no reliable producer without hot-loop instrumentation).

## B — Operator honesty
- **`nftban status`** BotScan row: cheap runstate read (last scan/duration/bans/signals/budget/health_state); **`DEGRADED`/`NO_INPUT` → "NOT currently enforcing (blind/degraded)"**; `action=alert` annotated **DETECT-ONLY**, `ban`==`both`=enforce.
- **Config honesty:** 4 dead keys (`ALERT`/`GEOIP`/`PROMETHEUS`/`PATTERN_FILES`) marked **NON-FUNCTIONAL/RESERVED**; scan-budget/tail-byte knobs documented; action-mode trio explained.
- **`nftban botscan help`:** BotGuard-vs-BotScan distinction; dropped "Automatically bans" wording.
- **New `nftban health` HTTP Exploit Scanner (BotScan) block** — **CHEAP-READ ONLY** (config/timer/spool-stat/runstate); **never scans access-log content** (log-read-at-init guard). Handoff-error truth deferred to PR-B. **Go four-axis loop / `ModulesJSON` untouched.**

## C — Search truth lock
Cache-only relabelled **"CACHE ONLY — not currently enforced"**; top-level `BANNED` stays **kernel-authoritative** (nft-set reads unchanged).

## D — Support bundle + docs
- Support bundle now collects **botscan** (status/config/runstate + pattern inventory); redaction intact; module count → 7.
- Docs: `TIMERS.md` botscan timer no longer attributed to *botguard*; README **BotScan row**; new `docs/operator/BOTGUARD_VS_BOTSCAN.md` + `FALSE_POSITIVE_AND_RECOVERY_DRILL.md`.

## Tests
- New `botscan_operator_truth_contract_v219_0_test.sh` **32/32** — behavioral health render (enabled/DEGRADED/alert/disabled) + **cheap-read guard** (no access-log content read) + source assertions across all surfaces.
- **Fixed a latent pipefail+SIGPIPE flake** in `botscan_operator_truth_v218_11`/`_v218_12` test helpers (`printf | grep -q` → pure-bash `[[ == ]]`), exposed by the new early help-text match. Verified deterministic 0/20.
- Regressions green: v218_11 14/14, v218_12, status_consistency, delimiter_v214, revslider_fp, exp_rfi_fp, v128 correlation, cli_hardening.

## Acceptance guarantees
- ✅ **DEGRADED/blind ≠ enforced/protected** (status + health)
- ✅ **cache-only ≠ BANNED** (search lock + relabel)
- ⏳ broken handoff ≠ healthy — **PR-B** (needs daemon status surface)
- ⏳ ban evidence survives consume (reason + matched URL) — **PR-B**

## Boundaries honored
0 Go · 0 schema · `ModulesJSON` untouched · 0 pattern (EXP_RFI/REDIS/TIMTHUMB untouched) · 0 workflow · no RPM-drift reconcile · no release-prep/tag/fleet.

## Hold
No merge without a separate GO. Do not tag/release after PR-A alone — release-prep waits for PR-A + PR-B both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)