### PR TITLE
fix(mail): honest per-producer report subjects (MAIL-F2, v1.227 Lane-1 PR 4/6)

### DIFF
--- a/cli/lib/nftban/cli/cmd_fhs.sh
+++ b/cli/lib/nftban/cli/cmd_fhs.sh
@@ -237,7 +237,7 @@ nftban_cmd_fhs() {
                     return 1
                 fi
                 echo "Sending FHS report to $recipient..."
-                nftban_mail_send "$report_path" "$recipient"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan FHS Report" nftban_mail_send "$report_path" "$recipient"
                 return $?
             else
                 # Generate report and mail it
@@ -247,7 +247,7 @@ nftban_cmd_fhs() {
                 if [[ $? -eq 0 && -f "$report_file" ]]; then
                     echo "✓ Report generated: $report_file"
                     echo "Sending via email..."
-                    nftban_mail_send "$report_file" "$recipient"
+                    NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan FHS Report" nftban_mail_send "$report_file" "$recipient"
                     return $?
                 else
                     echo "ERROR: Failed to generate HTML report" >&2

--- a/cli/lib/nftban/cli/cmd_mail.sh
+++ b/cli/lib/nftban/cli/cmd_mail.sh
@@ -376,7 +376,7 @@ NFTBAN_MAIL_ON_LOGIN_ALERT=\"YES\""
                 return 1
             fi
 
-            nftban_mail_send "$content" "$recipient"
+            NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Notification" nftban_mail_send "$content" "$recipient"
             return $?
             ;;
     esac

--- a/cli/lib/nftban/cli/cmd_module.sh
+++ b/cli/lib/nftban/cli/cmd_module.sh
@@ -209,7 +209,7 @@ nftban_cmd_module() {
                 if [[ -z "$save_to_file" ]]; then
                     nftban_module_report_status > "$report_file"
                 fi
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Report emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ Report emailed to: $email_to"
             fi
             
             return $result
@@ -231,7 +231,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-summary-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && echo "$output" > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Summary emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Summary" nftban_mail_send "$report_file" "$email_to" && echo "✓ Summary emailed to: $email_to"
             fi
 
             return $result
@@ -252,7 +252,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-report-XXXXXX.json)}"
                 [[ -z "$save_to_file" ]] && nftban_module_report_json > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ JSON emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Report (JSON)" nftban_mail_send "$report_file" "$email_to" && echo "✓ JSON emailed to: $email_to"
             fi
 
             return $result
@@ -277,7 +277,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-validation-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && nftban_module_validate_metadata > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Validation emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Validation Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ Validation emailed to: $email_to"
             fi
 
             return $result
@@ -302,7 +302,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-license-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && nftban_module_check_license > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ License report emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module License Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ License report emailed to: $email_to"
             fi
 
             return $result
@@ -327,7 +327,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-duplicates-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && nftban_module_check_duplicates > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Duplicate check report emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Duplicate-Check Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ Duplicate check report emailed to: $email_to"
             fi
 
             return $result
@@ -352,7 +352,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-author-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && nftban_module_check_author > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Author report emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Author Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ Author report emailed to: $email_to"
             fi
 
             return $result
@@ -376,7 +376,7 @@ nftban_cmd_module() {
             if [[ -n "$email_to" && $result -eq 0 ]]; then
                 local report_file="${save_to_file:-$(mktemp -t nftban-module-depends-XXXXXX.txt)}"
                 [[ -z "$save_to_file" ]] && nftban_module_analyze_dependencies > "$report_file"
-                nftban_mail_send "$report_file" "$email_to" && echo "✓ Dependency analysis emailed to: $email_to"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Dependency Report" nftban_mail_send "$report_file" "$email_to" && echo "✓ Dependency analysis emailed to: $email_to"
             fi
 
             return $result
@@ -400,7 +400,7 @@ nftban_cmd_module() {
                 
                 # If --email specified, send it
                 if [[ -n "$email_to" ]]; then
-                    nftban_mail_send "$report_file" "$email_to" && echo "✓ HTML report emailed to: $email_to"
+                    NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Report (HTML)" nftban_mail_send "$report_file" "$email_to" && echo "✓ HTML report emailed to: $email_to"
                 fi
                 
                 echo
@@ -452,7 +452,7 @@ nftban_cmd_module() {
                     return 1
                 fi
                 echo "Sending module report to $recipient..."
-                nftban_mail_send "$report_path" "$recipient"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Report" nftban_mail_send "$report_path" "$recipient"
                 return $?
             else
                 # Generate report and mail it
@@ -466,7 +466,7 @@ nftban_cmd_module() {
                     [[ -n "$save_to_file" ]] && cp "$report_file" "$save_to_file" && echo "✓ Saved to: $save_to_file"
                     
                     echo "Sending via email..."
-                    nftban_mail_send "$report_file" "$recipient"
+                    NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Module Report" nftban_mail_send "$report_file" "$recipient"
                     return $?
                 else
                     echo "ERROR: Failed to generate HTML report" >&2

--- a/cli/lib/nftban/cli/cmd_port.sh
+++ b/cli/lib/nftban/cli/cmd_port.sh
@@ -423,7 +423,7 @@ nftban_cmd_port() {
                     return 1
                 fi
                 echo "Sending port report to $recipient..."
-                nftban_mail_send "$report_path" "$recipient"
+                NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Port Report" nftban_mail_send "$report_path" "$recipient"
                 return $?
             else
                 # Generate report and mail it
@@ -433,7 +433,7 @@ nftban_cmd_port() {
                 if [[ $? -eq 0 && -f "$report_file" ]]; then
                     echo "✓ Report generated: $report_file"
                     echo "Sending via email..."
-                    nftban_mail_send "$report_file" "$recipient"
+                    NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Port Report" nftban_mail_send "$report_file" "$recipient"
                     return $?
                 else
                     echo "ERROR: Failed to generate HTML report" >&2

--- a/cli/lib/nftban/cli/cmd_report.sh
+++ b/cli/lib/nftban/cli/cmd_report.sh
@@ -398,7 +398,7 @@ EOF
 )
 
         # nftban_mail_send signature: content, recipient (optional)
-        if ! nftban_mail_send "$body" "$recipient"; then
+        if ! NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Statistics Report" nftban_mail_send "$body" "$recipient"; then
             echo "ERROR: Failed to send email" >&2
             rm -rf "$temp_dir"
             return 1

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -1016,7 +1016,7 @@ nftban_portscan_classic_send_alert() {
     if [[ "${PORTSCAN_NOTIFY_EMAIL:-false}" == "true" ]]; then
         local recipient="${PORTSCAN_NOTIFY_EMAIL_TO:-${NFTBAN_MAIL_RECIPIENT:-}}"
         if [[ -n "$recipient" ]]; then
-            nftban_mail_send "$message" "$recipient" 2>/dev/null || true
+            NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Port Scan Alert" nftban_mail_send "$message" "$recipient" 2>/dev/null || true
         fi
     fi
 

--- a/cli/lib/nftban/core/nftban_portscan_suricata.sh
+++ b/cli/lib/nftban/core/nftban_portscan_suricata.sh
@@ -722,7 +722,7 @@ nftban_portscan_suricata_send_alert() {
     if [[ "${PORTSCAN_NOTIFY_EMAIL:-false}" == "true" ]]; then
         local recipient="${PORTSCAN_NOTIFY_EMAIL_TO:-${NFTBAN_MAIL_RECIPIENT:-}}"
         if [[ -n "$recipient" ]]; then
-            nftban_mail_send "$message" "$recipient" 2>/dev/null || true
+            NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Port Scan Alert" nftban_mail_send "$message" "$recipient" 2>/dev/null || true
         fi
     fi
 

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -533,7 +533,7 @@ nftban_report_email_generate() {
     # ==========================================================================
 
     # Send via NFTBan unified mail mechanism (subject embedded in HTML)
-    if nftban_mail_send "$html" "$recipient" 2>/dev/null; then
+    if NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Statistics Report" nftban_mail_send "$html" "$recipient" 2>/dev/null; then
         echo "[SUCCESS] Report sent to ${recipient}"
         return 0
     else

--- a/cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh
+++ b/cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F2 subject authority (producers no longer mislabel "Report")
+# =============================================================================
+# meta:name="mail_subject_authority_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL-F2: report/alert producers set NFTBAN_MAIL_SUBJECT_OVERRIDE before nftban_mail_send so each report is delivered with an honest, path-specific subject instead of the generic default. Behavioral proof via the emulate sink (the override reaches the resolved subject; without it, the default 'Report from' subject is used) + static coverage that every enumerated producer send carries a non-empty override."
+# meta:input="None (sources nftban_mail.sh read-only + greps producer sources; emulate transport, no network)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep,jq,mktemp"
+# meta:inventory.files="cli/lib/nftban/core/nftban_mail.sh,cli/lib/nftban/cli/cmd_fhs.sh,cli/lib/nftban/cli/cmd_module.sh,cli/lib/nftban/cli/cmd_port.sh,cli/lib/nftban/cli/cmd_report.sh,cli/lib/nftban/cli/cmd_mail.sh"
+# meta:inventory.binaries="bash,grep,jq,mktemp"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_SUBJECT_OVERRIDE,NFTBAN_MAIL_EMULATE_SINK"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="mail_subject_authority_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="mail-subject-authority"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MAIL_LIB="$ROOT/cli/lib/nftban/core/nftban_mail.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== mail_subject_authority_v1227 ==="
+
+# --- behavioral: the override reaches the delivered subject via the emulate sink ---
+sent_subject() {
+    # $1 = override value ("" = none) ; echoes the subject the send resolved to
+    local override="$1" SB; SB="$(mktemp -d)"; mkdir -p "$SB/data"
+    local sink="$SB/sink.jsonl"
+    (
+        export NFTBAN_LIB_DIR="$ROOT/cli/lib/nftban" NFTBAN_DATA_DIR="$SB/data" \
+               NFTBAN_MAIL_METHOD="emulate" NFTBAN_MAIL_EMULATE_SINK="$sink" \
+               NFTBAN_MAIL_VALIDATE_RECIPIENTS="NO"
+        # shellcheck disable=SC1090
+        source "$MAIL_LIB"
+        if [[ -n "$override" ]]; then
+            NFTBAN_MAIL_SUBJECT_OVERRIDE="$override" nftban_mail_send "body" "to@example.test" >/dev/null 2>&1 || true
+        else
+            nftban_mail_send "body" "to@example.test" >/dev/null 2>&1 || true
+        fi
+    )
+    jq -r '.subject' "$sink" 2>/dev/null | tail -1
+    rm -rf "$SB"
+}
+
+# shellcheck disable=SC2034  # consumed by assert eval
+SUBJ_FHS="$(sent_subject 'NFTBan FHS Report')"
+# shellcheck disable=SC2034  # consumed by assert eval
+SUBJ_PORT="$(sent_subject 'NFTBan Port Report')"
+# shellcheck disable=SC2034  # consumed by assert eval
+SUBJ_DEFAULT="$(sent_subject '')"
+
+assert "OVERRIDE_REACHES_SUBJECT[fhs]"        '[[ "$SUBJ_FHS" == "NFTBan FHS Report" ]]'
+assert "OVERRIDE_REACHES_SUBJECT[port]"       '[[ "$SUBJ_PORT" == "NFTBan Port Report" ]]'
+assert "SUBJECT_DISTINCT_PER_PATH"            '[[ "$SUBJ_FHS" != "$SUBJ_PORT" ]]'
+# pre-fix behavior: with NO override the subject is the generic default ("... Report from <host>")
+assert "DEFAULT_WITHOUT_OVERRIDE_IS_GENERIC"  '[[ "$SUBJ_DEFAULT" == *"Report from"* ]]'
+assert "OVERRIDDEN_SUBJECT_NOT_THE_GENERIC"   '[[ "$SUBJ_FHS" != *"Report from"* ]]'
+
+# --- static coverage: every enumerated producer send carries a non-empty override ---
+# file : expected number of overridden nftban_mail_send producer sites
+declare -A EXPECT=(
+  ["cli/lib/nftban/cli/cmd_fhs.sh"]=2
+  ["cli/lib/nftban/cli/cmd_module.sh"]=11
+  ["cli/lib/nftban/cli/cmd_port.sh"]=2
+  ["cli/lib/nftban/cli/cmd_report.sh"]=1
+  ["cli/lib/nftban/cli/cmd_mail.sh"]=1
+  ["cli/lib/nftban/core/nftban_report_email.sh"]=1
+  ["cli/lib/nftban/core/nftban_portscan_suricata.sh"]=1
+  ["cli/lib/nftban/core/nftban_portscan_classic.sh"]=1
+)
+for f in "${!EXPECT[@]}"; do
+    want="${EXPECT[$f]}"
+    # shellcheck disable=SC2034  # consumed by assert eval
+    got=$(grep -cE 'NFTBAN_MAIL_SUBJECT_OVERRIDE="[^"]+" nftban_mail_send ' "$ROOT/$f" || true)
+    assert "COVERAGE[$(basename "$f")]=$want" '[[ "$got" -ge "$want" ]]'
+    # no override may be empty
+    if grep -qE 'NFTBAN_MAIL_SUBJECT_OVERRIDE="" nftban_mail_send' "$ROOT/$f"; then
+        bad "EMPTY_OVERRIDE in $(basename "$f")"
+    fi
+done
+
+echo ""
+echo "=== mail_subject_authority_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -143,6 +143,7 @@ logs_truth_v150_test	cli/lib/nftban/tests/logs_truth_v150_test.sh	health	test	lo
 mac_posture_v158_test	cli/lib/nftban/tests/mac_posture_v158_test.sh	security	test	mac-posture	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 mail_netrc_auth_transport_v1227_test	cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh	mail	test	mail-smtp-netrc	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+mail_subject_authority_v1227_test	cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh	mail	test	mail-subject-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh	firewall	test	maintenance-table-probe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 nft_counting_model_guard_v190_test	cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh	metrics	test	nft-counting-model	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 nft_loopback_before_invalid_v217_test	cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh	firewall	test	nft-schema-rule-order	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 4/6 — honest per-producer report subjects (MAIL-F2 · MED)

**Base:** rebased on `main` after PR 1–3. Failure domain: report subject labeling.

### Defect
`nftban_mail_send` is `(content, recipient)` — **no subject parameter**; unset, it resolves the generic default `"… Report from <host>"`. ~20 report/alert producers relied on that default, so every FHS / module / port / statistics / portscan report shipped **mislabeled** (the v1.223 `mail test` subject fix never reached the producers).

### Fix
Set `NFTBAN_MAIL_SUBJECT_OVERRIDE` (the existing dynamically-scoped override `nftban_mail.sh:674` reads — the same mechanism `mail test` uses) as an **inline env prefix** on each producer send, giving an honest, path-specific subject. The inline prefix **auto-scopes to that single call** (verified) — no leak to sibling sends, and **no interface change** to `nftban_mail_send` (a subject param would be Lane-2). Recipient + transport authority unchanged.

Sites: `cmd_fhs`(2) `cmd_module`(11, per subcommand) `cmd_port`(2) `cmd_report`(1) `cmd_mail`(1) `nftban_report_email`(1) `nftban_portscan_suricata`(1) `nftban_portscan_classic`(1).

### Proof
- `mail_subject_authority_v1227_test.sh` (`CI_HERMETIC_SHELL`) — **13/0**.
- **Behavioral** (emulate sink): the override reaches the delivered subject and is **distinct per path**; without it the generic `Report from` default is used (the pre-fix behavior).
- **Static coverage**: every enumerated producer send carries a non-empty override.
- **Mutation-proven**: strip overrides → coverage assertion fails; restore → byte-identical.

### Scope / guards
- Shell-only. **No Go. No schema change.** No new module-send authority. `DAEMON_BYTE_IMPACT = NONE`. Governed via existing index authority. Does not touch Mail Lanes 2–7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
