### PR TITLE
security(privacy): remove real IP from scanner example comment

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -160,6 +160,14 @@ jobs:
       # advisory and do NOT block. Findings are REDACTED (no raw secrets in logs).
       # This gate enforces NFTBAN_RELEASE_PUBLICATION = BLOCKED at the source tree;
       # the release job must also run it over the package staging tree before publish.
+      # v1.226.0 privacy hotfix: the scanner's own self-tests are BLOCKING — they prove
+      # the escaped-dot IPv4 bypass stays closed (a real dotted-quad written as a shell
+      # grep pattern with backslash-escaped dots must not evade the deny-authority or the
+      # IPv4 detector) and that the hardening introduces no false positives. Synthetic
+      # fixtures only; no real identifier is present. Runs before the release-surface gate.
+      - name: Privacy scanner self-tests + escaped-IPv4 bypass regression (BLOCKING)
+        run: python3 scripts/ci/privacy-scan-selftest.py
+
       - name: Check privacy — RELEASE surface (SEC-INFRA Gate A, BLOCKING)
         run: python3 scripts/ci/privacy-scan.py --scope release --strict
 

--- a/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
@@ -192,7 +192,7 @@ echo "[T4] re-add same IP → refresh (no duplicate)"
 # (T3 already added 192.0.2.122; re-add with different reason)
 call_firewall_whitelist_session add 192.0.2.122 --ttl 1h --reason refreshed >/dev/null 2>&1 || true
 T4_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
-T4_COUNT=$(printf '%s\n' "$T4_CONTENT" | grep -c "^62\.38\.150\.122" || true)
+T4_COUNT=$(printf '%s\n' "$T4_CONTENT" | grep -c "^192\.0\.2\.250" || true)
 assert_eq "$T4_COUNT" "1"                                            "T4.1 exactly one entry for IP"
 assert_contains "$T4_CONTENT" "REASON=refreshed"                     "T4.2 newer REASON present"
 assert_not_contains "$T4_CONTENT" "REASON=test-reason"               "T4.3 older REASON dropped"
@@ -231,7 +231,7 @@ echo "[T8] remove drops the entry"
 T8_OUT=$(call_firewall_whitelist_session remove 192.0.2.122 2>&1)
 assert_contains "$T8_OUT" "Removed: 192.0.2.122"                   "T8.1 stdout confirms remove"
 T8_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
-assert_not_contains "$T8_CONTENT" "^62\.38\.150\.122"                "T8.2 entry gone from file"
+assert_not_contains "$T8_CONTENT" "^192\.0\.2\.250"                "T8.2 entry gone from file"
 
 # ---------------------------------------------------------------------------
 # T9: cleanup drops expired but keeps active

--- a/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
@@ -120,7 +120,7 @@ assert_not_contains "$T1C" "EXPIRES_AT"                              "T1.7 NO EX
 echo; echo "[T2] re-add same IP → refresh (no duplicate)"
 call_add_static 192.0.2.122 >/dev/null 2>&1 || true
 T2C=$(cat "$MANUAL_FILE" 2>/dev/null || true)
-T2N=$(printf '%s\n' "$T2C" | grep -c "^62\.38\.150\.122" || true)
+T2N=$(printf '%s\n' "$T2C" | grep -c "^192\.0\.2\.250" || true)
 assert_eq "$T2N" "1"                                                 "T2.1 exactly one entry for IP"
 
 # ---------------------------------------------------------------------------

--- a/cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh
+++ b/cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh
@@ -124,7 +124,7 @@ o="$(run_server "host.example has IPv6 address fe80::1")"
 # 5. hostname -> the same public self IPv4 => admitted, deduped (Total stays 2)
 o="$(run_server "host.example has address 192.0.2.67")"
 [[ "$(total_line "$o")" == "2" ]] && ok "T5 hostname==self public dedups to one (Total=2)" || no "T5 dedup failed ($(total_line "$o"))"
