### PR TITLE
build: fail-closed provenance guard — never package a stale prebuilt; 3 build modes

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -152,6 +152,49 @@ jobs:
           retention-days: 1
 
   # ==========================================================================
+  # PROVENANCE NEGATIVE POLICY — prove a stale bin/* cannot survive a source
+  # build, and that verified-prebuilt mode rejects a tampered manifest.
+  # ==========================================================================
+  provenance-negative:
+    name: Provenance negative policy
+    needs: validate-dependencies
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
+        with:
+          go-version: '1.25.12'
+      - name: Stale bin is OVERWRITTEN by a source build (never packaged)
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          printf 'STALE-NOT-AN-ELF' > bin/nftband
+          printf 'STALE-NOT-AN-ELF' > bin/nftban-core
+          chmod +x build.sh && ./build.sh >/dev/null
+          # shellcheck source=packaging/lib/provenance.sh
+          source packaging/lib/provenance.sh
+          prov_resolve_source_identity "$PWD"
+          ec="$(prov_binary_embedded_commit bin/nftband)"
+          [ "$ec" = "$PROV_SOURCE_COMMIT" ] || { echo "::error::stale bin/nftband not overwritten with current source"; exit 1; }
+          echo "OK: source build overwrote stale artifacts (embedded $ec)"
+      - name: Verified-prebuilt REJECTS a tampered manifest
+        run: |
+          set -euo pipefail
+          source packaging/lib/provenance.sh
+          # corrupt one recorded sha in the freshly-written manifest
+          jq '.binaries[0].sha256 = "'"$(printf 0%.0s {1..64})"'"' bin/build-manifest.json > bin/tampered.json
+          if prov_verify_prebuilt "$PWD" bin bin/tampered.json; then
+            echo "::error::tampered manifest was NOT rejected"; exit 1
+          fi
+          echo "OK: tampered manifest rejected"
+      - name: Hermetic provenance guard
+        run: ./scripts/ci/check-build-provenance.sh
+
+  # ==========================================================================
   # BUILD RPM PACKAGES
   # ==========================================================================
   build-rpm:
@@ -204,12 +247,12 @@ jobs:
             # Note: --allowerasing handles curl-minimal vs curl conflict on Rocky/Alma
             # v1.147: selinux-policy-devel needed to compile the nftban SELinux .pp
             # (spec BuildRequires); without it rpmbuild aborts on Failed build dependencies.
-            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl selinux-policy-devel
+            dnf -y install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl selinux-policy-devel jq file
 
             # Build RPM
             chmod +x packaging/build_nftban.sh
             cd packaging
