### PR TITLE
feat(botscan): v1.219.0 PR-B — BotScan daemon-truth (handoff exposure + durable ban-evidence)

### DIFF
--- a/cli/lib/nftban/cli/cmd_health.sh
+++ b/cli/lib/nftban/cli/cmd_health.sh
@@ -602,7 +602,7 @@ nftban_health_cmd_truth() {
     # (config + timer + spool stat + runstate.json). NEVER scans access-log content — see the
     # log-read-at-init blow-up history (v1.187.1 cycle-timeout, v1.209.3 spool-OOM). BotScan can
     # ban via blacklist_manual_* independently of BotGuard, so it is surfaced as first-class here.
-    # The Go four-axis module (frozen ModulesJSON) is deferred to v1.220+; handoff-error truth to PR-B.
+    # The Go four-axis module (frozen ModulesJSON) is deferred to v1.220+; handoff-error truth via botscan_consumer_status.json (PR-B).
     _nftban_health_render_botscan
 
     # Render blacklist (composite)

--- a/cli/lib/nftban/core/nftban_health_checks_modules.sh
+++ b/cli/lib/nftban/core/nftban_health_checks_modules.sh
@@ -963,7 +963,7 @@ _health_eval_communication_component() {
 # MUST NOT scan/read access-log CONTENT synchronously (log-read-at-init blow-up guard:
 # v1.187.1 cycle-timeout, v1.209.3 spool-OOM). BotScan can ban via blacklist_manual_*
 # independently of BotGuard. Go four-axis module (frozen ModulesJSON) deferred to v1.220+;
-# consumer handoff-error truth to PR-B.
+# consumer hand-off truth now wired (v1.219.0 PR-B botscan_consumer_status.json).
 _nftban_health_botscan_facts() {
     # Emits: enabled|mode|timer|health_state|last_ago|bans|spool_state  (all cheap)
     local cfgdir="${NFTBAN_CONFIG_DIR:-/etc/nftban}" conf
@@ -990,20 +990,35 @@ _nftban_health_botscan_facts() {
     fi
     local spool="${BOTSCAN_SPOOL_DIR:-${NFTBAN_DATA_DIR:-/var/lib/nftban}/botscan/spool}" spool_state="absent"
     [[ -d "$spool" ]] && { spool_state="present"; [[ -r "$spool" ]] || spool_state="present/UNREADABLE"; }
-    printf '%s|%s|%s|%s|%s|%s|%s\n' "$enabled" "$mode" "$timer" "$hs" "$last" "$bans" "$spool_state"
+    # v1.219.0 PR-B — consumer hand-off truth from the daemon status snapshot (cheap jq read).
+    # handoff=UNKNOWN when the daemon hasn't written it yet (honest, never assumed-healthy).
+    local cs="${NFTBAN_DATA_DIR:-/var/lib/nftban}/botguard/botscan_consumer_status.json"
+    local handoff="UNKNOWN" stale="UNKNOWN"
+    if [[ -r "$cs" ]] && command -v jq &>/dev/null; then
+        handoff=$(jq -r '.batch_handoff_errors//0' "$cs" 2>/dev/null)
+        stale=$(jq -r '.batch_consumer_stale_backlog//false' "$cs" 2>/dev/null)
+    fi
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' "$enabled" "$mode" "$timer" "$hs" "$last" "$bans" "$spool_state" "$handoff" "$stale"
 }
 
 _nftban_health_render_botscan() {
     echo ""
     echo "  HTTP Exploit Scanner (BotScan) — periodic access-log exploit scanner (bans via blacklist_manual)"
     echo "  ────────────────────────────────────────────────────────────────────────────────────────────"
-    local enabled mode timer hs last bans spool
-    IFS='|' read -r enabled mode timer hs last bans spool < <(_nftban_health_botscan_facts)
+    local enabled mode timer hs last bans spool handoff stale
+    IFS='|' read -r enabled mode timer hs last bans spool handoff stale < <(_nftban_health_botscan_facts)
     local mode_note="enforces via blacklist_manual"
     [[ "$mode" == "alert" ]] && mode_note="DETECT-ONLY (does not ban)"
+    # v1.219.0 PR-B — a broken consumer hand-off (batch signals not draining to the kernel)
+    # must NOT read as healthy/enforcing: the scanner produces bans but they are not applied.
+    local broken_handoff="no"
+    [[ "$handoff" =~ ^[0-9]+$ && "$handoff" -gt 0 ]] && broken_handoff="yes"
+    [[ "$stale" == "true" ]] && broken_handoff="yes"
     local verdict
     if [[ "$enabled" != "true" ]]; then
         verdict="DISABLED (not scanning; no bans)"
+    elif [[ "$broken_handoff" == "yes" ]]; then
+        verdict="ENABLED but CONSUMER HAND-OFF BROKEN (handoff_errors=${handoff}, stale_backlog=${stale}) — bans NOT reaching the kernel"
     elif [[ "$hs" == DEGRADED_* || "$hs" == NO_INPUT_* ]]; then
         verdict="ENABLED but ${hs} — NOT currently enforcing (scanner blind/degraded)"
     elif [[ "$timer" != "active" ]]; then
@@ -1011,19 +1026,30 @@ _nftban_health_render_botscan() {
     else
         verdict="ENABLED + timer active — ${mode_note}"
     fi
+    local handoff_line
+    case "$handoff" in
+        UNKNOWN) handoff_line="handoff=UNKNOWN (daemon status not yet written)" ;;
+        *)       handoff_line="handoff_errors=${handoff} · stale_backlog=${stale}$([[ "$broken_handoff" == yes ]] && echo ' · BROKEN — bans not applied')" ;;
+    esac
     printf "  %-11s  %s\n" "State:" "$verdict"
     printf "  %-11s  enabled=%s · action=%s (%s) · timer=%s\n" "Config:" "$enabled" "$mode" "$mode_note" "$timer"
     printf "  %-11s  health_state=%s · last_scan=%s · bans_emitted=%s · spool=%s\n" "Runtime:" "$hs" "${last:+${last} ago}" "$bans" "$spool"
-    printf "  %-11s  consumer handoff-error truth not available until v1.219.0 PR-B (daemon status surface)\n" "Handoff:"
+    printf "  %-11s  %s\n" "Handoff:" "$handoff_line"
     echo "  (BotGuard disabled does NOT disable BotScan — they are independent. HTTP Guard = BotGuard.)"
 }
 
 # Shell health-check entrypoint (cheap-read; populates NFTBAN_HEALTH_RESULTS like the others).
 nftban_health_check_botscan() {
-    local enabled mode timer hs last bans spool status=$HEALTH_OK
-    IFS='|' read -r enabled mode timer hs last bans spool < <(_nftban_health_botscan_facts)
+    local enabled mode timer hs last bans spool handoff stale status=$HEALTH_OK
+    IFS='|' read -r enabled mode timer hs last bans spool handoff stale < <(_nftban_health_botscan_facts)
+    local broken_handoff="no"
+    [[ "$handoff" =~ ^[0-9]+$ && "$handoff" -gt 0 ]] && broken_handoff="yes"
+    [[ "$stale" == "true" ]] && broken_handoff="yes"
     if [[ "$enabled" == "true" ]]; then
-        if [[ "$hs" == DEGRADED_* || "$hs" == NO_INPUT_* ]]; then
+        if [[ "$broken_handoff" == "yes" ]]; then
+            NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner consumer HAND-OFF BROKEN (handoff_errors=${handoff}, stale_backlog=${stale}) — bans NOT reaching the kernel"
+            status=$HEALTH_WARNING
+        elif [[ "$hs" == DEGRADED_* || "$hs" == NO_INPUT_* ]]; then
             NFTBAN_HEALTH_ISSUES["botscan"]="HTTP Exploit Scanner ENABLED but ${hs} — NOT currently enforcing (blind/degraded)"
             status=$HEALTH_WARNING
         elif [[ "$timer" != "active" ]]; then

--- a/cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh
+++ b/cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.219.0 PR-B BotScan daemon-truth (shell consumes it)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_daemon_truth_v219_0_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-09"
+# meta:description="v1.219.0 PR-B — the shell nftban health BotScan render consumes the daemon-written botscan_consumer_status.json so a BROKEN consumer hand-off (batch_handoff_errors>0 or stale_backlog=true) renders 'CONSUMER HAND-OFF BROKEN — bans NOT reaching the kernel', NOT healthy/enforcing. Asserts: handoff_errors>0 → broken verdict; stale_backlog=true → broken; handoff=0 → not broken; missing consumer status → honest handoff=UNKNOWN (never assumed-healthy). Cheap-read only (jq on the status JSON; no access-log content)."
+# meta:input="None (extracts + stubs the health render with consumer-status fixtures)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,jq"
+# meta:inventory.files="cli/lib/nftban/core/nftban_health_checks_modules.sh,internal/botguard/botscan_truth.go"
+# meta:inventory.binaries="bash,awk,grep,jq"
+# meta:inventory.env_vars="NFTBAN_CONFIG_DIR,NFTBAN_DATA_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HMOD="$REPO/cli/lib/nftban/core/nftban_health_checks_modules.sh"
+GOSRC="$REPO/internal/botguard/botscan_truth.go"
+
+SB=$(mktemp -d); trap 'rm -rf "$SB"' EXIT
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ [[ "$1" == *"$2"* ]]; }
+
+echo "=== v1.219.0 PR-B BotScan daemon-truth (shell consumes handoff status) ==="
+
+awk '/^_nftban_health_botscan_facts\(\)/{c=1} c{print} /^_nftban_health_render_botscan\(\)/{r=1} r&&/^}/{print "";exit}' "$HMOD" > "$SB/render.sh"
+[[ -s "$SB/render.sh" ]] && ok "extracted health facts+render block" || no "extract render block"
+
+# render <handoff_errors|MISSING> <stale:true|false>
+render(){
+  local he="$1" stale="$2"
+  mkdir -p "$SB/conf.d/botscan" "$SB/data/botscan" "$SB/data/botguard"
+  printf 'BOTSCAN_ENABLED="true"\nBOTSCAN_ACTION_MODE="both"\n' > "$SB/conf.d/botscan/main.conf"
+  printf '{"health_state":"OK_SCANNED_NO_BOTS","last_run_ts":%s,"bans_emitted_total":5}\n' "$(date +%s)" > "$SB/data/botscan/runstate.json"
+  rm -f "$SB/data/botguard/botscan_consumer_status.json"
+  if [[ "$he" != MISSING ]]; then
+    printf '{"batch_handoff_errors":%s,"batch_consumer_stale_backlog":%s}\n' "$he" "$stale" > "$SB/data/botguard/botscan_consumer_status.json"
+  fi
+  NFTBAN_CONFIG_DIR="$SB" NFTBAN_DATA_DIR="$SB/data" STIMER=active bash -c '
+    set +e
+    systemctl(){ [ "${STIMER:-}" = active ] && return 0 || return 1; }
+    source "'"$SB/render.sh"'"
+    _nftban_health_render_botscan
+  '
+}
+
+out=$(render 3 true)
+has "$out" "CONSUMER HAND-OFF BROKEN" && ok "handoff_errors>0: renders HAND-OFF BROKEN (not healthy)" || no "broken handoff not surfaced"
+has "$out" "bans NOT reaching the kernel" && ok "broken handoff: 'bans NOT reaching the kernel'" || no "broken handoff wording"
+
+out=$(render 0 true)
+has "$out" "CONSUMER HAND-OFF BROKEN" && ok "stale_backlog=true: broken (even with 0 errors)" || no "stale not treated as broken"
+
+out=$(render 0 false)
+has "$out" "CONSUMER HAND-OFF BROKEN" && no "healthy handoff wrongly flagged broken" || ok "handoff_errors=0 + not stale: NOT broken"
+has "$out" "ENABLED + timer active" && ok "healthy handoff: enforcing verdict" || no "healthy verdict"
+
+out=$(render MISSING false)
+has "$out" "handoff=UNKNOWN" && ok "missing daemon status: honest UNKNOWN (not assumed-healthy)" || no "missing status not UNKNOWN"
+
+# Go side wired + present
+grep -q 'defer m.writeBotscanConsumerStatus()' "$REPO/internal/botguard/guard.go" && ok "go: consumer status published every cycle (defer)" || no "go: status not wired"
+grep -q 'm.appendBotscanEvidence(sig' "$REPO/internal/botguard/guard.go" && ok "go: durable evidence recorded on ban" || no "go: evidence not wired"
+[[ -f "$GOSRC" ]] && grep -q 'batch_signals.jsonl consume/delete' "$GOSRC" && ok "go: evidence documented to survive consume" || no "go: evidence file"
+
+# cheap-read invariant still holds (no access-log content read in the extended facts/render)
+if grep -nE 'access\.log|/var/log/(apache|httpd|nginx)|tail .*log' "$SB/render.sh" >/dev/null 2>&1; then
+  no "cheap-read invariant: handoff render reads access-log content"
+else ok "cheap-read invariant: handoff render still access-log-content-free"; fi
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/internal/botguard/botscan_truth.go
+++ b/internal/botguard/botscan_truth.go
@@ -41,6 +41,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/safety"
 )
 
 const (
@@ -82,12 +84,8 @@ func (m *Module) writeBotscanConsumerStatus() {
 		return
 	}
 	b = append(b, '\n')
-	path := filepath.Join(dir, botscanConsumerStatusName)
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o640); err != nil {
-		return
-	}
-	_ = os.Rename(tmp, path) // atomic replace
+	// Durable atomic write via the project's fsync-before-rename safety writer (v1.176 idiom).
+	_ = safety.SafeWriteFile(filepath.Join(dir, botscanConsumerStatusName), b, 0o640)
 }
 
 // appendBotscanEvidence appends a bounded durable evidence record for an ENFORCED BotScan ban.
