### PR TITLE
ci(test-authority): index-driven shell-test runner + ci-bash informational baseline (v1.226.0 PR-C)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -82,12 +82,34 @@ jobs:
       - name: Check uninstall firewall safety (no drop-policy chain after removal)
         run: ./scripts/ci/check-uninstall-firewall-safety.sh
 
-      # v1.225.0 PR-C: operator firewall-ownership uninstall message — DEB remove branch
-      # (once, not duplicated on purge) + RPM [ $1 -eq 0 ] final-erase branch; required
-      # semantics present, forbidden over-claims absent, cleanup precedes message, no
-      # uninstall behavior change. Hermetic static package-script inspection.
-      - name: uninstall firewall-ownership message (v1.225.0 PR-C)
-        run: bash cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh
+      # ── v1.226.0 PR-C: index-driven shell-test execution ─────────────────────
+      #   The canonical authority index (scripts/ci/test-authority-index.tsv) DRIVES
+      #   execution. The 46 policy-gates shell tests formerly invoked as individual
+      #   curated steps (with per-lane rationale) are now selected + executed by the
+      #   runner; provenance/rationale lives in each test file and the index columns.
+      #   The ci-bash class is added as INFORMATIONAL_BASELINE (non-blocking): it
+      #   surfaced 19 pre-existing failures — see scripts/ci/ci-bash-red-baseline-audit.md.
+      - name: Shell-test runner + integrity self-tests (v1.226.0 PR-C, BLOCKING)
+        run: |
+          bash scripts/ci/run-test-suite-selftest.sh
+          bash scripts/ci/check-ci-bash-baseline-selftest.sh
+      - name: Policy Gates shell-test suite — index-driven (v1.226.0 PR-C, BLOCKING)
+        run: bash scripts/ci/run-test-suite.sh run --gate policy-gates
+      # deferred + lab-manual: visible, never executed, never counted PASS
+      - name: Deferred / lab-manual shell tests — report-only (v1.226.0 PR-C)
+        run: |
+          bash scripts/ci/run-test-suite.sh report --gate deferred
+          bash scripts/ci/run-test-suite.sh report --gate lab-manual
+      # ci-bash: INFORMATIONAL_BASELINE — non-blocking BY EXPLICIT TEMPORARY POLICY.
+      # Executes all 184 classified ci-bash tests for visibility; 19 are pre-existing
+      # newly-exposed failures, triaged under PR-D. Writes a manifest consumed by the
+      # BLOCKING integrity gate below (one shared execution). Never renders the 19 as
+      # success; CI_BASH_ENFORCEMENT = INFORMATIONAL_BASELINE (not final enforcement).
+      - name: CI-bash observation — INFORMATIONAL_BASELINE (v1.226.0 PR-C, non-blocking)
+        continue-on-error: true
+        run: bash scripts/ci/run-test-suite.sh run --gate ci-bash --manifest ci-bash-manifest.txt
+      - name: CI-bash baseline integrity (v1.226.0 PR-C, BLOCKING)
+        run: bash scripts/ci/check-ci-bash-baseline.sh ci-bash-manifest.txt
 
       # v1.194 (8C): protection-claim matrix gate. Fails the PR if the matrix
       # regresses — wrong row count, missing/empty fields, invalid OWNER/MODE/
@@ -121,13 +143,6 @@ jobs:
       # dispatch command missing from the registry, an unmarked alias/deprecated verb).
       - name: Check CLI surface parity (registry/completion/dispatch)
         run: ./scripts/ci/check-cli-surface-parity.sh
-
-      # v1.225.0 PR-B: health-resources bash-completion parity — `resources` exported +
-      # completion-visible + runtime `nftban health <TAB>` offers it, and no exported health
-      # subcommand is silently unclassified (visible or explicit known-gap). Hermetic
-      # (static parse + isolated-subprocess completion invocation; no host).
-      - name: health resources completion parity (v1.225.0 PR-B)
-        run: bash cli/lib/nftban/tests/health_resources_completion_parity_v225_test.sh
 
       # v1.226.0 PR-A (Test-Suite Single Authority, Phase B substrate): the
       # canonical governance of a shell test (owner / execution class / gate /
@@ -212,13 +227,6 @@ jobs:
       - name: Check privacy — REPOSITORY debt (SEC-INFRA Gate B, advisory)
         continue-on-error: true
         run: python3 scripts/ci/privacy-scan.py --scope repository --report
-
-      # SEC-INFRA Guard 7: the support bundle is an intentionally-EXPORTED
-      # artifact, so its redaction contract is release-blocking. Drives the real
-      # _support_scrub_stream entrypoint over synthetic sensitive fixtures and
-      # asserts secrets are scrubbed while forensic identifiers survive.
-      - name: Support-bundle redaction (SEC-INFRA Guard 7)
-        run: bash cli/lib/nftban/tests/support_bundle_redaction_test.sh
 
       - name: Check netlink import policy
         run: |
@@ -656,12 +664,6 @@ jobs:
       - name: Schema version guard (G2-3)
         run: bash cli/lib/nftban/tests/test_schema_version_guard.sh
 
-      # v1.194 (8C): protection-claim matrix harness — runs the static guard
-      # (source tree) + the per-claim hermetic owner-bans fixtures referenced in
-      # the matrix FIXTURE column. Complements the standalone guard step above.
-      - name: Protection-claim matrix harness (8C)
-        run: bash cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh
-
       # =====================================================================
       # v1.85 M85-3: Module Completeness Gates
       # =====================================================================
@@ -669,119 +671,6 @@ jobs:
       # G8-4 is a runtime smoke test — skips gracefully in CI (no validator binary)
       - name: Module smoke test (G8-4)
         run: bash cli/lib/nftban/tests/test_module_selftest.sh
-
-      # =====================================================================
-      # v1.134 PR-D: help/code subcommand correlation gates
-      # =====================================================================
-      # Doctest guard: every primary-dispatch subcommand a command accepts must
-      # be documented in help, declared in the intentional-alias allowlist, or
-      # structural. Catches NEW undocumented subcommands (the drift class that
-      # produced D-05..D-11). Unparseable families are SKIPPED, never failed.
-      - name: Help/code doctest guard (v1.134 PR-D)
-        run: bash cli/lib/nftban/tests/v130_subcommand_flag_help_code_test.sh
-
-      # Allowlist integrity + D-26 (health rbl/fhs documented) + D-28 (metrics
-      # error-usage complete); fails if an allowlisted token is not actually
-      # dispatched (no phantom allowlist entries).
-      - name: Alias allowlist integrity (v1.134 PR-D P3)
-        run: bash cli/lib/nftban/tests/v134_pr_d_p3_alias_allowlist_test.sh
-
-      # =====================================================================
-      # v1.139.2 hotfix: CLI safety + truth-telling gates
-      # =====================================================================
-      # Rollback help-guard: `nftban rollback --help` MUST show help text and
-      # MUST NOT trigger a real rollback. Prior to v1.139.2 the dispatcher
-      # invoked _do_rollback without parsing --help; a CLI-audit invocation
-      # downgraded a host. Defense-in-depth guard is at _do_rollback's entry
-      # so every current and future caller is safe.
-      - name: Rollback --help guard (v1.139.2)
-        run: bash cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh
-
-      # CLI exit-code contract: bogus subcommand, ban (no arg), ban (invalid
-      # IP), and update --dry-run MUST return rc>=1 (declared by `nftban --help`
-      # itself: "0 Success / 1 Error / 2 Warning"). Locks the current correct
-      # behavior so a future PR cannot regress to silently swallowing errors
-      # in `nftban X || alert`-style automation.
-      - name: CLI exit-code contract (v1.139.2)
-        run: bash cli/lib/nftban/tests/cli_error_rc_contract_v1_139_2_test.sh
-
-      # =====================================================================
-      # v1.144.0 PR-D: D-UXV-13 runtime-hint reachability guard (class-killer)
-      # =====================================================================
-      # Reverse-direction guard for the doctest pair at lines 510 + 516 above:
-      # the v130 forward guard checks that every dispatched subcommand is
-      # documented; this v144 reverse guard checks that every echo/printf
-      # 'nftban X Y' literal in cli/sbin/nftban + cli/lib/nftban/cli/cmd_*.sh
-      # resolves to a reachable command. Catches the drift class that
-      # produced D-UXV-14 (cmd_connector.sh:234 'nftban connector edit' —
-      # no edit arm) and D-UXV-15 (cmd_port.sh four sites 'nftban reload' /
-      # 'nftban port reload' — neither command exists; canonical is
-      # 'nftban firewall reload'). Would also have caught the 2026-06-01
-      # audit's incorrect-by-half proposed replacement.
-      #
-      # T3-3/4/5 inside the test are the HARD pass criteria (would-have-
-      # caught the 3 historical broken hints). T3-2 reports legacy
-      # parser-heuristic drift as a v1.145.x sweep candidate (does not
-      # block CI). New broken hints introduced in any future PR will
-      # surface as additional violations and require explicit fix or
-      # allowlist entry with `reason` field.
-      - name: Runtime-hint reachability guard (v1.144.0 PR-D D-UXV-13)
-        run: bash cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh
-
-      # Companion that locks the allowlist's `reason` field requirement +
-      # restates the would-have-caught hypotheticals as defense-in-depth.
-      - name: Help-block reachability companion (v1.144.0 PR-D)
-        run: bash cli/lib/nftban/tests/cli_help_block_reachability_v144_test.sh
-
-      # =====================================================================
-      # v1.145 SSH-port lifecycle guards (PR-A/PR-B/PR-C2 + PR-G wiring)
-      # =====================================================================
-      # These static guards lock the set-driven SSH brute-force rate-limit
-      # (`tcp dport @ssh_ports ct count`): the ssh_ports set in every template,
-      # its presence in the schema inventory (both families), both-set
-      # (tcp_ports_in + ssh_ports) runtime parity, union detection, and the
-      # apply-path hardening. They existed since v1.145 but were never wired
-      # into CI (v1.145 PR-G audit finding); without these `run:` steps the
-      # guards provided zero regression protection.
-      - name: SSH ssh_ports template set-driven guard (v1.145 PR-A)
-        run: bash cli/lib/nftban/tests/v145_ssh_port_template_set_driven_static_test.sh
-
-      - name: SSH union detection guard (v1.145 PR-B)
-        run: bash cli/lib/nftban/tests/v145_ssh_port_detect_test.sh
-
-      - name: SSH both-set parity runtime guard (v1.145 PR-B)
-        run: bash cli/lib/nftban/tests/v145_pr_b_runtime_static_guard_test.sh
-
-      - name: SSH apply-path hardening guard (v1.145 PR-C2)
-        run: bash cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
-
-      - name: ssh_ports systemic-alignment invariants (v1.145 PR-G)
-        run: bash cli/lib/nftban/tests/v145_pr_g_ssh_ports_invariants_test.sh
-
-      # External admin SSH-port guard (OBS-SSHPORT-55000-FAMILY): warn-only +
-      # lockout-net. Asserts the guard warns on an external :55000->:22 redirect,
-      # session-whitelists the admin IP via the IPC whitelist-session path only
-      # (no direct nft write), keeps ssh_ports = {22} (REJECT import), and is a
-      # no-op off-session / on dry-run / on opt-out / on re-entry.
-      - name: External admin SSH-port guard (OBS-SSHPORT-55000)
-        run: bash cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh
-
-      # v1.155 PR-1 (item 3.2): socket-activated sshd port-mismatch warning.
-      # Asserts the guard warns ONLY when configured (sshd -T) != listening (ss)
-      # AND sshd is socket-activated, prints the exact remediation hint
-      # (`systemctl daemon-reload && systemctl restart ssh.socket`), and is
-      # silent when ports match or on a plain sshd.service. Hermetic.
-      - name: Socket-activated SSH port-mismatch warning (v1.155 PR-1)
-        run: bash cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh
-
-      # v1.155 PR-2 (item 3.3): SSH-port-change lifecycle validator invariants.
-      # Exercises tools/validation/ssh_port_change_lifecycle_validate.sh against a
-      # good rendered-ruleset fixture (exit 0) and four injected drifts (listener
-      # not in ssh_ports / not in tcp_ports_in; literal `tcp dport 22 ct count`
-      # instead of @ssh_ports; missing @ssh_ports rule), each failing with the
-      # right invariant message. Hermetic (inputs injected via env).
-      - name: SSH-port-change lifecycle validator (v1.155 PR-2)
-        run: bash cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh
 
       # v1.161: default-enabled-timer first-run guard (geoban lesson, v1.156->v1.159).
       # Enumerates the installer's auto-enabled timers (coreTimers in
