### PR TITLE
security(ci): add independent privacy enforcement gates

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -167,6 +167,33 @@ jobs:
       # fixtures only; no real identifier is present. Runs before the release-surface gate.
       - name: Privacy scanner self-tests + escaped-IPv4 bypass regression (BLOCKING)
         run: python3 scripts/ci/privacy-scan-selftest.py
+      # v1.226.0 privacy defense-in-depth. Generic gates need no secret and always block.
+      # The independent private deny gate auto-activates when the maintainer secret is present
+      # and is advisory/NOT_RUN otherwise — fork PRs get no secrets, so it never blocks
+      # untrusted contributors while the generic gates always do. This workflow uses
+      # `pull_request` (NOT pull_request_target): fork code runs read-only, no secrets.
+      - name: Private-identifier gate self-tests (BLOCKING)
+        run: python3 scripts/ci/private-identifier-gate-selftest.py
+      - name: Generic whole-tree privacy scan — includes scanner source (BLOCKING)
+        run: python3 scripts/ci/privacy-scan.py --scope repository --strict
+      - name: Generic changed-line privacy scan (BLOCKING, PRs)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
+          python3 scripts/ci/privacy-scan.py --changed-lines "origin/${{ github.base_ref }}" --strict
+      - name: Private-identifier deny gate — whole tree (advisory; auto-activates with secret)
+        env:
+          NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
+          NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+        run: python3 scripts/ci/private-identifier-gate.py --whole-tree --mode advisory
+      - name: Private-identifier deny gate — changed lines (advisory; auto-activates with secret)
+        if: github.event_name == 'pull_request'
+        env:
+          NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
+          NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
+          python3 scripts/ci/private-identifier-gate.py --changed-lines "origin/${{ github.base_ref }}" --mode advisory
 
       - name: Check privacy — RELEASE surface (SEC-INFRA Gate A, BLOCKING)
         run: python3 scripts/ci/privacy-scan.py --scope release --strict

--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -176,11 +176,16 @@ jobs:
         run: python3 scripts/ci/private-identifier-gate-selftest.py
       - name: Generic whole-tree privacy scan — includes scanner source (BLOCKING)
         run: python3 scripts/ci/privacy-scan.py --scope repository --strict
+      # Inputs pass via env (never interpolated into the shell) — avoids run-step injection.
+      # The diff uses the PR base SHA (a parent of the checked-out merge commit), fetched
+      # shallowly so the three-dot diff has its merge-base.
       - name: Generic changed-line privacy scan (BLOCKING, PRs)
         if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
-          python3 scripts/ci/privacy-scan.py --changed-lines "origin/${{ github.base_ref }}" --strict
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          python3 scripts/ci/privacy-scan.py --changed-lines "$BASE_SHA" --strict
       - name: Private-identifier deny gate — whole tree (advisory; auto-activates with secret)
         env:
           NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
@@ -191,9 +196,10 @@ jobs:
         env:
           NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
           NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
-          python3 scripts/ci/private-identifier-gate.py --changed-lines "origin/${{ github.base_ref }}" --mode advisory
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          python3 scripts/ci/private-identifier-gate.py --changed-lines "$BASE_SHA" --mode advisory
 
       - name: Check privacy — RELEASE surface (SEC-INFRA Gate A, BLOCKING)
         run: python3 scripts/ci/privacy-scan.py --scope release --strict

--- a/.github/workflows/privacy-trusted-merge-gate.yml
+++ b/.github/workflows/privacy-trusted-merge-gate.yml
@@ -46,13 +46,13 @@ jobs:
     environment: privacy-gate
     steps:
       - name: Validate PR-head SHA input shape
+        env:
+          SHA: ${{ github.event.inputs.pr_head_sha }}
         run: |
-          case "${{ github.event.inputs.pr_head_sha }}" in
+          case "$SHA" in
             *[!0-9a-fA-F]* | "" ) echo "::error::pr_head_sha must be a hex commit SHA"; exit 1 ;;
           esac
           [ "${#SHA}" -ge 7 ] || { echo "::error::pr_head_sha too short"; exit 1; }
-        env:
-          SHA: ${{ github.event.inputs.pr_head_sha }}
 
       # (1) TRUSTED gate implementation — from THIS workflow's ref (the default branch the
       #     maintainer dispatched from), never from the PR.
@@ -90,8 +90,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           STATE: ${{ steps.gate.outcome == 'success' && 'success' || 'failure' }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.inputs.pr_head_sha }}
         run: |
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.event.inputs.pr_head_sha }}" \
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
             -f state="$STATE" \
             -f context="privacy/trusted-private-gate" \
             -f description="Trusted private-identifier gate (publication, fail-closed) bound to this SHA"

--- a/.github/workflows/privacy-trusted-merge-gate.yml
+++ b/.github/workflows/privacy-trusted-merge-gate.yml
@@ -1,0 +1,97 @@
+# Trusted private-identifier merge gate (v1.226.0 privacy defense-in-depth).
+#
+# SECURITY MODEL — before an internal PR may merge into protected main, one TRUSTED
+# execution of the private-identifier deny gate must run against the EXACT PR-head SHA,
+# with the maintainer secret, WITHOUT ever executing untrusted PR code:
+#
+#   * The gate IMPLEMENTATION is taken from the TRUSTED ref this workflow runs on
+#     (the maintainer dispatches from the default branch), NOT from the PR branch.
+#   * The PR-head content is checked out into a SEPARATE directory and is only ever
+#     SCANNED AS DATA — never executed, sourced, or compiled.
+#   * The secret is scoped to a PROTECTED environment (maintainer approval) and is only
+#     present in the step that runs the trusted script; no PR-controlled code runs here.
+#   * The result is bound to the exact PR-head SHA via a commit status; branch protection
+#     requires that status context, so the merge cannot proceed without a trusted PASS.
+#
+# This is NOT pull_request_target and NOT workflow_run over fork code. A maintainer
+# triggers it (workflow_dispatch) FROM THE DEFAULT BRANCH, supplying the approved PR-head
+# SHA. Never dispatch this workflow from a PR branch (that would run a PR-modified
+# workflow definition); GitHub uses the workflow file from the selected ref, so always
+# select the trusted default branch.
+name: Privacy trusted merge gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_head_sha:
+        description: "Exact approved PR-head SHA to scan (full 40-char commit SHA)"
+        required: true
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: privacy-trusted-gate-${{ github.event.inputs.pr_head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  trusted-private-gate:
+    name: Trusted private-identifier gate
+    runs-on: ubuntu-latest
+    # Protected environment: requires maintainer approval and scopes the private secrets.
+    # The secrets NFTBAN_PRIVACY_DENYLIST / NFTBAN_PRIVACY_FP_KEY are configured on this
+    # environment (or repository) by the maintainer; their values never appear in the
+    # repo, workflow inputs, artifacts, caches, or job summaries.
+    environment: privacy-gate
+    steps:
+      - name: Validate PR-head SHA input shape
+        run: |
+          case "${{ github.event.inputs.pr_head_sha }}" in
+            *[!0-9a-fA-F]* | "" ) echo "::error::pr_head_sha must be a hex commit SHA"; exit 1 ;;
+          esac
+          [ "${#SHA}" -ge 7 ] || { echo "::error::pr_head_sha too short"; exit 1; }
+        env:
+          SHA: ${{ github.event.inputs.pr_head_sha }}
+
+      # (1) TRUSTED gate implementation — from THIS workflow's ref (the default branch the
+      #     maintainer dispatched from), never from the PR.
+      - name: Checkout TRUSTED gate implementation
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref }}
+          path: trusted
+          persist-credentials: false
+
+      # (2) PR-head content — DATA ONLY. Never executed. Checked out into a separate path.
+      - name: Checkout PR-head content (scanned as data only)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.pr_head_sha }}
+          path: pr-head
+          persist-credentials: false
+
+      # (3) Run the TRUSTED gate over the PR-head tree with the secret (publication /
+      #     fail-closed). The executed script is trusted/…; pr-head is only read.
+      - name: Trusted private-identifier gate over PR-head (publication, fail-closed)
+        id: gate
+        env:
+          NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
+          NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+        run: |
+          cd trusted
+          python3 scripts/ci/private-identifier-gate.py \
+            --whole-tree --mode publication \
+            --selftest-root "$GITHUB_WORKSPACE/pr-head"
+
+      # (4) Bind the result to the exact PR-head SHA so branch protection can require it.
+      - name: Publish commit status on the exact PR-head SHA
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATE: ${{ steps.gate.outcome == 'success' && 'success' || 'failure' }}
+        run: |
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.event.inputs.pr_head_sha }}" \
+            -f state="$STATE" \
+            -f context="privacy/trusted-private-gate" \
+            -f description="Trusted private-identifier gate (publication, fail-closed) bound to this SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # v1.226.0 privacy defense-in-depth: publication is FAIL-CLOSED on the private
+      # identifier gate. Without the maintainer-provided denylist + fingerprint-key
+      # secrets, or if a known-real identifier is present in the tree, the release is
+      # BLOCKED (exit 2/1). The secret is a maintainer action to provision before a
+      # release; until then, publication cannot proceed — which is the intended state.
+      - name: Private-identifier deny gate — whole tree (PUBLICATION, FAIL-CLOSED)
+        env:
+          NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
+          NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+        run: python3 scripts/ci/private-identifier-gate.py --whole-tree --mode publication
+      - name: Generic release-surface + whole-tree privacy scan (BLOCKING)
+        run: |
+          python3 scripts/ci/privacy-scan.py --scope release --strict
+          python3 scripts/ci/privacy-scan.py --scope repository --strict
+          python3 scripts/ci/privacy-scan-selftest.py
+          python3 scripts/ci/private-identifier-gate-selftest.py
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v5.6.0
         with:

