### PR TITLE
feat(rbl): typed provider metadata curation (registry slice 3A)

### DIFF
--- a/cli/lib/nftban/cli/cmd_rbl.sh
+++ b/cli/lib/nftban/cli/cmd_rbl.sh
@@ -1615,26 +1615,29 @@ EOF
 }
 
 # Split a TSV registry record into the named fields (empty-column-safe).
-_nftban_rbl_prov_read() { # $1=record; sets id/zone/qt/scope/family/access/weight/role/group/state/url
-    IFS=$'\x1f' read -r id zone qt scope family access weight role group state url \
-        <<< "${1//$'\t'/$'\x1f'}"
+_nftban_rbl_prov_read() { # $1=record; sets the 16 typed-record fields
+    IFS=$'\x1f' read -r id zone qt scope family access weight role group state \
+        op repl audit conf lic url <<< "${1//$'\t'/$'\x1f'}"
 }
 
 _nftban_rbl_providers_list() {
-    local id zone qt scope family access weight role group state url n=0
-    printf 'RBL Providers — effective configuration (registry substrate, slice 1)\n'
-    printf -- '─────────────────────────────────────────────────────────────────────\n'
-    printf '%-24s %-30s %-9s %-8s\n' "ID" "Zone" "Type" "State"
+    local id zone qt scope family access weight role group state op repl audit conf lic url n=0
+    printf 'RBL Providers — typed metadata (state = PROPOSED; effective query set unchanged)\n'
+    printf -- '─────────────────────────────────────────────────────────────────────────────\n'
+    printf '%-22s %-28s %-12s %-10s\n' "ID" "Zone" "Type" "State"
     while IFS= read -r rec; do
         [[ -z "$rec" ]] && continue
         _nftban_rbl_prov_read "$rec"
-        printf '%-24s %-30s %-9s %-8s\n' "$id" "$zone" "$qt" "$state"
+        printf '%-22s %-28s %-12s %-10s\n' "$id" "$zone" "$qt" "$state"
         n=$((n+1))
     done < <(nftban_rbl_registry_records)
-    printf -- '─────────────────────────────────────────────────────────────────────\n'
-    printf 'Effective IP providers: %s   (rbls.conf authoritative; no curation)\n' "$n"
-    if [[ ! -f "${NFTBAN_RBL_REGISTRY_FILE:-}" ]]; then
-        printf 'Registry data file: none (module-only) — legacy flat list projected.\n'
+    printf -- '─────────────────────────────────────────────────────────────────────────────\n'
+    printf 'Records: %s   Effective queried set: all %s zones in rbls.conf order (authoritative).\n' "$n" "$n"
+    if [[ -f "${NFTBAN_RBL_REGISTRY_FILE:-}" ]]; then
+        printf 'State/scope/access are metadata from the 2026-07-13 audit; NO provider is curated,\n'
+        printf 'enabled, disabled, or skipped — curation is a later slice. rbls.conf is unchanged.\n'
+    else
+        printf 'Registry data file: none — conservative legacy projection (all IP_DNSBL/enabled).\n'
     fi
     return 0
 }
@@ -1659,21 +1662,26 @@ _nftban_rbl_providers_validate() {
 _nftban_rbl_providers_explain() {
     local want="${1:-}"
     [[ -z "$want" ]] && { echo "ERROR: usage: nftban rbl providers explain <id>" >&2; return 1; }
-    local rec id zone qt scope family access weight role group state url
+    local rec id zone qt scope family access weight role group state op repl audit conf lic url
     rec="$(nftban_rbl_registry_get "$want")" || { echo "ERROR: no provider with id '$want' (see 'rbl providers list')" >&2; return 1; }
     _nftban_rbl_prov_read "$rec"
     cat <<EOF
-Provider:     ${id}
-  Zone:       ${zone}
-  Query type: ${qt}
-  Scope:      ${scope}
-  Family:     ${family}
-  Access:     ${access}
-  Weight:     ${weight:-(none)}
-  Role:       ${role}
-  Group:      ${group}
-  State:      ${state}
-  Info:       ${url:-—}
+Provider:            ${id}
+  Zone:              ${zone}
+  Query type:        ${qt}
+  Scope:             ${scope}
+  Family:            ${family}
+  Access:            ${access}
+  Weight:            ${weight:-(none)}
+  Role:              ${role}
+  Group:             ${group}
+  State (proposed):  ${state}
+  Operational:       ${op:-UNVERIFIED}
+  Replacement:       ${repl:-—}
+  Audit date:        ${audit:-—}
+  Confidence:        ${conf:-—}
+  License:           ${lic:-UNVERIFIED}
+  Info:              ${url:-—}
 EOF
     return 0
 }

--- a/cli/lib/nftban/core/nftban_rbl_registry.sh
+++ b/cli/lib/nftban/core/nftban_rbl_registry.sh
@@ -1,55 +1,49 @@
 #!/usr/bin/env bash
 # =============================================================================
-# NFTBan RBL Provider Registry — SLICE 1: substrate + flat-list compatibility
+# NFTBan RBL Provider Registry — substrate + typed metadata (slices 1/2/3A)
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 # meta:name="nftban_rbl_registry"
 # meta:type="core"
-# meta:version="1.0.0"
+# meta:version="1.1.0"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
-# meta:description="Additive typed-provider registry substrate for RBL (scope OPEN_SCOPE_RBL_PROVIDER_REGISTRY_SCOPE.md, slice 1). Provides a typed record model, a CONSERVATIVE projection of the legacy flat rbls.conf zones into typed records, a deterministic validator (fails on duplicate id/zone, bad enum, unsafe shell content, malformed structure), and an effective-provider projection. SLICE-1 INVARIANT: rbls.conf remains authoritative — the registry NEVER changes provider membership, order, or count; it only supplies typed metadata. Registry-absent or registry-invalid ⇒ the effective set is byte-identical to nftban_rbl_load_providers (never empty). No runtime YAML (keyed INI blocks parsed line-by-line, never sourced/evaled). Functions only; no top-level side effects; daemon byte-identical; RBL observe-only."
+# meta:description="Typed-provider registry for RBL (scope OPEN_SCOPE_RBL_PROVIDER_REGISTRY_SCOPE.md). Slice 1: additive substrate + flat-list compat. Slice 2: read-only providers CLI helpers. Slice 3A: truthful provider METADATA overlay — a 16-column typed record per configured zone (id/zone/query_type/scope/family/access/weight/role/group/state/operational_status/replacement/audit_date/confidence/license/info_url), sourced from an INI registry data file and validated deterministically. SLICE-3A INVARIANT: metadata ONLY — the effective queried set + order come from the authoritative legacy loader (rbls.conf); the registry NEVER changes membership, order, count, or which zone is queried. Registry-absent or registry-invalid yields the conservative legacy projection (byte-identical to slice-1 behavior). No runtime YAML (INI parsed line-by-line, never sourced/evaled). Functions only; no top-level side effects; daemon byte-identical; RBL observe-only."
 # meta:input="Legacy rbls.conf (via nftban_rbl_load_providers) + optional registry.conf (INI blocks)"
 # meta:output="TSV typed records + domain:url effective list on stdout"
-# meta:depends="bash,sort"
+# meta:depends="bash,sort,awk"
 # meta:inventory.files="/etc/nftban/conf.d/rbl/registry.conf"
-# meta:inventory.binaries="bash,sort"
-# meta:inventory.env_vars="NFTBAN_RBL_REGISTRY_FILE,NFTBAN_RBL_PROVIDERS_FILE,NFTBAN_CONFIG_DIR"
+# meta:inventory.binaries="bash,sort,awk,dig"
+# meta:inventory.env_vars="NFTBAN_RBL_REGISTRY_FILE,NFTBAN_RBL_PROVIDERS_FILE,NFTBAN_CONFIG_DIR,NFTBAN_RBL_TIMEOUT"
 # meta:inventory.config_files="/etc/nftban/conf.d/rbl/registry.conf"
 # meta:inventory.systemd_units=""
-# meta:inventory.network=""
+# meta:inventory.network="RBL DNS lookups (providers test only; read-only diagnostic)"
 # meta:inventory.privileges="none"
 # =============================================================================
 
-# Strict mode + single-load guard, matching the sibling sourced core libs
-# (core/nftban_hostaddr.sh). RBL callers already run under strict mode before
-# this file is sourced, so this is behavior-consistent, not a new side effect.
 set -Eeuo pipefail
 [[ -n "${_NFTBAN_RBL_REGISTRY_LOADED:-}" ]] && return 0
 _NFTBAN_RBL_REGISTRY_LOADED=1
 
-# Optional registry artifact — ABSENT by default (slice 1 ships no data file, so
-# the effective set is driven entirely by the authoritative rbls.conf).
+# Registry metadata artifact (slice 3A ships one). Absent yields the conservative
+# legacy projection. Present yields typed metadata OVERLAY only — never membership.
 : "${NFTBAN_RBL_REGISTRY_FILE:=${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/rbl/registry.conf}"
 
-# Internal TSV record schema (11 tab-separated columns), in this fixed order:
-#   id  zone  query_type  scope  family  access  weight  role  group  state  info_url
-# Allowed enum vocabularies (validation only; NO values are assigned to real
-# providers in slice 1 — curation is slice 3, externally verified).
+# Internal TSV record schema (16 tab-separated columns), fixed order:
+#  id zone query_type scope family access weight role group state
+#  operational_status replacement audit_date confidence license info_url
 _NFTBAN_RBL_REG_QT="IP_DNSBL DOMAIN_URIBL URI_REPUTATION"
-_NFTBAN_RBL_REG_SCOPE="MAIL_REPUTATION TOR_EXIT POLICY EXPLOIT MALWARE"
+_NFTBAN_RBL_REG_SCOPE="MAIL_REPUTATION TOR_EXIT POLICY EXPLOIT MALWARE NETWORK_ALLOCATION ASN_REPUTATION"
 _NFTBAN_RBL_REG_FAMILY="IPV4 IPV6 IPV4_IPV6"
-_NFTBAN_RBL_REG_ACCESS="PUBLIC DQS CREDENTIALED RATE_LIMITED_PUBLIC"
+_NFTBAN_RBL_REG_ACCESS="PUBLIC DQS CREDENTIALED RATE_LIMITED_PUBLIC REGISTERED_RESOLVER"
 _NFTBAN_RBL_REG_WEIGHT="HIGH MEDIUM LOW INFORMATIONAL"
-_NFTBAN_RBL_REG_ROLE="PRIMARY COMPONENT CLASSIFICATION SECONDARY"
+_NFTBAN_RBL_REG_ROLE="PRIMARY COMPONENT CLASSIFICATION SECONDARY AGGREGATE"
 _NFTBAN_RBL_REG_STATE="enabled disabled conditional retired excluded"
-_NFTBAN_RBL_REG_FIELDS="zone query_type scope family access weight role group state info_url"
+_NFTBAN_RBL_REG_FIELDS="zone query_type scope family access weight role group state operational_status replacement audit_date confidence license info_url"
 
-# Membership word in a space-padded list?
 _nftban_rbl_reg_in() { case " $2 " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
-# Reject values carrying shell-dangerous content. The registry is PARSED, never
-# sourced/evaled, but this is defence-in-depth so a hostile artifact can never
-# influence a later expansion. Blocks $ ` ; | < > \ ( ) newline and $( .
+# Reject shell-dangerous content (defence-in-depth; the registry is PARSED, never
+# sourced/evaled). Blocks $ ` ; | < > \ ( ) newline and $( .
 _nftban_rbl_reg_safe() {
     local v="$1"
     [[ "$v" == *'$('* ]] && return 1
@@ -57,56 +51,49 @@ _nftban_rbl_reg_safe() {
     [[ "$v" == *$'\n'* ]] && return 1
     return 0
 }
-
-# A strict DNS hostname (must be dotted) — same shape the loader enforces.
 _nftban_rbl_reg_is_dnsname() {
     [[ "$1" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,62}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,62}[A-Za-z0-9])?)+$ ]]
 }
