### PR TITLE
fix(packaging): generate DEB conffiles from staged config set — mail.conf/nftables.conf survive upgrade (MAIL-F8, v1.227 Lane-1 PR 5/6)

### DIFF
--- a/cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh
+++ b/cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F8 DEB conffile parity (operator configs survive apt upgrade)
+# =============================================================================
+# meta:name="deb_conffile_parity_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL-F8: the DEB conffiles list is generated from the staged config set (parity with the RPM %config(noreplace) wildcard) instead of a drifting hand-list that omitted mail.conf/nftables.conf/stats.conf/etc. Builds a fixture staged tree from the shipped source, runs the generation logic, and asserts every operator *.conf (incl mail.conf + nftables.conf) + conf.d yaml profiles are covered while defaults/examples/.local and non-conf.d runtime templates are excluded. Static-guards that build_nftban.sh uses the generator, not the old hand-list. NOTE: package-native upgrade preservation is proven separately on lab2 DEB + lab4 RPM (EXECUTION_DEFERRED)."
+# meta:input="None (reads shipped source configs + build_nftban.sh read-only; builds a temp fixture)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,find,sed,sort,grep"
+# meta:inventory.files="packaging/build_nftban.sh,etc/nftban/conf.d/mail.conf,install/nftables/nftables.conf"
+# meta:inventory.binaries="bash,find,sed,sort,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="deb_conffile_parity_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="deb-conffile-parity"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+# shellcheck disable=SC2034  # BUILD is consumed by the assert eval expressions
+BUILD="$ROOT/packaging/build_nftban.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== deb_conffile_parity_v1227 ==="
+
+# --- build a fixture staged /etc tree from the shipped source (mirrors build_deb staging) ---
+FX="$(mktemp -d)"; trap 'rm -rf "$FX"' EXIT
+mkdir -p "$FX/deb/etc/nftban/conf.d" "$FX/deb/etc/sysctl.d" "$FX/deb/etc/nftban/suricata/profiles"
+cp -r "$ROOT"/etc/nftban/conf.d/* "$FX/deb/etc/nftban/conf.d/" 2>/dev/null || true
+cp "$ROOT/install/nftables/nftables.conf" "$FX/deb/etc/nftban/nftables.conf"
+cp "$ROOT/install/config/nftban.conf"     "$FX/deb/etc/nftban/nftban.conf"
+cp "$ROOT"/etc/nftban/suricata/profiles/*.yaml "$FX/deb/etc/nftban/suricata/profiles/" 2>/dev/null || true
+touch "$FX/deb/etc/sysctl.d/90-nftban.conf"
+# adversarial references that MUST be excluded
+touch "$FX/deb/etc/nftban/conf.d/community_stats.conf.default" \
+      "$FX/deb/etc/nftban/conf.d/foo.conf.example" \
+      "$FX/deb/etc/nftban/conf.d/mail.conf.local"
+
+# --- run the generation logic (kept in lock-step with build_nftban.sh via the static guard below) ---
+CONFFILES="$FX/conffiles"
+{
+    (
+        cd "$FX/deb" || exit 0
+        find etc/nftban -type f -name '*.conf' \
+             ! -name '*.default' ! -name '*.example' ! -name '*.local' 2>/dev/null
+        find etc/nftban/conf.d -type f \( -name '*.yaml' -o -name '*.yml' \) \
+             ! -name '*.default' ! -name '*.example' ! -name '*.local' 2>/dev/null
+        [ -f etc/sysctl.d/90-nftban.conf ] && echo etc/sysctl.d/90-nftban.conf
+    ) | sed 's,^,/,' | LC_ALL=C sort -u
+} > "$CONFFILES"
+
+has() { grep -qxF "$1" "$CONFFILES"; }
+
+# --- MUST be protected (the headline + the previously-drifted set) ---
+assert "COVERS mail.conf (MAIL-F8 headline)"     'has "/etc/nftban/conf.d/mail.conf"'
+assert "COVERS nftables.conf"                    'has "/etc/nftban/nftables.conf"'
+assert "COVERS nftban.conf"                      'has "/etc/nftban/nftban.conf"'
+assert "COVERS stats.conf"                       'has "/etc/nftban/conf.d/stats.conf"'
+assert "COVERS login_alert.conf"                 'has "/etc/nftban/conf.d/login_alert.conf"'
+assert "COVERS connectors.conf"                  'has "/etc/nftban/conf.d/connectors.conf"'
+assert "COVERS a panels subdir config"           'has "/etc/nftban/conf.d/panels/plesk/main.conf"'
+assert "COVERS botguard yaml profile"            'has "/etc/nftban/conf.d/botguard/profiles/generic.yaml"'
+assert "COVERS sysctl drop-in"                   'has "/etc/sysctl.d/90-nftban.conf"'
+
+# --- every shipped operator conf.d *.conf is covered (true parity, no drift) ---
+missing=0
+while IFS= read -r rel; do
+    p="/etc/nftban/conf.d/${rel#"$FX/deb/etc/nftban/conf.d/"}"
+    has "$p" || { echo "    · uncovered: $p"; missing=$((missing+1)); }
+done < <(find "$FX/deb/etc/nftban/conf.d" -type f -name '*.conf' ! -name '*.default' ! -name '*.example' ! -name '*.local')
+assert "EVERY shipped conf.d/*.conf is covered (0 uncovered)" '[[ "$missing" -eq 0 ]]'
+
+# --- MUST be excluded (references + non-conf.d runtime templates) ---
+assert "EXCLUDES *.conf.default"                 '! has "/etc/nftban/conf.d/community_stats.conf.default"'
+assert "EXCLUDES *.conf.example"                 '! has "/etc/nftban/conf.d/foo.conf.example"'
+assert "EXCLUDES *.conf.local (operator override)" '! has "/etc/nftban/conf.d/mail.conf.local"'
+assert "EXCLUDES suricata runtime template yaml"  '! has "/etc/nftban/suricata/profiles/minimal.yaml"'
+
+# coverage strictly exceeds the old 23-entry hand-list
+assert "COVERAGE_EXCEEDS_OLD_HANDLIST (>23)"     '[[ "$(wc -l < "$CONFFILES")" -gt 23 ]]'
+
+# --- static guard: build_nftban.sh GENERATES conffiles (not the old static EOF hand-list) ---
+assert "BUILD uses find-generated conffiles"     'grep -q "find etc/nftban -type f -name .\\*\\.conf." "$BUILD"'
+assert "BUILD writes generated list to conffiles" 'grep -q "} > \"\${BUILD_DIR}/deb/DEBIAN/conffiles\"" "$BUILD"'
+assert "BUILD dropped the old hand-list heredoc"  '! grep -q "^/etc/nftban/conf.d/watchdog.conf$" "$BUILD"'
+
+echo ""
+echo "=== deb_conffile_parity_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
+++ b/cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh
@@ -55,7 +55,9 @@ grep -qiE 'keepalive|dead socket|dead-socket' "$CONF" && ok "PR1 rationale comme
 grep -qiE 'NO automatic live-kernel|no automatic live' "$CONF" && ok "PR1 no-auto-write note" || no "PR1 no-auto-write note"
 
 # ---- PR-2: packaging parity ----
-grep -qxF '/etc/sysctl.d/90-nftban.conf' <(sed -n '/DEBIAN\/conffiles/,/CONFFILES_EOF/p' "$BUILD") && ok "PR2 DEB conffiles declares sysctl" || no "PR2 DEB conffile"
+# v1.227 MAIL-F8: the DEB conffiles is now GENERATED from the staged tree (no CONFFILES_EOF
+# heredoc). Assert the generator emits the sysctl drop-in into DEBIAN/conffiles.
+grep -qE 'etc/sysctl\.d/90-nftban\.conf.*>>?.*conffiles|-f etc/sysctl\.d/90-nftban\.conf.*echo etc/sysctl\.d/90-nftban\.conf|echo etc/sysctl\.d/90-nftban\.conf' "$BUILD" && ok "PR2 DEB conffiles declares sysctl" || no "PR2 DEB conffile"
 grep -qE '%config\(noreplace\)\s+/etc/sysctl.d/90-nftban.conf' "$BUILD" && ok "PR2 RPM %config(noreplace) kept" || no "PR2 RPM noreplace"
 
 # ---- PR-3: registry + risk scan ----

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1961,36 +1961,31 @@ PRERM
         chmod 755 "${BUILD_DIR}/deb/DEBIAN/postrm"
     fi
 
-    # BUG-L52 FIX: Reduced conffiles to only base config files that ship with
-    # defaults. User-managed files (whitelist/blacklist) removed to avoid
-    # interactive prompts during non-interactive upgrades.
-    # Users should customize via .local override files (e.g., main.conf.local).
-    cat > "${BUILD_DIR}/deb/DEBIAN/conffiles" <<'CONFFILES_EOF'
-/etc/nftban/nftban.conf
-/etc/nftban/conf.d/feeds.conf
-/etc/nftban/conf.d/rbl/main.conf
-/etc/nftban/conf.d/rbl/rbls.conf
-/etc/nftban/conf.d/rbl/custom.conf
-/etc/nftban/conf.d/ddos/main.conf
-/etc/nftban/conf.d/portscan/main.conf
-/etc/nftban/conf.d/login/main.conf
-/etc/nftban/conf.d/suricata/interfaces.conf
-/etc/nftban/conf.d/botscan/main.conf
-/etc/nftban/conf.d/botguard/main.conf
-/etc/nftban/conf.d/botguard/allowed_crawlers.conf
-/etc/nftban/conf.d/botguard/denied_crawlers.conf
-/etc/nftban/conf.d/botguard/profiles/generic.yaml
-/etc/nftban/conf.d/botguard/profiles/wordpress.yaml
-/etc/nftban/conf.d/tunnel/main.conf
-/etc/nftban/conf.d/geoban/main.conf
-/etc/nftban/conf.d/geoip/main.conf
-/etc/nftban/conf.d/metrics.conf
-/etc/nftban/conf.d/persistent.conf
-/etc/nftban/conf.d/logs.conf
-/etc/nftban/conf.d/watchdog.conf
-/etc/nftban/conf.d/community_stats.conf.default
-/etc/sysctl.d/90-nftban.conf
-CONFFILES_EOF
+    # v1.227 MAIL-F8: GENERATE the DEB conffiles from the actually-staged config set instead
+    # of a hand-maintained list. dpkg has no %config wildcard (unlike the RPM spec), so the
+    # prior explicit list silently drifted — it omitted real shipped operator configs
+    # (mail.conf, stats.conf, login_alert.conf, nftables.conf, panels/*, connectors.conf, …),
+    # so those edits were OVERWRITTEN on `apt upgrade` while RPM's %config(noreplace) wildcard
+    # preserved them. Enumerating the staged tree (create_deb_control runs AFTER config staging)
+    # keeps DEB↔RPM parity automatically and makes future configs drift-proof.
+    #   protected = every operator-editable config under /etc/nftban:
+    #     - all *.conf (covers /etc/nftban/nftables.conf + every conf.d/**/*.conf)
+    #     - the botguard crawler profiles (conf.d/**/*.yaml|*.yml)
+    #     - the sysctl drop-in (/etc/sysctl.d/90-nftban.conf)
+    #   excluded = shipped references, never operator-owned-in-place:
+    #     - *.default / *.example (always-replaced templates)
+    #     - *.local (operator override files, dpkg must never touch)
+    #   NOT protected = shipped runtime templates outside conf.d (e.g. suricata/profiles/*.yaml)
+    {
+        (
+            cd "${BUILD_DIR}/deb" 2>/dev/null || exit 0
+            find etc/nftban -type f -name '*.conf' \
+                 ! -name '*.default' ! -name '*.example' ! -name '*.local' 2>/dev/null
+            find etc/nftban/conf.d -type f \( -name '*.yaml' -o -name '*.yml' \) \
+                 ! -name '*.default' ! -name '*.example' ! -name '*.local' 2>/dev/null
+            [ -f etc/sysctl.d/90-nftban.conf ] && echo etc/sysctl.d/90-nftban.conf
+        ) | sed 's,^,/,' | LC_ALL=C sort -u
+    } > "${BUILD_DIR}/deb/DEBIAN/conffiles"
 }
 
 build_deb() {

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -102,6 +102,7 @@ community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh	comms	te
 config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	test	config-local	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+deb_conffile_parity_v1227_test	cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh	mail	test	deb-conffile-parity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 error_text_3line_v153_test	cli/lib/nftban/tests/error_text_3line_v153_test.sh	cli	test	cli-ux	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_phase2_scale_guard_v1361_test	cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_resilience_v136_test	cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 5/6 — generate DEB conffiles from the staged config set (MAIL-F8 · MED, upgrade-safety)

**Base:** rebased on `main` after PR 1–4. Failure domain: DEB conffile upgrade-preservation.

### Defect
`DEBIAN/conffiles` was a hand-maintained 23-entry list. dpkg has **no `%config` wildcard** (the RPM spec uses `%config(noreplace) /etc/nftban/conf.d/*.conf` + `nftables.conf`), so the DEB list **silently drifted** — it omitted many real shipped operator configs (`mail.conf`, `stats.conf`, `login_alert.conf`, `nftables.conf`, `connectors.conf`, `panels/*/main.conf`, `login/scorer.conf`, …). Those were **overwritten on `apt upgrade`** while RPM preserved them.

### Fix
**Generate** the conffiles from the actually-staged tree (`create_deb_control` runs *after* config staging — verified): every `*.conf` under `/etc/nftban` (covers `nftables.conf` + all `conf.d/**/*.conf` incl `mail.conf`) + the `conf.d` yaml crawler profiles + the sysctl drop-in. Excludes `*.default`/`*.example` (always-replaced references) and `*.local` (operator overrides dpkg must never touch); does not protect non-`conf.d` runtime templates (`suricata/profiles/*.yaml`). Parity with RPM now holds **automatically** and future configs can't drift. RPM spec unchanged. Coverage **23 → 51** entries.

### Proof
- `deb_conffile_parity_v1227_test.sh` (`CI_HERMETIC_SHELL`) — **18/0**: `mail.conf`/`nftables.conf`/**every** shipped `conf.d/*.conf` covered; references + runtime templates excluded; static-guards that `build_nftban.sh` uses the generator.
- **Mutation-proven**: revert to the hand-list → static guards fail; restore → byte-identical.

### ⚠ Package-native gate — EXECUTION_DEFERRED
The **mandatory** package-native upgrade proof (lab2 **DEB**: install v1.226.0 → edit `mail.conf` → upgrade v1.227 → assert preserved; lab4 **RPM** regression) needs **built v1.227 packages**, produced at release-prep — the same point v1.226 did its lab validation. It is a **hard gate before v1.227 publish**, tracked in the release-prep RC. This PR ships the static parity proof; the package-native proof is deferred, not skipped.

### Scope / guards
- Packaging/shell only. **No Go. No schema change.** `DAEMON_BYTE_IMPACT = NONE`. Governed via existing index authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
