### PR TITLE
ci(test-authority): classify all shell tests under meta:ta.* (v1.226.0 PR-B)

### DIFF
--- a/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
+++ b/cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-alert@.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="alert_bookkeeping_nonfatal_v174_test"
+# meta:ta.owner="health"
+# meta:ta.module="alert"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh
+++ b/cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-alert@.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="alert_logger_devlog_sandbox_v1981_test"
+# meta:ta.owner="health"
+# meta:ta.module="alert"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/audit_rotate_retired_gateb_test.sh
+++ b/cli/lib/nftban/tests/audit_rotate_retired_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="audit_rotate_retired_gateb_test"
+# meta:ta.owner="core"
+# meta:ta.module="audit"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/b1_text_ux_v1872_test.sh
+++ b/cli/lib/nftban/tests/b1_text_ux_v1872_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="b1_text_ux_v1872_test"
+# meta:ta.owner="cli"
+# meta:ta.module="banner"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh
+++ b/cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="b1b_banner_compact_v1873_test"
+# meta:ta.owner="cli"
+# meta:ta.module="banner"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh
+++ b/cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="b2_badbot_aibot_v188_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/banner_nobanner_v153_test.sh
+++ b/cli/lib/nftban/tests/banner_nobanner_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="banner_nobanner_v153_test"
+# meta:ta.owner="cli"
+# meta:ta.module="banner"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh
+++ b/cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="blacklist_flush_manual_truth_v218_10_test"
+# meta:ta.owner="blacklist"
+# meta:ta.module="blacklist-flush"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh
+++ b/cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh
@@ -15,6 +15,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="root"
+# meta:ta.id="blacklist_refresh_no_failopen_v192_test"
+# meta:ta.owner="blacklist"
+# meta:ta.module="blacklist-refresh-atomicity"
+# meta:ta.execution_class="ROOT_LAB"
+# meta:ta.gate="lab-manual"
+# meta:ta.hermetic="false"
+# meta:ta.requires_root="true"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="true"
+# meta:ta.requires_package="false"
 # =============================================================================
 # F-FEED / F-GEO (D-NFTBAN-{FEED,GEOBAN}-REFRESH-FAILOPEN) runtime regression.
 #

--- a/cli/lib/nftban/tests/botguard_diag_6b2_test.sh
+++ b/cli/lib/nftban/tests/botguard_diag_6b2_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botguard_diag_6b2_test"
+# meta:ta.owner="botguard"
+# meta:ta.module="botguard-explain-diag"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botguard_explain_shell_6b1_test.sh
+++ b/cli/lib/nftban/tests/botguard_explain_shell_6b1_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botguard_explain_shell_6b1_test"
+# meta:ta.owner="botguard"
+# meta:ta.module="botguard-explain-client"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh
+++ b/cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_404_tail_bound_v1871_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-404-tail"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
+++ b/cli/lib/nftban/tests/botscan_adaptive_v207_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_adaptive_v207_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-adaptive"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh
+++ b/cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_admin_ip_exemption_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-exemption"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh
+++ b/cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_collector_gather_stream_v2092_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-collector-gather"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh
+++ b/cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_daemon_truth_v219_0_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-health-consumer-truth"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_deadline_rotation_v185_test.sh
+++ b/cli/lib/nftban/tests/botscan_deadline_rotation_v185_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_deadline_rotation_v185_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-deadline-rotation"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/botscan_direct_ban_flag_v1903_test.sh
+++ b/cli/lib/nftban/tests/botscan_direct_ban_flag_v1903_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_direct_ban_flag_v1903_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-direct-ban-flag"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_endpoint_flood_test.sh
+++ b/cli/lib/nftban/tests/botscan_endpoint_flood_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_endpoint_flood_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-endpoint-flood"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_exp_rfi_fp_v218_13_test.sh
+++ b/cli/lib/nftban/tests/botscan_exp_rfi_fp_v218_13_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_exp_rfi_fp_v218_13_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-pattern-exp-rfi"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
+++ b/cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_fcrdns_v189_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-fcrdns-crawler"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh
+++ b/cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_logsource_validity_r22a_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-logsource-validity"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"

--- a/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
+++ b/cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_nofork_parity_v1871_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh
+++ b/cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_operator_truth_contract_v219_0_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-operator-truth"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
+++ b/cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_operator_truth_v218_11_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-status-surface"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_pattern_ban_ifs_v1861_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-pattern-ban-ifs"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh
+++ b/cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_pattern_delimiter_v214_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-pattern-delimiter"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
+++ b/cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_read_authority_v178_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-read-authority-collector"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/botscan_request_class_classifier_v1913_test.sh
+++ b/cli/lib/nftban/tests/botscan_request_class_classifier_v1913_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_request_class_classifier_v1913_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh
+++ b/cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_revslider_fp_v218_10_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-patterns"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh
+++ b/cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_signal_flock_v212_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/botscan_spool_oom_v2093_test.sh
+++ b/cli/lib/nftban/tests/botscan_spool_oom_v2093_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_spool_oom_v2093_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-collector"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh
+++ b/cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_status_label_v218_12_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-status-render"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/botscan_throughput_v187_test.sh
+++ b/cli/lib/nftban/tests/botscan_throughput_v187_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_throughput_v187_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/botscan_trend_v208_test.sh
+++ b/cli/lib/nftban/tests/botscan_trend_v208_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="botscan_trend_v208_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan-trend"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
+++ b/cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh
@@ -17,6 +17,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges=""
+# meta:ta.id="botscan_wpadmin_context_gate_v1922_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="botscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh
+++ b/cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_ban_timeout_no_mutation_test"
+# meta:ta.owner="cli"
+# meta:ta.module="ban"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh
+++ b/cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_ban_timeout_validation_test"
+# meta:ta.owner="cli"
+# meta:ta.module="ban"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_connector_no_edit_hint_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="connector"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
+++ b/cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_empty_env_smoke_v156_test"
+# meta:ta.owner="cli"
+# meta:ta.module="dispatcher"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh
+++ b/cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_error_rc_contract_v1_139_2_test"
+# meta:ta.owner="cli"
+# meta:ta.module="rc-contract"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_error_with_hint_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="error-hint"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_exporter_exit2_phase_3_test.sh
+++ b/cli/lib/nftban/tests/cli_exporter_exit2_phase_3_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_exporter_exit2_phase_3_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_feeds_count_truth_test.sh
+++ b/cli/lib/nftban/tests/cli_feeds_count_truth_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_feeds_count_truth_test"
+# meta:ta.owner="feeds"
+# meta:ta.module="feeds"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_feeds_json_jq_construction_test.sh
+++ b/cli/lib/nftban/tests/cli_feeds_json_jq_construction_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_feeds_json_jq_construction_test"
+# meta:ta.owner="feeds"
+# meta:ta.module="feeds"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_feeds_select_input_contract_test.sh
+++ b/cli/lib/nftban/tests/cli_feeds_select_input_contract_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_feeds_select_input_contract_test"
+# meta:ta.owner="feeds"
+# meta:ta.module="feeds"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_fs3_da_v143_test.sh
+++ b/cli/lib/nftban/tests/cli_fs3_da_v143_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_fs3_da_v143_test"
+# meta:ta.owner="cli"
+# meta:ta.module="port"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_fs3_mutation_v143_test.sh
+++ b/cli/lib/nftban/tests/cli_fs3_mutation_v143_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_fs3_mutation_v143_test"
+# meta:ta.owner="cli"
+# meta:ta.module="rc-truth"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_hardening_v150_test.sh
+++ b/cli/lib/nftban/tests/cli_hardening_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_hardening_v150_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. Functions under
 # test are extracted from their source files by name and run in subshells with

--- a/cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_help_block_reachability_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="help-reachability"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_help_inertness_universal_test.sh
+++ b/cli/lib/nftban/tests/cli_help_inertness_universal_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_help_inertness_universal_test"
+# meta:ta.owner="cli"
+# meta:ta.module="help-inertness"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_help_inertness_v141_test.sh
+++ b/cli/lib/nftban/tests/cli_help_inertness_v141_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_help_inertness_v141_test"
+# meta:ta.owner="cli"
+# meta:ta.module="help-inertness"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_inet_filter_policy_v146_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="inet-filter"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_json_clean_output_test.sh
+++ b/cli/lib/nftban/tests/cli_json_clean_output_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_json_clean_output_test"
+# meta:ta.owner="cli"
+# meta:ta.module="json-output"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
+++ b/cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_mac_profiles_v147a_test"
+# meta:ta.owner="security"
+# meta:ta.module="mac-profiles"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh
+++ b/cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_nftables_include_idempotency_v146_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="firewall-include"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_no_banner_v141_test.sh
+++ b/cli/lib/nftban/tests/cli_no_banner_v141_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_no_banner_v141_test"
+# meta:ta.owner="cli"
+# meta:ta.module="output-banner"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_no_gui_doc_drift_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="command-registry-drift"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_output_truth_v167_test.sh
+++ b/cli/lib/nftban/tests/cli_output_truth_v167_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_output_truth_v167_test"
+# meta:ta.owner="cli"
+# meta:ta.module="output-truth"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
+++ b/cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_pipefail_arith_sweep_v172_test"
+# meta:ta.owner="cli"
+# meta:ta.module="pipefail-arith"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_port_reload_hint_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="port-reload-hint"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_runtime_hint_reachability_v144_test"
+# meta:ta.owner="cli"
+# meta:ta.module="runtime-hint-reachability"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_status_count_truth_test.sh
+++ b/cli/lib/nftban/tests/cli_status_count_truth_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_status_count_truth_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_status_json_no_contradict_test.sh
+++ b/cli/lib/nftban/tests/cli_status_json_no_contradict_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_status_json_no_contradict_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_status_kernel_verify_hint_test.sh
+++ b/cli/lib/nftban/tests/cli_status_kernel_verify_hint_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_status_kernel_verify_hint_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_stderr_contract_v141_test.sh
+++ b/cli/lib/nftban/tests/cli_stderr_contract_v141_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_stderr_contract_v141_test"
+# meta:ta.owner="cli"
+# meta:ta.module="stderr-contract"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_sudo_hint_v142_test.sh
+++ b/cli/lib/nftban/tests/cli_sudo_hint_v142_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_sudo_hint_v142_test"
+# meta:ta.owner="cli"
+# meta:ta.module="sudo-hint"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_trustfeeds_label_truth_v211_1_test.sh
+++ b/cli/lib/nftban/tests/cli_trustfeeds_label_truth_v211_1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_trustfeeds_label_truth_v211_1_test"
+# meta:ta.owner="trust"
+# meta:ta.module="trust-feeds-status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
+++ b/cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_update_dry_run_hint_v167_test"
+# meta:ta.owner="update"
+# meta:ta.module="update"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh
+++ b/cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cli_update_latv_unbound_v149_test"
+# meta:ta.owner="update"
+# meta:ta.module="update"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/cmd_blacklist_list_test.sh
+++ b/cli/lib/nftban/tests/cmd_blacklist_list_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_blacklist_list_test"
+# meta:ta.owner="blacklist"
+# meta:ta.module="blacklist"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Purpose: Cover the v1.119 A1 D2 fix in cli/lib/nftban/cli/cmd_blacklist.sh
 #   nftban_blacklist_list — query both blacklist_ipv4 (interval, CIDRs from

--- a/cli/lib/nftban/tests/cmd_firewall_takeover_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_takeover_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_firewall_takeover_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-takeover"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Purpose: Cover the v1.117 firewall-takeover discoverability surface:
 #   - nftban firewall takeover dispatcher (cmd_firewall.sh)

--- a/cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_firewall_trust_remerge_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-reload-trust"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Defect closed:  D-FIREWALL-RELOAD-DOES-NOT-REMERGE-TRUST-PROVIDERS
 # Scope file:     AUDIT_190_LIFECYCLE/V126_TRUST_WHITELIST_RELOAD_MERGE_SCOPE.md

--- a/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
@@ -19,6 +19,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_firewall_whitelist_session_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="whitelist-session"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing: stale real-IP grep patterns are privacy-scrub residue; the session test adds a synthetic documentation-range IP so the count and negative assertions fail"
+# meta:ta.activation_condition="re-enable after PR-E corrects the stale grep patterns to the synthetic fixture IP, then wire to ci-bash"
 # =============================================================================
 # Purpose: Cover the v1.120 whitelist-session CLI surface introduced in
 # cli/lib/nftban/cli/cmd_firewall.sh:

--- a/cli/lib/nftban/tests/cmd_login_stats_test.sh
+++ b/cli/lib/nftban/tests/cmd_login_stats_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_login_stats_test"
+# meta:ta.owner="loginmon"
+# meta:ta.module="loginmon"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Purpose: Cover the LoginMon source-state CLI surface introduced by the
 #          v1.116 Cand1 PR — daemon-first formatter that consumes the

--- a/cli/lib/nftban/tests/cmd_status_authority_test.sh
+++ b/cli/lib/nftban/tests/cmd_status_authority_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_status_authority_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status-authority"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Purpose: Cover the v1.118 B1 _status_section_authority + JSON authority
 #   surface. Authority + Conflicts are read from a sandbox install_state

--- a/cli/lib/nftban/tests/cmd_update_detection_v126_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_detection_v126_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_update_detection_v126_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-detection"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Defect closed:  D-DNS2-MIXED-HISTORY-AUTODETECT-FALSE-BLOCK
 # Scope file:     AUDIT_190_LIFECYCLE/V126_UPDATE_HISTORY_MIXED_INSTALL_DETECTOR_SCOPE.md

--- a/cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_update_detection_v135_clean_ownership_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-detection"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Defect closed:  D-UPDATE-MIXED-DRIFT (v1.135 Phase 2)
 # Scope file:     AUDIT_190_LIFECYCLE/V135_INSTALL_UPDATE_LIFECYCLE_SCOPE.md §2

--- a/cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh
+++ b/cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_update_lock_cleanup_v135_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-lock"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Defect closed:  D-UPDATE-LOCK-LEFT-BEHIND (v1.135 Phase 2)
 # Scope file:     AUDIT_190_LIFECYCLE/V135_INSTALL_UPDATE_LIFECYCLE_SCOPE.md §2

--- a/cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_whitelist_management_v218_10_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist-management"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. We extract the
 # v1.218.10 management functions (+ shared helpers) from cmd_whitelist.sh by name,

--- a/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
+++ b/cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh
@@ -19,6 +19,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="cmd_whitelist_static_v149_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist-static"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing: a stale real-IP grep pattern is privacy-scrub residue that the added synthetic documentation-range IP never matches, so the duplicate-count assertion fails"
+# meta:ta.activation_condition="re-enable after PR-E corrects the stale grep pattern to the synthetic fixture IP, then wire to ci-bash"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. We extract the
 # v1.149 --static functions (+ dispatcher) from cmd_whitelist.sh by name, patch