-
-# Trim leading/trailing whitespace.
 _nftban_rbl_reg_trim() {
     local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"
 }
 
-# CONSERVATIVE legacy projection: a bare `zone:url` → a typed record with safe,
-# non-committal defaults (query_type=IP_DNSBL, state=enabled, its OWN group so
-# nothing is grouped/deduped, PRIMARY role). NO weighting, NO grouping across
-# providers, NO reclassification — those are later slices.
+# CONSERVATIVE legacy projection: a bare `zone:url` -> a typed record with safe,
+# non-committal defaults. Used when no registry record matches the zone. The 5
+# slice-3A metadata columns default to UNVERIFIED/empty — never inferred.
 nftban_rbl_registry_legacy_record() {
     local zone="$1" url="${2:-}" id
-    id="${zone//[^a-z0-9_]/_}"     # lower-slug id; zones are already lowercase
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$id" "$zone" "IP_DNSBL" "MAIL_REPUTATION" "IPV4_IPV6" "PUBLIC" "" "PRIMARY" "$id" "enabled" "$url"
+    id="${zone//[^a-z0-9_]/_}"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$id" "$zone" "IP_DNSBL" "MAIL_REPUTATION" "IPV4_IPV6" "PUBLIC" "" "PRIMARY" "$id" "enabled" \
+        "UNVERIFIED" "" "" "UNVERIFIED" "UNVERIFIED" "$url"
 }
 
-# Parse an INI-block registry file into TSV records. Structural/enum/safety
-# errors print to stderr and return non-zero (deterministic failure). Never
-# sources the file. Emits nothing on error.
+# Parse an INI-block registry file into 16-col TSV. Structural/safety errors ->
+# stderr + non-zero. Never sources the file.
 nftban_rbl_registry_parse() {
     local file="${1:-$NFTBAN_RBL_REGISTRY_FILE}"
-    [[ -f "$file" ]] || return 0    # absent = empty registry, not an error
-    local line lineno=0 cur_id="" rc=0
-    local f_zone="" f_qt="IP_DNSBL" f_scope="MAIL_REPUTATION" f_family="IPV4_IPV6"
-    local f_access="PUBLIC" f_weight="" f_role="PRIMARY" f_group="" f_state="enabled" f_url=""
-    local out=""
+    [[ -f "$file" ]] || return 0
+    local line lineno=0 cur_id="" rc=0 out=""
+    local f_zone f_qt f_scope f_family f_access f_weight f_role f_group f_state f_op f_repl f_audit f_conf f_lic f_url
+    _reset(){ f_zone=""; f_qt="IP_DNSBL"; f_scope="MAIL_REPUTATION"; f_family="IPV4_IPV6"; f_access="PUBLIC"
+              f_weight=""; f_role="PRIMARY"; f_group=""; f_state="enabled"; f_op=""; f_repl=""; f_audit=""
+              f_conf=""; f_lic=""; f_url=""; }
+    _reset
     _flush() {
         [[ -z "$cur_id" ]] && return 0
         if [[ -z "$f_zone" ]]; then
             printf 'nftban: rbl registry: [%s] missing zone (%s)\n' "$cur_id" "$file" >&2; rc=1; return 0
         fi
         [[ -z "$f_group" ]] && f_group="$cur_id"
-        out+="${cur_id}	${f_zone}	${f_qt}	${f_scope}	${f_family}	${f_access}	${f_weight}	${f_role}	${f_group}	${f_state}	${f_url}"$'\n'
+        out+="${cur_id}	${f_zone}	${f_qt}	${f_scope}	${f_family}	${f_access}	${f_weight}	${f_role}	${f_group}	${f_state}	${f_op}	${f_repl}	${f_audit}	${f_conf}	${f_lic}	${f_url}"$'\n'
     }
     while IFS= read -r line || [[ -n "$line" ]]; do
         lineno=$((lineno+1))
         line="$(_nftban_rbl_reg_trim "$line")"
         [[ -z "$line" || "$line" == \#* ]] && continue
         if [[ "$line" =~ ^\[([A-Za-z0-9_]+)\]$ ]]; then
-            _flush
-            cur_id="${BASH_REMATCH[1]}"
-            f_zone=""; f_qt="IP_DNSBL"; f_scope="MAIL_REPUTATION"; f_family="IPV4_IPV6"
-            f_access="PUBLIC"; f_weight=""; f_role="PRIMARY"; f_group=""; f_state="enabled"; f_url=""
-            continue
+            _flush; cur_id="${BASH_REMATCH[1]}"; _reset; continue
         fi
         if [[ "$line" != *"="* ]]; then
             printf 'nftban: rbl registry: malformed line %d: %q (%s)\n' "$lineno" "$line" "$file" >&2; rc=1; continue
@@ -124,9 +111,10 @@ nftban_rbl_registry_parse() {
             printf 'nftban: rbl registry: unsafe value for %q in [%s] (%s:%d)\n' "$key" "$cur_id" "$file" "$lineno" >&2; rc=1; continue
         fi
         case "$key" in
-            zone) f_zone="$val" ;; query_type) f_qt="$val" ;; scope) f_scope="$val" ;;
-            family) f_family="$val" ;; access) f_access="$val" ;; weight) f_weight="$val" ;;
-            role) f_role="$val" ;; group) f_group="$val" ;; state) f_state="$val" ;; info_url) f_url="$val" ;;
+            zone) f_zone="$val";; query_type) f_qt="$val";; scope) f_scope="$val";; family) f_family="$val";;
+            access) f_access="$val";; weight) f_weight="$val";; role) f_role="$val";; group) f_group="$val";;
+            state) f_state="$val";; operational_status) f_op="$val";; replacement) f_repl="$val";;
+            audit_date) f_audit="$val";; confidence) f_conf="$val";; license) f_lic="$val";; info_url) f_url="$val";;
         esac
     done < "$file"
     _flush
