### PR TITLE
feat(ci): repository-authority and history-epoch guard (v1.228.0 Wave A, PR-H1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -202,5 +202,25 @@ for f in $STAGED_FILES; do
     fi
 done
 
+# -----------------------------------------------------------------------------
+# 9) Repository authority (v1.227.1) — never commit into a clone that is not the
+#    canonical development authority. The retired pre-rewrite tree accepted
+#    commits happily while sitting on an abandoned history epoch; this is the
+#    cheapest point to catch that. Offline: tag parity is checked in CI, not here.
+# -----------------------------------------------------------------------------
+if [[ -f "$REPO_ROOT/scripts/ci/check-repo-authority.sh" ]]; then
+    auth_rc=0
+    # --allow-fork-origin: a contributor working from a fork must still be able to
+    # commit. Identity, object-store, epoch, ancestry and branch-base checks all
+    # remain blocking; only the origin URL is downgraded to a notice. CI refuses
+    # this flag, so the canonical-origin requirement is still enforced on merge.
+    auth_out="$(bash "$REPO_ROOT/scripts/ci/check-repo-authority.sh" \
+                    --mode local --skip-network --allow-fork-origin 2>&1)" || auth_rc=$?
+    if [[ "$auth_rc" -ne 0 ]]; then
+        printf '%s\n' "$auth_out" | sed 's/^/    /'
+        fail "Repository authority check failed (exit $auth_rc). This clone is not the canonical development authority — see tools/repo-authority-guard.sh for remediation."
+    fi
+fi
+
 echo -e "${GREEN}[OK]${NC} All pre-commit policy checks passed"
 exit 0

--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -5,6 +5,10 @@
 # Purpose: Enforce architecture invariants and code policy gates
 #
 # Checks:
+#   - Repository authority / history epoch (v1.227.1): the checkout must BE the
+#     canonical repository — resolved toplevel identity (not a --git-dir success,
+#     which walks upward into any ancestor repo), no borrowed alternates,
+#     canonical origin, post-rewrite epoch ancestry, tag parity
 #   - nft write policy (single-writer via daemon)
 #   - Netlink import boundary (CLI must use IPC)
 #   - Public API surface guard (only pkg/ipc + pkg/version)
@@ -45,6 +49,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # v1.227.1 PR-H1: the repository-authority gate evaluates history-epoch
+          # ancestry and local/remote tag parity. Both are meaningless in the
+          # default shallow, tagless checkout — a shallow clone cannot answer
+          # "does HEAD descend from the post-rewrite anchor". The gate refuses to
+          # guess (A4 fails closed), so full history and tags are REQUIRED here.
+          fetch-depth: 0
+          fetch-tags: true
+
+      # =====================================================================
+      # REPOSITORY AUTHORITY (must run first — every check below assumes the
+      # checkout is the canonical repository and the correct history epoch)
+      # =====================================================================
+
+      - name: Check repository authority and history epoch
+        run: ./scripts/ci/check-repo-authority.sh --mode ci
+
+      - name: Repository authority — hermetic negative tests
+        # Proves the gate REJECTS known-bad repositories (ancestor-walk trap,
+        # borrowed alternates, wrong epoch, stale main, shallow, tag drift).
+        # A gate never exercised against bad input is an unverified claim.
+        run: ./scripts/ci/tests/check-repo-authority_test.sh
 
       # =====================================================================
       # EXISTING CHECKS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,6 +389,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # v1.227.1 PR-H1: full history + tags are required by the repository
+          # authority gate below (epoch ancestry and tag parity cannot be
+          # evaluated in a shallow, tagless checkout).
+          fetch-depth: 0
+          fetch-tags: true
+
+      # v1.227.1 PR-H1: never publish from a repository that is not the canonical
+      # authority. A release assembled from a wrong-epoch object store would ship
+      # artifacts built from pre-rewrite sources, including scrubbed private data.
+      # This runs BEFORE assembly verification: authority first, contents second.
+      - name: Verify repository authority and history epoch
+        run: ./scripts/ci/check-repo-authority.sh --mode ci
 
       # v1.221.1: resolve the release version from the tag on a real publish, or from
       # the VERSION file on a manual dry-run (no tag). REF is v-prefixed, VER is not.

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -83,6 +83,9 @@ Every release must pass this checklist.
 
 Before tagging a release:
 
+- [ ] **Repository authority confirmed** (`./tools/repo-authority-guard.sh`) — the clone is the
+      canonical repository on the post-rewrite history epoch, with no borrowed object store and
+      full tag parity. Releasing from a wrong-epoch clone would ship pre-rewrite sources.
 - [ ] VERSION file updated
 - [ ] CHANGELOG.md updated with release notes
 - [ ] All generated files regenerated (`./build/generate-fhs-outputs.sh`)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -193,8 +193,19 @@ answers *"can this break a consumer?"*; the category answers *"what was changed?
 | `DOCUMENTATION` | Documentation or metadata only |
 | `HOTFIX` | Expedited correction of a released defect |
 
-Example — v1.227.1 is `PATCH` + `MAINTENANCE_TOOLING`: repository-authority and workspace-lifecycle
-guards, with no product runtime, daemon, nft schema or config schema change.
+The two axes are independent, and the category must not drag the level upward: development-infrastructure
+work is still `PATCH` when it is backward compatible.
+
+**A worked example of the level changing with the evidence.** A maintenance train was originally scoped
+as `PATCH` + `MAINTENANCE_TOOLING` — repository-authority and workspace-lifecycle guards, no runtime,
+daemon, nft schema or config schema change. Clean-environment validation then exposed release-relevant
+runtime and packaging defects, which meant the eventual release would carry runtime correction as well as
+tooling. The planned patch was **not published**; the work was reclassified into the next minor train as
+`SECURITY_AND_INSTALL_CORRECTNESS`.
+
+The rule that produced that outcome: **classify from the change set that will actually ship, not from the
+one that was planned.** If validation changes the change set, reclassify before publishing — never
+publish under a level the contents no longer justify.
 
 ## Quick Reference
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -169,7 +169,32 @@ We follow [SemVer](https://semver.org/):
 
 - **MAJOR** (1.x.x): Breaking changes
 - **MINOR** (x.1.x): New features (backward compatible)
-- **PATCH** (x.x.1): Bug fixes
+- **PATCH** (x.x.1): Backward-compatible corrections. This covers more than product bug fixes:
+  - product bug fixes;
+  - release, build and test-infrastructure corrections;
+  - development-authority and repository-lifecycle tooling;
+  - documentation and metadata corrections.
+
+  A PATCH must introduce **no** intentional runtime feature and **no** incompatible schema or CLI
+  contract change. Do **not** take a MINOR bump merely because the work is development
+  infrastructure — the axis is compatibility, not subject matter.
+
+### Release category
+
+Orthogonal to the SemVer level, every release declares what kind of change it carries. The level
+answers *"can this break a consumer?"*; the category answers *"what was changed?"*.
+
+| `RELEASE_CATEGORY` | Meaning |
+|---|---|
+| `PRODUCT_FIX` | Defect in shipped runtime behaviour |
+| `SECURITY_FIX` | Security-relevant correction |
+| `MAINTENANCE_TOOLING` | Build, CI, test or development-lifecycle tooling |
+| `PACKAGING` | DEB/RPM packaging, install layout, unit files |
+| `DOCUMENTATION` | Documentation or metadata only |
+| `HOTFIX` | Expedited correction of a released defect |
+
+Example — v1.227.1 is `PATCH` + `MAINTENANCE_TOOLING`: repository-authority and workspace-lifecycle
+guards, with no product runtime, daemon, nft schema or config schema change.
 
 ## Quick Reference
 

--- a/scripts/ci/check-repo-authority.sh
+++ b/scripts/ci/check-repo-authority.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# meta:name="check-repo-authority"
+# meta:type="script"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="CI gate: the working repository must BE the canonical NFTBan development authority. Asserts repository identity (resolved toplevel, not merely 'git works here'), no borrowed object stores, canonical origin, post-rewrite history epoch, non-shallow ancestry, main==origin/main and local/remote tag parity."
+# meta:inventory.files=".git/objects/info/alternates, .git/info/grafts"
+# meta:inventory.binaries="bash, git, sort, comm, sed"
+# meta:inventory.env_vars="CI, NFTBAN_CANONICAL_ORIGIN, NFTBAN_HISTORY_EPOCH_ANCHOR, NFTBAN_PREREWRITE_FORBIDDEN_COMMIT, NFTBAN_AUTHORITY_ROOT, GIT_ALTERNATE_OBJECT_DIRECTORIES"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network="git ls-remote origin (tag parity; --mode local may skip)"
+# meta:inventory.privileges="none"
+# =============================================================================
+#
+# WHY THIS GATE EXISTS
+# --------------------
+# On 2026-07-25 the pre-rewrite shared repository was retired. Two defects made
+# that necessary and both are structural, not accidental:
+#
+#   1. A local checkout can silently be a DIFFERENT history epoch. The
+#      2026-07-15 privacy history rewrite replaced upstream history; the stale
+#      local tree still had the scrubbed pre-rewrite commits reachable. Branching
+#      from it would have resurrected scrubbed private data.
+#
+#   2. `git rev-parse --git-dir` SUCCEEDS from a directory that is not a
+#      repository, because git walks UPWARD. After the old repository was
+#      deleted, its path was recreated holding only a `.claude/` directory with
+#      no `.git` — and `rev-parse --git-dir` still resolved, to the unrelated
+#      parent repository. Any guard built on "did rev-parse succeed" passes from
+#      any subdirectory of any ancestor repository.
+#
+# Therefore this gate compares the RESOLVED `--show-toplevel` against the root
+# derived from this script's own location. Identity, never mere reachability.
+#
+# EXIT CODES
+#   0  authority confirmed
+#   1  authority violated (a check failed)
+#   2  usage error, or authority COULD NOT BE DETERMINED (safety refusal).
+#      Undeterminable is never reported as PASS.
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DEFAULT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+ROOT="${NFTBAN_AUTHORITY_ROOT:-$ROOT_DEFAULT}"
+
+# Canonical identity. Overridable so the gate carries no developer-specific
+# literal (a hardcoded home path classifies as PSEUDONYMOUS_DEV_PATH under
+# scripts/ci/privacy-scan.py and would add advisory findings on every run).
+CANONICAL_ORIGIN="${NFTBAN_CANONICAL_ORIGIN:-github.com/itcmsgr/nftban}"
+
+# History epoch anchors (v1.227.1). The anchor is the post-rewrite commit that
+# introduced the privacy scrub and its blocking gates; every legitimate HEAD
+# descends from it. The forbidden commit is the pre-rewrite tip, which exists
+# ONLY in the abandoned epoch — its presence proves a pre-rewrite object store.
+EPOCH_ANCHOR="${NFTBAN_HISTORY_EPOCH_ANCHOR:-f5dae9d13377782ee4803f528ebc7e13b59ffc6d}"
+FORBIDDEN_COMMIT="${NFTBAN_PREREWRITE_FORBIDDEN_COMMIT:-3752f68a2c29c63de6d24d20eae269a1a3bafb0d}"
+
+MODE="${CI:+ci}"; MODE="${MODE:-local}"
+SKIP_NETWORK=0
+ALLOW_FORK_ORIGIN=0
+FAIL=0
+
+usage() {
+    cat <<'USAGE'
+Usage: check-repo-authority.sh [--mode ci|local] [--skip-network] [--allow-fork-origin] [--help]
+
+  --mode ci             blocking; network required for tag parity (default when CI is set)
+  --mode local          developer-side; --skip-network permitted
+  --skip-network        skip tag parity against the remote (refused in --mode ci)
+  --allow-fork-origin   report a non-canonical origin as a NOTICE instead of a failure.
+                        For contributors working from a fork: identity, object-store,
+                        epoch and branch-base checks still apply in full. Refused in
+                        --mode ci — a release or merge gate must not accept a fork.
+
+Exit: 0 authority confirmed · 1 authority violated · 2 usage error or undeterminable.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode) MODE="${2:-}"; shift 2 || { echo "::error::--mode requires a value"; exit 2; } ;;
+        --skip-network) SKIP_NETWORK=1; shift ;;
+        --allow-fork-origin) ALLOW_FORK_ORIGIN=1; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "::error::unknown argument: $1"; usage; exit 2 ;;
+    esac
+done
+
+case "$MODE" in
+    ci|local) ;;
+    *) echo "::error::--mode must be 'ci' or 'local' (got: $MODE)"; exit 2 ;;
+esac
+
+if [[ "$MODE" == "ci" && "$SKIP_NETWORK" -eq 1 ]]; then
+    echo "::error::--skip-network is refused in --mode ci: tag parity is not optional in CI"
+    exit 2
+fi
+
+if [[ "$MODE" == "ci" && "$ALLOW_FORK_ORIGIN" -eq 1 ]]; then
+    echo "::error::--allow-fork-origin is refused in --mode ci: a CI gate must not accept a fork origin"
+    exit 2
+fi
+
+echo "========================================"
+echo "NFTBan CI: Repository Authority (mode=$MODE)"
+echo "========================================"
+
+# -----------------------------------------------------------------------------
+# A1. REPOSITORY IDENTITY — the resolved toplevel must BE this root.
+#     This is the check that defeats the upward-walk trap. A directory with no
+#     .git of its own resolves to an ancestor repository; comparing paths
+#     catches it, asking "did git succeed" does not.
+# -----------------------------------------------------------------------------
+echo "[A1] repository identity"
+actual_top_raw="$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$actual_top_raw" ]]; then
+    echo "::error::A1 not a git repository: $ROOT"
+    FAIL=1
+    actual_top=""
+else
+    actual_top="$(cd "$actual_top_raw" && pwd -P)"
+    if [[ "$actual_top" != "$ROOT" ]]; then
+        echo "::error::A1 repository identity mismatch — this directory is NOT its own repository"
+        echo "::error::A1   expected toplevel: $ROOT"
+        echo "::error::A1   resolved toplevel: $actual_top"
+        echo "::error::A1   git walked UPWARD to an ancestor repository; a --git-dir success proves nothing"
+        FAIL=1
+    else
+        echo "  toplevel resolves to this root — OK"
+    fi
+fi
+
+# Everything below needs a real repository at ROOT.
+if [[ -z "$actual_top" || "$actual_top" != "$ROOT" ]]; then
+    echo "RESULT: FAIL"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# A2. NO BORROWED OBJECT STORE. An alternates file (or the env equivalent) means
+#     objects come from another repository — including, historically, the
+#     pre-rewrite one. Clones must be independent.
+# -----------------------------------------------------------------------------
+echo "[A2] object-store independence"
+common_dir="$(git -C "$ROOT" rev-parse --git-common-dir)"
+[[ "$common_dir" = /* ]] || common_dir="$ROOT/$common_dir"
+alt_file="$common_dir/objects/info/alternates"
+if [[ -s "$alt_file" ]]; then
+    echo "::error::A2 borrowed object store: $alt_file is present and non-empty"
+    sed 's/^/::error::A2   alternate: /' "$alt_file"
+    FAIL=1
+elif [[ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]]; then
+    echo "::error::A2 GIT_ALTERNATE_OBJECT_DIRECTORIES is set — objects may come from another repository"
+    FAIL=1
+else
+    echo "  no alternates — OK"
+fi
+
+# -----------------------------------------------------------------------------
+# A3. CANONICAL ORIGIN. Normalised so ssh and https spellings compare equal.
+# -----------------------------------------------------------------------------
+echo "[A3] canonical origin"
+origin_url="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
+if [[ -z "$origin_url" ]]; then
+    echo "::error::A3 no 'origin' remote configured"
+    FAIL=1
+else
+    norm="$origin_url"
+    norm="${norm#https://}"; norm="${norm#http://}"; norm="${norm#ssh://}"
+    norm="${norm#git@}"; norm="${norm/://}"
+    norm="${norm%.git}"; norm="${norm%/}"
+    if [[ "$norm" != "$CANONICAL_ORIGIN" ]]; then
+        if [[ "$ALLOW_FORK_ORIGIN" -eq 1 ]]; then
+            echo "  NOTICE: origin is not canonical (expected $CANONICAL_ORIGIN, got $norm)"
+            echo "  NOTICE: accepted under --allow-fork-origin; every other authority check still applies"
+        else
+            echo "::error::A3 origin is not the canonical repository"
+            echo "::error::A3   expected: $CANONICAL_ORIGIN"
+            echo "::error::A3   actual:   $norm"
+            FAIL=1
+        fi
+    else
+        echo "  origin = $CANONICAL_ORIGIN — OK"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# A4. NON-SHALLOW, UNGRAFTED. Ancestry claims are meaningless in a shallow or
+#     grafted clone, so this must be established BEFORE A5 is trusted.
+#     (This is why ci-architecture.yml checks out with fetch-depth: 0.)
+# -----------------------------------------------------------------------------
+echo "[A4] ancestry is computable"
+if [[ "$(git -C "$ROOT" rev-parse --is-shallow-repository)" == "true" ]]; then
+    echo "::error::A4 shallow clone — history-epoch ancestry cannot be evaluated"
+    echo "::error::A4   the workflow must check out with fetch-depth: 0 and fetch-tags: true"
+    FAIL=1
+else
+    echo "  full history — OK"
+fi
+if [[ -s "$common_dir/info/grafts" ]]; then
+    echo "::error::A4 grafts file present — ancestry is rewritten locally"
+    FAIL=1
+fi
+if [[ -n "$(git -C "$ROOT" replace -l 2>/dev/null)" ]]; then
+    echo "::error::A4 replace refs present — ancestry is rewritten locally"
+    FAIL=1
+fi
+
+# -----------------------------------------------------------------------------
+# A5. HISTORY EPOCH. HEAD must descend from the post-rewrite anchor, and the
+#     pre-rewrite tip must not exist at all.
+# -----------------------------------------------------------------------------
+echo "[A5] history epoch"
+if ! git -C "$ROOT" cat-file -e "${EPOCH_ANCHOR}^{commit}" 2>/dev/null; then
+    echo "::error::A5 post-rewrite epoch anchor is absent: $EPOCH_ANCHOR"
+    echo "::error::A5   this history is not the canonical post-rewrite epoch"
+    FAIL=1
+elif ! git -C "$ROOT" merge-base --is-ancestor "$EPOCH_ANCHOR" HEAD 2>/dev/null; then
+    echo "::error::A5 HEAD does not descend from the post-rewrite epoch anchor $EPOCH_ANCHOR"
+    FAIL=1
+else
+    echo "  HEAD descends from the post-rewrite anchor — OK"
+fi
+
+if git -C "$ROOT" cat-file -e "${FORBIDDEN_COMMIT}^{commit}" 2>/dev/null; then
+    echo "::error::A5 PRE-REWRITE commit is present: $FORBIDDEN_COMMIT"
+    echo "::error::A5   this object store predates the privacy history rewrite — branching from it"
+    echo "::error::A5   would resurrect scrubbed private infrastructure data"
+    FAIL=1
+else
+    echo "  pre-rewrite tip absent — OK"
+fi
+
+# -----------------------------------------------------------------------------
+# A6. BRANCH BASE. A stale local `main` is what made the retired tree dangerous:
+#     it looked like main and was 7 releases behind on a dead epoch.
+# -----------------------------------------------------------------------------
+echo "[A6] local main tracks origin/main"
+if git -C "$ROOT" show-ref --verify --quiet refs/heads/main \
+   && git -C "$ROOT" show-ref --verify --quiet refs/remotes/origin/main; then
+    lm="$(git -C "$ROOT" rev-parse refs/heads/main)"
+    rm_="$(git -C "$ROOT" rev-parse refs/remotes/origin/main)"
+    if [[ "$lm" != "$rm_" ]]; then
+        echo "::error::A6 local main ($lm) != origin/main ($rm_) — never branch from a stale main"
+        FAIL=1
+    else
+        echo "  main == origin/main — OK"
+    fi
+else
+    echo "  NOTICE: refs/heads/main or refs/remotes/origin/main absent (typical CI checkout) — not evaluated"
+fi
+
+# -----------------------------------------------------------------------------
+# A7. TAG PARITY. The retired repository held 12 of 530 tags and still looked
+#     healthy. Undeterminable parity is a refusal (exit 2), never a pass.
+# -----------------------------------------------------------------------------
+echo "[A7] tag parity with origin"
+if [[ "$SKIP_NETWORK" -eq 1 ]]; then
+    echo "  SKIPPED (--skip-network, mode=local)"
+else
+    remote_tags_raw=""
+    if ! remote_tags_raw="$(git -C "$ROOT" ls-remote --tags origin 2>/dev/null)"; then
+        echo "::error::A7 cannot reach origin to verify tag parity — authority is UNDETERMINABLE"
+        echo "RESULT: REFUSED"
+        exit 2
+    fi
+    tmp_remote="$(mktemp)"; tmp_local="$(mktemp)"
+    # shellcheck disable=SC2064  # expand paths now: the temp names must not change
+    trap "rm -f '$tmp_remote' '$tmp_local'" EXIT
+    printf '%s\n' "$remote_tags_raw" \
+        | sed -n 's#.*refs/tags/\(.*\)#\1#p' | sed 's/\^{}$//' | sort -u > "$tmp_remote"
+    git -C "$ROOT" tag | sort -u > "$tmp_local"
+    only_remote="$(comm -13 "$tmp_local" "$tmp_remote" | head -20)"
+    only_local="$(comm -23 "$tmp_local" "$tmp_remote" | head -20)"
+    if [[ -n "$only_remote" ]]; then
+        echo "::error::A7 tags on origin but missing locally (fetch-tags: true required):"
+        printf '%s\n' "$only_remote" | sed 's/^/::error::A7   /'
+        FAIL=1
+    fi
+    if [[ -n "$only_local" ]]; then
+        echo "::error::A7 tags present locally but not on origin (local-only or pre-rewrite tags):"
+        printf '%s\n' "$only_local" | sed 's/^/::error::A7   /'
+        FAIL=1
+    fi
+    [[ -z "$only_remote$only_local" ]] && \
+        echo "  $(wc -l < "$tmp_local" | tr -d ' ') local == $(wc -l < "$tmp_remote" | tr -d ' ') remote — OK"
+fi
+
+echo "========================================"
+if [[ "$FAIL" -ne 0 ]]; then
+    echo "RESULT: FAIL"
+    exit 1
+fi
+echo "RESULT: PASS"
+exit 0

--- a/scripts/ci/tests/check-repo-authority_test.sh
+++ b/scripts/ci/tests/check-repo-authority_test.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# meta:name="check-repo-authority_test"
+# meta:type="script"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Hermetic tests for check-repo-authority.sh. Builds throwaway git repositories and proves each authority check fires on its own known-bad input: the ancestor-repository walk-up trap, borrowed alternates, wrong origin, missing/undescended history-epoch anchor, a surviving pre-rewrite commit, stale local main, shallow clone, tag divergence, and undeterminable-remote refusal. Every negative asserts BOTH the exit code and the specific diagnostic, so a check that stopped matching cannot pass silently."
+# meta:inventory.files=""
+# meta:inventory.binaries="bash, git, mktemp"
+# meta:inventory.env_vars="NFTBAN_AUTHORITY_ROOT, NFTBAN_CANONICAL_ORIGIN, NFTBAN_HISTORY_EPOCH_ANCHOR, NFTBAN_PREREWRITE_FORBIDDEN_COMMIT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -Eeuo pipefail
+# TEST HARNESS: deliberately runs cases that exit non-zero and records PASS/FAIL
+# rather than aborting. Every invocation is guarded (`|| rc=$?`), so errexit
+# still catches real harness bugs while expected failures are captured.
+#
+# NOTE ON SCOPE: no assertion may run inside a ( subshell ) — the PASS/FAIL
+# counters would be incremented in a child and discarded, letting a failing case
+# report success. Per-case environment is passed explicitly via RUNENV instead.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SCRIPT="$HERE/../check-repo-authority.sh"
+PASS=0; FAIL=0
+ok(){   echo "[PASS] $1"; PASS=$((PASS+1)); }
+bad(){  echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+WORKDIRS=()
+cleanup(){ local d; for d in "${WORKDIRS[@]:-}"; do [[ -n "$d" && -d "$d" ]] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.invalid"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.invalid"
+
+# mkfixture → echoes a base dir containing remote.git (bare, HEAD=main) and
+# work/ with: anchor commit, head commit, tag v1.0.0, main pushed, origin fetched.
+mkfixture() {
+    local base; base="$(mktemp -d)"
+    WORKDIRS+=("$base")
+    # -b main on the BARE repo matters: a bare repo whose HEAD points at a
+    # non-existent 'master' clones as "empty", which silently invalidates any
+    # fixture built by cloning it.
+    git init -q --bare -b main "$base/remote.git"
+    git init -q -b main "$base/work"
+    (
+        cd "$base/work"
+        git config commit.gpgsign false
+        echo anchor > a.txt; git add a.txt; git commit -qm "anchor commit"
+        echo head   > b.txt; git add b.txt; git commit -qm "head commit"
+        git tag v1.0.0
+        git remote add origin "$base/remote.git"
+        git push -q origin main --tags
+        git fetch -q origin
+    )
+    echo "$base"
+}
+
+# Normalised origin the guard will compute for a fixture's remote.
+expected_origin(){ echo "$1/remote"; }
+
+# RUNENV holds VAR=VALUE pairs for the next run; set_env resets it to the
+# standard four for a fixture, callers then override individual entries.
+RUNENV=()
+set_env() {  # set_env <base> <anchor_sha>
+    RUNENV=(
+        "NFTBAN_AUTHORITY_ROOT=$1/work"
+        "NFTBAN_CANONICAL_ORIGIN=$(expected_origin "$1")"
+        "NFTBAN_HISTORY_EPOCH_ANCHOR=$2"
+        "NFTBAN_PREREWRITE_FORBIDDEN_COMMIT=0000000000000000000000000000000000000000"
+    )
+}
+
+# run <expected_rc> <needle> <label> [args…] — asserts exit code AND diagnostic.
+run() {
+    local want="$1" needle="$2" label="$3"; shift 3
+    local out rc=0
+    out="$(env "${RUNENV[@]}" "$SCRIPT" "$@" 2>&1)" || rc=$?
+    if [[ "$rc" -ne "$want" ]]; then
+        bad "$label (exit $rc, wanted $want)"
+        printf '%s\n' "$out" | sed 's/^/       /' | tail -8
+        return 0
+    fi
+    if [[ -n "$needle" ]] && ! grep -qF -- "$needle" <<<"$out"; then
+        bad "$label (exit $want correct, but diagnostic missing: '$needle')"
+        printf '%s\n' "$out" | sed 's/^/       /' | tail -8
+        return 0
+    fi
+    ok "$label"
+}
+
+echo "=== check-repo-authority.sh — hermetic authority tests ==="
+
+# --- 1. POSITIVE -------------------------------------------------------------
+B="$(mkfixture)"; B_ANCHOR="$(git -C "$B/work" rev-parse HEAD~1)"
+set_env "$B" "$B_ANCHOR"
+run 0 "RESULT: PASS" "positive: well-formed repository passes (with remote)"    --mode local
+run 0 "RESULT: PASS" "positive: well-formed repository passes (--skip-network)" --mode local --skip-network
+
+# --- 2. ANCESTOR-WALK TRAP ---------------------------------------------------
+# A child directory with no .git of its own resolves, via git's upward walk, to
+# the PARENT repository. `rev-parse --git-dir` succeeds there; identity must not.
+B2="$(mkfixture)"
+mkdir -p "$B2/work/child/.claude"
+: > "$B2/work/child/.claude/settings.local.json"
+set_env "$B2" "$(git -C "$B2/work" rev-parse HEAD~1)"
+RUNENV[0]="NFTBAN_AUTHORITY_ROOT=$B2/work/child"
+run 1 "repository identity mismatch" "ancestor trap: child dir with no .git is rejected" \
+    --mode local --skip-network
+if git -C "$B2/work/child" rev-parse --git-dir >/dev/null 2>&1; then
+    ok "ancestor trap: naive 'rev-parse --git-dir' does succeed (guard must not rely on it)"
+else
+    bad "ancestor trap: fixture invalid — rev-parse --git-dir did not walk upward"
+fi
+
+# --- 3. BORROWED OBJECT STORE ------------------------------------------------
+B3="$(mkfixture)"
+mkdir -p "$B3/work/.git/objects/info"
+echo "$B/work/.git/objects" > "$B3/work/.git/objects/info/alternates"
+set_env "$B3" "$(git -C "$B3/work" rev-parse HEAD~1)"
+run 1 "borrowed object store" "alternates: borrowed object store is rejected" \
+    --mode local --skip-network
+
+# --- 4. WRONG ORIGIN ---------------------------------------------------------
+set_env "$B" "$B_ANCHOR"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=github.com/someone-else/not-nftban"
+run 1 "origin is not the canonical repository" "origin: non-canonical remote is rejected" \
+    --mode local --skip-network
+# A fork contributor must still be able to commit: origin is downgraded to a
+# notice while every other authority check stays blocking.
+run 0 "accepted under --allow-fork-origin" "origin: --allow-fork-origin downgrades a fork remote" \
+    --mode local --skip-network --allow-fork-origin
+# …but a fork origin must NEVER be accepted by a CI or release gate.
+run 2 "refused in --mode ci" "refusal: --allow-fork-origin is refused in CI mode" \
+    --mode ci --allow-fork-origin
+# The downgrade must be scoped to A3 only — a fork clone on the wrong epoch still fails.
+set_env "$B" "$B_ANCHOR"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=github.com/someone-else/not-nftban"
+RUNENV[3]="NFTBAN_PREREWRITE_FORBIDDEN_COMMIT=$(git -C "$B/work" rev-parse HEAD)"
+run 1 "PRE-REWRITE commit is present" \
+    "origin: --allow-fork-origin does NOT excuse a wrong history epoch" \
+    --mode local --skip-network --allow-fork-origin
+
+# --- 5. HISTORY EPOCH --------------------------------------------------------
+set_env "$B" "$B_ANCHOR"
+RUNENV[2]="NFTBAN_HISTORY_EPOCH_ANCHOR=1111111111111111111111111111111111111111"
+run 1 "epoch anchor is absent" "epoch: missing post-rewrite anchor is rejected" \
+    --mode local --skip-network
+
+set_env "$B" "$B_ANCHOR"
+RUNENV[3]="NFTBAN_PREREWRITE_FORBIDDEN_COMMIT=$(git -C "$B/work" rev-parse HEAD)"
+run 1 "PRE-REWRITE commit is present" "epoch: surviving pre-rewrite commit is rejected" \
+    --mode local --skip-network
+
+# HEAD must DESCEND from the anchor — an unrelated (orphan) anchor must fail.
+B5="$(mkfixture)"
+git -C "$B5/work" checkout -q --orphan sidelane
+git -C "$B5/work" rm -qrf . >/dev/null 2>&1 || true
+echo side > "$B5/work/s.txt"
+git -C "$B5/work" add s.txt
+git -C "$B5/work" commit -qm "unrelated epoch"
+ORPHAN="$(git -C "$B5/work" rev-parse HEAD)"
+git -C "$B5/work" checkout -q main
+set_env "$B5" "$ORPHAN"
+run 1 "does not descend from the post-rewrite epoch anchor" \
+    "epoch: HEAD not descending from the anchor is rejected" --mode local --skip-network
+
+# --- 6. STALE LOCAL MAIN -----------------------------------------------------
+B6="$(mkfixture)"
+echo drift > "$B6/work/c.txt"
+git -C "$B6/work" add c.txt
+git -C "$B6/work" commit -qm "local-only commit"
+set_env "$B6" "$(git -C "$B6/work" rev-parse HEAD~2)"
+run 1 "local main" "stale main: local main ahead of origin/main is rejected" \
+    --mode local --skip-network
+
+# --- 7. SHALLOW CLONE --------------------------------------------------------
+B7="$(mkfixture)"
+git clone -q --depth 1 "file://$B7/remote.git" "$B7/shallow"
+if [[ "$(git -C "$B7/shallow" rev-parse --is-shallow-repository)" != "true" ]]; then
+    bad "shallow: fixture invalid — clone --depth 1 did not produce a shallow repository"
+else
+    set_env "$B7" "$(git -C "$B7/shallow" rev-parse HEAD)"
+    RUNENV[0]="NFTBAN_AUTHORITY_ROOT=$B7/shallow"
+    RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=file://$B7/remote"
+    run 1 "shallow clone" "shallow: fetch-depth 1 checkout is rejected" --mode local --skip-network
+fi
+
+# --- 8. TAG DIVERGENCE -------------------------------------------------------
+B8="$(mkfixture)"
+git -C "$B8/work" tag v9.9.9-local-only
+set_env "$B8" "$(git -C "$B8/work" rev-parse HEAD~1)"
+run 1 "not on origin" "tags: local-only tag is rejected" --mode local
+
+# --- 9. SAFETY REFUSALS (exit 2, never PASS) ---------------------------------
+set_env "$B" "$B_ANCHOR"
+run 2 "refused in --mode ci" "refusal: --mode ci --skip-network is refused" --mode ci --skip-network
+run 2 "unknown argument"     "refusal: unknown argument"   --bogus-flag
+run 2 "--mode must be"       "refusal: invalid mode value" --mode nonsense
+
+B9="$(mkfixture)"
+git -C "$B9/work" remote set-url origin "$B9/does-not-exist.git"
+set_env "$B9" "$(git -C "$B9/work" rev-parse HEAD~1)"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$B9/does-not-exist"
+run 2 "UNDETERMINABLE" "refusal: unreachable origin is REFUSED, not passed" --mode local
+
+# --- 10. NOT A REPOSITORY AT ALL ---------------------------------------------
+B10="$(mktemp -d)"; WORKDIRS+=("$B10")
+set_env "$B" "$B_ANCHOR"
+RUNENV[0]="NFTBAN_AUTHORITY_ROOT=$B10"
+run 1 "not a git repository" "identity: a non-repository directory is rejected" \
+    --mode local --skip-network
+
+# =============================================================================
+# 11. FORK-ORIGIN SCOPE MATRIX
+#
+# Owner requirement: --allow-fork-origin must relax the origin check and NOTHING
+# else. Every other authority check is re-run here with the flag ON *and* a
+# non-canonical origin set, and must still fail with its own diagnostic. If the
+# flag ever widens into a general bypass, exactly one of these turns green and
+# this matrix fails.
+# =============================================================================
+FORK_ORIGIN="github.com/someone-else/not-nftban"
+
+# A1 identity — child directory with no .git of its own
+set_env "$B2" "$(git -C "$B2/work" rev-parse HEAD~1)"
+RUNENV[0]="NFTBAN_AUTHORITY_ROOT=$B2/work/child"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "repository identity mismatch" "fork-matrix A1: identity still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A2 alternates — borrowed object store
+set_env "$B3" "$(git -C "$B3/work" rev-parse HEAD~1)"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "borrowed object store" "fork-matrix A2: alternates still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A4 shallow — ancestry not computable
+set_env "$B7" "$(git -C "$B7/shallow" rev-parse HEAD)"
+RUNENV[0]="NFTBAN_AUTHORITY_ROOT=$B7/shallow"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "shallow clone" "fork-matrix A4: shallow still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A5a epoch anchor absent
+set_env "$B" "$B_ANCHOR"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+RUNENV[2]="NFTBAN_HISTORY_EPOCH_ANCHOR=1111111111111111111111111111111111111111"
+run 1 "epoch anchor is absent" "fork-matrix A5a: missing anchor still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A5b HEAD does not descend from the anchor
+set_env "$B5" "$ORPHAN"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "does not descend from the post-rewrite epoch anchor" \
+    "fork-matrix A5b: undescended anchor still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A5c pre-rewrite commit present  (contamination must never be excused by a fork)
+set_env "$B" "$B_ANCHOR"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+RUNENV[3]="NFTBAN_PREREWRITE_FORBIDDEN_COMMIT=$(git -C "$B/work" rev-parse HEAD)"
+run 1 "PRE-REWRITE commit is present" "fork-matrix A5c: contaminated epoch still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A6 stale local main
+set_env "$B6" "$(git -C "$B6/work" rev-parse HEAD~2)"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "local main" "fork-matrix A6: stale main still blocking" \
+    --mode local --skip-network --allow-fork-origin
+
+# A7 tag divergence (network path)
+set_env "$B8" "$(git -C "$B8/work" rev-parse HEAD~1)"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 1 "not on origin" "fork-matrix A7: tag divergence still blocking" \
+    --mode local --allow-fork-origin
+
+# Undeterminable remains a refusal, not a pass
+set_env "$B9" "$(git -C "$B9/work" rev-parse HEAD~1)"
+RUNENV[1]="NFTBAN_CANONICAL_ORIGIN=$FORK_ORIGIN"
+run 2 "UNDETERMINABLE" "fork-matrix: unreachable origin still REFUSED" \
+    --mode local --allow-fork-origin
+
+# The flag is a no-op when the origin is already canonical
+set_env "$B" "$B_ANCHOR"
+run 0 "RESULT: PASS" "fork-matrix: flag is a no-op on a canonical origin" \
+    --mode local --skip-network --allow-fork-origin
+
+# CI and release paths refuse the flag outright
+run 2 "refused in --mode ci" "fork-matrix: CI refuses the flag" --mode ci --allow-fork-origin
+
+echo "----------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/tools/repo-authority-guard.sh
+++ b/tools/repo-authority-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# =============================================================================
+# meta:name="repo-authority-guard"
+# meta:type="script"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:description="Developer-side wrapper around scripts/ci/check-repo-authority.sh. Confirms the working clone IS the canonical development authority before branching or releasing, and prints the remediation for each failure. Holds no checks of its own — the CI gate is the single authority."
+# meta:inventory.files="scripts/ci/check-repo-authority.sh"
+# meta:inventory.binaries="bash, git"
+# meta:inventory.env_vars="NFTBAN_AUTHORITY_OFFLINE"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network="delegated to check-repo-authority.sh (tag parity)"
+# meta:inventory.privileges="none"
+# =============================================================================
+#
+# Run this BEFORE creating a branch. The retired pre-rewrite tree looked healthy
+# by every casual signal — it had a `main`, a clean status and a remote — while
+# sitting 7 releases behind on an abandoned history epoch with 12 of 530 tags.
+#
+# This wrapper deliberately contains NO verification logic. Duplicating the
+# checks here would create a second authority that can drift from the CI gate;
+# the gate is the single source of truth and this only invokes it.
+# =============================================================================
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+GATE="$HERE/../scripts/ci/check-repo-authority.sh"
+
+if [[ ! -x "$GATE" && ! -f "$GATE" ]]; then
+    echo "ERROR: authority gate not found: $GATE" >&2
+    exit 2
+fi
+
+args=(--mode local)
+[[ -n "${NFTBAN_AUTHORITY_OFFLINE:-}" ]] && args+=(--skip-network)
+# Pass through any caller flags (e.g. --skip-network) unchanged.
+args+=("$@")
+
+rc=0
+bash "$GATE" "${args[@]}" || rc=$?
+
+case "$rc" in
+    0)
+        echo
+        echo "AUTHORITY: OK — safe to branch from this clone."
+        ;;
+    1)
+        cat >&2 <<'REMEDY'
+
+AUTHORITY: VIOLATED — do NOT branch, commit or release from this clone.
+
+Remediation by failure:
+
+  A1 identity mismatch      This directory is not its own repository; git resolved
+                            upward to an ancestor. You are probably in a subdirectory,
+                            or in a path that only looks like the repository.
+  A2 borrowed object store   The clone shares objects with another repository via
+                            alternates. Re-clone independently — never with
+                            --reference, --shared, --local or copied objects.
+  A3 wrong origin            Point origin at the canonical repository, or set
+                            NFTBAN_CANONICAL_ORIGIN if you are intentionally on a fork.
+  A4 shallow / grafted       Ancestry cannot be evaluated. Re-clone with full history
+                            (CI must check out with fetch-depth: 0 and fetch-tags: true).
+  A5 wrong history epoch     This object store predates the privacy history rewrite.
+                            Branching from it would resurrect scrubbed private data.
+                            Re-clone; do not attempt to repair it in place.
+  A6 stale local main        Your local main is not origin/main. Fetch and reset your
+                            local main to origin/main before branching.
+  A7 tag divergence          Local and remote tags differ. Fetch tags; if local-only
+                            tags remain, they belong to an abandoned epoch.
+
+REMEDY
+        ;;
+    2)
+        echo >&2
+        echo "AUTHORITY: UNDETERMINABLE — refused. This is never a pass." >&2
+        echo "  If you are offline, re-run with --skip-network (or NFTBAN_AUTHORITY_OFFLINE=1)" >&2
+        echo "  and re-verify with network access before branching or releasing." >&2
+        ;;
+esac
+
+exit "$rc"


### PR DESCRIPTION
## Why

A development checkout can silently be the wrong repository, or the right repository on the wrong history epoch, and nothing in CI could detect either. A retired pre-rewrite tree looked healthy by every casual signal — it had a `main`, a clean status and a remote — while sitting seven releases behind on an abandoned history epoch with 12 of 530 tags.

## What

`scripts/ci/check-repo-authority.sh` asserts that the working checkout **is** the canonical development authority:

| | Check |
|---|---|
| A1 | repository identity — resolved `--show-toplevel` equals the expected root |
| A2 | object-store independence — no alternates, no `GIT_ALTERNATE_OBJECT_DIRECTORIES` |
| A3 | canonical origin (normalised ssh/https) |
| A4 | ancestry computable — not shallow, no grafts, no replace refs |
| A5 | history epoch — HEAD descends from the post-rewrite anchor; pre-rewrite tip absent |
| A6 | branch base — local `main` == `origin/main` |
| A7 | tag parity — local tags == `git ls-remote --tags` |

**A1 is the load-bearing check.** `git rev-parse --git-dir` *succeeds* from a directory that is not a repository, because git walks upward. Observed live: a path holding only a `.claude/` directory and no `.git` still resolved — to an unrelated parent repository. Any guard built on "did rev-parse succeed" passes from any subdirectory of any ancestor repo. This compares resolved paths instead.

Undeterminable is never a pass: an unreachable origin exits **2** (safety refusal), matching the established `0 ok / 1 failure / 2 usage-or-safety-refusal` trio.

### `--allow-fork-origin`

Lets a contributor working from a fork still commit. It downgrades **A3 only** to a notice, and is refused outright in `--mode ci` so no CI or release path can accept a fork. A dedicated scope matrix re-runs every other check with the flag ON and a non-canonical origin and requires each to keep failing.

## Tests

`scripts/ci/tests/check-repo-authority_test.sh` — **31 assertions**, hermetic (throwaway repositories, no network). Each negative asserts **both** the exit code and the specific diagnostic, so a check that stops matching cannot pass silently.

Verified by mutation: neutering A1, the pre-rewrite check, or tag parity each turns the suite red.

## Wiring

- `ci-architecture.yml` — blocking gate + hermetic negative tests. Requires `fetch-depth: 0` + `fetch-tags: true`; epoch ancestry and tag parity cannot be evaluated in the default shallow, tagless checkout, and A4 fails closed rather than guessing.
- `release.yml` — authority verified **before** assembly, with full history. A release built from a wrong-epoch object store would ship pre-rewrite sources.
- `.githooks/pre-commit` — offline check with `--allow-fork-origin`.
- `RELEASE-CHECKLIST.md` — pre-tag item.
- `tools/repo-authority-guard.sh` — developer wrapper. Holds no checks of its own, so it cannot drift from the gate; prints per-check remediation.
- `VERSIONING.md` — PATCH now explicitly covers backward-compatible build, test, development-authority and documentation corrections, plus an orthogonal `RELEASE_CATEGORY` axis.

## Validation

Built and installed on **disposable clean VMs**, one build VM and a separate install VM per family, each from an immutable golden cloud image and destroyed afterwards.

| | DEB — Ubuntu 24.04.4 | RPM — AlmaLinux 9.7 |
|---|---|---|
| authority guard (`--mode ci`) | exit 0, A1–A7 PASS | exit 0, A1–A7 PASS |
| hermetic tests | 31/31 | 31/31 (bash 5.1) |
| build | PASS | PASS |
| SHA-chain | `BUILT==STAGED==PACKAGE_EXTRACTED` | `BUILT==STAGED==PACKAGE_EXTRACTED` |
| install / upgrade / remove | PASS | PASS |
| new scripts in package payload | **absent** | **absent** |

The suite passing on EL9's bash 5.1 as well as Ubuntu's bash 5.2 is deliberate portability evidence.

## Scope

```
tracked files   1798 -> 1801    added 3    deleted 0    mode changed 0
```

No product runtime, daemon Go, nft schema or config schema change. The commit adds **zero bytes** to either package payload — confirmed by `dpkg -c` and `rpm -qlp` on packages built from this exact commit.

Unrelated pre-existing defects surfaced during clean-VM validation are deliberately **not** included in this diff.