--- a/cli/lib/nftban/tests/comms_a1_centralization_test.sh
+++ b/cli/lib/nftban/tests/comms_a1_centralization_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a1_centralization_test"
+# meta:ta.owner="comms"
+# meta:ta.module="mail"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_a1b_emulate_test.sh
+++ b/cli/lib/nftban/tests/comms_a1b_emulate_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a1b_emulate_test"
+# meta:ta.owner="comms"
+# meta:ta.module="mail-emulate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh
+++ b/cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a2a_delivery_truth_test"
+# meta:ta.owner="comms"
+# meta:ta.module="mail"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
+++ b/cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a2b_operator_surfacing_test"
+# meta:ta.owner="comms"
+# meta:ta.module="health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
+++ b/cli/lib/nftban/tests/comms_a2c_support_summary_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a2c_support_summary_test"
+# meta:ta.owner="comms"
+# meta:ta.module="support"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh
+++ b/cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_a2r_rbl_visibility_test"
+# meta:ta.owner="comms"
+# meta:ta.module="rbl-alert-routing"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
+++ b/cli/lib/nftban/tests/comms_health_render_v2181_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_health_render_v2181_test"
+# meta:ta.owner="comms"
+# meta:ta.module="communication-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
+++ b/cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_new_user_remediation_ux_test"
+# meta:ta.owner="comms"
+# meta:ta.module="remediation-ux"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh
+++ b/cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_no_direct_send_guard_a0_test"
+# meta:ta.owner="comms"
+# meta:ta.module="ci-guard"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh
+++ b/cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_producer_signal_accuracy_test"
+# meta:ta.owner="comms"
+# meta:ta.module="health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh
+++ b/cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_rbl_tunnel_producer_recipient_test"
+# meta:ta.owner="comms"
+# meta:ta.module="health-communication-component"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_redact_debug_p_retire1_test"
+# meta:ta.owner="security"
+# meta:ta.module="redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_redact_failloud_p_retire2_test"
+# meta:ta.owner="security"
+# meta:ta.module="redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_redact_p2a_noleak_test"
+# meta:ta.owner="security"
+# meta:ta.module="redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/comms_redact_p2b1_test.sh
+++ b/cli/lib/nftban/tests/comms_redact_p2b1_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="comms_redact_p2b1_test"
+# meta:ta.owner="security"
+# meta:ta.module="redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/community_trial_v3_test.sh
+++ b/cli/lib/nftban/tests/community_trial_v3_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="community_trial_v3_test"
+# meta:ta.owner="comms"
+# meta:ta.module="community-trial"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/config_local_impl2_test.sh
+++ b/cli/lib/nftban/tests/config_local_impl2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="config_local_impl2_test"
+# meta:ta.owner="core"
+# meta:ta.module="config-local"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
+++ b/cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="config_local_source_helper_impl1_test"
+# meta:ta.owner="core"
+# meta:ta.module="config-local-source"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/error_text_3line_v153_test.sh
+++ b/cli/lib/nftban/tests/error_text_3line_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="error_text_3line_v153_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-ux"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh
+++ b/cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="exporter_exit2_phase2_scale_guard_v1361_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter-exit2"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Lane:    V1_136_EXPORTER_EXIT2_PHASE2_SCOPE.md  (vehicle v1.136.1)
 # Pinned:  V136_MONITOR_DEPLOY_AND_EXPORTER_BREADCRUMB_WATCH.md (run #73565)

--- a/cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh
+++ b/cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="exporter_exit2_resilience_v136_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter-exit2"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Lane:       V1_136_EXPORTER_EXIT2_RESILIENCE_SCOPE.md (Phase 1)
 # Origin:     EXPORTER_EXIT2_TRIAGE_READONLY_REPORT.md + EXPORTER_EXIT2_MUTATING_REPRO_REPORT.md

--- a/cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh
+++ b/cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="exporter_no_duplicate_goroutines_emit_v217_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter-goroutines"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh
+++ b/cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="exporter_sigterm_graceful_v151_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter-err-trap"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
+++ b/cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="feed_counters_unify_v167_test"
+# meta:ta.owner="feeds"
+# meta:ta.module="feeds"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/feeds_select_strict_e2e_v152_test.sh
+++ b/cli/lib/nftban/tests/feeds_select_strict_e2e_v152_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="feeds_select_strict_e2e_v152_test"
+# meta:ta.owner="feeds"
+# meta:ta.module="feeds"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/fetch_verified_v157_test.sh
+++ b/cli/lib/nftban/tests/fetch_verified_v157_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fetch_verified_v157_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="build-fetch"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/fhs_lane_v175_test.sh
+++ b/cli/lib/nftban/tests/fhs_lane_v175_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-firewall-validate.service,nftban-alert@.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fhs_lane_v175_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="fhs"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/firewall_transition_health_cli_v1921_test.sh
+++ b/cli/lib/nftban/tests/firewall_transition_health_cli_v1921_test.sh
@@ -15,6 +15,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="firewall_transition_health_cli_v1921_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-transition-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # NOTE: the health checks file enables set -e on source, and the engine always
 # calls checks guarded by `|| { ((errors++)); }`. We `set +e` after sourcing and

--- a/cli/lib/nftban/tests/firewall_transition_health_v1921_test.sh
+++ b/cli/lib/nftban/tests/firewall_transition_health_v1921_test.sh
@@ -15,6 +15,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="firewall_transition_health_v1921_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-transition-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # shellcheck disable=SC2034  # FTH_* fixtures (set_healthy etc.) are consumed by
 # the sourced helper via direct/indirect (${!var}) expansion — ShellCheck can't

--- a/cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
+++ b/cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fsync_residual_guard_v176_test"
+# meta:ta.owner="cross-cutting"
+# meta:ta.module="durability-fsync"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
+++ b/cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fw_l2cd_transition_counter_botguard_chain_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-transition-counter"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh
+++ b/cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fw_rebuild_preserve_timed_bans_l2a_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-rebuild"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh
+++ b/cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="fw_transition_health_truth_v1982_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-transition-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
+++ b/cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-geoban-refresh.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="geoban_refresh_execcondition_v159_test"
+# meta:ta.owner="geoban"
+# meta:ta.module="geoban"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
+++ b/cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-health.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="health_journalctl_bounded_v174_test"
+# meta:ta.owner="health"
+# meta:ta.module="health-journalctl-bound"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/health_timers_truth_v150_test.sh
+++ b/cli/lib/nftban/tests/health_timers_truth_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="health_timers_truth_v150_test"
+# meta:ta.owner="health"
+# meta:ta.module="health-timers"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. We extract the
 # target functions from the source files by name, stub `systemctl` as a bash

--- a/cli/lib/nftban/tests/help_verb_icons_v153_test.sh
+++ b/cli/lib/nftban/tests/help_verb_icons_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="help_verb_icons_v153_test"
+# meta:ta.owner="cli"
+# meta:ta.module="help-render"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh
+++ b/cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="hostname_fallback_v1_139_1_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="exporter"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/http_log_discovery_v177_test.sh
+++ b/cli/lib/nftban/tests/http_log_discovery_v177_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="http_log_discovery_v177_test"
+# meta:ta.owner="botscan"
+# meta:ta.module="http-logs"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
+++ b/cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="immutable_health_verify_v163_test"
+# meta:ta.owner="health"
+# meta:ta.module="immutable-flags-health"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/install_update_observability_v215_test.sh
+++ b/cli/lib/nftban/tests/install_update_observability_v215_test.sh
@@ -21,6 +21,17 @@
 # meta:inventory.privileges="none"
 # meta:created_date="2026-07-03"
 # meta:updated_date="2026-07-03"
+# meta:ta.id="install_update_observability_v215_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-observability"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/installer_wording_v153_test.sh
+++ b/cli/lib/nftban/tests/installer_wording_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="installer_wording_v153_test"
+# meta:ta.owner="installer"
+# meta:ta.module="installer"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh
+++ b/cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="l2e_replace_set_reachability_guard_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="set-apply-replace"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh
+++ b/cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="l3a_never_ban_add_element_guard_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="never-ban-guard"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
+++ b/cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="lifecycle_forensics_v1199_test"
+# meta:ta.owner="update"
+# meta:ta.module="lifecycle-forensics"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh
+++ b/cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="list_ipv6_clamp_v153_test"
+# meta:ta.owner="cli"
+# meta:ta.module="list"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/logretention_packaging_derivedstate_gateb_test.sh
+++ b/cli/lib/nftban/tests/logretention_packaging_derivedstate_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none (reads repo files)"
+# meta:ta.id="logretention_packaging_derivedstate_gateb_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="logretention"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="package-build"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 PASS=0; FAIL=0

--- a/cli/lib/nftban/tests/logretention_terminology_guard_gateb_test.sh
+++ b/cli/lib/nftban/tests/logretention_terminology_guard_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none (reads repo files)"
+# meta:ta.id="logretention_terminology_guard_gateb_test"
+# meta:ta.owner="core"
+# meta:ta.module="logretention"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/logretention_wiring_gateb_test.sh
+++ b/cli/lib/nftban/tests/logretention_wiring_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-maintenance.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="logretention_wiring_gateb_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="logretention"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/logrotate_behavioral_gateb_test.sh
+++ b/cli/lib/nftban/tests/logrotate_behavioral_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none (writes only under a temp dir)"
+# meta:ta.id="logrotate_behavioral_gateb_test"
+# meta:ta.owner="health"
+# meta:ta.module="logrotate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 PASS=0; FAIL=0

--- a/cli/lib/nftban/tests/logrotate_config_v137_test.sh
+++ b/cli/lib/nftban/tests/logrotate_config_v137_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="logrotate_config_v137_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="logrotate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Lane:    NFTBAN_ROADMAP/V1_137_LOG_DURABILITY_SCOPE.md (PR-A)
 # Gate:    OPEN_V1_137_PR_A_LOGROTATE_CONFIG_AND_PACKAGING

--- a/cli/lib/nftban/tests/logs_truth_v150_test.sh
+++ b/cli/lib/nftban/tests/logs_truth_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="logs_truth_v150_test"
+# meta:ta.owner="health"
+# meta:ta.module="log-truth"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. We read the
 # packaged logrotate template, the JSON registry and the shell sources from the

--- a/cli/lib/nftban/tests/mac_posture_v158_test.sh
+++ b/cli/lib/nftban/tests/mac_posture_v158_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="mac_posture_v158_test"
+# meta:ta.owner="security"
+# meta:ta.module="mac-posture"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
+++ b/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
@@ -17,6 +17,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="maint_table_absent_noise_v1930_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="maintenance-table-probe"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
+++ b/cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nft_counting_model_guard_v190_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="nft-counting-model"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
+++ b/cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh
@@ -21,6 +21,17 @@
 # meta:inventory.privileges="none"
 # meta:created_date="2026-07-05"
 # meta:updated_date="2026-07-05"
+# meta:ta.id="nft_loopback_before_invalid_v217_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="nft-schema-rule-order"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/nft_writer_authority_v150_test.sh
+++ b/cli/lib/nftban/tests/nft_writer_authority_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nft_writer_authority_v150_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="nft-writer-authority"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained; no host contact; no root; no nft/IPC. Static source reads +
 # a copied-logic harness with a drift-guard so the real code can't diverge

--- a/cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh
+++ b/cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_config_rhg_cosmetic_r1a6_test"
+# meta:ta.owner="core"
+# meta:ta.module="config-cosmetic-hygiene"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh
+++ b/cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_da_help_ssh_port_r1a2_test"
+# meta:ta.owner="installer"
+# meta:ta.module="directadmin-panel"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_file_cleanup_r1a5_test.sh
+++ b/cli/lib/nftban/tests/nftban_file_cleanup_r1a5_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_file_cleanup_r1a5_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="shipped-config-hygiene"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh
+++ b/cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_geoip_help_path_r1a1_test"
+# meta:ta.owner="geoip"
+# meta:ta.module="geoip"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
+++ b/cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_operator_readiness_r1b2_test"
+# meta:ta.owner="health"
+# meta:ta.module="operator-readiness"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_rbl_json_escaping_r1a3_test.sh
+++ b/cli/lib/nftban/tests/nftban_rbl_json_escaping_r1a3_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_rbl_json_escaping_r1a3_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-json-escaping"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh
+++ b/cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_render_findings_r1b1_test"
+# meta:ta.owner="health"
+# meta:ta.module="health-findings-render"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh
+++ b/cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="nftban_update_progress_r1b3_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-progress"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh
+++ b/cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="no_reintroduced_orphan_modules_v167_test"
+# meta:ta.owner="architecture"
+# meta:ta.module="orphan-modules"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/panel_group_retirement_v137_test.sh
+++ b/cli/lib/nftban/tests/panel_group_retirement_v137_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="panel_group_retirement_v137_test"
+# meta:ta.owner="security"
+# meta:ta.module="panel-group-retirement"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Lane:    v1.137 PR — nftban-panel authorization GROUP retirement
 # Gate:    OPEN_V1_137_BLOCKER_PANEL_GROUP_RETIREMENT

--- a/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
+++ b/cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="portscan_generic_corroborate_v149_test"
+# meta:ta.owner="portscan"
+# meta:ta.module="portscan-classic"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root. Extracts the classify +
 # corroboration + handler functions from nftban_portscan_classic.sh by name,

--- a/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
+++ b/cli/lib/nftban/tests/portscan_trusted_flow_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="portscan_trusted_flow_test"
+# meta:ta.owner="portscan"
+# meta:ta.module="portscan-trusted-flow"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 set +eE

--- a/cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh
+++ b/cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh
@@ -17,6 +17,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="protection_claim_matrix_v194_test"
+# meta:ta.owner="cross-cutting"
+# meta:ta.module="protection-claim-matrix"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/rbl_cli_correctness_v220_3_test.sh
+++ b/cli/lib/nftban/tests/rbl_cli_correctness_v220_3_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_cli_correctness_v220_3_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-cli-correctness"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_enable_readiness_test.sh
+++ b/cli/lib/nftban/tests/rbl_enable_readiness_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_enable_readiness_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-enable-readiness"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_false_clean_v150_test.sh
+++ b/cli/lib/nftban/tests/rbl_false_clean_v150_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_false_clean_v150_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-resolver-false-clean"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. We source the real
 # nftban_rbl.sh core module into subshells, then override resolver-related

