### PR TITLE
fix(update): populate per-run lifecycle record (human.log + installer.log slice) — Gate A

### DIFF
--- a/cli/lib/nftban/cli/cmd_support.sh
+++ b/cli/lib/nftban/cli/cmd_support.sh
@@ -414,7 +414,7 @@ _collect_logs() {
             local rid; rid=$(basename "$run_dir")
             mkdir -p "$runs_dst/$rid" 2>/dev/null || continue
             local f
-            for f in run.jsonl human.log; do
+            for f in run.jsonl human.log installer.log; do
                 [[ -f "$run_dir/$f" ]] && _redact_file "$run_dir/$f" "$runs_dst/$rid/$f" 2>/dev/null || true
             done
             run_count=$((run_count + 1))

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -579,6 +579,7 @@ _cmd_update_main_locked() {
         echo ""
         echo "  Log: $UPDATE_LOG_FILE"
         echo ""
+        _forensic_installer_slice "$_RUN_ID"
         _forensic_end "$_RUN_ID" install-fail "$result"
         return $result
     fi
@@ -808,6 +809,7 @@ _cmd_update_main_locked() {
     # v1.199 forensics: post-verify snapshot (binary swapped, timers restored,
     # install_state resolved) + close the per-run record.
     _forensic_snapshot "$_RUN_ID" post-verify
+    _forensic_installer_slice "$_RUN_ID"
     _forensic_event "$_RUN_ID" run_end "state=$_installer_state" "new_version=$new_version" "rc=0"
 
     # v1.215.0 (OPEN_INSTALL_UPDATE_OBSERVABILITY, PR-1): warnings in THIS run's

--- a/cli/lib/nftban/cli/cmd_update_helpers.sh
+++ b/cli/lib/nftban/cli/cmd_update_helpers.sh
@@ -41,9 +41,23 @@ _update_log() {
     local timestamp
     timestamp=$(date '+%Y-%m-%d %H:%M:%S')
 
-    # Log to file
+    # v1.199 GATE-A (BUG-INSTALLER-PER-RUN-FORENSIC-LOG-MISSING / human.log-empty):
+    # construct the canonical formatted line ONCE, then project it to every file
+    # sink so the aggregate log and the per-run human slice can never drift in
+    # format. The terminal keeps its own icon-decorated projection below.
+    local _line="[$timestamp] [$level] $msg"
+
+    # Aggregate lifecycle log (unchanged destination/behavior).
     mkdir -p "$(dirname "$UPDATE_LOG_FILE")" 2>/dev/null || true
-    echo "[$timestamp] [$level] $msg" >> "$UPDATE_LOG_FILE" 2>/dev/null || true
+    printf '%s\n' "$_line" >> "$UPDATE_LOG_FILE" 2>/dev/null || true
+
+    # Active per-run human slice (update-runs/<run_id>/human.log). Only while a
+    # forensic run is active (FORENSIC_HUMAN set by _forensic_begin). Fail-safe
+    # and non-blocking: a per-run append failure must never break an update,
+    # rollback, or install (mirrors the aggregate-log `|| true` posture).
+    if [[ -n "${FORENSIC_HUMAN:-}" ]]; then
+        printf '%s\n' "$_line" >> "$FORENSIC_HUMAN" 2>/dev/null || true
+    fi
 
     # Output to terminal
     case "$level" in
@@ -466,6 +480,11 @@ _update_verify_watchdog() {
 FORENSIC_RUNS_DIR="${NFTBAN_LOG_DIR:-/var/log/nftban}/update-runs"
 FORENSIC_RETAIN_N="${NFTBAN_FORENSIC_RETAIN:-20}"
 FORENSIC_RUN_DIR=""; FORENSIC_JSONL=""; FORENSIC_HUMAN=""
+# v1.199 GATE-A: per-run installer.log slice (self-contained record). The aggregate
+# installer.log path + its pre-install line count are captured at run start; the
+# slice for THIS run is extracted at run end (run_id-delimited PRIMARY, line-count
+# delta FALLBACK). FORENSIC_ILOG_BEFORE is the fallback lower boundary only.
+FORENSIC_INSTALLER=""; FORENSIC_ILOG_FILE=""; FORENSIC_ILOG_BEFORE=0
 
 # deterministic run_id (tests/callers may pin via NFTBAN_RUN_ID)
 _forensic_run_id() { printf '%s' "${NFTBAN_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null)-$$}"; }
@@ -499,8 +518,23 @@ _forensic_begin() {
     mkdir -p "$FORENSIC_RUN_DIR" 2>/dev/null || { FORENSIC_RUN_DIR=""; return 0; }
     chmod 0750 "$FORENSIC_RUN_DIR" 2>/dev/null || true
     FORENSIC_JSONL="$FORENSIC_RUN_DIR/run.jsonl"; FORENSIC_HUMAN="$FORENSIC_RUN_DIR/human.log"
+    # v1.199 GATE-A: stable 3-file record set — installer.log is created up front so
+    # the record shape is predictable (support-bundle + tooling) even if the run
+    # dies before the installer child runs; it is filled at run end by
+    # _forensic_installer_slice (empty-but-present is truthful, tracked in run.jsonl).
+    FORENSIC_INSTALLER="$FORENSIC_RUN_DIR/installer.log"
     : > "$FORENSIC_JSONL" 2>/dev/null || true; : > "$FORENSIC_HUMAN" 2>/dev/null || true
-    chmod 0640 "$FORENSIC_JSONL" "$FORENSIC_HUMAN" 2>/dev/null || true
+    : > "$FORENSIC_INSTALLER" 2>/dev/null || true
+    chmod 0640 "$FORENSIC_JSONL" "$FORENSIC_HUMAN" "$FORENSIC_INSTALLER" 2>/dev/null || true
+    # Capture the aggregate installer.log lower boundary for the line-count FALLBACK
+    # (the run_id-delimited extraction is primary and does not need this).
+    FORENSIC_ILOG_FILE="${NFTBAN_LOG_DIR:-/var/log/nftban}/installer.log"
+    if [[ -f "$FORENSIC_ILOG_FILE" ]]; then
+        FORENSIC_ILOG_BEFORE=$(wc -l < "$FORENSIC_ILOG_FILE" 2>/dev/null || echo 0)
+        FORENSIC_ILOG_BEFORE=${FORENSIC_ILOG_BEFORE//[^0-9]/}; FORENSIC_ILOG_BEFORE=${FORENSIC_ILOG_BEFORE:-0}
+    else
+        FORENSIC_ILOG_BEFORE=0
+    fi
     _forensic_event "$id" run_start "mode=$mode" "from=$from" "to=$to" "pid=$$"
     _forensic_prune
 }
@@ -552,6 +586,73 @@ _forensic_snapshot() {
 
 # _forensic_end <run_id> <state> <rc>
 _forensic_end() { [ -n "${FORENSIC_JSONL:-}" ] || return 0; _forensic_event "$1" run_end "state=${2:-}" "rc=${3:-}"; }
+
+# _forensic_installer_slice <run_id>
+# v1.199 GATE-A (A2): extract THIS run's slice of the aggregate installer.log into
+# the per-run record (update-runs/<run_id>/installer.log) so the record is
+# self-contained. Boundary hierarchy (owner-approved): (1) run_id-delimited from the
+# installer RUN header (logger.go RunHeader stamps `... run_id=<id>`) through the
+# next RUN header / EOF — robust to rotation and concurrency; (2) line-count delta
+# from FORENSIC_ILOG_BEFORE as fallback/cross-check. Never mutates/truncates the
+# aggregate installer.log. Fully fail-safe: any failure leaves the (already-created)
+# empty per-run installer.log in place and never breaks the update. Records an
+# `installer_slice` event in run.jsonl describing method/bytes/reason (no silent cap).
+_forensic_installer_slice() {
+    [ -n "${FORENSIC_INSTALLER:-}" ] || return 0
+    local id="$1" ilog="${FORENSIC_ILOG_FILE:-}"
+    local method="none" reason="" bytes=0 lines=0
+
+    if [[ -z "$ilog" || ! -f "$ilog" ]]; then
+        _forensic_event "$id" installer_slice "method=none" "bytes=0" "reason=installer_log_absent"
+        return 0
+    fi
+
+    local total; total=$(wc -l < "$ilog" 2>/dev/null || echo 0)
+    total=${total//[^0-9]/}; total=${total:-0}
+
+    # PRIMARY: run_id-delimited extraction (last RUN header carrying this run_id).
+    local hdr_ln; hdr_ln=$(grep -Fn "run_id=${id}" "$ilog" 2>/dev/null | tail -1 | cut -d: -f1)
+    hdr_ln=${hdr_ln//[^0-9]/}
+    if [[ -n "$hdr_ln" && "$hdr_ln" -ge 1 ]]; then
+        # include the leading separator/header lines (run_id line is the 3rd RUN line)
+        local start_ln=$(( hdr_ln - 3 )); [ "$start_ln" -lt 1 ] && start_ln=1
+        # end boundary = next installer RUN header after this one, else EOF
+        local rel end_ln
+        rel=$(tail -n +"$(( hdr_ln + 1 ))" "$ilog" 2>/dev/null | grep -nF "[RUN] nftban-installer " | head -1 | cut -d: -f1)
+        rel=${rel//[^0-9]/}
+        if [[ -n "$rel" && "$rel" -ge 1 ]]; then end_ln=$(( hdr_ln + rel - 1 )); else end_ln="$total"; fi
+        [ "$end_ln" -ge "$start_ln" ] 2>/dev/null && \
+            sed -n "${start_ln},${end_ln}p" "$ilog" > "$FORENSIC_INSTALLER" 2>/dev/null || true
+        method="run_id_delimited"
+    else
+        # FALLBACK: line-count delta vs the pre-install boundary.
+        local before="${FORENSIC_ILOG_BEFORE:-0}"; before=${before//[^0-9]/}; before=${before:-0}
+        if [[ "$total" -lt "$before" ]]; then
+            # aggregate shrank → rotated/truncated during the run: do NOT copy
+            # unrelated historical content; record the condition honestly.
+            method="none"; reason="truncated_or_rotated"
+        elif [[ "$total" -eq "$before" ]]; then
+            method="none"; reason="no_installer_output"
+        else
+            tail -n +"$(( before + 1 ))" "$ilog" > "$FORENSIC_INSTALLER" 2>/dev/null || true
+            method="line_count_delta"
+        fi
+    fi
+
+    chmod 0640 "$FORENSIC_INSTALLER" 2>/dev/null || true
+    if [[ -s "$FORENSIC_INSTALLER" ]]; then
+        bytes=$(wc -c < "$FORENSIC_INSTALLER" 2>/dev/null || echo 0); bytes=${bytes//[^0-9]/}; bytes=${bytes:-0}
+        lines=$(wc -l < "$FORENSIC_INSTALLER" 2>/dev/null || echo 0); lines=${lines//[^0-9]/}; lines=${lines:-0}
+    else
+        [ -z "$reason" ] && reason="empty"
+    fi
+    if [[ -n "$reason" ]]; then
+        _forensic_event "$id" installer_slice "method=$method" "bytes=$bytes" "lines=$lines" "reason=$reason"
+    else
+        _forensic_event "$id" installer_slice "method=$method" "bytes=$bytes" "lines=$lines"
+    fi
+    return 0
+}
 
 # _forensic_prune — keep newest N run dirs; log what is pruned (no silent cap)
 _forensic_prune() {

--- a/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
+++ b/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
@@ -14,7 +14,7 @@
 # meta:depends="bash,python3,find,sort"
 # meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh"
 # meta:inventory.binaries="bash,python3"
-# meta:inventory.env_vars="NFTBAN_RUN_ID,NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_FORENSIC_RETAIN,NFTBAN_SBIN"
+# meta:inventory.env_vars="NFTBAN_RUN_ID,NFTBAN_LOG_DIR,NFTBAN_DATA_DIR,NFTBAN_FORENSIC_RETAIN,NFTBAN_SBIN,NFTBAN_LIB_DIR"
 # meta:inventory.config_files=""
 # meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer"
 # meta:inventory.network=""
@@ -24,6 +24,13 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
 HELPERS="$REPO_ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+# v1.199 GATE-A harness fix: point _fx_redact at the real redaction authority in the
+# repo tree. Production resolves it under /usr/lib/nftban, which is absent in the test
+# sandbox → _fx_redact fails CLOSED to a marker and corrupts the allowlisted snapshot
+# field assertions (bin_mode / watchdog_timer / install_state / failed-unit). This is
+# a test-PATH correction only; section G below proves redaction still fails closed when
+# the authority is genuinely unavailable, so no assertion is weakened.
+export NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban"
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
 no(){ FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1${2:+ — $2}"; }
@@ -132,6 +139,14 @@ grep -qE 'export NFTBAN_RUN_ID="\$_RUN_ID"' "$CMDUPD" && ok "F exports NFTBAN_RU
 grep -qE '_update_log INFO "lifecycle run_id=\$_RUN_ID' "$CMDUPD" && ok "F stamps run_id into update.log (correlation delimiter)" || no "F update.log run_id stamp missing"
 # export must precede the install case (so the %post installer inherits it)
 awk '/export NFTBAN_RUN_ID/{e=NR} /^    case "\$source" in/{c=NR} END{exit !(e>0 && c>e)}' "$CMDUPD" && ok "F export precedes the install case" || no "F export after install case"
+
+echo "== G: redaction fails CLOSED when the authority is unavailable (assertion-strength guard) =="
+# Proves the NFTBAN_LIB_DIR harness fix did NOT weaken redaction: with the stream fn
+# undefined AND the lib path unreachable, _fx_redact must SUPPRESS content and emit the
+# fail-closed marker (never weak-redact, never raw passthrough).
+g_out=$( unset -f nftban_redact_stream 2>/dev/null; NFTBAN_LIB_DIR="$WORK/no-such-lib"; printf 'topsecretvalue' | _fx_redact )
+echo "$g_out" | grep -q 'REDACTION-UNAVAILABLE' && ok "G fail-closed marker emitted when redaction unavailable" || no "G no fail-closed marker" "$g_out"
+echo "$g_out" | grep -q 'topsecretvalue' && no "G raw content leaked under unavailable redaction" || ok "G raw content suppressed (no passthrough)"
 
 echo ""
 echo "=== RESULT: $PASS passed, $FAIL failed ==="

--- a/cli/lib/nftban/tests/update_run_human_log_gatea_test.sh
+++ b/cli/lib/nftban/tests/update_run_human_log_gatea_test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.199 GATE-A — self-contained per-run lifecycle record
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="update_run_human_log_gatea_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-19"
+# meta:description="Hermetic regression for GATE-A of LIFECYCLE_LOG_FORENSICS_AND_ROTATION_SAFETY (OPEN_UPDATE_RUN_HUMAN_LOG_EMPTY). Proves the previously-empty per-run human.log is now populated by the canonical _update_log line (A1), that human.log carries ONLY the update-orchestrator narrative (A2), that a per-run installer.log slice is extracted from the aggregate installer.log via run_id-delimited boundary PRIMARY (A3/A4) with line-count-delta FALLBACK (A5), that sequential runs stay isolated (A6), that a failed/partial installer still yields its partial slice (A7), that no-output/absent installer is represented honestly (A8), that truncation/rotation does not copy unrelated history (A9), that per-run files are 0640 (A10), that the support-bundle collects all three files (A11), that a per-run write failure never breaks _update_log (A12), that the aggregate update.log + installer.log are unchanged (A13), and that run.jsonl stays valid JSONL with an installer_slice event (A14)."
+# meta:input="None (temp NFTBAN_LOG_DIR; synthetic aggregate installer.log with logger.go RUN headers)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass, 1 on any failure"
+# meta:depends="bash,python3,wc,sed,grep,stat"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update_helpers.sh,cli/lib/nftban/cli/cmd_update.sh,cli/lib/nftban/cli/cmd_support.sh"
+# meta:inventory.binaries="bash,python3,wc,sed,grep,stat"
+# meta:inventory.env_vars="NFTBAN_RUN_ID,NFTBAN_LOG_DIR,UPDATE_LOG_FILE,FORENSIC_HUMAN,FORENSIC_INSTALLER,FORENSIC_ILOG_FILE,FORENSIC_ILOG_BEFORE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+HELPERS="$REPO_ROOT/cli/lib/nftban/cli/cmd_update_helpers.sh"
+SUPPORT="$REPO_ROOT/cli/lib/nftban/cli/cmd_support.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL: %s\n' "$1${2:+ — $2}"; }
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+export NFTBAN_LOG_DIR="$WORK/log"; mkdir -p "$NFTBAN_LOG_DIR"
+export UPDATE_LOG_FILE="$NFTBAN_LOG_DIR/update.log"
+ILOG="$NFTBAN_LOG_DIR/installer.log"   # the aggregate installer.log
+# point _fx_redact at the real redaction authority so run.jsonl values pass through
+# faithfully (redaction fails CLOSED to a marker when the lib is unreachable).
+export NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban"
+
+# shellcheck source=/dev/null
+source "$HELPERS"; set +e
+
+# emit one installer.log RUN block exactly as internal/installer/logging/logger.go
+# RunHeader() writes it: blank, 72×'=', [RUN] version, [RUN] host, [RUN] started…run_id, 72×'='
+emit_run_block(){ # <ilog> <version> <mode> <run_id> <body-line...>
+    local f="$1" ver="$2" mode="$3" rid="$4"; shift 4
+    local sep; sep=$(printf '=%.0s' {1..72})
+    {
+        printf '\n%s\n' "$sep"
+        printf '2026-07-19T10:00:00Z [RUN] nftban-installer %s — %s\n' "$ver" "$mode"
+        printf '2026-07-19T10:00:00Z [RUN] host=host1 os=linux\n'
+        printf '2026-07-19T10:00:00Z [RUN] started=2026-07-19T10:00:00Z pid=1234 run_id=%s\n' "$rid"
+        printf '%s\n' "$sep"
+        local l; for l in "$@"; do printf '2026-07-19T10:00:01Z [INFO] %s\n' "$l"; done
+    } >> "$f"
+}
+ev_field(){ python3 - "$1" "$2" "$3" <<'PY'
+import sys,json
+path,ev,field=sys.argv[1],sys.argv[2],sys.argv[3]
+for l in open(path):
+    l=l.strip()
+    if not l: continue
+    o=json.loads(l)
+    if o.get("event")==ev and field in o: print(o[field]); break
+PY
+}
+jsonl_valid(){ python3 - "$1" <<'PY'
+import sys,json
+ok=True
+for i,l in enumerate(open(sys.argv[1]),1):
+    l=l.strip()
+    if not l: continue
+    try:
+        o=json.loads(l)
+        if "run_id" not in o: print(f"line {i}: no run_id"); ok=False
+    except Exception as e: print(f"line {i}: {e}"); ok=False
+sys.exit(0 if ok else 1)
+PY
+}
+
+# ---------------------------------------------------------------------------
+echo "== A1/A2/A13: human.log populated with ONLY orchestrator lines; aggregates intact =="
+# pre-existing aggregate installer.log content (a prior run) — boundary baseline
+emit_run_block "$ILOG" "v1.221.3" update "PRIOR-RUN-0000" "prior installer phase A" "prior installer phase B"
+ILOG_SUM_BEFORE=$(cksum "$ILOG")
+export NFTBAN_RUN_ID="20260719T100000Z-r1"
+RID=$(_forensic_run_id)
+_forensic_begin "$RID" update 1.221.3 1.221.4 >/dev/null 2>&1
+D="$NFTBAN_LOG_DIR/update-runs/$RID"
+# orchestrator narrative via the REAL _update_log
+_update_log INFO "=== Update started v1.221.3 -> v1.221.4 ===" >/dev/null 2>&1
+_update_log OK   "pre-swap snapshot captured" >/dev/null 2>&1
+# now the installer child appends ITS phases to the aggregate installer.log
+emit_run_block "$ILOG" "v1.221.4" update "$RID" "installer phase 1: extract" "installer phase 2: validate"
+[ -s "$D/human.log" ] && ok "A1 human.log is non-empty after update" || no "A1 human.log still empty"
+grep -q "Update started v1.221.3" "$D/human.log" && ok "A1 human.log carries orchestrator line" || no "A1 orchestrator line missing"
+grep -q "installer phase 1: extract" "$D/human.log" && no "A2 installer child line leaked into human.log" || ok "A2 human.log excludes installer-child lines"
+grep -q "Update started v1.221.3" "$UPDATE_LOG_FILE" && ok "A13 aggregate update.log received the same line" || no "A13 update.log missing line"
+[ "$(cksum "$ILOG")" != "$ILOG_SUM_BEFORE" ] && ok "A13 aggregate installer.log grew from installer child (expected)" || no "A13 installer.log unexpectedly unchanged"
+
+echo "== A3/A4/A14: run_id-delimited slice = THIS run's installer block only =="
+_forensic_installer_slice "$RID"
+[ -s "$D/installer.log" ] && ok "A3 per-run installer.log populated" || no "A3 installer.log empty"
+grep -q "installer phase 1: extract" "$D/installer.log" && ok "A3 slice contains this run's installer lines" || no "A3 this-run lines missing"
+grep -q "prior installer phase A" "$D/installer.log" && no "A3 slice leaked PRIOR run content" || ok "A3 slice excludes prior-run content"
+grep -q "run_id=$RID" "$D/installer.log" && ok "A4 slice includes this run's RUN header" || no "A4 header missing"
+[ "$(ev_field "$D/run.jsonl" installer_slice method)" = "run_id_delimited" ] && ok "A4 method=run_id_delimited recorded" || no "A4 wrong method" "$(ev_field "$D/run.jsonl" installer_slice method)"
+jsonl_valid "$D/run.jsonl" && ok "A14 run.jsonl valid JSONL + every event carries run_id" || no "A14 run.jsonl invalid"
+grep -q '"event":"installer_slice"' "$D/run.jsonl" && ok "A14 installer_slice event present" || no "A14 no installer_slice event"
+
+echo "== A5: line-count-delta FALLBACK when installer stamps no run_id header =="
+export NFTBAN_RUN_ID="20260719T100500Z-r5"; RID5=$(_forensic_run_id)
+_forensic_begin "$RID5" update 1 2 >/dev/null 2>&1   # captures FORENSIC_ILOG_BEFORE
+D5="$NFTBAN_LOG_DIR/update-runs/$RID5"
+# old-style installer: append plain lines, NO run_id RUN header
+printf '2026-07-19T10:05:01Z [INFO] legacy installer line X\n2026-07-19T10:05:02Z [INFO] legacy installer line Y\n' >> "$ILOG"
+_forensic_installer_slice "$RID5"
+[ "$(ev_field "$D5/run.jsonl" installer_slice method)" = "line_count_delta" ] && ok "A5 method=line_count_delta" || no "A5 wrong method" "$(ev_field "$D5/run.jsonl" installer_slice method)"
+grep -q "legacy installer line X" "$D5/installer.log" && ok "A5 fallback captured new lines" || no "A5 new lines missing"
+grep -q "installer phase 1: extract" "$D5/installer.log" && no "A5 fallback over-captured earlier content" || ok "A5 fallback bounded to new lines only"
+
+echo "== A6: two sequential runs remain isolated =="
+[ -f "$D/human.log" ] && [ -f "$D5/human.log" ] && ! diff -q "$D/human.log" "$D5/human.log" >/dev/null && ok "A6 run r1 and r5 human.log differ (isolated)" || no "A6 runs not isolated"
+grep -q "Update started v1.221.3" "$D5/human.log" 2>/dev/null && no "A6 r1 orchestrator line bled into r5" || ok "A6 no cross-run orchestrator bleed"
+
+echo "== A7: failed/partial installer still yields its partial slice =="
+export NFTBAN_RUN_ID="20260719T100700Z-r7"; RID7=$(_forensic_run_id)
+_forensic_begin "$RID7" update 1 2 >/dev/null 2>&1
+D7="$NFTBAN_LOG_DIR/update-runs/$RID7"
+# installer wrote a header + one line, then failed mid-phase (no footer)
+emit_run_block "$ILOG" "v1.221.4" update "$RID7" "installer phase 1: extract (then failed)"
+_forensic_installer_slice "$RID7"
+[ -s "$D7/installer.log" ] && grep -q "then failed" "$D7/installer.log" && ok "A7 partial slice captured on failure" || no "A7 partial slice missing"
+
+echo "== A8: no-output + absent installer represented honestly =="
+export NFTBAN_RUN_ID="20260719T100800Z-r8"; RID8=$(_forensic_run_id)
+_forensic_begin "$RID8" update 1 2 >/dev/null 2>&1   # before == current total, nothing appended after
+D8="$NFTBAN_LOG_DIR/update-runs/$RID8"
+_forensic_installer_slice "$RID8"
+[ ! -s "$D8/installer.log" ] && ok "A8 no-output → per-run installer.log empty" || no "A8 unexpected content"
+[ "$(ev_field "$D8/run.jsonl" installer_slice reason)" = "no_installer_output" ] && ok "A8 reason=no_installer_output recorded" || no "A8 reason" "$(ev_field "$D8/run.jsonl" installer_slice reason)"
+# absent aggregate installer.log entirely (move it aside so FORENSIC_ILOG_FILE points at a missing file)
+mv "$ILOG" "$ILOG.bak"
+export NFTBAN_RUN_ID="20260719T100801Z-r8b"; RID8B=$(_forensic_run_id)
+_forensic_begin "$RID8B" update 1 2 >/dev/null 2>&1   # installer.log absent → before=0
+D8B="$NFTBAN_LOG_DIR/update-runs/$RID8B"
+_forensic_installer_slice "$RID8B"
+[ "$(ev_field "$D8B/run.jsonl" installer_slice reason)" = "installer_log_absent" ] && ok "A8 absent installer.log → reason=installer_log_absent" || no "A8 absent reason" "$(ev_field "$D8B/run.jsonl" installer_slice reason)"
+mv "$ILOG.bak" "$ILOG"   # restore aggregate for A9
+
+echo "== A9: truncation/rotation does not copy unrelated history =="
+export NFTBAN_RUN_ID="20260719T100900Z-r9"; RID9=$(_forensic_run_id)
+_forensic_begin "$RID9" update 1 2 >/dev/null 2>&1   # captures before = current (large) line count
+D9="$NFTBAN_LOG_DIR/update-runs/$RID9"
+# simulate logrotate replacing the aggregate with a fresh small file (no run_id header)
+printf '2026-07-19T10:09:00Z [INFO] freshly rotated installer.log unrelated line\n' > "$ILOG"
+_forensic_installer_slice "$RID9"
+[ ! -s "$D9/installer.log" ] && ok "A9 rotation → empty slice (no history copied)" || no "A9 copied unrelated history" "$(head -1 "$D9/installer.log")"
+[ "$(ev_field "$D9/run.jsonl" installer_slice reason)" = "truncated_or_rotated" ] && ok "A9 reason=truncated_or_rotated recorded" || no "A9 reason" "$(ev_field "$D9/run.jsonl" installer_slice reason)"
+
+echo "== A10: per-run files are mode 0640 =="
+m_h=$(stat -c '%a' "$D/human.log" 2>/dev/null); m_i=$(stat -c '%a' "$D/installer.log" 2>/dev/null)
+[ "$m_h" = "640" ] && ok "A10 human.log mode 0640" || no "A10 human.log mode" "$m_h"
+[ "$m_i" = "640" ] && ok "A10 installer.log mode 0640" || no "A10 installer.log mode" "$m_i"
+
+echo "== A11: support bundle collects all three per-run files (structural guard) =="
+grep -Eq 'for f in run\.jsonl human\.log installer\.log' "$SUPPORT" && ok "A11 cmd_support.sh collects run.jsonl + human.log + installer.log" || no "A11 support bundle does not collect installer.log"
+
+echo "== A12: per-run write failure never breaks _update_log =="
+SAVE_FH="$FORENSIC_HUMAN"
+export FORENSIC_HUMAN="$WORK/nonexistent-dir/human.log"   # parent missing → append fails
+_update_log INFO "containment probe line" >/dev/null 2>&1; rc=$?
+[ "$rc" = "0" ] && ok "A12 _update_log returns 0 despite per-run append failure" || no "A12 non-zero rc" "$rc"
+grep -q "containment probe line" "$UPDATE_LOG_FILE" && ok "A12 aggregate update.log still written under failure" || no "A12 update.log not written"
+export FORENSIC_HUMAN="$SAVE_FH"
+
+# ---------------------------------------------------------------------------
+echo
+echo "======================================================================"
+printf 'RESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Gate A of `LIFECYCLE_LOG_FORENSICS_AND_ROTATION_SAFETY`

Fixes `OPEN_UPDATE_RUN_HUMAN_LOG_EMPTY`: the per-run forensic record
`update-runs/<run_id>/human.log` was **created, truncated and permissioned but never written** — the only reference to `FORENSIC_HUMAN` in the whole tree was its setup in `_forensic_begin`. The human update stream went solely to the aggregate `update.log` + terminal, so every per-run `human.log` was **0 bytes** (fleet-wide, long-standing) and the per-run directory was not self-contained.

### Fix — self-contained 3-file record (owner-approved Option 2)

- **A1 — canonical-line tee.** `_update_log` constructs the formatted line **once** and projects it to `update.log` + the **active** per-run `human.log` (`[ -n "$FORENSIC_HUMAN" ]`, fail-safe `|| true`) + terminal. No format drift; aggregate/terminal/`run.jsonl` behavior unchanged.
- **A2 — installer slice.** New `_forensic_installer_slice` extracts **this run's** slice of the aggregate `installer.log` into `update-runs/<run_id>/installer.log`.
  - **PRIMARY:** run_id-delimited from the installer RUN header (`logger.go` stamps `… run_id=<id>`) through the next header / EOF — robust to rotation & concurrency.
  - **FALLBACK:** line-count delta vs the pre-install boundary (`FORENSIC_ILOG_BEFORE`).
  - Defensive on absent / created / rotated / truncated / no-output; **never mutates** the aggregate; records an `installer_slice` event (`method`/`bytes`/`reason`, no silent cap).

Record layout = **three distinct files** (`run.jsonl` machine · `human.log` orchestrator · `installer.log` installer child), created up front for a stable shape. Support bundle (`cmd_support.sh`) now collects all three.

### Scope (code-verified)

`_forensic_begin` has **exactly one caller** — `cmd_update.sh:431` (the update path). A **standalone fresh install** (`install.sh` / package `%post`) creates **no** per-run record at all → this PR is truthfully **update-path only** (incl. the installer child invoked *under* update). The broader fresh-install-entrypoint gap is tracked separately as `OPEN_STANDALONE_INSTALL_PER_RUN_FORENSIC_RECORD` and is **not** claimed here.

**Not in scope (Gate B):** no rotation / retention / compression / profile / disk changes. No `VERSION`/`CHANGELOG` bump (deferred to the combined release-prep after both gates merge).

### Tests

`update_run_human_log_gatea_test.sh` — **28/0**, covering A1–A14 (populated human.log; orchestrator-only isolation; run_id-delimited + line-count-fallback slicing; sequential-run isolation; partial-on-failure; honest no-output/absent; no history copy on rotation; 0640 perms; support-bundle collection; write-failure containment; aggregate logs unchanged; run.jsonl semantics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
