### PR TITLE
fix(portscan): canonicalize IPv6 trusted-flow destination matching

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan_trusted_flow.sh
+++ b/cli/lib/nftban/core/nftban_portscan_trusted_flow.sh
@@ -141,7 +141,14 @@ nftban_portscan_trusted_flow_load() {
         # destination port: single 1-65535 (no ranges, no 0, no all-port)
         if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port<1 || port>65535 )); then _ptf_perr "$lineno" "invalid destination port (single 1-65535; no ranges/0/all)"; continue; fi
         # destination selector: * or a valid IP (interface selectors unsupported this release)
-        if [[ "$dst" != "*" ]] && ! _ptf_is_ipv4 "$dst" && ! _ptf_is_ipv6 "$dst"; then _ptf_perr "$lineno" "destination selector must be * or a valid IP"; continue; fi
+        # destination selector: * | bare IP | single-host CIDR (/32 or /128 → normalised to the IP)
+        if [[ "$dst" != "*" ]]; then
+            case "$dst" in
+                */32)  _ptf_is_ipv4 "${dst%/32}"  && dst="${dst%/32}" ;;
+                */128) _ptf_is_ipv6 "${dst%/128}" && dst="${dst%/128}" ;;
+            esac
+            if ! _ptf_is_ipv4 "$dst" && ! _ptf_is_ipv6 "$dst"; then _ptf_perr "$lineno" "destination selector must be * , a valid IP, or a /32|/128 single host"; continue; fi
+        fi
         # rate: mandatory N/min, N>=1 (no 0, negative, missing, or unbounded)
         if [[ ! "$rate" =~ ^[1-9][0-9]*/min$ ]]; then _ptf_perr "$lineno" "rate must be a positive integer with /min suffix"; continue; fi
         key="${src}_${proto}_${port}_${dst}"
@@ -206,7 +213,9 @@ nftban_portscan_trusted_flow_suppress() { # src dst dport proto
     for ((i=0;i<n;i++)); do
         [[ "$proto" == "${_PTF_PROTO[$i]}" ]] || continue
         [[ "$dport" == "${_PTF_PORT[$i]}" ]] || continue
-        [[ "${_PTF_DST[$i]}" == "*" || "$dst" == "${_PTF_DST[$i]}" ]] || continue
+        # destination match: * (any) or IP-equivalence — notation-robust (the runtime
+        # dst arrives from the kernel log in EXPANDED IPv6 form, a config may be compressed).
+        if [[ "${_PTF_DST[$i]}" != "*" ]]; then _ptf_ip_in_cidr "$dst" "${_PTF_DST[$i]}" || continue; fi
         _ptf_ip_in_cidr "$src" "${_PTF_SRC[$i]}" || continue
         # matched tuple — apply rate bound
         if [[ "$(_ptf_rate_check "${_PTF_KEY[$i]}" "${_PTF_RATE[$i]}")" == "OK" ]]; then

--- a/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
+++ b/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
@@ -75,6 +75,25 @@ eq "0" "$(g V4CIDR)" "A4 IPv4 /24 CIDR + udp/161 suppressed"
 eq "3" "$(g TOT)"  "A5 suppressed_total incremented once per suppressed event (3)"
 
 # --------------------------------------------------------------------------
+# A6 — exact IPv6 destination is NOTATION-ROBUST: the kernel/parse_line dst arrives
+# EXPANDED (2a01:04f8:...:0001) while a config uses compressed (2a01:4f8:...::1),
+# and /128 on the destination selector is accepted (normalised to the bare IP).
+# --------------------------------------------------------------------------
+reset_state
+printf '2a01:4f8:c014:5ee1::1/128|tcp|10050|2a01:4f8:c014:f4da::1/128|120/min\n' > "$NFTBAN_PORTSCAN_TRUSTED_FLOWS_FILE"
+out6="$( source "$MOD" 2>/dev/null; set +eE
+  nftban_portscan_trusted_flow_load
+  echo "DECL=$_PTF_DECLARATIONS PERR=$_PTF_PARSE_ERRORS DST=${_PTF_DST[0]}"
+  nftban_portscan_trusted_flow_suppress 2a01:04f8:c014:5ee1:0000:0000:0000:0001 2a01:04f8:c014:f4da:0000:0000:0000:0001 10050 tcp; echo "EXP=$?"
+  nftban_portscan_trusted_flow_suppress 2a01:4f8:c014:5ee1::1 2a01:4f8:c014:f4da::1 10050 tcp; echo "CMP=$?"
+  nftban_portscan_trusted_flow_suppress 2a01:04f8:c014:5ee1:0000:0000:0000:0001 2a01:04f8:c014:ffff:0000:0000:0000:0009 10050 tcp; echo "WRONG=$?" )"
+k(){ printf '%s\n' "$out6" | sed -n "s/^$1=//p"; }
+eq "DECL=1 PERR=0 DST=2a01:4f8:c014:f4da::1" "$(printf '%s\n' "$out6"|grep -E '^DECL=')" "A6a /128 destination accepted + normalised to bare IP, parses clean"
+eq "0" "$(k EXP)" "A6b exact IPv6 dst matches EXPANDED runtime notation (kernel-log form) → suppressed"
+eq "0" "$(k CMP)" "A6c exact IPv6 dst matches COMPRESSED runtime notation → suppressed"
+eq "1" "$(k WRONG)" "A6d different IPv6 dst → VISIBLE"
+
+# --------------------------------------------------------------------------
 # B — negatives: every mismatch generates the event (return 1 = VISIBLE)
 # --------------------------------------------------------------------------
 reset_state