--- a/cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh
+++ b/cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh
@@ -20,6 +20,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_hostname_admission_v220_1_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-hostname-admission"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing collateral of OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the doc-range self-IP fixture classifies as non-public and a stale real-IP grep residue never matches"
+# meta:ta.activation_condition="re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs and removes the stale residue, then wire to ci-bash"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_nonpublic_admission_v220_1_test.sh
+++ b/cli/lib/nftban/tests/rbl_nonpublic_admission_v220_1_test.sh
@@ -19,6 +19,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_nonpublic_admission_v220_1_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-nonpublic-admission"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing collateral of OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the PUBLIC4/PUBLIC6 controls are documentation-range so nftban_hostaddr_is_public rejects them and the public-admit cases fail (the public-DNS control cases still pass)"
+# meta:ta.activation_condition="re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs, then wire to ci-bash"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh
+++ b/cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_prereq_ifs_dns_utils_v219_1_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-enable-prereq"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_provider_registry_slice1_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-provider-registry"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_provider_registry_slice2_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-provider-registry"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_provider_registry_slice3a_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-provider-registry"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_provider_registry_slice3c_test.sh
+++ b/cli/lib/nftban/tests/rbl_provider_registry_slice3c_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_provider_registry_slice3c_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-provider-registry"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
+++ b/cli/lib/nftban/tests/rbl_seven_state_v206_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_seven_state_v206_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-result-states"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # This harness shadows resolver/provider leaf functions (nftban_rbl_resolver,
 # dig, timeout, nftban_rbl_dns_lookup, nftban_rbl_load_providers, …) which are

--- a/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
+++ b/cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh
@@ -19,6 +19,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rbl_shared_address_authority_v220_0_test"
+# meta:ta.owner="rbl"
+# meta:ta.module="rbl-shared-address-authority"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing fixture OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the privacy scrub (3752f68a) replaced real self-IPs with documentation-range placeholders that classify as non-public, so the shared-address/public-admit assertions cannot hold, and a stale real-IP grep residue never matches"
+# meta:ta.activation_condition="re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs and removes the stale grep residue, then wire to ci-bash"
 # =============================================================================
 
 # Coding-standard header requires this line; the harness itself runs lenient (set +eE

--- a/cli/lib/nftban/tests/read_ra_ifs_v156_test.sh
+++ b/cli/lib/nftban/tests/read_ra_ifs_v156_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="read_ra_ifs_v156_test"
+# meta:ta.owner="portscan"
+# meta:ta.module="portscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh
+++ b/cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh
@@ -15,6 +15,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network="loopback test listener"
 # meta:inventory.privileges="root"
+# meta:ta.id="rebuild_no_syn_drop_v192_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-rebuild"
+# meta:ta.execution_class="ROOT_LAB"
+# meta:ta.gate="lab-manual"
+# meta:ta.hermetic="false"
+# meta:ta.requires_root="true"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="true"
+# meta:ta.requires_package="false"
 # =============================================================================
 # F-RB / D-NFTBAN-REBUILD-FLUSH-WINDOW runtime regression.
 #

--- a/cli/lib/nftban/tests/recovery_legacy_reconcile_v12012_test.sh
+++ b/cli/lib/nftban/tests/recovery_legacy_reconcile_v12012_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="recovery_legacy_reconcile_v12012_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="recovery"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh
+++ b/cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rollback_help_guard_v1_139_2_test"
+# meta:ta.owner="update"
+# meta:ta.module="rollback"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
+++ b/cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rpm_files_no_double_dir_listing_v165_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="rpm-files"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
+++ b/cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rpm_files_templates_dedup_v166_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="rpm-files"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
+++ b/cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rpm_spec_no_section_macro_in_comment_v165_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="rpm-spec"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/rpm_spec_single_install_v157_test.sh
+++ b/cli/lib/nftban/tests/rpm_spec_single_install_v157_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="rpm_spec_single_install_v157_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="rpm-spec"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="package-build"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh
+++ b/cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="ruleset_fingerprint_v138_test"
+# meta:ta.owner="security"
+# meta:ta.module="rulefp"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/service_alerts_v138_test.sh
+++ b/cli/lib/nftban/tests/service_alerts_v138_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="service_alerts_v138_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-conflicts"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
+++ b/cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="session_whitelist_flock_v173_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="session-whitelist"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh
+++ b/cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh
@@ -18,6 +18,19 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="set_apply_single_writer_v213_grep_guard_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="set-apply-single-writer"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="deferred"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:ta.exclusion_reason="known-failing: a stale point-in-time assertion pins an old VERSION value while the repo has advanced; its behavioral companion set_apply_single_writer_v213_test is healthy"
+# meta:ta.activation_condition="re-enable after the stale VERSION pin is dropped or refreshed, then wire to ci-bash"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh
+++ b/cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh
@@ -18,6 +18,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="set_apply_single_writer_v213_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="set-apply-single-writer"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained; no host contact; no root; no live nft/IPC. Sources the REAL
 # nft_ipc.sh single-writer helpers (nft_ipc_sync / nft_ipc_sync_or_apply) and

--- a/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
+++ b/cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="ssh_admin_port_guard_v150_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-admin-port-guard"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
+++ b/cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="ssh_port_change_lifecycle_v155_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-port-lifecycle-validate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
+++ b/cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="ssh.socket,sshd.socket"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="ssh_socket_port_mismatch_v155_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-admin-port-guard"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
+++ b/cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="state_write_atomicity_v171_test"
+# meta:ta.owner="core"
+# meta:ta.module="state-write-atomicity"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
+++ b/cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_count_reconcile_v206_2_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/stats_ip_history_v170_test.sh
+++ b/cli/lib/nftban/tests/stats_ip_history_v170_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_ip_history_v170_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/stats_json_top_sources_v150_test.sh
+++ b/cli/lib/nftban/tests/stats_json_top_sources_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_json_top_sources_v150_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/stats_manual_cache_v150_test.sh
+++ b/cli/lib/nftban/tests/stats_manual_cache_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_manual_cache_v150_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
+++ b/cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_manual_provenance_v206_1_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/stats_producer_reconcile_v152_test.sh
+++ b/cli/lib/nftban/tests/stats_producer_reconcile_v152_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_producer_reconcile_v152_test"
+# meta:ta.owner="metrics"
+# meta:ta.module="stats"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/stats_status_truth_v150_test.sh
+++ b/cli/lib/nftban/tests/stats_status_truth_v150_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="stats_status_truth_v150_test"
+# meta:ta.owner="cli"
+# meta:ta.module="stats-status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Self-contained sandbox; no host contact; no root required. Functions are
 # extracted from the real sources by name and run in stubbed subshells, so the

--- a/cli/lib/nftban/tests/status_consistency_v153_test.sh
+++ b/cli/lib/nftban/tests/status_consistency_v153_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="status_consistency_v153_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/status_rc_contract_v152_test.sh
+++ b/cli/lib/nftban/tests/status_rc_contract_v152_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="status_rc_contract_v152_test"
+# meta:ta.owner="cli"
+# meta:ta.module="status"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/support_bundle_redaction_test.sh
+++ b/cli/lib/nftban/tests/support_bundle_redaction_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="support_bundle_redaction_test"
+# meta:ta.owner="security"
+# meta:ta.module="redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh
+++ b/cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none (writes only under a temp dir)"
+# meta:ta.id="suricata_usr2_guard_gateb_test"
+# meta:ta.owner="suricata"
+# meta:ta.module="suricata-logrotate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 PASS=0; FAIL=0

--- a/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
+++ b/cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh
@@ -21,6 +21,17 @@
 # meta:inventory.privileges="none"
 # meta:created_date="2026-07-04"
 # meta:updated_date="2026-07-04"
+# meta:ta.id="sysctl_risk_idle_age_v2161_test"
+# meta:ta.owner="health"
+# meta:ta.module="sysctl"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
+++ b/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
@@ -21,6 +21,17 @@
 # meta:inventory.privileges="none"
 # meta:created_date="2026-07-03"
 # meta:updated_date="2026-07-03"
+# meta:ta.id="sysctl_safe_default_v216_test"
+# meta:ta.owner="health"
+# meta:ta.module="sysctl"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
+++ b/cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="tmpfiles_zz_v139_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="fhs"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="package-build"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh
+++ b/cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh
@@ -20,6 +20,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="trust_load_missing_whitelist_test"
+# meta:ta.owner="trust"
+# meta:ta.module="trust-load"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # Defect closed:  D-NFTBAN-TRUST-LOAD-SILENT-NOOP-WHEN-PROVIDER-ENABLED-VIA-LOCAL-OVERRIDE
 # Scope file:     AUDIT_190_LIFECYCLE/V126_1_LANE_C_HOTFIX_SCOPE.md (§4.6)

--- a/cli/lib/nftban/tests/update_force_delegation_v1223_test.sh
+++ b/cli/lib/nftban/tests/update_force_delegation_v1223_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="update_force_delegation_v1223_test"
+# meta:ta.owner="update"
+# meta:ta.module="update-force"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
+++ b/cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="update_msg_recovered_v174_test"
+# meta:ta.owner="update"
+# meta:ta.module="update"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/update_run_human_log_gatea_test.sh
+++ b/cli/lib/nftban/tests/update_run_human_log_gatea_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="update_run_human_log_gatea_test"
+# meta:ta.owner="update"
+# meta:ta.module="lifecycle-log-forensics"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh
+++ b/cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh
@@ -21,6 +21,17 @@
 # meta:inventory.privileges="none"
 # meta:created_date="2026-07-04"
 # meta:updated_date="2026-07-04"
+# meta:ta.id="update_warning_taxonomy_v2164_test"
+# meta:ta.owner="update"
+# meta:ta.module="warning-taxonomy"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/v127_ux1_p0_test.sh
+++ b/cli/lib/nftban/tests/v127_ux1_p0_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux1_p0_test"
+# meta:ta.owner="cli"
+# meta:ta.module="ux-lifecycle"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-1 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
+++ b/cli/lib/nftban/tests/v127_ux2_well_known_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux2_well_known_test"
+# meta:ta.owner="cli"
+# meta:ta.module="well-known-guard"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-2 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh
+++ b/cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux3_stats_banlog_test"
+# meta:ta.owner="cli"
+# meta:ta.module="stats-banlog"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-3 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v127_ux4_suricata_desurfacing_test.sh
+++ b/cli/lib/nftban/tests/v127_ux4_suricata_desurfacing_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux4_suricata_desurfacing_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-help-surface"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-4 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh
+++ b/cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux5_typo_discoverability_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-typo-suggestion"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-5 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
+++ b/cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v127_ux6_help_cleanup_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-help-surface"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V127_FULL_UX_CORRECTION_UMBRELLA_SCOPE.md (UX-6 lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh
+++ b/cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v128_doc_clarity_audit_test"
+# meta:ta.owner="cross-cutting"
+# meta:ta.module="docs"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md (PR-D lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v128_help_code_correlation_test.sh
+++ b/cli/lib/nftban/tests/v128_help_code_correlation_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v128_help_code_correlation_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-command-correlation"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md (PR-B lane)
 # =============================================================================

--- a/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
+++ b/cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v128_polkit_aware_wording_sweep_test"
+# meta:ta.owner="security"
+# meta:ta.module="polkit-wording"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V128_CLI_TEXT_AUTHORITY_ALIGNMENT_SCOPE.md (PR-A lane)
 # Architecture: memory/reference_nftban_group_and_polkit_architecture.md

--- a/cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh
+++ b/cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v129_pr_c_runtime_defect_fixes_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V129_PR_B_LAB2_EXECUTION_REPORT.md
 #        + AUDIT_190_LIFECYCLE/V129_PR_B_RPM_EXECUTION_REPORT.md

--- a/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
+++ b/cli/lib/nftban/tests/v130_polkit_validate_service_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v130_polkit_validate_service_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="polkit-validate-service"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DESIGN_ANALYSIS.md (Option C)
 #        + AUDIT_190_LIFECYCLE/V130_D6A_POLKIT_DECISION.md

--- a/cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh
+++ b/cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V134 PR-D doctest guard (Lane 2). Per command family, asserts the HIGH-VALUE invariant: every token the primary dispatch case accepts is either (a) documented in the command's help text, (b) declared in the intentional-alias allowlist (v134_help_code_alias_allowlist.tsv), or (c) a structural token (* / -h / --help / help / empty). This catches help<->code drift (a NEW undocumented subcommand) while letting genuine aliases/internal/universal-flag/deprecated tokens through via the allowlist. Deliberately single-direction + conservative: a family whose primary dispatch case OR help text cannot be confidently parsed is SKIPPED (reported, not failed) rather than producing the prose-extraction false positives that sank the v1.128 PR-B prototype. The reverse direction (advertised-but-unreachable) and exhaustive flag-level coverage are future hardening. Static scan; no host, no runtime, no privileges."
+# meta:ta.id="v130_subcommand_flag_help_code_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-help-code-doctest"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh
+++ b/cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v131_1_d13_option_c_output_capture_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-validate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: gate OPEN_V1_131_1_D13_OPTION_C_OUTPUT_CAPTURE_FIX (D13 only).
 # =============================================================================

--- a/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
+++ b/cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v131_2_d13_sandbox_write_repair_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-validate"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: gate OPEN_V1_131_2_D13_SANDBOX_WRITE_REPAIR (D13 only).
 # =============================================================================

--- a/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
+++ b/cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v131_3_d13_setgid_group_ownership_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="setgid-handoff-dir"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: gate OPEN_V1_131_3_D13_SETGID_GROUP_OWNERSHIP_FIX (D13 only).
 # =============================================================================

--- a/cli/lib/nftban/tests/v131_pr_a_2_double_zero_sweep_test.sh
+++ b/cli/lib/nftban/tests/v131_pr_a_2_double_zero_sweep_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V131 PR-A.2 regression guard. The bug class fixed in PR-A (CB-1/CB-3) is `VAR=$(... grep -c ... || echo \"0\")`: grep -c prints \"0\" AND exits 1 on no-match, so `|| echo \"0\"` appends a SECOND \"0\", producing \"0\\n0\" which breaks `$((... + VAR))` arithmetic and `printf %d`. PR-A.2 swept the remaining ~41 sites across 23 files, replacing `|| echo \"0\"` with `|| true` (grep -c's own \"0\" is preserved; errexit suppressed; no concat). This test asserts (a) ZERO `grep -c ... || echo \"0\"` sites remain in executable (non-comment) shell code under cli/lib/nftban/, and (b) every shell file under cli/lib/nftban/ still parses with `bash -n`. Comment lines are excluded from (a) because they legitimately DOCUMENT the old pattern."
+# meta:ta.id="v131_pr_a_2_double_zero_sweep_test"
+# meta:ta.owner="cross-cutting"
+# meta:ta.module="shell-hygiene"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -uo pipefail
 

--- a/cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh
+++ b/cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v131_pr_a_long_tail_code_bug_fix_test"
+# meta:ta.owner="cross-cutting"
+# meta:ta.module="code-bug-fix"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 #
 # Scope: AUDIT_190_LIFECYCLE/V130_PR_C_LONG_TAIL_BATTERY_REPORT_DEB.md §3
 # =============================================================================