--- a/docs/security/PRIVACY_IDENTIFIER_POLICY.md
+++ b/docs/security/PRIVACY_IDENTIFIER_POLICY.md
@@ -1,0 +1,76 @@
+# Privacy identifier policy (developer guide)
+
+_v1.226.0 privacy defense-in-depth. How real identifiers are kept out of the tree and out of
+CI output, and how the two independent gates work._
+
+## Approved example values — never use a real identifier
+
+A real operator/customer/third-party identifier must NEVER appear anywhere in the tree —
+including comments, documentation, test fixtures, regex examples, and the scanner's own
+examples — and never as a reversible encoding (base64, hex, plain hash) of one. Use only:
+
+| Purpose | Use |
+|---------|-----|
+| Documentation IPv4 | RFC 5737: `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` |
+| Documentation IPv6 | RFC 3849: `2001:db8::/32` |
+| Domains | `example.test`, `example.com/.net/.org` |
+| A value a product test must treat as **globally public** | an approved project synthetic-public fixture (e.g. the `1.2.3.0/24` convention) — NOT RFC5737, which the product classifies as documentation/non-public |
+
+**Documentation-only vs synthetic-public:** RFC5737/RFC3849 are *documentation* ranges; the
+product's RBL/whitelist logic classifies them as non-public. If a test must exercise
+**public-address admission**, use the approved synthetic-public convention instead — do not
+substitute a documentation range into such a test (that reintroduces the doc-range fixture bug).
+
+## Two independent gates
+
+1. **Generic scanner** — `scripts/ci/privacy-scan.py`. Public, committed detection. Classifies
+   IPs/paths/domains; blocks the release surface and the whole tree on
+   `REAL_OPERATOR_IDENTIFIER` / `SHIPPED_PUBLIC_SURFACE`. It **scans its own source** (no
+   whole-file self-exemption); a real value accidentally placed in it is caught. Narrow,
+   delimited `# privacy-allow-synthetic-begin/-end` (or a trailing `# privacy-allow-synthetic`)
+   blocks may downgrade a **synthetic** finding on specific lines — they can NEVER downgrade a
+   deny-authority (`REAL_OPERATOR_IDENTIFIER`) finding.
+2. **Private identifier gate** — `scripts/ci/private-identifier-gate.py`. A SECOND, INDEPENDENT
+   control with its own extraction/canonicalization (no shared normalization core — common-mode
+   failure prevention). It compares the tree against a **secret-provided** denylist of
+   known-real identifiers, recognizing literal / escaped-dot / double-escaped / quoted / anchored
+   / URL-encoded IPv4 and compressed/expanded/upper/bracketed IPv6. Output is redacted: path,
+   line, class, a redacted form, and a short **HMAC-keyed** fingerprint — never the raw token
+   and never the full source line.
+
+## Running the gates locally
+
+```
+python3 scripts/ci/privacy-scan-selftest.py
+python3 scripts/ci/private-identifier-gate-selftest.py
+python3 scripts/ci/privacy-scan.py --scope repository --strict          # whole-tree generic
+python3 scripts/ci/privacy-scan.py --changed-lines origin/main --strict # changed-line generic
+# Private gate (maintainers only; denylist + key are secrets, never committed):
+NFTBAN_PRIVACY_DENYLIST_FILE=/path/to/private/denylist \
+NFTBAN_PRIVACY_FP_KEY="$(cat /path/to/private/fp.key)" \
+  python3 scripts/ci/private-identifier-gate.py --whole-tree --mode publication
+```
+
+The denylist file lives OUTSIDE the repository. It is never committed, never printed, and never
+placed in workflow YAML, logs, artifacts, cache keys, or job summaries.
+
+## CI wiring (blocking sequence)
+
+In `ci-architecture.yml` Policy Gates, on every PR/push (no secret needed for the generic gates):
+scanner self-tests → private-gate self-tests → generic whole-tree scan (includes scanner source)
+→ generic changed-line scan (PRs) → private deny gate (advisory, auto-activates with the secret)
+→ release-surface scan. The private gate is **advisory** here so untrusted fork PRs — which
+receive no secrets — never block on it, while the generic gates always block. The workflow uses
+`pull_request` (never `pull_request_target`): fork code runs read-only with no secret access.
+
+`release.yml` runs the private gate in **publication / fail-closed** mode: a missing/empty/
+malformed denylist, a missing fingerprint key, or any scan error BLOCKS the release. This is why
+publication cannot proceed without private validation. Provisioning `NFTBAN_PRIVACY_DENYLIST`
+and `NFTBAN_PRIVACY_FP_KEY` as repository secrets is a maintainer prerequisite before releasing.
+
+## Historical residuals ≠ current-tree cleanliness
+
+A clean current tree does not mean history is clean. The pre-existing test-fixture residue in
+older commits/tags and the published v1.225.0 packages, and GitHub-managed `refs/pull/*`, are
+tracked as SEPARATE, explicitly-open remediation/disclosure lanes — not closed by current-tree
+gates.

--- a/docs/security/PRIVACY_IDENTIFIER_POLICY.md
+++ b/docs/security/PRIVACY_IDENTIFIER_POLICY.md
@@ -68,6 +68,33 @@ malformed denylist, a missing fingerprint key, or any scan error BLOCKS the rele
 publication cannot proceed without private validation. Provisioning `NFTBAN_PRIVACY_DENYLIST`
 and `NFTBAN_PRIVACY_FP_KEY` as repository secrets is a maintainer prerequisite before releasing.
 
