### PR TITLE
feat(rbl): v1.220.0 PR-B — shared host-address inventory authority + IPv6-safe RBL truth

### DIFF
--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -511,20 +511,25 @@ nftban_cmd_rbl_check() {
     # Get IPs to check
     local ips_to_check=()
 
+    # v1.220.0: entries are TAB-delimited "<ip>\t<tag>" (tag may be empty). A TAB
+    # can never appear inside an IP address, so full IPv6 addresses survive intact
+    # (the legacy ":"-split truncated 2a01:... to "2a01").
     if [[ -n "$ip" ]]; then
         # Check specific IP
-        ips_to_check+=("$ip")
+        ips_to_check+=("$ip"$'\t')
     else
-        # Auto-discover IPs
+        # Auto-discover IPs (public routable self v4+v6 via the inventory authority)
         if [[ "${NFTBAN_RBL_AUTO_DISCOVER_IPS:-YES}" == "YES" ]]; then
             while IFS= read -r discovered_ip; do
-                ips_to_check+=("$discovered_ip")
+                [[ -z "$discovered_ip" ]] && continue
+                ips_to_check+=("$discovered_ip"$'\t')
             done < <(nftban_rbl_get_public_ips)
         fi
 
-        # Add critical IPs
-        while IFS=: read -r critical_ip tag; do
-            ips_to_check+=("$critical_ip:$tag")
+        # Add operator critical IPs (IPv6-safe: get_critical_ips emits "<ip>\t<tag>")
+        while IFS=$'\t' read -r critical_ip tag; do
+            [[ -z "$critical_ip" ]] && continue
+            ips_to_check+=("$critical_ip"$'\t'"$tag")
         done < <(nftban_rbl_get_critical_ips)
     fi
 
@@ -535,10 +540,12 @@ nftban_cmd_rbl_check() {
 
     # Check each IP
     local any_listed=0
+    local any_degraded=0
     for ip_entry in "${ips_to_check[@]}"; do
-        local check_ip="${ip_entry%%:*}"
-        local ip_tag="${ip_entry#*:}"
-        [[ "$ip_tag" == "$check_ip" ]] && ip_tag=""
+        # TAB split — preserves full IPv6 addresses (no first-colon truncation).
+        local check_ip="${ip_entry%%$'\t'*}"
+        local ip_tag="${ip_entry#*$'\t'}"
+        [[ "$ip_tag" == "$ip_entry" ]] && ip_tag=""
 
         [[ $quiet -eq 0 ]] && echo ""
         [[ $quiet -eq 0 ]] && [[ -n "$ip_tag" ]] && echo "Checking: $check_ip (tag: $ip_tag)"
@@ -592,6 +599,7 @@ nftban_cmd_rbl_check() {
             elif [[ "$_rbl_state" == "degraded" ]]; then
                 # Persist degraded — NEVER clean. Posture/health must not show
                 # "fully protected" when the lookup could not be completed.
+                any_degraded=1
                 [[ $quiet -eq 0 ]] && echo "⚠️  RBL result DEGRADED for $check_ip — reputation NOT fully verified (not marked clean)"
                 nftban_rbl_update_state "$check_ip" "degraded"
             else
@@ -614,8 +622,12 @@ nftban_cmd_rbl_check() {
     # untouched — so no monitored-set and no full-scan guard are needed.
     nftban_rbl_prune_state 2>/dev/null || true
 
-    # Return exit code based on listings
-    return $any_listed
+    # Return-code contract (v1.220.0): 1 = listed; 2 = degraded/not-fully-verified
+    # (no listing but coverage incomplete); 0 = fully-verified clean. A degraded run
+    # is NEVER rc0 — automation must be able to tell "clean" from "could not verify".
+    [[ $any_listed -eq 1 ]] && return 1
+    [[ $any_degraded -eq 1 ]] && return 2
+    return 0
 }
 
 nftban_cmd_rbl_server() {
@@ -685,113 +697,139 @@ nftban_cmd_rbl_server() {
     [[ $quiet -eq 0 ]] && echo "Server: $hostname"
     [[ $quiet -eq 0 ]] && echo ""
 
-    # Collect all IPs
+    # Collect self IPs via the shared host-address inventory authority (DISCOVER
+    # ONCE / CLASSIFY ONCE). Entries are TAB-delimited "<address>\t<source>" — a TAB
+    # cannot appear inside an IP, so full IPv6 addresses survive intact (the legacy
+    # "$ip:ipv6" + first-colon split truncated 2a01:… to "2a01"). Display lists every
+    # local address with its scope; ONLY public routable addresses are checked.
     local all_ips=()
+    local _addr _fam _scope _iface _state _src
 
-    # 1. Auto-discovered IPv4
-    [[ $quiet -eq 0 ]] && echo "━━━ IPv4 Addresses ━━━"
-    local ipv4_count=0
-    while IFS= read -r ip; do
-        all_ips+=("$ip:ipv4")
-        # v1.19.20 FIX
-        ((ipv4_count++)) || true
-        [[ $quiet -eq 0 ]] && echo "  ✓ $ip"
-    done < <(ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '^127\.' | sort -u)
-    [[ $quiet -eq 0 ]] && [[ $ipv4_count -eq 0 ]] && echo "  (none found)"
-    [[ $quiet -eq 0 ]] && echo ""
-
-    # 2. Auto-discovered IPv6 (if enabled)
-    if [[ "${NFTBAN_RBL_CHECK_IPV6:-YES}" == "YES" ]]; then
-        [[ $quiet -eq 0 ]] && echo "━━━ IPv6 Addresses ━━━"
-        local ipv6_count=0
-        while IFS= read -r ip; do
-            all_ips+=("$ip:ipv6")
-            # v1.19.20 FIX
-            ((ipv6_count++)) || true
-            [[ $quiet -eq 0 ]] && echo "  ✓ $ip"
-        done < <(ip -6 addr show | grep -oP '(?<=inet6\s)[0-9a-f:]+' | grep -v '^::1' | grep -v '^fe80:' | grep -v '^fc00:' | grep -v '^fd00:' | sort -u)
-        [[ $quiet -eq 0 ]] && [[ $ipv6_count -eq 0 ]] && echo "  (none found)"
-        [[ $quiet -eq 0 ]] && echo "" || true
+    if [[ $quiet -eq 0 ]]; then
+        echo "━━━ IPv4 Addresses ━━━"
+        local _shown4=0
+        while IFS=$'\t' read -r _addr _fam _scope _iface _state _src; do
+            [[ "$_fam" == "ipv4" ]] || continue
+            echo "  • $_addr ($_scope, $_iface, $_state)"; _shown4=1
+        done < <(nftban_hostaddr_inventory)
+        [[ $_shown4 -eq 0 ]] && echo "  (none found)"
+        echo ""
+        if [[ "${NFTBAN_RBL_CHECK_IPV6:-YES}" == "YES" ]]; then
+            echo "━━━ IPv6 Addresses ━━━"
+            local _shown6=0
+            while IFS=$'\t' read -r _addr _fam _scope _iface _state _src; do
+                [[ "$_fam" == "ipv6" ]] || continue
+                echo "  • $_addr ($_scope, $_iface, $_state)"; _shown6=1
+            done < <(nftban_hostaddr_inventory)
+            [[ $_shown6 -eq 0 ]] && echo "  (none found)"
+            echo ""
+        fi
     fi
 
-    # 3. Hostname resolution
+    # Checkable set: public routable self IPs only (project_rbl; honors IPv6 gate,
+    # excludes private/ULA/CGNAT/link-local/loopback + tentative/deprecated + down).
+    while IFS= read -r _addr; do
+        [[ -z "$_addr" ]] && continue
+        all_ips+=("$_addr"$'\t'"self")
+    done < <(nftban_rbl_get_public_ips)
+
+    # Hostname-resolution leg (behavior unchanged; PR-C refines loopback/public-DNS
+    # truth). TAB-delimited source; no colon encoding.
     [[ $quiet -eq 0 ]] && echo "━━━ Hostname Resolution ━━━"
     while IFS= read -r ip; do
-        all_ips+=("$ip:hostname")
+        all_ips+=("$ip"$'\t'"hostname")
         [[ $quiet -eq 0 ]] && echo "  ✓ $hostname → $ip"
     done < <(host "$hostname" 2>/dev/null | grep "has address" | awk '{print $NF}')
     [[ $quiet -eq 0 ]] && echo ""
 
-    if [[ ${#all_ips[@]} -eq 0 ]]; then
-        echo "ERROR: No IPs found to check" >&2
-        return 1
+    # Dedup by address — same IP from multiple sources yields ONE RBL check.
+    local -a _uniq_ips=()
+    local -A _seen_ips=()
+    local _e _a
+    for _e in "${all_ips[@]:-}"; do
+        [[ -z "$_e" ]] && continue
+        _a="${_e%%$'\t'*}"
+        [[ -n "${_seen_ips[$_a]:-}" ]] && continue
+        _seen_ips[$_a]=1
+        _uniq_ips+=("$_e")
+    done
+    all_ips=("${_uniq_ips[@]:-}")
+
+    if [[ ${#all_ips[@]} -eq 0 || -z "${all_ips[0]:-}" ]]; then
+        # Inventory produced nothing checkable — reputation is UNKNOWN, never clean.
+        [[ $quiet -eq 0 ]] && echo "⚠️  No self IPs available to check — RBL coverage UNKNOWN (not verified, not clean)" >&2
+        return 2
     fi
 
     [[ $quiet -eq 0 ]] && echo "━━━ RBL Checks ━━━"
     [[ $quiet -eq 0 ]] && echo "Total IPs to check: ${#all_ips[@]}"
     [[ $quiet -eq 0 ]] && echo ""
 
-    # Check each IP
+    # Check each IP. v1.220.0 3-way truth (mirrors the scheduled path): every
+    # checked address is LISTED / DEGRADED / CLEAN. A timeout/error/degraded result
+    # NEVER increments clean and NEVER persists clean — covering BOTH the cache and
+    # fresh paths (the legacy code counted only the fresh branch, so cached degraded
+    # results scored 0/0 and the summary printed the false "All IPs are clean").
     local any_listed=0
     local total_listed=0
     local total_clean=0
+    local total_degraded=0
+    local total_checked=0
 
     for ip_entry in "${all_ips[@]}"; do
-        local check_ip="${ip_entry%%:*}"
-        local ip_source="${ip_entry#*:}"
-
-        # Filter public IPs only
-        if ! nftban_rbl_is_public_ip "$check_ip"; then
-            [[ $quiet -eq 0 ]] && echo "⚠️  Skipping private IP: $check_ip ($ip_source)"
-            continue
-        fi
+        # TAB split — preserves full IPv6 addresses.
+        local check_ip="${ip_entry%%$'\t'*}"
+        local ip_source="${ip_entry#*$'\t'}"
+        [[ "$ip_source" == "$ip_entry" ]] && ip_source="self"
 
         [[ $quiet -eq 0 ]] && echo "─────────────────────────────────────────────────────────────"
         [[ $quiet -eq 0 ]] && echo "Checking: $check_ip (source: $ip_source)"
         [[ $quiet -eq 0 ]] && echo ""
 
-        # Check cache if not fresh
-        local cache_file
+        # Obtain results from cache (if fresh not forced) or a live check.
+        local results="" cache_file
         if [[ $fresh -eq 0 ]] && cache_file=$(nftban_rbl_cache_get "$check_ip"); then
             [[ $quiet -eq 0 ]] && echo "(Using cached results)"
-            cat "$cache_file"
+            results="$(cat "$cache_file")"
         else
-            # Perform fresh check (parallel DNS by default)
-            local results
             if [[ $sequential -eq 1 ]]; then
                 results=$(nftban_rbl_check_ip "$check_ip" "$format")
             else
                 results=$(nftban_rbl_check_ip_parallel "$check_ip" "$format")
             fi
-
-            # Cache results
             echo "$results" | nftban_rbl_cache_set "$check_ip"
+        fi
+        [[ $quiet -eq 0 ]] && printf '%s\n' "$results"
 
-            # Output results
-            echo "$results"
+        total_checked=$((total_checked + 1))
 
-            # Track statistics
-            if echo "$results" | grep -q "LISTED"; then
-                any_listed=1
-                # v1.19.20 FIX
-                ((total_listed++)) || true
+        # Aggregate 3-way classification of this IP's result.
+        local _srv_state="clean"
+        if echo "$results" | grep -qE 'LISTED:|"listed": *[1-9]'; then
+            _srv_state="listed"
+        elif echo "$results" | grep -qE 'RESOLVER_BLOCKED|Degraded total:|"degraded": *[1-9]|"resolver_blocked": *[1-9]|⏱️|SKIPPED \(IPv4-only|UNSUPPORTED \(no IPv6'; then
+            _srv_state="degraded"
+        fi
 
-                # Send alert if requested
-                if [[ $alert -eq 1 ]] && [[ "${NFTBAN_RBL_ALERT_ON_NEW_LISTING:-YES}" == "YES" ]]; then
-                    if nftban_rbl_check_new_listing "$check_ip" "listed"; then
-                        local first_rbl
-                        local first_reason
-                        first_rbl=$(echo "$results" | grep "LISTED:" | head -n1 | awk '{print $3}' || true)
-                        first_reason=$(echo "$results" | grep "Reason:" | head -n1 | sed 's/.*Reason: //' || true)
-                        nftban_rbl_send_alert "$check_ip" "$first_rbl" "$first_reason" "$ip_source"
-                    fi
+        if [[ "$_srv_state" == "listed" ]]; then
+            any_listed=1
+            total_listed=$((total_listed + 1))
+            if [[ $alert -eq 1 ]] && [[ "${NFTBAN_RBL_ALERT_ON_NEW_LISTING:-YES}" == "YES" ]]; then
+                if nftban_rbl_check_new_listing "$check_ip" "listed"; then
+                    local first_rbl first_reason
+                    first_rbl=$(echo "$results" | grep "LISTED:" | head -n1 | awk '{print $3}' || true)
+                    first_reason=$(echo "$results" | grep "Reason:" | head -n1 | sed 's/.*Reason: //' || true)
+                    nftban_rbl_send_alert "$check_ip" "$first_rbl" "$first_reason" "$ip_source"
                 fi
-                nftban_rbl_update_state "$check_ip" "listed"
-            else
-                # v1.19.20 FIX
-                ((total_clean++)) || true
-                nftban_rbl_update_state "$check_ip" "clean"
             fi
+            nftban_rbl_update_state "$check_ip" "listed"
+        elif [[ "$_srv_state" == "degraded" ]]; then
+            total_degraded=$((total_degraded + 1))
+            [[ $quiet -eq 0 ]] && echo "⚠️  DEGRADED for $check_ip — reputation NOT fully verified (not marked clean)"
+            nftban_rbl_update_state "$check_ip" "degraded"
+        else
+            total_clean=$((total_clean + 1))
+            nftban_rbl_update_state "$check_ip" "clean"
         fi
 
         [[ $quiet -eq 0 ]] && echo "" || true
@@ -802,23 +840,35 @@ nftban_cmd_rbl_server() {
     [[ $quiet -eq 0 ]] && echo "Server RBL Check Summary"
     [[ $quiet -eq 0 ]] && echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     [[ $quiet -eq 0 ]] && echo "Server: $hostname"
-    [[ $quiet -eq 0 ]] && echo "IPs Checked: ${#all_ips[@]}"
+    [[ $quiet -eq 0 ]] && echo "IPs Checked: $total_checked"
     [[ $quiet -eq 0 ]] && echo "Listed: $total_listed"
-    [[ $quiet -eq 0 ]] && echo "Clean: $total_clean"
+    [[ $quiet -eq 0 ]] && echo "Clean (fully verified): $total_clean"
+    [[ $quiet -eq 0 ]] && echo "Degraded (not fully verified): $total_degraded"
     [[ $quiet -eq 0 ]] && echo ""
 
+    # v1.220.0 verdict truth: "All IPs are clean" is allowed ONLY when there are no
+    # listings, ZERO degraded/timeout/error, and every intended address was checked.
+    # A degraded result never reads as clean; no-listings-but-degraded is distinct.
     if [[ $total_listed -gt 0 ]]; then
         [[ $quiet -eq 0 ]] && echo "⚠️  WARNING: Server has $total_listed IP(s) on RBL blacklists!"
+    elif [[ $total_degraded -gt 0 || $total_checked -eq 0 ]]; then
+        [[ $quiet -eq 0 ]] && echo "⚠️  No listings found, but RBL coverage is degraded — NOT fully verified"
     else
-        [[ $quiet -eq 0 ]] && echo "✅ All IPs are clean (not blacklisted)" || true
+        [[ $quiet -eq 0 ]] && echo "✅ All IPs are clean (fully verified, not blacklisted)"
     fi
 
     # Update last check timestamp
     mkdir -p "${NFTBAN_RBL_CACHE_DIR}" || return 1
     date -Iseconds > "${NFTBAN_RBL_CACHE_DIR}/last_check"
 
-    # Return exit code based on listings
-    return $any_listed
+    # Return-code contract (v1.220.0): 1 = listed; 2 = degraded/not-fully-verified;
+    # 0 = fully-verified clean.
+    if [[ $any_listed -eq 1 ]]; then
+        return 1
+    elif [[ $total_degraded -gt 0 || $total_checked -eq 0 ]]; then
+        return 2
+    fi
+    return 0
 }
 
 nftban_cmd_rbl_status() {

--- a/cli/lib/nftban/core/nftban_hostaddr.sh
+++ b/cli/lib/nftban/core/nftban_hostaddr.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Host Address Inventory Authority (neutral, read-only)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_hostaddr"
+# meta:type="core"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:homepage="https://nftban.com"
+# meta:description="Single authority for local host/self-IP discovery + classification. DISCOVER ONCE, CLASSIFY ONCE, PROJECT PER CONSUMER. Read-only: no nft/whitelist/RBL/network writes."
+# meta:input="Local network interface addresses (ip -o addr show)"
+# meta:output="Classified TSV/JSON inventory + per-consumer projections"
+# meta:depends="ip,sort"
+# meta:platform="linux"
+# meta:inventory.files=""
+# meta:inventory.binaries="ip,sort"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+#
+# CONTRACT (v1.220.0 — locked by OPEN_COMMON_HOST_ADDRESS_INVENTORY_AUTHORITY_AUDIT.md §10):
+#   Invariant: DISCOVER ONCE - CLASSIFY ONCE - PROJECT PER CONSUMER.
+#   - Discovery: `ip -o addr show` only. NO external/public-IP network fallback.
+#   - Read-only: no nft ops, no whitelist writes, no RBL state/cache writes, no side effects.
+#   - Full compressed IPv6 preserved verbatim; NO colon-delimited address+metadata encoding.
+#   - Deterministic ordering; deduplicated by normalized address.
+#   Canonical record (TSV, internal + `nftban_hostaddr_inventory` output):
+#       address<TAB>family<TAB>scope<TAB>iface<TAB>state<TAB>source
+#   Projections:
+#       nftban_hostaddr_project_rbl        -> public routable self IPv4+IPv6, full addresses
+#       nftban_hostaddr_project_whitelist  -> never-ban/server-identity set (parity with legacy discovery)
+#       nftban_hostaddr_project_status     -> byte-for-byte == project_rbl (the exact scheduled-check input)
+# =============================================================================
+
+set -Eeuo pipefail
+
+# Prevent double-loading
+[[ -n "${_NFTBAN_HOSTADDR_LOADED:-}" ]] && return 0
+readonly _NFTBAN_HOSTADDR_LOADED=1
+
+# =============================================================================
+# CLASSIFICATION (pure; address string in, scope word out)
+# =============================================================================
+# scope in: loopback | private | ula | link-local | cgnat | documentation |
+#           multicast | unspecified | reserved | public
+nftban_hostaddr_scope() {
+    local a="$1"
+    if [[ "$a" == *:* ]]; then
+        # ---- IPv6 ----
+        local lc="${a,,}"
+        [[ "$lc" == "::1" ]] && { echo loopback; return; }
+        [[ "$lc" == "::" ]]  && { echo unspecified; return; }
+        # IPv4-mapped (::ffff:a.b.c.d) is normalized to IPv4 before this point;
+        # any remaining mapped form is treated by its textual class below.
+        case "$lc" in
+            fe8*|fe9*|fea*|feb*) echo link-local; return ;;   # fe80::/10
+            fc*|fd*)             echo ula; return ;;          # fc00::/7
+            ff*)                 echo multicast; return ;;    # ff00::/8
+            2001:db8:*|2001:0db8:*) echo documentation; return ;;  # 2001:db8::/32
+        esac
+        echo public; return
+    fi
+    # ---- IPv4 ----
+    case "$a" in
+        127.*)                 echo loopback; return ;;      # 127.0.0.0/8
+        0.0.0.0)               echo unspecified; return ;;
+        169.254.*)             echo link-local; return ;;    # 169.254.0.0/16
+        10.*|192.168.*)        echo private; return ;;
+        172.1[6-9].*|172.2[0-9].*|172.3[01].*) echo private; return ;;  # 172.16/12
+        100.6[4-9].*|100.[7-9][0-9].*|100.1[01][0-9].*|100.12[0-7].*) echo cgnat; return ;;  # 100.64/10
+        192.0.2.*|198.51.100.*|203.0.113.*) echo documentation; return ;;
+        22[4-9].*|23[0-9].*)   echo multicast; return ;;     # 224.0.0.0/4
+        24[0-9].*|25[0-5].*)   echo reserved; return ;;      # 240.0.0.0/4
+    esac
+    echo public
+}
+
+# Convenience: is this address public routable (RBL-eligible by scope alone)?
+nftban_hostaddr_is_public() {
+    [[ "$(nftban_hostaddr_scope "$1")" == "public" ]]
+}
+
+# =============================================================================
+# SCAN (internal) — one line per address, 7 TSV fields incl. iface up-state.
+#   address\tfamily\tscope\tiface\tstate\tsource\tup
+# Public API strips the 7th (up) field; projections use it.
+# =============================================================================
+_nftban_hostaddr_scan() {
+    # SAFE, not tampering: RESTORES the default whitespace IFS in a local scope so a
+    # strict-mode caller's IFS=$'\n\t' cannot break `set -- $line` word-splitting.
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
+    local IFS=$' \t\n'   # safe under a strict-mode caller (IFS=$'\n\t')
+    command -v ip >/dev/null 2>&1 || return 0
+
+    # Set of operational/up interfaces (names only; strip @ suffix like eth0@if2)
+    local up_ifaces=" "
+    local _l _n
+    while IFS= read -r _l; do
+        _n="${_l#*: }"; _n="${_n%%:*}"; _n="${_n%%@*}"
+        [[ -n "$_n" ]] && up_ifaces+="$_n "
+    done < <(ip -o link show up 2>/dev/null)
+
+    while IFS= read -r _l; do
+        [[ -z "$_l" ]] && continue
+        # shellcheck disable=SC2086  # deliberate word-split on the `ip -o` line
+        set -- $_l
+        # $1=<idx:> $2=<iface> $3=<inet|inet6> $4=<addr/plen>
+        [[ $# -ge 4 ]] || continue
+        local iface="$2" fam3="$3" addrp="$4" family address
+        case "$fam3" in
+            inet)  family=ipv4 ;;
+            inet6) family=ipv6 ;;
+            *) continue ;;
+        esac
+        iface="${iface%%@*}"
+        address="${addrp%%/*}"
+        # Normalize IPv4-mapped IPv6 (::ffff:1.2.3.4) -> IPv4 consistently.
+        if [[ "$family" == "ipv6" && "$address" == ::ffff:*.*.*.* ]]; then
+            address="${address##*:}"; family=ipv4
+        fi
+        local scope; scope="$(nftban_hostaddr_scope "$address")"
+        # Address state from flags on the same line.
+        local state=preferred
+        case " $_l " in
+            *" tentative "*|*" dadfailed "*) state=tentative ;;
+            *" deprecated "*)                state=deprecated ;;
+        esac
+        if [[ "$state" == "preferred" ]]; then
+            case " $_l " in *" temporary "*|*" mngtmpaddr "*) state=temporary ;; esac
+        fi
+        local up=no
+        [[ "$up_ifaces" == *" $iface "* ]] && up=yes
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$address" "$family" "$scope" "$iface" "$state" "interface" "$up"
+    done < <(ip -o addr show 2>/dev/null)
+}
+
+# =============================================================================
+# PUBLIC INVENTORY — classified, deduped, deterministic. TSV or JSON.
+# =============================================================================
+nftban_hostaddr_inventory() {
+    local json=0
+    [[ "${1:-}" == "--json" ]] && json=1
+
+    # Dedup by full record (address+family+scope+iface+state), deterministic sort.
+    local rows; rows="$(_nftban_hostaddr_scan | cut -f1-6 | sort -u)"
+
+    if [[ $json -eq 0 ]]; then
+        [[ -n "$rows" ]] && printf '%s\n' "$rows"
+        return 0
+    fi
+
+    # JSON: array of objects, same fields + ordering semantics.
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
+    local IFS=$'\n' first=1 a f s i st so
+    printf '['
+    while IFS=$'\t' read -r a f s i st so; do
+        [[ -z "$a" ]] && continue
+        [[ $first -eq 1 ]] || printf ','
+        first=0
+        printf '{"address":"%s","family":"%s","scope":"%s","iface":"%s","state":"%s","source":"%s"}' \
+            "$a" "$f" "$s" "$i" "$st" "$so"
+    done <<< "$rows"
+    printf ']\n'
+}
+
+# =============================================================================
+# PROJECTIONS (consumer policy — thin filters over the neutral scan)
+# =============================================================================
+
+# RBL: public routable self IPv4+IPv6 only; exclude loopback/private/ULA/CGNAT/
+# link-local/multicast/unspecified/reserved/documentation + tentative/deprecated/
+# temporary + down-interface. Full addresses, one per line, deduped, no tags.
+nftban_hostaddr_project_rbl() {
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
+    local IFS=$' \t\n'
+    _nftban_hostaddr_scan | awk -F'\t' '
+        $3=="public" && $5=="preferred" && $7=="yes" { print $1 }
+    ' | sort -u
+}
+
+# Status: exactly the RBL scheduled-check input (no separate discoverer).
+nftban_hostaddr_project_status() {
+    nftban_hostaddr_project_rbl
+}
+
+# Whitelist: never-ban / server-identity set. Parity with the legacy
+# `nftban_get_interface_ips` contract: every interface address EXCEPT loopback
+# (private/ULA/link-local/temporary/down included — never-ban is intentionally
+# broad). Loopback + session are added by the whitelist consumer, not here.
+nftban_hostaddr_project_whitelist() {
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
+    local IFS=$' \t\n'
+    _nftban_hostaddr_scan | awk -F'\t' '
+        $3!="loopback" { print $1 }
+    ' | sort -u
+}
+
+# =============================================================================
+# EXPORTS
+# =============================================================================
+export -f nftban_hostaddr_scope
+export -f nftban_hostaddr_is_public
+export -f _nftban_hostaddr_scan
+export -f nftban_hostaddr_inventory
+export -f nftban_hostaddr_project_rbl
+export -f nftban_hostaddr_project_status
+export -f nftban_hostaddr_project_whitelist

