### PR TITLE
test(mail): fix v1.223.0 mail guard T3 after SC2155 split + inventory header

### DIFF
--- a/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
+++ b/cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
@@ -12,6 +12,11 @@
 # meta:output="pass/fail; exit 0 all-pass, 1 on a regressed fix"
 # meta:depends="bash,grep"
 # meta:inventory.files="cli/lib/nftban/cli/cmd_mail.sh,cli/lib/nftban/core/nftban_mail.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
 # meta:inventory.privileges="none"
 # =============================================================================
 set -Eeuo pipefail
@@ -51,7 +56,7 @@ else
 fi
 
 # T3: send_test sets the override to a 'Test Email' subject before delivering.
-if grep -qE 'local NFTBAN_MAIL_SUBJECT_OVERRIDE=.*Test Email' "$NM"; then
+if grep -qE 'NFTBAN_MAIL_SUBJECT_OVERRIDE="?\$\{NFTBAN_MAIL_SUBJECT_PREFIX.*Test Email' "$NM"; then
     ok "T3 send_test labels the delivered message 'Test Email'"
 else
     no "T3 send_test does NOT set the Test Email subject override"


### PR DESCRIPTION
Test-only fix. The SC2155 declare/assign split (commit `56d9ce52`, in v1.223.0) broke the mail guard test's T3 regex (matched `local X=...` on one line), turning the committed guard RED (6/7) while the actual mail fix is intact. This makes T3 match the assignment line independently of `local` (now 7/0; still 0/7 against pre-fix), and adds the required `meta:inventory.*` header lines. No product code. Cherry-picked from db21c58e (mail-fix effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)