### PR TITLE
fix(botscan): validate HTTP log-source class + content, not just readability (R22A)

### DIFF
--- a/cli/lib/nftban/cli/cmd_botscan.sh
+++ b/cli/lib/nftban/cli/cmd_botscan.sh
@@ -786,10 +786,30 @@ _nftban_botscan_cmd_logs() {
             echo "  Verdict: UNKNOWN — cannot test readability as service account '${svc}' from this context."
             echo "    Re-run as root (so it can drop to '${svc}' via runuser) for an authoritative result."
             return 0 ;;
-        *)
-            echo "  Verdict: OK — ${_NFTBAN_HTTP_READ_COUNT_READABLE} of ${n} access log(s) readable by service account '${svc}'; BotScan will scan them."
-            [[ ${_NFTBAN_HTTP_READ_COUNT_UNREADABLE} -gt 0 ]] && echo "  Note: ${_NFTBAN_HTTP_READ_COUNT_UNREADABLE} discovered log(s) are NOT readable by '${svc}' and will be skipped."
+        INVALID_SOURCE)
+            echo "  Verdict: INVALID-SOURCE — ${n} file(s) matched but NONE are valid HTTP access logs."
+            echo "  They are readable by '${svc}' but their content is not HTTP access-log data (e.g. FTP"
+            echo "  transfer logs, bandwidth offset/byte-count state files, or other non-HTTP files)."
+            echo "  BotScan is NOT effectively scanning web traffic on this host."
+            if [[ ${#_NFTBAN_HTTP_LAST_INVALID[@]} -gt 0 ]]; then
+                echo "  Bound but not access logs:"; printf '    %s\n' "${_NFTBAN_HTTP_LAST_INVALID[@]}"
+            fi
+            echo "  Remediation: set BOTSCAN_LOG_PATHS to your real access-log glob(s) in"
+            echo "    /etc/nftban/conf.d/botscan/main.conf, then re-run."
+            return 2 ;;
+        NEVER_OBSERVED)
+            echo "  Verdict: NEVER-OBSERVED — ${_NFTBAN_HTTP_COUNT_NEVER} valid access log(s) are bound and readable by"
+            echo "  '${svc}', but empty (no HTTP request logged yet). The source is correct; there is simply"
+            echo "  no traffic to scan yet. This is NOT a failure and NOT degraded."
             return 0 ;;
+        OK)
+            echo "  Verdict: OK — ${_NFTBAN_HTTP_COUNT_VALID} valid access log(s) readable by service account '${svc}'; BotScan will scan them."
+            [[ ${_NFTBAN_HTTP_READ_COUNT_UNREADABLE} -gt 0 ]] && echo "  Note: ${_NFTBAN_HTTP_READ_COUNT_UNREADABLE} discovered log(s) are NOT readable by '${svc}' and will be skipped."
+            [[ ${_NFTBAN_HTTP_COUNT_INVALID} -gt 0 ]] && echo "  Note: ${_NFTBAN_HTTP_COUNT_INVALID} matched file(s) are not HTTP access logs and were ignored."
+            return 0 ;;
+        *)
+            echo "  Verdict: ${verdict} — unrecognized source-health state; treating as NOT healthy (fail-safe)."
+            return 2 ;;
     esac
 }
 

--- a/cli/lib/nftban/core/nftban_botscan.sh
+++ b/cli/lib/nftban/core/nftban_botscan.sh
@@ -1699,11 +1699,17 @@ nftban_botscan_status() {
         if [[ "$_spool_fed" -eq 1 && ( "$verdict" == "DEGRADED" || "$verdict" == "UNKNOWN" ) ]]; then
             echo "Readability:    OK via collector spool (direct source ${verdict} for ${svc}; collector feeding ${_spool})"
         else
-            echo "Readability:    ${verdict} (${_NFTBAN_HTTP_READ_COUNT_READABLE}/${_NFTBAN_HTTP_READ_COUNT_TOTAL} readable by ${svc})"
-            if [[ "$verdict" == "DEGRADED" ]]; then
-                echo "                BOTSCAN_READ_AUTHORITY open: access logs discovered but unreadable by the"
-                echo "                service account — install/enable nftban-botscan-collector.service (read-authority)."
-            fi
+            echo "Log source:     ${verdict} (valid:${_NFTBAN_HTTP_COUNT_VALID} never-observed:${_NFTBAN_HTTP_COUNT_NEVER} invalid:${_NFTBAN_HTTP_COUNT_INVALID} unreadable:${_NFTBAN_HTTP_READ_COUNT_UNREADABLE} of ${_NFTBAN_HTTP_READ_COUNT_TOTAL} as ${svc})"
+            case "$verdict" in
+                DEGRADED)
+                    echo "                BOTSCAN_READ_AUTHORITY open: access logs discovered but unreadable by the"
+                    echo "                service account — install/enable nftban-botscan-collector.service (read-authority)." ;;
+                INVALID_SOURCE)
+                    echo "                Bound file(s) are NOT HTTP access logs (FTP/offset/byte-count/state files) —"
+                    echo "                BotScan is not scanning web traffic. Set BOTSCAN_LOG_PATHS to the real access-log glob(s)." ;;
+                NEVER_OBSERVED)
+                    echo "                Valid access log(s) bound but empty — no HTTP request logged yet (not a failure, not degraded)." ;;
+            esac
         fi
     fi
 

