### PR TITLE
fix(report): script-safe + correct JSON injection in HTML report (MAIL-F4, v1.227 Lane-1 PR 3/6)

### DIFF
--- a/cli/lib/nftban/cli/cmd_report.sh
+++ b/cli/lib/nftban/cli/cmd_report.sh
@@ -1285,7 +1285,9 @@ nftban_report_generate_html() {
     local until="$3"
     local theme="${4:-dark}"
 
-    local template="/usr/share/nftban/templates/reports/stats_dashboard.html"
+    # Default template ships under /usr/share; NFTBAN_REPORT_TEMPLATE overrides it for
+    # testability (production default unchanged).
+    local template="${NFTBAN_REPORT_TEMPLATE:-/usr/share/nftban/templates/reports/stats_dashboard.html}"
 
     if [[ ! -f "$template" ]]; then
         echo "ERROR: HTML template not found: $template" >&2
@@ -1305,8 +1307,34 @@ nftban_report_generate_html() {
     local json_data
     json_data=$(cat "$temp_json")
 
-    # Inject data into template (replace placeholder)
-    html_content="${html_content//window.__NFTBAN_DATA__ = {            \/\/ Placeholder - will be replaced        }/window.__NFTBAN_DATA__ = ${json_data}}"
+    # v1.227 MAIL-F4: this JSON is injected into a <script> block. jq escapes quotes for JSON
+    # validity but does NOT neutralize characters the HTML parser acts on — a data value
+    # containing </script> (or <!--, ]]>, U+2028/U+2029) breaks out of the <script> element
+    # regardless of JS-string context, because the HTML tokenizer closes the tag on the literal
+    # </script>. \u-escape the HTML-significant characters INSIDE the compact JSON: they only
+    # occur inside string values, so this stays valid JSON and the browser decodes them back to
+    # the same text (identical render). This is NOT HTML-entity escaping (&lt; etc. would corrupt
+    # the JS). The replacement strings contain no <, >, or &, so escape order is immaterial.
+    json_data="${json_data//&/\\u0026}"
+    json_data="${json_data//</\\u003c}"
+    json_data="${json_data//>/\\u003e}"
+    json_data="${json_data//$'\u2028'/\\u2028}"
+    json_data="${json_data//$'\u2029'/\\u2029}"
+
+    # Inject data into template (replace the placeholder line).
+    # v1.227 MAIL-F4: the prior `${html_content//… = {  …  }/… = ${json_data}}` form was fragile —
+    # the literal `}` inside the substitution PATTERN prematurely closed bash's ${…} parse, so the
+    # data was mis-injected and the document was malformed (delimiter/replacement text leaked). Use
+    # awk keyed on the unique placeholder comment, with the (already \u-escaped) JSON passed via the
+    # ENVIRONMENT so neither the shell nor awk performs escape processing on the \uXXXX sequences and
+    # the JSON braces cannot perturb any brace parser.
+    html_content="$(NFTBAN_REPORT_JSON="$json_data" awk '
+        /window\.__NFTBAN_DATA__ = \{.*Placeholder - will be replaced/ {
+            print "window.__NFTBAN_DATA__ = " ENVIRON["NFTBAN_REPORT_JSON"]
+            next
+        }
+        { print }
+    ' "$template")"
 
     # Write final HTML
     echo "$html_content" > "$output"

--- a/cli/lib/nftban/tests/report_html_json_script_safe_v1227_test.sh
+++ b/cli/lib/nftban/tests/report_html_json_script_safe_v1227_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F4 report HTML JSON-in-<script> breakout safety
+# =============================================================================
+# meta:name="report_html_json_script_safe_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL-F4 behavioral proof: nftban_report_generate_html injects the stats JSON into a <script> block. A data value containing </script> must NOT break out. Drives the real function with a stub template + stubbed stats export whose value is </script><script>alert(1)</script>; asserts no data-origin </script>, the payload is \\uXXXX-escaped (NOT HTML-entity escaped) and stays valid JSON that decodes back to the original text. No network."
+# meta:input="None (sources cmd_report.sh read-only; stub template + stub stats export; no network)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,jq,grep,mktemp"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_report.sh"
+# meta:inventory.binaries="bash,jq,grep,mktemp"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_REPORT_TEMPLATE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="report_html_json_script_safe_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="report-html-script-safe"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== report_html_json_script_safe_v1227 ==="
+
+SB="$(mktemp -d)"; trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB"/{data,run,log,state}
+HOSTILE='</script><script>alert(1)</script>'
+
+# stub template: the data line is isolated so its own </script> is on a separate line
+TMPL="$SB/tmpl.html"
+{
+  echo '<html><body>'
+  echo '<script>'
+  echo 'window.__NFTBAN_DATA__ = {            // Placeholder - will be replaced        }'
+  echo '</script>'
+  echo '</body></html>'
+} > "$TMPL"
+
+# export the harness vars so the child bash -c reads them from the environment
+export ROOT HOSTILE SB TMPL
+export NFTBAN_LIB_DIR="$ROOT/cli/lib/nftban" NFTBAN_DATA_DIR="$SB/data" NFTBAN_RUN_DIR="$SB/run"
+export NFTBAN_LOG_DIR="$SB/log" NFTBAN_STATE_DIR="$SB/state" NFTBAN_REPORT_TEMPLATE="$TMPL"
+OUT="$(
+    bash -c '
+        set -Eeuo pipefail
+        # shellcheck disable=SC1090
+        source "$ROOT/cli/lib/nftban/cli/cmd_report.sh" 2>/dev/null || true
+        # stub the stats export: write JSON carrying the hostile value + &,<,> chars
+        nftban_stats_export_json() { jq -cn --arg h "$HOSTILE" "{host:\$h, note:\"a & b < c > d\"}" > "$1"; }
+        out="$SB/report.html"
+        nftban_report_generate_html "$out" "" "" dark >/dev/null 2>&1 || true
+        cat "$out" 2>/dev/null
+    '
+)"
+
+[[ -n "$OUT" ]] || { echo "  [FATAL] no HTML produced"; exit 1; }
+
+# the injected data line
+DATALINE="$(grep -F 'window.__NFTBAN_DATA__' <<<"$OUT" | head -1)"
+# the JSON payload = everything after "= "
+# shellcheck disable=SC2034  # PAYLOAD is consumed by the assert eval expressions below
+PAYLOAD="${DATALINE#*= }"
+
+assert "HTML produced with data line"          '[[ -n "$DATALINE" ]]'
+# injection correctness: the data line is exactly `window.__NFTBAN_DATA__ = {…}` with no leaked
+# substitution delimiter / template-tail garbage (the pre-fix ${var//…} brace-parse malformed it)
+assert "INJECTION_WELL_FORMED"                 '[[ "$DATALINE" =~ ^window\.__NFTBAN_DATA__\ =\ \{.*\}$ ]]'
+assert "NO_LEAKED_TEMPLATE_TAIL_IN_DATALINE"   '! grep -qF "</body>" <<<"$DATALINE"'
+assert "SCRIPT_BREAKOUT_NEUTRALIZED"           '! grep -qF "</script>" <<<"$DATALINE"'
+assert "LT_ESCAPED_AS_u003c"                   'grep -qF "\\u003c" <<<"$DATALINE"'
+assert "GT_ESCAPED_AS_u003e"                   'grep -qF "\\u003e" <<<"$DATALINE"'
+assert "AMP_ESCAPED_AS_u0026"                  'grep -qF "\\u0026" <<<"$DATALINE"'
+assert "NO_HTML_ENTITY_CORRUPTION"             '! grep -qE "&lt;|&gt;|&amp;" <<<"$DATALINE"'
+assert "PAYLOAD_STILL_VALID_JSON"              'jq -e . <<<"$PAYLOAD" >/dev/null'
+assert "PAYLOAD_DECODES_BACK_TO_ORIGINAL"      '[[ "$(jq -r .host <<<"$PAYLOAD")" == "$HOSTILE" ]]'
+assert "NOTE_FIELD_DECODES_BACK"               '[[ "$(jq -r .note <<<"$PAYLOAD")" == "a & b < c > d" ]]'
+# whole-document: the only </script> is the template's own closing tag (1), none from data
+assert "ONLY_TEMPLATE_CLOSING_SCRIPT_TAG"      '[[ "$(grep -cF "</script>" <<<"$OUT")" == "1" ]]'
+
+echo ""
+echo "=== report_html_json_script_safe_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -175,6 +175,7 @@ rbl_shared_address_authority_v220_0_test	cli/lib/nftban/tests/rbl_shared_address
 read_ra_ifs_v156_test	cli/lib/nftban/tests/read_ra_ifs_v156_test.sh	portscan	test	portscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 rebuild_no_syn_drop_v192_test	cli/lib/nftban/tests/rebuild_no_syn_drop_v192_test.sh	firewall	test	firewall-rebuild	ROOT_LAB	lab-manual	false	true	false	false	true	false			
 recovery_legacy_reconcile_v12012_test	cli/lib/nftban/tests/recovery_legacy_reconcile_v12012_test.sh	firewall	test	recovery	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+report_html_json_script_safe_v1227_test	cli/lib/nftban/tests/report_html_json_script_safe_v1227_test.sh	mail	test	report-html-script-safe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 rollback_help_guard_v1_139_2_test	cli/lib/nftban/tests/rollback_help_guard_v1_139_2_test.sh	update	test	rollback	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 rpm_files_no_double_dir_listing_v165_test	cli/lib/nftban/tests/rpm_files_no_double_dir_listing_v165_test.sh	packaging	test	rpm-files	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			
 rpm_files_templates_dedup_v166_test	cli/lib/nftban/tests/rpm_files_templates_dedup_v166_test.sh	packaging	test	rpm-files	PACKAGE_BUILD	policy-gates	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 3/6 — script-safe + correct JSON injection in the HTML report (MED-security)

**Base:** rebased on `main` after PR 1–2 merged. Failure domain: safe **and** correct injection of report data into the HTML template (owner-approved to fix both facets here — the escaping is only meaningful if the injection that carries it is well-formed).

### Two defects in `nftban_report_generate_html`
**1. XSS/breakout (MAIL-F4).** jq escapes quotes for JSON validity but does **not** neutralize characters the HTML tokenizer acts on. A data value (hostname/reason/user field) containing `</script>` — or `<!--`, `]]>`, U+2028/U+2029 — **broke out of the `<script>` element** regardless of JS-string context. Fix: `\uXXXX`-escape `< > & U+2028 U+2029` **inside the compact JSON** before injection (valid JSON the browser decodes back to identical text; **not** HTML-entity escaping, which would corrupt the JS).

**2. Malformed injection (pre-existing, found during this fix — reported and approved to fix in-scope).** The substitution `${html_content//… = { … }/… = ${json_data}}` had a **literal `}` inside the pattern**, which prematurely closes bash's `${…}` parse → the delimiter and replacement text leaked into the document, malforming the **default** html report path (`report generate --format html`). Replaced with `awk` keyed on the placeholder comment, passing the already-escaped JSON via **`ENVIRON`** so neither shell nor awk re-processes the `\uXXXX` sequences and no brace parser is perturbed.

### Proof
- `report_html_json_script_safe_v1227_test.sh` (`CI_HERMETIC_SHELL`) — **12/0**. A `</script><script>alert(1)</script>` value yields **no data-origin `</script>`**, the payload is `\u`-escaped (not `&lt;`), **well-formed** (`window.__NFTBAN_DATA__ = {…}`, no leaked template tail), **valid JSON**, and **decodes back** to the original text.
- **Mutation-proven twice:** remove the escaping → breakout returns; revert to the brace substitution → malformed injection. Both restore byte-identical.

### Scope / guards
- Shell/awk + JSON only. **No Go. No schema change** (nft 1.84.0 / config 1.1.0). `DAEMON_BYTE_IMPACT = NONE`.
- Added `NFTBAN_REPORT_TEMPLATE` override for testability — **production default unchanged**.
- No new module-send authority. Governed via existing index authority; no framework-logic files touched. Does not touch Mail Lanes 2–7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