-[[ "$(checked "$o" | grep -c '^46\.225\.150\.67$')" == "1" ]] && ok "T5b self public checked exactly once" || no "T5b duplicate check"
+[[ "$(checked "$o" | grep -c '^192\.0\.2\.251$')" == "1" ]] && ok "T5b self public checked exactly once" || no "T5b duplicate check"
 
 # 6. hostname -> mixed public-new + loopback => only public admitted (Total=3)
 o="$(run_server "$(printf '%s\n' 'host.example has address 8.8.8.8' 'host.example has address 127.0.1.1')")"

--- a/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
+++ b/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
@@ -123,7 +123,7 @@ hasline "$RBL" "2001:db8:c014:5ee1::2" && ok "T3 second distinct IPv6 preserved"
 { ! hasline "$RBL" "2001:db8:c014:5ee1::beef" && ! hasline "$RBL" "2001:db8:c014:5ee1::dead" && ! hasline "$RBL" "8.8.4.4"; } && ok "T8 tentative/temporary/down-iface excluded" || no "T8 excluded-state leaked into RBL"
 
 # T9 duplicate address (eth0+eth1) -> single RBL entry
-[[ "$(printf '%s\n' "$RBL" | grep -c '^46\.225\.150\.67$')" == "1" ]] && ok "T9 duplicate address deduped to one" || no "T9 duplicate not deduped"
+[[ "$(printf '%s\n' "$RBL" | grep -c '^192\.0\.2\.251$')" == "1" ]] && ok "T9 duplicate address deduped to one" || no "T9 duplicate not deduped"
 
 # T10 no ip:tag / colon-tag serialization in any projection line
 { ! has "$RBL" ":ipv4" && ! has "$RBL" ":ipv6"; } && ok "T10 no :ipv4/:ipv6 tag encoding" || no "T10 colon-tag encoding present"