--- a/cli/lib/nftban/lib/nftban_http_logs.sh
+++ b/cli/lib/nftban/lib/nftban_http_logs.sh
@@ -38,15 +38,19 @@ _NFTBAN_HTTP_LAST_SKIPPED=()   # "path: reason"
 # Last-classification diagnostics (populated by nftban_http_classify_candidates).
 # These describe SERVICE-ACCOUNT readability, used by the diagnostic/health surfaces
 # only — NOT the hot scan path.
-_NFTBAN_HTTP_LAST_CANDIDATES=()      # existing, non-excluded candidate access logs (pre-readability)
+_NFTBAN_HTTP_LAST_CANDIDATES=()      # existing, class-valid candidate access logs (pre-readability)
 _NFTBAN_HTTP_LAST_UNREADABLE=()      # candidates the service account cannot read
-_NFTBAN_HTTP_READ_VERDICT=""         # OK | DEGRADED | WARN_NO_LOGS | NO_LOGS | UNKNOWN
+_NFTBAN_HTTP_LAST_INVALID=()         # readable candidates whose CONTENT is not an HTTP access log
+_NFTBAN_HTTP_READ_VERDICT=""         # OK | NEVER_OBSERVED | INVALID_SOURCE | DEGRADED | UNKNOWN | WARN_NO_LOGS | NO_LOGS
 _NFTBAN_HTTP_READ_PERSPECTIVE=""     # how readability was evaluated (honest reporting)
 _NFTBAN_HTTP_READ_STACK=""           # detected web stack at classification time
 _NFTBAN_HTTP_READ_COUNT_TOTAL=0
 _NFTBAN_HTTP_READ_COUNT_READABLE=0
 _NFTBAN_HTTP_READ_COUNT_UNREADABLE=0
 _NFTBAN_HTTP_READ_COUNT_UNKNOWN=0
+_NFTBAN_HTTP_COUNT_VALID=0           # readable + content is a valid HTTP access log (active/quiet)
+_NFTBAN_HTTP_COUNT_NEVER=0           # readable + class-valid + empty (NEVER_OBSERVED)
+_NFTBAN_HTTP_COUNT_INVALID=0         # readable + non-empty + not an HTTP access log (SOURCE_INVALID)
 
 # --- panel / stack detection -------------------------------------------------
 nftban_http_detect_panel() {
@@ -84,6 +88,45 @@ nftban_http_candidate_globs() {
         '/usr/local/lsws/logs/*access*'
 }
 
+# --- source-validity contract (R22A) ----------------------------------------
+# CLASS: reject non-HTTP-access filenames (panel-independent, name-based) so a
+# bare panel glob (e.g. cPanel /usr/local/apache/domlogs/*) cannot select FTP
+# transfer logs, bandwidth offset/byte-count state files, mail logs, or
+# error/rotated/compressed logs. Returns 0 if the name MUST be excluded.
+_nftban_http_is_nonaccess_name() {
+    case "$1" in
+        *error_log|*error.log|*-error*|*_error*)                       return 0 ;;  # error logs
+        *.gz|*.bz2|*.xz|*.zip|*.[0-9]|*.[0-9][0-9]|*.rotated|*.processed) return 0 ;;  # compressed/rotated
+        *ftpxferlog*|*-ftp_log|*_ftp_log|*-ftpxfer*|*ftp.log)          return 0 ;;  # cPanel/panel FTP logs
+        *-imap_log|*_imap_log|*-pop3_log|*_pop3_log|*-smtp_log|*_smtp_log) return 0 ;;  # mail logs
+        *.offset|*.bytes|*.stats|*.db|*.lock|*.pid|*.tmp|*.bak|*.bkup) return 0 ;;  # state/byte-count/aux (NOT .json — an access log may be JSON-formatted)
+    esac
+    return 1
+}
+
+# CONTENT: a non-empty file is a valid HTTP access log only if a sampled line
+# carries an HTTP request signature. Prevents a non-empty non-HTTP file (e.g. a
+# binary state file that slipped the name filter) from being accepted/scanned.
+# Tolerant of the escaped-slash form (nginx JSON access logs: "GET \/ HTTP\/1.1").
+_nftban_http_looks_like_access_log() {
+    tail -n 50 "$1" 2>/dev/null | grep -Eq '"(GET|POST|HEAD|PUT|DELETE|OPTIONS|PATCH|PROPFIND|CONNECT|TRACE|BREW|LINK|UNLINK|MKCOL|COPY|MOVE|LOCK|PROPPATCH|REPORT|SEARCH) [^"]* HTTP\\?/[0-9]'
+}
+
+# STATE: classify one existing, CLASS-valid file by content + activity.
+# Echoes: SOURCE_ACTIVE | SOURCE_VALID_QUIET | NEVER_OBSERVED | SOURCE_INVALID
+#   empty (0 bytes)        -> NEVER_OBSERVED  (valid path/class, no data yet)
+#   non-empty, HTTP lines  -> SOURCE_ACTIVE (recent mtime) | SOURCE_VALID_QUIET
+#   non-empty, no HTTP     -> SOURCE_INVALID (never healthy, never scanned)
+_nftban_http_source_content_state() {
+    local f="$1"
+    [[ -s "$f" ]] || { echo "NEVER_OBSERVED"; return 0; }
+    _nftban_http_looks_like_access_log "$f" || { echo "SOURCE_INVALID"; return 0; }
+    local now mt win
+    now="$(date +%s 2>/dev/null || echo 0)"; mt="$(stat -c %Y "$f" 2>/dev/null || echo 0)"
+    win="${NFTBAN_HTTP_ACTIVITY_WINDOW_SEC:-86400}"
+    if [[ "$now" -gt 0 && $((now - mt)) -le "$win" ]]; then echo "SOURCE_ACTIVE"; else echo "SOURCE_VALID_QUIET"; fi
+}
+
 # Internal: expand a single glob and append existing readable non-error access
 # files to the global _NFTBAN_HTTP_FOUND; unreadable matches go to
 # _NFTBAN_HTTP_LAST_SKIPPED. Runs in the CURRENT shell (no subshell) so the
