### PR TITLE
v1.223.0: restore health-resource verdict truth across repair and revalidate

### DIFF
--- a/cli/lib/nftban/cli/cmd_mail.sh
+++ b/cli/lib/nftban/cli/cmd_mail.sh
@@ -131,7 +131,7 @@ _mail_setup_show() {
     echo "  Enabled:   ${NFTBAN_MAIL_ENABLED:-NO}"
     echo "  Recipient: ${NFTBAN_MAIL_RECIPIENT:-(not set)}"
     echo "  Method:    ${NFTBAN_MAIL_METHOD:-auto-detect}"
-    echo "  Sender:    ${NFTBAN_SENDER:-nftban@\$(hostname)}"
+    echo "  Sender:    ${NFTBAN_SENDER:-nftban@$(hostname -f)}"
     echo ""
     echo "Notification Triggers:"
     echo "  Health Critical: ${NFTBAN_MAIL_ON_HEALTH_CRITICAL:-NO}"
@@ -193,8 +193,12 @@ nftban_cmd_mail() {
                     *) [[ -z "$recipient" ]] && recipient="$_a" ;;
                 esac
             done
-            # Auto-detect from panel if not provided
-            if [[ -z "$recipient" ]] && declare -f nftban_panel_get_admin_email &>/dev/null; then
+            # Auto-detect from panel ONLY when neither a CLI arg NOR the configured
+            # global recipient is set. Precedence MUST be: CLI arg > NFTBAN_MAIL_RECIPIENT
+            # > panel admin. (Bug fix: the panel admin email previously overrode a
+            # configured NFTBAN_MAIL_RECIPIENT, so `mail test` silently misrouted every
+            # test to the panel admin on cPanel/Plesk/DirectAdmin hosts.)
+            if [[ -z "$recipient" && -z "${NFTBAN_MAIL_RECIPIENT:-}" ]] && declare -f nftban_panel_get_admin_email &>/dev/null; then
                 recipient=$(nftban_panel_get_admin_email 2>/dev/null) || true
                 if [[ -n "$recipient" && "$dry_run" == false ]]; then
                     echo "[INFO] Using panel admin email: $recipient"

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -983,7 +983,8 @@ EOF
     # message is labeled "Test Email" (matching the subject we printed above) rather
     # than the generic "Report" subject nftban_mail_send uses by default. (Bug fix:
     # the on-screen subject said "Test Email" but the sent subject was "Report".)
-    local NFTBAN_MAIL_SUBJECT_OVERRIDE="${NFTBAN_MAIL_SUBJECT_PREFIX:-[NFTBan]} Test Email from $(hostname -f)"
+    local NFTBAN_MAIL_SUBJECT_OVERRIDE
+    NFTBAN_MAIL_SUBJECT_OVERRIDE="${NFTBAN_MAIL_SUBJECT_PREFIX:-[NFTBan]} Test Email from $(hostname -f)"
     nftban_mail_send "$test_content" "$recipient"
 }
 

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -665,8 +665,13 @@ nftban_mail_send() {
     local sender="${NFTBAN_SENDER:-nftban@$(hostname -f)}"
     local from_name="${NFTBAN_FROM_NAME:-NFTBan Security System}"
     local subject_prefix="${NFTBAN_MAIL_SUBJECT_PREFIX:-[NFTBan]}"
+    # Subject: a caller may set NFTBAN_MAIL_SUBJECT_OVERRIDE (a dynamically-scoped
+    # local, e.g. from nftban_mail_send_test) to label the message accurately;
+    # otherwise the generic "Report" subject is used. NOTE: the subject is NOT a
+    # positional arg — $3 is reserved by existing callers (e.g. attachment path in
+    # cmd_support.sh), so it must not be repurposed.
     local subject
-    subject="${subject_prefix} Report from $(hostname -f)"
+    subject="${NFTBAN_MAIL_SUBJECT_OVERRIDE:-${subject_prefix} Report from $(hostname -f)}"
 
     # C5 fix: Sanitize email headers to prevent CRLF injection
     sender="${sender//$'\r'/}"
@@ -974,7 +979,11 @@ nftban_mail_send_test() {
 EOF
 )
 
-    # Send using main send function
+    # Send using main send function. Set the subject override so the DELIVERED
+    # message is labeled "Test Email" (matching the subject we printed above) rather
+    # than the generic "Report" subject nftban_mail_send uses by default. (Bug fix:
+    # the on-screen subject said "Test Email" but the sent subject was "Report".)
+    local NFTBAN_MAIL_SUBJECT_OVERRIDE="${NFTBAN_MAIL_SUBJECT_PREFIX:-[NFTBan]} Test Email from $(hostname -f)"
     nftban_mail_send "$test_content" "$recipient"
 }
 
