### PR TITLE
fix(opqueue): atomic single-transaction replace_set (netlink) — close transient-empty fail-open

### DIFF
--- a/cmd/nftband/replace_set_reject_guard_l2e_test.go
+++ b/cmd/nftband/replace_set_reject_guard_l2e_test.go
@@ -27,6 +27,7 @@ func (stubReplaceBackend) AddElements(table, set string, e []opqueue.SetElement)
 }
 func (stubReplaceBackend) DeleteElements(table, set string, e []opqueue.SetElement) error { return nil }
 func (stubReplaceBackend) GetSetElements(table, set string) ([]string, error)             { return nil, nil }
+func (stubReplaceBackend) ReplaceSet(table, set string, e []opqueue.SetElement) error     { return nil }
 
 const l2eBlockedMsg = "blocked for interval/protection set"
 

--- a/internal/botguard/guard_batchsignal_decisioncache_test.go
+++ b/internal/botguard/guard_batchsignal_decisioncache_test.go
@@ -270,6 +270,7 @@ func (b *recBackend) AddElements(table, set string, els []opqueue.SetElement) (i
 }
 func (b *recBackend) DeleteElements(table, set string, els []opqueue.SetElement) error { return nil }
 func (b *recBackend) GetSetElements(table, set string) ([]string, error)               { return nil, nil }