--- a/cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh
+++ b/cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V132 PR-C behavior-truth regression guard. Static assertions that the displayed CLI text matches actual code behavior after the PR-C truth-alignment fixes: C1 (version --json emits no raw sentinel line), C2 (flush no longer advertises an unimplemented --json), C3 (flush returns rc=2 for invalid target/option and help no longer documents a non-existent rc=3 polkit branch), C5 (stale fail2ban-era 'jails' top-type replaced by 'filters' backed by the real nftban_stats_top_sources; no dead top_jails key; no bogus 'nftban migrate fail2ban' command; no 'Protected with fail2ban' claim), C7 (firewall validate --strict help documents the reachable exit codes 1 and 40), C8 (validate shim returns 3 — not 2 — for a missing/unreachable validator so rc=2 means DOWN only). Pure static + bash -n; no host contact, no build, no privileges."
+# meta:ta.id="v132_pr_c_behavior_truth_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh
+++ b/cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V133 PR-B regression guard for A12–A15: operator-facing privileged-write/read paths must emit the canonical polkit-aware refusal instead of leaking a raw OS error. A15 (get_live_ruleset) is deterministic — a stubbed failing nft printing 'Operation not permitted (you must be root)' must be reframed to a polkit/CAP_NET_ADMIN-aware JSON error with NO 'you must be root' substring. A12 (nftban_pro), A13 (cmd_snapshot), A14 (nftban_report_module) get static structural assertions (EUID guard + '! -w' + canonical message present) always, plus a non-root behavioral refusal (rc=1 + polkit stderr + no raw 'Permission denied') that SKIPs under root (CI runners are root; real non-root proof is lab/local)."
+# meta:ta.id="v133_pr_b_write_guard_refusal_test"
+# meta:ta.owner="security"
+# meta:ta.module="polkit-write-refusal"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh
+++ b/cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V133 PR-D P2 targeted help/code-drift guard. Asserts the previously-undocumented dispatched subcommands are now documented in their command's help (D-05 status pending/queue; D-06 rbl config/stats/test; D-07 feeds config/stats/test; D-08 botscan stats/config + error fallback; D-09 geoban stats/test; D-10 login config/install; D-11 module duplicates) and that the stale references are gone tree-wide (D-01 'nftban gui', D-03 'emulate --out', D-04 'nftban profile select' — the latter allowed only in cmd_profile.sh which documents it as deprecated). NOT the comprehensive doctest guard or P3 alias allowlist (those are v1.134). D-02 was resolved in v1.132.0 PR-C and is not re-checked here."
+# meta:ta.id="v133_pr_d_p2_help_code_drift_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-help-code-drift"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh
+++ b/cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh
@@ -16,6 +16,17 @@
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
 # meta:description="V134 PR-D P3 Lane 1 guard. (1) D-26: health 'rbl'/'fhs' are documented in cmd_health.sh help. (2) D-28: cmd_metrics.sh error-usage string now includes evidence/evidence-json. (3) The intentional-alias allowlist manifest (v134_help_code_alias_allowlist.tsv) is well-formed (4 tab fields, valid class) and every allowlisted (cmd_file, token) pair is actually PRESENT in that command file — so the allowlist (basis for the Lane-2 doctest guard) can never silently allowlist a phantom/removed token. The rigorous per-family help<->dispatch correlation is Lane 2's doctest guard; this guard locks the allowlist basis + the two Lane-1 code fixes."
+# meta:ta.id="v134_pr_d_p3_alias_allowlist_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-alias-allowlist"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh
@@ -14,6 +14,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v145_pr_b_runtime_static_guard_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-port-detect"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
@@ -14,6 +14,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v145_pr_c2_apply_hardening_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-port-apply"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
@@ -14,6 +14,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v145_pr_g_ssh_ports_invariants_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-ports-set-invariants"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v145_ssh_port_detect_test.sh
+++ b/cli/lib/nftban/tests/v145_ssh_port_detect_test.sh
@@ -14,6 +14,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v145_ssh_port_detect_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="ssh-port-detect"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh
+++ b/cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v145_ssh_port_template_set_driven_static_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="nftables-ssh-templates"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/v1921_effective_port_render_failclosed_test.sh
+++ b/cli/lib/nftban/tests/v1921_effective_port_render_failclosed_test.sh
@@ -15,6 +15,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="v1921_effective_port_render_failclosed_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall-service-port-render"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 # D-V192-RESIDUAL-REBUILD-DROP inc3 (fail-closed) + inc7 (declarative):
 #   A failed effective-port render must NOT produce a successful rebuild with

--- a/cli/lib/nftban/tests/version_build_date_v151_test.sh
+++ b/cli/lib/nftban/tests/version_build_date_v151_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="version_build_date_v151_test"
+# meta:ta.owner="release"
+# meta:ta.module="version-build-date"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/version_release_date_authority_test.sh
+++ b/cli/lib/nftban/tests/version_release_date_authority_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="version_release_date_authority_test"
+# meta:ta.owner="release"
+# meta:ta.module="version"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
+++ b/cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units="nftban-watchdog.timer,nftban-maintenance.timer,nftban-watchdog.service"
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="watchdog_update_swap_race_v1983_test"
+# meta:ta.owner="update"
+# meta:ta.module="watchdog-update-swap"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
+++ b/cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="whitelist_list_timed_label_v169_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh
+++ b/cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh
@@ -17,6 +17,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="whitelist_rebuild_remerge_v1930_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="whitelist-rebuild-remerge"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 

--- a/cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
+++ b/cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="whitelist_set_timeout_flag_v168_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist-set-timeout-flag"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
+++ b/cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="whitelist_timeout_upgrade_activation_v168_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="whitelist-timeout-upgrade-activation"
+# meta:ta.execution_class="PACKAGE_BUILD"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/cli/lib/nftban/tests/whitelist_verify_v163_test.sh
+++ b/cli/lib/nftban/tests/whitelist_verify_v163_test.sh
@@ -19,6 +19,17 @@
 # meta:inventory.systemd_units=""
 # meta:inventory.network=""
 # meta:inventory.privileges="none"
+# meta:ta.id="whitelist_verify_v163_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist-verify"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
 IFS=$'\n\t'

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -1,245 +1,245 @@
 # GENERATED FILE — DO NOT EDIT
 # Source authority: meta:ta.* headers in tracked shell test files (cli/lib/nftban/tests/*_test.sh)
 # Regenerate: scripts/ci/test-authority.py generate   |   Verify: scripts/ci/test-authority.py check