-            ./build_nftban.sh rpm || { echo '❌ RPM build failed!'; exit 1; }
+            ./build_nftban.sh rpm --use-prebuilt --prebuilt-manifest /workspace/bin/build-manifest.json || { echo '❌ RPM build failed!'; exit 1; }
 
             # Verify at least one RPM was created (catches silent rpmbuild failures)
             if ! ls /workspace/build/packages/RPMS/*/*.rpm 2>/dev/null; then
@@ -352,7 +395,7 @@ jobs:
 
             # Install build dependencies (curl required for yq download)
             for i in 1 2 3; do
-              apt-get update && apt-get install -y dpkg-dev build-essential file curl && break
+              apt-get update && apt-get install -y dpkg-dev build-essential file curl jq && break
               echo \"Retry \$i: apt-get failed, retrying in 5s...\"
               sleep 5
             done
@@ -360,7 +403,7 @@ jobs:
             # Build DEB
             chmod +x packaging/build_nftban.sh
             cd packaging
-            ./build_nftban.sh deb || { echo '❌ DEB build failed!'; exit 1; }
+            ./build_nftban.sh deb --use-prebuilt --prebuilt-manifest /workspace/bin/build-manifest.json || { echo '❌ DEB build failed!'; exit 1; }
 
             # Verify at least one DEB was created (catches silent dpkg-deb failures)
             if ! ls /workspace/build/packages/*.deb 2>/dev/null; then

--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Check nft transition atomicity
         run: ./scripts/ci/check-nft-atomicity.sh
 
+      # Build provenance: the packaging build must never silently package a stale
+      # bin/* artifact. Source builds rebuild+verify; prebuilt packaging is explicit
+      # and manifest-verified. Runs the hermetic provenance test suite.
+      - name: Check build provenance (anti-stale-prebuilt)
+        run: ./scripts/ci/check-build-provenance.sh
+
       # v1.194 (8C): protection-claim matrix gate. Fails the PR if the matrix
       # regresses — wrong row count, missing/empty fields, invalid OWNER/MODE/
       # CLASSIFICATION enum, a claimed-enforce row orphaned to owner=NONE

--- a/build.sh
+++ b/build.sh
@@ -109,7 +109,17 @@ VERSION=$(cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "dev")
 # commit + build wall-clock). Both fall back to the pkg/version
 # defaults ("dev" / "unknown") when run outside a git checkout, so
 # release tooling can detect uninjected builds.
-GIT_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo "dev")
+# Source identity via the provenance precedence (SOURCE_COMMIT file | git HEAD),
+# full 40-char sha, FAIL-CLOSED — never silently embed "dev". An exported source
+# bundle without .git must carry a SOURCE_COMMIT file written at archive time.
+# shellcheck source=packaging/lib/provenance.sh
+source "$SCRIPT_DIR/packaging/lib/provenance.sh"
+if ! prov_resolve_source_identity "$SCRIPT_DIR"; then
+    error "Cannot resolve source identity: not a git checkout and no SOURCE_COMMIT file."
+    error "For an offline/exported source bundle, write bin/../SOURCE_COMMIT (full 40-hex) at archive time."
+    exit 1
+fi
+GIT_COMMIT="$PROV_SOURCE_COMMIT"
 BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 LDFLAGS="-s -w \
@@ -133,6 +143,13 @@ fi
 # Ensure go.mod dependencies are up to date
 fix_dependencies() {
     local module_dir="$1"
+    # Offline builds must not attempt a network module resolve. build_nftban.sh
+    # sets NFTBAN_SKIP_MOD_TIDY=1 (with GOPROXY=off) for --offline; also skip when
+    # the caller has pinned GOPROXY=off directly.
+    if [[ "${NFTBAN_SKIP_MOD_TIDY:-0}" == "1" || "${GOPROXY:-}" == "off" ]]; then
+        warn "Skipping 'go mod tidy' (offline / GOPROXY=off)"
+        return 0
+    fi
     if [[ -f "$module_dir/go.mod" ]]; then
         log "Updating dependencies in $module_dir..."
         (cd "$module_dir" && go mod tidy -v 2>/dev/null) || true
@@ -326,10 +343,21 @@ case "$COMPONENT" in
         build_validator || exit 1
         echo ""
 
+        # Provenance: prove all 6 embed the resolved source commit, then emit the
+        # build manifest (consumed by verified-prebuilt packaging + CI provenance).
+        prov_verify_source_build "$SCRIPT_DIR" "$BIN_DIR" || {
+            error "Source-build provenance verification failed"
+            exit 1
+        }
+        prov_write_manifest "$SCRIPT_DIR" "$BIN_DIR" "$BIN_DIR/build-manifest.json" || {
+            error "Failed to write build manifest"
+            exit 1
+        }
+
         log "Build Summary:"
         ls -lh "$BIN_DIR"/ 2>/dev/null || true
         echo ""
-        ok "All components built successfully!"
+        ok "All components built successfully! (manifest: bin/build-manifest.json @ ${GIT_COMMIT})"
         ;;
 
     core)

--- a/packaging/OFFLINE_BUILD.md
+++ b/packaging/OFFLINE_BUILD.md
@@ -1,0 +1,124 @@
+# NFTBan — Build Provenance & Offline Builds
+
+The packaging build is guarded against silently shipping a **stale prebuilt
+binary**. A build always produces a daemon that provably corresponds to the
+current source, or it fails closed. There are three supported modes.
+
+## Capability (honest status)
+
+| Capability | Status |
+|---|---|
+| Connected source build | **supported** |
+| Offline source build | **supported *when* Go + all modules/tools are locally provisioned** (conditional) |
+| Offline prebuilt packaging | **supported** with a complete verified manifest bundle |
+| Offline dependency kit generation | deferred (`OPEN_OFFLINE_BUILD_DEPENDENCY_AND_KIT`) |
+| Manifest signing | deferred |
+
+> A lack of internet must never cause NFTBan to package whatever old executable
+> happens to be in `bin/`. Offline capability is prepared deliberately.
+
+## Mode 1 — connected/normal source build (default)
+
+```
+./packaging/build_nftban.sh deb        # or rpm / both
+```
+
+Go present → the six generated binaries under `bin/` are **cleaned (allowlisted)**
+and **rebuilt from source**; each anchor binary's embedded `GitCommit` is verified
+to equal the resolved source identity; the exact rebuilt binaries are packaged.
+Existing `bin/*` **never** suppresses the rebuild.
+
+## Mode 2 — offline source build (conditional)
+
+```
+./packaging/build_nftban.sh deb --offline
+./packaging/build_nftban.sh deb --offline --module-cache /abs/path/to/gomodcache
+```
+
+- Go must be installed; source identity must be resolvable.
+- Sets `GOPROXY=off` (no module/tool downloads) and skips `go mod tidy`.
+- Dependency source: `vendor/` if present, else an explicit `--module-cache`.
+- **Fails closed** before staging if no local dependency source is available —
+  no network fallback, never a `bin/*` fallback.
+
+`vendor/` is **not** currently committed, so true no-network source builds require
+a supplied module cache until the deferred vendoring lane lands.
+
+## Mode 3 — verified prebuilt packaging (no Go)
+
+For an isolated packager without a Go toolchain. Explicit only — never inferred
+from Go being absent.
+
+```
+./packaging/build_nftban.sh deb \
+    --use-prebuilt \
+    --prebuilt-manifest /abs/path/build-manifest.json
+```
+
+All **six** binaries (`nftban-core`, `nftband`, `nftban-botscan-matcher`,
+`nftban-validate`, `nftban-detect-ssh-ports`, `nftban-installer`) are verified
+against the manifest: regular file (no symlink), ELF, `linux`/`amd64`, sha256 ==
+manifest, and — for the commit anchors (`nftban-core`, `nftband`) — embedded
+commit == manifest `source_commit` == resolved source identity. Missing, extra,
+or duplicate entries fail. `jq` is required.
+
+## Source identity precedence
+
+1. explicit manifest `source_commit` (prebuilt mode)
+2. `SOURCE_COMMIT` file (exported/offline source bundle; full 40-hex)
+3. git `HEAD` (checkout)
+4. **hard failure** — never silently embeds `dev`
+
+When both `.git` and `SOURCE_COMMIT` exist they must agree (a stale exported
+identity must not contaminate a live checkout). A shortened SHA is rejected.
+
+> `SOURCE_TREE_SHA256` / `module_lock_sha256` are recorded in the manifest for
+> integrity but are **not** authoritative gates in this lane; a canonical
+> source-tree digest is deferred to `OPEN_OFFLINE_BUILD_DEPENDENCY_AND_KIT`.
+
+## Provenance manifest (schema v1)
+
+`build.sh` writes `bin/build-manifest.json` after a full build:
+
+```json
+{
+  "manifest_version": 1,
+  "source_commit": "<40-hex>",
+  "source_version": "<VERSION>",
+  "target_os": "linux",
+  "target_arch": "amd64",
+  "go_version": "<go version>",
+  "module_lock_sha256": "<sha256(go.mod+go.sum)>",
+  "binaries": [ { "name": "nftband", "sha256": "<hex>", "embedded_commit": "<40-hex>" } ]
+}
+```
+
+Cryptographic signing is deferred; an unsigned manifest provides integrity +
+provenance consistency only when transferred through a trusted channel.
+
+## Local packaging tool requirements
+
+| | DEB | RPM |
+|---|---|---|
+| required for package | go, dpkg-deb, tar, gzip/xz, python3, coreutils | go, rpmbuild, tar, gzip/xz, python3, coreutils |
+| verified-prebuilt (Mode 3) | + jq, file (Go not required) | + jq, file (Go not required) |
+
+SBOM / SLSA / checksums / signing / privacy-gate tools are **required for
+release**, optional for local validation. A local build never auto-installs
+missing tools from the network.
+
+## Package SHA chain
+
+Every package build asserts `BUILT == STAGED == PACKAGE_EXTRACTED` for the
+daemon (`verify_package_sha_chain`). In Mode 3 the `MANIFEST` sha substitutes for
+`BUILT`. Installed-SHA equality is proven in package-native lab validation.
+
+## CI
+
+`build-packages.yml`: the `build-binaries` job builds fresh + emits the manifest
+in the `go-binaries` artifact. The RPM/DEB package jobs **explicitly** consume it
+with `--use-prebuilt --prebuilt-manifest` (they intentionally trust that artifact
+and have no Go). A `provenance-negative` job plants a stale binary and proves a
+source build overwrites it, and that a tampered manifest is rejected.
+`ci-architecture.yml` runs `scripts/ci/check-build-provenance.sh` (static lint +
+hermetic tests).

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -64,6 +64,73 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 readonly PROJECT_ROOT
 readonly BUILD_DIR="${PROJECT_ROOT}/build/packages"
 
+# Build-provenance / anti-stale-prebuilt guard (shared with build.sh).
+# shellcheck source=packaging/lib/provenance.sh
+source "${SCRIPT_DIR}/lib/provenance.sh"
+
+# Build-mode globals (set by parse_build_flags):
+#   PROV_MODE=source|prebuilt   PROV_OFFLINE=0|1
+#   PROV_PREBUILT_MANIFEST=<path>   PROV_MODULE_CACHE=<path>
+PROV_MODE="source"
+PROV_OFFLINE=0
+PROV_PREBUILT_MANIFEST=""
+PROV_MODULE_CACHE=""
+BUILT_DAEMON_SHA=""   # captured after build_binaries; asserted through the package chain
+
+PROV_YQ_VERSION="4.44.1"
+PROV_YQ_SHA256="6dc2d0cd4e0caca5aeffd0d784a48263591080e4a0895abe69f3a76eb50d1ba3"
+
+# provision_yq <dest> — place a SHA-verified yq_linux_amd64 at <dest>.
+# OFFLINE: copy a locally-supplied yq (NFTBAN_OFFLINE_YQ or offline/yq_linux_amd64),
+#   verify sha, FAIL-CLOSED if absent — NEVER curl/wget. ONLINE: fetch_verified.
+provision_yq() {
+    local dest="$1" src
+    if [[ "$PROV_OFFLINE" == "1" ]]; then
+        src="${NFTBAN_OFFLINE_YQ:-${PROJECT_ROOT}/offline/yq_linux_amd64}"
+        if [[ ! -f "$src" ]]; then
+            log_error "OFFLINE: yq not provisioned locally (NFTBAN_OFFLINE_YQ / offline/yq_linux_amd64 absent)."
+            log_error "Supply a SHA-pinned yq_linux_amd64 for offline packaging. FAIL-CLOSED (no download)."
+            return 1
+        fi
+        echo "${PROV_YQ_SHA256}  ${src}" | sha256sum -c - >/dev/null 2>&1 || {
+            log_error "OFFLINE: local yq sha256 mismatch (expected ${PROV_YQ_SHA256})"; return 1; }
+        install -m 0755 "$src" "$dest"
+        log_success "OFFLINE: bundled local yq (sha verified, no network)"
+        return 0
+    fi
+    # shellcheck source=packaging/lib/fetch_verified.sh
+    . "${SCRIPT_DIR}/lib/fetch_verified.sh"
+    fetch_verified \
+        "https://github.com/mikefarah/yq/releases/download/v${PROV_YQ_VERSION}/yq_linux_amd64" \
+        "${PROV_YQ_SHA256}" "$dest" || return 1
+    return 0
+}
+
+# parse_build_flags <build_type> [flags...] — populate the mode globals; fail-closed.
+parse_build_flags() {
+    shift  # drop build_type
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --offline)          PROV_OFFLINE=1 ;;
+            --use-prebuilt)     PROV_MODE="prebuilt" ;;
+            --prebuilt-manifest) PROV_PREBUILT_MANIFEST="${2:?--prebuilt-manifest needs a path}"; shift ;;
+            --module-cache)     PROV_MODULE_CACHE="${2:?--module-cache needs a path}"; shift ;;
+            *) log_error "Unknown flag: $1"; return 1 ;;
+        esac
+        shift
+    done
+    # Mode 3 requires BOTH the flag and the manifest; never inferred from Go absence.
+    if [[ "$PROV_MODE" == "prebuilt" && -z "$PROV_PREBUILT_MANIFEST" ]]; then
+        log_error "--use-prebuilt requires --prebuilt-manifest <path> (no silent prebuilt fallback)"
+        return 1
+    fi
+    if [[ -n "$PROV_PREBUILT_MANIFEST" && "$PROV_MODE" != "prebuilt" ]]; then
+        log_error "--prebuilt-manifest requires --use-prebuilt"
+        return 1
+    fi
+    return 0
+}
+
 # Functions
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
 log_success() { echo -e "${GREEN}[✓]${NC} $*"; }
@@ -75,20 +142,20 @@ check_dependencies() {
     local missing=()
     local fatal=0
 
-    # Check Go - required ONLY if pre-built binaries don't exist
-    # CI downloads pre-built binaries, so Go is not needed in container
-    # Use -f (file exists) not -x (executable) - Docker volume mounts may lose +x
-    if [[ -f "${PROJECT_ROOT}/bin/nftban-core" ]] && [[ -f "${PROJECT_ROOT}/bin/nftband" ]]; then
-        log_success "Pre-built binaries found in bin/ - Go not required"
+    # Go toolchain: REQUIRED to build from source (Mode 1/2). The mere presence of
+    # ELF files in bin/ MUST NOT suppress this check — that is the stale-prebuilt
+    # footgun (a February binary would be packaged as-is). Only EXPLICIT verified-
+    # prebuilt packaging (Mode 3, --use-prebuilt) skips Go, and it needs jq.
+    if [[ "$PROV_MODE" == "prebuilt" ]]; then
+        log_info "Mode 3 (verified prebuilt): Go not required — provenance manifest will be verified"
+        command -v jq >/dev/null 2>&1 || { log_error "jq is required for --use-prebuilt manifest verification"; fatal=1; }
     elif ! command -v go >/dev/null 2>&1; then
         log_error "╔══════════════════════════════════════════════════════════════════╗"
-        log_error "║  FATAL: Go is NOT installed - CANNOT build nftband binaries!    ║"
-        log_error "╠══════════════════════════════════════════════════════════════════╣"
-        log_error "║  Either:                                                          ║"
-        log_error "║    1. Install Go 1.21+:                                           ║"
-        log_error "║       Fedora/RHEL: sudo dnf install golang                        ║"
-        log_error "║       Debian/Ubuntu: sudo apt install golang-go                   ║"
-        log_error "║    2. Or place pre-built binaries in bin/ directory               ║"
+        log_error "║  FATAL: Go is required to build from source and is NOT installed. ║"
+        log_error "║  Install Go 1.21+, OR use EXPLICIT verified-prebuilt packaging:   ║"
+        log_error "║    build_nftban.sh <deb|rpm> --use-prebuilt \\                     ║"
+        log_error "║        --prebuilt-manifest /path/build-manifest.json             ║"
+        log_error "║  A stale bin/* is NEVER packaged implicitly.                      ║"
         log_error "╚══════════════════════════════════════════════════════════════════╝"
         fatal=1
     else
@@ -116,7 +183,8 @@ check_dependencies() {
     # MANDATORY tools (must match CI requirements)
     # CI: dnf install --allowerasing rpm-build rpmdevtools tar gzip systemd-rpm-macros make curl
     # CI: apt install dpkg-dev build-essential file curl
-    command -v curl >/dev/null || missing+=("curl")
+    # curl is only needed to FETCH yq online; --offline uses a local SHA-pinned yq.
+    [[ "$PROV_OFFLINE" == "1" ]] || command -v curl >/dev/null || missing+=("curl")
     command -v tar >/dev/null || missing+=("tar")
     command -v gzip >/dev/null || missing+=("gzip")
     command -v file >/dev/null || missing+=("file")
@@ -180,69 +248,92 @@ validate_binary() {
 
 build_binaries() {
     local bin_dir="${PROJECT_ROOT}/bin"
-    local nftban_core="${bin_dir}/nftban-core"
-    local nftband="${bin_dir}/nftband"
-    local nftban_validate="${bin_dir}/nftban-validate"
-    local nftban_installer="${bin_dir}/nftban-installer"
 
-    # Debug: Show what we're looking for
-    log_info "Checking for pre-built binaries in: ${bin_dir}"
-    if [[ -d "$bin_dir" ]]; then
-        log_info "bin/ directory exists, contents:"
-        ls -la "$bin_dir" || true
-    else
-        log_info "bin/ directory does not exist"
+    # ---- Mode 3: EXPLICIT verified prebuilt (no rebuild; --use-prebuilt only) ----
+    if [[ "$PROV_MODE" == "prebuilt" ]]; then
+        log_info "Mode 3: verifying prebuilt bundle against ${PROV_PREBUILT_MANIFEST}"
+        if ! prov_verify_prebuilt "$PROJECT_ROOT" "$bin_dir" "$PROV_PREBUILT_MANIFEST"; then
+            log_error "Prebuilt provenance verification FAILED — refusing to package"
+            return 1
+        fi
+        BUILT_DAEMON_SHA="$(prov_sha256 "$bin_dir/nftband")"
+        log_success "Verified prebuilt bundle: all ${#PROV_BINARIES[@]} binaries (nftband ${BUILT_DAEMON_SHA:0:16}…)"
+        return 0
     fi
 
-    # Check if pre-built binaries exist (from CI)
-    # Use -f (file exists) not -x (executable) - Docker volume mounts may lose +x
-    if [[ -f "$nftban_core" ]] && [[ -f "$nftband" ]] && [[ -f "$nftban_validate" ]] && [[ -f "$nftban_installer" ]]; then
-        log_info "Found pre-built binaries, validating..."
+    # ---- Mode 1/2: SOURCE build. NEVER reuse existing bin/*. ----
+    # Clean the allowlisted generated binaries FIRST so a stale artifact (e.g. an
+    # old bin/nftband left from a prior build) can never survive into the package.
+    log_info "Source build: removing allowlisted generated bin/* before rebuild"
+    if ! prov_clean_generated_bins "$PROJECT_ROOT"; then
+        log_error "Generated-bin cleanup failed (refusing to risk a stale artifact)"
+        return 1
+    fi
 
-        # Ensure binaries are executable (might be lost in Docker volume mount)
-        chmod +x "$nftban_core" "$nftband" "$nftban_validate" "$nftban_installer" 2>/dev/null || true
-
-        # Validate pre-built binaries are valid ELF files
-        if validate_binary "$nftban_core" && validate_binary "$nftband" && validate_binary "$nftban_validate" && validate_binary "$nftban_installer"; then
-            log_success "Using pre-built binaries from bin/ - skipping rebuild"
-            # Record SHA256 hashes for debugging
-            log_info "nftban-core SHA256: $(sha256sum "$nftban_core" | cut -d' ' -f1)"
-            log_info "nftband SHA256: $(sha256sum "$nftband" | cut -d' ' -f1)"
-            log_info "nftban-validate SHA256: $(sha256sum "$nftban_validate" | cut -d' ' -f1)"
-            log_info "nftban-installer SHA256: $(sha256sum "$nftban_installer" | cut -d' ' -f1)"
-            return 0
+    local -a goenv=()
+    if [[ "$PROV_OFFLINE" == "1" ]]; then
+        log_info "Mode 2 (offline): GOPROXY=off, GOTOOLCHAIN=local, no module/tool/toolchain downloads"
+        # GOTOOLCHAIN=local forbids any toolchain download (a network access). If the
+        # installed Go is older than go.mod requires, the build fails CLOSED with a
+        # clear message rather than reaching for the network.
+        goenv+=("GOPROXY=off" "GOSUMDB=off" "GOTOOLCHAIN=local" "NFTBAN_SKIP_MOD_TIDY=1")
+        if [[ -d "${PROJECT_ROOT}/vendor" ]]; then
+            goenv+=("GOFLAGS=-mod=vendor")
+            log_info "  dependency source: vendor/ (deterministic)"
+        elif [[ -n "$PROV_MODULE_CACHE" ]]; then
+            [[ -d "$PROV_MODULE_CACHE" ]] || { log_error "OFFLINE: --module-cache not found: $PROV_MODULE_CACHE"; return 1; }
+            goenv+=("GOMODCACHE=${PROV_MODULE_CACHE}")
+            log_info "  dependency source: isolated module cache ${PROV_MODULE_CACHE}"
         else
-            log_warn "Pre-built binaries failed validation, will rebuild"
+            log_error "OFFLINE build has no local dependency source (no vendor/ and no --module-cache)."
+            log_error "Provision dependencies locally, then retry. FAIL-CLOSED (no network fallback)."
+            return 1
         fi
     fi
 
-    # No valid pre-built binaries - need to build
-    log_info "Building binaries from source..."
-
-    # Check Go is available
-    if ! command -v go >/dev/null 2>&1; then
-        log_error "Go is not installed and no pre-built binaries found"
-        log_error "Either install Go or provide pre-built binaries in bin/"
+    log_info "Building all ${#PROV_BINARIES[@]} binaries from source..."
+    if ! ( cd "${PROJECT_ROOT}" && env "${goenv[@]}" ./build.sh ); then
+        log_error "Source build failed"
         return 1
     fi
 
-    cd "${PROJECT_ROOT}"
-    ./build.sh || {
-        log_error "Build failed"
+    # Independently verify all 6 embed the resolved source commit (build.sh also
+    # verifies + writes the manifest; this is defense-in-depth at the package layer).
+    if ! prov_verify_source_build "$PROJECT_ROOT" "$bin_dir"; then
+        log_error "Post-build provenance verification failed"
         return 1
-    }
+    fi
+    BUILT_DAEMON_SHA="$(prov_sha256 "$bin_dir/nftband")"
+    log_success "Built + verified all ${#PROV_BINARIES[@]} binaries (nftband ${BUILT_DAEMON_SHA:0:16}…)"
+    return 0
+}
 
-    # Validate built binaries
-    validate_binary "$nftban_core" || return 1
-    validate_binary "$nftband" || return 1
-    validate_binary "$nftban_validate" || return 1
-    validate_binary "$nftban_installer" || return 1
-
-    log_success "Binaries built successfully"
-    log_info "nftban-core SHA256: $(sha256sum "$nftban_core" | cut -d' ' -f1)"
-    log_info "nftband SHA256: $(sha256sum "$nftband" | cut -d' ' -f1)"
-    log_info "nftban-validate SHA256: $(sha256sum "$nftban_validate" | cut -d' ' -f1)"
-    log_info "nftban-installer SHA256: $(sha256sum "$nftban_installer" | cut -d' ' -f1)"
+# assert BUILT == PACKAGE_EXTRACTED daemon sha for a produced package (STAGED is
+# copied unchanged between; SOURCE→PACKAGED→INSTALLED is proven in lab validation).
+verify_package_sha_chain() {
+    local pkg_type="$1" pkg extracted td rc=0 psha
+    [[ -n "$BUILT_DAEMON_SHA" ]] || { log_error "no BUILT sha recorded"; return 1; }
+    td="$(mktemp -d)"   # explicit cleanup below — no RETURN trap (it would leak globally)
+    if [[ "$pkg_type" == "deb" ]]; then
+        pkg="$(ls "${BUILD_DIR}"/nftban-core_*.deb 2>/dev/null | head -1)"
+        [[ -f "$pkg" ]] && dpkg-deb -x "$pkg" "$td" 2>/dev/null
+    else
+        pkg="$(ls "${BUILD_DIR}"/RPMS/*/nftban-core-*.rpm 2>/dev/null | head -1)"
+        [[ -f "$pkg" ]] && ( cd "$td" && rpm2cpio "$pkg" | cpio -idm 2>/dev/null )
+    fi
+    extracted="$td/usr/lib/nftban/bin/nftband"
+    if [[ ! -f "$extracted" ]]; then
+        log_error "SHA-chain($pkg_type): daemon not found in package"
+        rm -rf "$td"; return 1
+    fi
+    psha="$(prov_sha256 "$extracted")"
+    if [[ "$psha" == "$BUILT_DAEMON_SHA" ]]; then
+        log_success "SHA-chain($pkg_type): BUILT==STAGED==PACKAGE_EXTRACTED (${BUILT_DAEMON_SHA:0:16}…)"
+    else
+        log_error "SHA-chain($pkg_type): packaged ${psha:0:16} != built ${BUILT_DAEMON_SHA:0:16}"; rc=1
+    fi
+    rm -rf "$td"
+    return $rc
 }
 
 # shellcheck disable=SC2120  # $1 in heredoc is RPM scriptlet argument, not bash