@@ -814,174 +703,10 @@ jobs:
       - name: Static nftables fallback is set-driven (v1.162 PR-B)
         run: bash cli/lib/nftban/tests/static_nftables_ssh_set_driven_v162.sh
 
-      # v1.165 PR-A: generated-spec comment-macro lint. rpm 4.16 (EL9/EL10)
-      # parses a bare unescaped %install token in a SPEC COMMENT as a second
-      # %install section (`error: second %install`) and fails Build RPM
-      # el9/el10 deterministically — this bit twice (v1.157 FIX_V157_PR_A,
-      # v1.164 PR-C revert) because rpm 4.18 (lab2) + rpm 6.x are lenient and
-      # miss it. This hermetic static guard catches the class BEFORE the
-      # expensive el9/el10 rpmbuild: zero %install outside the single section
-      # header, and no bare RPM section macro in any generated-spec comment.
-      - name: RPM spec has no section macro in a comment (v1.165 PR-A)
-        run: bash cli/lib/nftban/tests/rpm_spec_no_section_macro_in_comment_v165_test.sh
-
-      # v1.165 PR-B: the %files section both %include nftban-files.inc (which
-      # %dir-owns every /usr/lib/nftban payload dir) and used to repeat those
-      # dirs as bare payload paths, so strict rpm 4.16 warned "File listed
-      # twice". PR-B lists the 12 lib dirs as <dir>/* (inc keeps sole %dir
-      # ownership) and strips dotfiles in %install so the /* glob (which skips
-      # dotfiles) does not orphan tests/.gitkeep. This static guard asserts the
-      # dedup shape + the dotfile strip; the full no-double-listing / no-orphan
-      # parse is confirmed by Build RPM el9/el10.
-      - name: RPM %files lib-dir dedup (no double dir listing) (v1.165 PR-B)
-        run: bash cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh
-
-      # v1.166 PR-C: templates %files dedup via FHS-generator correction. The
-      # bare /usr/share/nftban/templates line both double-listed the generator
-      # %dir-owned dirs and solely owned the email/+partials/ staged .html (no
-      # inc %dir), so it could not be dropped naively. PR-C adds %dir for
-      # templates/email + templates/partials to build/fhs-spec.yaml (regenerated
-      # into nftban-files.inc), lists the 4 content subdirs as <dir>/*, keeps
-      # zabbix as an empty %dir, and strips dotfiles in %install. This guard
-      # asserts the dedup shape + generator ownership; the no-orphan/no-double
-      # parse is confirmed by Build RPM el9/el10. (FHS body changes by design —
-      # the "FHS spec generated files check" gate enforces generator parity.)
-      - name: RPM %files templates dedup (FHS-generator correction) (v1.166 PR-C)
-        run: bash cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh
-
-      # v1.167 UX-residual lane guards (were merged un-wired; wired here as part
-      # of the v1.167 blocker fix so future regressions are caught in CI).
-      - name: Feed-counter unification (v1.167 PR-1, BUG-CtCount-feeds)
-        run: bash cli/lib/nftban/tests/feed_counters_unify_v167_test.sh
-      - name: CLI output-truth + flag-parity (v1.167 PR-2)
-        run: bash cli/lib/nftban/tests/cli_output_truth_v167_test.sh
-      - name: No re-introduced orphan modules (v1.167 PR-3)
-        run: bash cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh
-      # v1.167 SHIP-BLOCKER guard: `nftban update --dry-run` must return rc=1 with
-      # the 3-line hint (NOT command-not-found rc=127). Also asserts the dispatcher
-      # sources cmd_common.sh so the 6 CLI-BUG-1 sibling error paths are reachable.
-      - name: update --dry-run hint rc=1 + CLI-BUG-1 reachability (v1.167)
-        run: bash cli/lib/nftban/tests/cli_update_dry_run_hint_v167_test.sh
-
-      # v1.168 CLI-BUG-2 whitelist-TTL lane guards: the 4 whitelist set decls
-      # must carry interval,timeout (render prereq) AND the DEB/RPM upgrade path
-      # must re-activate timeout-capable sets (GetOrCreateIntervalSet reuses
-      # existing flagless sets). The TTL-survives-FullSync invariant is a Go test
-      # (internal/setsync) run by ci-go.yml.
-      - name: Whitelist sets carry timeout flag (v1.168 render prereq)
-        run: bash cli/lib/nftban/tests/whitelist_set_timeout_flag_v168_test.sh
-      - name: Whitelist-TTL upgrade activation backstop (v1.168 deb+rpm)
-        run: bash cli/lib/nftban/tests/whitelist_timeout_upgrade_activation_v168_test.sh
-
-      # v1.169 CLI-BUG-3: `whitelist list` labels timed/session vs durable entries.
-      - name: Whitelist list timed/session label (v1.169 CLI-BUG-3)
-        run: bash cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh
-
-      # v1.169 CI-TEST-GAP: wire 6 substantive guards that shipped with their
-      # lanes (v1.158–v1.163) but were never added to any workflow. Each is
-      # hermetic (no host/root) — they only catch a future regression once run.
-      - name: MAC posture advisory surface (v1.158)
-        run: bash cli/lib/nftban/tests/mac_posture_v158_test.sh
-      - name: Geoban-refresh ExecCondition skip-not-fail (v1.159)
-        run: bash cli/lib/nftban/tests/geoban_refresh_execcondition_v159_test.sh
       - name: Firewall-pkg state-aware wording (v1.160)
         run: bash cli/lib/nftban/tests/firewall_pkg_wording_v160.sh
       - name: Permissions optional-module skip (v1.160)
         run: bash cli/lib/nftban/tests/permissions_optional_module_skip_v160.sh