@@ -95,11 +138,11 @@ _nftban_http_collect_glob() {
     mapfile -t matches < <(compgen -G "$g" 2>/dev/null || true)
     for f in "${matches[@]}"; do
         [[ -f "$f" ]] || continue
-        case "$f" in
-            *error_log|*error.log|*-error*|*_error*|*.gz|*.[0-9]) continue ;;  # skip error/rotated/compressed
-        esac
+        if _nftban_http_is_nonaccess_name "$f"; then
+            _NFTBAN_HTTP_LAST_SKIPPED+=("$f: non-access file (excluded)"); continue
+        fi
         if [[ -r "$f" ]]; then
-            _NFTBAN_HTTP_FOUND+=("$f")
+            _NFTBAN_HTTP_FOUND+=("$f")   # CONTENT validity deferred to post-cap (see discover) — keep the hot glob cheap
         else
             _NFTBAN_HTTP_LAST_SKIPPED+=("$f: unreadable")
         fi
@@ -163,6 +206,23 @@ nftban_http_discover_access_logs() {
         _NFTBAN_HTTP_LAST_SELECTED=("${uniq[@]}")
     fi
 
+    # CONTENT validity — bounded to the capped SELECTED set (≤MAX_FILES), NOT the
+    # full pre-cap glob, so discovery stays cheap on multi-vhost hosts. Drop a
+    # non-empty file that is not an HTTP access log (state/foreign file that slipped
+    # the name filter); KEEP an empty valid access log (NEVER_OBSERVED — no data yet).
+    if [[ ${#_NFTBAN_HTTP_LAST_SELECTED[@]} -gt 0 ]]; then
+        local -a _valid=(); local s
+        for s in "${_NFTBAN_HTTP_LAST_SELECTED[@]}"; do
+            if [[ -s "$s" ]] && ! _nftban_http_looks_like_access_log "$s"; then
+                _NFTBAN_HTTP_LAST_SKIPPED+=("$s: not an HTTP access log (invalid content)")
+            else
+                _valid+=("$s")
+            fi
+        done
+        _NFTBAN_HTTP_LAST_SELECTED=("${_valid[@]}")
+    fi
+    [[ ${#_NFTBAN_HTTP_LAST_SELECTED[@]} -eq 0 ]] && return 1
+
     printf '%s\n' "${_NFTBAN_HTTP_LAST_SELECTED[@]}"
     return 0
 }
@@ -214,9 +274,7 @@ _nftban_http_collect_candidate_glob() {
     mapfile -t matches < <(compgen -G "$g" 2>/dev/null || true)
     for f in "${matches[@]}"; do
         [[ -f "$f" ]] || continue
-        case "$f" in
-            *error_log|*error.log|*-error*|*_error*|*.gz|*.[0-9]) continue ;;  # access logs only
-        esac
+        _nftban_http_is_nonaccess_name "$f" && continue   # access-log names only (content judged at classify)
         _NFTBAN_HTTP_CAND+=("$f")
     done
 }
@@ -236,9 +294,10 @@ nftban_http_classify_candidates() {
     local panel stack
     panel="$(nftban_http_detect_panel)"; stack="$(nftban_http_detect_stack)"
     _NFTBAN_HTTP_READ_STACK="$stack"
-    _NFTBAN_HTTP_LAST_CANDIDATES=(); _NFTBAN_HTTP_LAST_UNREADABLE=()
+    _NFTBAN_HTTP_LAST_CANDIDATES=(); _NFTBAN_HTTP_LAST_UNREADABLE=(); _NFTBAN_HTTP_LAST_INVALID=()
     _NFTBAN_HTTP_READ_COUNT_TOTAL=0; _NFTBAN_HTTP_READ_COUNT_READABLE=0
     _NFTBAN_HTTP_READ_COUNT_UNREADABLE=0; _NFTBAN_HTTP_READ_COUNT_UNKNOWN=0
+    _NFTBAN_HTTP_COUNT_VALID=0; _NFTBAN_HTTP_COUNT_NEVER=0; _NFTBAN_HTTP_COUNT_INVALID=0
 
     _NFTBAN_HTTP_CAND=()
     local g
@@ -270,20 +329,41 @@ nftban_http_classify_candidates() {
         _NFTBAN_HTTP_READ_PERSPECTIVE="indeterminate (caller=$me, not root/$svc)"
     fi
 
-    local rc
+    local rc state
     for f in "${uniq[@]}"; do
         rc=0; nftban_http_service_can_read "$f" || rc=$?
         case "$rc" in
-            0) _NFTBAN_HTTP_READ_COUNT_READABLE=$((_NFTBAN_HTTP_READ_COUNT_READABLE+1)) ;;
+            0)
+                _NFTBAN_HTTP_READ_COUNT_READABLE=$((_NFTBAN_HTTP_READ_COUNT_READABLE+1))
+                # Readable → judge CONTENT as the service account can (we already
+                # confirmed it is readable-as-service). Validity, not mere readability.
+                state="$(_nftban_http_source_content_state "$f")"
+                case "$state" in
+                    SOURCE_ACTIVE|SOURCE_VALID_QUIET) _NFTBAN_HTTP_COUNT_VALID=$((_NFTBAN_HTTP_COUNT_VALID+1)) ;;
+                    NEVER_OBSERVED)                   _NFTBAN_HTTP_COUNT_NEVER=$((_NFTBAN_HTTP_COUNT_NEVER+1)) ;;
+                    SOURCE_INVALID)                   _NFTBAN_HTTP_COUNT_INVALID=$((_NFTBAN_HTTP_COUNT_INVALID+1)); _NFTBAN_HTTP_LAST_INVALID+=("$f") ;;
+                esac
+                ;;
             1) _NFTBAN_HTTP_READ_COUNT_UNREADABLE=$((_NFTBAN_HTTP_READ_COUNT_UNREADABLE+1)); _NFTBAN_HTTP_LAST_UNREADABLE+=("$f") ;;
             *) _NFTBAN_HTTP_READ_COUNT_UNKNOWN=$((_NFTBAN_HTTP_READ_COUNT_UNKNOWN+1)) ;;
         esac
     done
 