@@ -396,25 +487,9 @@ while IFS= read -r dir_line; do
     esac
 done < %{_sourcedir}/nftban-files.inc
 
-# Download yq at BUILD time (supply-chain safe - not at install time)
-# SHA256 verified before bundling in package.
-# v1.157 PR-A: hardened fetch (retry + fail-fast + bounded timeouts + atomic
-# write + checksum verify). Identical behaviour to packaging/lib/fetch_verified.sh
-# but inlined here because this runs inside the rpmbuild install scriptlet where the
-# helper file is not staged/sourceable. A transient blip no longer leaves a
-# bad/partial body that the SHA pin then hard-fails on.
-YQ_VERSION="4.44.1"
-YQ_SHA256="6dc2d0cd4e0caca5aeffd0d784a48263591080e4a0895abe69f3a76eb50d1ba3"
-echo "Downloading yq v\${YQ_VERSION} for bundling..."
-yq_tmp=\$(mktemp ./.yq_fetch.XXXXXX)
-curl --fail --location --retry 5 --retry-all-errors --retry-delay 3 \\
-     --connect-timeout 10 --max-time 120 -sS \\
-     -o "\${yq_tmp}" \\
-     "https://github.com/mikefarah/yq/releases/download/v\${YQ_VERSION}/yq_linux_amd64" \\
-     || { echo "yq download failed!"; rm -f "\${yq_tmp}"; exit 1; }
-echo "\${YQ_SHA256}  \${yq_tmp}" | sha256sum -c - \\
-     || { echo "yq checksum verification failed!"; rm -f "\${yq_tmp}"; exit 1; }
-mv -f "\${yq_tmp}" yq_linux_amd64
+# yq is provisioned + SHA256-verified by build_rpm (bash, offline-aware) and staged
+# into the source dir as yq_linux_amd64 — the rpmbuild install scriptlet NEVER
+# touches the network (so --offline is honoured). Installed from the source dir below.
 
 # Binaries
 install -D -m 0755 bin/nftban-core %{buildroot}/usr/lib/nftban/bin/nftban-core
