### PR TITLE
fix(firewall): whitelist-session cleanup fd-9 lock lifecycle (v1.226.0 PR-E1)

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -940,6 +940,15 @@ _whitelist_session_cleanup() {
     _whitelist_session_ensure_lock
     local removed
     removed=$(
+        # v1.226.0 (PR-E1): open the lock fd INSIDE this command substitution. A
+        # `) 9>LOCK` redirect on the enclosing `removed=$(...)` ASSIGNMENT is applied
+        # to the assignment's environment, not to this substitution subshell — so
+        # `flock 9` here ran with fd 9 unopened ("Bad file descriptor") and cleanup
+        # could never acquire the lock (broken since v1.173/#822: expired session
+        # entries were never pruned). Opening fd 9 with `exec` in the same shell
+        # execution context that flocks and closes it (on subshell exit) fixes it,
+        # matching the plain-subshell `( ... ) 9>LOCK` form used by add/remove.
+        exec 9>"$_NFTBAN_SESSION_WL_LOCK" || { echo "ERROR: could not open session-whitelist lock" >&2; exit 1; }
         flock 9 || { echo "ERROR: could not acquire session-whitelist lock" >&2; exit 1; }
 
         local now_unix
@@ -980,7 +989,7 @@ _whitelist_session_cleanup() {
         mv "$tmp" "$_NFTBAN_SESSION_WHITELIST_PATH"
         chmod 0640 "$_NFTBAN_SESSION_WHITELIST_PATH" 2>/dev/null || true
         echo "$_rm"
-    ) 9>"$_NFTBAN_SESSION_WL_LOCK" || return 1
+    ) || return 1
     removed=${removed//[^0-9]/}; removed=${removed:-0}
 
     if [[ "$removed" -gt 0 ]]; then

--- a/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
+++ b/cli/lib/nftban/tests/cmd_firewall_whitelist_session_test.sh
@@ -135,6 +135,11 @@ call_firewall_whitelist_session() {
         eval "$extracted"
         # Redirect the file path to the sandbox.
         _NFTBAN_SESSION_WHITELIST_PATH="$SESSION_FILE"
+        # Redirect the advisory lock to the sandbox too: the product default is
+        # /run/nftban/session_whitelist.lock, which a non-root test user cannot
+        # open, so add/remove/cleanup's `9>"$_NFTBAN_SESSION_WL_LOCK"` (and the
+        # v1.226.0 in-subshell `exec 9>`) would fail. (Product v1.173 §4.1 lock.)
+        _NFTBAN_SESSION_WL_LOCK="${SESSION_FILE}.lock"
         # Suppress chmod/chown failures (sandbox path likely fails ownership).
         firewall_whitelist_session "$@"
     )
@@ -205,7 +210,7 @@ echo "[T4] re-add same IP → refresh (no duplicate)"
 # (T3 already added 192.0.2.122; re-add with different reason)
 call_firewall_whitelist_session add 192.0.2.122 --ttl 1h --reason refreshed >/dev/null 2>&1 || true
 T4_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
-T4_COUNT=$(printf '%s\n' "$T4_CONTENT" | grep -c "^192\.0\.2\.250" || true)
+T4_COUNT=$(printf '%s\n' "$T4_CONTENT" | grep -c "^192\.0\.2\.122" || true)
 assert_eq "$T4_COUNT" "1"                                            "T4.1 exactly one entry for IP"
 assert_contains "$T4_CONTENT" "REASON=refreshed"                     "T4.2 newer REASON present"
 assert_not_contains "$T4_CONTENT" "REASON=test-reason"               "T4.3 older REASON dropped"
@@ -244,7 +249,7 @@ echo "[T8] remove drops the entry"
 T8_OUT=$(call_firewall_whitelist_session remove 192.0.2.122 2>&1)
 assert_contains "$T8_OUT" "Removed: 192.0.2.122"                   "T8.1 stdout confirms remove"
 T8_CONTENT=$(cat "$SESSION_FILE" 2>/dev/null || true)
-assert_not_contains "$T8_CONTENT" "^192\.0\.2\.250"                "T8.2 entry gone from file"
+assert_not_contains "$T8_CONTENT" "^192\.0\.2\.122"                "T8.2 entry gone from file"
 
 # ---------------------------------------------------------------------------
 # T9: cleanup drops expired but keeps active


### PR DESCRIPTION
## v1.226.0 PR-E1 — whitelist-session cleanup fd-9 lock fix

Bounded **product-fix** lane split out of PR-E after a confirmed runtime defect (stop-on-delta). Fixes only the fd-9 lock lifecycle in `_whitelist_session_cleanup`; no fixture/deferred/quarantine/RBL work (that is PR-E2).

### Defect (independently confirmed, 20/20 deterministic)
`_whitelist_session_cleanup` acquired its lock as `removed=$( flock 9 … ) 9>"$LOCK"`. The `9>LOCK` redirect binds to the **assignment**, not the `$()` command-substitution subshell where `flock 9` runs → fd 9 unopened → `flock: 9: Bad file descriptor` → cleanup returns 1 and **never prunes expired session-whitelist entries**. Broken since **v1.173/#822**. `add` (:755) and `remove` (:917) were unaffected — they use the working `( … ) 9>LOCK` plain-subshell form.

### Fix (minimal)
Open fd 9 with `exec 9>"$LOCK"` as the first statement **inside** the substitution — same shell context that flocks and (on subshell exit) closes it — and drop the redundant outer redirect. No suppression, no `errexit` disable, no flock-option change. Parent shell fd 9 untouched.

### Proof
```
ORIGINAL_REPRO = 20/20 FAIL ("Bad file descriptor")
FIXED_REPRO    = 100/100 PASS   FD9_ERRORS = 0   EXPIRED_REMOVAL = 100/100
IDEMPOTENCE = PASS   REACQUIRE_AFTER_SUCCESS = PASS   ERROR_PATH_RELEASE = PASS
PARENT_FD9_UNCHANGED = PASS   PARALLEL = PASS   MUTATION_PROOF = PASS (original placement refires)
```

### Target test
`cmd_firewall_whitelist_session_test` repaired **test-only** (sandbox lock redirect; stale privacy-scrub grep `192.0.2.250`→`192.0.2.122`, the IP it actually adds, RFC5737 TEST-NET-1) → **33/0 direct + runner**. It **stays `gate=deferred` intentionally** — PR-E1 fixes the product; **PR-E2 owns activation**. The retained classification is not incomplete PR-E1 validation.

### Scope
Exactly 2 files (`cmd_firewall.sh` + the target test). strict 241/241/0, index FRESH, shellcheck clean, **DEFERRED=6 / QUARANTINE=4 unchanged**, no VERSION/schema/registry/index/workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