-      - name: Whitelist verify read-only (v1.163)
-        run: bash cli/lib/nftban/tests/whitelist_verify_v163_test.sh
-      - name: Immutable-flag health verify (v1.163)
-        run: bash cli/lib/nftban/tests/immutable_health_verify_v163_test.sh
-
-      # v1.170 BUG-STATS-IP-HISTORY: `nftban stats ip <IP>` must single-emit (no
-      # pipefail double-`[]` arith crash for zero-record IPs) AND read compressed/
-      # rotated bans.log archives (zgrep); + gzip dep stays declared.
-      - name: stats ip history pipefail + compressed-log fix (v1.170)
-        run: bash cli/lib/nftban/tests/stats_ip_history_v170_test.sh
-
-      # v1.171 §4.2/§4.3/§3.6: daemon state writes are atomic (route through
-      # safety.SafeWriteFile); ssh_ports counter seeded. The atomic mechanism
-      # itself is proven by Go test internal/safety/atomic_write_v171_test.go.
-      - name: state-write atomicity call-site lock (v1.171)
-        run: bash cli/lib/nftban/tests/state_write_atomicity_v171_test.sh
-
-      # v1.172 CLI-PIPEFAIL-ARITH sweep: zero-match grep / SIGPIPE / jq-parse failures
-      # under set -Eeuo pipefail must not double-emit a numeric ("0\n0") that crashes a
-      # downstream [[ -eq/-gt ]] / jq tonumber. Behavioral single-emit checks + static
-      # lint that the previously-broken arith-fed sites no longer carry the unsafe forms.
-      - name: CLI pipefail-arith sweep (v1.172)
-        run: bash cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh
-
-      # v1.173 §4.1 session-whitelist flock (shell side): each of the 3
-      # cmd_firewall.sh session RMW funcs serializes its read-modify-write under
-      # flock(9) on the shared cross-language lock /run/nftban/session_whitelist.lock
-      # (same path the Go installer flock(2)s). Go side is covered by
-      # internal/installer/safety/session_whitelist_flock_v173_test.go.
-      - name: session-whitelist flock shell-side (v1.173)
-        run: bash cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh
-
-      # v1.174 HEALTH-OOM-JOURNALCTL: every actual journalctl invocation on the
-      # nftban-health.service health-check path is bounded (-n/--since), and the
-      # unit's MemoryMax is raised 128M->256M for the validator + concurrent-
-      # children RSS on large journals. The Go validator read is already bounded
-      # (internal/validator/journal.go --since -15m -n 200). The stale failed-
-      # unit classification half is covered by Go test
-      # internal/installer/validate/systemd_payload_v174_test.go.
-      - name: health journalctl bounded + MemoryMax 256M (v1.174)
-        run: bash cli/lib/nftban/tests/health_journalctl_bounded_v174_test.sh
-
-      # v1.174 ALERT-THROTTLE-NONFATAL: a state-write (throttle/diagnostics/
-      # failure-metric) permission failure must NOT fail/latch nftban-alert@*.service
-      # (monitor root cause), but a real alert DELIVERY failure still follows the rc
-      # contract. cli/sbin/nftban-service-alert.
-      - name: alert bookkeeping non-fatal, delivery keeps rc (v1.174)
-        run: bash cli/lib/nftban/tests/alert_bookkeeping_nonfatal_v174_test.sh
-
-      # v1.174 update-summary messaging: surface an auto-recovered pre-existing
-      # failed unit to the operator (transparency) + fix the misleading DEGRADED
-      # "known transient on the exporter" wording. cli/lib/nftban/cli/cmd_update.sh.
-      - name: update messaging recovered + DEGRADED (v1.174)
-        run: bash cli/lib/nftban/tests/update_msg_recovered_v174_test.sh
-
-      # v1.225.0 PR-A: DEGRADED render truth — strict-mode-safe absent SERVICES_FAILED
-      # (E1a) + all-filtered truthful hint (E1b). cli/lib/nftban/cli/cmd_update.sh.
-      # Hermetic (sources the file, drives the render helper in a subprocess; no host).
-      - name: update DEGRADED render truth (v1.225.0 PR-A)
-        run: bash cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh
-
-      # v1.223.0 mail recipient/subject/help guard — was UNWIRED on main (executed in zero
-      # workflows) despite being merged in #1131; this is the OPEN_TEST_SUITE_SINGLE_AUTHORITY
-      # Phase-A carve-out that closes the same gap-class that let the mail bug slip. Hermetic
-      # static grep guard (no host/root/network); belongs in Policy Gates.
-      - name: mail recipient/subject/help guard (v1.223.0)
-        run: bash cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh
-
-      # v1.175 FHS lane: (T1) GENERIC guard — no root-owned tmpfiles entry under a
-      # non-root declared parent (the systemd-tmpfiles exit-73 "unsafe path transition"
-      # class — structural BUG-TMPFILES regression lock); auditors→package +
-      # firewall-validate→ExecStartPre out of tmpfiles; ALERT-THROTTLE-FHS alerts dir;
-      # FHS-SMELL-SIDSTATS cache.go DataDir relocation + migration.
-      - name: FHS lane invariants — tmpfiles transition guard + relocations (v1.175)
-        run: bash cli/lib/nftban/tests/fhs_lane_v175_test.sh
-
-      # v1.176 DAEMON RELIABILITY: FSYNC-RESIDUAL durability-idiom class lock —
-      # no NEW hand-rolled temp+rename Go state writer outside internal/safety
-      # (route through safety.SafeWriteFile); regression-guards the F-1/F-2 fixes.
-      - name: FSYNC-RESIDUAL durability-idiom guard (v1.176)
-        run: bash cli/lib/nftban/tests/fsync_residual_guard_v176_test.sh
-
-      # v1.177 HTTP LOG DISCOVERY: panel-aware access-log discovery helper —
-      # DirectAdmin/cPanel/Plesk/generic/LiteSpeed globs, multi-log, dedup,
-      # error/rotated exclusion, MAX_FILES bound, IPv6 parse, incremental offset
-      # + rotation/copytruncate, and the legacy-miss vs new-find regression.
-      - name: HTTP log discovery + BotScan panel paths (v1.177)
-        run: bash cli/lib/nftban/tests/http_log_discovery_v177_test.sh
-
-      - name: BotScan read-authority collector + spool-first (v1.178-A)
-        run: bash cli/lib/nftban/tests/botscan_read_authority_v178_test.sh
-
-      - name: BotScan processor deadline + rotation (v1.185 Lane B)
-        run: bash cli/lib/nftban/tests/botscan_deadline_rotation_v185_test.sh
 
       # =====================================================================
       # v1.86 B86-4: Contract Enforcement — Legacy Regression Blockers

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ scripts/lab-deploy-servers.conf
 # Private exact host/IP patterns for privacy-scan (never commit)
 scripts/ci/privacy-forbidden.txt
 /nftban-core
+
+# v1.226.0 PR-C: ci-bash informational runner manifest (CI runtime artifact)
+ci-bash-manifest.txt

--- a/scripts/ci/check-ci-bash-baseline-selftest.sh
+++ b/scripts/ci/check-ci-bash-baseline-selftest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="check-ci-bash-baseline-selftest"
+# meta:type="script"
+# meta:version="1.226.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Hermetic self-tests for check-ci-bash-baseline.sh: proves the integrity gate passes clean baselines and blocks drift/regression/dup/empty-manifest"
+# meta:inventory.files="scripts/ci/check-ci-bash-baseline.sh"
+# meta:inventory.binaries="bash,git,mktemp,grep,printf,cat"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-tests for scripts/ci/check-ci-bash-baseline.sh (v1.226.0 PR-C).
+# Hermetic: builds synthetic git repos with a small index + baseline + manifest
+# and asserts the BLOCKING integrity gate passes clean baselines and BLOCKS
+# every drift/regression condition. All values synthetic.
+#
+# Expected-nonzero gate calls are captured in compounds (`... && bad || ok`) so
+# the required `set -Eeuo pipefail` never aborts on an intended failure.
+# =============================================================================
+set -Eeuo pipefail
+
+GATE="$(cd "$(dirname "$0")" && pwd)/check-ci-bash-baseline.sh"
+FAIL=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s  %s\n' "$1" "${2:-}"; FAIL=1; }
+
+# synthetic index: 4 ci-bash rows (t1..t4) + a non-ci-bash row (ignored)
+IDXHDR=$'id\tpath\towner\ttype\tmodule\texecution_class\tgate\th\trr\trn\trs\trnft\trp\ttimeout\texcl\tact'
+mkrepo() {
+    local r; r="$(mktemp -d)"; git init -q "$r"; git -C "$r" config user.email t@t; git -C "$r" config user.name t
+    mkdir -p "$r/scripts/ci"
+    { printf '#\n#\n#\n%s\n' "$IDXHDR"
+      for id in t1 t2 t3 t4; do printf '%s\tcli/lib/nftban/tests/%s.sh\to\tt\tm\tC\tci-bash\tt\tf\tf\tf\tf\tf\t\t\t\n' "$id" "$id"; done
+      printf 'x1\tcli/lib/nftban/tests/x1.sh\to\tt\tm\tC\tpolicy-gates\tt\tf\tf\tf\tf\tf\t\t\t\n'
+    } > "$r/scripts/ci/test-authority-index.tsv"
+    # baseline: SELECTED=4 FAIL=1, accepted failing id = t3
+    { printf 'CI_BASH_SELECTED=4\nCI_BASH_PASS=3\nCI_BASH_FAIL=1\nCI_BASH_TIMEOUT=0\nCI_BASH_ENFORCEMENT=INFORMATIONAL_BASELINE\nCI_BASH_INFORMATIONAL_BASELINE_SHA=x\n'
+      printf 'FAIL\tt3\tsource-spec-drift\n'
+    } > "$r/scripts/ci/ci-bash-informational-baseline.tsv"
+    printf '%s' "$r"
+}
+manifest() {  # repo  then rows "STATUS id" on stdin -> writes ci-bash-manifest.txt with matching SELECTED/FAIL
+    local r="$1"; shift
+    local tmp; tmp="$(mktemp)"; cat > "$tmp"
+    local sel pass fl to
+    # grep -c returns nonzero on a zero count (e.g. no TIMEOUT rows); guard under -e
+    sel="$(grep -c . "$tmp" || true)"; pass="$(grep -c '^PASS ' "$tmp" || true)"
+    fl="$(grep -c '^FAIL ' "$tmp" || true)"; to="$(grep -c '^TIMEOUT ' "$tmp" || true)"
+    { printf '# manifest\nGATE\tci-bash\nSELECTED\t%s\nPASS\t%s\nFAIL\t%s\nTIMEOUT\t%s\n' "$sel" "$pass" "$fl" "$to"
+      while read -r st id; do printf 'TEST\t%s\t%s\n' "$st" "$id"; done < "$tmp"
+    } > "$r/ci-bash-manifest.txt"
+    rm -f "$tmp"
+}
+runc() { ( cd "$1" && "$GATE" "$1/ci-bash-manifest.txt" ); }
+
+# clean baseline: exactly the accepted fail (t3), t1/t2/t4 pass -> exit 0
+t_clean() { local r; r="$(mkrepo)"; manifest "$r" <<<$'PASS t1\nPASS t2\nFAIL t3\nPASS t4'
+    runc "$r" >/dev/null 2>&1 && ok "clean baseline passes" || bad clean; rm -rf "$r"; }
+# NEW failing id t2 (regression) -> block
+t_regress() { local r; r="$(mkrepo)"; manifest "$r" <<<$'PASS t1\nFAIL t2\nFAIL t3\nPASS t4'
+    runc "$r" >/dev/null 2>&1 && bad regress_not_blocked || ok "new failing id (regression) BLOCKED"; rm -rf "$r"; }
+# improvement: t3 now passes, 0 fails -> allowed (exit 0)
+t_improve() { local r; r="$(mkrepo)"; manifest "$r" <<<$'PASS t1\nPASS t2\nPASS t3\nPASS t4'
+    runc "$r" >/dev/null 2>&1 && ok "improvement (accepted id now passes) allowed" || bad improve_blocked; rm -rf "$r"; }
+# disappeared test: only 3 selected -> block (SELECTED != index count 4)
+t_disappear() { local r; r="$(mkrepo)"; manifest "$r" <<<$'PASS t1\nPASS t2\nFAIL t3'
+    runc "$r" >/dev/null 2>&1 && bad disappear_not_blocked || ok "disappeared test BLOCKED"; rm -rf "$r"; }
+# extra/unknown test executed -> block (id set mismatch)
+t_extra() { local r; r="$(mkrepo)"; manifest "$r" <<<$'PASS t1\nPASS t2\nFAIL t3\nPASS t4\nPASS t9'
+    runc "$r" >/dev/null 2>&1 && bad extra_not_blocked || ok "unknown extra test BLOCKED"; rm -rf "$r"; }
+# duplicate execution -> block
+t_dup() { local r; r="$(mkrepo)"
+    # 4 rows but t1 twice, t4 missing -> SELECTED still 4, but duplicate + idset mismatch
+    manifest "$r" <<<$'PASS t1\nPASS t1\nPASS t2\nFAIL t3'
+    runc "$r" >/dev/null 2>&1 && bad dup_not_blocked || ok "duplicate execution BLOCKED"; rm -rf "$r"; }
+# empty manifest -> block (step never executed)
+t_empty() { local r; r="$(mkrepo)"; : > "$r/ci-bash-manifest.txt"
+    runc "$r" >/dev/null 2>&1 && bad empty_not_blocked || ok "empty manifest (step did not run) BLOCKED"; rm -rf "$r"; }
+# missing manifest -> block
+t_missing() { local r; r="$(mkrepo)"; rm -f "$r/ci-bash-manifest.txt"
+    runc "$r" >/dev/null 2>&1 && bad missing_not_blocked || ok "missing manifest BLOCKED"; rm -rf "$r"; }
+
+for t in t_clean t_regress t_improve t_disappear t_extra t_dup t_empty t_missing; do "$t"; done
+echo
+if [ "$FAIL" -eq 0 ]; then echo "CHECK_CI_BASH_BASELINE_SELFTEST_PASS"; exit 0
+else echo "CHECK_CI_BASH_BASELINE_SELFTEST_FAIL"; exit 1; fi