+    # Validity-aware verdict (R22A). A readable source is "healthy" (OK) ONLY when
+    # its content is a valid HTTP access log (SOURCE_ACTIVE or SOURCE_VALID_QUIET —
+    # a temporarily quiet valid log is NOT DEGRADED). A valid-but-empty source is
+    # NEVER_OBSERVED (bound, no data yet — not a false OK, not DEGRADED). Readable
+    # candidates that are ALL invalid content (state files / non-HTTP) →
+    # INVALID_SOURCE (never healthy — this is the false-healthy fix). Class-valid
+    # names that are all unreadable-as-service → DEGRADED (real permission failure).
     if [[ ${_NFTBAN_HTTP_READ_COUNT_TOTAL} -eq 0 ]]; then
         if [[ -n "$stack" ]]; then _NFTBAN_HTTP_READ_VERDICT="WARN_NO_LOGS"; else _NFTBAN_HTTP_READ_VERDICT="NO_LOGS"; fi
-    elif [[ ${_NFTBAN_HTTP_READ_COUNT_READABLE} -ge 1 ]]; then
+    elif [[ ${_NFTBAN_HTTP_COUNT_VALID} -ge 1 ]]; then
         _NFTBAN_HTTP_READ_VERDICT="OK"
+    elif [[ ${_NFTBAN_HTTP_COUNT_NEVER} -ge 1 ]]; then
+        _NFTBAN_HTTP_READ_VERDICT="NEVER_OBSERVED"
+    elif [[ ${_NFTBAN_HTTP_COUNT_INVALID} -ge 1 ]]; then
+        _NFTBAN_HTTP_READ_VERDICT="INVALID_SOURCE"
     elif [[ ${_NFTBAN_HTTP_READ_COUNT_UNKNOWN} -ge 1 ]]; then
         _NFTBAN_HTTP_READ_VERDICT="UNKNOWN"
     else

--- a/cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh
+++ b/cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh
@@ -101,5 +101,16 @@ rc=0; gather_one "$LOG3" "$BSPF" || rc=$?
 appended=$(stat -c %s "$BSPF")
 [[ "$rc" == 0 && "$appended" -le $((NFTBAN_HTTP_LOG_MAX_BYTES + 16)) ]] && ok "T6 large source bounded to MAX_BYTES ($appended B), streamed not slurped" || no "T6 large source append=$appended"
 
+# T7 (R22A): the collector applies the SHARED class filter (not the old bare case)
+# so cPanel ftpxferlog/.offset/.bytes/mail/state files are never spooled.
+grep -qE '_nftban_http_is_nonaccess_name "\$f" && continue' "$COLLECTOR" \
+  && ok "T7 collector uses shared _nftban_http_is_nonaccess_name class filter (R22A)" || no "T7 collector missing shared class filter"
+if grep -qE 'case "\$f" in \*error_log.*\*\.\[0-9\]\) continue' "$COLLECTOR"; then
+  no "T7 collector still uses the old insufficient bare-case exclusion"
+else ok "T7 old insufficient bare-case exclusion removed from collector"; fi
+# T8 (R22A): the collector content-gates a non-empty non-HTTP file before spooling.
+grep -qE '_nftban_http_looks_like_access_log "\$canon"' "$COLLECTOR" \
+  && ok "T8 collector content-validates (skips non-empty non-HTTP before spool)" || no "T8 collector missing content gate"
+
 echo "=== gather-stream: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" == 0 ]]

