### PR TITLE
fix(update): preserve degraded rendering when failed-unit keys are absent

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -867,6 +867,19 @@ jobs:
       - name: update messaging recovered + DEGRADED (v1.174)
         run: bash cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
 
+      # v1.225.0 PR-A: DEGRADED render truth — strict-mode-safe absent SERVICES_FAILED
+      # (E1a) + all-filtered truthful hint (E1b). cli/lib/nftban/cli/cmd_update.sh.
+      # Hermetic (sources the file, drives the render helper in a subprocess; no host).
+      - name: update DEGRADED render truth (v1.225.0 PR-A)
+        run: bash cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh
+
+      # v1.223.0 mail recipient/subject/help guard — was UNWIRED on main (executed in zero
+      # workflows) despite being merged in #1131; this is the OPEN_TEST_SUITE_SINGLE_AUTHORITY
+      # Phase-A carve-out that closes the same gap-class that let the mail bug slip. Hermetic
+      # static grep guard (no host/root/network); belongs in Policy Gates.
+      - name: mail recipient/subject/help guard (v1.223.0)
+        run: bash cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
+
       # v1.175 FHS lane: (T1) GENERIC guard — no root-owned tmpfiles entry under a
       # non-root declared parent (the systemd-tmpfiles exit-73 "unsafe path transition"
       # class — structural BUG-TMPFILES regression lock); auditors→package +

--- a/cli/lib/nftban/cli/cmd_update.sh
+++ b/cli/lib/nftban/cli/cmd_update.sh
@@ -408,6 +408,70 @@ _cmd_update_main() {
     return $_update_rc
 }
 