-id	path	owner	type	module	execution_class	gate	hermetic	requires_root	requires_network	requires_systemd	requires_nftables	requires_package	timeout	exclusion_reason
-alert_bookkeeping_nonfatal_v174_test	cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh		test			unassigned								
-alert_logger_devlog_sandbox_v1981_test	cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh		test			unassigned								
-audit_rotate_retired_gateb_test	cli/lib/nftban/tests/audit_rotate_retired_gateb_test.sh		test			unassigned								
-b1_text_ux_v1872_test	cli/lib/nftban/tests/b1_text_ux_v1872_test.sh		test			unassigned								
-b1b_banner_compact_v1873_test	cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh		test			unassigned								
-b2_badbot_aibot_v188_test	cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh		test			unassigned								
-banner_nobanner_v153_test	cli/lib/nftban/tests/banner_nobanner_v153_test.sh		test			unassigned								
-blacklist_flush_manual_truth_v218_10_test	cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh		test			unassigned								
-blacklist_refresh_no_failopen_v192_test	cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh		test			unassigned								
-botguard_diag_6b2_test	cli/lib/nftban/tests/botguard_diag_6b2_test.sh		test			unassigned								
-botguard_explain_shell_6b1_test	cli/lib/nftban/tests/botguard_explain_shell_6b1_test.sh		test			unassigned								
-botscan_404_tail_bound_v1871_test	cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh		test			unassigned								
-botscan_adaptive_v207_test	cli/lib/nftban/tests/botscan_adaptive_v207_test.sh		test			unassigned								
-botscan_admin_ip_exemption_test	cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh		test			unassigned								
-botscan_collector_gather_stream_v2092_test	cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh					unassigned								
-botscan_daemon_truth_v219_0_test	cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh		test			unassigned								
-botscan_deadline_rotation_v185_test	cli/lib/nftban/tests/botscan_deadline_rotation_v185_test.sh		test			unassigned								
-botscan_direct_ban_flag_v1903_test	cli/lib/nftban/tests/botscan_direct_ban_flag_v1903_test.sh		test			unassigned								
-botscan_endpoint_flood_test	cli/lib/nftban/tests/botscan_endpoint_flood_test.sh		test			unassigned								
-botscan_exp_rfi_fp_v218_13_test	cli/lib/nftban/tests/botscan_exp_rfi_fp_v218_13_test.sh		test			unassigned								
-botscan_fcrdns_v189_test	cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh		test			unassigned								
-botscan_logsource_validity_r22a_test	cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh		test			unassigned								
-botscan_nofork_parity_v1871_test	cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh		test			unassigned								
-botscan_operator_truth_contract_v219_0_test	cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh		test			unassigned								
-botscan_operator_truth_v218_11_test	cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh		test			unassigned								
-botscan_pattern_ban_ifs_v1861_test	cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh		test			unassigned								
-botscan_pattern_delimiter_v214_test	cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh		test			unassigned								
-botscan_read_authority_v178_test	cli/lib/nftban/tests/botscan_read_authority_v178_test.sh		test			unassigned								
-botscan_request_class_classifier_v1913_test	cli/lib/nftban/tests/botscan_request_class_classifier_v1913_test.sh		test			unassigned								
-botscan_revslider_fp_v218_10_test	cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh		test			unassigned								
-botscan_signal_flock_v212_test	cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh		test			unassigned								
-botscan_spool_oom_v2093_test	cli/lib/nftban/tests/botscan_spool_oom_v2093_test.sh		test			unassigned								
-botscan_status_label_v218_12_test	cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh		test			unassigned								
-botscan_throughput_v187_test	cli/lib/nftban/tests/botscan_throughput_v187_test.sh		test			unassigned								
-botscan_trend_v208_test	cli/lib/nftban/tests/botscan_trend_v208_test.sh		test			unassigned								
-botscan_wpadmin_context_gate_v1922_test	cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh		test			unassigned								
-cli_ban_timeout_no_mutation_test	cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh		test			unassigned								
-cli_ban_timeout_validation_test	cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh		test			unassigned								
-cli_connector_no_edit_hint_v144_test	cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh		test			unassigned								
-cli_empty_env_smoke_v156_test	cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh		test			unassigned								
-cli_error_rc_contract_v1_139_2_test	cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh		test			unassigned								
-cli_error_with_hint_v144_test	cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh		test			unassigned								
-cli_exporter_exit2_phase_3_test	cli/lib/nftban/tests/cli_exporter_exit2_phase_3_test.sh		test			unassigned								
-cli_feeds_count_truth_test	cli/lib/nftban/tests/cli_feeds_count_truth_test.sh		test			unassigned								
-cli_feeds_json_jq_construction_test	cli/lib/nftban/tests/cli_feeds_json_jq_construction_test.sh		test			unassigned								
-cli_feeds_select_input_contract_test	cli/lib/nftban/tests/cli_feeds_select_input_contract_test.sh		test			unassigned								
-cli_fs3_da_v143_test	cli/lib/nftban/tests/cli_fs3_da_v143_test.sh		test			unassigned								
-cli_fs3_mutation_v143_test	cli/lib/nftban/tests/cli_fs3_mutation_v143_test.sh		test			unassigned								
-cli_hardening_v150_test	cli/lib/nftban/tests/cli_hardening_v150_test.sh		test			unassigned								
-cli_help_block_reachability_v144_test	cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh		test			unassigned								
-cli_help_inertness_universal_test	cli/lib/nftban/tests/cli_help_inertness_universal_test.sh		test			unassigned								
-cli_help_inertness_v141_test	cli/lib/nftban/tests/cli_help_inertness_v141_test.sh		test			unassigned								
-cli_inet_filter_policy_v146_test	cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh		test			unassigned								
-cli_json_clean_output_test	cli/lib/nftban/tests/cli_json_clean_output_test.sh		test			unassigned								
-cli_mac_profiles_v147a_test	cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh		test			unassigned								
-cli_nftables_include_idempotency_v146_test	cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh		test			unassigned								
-cli_no_banner_v141_test	cli/lib/nftban/tests/cli_no_banner_v141_test.sh		test			unassigned								
-cli_no_gui_doc_drift_v144_test	cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh		test			unassigned								
-cli_output_truth_v167_test	cli/lib/nftban/tests/cli_output_truth_v167_test.sh		test			unassigned								
-cli_pipefail_arith_sweep_v172_test	cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh		test			unassigned								
-cli_port_reload_hint_v144_test	cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh		test			unassigned								
-cli_runtime_hint_reachability_v144_test	cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh		test			unassigned								
-cli_status_count_truth_test	cli/lib/nftban/tests/cli_status_count_truth_test.sh		test			unassigned								
-cli_status_json_no_contradict_test	cli/lib/nftban/tests/cli_status_json_no_contradict_test.sh		test			unassigned								
-cli_status_kernel_verify_hint_test	cli/lib/nftban/tests/cli_status_kernel_verify_hint_test.sh		test			unassigned								
-cli_stderr_contract_v141_test	cli/lib/nftban/tests/cli_stderr_contract_v141_test.sh		test			unassigned								
-cli_sudo_hint_v142_test	cli/lib/nftban/tests/cli_sudo_hint_v142_test.sh		test			unassigned								
-cli_trustfeeds_label_truth_v211_1_test	cli/lib/nftban/tests/cli_trustfeeds_label_truth_v211_1_test.sh		test			unassigned								
-cli_update_dry_run_hint_v167_test	cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh		test			unassigned								
-cli_update_latv_unbound_v149_test	cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh		test			unassigned								
-cmd_blacklist_list_test	cli/lib/nftban/tests/cmd_blacklist_list_test.sh		test			unassigned								
-cmd_firewall_takeover_test	cli/lib/nftban/tests/cmd_firewall_takeover_test.sh		test			unassigned								
-cmd_firewall_trust_remerge_test	cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh		test			unassigned								
-cmd_firewall_whitelist_session_test	cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh		test			unassigned								
-cmd_login_stats_test	cli/lib/nftban/tests/cmd_login_stats_test.sh		test			unassigned								
-cmd_status_authority_test	cli/lib/nftban/tests/cmd_status_authority_test.sh		test			unassigned								
-cmd_update_detection_v126_test	cli/lib/nftban/tests/cmd_update_detection_v126_test.sh		test			unassigned								
-cmd_update_detection_v135_clean_ownership_test	cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh		test			unassigned								
-cmd_update_lock_cleanup_v135_test	cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh		test			unassigned								
-cmd_whitelist_management_v218_10_test	cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh		test			unassigned								
-cmd_whitelist_static_v149_test	cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh		test			unassigned								
-comms_a1_centralization_test	cli/lib/nftban/tests/comms_a1_centralization_test.sh		test			unassigned								
-comms_a1b_emulate_test	cli/lib/nftban/tests/comms_a1b_emulate_test.sh		test			unassigned								
-comms_a2a_delivery_truth_test	cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh		test			unassigned								
-comms_a2b_operator_surfacing_test	cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh		test			unassigned								
-comms_a2c_support_summary_test	cli/lib/nftban/tests/comms_a2c_support_summary_test.sh		test			unassigned								
-comms_a2r_rbl_visibility_test	cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh		test			unassigned								
-comms_health_render_v2181_test	cli/lib/nftban/tests/comms_health_render_v2181_test.sh		test			unassigned								
-comms_new_user_remediation_ux_test	cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh		test			unassigned								
-comms_no_direct_send_guard_a0_test	cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh		test			unassigned								
-comms_producer_signal_accuracy_test	cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh		test			unassigned								
-comms_rbl_tunnel_producer_recipient_test	cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh		test			unassigned								
-comms_redact_debug_p_retire1_test	cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh		test			unassigned								
-comms_redact_failloud_p_retire2_test	cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh		test			unassigned								
-comms_redact_p2a_noleak_test	cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh		test			unassigned								
-comms_redact_p2b1_test	cli/lib/nftban/tests/comms_redact_p2b1_test.sh		test			unassigned								
-community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh		test			unassigned								
-config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh		test			unassigned								
-config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh		test			unassigned								
-error_text_3line_v153_test	cli/lib/nftban/tests/error_text_3line_v153_test.sh		test			unassigned								
-exporter_exit2_phase2_scale_guard_v1361_test	cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh		test			unassigned								
-exporter_exit2_resilience_v136_test	cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh		test			unassigned								
-exporter_no_duplicate_goroutines_emit_v217_test	cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh		test			unassigned								
-exporter_sigterm_graceful_v151_test	cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh		test			unassigned								
-feed_counters_unify_v167_test	cli/lib/nftban/tests/feed_counters_unify_v167_test.sh		test			unassigned								
-feeds_select_strict_e2e_v152_test	cli/lib/nftban/tests/feeds_select_strict_e2e_v152_test.sh		test			unassigned								
-fetch_verified_v157_test	cli/lib/nftban/tests/fetch_verified_v157_test.sh		test			unassigned								
-fhs_lane_v175_test	cli/lib/nftban/tests/fhs_lane_v175_test.sh		test			unassigned								
-firewall_transition_health_cli_v1921_test	cli/lib/nftban/tests/firewall_transition_health_cli_v1921_test.sh		test			unassigned								
-firewall_transition_health_v1921_test	cli/lib/nftban/tests/firewall_transition_health_v1921_test.sh		test			unassigned								
-fsync_residual_guard_v176_test	cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh		test			unassigned								
-fw_l2cd_transition_counter_botguard_chain_test	cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh		test			unassigned								
-fw_rebuild_preserve_timed_bans_l2a_test	cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh		test			unassigned								
-fw_transition_health_truth_v1982_test	cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh		test			unassigned								
-geoban_refresh_execcondition_v159_test	cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh		test			unassigned								
-health_failed_unit_remediation_v1222_1_test	cli/lib/nftban/tests/health_failed_unit_remediation_v1222_1_test.sh	installer	test	installer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false		
-health_journalctl_bounded_v174_test	cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh		test			unassigned								
-health_resource_dropin_packaging_guard_v1222_1_test	cli/lib/nftban/tests/health_resource_dropin_packaging_guard_v1222_1_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false		
-health_resources_cli_registration_v1222_1_test	cli/lib/nftban/tests/health_resources_cli_registration_v1222_1_test.sh	cli	test	health-resources	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false		
-health_resources_completion_parity_v225_test	cli/lib/nftban/tests/health_resources_completion_parity_v225_test.sh	cli	test	cli	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false		
-health_timers_truth_v150_test	cli/lib/nftban/tests/health_timers_truth_v150_test.sh		test			unassigned								
-help_verb_icons_v153_test	cli/lib/nftban/tests/help_verb_icons_v153_test.sh		test			unassigned								
-hostname_fallback_v1_139_1_test	cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh		test			unassigned								
-http_log_discovery_v177_test	cli/lib/nftban/tests/http_log_discovery_v177_test.sh		test			unassigned								
-immutable_health_verify_v163_test	cli/lib/nftban/tests/immutable_health_verify_v163_test.sh		test			unassigned								
-install_update_observability_v215_test	cli/lib/nftban/tests/install_update_observability_v215_test.sh		test			unassigned								
-installer_wording_v153_test	cli/lib/nftban/tests/installer_wording_v153_test.sh		test			unassigned								
-l2e_replace_set_reachability_guard_test	cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh		test			unassigned								
-l3a_never_ban_add_element_guard_test	cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh		test			unassigned								
-lifecycle_forensics_v1199_test	cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh		test			unassigned								
-list_ipv6_clamp_v153_test	cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh		test			unassigned								
-logretention_packaging_derivedstate_gateb_test	cli/lib/nftban/tests/logretention_packaging_derivedstate_gateb_test.sh		test			unassigned								
-logretention_terminology_guard_gateb_test	cli/lib/nftban/tests/logretention_terminology_guard_gateb_test.sh		test			unassigned								
-logretention_wiring_gateb_test	cli/lib/nftban/tests/logretention_wiring_gateb_test.sh		test			unassigned								
-logrotate_behavioral_gateb_test	cli/lib/nftban/tests/logrotate_behavioral_gateb_test.sh		test			unassigned								
-logrotate_config_v137_test	cli/lib/nftban/tests/logrotate_config_v137_test.sh		test			unassigned								
-logs_truth_v150_test	cli/lib/nftban/tests/logs_truth_v150_test.sh		test			unassigned								
-mac_posture_v158_test	cli/lib/nftban/tests/mac_posture_v158_test.sh		test			unassigned								
-mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false		
-maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh		test			unassigned								
-nft_counting_model_guard_v190_test	cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh		test			unassigned								
-nft_loopback_before_invalid_v217_test	cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh		test			unassigned								
-nft_writer_authority_v150_test	cli/lib/nftban/tests/nft_writer_authority_v150_test.sh		test			unassigned								
-nftban_config_rhg_cosmetic_r1a6_test	cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh		test			unassigned								
-nftban_da_help_ssh_port_r1a2_test	cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh		test			unassigned								
-nftban_file_cleanup_r1a5_test	cli/lib/nftban/tests/nftban_file_cleanup_r1a5_test.sh		test			unassigned								
-nftban_geoip_help_path_r1a1_test	cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh		test			unassigned								
-nftban_operator_readiness_r1b2_test	cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh		test			unassigned								
-nftban_rbl_json_escaping_r1a3_test	cli/lib/nftban/tests/nftban_rbl_json_escaping_r1a3_test.sh		test			unassigned								
-nftban_render_findings_r1b1_test	cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh		test			unassigned								
-nftban_update_progress_r1b3_test	cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh		test			unassigned								
-no_reintroduced_orphan_modules_v167_test	cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh		test			unassigned								
-panel_group_retirement_v137_test	cli/lib/nftban/tests/panel_group_retirement_v137_test.sh		test			unassigned								
-portscan_generic_corroborate_v149_test	cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh		test			unassigned								
-portscan_trusted_flow_test	cli/lib/nftban/tests/portscan_trusted_flow_test.sh		test			unassigned								
-protection_claim_matrix_v194_test	cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh		test			unassigned								
-rbl_cli_correctness_v220_3_test	cli/lib/nftban/tests/rbl_cli_correctness_v220_3_test.sh		test			unassigned								
-rbl_enable_readiness_test	cli/lib/nftban/tests/rbl_enable_readiness_test.sh		test			unassigned								
-rbl_false_clean_v150_test	cli/lib/nftban/tests/rbl_false_clean_v150_test.sh		test			unassigned								
-rbl_hostname_admission_v220_1_test	cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh		test			unassigned								
-rbl_nonpublic_admission_v220_1_test	cli/lib/nftban/tests/rbl_nonpublic_admission_v220_1_test.sh		test			unassigned								
-rbl_prereq_ifs_dns_utils_v219_1_test	cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh		test			unassigned								
-rbl_provider_registry_slice1_test	cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh		test			unassigned								
-rbl_provider_registry_slice2_test	cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh		test			unassigned								
-rbl_provider_registry_slice3a_test	cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh		test			unassigned								
-rbl_provider_registry_slice3c_test	cli/lib/nftban/tests/rbl_provider_registry_slice3c_test.sh		test			unassigned								
-rbl_seven_state_v206_test	cli/lib/nftban/tests/rbl_seven_state_v206_test.sh		test			unassigned								
-rbl_shared_address_authority_v220_0_test	cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh		test			unassigned								
-read_ra_ifs_v156_test	cli/lib/nftban/tests/read_ra_ifs_v156_test.sh		test			unassigned								
-rebuild_no_syn_drop_v192_test	cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh		test			unassigned								
-recovery_legacy_reconcile_v12012_test	cli/lib/nftban/tests/recovery_legacy_reconcile_v12012_test.sh		test			unassigned								
-rollback_help_guard_v1_139_2_test	cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh		test			unassigned								
-rpm_files_no_double_dir_listing_v165_test	cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh		test			unassigned								
-rpm_files_templates_dedup_v166_test	cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh		test			unassigned								
-rpm_spec_no_section_macro_in_comment_v165_test	cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh		test			unassigned								
-rpm_spec_single_install_v157_test	cli/lib/nftban/tests/rpm_spec_single_install_v157_test.sh		test			unassigned								
-ruleset_fingerprint_v138_test	cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh		test			unassigned								
-service_alerts_v138_test	cli/lib/nftban/tests/service_alerts_v138_test.sh		test			unassigned								
-session_whitelist_flock_v173_test	cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh		test			unassigned								
-set_apply_single_writer_v213_grep_guard_test	cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh		test			unassigned								
-set_apply_single_writer_v213_test	cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh		test			unassigned								
-ssh_admin_port_guard_v150_test	cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh		test			unassigned								
-ssh_port_change_lifecycle_v155_test	cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh		test			unassigned								
-ssh_socket_port_mismatch_v155_test	cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh		test			unassigned								
-state_write_atomicity_v171_test	cli/lib/nftban/tests/state_write_atomicity_v171_test.sh		test			unassigned								
-stats_count_reconcile_v206_2_test	cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh		test			unassigned								
-stats_ip_history_v170_test	cli/lib/nftban/tests/stats_ip_history_v170_test.sh		test			unassigned								
-stats_json_top_sources_v150_test	cli/lib/nftban/tests/stats_json_top_sources_v150_test.sh		test			unassigned								
-stats_manual_cache_v150_test	cli/lib/nftban/tests/stats_manual_cache_v150_test.sh		test			unassigned								
-stats_manual_provenance_v206_1_test	cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh		test			unassigned								
-stats_producer_reconcile_v152_test	cli/lib/nftban/tests/stats_producer_reconcile_v152_test.sh		test			unassigned								
-stats_status_truth_v150_test	cli/lib/nftban/tests/stats_status_truth_v150_test.sh		test			unassigned								
-status_consistency_v153_test	cli/lib/nftban/tests/status_consistency_v153_test.sh		test			unassigned								
-status_rc_contract_v152_test	cli/lib/nftban/tests/status_rc_contract_v152_test.sh		test			unassigned								
-support_bundle_redaction_test	cli/lib/nftban/tests/support_bundle_redaction_test.sh		test			unassigned								
-suricata_usr2_guard_gateb_test	cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh		test			unassigned								
-sysctl_risk_idle_age_v2161_test	cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh		test			unassigned								
-sysctl_safe_default_v216_test	cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh		test			unassigned								
-tmpfiles_zz_v139_test	cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh		test			unassigned								
-trust_load_missing_whitelist_test	cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh		test			unassigned								
-uninstall_firewall_ownership_message_v225_test	cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false		
-update_degraded_render_truth_v225_test	cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false		
-update_force_delegation_v1223_test	cli/lib/nftban/tests/update_force_delegation_v1223_test.sh		test			unassigned								
-update_msg_recovered_v174_test	cli/lib/nftban/tests/update_msg_recovered_v174_test.sh		test			unassigned								
-update_run_human_log_gatea_test	cli/lib/nftban/tests/update_run_human_log_gatea_test.sh		test			unassigned								
-update_warning_taxonomy_v2164_test	cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh		test			unassigned								
-v127_ux1_p0_test	cli/lib/nftban/tests/v127_ux1_p0_test.sh		test			unassigned								
-v127_ux2_well_known_test	cli/lib/nftban/tests/v127_ux2_well_known_test.sh		test			unassigned								
-v127_ux3_stats_banlog_test	cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh		test			unassigned								
-v127_ux4_suricata_desurfacing_test	cli/lib/nftban/tests/v127_ux4_suricata_desurfacing_test.sh		test			unassigned								
-v127_ux5_typo_discoverability_test	cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh		test			unassigned								
-v127_ux6_help_cleanup_test	cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh		test			unassigned								
-v128_doc_clarity_audit_test	cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh		test			unassigned								
-v128_help_code_correlation_test	cli/lib/nftban/tests/v128_help_code_correlation_test.sh		test			unassigned								
-v128_polkit_aware_wording_sweep_test	cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh		test			unassigned								
-v129_pr_c_runtime_defect_fixes_test	cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh		test			unassigned								
-v130_polkit_validate_service_test	cli/lib/nftban/tests/v130_polkit_validate_service_test.sh		test			unassigned								
-v130_subcommand_flag_help_code_test	cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh		test			unassigned								
-v131_1_d13_option_c_output_capture_test	cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh		test			unassigned								
-v131_2_d13_sandbox_write_repair_test	cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh		test			unassigned								
-v131_3_d13_setgid_group_ownership_test	cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh		test			unassigned								
-v131_pr_a_2_double_zero_sweep_test	cli/lib/nftban/tests/v131_pr_a_2_double_zero_sweep_test.sh		test			unassigned								
-v131_pr_a_long_tail_code_bug_fix_test	cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh		test			unassigned								
-v132_pr_c_behavior_truth_test	cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh		test			unassigned								
-v133_pr_b_write_guard_refusal_test	cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh		test			unassigned								
-v133_pr_d_p2_help_code_drift_test	cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh		test			unassigned								
-v134_pr_d_p3_alias_allowlist_test	cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh		test			unassigned								
-v145_pr_b_runtime_static_guard_test	cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh					unassigned								
-v145_pr_c2_apply_hardening_test	cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh					unassigned								
-v145_pr_g_ssh_ports_invariants_test	cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh					unassigned								
-v145_ssh_port_detect_test	cli/lib/nftban/tests/v145_ssh_port_detect_test.sh					unassigned								
-v145_ssh_port_template_set_driven_static_test	cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh		test			unassigned								
-v1921_effective_port_render_failclosed_test	cli/lib/nftban/tests/v1921_effective_port_render_failclosed_test.sh		test			unassigned								
-version_build_date_v151_test	cli/lib/nftban/tests/version_build_date_v151_test.sh		test			unassigned								
-version_release_date_authority_test	cli/lib/nftban/tests/version_release_date_authority_test.sh		test			unassigned								
-watchdog_update_swap_race_v1983_test	cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh		test			unassigned								
-whitelist_list_timed_label_v169_test	cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh		test			unassigned								
-whitelist_rebuild_remerge_v1930_test	cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh		test			unassigned								
-whitelist_set_timeout_flag_v168_test	cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh		test			unassigned								
-whitelist_timeout_upgrade_activation_v168_test	cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh		test			unassigned								
-whitelist_verify_v163_test	cli/lib/nftban/tests/whitelist_verify_v163_test.sh		test			unassigned								
+id	path	owner	type	module	execution_class	gate	hermetic	requires_root	requires_network	requires_systemd	requires_nftables	requires_package	timeout	exclusion_reason	activation_condition
+alert_bookkeeping_nonfatal_v174_test	cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh	health	test	alert	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+alert_logger_devlog_sandbox_v1981_test	cli/lib/nftban/tests/alert_logger_devlog_sandbox_v1981_test.sh	health	test	alert	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+audit_rotate_retired_gateb_test	cli/lib/nftban/tests/audit_rotate_retired_gateb_test.sh	core	test	audit	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+b1_text_ux_v1872_test	cli/lib/nftban/tests/b1_text_ux_v1872_test.sh	cli	test	banner	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+b1b_banner_compact_v1873_test	cli/lib/nftban/tests/b1b_banner_compact_v1873_test.sh	cli	test	banner	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+b2_badbot_aibot_v188_test	cli/lib/nftban/tests/b2_badbot_aibot_v188_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+banner_nobanner_v153_test	cli/lib/nftban/tests/banner_nobanner_v153_test.sh	cli	test	banner	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+blacklist_flush_manual_truth_v218_10_test	cli/lib/nftban/tests/blacklist_flush_manual_truth_v218_10_test.sh	blacklist	test	blacklist-flush	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+blacklist_refresh_no_failopen_v192_test	cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test.sh	blacklist	test	blacklist-refresh-atomicity	ROOT_LAB	lab-manual	false	true	false	false	true	false			
+botguard_diag_6b2_test	cli/lib/nftban/tests/botguard_diag_6b2_test.sh	botguard	test	botguard-explain-diag	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botguard_explain_shell_6b1_test	cli/lib/nftban/tests/botguard_explain_shell_6b1_test.sh	botguard	test	botguard-explain-client	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_404_tail_bound_v1871_test	cli/lib/nftban/tests/botscan_404_tail_bound_v1871_test.sh	botscan	test	botscan-404-tail	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_adaptive_v207_test	cli/lib/nftban/tests/botscan_adaptive_v207_test.sh	botscan	test	botscan-adaptive	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_admin_ip_exemption_test	cli/lib/nftban/tests/botscan_admin_ip_exemption_test.sh	botscan	test	botscan-exemption	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_collector_gather_stream_v2092_test	cli/lib/nftban/tests/botscan_collector_gather_stream_v2092_test.sh	botscan		botscan-collector-gather	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_daemon_truth_v219_0_test	cli/lib/nftban/tests/botscan_daemon_truth_v219_0_test.sh	botscan	test	botscan-health-consumer-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_deadline_rotation_v185_test	cli/lib/nftban/tests/botscan_deadline_rotation_v185_test.sh	botscan	test	botscan-deadline-rotation	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+botscan_direct_ban_flag_v1903_test	cli/lib/nftban/tests/botscan_direct_ban_flag_v1903_test.sh	botscan	test	botscan-direct-ban-flag	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_endpoint_flood_test	cli/lib/nftban/tests/botscan_endpoint_flood_test.sh	botscan	test	botscan-endpoint-flood	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_exp_rfi_fp_v218_13_test	cli/lib/nftban/tests/botscan_exp_rfi_fp_v218_13_test.sh	botscan	test	botscan-pattern-exp-rfi	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_fcrdns_v189_test	cli/lib/nftban/tests/botscan_fcrdns_v189_test.sh	botscan	test	botscan-fcrdns-crawler	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_logsource_validity_r22a_test	cli/lib/nftban/tests/botscan_logsource_validity_r22a_test.sh	botscan	test	botscan-logsource-validity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_nofork_parity_v1871_test	cli/lib/nftban/tests/botscan_nofork_parity_v1871_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_operator_truth_contract_v219_0_test	cli/lib/nftban/tests/botscan_operator_truth_contract_v219_0_test.sh	botscan	test	botscan-operator-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_operator_truth_v218_11_test	cli/lib/nftban/tests/botscan_operator_truth_v218_11_test.sh	botscan	test	botscan-status-surface	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_pattern_ban_ifs_v1861_test	cli/lib/nftban/tests/botscan_pattern_ban_ifs_v1861_test.sh	botscan	test	botscan-pattern-ban-ifs	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_pattern_delimiter_v214_test	cli/lib/nftban/tests/botscan_pattern_delimiter_v214_test.sh	botscan	test	botscan-pattern-delimiter	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_read_authority_v178_test	cli/lib/nftban/tests/botscan_read_authority_v178_test.sh	botscan	test	botscan-read-authority-collector	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+botscan_request_class_classifier_v1913_test	cli/lib/nftban/tests/botscan_request_class_classifier_v1913_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_revslider_fp_v218_10_test	cli/lib/nftban/tests/botscan_revslider_fp_v218_10_test.sh	botscan	test	botscan-patterns	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_signal_flock_v212_test	cli/lib/nftban/tests/botscan_signal_flock_v212_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_spool_oom_v2093_test	cli/lib/nftban/tests/botscan_spool_oom_v2093_test.sh	botscan	test	botscan-collector	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_status_label_v218_12_test	cli/lib/nftban/tests/botscan_status_label_v218_12_test.sh	botscan	test	botscan-status-render	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_throughput_v187_test	cli/lib/nftban/tests/botscan_throughput_v187_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_trend_v208_test	cli/lib/nftban/tests/botscan_trend_v208_test.sh	botscan	test	botscan-trend	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+botscan_wpadmin_context_gate_v1922_test	cli/lib/nftban/tests/botscan_wpadmin_context_gate_v1922_test.sh	botscan	test	botscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_ban_timeout_no_mutation_test	cli/lib/nftban/tests/cli_ban_timeout_no_mutation_test.sh	cli	test	ban	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_ban_timeout_validation_test	cli/lib/nftban/tests/cli_ban_timeout_validation_test.sh	cli	test	ban	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_connector_no_edit_hint_v144_test	cli/lib/nftban/tests/cli_connector_no_edit_hint_v144_test.sh	cli	test	connector	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_empty_env_smoke_v156_test	cli/lib/nftban/tests/cli_empty_env_smoke_v156_test.sh	cli	test	dispatcher	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_error_rc_contract_v1_139_2_test	cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh	cli	test	rc-contract	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_error_with_hint_v144_test	cli/lib/nftban/tests/cli_error_with_hint_v144_test.sh	cli	test	error-hint	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_exporter_exit2_phase_3_test	cli/lib/nftban/tests/cli_exporter_exit2_phase_3_test.sh	metrics	test	exporter	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_feeds_count_truth_test	cli/lib/nftban/tests/cli_feeds_count_truth_test.sh	feeds	test	feeds	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_feeds_json_jq_construction_test	cli/lib/nftban/tests/cli_feeds_json_jq_construction_test.sh	feeds	test	feeds	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_feeds_select_input_contract_test	cli/lib/nftban/tests/cli_feeds_select_input_contract_test.sh	feeds	test	feeds	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_fs3_da_v143_test	cli/lib/nftban/tests/cli_fs3_da_v143_test.sh	cli	test	port	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_fs3_mutation_v143_test	cli/lib/nftban/tests/cli_fs3_mutation_v143_test.sh	cli	test	rc-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_hardening_v150_test	cli/lib/nftban/tests/cli_hardening_v150_test.sh	cli	test	cli-health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_help_block_reachability_v144_test	cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh	cli	test	help-reachability	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_help_inertness_universal_test	cli/lib/nftban/tests/cli_help_inertness_universal_test.sh	cli	test	help-inertness	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_help_inertness_v141_test	cli/lib/nftban/tests/cli_help_inertness_v141_test.sh	cli	test	help-inertness	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_inet_filter_policy_v146_test	cli/lib/nftban/tests/cli_inet_filter_policy_v146_test.sh	packaging	test	inet-filter	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_json_clean_output_test	cli/lib/nftban/tests/cli_json_clean_output_test.sh	cli	test	json-output	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_mac_profiles_v147a_test	cli/lib/nftban/tests/cli_mac_profiles_v147a_test.sh	security	test	mac-profiles	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_nftables_include_idempotency_v146_test	cli/lib/nftban/tests/cli_nftables_include_idempotency_v146_test.sh	packaging	test	firewall-include	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_no_banner_v141_test	cli/lib/nftban/tests/cli_no_banner_v141_test.sh	cli	test	output-banner	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_no_gui_doc_drift_v144_test	cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh	cli	test	command-registry-drift	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_output_truth_v167_test	cli/lib/nftban/tests/cli_output_truth_v167_test.sh	cli	test	output-truth	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_pipefail_arith_sweep_v172_test	cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh	cli	test	pipefail-arith	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_port_reload_hint_v144_test	cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh	cli	test	port-reload-hint	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_runtime_hint_reachability_v144_test	cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh	cli	test	runtime-hint-reachability	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_status_count_truth_test	cli/lib/nftban/tests/cli_status_count_truth_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_status_json_no_contradict_test	cli/lib/nftban/tests/cli_status_json_no_contradict_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_status_kernel_verify_hint_test	cli/lib/nftban/tests/cli_status_kernel_verify_hint_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_stderr_contract_v141_test	cli/lib/nftban/tests/cli_stderr_contract_v141_test.sh	cli	test	stderr-contract	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_sudo_hint_v142_test	cli/lib/nftban/tests/cli_sudo_hint_v142_test.sh	cli	test	sudo-hint	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_trustfeeds_label_truth_v211_1_test	cli/lib/nftban/tests/cli_trustfeeds_label_truth_v211_1_test.sh	trust	test	trust-feeds-status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_update_dry_run_hint_v167_test	cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+cli_update_latv_unbound_v149_test	cli/lib/nftban/tests/cli_update_latv_unbound_v149_test.sh	update	test	update	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_blacklist_list_test	cli/lib/nftban/tests/cmd_blacklist_list_test.sh	blacklist	test	blacklist	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_firewall_takeover_test	cli/lib/nftban/tests/cmd_firewall_takeover_test.sh	firewall	test	firewall-takeover	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_firewall_trust_remerge_test	cli/lib/nftban/tests/cmd_firewall_trust_remerge_test.sh	firewall	test	firewall-reload-trust	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_firewall_whitelist_session_test	cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh	firewall	test	whitelist-session	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing: stale real-IP grep patterns are privacy-scrub residue; the session test adds a synthetic documentation-range IP so the count and negative assertions fail	re-enable after PR-E corrects the stale grep patterns to the synthetic fixture IP, then wire to ci-bash
+cmd_login_stats_test	cli/lib/nftban/tests/cmd_login_stats_test.sh	loginmon	test	loginmon	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_status_authority_test	cli/lib/nftban/tests/cmd_status_authority_test.sh	cli	test	status-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_update_detection_v126_test	cli/lib/nftban/tests/cmd_update_detection_v126_test.sh	update	test	update-detection	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_update_detection_v135_clean_ownership_test	cli/lib/nftban/tests/cmd_update_detection_v135_clean_ownership_test.sh	update	test	update-detection	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_update_lock_cleanup_v135_test	cli/lib/nftban/tests/cmd_update_lock_cleanup_v135_test.sh	update	test	update-lock	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_whitelist_management_v218_10_test	cli/lib/nftban/tests/cmd_whitelist_management_v218_10_test.sh	whitelist	test	whitelist-management	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cmd_whitelist_static_v149_test	cli/lib/nftban/tests/cmd_whitelist_static_v149_test.sh	whitelist	test	whitelist-static	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing: a stale real-IP grep pattern is privacy-scrub residue that the added synthetic documentation-range IP never matches, so the duplicate-count assertion fails	re-enable after PR-E corrects the stale grep pattern to the synthetic fixture IP, then wire to ci-bash
+comms_a1_centralization_test	cli/lib/nftban/tests/comms_a1_centralization_test.sh	comms	test	mail	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_a1b_emulate_test	cli/lib/nftban/tests/comms_a1b_emulate_test.sh	comms	test	mail-emulate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_a2a_delivery_truth_test	cli/lib/nftban/tests/comms_a2a_delivery_truth_test.sh	comms	test	mail	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_a2b_operator_surfacing_test	cli/lib/nftban/tests/comms_a2b_operator_surfacing_test.sh	comms	test	health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_a2c_support_summary_test	cli/lib/nftban/tests/comms_a2c_support_summary_test.sh	comms	test	support	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_a2r_rbl_visibility_test	cli/lib/nftban/tests/comms_a2r_rbl_visibility_test.sh	comms	test	rbl-alert-routing	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_health_render_v2181_test	cli/lib/nftban/tests/comms_health_render_v2181_test.sh	comms	test	communication-health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_new_user_remediation_ux_test	cli/lib/nftban/tests/comms_new_user_remediation_ux_test.sh	comms	test	remediation-ux	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_no_direct_send_guard_a0_test	cli/lib/nftban/tests/comms_no_direct_send_guard_a0_test.sh	comms	test	ci-guard	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_producer_signal_accuracy_test	cli/lib/nftban/tests/comms_producer_signal_accuracy_test.sh	comms	test	health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_rbl_tunnel_producer_recipient_test	cli/lib/nftban/tests/comms_rbl_tunnel_producer_recipient_test.sh	comms	test	health-communication-component	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_redact_debug_p_retire1_test	cli/lib/nftban/tests/comms_redact_debug_p_retire1_test.sh	security	test	redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_redact_failloud_p_retire2_test	cli/lib/nftban/tests/comms_redact_failloud_p_retire2_test.sh	security	test	redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_redact_p2a_noleak_test	cli/lib/nftban/tests/comms_redact_p2a_noleak_test.sh	security	test	redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+comms_redact_p2b1_test	cli/lib/nftban/tests/comms_redact_p2b1_test.sh	security	test	redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh	comms	test	community-trial	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	test	config-local	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+error_text_3line_v153_test	cli/lib/nftban/tests/error_text_3line_v153_test.sh	cli	test	cli-ux	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+exporter_exit2_phase2_scale_guard_v1361_test	cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+exporter_exit2_resilience_v136_test	cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+exporter_no_duplicate_goroutines_emit_v217_test	cli/lib/nftban/tests/exporter_no_duplicate_goroutines_emit_v217_test.sh	metrics	test	exporter-goroutines	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+exporter_sigterm_graceful_v151_test	cli/lib/nftban/tests/exporter_sigterm_graceful_v151_test.sh	metrics	test	exporter-err-trap	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+feed_counters_unify_v167_test	cli/lib/nftban/tests/feed_counters_unify_v167_test.sh	feeds	test	feeds	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+feeds_select_strict_e2e_v152_test	cli/lib/nftban/tests/feeds_select_strict_e2e_v152_test.sh	feeds	test	feeds	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+fetch_verified_v157_test	cli/lib/nftban/tests/fetch_verified_v157_test.sh	packaging	test	build-fetch	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+fhs_lane_v175_test	cli/lib/nftban/tests/fhs_lane_v175_test.sh	packaging	test	fhs	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
+firewall_transition_health_cli_v1921_test	cli/lib/nftban/tests/firewall_transition_health_cli_v1921_test.sh	firewall	test	firewall-transition-health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+firewall_transition_health_v1921_test	cli/lib/nftban/tests/firewall_transition_health_v1921_test.sh	firewall	test	firewall-transition-health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+fsync_residual_guard_v176_test	cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh	cross-cutting	test	durability-fsync	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+fw_l2cd_transition_counter_botguard_chain_test	cli/lib/nftban/tests/fw_l2cd_transition_counter_botguard_chain_test.sh	firewall	test	firewall-transition-counter	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+fw_rebuild_preserve_timed_bans_l2a_test	cli/lib/nftban/tests/fw_rebuild_preserve_timed_bans_l2a_test.sh	firewall	test	firewall-rebuild	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+fw_transition_health_truth_v1982_test	cli/lib/nftban/tests/fw_transition_health_truth_v1982_test.sh	firewall	test	firewall-transition-health	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+geoban_refresh_execcondition_v159_test	cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh	geoban	test	geoban	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+health_failed_unit_remediation_v1222_1_test	cli/lib/nftban/tests/health_failed_unit_remediation_v1222_1_test.sh	installer	test	installer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+health_journalctl_bounded_v174_test	cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh	health	test	health-journalctl-bound	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+health_resource_dropin_packaging_guard_v1222_1_test	cli/lib/nftban/tests/health_resource_dropin_packaging_guard_v1222_1_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+health_resources_cli_registration_v1222_1_test	cli/lib/nftban/tests/health_resources_cli_registration_v1222_1_test.sh	cli	test	health-resources	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+health_resources_completion_parity_v225_test	cli/lib/nftban/tests/health_resources_completion_parity_v225_test.sh	cli	test	cli	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+health_timers_truth_v150_test	cli/lib/nftban/tests/health_timers_truth_v150_test.sh	health	test	health-timers	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+help_verb_icons_v153_test	cli/lib/nftban/tests/help_verb_icons_v153_test.sh	cli	test	help-render	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+hostname_fallback_v1_139_1_test	cli/lib/nftban/tests/hostname_fallback_v1_139_1_test.sh	metrics	test	exporter	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+http_log_discovery_v177_test	cli/lib/nftban/tests/http_log_discovery_v177_test.sh	botscan	test	http-logs	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+immutable_health_verify_v163_test	cli/lib/nftban/tests/immutable_health_verify_v163_test.sh	health	test	immutable-flags-health	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+install_update_observability_v215_test	cli/lib/nftban/tests/install_update_observability_v215_test.sh	update	test	update-observability	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+installer_wording_v153_test	cli/lib/nftban/tests/installer_wording_v153_test.sh	installer	test	installer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+l2e_replace_set_reachability_guard_test	cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh	firewall	test	set-apply-replace	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+l3a_never_ban_add_element_guard_test	cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh	firewall	test	never-ban-guard	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+lifecycle_forensics_v1199_test	cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh	update	test	lifecycle-forensics	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+list_ipv6_clamp_v153_test	cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh	cli	test	list	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+logretention_packaging_derivedstate_gateb_test	cli/lib/nftban/tests/logretention_packaging_derivedstate_gateb_test.sh	packaging	test	logretention	PACKAGE_BUILD	package-build	true	false	false	false	false	false			
+logretention_terminology_guard_gateb_test	cli/lib/nftban/tests/logretention_terminology_guard_gateb_test.sh	core	test	logretention	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+logretention_wiring_gateb_test	cli/lib/nftban/tests/logretention_wiring_gateb_test.sh	packaging	test	logretention	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+logrotate_behavioral_gateb_test	cli/lib/nftban/tests/logrotate_behavioral_gateb_test.sh	health	test	logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+logrotate_config_v137_test	cli/lib/nftban/tests/logrotate_config_v137_test.sh	packaging	test	logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+logs_truth_v150_test	cli/lib/nftban/tests/logs_truth_v150_test.sh	health	test	log-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+mac_posture_v158_test	cli/lib/nftban/tests/mac_posture_v158_test.sh	security	test	mac-posture	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh	firewall	test	maintenance-table-probe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nft_counting_model_guard_v190_test	cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh	metrics	test	nft-counting-model	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nft_loopback_before_invalid_v217_test	cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh	firewall	test	nft-schema-rule-order	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nft_writer_authority_v150_test	cli/lib/nftban/tests/nft_writer_authority_v150_test.sh	firewall	test	nft-writer-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_config_rhg_cosmetic_r1a6_test	cli/lib/nftban/tests/nftban_config_rhg_cosmetic_r1a6_test.sh	core	test	config-cosmetic-hygiene	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_da_help_ssh_port_r1a2_test	cli/lib/nftban/tests/nftban_da_help_ssh_port_r1a2_test.sh	installer	test	directadmin-panel	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_file_cleanup_r1a5_test	cli/lib/nftban/tests/nftban_file_cleanup_r1a5_test.sh	packaging	test	shipped-config-hygiene	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_geoip_help_path_r1a1_test	cli/lib/nftban/tests/nftban_geoip_help_path_r1a1_test.sh	geoip	test	geoip	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_operator_readiness_r1b2_test	cli/lib/nftban/tests/nftban_operator_readiness_r1b2_test.sh	health	test	operator-readiness	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_rbl_json_escaping_r1a3_test	cli/lib/nftban/tests/nftban_rbl_json_escaping_r1a3_test.sh	rbl	test	rbl-json-escaping	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_render_findings_r1b1_test	cli/lib/nftban/tests/nftban_render_findings_r1b1_test.sh	health	test	health-findings-render	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nftban_update_progress_r1b3_test	cli/lib/nftban/tests/nftban_update_progress_r1b3_test.sh	update	test	update-progress	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+no_reintroduced_orphan_modules_v167_test	cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh	architecture	test	orphan-modules	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+panel_group_retirement_v137_test	cli/lib/nftban/tests/panel_group_retirement_v137_test.sh	security	test	panel-group-retirement	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+portscan_generic_corroborate_v149_test	cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh	portscan	test	portscan-classic	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+portscan_trusted_flow_test	cli/lib/nftban/tests/portscan_trusted_flow_test.sh	portscan	test	portscan-trusted-flow	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+protection_claim_matrix_v194_test	cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh	cross-cutting	test	protection-claim-matrix	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+rbl_cli_correctness_v220_3_test	cli/lib/nftban/tests/rbl_cli_correctness_v220_3_test.sh	rbl	test	rbl-cli-correctness	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_enable_readiness_test	cli/lib/nftban/tests/rbl_enable_readiness_test.sh	rbl	test	rbl-enable-readiness	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_false_clean_v150_test	cli/lib/nftban/tests/rbl_false_clean_v150_test.sh	rbl	test	rbl-resolver-false-clean	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_hostname_admission_v220_1_test	cli/lib/nftban/tests/rbl_hostname_admission_v220_1_test.sh	rbl	test	rbl-hostname-admission	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing collateral of OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the doc-range self-IP fixture classifies as non-public and a stale real-IP grep residue never matches	re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs and removes the stale residue, then wire to ci-bash
+rbl_nonpublic_admission_v220_1_test	cli/lib/nftban/tests/rbl_nonpublic_admission_v220_1_test.sh	rbl	test	rbl-nonpublic-admission	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing collateral of OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the PUBLIC4/PUBLIC6 controls are documentation-range so nftban_hostaddr_is_public rejects them and the public-admit cases fail (the public-DNS control cases still pass)	re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs, then wire to ci-bash
+rbl_prereq_ifs_dns_utils_v219_1_test	cli/lib/nftban/tests/rbl_prereq_ifs_dns_utils_v219_1_test.sh	rbl	test	rbl-enable-prereq	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_provider_registry_slice1_test	cli/lib/nftban/tests/rbl_provider_registry_slice1_test.sh	rbl	test	rbl-provider-registry	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_provider_registry_slice2_test	cli/lib/nftban/tests/rbl_provider_registry_slice2_test.sh	rbl	test	rbl-provider-registry	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_provider_registry_slice3a_test	cli/lib/nftban/tests/rbl_provider_registry_slice3a_test.sh	rbl	test	rbl-provider-registry	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_provider_registry_slice3c_test	cli/lib/nftban/tests/rbl_provider_registry_slice3c_test.sh	rbl	test	rbl-provider-registry	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_seven_state_v206_test	cli/lib/nftban/tests/rbl_seven_state_v206_test.sh	rbl	test	rbl-result-states	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rbl_shared_address_authority_v220_0_test	cli/lib/nftban/tests/rbl_shared_address_authority_v220_0_test.sh	rbl	test	rbl-shared-address-authority	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing fixture OPEN_RBL_V220_0_TEST_DOCRANGE_FIXTURE_ROT: the privacy scrub (3752f68a) replaced real self-IPs with documentation-range placeholders that classify as non-public, so the shared-address/public-admit assertions cannot hold, and a stale real-IP grep residue never matches	re-enable after PR-E re-scrubs the RBL fixtures with genuinely-public placeholder IPs and removes the stale grep residue, then wire to ci-bash
+read_ra_ifs_v156_test	cli/lib/nftban/tests/read_ra_ifs_v156_test.sh	portscan	test	portscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rebuild_no_syn_drop_v192_test	cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh	firewall	test	firewall-rebuild	ROOT_LAB	lab-manual	false	true	false	false	true	false			
+recovery_legacy_reconcile_v12012_test	cli/lib/nftban/tests/recovery_legacy_reconcile_v12012_test.sh	firewall	test	recovery	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+rollback_help_guard_v1_139_2_test	cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh	update	test	rollback	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+rpm_files_no_double_dir_listing_v165_test	cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh	packaging	test	rpm-files	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
+rpm_files_templates_dedup_v166_test	cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh	packaging	test	rpm-files	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
+rpm_spec_no_section_macro_in_comment_v165_test	cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh	packaging	test	rpm-spec	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
+rpm_spec_single_install_v157_test	cli/lib/nftban/tests/rpm_spec_single_install_v157_test.sh	packaging	test	rpm-spec	PACKAGE_BUILD	package-build	true	false	false	false	false	false			
+ruleset_fingerprint_v138_test	cli/lib/nftban/tests/ruleset_fingerprint_v138_test.sh	security	test	rulefp	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+service_alerts_v138_test	cli/lib/nftban/tests/service_alerts_v138_test.sh	firewall	test	firewall-conflicts	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+session_whitelist_flock_v173_test	cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh	firewall	test	session-whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+set_apply_single_writer_v213_grep_guard_test	cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	deferred	true	false	false	false	false	false		known-failing: a stale point-in-time assertion pins an old VERSION value while the repo has advanced; its behavioral companion set_apply_single_writer_v213_test is healthy	re-enable after the stale VERSION pin is dropped or refreshed, then wire to ci-bash
+set_apply_single_writer_v213_test	cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+ssh_admin_port_guard_v150_test	cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+ssh_port_change_lifecycle_v155_test	cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh	firewall	test	ssh-port-lifecycle-validate	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+ssh_socket_port_mismatch_v155_test	cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+state_write_atomicity_v171_test	cli/lib/nftban/tests/state_write_atomicity_v171_test.sh	core	test	state-write-atomicity	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+stats_count_reconcile_v206_2_test	cli/lib/nftban/tests/stats_count_reconcile_v206_2_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+stats_ip_history_v170_test	cli/lib/nftban/tests/stats_ip_history_v170_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+stats_json_top_sources_v150_test	cli/lib/nftban/tests/stats_json_top_sources_v150_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+stats_manual_cache_v150_test	cli/lib/nftban/tests/stats_manual_cache_v150_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+stats_manual_provenance_v206_1_test	cli/lib/nftban/tests/stats_manual_provenance_v206_1_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+stats_producer_reconcile_v152_test	cli/lib/nftban/tests/stats_producer_reconcile_v152_test.sh	metrics	test	stats	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+stats_status_truth_v150_test	cli/lib/nftban/tests/stats_status_truth_v150_test.sh	cli	test	stats-status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+status_consistency_v153_test	cli/lib/nftban/tests/status_consistency_v153_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+status_rc_contract_v152_test	cli/lib/nftban/tests/status_rc_contract_v152_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+support_bundle_redaction_test	cli/lib/nftban/tests/support_bundle_redaction_test.sh	security	test	redaction	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+suricata_usr2_guard_gateb_test	cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh	suricata	test	suricata-logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+sysctl_risk_idle_age_v2161_test	cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+sysctl_safe_default_v216_test	cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+tmpfiles_zz_v139_test	cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh	packaging	test	fhs	PACKAGE_BUILD	package-build	true	false	false	false	false	false			
+trust_load_missing_whitelist_test	cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh	trust	test	trust-load	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+uninstall_firewall_ownership_message_v225_test	cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+update_degraded_render_truth_v225_test	cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+update_force_delegation_v1223_test	cli/lib/nftban/tests/update_force_delegation_v1223_test.sh	update	test	update-force	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+update_msg_recovered_v174_test	cli/lib/nftban/tests/update_msg_recovered_v174_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+update_run_human_log_gatea_test	cli/lib/nftban/tests/update_run_human_log_gatea_test.sh	update	test	lifecycle-log-forensics	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+update_warning_taxonomy_v2164_test	cli/lib/nftban/tests/update_warning_taxonomy_v2164_test.sh	update	test	warning-taxonomy	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux1_p0_test	cli/lib/nftban/tests/v127_ux1_p0_test.sh	cli	test	ux-lifecycle	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux2_well_known_test	cli/lib/nftban/tests/v127_ux2_well_known_test.sh	cli	test	well-known-guard	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux3_stats_banlog_test	cli/lib/nftban/tests/v127_ux3_stats_banlog_test.sh	cli	test	stats-banlog	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux4_suricata_desurfacing_test	cli/lib/nftban/tests/v127_ux4_suricata_desurfacing_test.sh	cli	test	cli-help-surface	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux5_typo_discoverability_test	cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh	cli	test	cli-typo-suggestion	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v127_ux6_help_cleanup_test	cli/lib/nftban/tests/v127_ux6_help_cleanup_test.sh	cli	test	cli-help-surface	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v128_doc_clarity_audit_test	cli/lib/nftban/tests/v128_doc_clarity_audit_test.sh	cross-cutting	test	docs	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v128_help_code_correlation_test	cli/lib/nftban/tests/v128_help_code_correlation_test.sh	cli	test	cli-command-correlation	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v128_polkit_aware_wording_sweep_test	cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh	security	test	polkit-wording	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v129_pr_c_runtime_defect_fixes_test	cli/lib/nftban/tests/v129_pr_c_runtime_defect_fixes_test.sh	cli	test	cli	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v130_polkit_validate_service_test	cli/lib/nftban/tests/v130_polkit_validate_service_test.sh	firewall	test	polkit-validate-service	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v130_subcommand_flag_help_code_test	cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh	cli	test	cli-help-code-doctest	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v131_1_d13_option_c_output_capture_test	cli/lib/nftban/tests/v131_1_d13_option_c_output_capture_test.sh	firewall	test	firewall-validate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v131_2_d13_sandbox_write_repair_test	cli/lib/nftban/tests/v131_2_d13_sandbox_write_repair_test.sh	firewall	test	firewall-validate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v131_3_d13_setgid_group_ownership_test	cli/lib/nftban/tests/v131_3_d13_setgid_group_ownership_test.sh	packaging	test	setgid-handoff-dir	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v131_pr_a_2_double_zero_sweep_test	cli/lib/nftban/tests/v131_pr_a_2_double_zero_sweep_test.sh	cross-cutting	test	shell-hygiene	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v131_pr_a_long_tail_code_bug_fix_test	cli/lib/nftban/tests/v131_pr_a_long_tail_code_bug_fix_test.sh	cross-cutting	test	code-bug-fix	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v132_pr_c_behavior_truth_test	cli/lib/nftban/tests/v132_pr_c_behavior_truth_test.sh	cli	test	cli	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v133_pr_b_write_guard_refusal_test	cli/lib/nftban/tests/v133_pr_b_write_guard_refusal_test.sh	security	test	polkit-write-refusal	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v133_pr_d_p2_help_code_drift_test	cli/lib/nftban/tests/v133_pr_d_p2_help_code_drift_test.sh	cli	test	cli-help-code-drift	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+v134_pr_d_p3_alias_allowlist_test	cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh	cli	test	cli-alias-allowlist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v145_pr_b_runtime_static_guard_test	cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh	firewall		ssh-port-detect	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v145_pr_c2_apply_hardening_test	cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh	firewall		ssh-port-apply	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v145_pr_g_ssh_ports_invariants_test	cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh	firewall		ssh-ports-set-invariants	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v145_ssh_port_detect_test	cli/lib/nftban/tests/v145_ssh_port_detect_test.sh	firewall		ssh-port-detect	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v145_ssh_port_template_set_driven_static_test	cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh	firewall	test	nftables-ssh-templates	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+v1921_effective_port_render_failclosed_test	cli/lib/nftban/tests/v1921_effective_port_render_failclosed_test.sh	firewall	test	firewall-service-port-render	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+version_build_date_v151_test	cli/lib/nftban/tests/version_build_date_v151_test.sh	release	test	version-build-date	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+version_release_date_authority_test	cli/lib/nftban/tests/version_release_date_authority_test.sh	release	test	version	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+watchdog_update_swap_race_v1983_test	cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh	update	test	watchdog-update-swap	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+whitelist_list_timed_label_v169_test	cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh	whitelist	test	whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+whitelist_rebuild_remerge_v1930_test	cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh	firewall	test	whitelist-rebuild-remerge	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+whitelist_set_timeout_flag_v168_test	cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh	whitelist	test	whitelist-set-timeout-flag	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+whitelist_timeout_upgrade_activation_v168_test	cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh	packaging	test	whitelist-timeout-upgrade-activation	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
+whitelist_verify_v163_test	cli/lib/nftban/tests/whitelist_verify_v163_test.sh	whitelist	test	whitelist-verify	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			

