### PR TITLE
fix(mail): honest delivery wording — no false 'sent successfully' (v1.227 Lane-1 PR 6/6)

### DIFF
--- a/cli/lib/nftban/cli/cmd_report.sh
+++ b/cli/lib/nftban/cli/cmd_report.sh
@@ -378,7 +378,7 @@ nftban_report_cmd_email() {
         if type -t nftban_print_status >/dev/null 2>&1; then
             nftban_print_status "success" "Report emailed to ${recipient}"
         else
-            echo "[SUCCESS] Email sent to ${recipient}"
+            echo "[SUCCESS] Email submitted to ${recipient} (delivery not confirmed)"
         fi
     elif declare -f nftban_mail_send >/dev/null 2>&1; then
         # Fallback: Use mail module with basic content
@@ -407,7 +407,7 @@ EOF
         if type -t nftban_print_status >/dev/null 2>&1; then
             nftban_print_status "success" "Report emailed to ${recipient}"
         else
-            echo "[SUCCESS] Email sent to ${recipient}"
+            echo "[SUCCESS] Email submitted to ${recipient} (delivery not confirmed)"
         fi
     else
         echo ""

--- a/cli/lib/nftban/core/nftban_login_alert.sh
+++ b/cli/lib/nftban/core/nftban_login_alert.sh
@@ -563,7 +563,7 @@ EOF
 
     # Send via NFTBan unified mail mechanism
     if nftban_mail_send "$html" 2>/dev/null; then
-        nftban_login_alert_log "Login digest sent successfully ($count alerts)"
+        nftban_login_alert_log "Login digest submitted ($count alerts; delivery not confirmed)"
         # Clear digest after successful send
         nftban_login_digest_clear
         return 0

--- a/cli/lib/nftban/core/nftban_mail.sh
+++ b/cli/lib/nftban/core/nftban_mail.sh
@@ -871,7 +871,7 @@ CURLEOF
     local send_result=$?
 
     if (( send_result == 0 )); then
-        echo "✓ Email sent successfully to: $recipient"
+        echo "✓ Email submitted to transport for: $recipient (delivery not confirmed)"
 
         # Save sent email if debugging
         if [[ -n "${NFTBAN_MAIL_SAVE_SENT:-}" ]] && [[ -d "${NFTBAN_MAIL_SAVE_SENT}" ]]; then

--- a/cli/lib/nftban/core/nftban_report_email.sh
+++ b/cli/lib/nftban/core/nftban_report_email.sh
@@ -534,7 +534,7 @@ nftban_report_email_generate() {
 
     # Send via NFTBan unified mail mechanism (subject embedded in HTML)
     if NFTBAN_MAIL_SUBJECT_OVERRIDE="NFTBan Statistics Report" nftban_mail_send "$html" "$recipient" 2>/dev/null; then
-        echo "[SUCCESS] Report sent to ${recipient}"
+        echo "[SUCCESS] Report submitted to ${recipient} (delivery not confirmed)"
         return 0
     else
         echo "ERROR: Failed to send report email" >&2

--- a/cli/lib/nftban/tests/mail_honest_wording_v1227_test.sh
+++ b/cli/lib/nftban/tests/mail_honest_wording_v1227_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# NFTBan v1.227 Lane-1 — MAIL-F4b honest delivery wording (claims-truth)
+# =============================================================================
+# meta:name="mail_honest_wording_v1227_test"
+# meta:type="test"
+# meta:version="1.227.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="MAIL claims-truth: transport-accept paths that only know curl/MTA returned 0 must not claim the mail was 'sent successfully'/delivered. Asserts the provably-false success strings are gone and replaced with 'submitted … (delivery not confirmed)', the RBL honest model is untouched, and the send exit code is unchanged (wording-only, no control-flow change)."
+# meta:input="None (greps mail/report sources read-only + drives nftban_mail_send via emulate; no network)"
+# meta:output="Pass/fail assertions on stdout; exit 0 on all-pass"
+# meta:depends="bash,grep"
+# meta:inventory.files="cli/lib/nftban/core/nftban_mail.sh,cli/lib/nftban/cli/cmd_report.sh,cli/lib/nftban/core/nftban_report_email.sh,cli/lib/nftban/core/nftban_login_alert.sh,cli/lib/nftban/core/nftban_rbl.sh"
+# meta:inventory.binaries="bash,grep"
+# meta:inventory.env_vars="NFTBAN_MAIL_METHOD,NFTBAN_MAIL_EMULATE_SINK"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="mail_honest_wording_v1227_test"
+# meta:ta.owner="mail"
+# meta:ta.module="mail-honest-wording"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MAIL="$ROOT/cli/lib/nftban/core/nftban_mail.sh"
+# shellcheck disable=SC2034  # consumed by assert eval
+REPORT="$ROOT/cli/lib/nftban/cli/cmd_report.sh"
+# shellcheck disable=SC2034  # consumed by assert eval
+REPORT_EMAIL="$ROOT/cli/lib/nftban/core/nftban_report_email.sh"
+# shellcheck disable=SC2034  # consumed by assert eval
+LOGIN_ALERT="$ROOT/cli/lib/nftban/core/nftban_login_alert.sh"
+# shellcheck disable=SC2034  # consumed by assert eval
+RBL="$ROOT/cli/lib/nftban/core/nftban_rbl.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+assert() { if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+echo "=== mail_honest_wording_v1227 ==="
+
+# --- NO false DELIVERED/sent-successfully claim on transport-accept paths ---
+assert "NO 'sent successfully' in nftban_mail.sh"        '! grep -q "Email sent successfully" "$MAIL"'
+assert "NO 'Email sent to' in cmd_report.sh"             '! grep -q "\[SUCCESS\] Email sent to" "$REPORT"'
+assert "NO 'Report sent to' in nftban_report_email.sh"   '! grep -q "\[SUCCESS\] Report sent to" "$REPORT_EMAIL"'
+assert "NO 'digest sent successfully' in login_alert.sh" '! grep -q "digest sent successfully" "$LOGIN_ALERT"'
+
+# --- honest 'submitted / delivery not confirmed' wording present at each site ---
+assert "SUBMITTED wording in nftban_mail.sh"             'grep -q "Email submitted to transport for.*(delivery not confirmed)" "$MAIL"'
+assert "SUBMITTED wording in cmd_report.sh (x2)"         '[[ "$(grep -c "Email submitted to .*(delivery not confirmed)" "$REPORT")" -eq 2 ]]'
+assert "SUBMITTED wording in nftban_report_email.sh"     'grep -q "Report submitted to .*(delivery not confirmed)" "$REPORT_EMAIL"'
+assert "SUBMITTED wording in login_alert.sh"             'grep -q "Login digest submitted .*delivery not confirmed" "$LOGIN_ALERT"'
+
+# --- RBL honest model preserved (untouched) ---
+assert "RBL honest 'degraded' model intact"             'grep -q "degraded" "$RBL"'
+
+# --- wording-only: the changed lines are still echo/log statements (no exit/return injected) ---
+assert "mail.sh line stays an echo (no control-flow)"    'grep -q "echo \"✓ Email submitted to transport" "$MAIL"'
+assert "login_alert stays a log call"                    'grep -q "nftban_login_alert_log \"Login digest submitted" "$LOGIN_ALERT"'
+
+# --- behavioral: send exit code unchanged (emulate transport returns 0, no false-success text) ---
+SB="$(mktemp -d)"; trap 'rm -rf "$SB"' EXIT; mkdir -p "$SB/data"
+# shellcheck disable=SC2034  # consumed by assert eval
+out="$(
+    NFTBAN_LIB_DIR="$ROOT/cli/lib/nftban" NFTBAN_DATA_DIR="$SB/data" \
+    NFTBAN_MAIL_METHOD="emulate" NFTBAN_MAIL_EMULATE_SINK="$SB/sink.jsonl" \
+    NFTBAN_MAIL_VALIDATE_RECIPIENTS="NO" \
+    bash -c 'set -Eeuo pipefail; source "'"$MAIL"'"; nftban_mail_send "body" "to@example.test"; echo "RC=$?"' 2>&1
+)" || true
+assert "SEND_RC_UNCHANGED (emulate returns 0)"          'grep -q "RC=0" <<<"$out"'
+assert "NO false 'sent successfully' in live output"    '! grep -q "sent successfully" <<<"$out"'
+
+echo ""
+echo "=== mail_honest_wording_v1227: PASS=$PASS FAIL=$FAIL ==="
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -142,6 +142,7 @@ logrotate_behavioral_gateb_test	cli/lib/nftban/tests/logrotate_behavioral_gateb_
 logrotate_config_v137_test	cli/lib/nftban/tests/logrotate_config_v137_test.sh	packaging	test	logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 logs_truth_v150_test	cli/lib/nftban/tests/logs_truth_v150_test.sh	health	test	log-truth	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mac_posture_v158_test	cli/lib/nftban/tests/mac_posture_v158_test.sh	security	test	mac-posture	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+mail_honest_wording_v1227_test	cli/lib/nftban/tests/mail_honest_wording_v1227_test.sh	mail	test	mail-honest-wording	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mail_netrc_auth_transport_v1227_test	cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh	mail	test	mail-smtp-netrc	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 mail_subject_authority_v1227_test	cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh	mail	test	mail-subject-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## v1.227 Mail Lane-1 · PR 6/6 — honest delivery wording (MAIL claims-truth · MED)

**Base:** current `main` after PR 1–4 (PR-5 merges just before this). Failure domain: delivery claims-truth.

### Defect
Transport-accept paths that only know curl / the MTA returned `0` claimed the mail was **"sent successfully"** / `[SUCCESS] … sent to …`. A `0` exit means the message was *handed to / accepted by* the transport — **not delivered** (`RENDERED → ATTEMPTED → TRANSPORT_ACCEPTED → DELIVERED`). The audit flagged these as false-success strings.

### Fix (string-only)
Replace the five provably-false strings with transport-accurate wording — **"submitted … (delivery not confirmed)"** — at `nftban_mail.sh:869`, `cmd_report.sh:381/410`, `nftban_report_email.sh:537`, `nftban_login_alert.sh:566`. **No control-flow, no exit-code change, no delivery-state engine redesign** (that's Lane-2). The already-honest RBL model (`nftban_rbl.sh` spooled/degraded/not-delivered) is left as the reference.

### Proof
- `mail_honest_wording_v1227_test.sh` (`CI_HERMETIC_SHELL`) — **13/0**: false claims gone; submitted wording present at each site; RBL honest model intact; changed lines stay `echo`/log (no control-flow); **send exit code unchanged** (emulate returns 0, no "sent successfully" in live output).
- **Mutation-proven**: restore a false string → claims-truth assertion fails.

### Scope / guards
- Shell-only. **No Go. No schema change.** No new send authority. `DAEMON_BYTE_IMPACT = NONE`. Governed via existing index authority. Does not touch Mail Lanes 2–7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