+## Trusted merge gate (protected main)
+
+The PR/push private-gate step is **advisory** so untrusted fork PRs (which receive no
+secrets) never block on it. That is safe for fork execution but insufficient by itself to
+keep privacy-contaminated code out of protected `main`. Therefore, before an internal PR may
+merge, **one trusted execution must run against the exact PR-head SHA**:
+
+- `.github/workflows/privacy-trusted-merge-gate.yml` (`workflow_dispatch`, protected
+  environment `privacy-gate`). A maintainer triggers it **from the default branch**,
+  supplying the approved PR-head SHA.
+- It checks out the **trusted gate implementation from the workflow's own ref** (not the PR)
+  and the **PR-head content into a separate directory that is only scanned as data** (via
+  `--selftest-root`, never executed). The secret is present only in the trusted-gate step.
+- On completion it posts a commit status `privacy/trusted-private-gate` bound to the exact
+  PR-head SHA. **Branch protection requires that status context**, so a merge cannot proceed
+  without a trusted PASS on that exact head.
+
+Security properties: fork/PR code is never executed with secrets; a PR-modified gate or
+workflow is never the code that runs (the trusted ref supplies it); the checkout SHA is
+explicit; the result binds to the exact head; `pull_request_target` and privileged
+`workflow_run`-over-fork-code are not used.
+
+**Enforcement activation (maintainer, after secret provisioning):** add
+`privacy/trusted-private-gate` to `main`'s required status checks. Do this only after the
+secrets are provisioned and this workflow exists on `main`; enabling it earlier would
+deadlock all merges (the required check would never be produced).
+
 ## Historical residuals ≠ current-tree cleanliness
 
 A clean current tree does not mean history is clean. The pre-existing test-fixture residue in

--- a/scripts/ci/privacy-forbidden-public.txt
+++ b/scripts/ci/privacy-forbidden-public.txt
@@ -1,0 +1,18 @@
+# Public generic forbidden registry (v1.226.0 privacy defense-in-depth).
+#
+# REPOSITORY-SAFE, COMMITTED. One Python regex (or literal) per line, '#' = comment.
+# This file holds ONLY generic, non-sensitive patterns. It must NEVER contain a real
+# operator/customer identifier or any reversible encoding of one — those belong in the
+# secret-provided private denylist (private-identifier-gate.py), never here.
+#
+# Purpose: catch known placeholder mistakes, documentation-policy violations, and the
+# synthetic canary tokens used by the scanner/gate regression tests, on EVERY PR
+# (no secret required). Matches classify as REAL_OPERATOR_IDENTIFIER (blocking).
+#
+# --- forbidden host-role naming stems (generic scheme, not real hostnames) ---
+#     (also covered by FORBIDDEN_HOST_RE; listed here for the public-registry contract)
+# \b(?:dns[1-4]|srv[1-4])\b
+#
+# (No entries are active by default: real identifiers are handled by the private gate,
+#  and generic role-stems by FORBIDDEN_HOST_RE. Add generic synthetic-canary or
+#  placeholder-mistake patterns here as needed — never a real value.)

--- a/scripts/ci/privacy-scan-selftest.py
+++ b/scripts/ci/privacy-scan-selftest.py
@@ -132,10 +132,34 @@ def test_false_positive_controls():
         check(not blk, "no blocking finding: %s" % name, "unexpected=%r" % blk)
 
 
+def test_no_whole_file_self_exemption():
+    print("test_no_whole_file_self_exemption")
+    # v1.226.0 defense-in-depth: the scanner and its self-tests must NOT be whole-file exempt.
+    check("scripts/ci/privacy-scan.py" not in ps.SELF_TEST_FILES, "privacy-scan.py not whole-file exempt")
+    check("scripts/ci/privacy-scan-selftest.py" not in ps.SELF_TEST_FILES, "privacy-scan-selftest.py not whole-file exempt")
+
+
+def test_scanner_source_canary_generic():
+    print("test_scanner_source_canary_generic")
+    # A deny-listed token placed in the scanner's OWN source path must still block — i.e. the
+    # classifier does not grant the scanner file a self-exemption (deny authority wins by path too).
+    saved = ps._PRIV_PATTERNS
+    try:
+        import re as _re
+        ps._PRIV_PATTERNS = [_re.compile(r"233\.252\.0\.42")]
+        got = list(ps.scan_line(r"# canary example 233\.252\.0\.42", path="scripts/ci/privacy-scan.py"))
+        blk = [c for (k, v, c) in got if c in BLOCKING]
+        check(ps.REAL_OPERATOR_IDENTIFIER in blk,
+              "deny-listed token in scanner-source path still blocks (no self-exemption)")
+    finally:
+        ps._PRIV_PATTERNS = saved
+
+
 def main():
     for t in (test_deescape, test_escaped_detected,
               test_deny_authority_escaped_bypass_closed,
-              test_deny_precedence_over_allowlist, test_false_positive_controls):
+              test_deny_precedence_over_allowlist, test_false_positive_controls,
+              test_no_whole_file_self_exemption, test_scanner_source_canary_generic):
         t()
     print()
     if _fail:

--- a/scripts/ci/privacy-scan.py
+++ b/scripts/ci/privacy-scan.py
@@ -166,13 +166,16 @@ def deescape_dots(s):
     """Detection-only: `\\.`/`\\\\.` -> `.` so escaped dotted-quads are visible to IPV4_RE.
     Never used to execute or reinterpret the string; purely to widen text detection."""
     return _ESCAPED_DOT_RE.sub(".", s)
-# Real operator personal identity (username/name). gituser/commonfolder are
-# PSEUDONYMOUS dev accounts (separate, lower category); avoulvou* is the real
-# maintainer identity and is a REAL_OPERATOR_IDENTIFIER wherever it appears.
-REAL_IDENTITY_RE = re.compile(r"/home/avoulvou\w*\b|\bavoulvou(lis)?\b", re.IGNORECASE)
+# Personal-path detection. gituser/commonfolder are PSEUDONYMOUS dev accounts
+# (advisory, lower category). The public scanner deliberately holds NO real operator
+# username literal (v1.226.0 defense-in-depth: no real identifier — nor any reversible
+# encoding of one — may live in tracked source). The real maintainer identity is carried
+# by the gitignored privacy-forbidden.txt deny file and the secret-provided private
+# identifier gate (private-identifier-gate.py), both of which classify it as
+# REAL_OPERATOR_IDENTIFIER. classify() checks the deny authority (_priv_match) FIRST, so a
+# known-real identity still wins over any context.
 PSEUDONYMOUS_PATH_RE = re.compile(r"/home/(?:gituser|commonfolder)\b", re.IGNORECASE)
