### PR TITLE
feat(portscan): trusted-monitoring-flow exclusion (shell-emit event suppression)

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan.sh
+++ b/cli/lib/nftban/core/nftban_portscan.sh
@@ -279,6 +279,18 @@ _nftban_portscan_load_modules() {
         fi
     fi
 
+    # Load trusted-monitoring-flow exclusion module (event-emit suppression only;
+    # empty/opt-in default). Sourced alongside classic so the emit filter is
+    # available in nftban_portscan_classic_process_logs.
+    local tflow_module=""
+    for path in "${core_dir}/nftban_portscan_trusted_flow.sh" "${dev_core_dir}/nftban_portscan_trusted_flow.sh"; do
+        if [[ -f "$path" ]]; then tflow_module="$path"; break; fi
+    done
+    if [[ -n "$tflow_module" ]]; then
+        # shellcheck source=/dev/null
+        source "$tflow_module" || true
+    fi
+
     # Load suricata module
     local suricata_module=""
     for path in "${core_dir}/nftban_portscan_suricata.sh" "${dev_core_dir}/nftban_portscan_suricata.sh"; do
@@ -808,6 +820,12 @@ nftban_portscan_status() {
     echo ""
     echo "  Note: Put custom settings in main.conf.local (survives upgrades)"
     echo ""
+
+    # Trusted-monitoring-flow exclusion (event-generation suppression only)
+    if type -t nftban_portscan_trusted_flow_render &>/dev/null; then
+        nftban_portscan_trusted_flow_render
+        echo ""
+    fi
 
     # ==========================================================================
     # v1.19.20 (B8): OPEN PORTS VISIBILITY

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -525,6 +525,16 @@ nftban_portscan_classic_process_logs() {
                 continue
             fi
 
+            # Trusted-monitoring-flow exclusion: suppress EVENT GENERATION (no event,
+            # no spool/state entry) ONLY for an exactly-declared, within-rate trusted
+            # flow tuple. Any dimension mismatch or an over-rate matching flow falls
+            # through to the normal emit+record path (abnormal behaviour stays visible).
+            # Firewall acceptance, ban authority, whitelist, and the classifier are unchanged.
+            if type -t nftban_portscan_trusted_flow_suppress &>/dev/null \
+               && nftban_portscan_trusted_flow_suppress "$src_ip" "$dst_ip" "$dst_port" "$proto"; then
+                continue
+            fi
+
             # Emit micro-event for stealth aggregation (uses original log timestamp)
             local log_ts
             log_ts=$(_nftban_portscan_extract_timestamp "$line")
@@ -548,6 +558,16 @@ nftban_portscan_classic_process_logs() {
 
             # Skip whitelisted IPs - HARD GATE (no state accumulation)
             if nftban_portscan_classic_is_whitelisted "$src_ip"; then
+                continue
+            fi
+
+            # Trusted-monitoring-flow exclusion: suppress EVENT GENERATION (no event,
+            # no spool/state entry) ONLY for an exactly-declared, within-rate trusted
+            # flow tuple. Any dimension mismatch or an over-rate matching flow falls
+            # through to the normal emit+record path (abnormal behaviour stays visible).
+            # Firewall acceptance, ban authority, whitelist, and the classifier are unchanged.
+            if type -t nftban_portscan_trusted_flow_suppress &>/dev/null \
+               && nftban_portscan_trusted_flow_suppress "$src_ip" "$dst_ip" "$dst_port" "$proto"; then
                 continue
             fi
 

--- a/cli/lib/nftban/core/nftban_portscan_trusted_flow.sh
+++ b/cli/lib/nftban/core/nftban_portscan_trusted_flow.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Portscan Trusted-Monitoring-Flow Exclusion
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nftban_portscan_trusted_flow"
+# meta:type="core"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-15"
+# meta:description="Suppresses portscan EVENT GENERATION only for an exactly-declared, within-rate trusted monitoring flow tuple (source CIDR + protocol + destination port + optional destination selector + rate bound). Shell-emit suppression: a matched, within-rate flow is dropped before event emission and before the spool/classifier — the Go classifier, firewall, ban authority, whitelist, RBL, and BotScan are untouched. Any dimension mismatch OR an over-rate matching flow generates the normal event (abnormal behavior stays visible). Config /etc/nftban/conf.d/portscan/trusted-flows.conf is parsed never sourced/evaled, ships empty (opt-in, per-host). No 0.0.0.0/0 or ::/0, no wildcard source/proto/port/rate, no port ranges. Per-rule suppression + over-rate counters exposed; suppression is never silent. 0 Go; daemon byte-identical; schema 1.84.0."
+# meta:inventory.files="/etc/nftban/conf.d/portscan/trusted-flows.conf,/var/lib/nftban/portscan-trusted-flow.state"
+# meta:inventory.binaries="bash,flock,date"
+# meta:inventory.env_vars="NFTBAN_PORTSCAN_CONFIG_DIR,NFTBAN_STATE_DIR,NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+# meta:inventory.config_files="/etc/nftban/conf.d/portscan/trusted-flows.conf"
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+
+: "${NFTBAN_PORTSCAN_CONFIG_DIR:=${NFTBAN_CONFIG_DIR:-/etc/nftban}/conf.d/portscan}"
+: "${NFTBAN_STATE_DIR:=/var/lib/nftban}"
+: "${NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE:=${NFTBAN_PORTSCAN_CONFIG_DIR}/trusted-flows.conf}"
+_PTF_STATE_FILE="${NFTBAN_PTF_STATE_FILE:-${NFTBAN_STATE_DIR}/portscan-trusted-flow.state}"
+_PTF_RATE_WINDOW_SECS=60          # events_per_minute → fixed 60s window
+_PTF_SUPPORTED_PROTOS=" tcp udp " # explicitly supported protocols only
+
+# Parsed rule table (rebuilt per load; parallel arrays)
+_PTF_LOADED=0
+declare -a _PTF_SRC _PTF_PROTO _PTF_PORT _PTF_DST _PTF_RATE _PTF_KEY
+_PTF_PARSE_ERRORS=0
+_PTF_DECLARATIONS=0
+
+# --------------------------------------------------------------------------
+# CIDR containment (self-contained; mirrors the tested nftban_emulate logic)
+# --------------------------------------------------------------------------
+_ptf_ip_to_int() { local a b c d; IFS='.' read -r a b c d <<< "$1"; echo $(( (a<<24)+(b<<16)+(c<<8)+d )); }
+
+_ptf_v4_in_cidr() { # ip cidr
+    local ip="$1" cidr="$2" net prefix mask ipi neti
+    if [[ "$cidr" != *"/"* ]]; then [[ "$ip" == "$cidr" ]]; return; fi
+    net="${cidr%/*}"; prefix="${cidr#*/}"
+    ipi=$(_ptf_ip_to_int "$ip"); neti=$(_ptf_ip_to_int "$net")
+    if [[ "$prefix" -eq 0 ]]; then mask=0; else mask=$(( 0xFFFFFFFF << (32-prefix) )); fi
+    [[ $(( ipi & mask )) -eq $(( neti & mask )) ]]
+}
+
+_ptf_v6_expand() { # ip -> 32 lowercase hex nibbles
+    local ip="$1" expanded="" left right lg=0 rg=0 missing zeros="" g i
+    if [[ "$ip" == *"::"* ]]; then
+        left="${ip%%::*}"; right="${ip#*::}"
+        if [[ -n "$left" ]]; then lg=$(echo "$left" | tr -cd ':' | wc -c); lg=$((lg+1)); fi
+        if [[ -n "$right" ]]; then rg=$(echo "$right" | tr -cd ':' | wc -c); rg=$((rg+1)); fi
+        missing=$((8-lg-rg))
+        for ((i=0;i<missing;i++)); do zeros="${zeros}0000"; done
+        if [[ -n "$left" ]]; then IFS=':' read -ra _g <<< "$left"; for g in "${_g[@]}"; do printf -v g "%04s" "$g"; expanded="${expanded}${g// /0}"; done; fi
+        expanded="${expanded}${zeros}"
+        if [[ -n "$right" ]]; then IFS=':' read -ra _g <<< "$right"; for g in "${_g[@]}"; do printf -v g "%04s" "$g"; expanded="${expanded}${g// /0}"; done; fi
+    else
+        IFS=':' read -ra _g <<< "$ip"; for g in "${_g[@]}"; do printf -v g "%04s" "$g"; expanded="${expanded}${g// /0}"; done
+    fi
+    echo "${expanded,,}"
+}
+
+_ptf_hex_to_bin() {
+    local hex="$1" bin="" i
+    for ((i=0;i<${#hex};i++)); do case "${hex:$i:1}" in
+        0) bin+="0000";; 1) bin+="0001";; 2) bin+="0010";; 3) bin+="0011";; 4) bin+="0100";; 5) bin+="0101";;
+        6) bin+="0110";; 7) bin+="0111";; 8) bin+="1000";; 9) bin+="1001";; a|A) bin+="1010";; b|B) bin+="1011";;
+        c|C) bin+="1100";; d|D) bin+="1101";; e|E) bin+="1110";; f|F) bin+="1111";; esac; done
+    echo "$bin"
+}
+
+_ptf_v6_in_cidr() { # ip cidr
+    local ip="$1" cidr="$2" net prefix iph neth ipb netb
+    if [[ "$cidr" != *"/"* ]]; then [[ "$(_ptf_v6_expand "$ip")" == "$(_ptf_v6_expand "$cidr")" ]]; return; fi
+    net="${cidr%/*}"; prefix="${cidr#*/}"
+    iph="$(_ptf_v6_expand "$ip")"; neth="$(_ptf_v6_expand "$net")"
+    [[ "$prefix" -eq 0 ]] && return 0
+    if [[ "$prefix" -eq 128 ]]; then [[ "$iph" == "$neth" ]]; return; fi
+    ipb="$(_ptf_hex_to_bin "$iph")"; netb="$(_ptf_hex_to_bin "$neth")"
+    [[ "${ipb:0:$prefix}" == "${netb:0:$prefix}" ]]
+}
+
+_ptf_ip_in_cidr() { # ip cidr  -> 0 if ip within cidr
+    local ip="$1" cidr="$2"
+    if [[ "$ip" == *:* ]]; then
+        [[ "$cidr" == *:* ]] || return 1; _ptf_v6_in_cidr "$ip" "$cidr"
+    else
+        [[ "$cidr" == *:* ]] && return 1; _ptf_v4_in_cidr "$ip" "$cidr"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Validation helpers
+# --------------------------------------------------------------------------
+_ptf_is_ipv4() { [[ "$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+    local o; IFS='.' read -ra _o <<< "$1"; for o in "${_o[@]}"; do (( o>=0 && o<=255 )) || return 1; done; }
+_ptf_is_ipv6() { [[ "$1" =~ ^[0-9A-Fa-f:]+$ && "$1" == *:* ]]; }
+_ptf_is_ipv4_cidr() { [[ "$1" == */* ]] || return 1; local n="${1%/*}" p="${1#*/}"; _ptf_is_ipv4 "$n" && [[ "$p" =~ ^[0-9]+$ ]] && (( p>=1 && p<=32 )); }
+_ptf_is_ipv6_cidr() { [[ "$1" == */* ]] || return 1; local n="${1%/*}" p="${1#*/}"; _ptf_is_ipv6 "$n" && [[ "$p" =~ ^[0-9]+$ ]] && (( p>=1 && p<=128 )); }
+
+# Reject any shell metacharacter / control content (defence-in-depth; parsed, never eval'd)
+_ptf_field_safe() { [[ ! "$1" =~ [\$\`\;\|\<\>\\\(\)\{\}\&\!\*\ \	] || "$1" == "*" ]]; }
+
+# --------------------------------------------------------------------------
+# Load + validate the trusted-flows config into the rule table.
+# Row format: source_cidr|protocol|destination_port|destination_selector|rate_limit
+# Returns 0 always (fail-safe: bad rows are skipped and counted, valid rows apply).
+# --------------------------------------------------------------------------
+nftban_portscan_trusted_flow_load() {
+    _PTF_SRC=(); _PTF_PROTO=(); _PTF_PORT=(); _PTF_DST=(); _PTF_RATE=(); _PTF_KEY=()
+    _PTF_PARSE_ERRORS=0; _PTF_DECLARATIONS=0; _PTF_LOADED=1
+    local f="$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+    [[ -f "$f" ]] || { _ptf_state_set declarations 0; _ptf_state_set parse_errors 0; return 0; }
+
+    local line lineno=0 src proto port dst rate key extra
+    local -A seen_tuple=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        lineno=$((lineno+1))
+        line="${line#"${line%%[![:space:]]*}"}"; line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        # exactly 5 columns (extra columns rejected)
+        IFS='|' read -r src proto port dst rate extra <<< "$line"
+        if [[ -n "$extra" || -z "$src" || -z "$proto" || -z "$port" || -z "$dst" || -z "$rate" ]]; then
+            _ptf_perr "$lineno" "expected exactly 5 columns"; continue
+        fi
+        # per-field metachar safety
+        if ! _ptf_field_safe "$src" || ! _ptf_field_safe "$proto" || ! _ptf_field_safe "$port" \
+           || ! _ptf_field_safe "$dst" || ! _ptf_field_safe "$rate"; then
+            _ptf_perr "$lineno" "unsafe characters"; continue
+        fi
+        # source: valid v4/v6 CIDR (a bare IP is treated as /32 or /128); NEVER 0.0.0.0/0 or ::/0
+        if [[ "$src" == "0.0.0.0/0" || "$src" == "::/0" || "$src" == "*" ]]; then _ptf_perr "$lineno" "wildcard/any source forbidden"; continue; fi
+        if _ptf_is_ipv4 "$src"; then src="${src}/32"; elif _ptf_is_ipv6 "$src"; then src="${src}/128"; fi
+        if ! _ptf_is_ipv4_cidr "$src" && ! _ptf_is_ipv6_cidr "$src"; then _ptf_perr "$lineno" "invalid source CIDR"; continue; fi
+        # protocol: explicitly supported only (no wildcard)
+        proto="${proto,,}"
+        if [[ "$_PTF_SUPPORTED_PROTOS" != *" $proto "* ]]; then _ptf_perr "$lineno" "unsupported/unspecified protocol"; continue; fi
+        # destination port: single 1-65535 (no ranges, no 0, no all-port)
+        if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port<1 || port>65535 )); then _ptf_perr "$lineno" "invalid destination port (single 1-65535; no ranges/0/all)"; continue; fi
+        # destination selector: * or a valid IP (interface selectors unsupported this release)
+        if [[ "$dst" != "*" ]] && ! _ptf_is_ipv4 "$dst" && ! _ptf_is_ipv6 "$dst"; then _ptf_perr "$lineno" "destination selector must be * or a valid IP"; continue; fi
+        # rate: mandatory N/min, N>=1 (no 0, negative, missing, or unbounded)
+        if [[ ! "$rate" =~ ^[1-9][0-9]*/min$ ]]; then _ptf_perr "$lineno" "rate must be a positive integer with /min suffix"; continue; fi
+        key="${src}_${proto}_${port}_${dst}"
+        # duplicate + overlapping/ambiguous rejection
+        if [[ -n "${seen_tuple[$key]:-}" ]]; then _ptf_perr "$lineno" "duplicate tuple"; continue; fi
+        local ov="${src}_${proto}_${port}"
+        if [[ -n "${seen_tuple[ov:$ov]:-}" ]]; then _ptf_perr "$lineno" "overlapping/ambiguous rule for same source+proto+port (differing destination)"; continue; fi
+        seen_tuple[$key]=1; seen_tuple[ov:$ov]=1
+        _PTF_SRC+=("$src"); _PTF_PROTO+=("$proto"); _PTF_PORT+=("$port"); _PTF_DST+=("$dst")
+        _PTF_RATE+=("${rate%/min}"); _PTF_KEY+=("$key")
+        _PTF_DECLARATIONS=$((_PTF_DECLARATIONS+1))
+    done < "$f"
+    _ptf_state_set declarations "$_PTF_DECLARATIONS"
+    _ptf_state_set parse_errors "$_PTF_PARSE_ERRORS"
+    return 0
+}
+
+_ptf_perr() { _PTF_PARSE_ERRORS=$((_PTF_PARSE_ERRORS+1))
+    printf 'nftban: portscan trusted-flows: line %s: %s (%s)\n' "$1" "$2" "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE" >&2; }
+
+# --------------------------------------------------------------------------
+# Persistent state (counters + per-rule rate window). flock-guarded k=v store.
+# --------------------------------------------------------------------------
+_ptf_state_lock() { exec {_ptf_lockfd}>>"${_PTF_STATE_FILE}.lock" 2>/dev/null || return 1; flock -w 2 "$_ptf_lockfd" 2>/dev/null || return 1; }
+_ptf_state_unlock() { [[ -n "${_ptf_lockfd:-}" ]] && exec {_ptf_lockfd}>&- 2>/dev/null; _ptf_lockfd=""; }
+# NOTE: rule keys contain regex metacharacters (/ : * .) — use awk EXACT string
+# comparison, never grep regex, for get/set.
+_ptf_state_get() { [[ -f "$_PTF_STATE_FILE" ]] || { echo ""; return; }
+    awk -F= -v k="$1" '$1==k{sub(/^[^=]*=/,"");print;exit}' "$_PTF_STATE_FILE" 2>/dev/null; }
+_ptf_state_set() { # key value  (atomic replace)
+    mkdir -p "$(dirname "$_PTF_STATE_FILE")" 2>/dev/null || return 0
+    local tmp; tmp="$(mktemp "${_PTF_STATE_FILE}.XXXXXX" 2>/dev/null)" || return 0
+    { [[ -f "$_PTF_STATE_FILE" ]] && awk -F= -v k="$1" '$1!=k' "$_PTF_STATE_FILE" 2>/dev/null; echo "$1=$2"; } > "$tmp" 2>/dev/null
+    mv -f "$tmp" "$_PTF_STATE_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+}
+_ptf_state_incr() { local cur; cur="$(_ptf_state_get "$1")"; [[ "$cur" =~ ^[0-9]+$ ]] || cur=0; _ptf_state_set "$1" "$((cur + ${2:-1}))"; }
+
+# Fixed 60s window per rule key. Echoes OK (record + within bound) or OVER.
+_ptf_rate_check() { # key bound
+    local key="$1" bound="$2" now win start count
+    now=$(date +%s 2>/dev/null) || now=0
+    win="$(_ptf_state_get "win_${key}")"
+    start="${win%%:*}"; count="${win##*:}"
+    [[ "$start" =~ ^[0-9]+$ ]] || start=0; [[ "$count" =~ ^[0-9]+$ ]] || count=0
+    if (( now - start >= _PTF_RATE_WINDOW_SECS )); then start=$now; count=0; fi
+    if (( count < bound )); then
+        _ptf_state_set "win_${key}" "${start}:$((count+1))"; echo OK
+    else
+        _ptf_state_set "win_${key}" "${start}:${count}"; echo OVER
+    fi
+}
+
+# --------------------------------------------------------------------------
+# HOT PATH: return 0 (suppress) iff src∈CIDR ∧ proto= ∧ dport= ∧ dst(*|=) ∧ within-rate.
+# Over-rate or any mismatch → return 1 (event generated by the normal detector).
+# --------------------------------------------------------------------------
+nftban_portscan_trusted_flow_suppress() { # src dst dport proto
+    [[ "$_PTF_LOADED" -eq 1 ]] || nftban_portscan_trusted_flow_load
+    (( _PTF_DECLARATIONS == 0 )) && return 1
+    local src="$1" dst="$2" dport="$3" proto="${4,,}" i n
+    n=${#_PTF_KEY[@]}
+    for ((i=0;i<n;i++)); do
+        [[ "$proto" == "${_PTF_PROTO[$i]}" ]] || continue
+        [[ "$dport" == "${_PTF_PORT[$i]}" ]] || continue
+        [[ "${_PTF_DST[$i]}" == "*" || "$dst" == "${_PTF_DST[$i]}" ]] || continue
+        _ptf_ip_in_cidr "$src" "${_PTF_SRC[$i]}" || continue
+        # matched tuple — apply rate bound
+        if [[ "$(_ptf_rate_check "${_PTF_KEY[$i]}" "${_PTF_RATE[$i]}")" == "OK" ]]; then
+            _ptf_state_incr trusted_flow_suppressed_total
+            _ptf_state_incr "suppressed_by_rule.${_PTF_KEY[$i]}"
+            return 0   # suppress: no event, no spool entry
+        else
+            _ptf_state_incr trusted_flow_over_rate_total
+            return 1   # over-rate: stays visible
+        fi
+    done
+    return 1
+}
+
+# --------------------------------------------------------------------------
+# Diagnostics / status render (never silent). Echoes human-readable summary.
+# --------------------------------------------------------------------------
+nftban_portscan_trusted_flow_render() {
+    nftban_portscan_trusted_flow_load
+    echo "  Trusted-flow exclusion (portscan EVENT GENERATION only — firewall & ban authority unchanged):"
+    local decl="${_PTF_DECLARATIONS:-0}" perr="${_PTF_PARSE_ERRORS:-0}"
+    local sup ovr; sup="$(_ptf_state_get trusted_flow_suppressed_total)"; ovr="$(_ptf_state_get trusted_flow_over_rate_total)"
+    printf '    trusted_flow_declarations:   %s\n' "$decl"
+    printf '    trusted_flow_parse_errors:   %s\n' "$perr"
+    printf '    trusted_flow_suppressed_total: %s\n' "${sup:-0}"
+    printf '    trusted_flow_over_rate_total:  %s  (matched tuples above the rate bound — kept VISIBLE)\n' "${ovr:-0}"
+    if (( decl == 0 )); then
+        printf '    (no declarations — nothing suppressed; default is empty/opt-in)\n'
+        return 0
+    fi
+    local i
+    for ((i=0;i<${#_PTF_KEY[@]};i++)); do
+        printf '    rule: %s|%s|%s|%s|%s/min  suppressed=%s\n' \
+            "${_PTF_SRC[$i]}" "${_PTF_PROTO[$i]}" "${_PTF_PORT[$i]}" "${_PTF_DST[$i]}" "${_PTF_RATE[$i]}" \
+            "$(_ptf_state_get "suppressed_by_rule.${_PTF_KEY[$i]}" | grep -E '^[0-9]+$' || echo 0)"
+    done
+}
+
+# CLI/diagnostic validation entry — returns rc 0 if config valid (or absent), 1 if any parse error.
+nftban_portscan_trusted_flow_validate() {
+    nftban_portscan_trusted_flow_load
+    if (( _PTF_PARSE_ERRORS > 0 )); then
+        printf '❌ %s parse error(s) in %s — those rows are ignored (fail-safe: not suppressed).\n' "$_PTF_PARSE_ERRORS" "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE" >&2
+        return 1
+    fi
+    printf '✅ trusted-flows config valid — %s declaration(s).\n' "$_PTF_DECLARATIONS"
+    return 0
+}
+
+export -f _ptf_ip_to_int _ptf_v4_in_cidr _ptf_v6_expand _ptf_hex_to_bin _ptf_v6_in_cidr _ptf_ip_in_cidr 2>/dev/null || true
+export -f _ptf_is_ipv4 _ptf_is_ipv6 _ptf_is_ipv4_cidr _ptf_is_ipv6_cidr _ptf_field_safe _ptf_perr 2>/dev/null || true
+export -f _ptf_state_get _ptf_state_set _ptf_state_incr _ptf_rate_check 2>/dev/null || true
+export -f nftban_portscan_trusted_flow_load nftban_portscan_trusted_flow_suppress 2>/dev/null || true
+export -f nftban_portscan_trusted_flow_render nftban_portscan_trusted_flow_validate 2>/dev/null || true

--- a/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
+++ b/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090
+# =============================================================================
+# NFTBan - Portscan Trusted-Monitoring-Flow Exclusion test
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="portscan_trusted_flow_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-15"
+# meta:description="Locks the portscan trusted-monitoring-flow exclusion: shell-emit suppression of an exactly-declared, within-rate trusted flow tuple only; exact-match (v4/v6/dst-host/counter-once), negatives (wrong port/multi-port/wrong proto/wrong dst/over-rate/outside-CIDR/empty/malformed-fail-safe/duplicate+overlap-rejected), fixed 60s rate window (over-rate stays visible + spools), parser rejects (0.0.0.0/0, ::/0, wildcard src/proto/port/rate, port 0/ranges/all, unsupported proto, malformed CIDR, unsafe chars, extra columns), counters (declarations/suppressed_total/suppressed_by_rule/over_rate_total/parse_errors), render never silent, config parsed-never-sourced, hooked into classic process_logs before emit+record, 0 Go / firewall+ban+whitelist+classifier unchanged."
+# meta:input="the trusted-flow module + synthetic configs + classic.sh/portscan.sh wiring"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,date,flock"
+# meta:inventory.files="cli/lib/nftban/core/nftban_portscan_trusted_flow.sh,cli/lib/nftban/core/nftban_portscan_classic.sh,cli/lib/nftban/core/nftban_portscan.sh"
+# meta:inventory.binaries="bash,awk,grep,date"
+# meta:inventory.env_vars="NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE,NFTBAN_PTF_STATE_FILE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+set +eE
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if [[ -f "$SCRIPT_DIR/../core/nftban_portscan_trusted_flow.sh" ]]; then
+    LIB="$(cd "$SCRIPT_DIR/.." && pwd)"
+else
+    LIB="$(cd "$SCRIPT_DIR/../../../.." && pwd)/cli/lib/nftban"
+fi
+MOD="$LIB/core/nftban_portscan_trusted_flow.sh"
+CLASSIC="$LIB/core/nftban_portscan_classic.sh"
+PORTSCAN="$LIB/core/nftban_portscan.sh"
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+eq(){ [ "$1" = "$2" ] && ok "$3" || no "$3 (want [$1] got [$2])"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+export NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE="$WORK/tf.conf"
+export NFTBAN_PTF_STATE_FILE="$WORK/tf.state"
+
+# helper: run one suppress decision in a clean sourced env
+sup(){ ( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_suppress "$1" "$2" "$3" "$4"; echo $?; ) | tail -1; }
+reset_state(){ rm -f "$NFTBAN_PTF_STATE_FILE"* 2>/dev/null; }
+
+echo "=== portscan trusted-flow exclusion ==="
+
+# --------------------------------------------------------------------------
+# A — exact-match suppression (v4, v6, dst-host), counter increments once
+# --------------------------------------------------------------------------
+reset_state
+cat > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE" <<'EOF'
+2a01:4f8:c014:5ee1::1/128|tcp|10050|*|30/min
+192.0.2.10/32|tcp|10050|192.0.2.20|30/min
+198.51.100.0/24|udp|161|*|30/min
+EOF
+outA="$( source "$MOD" 2>/dev/null; set +eE
+  nftban_portscan_trusted_flow_load
+  echo "DECL=$_PTF_DECLARATIONS"
+  nftban_portscan_trusted_flow_suppress 2a01:4f8:c014:5ee1::1 fe80::9 10050 tcp; echo "V6=$?"
+  nftban_portscan_trusted_flow_suppress 192.0.2.10 192.0.2.20 10050 tcp; echo "V4=$?"
+  nftban_portscan_trusted_flow_suppress 198.51.100.77 10.0.0.5 161 udp; echo "V4CIDR=$?"
+  echo "TOT=$(_ptf_state_get trusted_flow_suppressed_total)"
+)"
+g(){ printf '%s\n' "$outA" | sed -n "s/^$1=//p"; }
+eq "3" "$(g DECL)" "A1 three valid declarations loaded"
+eq "0" "$(g V6)"   "A2 exact IPv6 flow suppressed"
+eq "0" "$(g V4)"   "A3 IPv4 /32 + exact dst-host suppressed"
+eq "0" "$(g V4CIDR)" "A4 IPv4 /24 CIDR + udp/161 suppressed"
+eq "3" "$(g TOT)"  "A5 suppressed_total incremented once per suppressed event (3)"
+
+# --------------------------------------------------------------------------
+# B — negatives: every mismatch generates the event (return 1 = VISIBLE)
+# --------------------------------------------------------------------------
+reset_state
+printf '192.0.2.10/32|tcp|10050|192.0.2.20|30/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+eq "1" "$(sup 192.0.2.10 192.0.2.99 10050 tcp)" "B1 wrong destination → VISIBLE"
+eq "1" "$(sup 192.0.2.10 192.0.2.20 22    tcp)" "B2 wrong destination port → VISIBLE"
+eq "1" "$(sup 192.0.2.10 192.0.2.20 3306  tcp)" "B3 second (fan-out) port → VISIBLE"
+eq "1" "$(sup 192.0.2.10 192.0.2.20 10050 udp)" "B4 wrong protocol → VISIBLE"
+eq "1" "$(sup 203.0.113.9 192.0.2.20 10050 tcp)" "B5 source outside CIDR → VISIBLE"
+
+# --------------------------------------------------------------------------
+# C — fixed 60s rate window: over-rate stays visible AND is counted
+# --------------------------------------------------------------------------
+reset_state
+printf '10.10.10.10/32|tcp|10050|*|3/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+outC="$( source "$MOD" 2>/dev/null; set +eE
+  nftban_portscan_trusted_flow_load
+  r=""
+  for _ in 1 2 3 4 5; do nftban_portscan_trusted_flow_suppress 10.10.10.10 10.0.0.1 10050 tcp; r="$r$?"; done
+  echo "SEQ=$r"
+  echo "SUP=$(_ptf_state_get trusted_flow_suppressed_total)"
+  echo "OVR=$(_ptf_state_get trusted_flow_over_rate_total)"
+)"
+h(){ printf '%s\n' "$outC" | sed -n "s/^$1=//p"; }
+eq "00011" "$(h SEQ)" "C1 first 3 suppressed (0), 4th/5th over-rate visible (1) within 60s window"
+eq "3" "$(h SUP)" "C2 exactly 3 suppressed under a 3/min bound"
+eq "2" "$(h OVR)" "C3 over_rate_total counts the 2 visible-over-bound events"
+
+# --------------------------------------------------------------------------
+# D — parser rejects (fail-safe: bad rows skipped + counted, never suppress)
+# --------------------------------------------------------------------------
+reset_state
+cat > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE" <<'EOF'
+0.0.0.0/0|tcp|10050|*|5/min
+::/0|tcp|10050|*|5/min
+*|tcp|10050|*|5/min
+10.0.0.0/8|icmp|10050|*|5/min
+10.0.0.0/8|sctp|10050|*|5/min
+10.0.0.0/8|tcp|0|*|5/min
+10.0.0.0/8|tcp|70000|*|5/min
+10.0.0.0/8|tcp|10050-10060|*|5/min
+10.0.0.0/8|tcp|*|*|5/min
+10.0.0.0/8|tcp|10050|*|0/min
+10.0.0.0/8|tcp|10050|*|-5/min
+10.0.0.0/8|tcp|10050|*|9999
+10.0.0.0/8|tcp|10050|*|unlimited
+10.0.0.999/8|tcp|10050|*|5/min
+10.0.0.0/8|tcp|10050|eth0|5/min
+10.0.0.0/8|tcp|10050|*|5/min|extra
+10.0.0.0/8|tcp|10050|*|5/min;rm -rf /
+EOF
+outD="$( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_load 2>/dev/null
+  echo "DECL=$_PTF_DECLARATIONS PERR=$_PTF_PARSE_ERRORS" )"
+eq "DECL=0 PERR=17" "$outD" "D1 all 17 invalid rows rejected, 0 declarations (fail-safe)"
+reset_state
+printf '0.0.0.0/0|tcp|10050|*|5/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+eq "1" "$(sup 8.8.8.8 1.1.1.1 10050 tcp)" "D2 a rejected any-source row suppresses NOTHING"
+
+# --------------------------------------------------------------------------
+# E — duplicate + overlapping(same src+proto+port) rejection
+# --------------------------------------------------------------------------
+reset_state
+cat > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE" <<'EOF'
+192.0.2.10/32|tcp|10050|192.0.2.20|5/min
+192.0.2.10/32|tcp|10050|192.0.2.20|9/min
+192.0.2.10/32|tcp|10050|192.0.2.99|5/min
+EOF
+outE="$( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_load 2>/dev/null
+  echo "DECL=$_PTF_DECLARATIONS PERR=$_PTF_PARSE_ERRORS" )"
+eq "DECL=1 PERR=2" "$outE" "E1 duplicate + ambiguous-overlap rows rejected (1 kept, 2 rejected)"
+
+# --------------------------------------------------------------------------
+# F — empty / absent config changes nothing (default opt-in)
+# --------------------------------------------------------------------------
+reset_state; : > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+eq "1" "$(sup 192.0.2.10 192.0.2.20 10050 tcp)" "F1 empty config → nothing suppressed"
+reset_state; rm -f "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+eq "1" "$(sup 192.0.2.10 192.0.2.20 10050 tcp)" "F2 absent config → nothing suppressed"
+
+# --------------------------------------------------------------------------
+# G — render never silent + validate rc
+# --------------------------------------------------------------------------
+reset_state
+printf '192.0.2.10/32|tcp|10050|*|5/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+REP="$( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_render )"
+{ echo "$REP"|grep -q 'trusted_flow_declarations' && echo "$REP"|grep -q 'trusted_flow_over_rate_total' \
+  && echo "$REP"|grep -q 'firewall & ban authority unchanged'; } && ok "G1 render exposes counters + states event-gen-only/no-ban" || no "G1 render"
+( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_validate >/dev/null 2>&1 ); eq "0" "$?" "G2 validate rc0 on valid config"
+printf 'bad|row\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+( source "$MOD" 2>/dev/null; set +eE; nftban_portscan_trusted_flow_validate >/dev/null 2>&1 ); eq "1" "$?" "G3 validate rc1 on invalid config"
+
+# --------------------------------------------------------------------------
+# H — structural invariants (0 Go, no firewall/ban/whitelist/classifier change,
+#     parsed-not-sourced, hooked before emit+record, empty default ship)
+# --------------------------------------------------------------------------
+# actual (non-comment) code must not source/eval the config
+CODE="$(grep -vE '^[[:space:]]*#' "$MOD")"
+printf '%s\n' "$CODE" | grep -qE '(^|[^_[:alnum:]])(eval)[[:space:]]|(^|[[:space:]])(source|\.)[[:space:]]+[^;]*(TRUSTED_FLOWS|trusted-flows)' \
+  && no "H1 config sourced/evaled" || ok "H1 config parsed, never sourced/evaled"
+# suppress hook sits AFTER whitelist and BEFORE emit+record in classic process_logs
+if grep -q 'nftban_portscan_trusted_flow_suppress' "$CLASSIC"; then
+  n=$(grep -c 'nftban_portscan_trusted_flow_suppress "\$src_ip"' "$CLASSIC")
+  eq "2" "$n" "H2 emit filter wired into both process_logs paths (journalctl + file)"
+else no "H2 not wired"; fi
+# a suppressed flow reaches neither emit nor record (the continue precedes both)
+awk '/trusted_flow_suppress/{f=1} f&&/_nftban_portscan_emit_event/{print "EMIT_AFTER"; exit}' "$CLASSIC" | grep -q EMIT_AFTER \
+  && ok "H3 suppress continue precedes emit_event + record_connection (no event, no spool)" || no "H3 ordering"
+grep -q 'nftban_portscan_trusted_flow' "$PORTSCAN" && ok "H4 module sourced by portscan.sh + status render wired" || no "H4 not sourced"
+# no firewall/ban/whitelist/nft MUTATION in actual (non-comment) code
+printf '%s\n' "$CODE" | grep -qiE 'nft[[:space:]]+(add|delete|flush|insert)|nftban_(un)?ban|AddIPWithTimeout|blacklist_(v4|v6|manual)|whitelist_(v4|v6)' \
+  && no "H5 module mutates firewall/ban/whitelist" || ok "H5 module does NOT touch firewall/ban/whitelist"
+# example config ships; live default absent
+[ -f "$LIB/../../../etc/nftban/conf.d/portscan/trusted-flows.conf.example" ] && ok "H6 example template ships" || no "H6 example missing"
+[ ! -f "$LIB/../../../etc/nftban/conf.d/portscan/trusted-flows.conf" ] && ok "H7 live config ships ABSENT (empty/opt-in default)" || no "H7 live config should not ship"
+
+# --------------------------------------------------------------------------
+# I — set -Eeuo pipefail safety: repeated calls don't error/hang
+# --------------------------------------------------------------------------
+reset_state
+printf '10.0.0.0/8|tcp|10050|*|1000/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+outI="$( set -Eeuo pipefail; source "$MOD" 2>/dev/null; set +e
+  nftban_portscan_trusted_flow_load
+  for _ in $(seq 1 20); do nftban_portscan_trusted_flow_suppress 10.1.2.3 10.0.0.1 10050 tcp >/dev/null 2>&1; done
+  echo "SUP=$(_ptf_state_get trusted_flow_suppressed_total)"; echo DONE )"
+case "$outI" in *DONE*) ok "I1 20 repeated suppress calls complete under strict mode (no hang/error)";; *) no "I1 repeated calls";; esac
+eq "SUP=20" "$(printf '%s\n' "$outI" | sed -n 's/^\(SUP=[0-9]*\)$/\1/p')" "I2 high-volume matching (under bound) all suppressed → no spool entries"
+
+echo "─────────────────────────────────────────────"
+printf 'RESULTS: %s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -ne 0 ] && { printf 'FAILED:\n'; printf '  - %s\n' "${FAILED[@]}"; exit 1; }
+echo "ALL PASS"; exit 0

--- a/etc/nftban/conf.d/portscan/trusted-flows.conf.example
+++ b/etc/nftban/conf.d/portscan/trusted-flows.conf.example
@@ -1,0 +1,43 @@
+# NFTBan — Portscan Trusted-Monitoring-Flow Exclusion (EXAMPLE / TEMPLATE)
+# =============================================================================
+# Copy to  /etc/nftban/conf.d/portscan/trusted-flows.conf  and edit to activate.
+# The live file ships ABSENT — suppression is OPT-IN and PER-HOST. With no live
+# file, nothing is suppressed.
+#
+# This file is PARSED, never sourced or evaluated.
+#
+# WHAT THIS DOES (and does NOT):
+#   • Suppresses portscan EVENT GENERATION (no event, no spool/state entry) for
+#     an exactly-declared, within-rate trusted monitoring flow — e.g. a Zabbix
+#     agent poll to tcp/10050. This removes the analyzer CPU + spool churn AT
+#     THE SOURCE.
+#   • Does NOT change firewall acceptance, ban authority, whitelist/exemption
+#     sets, the Go classifier verdict, RBL, or BotScan.
+#   • Any packet that does NOT match every declared dimension — a different
+#     destination port, port fan-out, different protocol, unexpected
+#     destination, or a rate ABOVE the declared bound — generates the normal
+#     portscan event. Abnormal behaviour from the trusted source stays VISIBLE.
+#
+# ROW FORMAT (exactly five | -delimited columns):
+#   source_cidr | protocol | destination_port | destination_selector | rate_limit
+#
+#   source_cidr           IPv4/IPv6 CIDR or bare IP (bare = /32 or /128).
+#                         0.0.0.0/0 and ::/0 are REJECTED. No wildcard source.
+#   protocol              tcp | udp  (exact; no wildcard).
+#   destination_port      single port 1-65535 (no ranges, no 0, no all-port).
+#   destination_selector  * (any local destination) OR a specific local IP.
+#   rate_limit            N/min  — positive integer events per minute. Matching
+#                         events beyond N within a 60s window are NOT suppressed
+#                         (they stay visible). Zero/negative/missing/unbounded
+#                         are REJECTED.
+#
+# EXAMPLES (commented — copy + adapt per host; declare only flows you verified):
+#   # Zabbix server (IPv6) polling this host's Zabbix agent, ~1 poll/5s:
+#   # 2a01:4f8:c014:5ee1::1/128|tcp|10050|*|12/min
+#   # Zabbix server (IPv4) polling a specific local address:
+#   # 192.0.2.10/32|tcp|10050|192.0.2.20|12/min
+#
+# Use * ONLY for the destination selector. Do not wildcard source, protocol,
+# port, or rate. Duplicate or overlapping (same source+proto+port) rows are
+# rejected. Malformed rows are skipped (fail-safe: never suppressed) and counted
+# under trusted_flow_parse_errors — see `nftban portscan status`.

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1491,6 +1491,10 @@ fi
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/ddos/*.conf
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/login/*.conf
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/portscan/*.conf
+# trusted-flows.conf.example is a documentation template (not operator config):
+# ship it plain so upgrades refresh it. The live trusted-flows.conf is opt-in and
+# is NOT shipped (operator copies + edits the example to activate).
+%attr(640,root,nftban) /etc/nftban/conf.d/portscan/*.conf.example
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/suricata/interfaces.conf
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/rbl/*
 %attr(640,root,nftban) %config(noreplace) /etc/nftban/conf.d/tunnel/main.conf


### PR DESCRIPTION
## Portscan trusted-monitoring-flow exclusion

Implements `GO_IMPLEMENT_PORTSCAN_TRUSTED_MONITORING_FLOW_EXCLUSION`. Suppresses portscan **event generation only** for an exactly-declared, within-rate trusted monitoring flow tuple (e.g. a Zabbix agent poll to `tcp/10050`), removing the analyzer CPU + spool churn at its source. **Independent lane** — not RBL/registry; no runtime overlap with the release lane.

### Suppression point = `SHELL_EMIT`
Filter runs in `nftban_portscan_classic_process_logs` **after** the whitelist gate and **before** `_nftban_portscan_emit_event` + `record_connection` — a matched, within-rate flow yields **no event and no spool/state entry**. The Go classifier needs no change; the daemon stays **byte-identical**.

### Exact behavioral contract
Suppress only when **all** match: source ∈ declared CIDR · protocol exact · destination port exact · destination selector (`*` or exact IP) · observed rate ≤ bound. **Any** mismatch — or a matching flow **above** the rate bound — generates the normal event. Abnormal behaviour (undeclared port, fan-out, wrong proto, unexpected destination, over-rate, malformed config) stays **fully visible**.

### Config (opt-in, per-host)
`/etc/nftban/conf.d/portscan/trusted-flows.conf` — **parsed, never sourced/evaled**; ships **absent** (empty default). Row: `source_cidr|protocol|destination_port|destination_selector|rate_limit`, rate `N/min` (fixed 60s window). Strict validator **rejects** `0.0.0.0/0` · `::/0` · wildcard source/proto/port/rate · non-tcp/udp · port 0/ranges/all · malformed CIDR · unsafe chars · extra columns · duplicate + overlapping tuples (malformed rows skipped fail-safe + counted).

### Observability (never silent)
`portscan status` renders `trusted_flow_declarations / _suppressed_total / _suppressed_by_rule / _over_rate_total / _parse_errors` + per-rule counts, and states that only event generation is affected — firewall & ban authority unchanged.

### Untouched
nftables acceptance · whitelist/exemption sets · ban/unban authority · Go classifier verdicts · BotScan · RBL · firewall · **daemon binary** · schema.

### Classification
shell/config/tests/docs · **0 Go** · daemon **byte-identical** · schema **1.84.0** · **VERSION unchanged (1.220.8)**.

### Tests
`portscan_trusted_flow_test.sh` **30/30** — exact-match (v4/v6/dst-host, counter-once), negatives (wrong port/fan-out/proto/dst/outside-CIDR), 60s rate window (over-rate visible + counted), all parser rejects, dup/overlap rejection, empty/absent config, render, and structural invariants (parsed-not-sourced, hooked before emit+record, no firewall/ban/whitelist mutation, example ships / live absent). Existing portscan test green; shellcheck `-S warning` clean; FHS `--check` clean.

No host configuration is added by this PR — the shipped default is empty/opt-in. Stops before release-prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)