### PR TITLE
ci(release): scope build-binaries to privacy-gate environment (v1.226.0 publish activation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ jobs:
   build-binaries:
     name: Build Go binaries
     runs-on: ubuntu-latest
+    # v1.226.0: this job runs the fail-closed publication privacy gate, whose
+    # secrets (NFTBAN_PRIVACY_DENYLIST / NFTBAN_PRIVACY_FP_KEY) live ONLY on the
+    # protected `privacy-gate` environment (not repo-level, by design). Declare the
+    # environment so they resolve here — preserving maintainer approval + scoping.
+    environment: privacy-gate
     # v1.157 PR-C: setup-go installs the exact go.mod patch (1.25.12); a single
     # unconditional setup-go feeds the build, so GOTOOLCHAIN=local avoids a
     # redundant toolchain re-download. Compiler version is unchanged (1.25.12),


### PR DESCRIPTION
Minimal prerequisite for v1.226.0 publication. `release.yml`'s build-binaries job runs the fail-closed publication privacy gate; its secrets (NFTBAN_PRIVACY_DENYLIST/FP_KEY) live only on the protected `privacy-gate` environment (not repo-level, by design), so without an `environment:` declaration they resolved empty → `PRIVATE_GATE = FAIL_CLOSED`. Adds **only** `environment: privacy-gate` to that one job.

Preserves: environment scoping · maintainer approval · secret isolation · fail-closed enforcement. **No** secret copy / privacy-logic / build-command / permission / trigger / VERSION / product / test change. CHANGED_FILES=1, env-declaration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)