--- a/scripts/ci/check-ci-bash-baseline.sh
+++ b/scripts/ci/check-ci-bash-baseline.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="check-ci-bash-baseline"
+# meta:type="script"
+# meta:version="1.226.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Blocking ci-bash observation-integrity gate: proves the informational runner executed all classified tests without drift or regression above baseline"
+# meta:inventory.files="scripts/ci/test-authority-index.tsv,scripts/ci/ci-bash-informational-baseline.tsv,ci-bash-manifest.txt"
+# meta:inventory.binaries="bash,git,awk,grep,sort,diff,sed,printf"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# ci-bash observation-integrity gate (v1.226.0 PR-C, BLOCKING).
+#
+# The ci-bash class runs INFORMATIONALLY (non-blocking) in CI.  This gate proves
+# that the informational step actually executed and did not silently drift or
+# regress — WITHOUT re-executing the 184 tests (it consumes the runner manifest
+# the informational step already produced; one shared execution).
+#
+# It BLOCKS (exit 1) if any of the following is violated against the committed
+# baseline (scripts/ci/ci-bash-informational-baseline.tsv) and the canonical
+# authority index:
+#   * the manifest is missing/empty  -> the informational step never ran
+#   * the manifest gate is not ci-bash
+#   * SELECTED != index ci-bash count            (a test disappeared / index drift)
+#   * SELECTED != baseline CI_BASH_SELECTED
+#   * executed-id set != index ci-bash id set    (a test disappeared / extra ran)
+#   * a test executed more than once
+#   * not every failing id is reported
+#   * a NEW failing id appears (not in the accepted baseline list) -> regression
+#   * FAIL exceeds the accepted CI_BASH_FAIL ceiling
+#
+# Allowed (reported, not blocked): a baseline-accepted id that now PASSES
+# (improvement) — tighten the baseline under PR-D.
+#
+# Usage: check-ci-bash-baseline.sh [MANIFEST]   (default: ci-bash-manifest.txt at root)
+# Exit:  0 ok · 1 integrity violation · 2 usage/inputs missing
+# =============================================================================
+set -Eeuo pipefail
+
+INDEX_REL="scripts/ci/test-authority-index.tsv"
+BASELINE_REL="scripts/ci/ci-bash-informational-baseline.tsv"
+
+die()  { printf 'check-ci-bash-baseline: %s\n' "$1" >&2; exit 2; }
+fail() { printf '  VIOLATION %s\n' "$1" >&2; VIOL=$((VIOL+1)); }
+
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
+manifest="${1:-$root/ci-bash-manifest.txt}"
+idx="$root/$INDEX_REL"
+base="$root/$BASELINE_REL"
+[ -f "$idx" ]  || die "authority index not found: $INDEX_REL"
+[ -f "$base" ] || die "baseline not found: $BASELINE_REL"
+
+# --- fail-closed: the informational step must have produced a non-empty manifest ---
+# `-s` is false for a missing OR empty file, so this covers both.
+if [ ! -s "$manifest" ]; then
+    printf 'check-ci-bash-baseline: INTEGRITY FAIL — manifest missing or empty (%s)\n' "$manifest" >&2
+    printf 'check-ci-bash-baseline: the ci-bash informational step did not execute.\n' >&2
+    exit 1
+fi
+
+VIOL=0
+
+# --- baseline values ---------------------------------------------------------
+b_selected="$(awk -F= '/^CI_BASH_SELECTED=/{print $2}' "$base")"
+b_fail="$(awk -F= '/^CI_BASH_FAIL=/{print $2}' "$base")"
+# accepted failing ids (column 2 of "FAIL<TAB>id<TAB>bucket" rows)
+accepted="$(awk -F'\t' '$1=="FAIL"{print $2}' "$base" | sort -u)"
+n_accepted="$(printf '%s\n' "$accepted" | grep -c . || true)"
+
+# --- index ci-bash id set ----------------------------------------------------
+idx_ids="$(awk -F'\t' '/^#/{next} !h{h=1;next} $7=="ci-bash"{print $1}' "$idx" | sort -u)"
+idx_count="$(printf '%s\n' "$idx_ids" | grep -c . || true)"
+
+# --- manifest values ---------------------------------------------------------
+m_gate="$(awk -F'\t' '$1=="GATE"{print $2}' "$manifest")"
+m_selected="$(awk -F'\t' '$1=="SELECTED"{print $2}' "$manifest")"
+m_fail="$(awk -F'\t' '$1=="FAIL"{print $2}' "$manifest")"
+exec_ids="$(awk -F'\t' '$1=="TEST"{print $3}' "$manifest" | sort)"
+exec_count="$(printf '%s\n' "$exec_ids" | grep -c . || true)"
+exec_uniq="$(printf '%s\n' "$exec_ids" | sort -u | grep -c . || true)"
+manifest_fail_ids="$(awk -F'\t' '$1=="TEST" && $2=="FAIL"{print $3}' "$manifest" | sort -u)"
+manifest_timeout_ids="$(awk -F'\t' '$1=="TEST" && $2=="TIMEOUT"{print $3}' "$manifest" | sort -u)"
+# TIMEOUT counts as a failing outcome for baseline-subset purposes
+manifest_bad_ids="$(printf '%s\n%s\n' "$manifest_fail_ids" "$manifest_timeout_ids" | grep -c . || true)"
+
+# --- checks ------------------------------------------------------------------
+[ "$m_gate" = "ci-bash" ] || fail "manifest gate is '$m_gate', expected ci-bash"
+[ "$m_selected" = "$idx_count" ]  || fail "SELECTED=$m_selected != index ci-bash count=$idx_count (a test disappeared or index drifted)"
+[ "$m_selected" = "$b_selected" ] || fail "SELECTED=$m_selected != baseline CI_BASH_SELECTED=$b_selected"
+[ "$exec_count" = "$m_selected" ] || fail "executed rows=$exec_count != SELECTED=$m_selected (not every selected test executed)"
+[ "$exec_count" = "$exec_uniq" ]  || fail "duplicate execution detected (executed=$exec_count unique=$exec_uniq)"
+
+# executed id set must equal the index ci-bash id set (no disappearance, no extra)
+if ! diff <(printf '%s\n' "$idx_ids") <(printf '%s\n' "$exec_ids") >/tmp/.rts_idsdiff 2>&1; then
+    fail "executed id set != index ci-bash id set:"; sed 's/^/      /' /tmp/.rts_idsdiff >&2
+fi
+rm -f /tmp/.rts_idsdiff
+
+# ceiling
+if [ -n "$m_fail" ] && [ -n "$b_fail" ]; then
+    [ "$m_fail" -le "$b_fail" ] || fail "FAIL=$m_fail exceeds accepted baseline ceiling CI_BASH_FAIL=$b_fail (new failures)"
+fi
+
+# every failing/timeout id must be in the accepted set; a NEW one is a regression
+new_bad=""
+while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    printf '%s\n' "$accepted" | grep -qxF "$id" || new_bad="$new_bad $id"
+done < <(printf '%s\n%s\n' "$manifest_fail_ids" "$manifest_timeout_ids")
+[ -z "$new_bad" ] || fail "NEW failing id(s) not in accepted baseline (regression):$new_bad"
+
+# improvements: accepted ids that now pass (report only)
+improved=""
+while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    printf '%s\n%s\n' "$manifest_fail_ids" "$manifest_timeout_ids" | grep -qxF "$id" \
+        || improved="$improved $id"
+done < <(printf '%s\n' "$accepted")
+
+# --- summary -----------------------------------------------------------------
+printf 'check-ci-bash-baseline: gate=%s SELECTED=%s FAIL=%s (accepted<=%s) index_count=%s accepted_ids=%s reported_bad=%s\n' \
+    "$m_gate" "$m_selected" "$m_fail" "$b_fail" "$idx_count" "$n_accepted" "$manifest_bad_ids" >&2
+[ -n "$improved" ] && printf 'check-ci-bash-baseline: IMPROVED (now passing, tighten baseline under PR-D):%s\n' "$improved" >&2
+
+if [ "$VIOL" -gt 0 ]; then
+    printf 'check-ci-bash-baseline: INTEGRITY FAIL — %d violation(s)\n' "$VIOL" >&2
+    exit 1
+fi
+printf 'check-ci-bash-baseline: OK — ci-bash informational baseline integrity holds\n' >&2
+exit 0