--- a/scripts/ci/test-authority-schema.md
+++ b/scripts/ci/test-authority-schema.md
@@ -40,7 +40,7 @@ All values are double-quoted: `# meta:ta.<field>="<value>"`.
 | `ta.owner` | yes | one of the controlled owner vocabulary (subsystem, e.g. `update`, `mail`, `packaging`, `cli`, `rbl`, …). |
 | `ta.module` | yes | subsystem/module label; non-blank (`cross-cutting` allowed). |
 | `ta.execution_class` | yes | `CI_STATIC`, `CI_HERMETIC_SHELL`, `PACKAGE_BUILD`, `PACKAGE_NATIVE_DEB`, `PACKAGE_NATIVE_RPM`, `ROOT_LAB`, `NETWORK_LAB`, `LIVE_CANARY`, `FLEET_RECONCILIATION`, `MANUAL_FORENSIC`, `HISTORICAL_ONLY`. |
-| `ta.gate` | yes | `policy-gates`, `ci-bash`, `package-build`, `package-native-deb`, `package-native-rpm`, `lab-manual`, `canary`, `fleet`, `manual-forensic`, `excluded`, `unassigned`. |
+| `ta.gate` | yes | `policy-gates`, `ci-bash`, `package-build`, `package-native-deb`, `package-native-rpm`, `lab-manual`, `canary`, `fleet`, `manual-forensic`, `excluded`, `deferred`, `unassigned`. |
 | `ta.hermetic` | yes | `true` / `false`. |
 | `ta.requires_root` | yes | `true` / `false`. |
 | `ta.requires_network` | yes | `true` / `false`. |