@@ -120,7 +118,9 @@ func (m *Module) appendBotscanEvidence(sig *BatchSignal, setName string, ttlSec 
 	if fi, serr := os.Stat(path); serr == nil && fi.Size() > botscanEvidenceMaxBytes {
 		trimBotscanEvidence(path)
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
+	// Append-only bounded JSONL log; path is internally derived from the trusted config
+	// (BatchSignalFile dir), never user input.
+	f, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) // #nosec G304 -- path from trusted config (DataDir/botguard)
 	if err != nil {
 		return
 	}
@@ -130,7 +130,7 @@ func (m *Module) appendBotscanEvidence(sig *BatchSignal, setName string, ttlSec 
 
 // trimBotscanEvidence keeps the most-recent line-aligned tail of the evidence log. Best-effort.
 func trimBotscanEvidence(path string) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- path from trusted config (DataDir/botguard)
 	if err != nil {
 		return
 	}
@@ -142,8 +142,6 @@ func trimBotscanEvidence(path string) {
 	if i := bytes.IndexByte(tail, '\n'); i >= 0 && i+1 <= len(tail) {
 		tail = tail[i+1:] // drop the partial first line so records stay whole
 	}
-	tmp := path + ".tmp"
-	if werr := os.WriteFile(tmp, tail, 0o640); werr == nil {
-		_ = os.Rename(tmp, path)
-	}
+	// Durable atomic replace via the project's fsync-before-rename safety writer (v1.176 idiom).
+	_ = safety.SafeWriteFile(path, tail, 0o640)
 }

--- a/internal/botguard/botscan_truth.go
+++ b/internal/botguard/botscan_truth.go
@@ -1,0 +1,149 @@
+// =============================================================================
+// NFTBan v1.219.0 PR-B - BotScan daemon-truth surfaces (handoff status + ban evidence)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// Package: botguard
+// Purpose: v1.219.0 PR-B — two durable, bounded artifacts written next to batch_signals.jsonl
+//          (DataDir/botguard) so the SHELL operator surfaces can tell the truth about the
+//          BotScan consumer without a daemon IPC:
+//            botscan_consumer_status.json — hand-off/consumer counters (BatchHandoffErrors,
+//              malformed, expired, stale-backlog). Lets `nftban health` render a BROKEN hand-off
+//              as WARN/DEGRADED instead of healthy/protected. Atomic snapshot, written via defer
+//              on EVERY consumer cycle so an error path is always surfaced.
+//            botscan_ban_evidence.jsonl — a per-ban side-record (ts/ip/reason(s)/action/…) that
+//              SURVIVES the batch_signals.jsonl consume/delete, so a support operator can still
+//              explain WHY an IP was BotScan-banned after the hand-off file is gone.
+//          Both are bounded (atomic status snapshot; tail-capped evidence log) and carry no
+//          secrets. The matched raw URL/path is NOT in BatchSignal today (shell-producer
+//          follow-up); sig.Reasons carries the pattern/why and is recorded verbatim.
+//
+// meta:name="botguard_botscan_truth"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:package="botguard"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-07-09"
+// meta:description="v1.219.0 PR-B BotScan daemon-truth surfaces: botscan_consumer_status.json (hand-off counters for shell health) + botscan_ban_evidence.jsonl (durable per-ban side-record surviving batch_signals consume)"
+// meta:inventory.files="botscan_truth.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+// =============================================================================
+
+package botguard
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	botscanConsumerStatusName = "botscan_consumer_status.json"
+	botscanBanEvidenceName    = "botscan_ban_evidence.jsonl"
+	botscanEvidenceMaxBytes   = 512 * 1024 // soft cap; tail-trim to ~half when exceeded (bounded growth)
+)
+
+// botscanTruthDir co-locates the truth artifacts with batch_signals.jsonl (DataDir/botguard).
+func (m *Module) botscanTruthDir() string {
+	if m.config.BatchSignalFile != "" {
+		return filepath.Dir(m.config.BatchSignalFile)
+	}
+	return "/var/lib/nftban/botguard"
+}
+
+// writeBotscanConsumerStatus atomically snapshots the consumer/hand-off counters so the shell
+// health check can read them cheaply (no daemon IPC). Call via defer on every consumer cycle,
+// so a broken hand-off (BatchHandoffErrors) is always surfaced. Never fatal.
+func (m *Module) writeBotscanConsumerStatus() {
+	dir := m.botscanTruthDir()
+	if dir == "" {
+		return
+	}
+	m.mu.RLock()
+	rec := map[string]any{
+		"ts":                           time.Now().Unix(),
+		"batch_consumer_runs":          m.stats.BatchConsumerRuns,
+		"batch_signals_processed":      m.stats.BatchSignalsProcessed,
+		"batch_signals_applied":        m.stats.BatchSignalsApplied,
+		"batch_signals_expired":        m.stats.BatchSignalsExpired,
+		"batch_signals_malformed":      m.stats.BatchSignalsMalformed,
+		"batch_handoff_errors":         m.stats.BatchHandoffErrors,
+		"batch_consumer_stale_backlog": m.stats.BatchConsumerStaleBacklog,
+	}
+	m.mu.RUnlock()
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	b = append(b, '\n')
+	path := filepath.Join(dir, botscanConsumerStatusName)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o640); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path) // atomic replace
+}
+
+// appendBotscanEvidence appends a bounded durable evidence record for an ENFORCED BotScan ban.
+// This SURVIVES the batch_signals.jsonl consume/delete (separate file), preserving the "why".
+// Best-effort: any error is ignored (never blocks a ban). No secrets are recorded.
+func (m *Module) appendBotscanEvidence(sig *BatchSignal, setName string, ttlSec uint32) {
+	dir := m.botscanTruthDir()
+	if dir == "" || sig == nil {
+		return
+	}
+	rec := map[string]any{
+		"ts":            time.Now().Unix(),
+		"source":        botscanProvenanceSrc, // "botscan" — distinguishes from admin/feed manual bans
+		"ip":            sig.IP,
+		"action":        sig.Action,
+		"family":        sig.ResolvedFamily(),
+		"request_class": sig.NormalizedRequestClass(),
+		"reasons":       sig.Reasons, // pattern/why: e.g. "wp_probe","404_flood","Matched patterns: …"
+		"set":           setName,
+		"ttl_sec":       ttlSec,
+		"url":           "", // reserved: matched URL/path not in BatchSignal (shell-producer follow-up)
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	b = append(b, '\n')
+	path := filepath.Join(dir, botscanBanEvidenceName)
+	// Bounded growth: tail-trim before appending if the log has grown past the soft cap.
+	if fi, serr := os.Stat(path); serr == nil && fi.Size() > botscanEvidenceMaxBytes {
+		trimBotscanEvidence(path)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
+	if err != nil {
+		return
+	}
+	_, _ = f.Write(b)
+	_ = f.Close()
+}
+
+// trimBotscanEvidence keeps the most-recent line-aligned tail of the evidence log. Best-effort.
+func trimBotscanEvidence(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	keep := botscanEvidenceMaxBytes / 2
+	if len(data) <= keep {
+		return
+	}
+	tail := data[len(data)-keep:]
+	if i := bytes.IndexByte(tail, '\n'); i >= 0 && i+1 <= len(tail) {
+		tail = tail[i+1:] // drop the partial first line so records stay whole
+	}
+	tmp := path + ".tmp"
+	if werr := os.WriteFile(tmp, tail, 0o640); werr == nil {
+		_ = os.Rename(tmp, path)
+	}
+}

--- a/internal/botguard/botscan_truth.go
+++ b/internal/botguard/botscan_truth.go
@@ -85,7 +85,7 @@ func (m *Module) writeBotscanConsumerStatus() {
 	}
 	b = append(b, '\n')
 	// Durable atomic write via the project's fsync-before-rename safety writer (v1.176 idiom).
-	_ = safety.SafeWriteFile(filepath.Join(dir, botscanConsumerStatusName), b, 0o640)
+	_ = safety.SafeWriteFile(filepath.Join(dir, botscanConsumerStatusName), b, 0o600)
 }
 
 // appendBotscanEvidence appends a bounded durable evidence record for an ENFORCED BotScan ban.
@@ -120,7 +120,7 @@ func (m *Module) appendBotscanEvidence(sig *BatchSignal, setName string, ttlSec 
 	}
 	// Append-only bounded JSONL log; path is internally derived from the trusted config
 	// (BatchSignalFile dir), never user input.
-	f, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640) // #nosec G304 -- path from trusted config (DataDir/botguard)
+	f, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- path from trusted config (DataDir/botguard)
 	if err != nil {
 		return
 	}