@@ -994,13 +1003,21 @@ nftban_mail_show_help() {
     local mta
     mta="$(nftban_mail_detect_mta)"
 
+    # Precompute the status' first line WITHOUT a pipe. A `... | head -1` inside the
+    # heredoc below makes nftban_mail_check_status receive SIGPIPE under
+    # `set -o pipefail` (exit 141), which the ERR trap reports as a failure and aborts
+    # `nftban mail` help. Slice the first line via parameter expansion instead.
+    local mail_status_line
+    mail_status_line="$(nftban_mail_check_status 2>&1)"
+    mail_status_line="${mail_status_line%%$'\n'*}"
+
     cat <<EOF
 
 Smart Mail Adapter - Auto-detects best available method
 ========================================================
 
 Current Method: $mta
-Status: $(nftban_mail_check_status 2>&1 | head -1)
+Status: ${mail_status_line}
 
 Supported Methods (auto-detected in priority order):
   postfix   - Local Postfix MTA (fastest)

--- a/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
+++ b/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.223.0 — mail recipient-precedence / subject / help-SIGPIPE guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="mail_recipient_subject_help_v1223_test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-21"
+# meta:description="Regression guard for three mail bugs seen on panel (DirectAdmin/cPanel/Plesk) hosts: (1) `nftban mail test` must honor the configured NFTBAN_MAIL_RECIPIENT and use the panel admin email ONLY as a last-resort fallback (was: panel email overrode config, misrouting every test); (2) the DELIVERED test subject must say 'Test Email' (was: hardcoded 'Report' while the CLI printed 'Test Email'); (3) `nftban mail` help must not SIGPIPE (exit 141) under set -o pipefail from a `| head -1` inside the help heredoc. All stubbed — sends nothing."
+# meta:input="repo cli/lib/nftban (read-only, sourced with stubs)"
+# meta:output="pass/fail; exit 0 all-pass, 1 on regression"
+# meta:depends="bash"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_mail.sh,cli/lib/nftban/core/nftban_mail.sh"
+# meta:inventory.privileges="none"
+# =============================================================================
+# NOTE: intentionally NOT run under `set -Eeuo pipefail` at file scope — the
+# production mail library is not written to be sourced under errexit/nounset.
+# The help-SIGPIPE case (T5) enables `set -o pipefail`+errexit locally, which is
+# exactly the runtime condition under which the original bug crashed.
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$TEST_DIR/.." && pwd)"          # .../cli/lib/nftban
+export NFTBAN_LIB_DIR="$LIB_DIR"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "=== v1.223.0 mail recipient/subject/help guard ==="
+
+# --- Stubs (defined BEFORE sourcing so load-time refs resolve) ----------------
+_source_local(){ :; }                                  # skip /etc config overlay
+nftban_banner(){ :; }
+nftban_mail_detect_mta(){ echo "sendmail"; }
+nftban_module_loaded(){ :; }
+nftban_panel_get_admin_email(){ echo "panel-admin@example.com"; }   # what a panel host returns
+
+# These production files call exit at source-time without the full nftban runtime
+# (lib/strict.sh, version.sh, JSON helper, etc.). Probe in a subshell first; if they
+# are not sourceable here (e.g. a bare dev box), SKIP cleanly — this test is meant to
+# run in the lab/CI on an nftban host, with NFTBAN_LIB_DIR pointed at the lib tree
+# under test (drop the fixed cmd_mail.sh/nftban_mail.sh into an isolated copy).
+if ! ( source "$LIB_DIR/core/nftban_mail.sh" && source "$LIB_DIR/cli/cmd_mail.sh" \
+       && declare -f nftban_cmd_mail >/dev/null ) >/dev/null 2>&1; then
+    echo "  ⊘ SKIP: nftban runtime not sourceable here (needs installed lib env)."
+    echo "         Run on an nftban host: NFTBAN_LIB_DIR=<lib-tree-with-fix> bash $0"
+    exit 0
+fi
+# shellcheck source=/dev/null
+source "$LIB_DIR/core/nftban_mail.sh" >/dev/null 2>&1
+# shellcheck source=/dev/null
+source "$LIB_DIR/cli/cmd_mail.sh"    >/dev/null 2>&1
+
+# Re-declare the controlling stubs AFTER sourcing so they win over any real
+# definitions the sourced files pulled in (e.g. the real nftban_panel_get_admin_email
+# from nftban_panel_common.sh, which on a live panel host returns the panel address).
+nftban_panel_get_admin_email(){ echo "panel-admin@example.com"; }
+nftban_mail_detect_mta(){ echo "sendmail"; }
+nftban_banner(){ :; }
+
+# Capturing stub for the actual sender (defined AFTER sourcing so it wins).
+CAP_RECIPIENT=""; CAP_SUBJECT=""
+nftban_mail_send(){
+    CAP_RECIPIENT="${2:-${NFTBAN_MAIL_RECIPIENT:-}}"
+    CAP_SUBJECT="${NFTBAN_MAIL_SUBJECT_OVERRIDE:-[NFTBan] Report from host}"
+    return 0
+}
+# helper: run `nftban mail test [arg]` in-process, echo the captured recipient|subject
+run_test_capture(){ CAP_RECIPIENT=""; CAP_SUBJECT=""; nftban_cmd_mail test "$@" >/dev/null 2>&1; printf '%s|%s' "$CAP_RECIPIENT" "$CAP_SUBJECT"; }
+
+# T1: configured NFTBAN_MAIL_RECIPIENT WINS over the panel admin email.
+NFTBAN_MAIL_RECIPIENT="configured@itcms.gr"; export NFTBAN_MAIL_RECIPIENT
+r="$(run_test_capture)"; got="${r%%|*}"
+[[ "$got" == "configured@itcms.gr" ]] \
+  && ok "T1 configured recipient wins over panel admin (no misroute)" \
+  || no "T1 recipient MISROUTED to panel despite NFTBAN_MAIL_RECIPIENT set" "got=[$got]"
+
+# T4: the DELIVERED subject says "Test Email" (uses the same run as T1).
+subj="${r#*|}"
+[[ "$subj" == *"Test Email"* ]] \
+  && ok "T4 sent subject labeled 'Test Email' (matches on-screen)" \
+  || no "T4 sent subject NOT 'Test Email'" "got=[$subj]"
+
+# T3: an explicit CLI recipient arg still wins over everything.
+r="$(run_test_capture "cli-arg@example.net")"; got="${r%%|*}"
+[[ "$got" == "cli-arg@example.net" ]] \
+  && ok "T3 explicit CLI recipient wins" \
+  || no "T3 CLI recipient arg ignored" "got=[$got]"
+
+# T2: with NO configured recipient AND no CLI arg, panel admin is the fallback.
+unset NFTBAN_MAIL_RECIPIENT
+r="$(run_test_capture)"; got="${r%%|*}"
+[[ "$got" == "panel-admin@example.com" ]] \
+  && ok "T2 panel admin used as fallback when nothing configured" \
+  || no "T2 panel fallback broken" "got=[$got]"
+
+# T5: `nftban mail` help must NOT SIGPIPE (exit 141) under pipefail, even when
+#     nftban_mail_check_status emits MANY lines (the original crash trigger).
+nftban_mail_check_status(){ printf '%s\n' "line-1-status" "line-2" "line-3" "line-4"; }
+help_out="$( set -o pipefail; set -e; nftban_mail_show_help 2>&1 )"; help_rc=$?
+[[ "$help_rc" -eq 0 ]] \
+  && ok "T5 help renders without SIGPIPE (exit 0 under pipefail+errexit)" \
+  || no "T5 help crashed (SIGPIPE/pipefail regression)" "exit=$help_rc"
+grep -q "Status: line-1-status" <<<"$help_out" \
+  && ok "T5b help Status shows the first status line" \
+  || no "T5b help Status line missing/incorrect"
+
+echo ""
+echo "=== RESULT: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
+++ b/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
@@ -1,109 +1,80 @@
 #!/usr/bin/env bash
 # =============================================================================
-# NFTBan v1.223.0 — mail recipient-precedence / subject / help-SIGPIPE guard
+# NFTBan v1.223.0 — mail recipient/subject/help fix guard (static)
 # =============================================================================
 # SPDX-License-Identifier: MPL-2.0
 # meta:name="mail_recipient_subject_help_v1223_test"
 # meta:type="test"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 # meta:created_date="2026-07-21"
-# meta:description="Regression guard for three mail bugs seen on panel (DirectAdmin/cPanel/Plesk) hosts: (1) `nftban mail test` must honor the configured NFTBAN_MAIL_RECIPIENT and use the panel admin email ONLY as a last-resort fallback (was: panel email overrode config, misrouting every test); (2) the DELIVERED test subject must say 'Test Email' (was: hardcoded 'Report' while the CLI printed 'Test Email'); (3) `nftban mail` help must not SIGPIPE (exit 141) under set -o pipefail from a `| head -1` inside the help heredoc. All stubbed — sends nothing."
-# meta:input="repo cli/lib/nftban (read-only, sourced with stubs)"
-# meta:output="pass/fail; exit 0 all-pass, 1 on regression"
-# meta:depends="bash"
+# meta:description="Locks three mail fixes that misbehaved on panel (DirectAdmin/cPanel/Plesk) hosts. (1) `nftban mail test` must gate the panel-admin auto-detect on BOTH an empty CLI arg AND an empty NFTBAN_MAIL_RECIPIENT, so a configured recipient is never overridden by the panel address. (2) the delivered test subject must be set via NFTBAN_MAIL_SUBJECT_OVERRIDE to 'Test Email' (was: hardcoded 'Report' while the CLI printed 'Test Email'). (3) the `nftban mail` help must NOT pipe nftban_mail_check_status into `head` inside its heredoc (SIGPIPE/exit 141 under pipefail) — it must slice a precomputed variable. Plus the setup --show Sender must expand hostname, not print a literal \$(hostname). Static guard (grep-based, like the fsync/heredoc guards) — the mail library exits at source-time without the full runtime, so behavioral coverage is provided by the lab/host validation; this locks the fix text against regression. Includes negative controls that FAIL if the original buggy patterns reappear."
+# meta:input="cli/lib/nftban source (read-only)"
+# meta:output="pass/fail; exit 0 all-pass, 1 on a regressed fix"
+# meta:depends="bash,grep"
 # meta:inventory.files="cli/lib/nftban/cli/cmd_mail.sh,cli/lib/nftban/core/nftban_mail.sh"
 # meta:inventory.privileges="none"
 # =============================================================================
-# NOTE: intentionally NOT run under `set -Eeuo pipefail` at file scope — the
-# production mail library is not written to be sourced under errexit/nounset.
-# The help-SIGPIPE case (T5) enables `set -o pipefail`+errexit locally, which is
-# exactly the runtime condition under which the original bug crashed.
+set -Eeuo pipefail
+IFS=$'\n\t'
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$TEST_DIR/.." && pwd)"          # .../cli/lib/nftban
-export NFTBAN_LIB_DIR="$LIB_DIR"
+CM="$LIB_DIR/cli/cmd_mail.sh"
+NM="$LIB_DIR/core/nftban_mail.sh"
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
 no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+have(){ grep -qF "$2" "$1"; }          # fixed-string present
+lacks(){ ! grep -qF "$2" "$1"; }       # fixed-string absent
 
-echo "=== v1.223.0 mail recipient/subject/help guard ==="
+echo "=== v1.223.0 mail recipient/subject/help fix guard ==="
+[[ -f "$CM" && -f "$NM" ]] || { echo "  ✗ source files not found"; exit 2; }
 
-# --- Stubs (defined BEFORE sourcing so load-time refs resolve) ----------------
-_source_local(){ :; }                                  # skip /etc config overlay
-nftban_banner(){ :; }
-nftban_mail_detect_mta(){ echo "sendmail"; }
-nftban_module_loaded(){ :; }
-nftban_panel_get_admin_email(){ echo "panel-admin@example.com"; }   # what a panel host returns
-
-# These production files call exit at source-time without the full nftban runtime
-# (lib/strict.sh, version.sh, JSON helper, etc.). Probe in a subshell first; if they
-# are not sourceable here (e.g. a bare dev box), SKIP cleanly — this test is meant to
-# run in the lab/CI on an nftban host, with NFTBAN_LIB_DIR pointed at the lib tree
-# under test (drop the fixed cmd_mail.sh/nftban_mail.sh into an isolated copy).
-if ! ( source "$LIB_DIR/core/nftban_mail.sh" && source "$LIB_DIR/cli/cmd_mail.sh" \
-       && declare -f nftban_cmd_mail >/dev/null ) >/dev/null 2>&1; then
-    echo "  ⊘ SKIP: nftban runtime not sourceable here (needs installed lib env)."
-    echo "         Run on an nftban host: NFTBAN_LIB_DIR=<lib-tree-with-fix> bash $0"
-    exit 0
+# T1: `mail test` panel auto-detect gated on empty CLI arg AND empty config recipient.
+if have "$CM" 'if [[ -z "$recipient" && -z "${NFTBAN_MAIL_RECIPIENT:-}" ]] && declare -f nftban_panel_get_admin_email'; then
+    ok "T1 panel auto-detect gated on empty NFTBAN_MAIL_RECIPIENT (config recipient wins)"
+else
+    no "T1 recipient-precedence fix MISSING (config recipient can be overridden by panel)"
 fi
-# shellcheck source=/dev/null
-source "$LIB_DIR/core/nftban_mail.sh" >/dev/null 2>&1
-# shellcheck source=/dev/null
-source "$LIB_DIR/cli/cmd_mail.sh"    >/dev/null 2>&1
+# T1-neg: the original bare form must be gone.
+if grep -qE 'if \[\[ -z "\$recipient" \]\] && declare -f nftban_panel_get_admin_email' "$CM"; then
+    no "T1-neg ORIGINAL bare panel-override reintroduced (panel overrides config again)"
+else
+    ok "T1-neg original bare panel-override removed"
+fi
 
-# Re-declare the controlling stubs AFTER sourcing so they win over any real
-# definitions the sourced files pulled in (e.g. the real nftban_panel_get_admin_email
-# from nftban_panel_common.sh, which on a live panel host returns the panel address).
-nftban_panel_get_admin_email(){ echo "panel-admin@example.com"; }
-nftban_mail_detect_mta(){ echo "sendmail"; }
-nftban_banner(){ :; }
+# T2: nftban_mail_send honors a NFTBAN_MAIL_SUBJECT_OVERRIDE (not hardcoded 'Report').
+if have "$NM" 'subject="${NFTBAN_MAIL_SUBJECT_OVERRIDE:-'; then
+    ok "T2 nftban_mail_send honors NFTBAN_MAIL_SUBJECT_OVERRIDE"
+else
+    no "T2 subject override plumbing MISSING (every mail still labeled 'Report')"
+fi
 
-# Capturing stub for the actual sender (defined AFTER sourcing so it wins).
-CAP_RECIPIENT=""; CAP_SUBJECT=""
-nftban_mail_send(){
-    CAP_RECIPIENT="${2:-${NFTBAN_MAIL_RECIPIENT:-}}"
-    CAP_SUBJECT="${NFTBAN_MAIL_SUBJECT_OVERRIDE:-[NFTBan] Report from host}"
-    return 0
-}
-# helper: run `nftban mail test [arg]` in-process, echo the captured recipient|subject
-run_test_capture(){ CAP_RECIPIENT=""; CAP_SUBJECT=""; nftban_cmd_mail test "$@" >/dev/null 2>&1; printf '%s|%s' "$CAP_RECIPIENT" "$CAP_SUBJECT"; }
+# T3: send_test sets the override to a 'Test Email' subject before delivering.
+if grep -qE 'local NFTBAN_MAIL_SUBJECT_OVERRIDE=.*Test Email' "$NM"; then
+    ok "T3 send_test labels the delivered message 'Test Email'"
+else
+    no "T3 send_test does NOT set the Test Email subject override"
+fi
 
-# T1: configured NFTBAN_MAIL_RECIPIENT WINS over the panel admin email.
-NFTBAN_MAIL_RECIPIENT="configured@itcms.gr"; export NFTBAN_MAIL_RECIPIENT
-r="$(run_test_capture)"; got="${r%%|*}"
-[[ "$got" == "configured@itcms.gr" ]] \
-  && ok "T1 configured recipient wins over panel admin (no misroute)" \
-  || no "T1 recipient MISROUTED to panel despite NFTBAN_MAIL_RECIPIENT set" "got=[$got]"
+# T4: help must NOT pipe check_status into head inside the heredoc (SIGPIPE fix).
+if grep -qE 'nftban_mail_check_status 2>&1 \| head' "$NM"; then
+    no "T4 help still pipes check_status | head (SIGPIPE/exit 141 under pipefail)"
+else
+    ok "T4 help no longer pipes check_status into head"
+fi
+if have "$NM" 'mail_status_line="${mail_status_line%%'; then
+    ok "T4b help slices a precomputed status line (no pipe)"
+else
+    no "T4b precomputed mail_status_line slice MISSING"
+fi
 
-# T4: the DELIVERED subject says "Test Email" (uses the same run as T1).
-subj="${r#*|}"
-[[ "$subj" == *"Test Email"* ]] \
-  && ok "T4 sent subject labeled 'Test Email' (matches on-screen)" \
-  || no "T4 sent subject NOT 'Test Email'" "got=[$subj]"
-
-# T3: an explicit CLI recipient arg still wins over everything.
-r="$(run_test_capture "cli-arg@example.net")"; got="${r%%|*}"
-[[ "$got" == "cli-arg@example.net" ]] \
-  && ok "T3 explicit CLI recipient wins" \
-  || no "T3 CLI recipient arg ignored" "got=[$got]"
-
-# T2: with NO configured recipient AND no CLI arg, panel admin is the fallback.
-unset NFTBAN_MAIL_RECIPIENT
-r="$(run_test_capture)"; got="${r%%|*}"
-[[ "$got" == "panel-admin@example.com" ]] \
-  && ok "T2 panel admin used as fallback when nothing configured" \
-  || no "T2 panel fallback broken" "got=[$got]"
-
-# T5: `nftban mail` help must NOT SIGPIPE (exit 141) under pipefail, even when
-#     nftban_mail_check_status emits MANY lines (the original crash trigger).
-nftban_mail_check_status(){ printf '%s\n' "line-1-status" "line-2" "line-3" "line-4"; }
-help_out="$( set -o pipefail; set -e; nftban_mail_show_help 2>&1 )"; help_rc=$?
-[[ "$help_rc" -eq 0 ]] \
-  && ok "T5 help renders without SIGPIPE (exit 0 under pipefail+errexit)" \
-  || no "T5 help crashed (SIGPIPE/pipefail regression)" "exit=$help_rc"
-grep -q "Status: line-1-status" <<<"$help_out" \
-  && ok "T5b help Status shows the first status line" \
-  || no "T5b help Status line missing/incorrect"
+# T5: setup --show Sender expands hostname (not a literal \$(hostname)).
+if grep -qE 'Sender:.*nftban@\$\(hostname' "$CM" && lacks "$CM" 'nftban@\$(hostname)'; then
+    ok "T5 setup --show Sender expands hostname"
+else
+    no "T5 setup --show Sender still prints a literal \$(hostname)"
+fi
 
 echo ""
 echo "=== RESULT: $PASS passed, $FAIL failed ==="

--- a/cli/lib/nftban/tests/update_force_delegation_v1223_test.sh
+++ b/cli/lib/nftban/tests/update_force_delegation_v1223_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.223.0 verdict-truth: update-force delegation (no shell verdict logic)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="update_force_delegation_v1223_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-20"
+# meta:description="v1.223.0 verdict-truth (RULING 2): the `nftban update force` branch must DELEGATE to the established Go installer entry point (which runs the corrected repair/resume/validate path → shared ResolveHealthResourceVerdict) and must contain NO health-resource / MemoryMax / OOM-tier / verdict computation of its own. Structural grep assertions: (1) the force branch delegates to _cmd_update_main; (2) the force branch body carries no verdict-computation tokens; (3) cmd_update.sh as a whole computes no health verdict; (4) cmd_update.sh references the nftban-installer binary as the verdict authority."
+# meta:input="cli/lib/nftban/cli/cmd_update.sh (static source; no execution)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,awk,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+UPD="$REPO/cli/lib/nftban/cli/cmd_update.sh"
+
+SB=$(mktemp -d); trap 'rm -rf "$SB"' EXIT
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf "  [PASS] %s\n" "$1"; PASS=$((PASS+1)); }
+no(){ printf "  [FAIL] %s\n" "$1"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+echo "=== v1.223.0 verdict-truth: update-force delegates to the installer (no shell verdict) ==="
+
+[[ -f "$UPD" ]] && ok "cmd_update.sh present" || no "cmd_update.sh present"
+
+# Extract the force branch body: from the `force|--force|reinstall)` case label to
+# the terminating `;;`.
+awk '/force\|--force\|reinstall\)/{c=1} c{print} c&&/;;/{exit}' "$UPD" > "$SB/force.sh"
+[[ -s "$SB/force.sh" ]] && ok "extracted force branch body" || no "extract force branch body"
+
+# (1) The force branch DELEGATES to the shared update orchestrator (_cmd_update_main),
+#     which drives the packaged Go installer (nftban-installer) → the corrected
+#     repair/resume/validate verdict path.
+if grep -q "_cmd_update_main" "$SB/force.sh"; then
+  ok "force branch delegates to _cmd_update_main (installer-driven path)"
+else
+  no "force branch must delegate to _cmd_update_main"
+fi
+
+# (2) The force branch body must contain NO health-verdict / OOM-tier / MemoryMax
+#     computation of its own.
+FORBIDDEN='MemoryMax=|MemoryHigh=|ClassifyEffective|HealthServiceMemoryLimits|FALLBACK_UNDERSIZED|ACTIVE_MATCH|health_resource_policy|ResolveHealthResource'
+if grep -Eq "$FORBIDDEN" "$SB/force.sh"; then
+  no "force branch must NOT compute a health verdict (found: $(grep -Eo "$FORBIDDEN" "$SB/force.sh" | tr '\n' ' '))"
+else
+  ok "force branch contains no health-verdict computation"
+fi
+
+# (3) The WHOLE cmd_update.sh computes no health verdict of its own (the verdict
+#     authority is the Go installer, shared ResolveHealthResourceVerdict).
+if grep -Eq "$FORBIDDEN" "$UPD"; then
+  no "cmd_update.sh must NOT compute a health verdict (found: $(grep -Eno "$FORBIDDEN" "$UPD" | tr '\n' ' '))"
+else
+  ok "cmd_update.sh contains no health-verdict computation anywhere"
+fi
+
+# (4) cmd_update.sh references the nftban-installer binary — the delegation target
+#     that owns the verdict authority.
+if grep -q "nftban-installer" "$UPD"; then
+  ok "cmd_update.sh references nftban-installer (delegation target / verdict authority)"
+else
+  no "cmd_update.sh must reference nftban-installer as the delegation target"
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+  printf 'FAILED: %s\n' "${FAILED[@]}"
+  exit 1
+fi
+exit 0

--- a/cmd/nftban-core/cmd_resources.go
+++ b/cmd/nftban-core/cmd_resources.go
@@ -200,7 +200,12 @@ func assembleReport(calc safety.HealthResourceProfile, sf *state.StateFile, pers
 	}
 	st := healthresource.ClassifyEffectiveDetailed(calc, effHigh, effMax, svc.Dropin.Loaded, otherDropins, svc.Dropin.OnDisk)
 	svc.State = string(st)
-	svc.ProtectionActive = st.ProtectionActive()
+	// v1.223.0 (BUG-RESOURCES-VERDICT-TIER-BLIND): decide "protected" via the SHARED
+	// tier-aware predicate — same as the installer's Verdict.Acceptable — so the CLI
+	// and installer never contradict. Previously used the tier-blind
+	// State.ProtectionActive(), which reported a medium/large FALLBACK_MATCH host as
+	// protected while the installer marked it DEGRADED.
+	svc.ProtectionActive = healthresource.AcceptableFor(calc.Tier, st)
 	if svc.ProtectionActive {
 		svc.Validation = "PASS"
 	} else {

--- a/cmd/nftban-core/cmd_resources.go
+++ b/cmd/nftban-core/cmd_resources.go
@@ -270,7 +270,16 @@ func runSystemctlShow() (map[string]string, error) {
 func resourcesExitCode(rep resourcesReport) int {
 	svc := rep.Service
 	if !svc.Effective.Available {
-		return 1 // incomplete evidence
+		// v1.223.0 verdict-truth (locked UNAVAILABLE policy): the live read could
+		// not be verified. A protection-REQUIRED tier (medium/large) is FAIL-CLOSED
+		// → exit 2, matching the installer's UNAVAILABLE→DEGRADED — the CLI and
+		// installer share the same acceptability stance and must not report a host
+		// whose REQUIRED protection cannot be verified as merely "incomplete". A
+		// non-required tier (small) stays exit 1 (incomplete evidence).
+		if healthresource.ProtectionRequired(safety.ResourceTier(rep.Host.ResourceTier)) {
+			return 2
+		}
+		return 1
 	}
 	if svc.ProtectionActive {
 		return 0

--- a/cmd/nftban-core/cmd_resources_test.go
+++ b/cmd/nftban-core/cmd_resources_test.go
@@ -94,8 +94,15 @@ func TestResourcesShowUnavailable(t *testing.T) {
 	if rep.Service.Effective.Available {
 		t.Error("show-unavailable must set Effective.Available=false")
 	}
-	if resourcesExitCode(rep) != 1 {
-		t.Errorf("show-unavailable exit=%d want 1 (incomplete evidence, never guessed active)", resourcesExitCode(rep))
+	// v1.223.0 locked: medium (protection-required) unverifiable → FAIL-CLOSED exit 2
+	// (matches the installer's UNAVAILABLE→DEGRADED). Never guessed active.
+	if resourcesExitCode(rep) != 2 {
+		t.Errorf("medium show-unavailable exit=%d want 2 (required-protection fail-closed)", resourcesExitCode(rep))
+	}
+	// small (not protection-required) unverifiable → exit 1 (incomplete evidence).
+	repSmall := assembleReport(calcFor(2<<30), nil, false, nil, errors.New("Failed to connect to bus"), true)
+	if resourcesExitCode(repSmall) != 1 {
+		t.Errorf("small show-unavailable exit=%d want 1 (incomplete evidence)", resourcesExitCode(repSmall))
 	}
 	if rep.Service.ProtectionActive {
 		t.Error("must never report protection active when systemctl is unavailable")

--- a/cmd/nftban-core/resources_parity_v1223_test.go
+++ b/cmd/nftban-core/resources_parity_v1223_test.go
@@ -124,17 +124,20 @@ func TestResourcesTierStateParity(t *testing.T) {
 	}
 }
 
-// The live-unreadable path (systemctl show failed) is INCOMPLETE evidence → exit 1
-// per resourcesExitCode, on any tier. This is the CLI "protection unverifiable"
-// alignment point (distinct from the installer assertion, which for a
-// protection-REQUIRED tier turns an unverifiable live read into DEGRADED).
-func TestResourcesLiveUnreadable_IncompleteExit1(t *testing.T) {
-	calc := calcFor(6 << 30) // medium
-	rep := assembleReport(calc, nil, false, nil, errors.New("systemctl show: unit not loaded"), false)
-	if rep.Service.Effective.Available {
+// The live-unreadable path (systemctl show failed) is unverifiable. LOCKED v1.223.0
+// policy: a protection-REQUIRED tier (medium/large) FAIL-CLOSES → exit 2 — the SAME
+// stance as the installer's UNAVAILABLE→DEGRADED (CLI and installer agree). A
+// non-required tier (small) is incomplete evidence → exit 1.
+func TestResourcesLiveUnreadable_TierAware(t *testing.T) {
+	medium := assembleReport(calcFor(6<<30), nil, false, nil, errors.New("systemctl show: unit not loaded"), false)
+	if medium.Service.Effective.Available {
 		t.Fatal("live read failed → Effective.Available must be false")
 	}
-	if got := resourcesExitCode(rep); got != 1 {
-		t.Errorf("live-unreadable exit=%d want 1 (incomplete evidence)", got)
+	if got := resourcesExitCode(medium); got != 2 {
+		t.Errorf("medium live-unreadable exit=%d want 2 (required-protection fail-closed)", got)
+	}
+	small := assembleReport(calcFor(2<<30), nil, false, nil, errors.New("systemctl show: unit not loaded"), false)
+	if got := resourcesExitCode(small); got != 1 {
+		t.Errorf("small live-unreadable exit=%d want 1 (incomplete evidence)", got)
 	}
 }

--- a/cmd/nftban-core/resources_parity_v1223_test.go
+++ b/cmd/nftban-core/resources_parity_v1223_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="resources_parity_v1223_test.go"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: CLI/installer parity. For each (tier,state) prove the read-only CLI's resourcesExitCode + rep.Service.ProtectionActive agree with the SHARED healthresource.AcceptableFor predicate (INSTALLER_ACCEPTABLE == CLI_PROTECTION_ACTIVE), and that human vs JSON render the SAME semantic accept/reject result. Also the live-unreadable incomplete-evidence exit (exit 1) per resourcesExitCode."
+// meta:inventory.files="cmd/nftban-core/resources_parity_v1223_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+)
+
+func i64(v int64) string { return strconv.FormatInt(v, 10) }
+
+// captureHuman renders printResourcesHuman to a string.
+func captureHuman(t *testing.T, rep resourcesReport) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	printResourcesHuman(rep)
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = orig
+	return buf.String()
+}
+
+// TestResourcesTierStateParity is the (tier,state) → accept/exit truth table. Every
+// readable row proves resourcesExitCode + ProtectionActive == AcceptableFor, and that
+// the human "Protection active" line matches the JSON protection_active field.
+func TestResourcesTierStateParity(t *testing.T) {
+	const (
+		smallHigh, smallMax   = int64(201326592), int64(268435456) // 192/256 MiB
+		mediumHigh, mediumMax = int64(268435456), int64(402653184) // 256/384 MiB
+		largeHigh, largeMax   = int64(402653184), int64(536870912) // 384/512 MiB
+	)
+	type row struct {
+		name            string
+		ram             int64
+		effHigh, effMax int64
+		dropins         string
+		onDisk          bool
+		wantState       healthresource.State
+		wantExit        int
+		wantAccept      bool
+	}
+	rows := []row{
+		{"small/ACTIVE_MATCH", 2 << 30, smallHigh, smallMax, healthresource.DropinFile, true, healthresource.StateActiveMatch, 0, true},
+		{"small/FALLBACK_MATCH", 2 << 30, smallHigh, smallMax, "", false, healthresource.StateFallbackMatch, 0, true},
+		{"medium/ACTIVE_MATCH", 6 << 30, mediumHigh, mediumMax, healthresource.DropinFile, true, healthresource.StateActiveMatch, 0, true},
+		{"medium/FALLBACK_MATCH", 6 << 30, mediumHigh, mediumMax, "", false, healthresource.StateFallbackMatch, 2, false},
+		{"medium/FALLBACK_UNDERSIZED", 6 << 30, smallHigh, smallMax, "", false, healthresource.StateFallbackUnder, 2, false},
+		{"large/ACTIVE_MATCH", 16 << 30, largeHigh, largeMax, healthresource.DropinFile, true, healthresource.StateActiveMatch, 0, true},
+		{"large/FALLBACK_MATCH", 16 << 30, largeHigh, largeMax, "", false, healthresource.StateFallbackMatch, 2, false},
+	}
+	for _, r := range rows {
+		t.Run(r.name, func(t *testing.T) {
+			calc := calcFor(r.ram)
+			rep := assembleReport(calc, nil, false, props(i64(r.effHigh), i64(r.effMax), "64", r.dropins), nil, r.onDisk)
+
+			// 1. State classification.
+			if rep.Service.State != string(r.wantState) {
+				t.Fatalf("state=%s want %s", rep.Service.State, r.wantState)
+			}
+			// 2. CLI exit code.
+			if got := resourcesExitCode(rep); got != r.wantExit {
+				t.Errorf("resourcesExitCode=%d want %d", got, r.wantExit)
+			}
+			// 3. CLI ProtectionActive == the SHARED AcceptableFor predicate == expected.
+			shared := healthresource.AcceptableFor(calc.Tier, r.wantState)
+			if shared != r.wantAccept {
+				t.Errorf("AcceptableFor(%s,%s)=%v want %v", calc.Tier, r.wantState, shared, r.wantAccept)
+			}
+			if rep.Service.ProtectionActive != shared {
+				t.Errorf("CLI ProtectionActive=%v != shared AcceptableFor=%v (installer/CLI must agree)", rep.Service.ProtectionActive, shared)
+			}
+
+			// 4. human vs JSON give the same semantic accept/reject result.
+			jb, err := json.Marshal(rep)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded struct {
+				Service struct {
+					ProtectionActive bool `json:"protection_active"`
+				} `json:"services_health"`
+			}
+			if err := json.Unmarshal(jb, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			human := captureHuman(t, rep)
+			wantLine := "Protection active....... " + map[bool]string{true: "yes", false: "no"}[r.wantAccept]
+			if !strings.Contains(human, wantLine) {
+				t.Errorf("human output missing %q; semantic mismatch human vs verdict", wantLine)
+			}
+			if decoded.Service.ProtectionActive != r.wantAccept {
+				t.Errorf("JSON protection_active=%v want %v", decoded.Service.ProtectionActive, r.wantAccept)
+			}
+			// human and JSON must agree with each other (same semantic result).
+			humanYes := strings.Contains(human, "Protection active....... yes")
+			if humanYes != decoded.Service.ProtectionActive {
+				t.Errorf("human(yes=%v) and JSON(%v) disagree on the accept/reject verdict", humanYes, decoded.Service.ProtectionActive)
+			}
+		})
+	}
+}
+
+// The live-unreadable path (systemctl show failed) is INCOMPLETE evidence → exit 1
+// per resourcesExitCode, on any tier. This is the CLI "protection unverifiable"
+// alignment point (distinct from the installer assertion, which for a
+// protection-REQUIRED tier turns an unverifiable live read into DEGRADED).
+func TestResourcesLiveUnreadable_IncompleteExit1(t *testing.T) {
+	calc := calcFor(6 << 30) // medium
+	rep := assembleReport(calc, nil, false, nil, errors.New("systemctl show: unit not loaded"), false)
+	if rep.Service.Effective.Available {
+		t.Fatal("live read failed → Effective.Available must be false")
+	}
+	if got := resourcesExitCode(rep); got != 1 {
+		t.Errorf("live-unreadable exit=%d want 1 (incomplete evidence)", got)
+	}
+}

--- a/cmd/nftban-installer/flags.go
+++ b/cmd/nftban-installer/flags.go
@@ -99,6 +99,11 @@ type config struct {
 	// auto-seed for the current run (operator can still use
 	// `nftban firewall whitelist-session add` explicitly).
 	sessionWhitelistTTL time.Duration // --session-whitelist-ttl: TTL for auto-seeded operator session entries
+	// v1.223.0 verdict-truth: DATA test-injection carrier. NIL in production and
+	// NEVER set by flag parsing — tests construct it directly on a *config to force
+	// a deterministic health-resource tier and a fixture systemd-payload input
+	// through the validation path (no mutable package global, no var-func seam).
+	inject *assertionTestInjection
 }
 
 func parseFlags() *config {

--- a/cmd/nftban-installer/inject.go
+++ b/cmd/nftban-installer/inject.go
@@ -14,8 +14,8 @@
 package main
 
 import (
-	coresafety "github.com/itcmsgr/nftban/internal/safety"
 	lr "github.com/itcmsgr/nftban/internal/logretention"
+	coresafety "github.com/itcmsgr/nftban/internal/safety"
 
 	"github.com/itcmsgr/nftban/internal/installer/validate"
 )

--- a/cmd/nftban-installer/inject.go
+++ b/cmd/nftban-installer/inject.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	coresafety "github.com/itcmsgr/nftban/internal/safety"
+	lr "github.com/itcmsgr/nftban/internal/logretention"
 
 	"github.com/itcmsgr/nftban/internal/installer/validate"
 )
@@ -37,6 +38,10 @@ type assertionTestInjection struct {
 	// ResolveHealthResourceVerdict so execution-path tests are host-independent.
 	// nil → the canonical safety.HealthServiceMemoryLimits() (real /proc facts).
 	healthProfile *coresafety.HealthResourceProfile
+	// logRetentionValidator, when non-nil, overrides the logrotate policy validator
+	// for the logretention_policy_ready assertion so execution-path tests do not
+	// depend on the `logrotate` binary (absent in CI). nil → real `logrotate -d`.
+	logRetentionValidator lr.Validator
 }
 
 // payload returns the injected systemd-payload input (nil-safe on a nil carrier).
@@ -53,4 +58,12 @@ func (i *assertionTestInjection) profile() *coresafety.HealthResourceProfile {
 		return nil
 	}
 	return i.healthProfile
+}
+
+// logValidator returns the injected logrotate validator (nil-safe on a nil carrier).
+func (i *assertionTestInjection) logValidator() lr.Validator {
+	if i == nil {
+		return nil
+	}
+	return i.logRetentionValidator
 }

--- a/cmd/nftban-installer/inject.go
+++ b/cmd/nftban-installer/inject.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="nftban-installer-inject"
+// meta:type="cmd"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-07-20"
+// meta:description="v1.223.0 verdict-truth: per-call, data-only test-injection carrier for the installer validation path. PRODUCTION never constructs one (nil), so all default behavior is byte-identical: real host systemd-payload gather + canonical safety.HealthServiceMemoryLimits tier. Tests set the carrier on config/phaseData to force a deterministic host-class tier and a fixture systemd-payload input WITHOUT any mutable package global or var-func seam."
+// meta:inventory.files="cmd/nftban-installer/inject.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package main
+
+import (
+	coresafety "github.com/itcmsgr/nftban/internal/safety"
+
+	"github.com/itcmsgr/nftban/internal/installer/validate"
+)
+
+// assertionTestInjection is the DATA dependency-injection carrier threaded through
+// config → phaseData for the validation path. It is NEVER populated in production
+// (nil), so nothing about the default install/upgrade/repair/revalidate behavior
+// changes: the systemd-payload assertions gather from the real host, and the
+// health-resource verdict resolves against the canonical safety RAM-tier authority.
+//
+// Owner constraint: no mutable package globals, no `var xFunc = ...` seams, no new
+// public API. The carrier is an unexported type with unexported fields set only by
+// tests (never by flag parsing).
+type assertionTestInjection struct {
+	// systemdPayload, when non-nil, is used verbatim by RunAssertionsWithOpts
+	// instead of gathering from the live host. A zero/empty value is validated
+	// exactly like an empty real gather (fail-safe preserved — no PASS shortcut).
+	systemdPayload *validate.SystemdPayloadInputs
+	// healthProfile, when non-nil, forces a deterministic host-class tier into
+	// ResolveHealthResourceVerdict so execution-path tests are host-independent.
+	// nil → the canonical safety.HealthServiceMemoryLimits() (real /proc facts).
+	healthProfile *coresafety.HealthResourceProfile
+}
+
+// payload returns the injected systemd-payload input (nil-safe on a nil carrier).
+func (i *assertionTestInjection) payload() *validate.SystemdPayloadInputs {
+	if i == nil {
+		return nil
+	}
+	return i.systemdPayload
+}
+
+// profile returns the injected health-resource profile (nil-safe on a nil carrier).
+func (i *assertionTestInjection) profile() *coresafety.HealthResourceProfile {
+	if i == nil {
+		return nil
+	}
+	return i.healthProfile
+}

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -165,6 +165,9 @@ func main() {
 	// session whitelist TTL. Default safety.DefaultSessionWhitelistTTL (30m)
 	// already applied in parseFlags when --session-whitelist-ttl is unset.
 	globalPhaseData.sessionWhitelistTTL = cfg.sessionWhitelistTTL
+	// v1.223.0 verdict-truth: propagate the DATA test-injection carrier (nil in
+	// production → default behavior byte-identical). Consumed by phaseValidate.
+	globalPhaseData.inject = cfg.inject
 
 	exitCode := run(ctx, exec, sf, cfg, log)
 
@@ -241,7 +244,7 @@ func run(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *
 		return runRevalidate(ctx, exec, sf, cfg, log)
 	}
 	if cfg.repair {
-		return runRepair(ctx, exec, sf, log)
+		return runRepair(ctx, exec, sf, cfg, log)
 	}
 	// v1.100 PR-22 / PR-23 uninstall dispatch.
 	//
@@ -461,7 +464,12 @@ func runInstall(ctx context.Context, exec executor.Executor, sf *state.StateFile
 }
 
 // runRepair reads the state file and resumes from the last failed phase.
-func runRepair(ctx context.Context, exec executor.Executor, sf *state.StateFile, log *logging.Logger) int {
+//
+// v1.223.0 verdict-truth: takes *config so a DIRECT test call propagates the DATA
+// test-injection carrier into globalPhaseData (production cfg.inject is nil, so
+// this is a no-op assignment on every real run — behavior unchanged).
+func runRepair(ctx context.Context, exec executor.Executor, sf *state.StateFile, cfg *config, log *logging.Logger) int {
+	globalPhaseData.inject = cfg.inject
 	log.Info("repair mode: current state is %s", sf.State)
 	log.Debug("previous failure: %s (phase=%s)", sf.FailureReason, sf.PhaseReached)
 

--- a/cmd/nftban-installer/main.go
+++ b/cmd/nftban-installer/main.go
@@ -596,7 +596,13 @@ func report(sf *state.StateFile, log *logging.Logger) int {
 		// (SERVICES_FAILED + attribution) — the exact failed unit(s), never a
 		// hardcoded nftban-botscan.service. A stale oneshot latch survives an
 		// upgrade and --repair does NOT clear it, so surface reset-failed first.
-		renderFailedUnitRemediation(sf, log)
+		// v1.223.0 (BUG-DEGRADED-REPORT-FALSE-FAILED-UNIT-CLAIM): only when a unit
+		// ACTUALLY failed. A resource-policy/verdict DEGRADED
+		// (health_resource_policy_active) has an empty SERVICES_FAILED and must NOT
+		// print "A failed NFTBan unit was detected" — that misdirects remediation.
+		if len(splitUnits(sf.ServicesFailed)) > 0 {
+			renderFailedUnitRemediation(sf, log)
+		}
 		// v1.131.4 (D-DEGRADED-REMEDIATION-CMD-BROKEN): use the full path —
 		// `nftban-installer` is not on the operator's PATH (it lives under
 		// /usr/lib/nftban/bin), so the bare form printed `command not found`.

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -624,9 +624,14 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	policy := panelfw.DefaultPolicy()
 	policy.OperatorDisabled = pd.noPanel
 	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
-	// v1.222.1 HEALTH-OOM Lane 2: feed the phaseConfigure reconciliation verdict
-	// to the health_resource_policy_active assertion (single policy path).
-	opts.HealthResource = &pd.healthResource
+	// v1.223.0 verdict-truth: resolve ONE authoritative health verdict for the
+	// health_resource_policy_active assertion. When phaseConfigure ran this process
+	// pd.healthResource is populated and used as-is; on a repair/resume that begins
+	// at PhaseValidate (phaseConfigure SKIPPED) pd.healthResource is the zero struct,
+	// so the resolver verifies LIVE systemd read-only instead of feeding a zero
+	// verdict into the assertion (BUG-REPAIR-HEALTH-VERDICT-EMPTY).
+	resolvedHealth := services.ResolveHealthResourceVerdict(exec, sf, log, pd.healthResource, version.Version)
+	opts.HealthResource = &resolvedHealth
 	// v1.222.1 Lane 4: capture the FATAL failed-unit set and propagate the
 	// STRUCTURED names into install_state (SERVICES_FAILED + attribution).
 	var failedUnits []validate.FailedUnitPostInstall

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -632,6 +632,7 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	// v1.223.0 verdict-truth: systemd-payload assertion inputs come from the real
 	// host by default (nil), or from a DATA test-injection carrier (nil-safe).
 	opts.SystemdPayloadInputs = pd.inject.payload()
+	opts.LogRetentionValidator = pd.inject.logValidator()
 	// v1.222.1 Lane 4: capture the FATAL failed-unit set and propagate the
 	// STRUCTURED names into install_state (SERVICES_FAILED + attribution).
 	var failedUnits []validate.FailedUnitPostInstall

--- a/cmd/nftban-installer/phases.go
+++ b/cmd/nftban-installer/phases.go
@@ -80,6 +80,11 @@ type phaseData struct {
 	// verdict produced in phaseConfigure and consumed by the phaseValidate
 	// health_resource_policy_active assertion (single policy path).
 	healthResource healthresource.Verdict
+	// v1.223.0 verdict-truth: per-call DATA test-injection carrier (nil in
+	// production; never set by flag parsing). Propagated from cfg.inject in main().
+	// phaseValidate consults it (nil-safe) to source the systemd-payload assertion
+	// inputs and to force a deterministic health-resource tier for the resolver.
+	inject *assertionTestInjection
 }
 
 // globalPhaseData is set by phaseDetect and consumed by later phases.
@@ -624,18 +629,23 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	policy := panelfw.DefaultPolicy()
 	policy.OperatorDisabled = pd.noPanel
 	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
-	// v1.223.0 verdict-truth: resolve ONE authoritative health verdict for the
-	// health_resource_policy_active assertion. When phaseConfigure ran this process
-	// pd.healthResource is populated and used as-is; on a repair/resume that begins
-	// at PhaseValidate (phaseConfigure SKIPPED) pd.healthResource is the zero struct,
-	// so the resolver verifies LIVE systemd read-only instead of feeding a zero
-	// verdict into the assertion (BUG-REPAIR-HEALTH-VERDICT-EMPTY).
-	resolvedHealth := services.ResolveHealthResourceVerdict(exec, sf, log, pd.healthResource, version.Version)
-	opts.HealthResource = &resolvedHealth
+	// v1.223.0 verdict-truth: systemd-payload assertion inputs come from the real
+	// host by default (nil), or from a DATA test-injection carrier (nil-safe).
+	opts.SystemdPayloadInputs = pd.inject.payload()
 	// v1.222.1 Lane 4: capture the FATAL failed-unit set and propagate the
 	// STRUCTURED names into install_state (SERVICES_FAILED + attribution).
 	var failedUnits []validate.FailedUnitPostInstall
 	opts.FailedUnitsOut = &failedUnits
+	// v1.223.0 verdict-truth (owner ruling: per-pass resolution): VALIDATE_1
+	// resolves ONE authoritative health verdict for the health_resource_policy_active
+	// assertion. When phaseConfigure ran this process pd.healthResource is populated
+	// and reused ("current"); on a repair/resume that begins at PhaseValidate
+	// (phaseConfigure SKIPPED) pd.healthResource is the zero struct, so the resolver
+	// verifies LIVE systemd read-only ("live") instead of feeding a zero verdict into
+	// the assertion (BUG-REPAIR-HEALTH-VERDICT-EMPTY). The optional injected profile
+	// forces a deterministic tier for execution-path tests (nil → canonical /proc).
+	resolved1 := services.ResolveHealthResourceVerdict(exec, sf, log, pd.healthResource, version.Version, pd.inject.profile())
+	opts.HealthResource = &resolved1
 	results := validate.RunAssertionsWithOpts(exec, pd.sshPort, log, opts)
 	persistFailedUnits(sf, failedUnits)
 
@@ -682,6 +692,16 @@ func phaseValidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	} else {
 		log.Warn("permissions enforce returned exit %d — re-validating anyway", fixRes.ExitCode)
 	}
+
+	// v1.223.0 verdict-truth (owner ruling: per-pass resolution): re-resolve the
+	// health verdict FRESH before VALIDATE_2 so it reflects CURRENT live truth (e.g.
+	// a drop-in that only becomes effective after the daemon-reload the retry may
+	// have triggered), NOT a cached VALIDATE_1 verdict. The extra read-only
+	// `systemctl show` happens ONLY on this DEGRADED retry path — accepted. The
+	// verdict-truth invariant belongs to validation, not to the permissions-enforce
+	// retry step.
+	resolved2 := services.ResolveHealthResourceVerdict(exec, sf, log, pd.healthResource, version.Version, pd.inject.profile())
+	opts.HealthResource = &resolved2
 
 	// v1.98 INV-I-013: Re-run assertions (VALIDATE_2) — only this result counts
 	results2 := validate.RunAssertionsWithOpts(exec, pd.sshPort, log, opts)

--- a/cmd/nftban-installer/revalidate.go
+++ b/cmd/nftban-installer/revalidate.go
@@ -99,13 +99,17 @@ func runRevalidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	policy := panelfw.DefaultPolicy()
 	policy.OperatorDisabled = cfg.noPanel
 	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
+	// v1.223.0 verdict-truth: systemd-payload assertion inputs from real host
+	// (nil) or the DATA test-injection carrier (nil-safe).
+	opts.SystemdPayloadInputs = cfg.inject.payload()
 	// v1.223.0 verdict-truth (BUG-REVALIDATE-MASKS-HEALTH-DEGRADE): revalidate never
 	// runs phaseConfigure, so without this it left opts.HealthResource nil → the
 	// health_resource_policy_active assertion SKIPped and a genuinely OOM-unprotected
 	// medium/large host was silently recommitted to COMMITTED. Resolve the LIVE
 	// verdict read-only (no zero verdict) so a real FALLBACK_UNDERSIZED keeps the
-	// host DEGRADED and an ACTIVE_MATCH truthfully recommits.
-	resolvedHealth := services.ResolveHealthResourceVerdict(exec, sf, log, healthresource.Verdict{}, version.Version)
+	// host DEGRADED and an ACTIVE_MATCH truthfully recommits. The optional injected
+	// profile forces a deterministic tier for execution-path tests (nil → /proc).
+	resolvedHealth := services.ResolveHealthResourceVerdict(exec, sf, log, healthresource.Verdict{}, version.Version, cfg.inject.profile())
 	opts.HealthResource = &resolvedHealth
 	results := validate.RunAssertionsWithOpts(exec, sshPort, log, opts)
 

--- a/cmd/nftban-installer/revalidate.go
+++ b/cmd/nftban-installer/revalidate.go
@@ -102,6 +102,7 @@ func runRevalidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	// v1.223.0 verdict-truth: systemd-payload assertion inputs from real host
 	// (nil) or the DATA test-injection carrier (nil-safe).
 	opts.SystemdPayloadInputs = cfg.inject.payload()
+	opts.LogRetentionValidator = cfg.inject.logValidator()
 	// v1.223.0 verdict-truth (BUG-REVALIDATE-MASKS-HEALTH-DEGRADE): revalidate never
 	// runs phaseConfigure, so without this it left opts.HealthResource nil → the
 	// health_resource_policy_active assertion SKIPped and a genuinely OOM-unprotected

--- a/cmd/nftban-installer/revalidate.go
+++ b/cmd/nftban-installer/revalidate.go
@@ -21,10 +21,12 @@ import (
 	"context"
 	"strings"
 
+	"github.com/itcmsgr/nftban/internal/healthresource"
 	"github.com/itcmsgr/nftban/internal/installer/executor"
 	"github.com/itcmsgr/nftban/internal/installer/fhs"
 	"github.com/itcmsgr/nftban/internal/installer/logging"
 	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+	"github.com/itcmsgr/nftban/internal/installer/services"
 	"github.com/itcmsgr/nftban/internal/installer/state"
 	"github.com/itcmsgr/nftban/internal/installer/validate"
 	"github.com/itcmsgr/nftban/pkg/version"
@@ -97,6 +99,14 @@ func runRevalidate(ctx context.Context, exec executor.Executor, sf *state.StateF
 	policy := panelfw.DefaultPolicy()
 	policy.OperatorDisabled = cfg.noPanel
 	opts := validate.AssertionOpts{}.WithPanelPolicy(policy)
+	// v1.223.0 verdict-truth (BUG-REVALIDATE-MASKS-HEALTH-DEGRADE): revalidate never
+	// runs phaseConfigure, so without this it left opts.HealthResource nil → the
+	// health_resource_policy_active assertion SKIPped and a genuinely OOM-unprotected
+	// medium/large host was silently recommitted to COMMITTED. Resolve the LIVE
+	// verdict read-only (no zero verdict) so a real FALLBACK_UNDERSIZED keeps the
+	// host DEGRADED and an ACTIVE_MATCH truthfully recommits.
+	resolvedHealth := services.ResolveHealthResourceVerdict(exec, sf, log, healthresource.Verdict{}, version.Version)
+	opts.HealthResource = &resolvedHealth
 	results := validate.RunAssertionsWithOpts(exec, sshPort, log, opts)
 
 	// Preserve recorded identity the Transition writer re-emits. main() blanked

--- a/cmd/nftban-installer/verdict_truth_fixture_test.go
+++ b/cmd/nftban-installer/verdict_truth_fixture_test.go
@@ -139,8 +139,9 @@ func newAllAssertionsPassFixture(t *testing.T) (*assertionTestInjection, *execut
 	m.Files["/etc/nftban/nftables.conf"] = []byte(nft)
 
 	// 6. logretention: real temp policy identical to the fallback template so
-	//    lr.Readiness (which uses the REAL filesystem + real logrotate validator)
-	//    returns READY_FALLBACK. mode 0644 is mandatory (Perm()==0o644 check).
+	//    lr.Readiness returns READY_FALLBACK. mode 0644 is mandatory (Perm()==0o644
+	//    check). The logrotate VALIDATOR is injected below (deterministic pass) so the
+	//    assertion does not depend on the `logrotate` binary — absent in CI containers.
 	d := t.TempDir()
 	body := []byte("/var/log/nftban/bans.log {\n    daily\n    rotate 7\n    size 10M\n}\n")
 	mainPath := d + "/nftban"
@@ -155,7 +156,12 @@ func newAllAssertionsPassFixture(t *testing.T) (*assertionTestInjection, *execut
 	// 7. systemd-payload assertions: inject a valid EMPTY input set (zero units, zero
 	//    failed units, no query error) → all four pass (fail-safe preserved: this is
 	//    the same verdict the pure validator gives an empty gather).
-	inj := &assertionTestInjection{systemdPayload: &validate.SystemdPayloadInputs{}}
+	inj := &assertionTestInjection{
+		systemdPayload: &validate.SystemdPayloadInputs{},
+		// Deterministic logrotate validator → logretention_policy_ready passes on any
+		// host (no `logrotate` binary needed; CI containers lack it).
+		logRetentionValidator: func([]string) (string, error) { return "logrotate", nil },
+	}
 
 	return inj, m, func() {}
 }

--- a/cmd/nftban-installer/verdict_truth_fixture_test.go
+++ b/cmd/nftban-installer/verdict_truth_fixture_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="verdict_truth_fixture_test.go"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: the all-assertions-pass fixture (newAllAssertionsPassFixture) that makes EVERY post-install assertion in RunAssertionsWithOpts pass EXCEPT health (each test sets the health live state). Explicit + readable — no blanket success-for-everything. Includes a fixture-validation test that asserts only allow-listed mock commands are issued."
+// meta:inventory.files="cmd/nftban-installer/verdict_truth_fixture_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_LR_MAIN,NFTBAN_LR_SURICATA,NFTBAN_LR_STATE,NFTBAN_LR_TEMPLATE"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/fhs"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/panelfw"
+	"github.com/itcmsgr/nftban/internal/installer/validate"
+	coresafety "github.com/itcmsgr/nftban/internal/safety"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+const miB = int64(1) << 20
+
+func nolog() *logging.Logger { return logging.New("/dev/null", false) }
+
+// ---- host-class profile helpers (internal/safety; forced tier, deterministic) ----
+
+func profileForRAM(totalRAM int64) coresafety.HealthResourceProfile {
+	p := coresafety.ServerProfile{TotalRAM: totalRAM, AvailRAM: totalRAM / 2, CPUCores: 4}
+	return coresafety.HealthServiceMemoryLimitsFor(p, coresafety.ClassifyResourceTier(p))
+}
+func smallProfile() coresafety.HealthResourceProfile  { return profileForRAM(2 << 30) } // 192/256
+func mediumProfile() coresafety.HealthResourceProfile { return profileForRAM(6 << 30) } // 256/384
+func largeProfile() coresafety.HealthResourceProfile  { return profileForRAM(16 << 30) }
+
+// ---- health systemctl-show seams (mirror internal/installer/services test helpers) ----
+
+func healthShowKey() string {
+	return strings.Join([]string{
+		"systemctl", "show", "nftban-health.service",
+		"-p", "MemoryHigh", "-p", "MemoryMax", "-p", "TasksMax", "-p", "DropInPaths", "-p", "FragmentPath",
+	}, ":")
+}
+
+func showOut(high, max, tasks int64, dropins string) string {
+	i := strconv.FormatInt
+	return "MemoryHigh=" + i(high, 10) + "\nMemoryMax=" + i(max, 10) + "\nTasksMax=" + i(tasks, 10) +
+		"\nDropInPaths=" + dropins + "\nFragmentPath=/usr/lib/systemd/system/nftban-health.service\n"
+}
+
+// setHealthActiveMatch makes the LIVE systemd read (queryEffectiveHealth) report the
+// exact calculated policy with OUR drop-in loaded → resolver yields ACTIVE_MATCH.
+func setHealthActiveMatch(m *executor.MockExecutor, p coresafety.HealthResourceProfile) {
+	m.RunResults[healthShowKey()] = executor.Result{Stdout: showOut(p.MemoryHigh, p.MemoryMax, 64, healthresource.DropinFile)}
+	m.Files[healthresource.DropinFile] = healthresource.Render(p, version.Version)
+}
+
+// setHealthFallbackUndersized makes the LIVE read report the packaged fallback below
+// the calculated policy, no drop-in loaded → resolver yields FALLBACK_UNDERSIZED.
+func setHealthFallbackUndersized(m *executor.MockExecutor) {
+	m.RunResults[healthShowKey()] = executor.Result{Stdout: showOut(192*miB, 256*miB, 64, "")}
+	delete(m.Files, healthresource.DropinFile)
+}
+
+// setHealthShowFails makes the LIVE read fail (systemctl show exit!=0) → resolver
+// falls to persisted reconstruction or explicit UNAVAILABLE.
+func setHealthShowFails(m *executor.MockExecutor) {
+	m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "unit not loaded"}
+	delete(m.Files, healthresource.DropinFile)
+}
+
+// ---- the all-assertions-pass fixture ----------------------------------------
+
+// allPassSSHPort is the SSH port every fixture seeds into ip nftban tcp_ports_in.
+const allPassSSHPort = 22
+
+// newAllAssertionsPassFixture seeds a MockExecutor + injection carrier so EVERY
+// assertion in RunAssertionsWithOpts passes EXCEPT health (the caller sets the health
+// live state via the setHealth* helpers + inject.healthProfile). It ALSO installs the
+// real-filesystem logretention fixtures (temp policy identical to the fallback
+// template + env overrides) so assertLogretentionPolicyREADY passes via the real
+// DefaultValidator (logrotate present on the CI host). Returns the injection carrier,
+// the mock, and a cleanup func (env restoration is handled by t.Setenv).
+func newAllAssertionsPassFixture(t *testing.T) (*assertionTestInjection, *executor.MockExecutor, func()) {
+	t.Helper()
+	m := executor.NewMockExecutor()
+
+	// 1. nftables + daemon active; nftban tables present; NO emergency table.
+	m.Services["nftables"] = true
+	m.Services["nftband.service"] = true
+	m.NftTables["ip:nftban"] = true
+	m.NftTables["ip6:nftban"] = true
+
+	// 2. SSH port present in ip nftban tcp_ports_in (assertSSHInSet with port 22).
+	m.NftSets["ip:nftban:tcp_ports_in"] = "22"
+
+	// 3. install_state file present.
+	m.Files[fhs.StateDir+"/install_state"] = []byte("INSTALL_STATE=DEGRADED\n")
+
+	// 4. payload inventory: the 8 required binaries/configs + 6 non-empty dirs.
+	for _, f := range []string{
+		"/usr/sbin/nftban",
+		"/usr/lib/nftban/bin/nftban-core",
+		"/usr/lib/nftban/bin/nftband",
+		"/usr/lib/nftban/bin/nftban-validate",
+		"/usr/lib/nftban/bin/nftban-installer",
+		"/usr/lib/nftban/VERSION",
+	} {
+		m.Files[f] = []byte("x")
+	}
+	for _, d := range []string{
+		"/usr/lib/nftban/cli", "/usr/lib/nftban/core", "/usr/lib/nftban/lib",
+		"/usr/lib/nftban/helpers", "/usr/lib/nftban/data", "/usr/lib/nftban/health",
+	} {
+		m.Dirs[d] = true
+	}
+
+	// 5. config integrity: nftban.conf (>=256B + SPDX token; also carries the
+	//    NFTBAN_RECONCILE_CORE_TIMERS=false line so the core-timer assertion takes
+	//    the intentional-opt-out Skipped→PASS path) and nftables.conf (>=512B + the
+	//    two required tokens).
+	conf := "# SPDX-License-Identifier: MPL-2.0\n" +
+		"NFTBAN_RECONCILE_CORE_TIMERS=\"false\"\n" +
+		"# nftban.conf fixture — padding to satisfy the >=256-byte minimum-viability\n" +
+		"# integrity check without any semantic parse. " + strings.Repeat("padpadpad ", 20) + "\n"
+	m.Files["/etc/nftban/nftban.conf"] = []byte(conf)
+	nft := "#!/usr/sbin/nft -f\n# SPDX-License-Identifier: MPL-2.0\ntable ip nftban {\n}\n" +
+		"# padding to satisfy the >=512-byte minimum-viability integrity check.\n" +
+		strings.Repeat("# pad pad pad pad pad pad pad pad pad pad pad pad pad pad\n", 12)
+	m.Files["/etc/nftban/nftables.conf"] = []byte(nft)
+
+	// 6. logretention: real temp policy identical to the fallback template so
+	//    lr.Readiness (which uses the REAL filesystem + real logrotate validator)
+	//    returns READY_FALLBACK. mode 0644 is mandatory (Perm()==0o644 check).
+	d := t.TempDir()
+	body := []byte("/var/log/nftban/bans.log {\n    daily\n    rotate 7\n    size 10M\n}\n")
+	mainPath := d + "/nftban"
+	tmplPath := d + "/nftban.logrotate"
+	writeMode0644(t, mainPath, body)
+	writeMode0644(t, tmplPath, body)
+	t.Setenv("NFTBAN_LR_MAIN", mainPath)
+	t.Setenv("NFTBAN_LR_TEMPLATE", tmplPath)
+	t.Setenv("NFTBAN_LR_STATE", d+"/nonexistent-state.json") // forces the fallback path
+	t.Setenv("NFTBAN_LR_SURICATA", d+"/nonexistent-suricata") // absent → skipped in fallback
+
+	// 7. systemd-payload assertions: inject a valid EMPTY input set (zero units, zero
+	//    failed units, no query error) → all four pass (fail-safe preserved: this is
+	//    the same verdict the pure validator gives an empty gather).
+	inj := &assertionTestInjection{systemdPayload: &validate.SystemdPayloadInputs{}}
+
+	return inj, m, func() {}
+}
+
+func writeMode0644(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil { // #nosec G306 -- logrotate policy is 0644 by contract
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil { // defeat umask; Perm()==0o644 is required
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// passOpts builds AssertionOpts wired to the fixture injection, an EMPTY explicit
+// panel-adapter slice (so the package-registered adapters are NOT consulted — keeps
+// the command allow-list tight), and the given resolved health verdict.
+func passOpts(inj *assertionTestInjection, health *healthresource.Verdict) validate.AssertionOpts {
+	o := validate.AssertionOpts{}.WithPanelPolicy(panelfw.DefaultPolicy())
+	o.PanelAdapters = []panelfw.PanelAdapter{}
+	o.SystemdPayloadInputs = inj.payload()
+	o.HealthResource = health
+	return o
+}
+
+// TASK 4: the fixture makes every assertion pass except health, and issues ONLY
+// allow-listed mock commands (an unknown command fails the test).
+func TestAllAssertionsPassFixture_OnlyAllowlistedCommands(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+
+	// Health forced to ACTIVE_MATCH so the WHOLE suite (incl. health) passes here.
+	health := &healthresource.Verdict{
+		Profile:        mediumProfile(),
+		EffectiveState: healthresource.StateActiveMatch,
+	}
+	results := validate.RunAssertionsWithOpts(m, allPassSSHPort, nolog(), passOpts(inj, health))
+
+	if !validate.AllPassed(results) {
+		t.Fatalf("all assertions must pass, failing: %v", validate.FailedNames(results))
+	}
+
+	// Allow-list: RunAssertionsWithOpts issues exactly one recorded Run command —
+	// the nftban input-chain probe. Everything else is a typed method (no record),
+	// the injected payload (no gather), the real-fs logretention validator (os/exec,
+	// not the mock), and the empty panel-adapter slice.
+	allowed := map[string]bool{
+		"nft list chain ip nftban input": true,
+	}
+	for _, c := range m.Commands {
+		key := c.Name + " " + strings.Join(c.Args, " ")
+		if !allowed[key] {
+			t.Errorf("UNKNOWN mock command issued (not in allow-list): %q", key)
+		}
+	}
+}
+
+// TASK 4: prove the fixture makes health the ONLY variable — a medium
+// FALLBACK_UNDERSIZED health verdict is the sole failing assertion.
+func TestAllAssertionsPassFixture_HealthIsTheOnlyVariable(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+
+	health := &healthresource.Verdict{
+		Profile:        mediumProfile(),
+		EffectiveState: healthresource.StateFallbackUnder,
+		CalculatedMax:  mediumProfile().MemoryMax,
+		EffectiveMax:   256 * miB,
+	}
+	results := validate.RunAssertionsWithOpts(m, allPassSSHPort, nolog(), passOpts(inj, health))
+
+	failed := validate.FailedNames(results)
+	if len(failed) != 1 || failed[0] != "health_resource_policy_active" {
+		t.Fatalf("health must be the ONLY failing assertion; got %v", failed)
+	}
+}

--- a/cmd/nftban-installer/verdict_truth_fixture_test.go
+++ b/cmd/nftban-installer/verdict_truth_fixture_test.go
@@ -149,7 +149,7 @@ func newAllAssertionsPassFixture(t *testing.T) (*assertionTestInjection, *execut
 	writeMode0644(t, tmplPath, body)
 	t.Setenv("NFTBAN_LR_MAIN", mainPath)
 	t.Setenv("NFTBAN_LR_TEMPLATE", tmplPath)
-	t.Setenv("NFTBAN_LR_STATE", d+"/nonexistent-state.json") // forces the fallback path
+	t.Setenv("NFTBAN_LR_STATE", d+"/nonexistent-state.json")  // forces the fallback path
 	t.Setenv("NFTBAN_LR_SURICATA", d+"/nonexistent-suricata") // absent → skipped in fallback
 
 	// 7. systemd-payload assertions: inject a valid EMPTY input set (zero units, zero

--- a/cmd/nftban-installer/verdict_truth_fixture_test.go
+++ b/cmd/nftban-installer/verdict_truth_fixture_test.go
@@ -38,9 +38,7 @@ func profileForRAM(totalRAM int64) coresafety.HealthResourceProfile {
 	p := coresafety.ServerProfile{TotalRAM: totalRAM, AvailRAM: totalRAM / 2, CPUCores: 4}
 	return coresafety.HealthServiceMemoryLimitsFor(p, coresafety.ClassifyResourceTier(p))
 }
-func smallProfile() coresafety.HealthResourceProfile  { return profileForRAM(2 << 30) } // 192/256
 func mediumProfile() coresafety.HealthResourceProfile { return profileForRAM(6 << 30) } // 256/384
-func largeProfile() coresafety.HealthResourceProfile  { return profileForRAM(16 << 30) }
 
 // ---- health systemctl-show seams (mirror internal/installer/services test helpers) ----
 
@@ -68,13 +66,6 @@ func setHealthActiveMatch(m *executor.MockExecutor, p coresafety.HealthResourceP
 // the calculated policy, no drop-in loaded → resolver yields FALLBACK_UNDERSIZED.
 func setHealthFallbackUndersized(m *executor.MockExecutor) {
 	m.RunResults[healthShowKey()] = executor.Result{Stdout: showOut(192*miB, 256*miB, 64, "")}
-	delete(m.Files, healthresource.DropinFile)
-}
-
-// setHealthShowFails makes the LIVE read fail (systemctl show exit!=0) → resolver
-// falls to persisted reconstruction or explicit UNAVAILABLE.
-func setHealthShowFails(m *executor.MockExecutor) {
-	m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "unit not loaded"}
 	delete(m.Files, healthresource.DropinFile)
 }
 

--- a/cmd/nftban-installer/verdict_truth_fixture_test.go
+++ b/cmd/nftban-installer/verdict_truth_fixture_test.go
@@ -183,6 +183,7 @@ func passOpts(inj *assertionTestInjection, health *healthresource.Verdict) valid
 	o := validate.AssertionOpts{}.WithPanelPolicy(panelfw.DefaultPolicy())
 	o.PanelAdapters = []panelfw.PanelAdapter{}
 	o.SystemdPayloadInputs = inj.payload()
+	o.LogRetentionValidator = inj.logValidator()
 	o.HealthResource = health
 	return o
 }
@@ -206,8 +207,8 @@ func TestAllAssertionsPassFixture_OnlyAllowlistedCommands(t *testing.T) {
 
 	// Allow-list: RunAssertionsWithOpts issues exactly one recorded Run command —
 	// the nftban input-chain probe. Everything else is a typed method (no record),
-	// the injected payload (no gather), the real-fs logretention validator (os/exec,
-	// not the mock), and the empty panel-adapter slice.
+	// the injected payload (no gather), the injected logretention validator (no
+	// os/exec, no mock command), and the empty panel-adapter slice.
 	allowed := map[string]bool{
 		"nft list chain ip nftban input": true,
 	}

--- a/cmd/nftban-installer/verdict_truth_matrix_test.go
+++ b/cmd/nftban-installer/verdict_truth_matrix_test.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="verdict_truth_matrix_test.go"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth regression matrix (installer entry points): runRepair resume-at-Validate (medium ACTIVE_MATCH→COMMITTED / ServicesComplete resume / FALLBACK_UNDERSIZED live-wins→DEGRADED), update-force delegation proofs (ACTIVE_MATCH→COMMITTED, medium underprotected→DEGRADED), per-pass Validate-retry (no masking; live-changes-between-passes uses current live truth; active pass-1 resolves once), and the DEGRADED report path (empty ServicesFailed→no false failed-unit claim; real failed unit→structured remediation). Deterministic on any host via the injected medium/small fixture profile."
+// meta:inventory.files="cmd/nftban-installer/verdict_truth_matrix_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars="NFTBAN_MIN_DISK_FREE_MB,NFTBAN_LR_MAIN,NFTBAN_LR_STATE,NFTBAN_LR_TEMPLATE,NFTBAN_LR_SURICATA"
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	coresafety "github.com/itcmsgr/nftban/internal/safety"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+func mediumProfilePtr() *coresafety.HealthResourceProfile { p := mediumProfile(); return &p }
+
+func seedPersistedActiveMatch(sf *state.StateFile) {
+	sf.HealthResourceState = string(healthresource.StateActiveMatch)
+	sf.HealthResourceProfile = string(coresafety.ResourceTierMedium)
+	sf.HealthResourceProtection = true
+	sf.HealthMemMaxEffective = mediumProfile().MemoryMax
+}
+
+// countHealthShow returns how many times the health-service `systemctl show` was
+// invoked on the mock (the resolver's per-pass live-verify probe).
+func countHealthShow(m *executor.MockExecutor) int {
+	n := 0
+	for _, c := range m.Commands {
+		if c.Name == "systemctl" && len(c.Args) >= 2 && c.Args[0] == "show" && c.Args[1] == "nftban-health.service" {
+			n++
+		}
+	}
+	return n
+}
+
+// driveRepair runs the REAL runRepair entry point with the all-pass fixture + the
+// injected medium profile. phaseDetect succeeds (sshd_config seeded, real temp
+// stateDir with free space), then resumes into phaseValidate where the health
+// verdict is RESOLVED (phaseConfigure skipped → live systemd read).
+func driveRepair(t *testing.T, startState state.InstallState, inj *assertionTestInjection, m *executor.MockExecutor, seedPersisted func(*state.StateFile)) (*state.StateFile, int) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("NFTBAN_MIN_DISK_FREE_MB", "1")
+	m.Files["/etc/ssh/sshd_config"] = []byte("Port 22\n") // phaseDetect → sshPort=22
+	sf := state.NewStateFile(dir)
+	sf.State = startState
+	sf.Version = version.Version
+	sf.SSHPort = 22
+	if seedPersisted != nil {
+		seedPersisted(sf)
+	}
+	cfg := &config{repair: true, stateDir: dir, inject: inj}
+	globalPhaseData = phaseData{}
+	log := logging.New(dir+"/installer.log", false)
+	rc := runRepair(context.Background(), m, sf, cfg, log)
+	return sf, rc
+}
+
+// ---- runRepair matrix -------------------------------------------------------
+
+// (a) StateDegraded + medium + live ACTIVE_MATCH + persisted ACTIVE_MATCH +
+// phaseConfigure skipped → COMMITTED, health PASS (no false DEGRADE on repair).
+func TestRunRepair_DegradedMediumActiveMatch_Commits(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile())
+
+	sf, rc := driveRepair(t, state.StateDegraded, inj, m, seedPersistedActiveMatch)
+
+	if sf.State != state.StateCommitted {
+		t.Fatalf("repair medium ACTIVE_MATCH: state=%s want COMMITTED (rc=%d)", sf.State, rc)
+	}
+	if sf.HealthResourceState != string(healthresource.StateActiveMatch) {
+		t.Errorf("resolver must have run and persisted ACTIVE_MATCH; got %q", sf.HealthResourceState)
+	}
+}
+
+// (b) StateServicesComplete + medium + live ACTIVE_MATCH → resumes at Validate,
+// resolver runs, COMMITTED.
+func TestRunRepair_ServicesCompleteMediumActiveMatch_Commits(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile())
+
+	sf, rc := driveRepair(t, state.StateServicesComplete, inj, m, nil)
+
+	if sf.State != state.StateCommitted {
+		t.Fatalf("repair-resume ServicesComplete ACTIVE_MATCH: state=%s want COMMITTED (rc=%d)", sf.State, rc)
+	}
+	if countHealthShow(m) < 1 {
+		t.Error("resolver must have performed a live systemd verify (health assertion did NOT skip)")
+	}
+	if sf.HealthResourceState != string(healthresource.StateActiveMatch) {
+		t.Errorf("resolver persisted state=%q want ACTIVE_MATCH", sf.HealthResourceState)
+	}
+}
+
+// (c) StateDegraded + medium + live FALLBACK_UNDERSIZED + persisted ACTIVE_MATCH →
+// live wins → stays DEGRADED (no false COMMIT; persisted ACTIVE_MATCH does NOT mask).
+func TestRunRepair_DegradedMediumUndersized_LiveWinsStaysDegraded(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthFallbackUndersized(m)
+
+	sf, rc := driveRepair(t, state.StateDegraded, inj, m, seedPersistedActiveMatch)
+
+	if sf.State != state.StateDegraded {
+		t.Fatalf("repair medium underprotected: state=%s want DEGRADED (rc=%d) — live must win over persisted ACTIVE_MATCH", sf.State, rc)
+	}
+	if sf.HealthResourceState != string(healthresource.StateFallbackUnder) {
+		t.Errorf("live verdict must overwrite persisted; got state=%q want FALLBACK_UNDERSIZED", sf.HealthResourceState)
+	}
+	if sf.ServicesFailed != "" {
+		t.Errorf("a resource-policy DEGRADED must have EMPTY SERVICES_FAILED; got %q", sf.ServicesFailed)
+	}
+}
+
+// ---- update-force delegation proofs (installer entry point) ------------------
+//
+// The shell `nftban update force` branch delegates to the Go installer (proven
+// structurally by cli/lib/nftban/tests/update_force_delegation_v1223_test.sh). These
+// two tests prove the DELEGATION TARGET (the installer resume/validate path) consumes
+// the RESOLVED verdict correctly, so the negative (underprotected) is proven in CI at
+// the installer level — NOT via dns2.
+
+// CI_UPDATE_FORCE_DELEGATION: force + live ACTIVE_MATCH → no false DEGRADED.
+func TestUpdateForceDelegation_LiveActiveMatch_NoFalseDegraded(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile())
+
+	sf, _ := driveRepair(t, state.StateDegraded, inj, m, seedPersistedActiveMatch)
+	if sf.State != state.StateCommitted {
+		t.Fatalf("force-delegated installer + live ACTIVE_MATCH: state=%s want COMMITTED (no false DEGRADED)", sf.State)
+	}
+}
+
+// UNDERPROTECTED_MEDIUM_FIXTURE: force-delegated installer + live FALLBACK_UNDERSIZED
+// (medium fixture) → remains DEGRADED, false COMMIT = 0.
+func TestUpdateForceDelegation_LiveUndersizedMedium_StaysDegraded(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthFallbackUndersized(m)
+
+	sf, _ := driveRepair(t, state.StateDegraded, inj, m, seedPersistedActiveMatch)
+	if sf.State != state.StateCommitted && sf.State != state.StateDegraded {
+		t.Fatalf("unexpected terminal state %s", sf.State)
+	}
+	if sf.State == state.StateCommitted {
+		t.Fatal("FALSE COMMIT: medium underprotected host must NOT be COMMITTED via update-force delegation")
+	}
+}
+
+// ---- per-pass Validate-retry (drive phaseValidate directly) -----------------
+
+// drivePhaseValidate runs the real phaseValidate with globalPhaseData wired to the
+// injected medium profile and the fixture mock (ssh port 22).
+func drivePhaseValidate(t *testing.T, inj *assertionTestInjection, m *executor.MockExecutor) (*state.StateFile, error) {
+	t.Helper()
+	dir := t.TempDir()
+	sf := state.NewStateFile(dir)
+	sf.State = state.StateServicesComplete
+	sf.Version = version.Version
+	sf.SSHPort = 22
+	globalPhaseData = phaseData{sshPort: 22, inject: inj}
+	log := logging.New(dir+"/installer.log", false)
+	err := phaseValidate(context.Background(), m, sf, log)
+	return sf, err
+}
+
+// VALIDATE_1 mismatch + NO live change → VALIDATE_2 mismatch → stays DEGRADED (no masking).
+func TestValidateRetry_NoLiveChange_StaysDegraded(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthFallbackUndersized(m) // static: both passes see FALLBACK_UNDERSIZED
+
+	sf, _ := drivePhaseValidate(t, inj, m)
+	if sf.State != state.StateDegraded {
+		t.Fatalf("no live change: state=%s want DEGRADED (VALIDATE_2 must not mask the persistent mismatch)", sf.State)
+	}
+	if countHealthShow(m) != 2 {
+		t.Errorf("per-pass resolution must probe live systemd exactly twice on the retry path; got %d", countHealthShow(m))
+	}
+}
+
+// VALIDATE_1 mismatch, then live becomes ACTIVE_MATCH before VALIDATE_2 → VALIDATE_2
+// uses CURRENT live truth (not a cached verdict) → COMMITTED. Proven via RunResultSeq.
+func TestValidateRetry_LiveChangesBetweenPasses_UsesCurrentTruth(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	p := mediumProfile()
+	inj.healthProfile = &p
+	// The health `systemctl show` returns UNDERSIZED on pass 1 and ACTIVE_MATCH on
+	// pass 2 — modeling a drop-in that only becomes effective after the retry.
+	m.RunResultSeq[healthShowKey()] = []executor.Result{
+		{Stdout: showOut(192*miB, 256*miB, 64, "")},                                 // VALIDATE_1: undersized
+		{Stdout: showOut(p.MemoryHigh, p.MemoryMax, 64, healthresource.DropinFile)}, // VALIDATE_2: active
+	}
+
+	sf, _ := drivePhaseValidate(t, inj, m)
+	if sf.State != state.StateCommitted {
+		t.Fatalf("live changed to ACTIVE_MATCH before VALIDATE_2: state=%s want COMMITTED (must use current live truth)", sf.State)
+	}
+	// VALIDATE_2 resolved a FRESH live verdict (not the VALIDATE_1 cache): the
+	// persisted state reflects the second pass's ACTIVE_MATCH.
+	if sf.HealthResourceState != string(healthresource.StateActiveMatch) {
+		t.Errorf("VALIDATE_2 must reflect the fresh live ACTIVE_MATCH; persisted=%q", sf.HealthResourceState)
+	}
+	if countHealthShow(m) != 2 {
+		t.Errorf("expected exactly 2 live probes (one per pass); got %d", countHealthShow(m))
+	}
+}
+
+// VALIDATE_1 active → COMMITTED with NO second resolution call (resolver/systemctl
+// show invoked exactly once).
+func TestValidateRetry_ActivePass1_ResolvesOnce(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile())
+
+	sf, _ := drivePhaseValidate(t, inj, m)
+	if sf.State != state.StateCommitted {
+		t.Fatalf("active pass 1: state=%s want COMMITTED", sf.State)
+	}
+	if got := countHealthShow(m); got != 1 {
+		t.Errorf("VALIDATE_1 all-pass must resolve the verdict EXACTLY once (no retry); live probes=%d want 1", got)
+	}
+}
+
+// ---- DEGRADED report path ---------------------------------------------------
+
+func captureReport(t *testing.T, sf *state.StateFile) string {
+	t.Helper()
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	log := logging.New(t.TempDir()+"/installer.log", false)
+	_ = report(sf, log)
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = origStdout
+	log.Close()
+	return buf.String()
+}
+
+// Resource-policy DEGRADED (empty ServicesFailed) → NO "failed NFTBan unit" claim
+// and no unit reset guidance (BUG-DEGRADED-REPORT-FALSE-FAILED-UNIT-CLAIM).
+func TestReportDegraded_EmptyServicesFailed_NoFalseUnitClaim(t *testing.T) {
+	sf := state.NewStateFile(t.TempDir())
+	sf.State = state.StateDegraded
+	sf.Authority = "UPDATE"
+	sf.FailureReason = "failed assertions after safe auto-fix: health_resource_policy_active (profile=medium ...)"
+	sf.ServicesFailed = "" // resource-policy verdict DEGRADED — no failed unit
+
+	out := captureReport(t, sf)
+
+	if strings.Contains(out, "failed NFTBan unit") {
+		t.Errorf("resource-policy DEGRADED must NOT claim a failed NFTBan unit; output:\n%s", out)
+	}
+	if strings.Contains(out, "reset-failed") || strings.Contains(out, "Failed unit:") {
+		t.Errorf("resource-policy DEGRADED must NOT print unit reset guidance; output:\n%s", out)
+	}
+	if !strings.Contains(out, "State: DEGRADED") {
+		t.Errorf("DEGRADED report must state DEGRADED; output:\n%s", out)
+	}
+}
+
+// A real failed unit (ServicesFailed set) → structured per-unit remediation present.
+func TestReportDegraded_RealFailedUnit_StructuredRemediation(t *testing.T) {
+	sf := state.NewStateFile(t.TempDir())
+	sf.State = state.StateDegraded
+	sf.FailureReason = "failed assertions after safe auto-fix: failed_units_postinstall_ok"
+	sf.ServicesFailed = "nftban-botscan.service"
+
+	out := captureReport(t, sf)
+
+	if !strings.Contains(out, "Failed unit: nftban-botscan.service") {
+		t.Errorf("real failed unit must be surfaced with structured remediation; output:\n%s", out)
+	}
+	if !strings.Contains(out, "systemctl start nftban-botscan.service") {
+		t.Errorf("structured remediation must include the start/verify step; output:\n%s", out)
+	}
+}

--- a/cmd/nftban-installer/verdict_truth_revalidate_test.go
+++ b/cmd/nftban-installer/verdict_truth_revalidate_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="verdict_truth_revalidate_test.go"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: runRevalidate health-verdict truth. medium ACTIVE_MATCH→COMMITTED; medium FALLBACK_UNDERSIZED→DEGRADED; persisted ACTIVE_MATCH + live mismatch→DEGRADED (live wins); persisted failure + live ACTIVE_MATCH→COMMITTED (live wins). Proves the health_resource_policy_active assertion is PRESENT and did NOT skip (the resolver performed a live systemd verify). Deterministic via the injected medium fixture profile + fixture mock."
+// meta:inventory.files="cmd/nftban-installer/verdict_truth_revalidate_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	coresafety "github.com/itcmsgr/nftban/internal/safety"
+	"github.com/itcmsgr/nftban/pkg/version"
+)
+
+// writeRevalStateHealth writes a DEGRADED install_state (version-matched, ssh 22)
+// carrying a persisted HEALTH_RESOURCE_* record so the "live wins over persisted"
+// cases can demonstrate that stale persisted evidence never masks live truth.
+func writeRevalStateHealth(t *testing.T, dir, persistedHealth string, protection bool) {
+	t.Helper()
+	sf := state.NewStateFile(dir)
+	sf.State = state.StateDegraded
+	sf.Version = version.Version
+	sf.Mode = "upgrade"
+	sf.SSHPort = 22
+	sf.HealthResourceState = persistedHealth
+	sf.HealthResourceProfile = string(coresafety.ResourceTierMedium)
+	sf.HealthResourceProtection = protection
+	sf.HealthMemMaxEffective = mediumProfile().MemoryMax
+	if err := sf.WriteAtomic(); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+}
+
+// driveRevalidate runs the REAL runRevalidate entry point against the fixture mock +
+// injected medium profile, after the given persisted state is on disk.
+func driveRevalidate(t *testing.T, inj *assertionTestInjection, m *executor.MockExecutor) (*state.StateFile, int) {
+	t.Helper()
+	dir := t.TempDir()
+	// on-disk persisted record (default: DEGRADED, no persisted health).
+	writeRevalState(t, dir, state.StateDegraded, version.Version)
+	return driveRevalidateDir(t, dir, inj, m)
+}
+
+func driveRevalidateDir(t *testing.T, dir string, inj *assertionTestInjection, m *executor.MockExecutor) (*state.StateFile, int) {
+	t.Helper()
+	cfg := &config{stateDir: dir, revalidate: true, inject: inj}
+	sf := newRevalSF(dir) // mimics main(): read on-disk, overwrite Version, blank Mode
+	log := logging.New(dir+"/installer.log", false)
+	rc := runRevalidate(context.Background(), m, sf, cfg, log)
+	// re-read the persisted terminal state for assertion.
+	got := state.NewStateFile(dir)
+	_ = got.Read()
+	return got, rc
+}
+
+// medium + live ACTIVE_MATCH → COMMITTED.
+func TestRevalidate_MediumActiveMatch_Commits(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile())
+
+	got, rc := driveRevalidate(t, inj, m)
+	if got.State != state.StateCommitted || rc != state.ExitCommitted {
+		t.Fatalf("medium ACTIVE_MATCH: state=%s rc=%d want COMMITTED", got.State, rc)
+	}
+	if countHealthShow(m) < 1 {
+		t.Error("health assertion must NOT skip — the resolver must perform a live systemd verify")
+	}
+}
+
+// medium + live FALLBACK_UNDERSIZED → DEGRADED (no false COMMIT).
+func TestRevalidate_MediumUndersized_StaysDegraded(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthFallbackUndersized(m)
+
+	got, rc := driveRevalidate(t, inj, m)
+	if got.State != state.StateDegraded || rc != state.ExitDegraded {
+		t.Fatalf("medium FALLBACK_UNDERSIZED: state=%s rc=%d want DEGRADED", got.State, rc)
+	}
+}
+
+// persisted ACTIVE_MATCH + live mismatch → DEGRADED (LIVE wins; persisted never masks).
+func TestRevalidate_PersistedActiveMatch_LiveMismatch_Degrades(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthFallbackUndersized(m) // live mismatch
+
+	dir := t.TempDir()
+	writeRevalStateHealth(t, dir, string(healthresource.StateActiveMatch), true) // stale persisted ACTIVE_MATCH
+	got, rc := driveRevalidateDir(t, dir, inj, m)
+
+	if got.State != state.StateDegraded || rc != state.ExitDegraded {
+		t.Fatalf("persisted ACTIVE_MATCH + live mismatch: state=%s rc=%d want DEGRADED (live must win)", got.State, rc)
+	}
+}
+
+// persisted failure + live ACTIVE_MATCH → COMMITTED (LIVE wins; stale failure cleared).
+func TestRevalidate_PersistedFailure_LiveActiveMatch_Commits(t *testing.T) {
+	inj, m, cleanup := newAllAssertionsPassFixture(t)
+	defer cleanup()
+	inj.healthProfile = mediumProfilePtr()
+	setHealthActiveMatch(m, mediumProfile()) // live ACTIVE_MATCH
+
+	dir := t.TempDir()
+	writeRevalStateHealth(t, dir, string(healthresource.StateFallbackUnder), false) // stale persisted failure
+	got, rc := driveRevalidateDir(t, dir, inj, m)
+
+	if got.State != state.StateCommitted || rc != state.ExitCommitted {
+		t.Fatalf("persisted failure + live ACTIVE_MATCH: state=%s rc=%d want COMMITTED (live must win)", got.State, rc)
+	}
+}

--- a/internal/healthresource/generate.go
+++ b/internal/healthresource/generate.go
@@ -40,6 +40,12 @@ const (
 	StateExternalConflict  State = "EXTERNAL_OVERRIDE_CONFLICT" // a non-NFTBan drop-in overrides the effective values
 	StateExpectedNotLoaded State = "EXPECTED_DROPIN_NOT_LOADED" // our drop-in on disk but not in systemd DropInPaths
 	StateEffectiveMismatch State = "EFFECTIVE_VALUES_MISMATCH"  // our drop-in loaded but effective != calculated (reload lag / stale)
+
+	// v1.223.0 verdict-truth: the resolver could not determine live protection
+	// state (systemctl show failed AND no persisted evidence). MARKED, never a
+	// silent zero: not protected, but not a fabricated policy failure either —
+	// the assertion surfaces it as UNVERIFIABLE (advisory), not DEGRADED.
+	StateUnavailable State = "UNAVAILABLE"
 )
 
 // ProtectionActive reports whether the health-OOM protection is effectively in

--- a/internal/healthresource/verdict.go
+++ b/internal/healthresource/verdict.go
@@ -41,16 +41,40 @@ func ProtectionRequired(tier safety.ResourceTier) bool {
 	return tier == safety.ResourceTierMedium || tier == safety.ResourceTierLarge
 }
 
-// Acceptable reports whether the verdict satisfies the host-class policy:
+// AcceptableFor is the SINGLE tier-aware protection predicate:
 //   - any tier + ACTIVE_MATCH            → acceptable
 //   - small     + FALLBACK_MATCH         → acceptable (fallback meets calc)
 //   - medium/large + anything-but-active → NOT acceptable (installer DEGRADED)
-func (v Verdict) Acceptable() bool {
-	if v.EffectiveState == StateActiveMatch {
+//
+// v1.223.0: extracted so the installer verdict (Verdict.Acceptable), the
+// repair/revalidate resolution, AND the read-only CLI (nftban health resources)
+// all consume ONE predicate — INSTALLER_ACCEPTABLE == CLI_PROTECTION_ACTIVE ==
+// REVALIDATE_ACCEPTABLE. Closes RESOURCES-VERDICT-TIER-BLIND (the CLI previously
+// decided "protected" via the tier-blind State.ProtectionActive()).
+func AcceptableFor(tier safety.ResourceTier, eff State) bool {
+	if eff == StateActiveMatch {
 		return true
 	}
-	if !ProtectionRequired(v.Profile.Tier) && v.EffectiveState == StateFallbackMatch {
+	if !ProtectionRequired(tier) && eff == StateFallbackMatch {
 		return true
 	}
 	return false
+}
+
+// Acceptable reports whether the verdict satisfies the host-class policy via the
+// shared AcceptableFor predicate.
+func (v Verdict) Acceptable() bool {
+	return AcceptableFor(v.Profile.Tier, v.EffectiveState)
+}
+
+// IsZero reports whether the verdict was never populated (a zero struct — e.g. a
+// validate-only entry point that skipped phaseConfigure). v1.223.0: validation
+// paths MUST resolve a real verdict (services.ResolveHealthResourceVerdict) rather
+// than pass a zero struct into the assertion; the assertion treats a zero verdict
+// as UNRESOLVED (honest skip-with-warning), NEVER as a fabricated 0/0 policy
+// failure and NEVER as silently protected.
+func (v Verdict) IsZero() bool {
+	return v.Profile.Tier == "" && v.EffectiveState == "" &&
+		v.CalculatedHigh == 0 && v.CalculatedMax == 0 &&
+		v.EffectiveHigh == 0 && v.EffectiveMax == 0
 }

--- a/internal/healthresource/verdict.go
+++ b/internal/healthresource/verdict.go
@@ -32,6 +32,16 @@ type Verdict struct {
 	DaemonReloaded   bool
 	ProtectionActive bool
 	ValidationError  string
+
+	// ResolvedFrom records WHICH precedence branch of ResolveHealthResourceVerdict
+	// produced this verdict: "current" (phaseConfigure reconciliation reused this
+	// process), "live" (read-only systemd verify), "persisted" (cautious
+	// install_state reconstruction), or "unavailable" (no live read + no persisted
+	// evidence). v1.223.0: a resolution-source marker so tests can PROVE a fresh
+	// per-pass live read happened (VALIDATE_2 must not reuse a mutated cache). It is
+	// diagnostic only and is DELIBERATELY IGNORED by IsZero — a resolved verdict is
+	// non-zero on its substantive fields regardless of this marker.
+	ResolvedFrom string
 }
 
 // ProtectionRequired reports whether an ACTIVE effective drop-in is MANDATORY for

--- a/internal/healthresource/verdict_test.go
+++ b/internal/healthresource/verdict_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="verdict_test.go"
+// meta:type="go"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: IsZero + the shared tier-aware AcceptableFor predicate (installer==CLI==revalidate). Closes the test-blindness that let RESOURCES-VERDICT-TIER-BLIND + the zero-verdict handling ship untested."
+package healthresource
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/safety"
+)
+
+func TestVerdictIsZero(t *testing.T) {
+	if !(Verdict{}).IsZero() {
+		t.Fatal("a zero Verdict must report IsZero")
+	}
+	if (Verdict{EffectiveState: StateActiveMatch}).IsZero() {
+		t.Fatal("populated EffectiveState is not zero")
+	}
+	if (Verdict{Profile: safety.HealthResourceProfile{Tier: safety.ResourceTierMedium}}).IsZero() {
+		t.Fatal("populated tier is not zero")
+	}
+	if (Verdict{CalculatedMax: 1}).IsZero() {
+		t.Fatal("populated calc is not zero")
+	}
+	// A resolved-but-unavailable verdict is MARKED, never zero.
+	if (Verdict{EffectiveState: StateUnavailable}).IsZero() {
+		t.Fatal("StateUnavailable is a marked verdict, not zero")
+	}
+}
+
+func TestAcceptableFor(t *testing.T) {
+	cases := []struct {
+		tier safety.ResourceTier
+		st   State
+		want bool
+	}{
+		{safety.ResourceTierSmall, StateActiveMatch, true},
+		{safety.ResourceTierMedium, StateActiveMatch, true},
+		{safety.ResourceTierLarge, StateActiveMatch, true},
+		{safety.ResourceTierSmall, StateFallbackMatch, true},   // small: packaged fallback meets calc
+		{safety.ResourceTierMedium, StateFallbackMatch, false}, // medium/large: fallback is underprotection
+		{safety.ResourceTierLarge, StateFallbackMatch, false},
+		{safety.ResourceTierMedium, StateFallbackUnder, false},
+		{safety.ResourceTierSmall, StateFallbackUnder, false},
+		{safety.ResourceTierMedium, State(""), false}, // zero state never acceptable (no silent-protect)
+		{safety.ResourceTier(""), State(""), false},
+		{safety.ResourceTierMedium, StateUnavailable, false},
+	}
+	for _, c := range cases {
+		if got := AcceptableFor(c.tier, c.st); got != c.want {
+			t.Errorf("AcceptableFor(%q,%q)=%v want %v", c.tier, c.st, got, c.want)
+		}
+	}
+}
+
+// Verdict.Acceptable must be exactly the shared predicate — the CLI and installer
+// cannot diverge (RESOURCES-VERDICT-TIER-BLIND).
+func TestAcceptableUsesSharedPredicate(t *testing.T) {
+	for _, tier := range []safety.ResourceTier{safety.ResourceTierSmall, safety.ResourceTierMedium, safety.ResourceTierLarge} {
+		for _, st := range []State{StateActiveMatch, StateFallbackMatch, StateFallbackUnder, StateUnavailable, State("")} {
+			v := Verdict{Profile: safety.HealthResourceProfile{Tier: tier}, EffectiveState: st}
+			if v.Acceptable() != AcceptableFor(tier, st) {
+				t.Errorf("Verdict.Acceptable diverged from AcceptableFor for tier=%q state=%q", tier, st)
+			}
+		}
+	}
+}

--- a/internal/installer/executor/mock.go
+++ b/internal/installer/executor/mock.go
@@ -121,6 +121,7 @@ var _ Executor = (*MockExecutor)(nil)
 func NewMockExecutor() *MockExecutor {
 	return &MockExecutor{
 		RunResults:       make(map[string]Result),
+		RunResultSeq:     make(map[string][]Result),
 		Files:            make(map[string][]byte),
 		FileStats:        make(map[string]FileMeta),
 		WrittenFiles:     make(map[string][]byte),

--- a/internal/installer/executor/mock.go
+++ b/internal/installer/executor/mock.go
@@ -37,6 +37,19 @@ type MockExecutor struct {
 	// If a command is not in RunResults, it returns exit 0 with empty output.
 	RunResults map[string]Result
 
+	// RunResultSeq maps a command key ("name:arg1:arg2") to an ORDERED list of
+	// Results; each Run of that exact key returns the next element in sequence.
+	// TEST-ONLY (v1.223.0 verdict-truth): lets a test model live systemd state
+	// CHANGING between two internal validation passes (e.g. VALIDATE_1
+	// FALLBACK_UNDERSIZED then VALIDATE_2 ACTIVE_MATCH). When a key's sequence is
+	// EXHAUSTED, Run returns a LOUD sentinel error Result (exit 255 + a marker on
+	// Stderr) and still records the command, so an unexpected extra call is
+	// detectable — it never silently falls back. Keys NOT present here fall through
+	// to the existing static RunResults behavior EXACTLY (all other tests unchanged).
+	// No production code path consults this map.
+	RunResultSeq map[string][]Result
+	seqCursor    map[string]int
+
 	// Files maps path -> content for ReadFile/FileExists.
 	Files map[string][]byte
 
@@ -147,10 +160,43 @@ func (m *MockExecutor) Run(name string, args ...string) Result {
 	if hasCb && cb != nil {
 		cb()
 	}
+	// TEST-ONLY sequential responses take precedence over static RunResults for
+	// keys explicitly populated in RunResultSeq (v1.223.0). Absent keys are
+	// untouched and fall through to the static behavior below.
+	if r, ok := m.nextSeqResult(name, args...); ok {
+		return r
+	}
 	if r, ok := m.lookupResult(name, args...); ok {
 		return r
 	}
 	return Result{ExitCode: 0}
+}
+
+// nextSeqResult returns the next ordered Result for a command key registered in
+// RunResultSeq, advancing that key's cursor. ok=false when the key is not
+// registered (caller falls through to static RunResults). When the sequence is
+// exhausted it returns a LOUD sentinel error Result (ok=true) so the test detects
+// an unexpected extra call rather than silently getting a static/zero result.
+func (m *MockExecutor) nextSeqResult(name string, args ...string) (Result, bool) {
+	key := name + ":" + strings.Join(args, ":")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	seq, ok := m.RunResultSeq[key]
+	if !ok {
+		return Result{}, false
+	}
+	if m.seqCursor == nil {
+		m.seqCursor = make(map[string]int)
+	}
+	i := m.seqCursor[key]
+	if i >= len(seq) {
+		return Result{
+			ExitCode: 255,
+			Stderr:   "MockExecutor: RunResultSeq exhausted for key " + key + " (unexpected extra call)",
+		}, true
+	}
+	m.seqCursor[key]++
+	return seq[i], true
 }
 
 func (m *MockExecutor) RunContext(_ context.Context, name string, args ...string) Result {

--- a/internal/installer/executor/mock_seq_test.go
+++ b/internal/installer/executor/mock_seq_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="mock_seq_test.go"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: MockExecutor TEST-ONLY sequential-response (RunResultSeq) contract — ordered per-key responses, static RunResults behavior preserved for keys without a sequence, sequence precedence over static for the same key, and FAIL-LOUD on exhaustion (sentinel exit 255 + recorded command) rather than a silent fall-back."
+// meta:inventory.files="internal/installer/executor/mock_seq_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunResultSeq_OrderedResponses(t *testing.T) {
+	m := NewMockExecutor()
+	m.RunResultSeq["systemctl:show:x"] = []Result{
+		{Stdout: "first"},
+		{Stdout: "second"},
+	}
+	if r := m.Run("systemctl", "show", "x"); r.Stdout != "first" {
+		t.Fatalf("call 1: got %q want first", r.Stdout)
+	}
+	if r := m.Run("systemctl", "show", "x"); r.Stdout != "second" {
+		t.Fatalf("call 2: got %q want second", r.Stdout)
+	}
+}
+
+func TestRunResultSeq_ExhaustionFailsLoud(t *testing.T) {
+	m := NewMockExecutor()
+	m.RunResultSeq["a:b"] = []Result{{Stdout: "only"}}
+	_ = m.Run("a", "b")  // consume the one element
+	r := m.Run("a", "b") // exhausted
+	if r.ExitCode != 255 {
+		t.Fatalf("exhausted call must fail loud (exit 255); got exit=%d", r.ExitCode)
+	}
+	if !strings.Contains(r.Stderr, "RunResultSeq exhausted") {
+		t.Errorf("exhausted call must carry the loud marker; stderr=%q", r.Stderr)
+	}
+	// The extra call is still RECORDED so the test can detect it.
+	if m.CommandCallCount("a", "b") != 2 {
+		t.Errorf("exhausted call must be recorded; call count=%d want 2", m.CommandCallCount("a", "b"))
+	}
+}
+
+func TestRunResultSeq_StaticBehaviorPreservedForOtherKeys(t *testing.T) {
+	m := NewMockExecutor()
+	m.RunResultSeq["seq:key"] = []Result{{Stdout: "seq"}}
+	m.RunResults["static:key"] = Result{Stdout: "static"}
+
+	// A key WITHOUT a sequence keeps the exact static behavior.
+	if r := m.Run("static", "key"); r.Stdout != "static" {
+		t.Errorf("static key: got %q want static (static RunResults must be untouched)", r.Stdout)
+	}
+	// A completely unmapped key still returns exit 0 empty.
+	if r := m.Run("no", "mapping"); r.ExitCode != 0 || r.Stdout != "" {
+		t.Errorf("unmapped key: got exit=%d out=%q want 0/empty", r.ExitCode, r.Stdout)
+	}
+}
+
+func TestRunResultSeq_PrecedenceOverStaticForSameKey(t *testing.T) {
+	m := NewMockExecutor()
+	m.RunResults["k:1"] = Result{Stdout: "static"}
+	m.RunResultSeq["k:1"] = []Result{{Stdout: "seq0"}}
+	// Sequence wins while it has elements.
+	if r := m.Run("k", "1"); r.Stdout != "seq0" {
+		t.Fatalf("sequence must take precedence over static for the same key; got %q", r.Stdout)
+	}
+	// Once exhausted it fails LOUD — it does NOT silently fall back to the static.
+	if r := m.Run("k", "1"); r.ExitCode != 255 {
+		t.Errorf("exhausted sequence must NOT silently fall back to static; got exit=%d out=%q", r.ExitCode, r.Stdout)
+	}
+}

--- a/internal/installer/services/dropin_authority_v1223_test.go
+++ b/internal/installer/services/dropin_authority_v1223_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="dropin_authority_v1223_test.go"
+// meta:type="go"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: drop-in authority adverse cases on verifyLiveWithProfile — DropInLoaded derives from systemd DropInPaths (systemctl show), NEVER from disk presence. file-present-but-not-in-DropInPaths→FALLBACK_MATCH (NOT ACTIVE_MATCH); file-absent-but-in-DropInPaths→EFFECTIVE_VALUES_MISMATCH; only-admin-sibling→EXTERNAL_OVERRIDE_CONFLICT; file-present+omitted+mismatch→EXPECTED_DROPIN_NOT_LOADED. Plus ResolveHealthResourceVerdict ResolvedFrom precedence markers (current/live/persisted/unavailable)."
+// meta:inventory.files="internal/installer/services/dropin_authority_v1223_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/safety"
+)
+
+// file exists + DropInPaths omits expected + effective != calc → EXPECTED_DROPIN_NOT_LOADED.
+func TestDropinAuthority_FileOnDisk_NotLoaded_Mismatch(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 << 30)
+	m.Files[healthresource.DropinFile] = healthresource.Render(p, verFixture) // ON DISK
+	setShow(m, 192*miB, 256*miB, 64, "")                                      // effective undersized, NO drop-in loaded
+	v := verifyLiveWithProfile(m, &state.StateFile{}, nolog(), verFixture, p)
+	if v.EffectiveState != healthresource.StateExpectedNotLoaded {
+		t.Fatalf("state=%s want EXPECTED_DROPIN_NOT_LOADED", v.EffectiveState)
+	}
+	if v.DropInLoaded {
+		t.Error("DropInLoaded must be FALSE (derived from DropInPaths, which omits our path) despite the file on disk")
+	}
+	if v.Acceptable() {
+		t.Error("EXPECTED_DROPIN_NOT_LOADED must NOT be acceptable")
+	}
+}
+
+// file ABSENT + DropInPaths INCLUDES expected + effective != calc → EFFECTIVE_VALUES_MISMATCH.
+// Proves DropInLoaded is derived from systemctl-show DropInPaths, not disk presence.
+func TestDropinAuthority_FileAbsent_LoadedFromShow_Mismatch(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 << 30)
+	// NO m.Files[DropinFile] → absent on disk.
+	setShow(m, 300*miB, 500*miB, 64, healthresource.DropinFile) // loaded per systemd, effective != calc
+	v := verifyLiveWithProfile(m, &state.StateFile{}, nolog(), verFixture, p)
+	if !v.DropInLoaded {
+		t.Fatal("DropInLoaded must be TRUE — derived from DropInPaths (systemctl show), even though the file is ABSENT on disk")
+	}
+	if v.EffectiveState != healthresource.StateEffectiveMismatch {
+		t.Fatalf("state=%s want EFFECTIVE_VALUES_MISMATCH", v.EffectiveState)
+	}
+	if v.Acceptable() {
+		t.Error("EFFECTIVE_VALUES_MISMATCH must NOT be acceptable")
+	}
+}
+
+// only an admin sibling drop-in loaded (effective != calc) → EXTERNAL_OVERRIDE_CONFLICT.
+func TestDropinAuthority_AdminSiblingOnly_ExternalConflict(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 << 30)
+	admin := "/etc/systemd/system/nftban-health.service.d/99-admin.conf"
+	setShow(m, 300*miB, 700*miB, 64, admin) // only the admin drop-in loaded
+	v := verifyLiveWithProfile(m, &state.StateFile{}, nolog(), verFixture, p)
+	if v.EffectiveState != healthresource.StateExternalConflict {
+		t.Fatalf("state=%s want EXTERNAL_OVERRIDE_CONFLICT", v.EffectiveState)
+	}
+	if !strings.Contains(v.ValidationError, admin) {
+		t.Errorf("conflict must name the external drop-in; error=%q", v.ValidationError)
+	}
+	if v.Acceptable() {
+		t.Error("EXTERNAL_OVERRIDE_CONFLICT must NOT be acceptable")
+	}
+}
+
+// file exists + effective values MATCH via the MAIN unit but our drop-in NOT in
+// DropInPaths → FALLBACK_MATCH (NOT ACTIVE_MATCH). Proves DropInLoaded is FALSE
+// (from DropInPaths) even though the file IS present on disk; medium is NOT protected.
+func TestDropinAuthority_MatchButNotLoaded_FallbackNotActive(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 << 30)                                                     // medium (protection-required)
+	m.Files[healthresource.DropinFile] = healthresource.Render(p, verFixture) // ON DISK
+	setShow(m, p.MemoryHigh, p.MemoryMax, 64, "")                             // effective == calc, but no drop-in loaded
+	v := verifyLiveWithProfile(m, &state.StateFile{}, nolog(), verFixture, p)
+	if v.EffectiveState != healthresource.StateFallbackMatch {
+		t.Fatalf("state=%s want FALLBACK_MATCH (NOT ACTIVE_MATCH — drop-in not in DropInPaths)", v.EffectiveState)
+	}
+	if v.DropInLoaded {
+		t.Error("DropInLoaded must be FALSE (DropInPaths omits our path) even though the file is on disk")
+	}
+	if v.Acceptable() {
+		t.Error("medium FALLBACK_MATCH must NOT be acceptable (protection required, drop-in not effective)")
+	}
+}
+
+// ResolveHealthResourceVerdict ResolvedFrom precedence markers.
+func TestResolvedFromMarkers(t *testing.T) {
+	p := profFor(6 << 30)
+
+	// current: a non-zero reconciliation verdict is reused → "current", no live probe.
+	t.Run("current", func(t *testing.T) {
+		m := executor.NewMockExecutor()
+		cur := healthresource.Verdict{Profile: p, EffectiveState: healthresource.StateActiveMatch, CalculatedMax: p.MemoryMax}
+		got := resolveWithProfile(m, &state.StateFile{}, nolog(), cur, verFixture, p)
+		if got.ResolvedFrom != "current" {
+			t.Fatalf("ResolvedFrom=%q want current", got.ResolvedFrom)
+		}
+	})
+	// live: zero current + a valid systemctl show → "live".
+	t.Run("live", func(t *testing.T) {
+		m := executor.NewMockExecutor()
+		setShow(m, p.MemoryHigh, p.MemoryMax, 64, healthresource.DropinFile)
+		m.Files[healthresource.DropinFile] = healthresource.Render(p, verFixture)
+		got := resolveWithProfile(m, &state.StateFile{}, nolog(), healthresource.Verdict{}, verFixture, p)
+		if got.ResolvedFrom != "live" {
+			t.Fatalf("ResolvedFrom=%q want live", got.ResolvedFrom)
+		}
+	})
+	// persisted: live unreadable + persisted evidence → "persisted".
+	t.Run("persisted", func(t *testing.T) {
+		m := executor.NewMockExecutor()
+		m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "boom"}
+		sf := &state.StateFile{
+			HealthResourceState:   string(healthresource.StateActiveMatch),
+			HealthResourceProfile: string(safety.ResourceTierMedium),
+			HealthMemMaxEffective: 402653184,
+		}
+		got := resolveWithProfile(m, sf, nolog(), healthresource.Verdict{}, verFixture, p)
+		if got.ResolvedFrom != "persisted" {
+			t.Fatalf("ResolvedFrom=%q want persisted", got.ResolvedFrom)
+		}
+	})
+	// unavailable: live unreadable + NO persisted → "unavailable" (never a silent zero).
+	t.Run("unavailable", func(t *testing.T) {
+		m := executor.NewMockExecutor()
+		m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "boom"}
+		got := resolveWithProfile(m, &state.StateFile{}, nolog(), healthresource.Verdict{}, verFixture, p)
+		if got.ResolvedFrom != "unavailable" {
+			t.Fatalf("ResolvedFrom=%q want unavailable", got.ResolvedFrom)
+		}
+		if got.IsZero() {
+			t.Error("unavailable verdict must be MARKED, not a silent zero")
+		}
+	})
+}

--- a/internal/installer/services/health_resource.go
+++ b/internal/installer/services/health_resource.go
@@ -127,6 +127,135 @@ func reconcileWithProfile(exec executor.Executor, sf *state.StateFile, log *logg
 	return v
 }
 
+// ResolveHealthResourceVerdict returns ONE authoritative health-resource verdict
+// for validation, regardless of which installer entry point is running. v1.223.0
+// (BUG-REPAIR-HEALTH-VERDICT-EMPTY + BUG-REVALIDATE-MASKS-HEALTH-DEGRADE): the
+// verdict previously existed only as transient phaseConfigure output, so
+// configure-skipping paths (repair-resume-at-validate, revalidate, update force)
+// fed a ZERO verdict into the assertion — a false DEGRADED on repair and a false
+// COMMIT on revalidate. Precedence (owner scope §5): live systemd effective policy
+// > current calculated canonical policy > cautious persisted reconstruction >
+// explicit UNAVAILABLE. It NEVER returns an unmarked zero-value verdict.
+func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string) healthresource.Verdict {
+	// 1. Current reconciliation verdict when available (phaseConfigure ran this
+	//    process → the verdict already reflects live systemd).
+	if !current.IsZero() {
+		return current
+	}
+	// 2. No verdict this process → VERIFY live systemd read-only (no write, no
+	//    reload) with the canonical policy. Authoritative current truth for
+	//    repair/revalidate/update-force. Persists the resolved truth so a stale
+	//    persisted ACTIVE_MATCH cannot override a live mismatch.
+	live := verifyLiveHealthResource(exec, sf, log, sourceVersion)
+	if live.EffectiveState != healthresource.StateUnavailable {
+		return live
+	}
+	// 3. Live read impossible → reconstruct cautiously from persisted evidence.
+	if persisted, ok := reconstructHealthResourceFromPersisted(sf, sourceVersion); ok {
+		if log != nil {
+			log.Warn("health-resource: live systemd read failed; reconstructed verdict from persisted install_state (state=%s) — evidence, not live truth", persisted.EffectiveState)
+		}
+		return persisted
+	}
+	// 4. Explicit, MARKED unavailable — never a silent zero.
+	if log != nil {
+		log.Warn("health-resource: verdict UNAVAILABLE — no live systemd read and no persisted evidence; assertion reports UNVERIFIABLE (advisory, not DEGRADED)")
+	}
+	return healthresource.Verdict{
+		Authority:       "internal/safety",
+		SourceVersion:   sourceVersion,
+		EffectiveState:  healthresource.StateUnavailable,
+		ValidationError: "health-resource verdict unavailable: live systemctl show failed and no persisted evidence",
+	}
+}
+
+// verifyLiveHealthResource computes the canonical policy and classifies the LIVE
+// systemd effective state WITHOUT writing/reloading (read-only). It persists the
+// resolved truth to install_state (owner scope §5: persisted must not override a
+// live mismatch). Returns EffectiveState == StateUnavailable when systemd cannot
+// be read (the caller then falls back to persisted reconstruction).
+func verifyLiveHealthResource(exec executor.Executor, sf *state.StateFile, log *logging.Logger, sourceVersion string) healthresource.Verdict {
+	p := safety.HealthServiceMemoryLimits()
+	v := healthresource.Verdict{
+		Profile:        p,
+		Authority:      "internal/safety",
+		CalculatedHigh: p.MemoryHigh,
+		CalculatedMax:  p.MemoryMax,
+		DropInPath:     healthresource.DropinFile,
+		SourceVersion:  sourceVersion,
+	}
+	if err := healthresource.Validate(p); err != nil {
+		v.GeneratedState = healthresource.StateInvalid
+		v.EffectiveState = healthresource.StateActivationFailed
+		v.ValidationError = "policy invalid: " + err.Error()
+		finishHealthResource(exec, sf, log, &v)
+		return v
+	}
+	// on-disk generated state (read-only; NO write)
+	desired := healthresource.Render(p, sourceVersion)
+	if existing, rerr := exec.ReadFile(healthresource.DropinFile); rerr == nil {
+		v.GeneratedState = healthresource.Classify(existing, desired)
+	} else {
+		v.GeneratedState = healthresource.StateAbsent
+	}
+	effHigh, effMax, effTasks, dropins, err := queryEffectiveHealth(exec)
+	if err != nil {
+		// cannot read live systemd → MARK unavailable; do NOT persist a false state.
+		v.EffectiveState = healthresource.StateUnavailable
+		v.ValidationError = "systemctl show: " + err.Error()
+		return v
+	}
+	v.EffectiveHigh, v.EffectiveMax, v.EffectiveTasksMax = effHigh, effMax, effTasks
+	v.LoadedDropIns = dropins
+	v.DropInLoaded = containsPath(dropins, healthresource.DropinFile)
+	if effHigh == healthresource.InfinityBytes || effMax == healthresource.InfinityBytes {
+		v.EffectiveState = healthresource.StateActivationFailed
+		v.ValidationError = "unbounded effective memory limit (infinity) violates bounded policy"
+		v.ProtectionActive = false
+		finishHealthResource(exec, sf, log, &v)
+		return v
+	}
+	otherDropins := 0
+	for _, dp := range dropins {
+		if dp != healthresource.DropinFile {
+			otherDropins++
+		}
+	}
+	v.EffectiveState = healthresource.ClassifyEffectiveDetailed(p, effHigh, effMax, v.DropInLoaded, otherDropins, true)
+	if v.EffectiveState == healthresource.StateExternalConflict && v.ValidationError == "" {
+		v.ValidationError = "external systemd drop-in overrides health-service memory limits: " + strings.Join(dropins, " ")
+	}
+	v.ProtectionActive = v.EffectiveState.ProtectionActive()
+	finishHealthResource(exec, sf, log, &v)
+	return v
+}
+
+// reconstructHealthResourceFromPersisted rebuilds a verdict from the persisted
+// HEALTH_RESOURCE_* install_state fields — a CAUTIOUS last resort used ONLY when
+// live systemd cannot be read. Persisted state is evidence, not live authority.
+func reconstructHealthResourceFromPersisted(sf *state.StateFile, sourceVersion string) (healthresource.Verdict, bool) {
+	if sf == nil || strings.TrimSpace(sf.HealthResourceState) == "" {
+		return healthresource.Verdict{}, false
+	}
+	v := healthresource.Verdict{
+		Profile:           safety.HealthResourceProfile{Tier: safety.ResourceTier(sf.HealthResourceProfile), Reason: sf.HealthResourceReason},
+		Authority:         "internal/safety",
+		CalculatedHigh:    sf.HealthMemHighCalculated,
+		CalculatedMax:     sf.HealthMemMaxCalculated,
+		EffectiveHigh:     sf.HealthMemHighEffective,
+		EffectiveMax:      sf.HealthMemMaxEffective,
+		EffectiveTasksMax: sf.HealthTasksMaxEffective,
+		DropInPath:        healthresource.DropinFile,
+		DropInLoaded:      sf.HealthResourceDropinLoaded,
+		GeneratedState:    healthresource.State(sf.HealthResourceGenerated),
+		EffectiveState:    healthresource.State(sf.HealthResourceState),
+		SourceVersion:     sourceVersion,
+		ProtectionActive:  sf.HealthResourceProtection,
+		ValidationError:   sf.HealthResourceError,
+	}
+	return v, true
+}
+
 // finishHealthResource persists the verdict to install_state and logs it.
 func finishHealthResource(_ executor.Executor, sf *state.StateFile, log *logging.Logger, v *healthresource.Verdict) {
 	v.ProtectionActive = v.EffectiveState.ProtectionActive()

--- a/internal/installer/services/health_resource.go
+++ b/internal/installer/services/health_resource.go
@@ -196,9 +196,16 @@ func verifyLiveWithProfile(exec executor.Executor, sf *state.StateFile, log *log
 		finishHealthResource(exec, sf, log, &v)
 		return v
 	}
-	// on-disk generated state (read-only; NO write)
+	// on-disk generated state (read-only; NO write). dropInOnDisk drives the
+	// "we expect our drop-in loaded" classify input — matching the read-only CLI
+	// (cmd_resources passes svc.Dropin.OnDisk). If the drop-in is absent we are on
+	// the packaged fallback (FALLBACK_MATCH/UNDERSIZED); if present-but-not-loaded
+	// it is EXPECTED_DROPIN_NOT_LOADED. reconcileWithProfile hardcodes true because
+	// it has just WRITTEN the drop-in; a read-only verify must not assume that.
 	desired := healthresource.Render(p, sourceVersion)
+	dropInOnDisk := false
 	if existing, rerr := exec.ReadFile(healthresource.DropinFile); rerr == nil {
+		dropInOnDisk = true
 		v.GeneratedState = healthresource.Classify(existing, desired)
 	} else {
 		v.GeneratedState = healthresource.StateAbsent
@@ -226,7 +233,7 @@ func verifyLiveWithProfile(exec executor.Executor, sf *state.StateFile, log *log
 			otherDropins++
 		}
 	}
-	v.EffectiveState = healthresource.ClassifyEffectiveDetailed(p, effHigh, effMax, v.DropInLoaded, otherDropins, true)
+	v.EffectiveState = healthresource.ClassifyEffectiveDetailed(p, effHigh, effMax, v.DropInLoaded, otherDropins, dropInOnDisk)
 	if v.EffectiveState == healthresource.StateExternalConflict && v.ValidationError == "" {
 		v.ValidationError = "external systemd drop-in overrides health-service memory limits: " + strings.Join(dropins, " ")
 	}

--- a/internal/installer/services/health_resource.go
+++ b/internal/installer/services/health_resource.go
@@ -136,28 +136,42 @@ func reconcileWithProfile(exec executor.Executor, sf *state.StateFile, log *logg
 // COMMIT on revalidate. Precedence (owner scope §5): live systemd effective policy
 // > current calculated canonical policy > cautious persisted reconstruction >
 // explicit UNAVAILABLE. It NEVER returns an unmarked zero-value verdict.
-func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string) healthresource.Verdict {
-	// Split from resolveWithProfile so tests inject a fixture tier (mirrors
-	// ReconcileHealthResource/reconcileWithProfile). Canonical facts read /proc.
-	return resolveWithProfile(exec, sf, log, current, sourceVersion, safety.HealthServiceMemoryLimits())
+// ResolveHealthResourceVerdict resolves ONE authoritative verdict. The optional
+// profile is DATA dependency-injection (no global seam): PRODUCTION passes nil and
+// the canonical safety.HealthServiceMemoryLimits (DetectServerProfile →
+// ClassifyResourceTier → the single RAM-tier authority) is used; execution-path
+// tests pass a fixture *HealthResourceProfile to force a deterministic tier on any
+// host. No new classifier, no new threshold table, no mutable package global.
+func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string, profile *safety.HealthResourceProfile) healthresource.Verdict {
+	p := safety.HealthServiceMemoryLimits()
+	if profile != nil {
+		p = *profile
+	}
+	// Split from resolveWithProfile (the unexported DI helper).
+	return resolveWithProfile(exec, sf, log, current, sourceVersion, p)
 }
 
 func resolveWithProfile(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string, p safety.HealthResourceProfile) healthresource.Verdict {
 	// 1. Current reconciliation verdict when available (phaseConfigure ran this
 	//    process → the verdict already reflects live systemd).
 	if !current.IsZero() {
+		current.ResolvedFrom = "current"
 		return current
 	}
 	// 2. No verdict this process → VERIFY live systemd read-only (no write, no
 	//    reload) with the canonical policy. Authoritative current truth for
 	//    repair/revalidate/update-force. Persists the resolved truth so a stale
-	//    persisted ACTIVE_MATCH cannot override a live mismatch.
+	//    persisted ACTIVE_MATCH cannot override a live mismatch. Re-run per
+	//    validation pass (owner ruling): the extra read-only `systemctl show` on a
+	//    DEGRADED retry is accepted so VALIDATE_2 reflects CURRENT live truth.
 	live := verifyLiveWithProfile(exec, sf, log, sourceVersion, p)
 	if live.EffectiveState != healthresource.StateUnavailable {
+		live.ResolvedFrom = "live"
 		return live
 	}
 	// 3. Live read impossible → reconstruct cautiously from persisted evidence.
 	if persisted, ok := reconstructHealthResourceFromPersisted(sf, sourceVersion); ok {
+		persisted.ResolvedFrom = "persisted"
 		if log != nil {
 			log.Warn("health-resource: live systemd read failed; reconstructed verdict from persisted install_state (state=%s) — evidence, not live truth", persisted.EffectiveState)
 		}
@@ -171,6 +185,7 @@ func resolveWithProfile(exec executor.Executor, sf *state.StateFile, log *loggin
 		Authority:       "internal/safety",
 		SourceVersion:   sourceVersion,
 		EffectiveState:  healthresource.StateUnavailable,
+		ResolvedFrom:    "unavailable",
 		ValidationError: "health-resource verdict unavailable: live systemctl show failed and no persisted evidence",
 	}
 }

--- a/internal/installer/services/health_resource.go
+++ b/internal/installer/services/health_resource.go
@@ -137,6 +137,12 @@ func reconcileWithProfile(exec executor.Executor, sf *state.StateFile, log *logg
 // > current calculated canonical policy > cautious persisted reconstruction >
 // explicit UNAVAILABLE. It NEVER returns an unmarked zero-value verdict.
 func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string) healthresource.Verdict {
+	// Split from resolveWithProfile so tests inject a fixture tier (mirrors
+	// ReconcileHealthResource/reconcileWithProfile). Canonical facts read /proc.
+	return resolveWithProfile(exec, sf, log, current, sourceVersion, safety.HealthServiceMemoryLimits())
+}
+
+func resolveWithProfile(exec executor.Executor, sf *state.StateFile, log *logging.Logger, current healthresource.Verdict, sourceVersion string, p safety.HealthResourceProfile) healthresource.Verdict {
 	// 1. Current reconciliation verdict when available (phaseConfigure ran this
 	//    process → the verdict already reflects live systemd).
 	if !current.IsZero() {
@@ -146,7 +152,7 @@ func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, l
 	//    reload) with the canonical policy. Authoritative current truth for
 	//    repair/revalidate/update-force. Persists the resolved truth so a stale
 	//    persisted ACTIVE_MATCH cannot override a live mismatch.
-	live := verifyLiveHealthResource(exec, sf, log, sourceVersion)
+	live := verifyLiveWithProfile(exec, sf, log, sourceVersion, p)
 	if live.EffectiveState != healthresource.StateUnavailable {
 		return live
 	}
@@ -169,13 +175,12 @@ func ResolveHealthResourceVerdict(exec executor.Executor, sf *state.StateFile, l
 	}
 }
 
-// verifyLiveHealthResource computes the canonical policy and classifies the LIVE
+// verifyLiveWithProfile classifies the LIVE
 // systemd effective state WITHOUT writing/reloading (read-only). It persists the
 // resolved truth to install_state (owner scope §5: persisted must not override a
 // live mismatch). Returns EffectiveState == StateUnavailable when systemd cannot
 // be read (the caller then falls back to persisted reconstruction).
-func verifyLiveHealthResource(exec executor.Executor, sf *state.StateFile, log *logging.Logger, sourceVersion string) healthresource.Verdict {
-	p := safety.HealthServiceMemoryLimits()
+func verifyLiveWithProfile(exec executor.Executor, sf *state.StateFile, log *logging.Logger, sourceVersion string, p safety.HealthResourceProfile) healthresource.Verdict {
 	v := healthresource.Verdict{
 		Profile:        p,
 		Authority:      "internal/safety",

--- a/internal/installer/services/resolve_verdict_test.go
+++ b/internal/installer/services/resolve_verdict_test.go
@@ -37,8 +37,8 @@ func TestResolveUsesCurrentWhenNonZero(t *testing.T) {
 	}
 }
 
-// 2. REPAIR-RESUME regression: zero current, medium host, live drop-in ACTIVE_MATCH
-//    → resolves ACTIVE_MATCH, acceptable, NO false DEGRADED, never a zero verdict.
+//  2. REPAIR-RESUME regression: zero current, medium host, live drop-in ACTIVE_MATCH
+//     → resolves ACTIVE_MATCH, acceptable, NO false DEGRADED, never a zero verdict.
 func TestResolveZeroMediumLiveActiveMatch(t *testing.T) {
 	m := executor.NewMockExecutor()
 	p := profFor(6 * 1024 * miB) // medium 256/384
@@ -56,8 +56,8 @@ func TestResolveZeroMediumLiveActiveMatch(t *testing.T) {
 	}
 }
 
-// 3. A genuinely underprotected medium host (live effective < calc) must REMAIN
-//    not-acceptable — the fix must not mask real underprotection.
+//  3. A genuinely underprotected medium host (live effective < calc) must REMAIN
+//     not-acceptable — the fix must not mask real underprotection.
 func TestResolveZeroMediumLiveUndersizedStaysDegraded(t *testing.T) {
 	m := executor.NewMockExecutor()
 	p := profFor(6 * 1024 * miB) // medium calc 256/384

--- a/internal/installer/services/resolve_verdict_test.go
+++ b/internal/installer/services/resolve_verdict_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="resolve_verdict_test.go"
+// meta:type="go"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth regression tests (MockExecutor + fixture profile): ResolveHealthResourceVerdict precedence — current>live>persisted>UNAVAILABLE, never a zero verdict. Covers BUG-REPAIR-HEALTH-VERDICT-EMPTY (repair-resume medium ACTIVE_MATCH must NOT false-DEGRADE) + real FALLBACK_UNDERSIZED must stay DEGRADED + persisted-fallback + explicit UNAVAILABLE."
+package services
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/installer/state"
+	"github.com/itcmsgr/nftban/internal/safety"
+)
+
+func setShow(m *executor.MockExecutor, high, max, tasks int64, dropins string) {
+	m.RunResults[healthShowKey()] = executor.Result{Stdout: showOut(high, max, tasks, dropins)}
+}
+
+func nolog() *logging.Logger { return logging.New("/dev/null", false) }
+
+// 1. current non-zero verdict → returned as-is; live systemd is NOT queried.
+func TestResolveUsesCurrentWhenNonZero(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 * 1024 * miB) // medium
+	cur := healthresource.Verdict{Profile: p, EffectiveState: healthresource.StateActiveMatch, CalculatedMax: p.MemoryMax}
+	got := resolveWithProfile(m, &state.StateFile{}, nolog(), cur, verFixture, p)
+	if got.EffectiveState != healthresource.StateActiveMatch {
+		t.Fatalf("want current verdict preserved, got %s", got.EffectiveState)
+	}
+	for _, c := range m.Commands {
+		if c.Name == "systemctl" {
+			t.Fatal("resolver must NOT query live systemd when a current verdict is present")
+		}
+	}
+}
+
+// 2. REPAIR-RESUME regression: zero current, medium host, live drop-in ACTIVE_MATCH
+//    → resolves ACTIVE_MATCH, acceptable, NO false DEGRADED, never a zero verdict.
+func TestResolveZeroMediumLiveActiveMatch(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 * 1024 * miB) // medium 256/384
+	setShow(m, p.MemoryHigh, p.MemoryMax, 64, healthresource.DropinFile)
+	m.Files[healthresource.DropinFile] = healthresource.Render(p, verFixture)
+	got := resolveWithProfile(m, &state.StateFile{}, nolog(), healthresource.Verdict{}, verFixture, p)
+	if got.IsZero() {
+		t.Fatal("resolver must NEVER return a zero verdict")
+	}
+	if got.EffectiveState != healthresource.StateActiveMatch {
+		t.Fatalf("want ACTIVE_MATCH from live systemd, got %s", got.EffectiveState)
+	}
+	if !got.Acceptable() {
+		t.Fatal("medium ACTIVE_MATCH must be acceptable — repair must NOT false-DEGRADE")
+	}
+}
+
+// 3. A genuinely underprotected medium host (live effective < calc) must REMAIN
+//    not-acceptable — the fix must not mask real underprotection.
+func TestResolveZeroMediumLiveUndersizedStaysDegraded(t *testing.T) {
+	m := executor.NewMockExecutor()
+	p := profFor(6 * 1024 * miB) // medium calc 256/384
+	setShow(m, 192*miB, 256*miB, 64, "")
+	got := resolveWithProfile(m, &state.StateFile{}, nolog(), healthresource.Verdict{}, verFixture, p)
+	if got.EffectiveState != healthresource.StateFallbackUnder {
+		t.Fatalf("want FALLBACK_UNDERSIZED, got %s", got.EffectiveState)
+	}
+	if got.Acceptable() {
+		t.Fatal("medium underprotected must NOT be acceptable (truthful DEGRADED)")
+	}
+}
+
+// 4. live systemd unreadable + persisted evidence → cautious reconstruction.
+func TestResolveShowFailsUsesPersisted(t *testing.T) {
+	m := executor.NewMockExecutor()
+	m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "boom"}
+	p := profFor(6 * 1024 * miB)
+	sf := &state.StateFile{
+		HealthResourceState:      string(healthresource.StateActiveMatch),
+		HealthResourceProfile:    string(safety.ResourceTierMedium),
+		HealthResourceProtection: true,
+		HealthMemMaxEffective:    402653184,
+	}
+	got := resolveWithProfile(m, sf, nolog(), healthresource.Verdict{}, verFixture, p)
+	if got.EffectiveState != healthresource.StateActiveMatch {
+		t.Fatalf("want persisted ACTIVE_MATCH reconstruction, got %s", got.EffectiveState)
+	}
+}
+
+// 5. live systemd unreadable + NO persisted → explicit, MARKED UNAVAILABLE (never zero).
+func TestResolveShowFailsNoPersistedUnavailable(t *testing.T) {
+	m := executor.NewMockExecutor()
+	m.RunResults[healthShowKey()] = executor.Result{ExitCode: 1, Stderr: "boom"}
+	got := resolveWithProfile(m, &state.StateFile{}, nolog(), healthresource.Verdict{}, verFixture, profFor(6*1024*miB))
+	if got.IsZero() {
+		t.Fatal("unresolved verdict must be MARKED UNAVAILABLE, not a silent zero")
+	}
+	if got.EffectiveState != healthresource.StateUnavailable {
+		t.Fatalf("want UNAVAILABLE, got %s", got.EffectiveState)
+	}
+}

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -72,6 +72,17 @@ type AssertionOpts struct {
 	// contexts that did not run the reconciler (assertion is skipped/PASS).
 	HealthResource *healthresource.Verdict
 
+	// SystemdPayloadInputs, when non-nil, is used VERBATIM by RunAssertionsWithOpts
+	// in place of GatherSystemdPayloadInputs(real host). v1.223.0 verdict-truth:
+	// DATA-only dependency-injection so the systemd-payload assertions are
+	// exercisable off-host WITHOUT a mutable package global or var-func seam.
+	// Production leaves it nil → the real host gather runs (byte-identical default).
+	// Fail-safe is PRESERVED: an empty/zero injected value is fed to
+	// ValidateInstalledSystemdPayload exactly like an empty real gather — there is
+	// NO nil/empty→PASS shortcut, so PAYLOAD-INVENTORY-001 (and the failed-unit
+	// query-error fail-closed) still fire on injected inputs that warrant them.
+	SystemdPayloadInputs *SystemdPayloadInputs
+
 	// FailedUnitsOut, when non-nil, receives the FINAL-pass FATAL failed-unit set
 	// (spr.FailedUnits) so the caller (phaseValidate) can propagate the STRUCTURED
 	// names into install_state SERVICES_FAILED — the v1.222.1 Lane 4 fix for
@@ -125,7 +136,16 @@ func RunAssertionsWithOpts(exec executor.Executor, sshPort int, log *logging.Log
 	// fails closed when nothing is supplied (every nftban-owned
 	// referenced path becomes "unknown"), so the gatherer SHOULD
 	// pass a populated set in production.
-	in, _ := GatherSystemdPayloadInputs(exec, log, defaultInventoryPaths())
+	// v1.223.0: use the injected inputs verbatim when supplied (tests), else gather
+	// from the real host (production default). Substitution ONLY — the validator and
+	// its fail-safe semantics are unchanged: an empty injected value validates the
+	// same as an empty real gather.
+	var in SystemdPayloadInputs
+	if opts.SystemdPayloadInputs != nil {
+		in = *opts.SystemdPayloadInputs
+	} else {
+		in, _ = GatherSystemdPayloadInputs(exec, log, defaultInventoryPaths())
+	}
 	spr := ValidateInstalledSystemdPayload(in)
 	// v1.222.1 Lane 4: hand the FATAL failed-unit set back to the caller so the
 	// STRUCTURED names reach install_state (single source of truth for remediation).
@@ -357,21 +377,38 @@ func assertLogretentionPolicyReady(log *logging.Logger) AssertionResult {
 func assertHealthResourcePolicyActive(opts AssertionOpts, log *logging.Logger) AssertionResult {
 	r := AssertionResult{Name: "health_resource_policy_active", Passed: true}
 	v := opts.HealthResource
-	// v1.223.0 verdict-truth: a nil OR zero-value verdict means "not resolved in
-	// this context" — the caller MUST resolve one (services.ResolveHealthResourceVerdict)
-	// before validation. Treat unresolved as an honest SKIP: never fabricate a 0/0
-	// policy failure (BUG-REPAIR-HEALTH-VERDICT-EMPTY) and never claim protection.
-	if v == nil || v.IsZero() {
-		r.Detail = "not evaluated (no verdict resolved in this context)"
-		log.Debug("ASSERT health_resource_policy_active: SKIP — unresolved verdict")
+	// nil = this caller does not evaluate the health verdict (e.g. a context that
+	// never wires it) → legitimate SKIP.
+	if v == nil {
+		r.Detail = "not evaluated (health verdict not supplied in this context)"
+		log.Debug("ASSERT health_resource_policy_active: SKIP — no verdict supplied")
 		return r
 	}
-	// v1.223.0: resolution genuinely could not read live systemd AND had no
-	// persisted evidence → UNVERIFIABLE. Advisory, NOT DEGRADED: we cannot prove a
-	// failure, so we must not fabricate one; but we also do not claim protection.
+	// v1.223.0: a zero STRUCT must NEVER reach the assertion — every validation
+	// entry point resolves a real verdict first (services.ResolveHealthResourceVerdict).
+	// If one does, the wiring regressed: FAIL CLOSED. Never silently pass unverified
+	// protection (the inverse of BUG-REPAIR-HEALTH-VERDICT-EMPTY) and never fabricate
+	// the misleading 0/0 policy failure.
+	if v.IsZero() {
+		r.Passed = false
+		r.Detail = "health verdict UNRESOLVED (resolver did not run for this path) — failing closed rather than committing unverified protection"
+		log.Error("ASSERT health_resource_policy_active: FAIL-CLOSED — a zero verdict reached validation; ResolveHealthResourceVerdict must run before the assertion")
+		return r
+	}
+	// v1.223.0 LOCKED UNAVAILABLE policy: live protection genuinely could not be
+	// verified (no systemd read AND no persisted evidence). A protection-REQUIRED
+	// tier (medium/large) must NOT commit unverified → FAIL (prevents the inverse
+	// bug: false SUCCESS from missing truth). A non-required tier (small) is
+	// advisory only. UNAVAILABLE is never a silent COMMIT path for medium/large.
 	if v.EffectiveState == healthresource.StateUnavailable {
-		r.Detail = "health-resource protection UNVERIFIABLE: " + v.ValidationError
-		log.Warn("ASSERT health_resource_policy_active: UNVERIFIABLE (advisory, not DEGRADED) — %s", v.ValidationError)
+		if healthresource.ProtectionRequired(v.Profile.Tier) {
+			r.Passed = false
+			r.Detail = fmt.Sprintf("OOM protection REQUIRED (tier=%s) but UNVERIFIABLE: %s", v.Profile.Tier, v.ValidationError)
+			log.Warn("ASSERT health_resource_policy_active: FAIL — required OOM protection UNVERIFIABLE on %s: %s", v.Profile.Tier, v.ValidationError)
+			return r
+		}
+		r.Detail = fmt.Sprintf("protection UNVERIFIABLE but not required (tier=%s): %s", v.Profile.Tier, v.ValidationError)
+		log.Warn("ASSERT health_resource_policy_active: advisory UNVERIFIABLE (tier not protection-required) — %s", v.ValidationError)
 		return r
 	}
 	if v.Acceptable() {

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -83,6 +83,14 @@ type AssertionOpts struct {
 	// query-error fail-closed) still fire on injected inputs that warrant them.
 	SystemdPayloadInputs *SystemdPayloadInputs
 
+	// LogRetentionValidator, when non-nil, overrides the logrotate policy validator
+	// used by the logretention_policy_ready assertion. v1.223.0 verdict-truth: nil in
+	// production (the assertion then uses the package readinessValidator → the real
+	// `logrotate -d`); execution-path tests inject a deterministic validator so the
+	// assertion does NOT depend on the `logrotate` binary being installed (it is
+	// absent in CI containers). Bounded DI, mirrors SystemdPayloadInputs.
+	LogRetentionValidator lr.Validator
+
 	// FailedUnitsOut, when non-nil, receives the FINAL-pass FATAL failed-unit set
 	// (spr.FailedUnits) so the caller (phaseValidate) can propagate the STRUCTURED
 	// names into install_state SERVICES_FAILED — the v1.222.1 Lane 4 fix for
@@ -127,7 +135,7 @@ func RunAssertionsWithOpts(exec executor.Executor, sshPort int, log *logging.Log
 	results = append(results, assertInstallStateFile(exec, log))
 	results = append(results, assertPayloadInventory(exec, log))
 	results = append(results, assertConfigIntegrity(exec, log))
-	results = append(results, assertLogretentionPolicyReady(log))
+	results = append(results, assertLogretentionPolicyReady(opts, log))
 
 	// PR26.1: systemd-payload invariants. One gather call feeds four
 	// assertions so we don't walk the unit dirs (or call systemctl)
@@ -335,19 +343,25 @@ func assertPayloadInventory(exec executor.Executor, log *logging.Logger) Asserti
 // exercisable without logrotate installed.
 var readinessValidator lr.Validator
 
-func assertLogretentionPolicyReady(log *logging.Logger) AssertionResult {
+func assertLogretentionPolicyReady(opts AssertionOpts, log *logging.Logger) AssertionResult {
 	envOr := func(k, def string) string {
 		if v := os.Getenv(k); v != "" {
 			return v
 		}
 		return def
 	}
+	// v1.223.0: prefer the caller-injected validator (execution-path tests); nil in
+	// production → the package readinessValidator (itself nil → real `logrotate -d`).
+	validator := opts.LogRetentionValidator
+	if validator == nil {
+		validator = readinessValidator
+	}
 	res := lr.Readiness(lr.ReadinessOptions{
 		MainPath:     envOr("NFTBAN_LR_MAIN", "/etc/logrotate.d/nftban"),
 		SuricataPath: envOr("NFTBAN_LR_SURICATA", "/etc/logrotate.d/nftban-suricata"),
 		StatePath:    envOr("NFTBAN_LR_STATE", "/var/lib/nftban/generated/logrotate/nftban-effective.state.json"),
 		TemplatePath: envOr("NFTBAN_LR_TEMPLATE", "/etc/nftban/templates/nftban.logrotate"),
-		Validator:    readinessValidator,
+		Validator:    validator,
 	})
 	r := AssertionResult{Name: "logretention_policy_ready", Passed: res.Ready()}
 	if res.Ready() {

--- a/internal/installer/validate/assertions.go
+++ b/internal/installer/validate/assertions.go
@@ -357,9 +357,21 @@ func assertLogretentionPolicyReady(log *logging.Logger) AssertionResult {
 func assertHealthResourcePolicyActive(opts AssertionOpts, log *logging.Logger) AssertionResult {
 	r := AssertionResult{Name: "health_resource_policy_active", Passed: true}
 	v := opts.HealthResource
-	if v == nil {
-		r.Detail = "not evaluated (no reconciliation verdict in this context)"
-		log.Debug("ASSERT health_resource_policy_active: SKIP — no verdict")
+	// v1.223.0 verdict-truth: a nil OR zero-value verdict means "not resolved in
+	// this context" — the caller MUST resolve one (services.ResolveHealthResourceVerdict)
+	// before validation. Treat unresolved as an honest SKIP: never fabricate a 0/0
+	// policy failure (BUG-REPAIR-HEALTH-VERDICT-EMPTY) and never claim protection.
+	if v == nil || v.IsZero() {
+		r.Detail = "not evaluated (no verdict resolved in this context)"
+		log.Debug("ASSERT health_resource_policy_active: SKIP — unresolved verdict")
+		return r
+	}
+	// v1.223.0: resolution genuinely could not read live systemd AND had no
+	// persisted evidence → UNVERIFIABLE. Advisory, NOT DEGRADED: we cannot prove a
+	// failure, so we must not fabricate one; but we also do not claim protection.
+	if v.EffectiveState == healthresource.StateUnavailable {
+		r.Detail = "health-resource protection UNVERIFIABLE: " + v.ValidationError
+		log.Warn("ASSERT health_resource_policy_active: UNVERIFIABLE (advisory, not DEGRADED) — %s", v.ValidationError)
 		return r
 	}
 	if v.Acceptable() {

--- a/internal/installer/validate/health_verdict_assertion_test.go
+++ b/internal/installer/validate/health_verdict_assertion_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="health_verdict_assertion_test.go"
+// meta:type="go"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: assertHealthResourcePolicyActive must SKIP (never fabricate a 0/0 DEGRADED) on a nil OR zero verdict (BUG-REPAIR-HEALTH-VERDICT-EMPTY), treat StateUnavailable as advisory (not DEGRADED), FAIL on real medium FALLBACK_UNDERSIZED, and PASS on ACTIVE_MATCH."
+package validate
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+	"github.com/itcmsgr/nftban/internal/safety"
+)
+
+func nolog() *logging.Logger { return logging.New("/dev/null", false) }
+
+// CORE regression: a zero verdict must SKIP (Passed), never a fabricated 0/0 FAIL.
+func TestAssertHealthZeroVerdictSkipsNotFail(t *testing.T) {
+	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: &healthresource.Verdict{}}, nolog())
+	if !r.Passed {
+		t.Fatalf("zero verdict must SKIP (pass), got FAIL: %s", r.Detail)
+	}
+}
+
+func TestAssertHealthNilVerdictSkips(t *testing.T) {
+	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: nil}, nolog())
+	if !r.Passed {
+		t.Fatal("nil verdict must SKIP")
+	}
+}
+
+// UNAVAILABLE is advisory — cannot prove a failure, must not fabricate DEGRADED.
+func TestAssertHealthUnavailableIsAdvisory(t *testing.T) {
+	v := &healthresource.Verdict{EffectiveState: healthresource.StateUnavailable, ValidationError: "systemctl show failed"}
+	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: v}, nolog())
+	if !r.Passed {
+		t.Fatal("UNAVAILABLE must be advisory (not DEGRADED)")
+	}
+}
+
+// A genuinely underprotected medium host must FAIL (no masking).
+func TestAssertHealthMediumUndersizedFails(t *testing.T) {
+	v := &healthresource.Verdict{
+		Profile:        safety.HealthResourceProfile{Tier: safety.ResourceTierMedium},
+		EffectiveState: healthresource.StateFallbackUnder,
+		CalculatedMax:  402653184,
+		EffectiveMax:   268435456,
+	}
+	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: v}, nolog())
+	if r.Passed {
+		t.Fatal("medium FALLBACK_UNDERSIZED must FAIL (real underprotection)")
+	}
+}
+
+func TestAssertHealthActiveMatchPasses(t *testing.T) {
+	v := &healthresource.Verdict{
+		Profile:        safety.HealthResourceProfile{Tier: safety.ResourceTierMedium},
+		EffectiveState: healthresource.StateActiveMatch,
+	}
+	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: v}, nolog())
+	if !r.Passed {
+		t.Fatal("ACTIVE_MATCH must PASS")
+	}
+}

--- a/internal/installer/validate/health_verdict_assertion_test.go
+++ b/internal/installer/validate/health_verdict_assertion_test.go
@@ -6,6 +6,7 @@
 package validate
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/itcmsgr/nftban/internal/healthresource"
@@ -15,14 +16,22 @@ import (
 
 func nolog() *logging.Logger { return logging.New("/dev/null", false) }
 
-// CORE regression: a zero verdict must SKIP (Passed), never a fabricated 0/0 FAIL.
-func TestAssertHealthZeroVerdictSkipsNotFail(t *testing.T) {
+// CORE regression (v1.223.0 owner-locked): a NON-NIL pointer to a ZERO verdict must
+// FAIL CLOSED — every validation entry point resolves a real verdict first
+// (services.ResolveHealthResourceVerdict), so a zero struct reaching the assertion
+// means the wiring regressed. It must NOT silently pass unverified protection (the
+// inverse of BUG-REPAIR-HEALTH-VERDICT-EMPTY) and must NOT fabricate a 0/0 message.
+func TestAssertHealthZeroVerdictFailsClosed(t *testing.T) {
 	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: &healthresource.Verdict{}}, nolog())
-	if !r.Passed {
-		t.Fatalf("zero verdict must SKIP (pass), got FAIL: %s", r.Detail)
+	if r.Passed {
+		t.Fatalf("zero verdict must FAIL CLOSED, got PASS: %s", r.Detail)
+	}
+	if strings.Contains(r.Detail, "0/0") {
+		t.Fatalf("must NOT fabricate a 0/0 policy-failure message; got %q", r.Detail)
 	}
 }
 
+// A truly nil verdict (this caller does not evaluate health) is a legitimate SKIP.
 func TestAssertHealthNilVerdictSkips(t *testing.T) {
 	r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: nil}, nolog())
 	if !r.Passed {

--- a/internal/installer/validate/unavailable_tier_v1223_test.go
+++ b/internal/installer/validate/unavailable_tier_v1223_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="unavailable_tier_v1223_test.go"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:description="v1.223.0 verdict-truth: assertHealthResourcePolicyActive UNAVAILABLE tier policy — small (protection NOT required) → advisory PASS (never a fabricated ACTIVE_MATCH); medium/large (protection REQUIRED) → FAIL (unverifiable protection must DEGRADE, the inverse of a false SUCCESS from missing truth). Plus the zero-verdict fail-closed guard (no 0/0)."
+// meta:inventory.files="internal/installer/validate/unavailable_tier_v1223_test.go"
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+package validate
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/healthresource"
+	"github.com/itcmsgr/nftban/internal/safety"
+)
+
+func unavailableVerdict(tier safety.ResourceTier) *healthresource.Verdict {
+	return &healthresource.Verdict{
+		Profile:         safety.HealthResourceProfile{Tier: tier},
+		EffectiveState:  healthresource.StateUnavailable,
+		ResolvedFrom:    "unavailable",
+		ValidationError: "live systemctl show failed and no persisted evidence",
+	}
+}
+
+func TestAssertHealthUnavailable_TierMatrix(t *testing.T) {
+	cases := []struct {
+		tier       safety.ResourceTier
+		wantPassed bool // small: advisory PASS; medium/large: FAIL (protection required)
+	}{
+		{safety.ResourceTierSmall, true},
+		{safety.ResourceTierMedium, false},
+		{safety.ResourceTierLarge, false},
+	}
+	for _, c := range cases {
+		t.Run(string(c.tier), func(t *testing.T) {
+			r := assertHealthResourcePolicyActive(AssertionOpts{HealthResource: unavailableVerdict(c.tier)}, nolog())
+			if r.Passed != c.wantPassed {
+				t.Fatalf("tier=%s UNAVAILABLE: Passed=%v want %v (detail=%s)", c.tier, r.Passed, c.wantPassed, r.Detail)
+			}
+			// UNAVAILABLE must never be reported as a fabricated ACTIVE_MATCH.
+			if r.Passed && c.tier == safety.ResourceTierSmall {
+				if wantsActiveMatch(r.Detail) {
+					t.Errorf("small UNAVAILABLE advisory-pass must NOT fabricate ACTIVE_MATCH; detail=%q", r.Detail)
+				}
+			}
+		})
+	}
+}
+
+func wantsActiveMatch(detail string) bool {
+	return detail == string(healthresource.StateActiveMatch)
+}


### PR DESCRIPTION
**Urgent stabilization release superseding the blocked v1.222.1 fleet rollout.** It preserves the verified v1.222.1 health-OOM correction and fixes health-resource verdict propagation across repair, resume, revalidate, update-force and validation-retry paths.

## Why (fleet blocker)
The v1.222.1 dns2 canary proved the OOM fix works (medium drop-in 256/384 MiB, no OOM) but caught a verdict-truth defect: the health-resource verdict existed only as transient `phaseConfigure` output, so validation entry points that skip `phaseConfigure` (repair-resume-at-Validate, `--revalidate`, `update force`) fed a **zero verdict** into `health_resource_policy_active` → **false DEGRADED on repair** and **false COMMIT on revalidate**. That halted the fleet.

## Primary scope (verdict-truth)
- Resolve the health-resource verdict in **every** validation entry path via one `ResolveHealthResourceVerdict` (precedence: current reconciliation → live systemd read-only → cautious persisted reconstruction → explicit `UNAVAILABLE`; **never a zero verdict**), marked with `Verdict.ResolvedFrom`.
- **Per-pass re-resolution** — `phaseValidate` re-resolves before VALIDATE_2 (never reuses a cached verdict pointer across passes).
- Prevent **repair false-DEGRADED** and **revalidate false-COMMIT**; persisted state never masks live truth (live wins both directions).
- **Fail closed** for unavailable *required* protection (medium/large → DEGRADED / CLI exit 2); small is advisory. Zero verdict → fail-closed (no fabricated `0/0` message).
- **Align CLI and installer** via the single shared tier-aware predicate `AcceptableFor` (`INSTALLER_ACCEPTABLE == CLI_PROTECTION_ACTIVE`).
- Prevent **false failed-unit claims** — a resource-policy DEGRADED (empty `SERVICES_FAILED`) no longer prints "a failed NFTBan unit was detected".
- **Deterministic assertion-input dependency injection** (via `AssertionOpts.SystemdPayloadInputs` + a per-call carrier, no mutable package globals) so the real `runRepair`/`runRevalidate` entry points are regression-testable; production behavior is byte-identical when nothing is injected.

Execution-path regression matrix (all green): repair ×3, revalidate ×4 (incl. persisted-vs-live both directions), validate-retry ×3 (per-pass re-resolution, exactly-2-probes on retry / 1 on active-pass), reporting ×2, UNAVAILABLE-by-tier + zero fail-closed, drop-in authority ×4 (loaded state derives from `systemctl show DropInPaths`, not disk presence), CLI/installer parity table, update-force delegation (installer + shell).

## Bundled scope (mail UX fix — owner-approved bundle)
Three shell files, no daemon involvement:
- `cli/lib/nftban/cli/cmd_mail.sh` — (a) `mail test` recipient **precedence** fixed to CLI arg > `NFTBAN_MAIL_RECIPIENT` > panel admin (previously the panel admin silently overrode a configured recipient on cPanel/Plesk/DirectAdmin hosts); (b) `setup --show` Sender expands `$(hostname -f)` instead of printing a literal.
- `cli/lib/nftban/core/nftban_mail.sh` — (a) `NFTBAN_MAIL_SUBJECT_OVERRIDE` so `mail test` sends subject "Test Email" matching the printed subject (was "Report"); (b) `nftban mail help` precomputes the status line to avoid a `| head` SIGPIPE (exit 141) under `pipefail`.
- `cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh` — static guard test (bites 7/0 on fixed, 0/7 pre-fix).

Mail behavior assertions (verified from the diff):
- `MAIL_DAEMON_BEHAVIOR_CHANGE = NO`
- `MAIL_DELIVERY_AUTHORITY_CHANGE = NO` (delivery method/MTA path unchanged; only recipient precedence)
- `DIRECT_MODULE_SEND_PATH_ADDED = NO` (routes through `nftban_mail_send`)
- `CENTRAL_COMMUNICATION_AUTHORITY_PRESERVED = YES` (local mail adapter only)

## Validation (pre-push gate, on lab2 / go1.25.12)
`go build ./...` PASS · `go vet ./...` PASS · `go test ./...` **88 ok / 0 FAIL / 0 panic** · `gofmt -l <touched>` CLEAN · shell `bash -n` PASS.

## Not included
No v1.224.0 debt (cgroup-tier-desync, classify-external-override, infinity self-defense, parse cleanup, completion drift, code-quality, PERF-VALIDATOR-NFT-JSON-OVERFETCH). No personal email / local paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
