### PR TITLE
feat(rbl): providers CLI + coverage rendering (registry slice 2, read-only)

### DIFF
--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -119,6 +119,7 @@ SUBCOMMANDS:
   config      Show RBL configuration
   stats       Show RBL statistics
   test        Test RBL configuration/connectivity
+  providers   Inspect the typed provider registry (list/validate/test/explain)
 
 CHECK OPTIONS:
   --ip IP           Check specific IP address
@@ -259,6 +260,9 @@ nftban_cmd_rbl() {
             ;;
         watchlist)
             nftban_cmd_rbl_watchlist "$@"
+            ;;
+        providers)
+            nftban_cmd_rbl_providers "$@"
             ;;
         *)
             echo "ERROR: Unknown subcommand: $subcommand" >&2
@@ -1585,8 +1589,163 @@ nftban_cmd_rbl_watchlist() {
     esac
 }
 
+# =============================================================================
+# PROVIDERS — typed provider-registry inspection (slice 2, READ-ONLY)
+# =============================================================================
+# `nftban rbl providers {list,validate,test,explain}`. Read-only inspection over
+# the additive registry substrate (slice 1). Does NOT change which providers are
+# queried, does NOT curate/weight/group, and does NOT mutate state — enable/
+# disable are deferred to a later sub-slice (the registry is still an additive
+# compatibility layer, not yet an authoritative data source).
+
+_nftban_rbl_providers_help() {
+    cat <<'EOF'
+Usage: nftban rbl providers <subcommand>
+
+  list                 Typed provider table (ID · Zone · Type · State) + counts
+  validate             Validate the registry data file (if any); report errors
+  test [<id>|--all]    Live RFC5782 reachability probe from this host's resolver
+                       (read-only; classifies each zone; changes NO state)
+  explain <id>         Full typed record for one provider
+  help                 This help
+
+Read-only. rbls.conf remains authoritative; no provider is curated, weighted,
+grouped, enabled, or disabled by these commands.
+EOF
+}
+
+# Split a TSV registry record into the named fields (empty-column-safe).
+_nftban_rbl_prov_read() { # $1=record; sets id/zone/qt/scope/family/access/weight/role/group/state/url
+    IFS=$'\x1f' read -r id zone qt scope family access weight role group state url \
+        <<< "${1//$'\t'/$'\x1f'}"
+}
+
+_nftban_rbl_providers_list() {
+    local id zone qt scope family access weight role group state url n=0
+    printf 'RBL Providers — effective configuration (registry substrate, slice 1)\n'
+    printf -- '─────────────────────────────────────────────────────────────────────\n'
+    printf '%-24s %-30s %-9s %-8s\n' "ID" "Zone" "Type" "State"
+    while IFS= read -r rec; do
+        [[ -z "$rec" ]] && continue
+        _nftban_rbl_prov_read "$rec"
+        printf '%-24s %-30s %-9s %-8s\n' "$id" "$zone" "$qt" "$state"
+        n=$((n+1))
+    done < <(nftban_rbl_registry_records)
+    printf -- '─────────────────────────────────────────────────────────────────────\n'
+    printf 'Effective IP providers: %s   (rbls.conf authoritative; no curation)\n' "$n"
+    if [[ ! -f "${NFTBAN_RBL_REGISTRY_FILE:-}" ]]; then
+        printf 'Registry data file: none (module-only) — legacy flat list projected.\n'
+    fi
+    return 0
+}
+
+_nftban_rbl_providers_validate() {
+    local rf="${NFTBAN_RBL_REGISTRY_FILE:-}"
+    if [[ -z "$rf" || ! -f "$rf" ]]; then
+        printf 'No registry data file present (module-only substrate).\n'
+        printf 'Legacy rbls.conf is authoritative — %s effective providers.\n' \
+            "$(nftban_rbl_load_providers 2>/dev/null | grep -c .)"
+        return 0
+    fi
+    printf 'Validating registry: %s\n' "$rf"
+    if nftban_rbl_registry_validate "$rf"; then
+        printf '✅ registry valid\n'; return 0
+    else
+        printf '❌ registry INVALID — the legacy rbls.conf set remains authoritative.\n' >&2
+        return 1
+    fi
+}
+
+_nftban_rbl_providers_explain() {
+    local want="${1:-}"
+    [[ -z "$want" ]] && { echo "ERROR: usage: nftban rbl providers explain <id>" >&2; return 1; }
+    local rec id zone qt scope family access weight role group state url
+    rec="$(nftban_rbl_registry_get "$want")" || { echo "ERROR: no provider with id '$want' (see 'rbl providers list')" >&2; return 1; }
+    _nftban_rbl_prov_read "$rec"
+    cat <<EOF
+Provider:     ${id}
+  Zone:       ${zone}
+  Query type: ${qt}
+  Scope:      ${scope}
+  Family:     ${family}
+  Access:     ${access}
+  Weight:     ${weight:-(none)}
+  Role:       ${role}
+  Group:      ${group}
+  State:      ${state}
+  Info:       ${url:-—}
+EOF
+    return 0
+}
+
+_nftban_rbl_providers_test() {
+    local target="${1:---all}" recs
+    recs="$(nftban_rbl_registry_records)"
+    local id zone qt scope family access weight role group state url
+    local queried=0 clean=0 listed=0 timeout=0 refused=0 servfail=0 reach=0 other=0
+    printf 'Provider reachability test (RFC5782 test point, this host'\''s resolver)\n'
+    printf -- '─────────────────────────────────────────────────────────────────────\n'
+    while IFS= read -r rec; do
+        [[ -z "$rec" ]] && continue
+        _nftban_rbl_prov_read "$rec"
+        [[ "$qt" == "IP_DNSBL" ]] || continue          # IP checker probes IP_DNSBL only
+        if [[ "$target" != "--all" && "$id" != "$target" ]]; then continue; fi
+        local res; res="$(nftban_rbl_registry_test_zone "$zone")"
+        queried=$((queried+1))
+        case "$res" in
+            CLEAN)              clean=$((clean+1)) ;;
+            LISTED_TESTPOINT)   listed=$((listed+1)) ;;
+            REACHABLE_NOANSWER) reach=$((reach+1)) ;;
+            TIMEOUT)            timeout=$((timeout+1)) ;;
+            REFUSED)            refused=$((refused+1)) ;;
+            SERVFAIL)           servfail=$((servfail+1)) ;;
+            *)                  other=$((other+1)) ;;
+        esac
+        printf '%-24s %-30s %s\n' "$id" "$zone" "$res"
+    done <<< "$recs"
+    [[ "$queried" -eq 0 ]] && { echo "No IP_DNSBL provider matched '$target'." >&2; return 1; }
+    printf -- '─────────────────────────────────────────────────────────────────────\n'
+    printf 'Provider coverage:\n'
+    printf '  Queried:              %s\n' "$queried"
+    printf '  Clean (NXDOMAIN):     %s\n' "$clean"
+    printf '  Listed (test point):  %s\n' "$listed"
+    printf '  Reachable/no-answer:  %s\n' "$reach"
+    printf '  Timeout:              %s\n' "$timeout"
+    printf '  Refused:              %s\n' "$refused"
+    printf '  SERVFAIL:             %s\n' "$servfail"
+    [[ "$other" -gt 0 ]] && printf '  Other:                %s\n' "$other"
+    local authoritative=$((clean+listed+reach))
+    if [[ "$authoritative" -eq "$queried" ]]; then
+        printf 'Verdict: OK — all %s providers returned an authoritative result.\n' "$queried"
+    else
+        printf 'Verdict: DEGRADED — %s/%s providers did not return an authoritative result.\n' \
+            "$((queried-authoritative))" "$queried"
+    fi
+    return 0
+}
+
+nftban_cmd_rbl_providers() {
+    local sub="${1:-list}"; [[ $# -gt 0 ]] && shift
+    case "$sub" in
+        list)          _nftban_rbl_providers_list "$@" ;;
+        validate)      _nftban_rbl_providers_validate "$@" ;;
+        test)          _nftban_rbl_providers_test "$@" ;;
+        explain)       _nftban_rbl_providers_explain "$@" ;;
+        enable|disable)
+            echo "ERROR: 'rbl providers $sub' is deferred to a later registry sub-slice." >&2
+            echo "       The registry is an additive compatibility substrate, not yet an" >&2
+            echo "       authoritative data source; provider state cannot be mutated here." >&2
+            return 2 ;;
+        help|--help|-h) _nftban_rbl_providers_help ;;
+        *) echo "ERROR: Unknown providers subcommand: $sub" >&2; _nftban_rbl_providers_help; return 1 ;;
+    esac
+}
+
 # Export main function and subcommands
 export -f nftban_cmd_rbl