+# _render_degraded_failed_units <install_state_file>
+# Renders the failed-NFTBan-unit remediation lines for a DEGRADED update, from the
+# STRUCTURED install_state (SERVICES_FAILED + attribution) — never a hardcoded unit.
+# Read-only; NEVER rewrites install_state. Output on stdout (caller supplies surrounding text).
+# LOCAL render helper only — NOT a general state-file parsing authority.
+#
+# Reachability: this runs only inside the DEGRADED branch, entered only after INSTALL_STATE
+# was read as "DEGRADED" from a readable file (a missing/unreadable state file defaults to
+# COMMITTED upstream — see out-of-scope UPDATE-STATE-READ-FAILURE-DEFAULTS-COMMITTED), so
+# file-missing / file-unreadable CANNOT reach here — those cases are not handled here.
+#
+# E1a (BUG-V1_222_1-UPDATE-STATEFILE-GREP-UNGUARDED): a bare `x=$(grep '^KEY=' file | cut ...)`
+#   aborts the renderer under `set -Eeuo pipefail` when KEY is ABSENT (grep rc=1 → pipefail →
+#   assignment rc=1 → errexit). Presence is tested with `grep -q` (rc=1 = key absent, benign in
+#   an `if` condition); the value is extracted with a single `sed` (first key authoritative,
+#   matching the prior `grep -m1` contract) — no strict-mode-aborting bare pipeline.
+# E1b (BUG-V1_222_1-UPDATE-DEGRADED-ALL-UNITS-FILTERED-NO-HINT): if the raw SERVICES_FAILED
+#   field is non-empty but every token is filtered as non-canonical, the loop renders nothing;
+#   emit a truthful hint that distinguishes "recorded-but-all-filtered" from "no list recorded".
+#   Never claims health/recovery; the DEGRADED verdict is owned by the caller and is unchanged.
+_render_degraded_failed_units() {
+    local _sf=$1
+    # Original inline variable names preserved (true move, not rewrite) so existing static
+    # source guards (e.g. `grep -qF 'systemctl reset-failed $_u'`) keep matching.
+    local _svc_failed="" _svc_pre="" _u _pre _rendered=0
+    local -a _units
+    # File readability is guaranteed here (the DEGRADED branch is entered only from a readable
+    # state file; a missing/unreadable file defaults to COMMITTED upstream — the accepted
+    # reachability). So a single `sed` per key cannot abort under `set -Eeuo pipefail` (sed rc=0
+    # on a readable file, head rc=0). No `grep -q` presence test is needed — a redundant second
+    # read whose only value is guarding the *unreachable* missing-file case; the render treats
+    # absent-key and present-empty identically. `head -n1` = first key authoritative (preserves
+    # the prior `grep -m1` contract for the machine-written state file).
+    _svc_failed=$(sed -n 's/^SERVICES_FAILED=//p' "$_sf" | head -n1)
+    _svc_pre=$(sed -n 's/^SERVICES_FAILED_PREEXISTING=//p' "$_sf" | head -n1)
+    if [[ -n "$_svc_failed" ]]; then
+        IFS=',' read -ra _units <<< "$_svc_failed"
+        for _u in "${_units[@]}"; do
+            [[ -n "$_u" ]] || continue
+            # Only render injection-safe canonical nftban unit names.
+            [[ "$_u" =~ ^nftband?[A-Za-z0-9@._-]*\.(service|timer|socket|target|path)$ ]] || continue
+            _pre="NO"; case ",$_svc_pre," in *",$_u,"*) _pre="YES";; esac
+            echo "      # Failed unit: $_u  (predates this upgrade: $_pre)"
+            [[ "$_pre" == "YES" ]] && echo "      systemctl reset-failed $_u   # clear the confirmed stale latch"
+            echo "      systemctl start $_u          # run once now (or wait for the timer)"
+            echo "      systemctl status $_u --no-pager"
+            _rendered=$((_rendered + 1))
+        done
+    fi
+    if [[ "$_rendered" -eq 0 ]]; then
+        if [[ -n "$_svc_failed" ]]; then
+            # Non-empty evidence, but every token filtered as non-canonical/non-actionable.
+            echo "      # Failed-unit evidence was recorded, but no canonical actionable NFTBan unit"
+            echo "      # remained after filtering. Review the raw state and systemd failed units:"
+            echo "      cat /var/lib/nftban/state/install_state"
+            echo "      systemctl --failed 'nftban-*'"
+        else
+            # No recorded failed-service list (key empty or absent).
+            echo "      # structured failed-unit list unavailable — do NOT guess a unit; inspect:"
+            echo "      systemctl --failed 'nftban-*'"
+        fi
+    fi
+}
+
 _cmd_update_main_locked() {
     # Update body — runs while the caller (_cmd_update_main) holds the exclusive
     # flock on fd 9. Every terminal `return` here propagates to the wrapper,
@@ -920,26 +984,8 @@ _cmd_update_main_locked() {
             # v1.222.1 Lane 4 (BUG-INSTALLER-FAILED-UNIT-REMEDIATION-HARDCODED-BOTSCAN):
             # render the ACTUAL failed unit(s) from the STRUCTURED install_state
             # (SERVICES_FAILED + attribution), never a hardcoded nftban-botscan.service.
-            local _svc_failed _svc_pre _u _pre
-            local -a _units
-            _svc_failed=$(grep -m1 '^SERVICES_FAILED=' "$_install_state_file" 2>/dev/null | cut -d= -f2-)
-            _svc_pre=$(grep -m1 '^SERVICES_FAILED_PREEXISTING=' "$_install_state_file" 2>/dev/null | cut -d= -f2-)
-            if [[ -n "$_svc_failed" ]]; then
-                IFS=',' read -ra _units <<< "$_svc_failed"
-                for _u in "${_units[@]}"; do
-                    [[ -n "$_u" ]] || continue
-                    # Only render injection-safe canonical nftban unit names.
-                    [[ "$_u" =~ ^nftband?[A-Za-z0-9@._-]*\.(service|timer|socket|target|path)$ ]] || continue
-                    _pre="NO"; case ",$_svc_pre," in *",$_u,"*) _pre="YES";; esac
-                    echo "      # Failed unit: $_u  (predates this upgrade: $_pre)"
-                    [[ "$_pre" == "YES" ]] && echo "      systemctl reset-failed $_u   # clear the confirmed stale latch"
-                    echo "      systemctl start $_u          # run once now (or wait for the timer)"
-                    echo "      systemctl status $_u --no-pager"
-                done
-            else
-                echo "      # structured failed-unit list unavailable — do NOT guess a unit; inspect:"
-                echo "      systemctl --failed 'nftban-*'"
-            fi
+            # Strict-mode-safe (E1a) + all-filtered truthful hint (E1b) — see helper above.
+            _render_degraded_failed_units "$_install_state_file"
             echo "      /usr/lib/nftban/bin/nftban-installer --repair   # re-run post-install validation"
             echo "      nftban support                                  # capture diagnostic bundle (optional)"
             echo ""

--- a/cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh
+++ b/cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - v1.225.0 PR-A: update DEGRADED render truth (E1a + E1b)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="update_degraded_render_truth_v225_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-22"
+# meta:description="Regression guard for v1.225.0 PR-A. E1a (BUG-V1_222_1-UPDATE-STATEFILE-GREP-UNGUARDED): _render_degraded_failed_units must NOT abort under set -Eeuo pipefail when SERVICES_FAILED is ABSENT from a readable DEGRADED install_state (grep rc=1 = key absent, not a read error), and must not fabricate success on a missing/unreadable file. E1b (BUG-V1_222_1-UPDATE-DEGRADED-ALL-UNITS-FILTERED-NO-HINT): a non-empty raw SERVICES_FAILED whose tokens are all non-canonical must still print a truthful 'recorded-but-all-filtered' hint distinct from the 'no list recorded' fallback; canonical units render; no false-health claims. Hermetic: sources cmd_update.sh, drives the helper with temp fixtures, no root/systemd/network/real state."
+# meta:inventory.files="cli/lib/nftban/cli/cmd_update.sh"
+# meta:inventory.binaries="bash,grep,cut"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+CMD_UPDATE="$REPO_ROOT/cli/lib/nftban/cli/cmd_update.sh"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+
+echo "v1.225.0 PR-A update DEGRADED render truth (E1a+E1b):"
+
+# Source only the function (definitions only; the file auto-runs nothing when sourced).
+# shellcheck disable=SC1090
+if ! source "$CMD_UPDATE" 2>/dev/null; then :; fi
+if ! declare -F _render_degraded_failed_units >/dev/null; then
+    no "_render_degraded_failed_units is defined after sourcing cmd_update.sh" "not found"
+    echo "RESULT: $PASS passed, $FAIL failed"; exit 1
+fi
+ok "_render_degraded_failed_units defined after sourcing cmd_update.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# render <state-body...>  → writes fixture, runs helper under strict mode, captures out/rc/err
+run_render() {
+    local body=$1 sf="$TMP/state"
+    printf '%s' "$body" > "$sf"
+    local out rc err
+    err="$TMP/err"
+    set +e
+    out=$( set -Eeuo pipefail; _render_degraded_failed_units "$sf" 2>"$err" ); rc=$?
+    set -e
+    LAST_OUT="$out"; LAST_RC=$rc; LAST_ERR="$(cat "$err")"
+}
+no_false_health() { # assert output makes no false-health / recovery claim
+    if echo "$LAST_OUT" | grep -qiE "no failed units|all services healthy|state recovered|recovered\b|healthy"; then
+        no "$1 makes no false-health claim" "found health claim"
+    else ok "$1 makes no false-health claim"; fi
+}
+
+# ---- E1a: strict-mode abort must be prevented ----
+# A. key present, canonical value
+run_render $'INSTALL_STATE=DEGRADED\nSERVICES_FAILED=nftban-botscan.service\n'
+{ [[ $LAST_RC -eq 0 ]] && echo "$LAST_OUT" | grep -q "Failed unit: nftban-botscan.service"; } \
+  && ok "E1a-A present canonical → rc0 + unit rendered" || no "E1a-A present canonical" "rc=$LAST_RC"
+
+# B. key present, empty value
+run_render $'INSTALL_STATE=DEGRADED\nSERVICES_FAILED=\n'
+{ [[ $LAST_RC -eq 0 ]] && echo "$LAST_OUT" | grep -q "structured failed-unit list unavailable"; } \
+  && ok "E1a-B present-empty → rc0 + no-list fallback" || no "E1a-B present-empty" "rc=$LAST_RC out=[$LAST_OUT]"
+
+# C. key ABSENT (the strict-mode abort bug) — must NOT abort
+# (missing/unreadable-file cases are UNREACHABLE in this renderer — INSTALL_STATE defaults to
+#  COMMITTED upstream on any unreadable/missing file — so they are intentionally NOT tested here.)
+run_render $'INSTALL_STATE=DEGRADED\nFAILURE_REASON=resource policy\n'
+{ [[ $LAST_RC -eq 0 ]] && echo "$LAST_OUT" | grep -q "structured failed-unit list unavailable"; } \
+  && ok "E1a-C absent-key → NO strict-mode abort (rc0) + fallback" || no "E1a-C absent-key strict abort" "rc=$LAST_RC"
+
+# absent key must never invent a Failed-unit line
+run_render $'INSTALL_STATE=DEGRADED\nFAILURE_REASON=resource policy\n'
+echo "$LAST_OUT" | grep -q "Failed unit:" && no "E1a absent-key never invents a unit line" "invented unit" \
+  || ok "E1a absent-key never invents a Failed-unit line"
+
+# stderr clean on the benign absent-key path
+run_render $'INSTALL_STATE=DEGRADED\n'
+[[ -z "$LAST_ERR" ]] && ok "E1a absent-key emits no stderr noise" || no "E1a stderr clean" "err=[$LAST_ERR]"
+
+# ---- E1b: filtered-units hint ----
+# canonical single
+run_render $'SERVICES_FAILED=nftban-health.service\n'
+echo "$LAST_OUT" | grep -q "Failed unit: nftban-health.service" \
+  && ok "E1b canonical single rendered" || no "E1b canonical single"
+
+# canonical multiple
+run_render $'SERVICES_FAILED=nftban-health.service,nftban-maintenance.timer\n'
+{ echo "$LAST_OUT" | grep -q "nftban-health.service" && echo "$LAST_OUT" | grep -q "nftban-maintenance.timer"; } \
+  && ok "E1b multiple canonical rendered" || no "E1b multiple canonical"
+
+# mixed canonical / non-canonical → only canonical rendered, no filtered-hint (>=1 rendered)
+run_render $'SERVICES_FAILED=nftban-health.service,evil;rm -rf,notaunit\n'
+{ echo "$LAST_OUT" | grep -q "Failed unit: nftban-health.service" \
+  && ! echo "$LAST_OUT" | grep -q "evil" \
+  && ! echo "$LAST_OUT" | grep -q "remained after filtering"; } \
+  && ok "E1b mixed → only canonical rendered, no filtered-hint" || no "E1b mixed"
+
+# ALL non-canonical → the E1b truthful 'recorded-but-all-filtered' hint (distinct from no-list)
+run_render $'INSTALL_STATE=DEGRADED\nSERVICES_FAILED=sshd.service,foo.bar,notaunit\n'
+{ [[ $LAST_RC -eq 0 ]] && echo "$LAST_OUT" | grep -q "remained after filtering" \
+  && ! echo "$LAST_OUT" | grep -q "Failed unit:"; } \
+  && ok "E1b all-filtered → truthful 'recorded but all filtered' hint" || no "E1b all-filtered hint" "out=[$LAST_OUT]"
+no_false_health "E1b all-filtered"
+
+# the all-filtered hint is DISTINCT from the no-list fallback
+run_render $'SERVICES_FAILED=onlyjunk\n'; ALLFILT="$LAST_OUT"
+run_render $'SERVICES_FAILED=\n'; NOLIST="$LAST_OUT"
+[[ "$ALLFILT" != "$NOLIST" ]] && ok "E1b all-filtered hint distinct from no-list fallback" || no "E1b hint distinctness"
+
+# whitespace-only field → deterministic (non-empty → all-filtered hint), rc0
+run_render $'SERVICES_FAILED=   \n'
+[[ $LAST_RC -eq 0 ]] && ok "E1b whitespace-only field → deterministic rc0" || no "E1b whitespace-only" "rc=$LAST_RC"
+
+echo "RESULT: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Release train: **v1.225.0** · PR: **A — update DEGRADED rendering truth** · Base: **v1.224.0 / 263d8fbf**

Handles:
- `BUG-V1_222_1-UPDATE-STATEFILE-GREP-UNGUARDED`
- `BUG-V1_222_1-UPDATE-DEGRADED-ALL-UNITS-FILTERED-NO-HINT`

## Implementation summary
- The existing failed-unit rendering block was **extracted into a local helper** `_render_degraded_failed_units()` in `cmd_update.sh` — **moved, not duplicated**; it is **not** a general state-file parser (LOCAL_RENDER_HELPER).
- A single **first-key-authoritative** `sed -n 's/^KEY=//p' | head -n1` read replaces the strict-mode-sensitive bare `grep '^SERVICES_FAILED=' | cut` assignment (which, under `set -Eeuo pipefail`, aborted the renderer when the key was absent: grep rc=1 → pipefail → assignment rc=1 → errexit).
- Missing `SERVICES_FAILED` and explicitly empty `SERVICES_FAILED=` are treated **equivalently at this renderer boundary** (both → the no-list fallback).
- Non-empty raw failed-unit evidence with **zero canonical rendered units** now produces a truthful explanatory hint.
- The overall **DEGRADED verdict is preserved**. **No** machine-written state is modified. **No** update exit-code, rollback, timer, package-selection, or restart-policy behavior is intentionally changed.

Original inline variable names (`_svc_failed`, `_u`, …) were preserved so existing static source guards keep matching (true move).

## Risk statement
Behavioral change is limited to **DEGRADED-state operator rendering**.
- Previously, an absent `SERVICES_FAILED` key could terminate the renderer under `set -Eeuo pipefail`. It now renders the existing fallback.
- Previously, a non-empty failed-unit field containing only filtered tokens could produce an empty remediation block. It now states that failed-unit evidence was recorded but no canonical actionable NFTBan units remained after filtering.

The update remains **DEGRADED**; the change does **not** convert failure evidence to success.

## Reachability
Missing/unreadable state files are resolved earlier by the install-state reader (`INSTALL_STATE` defaults to `COMMITTED`) and **do not enter this DEGRADED renderer** — those cases are intentionally not handled/tested here. The read-defaults-COMMITTED concern is tracked separately and out of scope: `UPDATE-STATE-READ-FAILURE-DEFAULTS-COMMITTED` (P2, OPEN).

## Evidence
```
E1A_ABSENT_KEY = PASS   E1A_PRESENT_EMPTY = PASS   E1A_PRESENT_NONEMPTY = PASS
E1B_ALL_FILTERED_HINT = PASS   E1B_MIXED_FILTERING = PASS   E1B_CANONICAL_RENDER = PASS
DEGRADED_VERDICT_PRESERVED = PASS   FALSE_HEALTH_CLAIMS = 0
STATE_READER_AUTHORITY_DELTA = 0 (5→5, 2 reads relocated into the helper)
GO_PRODUCT_CHANGE = 0   DAEMON_CHANGE = 0   SCHEMA_CHANGE = 0
NFTBAND / NFTBAN_CORE / NFTBAN_INSTALLER = BYTE_IDENTICAL vs base (fixed-ldflags build)
```

Focused regression: `cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh` (13/13).

## Pre-existing shell-test flake (not introduced here)
```
FULL_SHELL_BATCH = 14 PASS / 1 PRE_EXISTING_BASE_REPRODUCED_FLAKE / 0 NEW_FAILURES
```
`cmd_update_lock_cleanup_v135_test.sh :: static_s3_contention_path_does_not_remove_holders_file`
- BASE 263d8fbf: `[FAIL] ... (expected 'safe', got 'unsafe')` — 8 passed, 1 failed
- HEAD 3845940a: **identical signature** — 8 passed, 1 failed
- Touches the changed renderer path: **no** (0 references); no assertion weakened or skipped.
Reproduce: `git worktree add wt 263d8fbf && bash wt/cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Added: Phase-A CI wiring (test-execution authority — v1.225.0 test-infra spirit)
Satisfying "focused test executes in blocking CI" surfaced that `ci-architecture.yml` "architecture-check"/Policy-Gates is the only blocking executor of shell-test **assertions** (`ci-bash.yml` = shellcheck + `bash -n` only). Fresh audit: **225** tracked `tests/*_test.sh`, **43 wired / 182 UNWIRED** — a new test is shellchecked but never run. This is the `OPEN_TEST_SUITE_SINGLE_AUTHORITY` gap.

This PR wires **two hermetic guards** into Policy-Gates (blocking, push+PR), **no glob**:
- `update_degraded_render_truth_v225_test.sh` — this PR's E1a/E1b regression guard.
- `mail_recipient_subject_help_v1223_test.sh` — in main since #1131 but executed in **zero** workflows (the proof case of the gap; `FILE_EXISTS=YES / MANUAL_PASS=YES / CI_EXECUTION=NO`).

Both verified green before wiring; both hermetic static/subprocess (no host/root/network). This is **Phase A** (immediate carve-out); the manifest + strict runner + unclassified-test coverage guard is **Phase B** (next maintenance release; no blind glob).

**Changed files (3):** `cli/lib/nftban/cli/cmd_update.sh`, `cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh`, `.github/workflows/ci-architecture.yml`.