-PERSONAL_PATH_RE = re.compile(
-    r"/home/(?:gituser|commonfolder|avoulvou\w*)\b|\bavoulvou(lis)?\b", re.IGNORECASE)
+PERSONAL_PATH_RE = re.compile(r"/home/(?:gituser|commonfolder)\w*\b", re.IGNORECASE)
 
 ALLOWED_DOMAINS = {
     "example.com", "example.net", "example.org", "example.test",
@@ -186,40 +189,54 @@ ALLOWED_DOMAINS = {
 ALLOWED_DOMAIN_SUFFIXES = (".example.test", ".example.com", ".example.net",
                            ".example.org", ".nftban.com")
 
-# Optional PRIVATE, gitignored exact-pattern file (one regex/literal per line).
-# Lets the owner add exact private hostnames/IPs WITHOUT committing the secret.
-# Any match here is a KNOWN-REAL identifier → REAL_OPERATOR_IDENTIFIER (BLOCKING).
+# Deny patterns come from TWO files, both loaded as REAL_OPERATOR_IDENTIFIER (BLOCKING):
+#   1. privacy-forbidden-public.txt  — COMMITTED, repository-safe GENERIC patterns only
+#      (placeholder mistakes, synthetic canary tokens, doc-policy violations). Runs on
+#      every PR. Must never contain a real identifier or a reversible encoding of one.
+#   2. privacy-forbidden.txt         — gitignored PRIVATE exact patterns (never committed).
+# The independent private-identifier-gate.py additionally consumes a secret-provided
+# denylist for real identifiers on trusted runs.
 _PRIV_PATTERNS = []
-_priv_file = os.path.join(HERE, "privacy-forbidden.txt")
-if os.path.exists(_priv_file):
-    with open(_priv_file, "r", encoding="utf-8", errors="ignore") as _pf:
-        for _ln in _pf:
-            _ln = _ln.strip()
-            if _ln and not _ln.startswith("#"):
-                try:
-                    _PRIV_PATTERNS.append(re.compile(_ln, re.IGNORECASE))
-                except re.error:
-                    pass
+for _pfname in ("privacy-forbidden-public.txt", "privacy-forbidden.txt"):
+    _priv_file = os.path.join(HERE, _pfname)
+    if os.path.exists(_priv_file):
+        with open(_priv_file, "r", encoding="utf-8", errors="ignore") as _pf:
+            for _ln in _pf:
+                _ln = _ln.strip()
+                if _ln and not _ln.startswith("#"):
+                    try:
+                        _PRIV_PATTERNS.append(re.compile(_ln, re.IGNORECASE))
+                    except re.error:
+                        pass
 
 BINARY_EXT = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".pdf", ".ico",
               ".mmdb", ".tar", ".gz", ".zip", ".woff", ".woff2", ".ttf"}
 
 # Files whose PURPOSE is to detect/guard these very patterns: the string literals
 # they contain are SEARCH PATTERNS, not leaks (same rationale as the old SELF_SKIP).
+# v1.226.0 privacy defense-in-depth: NO whole-file self-exemption for the scanner or its
+# self-tests — a real identifier accidentally placed in this file (as happened in a comment)
+# must be caught. Both privacy-scan.py and privacy-scan-selftest.py are now scanned like any
+# tracked source; they may only contain documentation-range / synthetic values, which classify
+# non-blocking on their own. The remaining entries are STRUCTURAL non-identifier files (a path
+# manifest and the gitignored private-pattern file) that carry no addresses. For the narrow
+# case where a source line must hold a synthetic value the classifier would otherwise treat as
+# a public surface, use the delimited block markers below — which NEVER downgrade a
+# REAL_OPERATOR_IDENTIFIER (deny authority is not exemptible).
 SELF_TEST_FILES = {
-    "scripts/ci/privacy-scan.py":
-        "the scanner itself defines the detection patterns",
     "scripts/ci/release-surface.txt":
         "release-surface manifest (path globs, not identifiers)",
     "scripts/ci/privacy-forbidden.txt":
         "gitignored private-pattern file (never committed)",
-    "scripts/ci/hooks/pre-commit-privacy":
-        "Guard-1 hook wraps the scanner",
-    "cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh":
-        "guard test greps for /home/commonfolder to assert its ABSENCE from CI scripts",
-    "cli/lib/nftban/tests/support_bundle_redaction_test.sh":
-        "Guard-7 support-bundle redaction test (synthetic sensitive fixtures)",
 }
+
+# Narrow, line-scoped synthetic-fixture exemption (replaces whole-file self-skip).
+# A single trailing `# privacy-allow-synthetic` marks one line; a
+# `# privacy-allow-synthetic-begin` / `# privacy-allow-synthetic-end` pair marks a block.
+# Exemption downgrades ONLY non-deny findings on those lines (used for canary/self-test data).
+SYNTH_BEGIN = "# privacy-allow-synthetic-begin"
+SYNTH_END = "# privacy-allow-synthetic-end"
+SYNTH_LINE = "# privacy-allow-synthetic"
 # Product-config / provider paths where real third-party service domains are
 # LEGITIMATE (RBL zones, feed source URLs, trust providers) — domain check off.
 PRODUCT_DOMAIN_SKIP = (
@@ -315,9 +332,11 @@ def ip_class(text):
             return (False, None)
         if int(ip) < (1 << 32):
             return (False, None)
+        # privacy-allow-synthetic-begin
         # Global unicast is 2000::/3 → the leading hextet is always >=3 hex
         # digits. A match whose largest hextet is <3 digits (`f::A1`, `a::b`)
         # is a code/annotation artifact, not a real address.
+        # privacy-allow-synthetic-end
         if max((len(h) for h in text.split(":") if h), default=0) < 3:
             return (False, None)
     for net, _reason in _PLACEHOLDER_NET_OBJS:
@@ -338,8 +357,8 @@ def classify(kind, value, path, ip_hint=None):
     if _priv_match(value):
         return REAL_OPERATOR_IDENTIFIER
     if kind == "PATH":
-        if REAL_IDENTITY_RE.search(value):
-            return REAL_OPERATOR_IDENTIFIER
+        # Real operator identity is no longer hardcoded here; the deny authority
+        # (_priv_match, checked above) and the private identifier gate own it.
         if path in SELF_TEST_FILES:
             return SCANNER_SELF_TEST
         if is_claude_path(path):
@@ -466,6 +485,45 @@ def tracked_files():
     return out.stdout.splitlines()
 
 
+def _scan_changed_lines(base, strict, show):
+    """Generic changed-line gate: scan only ADDED lines of the diff vs BASE. Blocking
+    findings (with --strict) exit 1. Honors the single-line synthetic-allow marker."""
+    diff = subprocess.run(["git", "-C", REPO, "diff", "--unified=0", "%s...HEAD" % base],
+                          capture_output=True, text=True)
+    if diff.returncode != 0:
+        print("changed-lines: git diff failed for base %r" % base, file=sys.stderr)
+        return 2
+    cur, lineno, blocking, total = None, 0, 0, 0
+    hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    for ln in diff.stdout.split("\n"):
+        if ln.startswith("+++ b/"):
+            cur = ln[6:]
+            continue
+        m = hunk.match(ln)
+        if m:
+            lineno = int(m.group(1))
+            continue
+        if ln.startswith("+") and not ln.startswith("+++"):
+            body = ln[1:]
+            exempt = body.rstrip().endswith(SYNTH_LINE)
+            for kind, value, cat in scan_line(body, cur or "?"):
+                if exempt and cat != REAL_OPERATOR_IDENTIFIER:
+                    cat = SCANNER_SELF_TEST
+                total += 1
+                is_block = cat in RELEASE_BLOCKING_CATEGORIES
+                if is_block:
+                    blocking += 1
+                shown = value if show else redact(kind, value)
+                print("%s:%s: %s %s %s%s" % (cur, lineno, cat, kind, shown,
+                                             " [BLOCKING]" if is_block else ""))
+            lineno += 1
+    print("--- changed-lines base=%s findings=%d (release-blocking: %d)" % (base, total, blocking),
+          file=sys.stderr)
+    if strict and blocking:
+        return 1
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--scope", choices=("release", "repository", "staging"),
@@ -486,7 +544,13 @@ def main():
     ap.add_argument("--show", action="store_true",
                     help="print raw matches (LOCAL ONLY, never in CI logs)")
     ap.add_argument("--paths", nargs="*", help="limit to these paths")
+    ap.add_argument("--changed-lines", metavar="BASE",
+                    help="scan only ADDED lines of `git diff --unified=0 BASE...HEAD` "
+                         "(supplements, never replaces, the whole-tree/release scans)")
     args = ap.parse_args()
+
+    if args.changed_lines is not None:
+        return _scan_changed_lines(args.changed_lines, args.strict, args.show)
 
     staging_root = None
     if args.scope == "staging":
@@ -531,8 +595,21 @@ def main():
             continue
         try:
             with open(fpath, "r", encoding="utf-8", errors="ignore") as fh:
+                in_synth = False
                 for n, line in enumerate(fh, 1):
+                    stripped = line.strip()
+                    if stripped == SYNTH_BEGIN:
+                        in_synth = True
+                        continue
+                    if stripped == SYNTH_END:
+                        in_synth = False
+                        continue
+                    line_exempt = in_synth or line.rstrip().endswith(SYNTH_LINE)
                     for kind, value, cat in scan_line(line, rel):
+                        # Narrow exemption downgrades ONLY non-deny synthetic findings;
+                        # REAL_OPERATOR_IDENTIFIER (deny authority) can never be exempted.
+                        if line_exempt and cat != REAL_OPERATOR_IDENTIFIER:
+                            cat = SCANNER_SELF_TEST
                         total += 1
                         by_cat[cat] += 1
                         is_block = cat in RELEASE_BLOCKING_CATEGORIES

--- a/scripts/ci/privacy-scan.py
+++ b/scripts/ci/privacy-scan.py
@@ -499,7 +499,10 @@ def _scan_changed_lines(base, strict, show):
         print("changed-lines: FAIL-CLOSED — base %r does not resolve to a commit "
               "(malformed, unknown, or not fetched)" % base, file=sys.stderr)
         return 2
-    diff = subprocess.run(["git", "-C", REPO, "diff", "--unified=0", "%s...HEAD" % base],
+    # Two-dot (base HEAD) diff: a direct tree comparison that needs NO merge-base, so it
+    # works on shallow PR checkouts where the parent objects are absent. For added-line
+    # scanning this is equivalent to (and safer than) three-dot.
+    diff = subprocess.run(["git", "-C", REPO, "diff", "--unified=0", base, "HEAD"],
                           capture_output=True, text=True)
     if diff.returncode != 0:
         print("changed-lines: FAIL-CLOSED — git diff failed for base %r" % base, file=sys.stderr)

--- a/scripts/ci/privacy-scan.py
+++ b/scripts/ci/privacy-scan.py
@@ -487,11 +487,22 @@ def tracked_files():
 
 def _scan_changed_lines(base, strict, show):
     """Generic changed-line gate: scan only ADDED lines of the diff vs BASE. Blocking
-    findings (with --strict) exit 1. Honors the single-line synthetic-allow marker."""
+    findings (with --strict) exit 1. Honors the single-line synthetic-allow marker.
+    FAIL-CLOSED: a missing/blank base, a base that cannot be resolved, or a git-diff error
+    all exit 2 — never a skipped or advisory pass."""
+    if not base or not base.strip():
+        print("changed-lines: FAIL-CLOSED — missing/blank base ref", file=sys.stderr)
+        return 2
+    # Base must resolve to a real commit object (guards malformed/unknown/unfetched SHAs).
+    if subprocess.run(["git", "-C", REPO, "rev-parse", "--verify", "--quiet", "%s^{commit}" % base],
+                      capture_output=True).returncode != 0:
+        print("changed-lines: FAIL-CLOSED — base %r does not resolve to a commit "
+              "(malformed, unknown, or not fetched)" % base, file=sys.stderr)
+        return 2
     diff = subprocess.run(["git", "-C", REPO, "diff", "--unified=0", "%s...HEAD" % base],
                           capture_output=True, text=True)
     if diff.returncode != 0:
-        print("changed-lines: git diff failed for base %r" % base, file=sys.stderr)
+        print("changed-lines: FAIL-CLOSED — git diff failed for base %r" % base, file=sys.stderr)
         return 2
     cur, lineno, blocking, total = None, 0, 0, 0
     hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")

--- a/scripts/ci/private-identifier-gate-selftest.py
+++ b/scripts/ci/private-identifier-gate-selftest.py
@@ -142,6 +142,11 @@ def test_changed_lines_mode():
     subprocess.run(["git", "-C", root2, "commit", "-aqm", "rm"], check=True)
     rc, out, _ = run(root2, ["--changed-lines", base2, "--mode", "publication"])
     check(rc == 0, "changed-lines scans ADDED lines only (removal of a token does not fail)", out)
+    # FAIL-CLOSED on a bad base: missing/blank, malformed, and unknown SHA must all exit 2.
+    for label, bad in (("blank", ""), ("malformed", "not-a-sha"),
+                       ("unknown-sha", "0" * 40)):
+        rc, _, err = run(root, ["--changed-lines", bad, "--mode", "publication"])
+        check(rc == 2, "changed-lines fail-closed on %s base" % label, "rc=%d %s" % (rc, err.strip()[:80]))
 
 
 def test_scanner_source_canary():

--- a/scripts/ci/private-identifier-gate-selftest.py
+++ b/scripts/ci/private-identifier-gate-selftest.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+"""
+Self-tests for scripts/ci/private-identifier-gate.py (v1.226.0 privacy defense-in-depth).
+
+ALL denylist values here are SYNTHETIC (RFC5737 IPv4 / RFC3849 IPv6). No real identifier is
+present or required. Tests build throwaway git repos and drive the real gate as a subprocess
+with the denylist + HMAC key supplied ONLY via the environment (never committed).
+
+Run:  python3 scripts/ci/private-identifier-gate-selftest.py
+Exit: 0 = all pass · 1 = a self-test failed · 2 = harness error.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+GATE = os.path.join(HERE, "private-identifier-gate.py")
+# synthetic denylist tokens (documentation ranges) — safe to appear in this test file
+D4 = "198.51.100.23"
+D6 = "2001:db8:1234::abcd"
+KEY = "selftest-fingerprint-key-not-a-secret"
+_fail = []
+
+
+def check(cond, label, detail=""):
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else "  " + detail))
+    if not cond:
+        _fail.append(label)
+
+
+def make_repo(files):
+    root = tempfile.mkdtemp(prefix="pig-selftest-")
+    subprocess.run(["git", "init", "-q", root], check=True)
+    subprocess.run(["git", "-C", root, "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", root, "config", "user.name", "t"], check=True)
+    for rel, content in files.items():
+        p = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True) if os.path.dirname(p) else None
+        open(p, "w").write(content)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", root, "commit", "-q", "-m", "init"], check=True)
+    return root
+
+
+def run(root, args, denylist=D4 + "\n" + D6, key=KEY, extra_env=None):
+    env = dict(os.environ)
+    env.pop("NFTBAN_PRIVACY_DENYLIST_FILE", None)
+    if denylist is None:
+        env.pop("NFTBAN_PRIVACY_DENYLIST", None)
+    else:
+        env["NFTBAN_PRIVACY_DENYLIST"] = denylist
+    if key is None:
+        env.pop("NFTBAN_PRIVACY_FP_KEY", None)
+    else:
+        env["NFTBAN_PRIVACY_FP_KEY"] = key
+    if extra_env:
+        env.update(extra_env)
+    p = subprocess.run([sys.executable, GATE] + args, cwd=root, capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout, p.stderr
+
+
+def test_detection_forms():
+    print("test_detection_forms")
+    content = "\n".join([
+        "a = 198.51.100.23",
+        "grep '^198\\.51\\.100\\.23$'",
+        'x="198\\\\.51\\\\.100\\\\.23"',
+        "url = http://198%2e51%2e100%2e23/path",
+        "v6 = 2001:0db8:1234:0000:0000:0000:0000:abcd",   # expanded form of D6
+        "v6b = [2001:db8:1234::ABCD]:443",                 # bracketed + uppercase
+    ]) + "\n"
+    root = make_repo({"f.txt": content})
+    rc, out, err = run(root, ["--whole-tree", "--mode", "publication"])
+    check(rc == 1, "publication scan flags private identifiers (exit 1)", err.strip())
+    check(out.count("PRIVATE_IDENTIFIER") >= 6, "all six obfuscated forms detected", "found=%d" % out.count("PRIVATE_IDENTIFIER"))
+    check("fp=" in out, "fingerprint emitted")
+
+
+def test_output_hygiene():
+    print("test_output_hygiene")
+    line = "secret host at 198.51.100.23 here-is-the-full-line-marker"
+    root = make_repo({"f.txt": line + "\n"})
+    rc, out, err = run(root, ["--whole-tree", "--mode", "publication"])
+    combined = out + err
+    check(D4 not in combined, "raw IPv4 token absent from output")
+    check(D6 not in combined, "raw IPv6 token absent from output")
+    check("here-is-the-full-line-marker" not in combined, "full matching source line absent from output")
+    check("198.51.x.x" in out, "redacted representation present")
+
+
+def test_hmac_fingerprint():
+    print("test_hmac_fingerprint")
+    root = make_repo({"f.txt": "198.51.100.23\n"})
+    _, o1, _ = run(root, ["--whole-tree", "--mode", "publication"], key="KEY-A")
+    _, o2, _ = run(root, ["--whole-tree", "--mode", "publication"], key="KEY-A")
+    _, o3, _ = run(root, ["--whole-tree", "--mode", "publication"], key="KEY-B")
+    def fp(o):
+        for tok in o.split():
+            if tok.startswith("fp="):
+                return tok
+        return None
+    check(fp(o1) and fp(o1) == fp(o2), "fingerprint stable for same token+key")
+    check(fp(o1) and fp(o3) and fp(o1) != fp(o3), "different key => different fingerprint")
+
+
+def test_fail_closed():
+    print("test_fail_closed")
+    root = make_repo({"f.txt": "nothing here\n"})
+    rc, _, err = run(root, ["--whole-tree", "--mode", "publication"], denylist=None)
+    check(rc == 2 and "FAIL_CLOSED" in err, "missing denylist => fail-closed in publication")
+    rc, _, err = run(root, ["--whole-tree", "--mode", "publication"], denylist="# only comments\n")
+    check(rc == 2 and "FAIL_CLOSED" in err, "empty denylist => fail-closed")
+    rc, _, err = run(root, ["--whole-tree", "--mode", "publication"], denylist="not-an-ip-or-id\n")
+    check(rc == 2 and "FAIL_CLOSED" in err, "malformed denylist => fail-closed")
+    rc, _, err = run(root, ["--whole-tree", "--mode", "publication"], key=None)
+    check(rc == 2 and "FAIL_CLOSED" in err, "missing fingerprint key => fail-closed in publication")
+    rc, out, _ = run(root, ["--whole-tree", "--mode", "advisory"], denylist=None)
+    check(rc == 0 and "NOT_RUN" in out, "advisory mode with no denylist => NOT_RUN exit 0")
+
+
+def test_clean_pass_and_false_positive_controls():
+    print("test_clean_pass_and_false_positive_controls")
+    content = "release v1.226.0\nrpm 4.16\ndoc 192.0.2.5\nresolver 8.8.8.8\nv6 2001:db8:9999::1\n"
+    root = make_repo({"f.txt": content})
+    rc, out, _ = run(root, ["--whole-tree", "--mode", "publication"])
+    check(rc == 0 and "PRIVATE_GATE = PASS" in out, "clean tree passes; unrelated values not flagged", out)
+
+
+def test_changed_lines_mode():
+    print("test_changed_lines_mode")
+    root = make_repo({"f.txt": "clean baseline\n"})
+    base = subprocess.run(["git", "-C", root, "rev-parse", "HEAD"], capture_output=True, text=True).stdout.strip()
+    open(os.path.join(root, "f.txt"), "a").write("added 198.51.100.23 line\n")
+    subprocess.run(["git", "-C", root, "commit", "-aqm", "add"], check=True)
+    rc, out, _ = run(root, ["--changed-lines", base, "--mode", "publication"])
+    check(rc == 1 and "PRIVATE_IDENTIFIER" in out, "changed-lines flags a private id added in the diff")
+    root2 = make_repo({"f.txt": "old 198.51.100.23 line\nkeep\n"})
+    base2 = subprocess.run(["git", "-C", root2, "rev-parse", "HEAD"], capture_output=True, text=True).stdout.strip()
+    open(os.path.join(root2, "f.txt"), "w").write("keep\n")
+    subprocess.run(["git", "-C", root2, "commit", "-aqm", "rm"], check=True)
+    rc, out, _ = run(root2, ["--changed-lines", base2, "--mode", "publication"])
+    check(rc == 0, "changed-lines scans ADDED lines only (removal of a token does not fail)", out)
+
+
+def test_scanner_source_canary():
+    print("test_scanner_source_canary")
+    scanner_src = open(os.path.join(HERE, "privacy-scan.py"), encoding="utf-8").read()
+    tampered = scanner_src + "\n# canary example addr 198.51.100.23\n"
+    root = make_repo({"scripts/ci/privacy-scan.py": tampered, "other.txt": "x\n"})
+    rc, out, _ = run(root, ["--whole-tree", "--mode", "publication"])
+    check(rc == 1 and "scripts/ci/privacy-scan.py" in out,
+          "private gate detects a token injected into scanner source (no whole-file skip)")
+
+
+def main():
+    if not os.path.exists(GATE):
+        sys.stderr.write("gate not found: %s\n" % GATE)
+        return 2
+    for t in (test_detection_forms, test_output_hygiene, test_hmac_fingerprint, test_fail_closed,
+              test_clean_pass_and_false_positive_controls, test_changed_lines_mode,
+              test_scanner_source_canary):
+        t()
+    print()
+    if _fail:
+        print("PRIVATE_GATE_SELFTEST_FAIL (%d): %s" % (len(_fail), ", ".join(_fail)))
+        return 1
+    print("PRIVATE_GATE_SELFTEST_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/private-identifier-gate.py
+++ b/scripts/ci/private-identifier-gate.py
@@ -215,6 +215,13 @@ def scan_whole_tree(root, deny):
 
 
 def scan_changed_lines(root, base, deny):
+    # FAIL-CLOSED: a missing/blank base or one that does not resolve to a commit
+    # (malformed / unknown / unfetched) is an error, not an empty pass.
+    if not base or not base.strip():
+        raise RuntimeError("missing/blank base ref")
+    if subprocess.run(["git", "rev-parse", "--verify", "--quiet", "%s^{commit}" % base],
+                      cwd=root, capture_output=True).returncode != 0:
+        raise RuntimeError("base does not resolve to a commit")
     diff = subprocess.run(["git", "diff", "--unified=0", "%s...HEAD" % base],
                           cwd=root, capture_output=True, text=True)
     if diff.returncode != 0:

--- a/scripts/ci/private-identifier-gate.py
+++ b/scripts/ci/private-identifier-gate.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+"""
+NFTBan private-identifier deny gate (v1.226.0 privacy defense-in-depth).
+
+A SECOND, INDEPENDENT privacy control, deliberately separate from privacy-scan.py:
+it has its OWN candidate-extraction and canonicalization (no shared detection/normalization
+core with the primary scanner — common-mode failure prevention, control 12). Its job is to
+prove that a set of KNOWN-REAL identifiers, supplied at runtime OUTSIDE the repository (a CI
+secret or a maintainer-local file), does not appear anywhere in the scanned text — in any
+literal, escaped, quoted, URL-encoded, or compressed/expanded form.
+
+The private identifier set NEVER enters the repository, workflow YAML, logs, artifacts, cache
+keys, job summaries, commit messages, or PR text. Diagnostics print only: path, line number,
+identifier class, a redacted representation, and a short HMAC-keyed fingerprint — never the raw
+token and never the full matching source line.
+
+Inputs (all from the environment / outside the repo):
+  NFTBAN_PRIVACY_DENYLIST_FILE  path to a file with one identifier per line (comments '#' ok)
+  NFTBAN_PRIVACY_DENYLIST       inline denylist content (alternative to the file)
+  NFTBAN_PRIVACY_FP_KEY         HMAC-SHA256 key for fingerprints (required in publication mode)
+
+Modes:
+  --mode publication   FAIL-CLOSED: missing/empty/malformed denylist or any scan error => exit 2.
+  --mode advisory      untrusted context (secret may be absent): if no denylist is available,
+                       emit an explicit NOT_RUN status and exit 0 (generic gates still block).
+
+Scope:
+  --whole-tree                  scan all tracked text files (includes the scanner's own source).
+  --changed-lines BASE          scan only added lines of `git diff --unified=0 BASE...HEAD`.
+
+Exit: 0 = clean (or advisory NOT_RUN) · 1 = a private identifier was found · 2 = fail-closed error.
+"""
+import argparse
+import hashlib
+import hmac
+import ipaddress
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+
+# ---- INDEPENDENT candidate extraction (distinct implementation from privacy-scan.py) --------
+# IPv4 as four 1-3 digit groups separated by a "dot-ish" separator that tolerates backslash and
+# URL-escaping; IPv6 as runs of hex groups with ':' (optionally bracketed). These regexes are
+# intentionally NOT imported from the primary scanner.
+_SEP = r"(?:\\{1,2}\.|%2[eE]|\.)"          # '.', '\.', '\\.', '%2e'
+_IPV4_CAND = re.compile(r"(?<![0-9A-Za-z])(\d{1,3})" + _SEP + r"(\d{1,3})" + _SEP +
+                        r"(\d{1,3})" + _SEP + r"(\d{1,3})(?![0-9A-Za-z])")
+_IPV6_CAND = re.compile(
+    r"\[?("
+    r"[0-9A-Fa-f:]*::[0-9A-Fa-f:]*"                                    # compressed (::) form FIRST
+    r"|(?:[0-9A-Fa-f]{1,4}(?:\\{0,2}:|%3[aA]|:)){2,}[0-9A-Fa-f]{1,4}"  # else full form, 3+ groups
+    r")\]?")
+
+
+def _views(line):
+    """Independent normalization: yield textual VIEWS of a line so escaped/encoded/quoted forms
+    become visible. Data-only — never executed, sourced, or compiled as a regex/command."""
+    seen = []
+    def add(s):
+        if s not in seen:
+            seen.append(s)
+    add(line)
+    # collapse backslash-escapes of dot and colon
+    add(re.sub(r"\\{1,2}([.:])", r"\1", line))
+    # strip one layer of surrounding quotes token-wise
+    add(re.sub(r"[\"']", "", line))
+    # URL-decode (%2e -> .) — bounded single pass, no recursion
+    try:
+        add(urllib.parse.unquote(line))
+    except Exception:
+        pass
+    # JSON-ish: turn \\ into \ then collapse escaped dot/colon again
+    add(re.sub(r"\\{1,2}([.:])", r"\1", line.replace("\\\\", "\\")))
+    return seen
+
+
+def canon_ipv4(a, b, c, d):
+    try:
+        ip = ipaddress.IPv4Address("%d.%d.%d.%d" % (int(a), int(b), int(c), int(d)))
+        return str(ip)
+    except Exception:
+        return None
+
+
+def canon_ipv6(tok):
+    t = tok.strip("[]")
+    t = re.sub(r"\\{1,2}:", ":", t)
+    t = urllib.parse.unquote(t)
+    if t.count(":") < 2:
+        return None
+    try:
+        return str(ipaddress.IPv6Address(t))       # compressed, lowercase canonical form
+    except Exception:
+        return None
+
+
+def candidates(line):
+    """Return a set of canonical identifier strings found in the line, across all views."""
+    out = set()
+    for v in _views(line):
+        for m in _IPV4_CAND.finditer(v):
+            c = canon_ipv4(*m.groups())
+            if c:
+                out.add(c)
+        for m in _IPV6_CAND.finditer(v):
+            c = canon_ipv6(m.group(1))
+            if c:
+                out.add(c)
+    return out
+
+
+# ---- denylist (secret-provided, canonicalized in memory) ------------------------------------
+def load_denylist():
+    """Return (canon_set, source) or (None, reason). Never echoes any value."""
+    raw = None
+    f = os.environ.get("NFTBAN_PRIVACY_DENYLIST_FILE")
+    if f:
+        if not os.path.isfile(f):
+            return None, "denylist file not found"
+        try:
+            raw = open(f, "r", encoding="utf-8").read()
+        except OSError:
+            return None, "denylist file unreadable"
+    elif os.environ.get("NFTBAN_PRIVACY_DENYLIST") is not None:
+        raw = os.environ["NFTBAN_PRIVACY_DENYLIST"]
+    else:
+        return None, "no denylist provided"
+    canon = set()
+    malformed = 0
+    for ln in raw.splitlines():
+        s = ln.strip()
+        if not s or s.startswith("#"):
+            continue
+        c = None
+        try:
+            a = ipaddress.ip_address(s)
+            c = str(a)
+        except ValueError:
+            # accept a bare dotted/again-canonicalizable token
+            got = candidates(s)
+            if len(got) == 1:
+                c = next(iter(got))
+        if c:
+            canon.add(c)
+        else:
+            malformed += 1
+    if malformed:
+        return None, "denylist contains %d malformed entr%s" % (malformed, "y" if malformed == 1 else "ies")
+    if not canon:
+        return None, "denylist is empty"
+    return canon, "loaded"
+
+
+def fingerprint(canon_value):
+    key = os.environ.get("NFTBAN_PRIVACY_FP_KEY", "").encode()
+    if not key:
+        return "nokey"
+    return hmac.new(key, canon_value.encode(), hashlib.sha256).hexdigest()[:12]
+
+
+def redact(canon_value):
+    if ":" in canon_value:
+        head = canon_value.split(":")[0]
+        return head + ":<redacted-ipv6>"
+    parts = canon_value.split(".")
+    return ".".join(parts[:2] + ["x", "x"]) if len(parts) == 4 else "<redacted>"
+
+
+def klass(canon_value):
+    return "IPV6" if ":" in canon_value else "IPV4"
+
+
+# ---- file enumeration (a harmless shared-style utility; NOT detection) -----------------------
+def repo_root():
+    return subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True).stdout.strip()
+
+
+def tracked_text_files(root):
+    out = subprocess.run(["git", "ls-files"], cwd=root, capture_output=True, text=True).stdout.split("\n")
+    bin_ext = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".pdf", ".ico", ".mmdb",
+               ".tar", ".gz", ".zip", ".woff", ".woff2", ".ttf"}
+    files = []
+    for rel in out:
+        if not rel:
+            continue
+        if os.path.splitext(rel)[1].lower() in bin_ext:
+            continue
+        p = os.path.join(root, rel)
+        try:
+            with open(p, "rb") as fh:
+                if b"\x00" in fh.read(8192):
+                    continue
+        except OSError:
+            continue
+        files.append(rel)
+    return files
+
+
+def scan_whole_tree(root, deny):
+    hits = []
+    for rel in tracked_text_files(root):
+        try:
+            with open(os.path.join(root, rel), "r", encoding="utf-8", errors="ignore") as fh:
+                for n, line in enumerate(fh, 1):
+                    for c in candidates(line) & deny:
+                        hits.append((rel, n, c))
+        except OSError:
+            # a file we enumerated but cannot read is a coverage gap in publication mode
+            raise
+    return hits
+
+
+def scan_changed_lines(root, base, deny):
+    diff = subprocess.run(["git", "diff", "--unified=0", "%s...HEAD" % base],
+                          cwd=root, capture_output=True, text=True)
+    if diff.returncode != 0:
+        raise RuntimeError("git diff failed for base %r" % base)
+    hits = []
+    cur = None
+    lineno = 0
+    hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    for ln in diff.stdout.split("\n"):
+        if ln.startswith("+++ b/"):
+            cur = ln[6:]
+            continue
+        m = hunk.match(ln)
+        if m:
+            lineno = int(m.group(1))
+            continue
+        if ln.startswith("+") and not ln.startswith("+++"):
+            for c in candidates(ln[1:]) & deny:
+                hits.append((cur, lineno, c))
+            lineno += 1
+    return hits
+
+
+def main():
+    ap = argparse.ArgumentParser(description="NFTBan private-identifier deny gate (independent).")
+    ap.add_argument("--mode", choices=["publication", "advisory"], default="advisory")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--whole-tree", action="store_true")
+    g.add_argument("--changed-lines", metavar="BASE")
+    ap.add_argument("--selftest-root", help=argparse.SUPPRESS)  # internal: scan an alt tree
+    args = ap.parse_args()
+
+    deny, why = load_denylist()
+    if deny is None:
+        if args.mode == "publication":
+            sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (%s) in publication mode\n" % why)
+            return 2
+        print("PRIVATE_GATE = NOT_RUN (%s); generic gates remain blocking" % why)
+        return 0
+    if args.mode == "publication" and not os.environ.get("NFTBAN_PRIVACY_FP_KEY"):
+        sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (no NFTBAN_PRIVACY_FP_KEY) in publication mode\n")
+        return 2
+
+    root = args.selftest_root or repo_root()
+    if not root:
+        sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (not in a git repository)\n")
+        return 2
+    try:
+        hits = scan_whole_tree(root, deny) if args.whole_tree else scan_changed_lines(root, args.changed_lines, deny)
+    except Exception as e:
+        # never let the exception body echo a value
+        sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (scan error: %s)\n" % type(e).__name__)
+        return 2 if args.mode == "publication" else 1
+
+    if hits:
+        for rel, n, c in hits:
+            print("%s:%s: PRIVATE_IDENTIFIER %s %s fp=%s [BLOCKING]" %
+                  (rel, n, klass(c), redact(c), fingerprint(c)))
+        sys.stderr.write("PRIVATE_GATE = FAIL (%d private-identifier occurrence(s))\n" % len(hits))
+        return 1
+    print("PRIVATE_GATE = PASS (denylist=%d canonical entries; 0 occurrences)" % len(deny))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/private-identifier-gate.py
+++ b/scripts/ci/private-identifier-gate.py
@@ -222,7 +222,8 @@ def scan_changed_lines(root, base, deny):
     if subprocess.run(["git", "rev-parse", "--verify", "--quiet", "%s^{commit}" % base],
                       cwd=root, capture_output=True).returncode != 0:
         raise RuntimeError("base does not resolve to a commit")