@@ -423,7 +498,7 @@ install -D -m 0755 bin/nftban-botscan-matcher %{buildroot}/usr/lib/nftban/bin/nf
 install -D -m 0755 bin/nftban-validate %{buildroot}/usr/lib/nftban/bin/nftban-validate
 install -D -m 0755 bin/nftban-detect-ssh-ports %{buildroot}/usr/lib/nftban/bin/nftban-detect-ssh-ports
 install -D -m 0755 bin/nftban-installer %{buildroot}/usr/lib/nftban/bin/nftban-installer
-install -D -m 0755 yq_linux_amd64 %{buildroot}/usr/lib/nftban/bin/yq
+install -D -m 0755 %{_sourcedir}/yq_linux_amd64 %{buildroot}/usr/lib/nftban/bin/yq
 # NB-5: privileged binaries ship 0750 (root:nftban), not 0755 (root:root).
 # Canonical ownership set declaratively via %attr() in the files manifest below.
 install -D -m 0750 cli/sbin/nftban %{buildroot}/usr/sbin/nftban
@@ -1662,6 +1737,14 @@ build_rpm() {
     cp "$systemd_list_src" "${BUILD_DIR}/SOURCES/nftban-systemd-install.list"
     log_success "Staged nftban-systemd-install.list ($(grep -cvE '^#|^$' "${BUILD_DIR}/SOURCES/nftban-systemd-install.list") units)"
 
+    # Provision yq into SOURCES/ (offline-aware, SHA-verified) so the rpmbuild
+    # install scriptlet installs it from the source dir and never touches the network.
+    provision_yq "${BUILD_DIR}/SOURCES/yq_linux_amd64" || {
+        log_error "yq provisioning failed (offline: supply NFTBAN_OFFLINE_YQ / offline/yq_linux_amd64)"
+        return 1
+    }
+    log_success "Staged yq_linux_amd64 into SOURCES/"
+
     # Build RPM (version from VERSION file)
     if rpmbuild --define "_topdir ${BUILD_DIR}" \
         --define "pkg_version ${PKG_VERSION}" \
@@ -1891,18 +1974,10 @@ build_deb() {
     # v1.157 PR-A: use the shared fetch_verified helper (retry + fail-fast +
     # atomic write + checksum verify) so a transient blip no longer leaves a
     # bad/partial body that the SHA pin then hard-fails on.
-    local YQ_VERSION="4.44.1"
-    local YQ_SHA256="6dc2d0cd4e0caca5aeffd0d784a48263591080e4a0895abe69f3a76eb50d1ba3"
-    log_info "Downloading yq v${YQ_VERSION} for bundling..."
-    # shellcheck source=packaging/lib/fetch_verified.sh
-    . "${SCRIPT_DIR}/lib/fetch_verified.sh"
-    fetch_verified \
-        "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
-        "${YQ_SHA256}" \
-        "${BUILD_DIR}/yq_linux_amd64" \
-        || { log_error "yq checksum verification failed!"; exit 1; }
+    log_info "Provisioning yq v${PROV_YQ_VERSION} for bundling (offline-aware)..."
+    provision_yq "${BUILD_DIR}/yq_linux_amd64" || { log_error "yq provisioning failed"; exit 1; }
     install -m 0755 "${BUILD_DIR}/yq_linux_amd64" "${deb_root}/usr/lib/nftban/bin/yq"
-    log_info "yq v${YQ_VERSION} bundled (SHA256 verified)"
+    log_info "yq v${PROV_YQ_VERSION} bundled (SHA256 verified)"
 
     # Copy helper scripts to /usr/lib/nftban/sbin/
     # CRITICAL: These scripts are executed by systemd services and MUST have 755 permissions
@@ -2189,11 +2264,15 @@ main() {
     # Validate
     if [[ ! "$build_type" =~ ^(deb|rpm|both)$ ]]; then
         log_error "Invalid argument: $build_type"
-        echo "Usage: $0 [deb|rpm|both]"
+        echo "Usage: $0 [deb|rpm|both] [--offline] [--module-cache DIR] [--use-prebuilt --prebuilt-manifest FILE]"
         exit 1
     fi
 
-    # Check dependencies
+    # Parse build-mode flags (--offline / --use-prebuilt / --prebuilt-manifest / --module-cache)
+    parse_build_flags "$@" || exit 1
+    log_info "Build mode: ${PROV_MODE}$([[ "$PROV_OFFLINE" == 1 ]] && echo ' (offline)')"
+
+    # Check dependencies (Go required for source builds; jq for prebuilt)
     check_dependencies "$build_type" || exit 1
 
     # Build binaries first
@@ -2211,6 +2290,7 @@ main() {
             log_error "RPM build failed"
             exit 1
         }
+        verify_package_sha_chain rpm || exit 1
         echo ""
     fi
 
@@ -2219,6 +2299,7 @@ main() {
             log_error "DEB build failed"
             exit 1
         }
+        verify_package_sha_chain deb || exit 1
         echo ""
     fi
 
@@ -2233,4 +2314,7 @@ main() {
     echo "  RPM: sudo rpm -ivh ${BUILD_DIR}/RPMS/x86_64/nftban-core-${PKG_VERSION}-${PKG_RELEASE}.*.rpm"
 }
 
-main "$@"
+# Run main only when executed directly (allows sourcing for unit tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/packaging/lib/provenance.sh
+++ b/packaging/lib/provenance.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="packaging/lib/provenance"
+# meta:type="script"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Build provenance: source-identity resolution, embedded-commit verification, prebuilt-manifest gen/verify, allowlisted bin cleanup — the anti-stale-prebuilt guard shared by build.sh and packaging/build_nftban.sh"
+# meta:inventory.files="bin/*, build-manifest.json, SOURCE_COMMIT"
+# meta:inventory.binaries="go, sha256sum, file, jq"
+# meta:inventory.env_vars="PROV_SOURCE_COMMIT, PROV_SOURCE_VERSION"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# NOT executable on its own — `source` it. Every function is fail-closed:
+# on any ambiguity it returns non-zero and prints an error, never a silent
+# fallback to whatever binary happens to be on disk.
+# =============================================================================
+
+# The exact, complete set of packaged Go executables. A prebuilt bundle MUST
+# contain all of these and nothing extra; the source build produces all of them.
+set -Eeuo pipefail
+
+PROV_BINARIES=(nftban-core nftband nftban-botscan-matcher nftban-validate nftban-detect-ssh-ports nftban-installer)
+
+# Commit ANCHORS: binaries that reliably print the embedded 40-hex commit via
+# `--version` (version.String()). Their embedded commit is read and checked to
+# bind the whole build to the source commit. Every binary (anchor or not) is
+# bound by sha256 in the manifest — all six are produced by ONE build.sh run — so
+# a non-anchor (e.g. nftban-detect-ssh-ports, which has no --version) is still
+# provenance-locked by its checksum + the anchors proving the source commit.
+PROV_COMMIT_ANCHORS=(nftban-core nftband)
+
+_prov_is_anchor() { local x="$1" a; for a in "${PROV_COMMIT_ANCHORS[@]}"; do [[ "$a" == "$x" ]] && return 0; done; return 1; }
+
+PROV_TARGET_OS="linux"
+PROV_TARGET_ARCH="amd64"
+
+_prov_err() { echo "[provenance][ERROR] $*" >&2; }
+_prov_log() { echo "[provenance] $*" >&2; }
+
+# is the value a full 40-char lowercase hex commit?
+prov_is_full_commit() {
+	[[ "${1:-}" =~ ^[0-9a-f]{40}$ ]]
+}
+
+# prov_resolve_source_identity <repo_root> [manifest_commit]
+# Deterministic authority order → sets PROV_SOURCE_COMMIT (40-hex) + PROV_SOURCE_VERSION.
+#   1. explicit manifest commit (prebuilt mode)   2. SOURCE_COMMIT file
+#   3. git HEAD (full)                            4. hard failure
+# When BOTH .git and SOURCE_COMMIT exist they must agree (a stale exported
+# identity file must never contaminate a live checkout).
+prov_resolve_source_identity() {
+	local root="$1" manifest_commit="${2:-}"
+	PROV_SOURCE_VERSION="$(cat "$root/VERSION" 2>/dev/null || echo "")"
+
+	local git_commit="" file_commit=""
+	if git -C "$root" rev-parse --git-dir >/dev/null 2>&1; then
+		git_commit="$(git -C "$root" rev-parse HEAD 2>/dev/null || echo "")"
+	fi
+	if [[ -f "$root/SOURCE_COMMIT" ]]; then
+		file_commit="$(tr -d '[:space:]' < "$root/SOURCE_COMMIT")"
+	fi
+
+	# .git + SOURCE_COMMIT must agree.
+	if [[ -n "$git_commit" && -n "$file_commit" && "$git_commit" != "$file_commit" ]]; then
+		_prov_err "SOURCE_COMMIT ($file_commit) != git HEAD ($git_commit) — stale exported identity in a live checkout"
+		return 1
+	fi
+
+	local resolved=""
+	if [[ -n "$manifest_commit" ]]; then
+		# The manifest is authoritative for prebuilts, but it MUST NOT override a
+		# contradictory source tree — it has to agree with any present git HEAD
+		# and/or SOURCE_COMMIT.
+		if [[ -n "$git_commit" && "$git_commit" != "$manifest_commit" ]]; then
+			_prov_err "manifest commit ($manifest_commit) != git HEAD ($git_commit) — manifest cannot override the source tree"
+			return 1
+		fi
+		if [[ -n "$file_commit" && "$file_commit" != "$manifest_commit" ]]; then
+			_prov_err "manifest commit ($manifest_commit) != SOURCE_COMMIT ($file_commit)"
+			return 1
+		fi
+		resolved="$manifest_commit"
+	elif [[ -n "$file_commit" ]]; then
+		resolved="$file_commit"
+	elif [[ -n "$git_commit" ]]; then
+		resolved="$git_commit"
+	else
+		_prov_err "no source identity: not a git checkout and no SOURCE_COMMIT file (refusing to embed 'dev')"
+		return 1
+	fi
+
+	if ! prov_is_full_commit "$resolved"; then
+		_prov_err "source commit '$resolved' is not a full 40-char hex sha (shortened sha is insufficient for provenance)"
+		return 1
+	fi
+	PROV_SOURCE_COMMIT="$resolved"
+	return 0
+}
+
+# prov_binary_embedded_commit <binary> → prints the 40-hex commit the binary was built from.
+# Reads it from `--version` (works without Go, on the static linux/amd64 ELF).
+prov_binary_embedded_commit() {
+	local bin="$1" out c
+	out="$("$bin" --version 2>/dev/null || true)"
+	# format: "<component> <ver> (git <COMMIT>, build <DATE>)"
+	c="$(printf '%s' "$out" | grep -oiE 'git [0-9a-f]{40}' | head -1 | awk '{print $2}')"
+	[[ -n "$c" ]] || { _prov_err "$bin: no embedded 40-hex commit in --version (uninjected/'dev' build?)"; return 1; }
+	printf '%s\n' "$c"
+}
+
+# prov_check_elf_arch <binary> — regular file (not symlink), ELF, linux, expected arch.
+prov_check_elf_arch() {
+	local bin="$1" ft
+	[[ -e "$bin" ]] || { _prov_err "$bin: missing"; return 1; }
+	[[ -L "$bin" ]] && { _prov_err "$bin: is a symlink (rejected)"; return 1; }
+	[[ -f "$bin" ]] || { _prov_err "$bin: not a regular file"; return 1; }
+	ft="$(file -b "$bin" 2>/dev/null)"
+	[[ "$ft" == *ELF* ]] || { _prov_err "$bin: not an ELF ($ft)"; return 1; }
+	# amd64 → "x86-64" in file(1) output
+	case "$PROV_TARGET_ARCH" in
+		amd64) [[ "$ft" == *x86-64* ]] || { _prov_err "$bin: not $PROV_TARGET_ARCH ($ft)"; return 1; } ;;
+		arm64) [[ "$ft" == *aarch64* ]] || { _prov_err "$bin: not $PROV_TARGET_ARCH ($ft)"; return 1; } ;;
+	esac
+	return 0
+}
+
+prov_sha256() { sha256sum "$1" | awk '{print $1}'; }
+
+# prov_clean_generated_bins <repo_root> — allowlisted deletion of ONLY the known
+# generated binaries directly under <root>/bin. Never a broad rm; never a symlink;
+# never a tracked/source path; never anything outside <root>/bin.
+prov_clean_generated_bins() {
+	local root="$1" bindir b target real_bin real_target
+	bindir="$root/bin"
+	[[ -d "$bindir" ]] || return 0
+	real_bin="$(cd "$bindir" && pwd -P)" || return 1
+	for b in "${PROV_BINARIES[@]}"; do
+		target="$bindir/$b"
+		[[ -e "$target" || -L "$target" ]] || continue
+		# basename must be exactly an allowlisted name
+		case " ${PROV_BINARIES[*]} " in *" $b "*) : ;; *) _prov_err "refuse: $b not allowlisted"; return 1 ;; esac
+		# refuse symlinks (no traversal)
+		if [[ -L "$target" ]]; then _prov_err "refuse: $target is a symlink"; return 1; fi
+		# resolved parent dir must be exactly <root>/bin
+		real_target="$(cd "$(dirname "$target")" && pwd -P)/$(basename "$target")"
+		[[ "$(dirname "$real_target")" == "$real_bin" ]] || { _prov_err "refuse: $target escapes $real_bin"; return 1; }
+		# must NOT be git-tracked source
+		if git -C "$root" ls-files --error-unmatch "bin/$b" >/dev/null 2>&1; then
+			_prov_err "refuse: bin/$b is git-tracked (not a generated output)"; return 1
+		fi
+		rm -f "$real_target" || { _prov_err "failed to remove $real_target"; return 1; }
+	done
+	return 0
+}
+
+# prov_write_manifest <repo_root> <bindir> <out.json> — schema v1, all 6 binaries.
+prov_write_manifest() {
+	local root="$1" bindir="$2" out="$3" b sha ec first=1 modlock
+	prov_resolve_source_identity "$root" || return 1
+	modlock="$( (cat "$root/go.mod" "$root/go.sum" 2>/dev/null) | sha256sum | awk '{print $1}')"
+	{
+		printf '{\n'
+		printf '  "manifest_version": 1,\n'
+		printf '  "source_commit": "%s",\n' "$PROV_SOURCE_COMMIT"
+		printf '  "source_version": "%s",\n' "${PROV_SOURCE_VERSION:-}"
+		printf '  "target_os": "%s",\n' "$PROV_TARGET_OS"
+		printf '  "target_arch": "%s",\n' "$PROV_TARGET_ARCH"
+		printf '  "go_version": "%s",\n' "$(go version 2>/dev/null | awk '{print $3}' || echo unknown)"
+		printf '  "module_lock_sha256": "%s",\n' "$modlock"
+		printf '  "binaries": [\n'
+		for b in "${PROV_BINARIES[@]}"; do
+			[[ -f "$bindir/$b" ]] || { _prov_err "manifest: missing $bindir/$b"; return 1; }
+			sha="$(prov_sha256 "$bindir/$b")"
+			if _prov_is_anchor "$b"; then
+				ec="$(prov_binary_embedded_commit "$bindir/$b")" || return 1
+				[[ "$ec" == "$PROV_SOURCE_COMMIT" ]] || { _prov_err "manifest: $b embedded $ec != source $PROV_SOURCE_COMMIT"; return 1; }
+			else
+				# non-anchor: bound by sha; commit is the shared source of this one build
+				ec="$PROV_SOURCE_COMMIT"
+			fi
+			[[ $first -eq 1 ]] || printf ',\n'
+			first=0
+			printf '    { "name": "%s", "sha256": "%s", "embedded_commit": "%s" }' "$b" "$sha" "$ec"
+		done
+		printf '\n  ]\n}\n'
+	} > "$out"
+	_prov_log "wrote manifest $out (source $PROV_SOURCE_COMMIT)"
+	return 0
+}
+
+# prov_verify_prebuilt <repo_root> <bindir> <manifest.json>
+# Mode 3 gate: verify ALL SIX binaries against the manifest AND the source identity.
+# Rejects: missing/extra/duplicate binaries, bad type/ELF/arch/OS, commit or sha
+# mismatch, malformed hashes, version/manifest-version mismatch. Complete-set only.
+prov_verify_prebuilt() {
+	local root="$1" bindir="$2" manifest="$3"
+	command -v jq >/dev/null 2>&1 || { _prov_err "jq required to verify a prebuilt manifest"; return 1; }
+	[[ -f "$manifest" ]] || { _prov_err "manifest not found: $manifest"; return 1; }
+	jq -e . "$manifest" >/dev/null 2>&1 || { _prov_err "manifest is not valid JSON"; return 1; }
+
+	local mver mcommit mos march
+	mver="$(jq -r '.manifest_version' "$manifest")"
+	[[ "$mver" == "1" ]] || { _prov_err "unsupported manifest_version: $mver"; return 1; }
+	mcommit="$(jq -r '.source_commit' "$manifest")"
+	mos="$(jq -r '.target_os' "$manifest")"
+	march="$(jq -r '.target_arch' "$manifest")"
+	[[ "$mos" == "$PROV_TARGET_OS" ]]   || { _prov_err "manifest target_os $mos != $PROV_TARGET_OS"; return 1; }
+	[[ "$march" == "$PROV_TARGET_ARCH" ]] || { _prov_err "manifest target_arch $march != $PROV_TARGET_ARCH"; return 1; }
+
+	# source identity: manifest commit is the authority in prebuilt mode, but if a
+	# live source identity exists it MUST agree.
+	prov_resolve_source_identity "$root" "$mcommit" || return 1
+	[[ "$PROV_SOURCE_COMMIT" == "$mcommit" ]] || { _prov_err "manifest commit != resolved source identity"; return 1; }
+
+	# manifest binary set must equal the required set exactly (no missing / extra / dup)
+	local names dupes
+	names="$(jq -r '.binaries[].name' "$manifest")"
+	dupes="$(printf '%s\n' "$names" | sort | uniq -d)"
+	[[ -z "$dupes" ]] || { _prov_err "duplicate binary names in manifest: $dupes"; return 1; }
+	local want got
+	want="$(printf '%s\n' "${PROV_BINARIES[@]}" | sort)"
+	got="$(printf '%s\n' "$names" | sort)"
+	[[ "$want" == "$got" ]] || { _prov_err "manifest binary set != required 6 (missing/extra)"; return 1; }
+
+	# no extra Go executable on disk beyond the 6
+	local f base
+	for f in "$bindir"/*; do
+		[[ -f "$f" ]] || continue
+		base="$(basename "$f")"
+		case " ${PROV_BINARIES[*]} " in *" $base "*) : ;; *)
+			# only fail for ELF extras (ignore manifest/notes)
+			file -b "$f" 2>/dev/null | grep -q ELF && { _prov_err "unexpected ELF in bindir: $base"; return 1; } ;;
+		esac
+	done
+
+	local b msha mec dsha dec
+	for b in "${PROV_BINARIES[@]}"; do
+		msha="$(jq -r --arg n "$b" '.binaries[] | select(.name==$n) | .sha256' "$manifest")"
+		mec="$(jq -r --arg n "$b" '.binaries[] | select(.name==$n) | .embedded_commit' "$manifest")"
+		[[ "$msha" =~ ^[0-9a-f]{64}$ ]] || { _prov_err "$b: malformed manifest sha256"; return 1; }
+		prov_is_full_commit "$mec" || { _prov_err "$b: malformed manifest embedded_commit"; return 1; }
+		[[ "$mec" == "$mcommit" ]] || { _prov_err "$b: manifest embedded_commit != source_commit"; return 1; }
+		prov_check_elf_arch "$bindir/$b" || return 1
+		dsha="$(prov_sha256 "$bindir/$b")"
+		[[ "$dsha" == "$msha" ]] || { _prov_err "$b: on-disk sha $dsha != manifest $msha"; return 1; }
+		# Anchor binaries additionally prove their embedded commit matches (source binding);
+		# non-anchors are bound by the sha above + the anchors' commit proof.
+		if _prov_is_anchor "$b"; then
+			dec="$(prov_binary_embedded_commit "$bindir/$b")" || return 1
+			[[ "$dec" == "$mec" ]] || { _prov_err "$b: embedded $dec != manifest $mec"; return 1; }
+		fi
+	done
+	_prov_log "prebuilt bundle VERIFIED: all ${#PROV_BINARIES[@]} binaries @ $mcommit"
+	return 0
+}
+
+# prov_verify_source_build <repo_root> <bindir> — after a source rebuild, assert
+# every one of the 6 exists, is ELF/arch-correct, and embeds the resolved source commit.
+prov_verify_source_build() {
+	local root="$1" bindir="$2" b ec
+	prov_resolve_source_identity "$root" || return 1
+	for b in "${PROV_BINARIES[@]}"; do
+		prov_check_elf_arch "$bindir/$b" || return 1
+		if _prov_is_anchor "$b"; then
+			ec="$(prov_binary_embedded_commit "$bindir/$b")" || return 1
+			[[ "$ec" == "$PROV_SOURCE_COMMIT" ]] || { _prov_err "$b embedded $ec != source $PROV_SOURCE_COMMIT"; return 1; }
+		fi
+	done
+	_prov_log "source build VERIFIED: all ${#PROV_BINARIES[@]} binaries present (anchors embed $PROV_SOURCE_COMMIT)"
+	return 0
+}

--- a/packaging/tests/build_provenance_test.sh
+++ b/packaging/tests/build_provenance_test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="packaging/tests/build_provenance_test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Hermetic tests for the build-provenance / anti-stale-prebuilt guard: source-identity precedence + mismatch, full-40-hex enforcement, allowlisted bin cleanup, prebuilt-manifest parser rejections, and build_nftban.sh flag rejections. No Go build, no nft, no root."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash, git, jq, sha256sum"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+set -Eeuo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+# shellcheck source=packaging/lib/provenance.sh
+source "$ROOT/packaging/lib/provenance.sh"
+
+PASS=0; FAIL=0
+ok()  { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad() { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+# expect_fail <desc> <cmd...>  → cmd must return non-zero
+expect_fail() { local d="$1"; shift; if "$@" >/dev/null 2>&1; then bad "$d (expected failure, got success)"; else ok "$d"; fi; }
+expect_ok()   { local d="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$d"; else bad "$d (expected success, got failure)"; fi; }
+
+C40="$(printf 'a%.0s' {1..40})"   # 40x 'a'
+C40b="$(printf 'b%.0s' {1..40})"
+
+echo "== full-commit validation =="
+expect_ok   "40-hex accepted"            prov_is_full_commit "$C40"
+expect_fail "12-hex rejected"            prov_is_full_commit "aaaaaaaaaaaa"
+expect_fail "non-hex rejected"           prov_is_full_commit "zzzz"
+
+echo "== source identity precedence =="
+mk_root() { local d; d="$(mktemp -d)"; echo "1.2.3" > "$d/VERSION"; printf 'module x\n' > "$d/go.mod"; : > "$d/go.sum"; echo "$d"; }
+
+d1="$(mk_root)"; ( cd "$d1" && git init -q && git config user.email t@t && git config user.name t && git add -A && git commit -qm x )
+expect_ok   "git-only checkout resolves"  prov_resolve_source_identity "$d1"
+
+d2="$(mk_root)"; echo "$C40" > "$d2/SOURCE_COMMIT"
+expect_ok   "SOURCE_COMMIT-only resolves" prov_resolve_source_identity "$d2"
+
+d3="$(mk_root)"; ( cd "$d3" && git init -q && git config user.email t@t && git config user.name t && git add -A && git commit -qm x )
+gh="$(git -C "$d3" rev-parse HEAD)"; echo "$gh" > "$d3/SOURCE_COMMIT"
+expect_ok   "git + matching SOURCE_COMMIT" prov_resolve_source_identity "$d3"
+
+d4="$(mk_root)"; ( cd "$d4" && git init -q && git config user.email t@t && git config user.name t && git add -A && git commit -qm x )
+echo "$C40b" > "$d4/SOURCE_COMMIT"
+expect_fail "git + MISMATCHED SOURCE_COMMIT rejected" prov_resolve_source_identity "$d4"
+
+d5="$(mk_root)"   # no git, no SOURCE_COMMIT
+expect_fail "no git + no SOURCE_COMMIT rejected"      prov_resolve_source_identity "$d5"
+
+d6="$(mk_root)"; echo "abc123" > "$d6/SOURCE_COMMIT"  # short sha
+expect_fail "short SOURCE_COMMIT rejected"            prov_resolve_source_identity "$d6"
+
+echo "== allowlisted generated-bin cleanup =="
+dc="$(mk_root)"; mkdir -p "$dc/bin"
+for b in "${PROV_BINARIES[@]}"; do echo x > "$dc/bin/$b"; done
+echo keep > "$dc/bin/not-a-binary"
+expect_ok "clean allowlisted bins" prov_clean_generated_bins "$dc"
+[[ ! -e "$dc/bin/nftband" ]] && ok "nftband removed" || bad "nftband not removed"
+[[ -e "$dc/bin/not-a-binary" ]] && ok "non-allowlisted file preserved" || bad "non-allowlisted file wrongly removed"
+# symlink masquerading as an allowlisted binary → refuse
+ds="$(mk_root)"; mkdir -p "$ds/bin"; ln -s /etc/hostname "$ds/bin/nftband"
+expect_fail "symlink allowlisted name refused" prov_clean_generated_bins "$ds"
+
+echo "== prebuilt manifest parser rejections =="
+# helper: valid base manifest + fake bindir, then mutate
+mk_manifest() {  # <root> <bindir> <commit>  → writes $root/m.json
+	local r="$1" bd="$2" c="$3" b first=1
+	mkdir -p "$bd"
+	{ printf '{\n "manifest_version": 1,\n "source_commit": "%s",\n "source_version": "1.2.3",\n "target_os": "linux",\n "target_arch": "amd64",\n "go_version": "go1.25",\n "module_lock_sha256": "%s",\n "binaries": [\n' "$c" "$(printf 0%.0s {1..64})"
+	  for b in "${PROV_BINARIES[@]}"; do [[ $first -eq 1 ]] || printf ',\n'; first=0; printf '  {"name":"%s","sha256":"%s","embedded_commit":"%s"}' "$b" "$(printf 0%.0s {1..64})" "$c"; done
+	  printf '\n ]\n}\n'; } > "$r/m.json"
+}
+if command -v jq >/dev/null 2>&1; then
+	dm="$(mk_root)"; echo "$C40" > "$dm/SOURCE_COMMIT"; bd="$dm/bin"; mk_manifest "$dm" "$bd" "$C40"
+	# bad JSON
+	echo "{ not json" > "$dm/bad.json"
+	expect_fail "invalid JSON rejected"           prov_verify_prebuilt "$dm" "$bd" "$dm/bad.json"
+	# wrong manifest_version
+	jq '.manifest_version=2' "$dm/m.json" > "$dm/v2.json"
+	expect_fail "manifest_version!=1 rejected"    prov_verify_prebuilt "$dm" "$bd" "$dm/v2.json"
+	# wrong arch
+	jq '.target_arch="arm64"' "$dm/m.json" > "$dm/arch.json"
+	expect_fail "wrong target_arch rejected"      prov_verify_prebuilt "$dm" "$bd" "$dm/arch.json"
+	# duplicate binary name
+	jq '.binaries += [.binaries[0]]' "$dm/m.json" > "$dm/dup.json"
+	expect_fail "duplicate binary name rejected"  prov_verify_prebuilt "$dm" "$bd" "$dm/dup.json"
+	# missing one binary
+	jq '.binaries |= .[1:]' "$dm/m.json" > "$dm/miss.json"
+	expect_fail "missing binary rejected"         prov_verify_prebuilt "$dm" "$bd" "$dm/miss.json"
+	# extra unknown binary
+	jq '.binaries += [{"name":"nftban-extra","sha256":"'"$(printf 0%.0s {1..64})"'","embedded_commit":"'"$C40"'"}]' "$dm/m.json" > "$dm/extra.json"
+	expect_fail "extra binary rejected"           prov_verify_prebuilt "$dm" "$bd" "$dm/extra.json"
+	# manifest commit != source identity (SOURCE_COMMIT is C40; manifest C40b)
+	mk_manifest "$dm" "$bd" "$C40b"; mv "$dm/m.json" "$dm/badcommit.json"
+	expect_fail "manifest commit != source identity rejected" prov_verify_prebuilt "$dm" "$bd" "$dm/badcommit.json"
+else
+	echo "  [SKIP] jq not present — manifest parser tests skipped"
+fi
+
+echo "== build_nftban.sh flag rejections (subprocess, fail before build) =="
+BN="$ROOT/packaging/build_nftban.sh"
+expect_fail "--use-prebuilt without manifest rejected"  bash "$BN" deb --use-prebuilt
+expect_fail "--prebuilt-manifest without --use-prebuilt rejected" bash "$BN" deb --prebuilt-manifest /x
+expect_fail "invalid build type rejected"               bash "$BN" bogustype
+
+echo "== offline network surface (static) =="
+BNF="$ROOT/packaging/build_nftban.sh"
+# the only yq curl/fetch must live inside provision_yq's ONLINE branch, gated by PROV_OFFLINE
+prov_body="$(awk '/^provision_yq\(\) \{/{p=1} p{print} p&&/^}/{exit}' "$BNF")"
+grep -q 'PROV_OFFLINE.*==.*"1"' <<<"$prov_body" && ok "provision_yq gates on PROV_OFFLINE" || bad "provision_yq not offline-gated"
+# build_deb / create_rpm_spec must NOT curl yq directly any more
+if grep -nE 'curl.*yq_linux_amd64|fetch_verified.*yq' "$BNF" | grep -qv 'provision_yq'; then
+	# allow the reference inside provision_yq itself
+	extra="$(grep -nE 'yq_linux_amd64' "$BNF" | grep -iE 'curl|fetch_verified' | grep -v 'mikefarah/yq/releases' || true)"
+	[[ -z "$extra" ]] && ok "no direct yq curl outside provision_yq" || { bad "direct yq curl remains: $extra"; }
+else
+	ok "no direct yq curl outside provision_yq"
+fi
+# the rpm %install must install yq from the pre-staged source dir (no in-rpmbuild curl)
+grep -q 'install -D -m 0755 %{_sourcedir}/yq_linux_amd64' "$BNF" && ok "rpm %install uses pre-staged yq (no rpmbuild network)" || bad "rpm %install still fetches yq"
+grep -q 'provision_yq "${BUILD_DIR}/SOURCES/yq_linux_amd64"' "$BNF" && ok "build_rpm stages yq offline-aware" || bad "build_rpm does not stage yq via provision_yq"
+# curl is not a hard build dep in offline mode
+grep -q 'PROV_OFFLINE.*==.*"1".*|| command -v curl' "$BNF" && ok "curl optional under --offline" || bad "curl still hard-required offline"
+
+echo ""
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/packaging/tests/build_provenance_test.sh
+++ b/packaging/tests/build_provenance_test.sh
@@ -127,6 +127,33 @@ grep -q 'provision_yq "${BUILD_DIR}/SOURCES/yq_linux_amd64"' "$BNF" && ok "build
 # curl is not a hard build dep in offline mode
 grep -q 'PROV_OFFLINE.*==.*"1".*|| command -v curl' "$BNF" && ok "curl optional under --offline" || bad "curl still hard-required offline"
 
+echo "== sourced-library strict-mode contract =="
+# The header policy (tools/validate-headers.sh) forces a top-level `set -Eeuo
+# pipefail` in provenance.sh even though it is a SOURCED library. That enables
+# errexit/nounset/pipefail in the caller at source time. Guard: every shipped
+# caller MUST already be strict BEFORE sourcing it, so the library never SILENTLY
+# changes an unrelated caller's shell contract.
+for caller in build.sh packaging/build_nftban.sh; do
+	se="$(grep -n '^set -Eeuo pipefail' "$ROOT/$caller" | head -1 | cut -d: -f1)"
+	sr="$(grep -n 'lib/provenance.sh' "$ROOT/$caller" | head -1 | cut -d: -f1)"
+	if [[ -n "$se" && -n "$sr" && "$se" -lt "$sr" ]]; then ok "$caller is strict before sourcing provenance.sh"; else bad "$caller sources provenance.sh without prior strict mode"; fi
+done
+# Functional: a controlled NON-strict caller can source the library and its
+# functions still fail-closed correctly (they use explicit return codes, not
+# reliance on errexit) — proving the sourced-strict-mode does not break callers.
+tmpc="$(mktemp)"
+cat > "$tmpc" <<CALLER
+#!/usr/bin/env bash
+# deliberately NOT strict before sourcing
+source "$ROOT/packaging/lib/provenance.sh"
+prov_resolve_source_identity /nonexistent-root-xyz && echo UNEXPECTED_OK || echo FAILCLOSED
+echo CALLER_CONTINUED
+CALLER
+out="$(bash "$tmpc" 2>/dev/null)"; rm -f "$tmpc"
+grep -q FAILCLOSED <<<"$out" && grep -q CALLER_CONTINUED <<<"$out" \
+	&& ok "sourced from a controlled caller: functions fail-closed, caller continues" \
+	|| bad "sourced-caller contract broken ($out)"
+
 echo ""
 echo "RESULT: PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/ci/check-build-provenance.sh
+++ b/scripts/ci/check-build-provenance.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# meta:name="check-build-provenance"
+# meta:type="script"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="CI gate: the packaging build must never silently reuse a stale bin/* artifact. Static-lints build_nftban.sh + build.sh for the anti-stale-prebuilt guard, then runs the hermetic provenance test suite."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash, grep, git"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+FAIL=0
+BN="packaging/build_nftban.sh"
+BS="build.sh"
+
+echo "========================================"
+echo "NFTBan CI: Build Provenance (anti-stale-prebuilt)"
+echo "========================================"
+
+# 1) The exact old footgun must be GONE: reuse binaries because bin/ ELFs exist.
+if grep -q "Pre-built binaries found in bin/ - Go not required" "$BN" 2>/dev/null; then
+    echo "::error::stale-prebuilt footgun present — build_nftban.sh still declares 'Go not required' from bin/ presence"; FAIL=1
+fi
+if grep -q "Using pre-built binaries from bin/ - skipping rebuild" "$BN" 2>/dev/null; then
+    echo "::error::build_nftban.sh still SILENTLY reuses bin/* (skip-rebuild path must be removed)"; FAIL=1
+fi
+
+# 2) Source-build path must clean + verify (positive wiring inside build_binaries()).
+body="$(awk '/^build_binaries\(\) \{/{p=1} p{print} p&&/^}/{exit}' "$BN")"
+grep -q 'prov_clean_generated_bins' <<<"$body" || { echo "::error::build_binaries must clean allowlisted bin/* before rebuild"; FAIL=1; }
+grep -q 'prov_verify_source_build' <<<"$body"  || { echo "::error::build_binaries must verify the source build provenance"; FAIL=1; }
+grep -q 'prov_verify_prebuilt'     <<<"$body"  || { echo "::error::build_binaries must verify prebuilt provenance in Mode 3"; FAIL=1; }
+
+# 3) Mode 3 must require BOTH --use-prebuilt and a manifest (no silent prebuilt).
+grep -q 'use-prebuilt requires --prebuilt-manifest' "$BN" || { echo "::error::--use-prebuilt must require --prebuilt-manifest"; FAIL=1; }
+
+# 4) build.sh must resolve identity via provenance (no silent 'dev') + emit a manifest.
+grep -q 'prov_resolve_source_identity' "$BS" || { echo "::error::build.sh must resolve source identity via provenance"; FAIL=1; }
+grep -q 'prov_write_manifest'          "$BS" || { echo "::error::build.sh must emit a build manifest"; FAIL=1; }
+grep -qE 'rev-parse --short=12 HEAD .* echo "dev"' "$BS" && { echo "::error::build.sh still silently falls back to short-sha/'dev'"; FAIL=1; }
+
+# 5) bin/ must be gitignored (generated outputs never tracked).
+if ! git check-ignore -q bin/nftband 2>/dev/null; then
+    echo "::error::bin/ is not gitignored — generated binaries could be committed"; FAIL=1
+fi
+for b in nftban-core nftband nftban-botscan-matcher nftban-validate nftban-detect-ssh-ports nftban-installer; do
+    if git ls-files --error-unmatch "bin/$b" >/dev/null 2>&1; then
+        echo "::error::bin/$b is git-tracked (must be a generated output, not source)"; FAIL=1
+    fi
+done
+
+# 6) Hermetic provenance test suite must pass.
+echo "[hermetic] packaging/tests/build_provenance_test.sh"
+if bash packaging/tests/build_provenance_test.sh >/tmp/_prov_test.log 2>&1; then
+    echo "  PASS ($(grep -c '\[PASS\]' /tmp/_prov_test.log) assertions)"
+else
+    echo "::error::hermetic provenance tests failed:"; tail -20 /tmp/_prov_test.log; FAIL=1
+fi
+rm -f /tmp/_prov_test.log
+
+echo "========================================"
+if [[ "$FAIL" -eq 0 ]]; then echo "RESULT: PASS — build provenance guard holds"; exit 0; fi
+echo "RESULT: FAIL — stale-prebuilt guard violated (see ::error:: above)"; exit 1


### PR DESCRIPTION
## Defect

`packaging/build_nftban.sh` silently **reused stale, gitignored `bin/*` artifacts** whenever they were valid ELF files (the only "freshness" gate was an ELF-magic check via `validate_binary`), without binding them to the current source.

**Impact**
- Local/lab package builds could ship a daemon **unrelated to the reviewed source** (proven: a Feb-28 `bin/nftband` was packaged during the opqueue lab validation and hung under systemd).
- Package-native validation could reach **false conclusions**.
- It affected **all six** packaged Go binaries, while the old checks covered only 2–4.

## Fix

- **Default source builds** clean the allowlisted `bin/*` and **rebuild all six** binaries; **no implicit prebuilt fallback**.
- **Explicit Mode 3** verified-prebuilt packaging requires `--use-prebuilt` **and** `--prebuilt-manifest`; manifest/source-identity mismatches **fail closed**.
- **No-Git builds** resolve identity from a `SOURCE_COMMIT` file (full 40-hex); precedence `manifest > SOURCE_COMMIT > git HEAD > hard fail` (never silent `dev`); a present tree identity must **agree** with the manifest.
- **Offline builds** (`--offline`) set `GOPROXY=off`, `GOSUMDB=off`, `GOTOOLCHAIN=local` and require an **explicit local dependency source** (`vendor/` or `--module-cache`); a SHA-pinned local `yq` replaces the build-time `curl` (moved out of the rpmbuild install scriptlet). No `curl`/`dnf`/`apt`/toolchain download.
- **Package SHA-chain** verification (`BUILT==STAGED==PACKAGE_EXTRACTED`) is enforced on every build.
- **CI**: `build-binaries` emits the manifest into the `go-binaries` artifact; RPM/DEB fan-out jobs **explicitly** consume it in verified-prebuilt mode (`--use-prebuilt --prebuilt-manifest`, verified against the checked-out commit); a `provenance-negative` job proves stale-overwrite + tampered-manifest rejection; `ci-architecture.yml` runs `scripts/ci/check-build-provenance.sh` (static lint + hermetic suite).

## Lab evidence (lab2 DEB Ubuntu 24.04, lab4 RPM AlmaLinux 9.8 — production untouched)

```
LAB2_MODE1=PASS                 LAB4_MODE1=PASS
ALL_6_REBUILT=YES
STALE_ANCHOR_OVERWRITTEN=YES    STALE_NON_ANCHOR_OVERWRITTEN=YES   (nftban-detect-ssh-ports; proves all-6, not just anchors)
MODE3_NO_GO=PASS
PREBUILT_NEGATIVE_MATRIX=8/8_PASS   (non_anchor_tamper, manifest_sha, missing, extra, substitute_elf, symlink, wrong_arch, source_commit_mismatch)
OFFLINE_NO_CACHE=FAIL_CLOSED
OFFLINE_WITH_CACHE=PASS
NETWORK_DENIAL=unshare -n (loopback-only netns)
BUILT_EQUALS_STAGED_EQUALS_PACKAGE_EQUALS_INSTALLED=YES   (RPM proof from build_nftban.sh internal verify + installed match)
UNMANIFESTED_PACKAGED_BINARIES=0
LABS_RESTORED_TO_OFFICIAL=YES (bc9650be)
PRODUCTION_MUTATION=NONE
```

## Four implementation defects the lab found + fixed (disclosed)

1. **Leaking `RETURN` trap** in `verify_package_sha_chain` → `td: unbound` under `set -u` on the next function return → replaced with explicit cleanup.
2. **Manifest/source-identity contradiction** — a manifest commit could override a contradictory `SOURCE_COMMIT`/git HEAD → now must **agree** (Mode-3 caveat; `source_commit_mismatch` rejected).
3. **Missing `GOTOOLCHAIN=local`** offline — `GOSUMDB=off` + a toolchain *switch* failed; `local` forbids a toolchain **download** (itself network) and fails closed if local Go is too old.
4. **Literal `%install` in an RPM spec comment** → `rpm: error: second %install` → reworded ("install scriptlet"). Same footgun as the privacy lane.

## Scope

Excludes: startup lifecycle observability, vendoring, offline-kit generation, toolchain distribution, signed manifests, opqueue changes, release/version changes, production deployment. Deferred items registered as `OPEN_OFFLINE_BUILD_DEPENDENCY_AND_KIT`. **Daemon re-baseline is not implied** (no Go source changed). Unreleased; no version assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