@@ -134,59 +122,100 @@ nftban_rbl_registry_parse() {
     return $rc
 }
 
-# Validate a registry file deterministically. Non-zero on ANY of: parse error,
-# bad id, duplicate id, duplicate zone, invalid enum, invalid zone name, unsafe
-# content. Prints each violation to stderr.
+# Validate a registry file deterministically. Non-zero on ANY of: parse error;
+# bad/duplicate id or zone; invalid enum; invalid zone name; unsafe content;
+# missing/malformed audit_date/confidence/operational_status; replacement not
+# resolving to a declared record or an EXTERNAL: candidate; a cyclic internal
+# replacement chain. Prints each violation to stderr.
 nftban_rbl_registry_validate() {
     local file="${1:-$NFTBAN_RBL_REGISTRY_FILE}"
     [[ -f "$file" ]] || return 0
     local records rc=0
     records="$(nftban_rbl_registry_parse "$file")" || rc=1
-    local seen_id=" " seen_zone=" "
-    local id zone qt scope family access weight role group state url line
-    # TAB is an IFS-whitespace char, so `IFS=$'\t' read` COLLAPSES empty columns
-    # (e.g. an empty weight) and misaligns the record. Remap TAB → US (0x1f, not
-    # IFS-whitespace) so empty fields are preserved.
+    local seen_id=" " seen_zone=" " decl_zone=" " decl_id=" " repl_edges=""
+    local id zone qt scope family access weight role group state op repl audit conf lic url line
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        IFS=$'\x1f' read -r id zone qt scope family access weight role group state url <<< "${line//$'\t'/$'\x1f'}"
+        IFS=$'\x1f' read -r id zone qt scope family access weight role group state op repl audit conf lic url \
+            <<< "${line//$'\t'/$'\x1f'}"
         [[ -z "$id" ]] && continue
-        [[ "$id" =~ ^[a-z0-9_]+$ ]] || { printf 'nftban: rbl registry: invalid id %q (must be [a-z0-9_])\n' "$id" >&2; rc=1; }
+        [[ "$id" =~ ^[a-z0-9_]+$ ]] || { printf 'nftban: rbl registry: invalid id %q\n' "$id" >&2; rc=1; }
         _nftban_rbl_reg_is_dnsname "$zone" || { printf 'nftban: rbl registry: invalid zone %q in [%s]\n' "$zone" "$id" >&2; rc=1; }
         case "$seen_id" in *" $id "*) printf 'nftban: rbl registry: duplicate id %q\n' "$id" >&2; rc=1 ;; *) seen_id+="$id " ;; esac
         case "$seen_zone" in *" $zone "*) printf 'nftban: rbl registry: duplicate zone %q\n' "$zone" >&2; rc=1 ;; *) seen_zone+="$zone " ;; esac
-        _nftban_rbl_reg_in "$qt" "$_NFTBAN_RBL_REG_QT"       || { printf 'nftban: rbl registry: invalid query_type %q in [%s]\n' "$qt" "$id" >&2; rc=1; }
-        _nftban_rbl_reg_in "$scope" "$_NFTBAN_RBL_REG_SCOPE" || { printf 'nftban: rbl registry: invalid scope %q in [%s]\n' "$scope" "$id" >&2; rc=1; }
-        _nftban_rbl_reg_in "$family" "$_NFTBAN_RBL_REG_FAMILY" || { printf 'nftban: rbl registry: invalid family %q in [%s]\n' "$family" "$id" >&2; rc=1; }
-        _nftban_rbl_reg_in "$access" "$_NFTBAN_RBL_REG_ACCESS" || { printf 'nftban: rbl registry: invalid access %q in [%s]\n' "$access" "$id" >&2; rc=1; }
+        decl_zone+="$zone "; decl_id+="$id "
+        _nftban_rbl_reg_in "$qt" "$_NFTBAN_RBL_REG_QT"          || { printf 'nftban: rbl registry: invalid query_type %q in [%s]\n' "$qt" "$id" >&2; rc=1; }
+        _nftban_rbl_reg_in "$scope" "$_NFTBAN_RBL_REG_SCOPE"    || { printf 'nftban: rbl registry: invalid scope %q in [%s]\n' "$scope" "$id" >&2; rc=1; }
+        _nftban_rbl_reg_in "$family" "$_NFTBAN_RBL_REG_FAMILY"  || { printf 'nftban: rbl registry: invalid family %q in [%s]\n' "$family" "$id" >&2; rc=1; }
+        _nftban_rbl_reg_in "$access" "$_NFTBAN_RBL_REG_ACCESS"  || { printf 'nftban: rbl registry: invalid access %q in [%s]\n' "$access" "$id" >&2; rc=1; }
         [[ -z "$weight" ]] || _nftban_rbl_reg_in "$weight" "$_NFTBAN_RBL_REG_WEIGHT" || { printf 'nftban: rbl registry: invalid weight %q in [%s]\n' "$weight" "$id" >&2; rc=1; }
