### PR TITLE
fix(stats): version-aware sort for release-totals.csv

### DIFF
--- a/scripts/project_statistics.py
+++ b/scripts/project_statistics.py
@@ -233,8 +233,14 @@ def main():
     write_csv(os.path.join(args.out, "platform-totals.csv"),
               [{"platform": k, "downloads": v} for k, v in rel["per_platform"].items()],
               ["platform", "downloads"])
+    # Version-aware sort so releases order semantically (v1.9.0 < v1.10.0 <
+    # v1.220.8) and the newest release lands at the end — NOT lexical, which
+    # buried v1.220.x mid-file between v1.22 and v1.23.
+    def _relkey(item):
+        return tuple(int(p) for p in re.findall(r"\d+", item[0]))
     write_csv(os.path.join(args.out, "release-totals.csv"),
-              [{"tag": t, "asset_downloads": n} for t, n in sorted(rel["per_release"].items())],
+              [{"tag": t, "asset_downloads": n}
+               for t, n in sorted(rel["per_release"].items(), key=_relkey)],
               ["tag", "asset_downloads"])
     json.dump({"snapshot_at": snap_at, "platforms": [n for n, _, _ in PLATFORMS],
                "unclassified_legacy": rel["unclassified"]},


### PR DESCRIPTION
`release-totals.csv` was sorted **lexically**, so `v1.220.x` releases sorted between `v1.22` and `v1.23` (buried mid-file) instead of at the end — the newest release looked missing.

Fix: sort `per_release` by a numeric version key so releases order semantically (`v1.9.0 < v1.10.0 < v1.220.8`) and the latest lands last.

**Scope:** stats collector tooling only (`scripts/project_statistics.py`, 1 file, +7/-1). No product / daemon / schema / VERSION impact. The committed `release-totals.csv` on the `stats` branch reorders on the next collector run (or a one-off `sort -V` backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)