@@ -143,5 +143,5 @@ func trimBotscanEvidence(path string) {
 		tail = tail[i+1:] // drop the partial first line so records stay whole
 	}
 	// Durable atomic replace via the project's fsync-before-rename safety writer (v1.176 idiom).
-	_ = safety.SafeWriteFile(path, tail, 0o640)
+	_ = safety.SafeWriteFile(path, tail, 0o600)
 }

--- a/internal/botguard/botscan_truth_v219_test.go
+++ b/internal/botguard/botscan_truth_v219_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="botscan_truth_v219_test"
+// meta:type="test"
+// meta:package="botguard"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-07-09"
+// meta:description="v1.219.0 PR-B BotScan daemon-truth: (1) writeBotscanConsumerStatus surfaces the in-memory hand-off counters (BatchHandoffErrors, stale-backlog) to a cheap-read status file so a broken hand-off can render WARN/DEGRADED instead of healthy; (2) appendBotscanEvidence writes a durable per-ban side-record that SURVIVES the batch_signals.jsonl consume/delete, carrying source=botscan + ip + reason(s); (3) the two surfaces stay wired into processBatchSignals (defer) and applyBotscanBanSignal."
+// meta:inventory.files="botscan_truth_v219_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges=""
+
+package botguard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBotscanConsumerStatus_SurfacesBrokenHandoff(t *testing.T) {
+	dir := t.TempDir()
+	bdir := filepath.Join(dir, "botguard")
+	if err := os.MkdirAll(bdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := &Module{config: &Config{BatchSignalFile: filepath.Join(bdir, "batch_signals.jsonl")}}
+	m.stats.BatchHandoffErrors = 3
+	m.stats.BatchConsumerStaleBacklog = true
+	m.stats.BatchSignalsMalformed = 1
+
+	m.writeBotscanConsumerStatus()
+
+	b, err := os.ReadFile(filepath.Join(bdir, "botscan_consumer_status.json"))
+	if err != nil {
+		t.Fatalf("consumer status not written: %v", err)
+	}
+	var s map[string]any
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("consumer status not valid JSON: %v", err)
+	}
+	if s["batch_handoff_errors"].(float64) != 3 {
+		t.Fatalf("broken hand-off NOT surfaced to shell truth: %v", s)
+	}
+	if s["batch_consumer_stale_backlog"] != true {
+		t.Fatalf("stale backlog NOT surfaced: %v", s)
+	}
+}
+
+func TestBotscanEvidence_SurvivesConsume(t *testing.T) {
+	dir := t.TempDir()
+	bdir := filepath.Join(dir, "botguard")
+	if err := os.MkdirAll(bdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := &Module{config: &Config{BatchSignalFile: filepath.Join(bdir, "batch_signals.jsonl")}}
+
+	// A hand-off file exists, then is consumed (removed) — the evidence must outlive it.
+	sigFile := m.config.BatchSignalFile
+	if err := os.WriteFile(sigFile, []byte(`{"ip":"203.0.113.9","action":"ban","reasons":["wp_probe"]}`+"\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	sig := &BatchSignal{IP: "203.0.113.9", Action: "ban", Reasons: []string{"wp_probe", "Matched patterns: EXP_WPREST"}}
+	m.appendBotscanEvidence(sig, "blacklist_manual_ipv4", 86400)
+
+	// consume: the batch_signals hand-off file is removed
+	if err := os.Remove(sigFile); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sigFile); !os.IsNotExist(err) {
+		t.Fatal("test setup: batch_signals not consumed")
+	}
+
+	// evidence must still be there, carrying the WHY
+	ev := filepath.Join(bdir, "botscan_ban_evidence.jsonl")
+	b, err := os.ReadFile(ev)
+	if err != nil {
+		t.Fatalf("ban evidence gone after consume: %v", err)
+	}
+	s := string(b)
+	for _, want := range []string{"203.0.113.9", "wp_probe", `"source":"botscan"`, "blacklist_manual_ipv4"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("evidence missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestBotscanEvidence_Bounded(t *testing.T) {
+	dir := t.TempDir()
+	bdir := filepath.Join(dir, "botguard")
+	_ = os.MkdirAll(bdir, 0o755)
+	m := &Module{config: &Config{BatchSignalFile: filepath.Join(bdir, "batch_signals.jsonl")}}
+	ev := filepath.Join(bdir, botscanBanEvidenceName)
+	// Pre-seed the evidence log past the soft cap, then append — it must trim (bounded growth).
+	big := strings.Repeat(`{"ts":0,"ip":"1.2.3.4"}`+"\n", (botscanEvidenceMaxBytes/24)+100)
+	if err := os.WriteFile(ev, []byte(big), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	sig := &BatchSignal{IP: "203.0.113.9", Action: "ban", Reasons: []string{"latest"}}
+	m.appendBotscanEvidence(sig, "blacklist_manual_ipv4", 86400)
+	fi, err := os.Stat(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() > botscanEvidenceMaxBytes {
+		t.Fatalf("evidence log unbounded: %d bytes > cap %d", fi.Size(), botscanEvidenceMaxBytes)
+	}
+	b, _ := os.ReadFile(ev)
+	if !strings.Contains(string(b), "203.0.113.9") {
+		t.Fatal("newest record lost after trim")
+	}
+}
+
+func TestBotscanTruth_StaysWired(t *testing.T) {
+	src, err := os.ReadFile("guard.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "defer m.writeBotscanConsumerStatus()") {
+		t.Fatal("REGRESSION: processBatchSignals no longer publishes consumer hand-off truth")
+	}
+	if !strings.Contains(s, "m.appendBotscanEvidence(sig") {
+		t.Fatal("REGRESSION: applyBotscanBanSignal no longer records durable ban evidence")
+	}
+}

--- a/internal/botguard/guard.go
+++ b/internal/botguard/guard.go
@@ -329,21 +329,21 @@ type BotGuardStatusExtra struct {
 // map[string]any contract expected by module.Status.Extra.
 func (e BotGuardStatusExtra) ToExtraInfo() module.ExtraInfo {
 	info := module.ExtraInfo{
-		"loop_interval":           e.LoopInterval,
-		"pressure_mode":           e.PressureMode,
-		"tracked_ips":             e.TrackedIPs,
-		"total_ticks":             e.TotalTicks,
-		"suspects_found":          e.SuspectsFound,
-		"classified":              e.Classified,
-		"allow_count":             e.AllowCount,
-		"grey_count":              e.GreyCount,
-		"ban_count":               e.BanCount,
-		"emergency_count":         e.EmergencyCount,
-		"last_tick_duration":      e.LastTickDuration,
-		"verify_enqueued":         e.VerifyEnqueued,
-		"verify_completed":        e.VerifyCompleted,
-		"verify_verified":         e.VerifyVerified,
-		"verify_failed":           e.VerifyFailed,
+		"loop_interval":                e.LoopInterval,
+		"pressure_mode":                e.PressureMode,
+		"tracked_ips":                  e.TrackedIPs,
+		"total_ticks":                  e.TotalTicks,
+		"suspects_found":               e.SuspectsFound,
+		"classified":                   e.Classified,
+		"allow_count":                  e.AllowCount,
+		"grey_count":                   e.GreyCount,
+		"ban_count":                    e.BanCount,
+		"emergency_count":              e.EmergencyCount,
+		"last_tick_duration":           e.LastTickDuration,
+		"verify_enqueued":              e.VerifyEnqueued,
+		"verify_completed":             e.VerifyCompleted,
+		"verify_verified":              e.VerifyVerified,
+		"verify_failed":                e.VerifyFailed,
 		"batch_signals_processed":      e.BatchSignalsProcessed,
 		"batch_signals_applied":        e.BatchSignalsApplied,
 		"batch_signals_expired":        e.BatchSignalsExpired,
@@ -700,9 +700,9 @@ func (m *Module) pruneExpired() {
 
 // v1.209 — BotScan batch-signal consumer constants.
 const (
-	botscanManualSetV4   = "blacklist_manual_ipv4" // durable, drop-enforced (independent of BotGuard)
-	botscanManualSetV6   = "blacklist_manual_ipv6"
-	botscanProvenanceSrc = "botscan"
+	botscanManualSetV4             = "blacklist_manual_ipv4" // durable, drop-enforced (independent of BotGuard)
+	botscanManualSetV6             = "blacklist_manual_ipv6"
+	botscanProvenanceSrc           = "botscan"
 	botscanManualBanTTLSec  uint32 = 24 * 3600 // BotScan blacklist_manual ban TTL seconds (behavioral; re-confirmable)
 	botscanManualGreyTTLSec uint32 = 1 * 3600
 )
@@ -738,6 +738,10 @@ func (m *Module) processBatchSignals() {
 	if signalFile == "" {
 		return
 	}
+	// v1.219.0 PR-B — publish the consumer/hand-off truth on EVERY cycle (incl. the error
+	// return paths below) so the shell health check can render a broken hand-off as
+	// WARN/DEGRADED rather than healthy/protected.
+	defer m.writeBotscanConsumerStatus()
 	consumingFile := signalFile + batchSignalConsumingSuffix
 
 	// BatchConsumerRuns counts once per cycle regardless of which drains run below.
@@ -987,6 +991,9 @@ func (m *Module) applyBotscanBanSignal(sig *BatchSignal) bool {
 		log.Printf("[botguard] botscan blacklist_manual enqueue error for %s: %v", ip, err)
 		return false
 	}
+	// v1.219.0 PR-B — durable ban-evidence side-record BEFORE the batch_signals.jsonl consume
+	// removes the hand-off file, so the "why" (reasons/pattern) survives for forensics.
+	m.appendBotscanEvidence(sig, setName, ttlSec)
 	m.mu.Lock()
 	m.stats.BanCount++
 	m.mu.Unlock()


### PR DESCRIPTION
## Summary
**PR-B of two** — the minimal Go daemon re-baseline completing the v1.219.0 BotScan operator-truth contract's remaining two acceptance guarantees. Follows PR-A (#1067, merged). After this, v1.219.0 is content-complete → release-prep.

## 1. Broken hand-off ≠ healthy
- New **`botscan_consumer_status.json`** (atomic snapshot next to `batch_signals.jsonl`) exposes the previously in-memory-only consumer counters — `BatchHandoffErrors`, malformed, expired, **stale-backlog** — to a cheap-read shell surface. Published via **`defer m.writeBotscanConsumerStatus()`** in `processBatchSignals`, so **every** cycle — including the three hand-off error return paths — writes it.
- Shell `nftban health` BotScan block + check consume it: `handoff_errors>0` or `stale_backlog=true` → **"CONSUMER HAND-OFF BROKEN — bans NOT reaching the kernel"** (WARN), **never healthy**; missing file → honest **`handoff=UNKNOWN`** (never assumed-healthy). Replaces PR-A's placeholder line.

## 2. Ban evidence survives consume
- New **`botscan_ban_evidence.jsonl`** side-record written in `applyBotscanBanSignal` **before** the `batch_signals.jsonl` consume/delete removes the hand-off. Carries `ts / source=botscan / ip / action / family / request_class / reasons (pattern why) / set / ttl`. **Bounded** (tail-trim at 512 KiB soft cap), no secrets.
- ⚠ **Matched raw URL/path is not in `BatchSignal` today** (only IP/Score/Reasons/Action/TS/Family/RequestClass) — a reserved `url` field is included; the shell producer emitting the URL into the signal is a follow-up, **out of minimal PR-B scope**. `reasons` carries the pattern/why.

## Classification
**Daemon re-baseline REQUIRED** (Go changed). **nft schema 1.84.0 unchanged · `ModulesJSON` untouched.** No Go four-axis BotScan module (v1.220+); no pattern/EXP_* edits; no matcher/`test-url`/aliases; no RPM-drift reconcile.

## Changed files (6)
| Group | Files |
|---|---|
| **Go** | `internal/botguard/botscan_truth.go` (new), `internal/botguard/guard.go` (2-line wiring: defer + evidence call), `internal/botguard/botscan_truth_v219_test.go` (new) |
| **shell** | `core/nftban_health_checks_modules.sh` (consume status), `cli/cmd_health.sh` (comment) |
| **tests** | `botscan_daemon_truth_v219_0_test.sh` (new) |

## Tests
- **Go** `botscan_truth_v219_test.go`: **broken hand-off surfaced** · **evidence survives consume** (batch_signals removed, evidence + ip/reason/source persists) · bounded-growth trim · stays-wired guard.
- **Shell** `botscan_daemon_truth_v219_0_test.sh` **11/11**: broken→WARN, healthy→ok, stale→broken, missing→UNKNOWN, cheap-read.
- **Full botguard suite green** (29s, no regressions); PR-A operator-truth test + v218_11/12 + status_consistency + exp_rfi_fp all green.

## Acceptance guarantees (now all four closed across PR-A + PR-B)
- ✅ DEGRADED/blind ≠ enforced (PR-A) · ✅ cache-only ≠ BANNED (PR-A)
- ✅ **broken handoff ≠ healthy** (PR-B) · ✅ **ban evidence survives consume with reason** (PR-B; URL is a noted follow-up)

## Hold
No merge without a separate GO. Release-prep only after **both** PR-A (merged) + PR-B land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)