-        _nftban_rbl_reg_in "$role" "$_NFTBAN_RBL_REG_ROLE"   || { printf 'nftban: rbl registry: invalid role %q in [%s]\n' "$role" "$id" >&2; rc=1; }
-        [[ -z "$group" || "$group" =~ ^[a-z0-9_]+$ ]]        || { printf 'nftban: rbl registry: invalid group %q in [%s] (must be [a-z0-9_])\n' "$group" "$id" >&2; rc=1; }
-        _nftban_rbl_reg_in "$state" "$_NFTBAN_RBL_REG_STATE" || { printf 'nftban: rbl registry: invalid state %q in [%s]\n' "$state" "$id" >&2; rc=1; }
+        _nftban_rbl_reg_in "$role" "$_NFTBAN_RBL_REG_ROLE"      || { printf 'nftban: rbl registry: invalid role %q in [%s]\n' "$role" "$id" >&2; rc=1; }
+        [[ -z "$group" || "$group" =~ ^[a-z0-9_]+$ ]]           || { printf 'nftban: rbl registry: invalid group %q in [%s]\n' "$group" "$id" >&2; rc=1; }
+        _nftban_rbl_reg_in "$state" "$_NFTBAN_RBL_REG_STATE"    || { printf 'nftban: rbl registry: invalid state %q in [%s]\n' "$state" "$id" >&2; rc=1; }
+        [[ "$audit" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]          || { printf 'nftban: rbl registry: audit_date must be ISO YYYY-MM-DD in [%s] (got %q)\n' "$id" "$audit" >&2; rc=1; }
+        [[ "$conf" =~ ^[A-Z][A-Z_]*$ ]]                         || { printf 'nftban: rbl registry: confidence must be an UPPER_TOKEN in [%s] (got %q)\n' "$id" "$conf" >&2; rc=1; }
+        [[ "$op" =~ ^[A-Z][A-Z0-9_]*$ ]]                        || { printf 'nftban: rbl registry: operational_status must be an UPPER_TOKEN in [%s] (got %q)\n' "$id" "$op" >&2; rc=1; }
+        # license must be present (UNVERIFIED is first-class; never inferred permitted)
+        [[ -n "$lic" ]]                                         || { printf 'nftban: rbl registry: license required (use UNVERIFIED) in [%s]\n' "$id" >&2; rc=1; }
+        [[ -n "$repl" ]] && repl_edges+="${id}>${repl}"$'\n'
     done <<< "$records"
+    # RBL code runs under IFS=$'\n\t' (no space-splitting) — edges are newline-
+    # delimited and iterated with `read`, never `for x in $var`.
+    local e t src cur nxt depth e2
+    while IFS= read -r e; do
+        [[ -z "$e" ]] && continue
+        t="${e#*>}"
+        if [[ "$t" == EXTERNAL:* ]]; then
+            _nftban_rbl_reg_is_dnsname "${t#EXTERNAL:}" || { printf 'nftban: rbl registry: EXTERNAL replacement %q is not a dns name\n' "$t" >&2; rc=1; }
+        elif [[ "$decl_zone" != *" $t "* && "$decl_id" != *" $t "* ]]; then
+            printf 'nftban: rbl registry: replacement %q does not resolve to a declared record or EXTERNAL:<zone>\n' "$t" >&2; rc=1
+        fi
+    done <<< "$repl_edges"
+    while IFS= read -r e; do
+        [[ -z "$e" ]] && continue
+        src="${e%%>*}"; t="${e#*>}"; [[ "$t" == EXTERNAL:* ]] && continue
+        cur="$t"; depth=0
+        while [[ -n "$cur" ]]; do
+            [[ "$cur" == "$src" ]] && { printf 'nftban: rbl registry: cyclic replacement chain at %q\n' "$src" >&2; rc=1; break; }
+            depth=$((depth+1)); [[ $depth -gt 32 ]] && { printf 'nftban: rbl registry: replacement chain too deep from %q\n' "$src" >&2; rc=1; break; }
+            nxt=""
+            while IFS= read -r e2; do
+                [[ -z "$e2" ]] && continue
+                if [[ "${e2%%>*}" == "$cur" ]]; then nxt="${e2#*>}"; [[ "$nxt" == EXTERNAL:* ]] && nxt=""; break; fi
+            done <<< "$repl_edges"
+            cur="$nxt"
+        done
+    done <<< "$repl_edges"
     return $rc
 }
 
 # Typed records for the CURRENT effective provider set. Membership + order come
-# from the authoritative legacy loader (rbls.conf); each zone is projected to a
-# conservative legacy record. (Registry-supplied metadata overlay is a later
-# slice; slice 1 proves the projection + never changes membership.)
+# from the authoritative legacy loader (rbls.conf). When a VALID registry data
+# file is present, each zone's registry record is OVERLAID (metadata only); a
+# zone with no registry record — or any invalid registry — falls back to the
+# conservative legacy projection. NEVER changes membership, order, or count.
 nftban_rbl_registry_records() {
-    local line domain url
+    local reg="" have_reg=0
+    if [[ -f "$NFTBAN_RBL_REGISTRY_FILE" ]] && nftban_rbl_registry_validate "$NFTBAN_RBL_REGISTRY_FILE" >/dev/null 2>&1; then
+        reg="$(nftban_rbl_registry_parse "$NFTBAN_RBL_REGISTRY_FILE" 2>/dev/null)"; have_reg=1
+    fi
+    local line domain url match
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        domain="${line%%:*}"; url="${line#*:}"
-        [[ "$url" == "$line" ]] && url=""
-        nftban_rbl_registry_legacy_record "$domain" "$url"
+        domain="${line%%:*}"; url="${line#*:}"; [[ "$url" == "$line" ]] && url=""
+        match=""
+        [[ $have_reg -eq 1 ]] && match="$(printf '%s\n' "$reg" | awk -F'\t' -v z="$domain" '$2==z{print; exit}')"
+        if [[ -n "$match" ]]; then
+            printf '%s\n' "$match"
+        else
+            nftban_rbl_registry_legacy_record "$domain" "$url"
+        fi
     done < <(nftban_rbl_load_providers)
 }
 
-# Effective provider list (domain:url), the flat-list-compatibility bridge.
-# SLICE-1 GUARANTEE: byte-identical to nftban_rbl_load_providers. rbls.conf is
-# authoritative; the registry only supplies metadata and NEVER changes the set.
-# If a registry artifact is present but invalid, we emit a warning and STILL
-# return the authoritative legacy set — a malformed registry can never yield an
-# empty (or altered) effective provider list.
+# Effective provider list (domain:url) — the flat-list-compatibility bridge.
+# GUARANTEE: byte-identical to nftban_rbl_load_providers. rbls.conf is
+# authoritative; the registry supplies metadata only and NEVER changes the set.
 nftban_rbl_registry_effective() {
     if [[ -f "$NFTBAN_RBL_REGISTRY_FILE" ]]; then
         if ! nftban_rbl_registry_validate "$NFTBAN_RBL_REGISTRY_FILE" >/dev/null 2>&1; then
@@ -194,14 +223,11 @@ nftban_rbl_registry_effective() {
                 "$NFTBAN_RBL_REGISTRY_FILE" >&2
         fi
     fi
-    # Membership is always the authoritative legacy set in slice 1.
     nftban_rbl_load_providers
 }
 
-# ---- slice 2 (read-only inspection helpers; no state change) ----------------
+# ---- read-only inspection helpers (slice 2/3A; no state change) -------------
 
-# Echo the typed record (TSV) for a given id from the current effective set.
-# Returns non-zero if the id is not found.
 nftban_rbl_registry_get() {
     local want="$1" line
     while IFS= read -r line; do
@@ -210,10 +236,8 @@ nftban_rbl_registry_get() {
     return 1
 }
 
-# Live RFC5782 reachability probe of a DNSBL zone, FROM the operator's resolver.
-# Read-only diagnostic — changes NO state, issues NO ban, touches NO provider.
-# Classifies into the current RBL result vocabulary; a timeout and an NXDOMAIN
-# are NEVER conflated.
+# Live RFC5782 reachability probe FROM the operator's resolver. Read-only
+# diagnostic — changes NO state, issues NO ban. Timeout != NXDOMAIN.
 nftban_rbl_registry_test_zone() {
     local zone="$1" timeout="${NFTBAN_RBL_TIMEOUT:-4}" out st
     command -v dig >/dev/null 2>&1 || { printf 'NO_RESOLVER_TOOL'; return 0; }
@@ -222,11 +246,7 @@ nftban_rbl_registry_test_zone() {
     st="$(printf '%s\n' "$out" | sed -n 's/.*status: \([A-Z]*\),.*/\1/p' | head -1)"
     case "$st" in
         NOERROR)
-            if printf '%s\n' "$out" | grep -qE '[[:space:]]IN[[:space:]]+A[[:space:]]+127\.'; then
-                printf 'LISTED_TESTPOINT'
-            else
-                printf 'REACHABLE_NOANSWER'
-            fi ;;
+            if printf '%s\n' "$out" | grep -qE '[[:space:]]IN[[:space:]]+A[[:space:]]+127\.'; then printf 'LISTED_TESTPOINT'; else printf 'REACHABLE_NOANSWER'; fi ;;
         NXDOMAIN) printf 'CLEAN' ;;
         REFUSED)  printf 'REFUSED' ;;
         SERVFAIL) printf 'SERVFAIL' ;;
@@ -236,6 +256,6 @@ nftban_rbl_registry_test_zone() {
 }
 
 export -f nftban_rbl_registry_get nftban_rbl_registry_test_zone 2>/dev/null || true
-export -f _nftban_rbl_reg_in _nftban_rbl_reg_safe _nftban_rbl_reg_is_dnsname _nftban_rbl_reg_trim 2>/dev/null || true
 export -f nftban_rbl_registry_legacy_record nftban_rbl_registry_parse nftban_rbl_registry_validate 2>/dev/null || true
 export -f nftban_rbl_registry_records nftban_rbl_registry_effective 2>/dev/null || true