--- a/cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh
+++ b/cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - BotScan log-source validity & health-state truth (R22A) tests
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="botscan_logsource_validity_r22a"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-18"
+# meta:description="R22A BotScan log-source VALIDITY & health-state truth. Locks: cPanel domlogs excludes non-HTTP files (ftpxferlog/.offset/.bytes/-imap_log); readable non-HTTP content -> INVALID_SOURCE (the false-healthy fix); empty valid access log -> NEVER_OBSERVED (bound, no data; not OK, not DEGRADED); valid-but-quiet -> OK (never falsely DEGRADED); valid active -> OK; Plesk empty access_log -> NEVER_OBSERVED; DirectAdmin valid preserved -> OK; mixed valid+invalid -> OK with invalid counted; nginx JSON escaped-slash access log -> OK; ftp.example.com domain not over-excluded. Hermetic: temp trees, readability test-hook forces service-account readability so CONTENT validity is what is exercised; no root, no nft, no bans."
+# meta:inventory.files="cli/lib/nftban/lib/nftban_http_logs.sh"
+# meta:inventory.binaries="bash,grep,tail,stat,date,mktemp,printf"
+# meta:inventory.env_vars="NFTBAN_BOTSCAN_READ_TEST_HOOK,NFTBAN_BOTSCAN_SERVICE_USER,NFTBAN_HTTP_LOG_MAX_FILES,NFTBAN_HTTP_ACTIVITY_WINDOW_SEC"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO/cli/lib/nftban/lib/nftban_http_logs.sh"
+
+P=0; F=0
+ok(){ echo "  ✓ $1"; P=$((P+1)); }
+no(){ echo "  ✗ $1 ${2:-}"; F=$((F+1)); }
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+AL(){ printf '203.0.113.7 - - [01/Jan/2026:12:00:00 +0000] "GET /%s HTTP/1.1" 200 128 "-" "r22a"\n' "${1:-x}"; }
+
+# Force readability-as-service so the CONTENT-validity path is what is tested.
+# (env-var hook consumed by nftban_http_service_can_read in the sourced lib)
+allread(){ return 0; }
+export NFTBAN_BOTSCAN_READ_TEST_HOOK=allread
+
+echo "=== R22A BotScan log-source validity & health-state truth ==="
+
+# --- CLASS exclusion on the BIND path: cPanel domlogs must reject non-HTTP files ---
+mkdir -p "$WORK/cp/domlogs"
+AL example.com > "$WORK/cp/domlogs/example.com"                 # valid HTTP access log
+AL example.com > "$WORK/cp/domlogs/example.com-ssl_log"         # valid (ssl access)
+printf 'ftp transfer junk\n'   > "$WORK/cp/domlogs/ftpxferlog"          # FTP transfer log
+printf 'binary\n'              > "$WORK/cp/domlogs/example.com.offset"  # offset state file
+printf '12345\n'               > "$WORK/cp/domlogs/example.com.bytes"   # byte-count state
+printf 'imap login junk\n'     > "$WORK/cp/domlogs/example.com-imap_log" # mail log
+sel="$(nftban_http_discover_access_logs "$WORK/cp/domlogs/*" 2>/dev/null)"
+[[ "$sel" == *"/example.com"* ]] && ok "cPanel binds the valid HTTP access log" || no "cpanel valid bind" "$sel"
+if [[ "$sel" != *ftpxferlog* && "$sel" != *.offset* && "$sel" != *.bytes* && "$sel" != *imap_log* ]]; then
+    ok "cPanel EXCLUDES ftpxferlog/.offset/.bytes/-imap_log (non-HTTP)"
+else no "cpanel exclusion" "$sel"; fi
+
+# --- CONTENT (bind): a non-empty non-HTTP file is NOT bound for scanning ---
+mkdir -p "$WORK/inv"; printf 'this is not an http access log\nrandom junk line\n' > "$WORK/inv/access.log"
+selinv="$(nftban_http_discover_access_logs "$WORK/inv/*.log" 2>/dev/null || true)"
+[[ -z "$selinv" ]] && ok "non-HTTP content NOT bound for scanning (bind-path validity)" || no "invalid not bound" "$selinv"
+
+# --- HEALTH: readable non-HTTP content → INVALID_SOURCE (the false-healthy FIX) ---
+v="$(nftban_http_classify_candidates "$WORK/inv/*.log" 2>/dev/null)"
+[[ "$v" == "INVALID_SOURCE" ]] && ok "readable non-HTTP content → INVALID_SOURCE (never healthy)" || no "invalid_source verdict" "$v"
+
+# --- EMPTY valid path → NEVER_OBSERVED (bound, no data; not OK, not DEGRADED) ---
+mkdir -p "$WORK/emp"; : > "$WORK/emp/access.log"
+v="$(nftban_http_classify_candidates "$WORK/emp/*.log" 2>/dev/null)"
+[[ "$v" == "NEVER_OBSERVED" ]] && ok "empty valid access log → NEVER_OBSERVED (not OK, not DEGRADED)" || no "never_observed verdict" "$v"
+# and an empty valid log IS still bound (correct source, no data yet)
+selemp="$(nftban_http_discover_access_logs "$WORK/emp/*.log" 2>/dev/null || true)"
+[[ "$selemp" == *"/access.log"* ]] && ok "empty valid access log is still BOUND (correct source)" || no "empty bound" "$selemp"
+
+# --- VALID quiet (old mtime) → OK, never falsely DEGRADED ---
+mkdir -p "$WORK/q"; AL quiet > "$WORK/q/access.log"; touch -d '2020-01-01 00:00:00' "$WORK/q/access.log" 2>/dev/null || true
+v="$(nftban_http_classify_candidates "$WORK/q/*.log" 2>/dev/null)"
+[[ "$v" == "OK" ]] && ok "valid-but-quiet access log → OK (NOT DEGRADED)" || no "valid_quiet verdict" "$v"
+
+# --- VALID active → OK ---
+mkdir -p "$WORK/a"; AL active > "$WORK/a/access.log"
+v="$(nftban_http_classify_candidates "$WORK/a/*.log" 2>/dev/null)"
+[[ "$v" == "OK" ]] && ok "valid active access log → OK" || no "valid_active verdict" "$v"
+
+# --- Plesk empty access_log → NEVER_OBSERVED ---
+mkdir -p "$WORK/pl/example.com/logs"; : > "$WORK/pl/example.com/logs/access_log"
+v="$(nftban_http_classify_candidates "$WORK/pl/*/logs/access_log" 2>/dev/null)"
+[[ "$v" == "NEVER_OBSERVED" ]] && ok "Plesk empty access_log → NEVER_OBSERVED" || no "plesk empty verdict" "$v"
+
+# --- DirectAdmin valid preserved → OK (no regression) ---
+mkdir -p "$WORK/da/domains"; AL da > "$WORK/da/domains/example.com.log"
+v="$(nftban_http_classify_candidates "$WORK/da/domains/*.log" 2>/dev/null)"
+[[ "$v" == "OK" ]] && ok "DirectAdmin valid domain log → OK (preserved)" || no "da preserved verdict" "$v"
+
+# --- MIXED valid + invalid readable → OK (a valid source wins), invalid counted ---
+# Call classify DIRECTLY (not in $(...)) so the per-state global counters are
+# visible in this shell.
+mkdir -p "$WORK/mix"; AL good > "$WORK/mix/example.com"; printf 'not http at all\n' > "$WORK/mix/other.log"
+nftban_http_classify_candidates "$WORK/mix/example.com $WORK/mix/other.log" >/dev/null 2>&1 || true
+v="$_NFTBAN_HTTP_READ_VERDICT"
+if [[ "$v" == "OK" && "${_NFTBAN_HTTP_COUNT_VALID}" -ge 1 && "${_NFTBAN_HTTP_COUNT_INVALID}" -ge 1 ]]; then
+    ok "mixed valid+invalid → OK (valid wins), invalid counted"
+else no "mixed verdict" "v=$v valid=${_NFTBAN_HTTP_COUNT_VALID} invalid=${_NFTBAN_HTTP_COUNT_INVALID}"; fi
+
+# --- nginx JSON access log (escaped slash "GET \/ HTTP\/1.1") → OK, NOT INVALID ---
+mkdir -p "$WORK/js"
+printf '{"remote":"203.0.113.5","request":"GET \\/wp-login.php HTTP\\/1.1","status":200}\n' > "$WORK/js/access.json"
+v="$(nftban_http_classify_candidates "$WORK/js/*.json" 2>/dev/null)"
+[[ "$v" == "OK" ]] && ok "nginx JSON access log (escaped slash) → OK (not false INVALID)" || no "json escaped-slash" "$v"
+# and access.json must NOT be name-excluded (a JSON-formatted access log is valid)
+seljs="$(nftban_http_discover_access_logs "$WORK/js/*.json" 2>/dev/null || true)"
+[[ "$seljs" == *access.json* ]] && ok "access.json bound (not excluded by name)" || no "json name-excluded" "$seljs"
+
+# --- domain literally containing 'ftp' must NOT be over-excluded ---
+mkdir -p "$WORK/dom/domlogs"; AL x > "$WORK/dom/domlogs/ftp.example.com"
+seld="$(nftban_http_discover_access_logs "$WORK/dom/domlogs/*" 2>/dev/null || true)"
+[[ "$seld" == *ftp.example.com* ]] && ok "ftp.example.com access log NOT over-excluded" || no "ftp-domain over-excluded" "$seld"
+
+echo "=== RESULT: $P passed, $F failed ==="
+[[ $F -eq 0 ]]

--- a/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
+++ b/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
@@ -52,7 +52,7 @@ spool_of(){ printf '%s/%s' "$SPOOL" "$(realpath -- "$1" | tr '/' '_')"; }
 echo "=== v1.178-A BotScan read-authority (collector + spool-first) ==="
 
 # T1: collector reads an allowlisted fixture → spool file with content.
-printf 'l1 GET /a\nl2 POST /xmlrpc.php\n' > "$ALLOW/site.log"
+printf '203.0.113.7 - - [x] "GET /a HTTP/1.1" 200 1\n203.0.113.7 - - [x] "POST /xmlrpc.php HTTP/1.1" 200 1\n' > "$ALLOW/site.log"
 run_collector "$ALLOW/*.log" >/dev/null
 sf="$(spool_of "$ALLOW/site.log")"
 [[ -f "$sf" ]] && grep -q 'xmlrpc.php' "$sf" && ok "T1 collector reads allowlisted source → spool populated" || no "T1 collect→spool" "sf=$sf"
@@ -75,9 +75,9 @@ run_collector "$ALLOW/fifo.log" >/dev/null
 rm -f "$ALLOW/fifo.log"
 
 # T5: incremental — second run emits only NEW bytes.
-rm -rf "$SPOOL" "$OFF"; printf 'first\n' > "$ALLOW/inc.log"
+rm -rf "$SPOOL" "$OFF"; printf '203.0.113.7 - - [x] "GET /first HTTP/1.1" 200 1\n' > "$ALLOW/inc.log"
 run_collector "$ALLOW/inc.log" >/dev/null
-printf 'second\n' >> "$ALLOW/inc.log"
+printf '203.0.113.7 - - [x] "GET /second HTTP/1.1" 200 1\n' >> "$ALLOW/inc.log"
 run_collector "$ALLOW/inc.log" >/dev/null
 sf="$(spool_of "$ALLOW/inc.log")"
 [[ "$(grep -c first "$sf")" -eq 1 && "$(grep -c second "$sf")" -eq 1 ]] && ok "T5 incremental: new bytes appended once (no re-read of old)" || no "T5 incremental" "$(cat "$sf" 2>/dev/null)"
@@ -87,7 +87,8 @@ sf="$(spool_of "$ALLOW/inc.log")"
 # spooled WITHOUT being shortened; bounding moved to the total-dir cap + reaping
 # (covered by botscan_spool_oom_v2093_test.sh). Lock in the removal: the spool keeps
 # the full source (NOT trimmed to the old 512-byte cap).
-rm -rf "$SPOOL" "$OFF"; head -c 5000 /dev/zero | tr '\0' 'x' > "$ALLOW/big.log"; printf '\n' >> "$ALLOW/big.log"
+rm -rf "$SPOOL" "$OFF"; yes '203.0.113.7 - - [x] "GET / HTTP/1.1" 200 1' 2>/dev/null | head -c 5200 > "$ALLOW/big.log" || true   # head closes → yes SIGPIPE; pipefail-safe
+printf '\n' >> "$ALLOW/big.log"
 NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_SPOOL_DIR="$SPOOL" \
   NFTBAN_BOTSCAN_COLLECTOR_OFFSET_DIR="$OFF" NFTBAN_BOTSCAN_COLLECTOR_ALLOW_ROOTS="$ALLOW" \
   BOTSCAN_LOG_PATHS="$ALLOW/big.log" BOTSCAN_COLLECTOR_SPOOL_MAX_BYTES=512 \
@@ -97,12 +98,12 @@ sz="$(stat -c %s "$sf" 2>/dev/null || echo 0)"
 [[ "$sz" -ge 5000 ]] && ok "T6 per-file blind trim removed — full source spooled (size=$sz, not cursor-desyncing trim)" || no "T6 trim-removed" "size=$sz (expected ≥5000)"
 
 # T7: spool file mode 0640.
-rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/mode.log"; run_collector "$ALLOW/mode.log" >/dev/null
+rm -rf "$SPOOL" "$OFF"; printf '203.0.113.7 - - [x] "GET / HTTP/1.1" 200 1\n' > "$ALLOW/mode.log"; run_collector "$ALLOW/mode.log" >/dev/null
 m="$(stat -c %a "$(spool_of "$ALLOW/mode.log")" 2>/dev/null || echo '')"
 [[ "$m" == "640" ]] && ok "T7 spool file mode 0640" || no "T7 spool mode" "mode=$m"
 
 # T8: scanner SPOOL-FIRST — discover returns spool files when spool populated.
-rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/s1.log"; run_collector "$ALLOW/s1.log" >/dev/null
+rm -rf "$SPOOL" "$OFF"; printf '203.0.113.7 - - [x] "GET / HTTP/1.1" 200 1\n' > "$ALLOW/s1.log"; run_collector "$ALLOW/s1.log" >/dev/null
 # shellcheck source=/dev/null
 ( export NFTBAN_LIB_DIR="$REPO/cli/lib/nftban" BOTSCAN_SPOOL_DIR="$SPOOL"
   # shellcheck source=/dev/null
@@ -123,7 +124,7 @@ rm -rf "$SPOOL"; mkdir -p "$SPOOL"
 ) && ok "T9 scanner fallback when spool empty (no stale spool paths)" || no "T9 fallback"
 
 # T10: MAX_FILES cap.
-rm -rf "$SPOOL" "$OFF"; for i in 1 2 3 4; do printf 'x\n' > "$ALLOW/m$i.log"; done
+rm -rf "$SPOOL" "$OFF"; for i in 1 2 3 4; do printf '203.0.113.7 - - [x] "GET / HTTP/1.1" 200 1\n' > "$ALLOW/m$i.log"; done
 out="$(run_collector "$ALLOW/m*.log" 2)"
 echo "$out" | grep -q 'MAX_FILES=2' && ok "T10 MAX_FILES cap enforced + audited" || no "T10 max-files" "$out"
 
@@ -138,7 +139,7 @@ if grep -q '^User=nftban' "$COLLECTOR_UNIT" && grep -q '^AmbientCapabilities=CAP
 else no "T12 collector unit invariants"; fi
 
 # T13: audit trail emitted (read-authority observability).
-rm -rf "$SPOOL" "$OFF"; printf 'x\n' > "$ALLOW/audit.log"
+rm -rf "$SPOOL" "$OFF"; printf '203.0.113.7 - - [x] "GET / HTTP/1.1" 200 1\n' > "$ALLOW/audit.log"
 out="$(run_collector "$ALLOW/audit.log")"
 echo "$out" | grep -qE 'botscan-collector.*(collected|sources=)' && ok "T13 collector emits audit trail" || no "T13 audit" "$out"
 

--- a/cli/lib/nftban/tests/http_log_discovery_v177_test.sh
+++ b/cli/lib/nftban/tests/http_log_discovery_v177_test.sh
@@ -55,7 +55,9 @@ gen="$(nftban_http_candidate_globs '')"
 # -----------------------------------------------------------------------------
 # Build hermetic fixture trees mimicking each layout.
 # -----------------------------------------------------------------------------
-mk(){ mkdir -p "$(dirname "$1")"; printf '%s\n' "${2:-line}" > "$1"; }
+# R22A: fixtures that should be DISCOVERED must contain a VALID HTTP access-log line
+# (R22A validates sampled format before binding). The label becomes the request path.
+mk(){ mkdir -p "$(dirname "$1")"; printf '%s\n' "203.0.113.7 - - [01/Jan/2026:12:00:00 +0000] \"GET /${2:-x} HTTP/1.1\" 200 128 \"-\" \"r22a\"" > "$1"; }
 mk "$WORK/da/httpd/domains/example.com.log"      'DA apache'
 mk "$WORK/da/nginx/domains/example.com.log"      'DA nginx'
 mk "$WORK/cpanel/domlogs/example.com"            'cpanel'
@@ -113,7 +115,7 @@ else
 fi
 
 # T7: many-log bounded scan + skip-reason.
-mkdir -p "$WORK/many"; for i in $(seq 1 6); do printf 'x\n' > "$WORK/many/d$i.log"; done
+mkdir -p "$WORK/many"; for i in $(seq 1 6); do printf '203.0.113.7 - - [01/Jan/2026:12:00:00 +0000] "GET /d%s HTTP/1.1" 200 1\n' "$i" > "$WORK/many/d$i.log"; done
 NFTBAN_HTTP_LOG_MAX_FILES=3 disc "$WORK/many/*.log" >/dev/null 2>&1 || true
 if [[ "${#_NFTBAN_HTTP_LAST_SELECTED[@]}" -eq 3 ]] && printf '%s\n' "${_NFTBAN_HTTP_LAST_SKIPPED[@]}" | grep -q 'over MAX_FILES'; then
     ok "T7 many-log bounded to MAX_FILES=3 + skip-reason recorded"

--- a/cli/sbin/nftban-botscan-collector
+++ b/cli/sbin/nftban-botscan-collector
@@ -164,7 +164,7 @@ count=0 collected=0 skipped=0
 for g in "${globs[@]}"; do
     while IFS= read -r f; do
         [[ -f "$f" ]] || continue
-        case "$f" in *error_log|*error.log|*-error*|*_error*|*.gz|*.[0-9]) continue ;; esac
+        _nftban_http_is_nonaccess_name "$f" && continue   # R22A: exclude ftp/offset/bytes/mail/state/error/rotated (shared class filter)
         # SECURITY: canonicalize then re-validate inside an allowlisted root.
         canon="$(realpath -- "$f" 2>/dev/null)" || { skipped=$((skipped+1)); audit "skip realpath-failed: $f"; continue; }
         [[ -f "$canon" && ! -L "$canon" ]] || { skipped=$((skipped+1)); audit "skip not-regular: $f"; continue; }
@@ -177,6 +177,13 @@ for g in "${globs[@]}"; do
         # the source offset untouched so this cycle's bytes are collected once the scanner
         # has reaped consumed files and the total falls back under cap. Nothing is lost.
         if [[ "$backpressure" -eq 1 ]]; then skipped=$((skipped+1)); continue; fi
+        # R22A CONTENT validity: never spool a non-empty file that is not an HTTP
+        # access log (a state/foreign file that slipped the name filter — e.g. a
+        # cPanel ftpxferlog offset). An empty valid access log has no new bytes to
+        # append anyway, so it is harmless to skip the content gate here.
+        if [[ -s "$canon" ]] && ! _nftban_http_looks_like_access_log "$canon"; then
+            skipped=$((skipped+1)); audit "skip non-access-content: $canon"; continue
+        fi
         # Privileged incremental read of NEW bytes since the last cycle.
         # v1.209.2: STREAM the read straight to the spool file instead of capturing it in a bash
         # variable (`new="$(...)"`). The old capture materialized up to BOTSCAN_COLLECTOR_MAX_BYTES


### PR DESCRIPTION
## R22A — BotScan log-source validity & health (`GO_R22A_BOTSCAN_LOGSOURCE`)

Fixes the confirmed **P1 detection-blindness / false-healthy** defect: BotScan bound any *readable* file and reported source health `OK` for any readable candidate. On **cPanel** a bare `domlogs/*` glob bound FTP transfer logs and bandwidth `.offset`/`.bytes` state files; on **Plesk/generic** an empty `access.log` was accepted — both reported **healthy while 0 HTTP was seen** (production DirectAdmin unaffected; cPanel/Plesk/WHT audience exposed).

### Source-validity contract (evaluated as the `nftban` service account)
- **CLASS** — exclude non-HTTP names (`ftpxferlog`/`-ftp_log`/`.offset`/`.bytes`/`-imap_log`/`-pop3_log`/error/rotated/compressed/state) in discovery + classify.
- **CONTENT** — a non-empty file must carry an HTTP request signature (tolerant of nginx JSON escaped-slash `HTTP\/1.1`) to be bound/valid; else `SOURCE_INVALID`.
- **STATES** — `SOURCE_ACTIVE` / `SOURCE_VALID_QUIET` / `NEVER_OBSERVED` / `SOURCE_INVALID`.
- **Health verdict** is now validity-aware: `OK` only for a valid active/quiet source; `NEVER_OBSERVED` (empty valid — bound, no data, **not** DEGRADED); `INVALID_SOURCE` (readable but non-HTTP — **never healthy**, the false-healthy fix); `DEGRADED` (valid but unreadable-as-service) unchanged. **A valid-but-quiet log is never falsely DEGRADED.**
- Content validation is **bounded to the capped SELECTED set** (cheap on multi-vhost hosts).

### Determinations
- **Daemon Go bytes: unchanged** (shell-only; 0 `.go`). **nft schema: 1.84.0 unchanged.** **Config schema: unchanged.**
- **DirectAdmin preserved** (proven by tests). Go `internal/loginmon/webdiscovery.go` (LoginMon path) **out of scope**.

### Tests
- `http_log_discovery_v177_test.sh` **30/0** (fixtures updated to valid access-log content — the old placeholder content only passed because the old code didn't validate content).
- new `botscan_logsource_validity_r22a_test.sh` **14/0** (cPanel exclusion, INVALID_SOURCE, NEVER_OBSERVED, VALID_QUIET, Plesk empty, DirectAdmin preserved, nginx JSON, ftp-domain-not-over-excluded).
- shellcheck `-S warning` clean; adversarial review applied (perf: content-check moved post-cap; nginx-JSON regex; `.json` de-excluded).

### Explicit exclusions (untouched)
BotScan FP/threshold tuning · single-port SYN-flood ownership · DDoS policy · nftables schema/firewall rules · Go daemon · broad cross-module validity-contract redesign · unrelated UX/update-state/installer/metrics/enforcement-search work.

Scope + `LOG_SOURCE_OWNERSHIP_DECLARATION`: `NFTBAN_ROADMAP/R22A_BOTSCAN_LOGSOURCE_SCOPE_AND_DECLARATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