@@ -48,7 +48,21 @@ All values are double-quoted: `# meta:ta.<field>="<value>"`.
 | `ta.requires_nftables` | yes | `true` / `false`. |
 | `ta.requires_package` | yes | `true` / `false`. |
 | `ta.timeout` | optional | free text (e.g. `60s`); projected to the index as-is. |
-| `ta.exclusion_reason` | conditional | required and meaningful when `gate=excluded` or `execution_class=HISTORICAL_ONLY`; must be absent/empty when `gate=unassigned`. Placeholders (`TODO`, `TBD`, `none`, `n/a`, `-`) are rejected. |
+| `ta.exclusion_reason` | conditional | required and meaningful when `gate=excluded`, `gate=deferred`, or `execution_class=HISTORICAL_ONLY`; must be absent/empty when `gate=unassigned`. Placeholders (`TODO`, `TBD`, `none`, `n/a`, `-`) are rejected. |
+| `ta.activation_condition` | conditional | required and meaningful when `gate=deferred` (what re-enables the test); must be absent/empty for any other gate. |
+
+### The `deferred` gate (v1.226.0 PR-B)
+
+`deferred` represents a test that is **correctly classified for future execution** but
+is **withheld from a live gate right now** — the canonical case is a test whose true
+nature is hermetic CI but which currently *fails* on a known, separately-tracked defect
+(e.g. a stale fixture), so it must not block CI until the defect is repaired in a later
+PR. It is distinct from `excluded` (intentionally never executed) and must never be
+represented with `unassigned`. The validator enforces all three of: an accountable
+`ta.owner` (always required for a migrated test), a meaningful `ta.exclusion_reason`
+(why it is withheld), and a concrete `ta.activation_condition` (what re-enables it). A
+`deferred` test still declares its real `execution_class` (which must not be
+`HISTORICAL_ONLY`).
 
 ## Cross-field rules (consistency, not guesswork)
 