### PR DESCRIPTION
## Portscan trusted-flow IPv6 destination canonicalization hotfix

Implements `GO_PORTSCAN_TRUSTED_FLOW_IPV6_DST_MATCH_HOTFIX`. Fixes two portable product defects in v1.220.9 (all distros, both package families — the same shell module ships in DEB + RPM), caught by the srv3 exact-IPv6 canary.

### `BUG_PORTSCAN_TRUSTED_FLOW_IPV6_DST_NOTATION_SENSITIVE_MATCH`
The destination match used **raw string equality**. The kernel/`parse_line` delivers the runtime destination **expanded** (`2a01:04f8:c014:f4da:0000:0000:0000:0001`); a config uses **compressed** (`2001:db8:c014:f4da::1`) — the same address, but string equality says they differ, so an exact IPv6 destination **never matched → suppressed nothing** (fail-safe under-suppression; the *source* field was already correct via the CIDR matcher). **Fix:** compare the destination with the notation-independent IP-equivalence matcher (`_ptf_ip_in_cidr`, which expands both sides).

### `BUG_PORTSCAN_TRUSTED_FLOW_DST_SINGLE_HOST_CIDR_REJECTED`
The selector accepted only `*` or a bare IP, but the documented/gate usage is `<destination>/128`. **Fix:** normalize `/32` → bare IPv4 and `/128` → bare IPv6 (single exact host); broader destination CIDRs still rejected.

### Scope
Not affected: IPv4 exact destination · `dst=*` · source CIDR matching · firewall/ban/whitelist · Go classifier · RBL · ordinary portscan visibility. Failure mode was **fail-safe (under-suppression)** — events stayed visible. The missing coverage was **input-representation**, not package-family (the DEB/RPM package-native passes proved packaging/parsing/rate/rollback; both initially used compressed IPv6 on both sides).

### Classification / invariants
shell/config/tests · **0 Go** · daemon **byte-identical** · schema **1.84.0** · **VERSION unchanged (1.220.9)**.

### Tests
`portscan_trusted_flow_test` **34/34** — added: `/128` accepted + normalized to bare IP; exact IPv6 dst matches **expanded** (kernel-log form) and **compressed** runtime notation; a different IPv6 dst stays visible. shellcheck `-S warning` clean. Stops before release-prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