+export -f nftban_cmd_rbl_providers
+export -f _nftban_rbl_providers_help _nftban_rbl_prov_read _nftban_rbl_providers_list
+export -f _nftban_rbl_providers_validate _nftban_rbl_providers_explain _nftban_rbl_providers_test
 export -f nftban_cmd_rbl_alert
 export -f nftban_cmd_rbl_cache
 export -f nftban_cmd_rbl_check

--- a/cli/lib/nftban/core/nftban_rbl_registry.sh
+++ b/cli/lib/nftban/core/nftban_rbl_registry.sh
@@ -198,6 +198,44 @@ nftban_rbl_registry_effective() {
     nftban_rbl_load_providers
 }
 
+# ---- slice 2 (read-only inspection helpers; no state change) ----------------
+
+# Echo the typed record (TSV) for a given id from the current effective set.
+# Returns non-zero if the id is not found.
+nftban_rbl_registry_get() {
+    local want="$1" line
+    while IFS= read -r line; do
+        [[ "${line%%$'\t'*}" == "$want" ]] && { printf '%s\n' "$line"; return 0; }
+    done < <(nftban_rbl_registry_records)
+    return 1
+}
+
+# Live RFC5782 reachability probe of a DNSBL zone, FROM the operator's resolver.
+# Read-only diagnostic — changes NO state, issues NO ban, touches NO provider.
+# Classifies into the current RBL result vocabulary; a timeout and an NXDOMAIN
+# are NEVER conflated.
+nftban_rbl_registry_test_zone() {
+    local zone="$1" timeout="${NFTBAN_RBL_TIMEOUT:-4}" out st
+    command -v dig >/dev/null 2>&1 || { printf 'NO_RESOLVER_TOOL'; return 0; }
+    out="$(dig +time="$timeout" +tries=1 A "2.0.0.127.${zone}" 2>/dev/null)"
+    [[ -z "$out" ]] && { printf 'TIMEOUT'; return 0; }
+    st="$(printf '%s\n' "$out" | sed -n 's/.*status: \([A-Z]*\),.*/\1/p' | head -1)"
+    case "$st" in
+        NOERROR)
+            if printf '%s\n' "$out" | grep -qE '[[:space:]]IN[[:space:]]+A[[:space:]]+127\.'; then
+                printf 'LISTED_TESTPOINT'
+            else
+                printf 'REACHABLE_NOANSWER'
+            fi ;;
+        NXDOMAIN) printf 'CLEAN' ;;
+        REFUSED)  printf 'REFUSED' ;;
+        SERVFAIL) printf 'SERVFAIL' ;;
+        "")       printf 'TIMEOUT' ;;
+        *)        printf '%s' "$st" ;;
+    esac
+}
+
+export -f nftban_rbl_registry_get nftban_rbl_registry_test_zone 2>/dev/null || true
 export -f _nftban_rbl_reg_in _nftban_rbl_reg_safe _nftban_rbl_reg_is_dnsname _nftban_rbl_reg_trim 2>/dev/null || true
 export -f nftban_rbl_registry_legacy_record nftban_rbl_registry_parse nftban_rbl_registry_validate 2>/dev/null || true
 export -f nftban_rbl_registry_records nftban_rbl_registry_effective 2>/dev/null || true

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090  # $CMD_RBL is a runtime-resolved repo path, sourced in subshells
+# =============================================================================
+# NFTBan - RBL provider registry SLICE 2 (read-only providers CLI + coverage)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_provider_registry_slice2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-13"
+# meta:description="Locks OPEN_SCOPE_RBL_PROVIDER_REGISTRY slice 2 — READ-ONLY inspection surfaces. Proves nftban rbl providers list (23 rows, ID/Zone/Type/State + effective count + no-curation note), validate (no registry ⇒ legacy authoritative 23; invalid registry ⇒ non-zero + legacy-authoritative message), explain <id> (full typed record; unknown id errors), and test (RFC5782 reachability classification into the current result vocabulary + truthful coverage render + OK/DEGRADED verdict) — with dig STUBBED so there is no real network. Mutation is DEFERRED: providers enable/disable return a deferred error (rc2) and change nothing. Read-only invariant: the live loader nftban_rbl_load_providers and the legacy rbl list stay 23; rbls.conf/custom.conf are untouched by any providers command. Shell-only; daemon byte-identical; RBL observe-only; no curation/weighting/grouping/default-profile migration."
+# meta:input="Stubbed dig + repo cmd_rbl.sh/nftban_rbl.sh/nftban_rbl_registry.sh + real rbls.conf"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_rbl.sh,cli/lib/nftban/core/nftban_rbl_registry.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_RBL_PROVIDERS_FILE,NFTBAN_RBL_CUSTOM_FILE,NFTBAN_RBL_REGISTRY_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+set +eE
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if [[ -f "$SCRIPT_DIR/../core/nftban_rbl_registry.sh" ]]; then
+    NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+else
+    NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)/cli/lib/nftban"
+fi
+export NFTBAN_LIB_DIR
+REPO_ROOT="$(cd "$NFTBAN_LIB_DIR/../../.." && pwd)"
+CMD_RBL="$NFTBAN_LIB_DIR/cli/cmd_rbl.sh"
+REAL_RBLS="$REPO_ROOT/etc/nftban/conf.d/rbl/rbls.conf"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=== RBL provider registry — slice 2 (read-only providers CLI) ==="
+
+# common env for a sourced subshell
+COMMON='export NFTBAN_RBL_PROVIDERS_FILE="'"$REAL_RBLS"'" NFTBAN_RBL_CUSTOM_FILE=/nope-$$ NFTBAN_RBL_REGISTRY_FILE=/nope-reg-$$'
+
+# --------------------------------------------------------------------------
+# A — providers list
+# --------------------------------------------------------------------------
+outA="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers list ) 2>&1 )"
+[[ "$(printf '%s\n' "$outA" | grep -cE '[[:space:]]IP_DNSBL[[:space:]]')" -eq 23 ]] && ok "A1 list shows 23 IP_DNSBL rows" || no "A1 list rows ($(printf '%s\n' "$outA" | grep -cE 'IP_DNSBL'))"
+printf '%s\n' "$outA" | grep -q 'Effective IP providers: 23' && ok "A2 list effective count 23" || no "A2 count"
+printf '%s\n' "$outA" | grep -qi 'no curation' && ok "A3 list states 'no curation'" || no "A3 no-curation note"
+printf '%s\n' "$outA" | grep -qi 'module-only' && ok "A4 list notes module-only (no registry data)" || no "A4 module-only note"
+
+# --------------------------------------------------------------------------
+# B — providers validate (no registry, then invalid registry)
+# --------------------------------------------------------------------------
+outB="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers validate; echo "RC=$?" ) 2>&1 )"
+{ printf '%s\n' "$outB" | grep -qi 'No registry data file' && printf '%s\n' "$outB" | grep -q 'authoritative — 23' && printf '%s\n' "$outB" | grep -q 'RC=0'; } \
+  && ok "B1 validate (no registry) → legacy authoritative 23, rc0" || no "B1 validate no-registry ($outB)"
+outBi="$( ( eval "$COMMON"; RF="$(mktemp)"; printf '[x]\nzone = a.example.net\n[x]\nzone = b.example.net\n' > "$RF"; export NFTBAN_RBL_REGISTRY_FILE="$RF"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers validate; echo "RC=$?"; rm -f "$RF" ) 2>&1 )"
+{ printf '%s\n' "$outBi" | grep -qi 'INVALID' && ! printf '%s\n' "$outBi" | grep -q 'RC=0'; } \
+  && ok "B2 validate (invalid registry) → INVALID + non-zero, legacy remains authoritative" || no "B2 validate invalid ($outBi)"
+
+# --------------------------------------------------------------------------
+# C — providers explain
+# --------------------------------------------------------------------------
+outC="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers explain zen_spamhaus_org ) 2>&1 )"
+{ printf '%s\n' "$outC" | grep -q 'Zone:.*zen.spamhaus.org' && printf '%s\n' "$outC" | grep -q 'Query type:.*IP_DNSBL' && printf '%s\n' "$outC" | grep -q 'State:.*enabled'; } \
+  && ok "C1 explain <id> shows the typed record" || no "C1 explain ($outC)"
+outCe="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers explain no_such_id; echo "RC=$?" ) 2>&1 )"
+{ printf '%s\n' "$outCe" | grep -qi 'no provider with id' && ! printf '%s\n' "$outCe" | grep -q 'RC=0'; } \
+  && ok "C2 explain unknown id → error, non-zero" || no "C2 explain unknown ($outCe)"
+
+# --------------------------------------------------------------------------
+# D — mutation DEFERRED: enable/disable change nothing (rc2)
+# --------------------------------------------------------------------------
+for verb in enable disable; do
+  outD="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers "$verb" zen_spamhaus_org; echo "RC=$?" ) 2>&1 )"
+  { printf '%s\n' "$outD" | grep -qi 'deferred' && printf '%s\n' "$outD" | grep -q 'RC=2'; } \
+    && ok "D providers $verb is deferred (rc2, no mutation)" || no "D providers $verb ($outD)"
+done
+
+# --------------------------------------------------------------------------
+# E — providers test with STUBBED dig: classification + coverage (no network)
+# --------------------------------------------------------------------------
+# E1: registry_test_zone classification per DNS status
+classify(){ # $1 = canned dig stdout (empty = timeout)
+  ( source "$CMD_RBL" 2>/dev/null || true; set +eE
+    eval 'dig(){ printf '"'"'%s'"'"' "'"$1"'"; }'; export -f dig
+    nftban_rbl_registry_test_zone example.net )
+}
+[[ "$(classify ';; opcode: QUERY, status: NXDOMAIN, id: 1')" == CLEAN ]] && ok "E1 NXDOMAIN → CLEAN" || no "E1 nxdomain"
+[[ "$(classify ';; status: NOERROR, id: 1
+2.0.0.127.example.net. 300 IN A 127.0.0.2')" == LISTED_TESTPOINT ]] && ok "E2 NOERROR+127 → LISTED_TESTPOINT" || no "E2 listed"
+[[ "$(classify ';; status: REFUSED, id: 1')" == REFUSED ]] && ok "E3 REFUSED → REFUSED" || no "E3 refused"
+[[ "$(classify ';; status: SERVFAIL, id: 1')" == SERVFAIL ]] && ok "E4 SERVFAIL → SERVFAIL" || no "E4 servfail"
+[[ "$(classify '')" == TIMEOUT ]] && ok "E5 empty/no-answer → TIMEOUT (never CLEAN)" || no "E5 timeout"
+# E6: providers test --all with an all-NXDOMAIN dig stub → coverage OK, 23 clean
+outE="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE
+  eval 'dig(){ printf "%s" ";; status: NXDOMAIN, id: 1"; }'; export -f dig
+  nftban_cmd_rbl_providers test --all ) 2>&1 )"
+{ printf '%s\n' "$outE" | grep -q 'Queried:              23' && printf '%s\n' "$outE" | grep -q 'Clean (NXDOMAIN):     23' && printf '%s\n' "$outE" | grep -qi 'Verdict: OK'; } \
+  && ok "E6 test --all coverage render (23 queried, 23 clean, OK)" || no "E6 coverage ($(printf '%s\n' "$outE" | grep -E 'Queried|Clean|Verdict'))"
+
+# --------------------------------------------------------------------------
+# F — READ-ONLY invariant: live loader + legacy list unchanged; configs untouched
+# --------------------------------------------------------------------------
+PRE_RBLS="$(sha256sum "$REAL_RBLS" | awk '{print $1}')"
+outF="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE
+  legc="$(nftban_rbl_load_providers | grep -c .)"
+  listc="$(nftban_cmd_rbl_list 2>/dev/null | grep -oiE 'Total: *[0-9]+' | grep -oE '[0-9]+' | head -1)"
+  echo "LEG=$legc LIST=$listc" ) 2>&1 )"
+{ printf '%s\n' "$outF" | grep -q 'LEG=23' && printf '%s\n' "$outF" | grep -q 'LIST=23'; } \
+  && ok "F1 live loader + legacy 'rbl list' still 23 (unchanged)" || no "F1 live path changed ($outF)"
+POST_RBLS="$(sha256sum "$REAL_RBLS" | awk '{print $1}')"
+[[ "$PRE_RBLS" == "$POST_RBLS" ]] && ok "F2 rbls.conf byte-identical after providers commands" || no "F2 rbls.conf changed"
+
+# --------------------------------------------------------------------------
+echo "-------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"; exit 0

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -104,7 +104,7 @@ _nftban() {
     local polkit_cmds="validate static runtime status groups rules test help"
     local pro_cmds="status enroll disable token inventory license-check community help"
     local queue_cmds="status list process dlq metrics help"
-    local rbl_cmds="check server status list enable disable cache alert critical watchlist config stats test help"
+    local rbl_cmds="check server status list enable disable cache alert critical watchlist config stats test providers help"
     local support_cmds="--network help"
     local suricata_cmds="install enable disable status eve rules profile scan services sid category local custom recommend iface help"
     local update_cmds="check status github git local force repair rollback list history auto preflight verify auto-apply help"


### PR DESCRIPTION
## Summary

Slice 2 of `OPEN_SCOPE_RBL_PROVIDER_REGISTRY` — **READ-ONLY inspection surfaces** over the slice-1 substrate.

**Shell/config/tests only · 0 Go · daemon byte-identical · nft schema `1.84.0` · RBL observe-only · `rbls.conf` authoritative and byte-identical · no curation / weighting / grouping / default-profile migration · no change to which providers are queried.**

## `nftban rbl providers`
- **list** — typed table (ID · Zone · Type · State) + effective count + "no curation / module-only" notes.
- **validate** — validate a registry data file if present (deterministic errors); none ⇒ legacy `rbls.conf` authoritative (23).
- **test [`<id>`|`--all`]** — live RFC5782 reachability probe **from this host's resolver**, classified into the current result vocabulary (`CLEAN` / `LISTED_TESTPOINT` / `REACHABLE_NOANSWER` / `TIMEOUT` / `REFUSED` / `SERVFAIL` — a timeout and an NXDOMAIN are never conflated) + a **truthful coverage render** + OK/DEGRADED verdict. Read-only: changes **no** state, issues **no** ban.
- **explain `<id>`** — full typed record.

## Mutation deferred (per your guidance)
`providers enable|disable` return a **deferred error (rc2)** and change nothing — the registry is still an additive compatibility substrate, not an authoritative data source. Enable/disable land in a later sub-slice, after the registry becomes authoritative.

## Untouched
Live loader `nftban_rbl_load_providers`, legacy `rbl list`, query execution, cache keys, timeouts, verdict logic, timers, enablement — all unchanged.

## Tests
`rbl_provider_registry_slice2_test.sh` (18/18): list/validate/explain surfaces; deferred enable/disable (rc2, no mutation); `test` classification (NXDOMAIN→CLEAN · NOERROR+127→LISTED_TESTPOINT · REFUSED · SERVFAIL · empty→TIMEOUT) + coverage render with **dig stubbed (no real network)**; read-only invariant (live loader + legacy list still 23; `rbls.conf` byte-identical). Existing RBL suites green; `shellcheck -S warning` clean.

Next: enable/disable sub-slice (deferred) or **slice 3** (live provider audit + curation, externally verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)