### PR TITLE
fix(mail): netrc machine = SMTP connection host — auth silently off (MAIL-F1, v1.227 Lane-1 PR 1/6)

### DIFF
--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -826,7 +826,12 @@ EOF
                 # shellcheck disable=SC2064  # expand path now so the trap cleans this exact file
                 trap "rm -f '$_smtp_netrc' 2>/dev/null || true" EXIT INT TERM HUP QUIT
                 local _smtp_host
-                _smtp_host=$(echo "${NFTBAN_SMTP_SERVER:-localhost}" | cut -d: -f1)
+                # v1.227 MAIL-F1: the netrc "machine" MUST equal the host curl actually connects
+                # to (NFTBAN_SMTP_HOST, used by smtp_url above and guarded non-empty by the curl-SMTP
+                # dispatch). The prior code read NFTBAN_SMTP_SERVER — a variable set NOWHERE — so it
+                # defaulted to "localhost"; curl matches netrc creds by machine=host, so localhost
+                # never matched the real host and curl sent NO credentials while status showed "(ready)".
+                _smtp_host=$(echo "${NFTBAN_SMTP_HOST}" | cut -d: -f1)
                 echo "machine $_smtp_host login ${NFTBAN_SMTP_USER} password ${NFTBAN_SMTP_PASS:-}" > "$_smtp_netrc"
                 curl_args+=(--netrc-file "$_smtp_netrc")
             fi

--- a/cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh
+++ b/cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F1 netrc-host behavioral transport proof
+# =============================================================================
+# meta:name="mail_netrc_auth_transport_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL-F1 behavioral proof: drives the real nftban_mail_send curl-SMTP path with a fake curl that captures argv + the generated netrc; asserts the netrc machine == the connection host (NFTBAN_SMTP_HOST) and credentials are present. NO real network. Pre-fix FAIL (machine=localhost via the undefined NFTBAN_SMTP_SERVER), post-fix PASS."
+# meta:input="None (sources nftban_mail.sh read-only; fake curl on PATH; no network)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,mktemp,awk"
+# meta:inventory.files="cli/lib/nftban/core/nftban_mail.sh"
+# meta:inventory.binaries="bash,grep,mktemp,awk"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_SMTP_HOST,NFTBAN_SMTP_PORT,NFTBAN_SMTP_USER,NFTBAN_SMTP_PASS,NFTBAN_MAIL_RECIPIENT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="mail_netrc_auth_transport_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="mail-smtp-netrc"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MAIL_LIB="$ROOT/cli/lib/nftban/core/nftban_mail.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== mail_netrc_auth_transport_v1227 ==="
+
+# --- one hermetic send with a fake curl; returns the captured netrc + argv paths ---
+run_send() {
+    # $1=SMTP_HOST  $2=SMTP_USER  $3=SMTP_PASS  -> sets globals CAP NETRC OUT
+    local host="$1" user="$2" pass="$3"
+    SB="$(mktemp -d)"; mkdir -p "$SB"/{data,run,log,state}
+    CAP="$SB/curl.args"; NETRC="$SB/netrc.copy"
+    cat > "$SB/curl" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$CAP"
+prev=""; for a in "\$@"; do [[ "\$prev" == "--netrc-file" ]] && cp "\$a" "$NETRC" 2>/dev/null; prev="\$a"; done
+exit 0
+EOF
+    chmod +x "$SB/curl"
+    # shellcheck disable=SC2034  # OUT is a global consumed by the assertions after run_send returns
+    OUT="$(
+        PATH="$SB:$PATH" \
+        NFTBAN_LIB_DIR="$ROOT/cli/lib/nftban" NFTBAN_DATA_DIR="$SB/data" NFTBAN_RUN_DIR="$SB/run" \
+        NFTBAN_LOG_DIR="$SB/log" NFTBAN_STATE_DIR="$SB/state" \
+        NFTBAN_MAIL_METHOD="curl" NFTBAN_SMTP_HOST="$host" NFTBAN_SMTP_PORT="587" \
+        NFTBAN_SMTP_USER="$user" NFTBAN_SMTP_PASS="$pass" NFTBAN_MAIL_RECIPIENT="to@example.test" \
+        bash -c '
+            set -Eeuo pipefail
+            # shellcheck disable=SC1090
+            source "'"$MAIL_LIB"'"
+            nftban_mail_send "hermetic body" "to@example.test" 2>&1 || true
+        '
+    )"
+}
+
+# --- primary case: netrc machine MUST equal the connection host ------------------
+run_send "smtp.example.test" "test-user" "test-secret"
+assert "curl reached (argv captured)"                '[[ -s "$CAP" ]]'
+assert "netrc file was generated + passed to curl"   '[[ -s "$NETRC" ]]'
+assert "NETRC_MACHINE = connection host"             'grep -q "^machine smtp.example.test " "$NETRC"'
+assert "NETRC_MACHINE_EQUALS_CONNECTION_HOST"        '[[ "$(awk "/^machine/{print \$2; exit}" "$NETRC")" == "smtp.example.test" ]]'
+assert "NETRC_LOGIN_PRESENT"                         'grep -q "login test-user" "$NETRC"'
+assert "NETRC_PASSWORD_PRESENT"                      'grep -q "password test-secret" "$NETRC"'
+assert "CURL_SMTP_URL_HOST = connection host"        'grep -q "smtp://smtp.example.test:587\|smtps://smtp.example.test" "$CAP"'
+assert "no localhost machine (the pre-fix bug)"      '! grep -q "^machine localhost " "$NETRC"'
+assert "PASSWORD_NOT_PRINTED_IN_DIAGNOSTICS"         '! grep -q "test-secret" <<<"$OUT"'
+rm -rf "$SB"
+
+# --- edge (a): host:port on NFTBAN_SMTP_HOST → machine is host only (cut -d: -f1) ---
+run_send "h.test:2525" "u2" "p2"
+assert "EDGE_HOSTPORT machine strips :port"          '[[ "$(awk "/^machine/{print \$2; exit}" "$NETRC")" == "h.test" ]]'
+rm -rf "$SB"
+
+# --- edge (b): empty USER → NO netrc asserting false auth (existing :818 guard) ------
+run_send "smtp.example.test" "" ""
+assert "EDGE_EMPTY_USER adds no --netrc-file"        '! grep -q -- "--netrc-file" "$CAP"'
+assert "EDGE_EMPTY_USER writes no netrc"             '[[ ! -s "$NETRC" ]]'
+rm -rf "$SB"
+
+# --- edge (c): IPv6 bracketed host — DOCUMENTED KNOWN LIMITATION, not silently mishandled ---
+# cut -d: on "[2001:db8::1]" truncates; the connection host (smtp_url) has the same limitation
+# at :798 today. This is out of scope for MAIL-F1 (one failure domain = netrc/connection-host
+# equality). Assert only that machine == the cut-derived token so behavior is explicit, and
+# flag it: bracketed-IPv6 SMTP host is a separate follow-up (Lane-2 transport-addr, MAIL-F12).
+run_send "[2001:db8::1]" "u6" "p6"
+_m6="$(awk '/^machine/{print $2; exit}' "$NETRC")"
+echo "  [INFO] IPv6-bracketed host: netrc machine='$_m6' (KNOWN LIMITATION — MAIL-F12/Lane-2 follow-up; connection host has same cut behavior at :798)"
+rm -rf "$SB"
+
+echo ""
+echo "=== mail_netrc_auth_transport_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -140,6 +140,7 @@ logrotate_behavioral_gateb_test	cli/lib/nftban/tests/logrotate_behavioral_gateb_
 logrotate_config_v137_test	cli/lib/nftban/tests/logrotate_config_v137_test.sh	packaging	test	logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 logs_truth_v150_test	cli/lib/nftban/tests/logs_truth_v150_test.sh	health	test	log-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mac_posture_v158_test	cli/lib/nftban/tests/mac_posture_v158_test.sh	security	test	mac-posture	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+mail_netrc_auth_transport_v1227_test	cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh	mail	test	mail-smtp-netrc	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh	firewall	test	maintenance-table-probe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 nft_counting_model_guard_v190_test	cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh	metrics	test	nft-counting-model	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 1/6 — netrc-host SMTP auth (HIGH · security-first)

