### PR TITLE
feat(daemon): startup lifecycle observability + daemon-wide child NOTIFY_SOCKET isolation

### DIFF
--- a/cmd/nftband/daemon_handlers_status.go
+++ b/cmd/nftband/daemon_handlers_status.go
@@ -42,12 +42,45 @@ func (d *Daemon) handleStatusRequest() SocketResponse {
 			"uptime":         time.Since(d.startedAt).Truncate(time.Second).String(),
 			"uptime_seconds": int(time.Since(d.startedAt).Seconds()),
 			"modules":        len(d.registry.All()),
-			"events_total":  stats.Published,
-			"subscriptions": stats.Subscriptions,
+			"events_total":   stats.Published,
+			"subscriptions":  stats.Subscriptions,
 			// v1.13.12: Config reload tracking
 			"config_hash":   configHash,
 			"config_loaded": lastReload.Format(time.RFC3339),
+			// Startup lifecycle observability: additive rendering of the ONE
+			// canonical lifecycle snapshot (readiness, phase, degraded components).
+			// Existing fields above are unchanged for backward compatibility.
+			"lifecycle": d.lifecycleStatus(),
 		},
+	}
+}
+
+// lifecycleStatus renders the canonical startup-lifecycle snapshot as a stable,
+// additive object for the status IPC. Nil-safe so status never panics if the
+// lifecycle was not wired (e.g. degraded construction paths / tests).
+func (d *Daemon) lifecycleStatus() map[string]any {
+	if d.lifecycle == nil {
+		return map[string]any{"available": false}
+	}
+	s := d.lifecycle.Snapshot()
+	return map[string]any{
+		"phase":                    string(s.Phase),
+		"last_completed_phase":     string(s.LastCompletedPhase),
+		"state":                    s.State,
+		"ready":                    s.Ready,
+		"ready_attempted":          s.ReadyAttempted,
+		"ready_sent":               s.ReadySent,
+		"notify_expected":          s.NotifyExpected,
+		"shutdown_started":         s.ShutdownStarted,
+		"ipc_bound":                s.IPCBound,
+		"ipc_accepting":            s.IPCAccepting,
+		"nft_ready":                s.NFTReady,
+		"opqueue_ready":            s.OpQueueReady,
+		"modules_initialized":      s.ModulesInitialized,
+		"required_modules_started": s.RequiredModulesStarted,
+		"http_ready":               s.HTTPReady,
+		"watchdog_ready":           s.WatchdogReady,
+		"degraded_components":      s.DegradedComponents,
 	}
 }
 

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -57,9 +57,17 @@ func (d *Daemon) Run() error {
 	// Create context for lifecycle management
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	defer d.cancel()
+	d.lifecycle.CompletePhase(PhaseProcessStart)
+
+	// Arm the startup-pending diagnostic: if READY=1 is not sent before the systemd
+	// start deadline, one structured `event=startup_pending` line names the blocked
+	// phase in the journal. Cancelled automatically on ready/failure/shutdown.
+	d.lifecycle.startPendingWatch(resolveStartupPendingDelay())
 
 	// Ensure directories exist
+	d.lifecycle.BeginPhase(PhaseRuntimePathsInit, "paths")
 	if err := d.ensureDirectories(); err != nil {
+		d.lifecycle.FailPhase(PhaseRuntimePathsInit, err)
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
@@ -70,8 +78,11 @@ func (d *Daemon) Run() error {
 
 	// Write PID file
 	if err := d.writePidFile(); err != nil {
+		d.lifecycle.FailPhase(PhaseRuntimePathsInit, err)
 		return fmt.Errorf("failed to write PID file: %w", err)
 	}
+	d.lifecycle.setRuntimePathsReady(true)
+	d.lifecycle.CompletePhase(PhaseRuntimePathsInit)
 
 	// Set up signal handler IMMEDIATELY after PID file creation to ensure cleanup
 	// even if a signal arrives during initialization. The handler checks startupComplete
@@ -93,13 +104,17 @@ func (d *Daemon) Run() error {
 		os.Remove(pidFile)
 	}()
 
-	// Initialize OpQueue and SourceIndex (v1.13.0 async IPC)
+	// Initialize OpQueue and SourceIndex (v1.13.0 async IPC). NFT_MANAGER_INIT and
+	// OPQUEUE_INIT phases are recorded inside initOpQueue at their real boundaries;
+	// both are DEGRADABLE (async operations disabled if they fail).
 	if err := d.initOpQueue(); err != nil {
 		log.Printf("Warning: OpQueue init failed: %v (async operations disabled)", err)
 	}
 
 	// Initialize config hash for reload tracking (v1.13.12)
+	d.lifecycle.BeginPhase(PhaseConfigLoad, "config")
 	d.initConfigHash()
+	d.lifecycle.CompletePhase(PhaseConfigLoad)
 
 	// BUG-008 FIX: Set CIDR limit metric based on server tier at startup
 	cidrLimit, cidrTier := safety.GetMaxCIDRsHardWithTier()
@@ -107,13 +122,17 @@ func (d *Daemon) Run() error {
 	log.Printf("Server tier: %s (max CIDRs: %d)", cidrTier, cidrLimit)
 
 	// Register modules
+	d.lifecycle.BeginPhase(PhaseModulesInit, "registry")
 	d.registerModules()
 
 	// Initialize all modules with event bus
 	log.Println("Initializing modules...")
 	if err := d.registry.InitAll(d.bus); err != nil {
+		d.lifecycle.FailPhase(PhaseModulesInit, err)
 		return fmt.Errorf("failed to initialize modules: %w", err)
 	}
+	d.lifecycle.setModulesInitialized(true)
+	d.lifecycle.CompletePhase(PhaseModulesInit)
 
 	// Wire OpQueue to bot guard module (needs OpQueue for set enforcement)
 	if bgMod, ok := d.registry.Get(botguard.ModuleName); ok {
@@ -227,15 +246,21 @@ func (d *Daemon) Run() error {
 
 	// Start Unix socket
 	log.Println("Starting Unix socket...")
+	d.lifecycle.BeginPhase(PhaseIPCSocketInit, "ipc")
 	if err := d.startSocket(); err != nil {
+		d.lifecycle.FailPhase(PhaseIPCSocketInit, err)
 		return fmt.Errorf("failed to start socket: %w", err)
 	}
 	// v1.147: guard the deferred close against a nil listener. Under MAC
 	// confinement a systemd-passed socket fd can be mediated to nil (AppArmor
 	// "disconnected path"); degrade gracefully instead of nil-panicking here.
 	if d.socketLn == nil {
-		return fmt.Errorf("socket listener is nil after startSocket (socket activation may have been blocked by MAC confinement)")
+		err := fmt.Errorf("socket listener is nil after startSocket (socket activation may have been blocked by MAC confinement)")
+		d.lifecycle.FailPhase(PhaseIPCSocketInit, err)
+		return err
 	}
+	// startSocket set ipc_bound + ipc_accepting (accept loop reached serving state).
+	d.lifecycle.CompletePhase(PhaseIPCSocketInit)
 	defer func() {
 		if d.socketLn != nil {
 			_ = d.socketLn.Close() // best-effort close at shutdown; nothing actionable on error
@@ -244,9 +269,13 @@ func (d *Daemon) Run() error {
 
 	// Start HTTP server
 	log.Println("Starting HTTP API...")
+	d.lifecycle.BeginPhase(PhaseHTTPInit, "http")
 	if err := d.startHTTP(); err != nil {
+		d.lifecycle.FailPhase(PhaseHTTPInit, err)
 		return fmt.Errorf("failed to start HTTP: %w", err)
 	}
+	d.lifecycle.setHTTPReady(true)
+	d.lifecycle.CompletePhase(PhaseHTTPInit)
 
 	// Start pprof server if profiling enabled
 	if profileEnabled {
@@ -256,9 +285,12 @@ func (d *Daemon) Run() error {
 
 	// Start all modules
 	log.Println("Starting modules...")
+	d.lifecycle.BeginPhase(PhaseWorkersStart, "modules")
 	if err := d.registry.StartAll(d.ctx); err != nil {
+		d.lifecycle.FailPhase(PhaseWorkersStart, err)
 		return fmt.Errorf("failed to start modules: %w", err)
 	}
+	d.lifecycle.setRequiredModulesStarted(true)
 
 	// Initialize server info for stats
 	hostname, _ := os.Hostname()
@@ -286,11 +318,15 @@ func (d *Daemon) Run() error {
 	log.Println("Starting stats collector...")
 	d.stats.Start(d.ctx)
 
-	// Start dynamic watchdog
+	// Start dynamic watchdog. The watchdog is DEGRADABLE — if init failed earlier
+	// (d.watchdog == nil) the daemon still reaches readiness, and the lifecycle
+	// records it as a degraded component rather than blocking.
 	if d.watchdog != nil {
 		log.Println("Starting dynamic watchdog...")
 		go d.watchdog.Run(d.ctx)
+		d.lifecycle.setWatchdogReady(true)
 	}
+	d.lifecycle.CompletePhase(PhaseWorkersStart)
 
 	// Publish startup event
 	d.bus.Publish(eventbus.NewEvent(eventbus.EventModuleStart, "nftband").
@@ -331,10 +367,10 @@ func (d *Daemon) Run() error {
 		}
 	}()
 
-	// Wait for shutdown signal
-	d.waitForShutdown()
-
-	return nil
+	// Evaluate the readiness contract, send READY=1, then wait for shutdown. A
+	// fatal readiness-prerequisite failure returns here WITHOUT READY=1 having been
+	// sent, so systemd sees a start failure rather than a false "ready".
+	return d.waitForShutdown()
 }
 
 // ensureDirectories creates required directories
@@ -440,18 +476,29 @@ func (d *Daemon) initWatchdog() error {
 	return nil
 }
 
-// initOpQueue initializes the async operation queue (v1.13.0)
+// initOpQueue initializes the async operation queue (v1.13.0). It records the
+// NFT_MANAGER_INIT and OPQUEUE_INIT lifecycle phases at their real boundaries; both
+// are DEGRADABLE — a failure returns an error that Run() treats as non-fatal
+// (async operations disabled) and the lifecycle marks the component degraded.
 func (d *Daemon) initOpQueue() error {
 	// Get NFTManager from backend for shared netlink connection
+	d.lifecycle.BeginPhase(PhaseNFTManagerInit, "nftbackend")
 	nft := d.backend.GetNFTManager()
 	if nft == nil {
-		return fmt.Errorf("nftbackend has no NFTManager")
+		err := fmt.Errorf("nftbackend has no NFTManager")
+		d.lifecycle.DegradePhase(PhaseNFTManagerInit, "nft", err)
+		return err
 	}
+	d.lifecycle.setNFTReady(true)
+	d.lifecycle.CompletePhase(PhaseNFTManagerInit)
 
 	// Create backend wrapper for opqueue
+	d.lifecycle.BeginPhase(PhaseOpQueueInit, "opqueue")
 	wrapper, err := opqueue.NewNFTBackendWrapper(nft)
 	if err != nil {
-		return fmt.Errorf("failed to create NFTBackendWrapper: %w", err)
+		err = fmt.Errorf("failed to create NFTBackendWrapper: %w", err)
+		d.lifecycle.DegradePhase(PhaseOpQueueInit, "opqueue", err)
+		return err
 	}
 
 	// Create OpQueue with default config
@@ -523,6 +570,8 @@ func (d *Daemon) initOpQueue() error {
 		d.startPeriodicReconciliation(wrapper)
 	}()
 
+	d.lifecycle.setOpQueueReady(true)
+	d.lifecycle.CompletePhase(PhaseOpQueueInit)
 	log.Println("[OpQueue] Async operation queue initialized")
 	return nil
 }

--- a/cmd/nftband/daemon_lifecycle.go
+++ b/cmd/nftband/daemon_lifecycle.go
@@ -80,6 +80,10 @@ func (d *Daemon) handleSignals(pidFile string) {
 
 // gracefulShutdown performs orderly shutdown of all daemon components
 func (d *Daemon) gracefulShutdown() {
+	// Record the shutdown phases in the canonical lifecycle (also cancels the
+	// startup-pending diagnostic and pushes a STATUS= line).
+	d.lifecycle.beginShutdown()
+
 	// Notify systemd we are stopping (v1.29.1)
 	_, _ = daemon.SdNotify(false, daemon.SdNotifyStopping)
 
@@ -125,31 +129,36 @@ func (d *Daemon) gracefulShutdown() {
 	d.bgWg.Wait()
 
 	log.Println("nftband stopped")
+	d.lifecycle.completeShutdown()
 }
 
-// waitForShutdown blocks until the signal handler completes shutdown
-func (d *Daemon) waitForShutdown() {
+// waitForShutdown evaluates the readiness contract, sends systemd READY=1 exactly
+// once, then blocks until the signal handler completes shutdown. It returns a fatal
+// error when a mandatory readiness prerequisite is unmet — in that case READY=1 is
+// NOT sent and the caller (Run) propagates the error so startup fails cleanly.
+func (d *Daemon) waitForShutdown() error {
 	// Mark startup as complete so signal handler does graceful shutdown
 	d.sigMu.Lock()
 	d.startupComplete = true
 	d.sigMu.Unlock()
 
-	// Notify systemd that daemon is ready (v1.29.1)
-	sent, err := daemon.SdNotify(false, daemon.SdNotifyReady)
-	if err != nil {
-		log.Printf("sd_notify READY failed: %v", err)
-	} else if sent {
-		log.Println("sd_notify READY sent")
+	// Readiness gate + systemd READY=1 (exactly once, main process). A failed
+	// SdNotify is material but non-fatal (handled inside SendReady, prior
+	// semantics); a mandatory-prerequisite failure is fatal and returns here.
+	if err := d.lifecycle.SendReady(); err != nil {
+		return fmt.Errorf("daemon not ready: %w", err)
 	}
 
-	// Start watchdog heartbeat goroutine (WatchdogSec=30s, notify every 15s)
+	// Start watchdog heartbeat goroutine (WatchdogSec=120s, notify every 15s)
 	go d.watchdogHeartbeat()
 
+	d.lifecycle.enterRunning()
 	log.Println("Startup complete, waiting for shutdown signal...")
 
 	// Block until gracefulShutdown() is called by handleSignals
 	// We wait on the context which is cancelled during gracefulShutdown
 	<-d.ctx.Done()
+	return nil
 }
 
 // watchdogHeartbeat sends sd_notify WATCHDOG=1 every 15s (half of WatchdogSec=30s).

--- a/cmd/nftband/daemon_socket.go
+++ b/cmd/nftband/daemon_socket.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/v22/activation"
+	"github.com/itcmsgr/nftban/internal/constants"
 	"github.com/itcmsgr/nftban/internal/metrics"
 	"golang.org/x/sys/unix"
 )
@@ -56,6 +57,11 @@ func init() {
 func (d *Daemon) startSocket() error {
 	socketPath := getSocketPath()
 
+	// Accept-loop serving acknowledgment (closed by acceptSocketConnections when
+	// the loop reaches its serving state). Lets us mark ipc_accepting only when the
+	// loop is genuinely serving, not merely because the goroutine was launched.
+	d.acceptReady = make(chan struct{})
+
 	// Check for systemd socket activation first
 	listeners, err := activation.Listeners()
 	if err != nil {
@@ -66,9 +72,9 @@ func (d *Daemon) startSocket() error {
 		// Systemd socket activation - use the pre-configured socket
 		// Socket permissions (0660 root:nftban) are set by nftband.socket unit
 		d.socketLn = listeners[0]
+		d.lifecycle.setIPCBound(true)
 		log.Printf("Using systemd socket activation (socket from nftband.socket)")
-		go d.acceptSocketConnections()
-		return nil
+		return d.launchAcceptAndWait()
 	}
 	// v1.147: if activation reported listeners but the fd was mediated to nil
 	// under MAC confinement, fall through to manual socket creation rather than
@@ -88,6 +94,7 @@ func (d *Daemon) startSocket() error {
 		return err
 	}
 	d.socketLn = ln
+	d.lifecycle.setIPCBound(true)
 
 	// Set permissions: 0660 = owner+group read/write
 	// Socket owned by root:nftban so CLI users in nftban group can connect
@@ -102,9 +109,27 @@ func (d *Daemon) startSocket() error {
 	}
 
 	// Handle connections
-	go d.acceptSocketConnections()
+	return d.launchAcceptAndWait()
+}
 
-	return nil
+// acceptReadyTimeout bounds how long startSocket waits for the accept loop to reach
+// its serving state before treating the socket as not-serving. It is a package var
+// so tests can shorten it; production keeps the daemon-startup wait.
+var acceptReadyTimeout = constants.DaemonStartupWait
+
+// launchAcceptAndWait starts the accept loop and blocks (bounded) until the loop
+// signals it reached its serving state, then marks ipc_accepting. A socket that is
+// bound but never reaches serving state is a real defect: return a clear error
+// rather than an unbounded wait or a false "accepting".
+func (d *Daemon) launchAcceptAndWait() error {
+	go d.acceptSocketConnections()
+	select {
+	case <-d.acceptReady:
+		d.lifecycle.setIPCAccepting(true)
+		return nil
+	case <-time.After(acceptReadyTimeout):
+		return fmt.Errorf("IPC accept loop did not reach serving state within %s", acceptReadyTimeout)
+	}
 }
 
 // setSocketGroup sets the group ownership of a file
@@ -177,6 +202,12 @@ func validatePeerCredentials(conn net.Conn) (uint32, uint32, error) {
 
 // acceptSocketConnections handles incoming socket connections
 func (d *Daemon) acceptSocketConnections() {
+	// Signal that the accept loop reached its serving state (once). startSocket
+	// blocks on this before marking ipc_accepting, so a bound-but-not-serving
+	// socket is never reported as accepting.
+	if d.acceptReady != nil {
+		d.acceptReadyOnce.Do(func() { close(d.acceptReady) })
+	}
 	for {
 		conn, err := d.socketLn.Accept()
 		acceptTime := time.Now()

--- a/cmd/nftband/daemon_startup_lifecycle.go
+++ b/cmd/nftband/daemon_startup_lifecycle.go
@@ -1,0 +1,667 @@
+// =============================================================================
+// NFTBan v1.0 - nftband Daemon - Startup lifecycle state machine and readiness
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftband"
+// meta:type="cmd"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Canonical daemon startup lifecycle: phase state machine, readiness gate, startup-pending diagnostic, and structured phase logging"
+//
+// meta:inventory.files="/usr/lib/nftban/bin/nftband"
+// meta:inventory.binaries="nftband"
+// meta:inventory.env_vars="NFTBAN_STARTUP_PENDING_SEC"
+// meta:inventory.config_files="/etc/nftban/nftban.conf"
+// meta:inventory.systemd_units="nftband.service, nftband.socket"
+// meta:inventory.network="/run/nftban/nftband.sock (Unix)"
+// meta:inventory.privileges="root"
+// =============================================================================
+//
+// This file owns the ONE canonical, concurrency-safe startup lifecycle state for
+// the daemon. Readiness is made explicit here rather than inferred from startup
+// ordering: a socket may already be bound and accepting before modules finish and
+// before READY=1 is sent, so the state distinguishes ipc_bound from ipc_accepting
+// and gates the systemd READY=1 notification on a set of mandatory prerequisites.
+//
+// The lifecycle instrumentation does NOT change the underlying startup ORDER — it
+// records phase transitions around the existing sequence and exposes the result
+// through the journal (structured `event=startup_phase` lines), sd_notify STATUS=,
+// and the status IPC. All surfaces render this one snapshot; there is no second
+// authority.
+// =============================================================================
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// LifecyclePhase identifies a discrete daemon startup/shutdown phase. Phases map
+// to real code boundaries in daemon_init.go / daemon_socket.go / daemon_lifecycle.go.
+type LifecyclePhase string
+
+const (
+	PhaseProcessStart           LifecyclePhase = "PROCESS_START"
+	PhaseRuntimePathsInit       LifecyclePhase = "RUNTIME_PATHS_INIT"
+	PhaseNFTManagerInit         LifecyclePhase = "NFT_MANAGER_INIT"
+	PhaseOpQueueInit            LifecyclePhase = "OPQUEUE_INIT"
+	PhaseConfigLoad             LifecyclePhase = "CONFIG_LOAD"
+	PhaseModulesInit            LifecyclePhase = "MODULES_INIT"
+	PhaseIPCSocketInit          LifecyclePhase = "IPC_SOCKET_INIT"
+	PhaseHTTPInit               LifecyclePhase = "HTTP_INIT"
+	PhaseWorkersStart           LifecyclePhase = "WORKERS_START"
+	PhaseReadinessPrerequisites LifecyclePhase = "READINESS_PRECONDITIONS"
+	PhaseSystemdNotifyReady     LifecyclePhase = "SYSTEMD_NOTIFY_READY"
+	PhaseRunning                LifecyclePhase = "RUNNING"
+	PhaseShutdownBegin          LifecyclePhase = "SHUTDOWN_BEGIN"
+	PhaseShutdownComplete       LifecyclePhase = "SHUTDOWN_COMPLETE"
+)
+
+// phaseState is the transition state recorded for the current phase.
+const (
+	stateBegin    = "begin"
+	stateComplete = "complete"
+	stateFailed   = "failed"
+	stateDegraded = "degraded"
+)
+
+// phaseOrder gives a monotonic ordinal per phase so backwards transitions can be
+// detected and rejected. Only used for validation; it never reorders execution.
+var phaseOrder = map[LifecyclePhase]int{
+	PhaseProcessStart:           0,
+	PhaseRuntimePathsInit:       1,
+	PhaseNFTManagerInit:         2,
+	PhaseOpQueueInit:            3,
+	PhaseConfigLoad:             4,
+	PhaseModulesInit:            5,
+	PhaseIPCSocketInit:          6,
+	PhaseHTTPInit:               7,
+	PhaseWorkersStart:           8,
+	PhaseReadinessPrerequisites: 9,
+	PhaseSystemdNotifyReady:     10,
+	PhaseRunning:                11,
+	PhaseShutdownBegin:          12,
+	PhaseShutdownComplete:       13,
+}
+
+// systemd nftband.service has no explicit TimeoutStartSec, so systemd applies its
+// default (DefaultTimeoutStartSec, 90s on typical distros). The startup-pending
+// diagnostic must fire BEFORE that deadline so the blocked phase is captured in the
+// journal while the unit is still "activating" — 2/3 of the default gives headroom.
+const systemdDefaultStartTimeout = 90 * time.Second
+
+var defaultStartupPendingDelay = systemdDefaultStartTimeout * 2 / 3 // 60s
+
+// notifyFunc matches coreos/go-systemd daemon.SdNotify(false, state) — (sent, err).
+// A nil notifier means "not wired" (unit tests / non-systemd) and is a no-op.
+type notifyFunc func(state string) (bool, error)
+
+// LifecycleSnapshot is an immutable copy of the lifecycle state for rendering by
+// operator surfaces (status IPC, health). Field names are stable additive contract.
+type LifecycleSnapshot struct {
+	Phase                  LifecyclePhase `json:"phase"`
+	LastCompletedPhase     LifecyclePhase `json:"last_completed_phase"`
+	State                  string         `json:"state"`
+	Ready                  bool           `json:"ready"`
+	ReadyAttempted         bool           `json:"ready_attempted"`
+	ReadySent              bool           `json:"ready_sent"`
+	NotifyExpected         bool           `json:"notify_expected"`
+	ShutdownStarted        bool           `json:"shutdown_started"`
+	RuntimePathsReady      bool           `json:"runtime_paths_ready"`
+	NFTReady               bool           `json:"nft_ready"`
+	OpQueueReady           bool           `json:"opqueue_ready"`
+	ModulesInitialized     bool           `json:"modules_initialized"`
+	IPCBound               bool           `json:"ipc_bound"`
+	IPCAccepting           bool           `json:"ipc_accepting"`
+	HTTPReady              bool           `json:"http_ready"`
+	RequiredModulesStarted bool           `json:"required_modules_started"`
+	WatchdogReady          bool           `json:"watchdog_ready"`
+	DegradedComponents     []string       `json:"degraded_components"`
+	MainPID                int            `json:"main_pid"`
+	PhaseElapsedMs         int64          `json:"phase_elapsed_ms"`
+	TotalElapsedMs         int64          `json:"total_elapsed_ms"`
+}
+
+// startupLifecycle is the single canonical, mutex-protected lifecycle state.
+type startupLifecycle struct {
+	mu sync.Mutex
+
+	currentPhase       LifecyclePhase
+	lastCompletedPhase LifecyclePhase
+	phaseState         string
+	phaseError         string
+
+	startupStartedAt time.Time
+	phaseStartedAt   time.Time
+	mainPID          int
+
+	// Readiness signals (see evaluateReadinessLocked for mandatory vs degradable).
+	runtimePathsReady      bool
+	nftReady               bool
+	opqueueReady           bool
+	modulesInitialized     bool
+	ipcBound               bool
+	ipcAccepting           bool
+	httpReady              bool
+	requiredModulesStarted bool
+	watchdogReady          bool
+
+	// Separate ATTEMPT from RESULT — ready_sent must reflect the actual notify
+	// outcome and must not be set true before SdNotifyReady reports success.
+	readyAttempted  bool
+	readySent       bool
+	shutdownStarted bool
+
+	// notifyExpected records whether NOTIFY_SOCKET was present for the MAIN process
+	// at startup (captured before any child sanitization). It decides whether a
+	// failed/undelivered READY=1 is fatal (Type=notify service) or benign (a direct
+	// terminal run with no service manager). See SendReady.
+	notifyExpected bool
+
+	degradedComponents []string
+	degradedSeen       map[string]bool
+
+	// Injectable seams for tests.
+	now      func() time.Time
+	notifier notifyFunc
+
+	// READY=1 exactly-once guard.
+	readyOnce sync.Once
+
+	// startup-pending diagnostic: emitted at most once, cancellable.
+	pendingOnce    sync.Once
+	pendingResolve chan struct{}
+	pendingResolvd sync.Once
+}
+
+// newStartupLifecycle creates the canonical lifecycle with the real clock. The
+// caller wires a notifier (SdNotify) via setNotifier once systemd context exists.
+func newStartupLifecycle(mainPID int) *startupLifecycle {
+	now := time.Now()
+	return &startupLifecycle{
+		currentPhase:     PhaseProcessStart,
+		phaseState:       stateBegin,
+		phaseError:       "",
+		startupStartedAt: now,
+		phaseStartedAt:   now,
+		mainPID:          mainPID,
+		// Snapshot NOTIFY_SOCKET presence for the MAIN process now, before any
+		// child process is launched/sanitized, so the readiness gate can tell a
+		// systemd Type=notify run from a direct terminal run.
+		notifyExpected: os.Getenv("NOTIFY_SOCKET") != "",
+		degradedSeen:   map[string]bool{},
+		pendingResolve: make(chan struct{}),
+		now:            time.Now,
+	}
+}
+
+func (s *startupLifecycle) setNotifier(fn notifyFunc) {
+	s.mu.Lock()
+	s.notifier = fn
+	s.mu.Unlock()
+}
+
+// -----------------------------------------------------------------------------
+// Phase API — BeginPhase / CompletePhase / FailPhase / DegradePhase
+// -----------------------------------------------------------------------------
+
+// BeginPhase records entry into a phase. The canonical state is updated BEFORE the
+// caller enters the (possibly blocking) synchronous work, so the startup-pending
+// diagnostic can report the phase that is actually stuck. Backwards transitions are
+// logged and rejected (they indicate a programming error, not real progress).
+func (s *startupLifecycle) BeginPhase(phase LifecyclePhase, component string) {
+	s.mu.Lock()
+	if !s.validTransitionLocked(phase) {
+		cur := s.currentPhase
+		s.mu.Unlock()
+		log.Printf("event=startup_phase phase=%s state=invalid_transition pid=%d component=%s error=%s",
+			phase, s.mainPID, component, sanitizeLogValue(fmt.Sprintf("rejected transition from %s", cur)))
+		return
+	}
+	s.currentPhase = phase
+	s.phaseState = stateBegin
+	s.phaseError = ""
+	s.phaseStartedAt = s.now()
+	total := s.now().Sub(s.startupStartedAt).Milliseconds()
+	notifier := s.notifier
+	pid := s.mainPID
+	s.mu.Unlock()
+
+	emitPhase(phase, stateBegin, pid, component, 0, total, "")
+	// Only STARTUP phases push a "NFTBan startup: <phase>" systemd STATUS=. RUNNING
+	// and the shutdown phases have their own steady-state statuses ("NFTBan ready"
+	// from SendReady, "NFTBan shutting down" from beginShutdown); auto-sending here
+	// would clobber them (RUNNING runs right after READY).
+	if phase != PhaseRunning && phase != PhaseShutdownBegin && phase != PhaseShutdownComplete {
+		sendStatus(notifier, fmt.Sprintf("NFTBan startup: %s", phase))
+	}
+
+	// Test-only bounded startup blocker. Empty/unset in production (verified: no
+	// unit/package sets it). If this phase matches NFTBAN_DEBUG_BLOCK_PHASE, sleep
+	// up to NFTBAN_DEBUG_BLOCK_MS (hard-capped) so the startup-pending diagnostic
+	// can be exercised deterministically without an uncontrolled hang. The mutex is
+	// NOT held during the sleep, so Snapshot()/status IPC/pending diag stay live.
+	debugBlockPhase(phase)
+}
+
+// debugBlockCapMs hard-caps the test-only phase block so it can never hang a real
+// unit past its start timeout.
+const debugBlockCapMs = 30000
+
+func debugBlockPhase(phase LifecyclePhase) {
+	if os.Getenv("NFTBAN_DEBUG_BLOCK_PHASE") != string(phase) {
+		return
+	}
+	ms, err := strconv.Atoi(os.Getenv("NFTBAN_DEBUG_BLOCK_MS"))
+	if err != nil || ms <= 0 {
+		return
+	}
+	if ms > debugBlockCapMs {
+		ms = debugBlockCapMs
+	}
+	log.Printf("event=startup_debug_block phase=%s block_ms=%d (test-only NFTBAN_DEBUG_BLOCK_PHASE)", phase, ms)
+	time.Sleep(time.Duration(ms) * time.Millisecond)
+}
+
+// CompletePhase records successful completion of a phase.
+func (s *startupLifecycle) CompletePhase(phase LifecyclePhase) {
+	s.finishPhase(phase, stateComplete, "", "")
+}
+
+// FailPhase records a fatal failure of a phase (the daemon will not become ready).
+func (s *startupLifecycle) FailPhase(phase LifecyclePhase, err error) {
+	s.finishPhase(phase, stateFailed, "", sanitizeErr(err))
+}
+
+// DegradePhase records that a phase completed but a DEGRADABLE component is
+// unavailable. The daemon may still reach readiness, but the degraded component is
+// recorded, surfaced through status IPC, and must never be reported as healthy.
+func (s *startupLifecycle) DegradePhase(phase LifecyclePhase, component string, err error) {
+	s.finishPhase(phase, stateDegraded, component, sanitizeErr(err))
+}
+
+func (s *startupLifecycle) finishPhase(phase LifecyclePhase, state, component, errStr string) {
+	s.mu.Lock()
+	// Record completion timing relative to when this phase began.
+	elapsed := s.now().Sub(s.phaseStartedAt).Milliseconds()
+	total := s.now().Sub(s.startupStartedAt).Milliseconds()
+	s.phaseState = state
+	s.phaseError = errStr
+	if state == stateComplete || state == stateDegraded {
+		s.lastCompletedPhase = phase
+	}
+	if state == stateDegraded && component != "" && !s.degradedSeen[component] {
+		s.degradedSeen[component] = true
+		s.degradedComponents = append(s.degradedComponents, component)
+	}
+	notifier := s.notifier
+	pid := s.mainPID
+	s.mu.Unlock()
+
+	logComponent := component
+	if logComponent == "" {
+		logComponent = string(phase)
+	}
+	emitPhase(phase, state, pid, logComponent, elapsed, total, errStr)
+
+	switch state {
+	case stateDegraded:
+		sendStatus(notifier, fmt.Sprintf("NFTBan startup degraded: %s", phase))
+	case stateFailed:
+		// A failed phase resolves the pending diagnostic — startup is not going to
+		// reach READY on this path.
+		s.resolvePending()
+	}
+}
+
+// validTransitionLocked rejects strictly-backwards phase transitions. Re-entering
+// the SAME phase is allowed (idempotent begin); forward moves are allowed.
+func (s *startupLifecycle) validTransitionLocked(next LifecyclePhase) bool {
+	no, ok := phaseOrder[next]
+	if !ok {
+		return false
+	}
+	co := phaseOrder[s.currentPhase]
+	return no >= co
+}
+
+// -----------------------------------------------------------------------------
+// Readiness signal setters (each is a single canonical write).
+// -----------------------------------------------------------------------------
+
+func (s *startupLifecycle) setRuntimePathsReady(v bool)      { s.setFlag(&s.runtimePathsReady, v) }
+func (s *startupLifecycle) setNFTReady(v bool)               { s.setFlag(&s.nftReady, v) }
+func (s *startupLifecycle) setOpQueueReady(v bool)           { s.setFlag(&s.opqueueReady, v) }
+func (s *startupLifecycle) setModulesInitialized(v bool)     { s.setFlag(&s.modulesInitialized, v) }
+func (s *startupLifecycle) setIPCBound(v bool)               { s.setFlag(&s.ipcBound, v) }
+func (s *startupLifecycle) setIPCAccepting(v bool)           { s.setFlag(&s.ipcAccepting, v) }
+func (s *startupLifecycle) setHTTPReady(v bool)              { s.setFlag(&s.httpReady, v) }
+func (s *startupLifecycle) setRequiredModulesStarted(v bool) { s.setFlag(&s.requiredModulesStarted, v) }
+func (s *startupLifecycle) setWatchdogReady(v bool)          { s.setFlag(&s.watchdogReady, v) }
+
+func (s *startupLifecycle) setFlag(field *bool, v bool) {
+	s.mu.Lock()
+	*field = v
+	s.mu.Unlock()
+}
+
+// -----------------------------------------------------------------------------
+// Readiness gate + READY=1 notification
+// -----------------------------------------------------------------------------
+
+// evaluateReadinessLocked returns the list of unmet MANDATORY prerequisites and the
+// list of unavailable DEGRADABLE components. Mandatory prerequisites must all hold
+// before READY=1 is sent; degradable components may be absent (the daemon reports
+// ready-but-degraded rather than blocking).
+func (s *startupLifecycle) evaluateReadinessLocked() (missing, degraded []string) {
+	if !s.runtimePathsReady {
+		missing = append(missing, "runtime_paths_ready")
+	}
+	if !s.modulesInitialized {
+		missing = append(missing, "modules_initialized")
+	}
+	if !s.ipcBound {
+		missing = append(missing, "ipc_bound")
+	}
+	if !s.ipcAccepting {
+		missing = append(missing, "ipc_accepting")
+	}
+	if !s.httpReady {
+		missing = append(missing, "http_ready")
+	}
+	if !s.requiredModulesStarted {
+		missing = append(missing, "required_modules_started")
+	}
+	if !s.nftReady {
+		degraded = append(degraded, "nft")
+	}
+	if !s.opqueueReady {
+		degraded = append(degraded, "opqueue")
+	}
+	if !s.watchdogReady {
+		degraded = append(degraded, "watchdog")
+	}
+	return missing, degraded
+}
+
+// SendReady evaluates the readiness contract and, if the mandatory prerequisites
+// hold, sends systemd READY=1 exactly once. It returns a fatal error when a
+// mandatory prerequisite is unmet — the caller must then fail startup WITHOUT
+// sending READY=1. A failure of the SdNotify call itself is material but non-fatal
+// (retains prior semantics): it is logged and recorded, ready_sent reflects the
+// actual result, and the SYSTEMD_NOTIFY_READY phase is only marked complete on a
+// clean call.
+func (s *startupLifecycle) SendReady() error {
+	// Idempotent: once a ready attempt has been made, further calls are no-ops.
+	s.mu.Lock()
+	alreadyAttempted := s.readyAttempted
+	s.mu.Unlock()
+	if alreadyAttempted {
+		return nil
+	}
+
+	s.BeginPhase(PhaseReadinessPrerequisites, "readiness")
+
+	s.mu.Lock()
+	missing, degraded := s.evaluateReadinessLocked()
+	notifier := s.notifier
+	s.mu.Unlock()
+
+	if len(missing) > 0 {
+		err := fmt.Errorf("readiness prerequisites unmet: %s", strings.Join(missing, ","))
+		s.FailPhase(PhaseReadinessPrerequisites, err)
+		return err
+	}
+
+	if len(degraded) > 0 {
+		s.DegradePhase(PhaseReadinessPrerequisites, strings.Join(degraded, ","), nil)
+	} else {
+		s.CompletePhase(PhaseReadinessPrerequisites)
+	}
+
+	// The systemd READY=1 notification and its result handling run EXACTLY ONCE.
+	// ready_attempted is recorded here (inside the guard); ready_sent reflects a
+	// CONFIRMED send only. The outcome is classified by whether systemd
+	// notification was expected (NOTIFY_SOCKET present for the main process):
+	//
+	//   NOTIFY_EXPECTED=NO  + sent=false + err=nil        → direct run, non-fatal
+	//   NOTIFY_EXPECTED=YES + sent=true  + err=nil        → ready
+	//   NOTIFY_EXPECTED=YES + (err!=nil OR not delivered) → FATAL startup failure
+	//
+	// The fatal cases are the whole point of this gate: under a Type=notify unit,
+	// a daemon that keeps running without delivering READY=1 leaves systemd in
+	// "activating" until TimeoutStartSec — the exact ambiguity this lane removes.
+	var fatal error
+	s.readyOnce.Do(func() {
+		s.BeginPhase(PhaseSystemdNotifyReady, "systemd")
+
+		s.mu.Lock()
+		s.readyAttempted = true
+		expected := s.notifyExpected
+		s.mu.Unlock()
+
+		var sent bool
+		var notifyErr error
+		if notifier != nil {
+			sent, notifyErr = notifier("READY=1")
+		}
+
+		s.mu.Lock()
+		s.readySent = sent && notifyErr == nil
+		s.mu.Unlock()
+
+		switch {
+		case !expected:
+			// Direct terminal run: no service manager to be ready to. sent=false/
+			// err=nil is the normal terminal case and is NOT a failure.
+			if notifyErr != nil {
+				log.Printf("sd_notify READY returned an error with no NOTIFY_SOCKET (direct run), ignoring: %v", sanitizeErr(notifyErr))
+			}
+			s.CompletePhase(PhaseSystemdNotifyReady)
+		case notifyErr != nil:
+			// Type=notify unit, READY delivery errored → FATAL.
+			log.Printf("sd_notify READY failed under systemd (NOTIFY_SOCKET present): %v", sanitizeErr(notifyErr))
+			s.FailPhase(PhaseSystemdNotifyReady, notifyErr)
+			fatal = fmt.Errorf("sd_notify READY failed under systemd: %w", notifyErr)
+		case !sent:
+			// Type=notify unit, but READY was not delivered → FATAL.
+			e := fmt.Errorf("sd_notify READY not delivered though NOTIFY_SOCKET is present")
+			log.Printf("%v", e)
+			s.FailPhase(PhaseSystemdNotifyReady, e)
+			fatal = e
+		default:
+			log.Println("sd_notify READY sent")
+			sendStatus(notifier, "NFTBan ready")
+			s.CompletePhase(PhaseSystemdNotifyReady)
+		}
+
+		// Resolve the pending diagnostic on every terminal outcome (success →
+		// ready; fatal → fail fast). FailPhase already resolves it; idempotent.
+		s.resolvePending()
+	})
+	return fatal
+}
+
+// enterRunning marks the daemon as running (post-ready steady state).
+func (s *startupLifecycle) enterRunning() {
+	s.BeginPhase(PhaseRunning, "daemon")
+	s.CompletePhase(PhaseRunning)
+}
+
+// beginShutdown / completeShutdown record the shutdown phases in order.
+func (s *startupLifecycle) beginShutdown() {
+	s.mu.Lock()
+	s.shutdownStarted = true
+	notifier := s.notifier
+	s.mu.Unlock()
+	s.resolvePending()
+	s.BeginPhase(PhaseShutdownBegin, "daemon")
+	sendStatus(notifier, "NFTBan shutting down")
+	s.CompletePhase(PhaseShutdownBegin)
+}
+
+func (s *startupLifecycle) completeShutdown() {
+	s.BeginPhase(PhaseShutdownComplete, "daemon")
+	s.CompletePhase(PhaseShutdownComplete)
+}
+
+// -----------------------------------------------------------------------------
+// Startup-pending diagnostic
+// -----------------------------------------------------------------------------
+
+// startPendingWatch launches a single bounded timer that, if READY has not been
+// sent (and startup has not failed or begun shutdown) by the deadline, emits ONE
+// `event=startup_pending` line naming the current/last-completed phase so the
+// blocked phase is captured in the journal before systemd's start timeout. The
+// timer never mutates readiness state.
+func (s *startupLifecycle) startPendingWatch(delay time.Duration) {
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-s.pendingResolve:
+			return
+		case <-timer.C:
+			s.emitPending()
+		}
+	}()
+}
+
+func (s *startupLifecycle) resolvePending() {
+	s.pendingResolvd.Do(func() {
+		close(s.pendingResolve)
+	})
+}
+
+func (s *startupLifecycle) emitPending() {
+	s.pendingOnce.Do(func() {
+		s.mu.Lock()
+		if s.readySent || s.shutdownStarted || s.phaseState == stateFailed {
+			s.mu.Unlock()
+			return
+		}
+		snap := s.snapshotLocked()
+		s.mu.Unlock()
+
+		log.Printf("event=startup_pending last_completed_phase=%s current_phase=%s "+
+			"phase_elapsed_ms=%d total_elapsed_ms=%d main_pid=%d ipc_bound=%t ipc_accepting=%t "+
+			"nft_ready=%t opqueue_ready=%t required_modules_started=%t ready_attempted=%t ready_sent=%t",
+			snap.LastCompletedPhase, snap.Phase, snap.PhaseElapsedMs, snap.TotalElapsedMs, snap.MainPID,
+			snap.IPCBound, snap.IPCAccepting, snap.NFTReady, snap.OpQueueReady,
+			snap.RequiredModulesStarted, snap.ReadyAttempted, snap.ReadySent)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Snapshot
+// -----------------------------------------------------------------------------
+
+// Snapshot returns an immutable copy of the canonical state for rendering.
+func (s *startupLifecycle) Snapshot() LifecycleSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshotLocked()
+}
+
+func (s *startupLifecycle) snapshotLocked() LifecycleSnapshot {
+	ready := s.readySent
+	// make() returns a non-nil (possibly empty) slice, so this always marshals to
+	// a JSON array rather than null.
+	degraded := make([]string, len(s.degradedComponents))
+	copy(degraded, s.degradedComponents)
+	return LifecycleSnapshot{
+		Phase:                  s.currentPhase,
+		LastCompletedPhase:     s.lastCompletedPhase,
+		State:                  s.phaseState,
+		Ready:                  ready,
+		ReadyAttempted:         s.readyAttempted,
+		ReadySent:              s.readySent,
+		NotifyExpected:         s.notifyExpected,
+		ShutdownStarted:        s.shutdownStarted,
+		RuntimePathsReady:      s.runtimePathsReady,
+		NFTReady:               s.nftReady,
+		OpQueueReady:           s.opqueueReady,
+		ModulesInitialized:     s.modulesInitialized,
+		IPCBound:               s.ipcBound,
+		IPCAccepting:           s.ipcAccepting,
+		HTTPReady:              s.httpReady,
+		RequiredModulesStarted: s.requiredModulesStarted,
+		WatchdogReady:          s.watchdogReady,
+		DegradedComponents:     degraded,
+		MainPID:                s.mainPID,
+		PhaseElapsedMs:         s.now().Sub(s.phaseStartedAt).Milliseconds(),
+		TotalElapsedMs:         s.now().Sub(s.startupStartedAt).Milliseconds(),
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Emit + sanitize helpers
+// -----------------------------------------------------------------------------
+
+// emitPhase writes the single structured phase event to the journal (primary event
+// stream). Other surfaces render the canonical snapshot; they do not re-emit this.
+func emitPhase(phase LifecyclePhase, state string, pid int, component string, elapsedMs, totalMs int64, errStr string) {
+	if errStr == "" {
+		errStr = "-"
+	}
+	log.Printf("event=startup_phase phase=%s state=%s pid=%d component=%s elapsed_ms=%d total_elapsed_ms=%d error=%s",
+		phase, state, pid, component, elapsedMs, totalMs, errStr)
+}
+
+// sendStatus pushes a bounded sd_notify STATUS= line. Best-effort and degradable:
+// failures are ignored (STATUS= is a convenience surface, not the ready contract).
+// The text is a fixed phrase plus a phase name — never a raw error, config value,
+// or path.
+func sendStatus(notifier notifyFunc, text string) {
+	if notifier == nil {
+		return
+	}
+	if len(text) > 120 {
+		text = text[:120]
+	}
+	_, _ = notifier("STATUS=" + text)
+}
+
+// sanitizeErr converts an error into a bounded, single-line, safe log value.
+func sanitizeErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	return sanitizeLogValue(err.Error())
+}
+
+// sanitizeLogValue strips newlines/tabs and bounds length so a phase error cannot
+// inject extra log lines or dump large/sensitive payloads. It intentionally keeps
+// only a short, bounded fragment.
+func sanitizeLogValue(v string) string {
+	v = strings.ReplaceAll(v, "\n", " ")
+	v = strings.ReplaceAll(v, "\r", " ")
+	v = strings.ReplaceAll(v, "\t", " ")
+	v = strings.TrimSpace(v)
+	const maxLen = 200
+	if len(v) > maxLen {
+		v = v[:maxLen] + "…(truncated)"
+	}
+	if v == "" {
+		return "-"
+	}
+	return v
+}
+
+// resolveStartupPendingDelay derives the pending-diagnostic delay. Default is 2/3
+// of the systemd default start timeout; NFTBAN_STARTUP_PENDING_SEC overrides it
+// (used for tuning and by tests to avoid real 60s/90s sleeps).
+func resolveStartupPendingDelay() time.Duration {
+	if v := os.Getenv("NFTBAN_STARTUP_PENDING_SEC"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return defaultStartupPendingDelay
+}

--- a/cmd/nftband/daemon_startup_lifecycle_test.go
+++ b/cmd/nftband/daemon_startup_lifecycle_test.go
@@ -1,0 +1,766 @@
+// =============================================================================
+// NFTBan v1.0 - nftband Daemon - Startup lifecycle tests
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftband"
+// meta:type="cmd"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Deterministic behavioural tests for the daemon startup lifecycle: phase ordering/timing, readiness gate, exactly-once READY, startup-pending diagnostic, error sanitization, and log-secrecy"
+//
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_STARTUP_PENDING_SEC"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// -----------------------------------------------------------------------------
+// Test doubles: injectable clock + recording notifier
+// -----------------------------------------------------------------------------
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (f *fakeClock) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.t
+}
+
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	f.t = f.t.Add(d)
+	f.mu.Unlock()
+}
+
+type recNotifier struct {
+	mu         sync.Mutex
+	states     []string
+	readyCount int
+	sent       bool
+	err        error
+}
+
+func (r *recNotifier) fn(state string) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = append(r.states, state)
+	if state == "READY=1" {
+		r.readyCount++
+		return r.sent, r.err
+	}
+	return true, nil
+}
+
+func (r *recNotifier) readyCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.readyCount
+}
+
+func (r *recNotifier) statusStates() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.states))
+	copy(out, r.states)
+	return out
+}
+
+// newTestLifecycle builds a lifecycle with a fake clock and, optionally, a notifier.
+func newTestLifecycle(fc *fakeClock, n notifyFunc) *startupLifecycle {
+	s := newStartupLifecycle(4242)
+	s.now = fc.now
+	// Rebaseline the startup/phase clocks to the fake clock (production uses a
+	// single real clock for both, so this alignment is a test-only concern).
+	s.startupStartedAt = fc.now()
+	s.phaseStartedAt = fc.now()
+	s.notifier = n
+	return s
+}
+
+// markAllMandatoryReady sets every mandatory readiness prerequisite true.
+func markAllMandatoryReady(s *startupLifecycle) {
+	s.setRuntimePathsReady(true)
+	s.setModulesInitialized(true)
+	s.setIPCBound(true)
+	s.setIPCAccepting(true)
+	s.setHTTPReady(true)
+	s.setRequiredModulesStarted(true)
+}
+
+// syncBuffer is a mutex-guarded buffer so a background goroutine (the pending
+// diagnostic) that logs concurrently with the test reading the output does not
+// race. Production logs to the stdlib logger's own synchronized writer; this is a
+// test-only concern.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// captureLog redirects the stdlib logger to a synchronized buffer for the duration
+// of fn.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	buf := &syncBuffer{}
+	orig := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(orig)
+		log.SetFlags(flags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// -----------------------------------------------------------------------------
+// PHASE_ORDERING
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_PhaseOrdering(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(1000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	out := captureLog(t, func() {
+		s.CompletePhase(PhaseProcessStart)
+		s.BeginPhase(PhaseRuntimePathsInit, "paths")
+		s.CompletePhase(PhaseRuntimePathsInit)
+		s.BeginPhase(PhaseModulesInit, "registry")
+		s.CompletePhase(PhaseModulesInit)
+		// Backwards transition must be rejected (RUNTIME_PATHS < MODULES).
+		s.BeginPhase(PhaseRuntimePathsInit, "paths")
+	})
+
+	if !strings.Contains(out, "state=invalid_transition") {
+		t.Fatalf("expected invalid_transition rejection in log, got:\n%s", out)
+	}
+	snap := s.Snapshot()
+	if snap.Phase != PhaseModulesInit {
+		t.Fatalf("backwards transition mutated phase: got %s want %s", snap.Phase, PhaseModulesInit)
+	}
+	if snap.LastCompletedPhase != PhaseModulesInit {
+		t.Fatalf("last_completed_phase = %s, want %s", snap.LastCompletedPhase, PhaseModulesInit)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// BEGIN_COMPLETE_TIMINGS
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_BeginCompleteTimings(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(2000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	out := captureLog(t, func() {
+		s.BeginPhase(PhaseModulesInit, "registry")
+		fc.advance(250 * time.Millisecond)
+		s.CompletePhase(PhaseModulesInit)
+	})
+
+	// begin logs elapsed_ms=0; complete logs elapsed_ms=250, total advancing.
+	if !strings.Contains(out, "phase=MODULES_INIT state=begin") {
+		t.Fatalf("missing begin event:\n%s", out)
+	}
+	if !strings.Contains(out, "state=complete") || !strings.Contains(out, "elapsed_ms=250") {
+		t.Fatalf("expected complete with elapsed_ms=250, got:\n%s", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// FAILED_PHASE_STATE
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_FailedPhaseState(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(3000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	out := captureLog(t, func() {
+		s.BeginPhase(PhaseIPCSocketInit, "ipc")
+		s.FailPhase(PhaseIPCSocketInit, errors.New("bind refused"))
+	})
+	if !strings.Contains(out, "phase=IPC_SOCKET_INIT state=failed") {
+		t.Fatalf("expected failed phase event, got:\n%s", out)
+	}
+	if !strings.Contains(out, "error=bind refused") {
+		t.Fatalf("expected sanitized error in log, got:\n%s", out)
+	}
+	snap := s.Snapshot()
+	if snap.State != stateFailed {
+		t.Fatalf("state = %s, want failed", snap.State)
+	}
+	// A failed phase is not a completion.
+	if snap.LastCompletedPhase == PhaseIPCSocketInit {
+		t.Fatalf("failed phase must not be recorded as last_completed")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// DEGRADED_PHASE_STATE
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_DegradedPhaseState(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(4000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	out := captureLog(t, func() {
+		s.BeginPhase(PhaseOpQueueInit, "opqueue")
+		s.DegradePhase(PhaseOpQueueInit, "opqueue", errors.New("nftbackend has no NFTManager"))
+	})
+	if !strings.Contains(out, "state=degraded") {
+		t.Fatalf("expected degraded event, got:\n%s", out)
+	}
+	snap := s.Snapshot()
+	if len(snap.DegradedComponents) != 1 || snap.DegradedComponents[0] != "opqueue" {
+		t.Fatalf("degraded_components = %v, want [opqueue]", snap.DegradedComponents)
+	}
+	// A degraded phase still counts as completed (daemon may proceed).
+	if snap.LastCompletedPhase != PhaseOpQueueInit {
+		t.Fatalf("degraded phase should record last_completed, got %s", snap.LastCompletedPhase)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// READY_AFTER_MANDATORY_PREREQUISITES  (+ degradable allowed)
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_ReadyAfterMandatoryPrerequisites(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(5000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true // systemd Type=notify run
+
+	markAllMandatoryReady(s)
+	// Leave nft/opqueue/watchdog false → degradable, must NOT block readiness.
+
+	err := s.SendReady()
+	if err != nil {
+		t.Fatalf("SendReady returned error with all mandatory prereqs met: %v", err)
+	}
+	if n.readyCalls() != 1 {
+		t.Fatalf("READY=1 sent %d times, want 1", n.readyCalls())
+	}
+	snap := s.Snapshot()
+	if !snap.ReadySent {
+		t.Fatalf("ready_sent = false after successful notify")
+	}
+	// Degraded components surfaced, not hidden.
+	if len(snap.DegradedComponents) == 0 {
+		t.Fatalf("expected degraded components (nft/opqueue/watchdog) to be surfaced")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// READY_BLOCKED_WHEN_IPC_NOT_ACCEPTING
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_ReadyBlockedWhenIPCNotAccepting(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(6000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+
+	// Everything mandatory EXCEPT ipc_accepting (socket bound but not serving).
+	s.setRuntimePathsReady(true)
+	s.setModulesInitialized(true)
+	s.setIPCBound(true)
+	s.setIPCAccepting(false)
+	s.setHTTPReady(true)
+	s.setRequiredModulesStarted(true)
+
+	err := s.SendReady()
+	if err == nil {
+		t.Fatalf("expected fatal readiness error when ipc_accepting is false")
+	}
+	if !strings.Contains(err.Error(), "ipc_accepting") {
+		t.Fatalf("error should name ipc_accepting, got: %v", err)
+	}
+	if n.readyCalls() != 0 {
+		t.Fatalf("READY=1 must NOT be sent when a mandatory prereq is unmet (sent %d)", n.readyCalls())
+	}
+	snap := s.Snapshot()
+	if snap.ReadySent {
+		t.Fatalf("ready_sent must be false when readiness gate fails")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// IPC_BOUND_DISTINCT_FROM_ACCEPTING
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_IPCBoundDistinctFromAccepting(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(6500, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	s.setIPCBound(true)
+	snap := s.Snapshot()
+	if !snap.IPCBound {
+		t.Fatalf("ipc_bound not set")
+	}
+	if snap.IPCAccepting {
+		t.Fatalf("ipc_accepting must remain false until the accept loop is serving")
+	}
+	s.setIPCAccepting(true)
+	if !s.Snapshot().IPCAccepting {
+		t.Fatalf("ipc_accepting should be true once serving")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// READY_SENT_EXACTLY_ONCE
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_ReadySentExactlyOnce(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(7000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+	markAllMandatoryReady(s)
+
+	if err := s.SendReady(); err != nil {
+		t.Fatalf("first SendReady failed: %v", err)
+	}
+	// Repeated calls must not re-notify.
+	_ = s.SendReady()
+	_ = s.SendReady()
+
+	if n.readyCalls() != 1 {
+		t.Fatalf("READY=1 sent %d times, want exactly 1", n.readyCalls())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Test-only phase blocker: off by default, capped, matches only the named phase
+// -----------------------------------------------------------------------------
+
+func TestDebugBlockPhase(t *testing.T) {
+	// Unset → no block (near-instant).
+	t.Setenv("NFTBAN_DEBUG_BLOCK_PHASE", "")
+	start := time.Now()
+	debugBlockPhase(PhaseModulesInit)
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatalf("unset blocker should not sleep")
+	}
+
+	// Set but different phase → no block.
+	t.Setenv("NFTBAN_DEBUG_BLOCK_PHASE", "IPC_SOCKET_INIT")
+	t.Setenv("NFTBAN_DEBUG_BLOCK_MS", "5000")
+	start = time.Now()
+	debugBlockPhase(PhaseModulesInit)
+	if time.Since(start) > 50*time.Millisecond {
+		t.Fatalf("non-matching phase should not sleep")
+	}
+
+	// Matching phase, small ms → blocks ~that long.
+	t.Setenv("NFTBAN_DEBUG_BLOCK_PHASE", "MODULES_INIT")
+	t.Setenv("NFTBAN_DEBUG_BLOCK_MS", "60")
+	start = time.Now()
+	debugBlockPhase(PhaseModulesInit)
+	if d := time.Since(start); d < 50*time.Millisecond {
+		t.Fatalf("matching phase should block ~60ms, blocked %s", d)
+	}
+
+	// Invalid/zero ms → no block.
+	for _, bad := range []string{"abc", "0", "-1", ""} {
+		t.Setenv("NFTBAN_DEBUG_BLOCK_MS", bad)
+		start = time.Now()
+		debugBlockPhase(PhaseModulesInit)
+		if time.Since(start) > 50*time.Millisecond {
+			t.Fatalf("invalid ms %q should not sleep", bad)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Startup-pending timeout override safety
+//   PENDING_TIMEOUT_DEFAULT=60s / PENDING_TIMEOUT_INVALID_INPUT=SAFE
+// -----------------------------------------------------------------------------
+
+func TestResolveStartupPendingDelay(t *testing.T) {
+	// Default (unset) = 2/3 of the 90s systemd default = 60s.
+	t.Setenv("NFTBAN_STARTUP_PENDING_SEC", "")
+	if got := resolveStartupPendingDelay(); got != 60*time.Second {
+		t.Fatalf("default pending delay = %s, want 60s", got)
+	}
+
+	// Invalid / zero / negative must all SAFELY fall back to the default — they
+	// must never disable the diagnostic.
+	for _, bad := range []string{"abc", "0", "-5", "  ", "12x", "9999999999999999999999"} {
+		t.Setenv("NFTBAN_STARTUP_PENDING_SEC", bad)
+		if got := resolveStartupPendingDelay(); got != 60*time.Second {
+			t.Fatalf("invalid input %q → %s, want safe default 60s", bad, got)
+		}
+	}
+
+	// A valid positive override is honored (test-only tuning surface).
+	t.Setenv("NFTBAN_STARTUP_PENDING_SEC", "3")
+	if got := resolveStartupPendingDelay(); got != 3*time.Second {
+		t.Fatalf("override 3 → %s, want 3s", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// systemd-vs-direct-run readiness-notify semantics
+//   DIRECT_RUN_WITHOUT_NOTIFY_SOCKET / SYSTEMD_MODE_READY_SUCCESS /
+//   SYSTEMD_MODE_NOTIFY_ERROR_FATAL / SYSTEMD_MODE_NOT_SENT_FATAL /
+//   READY_SENT_STATE_ONLY_AFTER_CONFIRMED_SEND
+// -----------------------------------------------------------------------------
+
+// DIRECT_RUN_WITHOUT_NOTIFY_SOCKET: NOTIFY_EXPECTED=NO, sent=false, err=nil is the
+// normal terminal case and MUST NOT be fatal (daemon runs from a terminal).
+func TestLifecycle_DirectRunWithoutNotifySocket(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(8000, 0)}
+	n := &recNotifier{sent: false, err: nil}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = false // no NOTIFY_SOCKET
+	markAllMandatoryReady(s)
+
+	if err := s.SendReady(); err != nil {
+		t.Fatalf("direct run (no NOTIFY_SOCKET) must not be fatal, got: %v", err)
+	}
+	snap := s.Snapshot()
+	if snap.NotifyExpected {
+		t.Fatalf("notify_expected should be false in direct run")
+	}
+	if !snap.ReadyAttempted {
+		t.Fatalf("ready_attempted should be true")
+	}
+	if snap.ReadySent {
+		t.Fatalf("ready_sent must be false when there is no socket to send to")
+	}
+}
+
+// SYSTEMD_MODE_READY_SUCCESS: NOTIFY_EXPECTED=YES + sent=true + err=nil → ready.
+// Also proves READY_SENT_STATE_ONLY_AFTER_CONFIRMED_SEND (sent true ⇒ ready_sent).
+func TestLifecycle_SystemdModeReadySuccess(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(8100, 0)}
+	n := &recNotifier{sent: true, err: nil}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+	markAllMandatoryReady(s)
+
+	out := captureLog(t, func() {
+		if err := s.SendReady(); err != nil {
+			t.Fatalf("systemd-mode success must not error: %v", err)
+		}
+	})
+	snap := s.Snapshot()
+	if !snap.ReadySent {
+		t.Fatalf("ready_sent must be true after a confirmed send")
+	}
+	if !strings.Contains(out, "phase=SYSTEMD_NOTIFY_READY state=complete") {
+		t.Fatalf("expected SYSTEMD_NOTIFY_READY completion:\n%s", out)
+	}
+}
+
+// SYSTEMD_MODE_NOTIFY_ERROR_FATAL: NOTIFY_EXPECTED=YES + err!=nil → FATAL.
+func TestLifecycle_SystemdModeNotifyErrorFatal(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(8200, 0)}
+	n := &recNotifier{sent: false, err: errors.New("write /run/systemd/notify: connection refused")}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+	markAllMandatoryReady(s)
+
+	out := captureLog(t, func() {
+		if err := s.SendReady(); err == nil {
+			t.Fatalf("systemd-mode notify error MUST be fatal")
+		}
+	})
+	snap := s.Snapshot()
+	if snap.ReadySent {
+		t.Fatalf("ready_sent must be false on notify error")
+	}
+	if strings.Contains(out, "phase=SYSTEMD_NOTIFY_READY state=complete") {
+		t.Fatalf("SYSTEMD_NOTIFY_READY must NOT complete on notify error:\n%s", out)
+	}
+	if !strings.Contains(out, "state=failed") {
+		t.Fatalf("expected failed phase on notify error:\n%s", out)
+	}
+}
+
+// SYSTEMD_MODE_NOT_SENT_FATAL: NOTIFY_EXPECTED=YES + sent=false + err=nil → FATAL
+// (READY undelivered though NOTIFY_SOCKET present).
+func TestLifecycle_SystemdModeNotSentFatal(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(8300, 0)}
+	n := &recNotifier{sent: false, err: nil}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+	markAllMandatoryReady(s)
+
+	if err := s.SendReady(); err == nil {
+		t.Fatalf("systemd-mode not-sent MUST be fatal")
+	}
+	if s.Snapshot().ReadySent {
+		t.Fatalf("ready_sent must be false when READY was not delivered")
+	}
+}
+
+// READY_SENT_STATE_ONLY_AFTER_CONFIRMED_SEND: ready_sent is true iff sent && !err,
+// across the matrix.
+func TestLifecycle_ReadySentOnlyAfterConfirmedSend(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected bool
+		sent     bool
+		err      error
+		want     bool
+	}{
+		{"direct-nosocket", false, false, nil, false},
+		{"systemd-ok", true, true, nil, true},
+		{"systemd-err", true, false, errors.New("boom"), false},
+		{"systemd-notsent", true, false, nil, false},
+	}
+	for i, c := range cases {
+		fc := &fakeClock{t: time.Unix(int64(8400+i), 0)}
+		n := &recNotifier{sent: c.sent, err: c.err}
+		s := newTestLifecycle(fc, n.fn)
+		s.notifyExpected = c.expected
+		markAllMandatoryReady(s)
+		_ = s.SendReady()
+		if got := s.Snapshot().ReadySent; got != c.want {
+			t.Fatalf("%s: ready_sent=%t want %t", c.name, got, c.want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// STARTUP_PENDING_IDENTIFIES_BLOCKED_PHASE
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_StartupPendingIdentifiesBlockedPhase(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(9000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	// Simulate a startup that reaches MODULES_INIT and then blocks.
+	s.CompletePhase(PhaseProcessStart)
+	s.BeginPhase(PhaseRuntimePathsInit, "paths")
+	s.setRuntimePathsReady(true)
+	s.CompletePhase(PhaseRuntimePathsInit)
+	s.BeginPhase(PhaseModulesInit, "registry")
+
+	var out string
+	captured := captureLog(t, func() {
+		s.startPendingWatch(20 * time.Millisecond)
+		time.Sleep(80 * time.Millisecond)
+	})
+	out = captured
+	if !strings.Contains(out, "event=startup_pending") {
+		t.Fatalf("expected startup_pending emission, got:\n%s", out)
+	}
+	if !strings.Contains(out, "current_phase=MODULES_INIT") {
+		t.Fatalf("startup_pending must name the blocked phase, got:\n%s", out)
+	}
+	if !strings.Contains(out, "last_completed_phase=RUNTIME_PATHS_INIT") {
+		t.Fatalf("startup_pending must name last completed phase, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ready_sent=false") {
+		t.Fatalf("startup_pending should show ready_sent=false, got:\n%s", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// STARTUP_PENDING_CANCELLED_AFTER_READY
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_StartupPendingCancelledAfterReady(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(10000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+	markAllMandatoryReady(s)
+
+	out := captureLog(t, func() {
+		s.startPendingWatch(50 * time.Millisecond)
+		if err := s.SendReady(); err != nil { // resolves pending
+			t.Fatalf("SendReady failed: %v", err)
+		}
+		time.Sleep(120 * time.Millisecond)
+	})
+	if strings.Contains(out, "event=startup_pending") {
+		t.Fatalf("startup_pending must be cancelled after READY, got:\n%s", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// STARTUP_PENDING_CANCELLED_ON_FAILURE
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_StartupPendingCancelledOnFailure(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(11000, 0)}
+	s := newTestLifecycle(fc, nil)
+
+	out := captureLog(t, func() {
+		s.startPendingWatch(50 * time.Millisecond)
+		s.BeginPhase(PhaseIPCSocketInit, "ipc")
+		s.FailPhase(PhaseIPCSocketInit, errors.New("bind failed")) // resolves pending
+		time.Sleep(120 * time.Millisecond)
+	})
+	if strings.Contains(out, "event=startup_pending") {
+		t.Fatalf("startup_pending must be cancelled on phase failure, got:\n%s", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// SHUTDOWN_PHASE_ORDERING
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_ShutdownPhaseOrdering(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(12000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+
+	out := captureLog(t, func() {
+		s.beginShutdown()
+		s.completeShutdown()
+	})
+	beginIdx := strings.Index(out, "phase=SHUTDOWN_BEGIN")
+	completeIdx := strings.Index(out, "phase=SHUTDOWN_COMPLETE")
+	if beginIdx < 0 || completeIdx < 0 {
+		t.Fatalf("missing shutdown phase events:\n%s", out)
+	}
+	if beginIdx > completeIdx {
+		t.Fatalf("SHUTDOWN_BEGIN must precede SHUTDOWN_COMPLETE:\n%s", out)
+	}
+	snap := s.Snapshot()
+	if !snap.ShutdownStarted {
+		t.Fatalf("shutdown_started should be true")
+	}
+	// STATUS= "shutting down" pushed to systemd.
+	found := false
+	for _, st := range n.statusStates() {
+		if strings.Contains(st, "shutting down") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected STATUS= shutting down, got %v", n.statusStates())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ERROR_SANITIZATION
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_ErrorSanitization(t *testing.T) {
+	// Multi-line + overlong error must become a single bounded line.
+	long := strings.Repeat("A", 500)
+	err := errors.New("line1\nline2\r\ttabbed " + long)
+	got := sanitizeErr(err)
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Fatalf("sanitized error still contains control chars: %q", got)
+	}
+	if len(got) > 230 { // 200 + truncation marker
+		t.Fatalf("sanitized error too long (%d): %q", len(got), got)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation marker, got: %q", got)
+	}
+	// A nil error sanitizes to the empty string (no error); the log layer renders
+	// empty as "-".
+	if sanitizeErr(nil) != "" {
+		t.Fatalf("nil error should sanitize to empty, got %q", sanitizeErr(nil))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// NO_SECRET_VALUES_IN_LIFECYCLE_LOGS
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_NoSecretValuesInLogs(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(13000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+	markAllMandatoryReady(s)
+
+	// Plant a "secret" in the environment and confirm no phase event echoes it.
+	const secret = "SUPER_SECRET_TOKEN_deadbeef"
+	t.Setenv("NFTBAN_FAKE_SECRET", secret)
+
+	out := captureLog(t, func() {
+		s.BeginPhase(PhaseModulesInit, "registry")
+		s.CompletePhase(PhaseModulesInit)
+		_ = s.SendReady()
+		s.enterRunning()
+	})
+	if strings.Contains(out, secret) {
+		t.Fatalf("lifecycle log leaked an environment secret:\n%s", out)
+	}
+	// Structured lines carry only phase/state/component/timing/sanitized-error.
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.HasPrefix(line, "event=startup_phase") && !strings.Contains(line, "component=") {
+			t.Fatalf("phase line missing component field (unexpected shape): %q", line)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// STATUS= phase updates surfaced through the notifier
+// -----------------------------------------------------------------------------
+
+func TestLifecycle_StatusNotifyPhaseUpdates(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(14000, 0)}
+	n := &recNotifier{sent: true}
+	s := newTestLifecycle(fc, n.fn)
+	s.notifyExpected = true
+
+	s.BeginPhase(PhaseModulesInit, "registry")
+	markAllMandatoryReady(s)
+	_ = s.SendReady()
+	s.enterRunning() // must NOT clobber the ready status
+
+	var sawPhase, sawReady bool
+	for _, st := range n.statusStates() {
+		if strings.Contains(st, "STATUS=NFTBan startup: MODULES_INIT") {
+			sawPhase = true
+		}
+		if strings.Contains(st, "STATUS=NFTBan ready") {
+			sawReady = true
+		}
+	}
+	if !sawPhase {
+		t.Fatalf("expected STATUS= phase update, got %v", n.statusStates())
+	}
+	if !sawReady {
+		t.Fatalf("expected STATUS=NFTBan ready, got %v", n.statusStates())
+	}
+	// The steady-state STATUS after entering RUNNING must remain "NFTBan ready" —
+	// RUNNING/shutdown-begin phases must not emit a "startup: <phase>" status.
+	states := n.statusStates()
+	last := states[len(states)-1]
+	if !strings.Contains(last, "NFTBan ready") {
+		t.Fatalf("final STATUS should stay 'NFTBan ready', got %q", last)
+	}
+	for _, st := range states {
+		if strings.Contains(st, "startup: RUNNING") {
+			t.Fatalf("RUNNING must not emit a startup: status: %q", st)
+		}
+	}
+}

--- a/cmd/nftband/daemon_status_lifecycle_test.go
+++ b/cmd/nftband/daemon_status_lifecycle_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftband"
+// meta:type="cmd"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Tests that the status IPC exposes the lifecycle snapshot additively without dropping pre-existing fields."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/itcmsgr/nftban/internal/eventbus"
+	"github.com/itcmsgr/nftban/internal/module"
+)
+
+// STATUS_IPC_ADDITIVE_COMPATIBILITY: the lifecycle object is ADDED; every
+// pre-existing status field remains present and unchanged in name.
+func TestStatusIPC_AdditiveLifecycle(t *testing.T) {
+	d := &Daemon{
+		bus:       eventbus.New(),
+		registry:  module.NewRegistry(),
+		startedAt: time.Now(),
+		lifecycle: newStartupLifecycle(1),
+	}
+	d.lifecycle.setIPCBound(true)
+	d.lifecycle.setIPCAccepting(true)
+
+	resp := d.handleStatusRequest()
+	if !resp.Success {
+		t.Fatalf("status request not successful")
+	}
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("status data is not a map")
+	}
+
+	// Pre-existing fields (backward-compatibility contract).
+	for _, k := range []string{
+		"version", "uptime", "uptime_seconds", "modules",
+		"events_total", "subscriptions", "config_hash", "config_loaded",
+	} {
+		if _, present := data[k]; !present {
+			t.Fatalf("status IPC dropped pre-existing field %q", k)
+		}
+	}
+
+	// New additive object.
+	lc, present := data["lifecycle"].(map[string]any)
+	if !present {
+		t.Fatalf("status IPC missing additive lifecycle object")
+	}
+	for _, k := range []string{
+		"phase", "last_completed_phase", "state", "ready", "ready_sent",
+		"ipc_bound", "ipc_accepting", "nft_ready", "opqueue_ready", "degraded_components",
+	} {
+		if _, ok := lc[k]; !ok {
+			t.Fatalf("lifecycle object missing field %q", k)
+		}
+	}
+	if lc["ipc_bound"] != true || lc["ipc_accepting"] != true {
+		t.Fatalf("lifecycle did not reflect ipc bound/accepting: %v", lc)
+	}
+}
+
+// A nil lifecycle must not panic status rendering.
+func TestStatusIPC_NilLifecycleSafe(t *testing.T) {
+	d := &Daemon{
+		bus:       eventbus.New(),
+		registry:  module.NewRegistry(),
+		startedAt: time.Now(),
+		// lifecycle intentionally nil
+	}
+	resp := d.handleStatusRequest()
+	data := resp.Data.(map[string]any)
+	lc := data["lifecycle"].(map[string]any)
+	if lc["available"] != false {
+		t.Fatalf("nil lifecycle should render available=false, got %v", lc)
+	}
+}

--- a/cmd/nftband/daemon_types.go
+++ b/cmd/nftband/daemon_types.go
@@ -182,36 +182,36 @@ func getAutoSyncDelay() time.Duration {
 type Daemon struct {
 	bus       *eventbus.Bus
 	registry  *module.Registry
-	backend   *nftbackend.Backend // AUTHORITATIVE nft writer
-	stats     *stats.Collector    // Runtime stats collector
-	watchdog  *watchdog.Watchdog  // Dynamic watchdog
+	backend   *nftbackend.Backend       // AUTHORITATIVE nft writer
+	stats     *stats.Collector          // Runtime stats collector
+	watchdog  *watchdog.Watchdog        // Dynamic watchdog
 	wdMetrics *watchdog.MetricsExporter // Watchdog metrics exporter
 	ctx       context.Context
 	cancel    context.CancelFunc
 	socketLn  net.Listener
 	httpSrv   *http.Server
-	configDir string             // Config directory for whitelist loading
+	configDir string // Config directory for whitelist loading
 
 	// v1.13.0: Async IPC operation queue
 	opQueue     *opqueue.OpQueue     // Async operation queue for batched netlink
 	sourceIndex *opqueue.SourceIndex // Source tracking for shared sets
 
 	// v1.32.0: In-memory set element counters (huge set management)
-	setCounters *stats.SetCounters   // Per-set element counts (O(1) reads)
-	bgWg        sync.WaitGroup       // Tracks background goroutines for clean shutdown
+	setCounters *stats.SetCounters // Per-set element counts (O(1) reads)
+	bgWg        sync.WaitGroup     // Tracks background goroutines for clean shutdown
 
 	// v1.13.12: Config reload tracking
-	configHash    string       // SHA256 of loaded config files
-	lastReloadTs  time.Time    // When config was last loaded/reloaded
-	reloadMu      sync.RWMutex // Protects config reload operations
+	configHash   string       // SHA256 of loaded config files
+	lastReloadTs time.Time    // When config was last loaded/reloaded
+	reloadMu     sync.RWMutex // Protects config reload operations
 
 	// IPC rate limiting
 	connSem chan struct{} // Semaphore for limiting concurrent IPC connections
 
 	// IPC metrics tracking
-	activeConns     int64      // Current active connections (atomic)
-	peakConns       int64      // Peak connections since reset (atomic)
-	activeConnsMu   sync.Mutex // Protects peak calculation
+	activeConns   int64      // Current active connections (atomic)
+	peakConns     int64      // Peak connections since reset (atomic)
+	activeConnsMu sync.Mutex // Protects peak calculation
 
 	// v1.33.0: Daemon start time for uptime calculation
 	startedAt time.Time // Set when daemon starts
@@ -220,6 +220,18 @@ type Daemon struct {
 	sigCh           chan os.Signal // Signal channel for shutdown
 	startupComplete bool           // True when initialization is complete
 	sigMu           sync.Mutex     // Protects startupComplete
+
+	// Startup lifecycle observability: ONE canonical, concurrency-safe state that
+	// records startup phases, gates the systemd READY=1 notification on mandatory
+	// prerequisites, and is rendered by the journal, sd_notify STATUS=, and status
+	// IPC. See daemon_startup_lifecycle.go.
+	lifecycle *startupLifecycle
+
+	// IPC accept-loop serving acknowledgment: closed by acceptSocketConnections
+	// when the loop reaches its serving state, so startSocket can distinguish
+	// "socket bound" from "socket actually accepting" without an unbounded wait.
+	acceptReady     chan struct{}
+	acceptReadyOnce sync.Once
 
 	// v1.41.0: Ban correlation ID tracking (IP → banID for BAN→UNBAN linking)
 	banIDMap sync.Map // key: string (IP), value: string (banID)

--- a/cmd/nftband/main.go
+++ b/cmd/nftband/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/itcmsgr/nftban/internal/eventbus"
 	"github.com/itcmsgr/nftban/internal/module"
 	"github.com/itcmsgr/nftban/internal/nftbackend"
@@ -69,7 +70,22 @@ func main() {
 		configDir: configDir,
 		connSem:   make(chan struct{}, MaxConcurrentIPCConns),
 		startedAt: time.Now(),
+		lifecycle: newStartupLifecycle(os.Getpid()),
 	}
+
+	// Wire the canonical lifecycle to systemd sd_notify (READY=1 / STATUS=). Only
+	// the main process participates in the notification contract (NotifyAccess=main).
+	// NFTBAN_DEBUG_FAIL_READY is a bounded, test-only seam (empty/unset in
+	// production; no unit/package sets it): with a real NOTIFY_SOCKET present it
+	// forces the READY=1 delivery to fail so the fatal systemd-mode path can be
+	// proven WITHOUT touching the real /run/systemd/notify socket.
+	failReady := os.Getenv("NFTBAN_DEBUG_FAIL_READY") != ""
+	d.lifecycle.setNotifier(func(state string) (bool, error) {
+		if failReady && state == "READY=1" {
+			return false, fmt.Errorf("debug: forced READY failure (NFTBAN_DEBUG_FAIL_READY)")
+		}
+		return daemon.SdNotify(false, state)
+	})
 
 	// v1.209.x F2: wire the AUTHORITATIVE never-ban exemption guard at the durable apply
 	// boundary (Backend.Ban). Establishes the never-ban invariant for admin/management/

--- a/internal/botguard/suspect.go
+++ b/internal/botguard/suspect.go
@@ -38,11 +38,11 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/nftlock"
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // SuspectReader reads kernel-populated suspect sets.
@@ -106,7 +106,7 @@ func (r *SuspectReader) readSet(ctx context.Context, table, setName string) ([]n
 	args := append([]string{"list", "set"}, strings.Fields(table)...)
 	args = append(args, setName)
 
-	cmd := exec.CommandContext(ctx, "nft", args...) // #nosec G204 -- args built from trusted constants (table name + set name)
+	cmd := procenv.CommandContext(ctx, "nft", args...) // #nosec G204 -- args built from trusted constants (table name + set name)
 	output, err := cmd.CombinedOutput()
 
 	// Release lock immediately after kernel read

--- a/internal/ddos/module.go
+++ b/internal/ddos/module.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,6 +31,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/eventbus"
 	"github.com/itcmsgr/nftban/internal/module"
 	"github.com/itcmsgr/nftban/internal/nftbanconf"
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 const (
@@ -93,8 +93,8 @@ type Module struct {
 	suricataAvail bool
 
 	// IP tracking for ban decisions
-	ipTrackers    map[string]*ipTracker
-	bannedIPs     map[string]time.Time
+	ipTrackers map[string]*ipTracker
+	bannedIPs  map[string]time.Time
 }
 
 // New creates a new DDoS protection module
@@ -107,11 +107,11 @@ func New() *Module {
 		config: ddosConfig{
 			Enabled:           true,
 			Mode:              "auto",
-			EscalateThreshold: 3,                    // Default: 3 detections
-			BanDurationShort:  5 * time.Minute,     // Default: 5 min ban (first)
-			BanDurationMedium: 30 * time.Minute,    // Default: 30 min ban (repeat)
-			BanDurationLong:   1 * time.Hour,       // Default: 1 hour (persistent)
-			TrackWindow:       1 * time.Minute,     // Default: 1 min window
+			EscalateThreshold: 3,                // Default: 3 detections
+			BanDurationShort:  5 * time.Minute,  // Default: 5 min ban (first)
+			BanDurationMedium: 30 * time.Minute, // Default: 30 min ban (repeat)
+			BanDurationLong:   1 * time.Hour,    // Default: 1 hour (persistent)
+			TrackWindow:       1 * time.Minute,  // Default: 1 min window
 		},
 	}
 	// Load config from files (will override defaults)
@@ -333,7 +333,7 @@ func (m *Module) Status() module.Status {
 func (m *Module) detectMode() {
 	scriptPath := getDDOSScript()
 	// VULN-20: quote path via $1
-	out, err := exec.Command("bash", "-c", "source \"$1\" && nftban_ddos_get_mode", "_", scriptPath).Output()
+	out, err := procenv.Command("bash", "-c", "source \"$1\" && nftban_ddos_get_mode", "_", scriptPath).Output()
 	if err != nil {
 		m.mode = "classic" // Default fallback
 		return
@@ -341,19 +341,19 @@ func (m *Module) detectMode() {
 	m.mode = strings.TrimSpace(string(out))
 
 	// Check Suricata availability
-	out, _ = exec.Command("bash", "-c", "source \"$1\" && nftban_ddos_suricata_available && echo yes || echo no", "_", scriptPath).Output()
+	out, _ = procenv.Command("bash", "-c", "source \"$1\" && nftban_ddos_suricata_available && echo yes || echo no", "_", scriptPath).Output()
 	m.suricataAvail = strings.TrimSpace(string(out)) == "yes"
 }
 
 // enable enables DDoS protection
 func (m *Module) enable() error {
-	cmd := exec.Command("bash", "-c", "source \"$1\" && nftban_ddos_enable", "_", getDDOSScript())
+	cmd := procenv.Command("bash", "-c", "source \"$1\" && nftban_ddos_enable", "_", getDDOSScript())
 	return cmd.Run()
 }
 
 // disable disables DDoS protection
 func (m *Module) disable() error {
-	cmd := exec.Command("bash", "-c", "source \"$1\" && nftban_ddos_disable", "_", getDDOSScript())
+	cmd := procenv.Command("bash", "-c", "source \"$1\" && nftban_ddos_disable", "_", getDDOSScript())
 	return cmd.Run()
 }
 
@@ -438,7 +438,7 @@ func (m *Module) handleDDoSEvent(e eventbus.Event) {
 	if shouldBan && m.bus != nil {
 		m.bus.Publish(eventbus.NewEvent(eventbus.EventBan, ModuleName).
 			WithIP(e.IP).
-			WithMessage("Banning " + e.IP + ": DDoS threshold exceeded").
+			WithMessage("Banning "+e.IP+": DDoS threshold exceeded").
 			WithSeverity(eventbus.SeverityCritical).
 			WithData("duration", banDuration.String()).
 			WithData("reason", "ddos_protection").

--- a/internal/loginmon/module.go
+++ b/internal/loginmon/module.go
@@ -66,6 +66,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/metrics"
 	"github.com/itcmsgr/nftban/internal/module"
 	"github.com/itcmsgr/nftban/internal/nftbanconf"
+	"github.com/itcmsgr/nftban/internal/procenv"
 	"github.com/itcmsgr/nftban/internal/safeconv"
 )
 
@@ -945,7 +946,7 @@ func (m *Module) detectServices() {
 // serviceExists checks if a service is installed
 func (m *Module) serviceExists(name string) bool {
 	// Check systemd
-	cmd := exec.Command("systemctl", "list-unit-files", name+".service")
+	cmd := procenv.Command("systemctl", "list-unit-files", name+".service")
 	if output, err := cmd.Output(); err == nil && strings.Contains(string(output), name) {
 		return true
 	}
@@ -982,7 +983,7 @@ func (m *Module) checkSuricataAvailable() bool {
 	}
 
 	// Check if service is running
-	cmd := exec.Command("systemctl", "is-active", "suricata")
+	cmd := procenv.Command("systemctl", "is-active", "suricata")
 	if err := cmd.Run(); err == nil {
 		score++
 	}
@@ -1115,7 +1116,7 @@ func (m *Module) runJournalWatcherOnce(ctx context.Context, attempt int) error {
 		for _, f := range journalAuthFacilities {
 			args = append(args, "SYSLOG_FACILITY="+f)
 		}
-		cmd = exec.CommandContext(ctx, "journalctl", args...)
+		cmd = procenv.CommandContext(ctx, "journalctl", args...)
 	}
 	// Publish the journalctl child reference for Stop() to reap (guarded).
 	m.mu.Lock()
@@ -1319,7 +1320,7 @@ func queryEximLogPath() (string, error) {
 	}
 	// #nosec G204 -- exim path comes from PATH lookup, not user input.
 	// Arguments are hard-coded constants. This is a system tool query, not user dispatch.
-	cmd := exec.Command(exim, "-bP", "log_file_path")
+	cmd := procenv.Command(exim, "-bP", "log_file_path")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("exim -bP failed: %w", err)
@@ -1351,7 +1352,7 @@ func queryPostfixMaillogPath() (string, error) {
 	}
 	// #nosec G204 -- postconf path comes from PATH lookup, not user input.
 	// Arguments are hard-coded constants. This is a system tool query, not user dispatch.
-	cmd := exec.Command(postconf, "-h", "maillog_file")
+	cmd := procenv.Command(postconf, "-h", "maillog_file")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("postconf -h maillog_file failed: %w", err)
@@ -1599,7 +1600,7 @@ func (m *Module) runFileWatcherOnce(ctx context.Context, service, logPath string
 	if m.newWatcherCmd != nil {
 		cmd = m.newWatcherCmd(ctx, logPath)
 	} else {
-		cmd = exec.CommandContext(ctx, "tail", "-F", "-n", "0", logPath)
+		cmd = procenv.CommandContext(ctx, "tail", "-F", "-n", "0", logPath)
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -29,11 +29,11 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/itcmsgr/nftban/internal/procenv"
 	"github.com/itcmsgr/nftban/internal/safety"
 )
 
@@ -303,7 +303,7 @@ func (c *Collector) writeExporterMetrics(f *os.File, startTime time.Time) error 
 
 // getNFTablesSets retrieves all nftables sets in one efficient JSON call
 func (c *Collector) getNFTablesSets() (map[string]interface{}, error) {
-	cmd := exec.Command("nft", "-j", "list", "ruleset")
+	cmd := procenv.Command("nft", "-j", "list", "ruleset")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("nft list ruleset: %w", err)
@@ -322,7 +322,7 @@ func (c *Collector) countSetElements(nftSets map[string]interface{}, family, tab
 	// This is a simplified implementation - actual implementation would parse
 	// the JSON structure from nft -j output
 	// For now, fall back to direct nft command (still better than bash grep/awk)
-	cmd := exec.Command("nft", "list", "set", family, table, setName)
+	cmd := procenv.Command("nft", "list", "set", family, table, setName)
 	output, err := cmd.Output()
 	if err != nil {
 		return 0
@@ -376,7 +376,7 @@ func (c *Collector) getNetworkInterfaces() ([]string, error) {
 
 		// Skip loopback and virtual interfaces
 		if iface == "lo" || strings.HasPrefix(iface, "docker") ||
-		   strings.HasPrefix(iface, "veth") || strings.HasPrefix(iface, "br-") {
+			strings.HasPrefix(iface, "veth") || strings.HasPrefix(iface, "br-") {
 			continue
 		}
 
@@ -450,7 +450,7 @@ func (c *Collector) getHealthStatus(component string) int {
 
 // isServiceActive checks if a systemd service is active
 func (c *Collector) isServiceActive(service string) bool {
-	cmd := exec.Command("systemctl", "is-active", service)
+	cmd := procenv.Command("systemctl", "is-active", service)
 	output, err := cmd.Output()
 	if err != nil {
 		return false

--- a/internal/metrics/evidence_chains.go
+++ b/internal/metrics/evidence_chains.go
@@ -22,16 +22,18 @@ package metrics
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // ChainInfo holds presence information for a kernel chain.
 // Three states:
-//   Exists=true, Unknown=false → confirmed present
-//   Exists=false, Unknown=false → confirmed absent
-//   Unknown=true → collection failure; absence not known
+//
+//	Exists=true, Unknown=false → confirmed present
+//	Exists=false, Unknown=false → confirmed absent
+//	Unknown=true → collection failure; absence not known
 type ChainInfo struct {
 	Exists  bool `json:"exists"`
 	Unknown bool `json:"unknown,omitempty"`
@@ -98,9 +100,9 @@ func listChains(ctx context.Context, family string) (map[string]bool, bool) {
 func nftListTableText(ctx context.Context, family string) ([]byte, error) {
 	switch family {
 	case "ip":
-		return exec.CommandContext(ctx, "nft", "list", "table", "ip", "nftban").Output() // #nosec G204
+		return procenv.CommandContext(ctx, "nft", "list", "table", "ip", "nftban").Output() // #nosec G204
 	case "ip6":
-		return exec.CommandContext(ctx, "nft", "list", "table", "ip6", "nftban").Output() // #nosec G204
+		return procenv.CommandContext(ctx, "nft", "list", "table", "ip6", "nftban").Output() // #nosec G204
 	default:
 		return nil, nil
 	}

--- a/internal/metrics/evidence_journal.go
+++ b/internal/metrics/evidence_journal.go
@@ -26,27 +26,28 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // JournalEvidenceResult holds journal-based evidence for metrics.
 type JournalEvidenceResult struct {
-	LoginMonActive bool   `json:"loginmon_active"`         // recent ban/login_failed events found
-	LoginMonBans   int    `json:"loginmon_bans"`            // ban event count in window
-	LoginMonEvents int    `json:"loginmon_events"`          // login_failed event count in window
-	Unknown        bool   `json:"unknown,omitempty"`        // collection failed
+	LoginMonActive bool `json:"loginmon_active"`   // recent ban/login_failed events found
+	LoginMonBans   int  `json:"loginmon_bans"`     // ban event count in window
+	LoginMonEvents int  `json:"loginmon_events"`   // login_failed event count in window
+	Unknown        bool `json:"unknown,omitempty"` // collection failed
 }
 
 // DataFreshnessResult holds freshness checks for data pipeline artifacts.
 type DataFreshnessResult struct {
-	FeedFresh    bool   `json:"feed_fresh"`              // feed data files < 7 days old
-	FeedAge      string `json:"feed_age,omitempty"`      // human-readable age of newest feed
-	GeoIPFresh   bool   `json:"geoip_fresh"`             // GeoIP DB < 45 days old
-	GeoIPAge     string `json:"geoip_age,omitempty"`     // human-readable age
-	Unknown      bool   `json:"unknown,omitempty"`        // collection failed
+	FeedFresh  bool   `json:"feed_fresh"`          // feed data files < 7 days old
+	FeedAge    string `json:"feed_age,omitempty"`  // human-readable age of newest feed
+	GeoIPFresh bool   `json:"geoip_fresh"`         // GeoIP DB < 45 days old
+	GeoIPAge   string `json:"geoip_age,omitempty"` // human-readable age
+	Unknown    bool   `json:"unknown,omitempty"`   // collection failed
 }
 
 // CollectJournalEvidence queries nftband journal for LoginMon activity.
@@ -55,7 +56,7 @@ func CollectJournalEvidence(ctx context.Context) *JournalEvidenceResult {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	output, err := exec.CommandContext(ctx,
+	output, err := procenv.CommandContext(ctx,
 		"journalctl", "-u", "nftband", "--since", "-15m",
 		"--no-pager", "-o", "cat", "-n", "500",
 	).Output() // #nosec G204

--- a/internal/metrics/evidence_sets.go
+++ b/internal/metrics/evidence_sets.go
@@ -26,13 +26,16 @@ import (
 	"encoding/json"
 	"os/exec"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // SetInfo holds element count for a kernel set.
 // Three states:
-//   Exists=true, Count>=0, Unknown=false → collected successfully
-//   Exists=false, Count=0, Unknown=false → confirmed absent
-//   Unknown=true → collection failure/timeout/parse error; absence not known
+//
+//	Exists=true, Count>=0, Unknown=false → collected successfully
+//	Exists=false, Count=0, Unknown=false → confirmed absent
+//	Unknown=true → collection failure/timeout/parse error; absence not known
 type SetInfo struct {
 	Exists  bool `json:"exists"`
 	Count   int  `json:"count"`
@@ -71,10 +74,11 @@ func CollectSetElements(ctx context.Context) map[string]SetInfo {
 
 // countSetElementsJSON counts elements in a set using nft JSON output.
 // Returns (count, exists, unknown):
-//   count>0, exists=true, unknown=false → set present with elements
-//   count=0, exists=true, unknown=false → set present, empty
-//   count=0, exists=false, unknown=false → set confirmed absent
-//   count=0, exists=false, unknown=true → collection failed
+//
+//	count>0, exists=true, unknown=false → set present with elements
+//	count=0, exists=true, unknown=false → set present, empty
+//	count=0, exists=false, unknown=false → set confirmed absent
+//	count=0, exists=false, unknown=true → collection failed
 func countSetElementsJSON(ctx context.Context, family, name string) (count int, exists bool, unknown bool) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
@@ -102,9 +106,9 @@ func nftListSet(ctx context.Context, family, name string) ([]byte, error) {
 	var cmd *exec.Cmd
 	switch family {
 	case "ip":
-		cmd = exec.CommandContext(ctx, "nft", "-j", "list", "set", "ip", "nftban", name) // #nosec G204
+		cmd = procenv.CommandContext(ctx, "nft", "-j", "list", "set", "ip", "nftban", name) // #nosec G204
 	case "ip6":
-		cmd = exec.CommandContext(ctx, "nft", "-j", "list", "set", "ip6", "nftban", name) // #nosec G204
+		cmd = procenv.CommandContext(ctx, "nft", "-j", "list", "set", "ip6", "nftban", name) // #nosec G204
 	default:
 		return nil, nil
 	}
@@ -113,8 +117,9 @@ func nftListSet(ctx context.Context, family, name string) ([]byte, error) {
 
 // parseSetElementCount extracts element count from nft JSON set output.
 // Returns (count, found):
-//   found=true → a set object was present in the JSON
-//   found=false → no set object found (set absent or parse mismatch)
+//
+//	found=true → a set object was present in the JSON
+//	found=false → no set object found (set absent or parse mismatch)
 func parseSetElementCount(data []byte) (int, bool) {
 	var result struct {
 		NFTables []json.RawMessage `json:"nftables"`

--- a/internal/metrics/evidence_validator.go
+++ b/internal/metrics/evidence_validator.go
@@ -25,19 +25,19 @@ package metrics
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/constants"
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // ValidatorSnapshot holds extracted validator state for metrics enrichment.
 // This is NOT a truth object — it is a read-only observation of validator output.
 // Metrics cannot modify, override, or reinterpret these values.
 type ValidatorSnapshot struct {
-	Status   string            `json:"status"`   // protected/idle/degraded/down/unavailable
-	Modules  map[string]string `json:"modules"`  // module → effective state
-	Findings []string          `json:"findings"` // finding codes only
+	Status   string            `json:"status"`            // protected/idle/degraded/down/unavailable
+	Modules  map[string]string `json:"modules"`           // module → effective state
+	Findings []string          `json:"findings"`          // finding codes only
 	Unknown  bool              `json:"unknown,omitempty"` // true if collection failed
 }
 
@@ -66,7 +66,7 @@ func CollectValidatorSnapshot(ctx context.Context) *ValidatorSnapshot {
 
 // runValidator executes the validator binary.
 func runValidator(ctx context.Context) ([]byte, error) {
-	return exec.CommandContext(ctx, ValidatorBinPath, "--json").Output() // #nosec G204 -- fixed binary path
+	return procenv.CommandContext(ctx, ValidatorBinPath, "--json").Output() // #nosec G204 -- fixed binary path
 }
 
 // parseValidatorJSON extracts metrics-relevant fields from validator JSON.
@@ -75,14 +75,28 @@ func parseValidatorJSON(data []byte) *ValidatorSnapshot {
 	var val struct {
 		Status  string `json:"status"`
 		Modules struct {
-			BotGuard  *struct{ Effective string `json:"effective"` } `json:"botguard,omitempty"`
-			DDoS      *struct{ Effective string `json:"effective"` } `json:"ddos,omitempty"`
-			Portscan  *struct{ Effective string `json:"effective"` } `json:"portscan,omitempty"`
-			LoginMon  *struct{ Effective string `json:"effective"` } `json:"loginmon,omitempty"`
+			BotGuard *struct {
+				Effective string `json:"effective"`
+			} `json:"botguard,omitempty"`
+			DDoS *struct {
+				Effective string `json:"effective"`
+			} `json:"ddos,omitempty"`
+			Portscan *struct {
+				Effective string `json:"effective"`
+			} `json:"portscan,omitempty"`
+			LoginMon *struct {
+				Effective string `json:"effective"`
+			} `json:"loginmon,omitempty"`
 			Blacklist *struct {
-				Manual struct{ State string `json:"state"` } `json:"manual"`
-				Feeds  struct{ State string `json:"state"` } `json:"feeds"`
-				Geoban struct{ State string `json:"state"` } `json:"geoban"`
+				Manual struct {
+					State string `json:"state"`
+				} `json:"manual"`
+				Feeds struct {
+					State string `json:"state"`
+				} `json:"feeds"`
+				Geoban struct {
+					State string `json:"state"`
+				} `json:"geoban"`
 			} `json:"blacklist,omitempty"`
 		} `json:"modules"`
 		Findings []struct {

--- a/internal/metrics/rule_counters.go
+++ b/internal/metrics/rule_counters.go
@@ -22,11 +22,11 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/itcmsgr/nftban/internal/procenv"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -205,16 +205,16 @@ func parseNamedCountersJSONFiltered(data []byte, family string) (map[string]Coun
 // on fleet nftables versions (v1.0.2-v1.1.1). Global listing works everywhere.
 // Filtering by family and table happens in parseNamedCountersJSON().
 func nftListAllCountersJSON(ctx context.Context) ([]byte, error) {
-	return exec.CommandContext(ctx, "nft", "-j", "list", "counters").Output() // #nosec G204
+	return procenv.CommandContext(ctx, "nft", "-j", "list", "counters").Output() // #nosec G204
 }
 
 // nftListTable runs nft -j list table for a specific family.
 func nftListTable(family string) ([]byte, error) {
 	switch family {
 	case "ip":
-		return exec.Command("nft", "-j", "list", "table", "ip", "nftban").Output() // #nosec G204
+		return procenv.Command("nft", "-j", "list", "table", "ip", "nftban").Output() // #nosec G204
 	case "ip6":
-		return exec.Command("nft", "-j", "list", "table", "ip6", "nftban").Output() // #nosec G204
+		return procenv.Command("nft", "-j", "list", "table", "ip6", "nftban").Output() // #nosec G204
 	default:
 		return nil, nil
 	}

--- a/internal/metrics/sampler.go
+++ b/internal/metrics/sampler.go
@@ -30,13 +30,13 @@ import (
 	"bufio"
 	"log"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/itcmsgr/nftban/internal/nftbanconf"
+	"github.com/itcmsgr/nftban/internal/procenv"
 	"github.com/itcmsgr/nftban/internal/state"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -50,58 +50,58 @@ func getMetricsPaths() (configDir, dataDir string) {
 
 // Sample represents a single metrics snapshot
 type Sample struct {
-	Timestamp    time.Time              `json:"timestamp"`
-	Version      string                 `json:"version"`
-	BlockedIPs   int                    `json:"blocked_ips"`
-	RuleCount    int                    `json:"rule_count"`
-	HealthOK     bool                   `json:"health_ok"`
-	FeedsActive  int                    `json:"feeds_active"`
-	NetworkRxMbps float64               `json:"network_rx_mbps"`
-	NetworkTxMbps float64               `json:"network_tx_mbps"`
-	RawData      map[string]interface{} `json:"raw_data,omitempty"`
+	Timestamp     time.Time              `json:"timestamp"`
+	Version       string                 `json:"version"`
+	BlockedIPs    int                    `json:"blocked_ips"`
+	RuleCount     int                    `json:"rule_count"`
+	HealthOK      bool                   `json:"health_ok"`
+	FeedsActive   int                    `json:"feeds_active"`
+	NetworkRxMbps float64                `json:"network_rx_mbps"`
+	NetworkTxMbps float64                `json:"network_tx_mbps"`
+	RawData       map[string]interface{} `json:"raw_data,omitempty"`
 }
 
 // Sampler manages global metrics collection
 type Sampler struct {
-	mu              sync.RWMutex
-	running         bool
-	metricsEnabled  bool
-	activeSessions  int
-	period          time.Duration
-	maxSamples      int
-	samples         []Sample
-	lastSample      time.Time
-	stopChan        chan struct{}
-	ticker          *time.Ticker
+	mu             sync.RWMutex
+	running        bool
+	metricsEnabled bool
+	activeSessions int
+	period         time.Duration
+	maxSamples     int
+	samples        []Sample
+	lastSample     time.Time
+	stopChan       chan struct{}
+	ticker         *time.Ticker
 
 	// Prometheus metrics
-	registry          *prometheus.Registry
-	blockedIPsGauge   prometheus.Gauge
-	ruleCountGauge    prometheus.Gauge
-	healthGauge       prometheus.Gauge
-	feedsActiveGauge  prometheus.Gauge
+	registry           *prometheus.Registry
+	blockedIPsGauge    prometheus.Gauge
+	ruleCountGauge     prometheus.Gauge
+	healthGauge        prometheus.Gauge
+	feedsActiveGauge   prometheus.Gauge
 	feedsTotalIPsGauge prometheus.Gauge
-	sessionCountGauge prometheus.Gauge
-	uptimeGauge       prometheus.Gauge
-	networkRxGauge    prometheus.Gauge
-	networkTxGauge    prometheus.Gauge
+	sessionCountGauge  prometheus.Gauge
+	uptimeGauge        prometheus.Gauge
+	networkRxGauge     prometheus.Gauge
+	networkTxGauge     prometheus.Gauge
 
 	// Additional comprehensive metrics
 	// Removed: fail2ban gauges (v1.0 migration to Suricata)
-	geobanCountriesGauge    prometheus.Gauge
-	geobanRangesGauge       prometheus.Gauge
-	blacklistIPsGauge       prometheus.Gauge
-	whitelistIPsGauge       prometheus.Gauge
-	portscanBlocksGauge     prometheus.Gauge
-	ddosBlocksGauge         prometheus.Gauge
-	nftablesActiveGauge     prometheus.Gauge
+	geobanCountriesGauge prometheus.Gauge
+	geobanRangesGauge    prometheus.Gauge
+	blacklistIPsGauge    prometheus.Gauge
+	whitelistIPsGauge    prometheus.Gauge
+	portscanBlocksGauge  prometheus.Gauge
+	ddosBlocksGauge      prometheus.Gauge
+	nftablesActiveGauge  prometheus.Gauge
 	// Removed: fail2banActiveGauge (v1.0 migration to Suricata)
 
-	startTime        time.Time
+	startTime time.Time
 
 	// Network traffic tracking
-	lastRxBytes uint64
-	lastTxBytes uint64
+	lastRxBytes  uint64
+	lastTxBytes  uint64
 	lastNetCheck time.Time
 }
 
@@ -359,14 +359,14 @@ func (s *Sampler) GetStatus() map[string]interface{} {
 	defer s.mu.RUnlock()
 
 	return map[string]interface{}{
-		"running":          s.running,
-		"metrics_enabled":  s.metricsEnabled,
-		"active_sessions":  s.activeSessions,
-		"period_seconds":   s.period.Seconds(),
-		"samples_stored":   len(s.samples),
-		"max_samples":      s.maxSamples,
-		"last_sample":      s.lastSample,
-		"uptime_seconds":   time.Since(s.startTime).Seconds(),
+		"running":         s.running,
+		"metrics_enabled": s.metricsEnabled,
+		"active_sessions": s.activeSessions,
+		"period_seconds":  s.period.Seconds(),
+		"samples_stored":  len(s.samples),
+		"max_samples":     s.maxSamples,
+		"last_sample":     s.lastSample,
+		"uptime_seconds":  time.Since(s.startTime).Seconds(),
 	}
 }
 
@@ -508,8 +508,9 @@ func (s *Sampler) getNetworkStats() (rxMbps, txMbps float64) {
 
 // takeSample collects a single metrics snapshot
 // TWO-TIER COLLECTION:
-//   BASIC tier (always): reads from shared state (NO CLI calls)
-//   FULL tier (when metricsEnabled): adds geoban, portscan, ddos via file/CLI
+//
+//	BASIC tier (always): reads from shared state (NO CLI calls)
+//	FULL tier (when metricsEnabled): adds geoban, portscan, ddos via file/CLI
 func (s *Sampler) takeSample() {
 	start := time.Now()
 
@@ -676,7 +677,7 @@ func (s *Sampler) collectFeedStalenessMetrics() {
 
 // collectPortscanMetrics gets portscan blocks from stats
 func (s *Sampler) collectPortscanMetrics() int {
-	cmd := exec.Command("nftban", "portscan", "stats")
+	cmd := procenv.Command("nftban", "portscan", "stats")
 	output, err := cmd.Output()
 	if err != nil {
 		return 0
@@ -699,7 +700,7 @@ func (s *Sampler) collectPortscanMetrics() int {
 
 // collectDDoSMetrics gets DDoS protection blocks
 func (s *Sampler) collectDDoSMetrics() int {
-	cmd := exec.Command("nftban", "ddos", "stats")
+	cmd := procenv.Command("nftban", "ddos", "stats")
 	output, err := cmd.Output()
 	if err != nil {
 		return 0

--- a/internal/nftbackend/backend.go
+++ b/internal/nftbackend/backend.go
@@ -47,6 +47,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/itcmsgr/nftban/internal/netutil"
+	"github.com/itcmsgr/nftban/internal/procenv"
 	nftsync "github.com/itcmsgr/nftban/internal/setsync"
 )
 
@@ -837,9 +838,9 @@ func (b *Backend) ApplyRuleset(ctx context.Context, req ApplyRulesetRequest) err
 
 	var cmd *exec.Cmd
 	if req.Check {
-		cmd = exec.CommandContext(ctx, "nft", "-c", "-f", req.FilePath)
+		cmd = procenv.CommandContext(ctx, "nft", "-c", "-f", req.FilePath)
 	} else {
-		cmd = exec.CommandContext(ctx, "nft", "-f", req.FilePath)
+		cmd = procenv.CommandContext(ctx, "nft", "-f", req.FilePath)
 	}
 
 	output, err := cmd.CombinedOutput()
@@ -941,7 +942,7 @@ func (b *Backend) checkIPCLI(ctx context.Context, ip string, isIPv6 bool) (bool,
 		set = "blacklist_ipv4"
 	}
 
-	cmd := exec.CommandContext(ctx, "nft", "list", "set", table, set)
+	cmd := procenv.CommandContext(ctx, "nft", "list", "set", table, set)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, "", fmt.Errorf("nft list set failed: %w", err)
@@ -969,7 +970,7 @@ func (b *Backend) HealthCheck(ctx context.Context) error {
 	}
 
 	// Fall back to CLI
-	cmd := exec.CommandContext(ctx, "nft", "list", "tables")
+	cmd := procenv.CommandContext(ctx, "nft", "list", "tables")
 	_, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("nftables not operational: %w", err)

--- a/internal/nftbanconf/commands.go
+++ b/internal/nftbanconf/commands.go
@@ -30,8 +30,8 @@ package nftbanconf
 //
 // Usage:
 //   cmd := nftbanconf.Commands()
-//   exec.Command(cmd.Bin, "status")  // Uses NFTBAN_BIN from config
-//   exec.Command(cmd.CoreBin, "sync") // Uses NFTBAN_CORE_BIN from config
+//   procenv.Command(cmd.Bin, "status")  // Uses NFTBAN_BIN from config
+//   procenv.Command(cmd.CoreBin, "sync") // Uses NFTBAN_CORE_BIN from config
 // =============================================================================
 
 import (

--- a/internal/ports/panel_loader.go
+++ b/internal/ports/panel_loader.go
@@ -26,23 +26,23 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/itcmsgr/nftban/internal/procenv"
 	"github.com/itcmsgr/nftban/internal/safety"
 )
 
 // PanelConfig represents a control panel's port configuration
 type PanelConfig struct {
-	Name      string   // Panel name (directadmin, cpanel, plesk)
-	Enabled   bool     // Whether panel is enabled
-	ConfigFile string  // Path to panel config file
-	TCPIn     []int    // TCP input ports
-	TCPOut    []int    // TCP output ports (for OUTPUT chain)
-	UDPIn     []int    // UDP input ports
-	UDPOut    []int    // UDP output ports (for OUTPUT chain)
+	Name       string // Panel name (directadmin, cpanel, plesk)
+	Enabled    bool   // Whether panel is enabled
+	ConfigFile string // Path to panel config file
+	TCPIn      []int  // TCP input ports
+	TCPOut     []int  // TCP output ports (for OUTPUT chain)
+	UDPIn      []int  // UDP input ports
+	UDPOut     []int  // UDP output ports (for OUTPUT chain)
 }
 
 // PanelStateFile location
@@ -196,7 +196,7 @@ func LoadPanelConfig(configDir, panelName string) (*PanelConfig, error) {
 	for varName, portList := range varNames {
 		// VULN-20: quote path via $1 to prevent injection
 		bashCmd := fmt.Sprintf("source \"$1\" && echo \"${%s:-}\"", varName)
-		cmd := exec.Command("bash", "-c", bashCmd, "_", panelConfigPath)
+		cmd := procenv.Command("bash", "-c", bashCmd, "_", panelConfigPath)
 		output, err := cmd.Output()
 		if err != nil {
 			// Variable might not be defined - that's OK, skip it

--- a/internal/portscan/module.go
+++ b/internal/portscan/module.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -33,6 +32,7 @@ import (
 	"github.com/itcmsgr/nftban/internal/eventbus"
 	"github.com/itcmsgr/nftban/internal/module"
 	"github.com/itcmsgr/nftban/internal/nftbanconf"
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 const (
@@ -93,8 +93,8 @@ type Module struct {
 	scansDetected int64
 
 	// IP tracking for ban decisions
-	ipTrackers    map[string]*ipTracker
-	bannedIPs     map[string]time.Time // Track recently banned to avoid duplicates
+	ipTrackers map[string]*ipTracker
+	bannedIPs  map[string]time.Time // Track recently banned to avoid duplicates
 }
 
 // New creates a new portscan detection module
@@ -107,9 +107,9 @@ func New() *Module {
 		config: portscanConfig{
 			Enabled:      true,
 			Mode:         "auto",
-			BanThreshold: 3,                    // Default: 3 detections
-			BanDuration:  constants.PortscanBanDuration,  // Default: 30 min ban
-			TrackWindow:  constants.PortscanTrackWindow,  // Default: 5 min window
+			BanThreshold: 3,                             // Default: 3 detections
+			BanDuration:  constants.PortscanBanDuration, // Default: 30 min ban
+			TrackWindow:  constants.PortscanTrackWindow, // Default: 5 min window
 		},
 	}
 	// Load config from files (will override defaults)
@@ -325,7 +325,7 @@ func (m *Module) Status() module.Status {
 func (m *Module) detectMode() {
 	scriptPath := getPortscanScript()
 	// Source the script and get mode (VULN-20: quote path via $1)
-	out, err := exec.Command("bash", "-c",
+	out, err := procenv.Command("bash", "-c",
 		"source \"$1\" 2>/dev/null && nftban_portscan_load_config && _nftban_portscan_detect_mode", "_", scriptPath).Output()
 	if err != nil {
 		m.mode = "classic" // Default fallback
@@ -334,20 +334,20 @@ func (m *Module) detectMode() {
 	m.mode = strings.TrimSpace(string(out))
 
 	// Check Suricata availability
-	out, _ = exec.Command("bash", "-c",
+	out, _ = procenv.Command("bash", "-c",
 		"source \"$1\" 2>/dev/null && _nftban_portscan_suricata_is_available && echo yes || echo no", "_", scriptPath).Output()
 	m.suricataAvail = strings.TrimSpace(string(out)) == "yes"
 }
 
 // enable enables portscan detection
 func (m *Module) enable() error {
-	cmd := exec.Command("bash", "-c", "source \"$1\" && nftban_portscan_enable", "_", getPortscanScript())
+	cmd := procenv.Command("bash", "-c", "source \"$1\" && nftban_portscan_enable", "_", getPortscanScript())
 	return cmd.Run()
 }
 
 // disable disables portscan detection
 func (m *Module) disable() error {
-	cmd := exec.Command("bash", "-c", "source \"$1\" && nftban_portscan_disable", "_", getPortscanScript())
+	cmd := procenv.Command("bash", "-c", "source \"$1\" && nftban_portscan_disable", "_", getPortscanScript())
 	return cmd.Run()
 }
 
@@ -369,7 +369,7 @@ func (m *Module) runDetectionCycle(ctx context.Context) {
 // runCycle runs a single detection cycle
 func (m *Module) runCycle() {
 	// Run the bash detection script
-	cmd := exec.Command("bash", "-c", "source \"$1\" && nftban_portscan_run", "_", getPortscanScript())
+	cmd := procenv.Command("bash", "-c", "source \"$1\" && nftban_portscan_run", "_", getPortscanScript())
 	err := cmd.Run()
 
 	m.mu.Lock()
@@ -434,7 +434,7 @@ func (m *Module) handlePortscanEvent(e eventbus.Event) {
 	if shouldBan && m.bus != nil {
 		m.bus.Publish(eventbus.NewEvent(eventbus.EventBan, ModuleName).
 			WithIP(e.IP).
-			WithMessage("Banning " + e.IP + ": portscan threshold exceeded").
+			WithMessage("Banning "+e.IP+": portscan threshold exceeded").
 			WithSeverity(eventbus.SeverityCritical).
 			WithData("duration", banDuration.String()).
 			WithData("reason", "portscan_detection").

--- a/internal/procenv/procenv.go
+++ b/internal/procenv/procenv.go
@@ -94,7 +94,8 @@ func StripSystemdVars(env []string) []string {
 // dangerous-exec-command finding on the pass-through below is a wrapper false
 // positive (gosec G204 does not flag it); suppressed with justification.
 func Command(name string, arg ...string) *exec.Cmd {
-	c := exec.Command(name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	c := exec.Command(name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface
 	c.Env = SanitizedSystemdEnv()
 	return c
 }
@@ -102,7 +103,8 @@ func Command(name string, arg ...string) *exec.Cmd {
 // CommandContext is the context-aware counterpart of Command. Same security
 // boundary as Command: input-safety lives at the call sites.
 func CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
-	c := exec.CommandContext(ctx, name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	c := exec.CommandContext(ctx, name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface
 	c.Env = SanitizedSystemdEnv()
 	return c
 }

--- a/internal/procenv/procenv.go
+++ b/internal/procenv/procenv.go
@@ -84,15 +84,25 @@ func StripSystemdVars(env []string) []string {
 // variables stripped). Use it for daemon-spawned helpers that do not participate
 // in the systemd notification contract, so they cannot emit notifications on the
 // daemon's behalf. Everything else in the environment is preserved.
+//
+// Security boundary: this is a thin, general-purpose wrapper — it introduces no
+// command/argument itself and adds no injection surface beyond stdlib exec.Command.
+// The command name and args come entirely from the caller; every caller in this
+// repo passes a static/validated command (the callers previously carried the
+// per-site `#nosec G204 -- trusted constants` annotations). Input-safety therefore
+// lives at the call sites, identical to using exec.Command directly. The Semgrep
+// dangerous-exec-command finding on the pass-through below is a wrapper false
+// positive (gosec G204 does not flag it); suppressed with justification.
 func Command(name string, arg ...string) *exec.Cmd {
-	c := exec.Command(name, arg...)
+	c := exec.Command(name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 	c.Env = SanitizedSystemdEnv()
 	return c
 }
 
-// CommandContext is the context-aware counterpart of Command.
+// CommandContext is the context-aware counterpart of Command. Same security
+// boundary as Command: input-safety lives at the call sites.
 func CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
-	c := exec.CommandContext(ctx, name, arg...)
+	c := exec.CommandContext(ctx, name, arg...) // #nosec G204 -- trusted caller-supplied command; wrapper adds no injection surface // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 	c.Env = SanitizedSystemdEnv()
 	return c
 }

--- a/internal/procenv/procenv.go
+++ b/internal/procenv/procenv.go
@@ -1,0 +1,112 @@
+// =============================================================================
+// NFTBan - procenv - child process environment sanitization
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="procenv"
+// meta:type="internal"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Sanitized environment for spawned child processes: strips systemd sd_notify/watchdog variables from children that do not participate in the daemon's systemd notification contract"
+//
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NOTIFY_SOCKET, WATCHDOG_USEC, WATCHDOG_PID"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units="nftband.service"
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// Under systemd Type=notify, the daemon inherits NOTIFY_SOCKET (and WATCHDOG_USEC/
+// WATCHDOG_PID). Go's exec.Command inherits the FULL parent environment by default
+// (cmd.Env == nil), so every helper the daemon spawns also inherits these. Only the
+// main daemon process legitimately participates in the notification contract
+// (NotifyAccess=main), so a child that touches the inherited NOTIFY_SOCKET produces
+// spurious "notification from PID … reception only permitted for main PID" warnings.
+//
+// SanitizedSystemdEnv returns the parent environment with exactly those three
+// variables removed, so spawned helpers cannot emit notifications on the daemon's
+// behalf. It is deliberately narrow: everything else is preserved, and it never
+// unsets the variables in the daemon's own process (the main process still needs
+// them for READY=1 and the watchdog heartbeat).
+// =============================================================================
+
+package procenv
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// systemdNotifyVars are the environment variables that only the main daemon
+// process should carry. Children that are not systemd-notify-aware must not
+// inherit them.
+var systemdNotifyVars = []string{
+	"NOTIFY_SOCKET",
+	"WATCHDOG_USEC",
+	"WATCHDOG_PID",
+}
+
+// SanitizedSystemdEnv returns a copy of the current process environment with the
+// systemd notification variables removed. Assign the result to exec.Cmd.Env for
+// child processes that do not participate in the daemon's systemd notification
+// contract. The returned slice is safe to mutate by the caller.
+func SanitizedSystemdEnv() []string {
+	return StripSystemdVars(os.Environ())
+}
+
+// StripSystemdVars returns a NEW slice: a copy of env with exactly the three
+// systemd notification variables removed. Exposed separately so it can be
+// unit-tested without touching the real process environment.
+//
+// Contract:
+//   - the input slice is never mutated (a fresh slice is returned);
+//   - only exact-name matches of NOTIFY_SOCKET / WATCHDOG_USEC / WATCHDOG_PID are
+//     removed — a variable that merely contains the substring is preserved;
+//   - EVERY occurrence of a blocked key is removed (duplicate keys handled);
+//   - every other entry passes through verbatim and in order, including any
+//     malformed entry that lacks '=' (we do not editorialize non-target entries;
+//     os.Environ never produces such entries, so this is a defensive guarantee).
+func StripSystemdVars(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if isSystemdNotifyVar(kv) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// Command wraps exec.Command and pre-sets a sanitized environment (systemd notify
+// variables stripped). Use it for daemon-spawned helpers that do not participate
+// in the systemd notification contract, so they cannot emit notifications on the
+// daemon's behalf. Everything else in the environment is preserved.
+func Command(name string, arg ...string) *exec.Cmd {
+	c := exec.Command(name, arg...)
+	c.Env = SanitizedSystemdEnv()
+	return c
+}
+
+// CommandContext is the context-aware counterpart of Command.
+func CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	c := exec.CommandContext(ctx, name, arg...)
+	c.Env = SanitizedSystemdEnv()
+	return c
+}
+
+func isSystemdNotifyVar(kv string) bool {
+	eq := strings.IndexByte(kv, '=')
+	if eq < 0 {
+		return false
+	}
+	name := kv[:eq]
+	for _, v := range systemdNotifyVars {
+		if name == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/procenv/procenv_test.go
+++ b/internal/procenv/procenv_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="procenv_test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="Tests that child-process environment sanitization strips systemd sd_notify/watchdog variables while preserving everything else."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NOTIFY_SOCKET, WATCHDOG_USEC, WATCHDOG_PID"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+
+package procenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// CHILD_ENV_STRIPS_SYSTEMD_NOTIFY_VARIABLES
+func TestStripSystemdVars(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"NOTIFY_SOCKET=/run/systemd/notify",
+		"HOME=/root",
+		"WATCHDOG_USEC=120000000",
+		"WATCHDOG_PID=1234",
+		"NFTBAN_CONFIG_DIR=/etc/nftban",
+	}
+	out := StripSystemdVars(in)
+
+	joined := strings.Join(out, "\n")
+	for _, banned := range []string{"NOTIFY_SOCKET=", "WATCHDOG_USEC=", "WATCHDOG_PID="} {
+		if strings.Contains(joined, banned) {
+			t.Fatalf("sanitized env still contains %s:\n%s", banned, joined)
+		}
+	}
+	// Everything else must be preserved, in order.
+	for _, keep := range []string{"PATH=/usr/bin", "HOME=/root", "NFTBAN_CONFIG_DIR=/etc/nftban"} {
+		if !strings.Contains(joined, keep) {
+			t.Fatalf("sanitized env dropped a non-systemd var %q:\n%s", keep, joined)
+		}
+	}
+	if len(out) != 3 {
+		t.Fatalf("expected 3 vars after stripping 3 of 6, got %d: %v", len(out), out)
+	}
+}
+
+// A variable that merely CONTAINS the substring but is a different name must be kept
+// (exact-name match only).
+func TestStripSystemdVars_ExactNameOnly(t *testing.T) {
+	in := []string{
+		"MY_NOTIFY_SOCKET=x",     // different name
+		"NOTIFY_SOCKET_BACKUP=y", // different name
+		"NOTIFY_SOCKET=z",        // exact — stripped
+	}
+	out := StripSystemdVars(in)
+	if len(out) != 2 {
+		t.Fatalf("exact-name match failed, got %v", out)
+	}
+	joined := strings.Join(out, "\n")
+	if strings.Contains(joined, "NOTIFY_SOCKET=z") {
+		t.Fatalf("exact NOTIFY_SOCKET not stripped: %s", joined)
+	}
+	if !strings.Contains(joined, "MY_NOTIFY_SOCKET=x") || !strings.Contains(joined, "NOTIFY_SOCKET_BACKUP=y") {
+		t.Fatalf("similarly-named vars wrongly stripped: %s", joined)
+	}
+}
+
+// Explicit coverage of the stated policy invariants:
+// INPUT_ENV_NOT_MUTATED / *_REMOVED / UNRELATED_ENV_PRESERVED /
+// DUPLICATE_KEYS_HANDLED / MALFORMED_ENTRIES_HANDLED_SAFELY.
+func TestStripSystemdVars_Invariants(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"NOTIFY_SOCKET=/run/systemd/notify",
+		"NOTIFY_SOCKET=/run/dup", // duplicate blocked key — both must go
+		"WATCHDOG_USEC=120000000",
+		"WATCHDOG_PID=1234",
+		"DUP=1", // duplicate normal key — both must stay
+		"DUP=2",
+		"MALFORMED_NO_EQUALS", // no '=' — preserved verbatim
+		"EMPTYVAL=",           // valid, empty value — preserved
+	}
+	// Snapshot the input to assert it is not mutated.
+	orig := append([]string(nil), in...)
+
+	out := StripSystemdVars(in)
+
+	// INPUT_ENV_NOT_MUTATED
+	for i := range orig {
+		if in[i] != orig[i] {
+			t.Fatalf("input env was mutated at %d: %q != %q", i, in[i], orig[i])
+		}
+	}
+	joined := strings.Join(out, "\n")
+
+	// *_REMOVED (all occurrences)
+	if strings.Contains(joined, "NOTIFY_SOCKET=") ||
+		strings.Contains(joined, "WATCHDOG_USEC=") ||
+		strings.Contains(joined, "WATCHDOG_PID=") {
+		t.Fatalf("a blocked systemd var survived:\n%s", joined)
+	}
+
+	// DUPLICATE_KEYS_HANDLED: both DUP kept, both NOTIFY_SOCKET gone
+	dupCount := 0
+	for _, e := range out {
+		if strings.HasPrefix(e, "DUP=") {
+			dupCount++
+		}
+	}
+	if dupCount != 2 {
+		t.Fatalf("duplicate normal key not preserved (got %d DUP entries)", dupCount)
+	}
+
+	// UNRELATED_ENV_PRESERVED + MALFORMED_ENTRIES + empty value
+	for _, keep := range []string{"PATH=/usr/bin", "MALFORMED_NO_EQUALS", "EMPTYVAL="} {
+		if !strings.Contains(joined, keep) {
+			t.Fatalf("expected %q preserved:\n%s", keep, joined)
+		}
+	}
+
+	// 5 blocked-removed → 9 in, 4 blocked → 5 out? blocked = 2 NOTIFY + 1 USEC + 1 PID = 4.
+	if len(out) != len(in)-4 {
+		t.Fatalf("expected %d entries after removing 4 blocked, got %d", len(in)-4, len(out))
+	}
+}
+
+// An empty environment must not panic and must return an empty (usable) slice.
+func TestStripSystemdVars_Empty(t *testing.T) {
+	out := StripSystemdVars(nil)
+	if len(out) != 0 {
+		t.Fatalf("empty input should yield empty output, got %v", out)
+	}
+}
+
+// Command / CommandContext must pre-set a sanitized environment.
+func TestCommand_SetsSanitizedEnv(t *testing.T) {
+	t.Setenv("NOTIFY_SOCKET", "/run/systemd/notify")
+	t.Setenv("NFTBAN_KEEPME", "yes")
+
+	c := Command("true")
+	if c.Env == nil {
+		t.Fatalf("Command did not set a sanitized Env")
+	}
+	joined := strings.Join(c.Env, "\n")
+	if strings.Contains(joined, "NOTIFY_SOCKET=") {
+		t.Fatalf("Command Env still carries NOTIFY_SOCKET:\n%s", joined)
+	}
+	if !strings.Contains(joined, "NFTBAN_KEEPME=yes") {
+		t.Fatalf("Command Env dropped a normal var:\n%s", joined)
+	}
+}

--- a/internal/rulefp/baseline.go
+++ b/internal/rulefp/baseline.go
@@ -27,9 +27,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // VerifyStatus is the outcome of a verify-rules check.
@@ -139,14 +140,14 @@ func LiveRuleset(ctx context.Context) (string, error) {
 	var firstErr error
 	got := false
 
-	if out, err := exec.CommandContext(ctx, "nft", "list", "table", "ip", "nftban").Output(); err == nil {
+	if out, err := procenv.CommandContext(ctx, "nft", "list", "table", "ip", "nftban").Output(); err == nil {
 		combined += "# family ip\n" + string(out) + "\n"
 		got = true
 	} else {
 		firstErr = err
 	}
 
-	if out, err := exec.CommandContext(ctx, "nft", "list", "table", "ip6", "nftban").Output(); err == nil {
+	if out, err := procenv.CommandContext(ctx, "nft", "list", "table", "ip6", "nftban").Output(); err == nil {
 		combined += "# family ip6\n" + string(out) + "\n"
 		got = true
 	} else if firstErr == nil {

--- a/internal/safety/detect.go
+++ b/internal/safety/detect.go
@@ -26,17 +26,18 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strings"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // SystemIPs holds all critical IPs that must NEVER be blocked
 type SystemIPs struct {
-	ServerIPs     []net.IP     // All server interface IPs
-	CurrentUserIP net.IP       // IP of current SSH connection
-	GatewayIPs    []net.IP     // Default gateway
-	DNSServers    []net.IP     // DNS servers from /etc/resolv.conf
-	LoopbackCIDRs []net.IPNet  // 127.0.0.0/8, ::1/128
+	ServerIPs     []net.IP    // All server interface IPs
+	CurrentUserIP net.IP      // IP of current SSH connection
+	GatewayIPs    []net.IP    // Default gateway
+	DNSServers    []net.IP    // DNS servers from /etc/resolv.conf
+	LoopbackCIDRs []net.IPNet // 127.0.0.0/8, ::1/128
 }
 
 // DetectSystemIPs auto-detects all critical IPs that must be whitelisted
@@ -77,8 +78,8 @@ func DetectSystemIPs() (*SystemIPs, error) {
 
 	// 5. Add loopback ranges (always whitelist!)
 	sys.LoopbackCIDRs = []net.IPNet{
-		{IP: net.IPv4(127, 0, 0, 0), Mask: net.CIDRMask(8, 32)},  // 127.0.0.0/8
-		{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},   // ::1/128
+		{IP: net.IPv4(127, 0, 0, 0), Mask: net.CIDRMask(8, 32)}, // 127.0.0.0/8
+		{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},  // ::1/128
 	}
 
 	return sys, nil
@@ -156,7 +157,7 @@ func detectCurrentUserIP() (net.IP, error) {
 	}
 
 	// Method 3: Parse output of 'who' command
-	cmd := exec.Command("who", "-u")
+	cmd := procenv.Command("who", "-u")
 	output, err := cmd.Output()
 	if err == nil {
 		lines := strings.Split(string(output), "\n")
@@ -177,7 +178,7 @@ func detectCurrentUserIP() (net.IP, error) {
 	}
 
 	// Method 4: Parse output of 'w' command
-	cmd = exec.Command("w", "-h")
+	cmd = procenv.Command("w", "-h")
 	output, err = cmd.Output()
 	if err == nil {
 		lines := strings.Split(string(output), "\n")
@@ -202,7 +203,7 @@ func detectGatewayIPs() ([]net.IP, error) {
 	var ips []net.IP
 
 	// Method 1: Parse 'ip route' output
-	cmd := exec.Command("ip", "route", "show", "default")
+	cmd := procenv.Command("ip", "route", "show", "default")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/setsync/nft_cli.go
+++ b/internal/setsync/nft_cli.go
@@ -27,9 +27,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // =============================================================================
@@ -74,7 +75,7 @@ func runNftWithTimeout(timeout time.Duration, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "nft", args...)
+	cmd := procenv.CommandContext(ctx, "nft", args...)
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/internal/validator/journal.go
+++ b/internal/validator/journal.go
@@ -46,6 +46,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // JournalQuery defines a bounded journal search.
@@ -132,7 +134,7 @@ func (SystemdJournalReader) Query(ctx context.Context, q JournalQuery) JournalEv
 
 	// Fixed binary "journalctl"; buildJournalArgs returns bounded internal constants,
 	// each pattern regexp.QuoteMeta-escaped, passed as argv (no shell, no tainted input).
-	cmd := exec.CommandContext(ctx, "journalctl", buildJournalArgs(q)...) // #nosec G204 -- args are bounded internal constants, escaped, argv-only (no shell)
+	cmd := procenv.CommandContext(ctx, "journalctl", buildJournalArgs(q)...) // #nosec G204 -- args are bounded internal constants, escaped, argv-only (no shell)
 
 	out, err := cmd.Output()
 	return parseJournalResult(q, out, err, ctx.Err())

--- a/internal/validator/module_health.go
+++ b/internal/validator/module_health.go
@@ -25,10 +25,11 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // ConfigDir is the base config directory. Overridable for testing.
@@ -789,7 +790,7 @@ func countSetElements(family, setName string) int {
 // manual blacklist). The cost is one nft command per set query.
 func countSetElementsReal(family, setName string) int {
 	table := "nftban"
-	out, err := exec.Command("nft", "-j", "list", "set", family, table, setName).Output()
+	out, err := procenv.Command("nft", "-j", "list", "set", family, table, setName).Output()
 	if err != nil {
 		return 0
 	}
@@ -839,7 +840,7 @@ func countSetElementsState(family, setName string) (count int, exists bool, unkn
 
 func countSetElementsStateReal(family, setName string) (count int, exists bool, unknown bool) {
 	table := "nftban"
-	out, err := exec.Command("nft", "-j", "list", "set", family, table, setName).Output()
+	out, err := procenv.Command("nft", "-j", "list", "set", family, table, setName).Output()
 	if err != nil {
 		// Command failure: could be a missing set, but also a timeout/permission/
 		// exec error. Mark unknown so callers never treat failure as confirmed empty.

--- a/internal/validator/nftjson.go
+++ b/internal/validator/nftjson.go
@@ -24,6 +24,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // NftRuleset represents the top-level nft -j list ruleset output.
@@ -45,9 +47,9 @@ type NftObject struct {
 
 // NftMetainfo holds nft version info.
 type NftMetainfo struct {
-	Version    string `json:"version"`
-	ReleaseName string `json:"release_name"`
-	JsonSchemaVersion int `json:"json_schema_version"`
+	Version           string `json:"version"`
+	ReleaseName       string `json:"release_name"`
+	JsonSchemaVersion int    `json:"json_schema_version"`
 }
 
 // NftTable represents an nftables table.
@@ -132,7 +134,7 @@ func LoadRulesetJSON(ctx context.Context) (*NftRuleset, error) {
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(ctx, "nft", "-j", "list", "ruleset")
+	cmd := procenv.CommandContext(ctx, "nft", "-j", "list", "ruleset")
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -22,9 +22,10 @@ package validator
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
 )
 
 // ServiceChecker abstracts service-state queries so unit tests can mock
@@ -43,7 +44,7 @@ type SystemdChecker struct{}
 // CheckUnit queries systemd for the unit's active state.
 // This is a read-only query — zero side effects.
 func (SystemdChecker) CheckUnit(unit string) (RuntimeState, string) {
-	out, err := exec.Command("systemctl", "is-active", unit).Output()
+	out, err := procenv.Command("systemctl", "is-active", unit).Output()
 	detail := strings.TrimSpace(string(out))
 	if err != nil {
 		if detail == "" {
@@ -88,7 +89,7 @@ type SystemdTimerChecker struct{}
 // CountActiveTimers queries systemd for active nftban-* timers.
 // Read-only — zero side effects.
 func (SystemdTimerChecker) CountActiveTimers() (int, error) {
-	out, err := exec.Command("systemctl", "list-timers", "nftban-*", "--no-legend").Output()
+	out, err := procenv.Command("systemctl", "list-timers", "nftban-*", "--no-legend").Output()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Daemon startup lifecycle observability + daemon-wide child systemd-notify isolation

### Operational defect this fixes
`nftband` could remain in systemd **`activating`** with a **live process, a bound socket, and partial worker activity**, while exposing **no authoritative blocked startup phase and no readiness truth**. A stuck start took ~1h to classify (Type=notify never reached READY, IPC unresponsive, near-empty logs). This lane makes startup and readiness diagnosable from logs and status output — no stack inspection, binary archaeology, or manual tracing.

### Corrected readiness contract
```
Direct execution (terminal):
  NOTIFY_SOCKET absent
  READY not delivered
  daemon may run   (non-fatal)

Systemd Type=notify execution:
  NOTIFY_SOCKET present
  READY must be confirmed delivered
  delivery failure is FATAL   (Run returns error → start-failure, never a silent activating-hang)
```
`READY=1` is: **attempted once** (`sync.Once`); **delivered by the main PID** only; **sent only after mandatory prerequisites**; and reflected as **`ready_sent=true` only after confirmed delivery**. `notify_expected` is snapshotted from `NOTIFY_SOCKET` at construction (before any child sanitization).

### What's included
- **One canonical, mutex-guarded lifecycle state** owned by the daemon; rendered by journal, `sd_notify STATUS=`, and status IPC (no competing authorities).
- **14 phases** — `PROCESS_START, RUNTIME_PATHS_INIT, NFT_MANAGER_INIT, OPQUEUE_INIT, CONFIG_LOAD, MODULES_INIT, IPC_SOCKET_INIT, HTTP_INIT, WORKERS_START, READINESS_PRECONDITIONS, SYSTEMD_NOTIFY_READY, RUNNING, SHUTDOWN_BEGIN, SHUTDOWN_COMPLETE` — mapped to real code boundaries; **startup order unchanged**.
- **Structured phase logs**: `event=startup_phase phase=… state=begin|complete|failed|degraded pid=… component=… elapsed_ms=… total_elapsed_ms=… error=…` (errors sanitized: single-line, bounded, no secrets/config/env).
- **`sd_notify STATUS=`** per phase; steady-state stays `"NFTBan ready"`.
- **Bounded startup-pending diagnostic**: one `event=startup_pending` naming the blocked/last-completed phase before the systemd start deadline (60s default = 2/3 × systemd default 90s; `NFTBAN_STARTUP_PENDING_SEC` override, invalid/zero/negative → safe default). Cancelled on ready/failure/shutdown.
- **Explicit readiness prerequisites** — mandatory: `runtime_paths_ready, modules_initialized, ipc_bound, ipc_accepting, http_ready, required_modules_started` (unmet ⇒ fatal, no READY). Degradable: `nft, opqueue, watchdog` (surfaced as `degraded_components`, **never** reported as ready-and-healthy).
- **systemd-vs-direct-run notification semantics** (above).
- **Additive lifecycle status IPC** — new `lifecycle` object; **all pre-existing status fields unchanged**; nil-safe.
- **IPC bound-vs-accepting distinction** — a bound socket is not readiness; `ipc_accepting` is set only when the accept loop reaches its serving state (bounded ack, no unbounded wait). Socket order intentionally unchanged — the distinction is *exposed*, not relocated.
- **Daemon-wide child environment sanitization** via new `internal/procenv`.
- **Tests and guards** for all of the above.

### procenv coverage (child systemd-notify isolation)
```
TOTAL_PROCESS_SPAWN_SITES=57
DAEMON_REACHABLE_SITES=49
DAEMON_SITES_SANITIZED=49/49
NON_DAEMON_RAW_SITES=8   (cmd/nftban-core, installer, smoke, suricata, configloader — no NOTIFY_SOCKET to inherit)
SYSTEMD_AWARE_CHILD_EXCEPTIONS=0
```
Daemon-launched children lose **only** `NOTIFY_SOCKET`, `WATCHDOG_USEC`, `WATCHDOG_PID`; every other variable is preserved. The **main daemon retains them** (needed for READY/WATCHDOG/STOPPING/STATUS). Never `os.Unsetenv` globally. No spawn site sets a custom `cmd.Env`, so the shared-helper swap is behavior-preserving; stripping absent vars in non-daemon contexts is a no-op.

### Lab evidence (package-native)
```
LAB2_DEB=PASS                         LAB4_RPM_EL9=PASS
SOURCE_PACKAGE_INSTALLED_SHA_CHAIN=PASS (lab2 b9669721; lab4 7c647b50; SOURCE==PACKAGED==INSTALLED)
PHASE_ORDER=PASS                      READY_COUNT=1
READY_SENDER_IS_MAIN_PID=YES          STATUS_TEXT="NFTBan ready"
STATUS_IPC_LIFECYCLE=PASS             BLOCKED_PHASE_PENDING_EVENT=PASS   PENDING_EVENT_COUNT=1
SYSTEMD_NOTIFY_FAILURE_FATAL=PASS     DIRECT_RUN_WITHOUT_NOTIFY=PASS
CHILD_NOTIFY_ENV_SANITIZATION=PASS    NON_MAIN_NOTIFY_WARNINGS=0
SOCKET_ACTIVATION (lab4)=PASS         IPC_ACCEPTING_BEFORE_READY_OBSERVED_AND_REPORTED=YES
LABS_RESTORED_OFFICIAL=YES (bc9650be) PRODUCTION_MUTATION=NONE
```
- Blocked-phase (bounded test-only injection): `activating` @4s → `active` @12s (controlled continuation); pending fired once — `current_phase=MODULES_INIT`, `last_completed_phase=CONFIG_LOAD`, `ipc_bound=false`, `ready_sent=false`.
- Notify-failure (safe seam, real `NOTIFY_SOCKET` untouched): `Result=exit-code`, RUNNING not reached, `READY_sent=0` — fatal, not a hang.
- Direct-run (no `NOTIFY_SOCKET`): reaches RUNNING, `ready_sent=false`, graceful SIGTERM exit.
- Child env: loginmon `journalctl` + 4× `tail -F` children `notify_vars=0` via `/proc/<pid>/environ`; main retains `NOTIFY_SOCKET`.

### Lab-found regression (disclosed + fixed)
Entering the `RUNNING` phase initially emitted a `STATUS=NFTBan startup: RUNNING`, **overwriting `"NFTBan ready"`**. Corrected so `RUNNING`/shutdown phases do not emit a `startup:` STATUS; the steady-state systemd status remains `"NFTBan ready"`. **Regression test added.**

### Test-only seams (bounded, off by default, verified absent from production unit/package)
`NFTBAN_STARTUP_PENDING_SEC` (tuning), `NFTBAN_DEBUG_BLOCK_PHASE`/`NFTBAN_DEBUG_BLOCK_MS` (capped 30s startup blocker), `NFTBAN_DEBUG_FAIL_READY` (forces the systemd-mode fatal path without touching `/run/systemd/notify`).

### Verification (isolated branch)
```
GO_TESTS=84/84   GO_VET=PASS   STATICCHECK=PASS   RACE_TESTS=PASS   GOFMT=PASS (changed files)
STARTUP_ORDER_CHANGED=NO   READY_NOTIFY_SEND_SITES=1   RAW_DAEMON_REACHABLE_EXEC_COMMANDS=0
PROCENV_DAEMON_COVERAGE=49/49   SCHEMA_CHANGE=NO   VERSION_CHANGE=NO   UNRELATED_CHANGES=0
DAEMON_REBASELINE_DECLARED=YES (Go daemon changed → byte-identity gone)
FILES_CHANGED=32
```

### Explicitly out of scope
No version bump to 1.221.0; no release prep; no reproducible-build/`BUILD_DATE` change (split to `OPEN_REPRODUCIBLE_BUILD_DATE_AND_SOURCE_EPOCH`); no startup reordering; no socket-behavior redesign; no vendoring/offline-kit; no nftables schema change; no unrelated module behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