--- a/scripts/ci/privacy-scan-selftest.py
+++ b/scripts/ci/privacy-scan-selftest.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+"""
+Self-tests for scripts/ci/privacy-scan.py — focused on the v1.226.0 hardening that
+closes the ESCAPED-DOT IPv4 bypass (a real dotted-quad written as a shell grep
+pattern with backslash-escaped dots evaded the literal-dot detector).
+
+ALL fixtures here are SYNTHETIC (RFC5737 documentation / RFC5771 doc-multicast /
+private ranges / made-up deny patterns). No real operator identifier appears in
+this file, and none is required to prove the gap is closed.
+
+Run:  python3 scripts/ci/privacy-scan-selftest.py
+Exit: 0 = all pass · 1 = a self-test failed · 2 = harness error.
+"""
+import importlib.util
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+_spec = importlib.util.spec_from_file_location("privacy_scan", os.path.join(HERE, "privacy-scan.py"))
+ps = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ps)
+
+BLOCKING = ps.RELEASE_BLOCKING_CATEGORIES
+_fail = []
+
+
+def check(cond, label, detail=""):
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else "  " + detail))
+    if not cond:
+        _fail.append(label)
+
+
+def findings(line):
+    return list(ps.scan_line(line, path="cli/lib/nftban/tests/example_test.sh"))
+
+
+def ipv4_values(line):
+    return [v for (k, v, c) in findings(line) if k == "IPV4"]
+
+
+def blocking_findings(line):
+    return [(k, v, c) for (k, v, c) in findings(line) if c in BLOCKING]
+
+
+# ---- 1. de-escape normalization is data-only and correct ----------------------
+def test_deescape():
+    print("test_deescape_dots")
+    check(ps.deescape_dots(r"^203\.0\.113\.5$") == "^203.0.113.5$", "single-backslash dots collapse")
+    check(ps.deescape_dots(r'"203\\.0\\.113\\.5"') == '"203.0.113.5"', "double-backslash dots collapse")
+    check(ps.deescape_dots("203.0.113.5") == "203.0.113.5", "unescaped text unchanged")
+    check(ps.deescape_dots(r"\d{1,3}\.\d{1,3}") == r"\d{1,3}.\d{1,3}", "de-escape does not fabricate digits")
+
+
+# ---- 2. detection: escaped dotted-quads are now visible to IPV4_RE -------------
+# (Doc-range IPs are intentionally NOT yielded as findings — they are clean — so this
+# asserts detection at the normalization+regex layer that feeds every classifier.)
+def _detects(line):
+    for src in (line, ps.deescape_dots(line)):
+        if ps.IPV4_RE.search(src):
+            return ps.IPV4_RE.search(src).group(0)
+    return None
+
+
+def test_escaped_detected():
+    print("test_escaped_ipv4_detected")
+    check(_detects(r"n=$(grep -c '^203\.0\.113\.5$')") == "203.0.113.5", "anchored escaped grep pattern detected")
+    check(_detects(r'assert_not_contains "$X" "^198\.51\.100\.9"') == "198.51.100.9", "quoted escaped pattern detected")
+    check(_detects(r'T=$(printf "%s" "$C" | grep -c "^203\\.0\\.113\\.5")') == "203.0.113.5", "double-escaped-in-grep detected")
+    check(_detects("plain 203.0.113.5 here") == "203.0.113.5", "literal form still detected (no regression)")
+    # and the raw literal-dot regex ALONE (pre-hardening behavior) would miss the escaped form:
+    check(ps.IPV4_RE.search(r"^203\.0\.113\.5$") is None, "regression witness: raw regex misses escaped form")
+
+
+# ---- 3. ESCAPED_IPV4_BYPASS_TEST: a deny-listed value blocks in escaped form ---
+def test_deny_authority_escaped_bypass_closed():
+    print("test_deny_authority_escaped_bypass_closed")
+    saved = ps._PRIV_PATTERNS
+    try:
+        # synthetic 'forbidden' identifier (doc-multicast test range) — stands in for a
+        # real operator IP the owner would list in the gitignored privacy-forbidden.txt.
+        ps._PRIV_PATTERNS = [re.compile(r"233\.252\.0\.99")]
+        forms = {
+            "literal":        "x 233.252.0.99 x",
+            "escaped":        r"grep '^233\.252\.0\.99$'",
+            "double-escaped": r'grep "^233\\.252\\.0\\.99$"',
+            "anchored":       r"[[ $(grep -c '^233\.252\.0\.99$') == 1 ]]",
+            "quoted":         r'assert_not_contains "$X" "233\.252\.0\.99"',
+            "heredoc-line":   r"233\.252\.0\.99",
+        }
+        for name, ln in forms.items():
+            blk = blocking_findings(ln)
+            hit = any(v == "233.252.0.99" and c == ps.REAL_OPERATOR_IDENTIFIER for (k, v, c) in blk)
+            check(hit, "deny authority blocks form: %s" % name, "findings=%r" % blk)
+        # documented boundary: whitespace/char-class obfuscation is NOT normalized
+        blk = blocking_findings(r"233 . 252 . 0 . 99")
+        check(not blk, "documented boundary: space-split obfuscation not normalized (out of scope)")
+    finally:
+        ps._PRIV_PATTERNS = saved
+
+
+# ---- 4. precedence: deny beats allowlist / synthetic classification ------------
+def test_deny_precedence_over_allowlist():
+    print("test_deny_precedence_over_allowlist")
+    saved = ps._PRIV_PATTERNS
+    try:
+        # deny-list a value that ALSO falls in the RFC5737 synthetic range: deny must win.
+        ps._PRIV_PATTERNS = [re.compile(r"192\.0\.2\.7")]
+        blk = blocking_findings(r"grep '^192\.0\.2\.7$'")
+        hit = any(v == "192.0.2.7" and c == ps.REAL_OPERATOR_IDENTIFIER for (k, v, c) in blk)
+        check(hit, "deny authority overrides synthetic classification (escaped)", "findings=%r" % blk)
+    finally:
+        ps._PRIV_PATTERNS = saved
+
+
+# ---- 5. false-positive controls: none of these produce a BLOCKING finding ------
+def test_false_positive_controls():
+    print("test_false_positive_controls")
+    cases = {
+        "3-part version v1.226.0":        "release v1.226.0 shipped",
+        "package version rpm 4.16":       "requires rpm >= 4.16 on el9",
+        "4-part synthetic 1.2.3.4":       "example client 1.2.3.4 banned",
+        "RFC5737 doc 192.0.2.5":          "fixture ip 192.0.2.5 added",
+        "RFC5737 escaped 203\\.0\\.113":  r"grep '^203\.0\.113\.5$'",
+        "well-known DNS 8.8.8.8":         "resolver 8.8.8.8 configured",
+        "escaped regex metachar non-IP":  r"pattern \d{1,3}\.\d{1,3}\.\d{1,3}",
+        "version-context dotted quad":    "version string 10.20.30.40 in changelog",
+    }
+    for name, ln in cases.items():
+        blk = blocking_findings(ln)
+        check(not blk, "no blocking finding: %s" % name, "unexpected=%r" % blk)
+
+
+def main():
+    for t in (test_deescape, test_escaped_detected,
+              test_deny_authority_escaped_bypass_closed,
+              test_deny_precedence_over_allowlist, test_false_positive_controls):
+        t()
+    print()
+    if _fail:
+        print("PRIVACY_SELFTEST_FAIL (%d): %s" % (len(_fail), ", ".join(_fail)))
+        return 1
+    print("PRIVACY_SELFTEST_PASS (escaped-IPv4 bypass closed; no false positives)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/privacy-scan.py
+++ b/scripts/ci/privacy-scan.py
@@ -152,6 +152,20 @@ DOMAIN_RE = re.compile(
     re.IGNORECASE)
 IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])")
 IPV6_RE = re.compile(r"(?<![\w:])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}(?![\w:])")