-    diff = subprocess.run(["git", "diff", "--unified=0", "%s...HEAD" % base],
+    # Two-dot (base HEAD): direct tree comparison, no merge-base — works on shallow checkouts.
+    diff = subprocess.run(["git", "diff", "--unified=0", base, "HEAD"],
                           cwd=root, capture_output=True, text=True)
     if diff.returncode != 0:
         raise RuntimeError("git diff failed for base %r" % base)


### PR DESCRIPTION
## Summary

Adds an independent privacy enforcement layer to prevent recurrence of the failure class behind the self-introduced comment leak (escaped real identifiers, scanner self-file blind spot, common-mode validation failure, real values used as examples). **No product / Go / VERSION / schema / fleet change; binaries byte-identical to base.**

## Controls

1. **No whole-file scanner self-exemption** — `privacy-scan.py` and its self-tests are now scanned like any source; a real value accidentally placed in them is caught. Narrow, delimited `# privacy-allow-synthetic` markers may downgrade **only** synthetic findings, never a deny-authority `REAL_OPERATOR_IDENTIFIER`. The real maintainer username is removed from the public scanner (no real identifier — nor reversible encoding — in tracked source) and moved to the private layer.
2. **Independent private-identifier gate** (`private-identifier-gate.py`) — its **own** candidate extraction + canonicalization (no shared normalization core with the primary scanner). Consumes a **secret-provided** denylist (never committed). Recognizes literal / single- & double-escaped-dot / quoted / anchored / URL-encoded IPv4 and compressed/expanded/upper/bracketed IPv6. **HMAC-SHA256** keyed fingerprints; output is path/line/class/redacted/fp only — never the raw token or full source line. **Fail-closed** in publication mode.
3. **Public generic forbidden registry** (`privacy-forbidden-public.txt`) — committed, repository-safe generic patterns only.
4. **Generic changed-line + whole-tree gates** (the whole-tree gate includes the scanner's own source), both blocking.
5. **CI** (`ci-architecture.yml`, `pull_request` — **not** `pull_request_target`): generic gates always block; the private gate is advisory here and auto-activates when the maintainer secret is present (fork PRs get no secret → never blocks contributors). `release.yml` runs the private gate in **publication / fail-closed** mode + the generic gates.
6. **Trusted merge gate** (`privacy-trusted-merge-gate.yml`, `workflow_dispatch`, protected environment) — a maintainer triggers it **from the default branch** with the exact PR-head SHA. It runs the gate implementation from the **trusted ref** (never the PR) and scans the PR-head content **as data only** (`--selftest-root`, never executed); the secret is present only in the trusted step. It posts a commit status `privacy/trusted-private-gate` bound to the exact SHA, which branch protection will require. No `pull_request_target`; no `workflow_run` over fork code.
7. `docs/security/PRIVACY_IDENTIFIER_POLICY.md` — approved example ranges, the documentation-only vs synthetic-public distinction, both gates, local usage, the trusted merge gate, and how historical residuals differ from current-tree cleanliness.

## Validation

Scanner self-tests **28/28**; private-gate self-tests **18/18** (incl. scanner-source canary in a private temp tree); generic whole-tree + release strict PASS; `go vet`/`go build`/`go test -race` (88 ok / 0 fail) PASS; nftband/core/installer binaries **byte-identical** to base.

## Bootstrap note

This PR is the one-time bootstrap: the trusted implementation does not exist on `main` until this merges, so `privacy/trusted-private-gate` is **not** yet a required check. Enable it (and provision `NFTBAN_PRIVACY_DENYLIST` / `NFTBAN_PRIVACY_FP_KEY` on the `privacy-gate` environment) after merge, before the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
