### PR TITLE
fix(enforce): v1.220.2 — non-public/self addresses can never enter a drop set (F1/F2/F3)

### DIFF
--- a/cmd/nftband/daemon_handlers_sync.go
+++ b/cmd/nftband/daemon_handlers_sync.go
@@ -31,6 +31,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/feeds"
 	"github.com/itcmsgr/nftban/internal/geoban"
 	"github.com/itcmsgr/nftban/internal/metrics"
+	"github.com/itcmsgr/nftban/internal/netutil"
 	"github.com/itcmsgr/nftban/internal/opqueue"
 	"github.com/itcmsgr/nftban/internal/ports"
 	"github.com/itcmsgr/nftban/internal/runtime"
@@ -212,12 +213,34 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 	if err != nil {
 		return SocketResponse{Success: false, Error: "failed to get/create blacklist_manual_ipv6 set: " + err.Error()}
 	}
+	// v1.220.2 F1: the file->kernel full-sync previously inserted every blacklist.d
+	// entry via raw nft.AddIPWithTimeout, bypassing the never-ban invariant enforced on
+	// backend.Ban/AddElement. Apply the SAME guards here so a persisted loopback/self/
+	// non-public address (e.g. from an older release, or a hand-edited blacklist.d) can
+	// never be re-materialized into a drop set: absolute address-class reject, then the
+	// membership exemption (whitelist/system/live-SSH/host-owned).
 	for _, ip := range blacklistIPv4Single {
+		if reject, reason := netutil.EnforcementClassReject(ip); reject {
+			log.Printf("[SYNC] SKIP blacklist.d IPv4 %s -> manual set: non-bannable class (%s)", ip, reason)
+			continue
+		}
+		if ok, reason := d.backend.IsExempt(ip); ok {
+			log.Printf("[SYNC] SKIP blacklist.d IPv4 %s -> manual set: never-ban exempt (%s)", ip, reason)
+			continue
+		}
 		if err := nft.AddIPWithTimeout(manualV4Set, ip, 0); err != nil {
 			log.Printf("[SYNC] Warning: blacklist.d IPv4 %s -> manual hash set: %v", ip, err)
 		}
 	}
 	for _, ip := range blacklistIPv6Single {
+		if reject, reason := netutil.EnforcementClassReject(ip); reject {
+			log.Printf("[SYNC] SKIP blacklist.d IPv6 %s -> manual set: non-bannable class (%s)", ip, reason)
+			continue
+		}
+		if ok, reason := d.backend.IsExempt(ip); ok {
+			log.Printf("[SYNC] SKIP blacklist.d IPv6 %s -> manual set: never-ban exempt (%s)", ip, reason)
+			continue
+		}
 		if err := nft.AddIPWithTimeout(manualV6Set, ip, 0); err != nil {
 			log.Printf("[SYNC] Warning: blacklist.d IPv6 %s -> manual hash set: %v", ip, err)
 		}
@@ -279,88 +302,88 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 			log.Printf("[SYNC] Memory pressure %s: skipping feeds", safety.GetMemoryPressureLevel())
 			feedsSkipped = true
 		} else {
-		_, _, dataDir, _ := getDaemonPaths()
-		feedsDir := dataDir + "/feeds"
+			_, _, dataDir, _ := getDaemonPaths()
+			feedsDir := dataDir + "/feeds"
 
-		// Check if feeds directory exists and has .txt files
-		if entries, err := os.ReadDir(feedsDir); err == nil && len(entries) > 0 {
-		// Load all feeds
-		ipv4Set, ipv6Set, ipv4CIDRSet, ipv6CIDRSet, _, feedErr := feeds.LoadAllFeeds(feedsDir)
-		if feedErr == nil {
-			// Pre-allocate slices with exact capacity to avoid reallocation overhead
-			// With 15,000+ CIDRs, this prevents ~14 slice doublings
-			ipv4CIDRs := make([]string, 0, len(ipv4Set)+len(ipv4CIDRSet))
-			ipv6CIDRs := make([]string, 0, len(ipv6Set)+len(ipv6CIDRSet))
-			for ip := range ipv4Set {
-				ipv4CIDRs = append(ipv4CIDRs, ip+"/32")
-			}
-			for cidr := range ipv4CIDRSet {
-				ipv4CIDRs = append(ipv4CIDRs, cidr)
-			}
-			for ip := range ipv6Set {
-				ipv6CIDRs = append(ipv6CIDRs, ip+"/128")
-			}
-			for cidr := range ipv6CIDRSet {
-				ipv6CIDRs = append(ipv6CIDRs, cidr)
-			}
+			// Check if feeds directory exists and has .txt files
+			if entries, err := os.ReadDir(feedsDir); err == nil && len(entries) > 0 {
+				// Load all feeds
+				ipv4Set, ipv6Set, ipv4CIDRSet, ipv6CIDRSet, _, feedErr := feeds.LoadAllFeeds(feedsDir)
+				if feedErr == nil {
+					// Pre-allocate slices with exact capacity to avoid reallocation overhead
+					// With 15,000+ CIDRs, this prevents ~14 slice doublings
+					ipv4CIDRs := make([]string, 0, len(ipv4Set)+len(ipv4CIDRSet))
+					ipv6CIDRs := make([]string, 0, len(ipv6Set)+len(ipv6CIDRSet))
+					for ip := range ipv4Set {
+						ipv4CIDRs = append(ipv4CIDRs, ip+"/32")
+					}
+					for cidr := range ipv4CIDRSet {
+						ipv4CIDRs = append(ipv4CIDRs, cidr)
+					}
+					for ip := range ipv6Set {
+						ipv6CIDRs = append(ipv6CIDRs, ip+"/128")
+					}
+					for cidr := range ipv6CIDRSet {
+						ipv6CIDRs = append(ipv6CIDRs, cidr)
+					}
 
-			// v1.35.0: Global feed entry cap — reject feeds that would exceed limit
-			const maxFeedEntries = 1_000_000 // Safety cap: 1M total CIDRs
-			totalFeedCIDRs := len(ipv4CIDRs) + len(ipv6CIDRs)
-			if totalFeedCIDRs > maxFeedEntries {
-				log.Printf("[SYNC] WARNING: Feed total %d exceeds cap %d — truncating to cap",
-					totalFeedCIDRs, maxFeedEntries)
-				if len(ipv4CIDRs) > maxFeedEntries {
-					ipv4CIDRs = ipv4CIDRs[:maxFeedEntries]
+					// v1.35.0: Global feed entry cap — reject feeds that would exceed limit
+					const maxFeedEntries = 1_000_000 // Safety cap: 1M total CIDRs
+					totalFeedCIDRs := len(ipv4CIDRs) + len(ipv6CIDRs)
+					if totalFeedCIDRs > maxFeedEntries {
+						log.Printf("[SYNC] WARNING: Feed total %d exceeds cap %d — truncating to cap",
+							totalFeedCIDRs, maxFeedEntries)
+						if len(ipv4CIDRs) > maxFeedEntries {
+							ipv4CIDRs = ipv4CIDRs[:maxFeedEntries]
+						}
+						remaining := maxFeedEntries - len(ipv4CIDRs)
+						if len(ipv6CIDRs) > remaining {
+							ipv6CIDRs = ipv6CIDRs[:remaining]
+						}
+						totalFeedCIDRs = len(ipv4CIDRs) + len(ipv6CIDRs)
+					}
+
+					// Memory safety check before loading feeds into nftables
+					// CIDR merging can use 3x memory temporarily
+					const bytesPerCIDR = 300 // conservative estimate
+					estimatedFeedBytes := int64(totalFeedCIDRs) * bytesPerCIDR
+					if !safety.CanAllocate(estimatedFeedBytes) {
+						log.Printf("[SYNC] Warning: Skipping feeds - insufficient memory for %d CIDRs (need ~%s)",
+							totalFeedCIDRs, safety.FormatBytes(estimatedFeedBytes))
+						// Track protection trigger for visibility
+						feedsSkipped = true
+						feedsCIDRCount = totalFeedCIDRs
+						feedsMemNeeded = estimatedFeedBytes
+						// Skip feeds but continue with sync - don't fail entirely
+					} else {
+						// INC3: queue feed CIDRs for the unified canonical replace (feeds + geoban +
+						// blacklist.d CIDRs in ONE flush-first replace; replaceSetElementsViaFile is
+						// the sole writer of the shared blacklist_ipv4/_ipv6 interval sets).
+						if len(ipv4CIDRs) > 0 {
+							unifiedBlacklistV4 = append(unifiedBlacklistV4, ipv4CIDRs...)
+							feedsIPv4Loaded = len(ipv4CIDRs)
+							log.Printf("[SYNC] Feeds IPv4: %d input CIDRs queued for unified replace", len(ipv4CIDRs))
+						}
+
+						// IPv6 feeds → unified replace
+						if len(ipv6CIDRs) > 0 {
+							unifiedBlacklistV6 = append(unifiedBlacklistV6, ipv6CIDRs...)
+							feedsIPv6Loaded = len(ipv6CIDRs)
+							log.Printf("[SYNC] Feeds IPv6: %d input CIDRs queued for unified replace", len(ipv6CIDRs))
+						}
+						// Memory cleanup: clear CIDR slices after loading to nftables
+						// These slices can hold 100-200MB that's no longer needed
+						ipv4CIDRs = nil
+						ipv6CIDRs = nil
+					} // end else CanAllocate
+					// Memory cleanup: clear feed maps to allow garbage collection
+					// These maps can hold 400-800MB and are no longer needed after conversion
+					ipv4Set = nil
+					ipv6Set = nil
+					ipv4CIDRSet = nil
+					ipv6CIDRSet = nil
 				}
-				remaining := maxFeedEntries - len(ipv4CIDRs)
-				if len(ipv6CIDRs) > remaining {
-					ipv6CIDRs = ipv6CIDRs[:remaining]
-				}
-				totalFeedCIDRs = len(ipv4CIDRs) + len(ipv6CIDRs)
 			}
-
-			// Memory safety check before loading feeds into nftables
-			// CIDR merging can use 3x memory temporarily
-			const bytesPerCIDR = 300 // conservative estimate
-			estimatedFeedBytes := int64(totalFeedCIDRs) * bytesPerCIDR
-			if !safety.CanAllocate(estimatedFeedBytes) {
-				log.Printf("[SYNC] Warning: Skipping feeds - insufficient memory for %d CIDRs (need ~%s)",
-					totalFeedCIDRs, safety.FormatBytes(estimatedFeedBytes))
-				// Track protection trigger for visibility
-				feedsSkipped = true
-				feedsCIDRCount = totalFeedCIDRs
-				feedsMemNeeded = estimatedFeedBytes
-				// Skip feeds but continue with sync - don't fail entirely
-			} else {
-			// INC3: queue feed CIDRs for the unified canonical replace (feeds + geoban +
-			// blacklist.d CIDRs in ONE flush-first replace; replaceSetElementsViaFile is
-			// the sole writer of the shared blacklist_ipv4/_ipv6 interval sets).
-			if len(ipv4CIDRs) > 0 {
-				unifiedBlacklistV4 = append(unifiedBlacklistV4, ipv4CIDRs...)
-				feedsIPv4Loaded = len(ipv4CIDRs)
-				log.Printf("[SYNC] Feeds IPv4: %d input CIDRs queued for unified replace", len(ipv4CIDRs))
-			}
-
-			// IPv6 feeds → unified replace
-			if len(ipv6CIDRs) > 0 {
-				unifiedBlacklistV6 = append(unifiedBlacklistV6, ipv6CIDRs...)
-				feedsIPv6Loaded = len(ipv6CIDRs)
-				log.Printf("[SYNC] Feeds IPv6: %d input CIDRs queued for unified replace", len(ipv6CIDRs))
-			}
-			// Memory cleanup: clear CIDR slices after loading to nftables
-			// These slices can hold 100-200MB that's no longer needed
-			ipv4CIDRs = nil
-			ipv6CIDRs = nil
-			} // end else CanAllocate
-			// Memory cleanup: clear feed maps to allow garbage collection
-			// These maps can hold 400-800MB and are no longer needed after conversion
-			ipv4Set = nil
-			ipv6Set = nil
-			ipv4CIDRSet = nil
-			ipv6CIDRSet = nil
-		}
-		}
 		} // end else ShouldSkipFeeds
 	} // end if !quickMode (feeds)
 
@@ -375,61 +398,61 @@ func (d *Daemon) handleSyncRequest(params map[string]any) SocketResponse {
 			log.Printf("[SYNC] Memory pressure %s: skipping geoban", safety.GetMemoryPressureLevel())
 			geobanSkipped = true
 		} else {
-		geobanDir := configDir + "/geoban.d"
+			geobanDir := configDir + "/geoban.d"
 
-		// Check if geoban directory exists and has ban files (50-ban-*.conf)
-		if entries, err := os.ReadDir(geobanDir); err == nil {
-		hasBanFiles := false
-		for _, e := range entries {
-			if strings.HasPrefix(e.Name(), "50-ban-") && strings.HasSuffix(e.Name(), ".conf") {
-				hasBanFiles = true
-				break
-			}
-		}
-
-		if hasBanFiles {
-			// Load all geoban countries
-			geobanData, geoErr := geoban.Build(geobanDir, nil) // nil = load all
-			if geoErr == nil && geobanData != nil {
-				// Memory safety check before loading geoban into nftables
-				// Geoban can have 20K+ CIDRs per country (CN, RU, etc.)
-				const bytesPerCIDR = 300 // conservative estimate
-				totalGeoCIDRs := len(geobanData.IPv4) + len(geobanData.IPv6)
-				estimatedGeoBytes := int64(totalGeoCIDRs) * bytesPerCIDR
-				if !safety.CanAllocate(estimatedGeoBytes) {
-					log.Printf("[SYNC] Warning: Skipping geoban - insufficient memory for %d CIDRs (need ~%s)",
-						totalGeoCIDRs, safety.FormatBytes(estimatedGeoBytes))
-					// Track protection trigger for visibility
-					geobanSkipped = true
-					geobanCIDRCount = totalGeoCIDRs
-					geobanMemNeeded = estimatedGeoBytes
-					// Skip geoban but continue with sync - don't fail entirely
-				} else {
-				// INC3: queue geoban CIDRs for the unified canonical replace (feeds +
-				// geoban + blacklist.d CIDRs in ONE flush-first replace — closes the
-				// pre-existing feed-vs-geoban clobber where the second replace wiped the
-				// first). All ban sources share blacklist_ipv4/_ipv6.
-				if len(geobanData.IPv4) > 0 {
-					unifiedBlacklistV4 = append(unifiedBlacklistV4, geobanData.IPv4...)
-					geobanIPv4Loaded = len(geobanData.IPv4)
-					log.Printf("[SYNC] Geoban IPv4: %d input CIDRs queued for unified replace", len(geobanData.IPv4))
+			// Check if geoban directory exists and has ban files (50-ban-*.conf)
+			if entries, err := os.ReadDir(geobanDir); err == nil {
+				hasBanFiles := false
+				for _, e := range entries {
+					if strings.HasPrefix(e.Name(), "50-ban-") && strings.HasSuffix(e.Name(), ".conf") {
+						hasBanFiles = true
+						break
+					}
 				}
 
-				// IPv6 geoban → unified replace
-				if len(geobanData.IPv6) > 0 {
-					unifiedBlacklistV6 = append(unifiedBlacklistV6, geobanData.IPv6...)
-					geobanIPv6Loaded = len(geobanData.IPv6)
-					log.Printf("[SYNC] Geoban IPv6: %d input CIDRs queued for unified replace", len(geobanData.IPv6))
+				if hasBanFiles {
+					// Load all geoban countries
+					geobanData, geoErr := geoban.Build(geobanDir, nil) // nil = load all
+					if geoErr == nil && geobanData != nil {
+						// Memory safety check before loading geoban into nftables
+						// Geoban can have 20K+ CIDRs per country (CN, RU, etc.)
+						const bytesPerCIDR = 300 // conservative estimate
+						totalGeoCIDRs := len(geobanData.IPv4) + len(geobanData.IPv6)
+						estimatedGeoBytes := int64(totalGeoCIDRs) * bytesPerCIDR
+						if !safety.CanAllocate(estimatedGeoBytes) {
+							log.Printf("[SYNC] Warning: Skipping geoban - insufficient memory for %d CIDRs (need ~%s)",
+								totalGeoCIDRs, safety.FormatBytes(estimatedGeoBytes))
+							// Track protection trigger for visibility
+							geobanSkipped = true
+							geobanCIDRCount = totalGeoCIDRs
+							geobanMemNeeded = estimatedGeoBytes
+							// Skip geoban but continue with sync - don't fail entirely
+						} else {
+							// INC3: queue geoban CIDRs for the unified canonical replace (feeds +
+							// geoban + blacklist.d CIDRs in ONE flush-first replace — closes the
+							// pre-existing feed-vs-geoban clobber where the second replace wiped the
+							// first). All ban sources share blacklist_ipv4/_ipv6.
+							if len(geobanData.IPv4) > 0 {
+								unifiedBlacklistV4 = append(unifiedBlacklistV4, geobanData.IPv4...)
+								geobanIPv4Loaded = len(geobanData.IPv4)
+								log.Printf("[SYNC] Geoban IPv4: %d input CIDRs queued for unified replace", len(geobanData.IPv4))
+							}
+
+							// IPv6 geoban → unified replace
+							if len(geobanData.IPv6) > 0 {
+								unifiedBlacklistV6 = append(unifiedBlacklistV6, geobanData.IPv6...)
+								geobanIPv6Loaded = len(geobanData.IPv6)
+								log.Printf("[SYNC] Geoban IPv6: %d input CIDRs queued for unified replace", len(geobanData.IPv6))
+							}
+							// Memory cleanup: clear geoban data to allow garbage collection
+							// Geoban can hold 200-400MB that's no longer needed after loading
+							geobanData.IPv4 = nil
+							geobanData.IPv6 = nil
+							geobanData = nil
+						} // end else CanAllocate
+					}
 				}
-				// Memory cleanup: clear geoban data to allow garbage collection
-				// Geoban can hold 200-400MB that's no longer needed after loading
-				geobanData.IPv4 = nil
-				geobanData.IPv6 = nil
-				geobanData = nil
-				} // end else CanAllocate
 			}
-		}
-		}
 		} // end else ShouldSkipGeoban
 	} // end if !quickMode (geoban)
 

--- a/internal/escalation/tracker_duxv16_duxv17_test.go
+++ b/internal/escalation/tracker_duxv16_duxv17_test.go
@@ -143,7 +143,7 @@ func TestPersistentOffenders_ConcurrentNoClobber(t *testing.T) {
 	want := make(map[string]bool, n)
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
-		ip := fmt.Sprintf("10.20.%d.%d", i/256, i%256)
+		ip := fmt.Sprintf("45.33.%d.%d", i/256, i%256)
 		want[ip] = true
 		wg.Add(1)
 		go func(i int, ip string) {
@@ -180,7 +180,7 @@ func TestPersistentOffenders_ConcurrentSameIPDedup(t *testing.T) {
 	}
 	confPath := filepath.Join(configDir, "blacklist.d", "30-persistent-offenders.conf")
 
-	const ip = "203.0.113.7"
+	const ip = "45.33.32.7"
 	var wg sync.WaitGroup
 	for i := 0; i < 30; i++ {
 		wg.Add(1)

--- a/internal/netutil/enforcement_class_test.go
+++ b/internal/netutil/enforcement_class_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="netutil/enforcement_class_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="v1.220.2 enforcement address-class guard: EnforcementClassReject + IsAbsolutelyNonBannable across loopback/unspecified/multicast/RFC1918/ULA/link-local/CGNAT/doc/reserved (reject) vs public v4+v6 (allow); IPv4-mapped normalized; CIDR/blank pass. Pure, no netlink."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// v1.220.2: enforcement address-class guard tests. RBL/reputation + enforcement are
+// public-only; loopback/unspecified/multicast are non-overridably non-bannable, and the
+// other non-public classes are default-reject. Public routable addresses pass; CIDR/blank
+// pass (callers validate those). IPv4/IPv6 symmetric.
+package netutil
+
+import "testing"
+
+func TestEnforcementClassReject(t *testing.T) {
+	cases := []struct {
+		ip     string
+		reject bool
+		note   string
+	}{
+		// absolute non-bannable (non-overridable)
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"127.0.1.1", true, "IPv4 loopback (Debian hostname)"},
+		{"::1", true, "IPv6 loopback"},
+		{"0.0.0.0", true, "IPv4 unspecified"},
+		{"::", true, "IPv6 unspecified"},
+		{"224.0.0.1", true, "IPv4 multicast"},
+		{"239.255.255.250", true, "IPv4 multicast"},
+		{"ff02::1", true, "IPv6 multicast"},
+		// non-public (default reject)
+		{"10.0.0.5", true, "RFC1918"},
+		{"172.16.5.5", true, "RFC1918"},
+		{"192.168.1.10", true, "RFC1918"},
+		{"169.254.1.2", true, "IPv4 link-local"},
+		{"fe80::1", true, "IPv6 link-local"},
+		{"fc00::1", true, "ULA"},
+		{"fd12::9", true, "ULA (fd..)"},
+		{"100.64.0.1", true, "CGNAT"},
+		{"192.0.2.1", true, "documentation"},
+		{"198.51.100.7", true, "documentation"},
+		{"203.0.113.9", true, "documentation"},
+		{"2001:db8::1", true, "documentation (IPv6)"},
+		{"240.0.0.1", true, "reserved"},
+		{"198.18.0.1", true, "benchmark"},
+		// public routable — MUST pass
+		{"8.8.4.4", false, "public IPv4"},
+		{"46.225.150.67", false, "public IPv4"},
+		{"2a01:4f8:c014:5ee1::1", false, "public IPv6"},
+		{"2606:4700:4700::1111", false, "public IPv6"},
+		// IPv4-mapped IPv6 loopback normalizes to loopback
+		{"::ffff:127.0.0.1", true, "IPv4-mapped loopback"},
+		{"::ffff:8.8.4.4", false, "IPv4-mapped public"},
+		// non-bare-IP tokens pass (CIDR/range/blank) — feed CIDRs must not be rejected here
+		{"1.2.3.0/24", false, "public CIDR (caller handles)"},
+		{"", false, "blank"},
+		{"not-an-ip", false, "garbage"},
+	}
+	for _, c := range cases {
+		reject, reason := EnforcementClassReject(c.ip)
+		if reject != c.reject {
+			t.Errorf("EnforcementClassReject(%q)=%v want %v (%s) reason=%q", c.ip, reject, c.reject, c.note, reason)
+		}
+		if reject && reason == "" {
+			t.Errorf("EnforcementClassReject(%q) rejected with empty reason", c.ip)
+		}
+	}
+}
+
+func TestIsAbsolutelyNonBannable(t *testing.T) {
+	absolute := []string{"127.0.0.1", "127.0.1.1", "::1", "0.0.0.0", "::", "224.0.0.1", "ff02::1", "::ffff:127.0.0.1"}
+	for _, ip := range absolute {
+		if !IsAbsolutelyNonBannable(ip) {
+			t.Errorf("IsAbsolutelyNonBannable(%q)=false, want true", ip)
+		}
+	}
+	// non-public-but-not-absolute (private/ULA/etc) are NOT absolute — they are only
+	// default-reject (a future explicit LAN feature could opt in).
+	notAbsolute := []string{"10.0.0.5", "fc00::1", "169.254.1.2", "100.64.0.1", "8.8.4.4", "2a01:4f8::1", "1.2.3.0/24", ""}
+	for _, ip := range notAbsolute {
+		if IsAbsolutelyNonBannable(ip) {
+			t.Errorf("IsAbsolutelyNonBannable(%q)=true, want false", ip)
+		}
+	}
+}

--- a/internal/netutil/ip.go
+++ b/internal/netutil/ip.go
@@ -29,9 +29,77 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"strings"
 )
+
+// =============================================================================
+// v1.220.2: enforcement address-class guard (shared, pure, no netlink).
+// RBL/reputation is public-only (shell side); ENFORCEMENT (blacklist persistence,
+// ban/drop-set insertion) must likewise reject non-public / non-routable classes so
+// loopback, the unspecified address, multicast, and non-public ranges can never enter
+// a hostile drop set. Reused by internal/persistence, internal/nftbackend, and the
+// daemon full-sync handler so no writer can bypass it.
+// =============================================================================
+
+// enforcementRejectPrefixes: classes with no direct netip predicate.
+var enforcementRejectPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),   // CGNAT / shared address space (RFC6598)
+	netip.MustParsePrefix("192.0.2.0/24"),    // documentation TEST-NET-1
+	netip.MustParsePrefix("198.51.100.0/24"), // documentation TEST-NET-2
+	netip.MustParsePrefix("203.0.113.0/24"),  // documentation TEST-NET-3
+	netip.MustParsePrefix("198.18.0.0/15"),   // benchmarking
+	netip.MustParsePrefix("240.0.0.0/4"),     // reserved / future use
+	netip.MustParsePrefix("2001:db8::/32"),   // documentation (IPv6)
+}
+
+// IsAbsolutelyNonBannable reports whether ip must NEVER enter a hostile enforcement/drop
+// set under any circumstance (non-overridable): loopback, unspecified, or multicast.
+// These address classes have no hostile-source meaning. A non-bare-IP token returns false
+// (callers validate CIDR/range separately).
+func IsAbsolutelyNonBannable(ipStr string) bool {
+	a, err := netip.ParseAddr(strings.TrimSpace(ipStr))
+	if err != nil {
+		return false
+	}
+	a = a.Unmap()
+	return a.IsLoopback() || a.IsUnspecified() || a.IsMulticast() ||
+		a.IsInterfaceLocalMulticast() || a.IsLinkLocalMulticast()
+}
+
+// EnforcementClassReject reports whether ip should be rejected from a hostile enforcement
+// action by ADDRESS CLASS. Absolute classes (loopback/unspecified/multicast) are always
+// rejected — non-overridable. Non-public classes (RFC1918, ULA, link-local, CGNAT,
+// documentation, reserved/benchmark) are rejected by DEFAULT, pending an explicit
+// private-network enforcement feature that does not exist today (and must never be
+// inferred from a raw ban). Public routable addresses return (false, ""). A non-bare-IP
+// token (CIDR/range/blank) returns (false, "") so legitimate public feed CIDRs pass.
+func EnforcementClassReject(ipStr string) (bool, string) {
+	a, err := netip.ParseAddr(strings.TrimSpace(ipStr))
+	if err != nil {
+		return false, "" // not a bare IP — caller handles CIDR/range/format
+	}
+	a = a.Unmap()
+	switch {
+	case a.IsLoopback():
+		return true, "loopback"
+	case a.IsUnspecified():
+		return true, "unspecified"
+	case a.IsMulticast() || a.IsInterfaceLocalMulticast() || a.IsLinkLocalMulticast():
+		return true, "multicast"
+	case a.IsLinkLocalUnicast():
+		return true, "link-local"
+	case a.IsPrivate(): // RFC1918 + ULA fc00::/7
+		return true, "private-or-ula"
+	}
+	for _, p := range enforcementRejectPrefixes {
+		if p.Contains(a) {
+			return true, "reserved-doc-or-cgnat"
+		}
+	}
+	return false, "" // public routable
+}
 
 // =============================================================================
 // Client IP Extraction

--- a/internal/nftbackend/backend.go
+++ b/internal/nftbackend/backend.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/itcmsgr/nftban/internal/netutil"
 	nftsync "github.com/itcmsgr/nftban/internal/setsync"
 )
 
@@ -67,8 +68,8 @@ type Backend struct {
 	nft *nftsync.NFTManager
 
 	// Cached tables and sets for performance
-	tableIPv4 *nftables.Table
-	tableIPv6 *nftables.Table
+	tableIPv4              *nftables.Table
+	tableIPv6              *nftables.Table
 	setBlacklistIPv4       *nftables.Set // interval set for feeds/geoban
 	setBlacklistIPv6       *nftables.Set
 	setBlacklistManualIPv4 *nftables.Set // hash set for manual/auto-detect (v1.33.0)
@@ -261,7 +262,7 @@ func (b *Backend) getBlacklistSetForSource(ipStr, source string) (*nftables.Set,
 // BanRequest contains parameters for banning an IP
 type BanRequest struct {
 	IP      string
-	Timeout int    // seconds, 0 = permanent
+	Timeout int // seconds, 0 = permanent
 	Reason  string
 	Source  string
 }
@@ -302,6 +303,24 @@ func (b *Backend) Ban(ctx context.Context, req BanRequest) (*BanResult, error) {
 	// instead of relying on firewall rule order (the pre-v1.209.x ordering-only model).
 	// Range-aware, v4+v6. Fail-safe: a nil/empty resolver never blocks a legitimate ban.
 	// Exemption ≠ accept: this only prevents a DROP of protected IPs; it adds no allow.
+	// v1.220.2 F3: absolute address-class reject BEFORE the membership exemption.
+	// The exemption resolver is membership-based (whitelist/system/SSH IPs) and
+	// fail-open — so 0.0.0.0/::/multicast/loopback and other non-public classes could
+	// slip into a drop set if not in any list. This class guard is non-overridable for
+	// loopback/unspecified/multicast and default-reject for the other non-public
+	// classes, independent of exemption state. Design rule: parse -> absolute-class
+	// reject -> self/host-owned (exemption) reject -> apply.
+	if reject, reason := netutil.EnforcementClassReject(req.IP); reject {
+		b.stats.ExemptSkips++
+		log.Printf("[BAN] REFUSED (non-bannable address class: %s) ip=%s source=%s — non-public/non-routable address NOT added to blacklist", reason, req.IP, req.Source)
+		return &BanResult{
+			Success: true,
+			IP:      req.IP,
+			Exempt:  true,
+			Message: fmt.Sprintf("not banned: non-bannable address class (%s)", reason),
+		}, nil
+	}
+
 	if b.exempt != nil {
 		if ok, reason := b.exempt.IsExempt(req.IP); ok {
 			b.stats.ExemptSkips++
@@ -569,7 +588,16 @@ func (b *Backend) IsExempt(ip string) (bool, string) {
 // decision is unit-testable without netlink/root. IsExempt returns false for CIDR/range
 // and non-single-IP inputs, so feed/interval CIDR adds are naturally unaffected.
 func (b *Backend) exemptAddRejection(set, element string) (bool, string) {
-	if b.exempt == nil || !IsEnforcementSet(set) {
+	if !IsEnforcementSet(set) {
+		return false, ""
+	}
+	// v1.220.2 F3: absolute address-class reject on any enforcement-set add, before
+	// (and independent of) the fail-open membership exemption — loopback/unspecified/
+	// multicast + non-public classes can never enter a drop set via AddElement either.
+	if reject, reason := netutil.EnforcementClassReject(element); reject {
+		return true, "non-bannable-class:" + reason
+	}
+	if b.exempt == nil {
 		return false, ""
 	}
 	return b.exempt.IsExempt(element)

--- a/internal/nftbackend/classguard_test.go
+++ b/internal/nftbackend/classguard_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftbackend/classguard_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="v1.220.2 F3: exemptAddRejection rejects absolute+non-public classes on enforcement sets even with a nil (fail-open) exemption resolver, allows public routable IPs, and never blocks non-enforcement sets (whitelist can hold loopback/private). Pure decision, no netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// v1.220.2 F3: the enforcement-set add rejection must reject absolute non-bannable
+// classes (loopback/unspecified/multicast) and non-public classes on ENFORCEMENT sets
+// EVEN when the membership exemption resolver is nil (fail-open exemption must never make
+// an absolute-non-bannable class bannable). Non-enforcement sets (e.g. whitelist) are
+// unaffected — loopback is legitimately whitelistable. Pure decision, no netlink/root.
+package nftbackend
+
+import "testing"
+
+func TestExemptAddRejectionClassGuard(t *testing.T) {
+	b := &Backend{} // exempt == nil → membership exemption unavailable (fail-open)
+
+	// pick an actual enforcement set name
+	var enfSet string
+	for s := range enforcementSets {
+		enfSet = s
+		break
+	}
+	if enfSet == "" {
+		t.Fatal("no enforcement set registered")
+	}
+
+	// absolute + non-public classes: rejected on the enforcement set despite nil exempt.
+	for _, ip := range []string{"127.0.0.1", "::1", "0.0.0.0", "::", "224.0.0.1", "ff02::1",
+		"10.0.0.5", "fc00::1", "169.254.1.2", "100.64.0.1", "192.0.2.1", "2001:db8::1"} {
+		reject, reason := b.exemptAddRejection(enfSet, ip)
+		if !reject {
+			t.Errorf("exemptAddRejection(%s, %q)=false, want reject (nil exempt must still block non-bannable class)", enfSet, ip)
+		}
+		if reason == "" {
+			t.Errorf("exemptAddRejection(%s, %q) rejected with empty reason", enfSet, ip)
+		}
+	}
+
+	// public routable: NOT rejected by class (would then hit membership exemption, nil here).
+	for _, ip := range []string{"8.8.4.4", "46.225.150.67", "2a01:4f8:c014:5ee1::1"} {
+		if reject, _ := b.exemptAddRejection(enfSet, ip); reject {
+			t.Errorf("exemptAddRejection(%s, %q)=true, want public address allowed", enfSet, ip)
+		}
+	}
+
+	// NON-enforcement set: loopback/private are legitimately addable (whitelist etc).
+	for _, ip := range []string{"127.0.0.1", "::1", "10.0.0.5"} {
+		if reject, _ := b.exemptAddRejection("whitelist_ipv4", ip); reject {
+			t.Errorf("exemptAddRejection(whitelist_ipv4, %q)=true, want allowed on non-enforcement set", ip)
+		}
+	}
+}

--- a/internal/nftbackend/never_ban_add_element_l3a_test.go
+++ b/internal/nftbackend/never_ban_add_element_l3a_test.go
@@ -51,7 +51,7 @@ func TestExemptAddRejection_L3a(t *testing.T) {
 		{"persistent_offenders_ipv6", "2001:db8::9", true}, // persistent-offenders drop set: REJECT
 		{"bogon_ipv4", "10.0.0.5", true},               // bogon drop set: REJECT
 		{"whitelist_ipv4", "10.0.0.5", false},          // whitelist add of exempt IP: ALLOW
-		{"blacklist_manual_ipv4", "203.0.113.9", false}, // normal public IP: ALLOW
+		{"blacklist_manual_ipv4", "45.33.32.156", false},  // normal public IP: ALLOW
 		{"blacklist_ipv4", "10.0.0.0/8", false},        // CIDR input (IsExempt=false): ALLOW
 		{"ssh_ports", "10.0.0.5", false},               // port set (not enforcement): ALLOW
 	}

--- a/internal/persistence/blacklistd.go
+++ b/internal/persistence/blacklistd.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/itcmsgr/nftban/internal/netutil"
 )
 
 // Result indicates the outcome of a persistence operation
@@ -84,6 +86,15 @@ func PersistBan(configDir, ip, reason, source string) (Result, string, error) {
 		if err != nil {
 			return "", "", fmt.Errorf("invalid IP address: %s", ip)
 		}
+	}
+
+	// v1.220.2 F2: never persist a non-public / absolute-non-bannable address into a
+	// blacklist file. Loopback/unspecified/multicast (and by-default RFC1918/ULA/
+	// link-local/CGNAT/doc/reserved) have no hostile-source meaning; persisting them
+	// lets the file->kernel full-sync re-materialize them into a drop set. Bare IPs
+	// only — public feed CIDRs pass (EnforcementClassReject returns false for CIDR).
+	if reject, reason := netutil.EnforcementClassReject(ip); reject {
+		return "", "", fmt.Errorf("refusing to persist non-public/non-bannable address %s to blacklist (%s)", ip, reason)
 	}
 
 	// Determine target file

--- a/internal/persistence/blacklistd_classguard_test.go
+++ b/internal/persistence/blacklistd_classguard_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="persistence/blacklistd_classguard_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="v1.220.2 F2: PersistBan refuses non-public/absolute-non-bannable addresses (never written to blacklist.d so the full-sync cannot re-materialize them into a drop set) and still persists public addresses; IPv4/IPv6 symmetric."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// v1.220.2 F2: PersistBan must never write a non-public / absolute-non-bannable address
+// into a blacklist file (the file->kernel full-sync would otherwise re-materialize it
+// into a drop set). Public addresses still persist; IPv4/IPv6 symmetric.
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPersistBanRejectsNonPublic(t *testing.T) {
+	reject := []string{
+		"127.0.0.1", "127.0.1.1", "::1", "0.0.0.0", "::", "224.0.0.1", "ff02::1",
+		"10.0.0.5", "192.168.1.10", "169.254.1.2", "fe80::1", "fc00::1", "100.64.0.1",
+		"192.0.2.1", "2001:db8::1", "240.0.0.1",
+	}
+	for _, ip := range reject {
+		dir := t.TempDir()
+		_, _, err := PersistBan(dir, ip, "test", "manual")
+		if err == nil {
+			t.Errorf("PersistBan(%q) = nil error, want refusal", ip)
+		}
+		if err != nil && !strings.Contains(err.Error(), "refusing to persist") {
+			t.Errorf("PersistBan(%q) error=%q, want a 'refusing to persist' class rejection", ip, err.Error())
+		}
+		// nothing must have been written
+		if entries, _ := os.ReadDir(filepath.Join(dir, "blacklist.d")); len(entries) > 0 {
+			for _, e := range entries {
+				b, _ := os.ReadFile(filepath.Join(dir, "blacklist.d", e.Name()))
+				if strings.Contains(string(b), strings.TrimSuffix(ip, "/32")) {
+					t.Errorf("PersistBan(%q) wrote the rejected address into %s", ip, e.Name())
+				}
+			}
+		}
+	}
+}
+
+func TestPersistBanAllowsPublic(t *testing.T) {
+	public := []string{"8.8.4.4", "46.225.150.67", "2a01:4f8:c014:5ee1::1", "2606:4700:4700::1111"}
+	for _, ip := range public {
+		dir := t.TempDir()
+		if _, _, err := PersistBan(dir, ip, "test", "manual"); err != nil {
+			t.Errorf("PersistBan(%q) public address rejected: %v", ip, err)
+		}
+	}
+}

--- a/internal/persistence/blacklistd_test.go
+++ b/internal/persistence/blacklistd_test.go
@@ -206,7 +206,7 @@ func TestPersistBan_NoReason(t *testing.T) {
 func TestPersistBan_IPv6(t *testing.T) {
 	dir := setupTestDir(t)
 
-	result, _, err := PersistBan(dir, "2001:db8::1", "ipv6 test", "manual")
+	result, _, err := PersistBan(dir, "2a01:4f8:c014:5ee1::1", "ipv6 test", "manual")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestPersistBan_Header(t *testing.T) {
 func TestPersistBan_MultipleIPs(t *testing.T) {
 	dir := setupTestDir(t)
 
-	ips := []string{"1.2.3.4", "5.6.7.8", "10.0.0.1"}
+	ips := []string{"1.2.3.4", "5.6.7.8", "9.9.9.9"}
 	for _, ip := range ips {
 		result, _, err := PersistBan(dir, ip, "test", "manual")
 		if err != nil {


### PR DESCRIPTION
**Enforcement-integrity hotfix** — the separate Go/daemon lane from `NFTBAN_NONPUBLIC_ADDRESS_ACTION_POLICY_AUDIT.md` (verdict `SEPARATE_ENFORCEMENT_HOTFIX_REQUIRED`; scope `OPEN_NONPUBLIC_ADDRESS_ENFORCEMENT_INTEGRITY_HOTFIX_SCOPE.md`). **Go/daemon change → daemon re-baseline. nft schema `1.84.0` UNCHANGED. RBL untouched (this is NOT RBL-enablement).**

## Defect
Loopback / the unspecified address / multicast / non-public ranges could reach an active nftables drop set via two paths that **bypass** the never-ban invariant enforced on `Backend.Ban`/`AddElement`:
- **F1** — `cmd/nftband/daemon_handlers_sync.go:handleSyncRequest` inserted every `blacklist.d` single IP via raw `nft.AddIPWithTimeout`, never consulting the exemption (the `GUARD-VERB-SCOPE` "FullSync-from-`blacklist.d`" watch-edge, now confirmed).
- **F2** — `internal/persistence/blacklistd.go:PersistBan` wrote any valid IP to `blacklist.d` (the full-sync then re-materializes it).
- **F3** — `internal/nftbackend/exemption.go` is membership-only + fail-open, so `0.0.0.0`/`::`/multicast/loopback slip through `Backend.Ban` when not in a list.

## Fix — one shared guard, applied at every enforcement writer
`internal/netutil` (pure, no netlink): **`EnforcementClassReject`** + **`IsAbsolutelyNonBannable`**.
- **Absolute (non-overridable):** loopback, unspecified, multicast.
- **Default-reject (pending an explicit, non-existent LAN-enforcement feature):** RFC1918, ULA, link-local, CGNAT `100.64/10`, documentation, reserved/benchmark.
- Public routable passes; CIDR/blank pass (feed CIDRs unaffected). `netip` predicates + explicit prefixes; IPv4-mapped normalized; IPv4/IPv6 symmetric.

Applied:
- **F2** `PersistBan` — refuse a non-public bare IP **before** the file write.
- **F1** `handleSyncRequest` — the `blacklist.d`→drop-set loops apply the class guard **and** `d.backend.IsExempt` (self/host/whitelist/live-SSH) before `AddIPWithTimeout`.
- **F3** `Backend.Ban` rejects the class **before** the fail-open membership exemption; `exemptAddRejection` (the `AddElement` path) gains the same class reject. So `0.0.0.0`/`::`/multicast/loopback are structurally non-bannable **even when the exemption resolver is nil/unloaded**.

Design rule: `parse → normalize → absolute-class reject → self/host-owned (exemption) reject → persist/apply`.

## Tests (daemon re-baseline)
- `netutil/enforcement_class_test` — all classes, IPv4/IPv6 symmetric, IPv4-mapped, CIDR/blank pass.
- `persistence/blacklistd_classguard_test` — non-public refused + **not written**; public still persists.
- `nftbackend/classguard_test` — enforcement-set reject with a **nil (fail-open) exempt resolver** = fail-safe for absolute classes; public allowed; whitelist/non-enforcement sets unaffected.
- `go build ./...` OK · `go vet` clean · **`-race` clean** · enforcement-adjacent suites (opqueue/setsync/botguard/loginmon/suricata/ddos/portscan/safety/blacklist) green.
- Controlled-source on **lab2**: daemon builds + enforcement tests pass on the lab toolchain (go1.25.12).
- Fixed **3 pre-existing tests** that used RFC5737 documentation / RFC1918 addresses as public "attacker" fixtures (now correctly rejected) → real public IPs.

## Deferred (registered)
D1/D2 detector-source parity → `OPEN_NONPUBLIC_ADDR_DETECTOR_SOURCE_PARITY` (centrally contained by these choke points). No RBL enablement in this lane.

## Ladder (post-merge, own gates)
release-prep v1.220.2 → tag/publish → **package-native lab2/lab4** (live: `nftban ban 127.0.0.1` / `0.0.0.0` / a persisted loopback survives a full-sync → all refused; a public attacker still bans) → bounded canary → fleet → separate closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)