+
+# Backslash-escaped-dot normalization (v1.226.0 privacy hotfix). Shell grep patterns
+# write dotted-quads with escaped dots (e.g. ^62\.38\.150\.122$ or "62\\.38\\.150\\.122"),
+# which the literal-dot IPV4_RE cannot see — a confirmed blocking-gate bypass. We collapse
+# one-or-more backslashes before a dot to a single literal dot and re-scan a COPY of the
+# line for detection only. This is DATA-ONLY: the normalized text is never executed,
+# sourced, or compiled as a regex/command — it is fed only to the same read-only detectors.
+_ESCAPED_DOT_RE = re.compile(r"\\+\.")
+
+
+def deescape_dots(s):
+    """Detection-only: `\\.`/`\\\\.` -> `.` so escaped dotted-quads are visible to IPV4_RE.
+    Never used to execute or reinterpret the string; purely to widen text detection."""
+    return _ESCAPED_DOT_RE.sub(".", s)
 # Real operator personal identity (username/name). gituser/commonfolder are
 # PSEUDONYMOUS dev accounts (separate, lower category); avoulvou* is the real
 # maintainer identity and is a REAL_OPERATOR_IDENTIFIER wherever it appears.
@@ -374,10 +388,20 @@ def scan_line(line, path=""):
     # allowlist, doc-range, placeholder, or version-context rule. Values matched
     # here are skipped by the detectors below so they are not double-counted.
     denied = []
+    # Deny authority is also escape-aware: a privacy-forbidden.txt entry for a real
+    # identifier must catch its backslash-escaped grep-pattern form, not just the literal.
+    _dn = deescape_dots(line)
+    _deny_sources = (line,) if _dn == line else (line, _dn)
+    _seen_deny = set()
     for pat in _PRIV_PATTERNS:
-        for m in pat.finditer(line):
-            denied.append(m.group(0))
-            yield ("PRIVATE", m.group(0), REAL_OPERATOR_IDENTIFIER)
+        for _s in _deny_sources:
+            for m in pat.finditer(_s):
+                g = m.group(0)
+                if g in _seen_deny:
+                    continue
+                _seen_deny.add(g)
+                denied.append(g)
+                yield ("PRIVATE", g, REAL_OPERATOR_IDENTIFIER)
     if not any(path.startswith(p) or p in path for p in PRODUCT_DOMAIN_SKIP):
         for m in DOMAIN_RE.finditer(line):
             if m.group(0) in denied:
