### PR TITLE
fix(rbl): make enable prereq DNS-tool check IFS-safe

### DIFF
--- a/cli/lib/nftban/lib/nftban_prereq.sh
+++ b/cli/lib/nftban/lib/nftban_prereq.sh
@@ -66,7 +66,7 @@ nftban_prereq_require_cmd() {
     # Returns: 0 if binary found, 1 if missing
     #
     # Example: nftban_prereq_require_cmd "suricata" "suricata" "IDS engine"
-    #          nftban_prereq_require_cmd "host" "bind_utils" "DNS lookup"
+    #          nftban_prereq_require_cmd "host" "dns_utils" "DNS lookup"
 
     local binary="$1"
     local pkg_key="$2"
@@ -105,6 +105,13 @@ nftban_prereq_require_any_cmd() {
     local binaries_str="$1"
     local pkg_keys_str="$2"
     local description="${3:-transport}"
+
+    # CONTRACT (v1.219.1): prereq helpers MUST be safe when sourced by strict-mode callers
+    # that set IFS=$'\n\t' (e.g. cmd_rbl.sh). The space-separated "b1 b2 b3" args below rely on
+    # whitespace word-splitting, so restore a whitespace IFS locally. Without this, a caller's
+    # IFS=$'\n\t' makes `for bin in $binaries_str` iterate ONCE over the whole joined string
+    # ("host dig nslookup") → false-MISSING even when a tool exists (the RBL enable hard-block).
+    local IFS=$' \t\n'
 
     # Check each binary
     local bin
@@ -267,7 +274,7 @@ nftban_prereq_check_rbl() {
     nftban_prereq_init
     nftban_prereq_require_any_cmd \
         "host dig nslookup" \
-        "bind_utils bind_utils bind_utils" \
+        "dns_utils dns_utils dns_utils" \
         "DNS lookup tool" || true
 }
 

--- a/cli/lib/nftban/lib/nftban_prereq.sh
+++ b/cli/lib/nftban/lib/nftban_prereq.sh
@@ -111,9 +111,10 @@ nftban_prereq_require_any_cmd() {
     # whitespace word-splitting, so restore a whitespace IFS locally. Without this, a caller's
     # IFS=$'\n\t' makes `for bin in $binaries_str` iterate ONCE over the whole joined string
     # ("host dig nslookup") → false-MISSING even when a tool exists (the RBL enable hard-block).
-    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering -- intentional & safe: this RESTORES
-    # the DEFAULT whitespace IFS, `local`-scoped (auto-restored on return), to make word-splitting
-    # correct regardless of a strict-mode caller's IFS=$'\n\t'. It is the opposite of tampering.
+    # SAFE, not tampering: this RESTORES the DEFAULT whitespace IFS, `local`-scoped (auto-restored on
+    # return), so a strict-mode caller's IFS=$'\n\t' cannot break word-splitting — the opposite of
+    # tampering. nosemgrep must sit on the line IMMEDIATELY preceding the statement it suppresses:
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
     local IFS=$' \t\n'
 
     # Check each binary

--- a/cli/lib/nftban/lib/nftban_prereq.sh
+++ b/cli/lib/nftban/lib/nftban_prereq.sh
@@ -111,6 +111,9 @@ nftban_prereq_require_any_cmd() {
     # whitespace word-splitting, so restore a whitespace IFS locally. Without this, a caller's
     # IFS=$'\n\t' makes `for bin in $binaries_str` iterate ONCE over the whole joined string
     # ("host dig nslookup") → false-MISSING even when a tool exists (the RBL enable hard-block).
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering -- intentional & safe: this RESTORES
+    # the DEFAULT whitespace IFS, `local`-scoped (auto-restored on return), to make word-splitting
+    # correct regardless of a strict-mode caller's IFS=$'\n\t'. It is the opposite of tampering.
     local IFS=$' \t\n'
 
     # Check each binary

--- a/cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh
+++ b/cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Tests for v1.219.1 RBL enable-prereq IFS-safety + dns_utils package key
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_prereq_ifs_dns_utils_v219_1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-10"
+# meta:description="v1.219.1 PR-A: nftban_prereq_require_any_cmd must be safe when sourced by strict-mode callers (cmd_rbl.sh sets IFS=\$'\\n\\t'). Before the fix, 'for bin in \$binaries_str' + 'read -a' did not split the space-separated 'host dig nslookup' under IFS=\$'\\n\\t', so it checked one literal binary 'host dig nslookup' → false-MISSING even when a tool existed (the RBL enable hard-block since 2025-12-31). Asserts: (1) under IFS=\$'\\n\\t' the helper returns 0 when at least one tool exists; (2) when none exist, the missing HINT lists each split option (host/dig/nslookup) separately, not one joined string; (3) the RBL prereq uses the valid 'dns_utils' package key (never the unmapped 'bind_utils'); (4) the central per-distro maps resolve dns_utils to bind9-dnsutils on apt distros and bind-utils on dnf distros, on every distro conf. Shell/config/tests only; daemon byte-identical; no scan-behavior change; RBL not enabled."
+# meta:input="None (extracts + stubs the prereq helper; greps the lib + distro confs)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep"
+# meta:inventory.files="cli/lib/nftban/lib/nftban_prereq.sh,etc/nftban/distros/*.conf"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars="IFS"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+LIB="$REPO/cli/lib/nftban/lib/nftban_prereq.sh"
+DISTROS="$REPO/etc/nftban/distros"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=== v1.219.1 RBL enable-prereq IFS-safety + dns_utils ==="
+
+# Harness: extract the helper, run under strict IFS with stubbed have_cmd + arrays.
+run_prereq(){ # run_prereq <have:present|absent>  → prints "RC=<rc>|HINT=<suggestion>"
+  local mode="$1"
+  bash -c '
+    set +e
+    IFS=$'"'"'\n\t'"'"'                      # strict mode, exactly like cmd_rbl.sh
+    MODE="'"$mode"'"
+    nftban_have_cmd(){ [ "$MODE" = present ] && [ "$1" = dig ] && return 0; return 1; }
+    _nftban_prereq_install_cmd(){ echo "apt-get install -y"; }
+    NFTBAN_PREREQ_MISSING=(); NFTBAN_PREREQ_HINTS=()
+    '"$(awk '/^nftban_prereq_require_any_cmd\(\)/,/^}/' "$LIB")"'
+    nftban_prereq_require_any_cmd "host dig nslookup" "dns_utils dns_utils dns_utils" "DNS lookup tool"
+    rc=$?
+    printf "RC=%s|HINT=%s\n" "$rc" "${NFTBAN_PREREQ_HINTS[*]:-}"
+  '
+}
+
+# (1) positive under strict IFS — a tool exists → returns 0
+out=$(run_prereq present)
+[[ "$out" == RC=0\|* ]] && ok "strict IFS + tool present → returns 0 (enable gate not false-blocked)" || no "strict-IFS positive ($out)"
+
+# (2) negative — no tools → returns 1 AND the hint lists each option split (not one joined string)
+out=$(run_prereq absent)
+[[ "$out" == RC=1\|* ]] && ok "no tool → returns 1 (honest missing)" || no "negative rc ($out)"
+# split correctness: the hint must mention host, dig AND nslookup as separate options,
+# and must NOT contain the joined 'host dig nslookup (' token (the pre-fix bug shape).
+if [[ "$out" == *"host ("* && "$out" == *"dig ("* && "$out" == *"nslookup ("* ]]; then
+  ok "missing hint lists all 3 options split (host/dig/nslookup)"
+else no "hint not split correctly ($out)"; fi
+[[ "$out" != *"host dig nslookup ("* ]] && ok "hint is NOT one joined 'host dig nslookup (…)' string" || no "hint joined (pre-fix bug)"
+
+# (3) the IFS contract fix is present in the lib
+grep -q "local IFS=\$' \\\\t\\\\n'" "$LIB" && ok "require_any_cmd resets IFS locally (contract)" || no "no local IFS reset in lib"
+
+# (4) RBL prereq uses dns_utils, never bind_utils
+grep -A6 'nftban_prereq_check_rbl' "$LIB" | grep -q 'dns_utils dns_utils dns_utils' && ok "RBL prereq uses dns_utils key" || no "RBL prereq not dns_utils"
+grep -q 'bind_utils' "$LIB" && no "invalid 'bind_utils' still present in lib" || ok "no 'bind_utils' anywhere in lib"
+
+# (5) per-distro central maps: dns_utils present in every conf, correct pkg per package-manager
+missing=0; wrong=0; total=0
+for f in "$DISTROS"/*.conf; do
+  total=$((total+1))
+  line=$(grep -E '^[[:space:]]*dns_utils[[:space:]]*=' "$f" | head -1)
+  [[ -z "$line" ]] && { missing=$((missing+1)); continue; }
+  # EXACT value after '=' (parser does NOT strip inline comments → an inline # would corrupt it)
+  val="${line#*=}"; val="${val#"${val%%[![:space:]]*}"}"; val="${val%"${val##*[![:space:]]}"}"
+  t=$(grep -m1 '^type = ' "$f" | awk '{print $3}')
+  case "$t" in
+    apt)     [[ "$val" == "bind9-dnsutils" ]] || { wrong=$((wrong+1)); echo "        apt conf wrong: $(basename "$f"): [$val]"; } ;;
+    dnf|yum) [[ "$val" == "bind-utils" ]]     || { wrong=$((wrong+1)); echo "        dnf conf wrong: $(basename "$f"): [$val]"; } ;;
+  esac
+done
+[[ $missing -eq 0 ]] && ok "dns_utils present in ALL $total distro confs" || no "$missing distro confs missing dns_utils"
+[[ $wrong -eq 0 ]] && ok "dns_utils resolves correctly per distro (apt→bind9-dnsutils, dnf→bind-utils)" || no "$wrong confs wrong pkg"
+grep -rl 'bind_utils' "$DISTROS" 2>/dev/null | grep -q . && no "invalid 'bind_utils' in a distro conf" || ok "no 'bind_utils' in any distro conf"
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/etc/nftban/distros/almalinux-10.conf
+++ b/etc/nftban/distros/almalinux-10.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/almalinux-9.conf
+++ b/etc/nftban/distros/almalinux-9.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/centos-10.conf
+++ b/etc/nftban/distros/centos-10.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/centos-9.conf
+++ b/etc/nftban/distros/centos-9.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/centos-stream-10.conf
+++ b/etc/nftban/distros/centos-stream-10.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/centos-stream-9.conf
+++ b/etc/nftban/distros/centos-stream-9.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/centos.conf
+++ b/etc/nftban/distros/centos.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/debian-11.conf
+++ b/etc/nftban/distros/debian-11.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/debian-12.conf
+++ b/etc/nftban/distros/debian-12.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/debian-13.conf
+++ b/etc/nftban/distros/debian-13.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/debian-14.conf
+++ b/etc/nftban/distros/debian-14.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/debian.conf
+++ b/etc/nftban/distros/debian.conf
@@ -49,6 +49,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/fedora-43.conf
+++ b/etc/nftban/distros/fedora-43.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/fedora.conf
+++ b/etc/nftban/distros/fedora.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/rocky-10.conf
+++ b/etc/nftban/distros/rocky-10.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/rocky-8.conf
+++ b/etc/nftban/distros/rocky-8.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/rocky-9.conf
+++ b/etc/nftban/distros/rocky-9.conf
@@ -36,6 +36,7 @@ search_cmd = dnf search
 info_cmd = dnf info
 
 [packages]
+dns_utils = bind-utils
 nftables = nftables
 curl = curl
 iproute = iproute

--- a/etc/nftban/distros/ubuntu-22.conf
+++ b/etc/nftban/distros/ubuntu-22.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/ubuntu-24.conf
+++ b/etc/nftban/distros/ubuntu-24.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/ubuntu-26.conf
+++ b/etc/nftban/distros/ubuntu-26.conf
@@ -36,6 +36,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2

--- a/etc/nftban/distros/ubuntu.conf
+++ b/etc/nftban/distros/ubuntu.conf
@@ -55,6 +55,7 @@ search_cmd = apt-cache search
 info_cmd = apt-cache show
 
 [packages]
+dns_utils = bind9-dnsutils
 nftables = nftables
 curl = curl
 iproute = iproute2


### PR DESCRIPTION
## Summary
**PR-A of the RBL truth hotfix (target v1.219.1).** Fixes **only** the RBL enable prerequisite hard-block + the invalid package hint. **No scan / IPv6 / status / verdict behavior change** — those stay in PR-B/PR-C (v1.220.0). Shell/config/tests only · **daemon byte-identical · 0 Go · nft schema 1.84.0 · RBL not enabled.**

## Root cause
`cmd_rbl.sh` runs under strict mode `IFS=$'\n\t'`. `nftban_prereq_require_any_cmd` word-split the space-separated `"host dig nslookup"` via `for bin in $binaries_str` and `read -a` — **neither splits on spaces under `IFS=$'\n\t'`** — so it checked one literal binary `"host dig nslookup"` and reported `[MISSING] DNS lookup tool` even when `dig`/`nslookup` exist. `rbl enable` was hard-blocked on every host since 2025-12-31 (`e6998e26`). The hint also printed an unmapped/invalid `bind_utils` key.

## Fix
- **`nftban_prereq.sh`** — `require_any_cmd` resets `IFS` locally (`local IFS=$' \t\n'`) with a **CONTRACT comment**: prereq helpers must be safe when sourced by strict-mode callers. Both the binary loop and the suggestion `read -a` now split correctly regardless of caller IFS.
- RBL prereq key `bind_utils` → **`dns_utils`** (+ example comment). No `bind_utils` remains anywhere (0 files).
- **Central per-distro map** — added `dns_utils` to **all 21** `etc/nftban/distros/*.conf`, resolved **per distro/release by package manager**: apt (Debian 11–14 / Ubuntu 22–26) = **`bind9-dnsutils`**; dnf (Alma/Rocky/CentOS/CentOS-Stream 8–10, Fedora) = **`bind-utils`**. Inline comments stripped (the distro parser doesn't strip them → would corrupt the parsed value).

## Empirical per-distro verification (read-only fleet sweep — "how each distro has it")
| Distro/release | pkg that owns `dig` | mapped |
|---|---|---|
| Ubuntu 22.04 · 26.04 | **bind9-dnsutils** ✅ | bind9-dnsutils |
| AlmaLinux 9 · 10 · Rocky 10 · CentOS-Stream 10 | **bind-utils** ✅ | bind-utils |

*(Ubuntu is Debian-family apt → confirms the Debian `bind9-dnsutils` name; no Debian host on the fleet to probe directly, and no pre-bullseye/pre-jammy `dnsutils`-era conf exists in the tree.)*

## Tests
`rbl_prereq_ifs_dns_utils_v219_1_test.sh` **10/10**: strict-IFS positive returns 0 (enable gate no longer false-blocks); negative returns 1 with the hint **split** (host/dig/nslookup separately, not joined); IFS contract present; RBL prereq uses `dns_utils`; per-distro map resolves to the **exact** package (guards the inline-comment-corruption class); no `bind_utils` anywhere. shellcheck clean. *(Pre-existing `test_distro_config`/`validate_distro_configs` failures are about unrelated `NFTBAN_PORTAL_*` lines — red on main before this PR.)*

## Boundaries honored
No IPv6 colon-split fix · no `rbl check` scan behavior · no scheduled-timer change · no final-verdict/rc change · no PTR/FCrDNS · no `rbl status` change · no watchlist change · **RBL not enabled** · no host mutation · 0 Go · schema unchanged · no PR-B/PR-C · no release-prep.

## Hold
No merge without a separate GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)