+func (b *recBackend) ReplaceSet(table, set string, els []opqueue.SetElement) error     { return nil }
 func (b *recBackend) has(set, ip string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/opqueue/buffer.go
+++ b/internal/opqueue/buffer.go
@@ -218,7 +218,7 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceI
 	if replaceOp != nil {
 		// L2b truth-bearing: applied == actually_applied; err set on flush failure OR
 		// partial apply (applied < intended). WasReplace stays true even on partial.
-		applied, intended, replErr := buf.applyReplace(backend, table, setName, replaceOp, maxBatchSize)
+		applied, intended, replErr := buf.applyReplace(backend, table, setName, replaceOp)
 		result.Applied = applied
 		result.Intended = intended
 		result.Adds = applied
@@ -227,13 +227,23 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceI
 			result.Err = replErr
 		}
 	} else if flushPending {
-		if err := backend.FlushSet(table, setName); err != nil {
-			log.Printf("[opqueue] Flush %s failed: %v", setName, err)
-			result.Err = err
+		// Atomic flush == atomic replacement with the intended post-flush add set.
+		// The barrier model routes post-flush adds to postBarrier (re-enqueued), so
+		// `pending` is normally empty here → an explicit atomic empty flush. Any
+		// pending ADDs are folded into the SAME transaction; pending DELETEs are
+		// no-ops against the emptied set and are dropped. This replaces the former
+		// standalone committed backend.FlushSet(), removing the fail-OPEN window.
+		finalAdds := pendingAddSetElements(pending)
+		if rerr := backend.ReplaceSet(table, setName, finalAdds); rerr != nil {
+			log.Printf("[opqueue] flush_source %s: atomic flush failed, prior contents preserved: %v", setName, rerr)
+			result.Err = rerr
 		} else {
-			result.Applied = 1
 			result.WasFlush = true
+			result.Applied = 1 + len(finalAdds)
+			result.Adds = len(finalAdds)
 		}
+		// Consumed atomically above — prevent the incremental path below from re-applying.
+		pending = nil
 	}
 
 	// Apply pending individual ops
@@ -258,58 +268,49 @@ func (buf *SetBuffer) flush(backend NetlinkBackend, maxBatchSize int, si SourceI
 // succeeds followed by a lost add batch leaves the set partially populated; we now report that
 // as an error instead of a success-shaped short count. We do NOT abort on the first bad batch
 // (later batches still attempt), and we do NOT fail-close the caller — surfacing is the job.
-func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string, op *SetOp, maxBatchSize int) (applied int, intended int, err error) {
-	// Step 1: Flush existing
-	if ferr := backend.FlushSet(table, setName); ferr != nil {
-		log.Printf("[opqueue] replace_set flush %s failed: %v", setName, ferr)
-		return 0, 0, fmt.Errorf("replace_set flush %s: %w", setName, ferr)
-	}
-
-	if len(op.Elements) == 0 {
-		return 0, 0, nil
-	}
+func (buf *SetBuffer) applyReplace(backend NetlinkBackend, table, setName string, op *SetOp) (applied int, intended int, err error) {
 	intended = len(op.Elements)
 
-	// Step 2: Bulk add in batches
-	isIPv6 := strings.HasSuffix(setName, "_ipv6")
+	// Route the FULL element set through the atomic primitive — ONE netlink
+	// transaction (flush + add + single commit). We MUST NOT call
+	// backend.FlushSet()/AddElements() separately here: a standalone committed
+	// flush reintroduces the transient-empty fail-OPEN window this lane removes.
+	// Family is derived from the set's KeyType inside ReplaceSet, never from the
+	// name (so http_bot_*6 etc. are handled correctly). op.TTL applies to every
+	// element (0 = permanent, e.g. feeds/geoban).
 	elements := make([]SetElement, 0, len(op.Elements))
 	for _, e := range op.Elements {
 		elements = append(elements, SetElement{
-			Value:  e,
-			TTL:    0, // Feeds/geoban are permanent
-			IsIPv6: isIPv6,
+			Value: e,
+			TTL:   op.TTL,
 		})
 	}
 
-	// Batch by maxBatchSize — sum the TRUE applied count from each batch.
-	var firstErr error
-	for i := 0; i < len(elements); i += maxBatchSize {
-		end := i + maxBatchSize
-		if end > len(elements) {
-			end = len(elements)
-		}
-		batch := elements[i:end]
-
-		n, addErr := backend.AddElements(table, setName, batch)
-		applied += n
-		if addErr != nil {
-			log.Printf("[opqueue] replace_set add %s batch %d failed (%d/%d): %v", setName, i/maxBatchSize, n, len(batch), addErr)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("replace_set add %s batch %d: %w", setName, i/maxBatchSize, addErr)
-			}
-		}
+	if rerr := backend.ReplaceSet(table, setName, elements); rerr != nil {
+		// Atomic all-or-nothing: nothing committed, prior (blocked) contents kept.
+		log.Printf("[opqueue] replace_set %s: atomic replace failed, prior contents preserved: %v", setName, rerr)
+		return 0, intended, fmt.Errorf("replace_set %s: %w", setName, rerr)
 	}
 
-	if applied < intended {
-		if firstErr == nil {
-			firstErr = fmt.Errorf("replace_set %s: applied %d of %d (partial)", setName, applied, intended)
-		}
-		log.Printf("[opqueue] replace_set %s: PARTIAL apply %d/%d — %v", setName, applied, intended, firstErr)
-		return applied, intended, firstErr
-	}
+	log.Printf("[opqueue] replace_set %s: %d elements atomically replaced", setName, intended)
+	return intended, intended, nil
+}
 
-	log.Printf("[opqueue] replace_set %s: %d elements applied", setName, applied)
-	return applied, intended, nil
+// pendingAddSetElements extracts the ADD ops from a pending map as SetElements for
+// an atomic replacement. DELETE ops are omitted: after an atomic flush the set is
+// empty, so a delete is a no-op. Used to fold the flush_source path into a single
+// atomic ReplaceSet transaction.
+func pendingAddSetElements(pending map[string]*PendingOp) []SetElement {
+	if len(pending) == 0 {
+		return nil
+	}
+	out := make([]SetElement, 0, len(pending))
+	for _, p := range pending {
+		if p.Type == OpAdd {
+			out = append(out, SetElement{Value: p.Element, TTL: p.TTL})
+		}
+	}
+	return out
 }
 
 // applyPendingCounted applies individual add/delete operations and returns separate counts

--- a/internal/opqueue/enqueue_ban_never_ban_guard_l3b_test.go
+++ b/internal/opqueue/enqueue_ban_never_ban_guard_l3b_test.go
@@ -23,6 +23,7 @@ func (l3bStubBackend) AddElements(table, set string, e []SetElement) (int, error
 }
 func (l3bStubBackend) DeleteElements(table, set string, e []SetElement) error { return nil }
 func (l3bStubBackend) GetSetElements(table, set string) ([]string, error)     { return nil, nil }
+func (l3bStubBackend) ReplaceSet(table, set string, e []SetElement) error     { return nil }
 
 // resolver mirroring the daemon closure: enforcement set + exempt single IP → refuse.
 func l3bResolver(set, ip string) (bool, string) {

--- a/internal/opqueue/nftbackend_wrapper.go
+++ b/internal/opqueue/nftbackend_wrapper.go
@@ -151,6 +151,49 @@ func (w *NFTBackendWrapper) AddElements(tableName, setName string, elements []Se
 	return applied, nil
 }
 
+// resolveExistingSet finds the set in the LIVE kernel tables (ip6 then ip),
+// returning its authoritative *nftables.Set (real address family + Interval flag).
+// It does NOT infer the family from the set name and does NOT create the set: a
+// replacement targets an existing enforcement set, so a missing set is an error
+// (fail-closed) rather than a silently-fabricated bogus interval set. This is the
+// resolution step the replace path uses instead of the name-suffix getTable()
+// (which mis-resolves names like http_bot_ban6 that do not end in _ipv6).
+func (w *NFTBackendWrapper) resolveExistingSet(setName string) (*nftables.Set, error) {
+	for _, tbl := range []*nftables.Table{w.tableIPv6, w.tableIPv4} {
+		s, err := w.nft.FindSetInTable(tbl, setName)
+		if err != nil {
+			return nil, err
+		}
+		if s != nil {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("replace_set: set %s not found in ip or ip6 nftban table", setName)
+}
+
+// ReplaceSet atomically replaces the entire contents of a set in ONE netlink
+// transaction, delegating to the shared NFTManager connection. It does NOT call
+// the separately-committing FlushSet()/AddElements() methods — flush + add +
+// commit happen as a single transaction, so the set is never transiently empty
+// (fail-CLOSED on failure). The address family is derived from the resolved set's
+// KeyType inside ReplaceSetElements, never from setName.
+func (w *NFTBackendWrapper) ReplaceSet(tableName, setName string, elements []SetElement) error {
+	set, err := w.resolveExistingSet(setName)
+	if err != nil {
+		return err
+	}
+
+	inputs := make([]nftsync.SetElementInput, 0, len(elements))
+	for _, e := range elements {
+		inputs = append(inputs, nftsync.SetElementInput{
+			Value:   e.Value,
+			Timeout: time.Duration(e.TTL) * time.Second,
+		})
+	}
+
+	return w.nft.ReplaceSetElements(set, inputs)
+}
+
 // DeleteElements removes elements from a set (batched)
 func (w *NFTBackendWrapper) DeleteElements(tableName, setName string, elements []SetElement) error {
 	if len(elements) == 0 {

--- a/internal/opqueue/replace_apply_truth_l2b_test.go
+++ b/internal/opqueue/replace_apply_truth_l2b_test.go
@@ -71,6 +71,26 @@ func (m *mockPartialBackend) AddElements(table, set string, els []SetElement) (i
 func (m *mockPartialBackend) DeleteElements(table, set string, els []SetElement) error { return nil }
 func (m *mockPartialBackend) GetSetElements(table, set string) ([]string, error)        { return nil, nil }
 
+// ReplaceSet models the ATOMIC contract: it applies either ALL elements or NONE.
+// A configured flush failure, or an inability to accept every element (acceptLimit
+// exceeded), records nothing and returns an error — never a partial state. This
+// mirrors the single-transaction netlink primitive (flush+add+one commit).
+func (m *mockPartialBackend) ReplaceSet(table, set string, els []SetElement) error {
+	if m.flushErr != nil {
+		return m.flushErr
+	}
+	if m.acceptLimit >= 0 && len(els) > m.acceptLimit {
+		return fmt.Errorf("simulated atomic replace failure: cannot accept %d elements (limit %d)", len(els), m.acceptLimit)
+	}
+	m.flushed = true
+	m.accepted = len(els)
+	m.added = m.added[:0]
+	for _, e := range els {
+		m.added = append(m.added, e.Value)
+	}
+	return nil
+}
+
 func replaceElements(n int) []string {
 	els := make([]string, n)
 	for i := 0; i < n; i++ {
@@ -86,9 +106,11 @@ func flushReplace(backend NetlinkBackend, setName string, n, batchSize int) Flus
 	return buf.flush(backend, batchSize, nil)
 }
 
-// --- Invariant 1: reported_applied == actually_applied (on a partial) ---
+// --- Invariant 1: reported_applied == actually_applied (atomic → 0 on failure) ---
+// Under the atomic netlink primitive a replacement is all-or-nothing, so a backend
+// that cannot accept every element applies NOTHING; reported still equals actual.
 func TestReplaceApplyTruth_ReportedAppliedEqualsActuallyApplied(t *testing.T) {
-	m := &mockPartialBackend{acceptLimit: 150}
+	m := &mockPartialBackend{acceptLimit: 150} // < 250 → atomic replace applies none
 	res := flushReplace(m, "blacklist_ipv4", 250, 100)
 
 	if res.Applied != m.accepted {
@@ -97,27 +119,30 @@ func TestReplaceApplyTruth_ReportedAppliedEqualsActuallyApplied(t *testing.T) {
 	if res.Applied != len(m.added) {
 		t.Fatalf("reported_applied(%d) != len(added)(%d)", res.Applied, len(m.added))
 	}
-	if res.Applied != 150 {
-		t.Fatalf("expected 150 actually applied, got %d", res.Applied)
+	if res.Applied != 0 {
+		t.Fatalf("atomic replace on a rejecting backend must apply 0, got %d", res.Applied)
+	}
+	if res.Err == nil {
+		t.Fatal("atomic replace that could not commit must report Err (no success-shaped result)")
 	}
 }
 
-// --- Invariant 2: partial_apply != success ---
+// --- Invariant 2: a failed replace is NOT success and leaves NO partial state ---
 func TestReplaceApplyTruth_PartialApplyIsNotSuccess(t *testing.T) {
 	m := &mockPartialBackend{acceptLimit: 150}
 	res := flushReplace(m, "blacklist_ipv4", 250, 100)
 
 	if res.Err == nil {
-		t.Fatal("partial apply reported success (Err == nil) — this is the L2b fail-open bug")
+		t.Fatal("failed replace reported success (Err == nil) — this is the fail-open bug")
 	}
 	if res.Intended != 250 {
 		t.Fatalf("Intended=%d, want 250", res.Intended)
 	}
-	if res.Applied >= res.Intended {
-		t.Fatalf("Applied(%d) should be < Intended(%d) on a partial", res.Applied, res.Intended)
+	if res.Applied != 0 {
+		t.Fatalf("atomic replace is all-or-nothing: Applied(%d) must be 0 on failure", res.Applied)
 	}
 	if !res.WasReplace {
-		t.Fatal("WasReplace must stay true even on a partial replace")
+		t.Fatal("WasReplace must stay true even on a failed replace")
 	}
 }
 

--- a/internal/opqueue/replace_set_atomic_test.go
+++ b/internal/opqueue/replace_set_atomic_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="opqueue/replace_set_atomic_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Proves the opqueue replace_set and flush_source paths route through the atomic ReplaceSet primitive and NEVER call the separately-committing FlushSet()/AddElements(). A recording backend asserts: applyReplace → exactly one ReplaceSet, zero FlushSet/AddElements; flush_source → one ReplaceSet (explicit atomic flush); atomic failure preserves old state (Applied==0). Hermetic; no nft/netlink/root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package opqueue
+
+import (
+	"errors"
+	"testing"
+)
+
+// recordingBackend counts every backend call so we can prove the replace/flush
+// paths use ReplaceSet exclusively (no standalone committed flush + later adds).
+type recordingBackend struct {
+	replaceCalls  int
+	flushSetCalls int
+	addCalls      int
+	deleteCalls   int
+	lastReplace   []SetElement
+	replaceErr    error
+}
+
+func (b *recordingBackend) FlushSet(table, set string) error {
+	b.flushSetCalls++
+	return nil
+}
+func (b *recordingBackend) AddElements(table, set string, e []SetElement) (int, error) {
+	b.addCalls++
+	return len(e), nil
+}
+func (b *recordingBackend) DeleteElements(table, set string, e []SetElement) error {
+	b.deleteCalls++
+	return nil
+}
+func (b *recordingBackend) GetSetElements(table, set string) ([]string, error) { return nil, nil }
+func (b *recordingBackend) ReplaceSet(table, set string, e []SetElement) error {
+	b.replaceCalls++
+	b.lastReplace = e
+	return b.replaceErr
+}
+
+// NO_STANDALONE_FLUSHSET_IN_APPLY_REPLACE + applyReplace → ReplaceSet.
+func TestApplyReplace_RoutesThroughReplaceSetOnly(t *testing.T) {
+	b := &recordingBackend{}
+	buf := newSetBuffer("geoban_ipv4")
+	buf.replaceOp = &SetOp{Type: OpReplaceSet, Elements: []string{"192.0.2.1", "192.0.2.2"}}
+
+	res := buf.flush(b, 100, nil)
+
+	if b.replaceCalls != 1 {
+		t.Fatalf("applyReplace must call ReplaceSet exactly once, got %d", b.replaceCalls)
+	}
+	if b.flushSetCalls != 0 {
+		t.Fatalf("applyReplace must NOT call the standalone FlushSet(), got %d", b.flushSetCalls)
+	}
+	if b.addCalls != 0 {
+		t.Fatalf("applyReplace must NOT call the standalone AddElements(), got %d", b.addCalls)
+	}
+	if !res.WasReplace || res.Applied != 2 || res.Intended != 2 {
+		t.Fatalf("replace result wrong: WasReplace=%v Applied=%d Intended=%d", res.WasReplace, res.Applied, res.Intended)
+	}
+	if len(b.lastReplace) != 2 {
+		t.Fatalf("ReplaceSet must receive the full element set, got %d", len(b.lastReplace))
+	}
+}
+
+// FLUSH_SOURCE_ATOMIC — the flush path routes through ReplaceSet (explicit atomic
+// flush), never a standalone committed FlushSet().
+func TestFlushSource_RoutesThroughReplaceSet(t *testing.T) {
+	b := &recordingBackend{}
+	buf := newSetBuffer("geoban_ipv4")
+	buf.enqueue(&SetOp{Type: OpFlushSet})
+
+	res := buf.flush(b, 100, nil)
+
+	if b.replaceCalls != 1 {
+		t.Fatalf("flush_source must call ReplaceSet exactly once, got %d", b.replaceCalls)
+	}
+	if b.flushSetCalls != 0 {
+		t.Fatalf("flush_source must NOT call the standalone FlushSet(), got %d", b.flushSetCalls)
+	}
+	if b.addCalls != 0 {
+		t.Fatalf("flush_source must NOT call the standalone AddElements(), got %d", b.addCalls)
+	}
+	if !res.WasFlush {
+		t.Fatalf("flush result must set WasFlush")
+	}
+	if len(b.lastReplace) != 0 {
+		t.Fatalf("a pure flush_source must be an EMPTY atomic replacement, got %d elements", len(b.lastReplace))
+	}
+}
+
+// Atomic failure preserves old state: Applied==0, error surfaced, WasReplace kept.
+func TestApplyReplace_AtomicFailurePreservesOldState(t *testing.T) {
+	b := &recordingBackend{replaceErr: errors.New("netlink commit boom")}
+	buf := newSetBuffer("geoban_ipv4")
+	buf.replaceOp = &SetOp{Type: OpReplaceSet, Elements: []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}}
+
+	res := buf.flush(b, 100, nil)
+
+	if res.Err == nil {
+		t.Fatal("atomic replace failure must surface as result.Err")
+	}
+	if res.Applied != 0 {
+		t.Fatalf("atomic replace is all-or-nothing: Applied must be 0 on failure, got %d", res.Applied)
+	}
+	if !res.WasReplace {
+		t.Fatal("WasReplace must stay true on a failed replace")
+	}
+	if res.Intended != 3 {
+		t.Fatalf("Intended must be preserved (3), got %d", res.Intended)
+	}
+}

--- a/internal/opqueue/types.go
+++ b/internal/opqueue/types.go
@@ -150,6 +150,16 @@ type NetlinkBackend interface {
 	// callers rely on partial_apply != success.
 	AddElements(table, set string, elements []SetElement) (applied int, err error)
 
+	// ReplaceSet atomically replaces the ENTIRE contents of a set in ONE netlink
+	// transaction (flush + add + single commit). It is the atomic primitive for the
+	// replace_set / flush_source paths: on any failure NOTHING commits and the set
+	// retains its prior contents (fail-CLOSED), never the transient-empty fail-OPEN
+	// of a standalone FlushSet()-then-AddElements(). Elements are validated before
+	// the connection is mutated; an empty slice is an explicit atomic flush. Callers
+	// MUST route replacement through this and MUST NOT call FlushSet()+AddElements()
+	// separately for a replacement.
+	ReplaceSet(table, set string, elements []SetElement) error
+
 	// DeleteElements removes elements from a set (batched)
 	DeleteElements(table, set string, elements []SetElement) error
 

--- a/internal/setsync/nft_replace_atomic.go
+++ b/internal/setsync/nft_replace_atomic.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="setsync/nft_replace_atomic" meta:type="package" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Atomic single-transaction netlink set replacement for the opqueue replace_set path (no standalone committed flush)"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="root"
+
+package setsync
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/google/nftables"
+)
+
+// SetElementInput is a single element for an atomic set replacement: a bare IP
+// (non-CIDR) plus an optional TTL. The address family is NEVER inferred from the
+// value or the set name — it is validated against the resolved set's KeyType.
+type SetElementInput struct {
+	Value   string        // bare IPv4/IPv6 address (CIDR/interval elements are rejected here)
+	Timeout time.Duration // 0 = permanent
+}
+
+// nftConn is the minimal subset of *nftables.Conn used by the atomic replacement.
+// It exists so the single-transaction / call-ordering semantics are unit-testable
+// with a recording fake, without nft, netlink, or root. *nftables.Conn satisfies it.
+type nftConn interface {
+	FlushSet(s *nftables.Set)
+	SetAddElements(s *nftables.Set, vals []nftables.SetElement) error
+	Flush() error
+}
+
+// replaceAddBatch bounds how many elements go into a single SetAddElements call.
+// A single netlink message has a size limit; queuing too many elements in one
+// SetAddElements produces an oversized message that the kernel silently applies
+// only partially (observed ~1900-element cap on real hardware). Batching well
+// under that — every batch queued on the SAME connection and committed by ONE
+// Flush() — keeps the replacement BOTH atomic AND complete for large sets.
+const replaceAddBatch = 1000
+
+// FindSetInTable returns the existing set with the given name from the table's
+// live kernel definition (carrying its real KeyType and Interval flag), or
+// (nil, nil) if the table has no such set. It is NON-creating: it is used to
+// resolve a set's address family authoritatively for the replace path instead of
+// inferring the family from the set name (names like http_bot_ban6 do not end in
+// _ipv6, so a name-suffix guess resolves the wrong table and can fabricate a
+// bogus interval set).
+func (m *NFTManager) FindSetInTable(table *nftables.Table, name string) (*nftables.Set, error) {
+	if table == nil {
+		return nil, nil
+	}
+	sets, err := m.conn.GetSets(table)
+	if err != nil {
+		return nil, fmt.Errorf("list sets in %s: %w", table.Name, err)
+	}
+	for _, s := range sets {
+		if s.Name == name {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+// ReplaceSetElements atomically replaces the ENTIRE contents of a non-interval
+// (hash) set in a SINGLE netlink transaction: flush + add + exactly one commit.
+//
+// It is the atomic counterpart of the opqueue replace_set path's former
+// standalone FlushSet()+AddElements() (two separately committed transactions),
+// which left the kernel set transiently EMPTY between the flush commit and the
+// adds — a fail-OPEN window on enforcement sets. Here the flush and the adds are
+// queued together and committed by one conn.Flush(): the kernel applies them as
+// one transaction, so readers never observe the set empty or partial. On commit
+// failure NOTHING is applied and the set retains its prior (blocked) contents —
+// fail-CLOSED.
+//
+// Contract:
+//   - Every element is validated + canonicalized BEFORE the connection is mutated;
+//     any invalid element (bad IP, wrong family, CIDR/interval) returns an error
+//     with the set untouched.
+//   - Address family is derived from set.KeyType (authoritative), never from the
+//     set name — so names like http_bot_ban6 (no _ipv6 suffix) are handled
+//     correctly.
+//   - Duplicate elements are de-duplicated deterministically (first occurrence
+//     wins) so the single transaction cannot self-conflict.
+//   - An empty replacement is an EXPLICIT atomic flush (one commit, zero adds),
+//     not an accidental empty-set fail-open.
+//   - Interval sets are rejected: they are owned by the atomic FULL-sync path.
+func (m *NFTManager) ReplaceSetElements(set *nftables.Set, elements []SetElementInput) error {
+	return replaceSetElementsOnConn(m.conn, set, elements)
+}
+
+// replaceSetElementsOnConn is the testable core: pure validation, then the
+// single-commit transaction on the supplied connection.
+func replaceSetElementsOnConn(conn nftConn, set *nftables.Set, elements []SetElementInput) error {
+	if set == nil {
+		return fmt.Errorf("replace set: nil set")
+	}
+	if set.Interval {
+		return fmt.Errorf("replace set %s: interval set not supported by the atomic netlink replace primitive (owned by the FULL-sync path)", set.Name)
+	}
+
+	// Family is authoritative from the set key type — never from the name.
+	var isV4 bool
+	switch set.KeyType {
+	case nftables.TypeIPAddr:
+		isV4 = true
+	case nftables.TypeIP6Addr:
+		isV4 = false
+	default:
+		return fmt.Errorf("replace set %s: unsupported key type %v", set.Name, set.KeyType)
+	}
+
+	// Phase 1: validate + canonicalize EVERY element before touching the connection.
+	nlElems := make([]nftables.SetElement, 0, len(elements))
+	seen := make(map[string]struct{}, len(elements))
+	for _, e := range elements {
+		ip := net.ParseIP(e.Value)
+		if ip == nil {
+			return fmt.Errorf("replace set %s: invalid IP %q (CIDR/interval not accepted here)", set.Name, e.Value)
+		}
+		var key []byte
+		if isV4 {
+			key = ip.To4()
+			if key == nil {
+				return fmt.Errorf("replace set %s: %q is not IPv4 but the set is ipv4_addr", set.Name, e.Value)
+			}
+		} else {
+			if ip.To4() != nil {
+				return fmt.Errorf("replace set %s: %q is IPv4 but the set is ipv6_addr", set.Name, e.Value)
+			}
+			key = ip.To16()
+			if key == nil {
+				return fmt.Errorf("replace set %s: %q is not a valid IPv6 address", set.Name, e.Value)
+			}
+		}
+		// Deterministic dedup by canonical key bytes (first occurrence wins).
+		if _, dup := seen[string(key)]; dup {
+			continue
+		}
+		seen[string(key)] = struct{}{}
+
+		el := nftables.SetElement{Key: key}
+		if e.Timeout > 0 {
+			el.Timeout = e.Timeout
+		}
+		nlElems = append(nlElems, el)
+	}
+
+	// Phase 2: ONE transaction. Flush first, then all adds, then a single commit.
+	// Elements are pre-validated to the exact key width for this set's KeyType, so
+	// SetAddElements cannot fail marshaling here; queuing the flush before the adds
+	// keeps flush-before-add ordering inside the one batch.
+	conn.FlushSet(set)
+	for start := 0; start < len(nlElems); start += replaceAddBatch {
+		end := start + replaceAddBatch
+		if end > len(nlElems) {
+			end = len(nlElems)
+		}
+		if err := conn.SetAddElements(set, nlElems[start:end]); err != nil {
+			// Do not commit: without a Flush() the queued flush is never applied,
+			// so the kernel set is unchanged (fail-CLOSED).
+			return fmt.Errorf("replace set %s: queue add batch [%d:%d]: %w", set.Name, start, end, err)
+		}
+	}
+	if err := conn.Flush(); err != nil {
+		// The whole batch (flush + adds) is rejected atomically → prior contents kept.
+		return fmt.Errorf("replace set %s: commit transaction: %w", set.Name, err)
+	}
+	return nil
+}

--- a/internal/setsync/nft_replace_atomic_test.go
+++ b/internal/setsync/nft_replace_atomic_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="setsync/nft_replace_atomic_test" meta:type="test" meta:version="1.0.0" meta:owner="Antonios Voulvoulis <contact@nftban.com>" meta:description="Proves the atomic netlink set replacement: all elements validated before the connection is mutated, flush-before-add ordering, exactly ONE commit per replace, prior contents preserved on commit failure, explicit empty replacement, IPv4/IPv6 parity, family derived from KeyType (http_bot_*6), deterministic dedup, interval/CIDR rejection. Uses a recording fake connection — no nft, netlink, or root."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package setsync
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/nftables"
+)
+
+// recordingConn is a fake nftConn that records call order and counts, and can be
+// told to fail SetAddElements or Flush. It never touches the kernel.
+type recordingConn struct {
+	order         []string
+	flushSetCalls int
+	addCalls      int
+	addedTotal    int
+	flushCalls    int
+	addErr        error
+	flushErr      error
+}
+
+func (c *recordingConn) FlushSet(s *nftables.Set) {
+	c.order = append(c.order, "flushset")
+	c.flushSetCalls++
+}
+
+func (c *recordingConn) SetAddElements(s *nftables.Set, vals []nftables.SetElement) error {
+	c.order = append(c.order, "add")
+	if c.addErr != nil {
+		return c.addErr
+	}
+	c.addCalls++
+	c.addedTotal += len(vals)
+	return nil
+}
+
+func (c *recordingConn) Flush() error {
+	c.order = append(c.order, "flush")
+	c.flushCalls++
+	return c.flushErr
+}
+
+func v4Set() *nftables.Set {
+	return &nftables.Set{Name: "blacklist_manual_ipv4", KeyType: nftables.TypeIPAddr}
+}
+
+// http_bot_ban6 deliberately does NOT end in _ipv6 — the family must come from
+// KeyType, not the name.
+func v6Set() *nftables.Set {
+	return &nftables.Set{Name: "http_bot_ban6", KeyType: nftables.TypeIP6Addr}
+}
+
+func in(vals ...string) []SetElementInput {
+	out := make([]SetElementInput, len(vals))
+	for i, v := range vals {
+		out[i] = SetElementInput{Value: v}
+	}
+	return out
+}
+
+// VALIDATE_ALL_ELEMENTS_BEFORE_MUTATION
+func TestReplace_ValidateBeforeMutation(t *testing.T) {
+	c := &recordingConn{}
+	err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.1", "not-an-ip", "192.0.2.2"))
+	if err == nil {
+		t.Fatal("expected error for invalid element")
+	}
+	if c.flushSetCalls != 0 || c.addCalls != 0 || c.flushCalls != 0 {
+		t.Fatalf("connection was mutated before validation completed: %+v", c.order)
+	}
+}
+
+// ONE_NETLINK_FLUSH_PER_REPLACE + flush-before-add ordering
+func TestReplace_SingleFlushAndOrdering(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.1", "192.0.2.2", "192.0.2.3")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.flushCalls != 1 {
+		t.Fatalf("expected exactly 1 commit, got %d", c.flushCalls)
+	}
+	if c.addedTotal != 3 {
+		t.Fatalf("expected 3 elements added, got %d", c.addedTotal)
+	}
+	// flushset must be first, and must precede every add; exactly one final flush.
+	if len(c.order) == 0 || c.order[0] != "flushset" {
+		t.Fatalf("flushset must be queued first, order=%v", c.order)
+	}
+	if c.order[len(c.order)-1] != "flush" {
+		t.Fatalf("commit must be last, order=%v", c.order)
+	}
+	for i, op := range c.order {
+		if op == "add" {
+			// every add must come after the flushset (index 0)
+			if i == 0 {
+				t.Fatalf("add queued before flushset, order=%v", c.order)
+			}
+		}
+	}
+}
+
+// EMPTY_REPLACEMENT_IS_EXPLICIT — one flush + one commit, zero adds, no error.
+func TestReplace_EmptyIsExplicitAtomicFlush(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v4Set(), nil); err != nil {
+		t.Fatalf("empty replacement must succeed atomically, got %v", err)
+	}
+	if c.flushSetCalls != 1 || c.flushCalls != 1 {
+		t.Fatalf("empty replacement must be one flushset + one commit, got flushset=%d flush=%d", c.flushSetCalls, c.flushCalls)
+	}
+	if c.addCalls != 0 {
+		t.Fatalf("empty replacement must queue no adds, got %d", c.addCalls)
+	}
+}
+
+// OLD_CONTENTS_PRESERVED_ON_FAILURE — commit failure surfaces as error (nothing applied).
+func TestReplace_CommitFailurePreservesOldContents(t *testing.T) {
+	c := &recordingConn{flushErr: errors.New("netlink commit boom")}
+	err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.1", "192.0.2.2"))
+	if err == nil {
+		t.Fatal("commit failure must surface as an error (fail-closed)")
+	}
+	if c.flushCalls != 1 {
+		t.Fatalf("exactly one commit attempt expected, got %d", c.flushCalls)
+	}
+	// The single transaction was rejected as a whole → the kernel set is unchanged.
+}
+
+// If SetAddElements fails to queue, the transaction is never committed (no Flush()).
+func TestReplace_AddQueueFailureDoesNotCommit(t *testing.T) {
+	c := &recordingConn{addErr: errors.New("marshal boom")}
+	err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.1"))
+	if err == nil {
+		t.Fatal("add-queue failure must surface as an error")
+	}
+	if c.flushCalls != 0 {
+		t.Fatalf("must NOT commit when add queuing fails, got %d commits", c.flushCalls)
+	}
+}
+
+// IPV4_REPLACE
+func TestReplace_IPv4(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.10", "203.0.113.5")); err != nil {
+		t.Fatalf("valid IPv4 replace failed: %v", err)
+	}
+	if c.addedTotal != 2 {
+		t.Fatalf("expected 2 IPv4 elements, got %d", c.addedTotal)
+	}
+}
+
+// IPV6_REPLACE
+func TestReplace_IPv6(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v6Set(), in("2001:db8::1", "2001:db8::2")); err != nil {
+		t.Fatalf("valid IPv6 replace failed: %v", err)
+	}
+	if c.addedTotal != 2 {
+		t.Fatalf("expected 2 IPv6 elements, got %d", c.addedTotal)
+	}
+}
+
+// Wrong-family rejection — before any mutation, both directions.
+func TestReplace_WrongFamilyRejected(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v4Set(), in("2001:db8::1")); err == nil {
+		t.Fatal("IPv6 element in an ipv4_addr set must be rejected")
+	}
+	if err := replaceSetElementsOnConn(c, v6Set(), in("192.0.2.1")); err == nil {
+		t.Fatal("IPv4 element in an ipv6_addr set must be rejected")
+	}
+	if c.flushSetCalls != 0 || c.flushCalls != 0 {
+		t.Fatal("wrong-family input must not mutate the connection")
+	}
+}
+
+// HTTP_BOT_SUFFIX6_FAMILY — family from KeyType, not the "6" suffix name.
+func TestReplace_HTTPBotSuffix6FamilyFromKeyType(t *testing.T) {
+	c := &recordingConn{}
+	// http_bot_ban6 is TypeIP6Addr → IPv6 accepted.
+	if err := replaceSetElementsOnConn(c, v6Set(), in("2001:db8::dead")); err != nil {
+		t.Fatalf("http_bot_ban6 (ip6) must accept an IPv6 element: %v", err)
+	}
+	// ...and IPv4 rejected, proving the name suffix is not consulted.
+	if err := replaceSetElementsOnConn(&recordingConn{}, v6Set(), in("192.0.2.1")); err == nil {
+		t.Fatal("http_bot_ban6 (ip6) must reject an IPv4 element (family is from KeyType)")
+	}
+}
+
+// Deterministic dedup — duplicates collapse to a single queued element.
+func TestReplace_DeterministicDedup(t *testing.T) {
+	c := &recordingConn{}
+	if err := replaceSetElementsOnConn(c, v4Set(), in("192.0.2.1", "192.0.2.1", "192.0.2.2")); err != nil {
+		t.Fatalf("dedup replace failed: %v", err)
+	}
+	if c.addedTotal != 2 {
+		t.Fatalf("duplicate must be de-duplicated: expected 2 unique, got %d", c.addedTotal)
+	}
+}
+
+// Large sets are batched across multiple SetAddElements messages (netlink
+// message-size safety) but committed by EXACTLY ONE Flush() — atomic AND complete.
+func TestReplace_LargeSetBatchedSingleCommit(t *testing.T) {
+	c := &recordingConn{}
+	n := 2500 // > 2*replaceAddBatch → at least 3 add batches
+	els := make([]SetElementInput, n)
+	for i := 0; i < n; i++ {
+		els[i] = SetElementInput{Value: fmt.Sprintf("10.%d.%d.%d", (i>>16)&0xff, (i>>8)&0xff, i&0xff)}
+	}
+	if err := replaceSetElementsOnConn(c, v4Set(), els); err != nil {
+		t.Fatalf("large replace failed: %v", err)
+	}
+	wantBatches := (n + replaceAddBatch - 1) / replaceAddBatch
+	if c.addCalls != wantBatches {
+		t.Fatalf("expected %d SetAddElements batches for %d elements (batch=%d), got %d", wantBatches, n, replaceAddBatch, c.addCalls)
+	}
+	if c.addedTotal != n {
+		t.Fatalf("expected all %d elements queued, got %d", n, c.addedTotal)
+	}
+	if c.flushCalls != 1 {
+		t.Fatalf("large batched replace must still commit EXACTLY once, got %d", c.flushCalls)
+	}
+	if c.flushSetCalls != 1 {
+		t.Fatalf("exactly one flushset for the whole replace, got %d", c.flushSetCalls)
+	}
+}
+
+// Interval and CIDR are rejected (this primitive is hash-set only).
+func TestReplace_IntervalAndCIDRRejected(t *testing.T) {
+	c := &recordingConn{}
+	interval := &nftables.Set{Name: "blacklist_ipv4", KeyType: nftables.TypeIPAddr, Interval: true}
+	if err := replaceSetElementsOnConn(c, interval, in("192.0.2.1")); err == nil || !strings.Contains(err.Error(), "interval") {
+		t.Fatalf("interval set must be rejected, got %v", err)
+	}
+	if err := replaceSetElementsOnConn(&recordingConn{}, v4Set(), in("192.0.2.0/24")); err == nil {
+		t.Fatal("CIDR element must be rejected by the hash-set replace primitive")
+	}
+	if c.flushCalls != 0 {
+		t.Fatal("interval/CIDR rejection must not commit anything")
+	}
+}

--- a/scripts/ci/check-nft-atomicity.sh
+++ b/scripts/ci/check-nft-atomicity.sh
@@ -138,6 +138,68 @@ fi
 echo ""
 
 # -----------------------------------------------------------------------------
+# V-OPQUEUE-REPLACE-ATOMICITY (netlink replace_set / flush_source)
+# -----------------------------------------------------------------------------
+# The opqueue replace_set + flush_source apply paths run over the SHARED netlink
+# connection. A standalone backend.FlushSet() that COMMITS before the adds leaves
+# the kernel set transiently EMPTY (fail-OPEN on enforcement sets — the sibling of
+# F-FEED/F-GEO on the netlink side, invisible to the setsync/shell scans above).
+# They MUST route through the atomic backend.ReplaceSet() primitive (one netlink
+# transaction: flush + add + single commit); the primitive must commit EXACTLY
+# once per replace. (Incremental backend.AddElements() for ban/unban is fine — a
+# committed flush is not.)
+BUF="internal/opqueue/buffer.go"
+PRIM="internal/setsync/nft_replace_atomic.go"
+echo "[V-OPQUEUE-REPLACE-ATOMICITY] scanning $BUF + $PRIM ..."
+OPQ_FAIL=0
+# drop `grep -n` lines (LINE:content) whose content is a // or * comment
+nocomment() { grep -vE '^[0-9]+:[[:space:]]*(//|\*)'; }
+
+# (a) NEGATIVE: no standalone committed backend.FlushSet() anywhere in buffer.go.
+BUF_FLUSH_HITS="$(grep -nE 'backend\.FlushSet\(' "$BUF" 2>/dev/null | nocomment || true)"
+if [[ -n "$BUF_FLUSH_HITS" ]]; then
+    echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — standalone backend.FlushSet() in $BUF (use backend.ReplaceSet for an atomic flush/replace):"
+    echo "$BUF_FLUSH_HITS"
+    OPQ_FAIL=1; FAIL=1
+fi
+
+# (b) POSITIVE: applyReplace routes through backend.ReplaceSet and does NOT call
+#     the separately-committing FlushSet()/AddElements() in its body.
+APPLY_BODY="$(awk '/func \(buf \*SetBuffer\) applyReplace\(/{p=1} p{print} p&&/^}/{exit}' "$BUF")"
+if ! grep -qE 'backend\.ReplaceSet\(' <<<"$APPLY_BODY"; then
+    echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — applyReplace does not call backend.ReplaceSet()."
+    OPQ_FAIL=1; FAIL=1
+fi
+if grep -vE '^[[:space:]]*//' <<<"$APPLY_BODY" | grep -qE 'backend\.(FlushSet|AddElements)\('; then
+    echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — applyReplace still calls the separately-committing FlushSet()/AddElements()."
+    OPQ_FAIL=1; FAIL=1
+fi
+
+# (c) POSITIVE: the flush_source branch is folded into the atomic primitive.
+if ! grep -qE '\} else if flushPending \{' "$BUF" || ! grep -qE 'pendingAddSetElements\(' "$BUF"; then
+    echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — flush_source path not folded into the atomic ReplaceSet primitive."
+    OPQ_FAIL=1; FAIL=1
+fi
+
+# (d) POSITIVE: the primitive exists and commits EXACTLY ONCE per replace.
+if [[ ! -f "$PRIM" ]]; then
+    echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — atomic primitive $PRIM missing."
+    OPQ_FAIL=1; FAIL=1
+else
+    PRIM_BODY="$(awk '/func replaceSetElementsOnConn\(/{p=1} p{print} p&&/^}/{exit}' "$PRIM")"
+    FLUSH_COMMITS="$(grep -cE 'conn\.Flush\(\)' <<<"$PRIM_BODY" || true)"
+    if [[ "$FLUSH_COMMITS" != "1" ]]; then
+        echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — replaceSetElementsOnConn must commit exactly once (conn.Flush()); found $FLUSH_COMMITS."
+        OPQ_FAIL=1; FAIL=1
+    fi
+fi
+
+if [[ "$OPQ_FAIL" -eq 0 ]]; then
+    echo "  PASS — opqueue replace_set/flush_source route through the single-transaction atomic ReplaceSet."
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
 # V-NFT-SERVICE-PORTS-RENDERED-COMPLETE (static, v1.192.1)
 # -----------------------------------------------------------------------------
 # Every PRODUCTION render path that substitutes the nftables template


### PR DESCRIPTION
## Defect

The opqueue `replace_set` apply path committed a standalone `FlushSet()` (its own netlink transaction) and then added elements in **later** transaction(s). Between the flush commit and the adds, the kernel set was **transiently EMPTY** — a fail-open window on enforcement sets (the netlink-side sibling of the F-FEED/F-GEO class, invisible to the existing setsync/shell atomicity guard).

Scope of the affected path: the L2e reject-guard already fences `blacklist_ipv4/6` (owned by the atomic FULL-sync path, PR #1018), so this path **excludes** the interval blacklist sets — but it still reaches the **other** enforcement/allow hash sets (`http_bot_*`, `blacklist_manual_*`-class, port/allow sets). `replace_set` currently has no shipped caller (feeds/geoban/trust use FULL sync), so this is **defense-in-depth**: it makes the reachable path fail-CLOSED so any future/manual `replace_set` cannot fail-open.

## Fix

- **Netlink single transaction** (`internal/setsync/nft_replace_atomic.go`): `conn.FlushSet` + `conn.SetAddElements`(batched) + **exactly one** `conn.Flush()`. The kernel applies flush+adds atomically → observers only ever see the complete OLD or the complete NEW set. On commit failure nothing applies (fail-CLOSED). All elements are validated/canonicalized **before** the connection is mutated.
- **`applyReplace` migration** (`buffer.go`): routes the full element set through `backend.ReplaceSet` — no standalone `FlushSet()`/`AddElements()`.
- **`flush_source` sibling migration**: the `flushPending` branch is folded into the **same** atomic primitive (an explicit atomic empty replacement), removing its standalone committed flush.
- **Family from the real kernel set, not the name**: family is derived from `set.KeyType`, and set resolution uses a new authoritative, **non-creating** `resolveExistingSet()` / `NFTManager.FindSetInTable()` (live ip6-then-ip lookup) instead of a `HasSuffix(name,"_ipv6")` guess.
- **1,000-element batching within one final `Flush()`** — multiple `SetAddElements` messages, single commit → atomic **and** complete for large sets.
- Extended `scripts/ci/check-nft-atomicity.sh` with a `V-OPQUEUE-REPLACE-ATOMICITY` section scanning `internal/opqueue` (the prior guard only scanned setsync/shell).

## Two defects the real-lab validation found and fixed (folded in — same path)

1. **Suffix-based wrong-table resolution**: `http_bot_ban6` (ends in `6`, not `_ipv6`) resolved to the IPv4 table → `GetOrCreateIntervalSet` fabricated a bogus interval set. Fixed by the authoritative non-creating lookup above (missing set → fail-closed error, never a bogus creation).
2. **Oversized netlink batch silent partial commit**: a 10,000-element batch put 6,000 elements in one oversized netlink message; the kernel silently committed only ~1,904 while reporting success. Fixed by batching at 1,000 (still one `Flush`).

## Validation (lab2 DEB Ubuntu 24.04, lab4 RPM AlmaLinux 9.8 — production untouched)

```
LAB2_REAL_EMPTY=0   LAB2_MIXED=0   LAB2_LARGE_SET=6000/6000   LAB2_FAILURE_PRESERVED=YES
LAB4_REAL_EMPTY=0   LAB4_MIXED=0   LAB4_LARGE_SET=6000/6000   LAB4_FAILURE_PRESERVED=YES
OFFICIAL_POSITIVE_CONTROL_EMPTY_WINDOWS=13   (official non-atomic daemon — proves the bug + method)
PRODUCTION_MUTATION=NONE   LABS_RESTORED_TO_OFFICIAL=YES
```

- Atomic OLD→NEW proven on `http_bot_ban6` (ipv6_addr hash) + `http_bot_ban` (ipv4), across ~1500 header-validated snapshots per lab: **0 real empty, 0 mixed** (the few apparent empties were `nft list` truncation artifacts under poll load, each disproven via O(1) `nft get element`). A **positive control** on the official non-atomic daemon showed **13 real empty windows**.
- Failure inputs (malformed IP / wrong-family / CIDR) leave the old contents **unchanged** (`PRESERVED=YES`).
- Build hygiene: built fresh with `bin/` removed; verified `SOURCE_BUILD_SHA == PACKAGED == INSTALLED` on each lab independently. Ad-hoc lab daemon hashes differ (DEB `868bbb4a` vs RPM `174e2089`) in embedded build metadata only — **behavioral parity proven** (identical OLD/NEW set-hashes on both labs) and the release lane produces byte-identical DEB/RPM daemons.

## Notes

- **Daemon re-baseline required** (Go daemon change; byte-identity no longer holds — expected).
- Residual `backend.FlushSet` in `queue.go` (5) are **out of this lane's scope**: 1 is the fast-lane pure single-flush op; 4 are in **dead** streaming/bulk paths (`EnqueueBulk*`/`EnqueueReplaceFromFile` have 0 shipped callers). Migrating/removing those is a candidate follow-up, deliberately excluded here (no unrelated opqueue cleanup).
- Excluded by design: build-hygiene stale-prebuilt guard, daemon startup lifecycle logging, egress/trust-feed/schema lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