@@ -393,18 +417,30 @@ def scan_line(line, path=""):
             continue
         yield ("PATH", m.group(0), classify("PATH", m.group(0), path))
     version_ctx = bool(VERSION_CONTEXT_RE.search(line))
-    for m in IPV4_RE.finditer(line):
-        v = m.group(0)
-        if v in denied:
-            continue
-        # Version-context reinterpretation: excuse a dotted-quad only when the
-        # line is a version context AND the value is not a known-real identifier
-        # (a real operator IP is never excused by context).
-        if version_ctx and not _priv_match(v):
-            continue
-        finding, hint = ip_class(v)
-        if finding:
-            yield ("IPV4", v, classify("IPV4", v, path, hint))
+    # Scan the raw line AND a detection-only de-escaped copy, so escaped-dot dotted-quads
+    # inside grep patterns cannot bypass the gate. Dedup by value so an unescaped IP that
+    # also survives normalization is reported once.
+    _sources = [line]
+    _norm = deescape_dots(line)
+    if _norm != line:
+        _sources.append(_norm)
+    _seen_ipv4 = set()
+    for _src in _sources:
+        for m in IPV4_RE.finditer(_src):
+            v = m.group(0)
+            if v in _seen_ipv4:
+                continue
+            _seen_ipv4.add(v)
+            if v in denied:
+                continue
+            # Version-context reinterpretation: excuse a dotted-quad only when the
+            # line is a version context AND the value is not a known-real identifier
+            # (a real operator IP is never excused by context).
+            if version_ctx and not _priv_match(v):
+                continue
+            finding, hint = ip_class(v)
+            if finding:
+                yield ("IPV4", v, classify("IPV4", v, path, hint))
     for m in IPV6_RE.finditer(line):
         v = m.group(0)
         if v in denied or v.count(":") < 2:

--- a/scripts/ci/privacy-scan.py
+++ b/scripts/ci/privacy-scan.py
@@ -154,7 +154,7 @@ IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])")
 IPV6_RE = re.compile(r"(?<![\w:])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}(?![\w:])")
 
 # Backslash-escaped-dot normalization (v1.226.0 privacy hotfix). Shell grep patterns
-# write dotted-quads with escaped dots (e.g. ^62\.38\.150\.122$ or "62\\.38\\.150\\.122"),
+# write dotted-quads with escaped dots (e.g. ^203\.0\.113\.5$ or "203\\.0\\.113\\.5"),
 # which the literal-dot IPV4_RE cannot see — a confirmed blocking-gate bypass. We collapse
 # one-or-more backslashes before a dot to a single literal dot and re-scan a COPY of the
 # line for detection only. This is DATA-ONLY: the normalized text is never executed,


### PR DESCRIPTION
## Summary

Follow-up to the escaped-IPv4 privacy hotfix (#1139). That hotfix's hardening comment in `scripts/ci/privacy-scan.py` illustrated the escaped-dot bypass using a **real** operator IPv4 value as the example — a residue introduced by the hotfix itself.

Neither the scanner nor the release gate flagged it: the scanner **self-skips its own file** (it legitimately holds detection regexes), and `scripts/ci/` is **not** part of the shipped payload. The **post-merge escape-tolerant residue sweep** caught it.

## Change

- Replace the example value with an RFC5737 documentation value (`203.0.113.5`) in both single- and double-escaped forms. **Comment-only; no logic change.**
- Scanner compiles; self-tests **25/25** still pass.

## Process lesson

The pre-commit residue guard used a literal-dot pattern which — exactly like the bug being fixed — did **not** match the escaped form. Residue sweeps must use an escape-tolerant pattern.

## Boundary

Fixes the current tree. Does **not** close historical GitHub `refs/pull/*` or past external publication surfaces (still open). Exact original value is not disclosed in this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
