### PR TITLE
fix(config): redact credential values in `config show` (MAIL-F3, v1.227 Lane-1 PR 2/6)

### DIFF
--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -267,8 +267,18 @@ nftban_cmd_config_show() {
     local effective
     effective=$(nftban_config_load_effective)
 
+    # v1.227 MAIL-F3: redact credential VALUES (schema "sensitive": true, plus a suffix
+    # fail-safe for schema-unknown keys). ONE classification drives both renders so text
+    # and --json never diverge. Non-sensitive keys — including in-schema *_SINGLE_PASS —
+    # render their real value.
+    local _sensitive_keys="[]"
+    if command -v nftban_config_sensitive_keys_json >/dev/null 2>&1; then
+        _sensitive_keys=$(nftban_config_sensitive_keys_json "$effective")
+    fi
+
     if [[ "$json_mode" == "--json" || "$json_mode" == "1" ]]; then
-        echo "$effective" | jq '.'
+        echo "$effective" | jq --argjson s "$_sensitive_keys" \
+            'with_entries(if (.key as $k | $s | index($k)) then .value = "[REDACTED]" else . end)'
     else
         echo "Effective Configuration (all sources merged)"
         echo "════════════════════════════════════════════════════════════"
@@ -276,9 +286,9 @@ nftban_cmd_config_show() {
 
         # OPTIMIZED: Single jq call, sorted alphabetically
         # Category grouping removed for performance (was causing 100+ jq calls)
-        echo "$effective" | jq -r '
+        echo "$effective" | jq -r --argjson s "$_sensitive_keys" '
             to_entries | sort_by(.key) | .[] |
-            "  \(.key)\("                                   "[0:35-(.key|length)]) = \(.value)"
+            "  \(.key)\("                                   "[0:35-(.key|length)]) = \((.key as $k | $s | index($k)) as $sec | if $sec then "[REDACTED]" else .value end)"
         '
 
         # v1.43.0 P3-35: Divergence explanation footer

--- a/cli/lib/nftban/core/nftban_config_schema.sh
+++ b/cli/lib/nftban/core/nftban_config_schema.sh
@@ -291,6 +291,55 @@ nftban_schema_get_renamed() {
     jq -r '.renamed // {}' "$schema_file" 2>/dev/null || true
 }
 
+# v1.227 MAIL-F3: secret-value classification for redaction in `config show`.
+# AUTHORITY = schema "sensitive": true (a credential VALUE). A schema key WITHOUT
+# sensitive:true is NEVER redacted — so in-schema flags/settings that merely end in
+# _PASS (e.g. NFTBAN_COLLECT_LOG_SINGLE_PASS) or name a header (…_API_KEY_HEADER) are
+# shown, not masked. A suffix fail-safe applies ONLY to keys ABSENT from the schema,
+# so an unknown FOO_TOKEN is still masked rather than leaked.
+# Returns 0 (sensitive) / 1 (not).
+nftban_config_key_is_sensitive() {
+    local key="$1"
+    local schema_file="${2:-$NFTBAN_SCHEMA_FILE}"
+    if [[ -f "$schema_file" ]]; then
+        local flagged known
+        flagged=$(jq -r --arg k "$key" '.properties[$k].sensitive // false' "$schema_file" 2>/dev/null || echo false)
+        [[ "$flagged" == "true" ]] && return 0
+        known=$(jq -r --arg k "$key" 'if (.properties | has($k)) then "yes" else "no" end' "$schema_file" 2>/dev/null || echo no)
+        [[ "$known" == "yes" ]] && return 1   # in-schema but not sensitive → never redact
+    fi
+    # schema-unknown key → suffix fail-safe
+    [[ "$key" =~ (PASS|PASSWORD|SECRET|TOKEN|API_KEY)$ ]] && return 0
+    return 1
+}
+
+# v1.227 MAIL-F3: emit the JSON array of keys to redact for a given effective-config
+# JSON object, so `config show` text AND --json share ONE classification (no drift).
+# = (schema sensitive keys) ∪ (effective keys absent from schema that match the
+# credential suffix). With no argument, returns just the schema sensitive keys.
+nftban_config_sensitive_keys_json() {
+    local effective_json="${1:-}"
+    local schema_file="${2:-$NFTBAN_SCHEMA_FILE}"
+    local schema_sensitive="[]" schema_keys="[]"
+    if [[ -f "$schema_file" ]]; then
+        schema_sensitive=$(jq -c '[.properties | to_entries[] | select(.value.sensitive == true) | .key]' "$schema_file" 2>/dev/null || echo '[]')
+        schema_keys=$(jq -c '[.properties | keys[]]' "$schema_file" 2>/dev/null || echo '[]')
+    fi
+    if [[ -z "$effective_json" ]]; then
+        printf '%s' "$schema_sensitive"
+        return 0
+    fi
+    printf '%s' "$effective_json" | jq -c \
+        --argjson sens "$schema_sensitive" \
+        --argjson known "$schema_keys" '
+        ([keys[] | select(
+            (. as $k | $known | index($k) | not) and
+            (test("(PASS|PASSWORD|SECRET|TOKEN|API_KEY)$"))
+        )]) as $suffix
+        | ($sens + $suffix) | unique
+    ' 2>/dev/null || printf '%s' "$schema_sensitive"
+}
+
 # =============================================================================
 # CONFIG LOADING AND MERGING
 # =============================================================================

--- a/cli/lib/nftban/data/config-schema.json
+++ b/cli/lib/nftban/data/config-schema.json
@@ -5802,7 +5802,8 @@
       "introduced_in": "1.0.0",
       "category": "notifications",
       "config_file": "conf.d/mail.conf",
-      "active_when": "always"
+      "active_when": "always",
+      "sensitive": true
     },
     "NFTBAN_SMTP_PORT": {
       "type": "string",
@@ -12790,7 +12791,8 @@
       "type": "string",
       "description": "Nftban connector elasticsearch api key",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_ELASTICSEARCH_AUTH": {
       "type": "string",
@@ -12830,7 +12832,8 @@
       "type": "string",
       "description": "Nftban connector elasticsearch pass",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_ELASTICSEARCH_TLS": {
       "type": "string",
@@ -12864,7 +12867,8 @@
       "type": "string",
       "description": "Nftban connector es api key",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_ES_INDEX_PATTERN": {
       "type": "string",
@@ -12877,7 +12881,8 @@
       "type": "string",
       "description": "Nftban connector es password",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_ES_TLS_SKIP_VERIFY": {
       "type": "string",
@@ -12971,13 +12976,15 @@
       "type": "string",
       "description": "Nftban connector kafka sasl pass",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_KAFKA_SASL_PASSWORD": {
       "type": "string",
       "description": "Nftban connector kafka sasl password",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_KAFKA_SASL_USER": {
       "type": "string",
@@ -13044,7 +13051,8 @@
       "type": "string",
       "description": "Nftban connector webhook api key",
       "introduced_in": "1.43.0",
-      "module": "connectors"
+      "module": "connectors",
+      "sensitive": true
     },
     "NFTBAN_CONNECTOR_WEBHOOK_API_KEY_HEADER": {
       "type": "string",

--- a/cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh
+++ b/cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F3 `config show` secret-value redaction
+# =============================================================================
+# meta:name="config_show_secret_redaction_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL-F3 behavioral proof: nftban_cmd_config_show redacts credential VALUES in both text and --json renders. Authority = schema sensitive:true; suffix fail-safe only for schema-unknown keys. Asserts secret literal never leaks, JSON stays valid, and in-schema non-secrets (SINGLE_PASS, API_KEY_HEADER) are NOT over-redacted."
+# meta:input="None (sources config schema + cmd_config read-only; stubbed effective config; no network)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_config_schema.sh,cli/lib/nftban/cli/cmd_config.sh,cli/lib/nftban/data/config-schema.json"
+# meta:inventory.binaries="bash,jq,grep"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="config_show_secret_redaction_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="config-secret-redaction"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+export NFTBAN_LIB_DIR="$ROOT/cli/lib/nftban"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== config_show_secret_redaction_v1227 ==="
+
+SECRET='p@$$"&<>|`'                       # quotes, ampersand, angle brackets, pipe, backtick
+# shellcheck source=/dev/null
+source "$ROOT/cli/lib/nftban/core/nftban_config_schema.sh"
+# shellcheck source=/dev/null
+source "$ROOT/cli/lib/nftban/cli/cmd_config.sh" 2>/dev/null || true
+
+command -v nftban_config_sensitive_keys_json >/dev/null 2>&1 || { echo "  [FATAL] helper missing"; exit 1; }
+command -v nftban_cmd_config_show          >/dev/null 2>&1 || { echo "  [FATAL] nftban_cmd_config_show missing"; exit 1; }
+
+# crafted effective config: real secret / normal value / in-schema non-secret flag /
+# schema-unknown suffix secret / schema-marked-sensitive-without-suffix / empty secret
+EFF=$(jq -cn --arg s "$SECRET" '{
+  NFTBAN_SMTP_PASS: $s,
+  NFTBAN_SMTP_HOST: "smtp.example.test",
+  NFTBAN_COLLECT_LOG_SINGLE_PASS: "true",
+  FOO_TOKEN: "unknown-suffix-secret",
+  NFTBAN_CONNECTOR_WEBHOOK_API_KEY: "connector-key-should-mask",
+  NFTBAN_CONNECTOR_WEBHOOK_API_KEY_HEADER: "X-Api-Key",
+  NFTBAN_SMTP_USER: ""
+}')
+nftban_config_load_effective() { printf '%s' "$EFF"; }
+
+# shellcheck disable=SC2034  # TEXT/JSON are consumed by the assert eval expressions below
+TEXT="$(nftban_cmd_config_show 2>/dev/null)"
+# shellcheck disable=SC2034
+JSON="$(nftban_cmd_config_show --json 2>/dev/null)"
+
+assert "TEXT_SHOW_SECRET_REDACTED"        'grep -qE "NFTBAN_SMTP_PASS[[:space:]]+= \[REDACTED\]" <<<"$TEXT"'
+assert "JSON_SHOW_SECRET_REDACTED"        '[[ "$(jq -r ".NFTBAN_SMTP_PASS" <<<"$JSON")" == "[REDACTED]" ]]'
+assert "JSON_STILL_VALID"                 'jq -e . <<<"$JSON" >/dev/null'
+assert "RAW_SECRET_OCCURRENCES = 0 (text)" '! grep -qF "$SECRET" <<<"$TEXT"'
+assert "RAW_SECRET_OCCURRENCES = 0 (json)" '! grep -qF "$SECRET" <<<"$JSON"'
+assert "SPECIAL_CHAR_SECRET_NOT_LEAKED"    '[[ "$(grep -cF "$SECRET" <<<"$TEXT$JSON")" == "0" ]]'
+assert "NONSECRET_VALUES_UNCHANGED (text)" 'grep -qE "NFTBAN_SMTP_HOST[[:space:]]+= smtp.example.test" <<<"$TEXT"'
+assert "NONSECRET_VALUES_UNCHANGED (json)" '[[ "$(jq -r ".NFTBAN_SMTP_HOST" <<<"$JSON")" == "smtp.example.test" ]]'
+assert "SINGLE_PASS_NOT_REDACTED"          '[[ "$(jq -r ".NFTBAN_COLLECT_LOG_SINGLE_PASS" <<<"$JSON")" == "true" ]]'
+assert "API_KEY_HEADER_NAME_NOT_REDACTED"  '[[ "$(jq -r ".NFTBAN_CONNECTOR_WEBHOOK_API_KEY_HEADER" <<<"$JSON")" == "X-Api-Key" ]]'
+assert "UNKNOWN_SECRET_SUFFIX_FAILSAFE"    '[[ "$(jq -r ".FOO_TOKEN" <<<"$JSON")" == "[REDACTED]" ]]'
+assert "SCHEMA_SENSITIVE_KEY_REDACTED"     '[[ "$(jq -r ".NFTBAN_CONNECTOR_WEBHOOK_API_KEY" <<<"$JSON")" == "[REDACTED]" ]]'
+assert "EMPTY_SECRET_HANDLED (no crash)"   '[[ -n "$JSON" ]] && jq -e . <<<"$JSON" >/dev/null'
+
+# schema authority sanity: the 8 credential VALUES are flagged, the 2 lookalikes are not
+assert "SCHEMA_FLAGS_8_CREDENTIALS"        '[[ "$(jq "[.properties|to_entries[]|select(.value.sensitive==true)]|length" "$ROOT/cli/lib/nftban/data/config-schema.json")" == "8" ]]'
+assert "SINGLE_PASS_NOT_SCHEMA_SENSITIVE"  '! nftban_config_key_is_sensitive NFTBAN_COLLECT_LOG_SINGLE_PASS'
+assert "API_KEY_HEADER_NOT_SCHEMA_SENSITIVE" '! nftban_config_key_is_sensitive NFTBAN_CONNECTOR_WEBHOOK_API_KEY_HEADER'
+
+echo ""
+echo "=== config_show_secret_redaction_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -101,6 +101,7 @@ comms_redact_p2b1_test	cli/lib/nftban/tests/comms_redact_p2b1_test.sh	security	t
 community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh	comms	test	community-trial	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	test	config-local	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 error_text_3line_v153_test	cli/lib/nftban/tests/error_text_3line_v153_test.sh	cli	test	cli-ux	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_phase2_scale_guard_v1361_test	cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_resilience_v136_test	cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 2/6 — `config show` secret redaction (MED-security · security-first)

**Base:** rebased on `main` after PR 1/6 (netrc) merged. One failure domain: secret-disclosure.

### Defect (MAIL-F3)
`nftban_cmd_config_show` rendered every effective value via a bulk `jq` with **no redaction**, so `NFTBAN_SMTP_PASS` and connector secrets printed in **cleartext** in both the text and `--json` output.

### Fix — schema-authoritative redaction, one classification for both renders
1. Mark the 8 shipped credential **VALUES** `"sensitive": true` in the runtime `config-schema.json` (`NFTBAN_SMTP_PASS` + the ES/Kafka/webhook connector secrets).
2. Central classifier in `nftban_config_schema.sh`: `nftban_config_key_is_sensitive` / `nftban_config_sensitive_keys_json`. Authority = schema `sensitive:true`; a **suffix fail-safe** (`PASS|PASSWORD|SECRET|TOKEN|API_KEY`) applies **only to keys absent from the schema**.
3. Both render paths in `cmd_config.sh` consult the same classification → text and `--json` never diverge; sensitive values become `[REDACTED]`.

**Anti-over-redaction:** an in-schema flag like `NFTBAN_COLLECT_LOG_SINGLE_PASS` or the header-NAME `…_API_KEY_HEADER` is **shown, not masked** (in-schema-but-not-sensitive is never redacted).

### Proof
- `config_show_secret_redaction_v1227_test.sh` (`CI_HERMETIC_SHELL`, `meta:ta`-governed) — **16/0**. Secret literal (incl. `"` `&` `<` `>` `|` `` ` ``) never leaks in text or JSON; JSON stays valid; `SINGLE_PASS`/`API_KEY_HEADER` not over-redacted; unknown `FOO_TOKEN` masked by fail-safe.
- **Mutation-proven:** revert the render redaction → secret leaks (FAIL); remove the schema `sensitive` flags → `SMTP_PASS` leaks (FAIL); both restore byte-identical.

### Scope / guards
- `config show` **only**. `diff`/`export`/`doctor`/support-bundle routing is **Lane-3** (flagged, not bundled).
- Additive schema `sensitive` annotation only — **CONFIG_SCHEMA stays 1.1.0**, nft schema 1.84.0 unchanged. Shell/JSON only, **no Go**. Runtime schema (`cli/lib/nftban/data`) touched; the divergent `install/` copy is pre-existing **Lane-3**.
- No new module-send authority. `DAEMON_BYTE_IMPACT = NONE`. Governed via existing index authority (no framework-logic files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