**Base:** `v1.226.0` tag (`9e22ebf2`). One failure domain: SMTP transport auth.

### Defect (MAIL-F1)
`nftban_mail.sh` built the curl `--netrc-file` `machine` line from `$NFTBAN_SMTP_SERVER` — a variable **set nowhere in the tree** — so it defaulted to `localhost`. curl matches netrc credentials by `machine == connection-host`, and the connection host is `NFTBAN_SMTP_HOST` (used by `smtp_url` at `:798`). `localhost` never matched the real host → **authenticated SMTP silently sent no credentials** while `mail status` reported `(ready)`.

### Fix
Derive the netrc `machine` from `NFTBAN_SMTP_HOST` (the host curl actually dials, guarded non-empty by the curl-SMTP dispatch). One-line functional change + explanatory comment.

### Proof
- **Regression test:** `mail_netrc_auth_transport_v1227_test.sh` — `CI_HERMETIC_SHELL`, governed via `meta:ta`; drives the real `nftban_mail_send` curl-SMTP path with a fake curl, captures the generated netrc + argv, asserts `machine == connection host` and credentials present. **No network.**
- **Original-failure proof:** pre-fix → 4 FAIL (machine=`localhost`).
- **Fixed proof:** 12/0 PASS.
- **Mutation proof:** revert the var → test re-FAILs (exit 1); restore → PASS; file byte-identical.
- Edge cases asserted: `host:port` strips port; empty user adds no `--netrc-file`; IPv6-bracketed host documented as a known Lane-2 follow-up (MAIL-F12), not silently mishandled.

### Scope / guards
- Shell-only. **No Go change. No schema change** (nft 1.84.0 / config 1.1.0 unchanged).
- Centralized dispatch (`nftban_mail_send`) unchanged — **no new module-send authority** (`comms_no_direct_send_guard_a0_test` passes).
- New test governed through the existing index-driven authority (index regenerated, `INDEX_FRESH=YES`, strict validate 242/242). No framework-logic files touched.
- `DAEMON_BYTE_IMPACT = NONE`. Does not touch Mail Lanes 2–7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