--- a/scripts/ci/ci-bash-informational-baseline.tsv
+++ b/scripts/ci/ci-bash-informational-baseline.tsv
@@ -1,0 +1,51 @@
+# NFTBan ci-bash INFORMATIONAL baseline — v1.226.0 PR-C.  NOT the final enforcement state.
+#
+# The `ci-bash` execution class is driven by the canonical authority index and executed
+# by scripts/ci/run-test-suite.sh.  In PR-C the class runs INFORMATIONALLY (non-blocking):
+# it exists to give the previously-unenforced ci-bash tests real execution visibility.
+#
+# Executing the class exposed 19 PRE_EXISTING_NEWLY_EXPOSED_TEST_FAILURES.  They are NOT
+# PR-C regressions (all 19 reproduce under direct `bash <test>` invocation from repo root;
+# runner-caused failures = 0).  They must not be silently changed to PASS, skipped, or
+# deleted.  PR-D owns their triage and the transition to blocking enforcement.
+#
+# The BLOCKING integrity gate (scripts/ci/check-ci-bash-baseline.sh) consumes the runner
+# manifest and enforces observation integrity against this file:
+#   * SELECTED must equal the index ci-bash count AND CI_BASH_SELECTED below
+#   * every failing id must be reported in the manifest
+#   * no test may execute twice
+#   * the informational step must actually have executed (non-empty manifest)
+#   * the failing-id SET must be a SUBSET of the accepted list below
+#       - a NEW failing id (not listed) => regression => BLOCK
+#       - a listed id that now PASSES  => improvement => allowed (tighten under PR-D)
+#   * CI_BASH_FAIL is a CEILING, never a permanent "exactly-19" invariant
+#
+# Counts (accepted baseline):
+CI_BASH_SELECTED=184
+CI_BASH_PASS=165
+CI_BASH_FAIL=19
+CI_BASH_TIMEOUT=0
+CI_BASH_ENFORCEMENT=INFORMATIONAL_BASELINE
+CI_BASH_INFORMATIONAL_BASELINE_SHA=12a93ff05a6b61f3151cf6d5eda9fde8224233e7
+#
+# Accepted pre-existing failing ids (id <TAB> bucket).  Buckets are PROVISIONAL PR-C
+# dispositions; PR-D challenges each individually.
+FAIL	b2_badbot_aibot_v188_test	source-spec-drift
+FAIL	banner_nobanner_v153_test	source-spec-drift
+FAIL	botguard_diag_6b2_test	source-spec-drift
+FAIL	botguard_explain_shell_6b1_test	source-spec-drift
+FAIL	logs_truth_v150_test	source-spec-drift
+FAIL	stats_manual_cache_v150_test	source-spec-drift
+FAIL	stats_producer_reconcile_v152_test	source-spec-drift
+FAIL	stats_status_truth_v150_test	source-spec-drift
+FAIL	v127_ux4_suricata_desurfacing_test	source-spec-drift
+FAIL	v127_ux6_help_cleanup_test	source-spec-drift
+FAIL	v128_help_code_correlation_test	source-spec-drift
+FAIL	v128_polkit_aware_wording_sweep_test	source-spec-drift
+FAIL	cmd_firewall_takeover_test	behavior-regression-investigation
+FAIL	cmd_firewall_trust_remerge_test	behavior-regression-investigation
+FAIL	cmd_update_lock_cleanup_v135_test	behavior-regression-investigation
+FAIL	v129_pr_c_runtime_defect_fixes_test	behavior-regression-investigation
+FAIL	rbl_seven_state_v206_test	rbl-fixture-debt-PR-E
+FAIL	botscan_spool_oom_v2093_test	spool-timing-investigation
+FAIL	botscan_throughput_v187_test	spool-timing-investigation

--- a/scripts/ci/ci-bash-red-baseline-audit.md
+++ b/scripts/ci/ci-bash-red-baseline-audit.md
@@ -1,0 +1,48 @@
+# ci-bash INFORMATIONAL_BASELINE — 19 pre-existing newly-exposed failures
+
+**Lane:** v1.226.0 PR-C (index-driven runner). **State:** `CI_BASH_ENFORCEMENT = INFORMATIONAL_BASELINE` (non-blocking).
+**Classification:** `PRE_EXISTING_NEWLY_EXPOSED_TEST_FAILURES` — not PR-C regressions.
+
+Executing the previously-unenforced `ci-bash` class through the authority runner exposed 19 failing
+tests. All 19 reproduce under direct `bash <test>` invocation from the repository root (runner-caused
+failures = 0; harness mismatch = 0). They are recorded here as evidence and carried as a bounded,
+non-increasing baseline (`scripts/ci/ci-bash-informational-baseline.tsv`). They **must not** be
+silently changed to PASS, skipped, or deleted. PR-D owns triage and the transition to blocking
+enforcement; product defects, if confirmed, split into their own failure-domain lanes.
+
+Baseline (this PR-C head): SELECTED=184 · PASS=165 · FAIL=19 · TIMEOUT=0.
+
+Buckets: source/spec drift = 12 · behavior/regression investigation = 4 · RBL fixture debt = 1 · spool/timing investigation = 2.
+
+| # | ta.id | path (repo-relative, `cli/lib/nftban/tests/…`) | gate | bucket | observed (concise) | serial repro | provisional disposition | finding handle |
+|---|-------|-----|------|--------|--------------------|--------------|-------------------------|----------------|
+| 1 | banner_nobanner_v153_test | banner_nobanner_v153_test.sh | ci-bash | source-spec-drift | subcommands not routed to one-line header — `PATH:NONE-OR-FULLBODY` (10P/6F) | fails | challenge test vs current banner routing source | V1226-CIBASH-DRIFT-01 |
+| 2 | b2_badbot_aibot_v188_test | b2_badbot_aibot_v188_test.sh | ci-bash | source-spec-drift | spec must ship `*.patterns` as `config(noreplace)` glob | fails | challenge test vs current RPM spec | V1226-CIBASH-DRIFT-02 |
+| 3 | botguard_diag_6b2_test | botguard_diag_6b2_test.sh | ci-bash | source-spec-drift | botguard diag surface assertion drift | fails | challenge test vs current botguard diag | V1226-CIBASH-DRIFT-03 |
+| 4 | botguard_explain_shell_6b1_test | botguard_explain_shell_6b1_test.sh | ci-bash | source-spec-drift | render must label section TEMPORARY/not-durable | fails | challenge test vs current explain render | V1226-CIBASH-DRIFT-04 |
+| 5 | logs_truth_v150_test | logs_truth_v150_test.sh | ci-bash | source-spec-drift | T4.1 header exact-path enumeration wording | fails | challenge test vs current logs header | V1226-CIBASH-DRIFT-05 |
+| 6 | stats_manual_cache_v150_test | stats_manual_cache_v150_test.sh | ci-bash | source-spec-drift | display: IPv4 `manual:` label | fails | challenge test vs current stats display | V1226-CIBASH-DRIFT-06 |
+| 7 | stats_producer_reconcile_v152_test | stats_producer_reconcile_v152_test.sh | ci-bash | source-spec-drift | consumer manual-subset label missing | fails | challenge test vs current stats producer | V1226-CIBASH-DRIFT-07 |
+| 8 | stats_status_truth_v150_test | stats_status_truth_v150_test.sh | ci-bash | source-spec-drift | T9.2 `.local` override still sourced | fails | challenge test vs current stats status | V1226-CIBASH-DRIFT-08 |
+| 9 | v127_ux4_suricata_desurfacing_test | v127_ux4_suricata_desurfacing_test.sh | ci-bash | source-spec-drift | E1: scope-creep `levenshtein\|edit_distance` now present in nftban | fails | challenge test vs intentional current surface | V1226-CIBASH-DRIFT-09 |
+| 10 | v127_ux6_help_cleanup_test | v127_ux6_help_cleanup_test.sh | ci-bash | source-spec-drift | F3/F4 help REQUIRES-section polkit-aware wording | fails | challenge test vs current help blocks | V1226-CIBASH-DRIFT-10 |
+| 11 | v128_help_code_correlation_test | v128_help_code_correlation_test.sh | ci-bash | source-spec-drift | C4: 1 `cmd_<X>.sh` has no canonical-command match | fails | challenge test vs current command registry | V1226-CIBASH-DRIFT-11 |
+| 12 | v128_polkit_aware_wording_sweep_test | v128_polkit_aware_wording_sweep_test.sh | ci-bash | source-spec-drift | A3/A4: `requires root`/`must run as root` strings present in CLI | fails | challenge test vs current CLI wording policy | V1226-CIBASH-DRIFT-12 |
+| 13 | cmd_firewall_takeover_test | cmd_firewall_takeover_test.sh | ci-bash | behavior-regression-investigation | T6.1 non-root refusal | fails | runtime reachability + env-sensitivity analysis | V1226-CIBASH-BEHAV-01 |
+| 14 | cmd_firewall_trust_remerge_test | cmd_firewall_trust_remerge_test.sh | ci-bash | behavior-regression-investigation | missing warning: `Failed to re-apply trust providers…` | fails | confirm defect vs stale expectation | V1226-CIBASH-BEHAV-02 |
+| 15 | cmd_update_lock_cleanup_v135_test | cmd_update_lock_cleanup_v135_test.sh | ci-bash | behavior-regression-investigation | S3 contention path removes holders file (`unsafe`) | fails | confirm defect vs stale expectation | V1226-CIBASH-BEHAV-03 |
+| 16 | v129_pr_c_runtime_defect_fixes_test | v129_pr_c_runtime_defect_fixes_test.sh | ci-bash | behavior-regression-investigation | 1 assertion failing | fails | confirm defect vs stale expectation | V1226-CIBASH-BEHAV-04 |
+| 17 | rbl_seven_state_v206_test | rbl_seven_state_v206_test.sh | ci-bash | rbl-fixture-debt-PR-E | T7.1 unsupported_ipv6_zone, T8.1 skipped_ipv4_only_zone | fails | **assigned to PR-E** synthetic-public fixture correction | V1226-CIBASH-RBL-01 (→ PR-E) |
+| 18 | botscan_spool_oom_v2093_test | botscan_spool_oom_v2093_test.sh | ci-bash | spool-timing-investigation | T2/T3/T6 spool byte/size = 0 (`/tmp` spool) | fails | inspect fixed `/tmp` names, isolation, timing, real-log deps | V1226-CIBASH-SPOOL-01 |
+| 19 | botscan_throughput_v187_test | botscan_throughput_v187_test.sh | ci-bash | spool-timing-investigation | prefilter kept 2 candidates, expected 1 | fails | inspect prefilter counting, isolation, timing | V1226-CIBASH-SPOOL-02 |
+
+## PR-D responsibilities (not "fix all 19")
+
+PR-D is authority-enforcement policy, not a bulk product-fix lane. For each of the 19 it must determine
+whether the **product** is wrong, the **test expectation** is stale, the test is **environment-sensitive**,
+the test **belongs to PR-E**, the test is **flaky**, or the **classification** is wrong — then introduce a
+justified temporary quarantine/deferred mechanism (owner + reason + finding handle + review condition),
+activate blocking `ci-bash` for all non-quarantined tests, and add zero-unclassified / execution-completeness
+blockers. Any product change requires its own failure-domain GO. The RBL row stays with PR-E. If runner
+concurrency is ever shown to cause a spool/timing failure, the runner is fixed; serial reproduction (as
+recorded above) means the failure is genuine test/timing debt, handled separately.