--- a/cli/lib/nftban/core/nftban_rbl.sh
+++ b/cli/lib/nftban/core/nftban_rbl.sh
@@ -43,6 +43,14 @@ readonly NFTBAN_RBL_CORE_LOADED=1
 # Determine library path
 _NFTBAN_RBL_LIB_DIR="${NFTBAN_LIB_DIR:-/usr/lib/nftban}"
 
+# v1.220.0: shared host-address inventory authority (DISCOVER ONCE / CLASSIFY ONCE /
+# PROJECT PER CONSUMER). RBL self-IP discovery + public classification route through
+# this; RBL never re-implements `ip … addr show` self-IP discovery.
+if [[ -f "${_NFTBAN_RBL_LIB_DIR}/core/nftban_hostaddr.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${_NFTBAN_RBL_LIB_DIR}/core/nftban_hostaddr.sh" || return 1
+fi
+
 # Load timestamp library (for nftban_timestamp, nftban_timestamp_unix)
 if [[ -f "${_NFTBAN_RBL_LIB_DIR}/lib/nftban_timestamp.sh" ]]; then
     # shellcheck source=/dev/null
@@ -120,69 +128,67 @@ nftban_rbl_log() {
 # =============================================================================
 
 nftban_rbl_get_public_ips() {
-    # Auto-discover public IPs from network interfaces
-    # Output: One IP per line
-
-    local ips=()
-
-    # Get all IPv4 addresses from interfaces (excluding loopback)
-    while IFS= read -r ip; do
-        if nftban_rbl_is_public_ip "$ip"; then
-            ips+=("$ip")
-        fi
-    done < <(ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '^127\.')
-
-    # Get all IPv6 addresses if enabled (excluding link-local and loopback)
+    # Auto-discover public routable self IPs (IPv4 + IPv6) for RBL self-monitoring.
+    # v1.220.0: single source of truth — the host-address inventory authority's RBL
+    # projection (public + preferred + up-interface, full addresses, deduped). No
+    # inline `ip … addr show` here. IPv6 gate honored: drop v6 records when disabled.
+    # Output: one full address per line.
     if [[ "${NFTBAN_RBL_CHECK_IPV6:-YES}" == "YES" ]]; then
-        while IFS= read -r ip; do
-            if nftban_rbl_is_public_ip "$ip"; then
-                ips+=("$ip")
-            fi
-        done < <(ip -6 addr show | grep -oP '(?<=inet6\s)[0-9a-f:]+' | grep -v '^::1' | grep -v '^fe80:')
+        nftban_hostaddr_project_rbl
+    else
+        # IPv4 only: exclude any address containing ':'
+        nftban_hostaddr_project_rbl | grep -v ':'
     fi
-
-    # Remove duplicates and output
-    printf '%s\n' "${ips[@]}" | sort -u
 }
 
 nftban_rbl_get_critical_ips() {
-    # Get critical IPs from configuration
-    # Format: NFTBAN_RBL_CRITICAL_IPS="1.2.3.4:mail,5.6.7.8:web"
-    # Output: IP:tag (one per line)
-
+    # Get operator-configured critical IPs. v1.220.0: IPv6-SAFE parsing.
+    #   Canonical (new):  NFTBAN_RBL_CRITICAL_IPS="2a01:...::1|mail,203.0.113.5|web"
+    #   Legacy (v4-only): NFTBAN_RBL_CRITICAL_IPS="1.2.3.4:mail,5.6.7.8:web"
+    # Output: "<ip>\t<tag>" (one per line; tag may be empty). NEVER splits an IPv6
+    # address at a colon. Legacy IPv4 "ip:tag" is still read (with a one-time warn);
+    # malformed entries are passed through as a bare IP (not silently reinterpreted).
     if [[ -z "${NFTBAN_RBL_CRITICAL_IPS:-}" ]]; then
         return 0
     fi
 
-    # Split by comma and output
-    echo "$NFTBAN_RBL_CRITICAL_IPS" | tr ',' '\n' | grep -v '^$'
+    local _legacy_seen=0 entry ip tag
+    # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
+    local IFS=','
+    for entry in ${NFTBAN_RBL_CRITICAL_IPS}; do
+        # trim surrounding whitespace
+        entry="${entry#"${entry%%[![:space:]]*}"}"
+        entry="${entry%"${entry##*[![:space:]]}"}"
+        [[ -z "$entry" ]] && continue
+        if [[ "$entry" == *"|"* ]]; then
+            # New IPv6-safe format: ip|tag (ip may be IPv6 with colons)
+            ip="${entry%%|*}"
+            tag="${entry#*|}"
+        elif [[ "$entry" == *:*:* ]]; then
+            # Two or more colons → an IPv6 address with NO tag. Do NOT split.
+            ip="$entry"; tag=""
+        elif [[ "$entry" == *:* ]]; then
+            # Exactly one colon: legacy IPv4 "ip:tag".
+            ip="${entry%%:*}"; tag="${entry#*:}"
+            _legacy_seen=1
+        else
+            ip="$entry"; tag=""
+        fi
+        printf '%s\t%s\n' "$ip" "$tag"
+    done
+
+    if [[ $_legacy_seen -eq 1 ]]; then
+        nftban_rbl_log "WARN" "NFTBAN_RBL_CRITICAL_IPS uses the legacy IPv4 'ip:tag' format; migrate to the IPv6-safe 'ip|tag' format (colon-tag cannot hold an IPv6 address)." 2>/dev/null || true
+    fi
 }
 
 nftban_rbl_is_public_ip() {
-    # Check if IP is public (not private/loopback)
-    # Args: $1 = IP address (IPv4 or IPv6)
-    # Return: 0 if public, 1 if private
-
-    local ip="$1"
-
-    # IPv4 private ranges
-    if [[ "$ip" =~ ^10\. ]] ||              # 10.0.0.0/8
-       [[ "$ip" =~ ^172\.(1[6-9]|2[0-9]|3[0-1])\. ]] ||  # 172.16.0.0/12
-       [[ "$ip" =~ ^192\.168\. ]] ||        # 192.168.0.0/16
-       [[ "$ip" =~ ^127\. ]] ||             # 127.0.0.0/8 (loopback)
-       [[ "$ip" =~ ^169\.254\. ]]; then     # 169.254.0.0/16 (link-local)
-        return 1
-    fi
-
-    # IPv6 private/special ranges
-    if [[ "$ip" =~ ^::1$ ]] ||              # Loopback
-       [[ "$ip" =~ ^fe80: ]] ||             # Link-local
-       [[ "$ip" =~ ^fc00: ]] ||             # Unique local (ULA)
-       [[ "$ip" =~ ^fd00: ]]; then          # Unique local (ULA)
-        return 1
-    fi
-
-    return 0
+    # Check if IP is public routable (not private/loopback/special).
+    # v1.220.0: CLASSIFY ONCE — delegate to the host-address inventory authority so
+    # RBL and every other consumer share identical scope classification (fixes the
+    # legacy ULA fc00::/7 gap + adds CGNAT/doc/multicast/reserved).
+    # Args: $1 = IP address (IPv4 or IPv6). Return: 0 if public, 1 otherwise.
+    nftban_hostaddr_is_public "$1"
 }
 
 nftban_rbl_reverse_ip() {
@@ -1557,13 +1563,20 @@ nftban_rbl_status() {
         timer_status="disabled"
     fi
 
-    # Count monitored IPs (auto-discovered)
+    # Count monitored IPs (auto-discovered). v1.220.0: the EXACT scheduled-check
+    # input — the status projection == the RBL projection == what the timer checks.
+    # No separate status discoverer, no inline `ip … addr show`.
     local monitored_ipv4=0 monitored_ipv6=0
     if [[ "${NFTBAN_RBL_ENABLED}" == "YES" ]]; then
-        monitored_ipv4=$(ip -4 addr show 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '^127\.' | sort -u | wc -l)
-        if [[ "${NFTBAN_RBL_CHECK_IPV6:-YES}" == "YES" ]]; then
-            monitored_ipv6=$(ip -6 addr show 2>/dev/null | grep -oP '(?<=inet6\s)[0-9a-f:]+' | grep -v '^::1' | grep -v '^fe80:' | grep -v '^fc00:' | grep -v '^fd00:' | sort -u | wc -l)
-        fi
+        local _mon_ip
+        while IFS= read -r _mon_ip; do
+            [[ -z "$_mon_ip" ]] && continue
+            if [[ "$_mon_ip" == *:* ]]; then
+                monitored_ipv6=$((monitored_ipv6 + 1))
+            else
+                monitored_ipv4=$((monitored_ipv4 + 1))
+            fi
+        done < <(nftban_rbl_get_public_ips)
     fi
     local monitored_total=$((monitored_ipv4 + monitored_ipv6))
 

--- a/cli/lib/nftban/core/nftban_system_ip.sh
+++ b/cli/lib/nftban/core/nftban_system_ip.sh
@@ -37,6 +37,11 @@ readonly NFTBAN_SYSTEM_IP_LOADED=1
 if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_file_ops.sh" ]]; then
     source "${NFTBAN_LIB_DIR}/core/nftban_file_ops.sh" || return 1
 fi
+# v1.220.0: shared host-address inventory authority — the whitelist discovery source
+# routes through its whitelist projection (DISCOVER ONCE). No behavior change.
+if [[ -f "${NFTBAN_LIB_DIR}/core/nftban_hostaddr.sh" ]]; then
+    source "${NFTBAN_LIB_DIR}/core/nftban_hostaddr.sh" || return 1
+fi
 # v1.18.0: IPC library for daemon communication
 # shellcheck source=/dev/null
 source "${NFTBAN_LIB_DIR}/lib/nft_ipc.sh" 2>/dev/null || true
@@ -142,8 +147,17 @@ nftban_get_current_user_ip() {
 # =============================================================================
 
 nftban_get_interface_ips() {
-    # Get all IPv4 and IPv6 addresses from all interfaces
-    # Excludes 127.0.0.1 and ::1 (handled separately)
+    # Get all IPv4 and IPv6 addresses from all interfaces (excludes loopback).
+    # v1.220.0: DISCOVER ONCE — delegate to the host-address inventory authority's
+    # whitelist projection (never-ban/server-identity: every interface address except
+    # loopback, including private/ULA/link-local, deduped, deterministic). Behavior is
+    # byte-identical to the legacy `ip -o addr show | awk … | grep -v 127/::1 | sort -u`
+    # (parity-locked by test). Loopback + session are added by the caller, as before.
+    if declare -F nftban_hostaddr_project_whitelist >/dev/null 2>&1; then
+        nftban_hostaddr_project_whitelist
+        return
+    fi
+    # Fallback (authority unavailable): legacy inline discovery, unchanged.
     ip -o addr show 2>/dev/null | \
         awk '/inet/ {gsub(/\/.*/, "", $4); print $4}' | \
         grep -v "^127\." | \

--- a/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
+++ b/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.220.0 PR-B: shared host-address inventory authority + RBL migration
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_shared_address_authority_v220_0_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-10"
+# meta:description="Locks the v1.220.0 PR-B contract: core/nftban_hostaddr.sh is the single classified host-address inventory authority (DISCOVER ONCE / CLASSIFY ONCE / PROJECT PER CONSUMER). Uses a stubbed `ip` to drive a fixed interface set and asserts: full IPv4/IPv6 preserved (no first-colon 2a01 truncation, no ip:tag), scope classification (public/private/ula/cgnat/link-local/loopback/multicast/doc), RBL projection excludes non-public + tentative/deprecated/temporary + down-interface + dedups, status==rbl projection, whitelist projection parity vs legacy get_interface_ips, IPv6-safe critical-IP parsing (legacy v4 + new pipe), false-clean fix (degraded never renders/persists as clean; inventory-failure => not clean; rc contract 0/1/2), and the anti-duplication source guards. Shell-only; RBL stays observe-only; daemon byte-identical."
+# meta:input="Stubbed `ip` fixtures + repo source files"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,sort"
+# meta:inventory.files="cli/lib/nftban/core/nftban_hostaddr.sh,cli/lib/nftban/core/nftban_rbl.sh,cli/lib/nftban/cli/cmd_rbl.sh,cli/lib/nftban/core/nftban_system_ip.sh"
+# meta:inventory.binaries="bash,awk,grep,sort"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+# Coding-standard header requires this line; the harness itself runs lenient (set +eE
+# below) so failing assertions accumulate instead of aborting.
+set -Eeuo pipefail
+set +eE
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban"
+HOSTADDR="$NFTBAN_LIB_DIR/core/nftban_hostaddr.sh"
+RBL_CORE="$NFTBAN_LIB_DIR/core/nftban_rbl.sh"
+CMD_RBL="$NFTBAN_LIB_DIR/cli/cmd_rbl.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+has(){ [[ "$1" == *"$2"* ]]; }
+# line-exact membership (an address is a whole line, not a substring — '::1' must
+# not match inside '2a01:…::1').
+hasline(){ printf '%s\n' "$1" | grep -qxF "$2"; }
+
+# ---------------------------------------------------------------------------
+# Stubbed `ip`: a fixed interface set exercising every classification branch.
+#   eth0 (up):  public v4, private v4, CGNAT v4, public v6 x2, ULA v6, link-local
+#               v6, temporary v6, tentative v6
+#   eth1 (up):  duplicate of the public v4 (dedup test)
+#   down0 (DOWN): a public v4 on a down interface (must be excluded from RBL)
+#   lo (up):    loopback v4/v6
+# ---------------------------------------------------------------------------
+ip() {
+  local joined="$*"
+  if [[ "$joined" == *"link show up"* ]]; then
+    cat <<'EOF'
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+EOF
+    return 0
+  fi
+  if [[ "$joined" == *"-o addr show"* || "$joined" == "-o addr show" ]]; then
+    cat <<'EOF'
+1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+1: lo    inet6 ::1/128 scope host \       valid_lft forever preferred_lft forever
+2: eth0    inet 46.225.150.67/24 brd 46.225.150.255 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.0.0.5/24 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 100.64.0.9/10 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet6 2a01:4f8:c014:5ee1::1/64 scope global \       valid_lft forever preferred_lft forever
+2: eth0    inet6 2a01:4f8:c014:5ee1::2/64 scope global \       valid_lft forever preferred_lft forever
+2: eth0    inet6 fd12::9/64 scope global \       valid_lft forever preferred_lft forever
+2: eth0    inet6 fe80::1/64 scope link \       valid_lft forever preferred_lft forever
+2: eth0    inet6 2a01:4f8:c014:5ee1::dead/64 scope global temporary dynamic \       valid_lft 600sec preferred_lft 600sec
+2: eth0    inet6 2a01:4f8:c014:5ee1::beef/64 scope global tentative \       valid_lft forever preferred_lft forever
+4: eth1    inet 46.225.150.67/24 scope global eth1\       valid_lft forever preferred_lft forever
+3: down0    inet 8.8.4.4/24 scope global down0\       valid_lft forever preferred_lft forever
+EOF
+    return 0
+  fi
+  return 0
+}
+export -f ip
+
+# shellcheck source=/dev/null
+source "$HOSTADDR"
+set +eE   # the lib enables set -e when sourced; keep the harness lenient
+
+echo "=== v1.220.0 shared host-address inventory authority ==="
+
+RBL="$(nftban_hostaddr_project_rbl)"
+WL="$(nftban_hostaddr_project_whitelist)"
+STATUS="$(nftban_hostaddr_project_status)"
+
+# T1 public IPv4 selected
+hasline "$RBL" "46.225.150.67" && ok "T1 public IPv4 in RBL projection" || no "T1 public IPv4 missing"
+
+# T2 full compressed IPv6 preserved intact (no 2a01 truncation)
+hasline "$RBL" "2a01:4f8:c014:5ee1::1" && ok "T2 full IPv6 preserved (::1)" || no "T2 IPv6 ::1 truncated/missing"
+{ ! hasline "$RBL" "2a01"; } && ok "T2b no '2a01' truncation" || no "T2b IPv6 truncated to 2a01"
+
+# T3 multiple distinct IPv6 preserved
+hasline "$RBL" "2a01:4f8:c014:5ee1::2" && ok "T3 second distinct IPv6 preserved" || no "T3 second IPv6 missing"
+
+# T4 private IPv4 excluded from RBL, retained by whitelist
+{ ! hasline "$RBL" "10.0.0.5"; } && hasline "$WL" "10.0.0.5" && ok "T4 private v4: RBL-excluded, whitelist-kept" || no "T4 private v4 policy wrong"
+
+# T5 ULA excluded from RBL, retained by whitelist
+{ ! hasline "$RBL" "fd12::9"; } && hasline "$WL" "fd12::9" && ok "T5 ULA: RBL-excluded, whitelist-kept" || no "T5 ULA policy wrong"
+
+# T6 CGNAT excluded from RBL
+{ ! hasline "$RBL" "100.64.0.9"; } && ok "T6 CGNAT excluded from RBL" || no "T6 CGNAT leaked into RBL"
+
+# T7 loopback + link-local excluded from RBL
+{ ! hasline "$RBL" "127.0.0.1" && ! hasline "$RBL" "::1" && ! hasline "$RBL" "fe80::1"; } && ok "T7 loopback+link-local excluded from RBL" || no "T7 loopback/link-local leaked"
+
+# T8 tentative / temporary / down-interface excluded from RBL
+{ ! hasline "$RBL" "2a01:4f8:c014:5ee1::beef" && ! hasline "$RBL" "2a01:4f8:c014:5ee1::dead" && ! hasline "$RBL" "8.8.4.4"; } && ok "T8 tentative/temporary/down-iface excluded" || no "T8 excluded-state leaked into RBL"
+
+# T9 duplicate address (eth0+eth1) -> single RBL entry
+[[ "$(printf '%s\n' "$RBL" | grep -c '^46\.225\.150\.67$')" == "1" ]] && ok "T9 duplicate address deduped to one" || no "T9 duplicate not deduped"
+
+# T10 no ip:tag / colon-tag serialization in any projection line
+{ ! has "$RBL" ":ipv4" && ! has "$RBL" ":ipv6"; } && ok "T10 no :ipv4/:ipv6 tag encoding" || no "T10 colon-tag encoding present"
+
+# T11/T12 status projection == RBL projection (same full-address input)
+[[ "$STATUS" == "$RBL" ]] && ok "T11/T12 status projection == RBL scheduled input" || no "T11/T12 status != RBL projection"
+
+# T16 whitelist projection parity vs legacy get_interface_ips
+LEGACY="$(ip -o addr show 2>/dev/null | awk '/inet/ {gsub(/\/.*/, "", $4); print $4}' | grep -v '^127\.' | grep -v '^::1$' | sort -u)"
+[[ "$WL" == "$LEGACY" ]] && ok "T16 whitelist projection == legacy get_interface_ips (parity)" || { no "T16 whitelist parity broken"; diff <(echo "$LEGACY") <(echo "$WL") | head; }
+
+# scope classification spot-checks
+_scope_ok=1
+for pair in "46.225.150.67=public" "2a01:4f8::1=public" "10.0.0.5=private" "100.64.0.9=cgnat" \
+            "fd12::9=ula" "fcab::1=ula" "fe80::1=link-local" "169.254.1.1=link-local" \
+            "::1=loopback" "127.0.0.1=loopback" "ff02::1=multicast" "224.0.0.1=multicast" \
+            "192.0.2.9=documentation" "2001:db8::5=documentation"; do
+  a="${pair%=*}"; want="${pair#*=}"; got="$(nftban_hostaddr_scope "$a")"
+  [[ "$got" == "$want" ]] || { _scope_ok=0; echo "        scope($a)=$got want=$want"; }
+done
+[[ $_scope_ok -eq 1 ]] && ok "scope classification correct (incl ULA fc00::/7, CGNAT, doc)" || no "scope classification wrong"
+
+# inventory has no side effects (read-only): run twice, identical, no files written
+snap_before="$(ls -la /tmp 2>/dev/null | wc -l)"
+_a="$(nftban_hostaddr_inventory)"; _b="$(nftban_hostaddr_inventory)"
+snap_after="$(ls -la /tmp 2>/dev/null | wc -l)"
+[[ "$_a" == "$_b" && "$snap_before" == "$snap_after" ]] && ok "inventory deterministic + side-effect-free" || no "inventory non-deterministic or wrote files"
+
+# JSON projection carries same addresses
+J="$(nftban_hostaddr_inventory --json)"
+has "$J" '"address":"2a01:4f8:c014:5ee1::1"' && has "$J" '"scope":"public"' && ok "JSON inventory carries full fields" || no "JSON inventory malformed"
+
+# ---------------------------------------------------------------------------
+# Critical-IP IPv6-safe parsing (source RBL core; keep the stubbed ip)
+# ---------------------------------------------------------------------------
+# shellcheck source=/dev/null
+source "$RBL_CORE" 2>/dev/null || true
+set +eE   # the strict-mode lib flips set -e on when sourced; keep the harness lenient
+
+# T18 legacy IPv4 ip:tag still readable
+out="$(NFTBAN_RBL_CRITICAL_IPS='1.2.3.4:mail,5.6.7.8:web' nftban_rbl_get_critical_ips)"
+has "$out" $'1.2.3.4\tmail' && has "$out" $'5.6.7.8\tweb' && ok "T18 legacy IPv4 ip:tag critical config still read" || no "T18 legacy critical parse broke ($out)"
+
+# T19 IPv6-safe new format round-trip (never split IPv6 at colon)
+out="$(NFTBAN_RBL_CRITICAL_IPS='2a01:4f8:c014:5ee1::1|mail,203.0.113.5|web' nftban_rbl_get_critical_ips)"
+has "$out" $'2a01:4f8:c014:5ee1::1\tmail' && ok "T19 new ip|tag preserves full IPv6" || no "T19 new IPv6 critical parse wrong ($out)"
+out="$(NFTBAN_RBL_CRITICAL_IPS='2a01:4f8:c014:5ee1::1' nftban_rbl_get_critical_ips)"
+has "$out" $'2a01:4f8:c014:5ee1::1\t' && ! has "$out" $'2a01\t' && ok "T19b bare IPv6 critical not split at colon" || no "T19b bare IPv6 split ($out)"
+
+# is_public delegates to authority (classify once)
+nftban_rbl_is_public_ip 46.225.150.67 && ! nftban_rbl_is_public_ip fd12::9 && ok "is_public delegates to authority" || no "is_public delegation wrong"
+
+# get_public_ips (RBL projection) honors IPv6 gate
+g6="$(NFTBAN_RBL_CHECK_IPV6=YES nftban_rbl_get_public_ips)"
+g4="$(NFTBAN_RBL_CHECK_IPV6=NO  nftban_rbl_get_public_ips)"
+has "$g6" "2a01:4f8:c014:5ee1::1" && ! has "$g4" ":" && has "$g4" "46.225.150.67" && ok "get_public_ips honors IPv6 gate" || no "get_public_ips IPv6 gate wrong"
+
+# ---------------------------------------------------------------------------
+# T13/T14/T15 false-clean fix — drive nftban_cmd_rbl_server with stubbed checker
+# ---------------------------------------------------------------------------
+run_server() { # $1 = results string the checker returns ; prints verdict output + RC
+  local RESULTS="$1"
+  (
+    # shellcheck source=/dev/null
+    source "$RBL_CORE" 2>/dev/null || true
+    # shellcheck source=/dev/null
+    source "$CMD_RBL" 2>/dev/null || true
+    set +eE   # sourced strict-mode libs flip set -e; a nonzero rc must not abort us
+    export NFTBAN_RBL_CACHE_DIR; NFTBAN_RBL_CACHE_DIR="$(mktemp -d)"
+    hostname() { echo "test.example"; }
+    host() { return 0; }                             # no hostname A records
+    nftban_rbl_cache_get() { return 1; }             # force fresh path
+    nftban_rbl_cache_set() { cat >/dev/null; }
+    nftban_rbl_update_state() { :; }
+    nftban_rbl_check_new_listing() { return 1; }
+    nftban_rbl_send_alert() { :; }
+    nftban_rbl_check_ip_parallel() { printf '%s\n' "$RESULTS"; }
+    nftban_rbl_check_ip() { printf '%s\n' "$RESULTS"; }
+    export -f hostname host nftban_rbl_cache_get nftban_rbl_cache_set nftban_rbl_update_state \
+              nftban_rbl_check_new_listing nftban_rbl_send_alert nftban_rbl_check_ip_parallel nftban_rbl_check_ip
+    local rc=0
+    nftban_cmd_rbl_server check --fresh 2>&1 || rc=$?
+    echo "RC=$rc"
+  )
+}
+
+# T14 mixed clean + timeout => degraded verdict, never "All IPs are clean"
+DEG=$'RBL Check Results for: 46.225.150.67\n⏱️  TIMEOUT: dnsbl.inps.de\nSummary:\n  Listed: 0\n  Clean: 21\n  Timeout: 1\n  Degraded total: 1 (RBL coverage incomplete — NOT fully verified)'
+o="$(run_server "$DEG")"
+{ has "$o" "NOT fully verified" && ! has "$o" "All IPs are clean (fully verified"; } && ok "T14 degraded verdict, no false 'All IPs are clean'" || no "T14 false-clean not fixed ($(echo "$o" | tail -3 | tr '\n' '|'))"
+has "$o" "RC=2" && ok "T14b degraded rc=2" || no "T14b degraded rc not 2 ($(echo "$o" | tail -1))"
+
+# T13 all-error => not clean, rc=2
+ERR=$'RBL Check Results for: 46.225.150.67\n⏱️  ERROR: zen.spamhaus.org\nSummary:\n  Listed: 0\n  Clean: 0\n  Timeout: 1\n  Degraded total: 1 (RBL coverage incomplete — NOT fully verified)'
+o="$(run_server "$ERR")"
+{ ! has "$o" "All IPs are clean" && has "$o" "RC=2"; } && ok "T13 all-error => not clean, rc=2" || no "T13 all-error mishandled"
+
+# fully-verified clean => allowed, rc=0
+CLEAN=$'RBL Check Results for: 46.225.150.67\nSummary:\n  Listed: 0\n  Clean: 23\n  Timeout: 0'
+o="$(run_server "$CLEAN")"
+{ has "$o" "All IPs are clean (fully verified" && has "$o" "RC=0"; } && ok "fully-verified clean => rc=0 + clean verdict" || no "clean path wrong ($(echo "$o" | tail -2 | tr '\n' '|'))"
+
+# listed => warning + rc=1
+LISTED=$'RBL Check Results for: 46.225.150.67\nLISTED: zen.spamhaus.org\nSummary:\n  Listed: 1\n  Clean: 22'
+o="$(run_server "$LISTED")"
+{ has "$o" "on RBL blacklists" && has "$o" "RC=1"; } && ok "listed => warning + rc=1" || no "listed path wrong"
+
+# ---------------------------------------------------------------------------
+# Anti-duplication SOURCE guards
+# ---------------------------------------------------------------------------
+# G1: no new inline `ip … addr show` self-IP discovery in migrated RBL files
+#     (allow only the documented fallback comment references; assert the live
+#      discovery paths do not call `ip -[46] addr show` / `ip -o addr show`).
+# strip comment lines (POSIX: [[:space:]], not \s) before pattern-hunting
+strip_comments(){ grep -vE '^[[:space:]]*#'; }
+guard_no_inline() {
+  local f="$1"
+  grep -nE 'ip +-[46o] +addr +show' "$f" 2>/dev/null | strip_comments | grep -viE 'legacy|fallback'
+}
+g="$(guard_no_inline "$RBL_CORE")$(guard_no_inline "$CMD_RBL")"
+[[ -z "$g" ]] && ok "G1 no inline 'ip .. addr show' self-IP discovery in RBL files" || { no "G1 inline discovery remains"; echo "$g" | head; }
+
+# G2: no $ip:ipv6 / :ipv4 colon-tag encoding in migrated RBL files (code, not comments)
+g="$(grep -nE '\$ip:ipv6|\$ip:ipv4|:ipv6"|:ipv4"' "$CMD_RBL" "$RBL_CORE" 2>/dev/null | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#')"
+[[ -z "$g" ]] && ok "G2 no \$ip:ipv6 colon-tag encoding" || { no "G2 colon-tag encoding present"; echo "$g" | head; }
+
+# G3: RBL status + scheduled both consume the projection (get_public_ips)
+grep -q 'nftban_rbl_get_public_ips' "$CMD_RBL" && grep -q 'nftban_rbl_get_public_ips' "$RBL_CORE" \
+  && ok "G3 status + scheduled route through the projection" || no "G3 projection not shared"
+
+# G4: no direct watchlist insertion from self-IP monitoring paths
+g="$(grep -nE 'watchlist_add|watchlist.*>>|>> .*watchlist' "$CMD_RBL" | grep -iE 'self|monitor|discover|project_rbl')"
+[[ -z "$g" ]] && ok "G4 no self-IP insertion into watchlist" || { no "G4 self-IP writes watchlist"; echo "$g"; }
+
+# G5: authority is read-only (no nft/whitelist/state writes, no external IP fallback)
+g="$(grep -nE 'nft (add|delete|flush)|ipify|icanhazip|curl|wget|> /|>> ' "$HOSTADDR" | grep -vE '^\s*#')"
+[[ -z "$g" ]] && ok "G5 authority read-only (no nft/write/network)" || { no "G5 authority has side effects"; echo "$g"; }
+
+echo
+echo "=== RESULTS: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/install/systemd/nftban-rbl-check.service
+++ b/install/systemd/nftban-rbl-check.service
@@ -33,6 +33,12 @@ Group=nftban
 # Run RBL check with quiet mode and alert
 ExecStart=/usr/sbin/nftban rbl check --quiet --alert
 
+# v1.220.0 RBL rc contract: 0=fully-verified-clean, 1=listed, 2=degraded/not-fully-
+# verified. Listed and degraded are valid informational outcomes (new listings are
+# alerted in-band via --alert), NOT unit failures — so the timer is not marked failed
+# on a listing or a transient DNSBL timeout. Only an unexpected rc (>2) fails the unit.
+SuccessExitStatus=1 2
+
 # Logging
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
**v1.220.0 RBL truth train — PR-B.** Establishes ONE neutral host-address inventory authority and migrates RBL onto it, fixing the IPv6 false-clean + degraded-as-clean defects. **Invariant: DISCOVER ONCE · CLASSIFY ONCE · PROJECT PER CONSUMER** (locked by `OPEN_COMMON_HOST_ADDRESS_INVENTORY_AUTHORITY_AUDIT.md` §10 + RBL scope §§11–12).

**Classification:** shell/core/tests only · **0 Go · daemon byte-identical** · nft schema **1.84.0 unchanged** · RBL stays **observe-only** (no bans/nft writes, **not enabled**).

## The authority — `core/nftban_hostaddr.sh` (new, read-only)
No nft/whitelist/RBL/network writes; safe under strict caller IFS.
- `nftban_hostaddr_inventory [--json]` → classified TSV `address<TAB>family<TAB>scope<TAB>iface<TAB>state<TAB>source` (**no `ip:tag`**).
- Scope classification fixes the legacy gaps: **ULA `fc00::/7`** (was literal `fc00:`/`fd00:` only → missed `fd12:`, `fcab:`), **CGNAT `100.64/10`**, documentation nets, multicast, unspecified, reserved.
- Projections: `project_rbl` (public + preferred + up-interface, full addresses, deduped) · `project_whitelist` (never-ban parity) · `project_status` (== `project_rbl`).

## RBL migration (`nftban_rbl.sh`, `cmd_rbl.sh`)
- `get_public_ips` → `project_rbl`; `is_public_ip` → authority (classify once); status monitored-count → `project_rbl`; **retired the inline `ip … addr show`** self-IP blocks.
- **Deleted the `"$ip:ipv6"` encoding + first-colon split** — server-check **and** the scheduled path both truncated `2a01:…` to `2a01`; entries are now TAB-delimited (a TAB can't appear in an IP).
- Critical IPs: IPv6-safe `ip|tag` + legacy IPv4 `ip:tag` read-compat (one-time warn); **an IPv6 address is never split into a tag**.
- **False-clean fix:** 3-way per-IP verdict (listed/degraded/clean) across **both cache and fresh paths** — the legacy code counted only the fresh branch, so cached degraded scored 0/0 and printed the false "All IPs are clean". `✅ All IPs are clean` now requires **listed=0 AND degraded=0 AND every intended address checked AND inventory succeeded**; degraded/empty-inventory never renders or persists as clean. **rc contract 0=clean / 1=listed / 2=degraded.**
- `nftban-rbl-check.service`: `SuccessExitStatus=1 2` — listed/degraded are informational (alerting stays in-band via `--alert`), not systemd unit failures (rc-caller audit below).

## Whitelist (`nftban_system_ip.sh`)
`nftban_get_interface_ips` delegates to `project_whitelist`; **accepted set byte-identical** (parity test), legacy inline fallback retained. Management `99-management.conf` untouched.

## rc-contract caller audit
Only consumer of the scheduled `rbl check` exit code is `nftban-rbl-check.service` (`Type=oneshot`, no `OnFailure`, alerting in-band via `--alert`). Previously `listed`→rc1 already marked the unit failed; adding `degraded`→rc2 would newly mark common transient timeouts as failed. Fixed by `SuccessExitStatus=1 2` (both are valid informational outcomes). No shell caller branches on the rc.

## Tests + anti-duplication guards
`rbl_shared_address_authority_v220_0_test.sh` **31/31** — full IPv4/IPv6 preserved (no `2a01` truncation), scope classes, RBL exclusions (private/ULA/CGNAT/link-local/loopback/multicast/**tentative/deprecated/temporary/down-iface**), dedup, no `ip:tag`, status==scheduled input, **whitelist parity**, IPv6-safe critical parse (legacy + new), false-clean + rc contract, and source guards **G1–G5** (no inline `ip … addr show` in RBL, no `$ip:ipv6`, shared projection, no watchlist mutation, authority read-only). Regressions green: `rbl_false_clean_v150`, `rbl_seven_state_v206`, `rbl_enable_readiness`, `rbl_prereq_ifs_dns_utils_v219_1`, whitelist suites. shellcheck clean; FHS `--check` clean.

## Lab-first validation (controlled source, read-only — no install, no live DNSBL)
- **lab2 (Ubuntu 24.04 DEB):** suite 31/31; live `project_rbl` = `198.51.100.15` + **`2a01:4f9:c013:3f7a::1` (full IPv6)**; whitelist parity OK; RBL disabled + timer inactive; daemon active; validate rc0; 0 failed units.
- **lab4 (AlmaLinux 9.8 EL9 RPM):** suite 31/31; live `project_rbl` = `46.62.213.143` + **`2a01:4f9:c013:8c85::1` (full IPv6)**; whitelist parity OK; RBL disabled + timer inactive; daemon active; validate rc0; 0 failed units.

## Deferred (NOT PR-B)
PR-C (hostname/PTR/FCrDNS/operator status-UX/watchlist wording); the broad consumer consolidation (`OPEN_HOST_ADDRESS_INVENTORY_CONSUMER_CONSOLIDATION`, blocked until v1.220.0 fleet closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