+export -f _nftban_rbl_reg_in _nftban_rbl_reg_safe _nftban_rbl_reg_is_dnsname _nftban_rbl_reg_trim 2>/dev/null || true

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh
@@ -114,6 +114,10 @@ access = PUBLIC
 role = PRIMARY
 group = spamhaus
 state = enabled
+operational_status = USABLE_PUBLIC
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
 info_url = https://www.spamhaus.org/zen/
 
 [barracuda]
@@ -121,6 +125,10 @@ zone = b.barracudacentral.org
 query_type = IP_DNSBL
 access = CREDENTIALED
 state = conditional
+operational_status = UNUSABLE_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
 EOF
 grep -q 'rc=0' <<<"$(runval "$VALID")" && ok "C1 valid registry validates (rc0)" || no "C1 valid rejected"
 

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
@@ -50,9 +50,9 @@ COMMON='export NFTBAN_RBL_PROVIDERS_FILE="'"$REAL_RBLS"'" NFTBAN_RBL_CUSTOM_FILE
 # --------------------------------------------------------------------------
 outA="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers list ) 2>&1 )"
 [[ "$(printf '%s\n' "$outA" | grep -cE '[[:space:]]IP_DNSBL[[:space:]]')" -eq 23 ]] && ok "A1 list shows 23 IP_DNSBL rows" || no "A1 list rows ($(printf '%s\n' "$outA" | grep -cE 'IP_DNSBL'))"
-printf '%s\n' "$outA" | grep -q 'Effective IP providers: 23' && ok "A2 list effective count 23" || no "A2 count"
-printf '%s\n' "$outA" | grep -qi 'no curation' && ok "A3 list states 'no curation'" || no "A3 no-curation note"
-printf '%s\n' "$outA" | grep -qi 'module-only' && ok "A4 list notes module-only (no registry data)" || no "A4 module-only note"
+printf '%s\n' "$outA" | grep -q 'Records: 23' && ok "A2 list record count 23" || no "A2 count"
+printf '%s\n' "$outA" | grep -qi 'legacy projection' && ok "A3 list states conservative legacy projection" || no "A3 no-curation note"
+printf '%s\n' "$outA" | grep -qi 'Registry data file: none' && ok "A4 list notes no registry data file" || no "A4 module-only note"
 
 # --------------------------------------------------------------------------
 # B — providers validate (no registry, then invalid registry)
@@ -68,7 +68,7 @@ outBi="$( ( eval "$COMMON"; RF="$(mktemp)"; printf '[x]\nzone = a.example.net\n[
 # C — providers explain
 # --------------------------------------------------------------------------
 outC="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers explain zen_spamhaus_org ) 2>&1 )"