--- a/scripts/ci/test-authority-selftest.py
+++ b/scripts/ci/test-authority-selftest.py
@@ -165,6 +165,16 @@ NEGATIVES = [
      ta_with(execution_class="PACKAGE_NATIVE_DEB", gate="package-native-deb",
              hermetic="false", requires_package="false"),
      "requires requires_package=true"),
+    # deferred contract (v1.226.0 PR-B extension)
+    ("deferred_needs_reason",
+     ta_with(gate="deferred", activation_condition="fixed after PR-E"),
+     "gate=deferred requires a meaningful ta.exclusion_reason"),
+    ("deferred_needs_activation",
+     ta_with(gate="deferred", exclusion_reason="known-failing fixture"),
+     "gate=deferred requires a concrete ta.activation_condition"),
+    ("activation_only_when_deferred",
+     ta_with(gate="ci-bash", activation_condition="someday"),
+     "only valid when gate=deferred"),
 ]
 
 
@@ -174,6 +184,20 @@ def test_negatives():
         root = make_repo({name + "_test.sh": header})
         rc, _, err = run(root, "validate", "--mode", "transition")
         expect(rc == 1 and needle in err, "reject: %s" % name, "rc=%d err=%s" % (rc, err.strip()[:160]))
+
+
+def test_deferred_valid():
+    print("test_deferred_valid")
+    # A correctly-classified hermetic test withheld from a live gate: reason + activation.
+    hdr = ta_with(gate="deferred",
+                  exclusion_reason="known-failing fixture OPEN_EXAMPLE_FIXTURE_ROT",
+                  activation_condition="re-enable once the fixture is repaired in a later PR")
+    root = make_repo({"good_test.sh": hdr})
+    rc, out, err = run(root, "validate", "--mode", "strict")
+    expect(rc == 0, "valid deferred entry (reason+activation) passes strict", err)
+    rc, _, _ = run(root, "generate")
+    rc, out, _ = run(root, "check")
+    expect(rc == 0 and "INDEX_FRESH = YES" in out, "deferred entry generates a fresh index", out)
 
 
 def test_duplicate_id():
@@ -218,9 +242,9 @@ def main():
         _die("tool not found: %s" % TOOL)
     tests = [
         test_happy_path, test_transition_allows_legacy, test_determinism,
-        test_stale_index_detected, test_negatives, test_duplicate_id,
-        test_duplicate_key_in_file, test_header_region_stops_at_code,
-        test_tool_failure_exit2,
+        test_stale_index_detected, test_negatives, test_deferred_valid,
+        test_duplicate_id, test_duplicate_key_in_file,
+        test_header_region_stops_at_code, test_tool_failure_exit2,
     ]
     for t in tests:
         t()

--- a/scripts/ci/test-authority.py
+++ b/scripts/ci/test-authority.py
@@ -53,7 +53,7 @@ EXECUTION_CLASSES = {
 GATES = {
     "policy-gates", "ci-bash", "package-build", "package-native-deb",
     "package-native-rpm", "lab-manual", "canary", "fleet", "manual-forensic",
-    "excluded", "unassigned",
+    "excluded", "deferred", "unassigned",
 }
 BOOL_TRUE, BOOL_FALSE = "true", "false"
 PLACEHOLDER_REASONS = {"", "todo", "tbd", "none", "n/a", "na", "-"}
@@ -74,6 +74,7 @@ INDEX_COLS = [
     "id", "path", "owner", "type", "module", "execution_class", "gate",
     "hermetic", "requires_root", "requires_network", "requires_systemd",
     "requires_nftables", "requires_package", "timeout", "exclusion_reason",
+    "activation_condition",
 ]
 
 
@@ -188,6 +189,7 @@ def validate_one(rel, keys, mode, errors):
     ec = keys.get("ta.execution_class")
     gate = keys.get("ta.gate")
     reason = keys.get("ta.exclusion_reason")
+    activation = keys.get("ta.activation_condition")
 
     # exclusion_reason contract
     needs_reason = (gate == "excluded") or (ec == "HISTORICAL_ONLY")
@@ -196,6 +198,20 @@ def validate_one(rel, keys, mode, errors):
             err("ta.exclusion_reason", "required and must be meaningful when gate=excluded or execution_class=HISTORICAL_ONLY")
     if gate == "unassigned" and reason is not None and reason.strip() != "":
         err("ta.exclusion_reason", "must not be set when gate=unassigned")
+
+    # deferred contract: a test correctly classified for future execution but
+    # withheld from a live gate now (e.g. a known-failing fixture pending repair).
+    # It must carry a real reason AND a concrete activation condition, and its
+    # true execution_class must not itself be HISTORICAL_ONLY (that is 'excluded').
+    if gate == "deferred":
+        if reason is None or reason.strip().lower() in PLACEHOLDER_REASONS:
+            err("ta.exclusion_reason", "gate=deferred requires a meaningful ta.exclusion_reason (why it is withheld now)")
+        if activation is None or activation.strip().lower() in PLACEHOLDER_REASONS:
+            err("ta.activation_condition", "gate=deferred requires a concrete ta.activation_condition (what re-enables it)")
+        if ec == "HISTORICAL_ONLY":
+            err("ta.gate", "HISTORICAL_ONLY belongs to gate=excluded, not deferred")
+    elif activation is not None and activation.strip() != "":
+        err("ta.activation_condition", "ta.activation_condition is only valid when gate=deferred")
 
     # cross-field contradictions (owner-declared metadata authoritative, checked for consistency)
     def is_true(f):
@@ -261,6 +277,7 @@ def collect(root):
             "requires_package": keys.get("ta.requires_package", ""),
             "timeout": keys.get("ta.timeout", ""),
             "exclusion_reason": keys.get("ta.exclusion_reason", ""),
+            "activation_condition": keys.get("ta.activation_condition", ""),
             "_keys": keys,
         }
         records.append(rec)


### PR DESCRIPTION
## Summary

Completes the shell-test single-authority migration: **all 241 tracked shell tests are now classified** under the canonical `meta:ta.*` headers (was 7 migrated / 234 transitional). Classification-only — **no product, Go, workflow, VERSION, or fleet change**.

- Evidence-based classification (owner/module/execution_class/gate/hermetic/requires_*), each test read and verified.
- Schema extension already reviewed: gate `deferred` + `ta.activation_condition` for known-failing hermetic tests (validator enforces owner + reason + activation).
- Generated `test-authority-index.tsv` regenerated (non-authoritative projection).

## End state

```
TRACKED = 241 · MIGRATED = 241 · TRANSITIONAL = 0 · UNASSIGNED = 0
DUPLICATE_IDS = 0 · DUPLICATE_PATHS = 0 · INDEX_FRESH = YES · STRICT_VALIDATOR = PASS
by_gate = policy-gates 46 · ci-bash 184 · package-build 3 · deferred 6 · lab-manual 2
```

The 6 `deferred` tests are known-failing hermetic tests (RBL doc-range fixture rot + collateral, whitelist grep-residue, a stale VERSION pin) — each with owner + reason + activation condition; repaired in the PR-E lane. The strict zero-unclassified **blocking** gate is activated in PR-D, not here.

Classification-only invariants: test behavior changes = 0 · RBL fixture repair = 0 · product/Go/workflow/VERSION/schema(config) change = 0. No real identifier residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