--- a/scripts/ci/run-test-suite-selftest.sh
+++ b/scripts/ci/run-test-suite-selftest.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="run-test-suite-selftest"
+# meta:type="script"
+# meta:version="1.226.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Hermetic self-tests for run-test-suite.sh: selection, isolation, false-green mutation, injection inertness, fail-closed validation"
+# meta:inventory.files="scripts/ci/run-test-suite.sh"
+# meta:inventory.binaries="bash,git,mktemp,awk,grep,sed,printf,wc,sort"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# Self-tests for scripts/ci/run-test-suite.sh (v1.226.0 PR-C).
+#
+# Hermetic: builds throwaway git repos with a SYNTHETIC index + tiny fixture
+# tests and drives the real runner, asserting the 22-point safety contract,
+# class semantics, isolation, and a false-green mutation. No network, no root,
+# no dependency on the live 241-test corpus. All values are synthetic.
+# =============================================================================
+# This harness runs the runner with inputs EXPECTED to exit nonzero
+# (fail/timeout/safety-refusal). NFTBan coding standards require `set -Eeuo
+# pipefail`, so every expected-nonzero call is captured in a compound
+# (`... || rc=$?`, or `if ... then/else`) so -e never aborts on an intended failure.
+set -Eeuo pipefail
+
+RUNNER="$(cd "$(dirname "$0")" && pwd)/run-test-suite.sh"
+FAIL=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s  %s\n' "$1" "${2:-}"; FAIL=1; }
+
+# Header row mirrors the real 16-column index; only id(1) path(2) gate(7) timeout(14) are read.
+HEADER=$'id\tpath\towner\ttype\tmodule\texecution_class\tgate\thermetic\trequires_root\trequires_network\trequires_systemd\trequires_nftables\trequires_package\ttimeout\texclusion_reason\tactivation_condition'
+
+mkrepo() {
+    local root; root="$(mktemp -d)"
+    git init -q "$root"; git -C "$root" config user.email t@t; git -C "$root" config user.name t
+    mkdir -p "$root/cli/lib/nftban/tests" "$root/scripts/ci"
+    printf '%s' "$root"
+}
+addtest() {  # root name body
+    printf '#!/usr/bin/env bash\n%b\n' "$3" > "$1/cli/lib/nftban/tests/$2"
+}
+mkindex() {  # root then rows on stdin -> writes index with banner+header
+    { printf '# GENERATED FILE — DO NOT EDIT\n#\n#\n%s\n' "$HEADER"; cat; } > "$1/scripts/ci/test-authority-index.tsv"
+}
+row() {  # id gate [timeout] -> a full 16-col row for cli/lib/nftban/tests/<id>.sh
+    local id="$1" gate="$2" tmo="${3:-}"
+    printf '%s\tcli/lib/nftban/tests/%s.sh\to\ttest\tm\tCI_HERMETIC_SHELL\t%s\ttrue\tfalse\tfalse\tfalse\tfalse\tfalse\t%s\t\t\n' "$id" "$id" "$gate" "$tmo"
+}
+runr() { ( cd "$1" && shift && "$RUNNER" "$@" ); }   # run runner inside repo root
+
+# ---- selection + execution ---------------------------------------------------
+test_valid_run() {
+    echo test_valid_run
+    local r; r="$(mkrepo)"
+    addtest "$r" a_test.sh 'exit 0'; addtest "$r" b_test.sh 'exit 0'
+    mkindex "$r" <<< "$(row a_test ci-bash; row b_test ci-bash)"
+    local out rc=0; out="$(runr "$r" run --gate ci-bash 2>/dev/null)" || rc=$?
+    [ $rc -eq 0 ] && grep -q 'total=2 pass=2 fail=0' <<<"$out" && ok "valid gate runs and passes" || bad "valid_run" "$out"
+    rm -rf "$r"
+}
+test_fail_propagates() {
+    echo test_fail_propagates
+    local r; r="$(mkrepo)"
+    addtest "$r" a_test.sh 'exit 0'; addtest "$r" f_test.sh 'exit 1'
+    mkindex "$r" <<< "$(row a_test ci-bash; row f_test ci-bash)"
+    local rc=0; runr "$r" run --gate ci-bash >/dev/null 2>&1 || rc=$?
+    [ $rc -eq 1 ] && ok "an executed FAIL propagates nonzero" || bad "fail_propagates" "rc=$rc"
+    rm -rf "$r"
+}
+test_timeout_propagates() {
+    echo test_timeout_propagates
+    local r; r="$(mkrepo)"
+    addtest "$r" slow_test.sh 'sleep 30'
+    mkindex "$r" <<< "$(row slow_test ci-bash 1)"   # 1s timeout
+    local rc=0 out; out="$(runr "$r" run --gate ci-bash 2>&1)" || rc=$?
+    [ $rc -eq 1 ] && grep -q 'timeout=1' <<<"$out" && ok "TIMEOUT propagates nonzero" || bad "timeout" "rc=$rc $out"
+    rm -rf "$r"
+}
+test_deferred_not_executed() {
+    echo test_deferred_not_executed
+    local r; r="$(mkrepo)"
+    addtest "$r" d_test.sh 'exit 1'    # would fail IF executed
+    mkindex "$r" <<< "$(row d_test deferred)"
+    # run must refuse deferred as non-executable
+    local rc=0; runr "$r" run --gate deferred >/dev/null 2>&1 || rc=$?
+    [ $rc -eq 2 ] && ok "deferred refused by run (never executed)" || bad "deferred_run" "rc=$rc"
+    # report shows it, exit 0, no execution
+    local out; out="$(runr "$r" report --gate deferred 2>&1)"
+    grep -q 'count=1' <<<"$out" && ok "deferred visible in report (not counted PASS)" || bad "deferred_report" "$out"
+    rm -rf "$r"
+}
+test_lab_manual_and_package() {
+    echo test_lab_manual_and_package
+    local r; r="$(mkrepo)"
+    addtest "$r" l_test.sh 'exit 1'; addtest "$r" p_test.sh 'exit 1'
+    mkindex "$r" <<< "$(row l_test lab-manual; row p_test package-build)"
+    runr "$r" run --gate lab-manual >/dev/null 2>&1 && bad "lab_run_should_refuse" || ok "lab-manual not executable via run"
+    runr "$r" run --gate package-build >/dev/null 2>&1 && bad "pkg_run_should_refuse" || ok "package-build excluded from ordinary run"
+    local prc=0; runr "$r" run --gate package-build --allow-package >/dev/null 2>&1 || prc=$?
+    [ "$prc" -eq 1 ] && ok "package-build runs only with --allow-package (and the failing fixture fails)" || bad "pkg_allow"
+    rm -rf "$r"
+}
+# ---- validation / safety -----------------------------------------------------
+test_reject_unknown_gate() {
+    echo test_reject_unknown_gate
+    local r; r="$(mkrepo)"; addtest "$r" a_test.sh 'exit 0'
+    mkindex "$r" <<< "$(row a_test not-a-gate)"
+    runr "$r" verify >/dev/null 2>&1 && bad "unknown_gate_accepted" || ok "unknown gate value rejected (exit 2)"
+    rm -rf "$r"
+}
+test_reject_dupes_and_missing() {
+    echo test_reject_dupes_and_missing
+    local r
+    r="$(mkrepo)"; addtest "$r" a_test.sh 'exit 0'
+    mkindex "$r" <<< "$(row a_test ci-bash; row a_test ci-bash)"   # dup id+path
+    runr "$r" verify >/dev/null 2>&1 && bad "dup_accepted" || ok "duplicate id/path rejected"
+    rm -rf "$r"
+    r="$(mkrepo)"   # missing path (no file)
+    mkindex "$r" <<< "$(row ghost_test ci-bash)"
+    local rc=0 out; out="$(runr "$r" run --gate ci-bash 2>&1)" || rc=$?
+    grep -q 'MISSING' <<<"$out" && [ $rc -eq 1 ] && ok "missing test path -> MISSING + nonzero" || bad "missing_path" "rc=$rc"
+    rm -rf "$r"
+}
+test_reject_traversal() {
+    echo test_reject_traversal
+    local r; r="$(mkrepo)"; addtest "$r" a_test.sh 'exit 0'
+    mkindex "$r" <<< $'evil\tcli/lib/nftban/tests/../../../etc/passwd\to\ttest\tm\tCI_HERMETIC_SHELL\tci-bash\ttrue\tfalse\tfalse\tfalse\tfalse\tfalse\t\t\t'
+    runr "$r" verify >/dev/null 2>&1 && bad "traversal_accepted" || ok "path traversal rejected"
+    rm -rf "$r"
+}
+test_injection_inert() {
+    echo test_injection_inert
+    local r; r="$(mkrepo)"
+    # a test id/path containing shell metacharacters must be treated as inert data.
+    addtest "$r" 'inj_test.sh' 'exit 0'
+    mkindex "$r" <<< $'inj_test; touch /tmp/PWNED_rts\tcli/lib/nftban/tests/inj_test.sh\to\ttest\tm\tCI_HERMETIC_SHELL\tci-bash\ttrue\tfalse\tfalse\tfalse\tfalse\tfalse\t\t\t'
+    rm -f /tmp/PWNED_rts
+    runr "$r" run --gate ci-bash >/dev/null 2>&1 || true
+    [ ! -e /tmp/PWNED_rts ] && ok "metadata command-injection is inert (no side effect)" || { bad "injection"; rm -f /tmp/PWNED_rts; }
+    rm -rf "$r"
+}
+test_isolation() {
+    echo test_isolation
+    local r; r="$(mkrepo)"
+    # test 1 changes dir + shell options + exports; test 2 must be unaffected and pass.
+    addtest "$r" one_test.sh 'cd /; set +e; export LEAK=1; exit 0'
+    addtest "$r" two_test.sh '[ "${LEAK:-}" = "1" ] && exit 1; [ "$(pwd)" = "/" ] && exit 1; exit 0'
+    mkindex "$r" <<< "$(row one_test ci-bash; row two_test ci-bash)"
+    runr "$r" run --gate ci-bash >/dev/null 2>&1 && ok "subprocess isolation: one test cannot contaminate the next" || bad "isolation"
+    rm -rf "$r"
+}
+test_no_double_exec() {
+    echo test_no_double_exec
+    local r; r="$(mkrepo)"
+    addtest "$r" c_test.sh "printf x >> '$r/counter'; exit 0"
+    mkindex "$r" <<< "$(row c_test ci-bash)"
+    : > "$r/counter"
+    runr "$r" run --gate ci-bash >/dev/null 2>&1
+    [ "$(wc -c < "$r/counter")" -eq 1 ] && ok "each selected test executes exactly once" || bad "double_exec count=$(wc -c < "$r/counter")"
+    rm -rf "$r"
+}
+test_empty_and_deterministic() {
+    echo test_empty_and_deterministic
+    local r; r="$(mkrepo)"; addtest "$r" a_test.sh 'exit 0'
+    mkindex "$r" <<< "$(row a_test policy-gates)"
+    local out; out="$(runr "$r" run --gate ci-bash 2>&1)"   # ci-bash selects 0 here
+    grep -q 'total=0' <<<"$out" && ok "empty selected gate explicitly reported total=0 (exit 0)" || bad "empty_gate" "$out"
+    rm -rf "$r"
+}
+test_false_green_mutation() {
+    echo test_false_green_mutation
+    local r; r="$(mkrepo)"
+    addtest "$r" m_test.sh 'grep -q EXPECTED_TOKEN "$0" && exit 0 || exit 1
+# EXPECTED_TOKEN'
+    mkindex "$r" <<< "$(row m_test ci-bash)"
+    runr "$r" run --gate ci-bash >/dev/null 2>&1 && local base=0 || local base=1
+    # mutate: remove the token the test asserts on
+    sed -i 's/EXPECTED_TOKEN//g' "$r/cli/lib/nftban/tests/m_test.sh"
+    runr "$r" run --gate ci-bash >/dev/null 2>&1 && local mut=0 || local mut=1
+    [ $base -eq 0 ] && [ $mut -eq 1 ] && ok "false-green mutation: runner fails when a required test is broken" || bad "mutation base=$base mut=$mut"
+    rm -rf "$r"
+}
+test_missing_index_fail_closed() {
+    echo test_missing_index_fail_closed
+    local r; r="$(mkrepo)"; rm -f "$r/scripts/ci/test-authority-index.tsv"
+    runr "$r" verify >/dev/null 2>&1 && bad "missing_index_accepted" || ok "missing index fails closed (exit 2)"
+    rm -rf "$r"
+}
+
+for t in test_valid_run test_fail_propagates test_timeout_propagates test_deferred_not_executed \
+         test_lab_manual_and_package test_reject_unknown_gate test_reject_dupes_and_missing \
+         test_reject_traversal test_injection_inert test_isolation test_no_double_exec \
+         test_empty_and_deterministic test_false_green_mutation test_missing_index_fail_closed; do
+    "$t"
+done
+echo
+if [ "$FAIL" -eq 0 ]; then echo "RUN_TEST_SUITE_SELFTEST_PASS"; exit 0
+else echo "RUN_TEST_SUITE_SELFTEST_FAIL"; exit 1; fi