-{ printf '%s\n' "$outC" | grep -q 'Zone:.*zen.spamhaus.org' && printf '%s\n' "$outC" | grep -q 'Query type:.*IP_DNSBL' && printf '%s\n' "$outC" | grep -q 'State:.*enabled'; } \
+{ printf '%s\n' "$outC" | grep -q 'Zone:.*zen.spamhaus.org' && printf '%s\n' "$outC" | grep -q 'Query type:.*IP_DNSBL' && printf '%s\n' "$outC" | grep -q 'State.*enabled'; } \
   && ok "C1 explain <id> shows the typed record" || no "C1 explain ($outC)"
 outCe="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers explain no_such_id; echo "RC=$?" ) 2>&1 )"
 { printf '%s\n' "$outCe" | grep -qi 'no provider with id' && ! printf '%s\n' "$outCe" | grep -q 'RC=0'; } \

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090  # $CMD_RBL/$RBL_CORE are runtime-resolved repo paths, sourced in subshells
+# =============================================================================
+# NFTBan - RBL provider registry SLICE 3A (typed metadata curation)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl_provider_registry_slice3a_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-13"
+# meta:description="Locks OPEN_SCOPE_RBL_PROVIDER_REGISTRY slice 3A — typed provider METADATA. Proves the shipped registry.conf: validates deterministically; carries exactly one record per configured rbls.conf zone (23) with unique stable IDs; every record has an ISO audit_date + confidence + license (UNVERIFIED rendered verbatim, never inferred permitted); valid enums incl the new scope/access/role tokens; the accepted metadata decisions are encoded (Spamhaus ZEN=AGGREGATE/conditional, SBL/XBL/PBL=COMPONENT/excluded, CBL replacement=xbl.spamhaus.org, URIBL=DOMAIN_URIBL/excluded, UCEPROTECT L1/L2/L3 scopes, tor=TOR_EXIT/CLASSIFICATION, Barracuda=REGISTERED_RESOLVER, SpamRATS=CREDENTIALED, DroneBL replacement=EXTERNAL:dnsbl.dronebl.org, dead providers=retired, anti-spam.org.cn UNUSABLE_FROM_TESTED_RESOLVER+HIGH_STATUS_LOW_SEMANTICS). The METADATA OVERLAY never changes membership: effective==legacy byte-identical, 23 zones in order, providers enable/disable still rc2. Validator negatives: replacement cycle, undeclared non-EXTERNAL replacement, missing audit_date, missing license, unsafe injection all fail. Registry is parsed, never sourced/evaled. providers list+explain expose the metadata. Shell-only; daemon byte-identical; RBL observe-only; rbls.conf byte-identical."
+# meta:input="Repo registry.conf + rbls.conf + cmd_rbl.sh/nftban_rbl.sh/nftban_rbl_registry.sh; synthetic negatives"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,sort"
+# meta:inventory.files="cli/lib/nftban/core/nftban_rbl_registry.sh,cli/lib/nftban/cli/cmd_rbl.sh,etc/nftban/conf.d/rbl/registry.conf,etc/nftban/conf.d/rbl/rbls.conf"
+# meta:inventory.binaries="bash,awk,grep,sort"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_RBL_PROVIDERS_FILE,NFTBAN_RBL_CUSTOM_FILE,NFTBAN_RBL_REGISTRY_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+set +eE
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if [[ -f "$SCRIPT_DIR/../core/nftban_rbl_registry.sh" ]]; then
+    NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+else
+    NFTBAN_LIB_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)/cli/lib/nftban"
+fi
+export NFTBAN_LIB_DIR
+REPO_ROOT="$(cd "$NFTBAN_LIB_DIR/../../.." && pwd)"
+CMD_RBL="$NFTBAN_LIB_DIR/cli/cmd_rbl.sh"
+RBL_CORE="$NFTBAN_LIB_DIR/core/nftban_rbl_registry.sh"
+REAL_RBLS="$REPO_ROOT/etc/nftban/conf.d/rbl/rbls.conf"
+REAL_REG="$REPO_ROOT/etc/nftban/conf.d/rbl/registry.conf"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+COMMON='export NFTBAN_RBL_PROVIDERS_FILE="'"$REAL_RBLS"'" NFTBAN_RBL_CUSTOM_FILE=/nope-$$ NFTBAN_RBL_REGISTRY_FILE="'"$REAL_REG"'"'
+
+echo "=== RBL provider registry — slice 3A (typed metadata) ==="
+
+# --------------------------------------------------------------------------
+# A — shipped registry validates + one record per configured zone + unique ids
+# --------------------------------------------------------------------------
+outA="$( ( eval "$COMMON"; source "$RBL_CORE" 2>/dev/null || true; set +eE
+  nftban_rbl_registry_validate "$REAL_REG"; echo "VRC=$?"
+  recs="$(nftban_rbl_registry_parse "$REAL_REG")"
+  echo "N=$(printf '%s\n' "$recs" | grep -c .)"
+  echo "IDS=$(printf '%s\n' "$recs" | awk -F'\t' '{print $1}' | sort -u | grep -c .)"
+  # registry zones == rbls.conf zones (membership authority)
+  rz="$(grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$REAL_RBLS" | cut -d: -f1 | sed 's/[[:blank:]]//g' | grep . | sort)"
+  gz="$(printf '%s\n' "$recs" | awk -F'\t' '{print $2}' | sort)"
+  [ "$rz" = "$gz" ] && echo "ZMATCH=1" || echo "ZMATCH=0"
+  # every record carries ISO audit_date + non-empty confidence + license
+  bad=$(printf '%s\n' "$recs" | awk -F'\t' '$13!~/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/ || $14=="" || $15==""{n++} END{print n+0}')
+  echo "MISS=$bad"
+) 2>&1 )"
+grep -q 'VRC=0' <<<"$outA" && ok "A1 shipped registry.conf validates (rc0)" || no "A1 registry invalid ($outA)"
+grep -q 'N=23' <<<"$outA" && ok "A2 exactly 23 typed records" || no "A2 record count ($(grep -o 'N=[0-9]*' <<<"$outA"))"
+grep -q 'IDS=23' <<<"$outA" && ok "A3 23 unique stable IDs" || no "A3 ids ($(grep -o 'IDS=[0-9]*' <<<"$outA"))"
+grep -q 'ZMATCH=1' <<<"$outA" && ok "A4 exactly one record per configured rbls.conf zone" || no "A4 zone mismatch"
+grep -q 'MISS=0' <<<"$outA" && ok "A5 every record carries ISO audit_date + confidence + license" || no "A5 missing metadata ($(grep -o 'MISS=[0-9]*' <<<"$outA"))"
+
+# --------------------------------------------------------------------------
+# B — METADATA OVERLAY never changes membership (effective==legacy, 23, order, rc2)
+# --------------------------------------------------------------------------
+outB="$( ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE
+  leg="$(nftban_rbl_load_providers)"; eff="$(nftban_rbl_registry_effective 2>/dev/null)"
+  [ "$leg" = "$eff" ] && echo "EFFEQ=1" || echo "EFFEQ=0"
+  echo "RECS=$(nftban_rbl_registry_records | grep -c .)"
+  # legacy rbl list still 23
+  echo "LIST=$(nftban_cmd_rbl_list 2>/dev/null | grep -oiE 'Total: *[0-9]+' | grep -oE '[0-9]+' | head -1)"
+  nftban_cmd_rbl_providers enable spamhaus_zen >/dev/null 2>&1; echo "EN=$?"
+  nftban_cmd_rbl_providers disable spamhaus_zen >/dev/null 2>&1; echo "DIS=$?"
+) 2>&1 )"
+{ grep -q 'EFFEQ=1' <<<"$outB" && grep -q 'RECS=23' <<<"$outB" && grep -q 'LIST=23' <<<"$outB"; } \
+  && ok "B1 overlay: effective==legacy, 23 records, legacy rbl list=23 (membership unchanged)" || no "B1 membership changed ($outB)"
+{ grep -q 'EN=2' <<<"$outB" && grep -q 'DIS=2' <<<"$outB"; } && ok "B2 providers enable/disable still rc2 (non-mutating)" || no "B2 enable/disable ($outB)"
+
+# --------------------------------------------------------------------------
+# C — accepted metadata decisions encoded (explain <id>)
+# --------------------------------------------------------------------------
+xget(){ ( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers explain "$1" 2>/dev/null ); }
+chk(){ printf '%s\n' "$2" | grep -qE "$3"; } # $1 label $2 text $3 regex
+E="$(xget spamhaus_zen)"; { chk _ "$E" 'Role:.*AGGREGATE' && chk _ "$E" 'State.*conditional' && chk _ "$E" 'Access:.*DQS'; } && ok "C1 Spamhaus ZEN = AGGREGATE/conditional/DQS" || no "C1 zen ($E)"
+E="$(xget spamhaus_sbl)"; { chk _ "$E" 'Role:.*COMPONENT' && chk _ "$E" 'Group:.*spamhaus' && chk _ "$E" 'State.*excluded'; } && ok "C2 SBL = COMPONENT/spamhaus/excluded" || no "C2 sbl"
+E="$(xget cbl_abuseat)"; chk _ "$E" 'Replacement:.*xbl.spamhaus.org' && ok "C3 CBL replacement = xbl.spamhaus.org (declared)" || no "C3 cbl repl"
+E="$(xget uribl_multi)"; { chk _ "$E" 'Query type:.*DOMAIN_URIBL' && chk _ "$E" 'State.*excluded'; } && ok "C4 URIBL = DOMAIN_URIBL/excluded" || no "C4 uribl"
+E1="$(xget uceprotect_l1)"; E2="$(xget uceprotect_l2)"; E3="$(xget uceprotect_l3)"
+{ chk _ "$E1" 'Scope:.*MAIL_REPUTATION' && chk _ "$E2" 'Scope:.*NETWORK_ALLOCATION' && chk _ "$E3" 'Scope:.*ASN_REPUTATION'; } && ok "C5 UCEPROTECT L1=IP / L2=allocation / L3=ASN" || no "C5 uceprotect"
+E="$(xget tor_dan)"; { chk _ "$E" 'Scope:.*TOR_EXIT' && chk _ "$E" 'Role:.*CLASSIFICATION'; } && ok "C6 tor.dan = TOR_EXIT/CLASSIFICATION" || no "C6 tor"
+E="$(xget barracuda_brbl)"; chk _ "$E" 'Access:.*REGISTERED_RESOLVER' && ok "C7 Barracuda = REGISTERED_RESOLVER" || no "C7 barracuda"
+E="$(xget spamrats)"; { chk _ "$E" 'Access:.*CREDENTIALED' && chk _ "$E" 'State.*conditional'; } && ok "C8 SpamRATS = CREDENTIALED/conditional" || no "C8 spamrats"
+E="$(xget dronebl)"; { chk _ "$E" 'Replacement:.*EXTERNAL:dnsbl.dronebl.org' && chk _ "$E" 'State.*disabled'; } && ok "C9 DroneBL zone-defect replacement=EXTERNAL:dnsbl.dronebl.org" || no "C9 dronebl"
+
+# --------------------------------------------------------------------------
+# D — lifecycle: dead=retired; anti-spam.org.cn separates status from semantics;
+#     UNVERIFIED license rendered verbatim (never inferred permitted)
+# --------------------------------------------------------------------------
+for id in sorbs_dnsbl sorbs_dul wpbl inps_de abusech_drone casa_cblless casa_cdl; do
+  E="$(xget "$id")"; chk _ "$E" 'State.*retired' || { no "D dead provider $id not retired"; break; }
+done
+[ $FAIL -eq 0 ] && ok "D1 all shutdown/defunct providers state=retired" 2>/dev/null || true
+E="$(xget casa_cblless)"; { chk _ "$E" 'Operational:.*UNUSABLE_FROM_TESTED_RESOLVER' && chk _ "$E" 'Confidence:.*HIGH_STATUS_LOW_SEMANTICS'; } \
+  && ok "D2 anti-spam.org.cn: UNUSABLE_FROM_TESTED_RESOLVER + HIGH_STATUS_LOW_SEMANTICS" || no "D2 casa ($E)"
+E="$(xget sorbs_dnsbl)"; chk _ "$E" 'License:.*UNVERIFIED' && ok "D3 UNVERIFIED license rendered verbatim (never inferred permitted)" || no "D3 license"
+
+# --------------------------------------------------------------------------
+# E — validator NEGATIVES (each deterministically rejected)
+# --------------------------------------------------------------------------
+reg(){ mktemp; }
+val(){ ( eval "$COMMON"; source "$RBL_CORE" 2>/dev/null || true; set +eE; nftban_rbl_registry_validate "$1" >/dev/null 2>&1; echo "rc=$?" ); }
+base='operational_status = OK
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED'
+CYC="$(reg)"; printf '[a]\nzone = a.example.net\nreplacement = b\n%s\n[b]\nzone = b.example.net\nreplacement = a\n%s\n' "$base" "$base" > "$CYC"
+grep -q 'rc=0' <<<"$(val "$CYC")" && no "E1 replacement cycle not caught" || ok "E1 replacement cycle rejected"
+UND="$(reg)"; printf '[a]\nzone = a.example.net\nreplacement = c.example.net\n%s\n' "$base" > "$UND"
+grep -q 'rc=0' <<<"$(val "$UND")" && no "E2 undeclared non-EXTERNAL replacement not caught" || ok "E2 undeclared replacement rejected"
+NOAUD="$(reg)"; printf '[a]\nzone = a.example.net\noperational_status = OK\nconfidence = HIGH\nlicense = UNVERIFIED\n' > "$NOAUD"
+grep -q 'rc=0' <<<"$(val "$NOAUD")" && no "E3 missing audit_date not caught" || ok "E3 missing audit_date rejected"
+NOLIC="$(reg)"; printf '[a]\nzone = a.example.net\noperational_status = OK\naudit_date = 2026-07-13\nconfidence = HIGH\n' > "$NOLIC"
+grep -q 'rc=0' <<<"$(val "$NOLIC")" && no "E4 missing license not caught" || ok "E4 missing license rejected"
+INJ="$(reg)"; printf '[a]\nzone = a.example.net\nlicense = free$(rm -rf x)\n%s\n' "$base" > "$INJ"
+grep -q 'rc=0' <<<"$(val "$INJ")" && no "E5 unsafe injection not caught" || ok "E5 unsafe field content rejected"
+EXT="$(reg)"; printf '[a]\nzone = a.example.net\nreplacement = EXTERNAL:good.example.org\n%s\n' "$base" > "$EXT"
+grep -q 'rc=0' <<<"$(val "$EXT")" && ok "E6 EXTERNAL:<dnsname> replacement accepted" || no "E6 EXTERNAL replacement rejected"
+rm -f "$CYC" "$UND" "$NOAUD" "$NOLIC" "$INJ" "$EXT"
+
+# --------------------------------------------------------------------------
+# F — registry parsed, never sourced/evaled; rbls.conf byte-identical
+# --------------------------------------------------------------------------
+grep -qE '(^|[^_a-z])(source|eval)[[:space:]]+"?\$?\{?NFTBAN_RBL_REGISTRY_FILE|(source|\.)[[:space:]].*registry\.conf' "$RBL_CORE" \
+  && no "F1 registry sourced/evaled" || ok "F1 registry never sourced/evaled"
+PRE="$(sha256sum "$REAL_RBLS" | awk '{print $1}')"
+( eval "$COMMON"; source "$CMD_RBL" 2>/dev/null || true; set +eE; nftban_cmd_rbl_providers list >/dev/null 2>&1; nftban_cmd_rbl_providers validate >/dev/null 2>&1 )
+[ "$PRE" = "$(sha256sum "$REAL_RBLS" | awk '{print $1}')" ] && ok "F2 rbls.conf byte-identical after providers commands" || no "F2 rbls.conf changed"
+
+# --------------------------------------------------------------------------
+echo "-------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED: %s\n' "${FAILED[@]}"; exit 1; fi
+echo "ALL PASS"; exit 0

--- a/etc/nftban/conf.d/rbl/registry.conf
+++ b/etc/nftban/conf.d/rbl/registry.conf
@@ -1,0 +1,371 @@
+# =============================================================================
+# NFTBan RBL Provider Registry — typed metadata (slice 3A)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="rbl-provider-registry"
+# meta:type="config"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Typed provider metadata for the RBL provider registry (slice 3A). One record per zone configured in rbls.conf. METADATA ONLY — this file does NOT change which providers are queried; rbls.conf remains the authoritative effective-set source. All lifecycle states here are PROPOSED (from the 2026-07-13 external audit RBL_PROVIDER_REGISTRY_SLICE_3_EXTERNAL_AUDIT_2026_07_13.md); they become active only in a later curation slice. Parsed line-by-line (INI blocks), never sourced/evaled. Fields: zone query_type scope family access weight role group state operational_status replacement audit_date confidence license info_url."
+# meta:inventory.files=""
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_RBL_REGISTRY_FILE"
+# meta:inventory.config_files="/etc/nftban/conf.d/rbl/rbls.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Evidence: 2026-07-13 external audit. Live dig from fleet resolver 127.0.0.53 +
+# web-sourced access/licensing/status. PROPOSED states only; no active change.
+
+# ── Spamhaus (aggregate + components; access-blocked from public resolver) ──
+[spamhaus_zen]
+zone = zen.spamhaus.org
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4_IPV6
+access = DQS
+weight = HIGH
+role = AGGREGATE
+group = spamhaus
+state = conditional
+operational_status = ACCESS_BLOCKED_OPEN_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = NO_REDISTRIBUTION_FREE_TIER
+info_url = https://www.spamhaus.org/zen/
+
+[spamhaus_sbl]
+zone = sbl.spamhaus.org
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+access = DQS
+role = COMPONENT
+group = spamhaus
+state = excluded
+operational_status = SPAMHAUS_COMPONENT_OF_ZEN
+audit_date = 2026-07-13
+confidence = HIGH
+license = NO_REDISTRIBUTION_FREE_TIER
+info_url = https://www.spamhaus.org/sbl/
+
+[spamhaus_xbl]
+zone = xbl.spamhaus.org
+query_type = IP_DNSBL
+scope = EXPLOIT
+access = DQS
+role = COMPONENT
+group = spamhaus
+state = excluded
+operational_status = SPAMHAUS_COMPONENT_OF_ZEN
+audit_date = 2026-07-13
+confidence = HIGH
+license = NO_REDISTRIBUTION_FREE_TIER
+info_url = https://www.spamhaus.org/xbl/
+
+[spamhaus_pbl]
+zone = pbl.spamhaus.org
+query_type = IP_DNSBL
+scope = POLICY
+access = DQS
+role = COMPONENT
+group = spamhaus
+state = excluded
+operational_status = SPAMHAUS_COMPONENT_OF_ZEN
+audit_date = 2026-07-13
+confidence = HIGH
+license = NO_REDISTRIBUTION_FREE_TIER
+info_url = https://www.spamhaus.org/pbl/
+
+[cbl_abuseat]
+zone = cbl.abuseat.org
+query_type = IP_DNSBL
+scope = EXPLOIT
+access = DQS
+role = COMPONENT
+group = spamhaus
+state = retired
+operational_status = SUPERSEDED_BY_SPAMHAUS_XBL
+replacement = xbl.spamhaus.org
+audit_date = 2026-07-13
+confidence = HIGH
+license = NO_REDISTRIBUTION_FREE_TIER
+info_url = https://www.spamhaus.org/resource-hub/dnsbl/update-for-composite-blocklist-cbl-users/
+
+# ── SORBS (defunct — Proofpoint shutdown 2024-06-05) ──
+[sorbs_dnsbl]
+zone = dnsbl.sorbs.net
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+access = PUBLIC
+role = PRIMARY
+group = sorbs
+state = retired
+operational_status = DEFUNCT_SHUTDOWN
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.sorbs.net/
+
+[sorbs_dul]
+zone = dul.dnsbl.sorbs.net
+query_type = IP_DNSBL
+scope = POLICY
+access = PUBLIC
+role = PRIMARY
+group = sorbs
+state = retired
+operational_status = DEFUNCT_SHUTDOWN
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.sorbs.net/
+
+# ── Barracuda (works from tested resolver; registration required) ──
+[barracuda_brbl]
+zone = b.barracudacentral.org
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4
+access = REGISTERED_RESOLVER
+weight = HIGH
+role = PRIMARY
+group = barracuda
+state = conditional
+operational_status = USABLE_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = MEDIUM_HIGH
+license = UNVERIFIED
+info_url = http://www.barracudacentral.org/rbl
+
+# ── Working public IP-DNSBLs ──
+[psbl_surriel]
+zone = psbl.surriel.com
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4
+access = PUBLIC
+role = PRIMARY
+group = psbl
+state = enabled
+operational_status = USABLE_PUBLIC_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://psbl.org/
+
+[spamcop_bl]
+zone = bl.spamcop.net
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4
+access = PUBLIC
+role = PRIMARY
+group = spamcop
+state = enabled
+operational_status = USABLE_PUBLIC_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = AS_IS_PUBLIC
+info_url = https://www.spamcop.net/bl.shtml
+
+# ── SpamRATS (credentialed; timed out from public resolver — NOT dead) ──
+[spamrats]
+zone = spam.spamrats.com
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4
+access = CREDENTIALED
+role = PRIMARY
+group = spamrats
+state = conditional
+operational_status = UNUSABLE_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.spamrats.com/
+
+# ── abuse.ch DNSBL (defunct ~2014; exact date lower confidence) ──
+[abusech_drone]
+zone = drone.abuse.ch
+query_type = IP_DNSBL
+scope = EXPLOIT
+access = PUBLIC
+role = PRIMARY
+group = abusech
+state = retired
+operational_status = DEFUNCT_SHUTDOWN
+audit_date = 2026-07-13
+confidence = HIGH_STATUS_MEDIUM_DATE
+license = UNVERIFIED
+info_url = https://www.abuse.ch/
+
+# ── Tor exit classification (informational, not spam reputation) ──
+[tor_dan]
+zone = tor.dan.me.uk
+query_type = IP_DNSBL
+scope = TOR_EXIT
+family = IPV4_IPV6
+access = PUBLIC
+weight = INFORMATIONAL
+role = CLASSIFICATION
+group = tor_dan
+state = enabled
+operational_status = USABLE_PUBLIC_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = AS_IS_PUBLIC
+info_url = https://www.dan.me.uk/dnsbl
+
+# ── UCEPROTECT levels (L1 direct-IP; L2 allocation; L3 ASN) ──
+[uceprotect_l1]
+zone = dnsbl-1.uceprotect.net
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+family = IPV4
+access = PUBLIC
+role = PRIMARY
+group = uceprotect
+state = enabled
+operational_status = USABLE_PUBLIC_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.uceprotect.net/
+
+[uceprotect_l2]
+zone = dnsbl-2.uceprotect.net
+query_type = IP_DNSBL
+scope = NETWORK_ALLOCATION
+family = IPV4
+access = PUBLIC
+weight = INFORMATIONAL
+role = SECONDARY
+group = uceprotect
+state = disabled
+operational_status = BROAD_ALLOCATION_LEVEL
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.uceprotect.net/
+
+[uceprotect_l3]
+zone = dnsbl-3.uceprotect.net
+query_type = IP_DNSBL
+scope = ASN_REPUTATION
+family = IPV4
+access = PUBLIC
+weight = INFORMATIONAL
+role = SECONDARY
+group = uceprotect
+state = excluded
+operational_status = BROAD_ASN_LEVEL
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://www.uceprotect.net/
+
+# ── DroneBL (configured-zone defect; correct zone is dnsbl.dronebl.org) ──
+[dronebl]
+zone = dnsbl-1.dronebl.org
+query_type = IP_DNSBL
+scope = EXPLOIT
+family = IPV4
+access = PUBLIC
+role = PRIMARY
+group = dronebl
+state = disabled
+operational_status = ZONE_DEFECT_NXDOMAIN
+replacement = EXTERNAL:dnsbl.dronebl.org
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = https://dronebl.org/
+
+# ── WPBL (defunct — shutdown 2023/2024) ──
+[wpbl]
+zone = db.wpbl.info
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+access = PUBLIC
+role = PRIMARY
+group = wpbl
+state = retired
+operational_status = DEFUNCT_SHUTDOWN
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = https://www.wpbl.info/
+
+# ── URIBL (DOMAIN/URI — wrong query type for a reversed-IP checker) ──
+[uribl_multi]
+zone = multi.uribl.com
+query_type = DOMAIN_URIBL
+scope = MAIL_REPUTATION
+access = RATE_LIMITED_PUBLIC
+role = AGGREGATE
+group = uribl
+state = excluded
+operational_status = WRONG_QUERY_TYPE_FOR_IP_CHECKER
+audit_date = 2026-07-13
+confidence = HIGH
+license = NONCOMMERCIAL_UNDER_100K_ELSE_PAID
+info_url = https://uribl.com/
+
+[uribl_black]
+zone = black.uribl.com
+query_type = DOMAIN_URIBL
+scope = MAIL_REPUTATION
+access = RATE_LIMITED_PUBLIC
+role = COMPONENT
+group = uribl
+state = excluded
+operational_status = WRONG_QUERY_TYPE_FOR_IP_CHECKER
+audit_date = 2026-07-13
+confidence = HIGH
+license = NONCOMMERCIAL_UNDER_100K_ELSE_PAID
+info_url = https://uribl.com/
+
+# ── CASA China anti-spam (unusable from tested resolver; historically defunct) ──
+[casa_cblless]
+zone = cblless.anti-spam.org.cn
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+access = PUBLIC
+role = PRIMARY
+group = casa
+state = retired
+operational_status = UNUSABLE_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH_STATUS_LOW_SEMANTICS
+license = UNVERIFIED
+info_url = http://www.anti-spam.org.cn/
+
+[casa_cdl]
+zone = cdl.anti-spam.org.cn
+query_type = IP_DNSBL
+scope = POLICY
+access = PUBLIC
+role = PRIMARY
+group = casa
+state = retired
+operational_status = UNUSABLE_FROM_TESTED_RESOLVER
+audit_date = 2026-07-13
+confidence = HIGH_STATUS_LOW_SEMANTICS
+license = UNVERIFIED
+info_url = http://www.anti-spam.org.cn/
+
+# ── INPS.de (defunct — offline 2020-05) ──
+[inps_de]
+zone = dnsbl.inps.de
+query_type = IP_DNSBL
+scope = MAIL_REPUTATION
+access = PUBLIC
+role = PRIMARY
+group = inps_de
+state = retired
+operational_status = DEFUNCT_SHUTDOWN
+audit_date = 2026-07-13
+confidence = HIGH
+license = UNVERIFIED
+info_url = http://dnsbl.inps.de/