--- a/scripts/ci/run-test-suite.sh
+++ b/scripts/ci/run-test-suite.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="run-test-suite"
+# meta:type="script"
+# meta:version="1.226.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Index-driven shell-test runner: the authority index drives selection + isolated execution by gate"
+# meta:inventory.files="scripts/ci/test-authority-index.tsv,scripts/ci/test-authority.py"
+# meta:inventory.binaries="bash,git,awk,grep,sort,cut,realpath,timeout,printf,sed,python3"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+# NFTBan index-driven shell-test runner (v1.226.0 PR-C).
+#
+# The canonical generated authority index (scripts/ci/test-authority-index.tsv)
+# DRIVES shell-test execution. This runner NEVER discovers tests by filesystem
+# glob, NEVER sources a test, NEVER eval's, and NEVER builds a command from row
+# content — every test path is validated and passed as a single quoted argument
+# to an isolated `bash` subprocess with a bounded timeout.
+#
+#   Modes:
+#     run    --gate <gate> [--gate <gate>...]   execute the selected gate(s)
+#     report --gate <gate> [...]                list selection WITHOUT executing
+#     verify                                     validate the index only
+#     summary                                    counts by gate
+#
+#   A test is selected by its `gate` column. Executable gates run; deferred and
+#   lab-manual are reported (never executed, never counted PASS); package-build is
+#   selectable only under an explicit package authority (never ordinary CI).
+#
+#   Exit: 0 = ok · 1 = a validation error / an executed test FAILED or TIMED OUT
+#         2 = usage / safety-refusal (bad root, malformed index, unsafe path).
+# =============================================================================
+set -Eeuo pipefail
+
+INDEX_REL="scripts/ci/test-authority-index.tsv"
+TESTS_PREFIX="cli/lib/nftban/tests/"
+DEFAULT_TIMEOUT="120"          # seconds per test unless the row declares ta.timeout
+EXECUTABLE_GATES="policy-gates ci-bash"     # run in ordinary CI
+PACKAGE_GATES="package-build"               # only under --allow-package
+KNOWN_GATES="policy-gates ci-bash package-build package-native-deb package-native-rpm lab-manual canary fleet manual-forensic excluded deferred unassigned"
+MANIFEST=""                                 # optional --manifest FILE: machine-readable run record
+
+die_usage() { printf 'run-test-suite: %s\n' "$1" >&2; exit 2; }
+log()       { printf '%s\n' "$1" >&2; }
+
+# --- repository root: resolve and REFUSE to run outside the expected repo ------
+resolve_root() {
+    local root
+    root="$(git rev-parse --show-toplevel 2>/dev/null)" || die_usage "not inside a git repository"
+    [ -f "$root/$INDEX_REL" ] || die_usage "authority index not found under repo root: $INDEX_REL"
+    printf '%s' "$root"
+}
+
+# --- index validation (fail-closed): freshness + structural safety ------------
+# Reads the committed index; rejects malformed rows / missing paths / duplicate
+# id|path / unknown gate / path traversal. Also asserts the index is FRESH vs the
+# canonical generator so a stale index cannot silently drive execution.
+validate_index() {
+    local root="$1" idx="$1/$INDEX_REL"
+    # freshness: the generator must reproduce the committed index byte-for-byte
+    if command -v python3 >/dev/null 2>&1 && [ -f "$root/scripts/ci/test-authority.py" ]; then
+        python3 "$root/scripts/ci/test-authority.py" check >/dev/null 2>&1 \
+            || die_usage "authority index is STALE (regenerate: test-authority.py generate)"
+    fi
+    # structural pass over data rows (skip banner '#' lines and the header row)
+    awk -F'\t' -v prefix="$TESTS_PREFIX" -v known="$KNOWN_GATES" '
+        BEGIN { split(known, kg, " "); for (i in kg) gate_ok[kg[i]] = 1; ncol = 0 }
+        /^#/ { next }
+        !seen_header { seen_header = 1; ncol = NF; next }
+        {
+            if (NF != ncol)        { print "ROW_NCOL " NR; bad = 1; next }
+            id = $1; path = $2; gate = $7
+            if (id == "")          { print "EMPTY_ID " NR; bad = 1 }
+            if (path !~ ("^" prefix)) { print "PATH_PREFIX " NR " " path; bad = 1 }
+            if (path ~ /\.\.\//)   { print "PATH_TRAVERSAL " NR " " path; bad = 1 }
+            if (path ~ /[ \t]/ && path !~ ("^" prefix "[A-Za-z0-9_./-]+_test\\.sh$")) { }
+            if (!(gate in gate_ok)) { print "UNKNOWN_GATE " NR " " gate; bad = 1 }
+            if (id in seen_id)     { print "DUP_ID " id; bad = 1 } else seen_id[id] = 1
+            if (path in seen_path) { print "DUP_PATH " path; bad = 1 } else seen_path[path] = 1
+        }
+        END { if (bad) exit 1 }
+    ' "$idx" >"$root/.rts_valerr" 2>&1 || {
+        log "run-test-suite: index validation FAILED:"; sed 's/^/  /' "$root/.rts_valerr" >&2
+        rm -f "$root/.rts_valerr"; exit 2
+    }
+    rm -f "$root/.rts_valerr"
+}
+
+# --- selection: emit "id<TAB>path<TAB>timeout" for rows whose gate matches ------
+select_rows() {
+    local root="$1"; shift
+    local gates=" $* "
+    awk -F'\t' -v want="$gates" '
+        /^#/ { next }
+        !seen_header { seen_header = 1; next }
+        {
+            id = $1; path = $2; gate = $7; timeout = $14
+            if (index(want, " " gate " ") > 0) print id "\t" path "\t" timeout
+        }
+    ' "$root/$INDEX_REL"
+}
+
+# --- run one test as an isolated subprocess with a bounded timeout -------------
+# The path is validated (prefix + realpath inside repo) and passed as a single
+# quoted argument. Never sourced, never eval'd. Returns PASS/FAIL/TIMEOUT.
+run_one() {
+    local root="$1" path="$2" tmo="$3"
+    local abs="$root/$path"
+    case "$path" in
+        "$TESTS_PREFIX"*_test.sh) ;;
+        *) printf 'SAFETY'; return ;;
+    esac
+    [ -f "$abs" ] || { printf 'MISSING'; return; }
+    local real; real="$(realpath -- "$abs" 2>/dev/null || printf '')"
+    case "$real" in "$root"/*) ;; *) printf 'SAFETY'; return ;; esac
+    [ "$tmo" -gt 0 ] 2>/dev/null || tmo="$DEFAULT_TIMEOUT"
+    local rc=0
+    timeout -k 5 "$tmo" bash -- "$abs" </dev/null >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -eq 0 ]; then printf 'PASS'
+    elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then printf 'TIMEOUT'
+    else printf 'FAIL'; fi
+}
+
+cmd_run() {
+    local root="$1"; shift
+    local gates=("$@")
+    [ "${#gates[@]}" -gt 0 ] || die_usage "run requires at least one --gate"
+    local g
+    for g in "${gates[@]}"; do
+        case " $EXECUTABLE_GATES $PACKAGE_GATES " in *" $g "*) ;; *)
+            die_usage "gate '$g' is not executable by this mode" ;; esac
+    done
+    validate_index "$root"
+    # duplicate-selection guard BEFORE executing anything
+    local sel; sel="$(select_rows "$root" "${gates[@]}")"
+    local nids ndistinct
+    nids="$(printf '%s\n' "$sel" | grep -c . || true)"
+    ndistinct="$(printf '%s\n' "$sel" | cut -f1 | sort -u | grep -c . || true)"
+    [ "$nids" = "$ndistinct" ] || die_usage "duplicate selected test IDs — refusing to execute"
+    # optional machine-readable manifest: truncate + header now so a skipped/aborted
+    # run leaves an EMPTY-or-absent manifest (the integrity gate treats that as "step
+    # did not execute" — fail-closed), never a false record.
+    if [ -n "$MANIFEST" ]; then
+        : > "$MANIFEST" || die_usage "cannot write manifest: $MANIFEST"
+        printf '# run-test-suite manifest (machine-readable, do not edit)\nGATE\t%s\n' "${gates[*]}" >> "$MANIFEST"
+    fi
+    if [ "$nids" -eq 0 ]; then
+        log "run-test-suite: gate(s) '${gates[*]}' selected 0 tests"
+        printf 'RESULT gate=%s total=0 pass=0 fail=0 timeout=0\n' "${gates[*]}"
+        [ -n "$MANIFEST" ] && printf 'SELECTED\t0\nPASS\t0\nFAIL\t0\nTIMEOUT\t0\n' >> "$MANIFEST"
+        return 0
+    fi
+    local pass=0 fail=0 tmoc=0 total=0 failed_ids="" manifest_rows=""
+    # deterministic order: sort by id
+    while IFS=$'\t' read -r id path tmo; do
+        [ -n "$id" ] || continue
+        total=$((total+1))
+        local res; res="$(run_one "$root" "$path" "${tmo:-0}")"
+        case "$res" in
+            PASS)    pass=$((pass+1)) ;;
+            TIMEOUT) tmoc=$((tmoc+1)); failed_ids="$failed_ids $id(TIMEOUT)" ;;
+            *)       fail=$((fail+1)); failed_ids="$failed_ids $id($res)" ;;
+        esac
+        printf '  %-8s %s\n' "$res" "$id" >&2
+        manifest_rows="${manifest_rows}TEST	${res}	${id}"$'\n'
+    done < <(printf '%s\n' "$sel" | sort -t$'\t' -k1,1)
+    printf 'RESULT gate=%s total=%d pass=%d fail=%d timeout=%d\n' "${gates[*]}" "$total" "$pass" "$fail" "$tmoc"
+    if [ -n "$MANIFEST" ]; then
+        printf 'SELECTED\t%d\nPASS\t%d\nFAIL\t%d\nTIMEOUT\t%d\n' "$total" "$pass" "$fail" "$tmoc" >> "$MANIFEST"
+        printf '%s' "$manifest_rows" >> "$MANIFEST"
+    fi
+    if [ "$fail" -gt 0 ] || [ "$tmoc" -gt 0 ]; then
+        log "run-test-suite: FAILED tests:${failed_ids}"
+        return 1
+    fi
+    return 0
+}
+
+cmd_report() {
+    local root="$1"; shift
+    local gates=("$@")
+    [ "${#gates[@]}" -gt 0 ] || die_usage "report requires at least one --gate"
+    validate_index "$root"
+    local sel; sel="$(select_rows "$root" "${gates[@]}")"
+    local n; n="$(printf '%s\n' "$sel" | grep -c . || true)"
+    printf 'REPORT gate=%s count=%d (not executed)\n' "${gates[*]}" "$n"
+    printf '%s\n' "$sel" | sort -t$'\t' -k1,1 | while IFS=$'\t' read -r id path tmo; do
+        [ -n "$id" ] && printf '  %-10s %s  %s\n' "REPORTED" "$id" "$path" >&2
+    done
+    return 0
+}
+
+cmd_summary() {
+    local root="$1"
+    validate_index "$root"
+    awk -F'\t' '/^#/{next} !h{h=1;next} {c[$7]++} END{for(g in c) printf "  %-16s %d\n", g, c[g]}' \
+        "$root/$INDEX_REL" | sort
+}
+
+main() {
+    [ $# -ge 1 ] || die_usage "usage: run-test-suite.sh {run|report|verify|summary} [--gate <gate>]..."
+    local mode="$1"; shift
+    local root; root="$(resolve_root)"
+    local gates=() allow_package=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --gate) shift; [ $# -ge 1 ] || die_usage "--gate needs a value"; gates+=("$1") ;;
+            --manifest) shift; [ $# -ge 1 ] || die_usage "--manifest needs a value"; MANIFEST="$1" ;;
+            --allow-package) allow_package=1 ;;
+            *) die_usage "unknown argument: $1" ;;
+        esac
+        shift
+    done
+    # package-build is executable ONLY with the explicit package authority flag
+    local g
+    for g in "${gates[@]:-}"; do
+        [ "$g" = "package-build" ] && [ "$allow_package" -ne 1 ] \
+            && die_usage "gate 'package-build' requires --allow-package (package authority only)"
+    done
+    case "$mode" in
+        run)     cmd_run "$root" "${gates[@]}" ;;
+        report)  cmd_report "$root" "${gates[@]}" ;;
+        verify)  validate_index "$root"; log "run-test-suite: index VALID"; ;;
+        summary) cmd_summary "$root" ;;
+        *) die_usage "unknown mode: $mode" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## v1.226.0 PR-C — index-driven shell-test runner + ci-bash informational baseline

Makes the canonical authority index (`scripts/ci/test-authority-index.tsv`) **drive** shell-test execution through one strict runner, replacing 46 manually curated Policy-Gates invocations where authority equivalence is proven. **Migration state — not the final v1.226.0 enforcement state.**

No product / Go / RBL-fixture / VERSION / schema / index change.

### Runner — `scripts/ci/run-test-suite.sh`
Modes `run|report|verify|summary`. Selects tests by the index `gate` column (**never a filesystem glob**); executes each in an isolated `timeout -k5 <ta.timeout|120> bash -- <abs> </dev/null` subprocess — never sourced, never `eval`'d, path prefix-validated + realpath-confined. Deterministic id-sorted order; duplicate-selection refusal; per-gate PASS/FAIL/TIMEOUT tally; `--manifest` machine record.

### Execution policy (owner `GO_OPTION_1_TEMPORARY_INFORMATIONAL`)
| class | mode |
|-------|------|
| `policy-gates` | **BLOCKING** — 46/46 PASS, exact parity with the curated set |
| `ci-bash` | `INFORMATIONAL_BASELINE`, **non-blocking** (`continue-on-error`) |
| `deferred` / `lab-manual` | report-only (visible, never executed, never PASS) |
| `package-build` | package-authority only (`--allow-package`) |
| runner + integrity self-tests | **BLOCKING** |

### The ci-bash finding
Executing the previously-unenforced `ci-bash` class exposed **19/184 failing tests** — `PRE_EXISTING_NEWLY_EXPOSED_TEST_FAILURES`. All 19 reproduce under direct `bash <test>` from repo root (runner-caused failures = 0; zero overlap with the 46 curated policy-gates). They are **recorded, not silenced**:
- `scripts/ci/ci-bash-informational-baseline.tsv` — SELECTED=184 PASS=165 FAIL=19 TIMEOUT=0 + the 19 accepted ids/buckets.
- `scripts/ci/ci-bash-red-baseline-audit.md` — 19 rows (id/path/gate/bucket/observed/repro/disposition/finding-handle). Buckets: source-spec-drift 12 · behavior-regression 4 · rbl-fixture→PR-E 1 · spool-timing 2.

A **BLOCKING** integrity gate `scripts/ci/check-ci-bash-baseline.sh` consumes the manifest the informational step already produced (**one shared execution, no re-run**) and fails if: the step did not run · a test disappeared · the selected set drifts from the index · a test executes twice · a failing id is unreported · a NEW failing id appears · FAIL exceeds the accepted 19 ceiling. Improvements (a listed id that now passes) are allowed and reported.

### CI migration (`.github/workflows/ci-architecture.yml`)
Removed the 46 curated policy-gates 2-line steps and their now-orphaned per-lane rationale comments (rationale lives in each test file + index columns); inserted one runner block; **RETAINED the 8 non-index scripts** (not `*_test.sh` / outside index authority). `ci-bash-manifest.txt` gitignored.

### Acceptance (this head)
```
POLICY_GATES_MODE=BLOCKING  SELECTED=46 PASS=46 FAIL=0
CI_BASH_MODE=INFORMATIONAL_BASELINE  SELECTED=184 PASS=165 FAIL=19 TIMEOUT=0
CI_BASH_FAILURE_IDS_REPORTED=19/19  CI_BASH_STEP_EXECUTED=YES  FALSE_SUCCESS_RENDERING=0
CURATED_PARITY=EXACT(46==46)  DUPLICATE_EXECUTION=0
RUNNER_SELFTESTS=14/14  INTEGRITY_SELFTESTS=8/8
PRE_EXISTING_RED_TESTS=19  RUNNER_CAUSED_FAILURES=0  DIRECT_REPRODUCIBLE=19/19
NEW_PRODUCT_FIXES=0  RBL_FIXTURE_CHANGES=0
```

### Scope / follow-ups
PR-D (not "fix all 19") owns authority-enforcement policy: challenge each of the 19 (product-wrong / stale-test / env-sensitive / PR-E / flaky / misclassified), introduce justified quarantine with expiry, then activate blocking ci-bash for non-quarantined tests. **Prohibited until PR-D:** claims of full strict enforcement or zero failing classified tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