### PR DESCRIPTION
## Summary

Slice 3A of `OPEN_SCOPE_RBL_PROVIDER_REGISTRY` — encodes truthful provider **METADATA** from the 2026-07-13 external audit. **Metadata only:** the effective queried set + order come from the authoritative legacy loader (`rbls.conf`); the registry never changes membership, order, count, or which zone is queried.

**Shell/config/tests only · 0 Go · daemon byte-identical · nft schema `1.84.0` · RBL observe-only · `rbls.conf` byte-identical · VERSION unchanged · no active provider change** (no add/remove/enable/disable/skip; no zone correction becomes active; `enable|disable` stay rc2; no default-profile migration).

## What ships
- **`core/nftban_rbl_registry.sh`** — schema 11→16 cols (`+operational_status, replacement, audit_date, confidence, license`). Validator requires ISO `audit_date` + `confidence` + `operational_status` + `license` (UNVERIFIED first-class, never inferred permitted); new enum tokens (`NETWORK_ALLOCATION`, `ASN_REPUTATION`, `REGISTERED_RESOLVER`, `AGGREGATE`); replacement resolves to a declared record or `EXTERNAL:<dnsname>`; **cyclic replacement chains rejected**. `records()` **overlays** registry metadata onto the legacy zones (membership still the loader); registry-absent/invalid ⇒ conservative legacy projection.
- **`etc/nftban/conf.d/rbl/registry.conf`** — 23 typed records, one per configured zone (Spamhaus ZEN=AGGREGATE/DQS/conditional, SBL/XBL/PBL=COMPONENT/excluded, CBL retired→`xbl.spamhaus.org`, URIBL=DOMAIN_URIBL/excluded, UCEPROTECT L1=MAIL/L2=NETWORK_ALLOCATION/L3=ASN_REPUTATION, tor=TOR_EXIT/CLASSIFICATION, Barracuda=REGISTERED_RESOLVER, SpamRATS=CREDENTIALED, DroneBL replacement=`EXTERNAL:dnsbl.dronebl.org`, dead providers=retired). Auto-ships via the existing `conf.d/rbl/*` glob; FHS tracks the dir only.
- **`cli/cmd_rbl.sh`** — `providers list` + `explain` expose the metadata (proposed states + a note the effective query set is unchanged).

## Validation
`rbl_provider_registry_slice3a_test.sh` **27/27**: validate; 23 records one-per-configured-zone; unique IDs; audit_date+confidence+license present; **overlay never changes membership** (effective==legacy, 23, order, rc2); accepted decisions encoded; dead=retired; anti-spam.org.cn `UNUSABLE_FROM_TESTED_RESOLVER`+`HIGH_STATUS_LOW_SEMANTICS`; UNVERIFIED license verbatim; validator negatives (cycle / undeclared replacement / missing audit_date / missing license / unsafe injection); never sourced; `rbls.conf` byte-identical. slice1/slice2 updated to the evolved schema/format (20/20, 18/18); full RBL suite 11/11; shellcheck clean; live loader byte-identical with/without the registry.

Deferred: `SLICE_3B_RESOLVER_QUALIFICATION`, `SLICE_3C_CURATED_PROJECTION` (zone fix, removals, conditional activation, effective-set reduction), slice 4, slice 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)