### PR TITLE
docs+ci: runtime mode authority doctrine, admission ledger and static gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -92,9 +92,16 @@ detection, banning, health, or status.  Delete this whole section only if none a
 Authority: docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md  ·  ADR-0001
 AN UNANSWERED FIELD BLOCKS MERGE. "N/A" is an answer; blank is not.
 
-Presence != readiness.      Started != running.        Defined != reachable.
-Enabled != detecting.       Detected != banned.        Set membership != enforcement.
-Status text != runtime truth.   Test PASS != injection proven.
+A feature is not merely code that exists. A feature is a complete production path that is
+REACHABLE, OBSERVABLE, ENFORCEABLE, TESTABLE and RECOVERABLE.
+
+  DEFINED        != REACHABLE
+  CONFIGURED     != EFFECTIVE
+  ENABLED        != DETECTING
+  RUNNING        != RECEIVING INPUT
+  DETECTED       != ENFORCED
+  SET MEMBERSHIP != FIREWALL BLOCK
+  PASS           != INJECTION PROVEN
 -->
 
 - **MODULE:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -83,6 +83,41 @@
 
 ---
 
+### Runtime Mode Authority — MANDATORY for module/mode changes
+
+<!--
+REQUIRED if this PR touches: modules, modes (auto/classic/suricata/hybrid), Suricata,
+detection, banning, health, or status.  Delete this whole section only if none apply.
+
+Authority: docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md  ·  ADR-0001
+AN UNANSWERED FIELD BLOCKS MERGE. "N/A" is an answer; blank is not.
+
+Presence != readiness.      Started != running.        Defined != reachable.
+Enabled != detecting.       Detected != banned.        Set membership != enforcement.
+Status text != runtime truth.   Test PASS != injection proven.
+-->
+
+- **MODULE:**
+- **CONFIGURED MODES:**
+- **EFFECTIVE MODE RESOLUTION:** <!-- resolver + where the result is recorded -->
+- **PRODUCTION ENTRYPOINT:** <!-- service/timer/scheduler/dispatcher, not a private helper -->
+- **DETECTION AUTHORITY:** <!-- kernel nftables | shell detector | EVE consumer | Go publisher -->
+- **BAN AUTHORITY:**
+- **ENFORCEMENT AUTHORITY:** <!-- set -> referencing rule -> HOOKED chain -> drop/reject -->
+- **HEALTH AUTHORITY:** <!-- proves the SELECTED mode is active -->
+- **LOG SOURCE:**
+- **CONSUMER IDENTITY:** <!-- the uid/gid actually reading that source -->
+- **ZERO-INPUT BEHAVIOR:** <!-- ACTIVE_ZERO_INPUT vs SOURCE_MISSING vs reported healthy -->
+- **FALLBACK BEHAVIOR:** <!-- and whether it is silent -->
+- **HYBRID DEDUP:** <!-- canonical event identity + single ban authority, or N/A -->
+- **STATIC TEST:**
+- **MUTATION TEST:** <!-- the guard was SEEN to fail when the behaviour was removed -->
+- **CROSS-VM TEST:** <!-- real traffic from a separate host, or explicitly not yet -->
+- **UNPROVEN ITEMS:** <!-- state them; do not leave blank to imply completeness -->
+- **MODE LEDGER UPDATED:** <!-- docs/MODE_ADMISSION_LEDGER.md row + new status -->
+
+---
+
 **By submitting this pull request, I confirm that:**
 1. My contribution is made under the MPL-2.0 license
 2. I have signed off my commits with the DCO (Developer Certificate of Origin)

--- a/.github/mode-authority-gate.yml
+++ b/.github/mode-authority-gate.yml
@@ -1,0 +1,45 @@
+# =============================================================================
+# Mode Authority Gate — repository policy declaration
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# Authority: docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md · docs/adr/ADR-0001-runtime-mode-authority.md
+#
+# THIS FILE IS THE DECLARATION. Branch names are not authoritative — they are
+# mutable and inconsistently used. A PR that claims to close mode-authority debt
+# must say so explicitly, either here or via workflow_dispatch input, and the
+# guard then VERIFIES that the declared scope covers every authority surface the
+# change actually touches.
+#
+# policy:
+#   drift     block NEW + STALE. Report existing MUST_FIX / ACCEPTED_DEBT.
+#             CI may pass; global admission stays BLOCKED.
+#   targeted  additionally block unresolved MUST_FIX rows INSIDE `scope`.
+#             Unrelated pre-existing debt is reported only.
+#             Requires `scope`. Grants admission for the declared scope ONLY.
+#   all       block ANY MUST_FIX. Reserved for a milestone claiming complete
+#             closure, a global mode-admission release, or an operator request.
+# =============================================================================
+
+policy: drift
+
+# Modules whose mode-authority debt this repository state claims to close.
+# Empty under `drift`: v1.228.0 explicitly does NOT claim runtime-mode repair.
+scope: []
+
+# v1.228.0 defers the confirmed runtime-mode defects to the runtime lane. The
+# authority for that deferral — the ledger rows and the release statement — must
+# remain present and must continue to describe the findings as OPEN. The release
+# gate verifies these files rather than trusting the claim.
+deferred_must_fix_authority:
+  - docs/MODE_ADMISSION_LEDGER.md
+  - docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md
+
+# Phrases that must NEVER appear in the deferred-authority documents while the
+# corresponding rows are still MUST_FIX. A release may not claim a repair it did
+# not perform.
+forbidden_release_claims:
+  - "runtime-mode defects corrected"
+  - "runtime mode defects fixed"
+  - "all modes admitted"
+  - "DDoS suricata fixed"

--- a/.github/workflows/ci-mode-authority.yml
+++ b/.github/workflows/ci-mode-authority.yml
@@ -104,8 +104,15 @@ jobs:
       - name: Resolve declared policy
         id: mode
         shell: bash
+        # SECURITY: never interpolate ${{ github.* }} or ${{ inputs.* }} directly
+        # into a `run:` block — `inputs.scope` is operator-supplied via
+        # workflow_dispatch and would be shell injection. Pass through env, where
+        # the value is data rather than code.
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF:   ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          IN_POLICY:  ${{ inputs.policy }}
+          IN_SCOPE:   ${{ inputs.scope }}
         run: |
           set -Eeuo pipefail
           man=".github/mode-authority-gate.yml"
@@ -116,9 +123,19 @@ jobs:
             scope="$(sed -n '/^scope:/,/^[a-z_]*:/p' "${man}" \
                      | grep -oE '^\s*-\s*[a-z]+' | awk '{print $2}' | paste -sd, - || true)"
           fi
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            [[ -n "${{ inputs.policy }}" ]] && { policy="${{ inputs.policy }}"; why="operator input"; }
-            [[ -n "${{ inputs.scope }}"  ]] && scope="${{ inputs.scope }}"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            [[ -n "${IN_POLICY:-}" ]] && { policy="${IN_POLICY}"; why="operator input"; }
+            [[ -n "${IN_SCOPE:-}"  ]] && scope="${IN_SCOPE}"
+          fi
+          # Validate before use. The guard allowlists scope values too, but a
+          # workflow must not pass unvalidated operator input onward.
+          case "${policy}" in
+            drift|targeted|all) ;;
+            *) echo "::error::invalid policy '${policy}'"; exit 2 ;;
+          esac
+          if [[ -n "${scope}" && ! "${scope}" =~ ^[a-z,]+$ ]]; then
+            echo "::error::invalid scope '${scope}' (expected comma-separated lowercase module names)"
+            exit 2
           fi
           git diff --name-only "origin/${BASE_REF:-main}...HEAD" > /tmp/changed.txt 2>/dev/null || : > /tmp/changed.txt
           echo "policy=${policy}" >> "$GITHUB_OUTPUT"
@@ -129,10 +146,13 @@ jobs:
       - name: Mode authority guard
         id: guard
         shell: bash
+        env:
+          POLICY: ${{ steps.mode.outputs.policy }}
+          SCOPE:  ${{ steps.mode.outputs.scope }}
         run: |
           set -Eeuo pipefail
-          args=(--policy "${{ steps.mode.outputs.policy }}" --changed-paths /tmp/changed.txt)
-          [[ -n "${{ steps.mode.outputs.scope }}" ]] && args+=(--scope "${{ steps.mode.outputs.scope }}")
+          args=(--policy "${POLICY}" --changed-paths /tmp/changed.txt)
+          [[ -n "${SCOPE:-}" ]] && args+=(--scope "${SCOPE}")
           ./scripts/ci/check-mode-authority.sh "${args[@]}" | tee /tmp/mode-authority.txt
 
       # A deferred defect must stay visible and must never be described as fixed.

--- a/.github/workflows/ci-mode-authority.yml
+++ b/.github/workflows/ci-mode-authority.yml
@@ -84,17 +84,46 @@ jobs:
       # a synthetic bad tree and must FLAG it, and to a clean tree and must NOT.
       # A check whose control does not fire reports NOT_YET_VERIFIED, never PASS.
       # This is what stops the gate from passing decoratively.
-      - name: Mode authority guard (blocking on NEW drift)
+      # TWO GATES, per the ratchet policy:
+      #
+      #   ordinary PR CI                        --fail-on drift
+      #   runtime-lane / release-prep / trusted --fail-on all   (STRICT, MANDATORY)
+      #
+      # Strict is MANDATORY wherever the change claims to fix or admit a mode, and
+      # at release admission. Ratchet must never let a release ship a BROKEN
+      # selectable mode merely because the defect predates the PR.
+      - name: Select gate mode
+        id: mode
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -Eeuo pipefail
+          mode="drift"; why="ordinary PR CI"
+          # the fix lane: any change to the module runtimes themselves must clear
+          # its targeted MUST_FIX rows before it can merge
+          if git diff --name-only "origin/${BASE_REF:-main}...HEAD" 2>/dev/null \
+               | grep -qE '^internal/(ddos|portscan|loginmon)/'; then
+            mode="all"; why="runtime-lane change (internal/{ddos,portscan,loginmon})"
+          fi
+          case "${HEAD_REF}" in
+            *runtime-mode*|*mode-authority*|*release-prep*|release/*)
+              mode="all"; why="runtime-lane or release-prep branch" ;;
+          esac
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.strict }}" == "true" ]]; then
+            mode="all"; why="operator requested strict"
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+          echo "Gate mode: --fail-on ${mode}  (${why})"
+
+      - name: Mode authority guard
         id: guard
         shell: bash
         run: |
           set -Eeuo pipefail
-          mode="drift"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.strict }}" == "true" ]]; then
-            mode="all"
-          fi
-          echo "running with --fail-on ${mode}"
-          ./scripts/ci/check-mode-authority.sh --fail-on "${mode}" | tee /tmp/mode-authority.txt
+          ./scripts/ci/check-mode-authority.sh --fail-on "${{ steps.mode.outputs.mode }}" \
+            | tee /tmp/mode-authority.txt
 
       - name: Publish open MUST_FIX debt to the job summary
         if: always()

--- a/.github/workflows/ci-mode-authority.yml
+++ b/.github/workflows/ci-mode-authority.yml
@@ -52,10 +52,15 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      strict:
-        description: 'Fail on MUST_FIX debt as well as new drift'
-        type: boolean
-        default: false
+      policy:
+        description: 'Gate policy (declaration, not inference)'
+        type: choice
+        options: [drift, targeted, all]
+        default: drift
+      scope:
+        description: 'Modules this run claims to close, e.g. ddos or ddos,portscan (required for targeted)'
+        type: string
+        default: ''
 
 concurrency:
   group: ci-mode-authority-${{ github.ref }}
@@ -92,38 +97,79 @@ jobs:
       # Strict is MANDATORY wherever the change claims to fix or admit a mode, and
       # at release admission. Ratchet must never let a release ship a BROKEN
       # selectable mode merely because the defect predates the PR.
-      - name: Select gate mode
+      # POLICY IS DECLARED, NOT INFERRED. Branch names are mutable and are NOT
+      # authoritative. Precedence: workflow_dispatch input > repository manifest
+      # (.github/mode-authority-gate.yml) > drift. Changed paths are evidence
+      # used to VERIFY the declaration, never to select it.
+      - name: Resolve declared policy
         id: mode
         shell: bash
         env:
-          HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -Eeuo pipefail
-          mode="drift"; why="ordinary PR CI"
-          # the fix lane: any change to the module runtimes themselves must clear
-          # its targeted MUST_FIX rows before it can merge
-          if git diff --name-only "origin/${BASE_REF:-main}...HEAD" 2>/dev/null \
-               | grep -qE '^internal/(ddos|portscan|loginmon)/'; then
-            mode="all"; why="runtime-lane change (internal/{ddos,portscan,loginmon})"
+          man=".github/mode-authority-gate.yml"
+          policy="drift"; scope=""; why="default"
+          if [[ -r "${man}" ]]; then
+            p="$(grep -E '^policy:' "${man}" | head -1 | awk '{print $2}' || true)"
+            [[ -n "${p}" ]] && { policy="${p}"; why="manifest ${man}"; }
+            scope="$(sed -n '/^scope:/,/^[a-z_]*:/p' "${man}" \
+                     | grep -oE '^\s*-\s*[a-z]+' | awk '{print $2}' | paste -sd, - || true)"
           fi
-          case "${HEAD_REF}" in
-            *runtime-mode*|*mode-authority*|*release-prep*|release/*)
-              mode="all"; why="runtime-lane or release-prep branch" ;;
-          esac
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.strict }}" == "true" ]]; then
-            mode="all"; why="operator requested strict"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            [[ -n "${{ inputs.policy }}" ]] && { policy="${{ inputs.policy }}"; why="operator input"; }
+            [[ -n "${{ inputs.scope }}"  ]] && scope="${{ inputs.scope }}"
           fi
-          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
-          echo "Gate mode: --fail-on ${mode}  (${why})"
+          git diff --name-only "origin/${BASE_REF:-main}...HEAD" > /tmp/changed.txt 2>/dev/null || : > /tmp/changed.txt
+          echo "policy=${policy}" >> "$GITHUB_OUTPUT"
+          echo "scope=${scope}"   >> "$GITHUB_OUTPUT"
+          echo "Declared policy: ${policy}  scope='${scope}'  (source: ${why})"
+          echo "Changed paths under evaluation: $(wc -l < /tmp/changed.txt)"
 
       - name: Mode authority guard
         id: guard
         shell: bash
         run: |
           set -Eeuo pipefail
-          ./scripts/ci/check-mode-authority.sh --fail-on "${{ steps.mode.outputs.mode }}" \
-            | tee /tmp/mode-authority.txt
+          args=(--policy "${{ steps.mode.outputs.policy }}" --changed-paths /tmp/changed.txt)
+          [[ -n "${{ steps.mode.outputs.scope }}" ]] && args+=(--scope "${{ steps.mode.outputs.scope }}")
+          ./scripts/ci/check-mode-authority.sh "${args[@]}" | tee /tmp/mode-authority.txt
+
+      # A deferred defect must stay visible and must never be described as fixed.
+      # This is what stops a release from silently absorbing the runtime lane's
+      # obligations by editing prose instead of code.
+      - name: Deferred-authority consistency
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          man=".github/mode-authority-gate.yml"
+          rc=0
+          while IFS= read -r f; do
+            [[ -n "${f}" ]] || continue
+            if [[ ! -r "${f}" ]]; then
+              echo "::error::deferred-authority document missing: ${f}"; rc=1; continue
+            fi
+            echo "deferred authority present: ${f}"
+          done < <(sed -n '/^deferred_must_fix_authority:/,/^[a-z_]*:/p' "${man}" \
+                   | grep -oE '^\s*-\s*\S+' | awk '{print $2}')
+          while IFS= read -r claim; do
+            [[ -n "${claim}" ]] || continue
+            while IFS= read -r f; do
+              [[ -r "${f}" ]] || continue
+              if grep -qiF "${claim}" "${f}"; then
+                echo "::error::${f} claims '${claim}' while MUST_FIX rows remain open"; rc=1
+              fi
+            done < <(sed -n '/^deferred_must_fix_authority:/,/^[a-z_]*:/p' "${man}" \
+                     | grep -oE '^\s*-\s*\S+' | awk '{print $2}')
+          done < <(sed -n '/^forbidden_release_claims:/,$p' "${man}" \
+                   | grep -oE '^\s*-\s*".*"' | sed 's/^[^"]*"//; s/"$//')
+          # the ledger must still record the open rows
+          if ! grep -q 'BROKEN' docs/MODE_ADMISSION_LEDGER.md; then
+            echo "::error::no BROKEN row remains in the ledger — a deferred finding vanished without evidence"; rc=1
+          fi
+          [[ ${rc} -eq 0 ]] && echo "deferred-authority consistency PASS"
+          exit ${rc}
 
       - name: Publish open MUST_FIX debt to the job summary
         if: always()

--- a/.github/workflows/ci-mode-authority.yml
+++ b/.github/workflows/ci-mode-authority.yml
@@ -1,0 +1,120 @@
+# =============================================================================
+# NFTBan — CI: Runtime Mode Authority Gate
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# Enforces docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md (ADR-0001) statically.
+#
+# WHAT THIS GATE CAN AND CANNOT DO
+#   Static analysis cannot prove a mode operates. Static reachability is ONE of
+#   the six promotion requirements in docs/MODE_ADMISSION_LEDGER.md. A green run
+#   here NEVER promotes a ledger row — cross-VM traffic, enforcement proof and
+#   clean recovery are proven by the lifecycle and attack matrices, not here.
+#
+# TWO-STAGE ENFORCEMENT (deliberate)
+#   Stage 1 (blocking, now): --fail-on drift. Any NEW violation, or a stale
+#     allowlist row, fails the build. This makes the gate do real work from day
+#     one without gating unrelated PRs on pre-existing debt.
+#   Stage 2 (the end state): drop --fail-on drift so MUST_FIX also blocks. The
+#     exit criterion is discharging the BROKEN rows in the ledger — chiefly
+#     DDoS/suricata, whose processor has no reachable caller, and LoginMon/auto,
+#     whose readiness is resolved from presence rather than produced input.
+#
+#   MUST_FIX debt is NEVER downgraded to PASS and never silently allowlisted —
+#   it is printed in full on every run and re-published in the job summary.
+#   Hiding it would be the exact failure this gate exists to prevent.
+# =============================================================================
+
+name: Runtime Mode Authority Gate
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'internal/ddos/**'
+      - 'internal/portscan/**'
+      - 'internal/loginmon/**'
+      - 'internal/botguard/**'
+      - 'cli/lib/nftban/core/nftban_ddos*.sh'
+      - 'cli/lib/nftban/core/nftban_portscan*.sh'
+      - 'cli/lib/nftban/core/nftban_login*.sh'
+      - 'cli/lib/nftban/helpers/nftban_mode.sh'
+      - 'cli/lib/nftban/cli/cmd_modes.sh'
+      - 'cli/lib/nftban/cli/cmd_ddos.sh'
+      - 'cli/lib/nftban/cli/cmd_portscan.sh'
+      - 'docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md'
+      - 'docs/MODE_ADMISSION_LEDGER.md'
+      - 'docs/adr/ADR-0001-runtime-mode-authority.md'
+      - 'scripts/ci/check-mode-authority.sh'
+      - 'scripts/ci/mode-authority-known.txt'
+      - '.github/workflows/ci-mode-authority.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Fail on MUST_FIX debt as well as new drift'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ci-mode-authority-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mode-authority:
+    name: Mode Authority (static)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Shellcheck the guard itself
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y shellcheck
+          shellcheck -S error scripts/ci/check-mode-authority.sh
+
+      # The guard runs its own negative controls first: each check is applied to
+      # a synthetic bad tree and must FLAG it, and to a clean tree and must NOT.
+      # A check whose control does not fire reports NOT_YET_VERIFIED, never PASS.
+      # This is what stops the gate from passing decoratively.
+      - name: Mode authority guard (blocking on NEW drift)
+        id: guard
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mode="drift"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.strict }}" == "true" ]]; then
+            mode="all"
+          fi
+          echo "running with --fail-on ${mode}"
+          ./scripts/ci/check-mode-authority.sh --fail-on "${mode}" | tee /tmp/mode-authority.txt
+
+      - name: Publish open MUST_FIX debt to the job summary
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          {
+            echo "## Runtime Mode Authority"
+            echo
+            grep -E '^MODE_AUTHORITY_' /tmp/mode-authority.txt 2>/dev/null | sed 's/^/    /' || true
+            echo
+            if grep -q 'MODE_AUTHORITY_MUST_FIX_VIOLATIONS=0' /tmp/mode-authority.txt 2>/dev/null; then
+              echo "No open MUST_FIX debt — this gate can be flipped to \`--fail-on all\`."
+            else
+              echo "### Open MUST_FIX debt (ledger row is BROKEN)"
+              echo
+              grep -A1 'MUST_FIX ' /tmp/mode-authority.txt 2>/dev/null | sed 's/^/    /' || true
+              echo
+              echo "These do not block today. They are tracked in \`scripts/ci/mode-authority-known.txt\`"
+              echo "and in \`docs/MODE_ADMISSION_LEDGER.md\`. A BROKEN mode must be rejected at config"
+              echo "validation or explicitly marked unavailable — hiding it from help is insufficient."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ NFTBan enforces correctness through:
 
 - [STATUS.md](STATUS.md) — CI/CD audit surface (build, security, contract gates)
 - [docs/DESIGN_PRINCIPLES.md](docs/DESIGN_PRINCIPLES.md) — engineering contract
+- [docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md](docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md) — runtime mode
+  authority and evidence standard ([ADR-0001](docs/adr/ADR-0001-runtime-mode-authority.md),
+  [mode admission ledger](docs/MODE_ADMISSION_LEDGER.md))
 
 All contributions must preserve:
 
@@ -15,6 +18,24 @@ All contributions must preserve:
 - Validator-derived truth
 - Evidence-based protection
 - CI-enforced invariants
+
+### A feature is a complete production path
+
+> A feature is not merely code that exists. A feature is a complete production path that is
+> **reachable, observable, enforceable, testable and recoverable.**
+
+```
+DEFINED         ≠  REACHABLE
+CONFIGURED      ≠  EFFECTIVE
+ENABLED         ≠  DETECTING
+RUNNING         ≠  RECEIVING INPUT
+DETECTED        ≠  ENFORCED
+SET MEMBERSHIP  ≠  FIREWALL BLOCK
+PASS            ≠  INJECTION PROVEN
+```
+
+PRs touching modules, modes, Suricata, detection, banning, health or status must complete the
+mode-authority section of the pull request template. An unanswered field blocks merge.
 
 Changes that violate these principles must not be merged.
 

--- a/docs/MODE_ADMISSION_LEDGER.md
+++ b/docs/MODE_ADMISSION_LEDGER.md
@@ -50,5 +50,35 @@ reaches it.
 
 ## Standing rule for `BROKEN`
 
-A `BROKEN` mode must be hidden from help, rejected at config validation, or explicitly marked
-`unavailable` in status. It must never be silently selectable.
+A `BROKEN` mode **must be rejected at configuration validation or explicitly marked
+`unavailable`**. It must not be selectable as an operational mode. Hiding it from help alone is
+insufficient — an existing configuration file would keep selecting it silently.
+
+## OPEN runtime-lane defect — validation is not module × mode aware
+
+**Status: confirmed, not fixed in v1.228.0.** Flagged by the static guard.
+
+`cli/lib/nftban/helpers/nftban_mode.sh:32` declares a single global vocabulary:
+
+```
+NFTBAN_VALID_MODES="auto classic suricata hybrid"
+```
+
+This is the configuration-validation accept-list. It accepts modes this ledger marks `BROKEN`, so
+the validator still admits a mode that must not be operationally selectable.
+
+**This is a runtime-lane product defect, not a documentation defect.** The interim behaviour must
+be chosen explicitly:
+
+| Option | Behaviour |
+|---|---|
+| **A** | reject specifically `BROKEN` module × mode combinations |
+| **B** | accept syntax, fail semantic validation as unavailable |
+| **C** | preserve parsing compatibility, refuse activation, and report `CONFIGURED_MODE=<value>` / `EFFECTIVE_MODE=unavailable` / `MODE_REASON=<stable reason>` |
+
+**Constraint:** do **not** remove `suricata` or `hybrid` globally from the shared vocabulary.
+PortScan and LoginMon do not share an admission state with DDoS — PortScan/suricata is
+`STATICALLY_REACHABLE` while DDoS/suricata is `BROKEN`. Validation must be **module × mode aware**,
+not a global four-word allowlist.
+
+Until this is resolved, the guard reports these rows as `MUST_FIX` / `BLOCKED_FROM_ADMISSION`.

--- a/docs/MODE_ADMISSION_LEDGER.md
+++ b/docs/MODE_ADMISSION_LEDGER.md
@@ -1,0 +1,54 @@
+# NFTBan Mode Admission Ledger
+
+Authority: [`RUNTIME_MODE_AUTHORITY_CONTRACT.md`](RUNTIME_MODE_AUTHORITY_CONTRACT.md).
+
+One row per module × configured mode. A mode may appear in user-facing help only with an explicit
+status. **`DECLARED` alone never justifies advertising a mode as available.**
+
+Statuses: `DECLARED` → `STATICALLY_REACHABLE` → `FIXTURE_PROVEN` → `TRAFFIC_PROVEN` → `SUSTAINED`,
+plus `BROKEN` and `DEMOTED`.
+
+## Current state — v1.228.0
+
+Evidence basis: direct source trace 2026-07-26, plus a live ruleset capture on a v1.228.0 target.
+Every row cites what was actually checked. Rows without traffic evidence are **not** promoted.
+
+| Module | Mode | Status | Evidence / blocker |
+|---|---|---|---|
+| DDoS | classic | `STATICALLY_REACHABLE` (partial traffic) | Enforcement is in-kernel: `syn_meter_v4` rate-limit observed live in the hooked `input` chain. No bounded-traffic fixture yet. |
+| DDoS | suricata | **`BROKEN`** | `nftban_ddos_suricata_process` has **zero external callers** (definition + one internal call + `export -f`). No mode dispatcher exists for DDoS at all. The mode name resolves to nothing. |
+| DDoS | hybrid | `DECLARED` | No dispatcher exists; dedup authority undefined. |
+| DDoS | auto | `DECLARED` | Resolver `internal/ddos/module.go` not yet traced end to end. |
+| PortScan | classic | `STATICALLY_REACHABLE` | `nftban_portscan_run` → `nftban_portscan_classic_run` (`nftban_portscan_classic.sh`). Gated on `PORTSCAN_ENABLED`. No traffic fixture yet. |
+| PortScan | suricata | `STATICALLY_REACHABLE` | `nftban_portscan_run` → `nftban_portscan_suricata_run` (`nftban_portscan_suricata.sh`). Source readiness unproven. |
+| PortScan | hybrid | `DECLARED` | Both branches invoked; **dedup authority unproven** — cannot be promoted (Lesson F). |
+| PortScan | auto | `DECLARED` | Resolver not traced end to end. |
+| LoginMon | classic | `STATICALLY_REACHABLE` | `Start()` → `runJournalWatcher`. |
+| LoginMon | suricata | **`BROKEN` when source missing** | Selected on presence (score ≥ 2 = binary + service, **no EVE required**); `Start()` then runs **only** the EVE watcher. `runEVEWatcher` exits on open failure while status stays `RUNNING` (Lessons A + B). |
+| LoginMon | hybrid | `DECLARED` | Both watchers started; dedup authority unproven. |
+| LoginMon | auto | **`BROKEN` readiness resolution** | `auto` + Suricata present ⇒ `ModeSuricata` on presence alone, silently darkening journal sources. Fail-safe direction is correct (configured `suricata` + unavailable ⇒ falls back to `classic`). |
+
+### Not in this table
+
+BotScan, BotGuard, GeoBan, RBL and Watchdog have not been mode-resolved. Absence from this ledger
+means **unassessed**, not healthy.
+
+## Promotion requirements
+
+A row moves to `TRAFFIC_PROVEN` only with **all** of:
+
+1. static reachability traced (resolver → dispatcher → entrypoint)
+2. committed positive fixture
+3. committed negative fixture (proves the check can fail)
+4. real cross-VM traffic from a dedicated attacker host
+5. enforcement proven: set → referencing rule → **hooked** chain → observed block
+6. clean recovery (expiry/unban restores access)
+
+The traffic test must enter through the shipped production lifecycle. **A synthetic direct call to
+a private helper does not promote a row** — it proves the function runs, not that the product
+reaches it.
+
+## Standing rule for `BROKEN`
+
+A `BROKEN` mode must be hidden from help, rejected at config validation, or explicitly marked
+`unavailable` in status. It must never be silently selectable.

--- a/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
+++ b/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
@@ -18,8 +18,8 @@ For NFTBan that means all five, not a subset:
 | **TESTABLE** | positive, negative **and mutation** fixtures prove it |
 | **RECOVERABLE** | disable, unban, restart, rebuild and reboot behave correctly |
 
-Code that satisfies four of the five is not a feature. It is an unfinished path that will be
-reported as working.
+Code that satisfies four of the five is not an **admitted** feature. Without these gates, it risks
+being reported as working despite an incomplete production path.
 
 ## The invariant
 
@@ -254,8 +254,16 @@ modes:
     dedup_authority: REQUIRED
 ```
 
-Format may be YAML, Go metadata or a registry. The principle is fixed: the declaration is the
-authority, and CI checks the code against it.
+Format may be YAML, Go metadata or a registry. The principle is fixed:
+
+> The machine-readable declaration is the canonical **mode inventory and specification authority**.
+> It is **not runtime truth**. Runtime enforcement authority remains the **kernel**, and runtime
+> health interpretation remains the **validator**. CI checks implementation and documentation
+> against the declaration.
+
+This preserves the established hierarchy — kernel enforces, validator interprets, CLI renders,
+config records intent — and deliberately does not create a second runtime truth source or compete
+with `ModuleHealthMap`.
 
 ---
 

--- a/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
+++ b/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
@@ -3,6 +3,24 @@
 A standing contributor and auditor contract. This is not a forensic report and does not
 expire with a release.
 
+## What a feature is
+
+A feature is not merely code that exists. **A feature is a complete production path that is
+reachable, observable, enforceable, testable and recoverable.**
+
+For NFTBan that means all five, not a subset:
+
+| Property | Requirement |
+|---|---|
+| **REACHABLE** | the shipped runtime actually calls it |
+| **OBSERVABLE** | logs, health and status expose its real state |
+| **ENFORCEABLE** | detection reaches the authoritative ban/firewall path |
+| **TESTABLE** | positive, negative **and mutation** fixtures prove it |
+| **RECOVERABLE** | disable, unban, restart, rebuild and reboot behave correctly |
+
+Code that satisfies four of the five is not a feature. It is an unfinished path that will be
+reported as working.
+
 ## The invariant
 
 ```
@@ -13,17 +31,30 @@ configuration → resolution → dispatcher → detector
               → decision → enforcement → health → recovery
 ```
 
-A feature is not the code that exists. **A feature is the complete production path that can be
-reached, observed, verified and recovered.**
+## The compact standing rule
 
-## The failure pattern this exists to stop
+This is the canonical short form. Quote it verbatim; do not paraphrase it.
 
 ```
-configured name  ≠  runtime reachability  ≠  active detection
-                 ≠  effective enforcement ≠  truthful health
+DEFINED         ≠  REACHABLE
+CONFIGURED      ≠  EFFECTIVE
+ENABLED         ≠  DETECTING
+RUNNING         ≠  RECEIVING INPUT
+DETECTED        ≠  ENFORCED
+SET MEMBERSHIP  ≠  FIREWALL BLOCK
+PASS            ≠  INJECTION PROVEN
 ```
 
-Every one of those inequalities has been observed in this product. They are not hypothetical.
+**Every one of these has been observed in this product.** They are not hypothetical:
+a defined-but-uncalled Suricata processor; `auto` resolving to a mode whose source is absent;
+a module RUNNING with its only watcher exited; a ban present in a set that no hooked chain
+referenced; and harness cases that printed PASS while asserting nothing.
+
+## Scope
+
+This governs **DDoS, PortScan, LoginMon, Suricata, BotScan, ban/unban, package lifecycle, health,
+reporting — and every future module.** It is not limited to the modules that happened to surface
+the defects.
 
 ## Position in architecture
 

--- a/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
+++ b/docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
@@ -1,0 +1,297 @@
+# NFTBan Runtime Mode Authority and Evidence Standard (v1.228)
+
+A standing contributor and auditor contract. This is not a forensic report and does not
+expire with a release.
+
+## The invariant
+
+```
+NO CONFIGURED MODE MAY BE REPORTED ACTIVE
+UNLESS ITS EFFECTIVE RUNTIME CHAIN IS PROVEN:
+
+configuration → resolution → dispatcher → detector
+              → decision → enforcement → health → recovery
+```
+
+A feature is not the code that exists. **A feature is the complete production path that can be
+reached, observed, verified and recovered.**
+
+## The failure pattern this exists to stop
+
+```
+configured name  ≠  runtime reachability  ≠  active detection
+                 ≠  effective enforcement ≠  truthful health
+```
+
+Every one of those inequalities has been observed in this product. They are not hypothetical.
+
+## Position in architecture
+
+| Layer | Role | Authority |
+|-------|------|-----------|
+| Configuration | Operator intent | Declares, never proves |
+| Resolver | Intent → effective mode | Must record both, and the reason |
+| Dispatcher | Effective mode → entrypoint | Missing entrypoint is a FAILURE, never a no-op |
+| Detector | Event production | Requires a readable, producing source |
+| Ban authority | Decision | Exactly one per event |
+| Kernel (nftables) | Enforcement | Source of truth |
+| Health | Interpretation of the **selected** path | Must be able to report failure |
+
+---
+
+## Lessons
+
+These are stated as rules because each was learned from a real defect.
+
+### Lesson A — Presence is not readiness
+
+**Wrong:** `binary exists + service active = available`.
+
+**Required readiness**, all of:
+
+- binary exists
+- service active
+- required source exists
+- source readable **by the actual consumer identity**
+- source producing the **required event class**
+- cursor/watcher advancing
+- parser accepts current schema
+
+> Observed: `checkSuricataAvailable()` scores binary(+1), `systemctl is-active`(+1), fresh EVE(+1)
+> and returns `score >= 2`. Binary plus service therefore selects Suricata **with no EVE file at
+> all**. Presence scored as readiness.
+
+### Lesson B — Started is not running
+
+**Wrong:** goroutine launched → module `RUNNING`.
+
+**Required:** worker started **and** still alive **and** source attached **and** input authority
+proven **and** progress/heartbeat observed. A worker that exits immediately must not leave module
+status at `RUNNING`.
+
+> Observed: `runEVEWatcher` fails to open EVE, calls `RecordError`, and `return`s — the goroutine
+> exits with no retry and no fallback, while `MarkRunning()` had already been set. The module
+> reported running with zero detection.
+
+### Lesson C — Function existence is not runtime reachability
+
+**Wrong:** function defined and `export -f`'d → feature implemented.
+
+**Required:** production caller → selected dispatcher branch → invocation → observable output.
+
+> Observed: `nftban_ddos_suricata_process` exists, is exported, and has **zero external callers**.
+> `DDOS_MODE=suricata` names a mode whose processor never runs.
+
+### Lesson D — Configured mode and effective mode are different authorities
+
+Always record **both**, plus the reason:
+
+```
+CONFIGURED_MODE=auto
+EFFECTIVE_MODE=classic
+MODE_REASON=suricata_source_not_ready
+```
+
+Never overwrite operator intent with the resolved value without preserving both. A status surface
+that shows only one of them cannot be audited.
+
+### Lesson E — Health must test the *selected* path
+
+Health may not merely assert process active / service active / config says enabled. It must test
+the path the effective mode selected:
+
+| Effective mode | Health must prove |
+|---|---|
+| `classic` | native/kernel detector path alive |
+| `suricata` | EVE source readable **and consumer progressing** |
+| `hybrid` | both paths progressing **and** deduplicating |
+| `auto` | resolver result recorded **and** selected path healthy |
+
+Health states must distinguish:
+`ACTIVE_AND_RECEIVING` · `ACTIVE_ZERO_INPUT` · `SOURCE_MISSING` · `SOURCE_UNREADABLE` ·
+`PARSER_REJECTING` · `CURSOR_STALLED`.
+
+### Lesson F — Hybrid is a separate architecture
+
+Hybrid is not "classic plus Suricata" behind a checkbox. It requires a canonical event identity,
+one deduplication authority, one ban authority, one expiry decision, one notification, and
+independent health for each input.
+
+Without proven deduplication, two valid detectors produce duplicate events, duplicate bans,
+competing expiry values, conflicting severity, double notifications and inconsistent counters.
+**Until dedup is proven, hybrid is unsupported or experimental — never "supported".**
+
+### Lesson G — Silent no-op is failure
+
+This pattern is prohibited as a success path:
+
+```bash
+type -t some_function >/dev/null && some_function     # missing fn ⇒ rc0, nothing ran
+```
+
+**Required:** selected-mode entrypoint missing ⇒ `DEGRADED` or `FAILED`, with an explicit
+machine-readable reason and a non-success operation result.
+
+```
+SELECTED MODE + MISSING ENTRYPOINT = FAILED/DEGRADED     never rc0/no-op
+```
+
+### Lesson H — Tests must prove their injection
+
+A test does not count because its assertions passed. Every critical test must establish:
+
+```
+PRECONDITION → INJECTION_APPLIED → EXPECTED_PATH_EXECUTED
+             → OBSERVATION → NEGATIVE_CONTROL_FAILED → CLEANUP_COMPLETE
+```
+
+If the injection did not take, the case is `NOT_YET_VERIFIED` — never `PASS`, and never
+`FAIL_PRODUCT` (which would misattribute a harness gap to the product). This applies equally to
+product code and to lifecycle/attack harnesses.
+
+---
+
+## Required resolution — the ten fields
+
+Before any claim or mutation involving DDoS, PortScan, LoginMon, BotScan, Suricata,
+enable/disable, detection, banning, health or status, resolve all ten:
+
+| # | Field | Must name |
+|---|-------|-----------|
+| 1 | MODULE | ddos · portscan · loginmon · other |
+| 2 | CONFIGURED MODE | auto · classic · suricata · hybrid |
+| 3 | EFFECTIVE MODE | the mode actually selected after dependency/config resolution |
+| 4 | RUNTIME ENTRYPOINT | exact service/timer/Go scheduler/shell dispatcher/kernel rule |
+| 5 | DETECTION AUTHORITY | kernel nftables · shell detector · EVE consumer · Go publisher |
+| 6 | BAN AUTHORITY | exact function/process that requests or performs the ban |
+| 7 | ENFORCEMENT AUTHORITY | set → referencing rule → **reachable hooked chain** → drop/reject |
+| 8 | HEALTH AUTHORITY | the consumer proving the **selected** mode is active |
+| 9 | LOG AUTHORITY | source log/event stream **and the runtime identity consuming it** |
+| 10 | TEST EVIDENCE | static reachability + committed fixture + real cross-VM traffic |
+
+**Never infer that a configured mode is operational because:** status prints its name · a function
+exists · a function is exported · a Go module starts · enable returns rc0 · a source file is
+installed · Suricata is installed · a detector prints a message.
+
+---
+
+## Mode admission ledger
+
+Each module × mode carries exactly one status. A mode may appear in user-facing help only with an
+explicit status of `supported`, `experimental`, `unavailable` or `broken`.
+
+| Status | Meaning |
+|---|---|
+| `DECLARED` | The mode name exists in config/help |
+| `STATICALLY_REACHABLE` | Resolver → dispatcher → entrypoint traced in code |
+| `FIXTURE_PROVEN` | Committed positive **and** negative fixture pass |
+| `TRAFFIC_PROVEN` | Real cross-VM traffic, enforcement proven, clean recovery |
+| `SUSTAINED` | Traffic-proven across restart/rebuild/reboot/upgrade |
+| `BROKEN` | Named but not reachable, or reachable but not truthful |
+| `DEMOTED` | Previously admitted, now failing — must be hidden or marked unavailable |
+
+Promotion requires **all** of: static reachability, a committed positive fixture, a committed
+negative fixture, real cross-VM traffic, enforcement proof, and clean recovery. The traffic test
+must enter through the **shipped production lifecycle** — never by calling a private helper
+directly. A synthetic direct call proves the function works; it proves nothing about the product.
+
+Current ledger: see [`MODE_ADMISSION_LEDGER.md`](MODE_ADMISSION_LEDGER.md).
+
+---
+
+## Machine-readable mode declaration
+
+Supported modes must be **inventoried, not inferred from scattered code**. Each module declares:
+
+```yaml
+module: loginmon
+configured_modes: [auto, classic, suricata, hybrid]
+modes:
+  classic:
+    dispatcher: internal/loginmon.Module.Start
+    detector: journal_watcher
+    required_sources: [systemd-journal]
+    health: [watcher_alive, source_attached, progress_observed]
+  suricata:
+    dispatcher: internal/loginmon.Module.Start
+    detector: eve_watcher
+    required_sources: [suricata-service, eve-json, required-event-classes]
+    fallback: classic
+    health: [watcher_alive, eve_readable, cursor_advancing]
+  hybrid:
+    detectors: [journal_watcher, eve_watcher]
+    dedup_authority: REQUIRED
+```
+
+Format may be YAML, Go metadata or a registry. The principle is fixed: the declaration is the
+authority, and CI checks the code against it.
+
+---
+
+## CI guards
+
+Static guards cannot prove runtime operation. They exist to stop architectural drift:
+
+- every documented mode has a resolver branch
+- every resolver output has a dispatcher branch
+- every dispatcher branch references an existing entrypoint
+- a missing selected entrypoint cannot return success
+- every `MarkRunning()` has a worker-liveness/error transition
+- every Suricata mode declares source-readiness checks
+- every hybrid mode declares a deduplication authority
+- help/status cannot advertise a mode marked `BROKEN`
+
+## Mutation fixtures
+
+Guards are only trustworthy if they have been seen to fail. Each of these must flip its guard red:
+
+| Mutation | Guard that must fail |
+|---|---|
+| remove the DDoS Suricata caller | reachability test |
+| remove a PortScan mode function | selected-mode test returns FAILED, not rc0 |
+| make the EVE path absent | LoginMon must not report healthy Suricata |
+| stop the EVE watcher after startup | status must leave RUNNING |
+| send duplicate journal + EVE events | hybrid must produce exactly one decision |
+| change auto readiness to presence-only | readiness fixture |
+
+---
+
+## Threshold retuning
+
+Retuning is **prohibited** until reachability and ownership are proven for the mode being tuned.
+
+Thresholds are not numerically comparable across modes, because the observation models differ:
+
+- kernel meter observes packets/connections directly
+- Suricata observes classified events after capture, decode, rule evaluation and EVE output
+- shell polling adds interval and batching behaviour
+
+```
+same config number  ≠  same effective sensitivity
+```
+
+Retuning must therefore produce per-mode defaults or an explicit normalization model — never one
+number reused across modes.
+
+---
+
+## STOP-ON-MODE-AMBIGUITY
+
+Stop and report **before mutation** when any of these is unknown:
+
+configured mode · effective mode · runtime dispatcher · selected function exists but caller
+unproven · selected mode silently no-ops · classic/Suricata ownership overlap · hybrid dedup
+unproven · auto resolution not reproducible · health disagrees with observed traffic behaviour ·
+Suricata presence changes another module's inputs · a test enters through a private helper rather
+than the shipped entrypoint.
+
+**Do not repair, retune, or declare support until the ambiguity is resolved.**
+
+---
+
+## Related
+
+- [`EVIDENCE_CONTRACT.md`](EVIDENCE_CONTRACT.md) — evidence has no authority over status
+- [`CONTRACT_RULES.md`](CONTRACT_RULES.md)
+- [`adr/ADR-0001-runtime-mode-authority.md`](adr/ADR-0001-runtime-mode-authority.md)
+- [`MODE_ADMISSION_LEDGER.md`](MODE_ADMISSION_LEDGER.md)

--- a/docs/SHELL_INPUT_PARSING_STANDARD.md
+++ b/docs/SHELL_INPUT_PARSING_STANDARD.md
@@ -52,45 +52,18 @@ Both are instances of the standing rule: **PASS ≠ INJECTION PROVEN**.
 
 ---
 
-## Register entry — ready for transcription
+## Tracking
 
-The authoritative open-work register is owned elsewhere; this entry is recorded here for
-transcription rather than edited in directly.
+Open work for this standard is tracked **only** in the master register:
 
 ```
-TODO-SHELL-INPUT-PARSING-AUTHORITY
-
-Problem:
-Several shell paths may parse comma-separated or externally supplied values by
-temporarily assigning IFS. Repository security policy flags IFS-based input
-splitting because parsing behaviour can become implicit, difficult to audit, or
-accidentally leak into adjacent code.
-
-Required action:
-- inventory IFS assignments used for external/config/CLI input parsing;
-- distinguish local bounded uses from persistent/global IFS mutation;
-- replace policy-violating cases with explicit parsers;
-- validate parsed tokens against a strict allowlist;
-- reject empty, unknown, duplicated or malformed values where appropriate;
-- prohibit `... || true` from hiding parser failures;
-- add positive, malformed-input and mutation tests;
-- verify no behaviour change for valid existing input.
-
-Acceptance:
-- repository security scanner passes;
-- valid comma-separated values parse identically;
-- whitespace around tokens is accepted;
-- empty and unknown tokens fail deterministically;
-- no parsing state leaks after the parser returns;
-- negative control proves the guard detects reintroduced IFS-based parsing.
-
-Disposition:
-LOW / defense-in-depth / CI-compliance hygiene.
-Do not describe as a confirmed vulnerability unless an actual state-leak or
-input-confusion exploit is reproduced.
+NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md  →  TODO-SHELL-INPUT-PARSING-AUTHORITY
 ```
 
-**Known population (not yet triaged):** the scanner reports pre-existing `ifs-tampering` findings on
-`main` in `cli/lib/nftban/cli/cmd_logs.sh`, `cli/lib/nftban/core/nftban_rbl.sh` and
-`cli/lib/nftban/core/nftban_hostaddr.sh`. Those are a **triage population, not a defect count** —
-each needs the local-versus-global distinction applied before any claim.
+This file is the *standard* (how to write the parser). It is not a TODO list and must not grow one —
+there is one master register, and duplicate trackers drift.
+
+**Known scanner population (not yet triaged):** pre-existing `ifs-tampering` findings on `main` in
+`cli/lib/nftban/cli/cmd_logs.sh`, `cli/lib/nftban/core/nftban_rbl.sh` and
+`cli/lib/nftban/core/nftban_hostaddr.sh`. That is a **triage population, not a defect count** — each
+needs the local-versus-global distinction applied before any claim.

--- a/docs/SHELL_INPUT_PARSING_STANDARD.md
+++ b/docs/SHELL_INPUT_PARSING_STANDARD.md
@@ -1,0 +1,96 @@
+# Shell Input Parsing Standard
+
+**Classification:** shell input-parsing / CI-compliance hygiene · **Severity:** LOW ·
+**Security impact:** defense-in-depth · **Runtime defect:** NOT PROVEN
+
+This is a secure-parsing standard and a regression-prevention item. It is **not** a confirmed
+vulnerability, and must not be described as one unless an actual state-leak or input-confusion
+exploit is reproduced. A locally scoped `IFS=x read` inside a tight function is not inherently
+exploitable; the repository's scanner prohibits IFS-based input splitting as **policy**.
+
+## The standard
+
+> Do not mutate shell-global parsing state to parse untrusted or externally supplied lists when a
+> bounded, explicit parser can be used.
+
+Required properties of a list parser:
+
+- no global or persistent `IFS` mutation for splitting input
+- `IFS=` **on the read** so `read` does not trim implicitly — trimming stays explicit and auditable
+- only **surrounding** whitespace trimmed, so identifiers containing internal spaces survive
+- explicit empty-item handling
+- no `|| true` concealing a pipeline failure
+- tokens validated against a **strict allowlist**; unknown values fail deterministically
+- a trailing newline on the input stream (see the trap below)
+
+## Reference implementation
+
+```bash
+declare -A SCOPE_SET=()
+while IFS= read -r _m; do
+    _m="${_m#"${_m%%[![:space:]]*}"}"      # trim leading
+    _m="${_m%"${_m##*[![:space:]]}"}"      # trim trailing
+    [[ -z "${_m}" ]] && continue
+    case "${_m}" in
+        ddos|portscan|loginmon) SCOPE_SET["${_m}"]=1 ;;
+        *) printf 'Invalid scope: %s\n' "${_m}" >&2; exit 2 ;;
+    esac
+done < <(printf '%s\n' "${RAW}" | tr ',' '\n')
+```
+
+## Two traps, both found by RUNNING the parser rather than reading it
+
+**`[:space:]` includes the newline.** `tr -d '[:space:]'` after splitting collapses
+`"a,b"` back into a single token `ab`. Single-value input still parses correctly, which hides the
+defect. Use `[:blank:]`, or trim per-token as above.
+
+**`printf '%s'` emits no trailing newline.** `read` then hits EOF and returns non-zero on the final
+token, so the `while` body **never executes** and every list parses as empty — while the caller
+reports a confident verdict about a list nobody successfully declared. Use `printf '%s\n'`.
+
+Both are instances of the standing rule: **PASS ≠ INJECTION PROVEN**.
+
+---
+
+## Register entry — ready for transcription
+
+The authoritative open-work register is owned elsewhere; this entry is recorded here for
+transcription rather than edited in directly.
+
+```
+TODO-SHELL-INPUT-PARSING-AUTHORITY
+
+Problem:
+Several shell paths may parse comma-separated or externally supplied values by
+temporarily assigning IFS. Repository security policy flags IFS-based input
+splitting because parsing behaviour can become implicit, difficult to audit, or
+accidentally leak into adjacent code.
+
+Required action:
+- inventory IFS assignments used for external/config/CLI input parsing;
+- distinguish local bounded uses from persistent/global IFS mutation;
+- replace policy-violating cases with explicit parsers;
+- validate parsed tokens against a strict allowlist;
+- reject empty, unknown, duplicated or malformed values where appropriate;
+- prohibit `... || true` from hiding parser failures;
+- add positive, malformed-input and mutation tests;
+- verify no behaviour change for valid existing input.
+
+Acceptance:
+- repository security scanner passes;
+- valid comma-separated values parse identically;
+- whitespace around tokens is accepted;
+- empty and unknown tokens fail deterministically;
+- no parsing state leaks after the parser returns;
+- negative control proves the guard detects reintroduced IFS-based parsing.
+
+Disposition:
+LOW / defense-in-depth / CI-compliance hygiene.
+Do not describe as a confirmed vulnerability unless an actual state-leak or
+input-confusion exploit is reproduced.
+```
+
+**Known population (not yet triaged):** the scanner reports pre-existing `ifs-tampering` findings on
+`main` in `cli/lib/nftban/cli/cmd_logs.sh`, `cli/lib/nftban/core/nftban_rbl.sh` and
+`cli/lib/nftban/core/nftban_hostaddr.sh`. Those are a **triage population, not a defect count** —
+each needs the local-versus-global distinction applied before any claim.

--- a/docs/adr/ADR-0001-runtime-mode-authority.md
+++ b/docs/adr/ADR-0001-runtime-mode-authority.md
@@ -26,6 +26,10 @@ A further hazard is structural: the PortScan dispatcher guards each branch with
 
 ## Decision
 
+**A feature is a complete production path that is REACHABLE, OBSERVABLE, ENFORCEABLE, TESTABLE and
+RECOVERABLE — not merely code that exists.** This governs DDoS, PortScan, LoginMon, Suricata,
+BotScan, ban/unban, package lifecycle, health, reporting, and every future module.
+
 **NFTBan treats each module mode as an independently admitted runtime implementation.**
 
 A configured mode is not supported until its production path, source readiness, health semantics,

--- a/docs/adr/ADR-0001-runtime-mode-authority.md
+++ b/docs/adr/ADR-0001-runtime-mode-authority.md
@@ -55,7 +55,13 @@ UNLESS ITS EFFECTIVE RUNTIME CHAIN IS PROVEN END TO END
 - Hybrid requires a deduplication authority before it may be called supported.
 - Silent fallback and silent no-op are prohibited: a selected mode with a missing entrypoint is
   `FAILED` or `DEGRADED` with a machine-readable reason, never rc0.
-- Broken modes are hidden, rejected at validation, or explicitly marked unavailable.
+- **A broken mode must be rejected at configuration validation or explicitly marked unavailable.
+  It must not be selectable as an operational mode. Hiding it from help alone is insufficient** —
+  an existing configuration file would otherwise keep selecting it silently.
+- **The mode declaration and admission ledger are specification and admission authorities, not
+  runtime truth.** Runtime enforcement authority remains the nftables kernel; health interpretation
+  remains the validator; configuration records operator intent. The ledger never replaces
+  kernel/validator truth.
 - Health must test the path the effective mode selected, and must be able to report failure —
   distinguishing `ACTIVE_ZERO_INPUT` from `ACTIVE_AND_RECEIVING`.
 - Threshold retuning is blocked until reachability and ownership are proven, and may not reuse one
@@ -69,6 +75,22 @@ architectural — a missing admission boundary — not three unrelated bugs.
 
 **Keep the contract only in agent/assistant memory.** Rejected by the owner. Institutional
 knowledge must live in the repository where contributors, auditors and CI can enforce it.
+
+## Revisit criteria
+
+This ADR may be superseded only if NFTBan adopts a different runtime-mode architecture that
+preserves equivalent or stronger guarantees for:
+
+- configured versus effective mode separation
+- source readiness
+- production-path reachability
+- enforcement authority
+- health truth
+- negative and cross-VM validation
+- recovery and deduplication
+
+A refactor that removes the admission model without providing equivalent guarantees does not
+supersede this ADR; it violates it.
 
 ## Compliance
 

--- a/docs/adr/ADR-0001-runtime-mode-authority.md
+++ b/docs/adr/ADR-0001-runtime-mode-authority.md
@@ -1,0 +1,74 @@
+# ADR-0001 — Runtime Mode Authority
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Scope:** every module exposing a mode (DDoS, PortScan, LoginMon, and any future module)
+
+## Context
+
+NFTBan modules expose four user-facing mode values — `auto`, `classic`, `suricata`, `hybrid`.
+Investigation of v1.228.0 established that a configured mode name does not imply a reachable,
+observable or enforceable runtime path. Three findings, each by direct source trace:
+
+1. `DDOS_MODE=suricata` names a mode whose EVE processor has **zero external callers**, and DDoS
+   has no mode dispatcher at all. The mode resolves to nothing while status renders its name.
+2. LoginMon `auto` selects Suricata from **presence** (binary + active service, EVE not required),
+   then starts only the EVE watcher — silently darkening journal-based SSH, su, sudo, mail and FTP
+   detection.
+3. When the EVE source is absent, that watcher goroutine exits immediately while module status
+   remains `RUNNING`.
+
+These are not tuning problems and would not have been found by threshold work. They share one
+shape: **a name in configuration that does not correspond to a proven production path.**
+
+A further hazard is structural: the PortScan dispatcher guards each branch with
+`type -t fn && fn`, so a missing mode function is indistinguishable from a successful run.
+
+## Decision
+
+**NFTBan treats each module mode as an independently admitted runtime implementation.**
+
+A configured mode is not supported until its production path, source readiness, health semantics,
+enforcement, recovery and cross-VM behaviour are proven. Admission is tracked per module × mode in
+a ledger, and promotion requires static reachability, committed positive and negative fixtures,
+real cross-VM traffic, enforcement proof and clean recovery — entered through the shipped
+production lifecycle, never a private helper.
+
+The governing invariant:
+
+```
+NO CONFIGURED MODE MAY BE REPORTED ACTIVE
+UNLESS ITS EFFECTIVE RUNTIME CHAIN IS PROVEN END TO END
+```
+
+## Consequences
+
+- The four mode values are tested **independently**; they are never collapsed into
+  "with Suricata / without Suricata".
+- `auto` must record `CONFIGURED_MODE`, `EFFECTIVE_MODE` and `MODE_REASON` separately. Operator
+  intent is never overwritten by the resolved value without preserving both.
+- Suricata readiness requires the source to be **producing input**, not merely present.
+- Hybrid requires a deduplication authority before it may be called supported.
+- Silent fallback and silent no-op are prohibited: a selected mode with a missing entrypoint is
+  `FAILED` or `DEGRADED` with a machine-readable reason, never rc0.
+- Broken modes are hidden, rejected at validation, or explicitly marked unavailable.
+- Health must test the path the effective mode selected, and must be able to report failure —
+  distinguishing `ACTIVE_ZERO_INPUT` from `ACTIVE_AND_RECEIVING`.
+- Threshold retuning is blocked until reachability and ownership are proven, and may not reuse one
+  numeric threshold across modes with different observation models.
+
+## Alternatives considered
+
+**Fix the specific bugs and move on.** Rejected: the same class had already recurred across
+independent modules, and the finding would have disappeared with the release. The defect is
+architectural — a missing admission boundary — not three unrelated bugs.
+
+**Keep the contract only in agent/assistant memory.** Rejected by the owner. Institutional
+knowledge must live in the repository where contributors, auditors and CI can enforce it.
+
+## Compliance
+
+- Contract: [`../RUNTIME_MODE_AUTHORITY_CONTRACT.md`](../RUNTIME_MODE_AUTHORITY_CONTRACT.md)
+- Ledger: [`../MODE_ADMISSION_LEDGER.md`](../MODE_ADMISSION_LEDGER.md)
+- PR gate: the mode-authority section of `.github/PULL_REQUEST_TEMPLATE.md` — an unanswered field
+  blocks merge.

--- a/docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md
+++ b/docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md
@@ -1,0 +1,78 @@
+# v1.228.0 — Validation Authority Statement
+
+Permanent release interpretation. Authority for the principle:
+[`../RUNTIME_MODE_AUTHORITY_CONTRACT.md`](../RUNTIME_MODE_AUTHORITY_CONTRACT.md) and
+[`../adr/ADR-0001-runtime-mode-authority.md`](../adr/ADR-0001-runtime-mode-authority.md).
+
+## Statement
+
+> v1.228.0 introduced stronger package, runtime, enforcement and lifecycle gates. Those gates
+> uncovered several small but material gaps in behaviour that had previously been assumed complete
+> because the corresponding code or configuration existed. The release corrected the confirmed
+> **package-boundary** defects, converted major validation paths into durable tests, and materially
+> increased confidence in the parts of NFTBan that are now proven end to end. Confirmed
+> **runtime-mode** defects are recorded explicitly and are **not** corrected in this release.
+> Remaining unverified paths are recorded explicitly and are not represented as complete.
+
+## What this release did and did not reveal
+
+It did **not** reveal that NFTBan had no implementation. It revealed something more specific:
+
+> Several features, modes, lifecycle paths and status claims existed in code, but some were
+> incomplete, unreachable, insufficiently verified, or not proven end to end.
+
+## The gates that exposed them
+
+package lifecycle gates · runtime mode authority checks · real DEB/RPM package validation ·
+cross-VM attack tests · hooked-chain enforcement checks · negative controls · mutation fixtures ·
+read-only verification proofs · configured-vs-effective mode tracing
+
+## Findings, split by disposition
+
+**CORRECTED in v1.228.0 — package boundary**
+
+- missing package outcome truth (a package manager reporting success over a failed install)
+- stale historical state confused with the current transaction
+- silent no-installer path emitting no machine-readable result
+- RPM build failure hidden behind a successful wrapper result (**no package produced at all**)
+- timestamp precision defect producing a false `STALE_STATE` on a healthy install
+- a dead, contradictory verdict-to-exit authority
+
+**CONFIRMED AND RECORDED — not corrected in this release** (runtime lane, `PLAN_AFTER_PROOF`)
+
+- mode names without proven runtime reachability (`DDOS_MODE=suricata` — processor has no caller)
+- Suricata readiness based on presence rather than producing input (LoginMon `auto`)
+- health reporting `RUNNING` while the active watcher had exited
+- `STATE_READ_ERROR` has no producer; read errors report as `MISSING_STATE`
+- silent no-op mode dispatch (`type -t fn && fn` returning success when the entrypoint is absent)
+
+**METHOD DEFECTS — corrected in the harnesses themselves**
+
+- harnesses that could report `PASS` without proving the intended injection
+- missing lifecycle and attack-path coverage
+
+## Scope of confidence
+
+```
+PROVEN AREAS              stronger confidence
+UNPROVEN / INCOMPLETE     remain explicitly open
+NO GREEN LABEL            may hide a skipped, unreachable or unverified path
+```
+
+Confidence is scoped to what was proven, and proof means the full production path — not that the
+code exists. Areas absent from a ledger or matrix are **unassessed**, not healthy.
+
+## Standing lesson
+
+> A feature is not merely code that exists. A feature is a complete production path that is
+> **reachable, observable, enforceable, testable and recoverable.**
+
+```
+DEFINED         ≠  REACHABLE
+CONFIGURED      ≠  EFFECTIVE
+ENABLED         ≠  DETECTING
+RUNNING         ≠  RECEIVING INPUT
+DETECTED        ≠  ENFORCED
+SET MEMBERSHIP  ≠  FIREWALL BLOCK
+PASS            ≠  INJECTION PROVEN
+```

--- a/scripts/ci/check-mode-authority.sh
+++ b/scripts/ci/check-mode-authority.sh
@@ -58,6 +58,9 @@ RUN_CONTROLS=1
 VERBOSE=0
 
 FAIL_ON="${FAIL_ON:-all}"
+# label used for BROKEN-row findings: a real FAIL under --fail-on all, known
+# non-blocking debt under --fail-on drift.
+MUSTFIX_LABEL="MUST_FIX"
 
 usage() {
     cat <<'EOF'
@@ -197,7 +200,7 @@ record() {
     if [[ "${KNOWN_DISP[${key}]}" == "MUST_FIX" ]]; then
         CHECK_MUSTFIX["${check}"]=$(( ${CHECK_MUSTFIX[${check}]:-0} + 1 ))
         MUSTFIX_TOTAL=$(( MUSTFIX_TOTAL + 1 ))
-        say "  MUST_FIX       ${key}"
+        say "  ${MUSTFIX_LABEL}       ${key}"
         say "                 ledger=${KNOWN_STATUS[${key}]} — ${detail}"
         return
     fi
@@ -736,6 +739,8 @@ say "  scope note   : static only. Static reachability is 1 of the 6 promotion"
 say "                 requirements in MODE_ADMISSION_LEDGER.md. A clean run of this"
 say "                 guard never promotes a ledger row."
 
+[[ "${FAIL_ON}" == "drift" ]] && MUSTFIX_LABEL="KNOWN_MUST_FIX"
+
 head2 "CONTROLS (each check must be seen to fail before its result is trusted)"
 if [[ ${RUN_CONTROLS} -eq 1 ]]; then
     IN_CONTROL=1
@@ -800,14 +805,20 @@ for c in SILENT_NO_OP ORPHAN_ENTRYPOINT LEDGER_CONSISTENCY MARKRUNNING_LIVENESS;
         result="FAIL"
         RC=1
     elif [[ "${mustfix}" -gt 0 ]]; then
-        # MUST_FIX = a violation whose ledger row is BROKEN. In `all` (default)
-        # it blocks, which is the contract's end state. In `drift` it is still
-        # printed as FAIL and still counted — it just does not gate unrelated
-        # PRs while the obligation is open. It is never downgraded to PASS and
-        # never silently accepted: that would be the exact failure this guard
-        # exists to prevent.
-        result="FAIL"
-        [[ "${FAIL_ON}" == "all" ]] && RC=1
+        # MUST_FIX = a violation whose ledger row is BROKEN.
+        #
+        # Under `all` it blocks and is a genuine FAIL. Under `drift` the job
+        # itself passes, so calling it "FAIL" would print a failure beside a
+        # green workflow — a truth mismatch of exactly the kind this guard
+        # exists to prevent. It is classified KNOWN_MUST_FIX instead: known
+        # release debt, blocked from admission, non-blocking in this mode.
+        # It is never downgraded to PASS and never silently accepted.
+        if [[ "${FAIL_ON}" == "all" ]]; then
+            result="FAIL"
+            RC=1
+        else
+            result="KNOWN_MUST_FIX"
+        fi
     else
         result="PASS"
     fi
@@ -825,5 +836,19 @@ printf 'MODE_AUTHORITY_FAIL_ON=%s\n' "${FAIL_ON}"
 # does not gate. It is never downgraded to PASS.
 if [[ ${NEW_TOTAL} -gt 0 || ${STALE} -gt 0 ]]; then RC=1; fi
 if [[ ${MUSTFIX_TOTAL} -gt 0 && "${FAIL_ON}" == "all" ]]; then RC=1; fi
-printf 'MODE_AUTHORITY_RESULT=%s\n' "$([[ ${RC} -eq 0 ]] && echo PASS || echo FAIL)"
+# Admission is a SEPARATE axis from the CI verdict. A ratchet run can be green
+# (no new drift) while admission is still blocked by known BROKEN rows.
+if [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
+    printf 'MODE_AUTHORITY_ADMISSION=BLOCKED_FROM_ADMISSION\n'
+else
+    printf 'MODE_AUTHORITY_ADMISSION=ELIGIBLE\n'
+fi
+if [[ ${RC} -ne 0 ]]; then
+    printf 'MODE_AUTHORITY_RESULT=FAIL\n'
+elif [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
+    # green build, but do not call it a clean PASS
+    printf 'MODE_AUTHORITY_RESULT=CI_RATCHET_NONBLOCKING\n'
+else
+    printf 'MODE_AUTHORITY_RESULT=PASS\n'
+fi
 exit "${RC}"

--- a/scripts/ci/check-mode-authority.sh
+++ b/scripts/ci/check-mode-authority.sh
@@ -57,7 +57,9 @@ KNOWN_FILE="${SCRIPT_DIR}/mode-authority-known.txt"
 RUN_CONTROLS=1
 VERBOSE=0
 
-FAIL_ON="${FAIL_ON:-all}"
+POLICY="${POLICY:-all}"
+SCOPE_RAW="${SCOPE_RAW:-}"
+CHANGED_FILE="${CHANGED_FILE:-}"
 # label used for BROKEN-row findings: a real FAIL under --fail-on all, known
 # non-blocking debt under --fail-on drift.
 MUSTFIX_LABEL="MUST_FIX"
@@ -70,10 +72,17 @@ Usage: check-mode-authority.sh [--root DIR] [--known FILE] [--no-controls] [-v]
   --known FILE    allowlist of accepted violations
                   (default: scripts/ci/mode-authority-known.txt)
   --no-controls   skip the negative/positive controls (NOT for CI)
-  --fail-on MODE  drift  : fail on NEW violations only; MUST_FIX debt is
-                           reported loudly but does not block (ratchet mode)
-                  all    : fail on NEW *and* MUST_FIX (default; the end state
-                           once the BROKEN ledger rows are discharged)
+  --policy P      drift    : block NEW + STALE. Report MUST_FIX/ACCEPTED_DEBT.
+                             CI may pass; admission stays blocked.
+                  targeted : also block unresolved MUST_FIX rows INSIDE the
+                             declared --scope. Unrelated debt is reported only.
+                  all      : block ANY MUST_FIX, NEW or STALE. Global admission.
+  --scope LIST    comma-separated modules the change DECLARES it closes
+                  (ddos,portscan,loginmon). Required for --policy targeted.
+  --changed-paths FILE
+                  file of changed paths (one per line). Used to VERIFY that the
+                  declared scope covers every mode-authority surface touched.
+  --fail-on MODE  deprecated alias: drift|all -> --policy
   -v              print every violation line, including known ones
 EOF
 }
@@ -85,10 +94,18 @@ while [[ $# -gt 0 ]]; do
         --no-controls) RUN_CONTROLS=0; shift ;;
         --fail-on)
             case "$2" in
-                drift|all) FAIL_ON="$2" ;;
+                drift|all) POLICY="$2" ;;
                 *) echo "--fail-on expects 'drift' or 'all'" >&2; exit 2 ;;
             esac
             shift 2 ;;
+        --policy)
+            case "$2" in
+                drift|targeted|all) POLICY="$2" ;;
+                *) echo "--policy expects drift|targeted|all" >&2; exit 2 ;;
+            esac
+            shift 2 ;;
+        --scope)        SCOPE_RAW="$2"; shift 2 ;;
+        --changed-paths) CHANGED_FILE="$2"; shift 2 ;;
         -v|--verbose) VERBOSE=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
@@ -148,6 +165,8 @@ declare -A KNOWN_HIT=()
 NEW_TOTAL=0
 KNOWN_TOTAL=0
 MUSTFIX_TOTAL=0
+MUSTFIX_IN_SCOPE=0
+SCOPE_VALIDATION=PASS
 NYV_TOTAL=0
 IN_CONTROL=0
 declare -A CHECK_NEW=()
@@ -200,6 +219,9 @@ record() {
     if [[ "${KNOWN_DISP[${key}]}" == "MUST_FIX" ]]; then
         CHECK_MUSTFIX["${check}"]=$(( ${CHECK_MUSTFIX[${check}]:-0} + 1 ))
         MUSTFIX_TOTAL=$(( MUSTFIX_TOTAL + 1 ))
+        if [[ "${POLICY}" == "targeted" ]] && in_scope "${key}"; then
+            MUSTFIX_IN_SCOPE=$(( MUSTFIX_IN_SCOPE + 1 ))
+        fi
         say "  ${MUSTFIX_LABEL}       ${key}"
         say "                 ledger=${KNOWN_STATUS[${key}]} — ${detail}"
         return
@@ -739,7 +761,49 @@ say "  scope note   : static only. Static reachability is 1 of the 6 promotion"
 say "                 requirements in MODE_ADMISSION_LEDGER.md. A clean run of this"
 say "                 guard never promotes a ledger row."
 
-[[ "${FAIL_ON}" == "drift" ]] && MUSTFIX_LABEL="KNOWN_MUST_FIX"
+FAIL_ON="${POLICY}"
+[[ "${POLICY}" != "all" ]] && MUSTFIX_LABEL="KNOWN_MUST_FIX"
+
+# --- scope model -------------------------------------------------------------
+# A MUST_FIX key carries its module either in field 2 (ORPHAN_ENTRYPOINT,
+# LEDGER_BROKEN_ADVERTISED) or inside a path (MARKRUNNING_LIVENESS).
+key_module() { # key -> ddos|portscan|loginmon|unknown
+    local k="$1" f2
+    f2="$(cut -d"|" -f2 <<<"${k}")"
+    case "${f2}" in
+        ddos|portscan|loginmon) printf "%s" "${f2}"; return ;;
+    esac
+    case "${k}" in
+        *ddos*)              printf "ddos" ;;
+        *portscan*)          printf "portscan" ;;
+        *loginmon*|*login*)  printf "loginmon" ;;
+        *)                   printf "unknown" ;;
+    esac
+}
+# a changed path -> the module authority surface(s) it touches
+path_modules() { # path -> zero or more modules, one per line
+    local p="$1"
+    case "${p}" in
+        internal/ddos/*|*nftban_ddos*|*cmd_ddos*)             echo ddos ;;
+        internal/portscan/*|*nftban_portscan*|*cmd_portscan*) echo portscan ;;
+        internal/loginmon/*|*nftban_login*|*cmd_login*)       echo loginmon ;;
+        # SHARED mode surfaces: a change here touches every module that
+        # currently carries a MUST_FIX row referencing the file. Declaring one
+        # module while editing shared authority code must not pass.
+        *helpers/nftban_mode.sh|*cmd_modes.sh)
+            grep -oE "^[A-Z_]+\|(ddos|portscan|loginmon)\|" "${KNOWN_FILE}" 2>/dev/null \
+                | cut -d"|" -f2 | sort -u ;;
+    esac
+}
+declare -A SCOPE_SET=()
+if [[ -n "${SCOPE_RAW}" ]]; then
+    IFS="," read -r -a _sc <<<"${SCOPE_RAW}"
+    for _m in "${_sc[@]}"; do
+        _m="$(tr -d "[:space:]" <<<"${_m}")"
+        [[ -n "${_m}" ]] && SCOPE_SET["${_m}"]=1
+    done
+fi
+in_scope() { [[ -n "${SCOPE_SET[$(key_module "$1")]:-}" ]]; }
 
 head2 "CONTROLS (each check must be seen to fail before its result is trusted)"
 if [[ ${RUN_CONTROLS} -eq 1 ]]; then
@@ -790,6 +854,50 @@ done
 [[ ${STALE} -eq 0 ]] && say "  no stale rows (${#KNOWN_KEYS[@]}/${#KNOWN_KEYS[@]} accepted rows still reproduce)"
 
 # -----------------------------------------------------------------------------
+# Scope validation — the PR must DECLARE what it claims to close.
+#
+# Changed paths are evidence, never the declaration. A PR touching a module's
+# authority code while declaring a different (or no) scope must fail: otherwise
+# "targeted" would silently grant admission for surfaces nobody claimed.
+#   required:  declared scope  ⊇  modules whose authority surfaces were touched
+# -----------------------------------------------------------------------------
+if [[ "${POLICY}" == "targeted" ]]; then
+    head2 "SCOPE VALIDATION"
+    if [[ ${#SCOPE_SET[@]} -eq 0 ]]; then
+        say "  FAIL   --policy targeted requires an explicit --scope"
+        SCOPE_VALIDATION=FAIL
+    else
+        say "  declared scope: ${SCOPE_RAW}"
+    fi
+    if [[ -n "${CHANGED_FILE}" && -r "${CHANGED_FILE}" ]]; then
+        declare -A TOUCHED=()
+        while IFS= read -r _p; do
+            [[ -n "${_p}" ]] || continue
+            while IFS= read -r _m; do
+                [[ -n "${_m}" ]] && TOUCHED["${_m}"]=1
+            done < <(path_modules "${_p}")
+        done < "${CHANGED_FILE}"
+        if [[ ${#TOUCHED[@]} -eq 0 ]]; then
+            say "  no mode-authority surface touched by the changed paths"
+        else
+            say "  touched authority surfaces: ${!TOUCHED[*]}"
+            for _m in "${!TOUCHED[@]}"; do
+                if [[ -z "${SCOPE_SET[${_m}]:-}" ]]; then
+                    say "  FAIL   '${_m}' authority code is modified but NOT in the declared scope"
+                    say "         declared scope must cover every touched surface, or the change"
+                    say "         must not touch it. Expand --scope or split the PR."
+                    SCOPE_VALIDATION=FAIL
+                fi
+            done
+        fi
+    else
+        not_yet_verified "declared scope was not verified against changed paths" \
+            "pass --changed-paths <(git diff --name-only origin/main...HEAD)"
+    fi
+    [[ "${SCOPE_VALIDATION}" == "PASS" ]] && say "  scope validation PASS — declaration covers every touched surface"
+fi
+
+# -----------------------------------------------------------------------------
 # Machine-readable summary
 # -----------------------------------------------------------------------------
 head2 "MACHINE-READABLE SUMMARY"
@@ -834,21 +942,47 @@ printf 'MODE_AUTHORITY_FAIL_ON=%s\n' "${FAIL_ON}"
 # NEW drift and a stale allowlist always block. MUST_FIX blocks only under the
 # default --fail-on all; under --fail-on drift it stays visible and counted but
 # does not gate. It is never downgraded to PASS.
+# NEW drift and stale rows always block, under every policy.
 if [[ ${NEW_TOTAL} -gt 0 || ${STALE} -gt 0 ]]; then RC=1; fi
-if [[ ${MUSTFIX_TOTAL} -gt 0 && "${FAIL_ON}" == "all" ]]; then RC=1; fi
+case "${POLICY}" in
+    all)      [[ ${MUSTFIX_TOTAL}    -gt 0 ]] && RC=1 ;;
+    targeted) [[ ${MUSTFIX_IN_SCOPE} -gt 0 ]] && RC=1
+              [[ "${SCOPE_VALIDATION}" == "FAIL" ]] && RC=1 ;;
+    drift)    : ;;   # known debt reported, never silently accepted
+esac
 # Admission is a SEPARATE axis from the CI verdict. A ratchet run can be green
 # (no new drift) while admission is still blocked by known BROKEN rows.
-if [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
-    printf 'MODE_AUTHORITY_ADMISSION=BLOCKED_FROM_ADMISSION\n'
-else
-    printf 'MODE_AUTHORITY_ADMISSION=ELIGIBLE\n'
+# POLICY TRUTH. CI success != global admission; targeted closure != unrelated
+# debt closure; a deferred defect is never a defect accepted as healthy.
+printf 'MODE_AUTHORITY_POLICY=%s\n' "${POLICY}"
+printf 'MODE_AUTHORITY_SCOPE=%s\n' "${SCOPE_RAW:-none}"
+printf 'MODE_AUTHORITY_MUST_FIX_IN_SCOPE=%s\n' "${MUSTFIX_IN_SCOPE}"
+
+if [[ "${POLICY}" == "targeted" ]]; then
+    if [[ "${SCOPE_VALIDATION}" == "FAIL" ]]; then
+        printf 'MODE_AUTHORITY_SCOPE_VALIDATION=FAIL\n'
+        printf 'MODE_AUTHORITY_ADMISSION_SCOPE_RESULT=FAIL\n'
+    elif [[ ${MUSTFIX_IN_SCOPE} -gt 0 ]]; then
+        printf 'MODE_AUTHORITY_SCOPE_VALIDATION=PASS\n'
+        printf 'MODE_AUTHORITY_ADMISSION_SCOPE_RESULT=FAIL\n'
+    else
+        printf 'MODE_AUTHORITY_SCOPE_VALIDATION=PASS\n'
+        printf 'MODE_AUTHORITY_ADMISSION_SCOPE_RESULT=PASS\n'
+    fi
 fi
-if [[ ${RC} -ne 0 ]]; then
-    printf 'MODE_AUTHORITY_RESULT=FAIL\n'
-elif [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
-    # green build, but do not call it a clean PASS
-    printf 'MODE_AUTHORITY_RESULT=CI_RATCHET_NONBLOCKING\n'
+
+# GLOBAL admission is a separate axis and is NOT granted by a targeted pass.
+if [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
+    printf 'MODE_AUTHORITY_GLOBAL_ADMISSION=BLOCKED\n'
 else
-    printf 'MODE_AUTHORITY_RESULT=PASS\n'
+    printf 'MODE_AUTHORITY_GLOBAL_ADMISSION=ELIGIBLE\n'
+fi
+
+if [[ ${RC} -ne 0 ]]; then
+    printf 'MODE_AUTHORITY_CI_RESULT=FAIL\n'
+elif [[ ${MUSTFIX_TOTAL} -gt 0 ]]; then
+    printf 'MODE_AUTHORITY_CI_RESULT=CI_RATCHET_NONBLOCKING\n'
+else
+    printf 'MODE_AUTHORITY_CI_RESULT=PASS\n'
 fi
 exit "${RC}"

--- a/scripts/ci/check-mode-authority.sh
+++ b/scripts/ci/check-mode-authority.sh
@@ -797,11 +797,31 @@ path_modules() { # path -> zero or more modules, one per line
 }
 declare -A SCOPE_SET=()
 if [[ -n "${SCOPE_RAW}" ]]; then
-    IFS="," read -r -a _sc <<<"${SCOPE_RAW}"
-    for _m in "${_sc[@]}"; do
-        _m="$(tr -d "[:space:]" <<<"${_m}")"
-        [[ -n "${_m}" ]] && SCOPE_SET["${_m}"]=1
-    done
+    # Explicit bounded parser. No global or persistent IFS mutation (repository
+    # security policy flags IFS-based input splitting), no `|| true` concealing a
+    # pipeline failure, and tokens validated against an allowlist rather than
+    # merely split — an unknown scope must fail deterministically, not silently
+    # match nothing and appear to pass.
+    #
+    # `IFS=` on the read is deliberate even though it is not splitting: it stops
+    # read trimming implicitly, so trimming stays explicit and auditable. Only
+    # SURROUNDING whitespace is stripped, so a future identifier containing
+    # internal spaces would not be corrupted.
+    while IFS= read -r _m; do
+        _m="${_m#"${_m%%[![:space:]]*}"}"
+        _m="${_m%"${_m##*[![:space:]]}"}"
+        [[ -z "${_m}" ]] && continue
+        case "${_m}" in
+            ddos|portscan|loginmon) SCOPE_SET["${_m}"]=1 ;;
+            *)
+                printf 'Invalid mode-authority scope: %s\n' "${_m}" >&2
+                exit 2 ;;
+        esac
+    # printf '%s\n', NOT '%s': without a trailing newline `read` hits EOF and
+    # returns non-zero on the final token, so the while body never runs and EVERY
+    # scope parses as empty. That failed silently — the guard simply reported
+    # "targeted requires an explicit --scope" for a scope that was supplied.
+    done < <(printf '%s\n' "${SCOPE_RAW}" | tr ',' '\n')
 fi
 in_scope() { [[ -n "${SCOPE_SET[$(key_module "$1")]:-}" ]]; }
 

--- a/scripts/ci/check-mode-authority.sh
+++ b/scripts/ci/check-mode-authority.sh
@@ -1,0 +1,829 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-mode-authority.sh — static CI guard for the Runtime Mode Authority contract
+# =============================================================================
+#
+# Authority:
+#   docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
+#   docs/MODE_ADMISSION_LEDGER.md
+#   docs/adr/ADR-0001-runtime-mode-authority.md
+#
+# What this guard IS:
+#   A static drift detector. It enforces the statically decidable subset of the
+#   contract's "CI guards" section. Nothing here proves runtime operation.
+#
+# What this guard IS NOT:
+#   Proof that a mode works. Static reachability is one of six promotion
+#   requirements (see MODE_ADMISSION_LEDGER.md "Promotion requirements").
+#   Anything this guard cannot decide is printed as NOT_YET_VERIFIED with the
+#   exact command that WOULD settle it on a live host — never as PASS.
+#
+# Checks:
+#   1 SILENT_NO_OP          Lesson G — `type -t F && F` used as a MODE DISPATCH
+#                           branch, where a missing F yields rc0 / no-op.
+#   2 ORPHAN_ENTRYPOINT     Lesson C — a mode-specific entrypoint with no caller.
+#   3 LEDGER_CONSISTENCY    Ledger completeness + `BROKEN` must not be advertised.
+#   4 MARKRUNNING_LIVENESS  Lesson B — MarkRunning() with a worker that can exit
+#                           without any status transition. (approximation)
+#
+# Every check carries a NEGATIVE CONTROL (a synthetic bad tree that the check
+# MUST flag) and, where cheap, a POSITIVE CONTROL (a synthetic clean tree that
+# the check MUST NOT flag). A check whose negative control does not fire is
+# reported NOT_YET_VERIFIED, never PASS — an unfalsifiable guard is not a guard
+# (Lesson H).
+#
+# Known/accepted violations live in scripts/ci/mode-authority-known.txt, each
+# row citing its ledger status and a disposition:
+#   ACCEPTED_DEBT — tracked, does not block
+#   MUST_FIX      — tracked and blocks under the default --fail-on all, because
+#                   its ledger row is BROKEN and the contract's standing rule is
+#                   an open obligation. Never downgraded to PASS.
+# A row that stops reproducing is reported STALE and blocks, so this file cannot
+# outlive the defect it records.
+#
+# Exit codes:  0 = clean   1 = NEW drift, stale allowlist, or (default) MUST_FIX
+#              2 = guard fault / bad invocation
+# =============================================================================
+
+set -uo pipefail
+
+# -----------------------------------------------------------------------------
+# Locations
+# -----------------------------------------------------------------------------
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+KNOWN_FILE="${SCRIPT_DIR}/mode-authority-known.txt"
+
+RUN_CONTROLS=1
+VERBOSE=0
+
+FAIL_ON="${FAIL_ON:-all}"
+
+usage() {
+    cat <<'EOF'
+Usage: check-mode-authority.sh [--root DIR] [--known FILE] [--no-controls] [-v]
+
+  --root DIR      tree to analyse (default: repository root)
+  --known FILE    allowlist of accepted violations
+                  (default: scripts/ci/mode-authority-known.txt)
+  --no-controls   skip the negative/positive controls (NOT for CI)
+  --fail-on MODE  drift  : fail on NEW violations only; MUST_FIX debt is
+                           reported loudly but does not block (ratchet mode)
+                  all    : fail on NEW *and* MUST_FIX (default; the end state
+                           once the BROKEN ledger rows are discharged)
+  -v              print every violation line, including known ones
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root)  REPO_ROOT="$(cd -- "$2" && pwd)"; shift 2 ;;
+        --known) KNOWN_FILE="$2"; shift 2 ;;
+        --no-controls) RUN_CONTROLS=0; shift ;;
+        --fail-on)
+            case "$2" in
+                drift|all) FAIL_ON="$2" ;;
+                *) echo "--fail-on expects 'drift' or 'all'" >&2; exit 2 ;;
+            esac
+            shift 2 ;;
+        -v|--verbose) VERBOSE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Contract constants
+# -----------------------------------------------------------------------------
+# The four user-facing mode values (ADR-0001 "Context").
+MODES=(auto classic suricata hybrid)
+# Modules that carry a mode and are tracked in the ledger.
+LEDGER_MODULES=(ddos portscan loginmon)
+
+# Mode-specific entrypoints. Format:
+#   module|mode|function|defining-file|scope
+# scope=external_file : shell libs are sourced units; the caller must live in a
+#                       DIFFERENT file, otherwise the function is dead weight.
+# scope=any_caller    : Go workers are called from their own package/file by
+#                       design (Module.Start), so "outside its file" would be a
+#                       false positive; any non-definition caller counts.
+ENTRYPOINTS=(
+  "portscan|classic|nftban_portscan_classic_run|cli/lib/nftban/core/nftban_portscan_classic.sh|external_file"
+  "portscan|suricata|nftban_portscan_suricata_run|cli/lib/nftban/core/nftban_portscan_suricata.sh|external_file"
+  "ddos|classic|nftban_ddos_classic_enable|cli/lib/nftban/core/nftban_ddos_classic.sh|external_file"
+  "ddos|suricata|nftban_ddos_suricata_process|cli/lib/nftban/core/nftban_ddos_suricata.sh|external_file"
+  "loginmon|classic|runJournalWatcher|internal/loginmon/module.go|any_caller"
+  "loginmon|suricata|runEVEWatcher|internal/loginmon/module.go|any_caller"
+)
+
+# Surfaces that advertise mode values to a human operator. A `BROKEN` ledger row
+# must not appear here without an explicit availability marker
+# (RUNTIME_MODE_AUTHORITY_CONTRACT.md, "Standing rule for BROKEN").
+declare -A HELP_SURFACES=(
+  [ddos]="cli/lib/nftban/cli/cmd_ddos.sh cli/lib/nftban/core/nftban_ddos.sh"
+  [portscan]="cli/lib/nftban/cli/cmd_portscan.sh cli/lib/nftban/core/nftban_portscan.sh"
+  [loginmon]="cli/lib/nftban/cli/cmd_login.sh cli/lib/nftban/core/nftban_login_suricata.sh"
+)
+SHARED_HELP_SURFACES="cli/lib/nftban/cli/cmd_modes.sh cli/lib/nftban/helpers/nftban_mode.sh install/bash-completion/nftban"
+# Words that make a mode listing honest rather than an advertisement.
+AVAILABILITY_MARKERS='unavailable|broken|BROKEN|experimental|EXPERIMENTAL|not supported|disabled'
+
+LEDGER_REL="docs/MODE_ADMISSION_LEDGER.md"
+
+# -----------------------------------------------------------------------------
+# Bookkeeping
+# -----------------------------------------------------------------------------
+TMPDIR_GUARD="$(mktemp -d "${TMPDIR:-/tmp}/mode-authority.XXXXXX")" || exit 2
+cleanup() { rm -rf "${TMPDIR_GUARD}"; }
+trap cleanup EXIT
+
+declare -A KNOWN_KEYS=()
+declare -A KNOWN_DISP=()
+declare -A KNOWN_STATUS=()
+declare -A KNOWN_HIT=()
+
+NEW_TOTAL=0
+KNOWN_TOTAL=0
+MUSTFIX_TOTAL=0
+NYV_TOTAL=0
+IN_CONTROL=0
+declare -A CHECK_NEW=()
+declare -A CHECK_KNOWN=()
+declare -A CHECK_MUSTFIX=()
+declare -A CHECK_CONTROL=()   # PASS | FAIL | SKIPPED
+
+say()  { printf '%s\n' "$*"; }
+head2() { printf '\n== %s\n' "$*"; }
+
+# Allowlist row format (TAB separated):
+#   KEY <TAB> DISPOSITION <TAB> LEDGER_STATUS <TAB> NOTE
+# DISPOSITION:
+#   ACCEPTED_DEBT — recorded, tracked, does NOT fail the build. Use only where
+#                   the ledger status is not BROKEN.
+#   MUST_FIX      — recorded and STILL FAILS the build. Used for rows the ledger
+#                   itself marks BROKEN: the contract's standing rule ("a BROKEN
+#                   mode must be hidden, rejected at validation, or explicitly
+#                   marked unavailable — never silently selectable") is an open
+#                   obligation, not accepted debt. Hiding it in an allowlist
+#                   would be exactly the failure this contract exists to stop.
+load_known() {
+    [[ -f "${KNOWN_FILE}" ]] || return 0
+    local line key disp status
+    while IFS= read -r line; do
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "${line}" == \#* ]] && continue
+        key="${line%%$'\t'*}"
+        disp="${line#*$'\t'}";   disp="${disp%%$'\t'*}"
+        status="${line#*$'\t'}"; status="${status#*$'\t'}"; status="${status%%$'\t'*}"
+        KNOWN_KEYS["${key}"]=1
+        KNOWN_DISP["${key}"]="${disp}"
+        KNOWN_STATUS["${key}"]="${status}"
+    done < "${KNOWN_FILE}"
+}
+
+# record CHECK KEY DETAIL — classifies against the allowlist and counts.
+record() {
+    local check="$1" key="$2" detail="$3"
+    # During controls the allowlist is ignored: a control must prove the check
+    # itself fires, not that the allowlist happens to name the fixture.
+    if [[ ${IN_CONTROL} -eq 1 || -z "${KNOWN_KEYS[${key}]:-}" ]]; then
+        CHECK_NEW["${check}"]=$(( ${CHECK_NEW[${check}]:-0} + 1 ))
+        NEW_TOTAL=$(( NEW_TOTAL + 1 ))
+        say "  NEW VIOLATION  ${key}"
+        say "                 ${detail}"
+        return
+    fi
+    KNOWN_HIT["${key}"]=1
+    if [[ "${KNOWN_DISP[${key}]}" == "MUST_FIX" ]]; then
+        CHECK_MUSTFIX["${check}"]=$(( ${CHECK_MUSTFIX[${check}]:-0} + 1 ))
+        MUSTFIX_TOTAL=$(( MUSTFIX_TOTAL + 1 ))
+        say "  MUST_FIX       ${key}"
+        say "                 ledger=${KNOWN_STATUS[${key}]} — ${detail}"
+        return
+    fi
+    CHECK_KNOWN["${check}"]=$(( ${CHECK_KNOWN[${check}]:-0} + 1 ))
+    KNOWN_TOTAL=$(( KNOWN_TOTAL + 1 ))
+    if [[ ${VERBOSE} -eq 1 ]]; then
+        say "  KNOWN          ${key}"
+        say "                 ledger=${KNOWN_STATUS[${key}]} — ${detail}"
+    fi
+}
+
+not_yet_verified() {
+    local what="$1" cmd="$2"
+    NYV_TOTAL=$(( NYV_TOTAL + 1 ))
+    say "  NOT_YET_VERIFIED  ${what}"
+    say "                    settle with: ${cmd}"
+}
+
+# =============================================================================
+# CHECK 1 — SILENT_NO_OP  (Lesson G)
+# =============================================================================
+# Scoping, stated so a reader can judge false positives:
+#
+#   `type -t F && F` is legitimate in plenty of places (optional helpers,
+#   logging shims, availability probes). It is a DEFECT only when it guards the
+#   branch that implements a selected mode, because then a missing F is
+#   indistinguishable from a successful detection cycle.
+#
+#   A construct is therefore flagged only when ALL FOUR hold:
+#     (a) it sits inside a function whose body contains a `case` with >= 2 of
+#         the labels auto|classic|suricata|hybrid  -> a MODE DISPATCH function;
+#     (b) the guarded name matches a mode entrypoint shape
+#         ^nftban_(portscan|ddos|login|loginmon)_(classic|suricata)_ ;
+#     (c) the guarded name is invoked as a BARE COMMAND inside the block
+#         (so `echo "$(fn_get_status)"` inside a branch is not flagged);
+#     (d) the guard has no `else`/`elif` arm at all, i.e. a missing F falls
+#         through with rc0.
+#
+#   A guard WITH an else arm is not flagged even if the arm is weak — deciding
+#   whether an else arm truly fails is left to review, and is listed under
+#   NOT_YET_VERIFIED below.
+#
+#   Function extent heuristic: `name() {` at column 0 to the next `}` at column
+#   0. This is the repo's uniform style; a file that departs from it would be
+#   under-scanned, not falsely flagged.
+# -----------------------------------------------------------------------------
+scan_silent_no_op() {
+    local root="$1" out="$2"
+    : > "${out}"
+    local f
+    while IFS= read -r f; do
+        awk -v FNAME="${f#"${root}"/}" '
+        function is_mode_label(s) {
+            return (s ~ /^[[:space:]]*(auto|classic|suricata|hybrid)(\|(auto|classic|suricata|hybrid))*\)[[:space:]]*$/)
+        }
+        { L[NR] = $0 }
+        END {
+            n = NR
+            for (i = 1; i <= n; i++) {
+                if (L[i] !~ /^[A-Za-z_][A-Za-z0-9_]*\(\)[[:space:]]*\{[[:space:]]*$/) continue
+                fname = L[i]; sub(/\(\).*/, "", fname)
+                e = 0
+                for (j = i + 1; j <= n; j++) if (L[j] ~ /^\}[[:space:]]*$/) { e = j; break }
+                if (e == 0) continue
+
+                # (a) is this a mode dispatch function?
+                delete seen; cnt = 0
+                for (k = i; k <= e; k++) {
+                    if (!is_mode_label(L[k])) continue
+                    lbl = L[k]; gsub(/[[:space:]]|\)/, "", lbl)
+                    if (!(lbl in seen)) { seen[lbl] = 1; cnt++ }
+                }
+                if (cnt < 2) { i = e; continue }
+
+                for (k = i; k <= e; k++) {
+                    line = L[k]
+                    if (!match(line, /(type -t|declare -F)[[:space:]]+[A-Za-z0-9_]+/)) continue
+                    g = substr(line, RSTART, RLENGTH)
+                    sub(/^(type -t|declare -F)[[:space:]]+/, "", g)
+                    # (b) mode entrypoint shape
+                    if (g !~ /^nftban_(portscan|ddos|login|loginmon)_(classic|suricata)_/) continue
+
+                    if (line !~ /^[[:space:]]*if[[:space:]]/) {
+                        # bare `type -t F ... && F` — the canonical Lesson G form
+                        if (line ~ /&&/)
+                            printf "%s\t%d\t%s\t%s\t%s\n", FNAME, k, fname, g, "ANDAND"
+                        continue
+                    }
+                    # if-guard: locate the matching fi, note any else/elif at depth 1
+                    depth = 1; hasElse = 0; fi = 0
+                    for (m = k + 1; m <= e; m++) {
+                        if (L[m] ~ /^[[:space:]]*if[[:space:]]/) depth++
+                        else if (L[m] ~ /^[[:space:]]*fi[[:space:]]*$/) {
+                            depth--
+                            if (depth == 0) { fi = m; break }
+                        } else if (depth == 1 && L[m] ~ /^[[:space:]]*(else|elif)([[:space:]]|$)/) hasElse = 1
+                    }
+                    if (fi == 0) continue
+                    # (c) bare invocation inside the guarded block
+                    bare = 0
+                    for (m = k + 1; m < fi; m++)
+                        if (L[m] ~ ("^[[:space:]]*" g "([[:space:]]*$|[[:space:]]|;|\\||&)")) bare = 1
+                    if (!bare) continue
+                    # (d) no else arm at all
+                    if (!hasElse)
+                        printf "%s\t%d\t%s\t%s\t%s\n", FNAME, k, fname, g, "IF_NO_ELSE"
+                }
+                i = e
+            }
+        }' "${f}" >> "${out}"
+    done < <(find "${root}/cli" "${root}/install" -name '*.sh' -type f 2>/dev/null | sort)
+}
+
+check_silent_no_op() {
+    local root="$1" raw="${TMPDIR_GUARD}/sno.$$.tsv"
+    scan_silent_no_op "${root}" "${raw}"
+    # collapse to one key per (file, dispatcher, guarded fn); keep all line numbers
+    local key file line disp fn kind lines
+    while IFS= read -r key; do
+        file="${key%%|*}"; local rest="${key#*|}"
+        disp="${rest%%|*}"; fn="${rest#*|}"
+        lines="$(awk -F'\t' -v f="${file}" -v d="${disp}" -v g="${fn}" \
+                  '$1==f && $3==d && $4==g {printf "%s%s", (c++?",":""), $2}' "${raw}")"
+        kind="$(awk -F'\t' -v f="${file}" -v d="${disp}" -v g="${fn}" \
+                  '$1==f && $3==d && $4==g {print $5; exit}' "${raw}")"
+        record SILENT_NO_OP "SILENT_NO_OP|${file}|${disp}|${fn}" \
+               "${file}:${lines} dispatcher=${disp}() guarded=${fn} form=${kind} (missing fn => rc0 no-op)"
+    done < <(awk -F'\t' '{print $1"|"$3"|"$4}' "${raw}" | sort -u)
+    # keep unused-var warnings quiet and the parse honest
+    : "${line:-}"
+}
+
+# =============================================================================
+# CHECK 2 — ORPHAN_ENTRYPOINT  (Lesson C)
+# =============================================================================
+# Caller corpus exclusions, stated so a reader can judge:
+#   - the defining file itself (a self-call is not reachability)
+#   - `export -f` lines (Lesson C: export is not a caller)
+#   - comment lines
+#   - this guard script and its allowlist (they name the functions as data)
+#   - tests/ and *_test.sh / *_test.go — the contract is explicit that "a
+#     synthetic direct call to a private helper does not promote a row", so a
+#     test caller does not count as production reachability.
+# -----------------------------------------------------------------------------
+orphan_callers() {
+    local root="$1" fn="$2" defpath="$3" scope="$4"
+    if [[ "${scope}" == "external_file" ]]; then
+        grep -rnE "(^|[^A-Za-z0-9_])${fn}([^A-Za-z0-9_]|$)" \
+             --include='*.sh' "${root}/cli" "${root}/install" "${root}/scripts" 2>/dev/null \
+          | grep -v "^${defpath}:" \
+          | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
+          | grep -v 'export -f' \
+          | grep -vE '(^|/)(tests?)/|_test\.sh:' \
+          | grep -v 'check-mode-authority\.sh:' \
+          | grep -v 'mode-authority-known' || true
+    else
+        grep -rnE "(^|[^A-Za-z0-9_.])(m|g|s)?\.?${fn}\(" \
+             --include='*.go' "$(dirname "${defpath}")" 2>/dev/null \
+          | grep -vE "func[[:space:]]*\([^)]*\)[[:space:]]*${fn}\(" \
+          | grep -vE '^[^:]*:[0-9]+:[[:space:]]*//' \
+          | grep -v '_test\.go:' || true
+    fi
+}
+
+check_orphan_entrypoint() {
+    local root="$1" row module mode fn deffile scope callers defpath
+    for row in "${ENTRYPOINTS[@]}"; do
+        IFS='|' read -r module mode fn deffile scope <<< "${row}"
+        defpath="${root}/${deffile}"
+        if [[ ! -f "${defpath}" ]]; then
+            say "  SKIP   ${module}/${mode} ${fn} — defining file absent: ${deffile}"
+            continue
+        fi
+        callers="$(orphan_callers "${root}" "${fn}" "${defpath}" "${scope}")"
+        if [[ -z "${callers}" ]]; then
+            record ORPHAN_ENTRYPOINT "ORPHAN_ENTRYPOINT|${module}|${mode}|${fn}" \
+                   "defined ${deffile} — zero callers (scope=${scope}; definition and 'export -f' excluded). Mode name resolves to nothing."
+        else
+            say "  ok     ${module}/${mode} ${fn} — $(printf '%s\n' "${callers}" | wc -l) caller line(s), scope=${scope}"
+        fi
+    done
+}
+
+# =============================================================================
+# CHECK 3 — LEDGER_CONSISTENCY
+# =============================================================================
+check_ledger() {
+    local root="$1"
+    local ledger="${root}/${LEDGER_REL}"
+    if [[ ! -f "${ledger}" ]]; then
+        record LEDGER_CONSISTENCY "LEDGER_CONSISTENCY|missing|ledger|${LEDGER_REL}" \
+               "ledger file not found — the contract requires one row per module x mode"
+        return
+    fi
+    local rows="${TMPDIR_GUARD}/ledger.$$.tsv"
+    awk -F'|' '
+        NF >= 5 && $2 ~ /[A-Za-z]/ {
+            m = $2; md = $3; st = $4
+            gsub(/[[:space:]`*]/, "", m); gsub(/[[:space:]`*]/, "", md)
+            m = tolower(m); md = tolower(md)
+            if (md !~ /^(auto|classic|suricata|hybrid)$/) next
+            broken = (st ~ /BROKEN/) ? "BROKEN" : "OK"
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", st)
+            printf "%s\t%s\t%s\t%s\n", m, md, broken, st
+        }' "${ledger}" > "${rows}"
+
+    # 3a — completeness: every module x mode must have a row
+    local module mode
+    for module in "${LEDGER_MODULES[@]}"; do
+        for mode in "${MODES[@]}"; do
+            if ! awk -F'\t' -v m="${module}" -v d="${mode}" \
+                 'tolower($1)==m && $2==d {found=1} END{exit !found}' "${rows}"; then
+                record LEDGER_CONSISTENCY "LEDGER_MISSING_ROW|${module}|${mode}|-" \
+                       "${LEDGER_REL} has no row for ${module} x ${mode} — undeclared mode (contract: 'Absence from this ledger means unassessed, not healthy')"
+            fi
+        done
+    done
+
+    # 3b — a BROKEN mode must not be advertised without an availability marker
+    local brk surfaces s hits
+    while IFS=$'\t' read -r module mode brk _st; do
+        [[ "${brk}" == "BROKEN" ]] || continue
+        surfaces="${HELP_SURFACES[${module}]:-} ${SHARED_HELP_SURFACES}"
+        for s in ${surfaces}; do
+            [[ -f "${root}/${s}" ]] || continue
+            # A line "advertises the mode vocabulary" when it names >= 2 distinct
+            # mode values on one line (covers `auto|classic|suricata|hybrid`,
+            # `auto, classic, suricata, hybrid`, and compgen word lists) AND names
+            # this mode. Pure comment lines are excluded; so are lines already
+            # carrying an availability marker.
+            hits="$(awk -v md="${mode}" -v markers="${AVAILABILITY_MARKERS}" '
+                /^[[:space:]]*#/ { next }
+                {
+                    c = 0
+                    if ($0 ~ /(^|[^a-z])auto([^a-z]|$)/)     c++
+                    if ($0 ~ /(^|[^a-z])classic([^a-z]|$)/)  c++
+                    if ($0 ~ /(^|[^a-z])suricata([^a-z]|$)/) c++
+                    if ($0 ~ /(^|[^a-z])hybrid([^a-z]|$)/)   c++
+                    if (c < 2) next
+                    if ($0 !~ ("(^|[^a-z])" md "([^a-z]|$)")) next
+                    if ($0 ~ markers) next
+                    print NR ":" $0
+                }' "${root}/${s}" 2>/dev/null || true)"
+            [[ -z "${hits}" ]] && continue
+            record LEDGER_CONSISTENCY "LEDGER_BROKEN_ADVERTISED|${module}|${mode}|${s}" \
+                   "ledger says ${module}/${mode}=BROKEN but ${s} advertises the mode list with no availability marker at line(s): $(printf '%s\n' "${hits}" | cut -d: -f1 | paste -sd, -)"
+        done
+    done < "${rows}"
+
+    # 3c — statuses this guard cannot decide
+    not_yet_verified "ledger rows above STATICALLY_REACHABLE (FIXTURE_PROVEN / TRAFFIC_PROVEN / SUSTAINED) cannot be confirmed statically" \
+        "on a live target: nftban portscan mode set suricata && nftban portscan check && nft list set ip nftban portscan_offenders"
+}
+
+# =============================================================================
+# CHECK 4 — MARKRUNNING_LIVENESS  (Lesson B)  — APPROXIMATION
+# =============================================================================
+# This is explicitly a static approximation. It cannot observe a goroutine.
+# What it does decide:
+#   for every function containing `MarkRunning()`, take every `go <recv>.<w>(`
+#   launched in that same function; resolve <w> in the same package; and flag
+#   <w> when its body contains a `return` that is NOT the ctx.Done() shutdown
+#   path AND the body contains no status transition
+#   (MarkStopped|MarkDegraded|MarkFailed|MarkNotRunning).
+# Meaning of a hit: "this worker has an exit path after which module status can
+# still read RUNNING". It does not prove the path is taken at runtime.
+# -----------------------------------------------------------------------------
+check_markrunning() {
+    local root="$1" f
+    local found=0
+    while IFS= read -r f; do
+        [[ "${f}" == *_test.go ]] && continue
+        local pkgdir; pkgdir="$(dirname "${f}")"
+        local rel="${f#"${root}"/}"
+        local starters; starters="$(awk '
+            /^func /{ fn=$0; sub(/^func +(\([^)]*\) *)?/, "", fn); sub(/\(.*/, "", fn); start=NR; body="" ; inb=1 }
+            inb { buf[NR]=$0 }
+            /^}/ && inb { for (i=start;i<=NR;i++) body = body buf[i] "\n"
+                          if (body ~ /MarkRunning\(\)/) {
+                              nlines = split(body, arr, "\n")
+                              for (i=1;i<=nlines;i++)
+                                  if (arr[i] ~ /^[[:space:]]*go [A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\(/) {
+                                      w = arr[i]; sub(/^[[:space:]]*go [A-Za-z_][A-Za-z0-9_]*\./, "", w); sub(/\(.*/, "", w)
+                                      print fn "\t" w
+                                  }
+                          }
+                          inb=0; delete buf }
+        ' "${f}" | sort -u)"
+        [[ -z "${starters}" ]] && continue
+        local startfn worker wbody
+        while IFS=$'\t' read -r startfn worker; do
+            [[ -z "${worker}" ]] && continue
+            found=1
+            wbody="$(awk -v W="${worker}" '
+                $0 ~ ("^func +(\\([^)]*\\) *)?" W "\\(") { inb=1 }
+                inb { print }
+                inb && /^}/ { inb=0 }
+            ' "${pkgdir}"/*.go 2>/dev/null)"
+            if [[ -z "${wbody}" ]]; then
+                not_yet_verified "worker ${worker} launched from ${rel}:${startfn} not resolvable in package $(basename "${pkgdir}")" \
+                    "grep -rn 'func.*${worker}(' ${pkgdir}"
+                continue
+            fi
+            if printf '%s' "${wbody}" | grep -qE 'Mark(Stopped|Degraded|Failed|NotRunning)\('; then
+                say "  ok     ${rel}:${startfn}() -> ${worker}() has a status transition"
+                continue
+            fi
+            # a `return` that is not the ctx.Done() shutdown path
+            local risky
+            risky="$(printf '%s\n' "${wbody}" | awk '
+                /ctx\.Done\(\)|<-ctx\.Done/ { guard = NR }
+                /^[[:space:]]*return[[:space:]]*$|^[[:space:]]*return [^ ]/ {
+                    if (guard == "" || NR - guard > 4) print NR
+                }')"
+            if [[ -n "${risky}" ]]; then
+                record MARKRUNNING_LIVENESS "MARKRUNNING_LIVENESS|${rel}|${startfn}|${worker}" \
+                       "${startfn}() calls MarkRunning() then 'go ...${worker}()'; ${worker}() returns on a non-ctx.Done path with no Mark{Stopped,Degraded,Failed} — status can stay RUNNING with a dead worker (STATIC APPROXIMATION)"
+            else
+                say "  ok     ${rel}:${startfn}() -> ${worker}() has no non-shutdown early return"
+            fi
+        done <<< "${starters}"
+    done < <(find "${root}/internal" "${root}/cmd" -name '*.go' -type f 2>/dev/null | sort)
+    if [[ ${found} -eq 0 ]]; then
+        not_yet_verified "no MarkRunning()+goroutine pair found under internal/ or cmd/ — check did not exercise" \
+            "grep -rn 'MarkRunning()' --include='*.go' ${root}"
+    fi
+    not_yet_verified "whether a flagged worker's exit path is actually reached, and whether health reports it, is a RUNTIME question" \
+        "on a live target: systemctl stop suricata && rm -f /var/log/suricata/eve.json && systemctl restart nftban && nftban login status --json | jq '.running,.healthy'"
+}
+
+# =============================================================================
+# CONTROLS — every check must be seen to fail (Lesson H)
+# =============================================================================
+# Each control builds a synthetic tree under a temp dir and asserts the SCANNER
+# behaves. Controls call the scanners directly (not `record`), so the counters
+# of the real run are untouched.
+
+ctl_pass() { CHECK_CONTROL["$1"]=PASS; say "  control  $1: NEGATIVE CONTROL FIRED (+ positive control clean) -> check is falsifiable"; }
+ctl_fail() { CHECK_CONTROL["$1"]=FAIL; say "  control  $1: NEGATIVE CONTROL DID NOT FIRE -> check reported NOT_YET_VERIFIED, not PASS"; }
+
+control_silent_no_op() {
+    local bad="${TMPDIR_GUARD}/nc1/bad" good="${TMPDIR_GUARD}/nc1/good"
+    mkdir -p "${bad}/cli" "${bad}/install" "${good}/cli" "${good}/install"
+    cat > "${bad}/cli/dispatch.sh" <<'EOF'
+#!/usr/bin/env bash
+nftban_fixture_run() {
+    case "$mode" in
+        classic)
+            if type -t nftban_portscan_classic_run &>/dev/null; then
+                nftban_portscan_classic_run
+            fi
+            ;;
+        suricata)
+            type -t nftban_portscan_suricata_run &>/dev/null && nftban_portscan_suricata_run
+            ;;
+    esac
+    return 0
+}
+EOF
+    # good tree: same dispatcher, but a missing entrypoint FAILS (contract-compliant)
+    cat > "${good}/cli/dispatch.sh" <<'EOF'
+#!/usr/bin/env bash
+nftban_fixture_run() {
+    case "$mode" in
+        classic)
+            if type -t nftban_portscan_classic_run &>/dev/null; then
+                nftban_portscan_classic_run
+            else
+                echo "FAILED: classic entrypoint missing" >&2
+                return 1
+            fi
+            ;;
+        suricata)
+            if type -t nftban_portscan_suricata_run &>/dev/null; then
+                nftban_portscan_suricata_run
+            else
+                return 1
+            fi
+            ;;
+    esac
+}
+# non-dispatch context: legitimate optional helper, must NOT be flagged
+nftban_fixture_helper() {
+    if type -t nftban_portscan_classic_render &>/dev/null; then
+        nftban_portscan_classic_render
+    fi
+}
+EOF
+    local rb="${TMPDIR_GUARD}/nc1.bad.tsv" rg="${TMPDIR_GUARD}/nc1.good.tsv"
+    scan_silent_no_op "${bad}" "${rb}"
+    scan_silent_no_op "${good}" "${rg}"
+    local nb ng
+    nb="$(wc -l < "${rb}")"; ng="$(wc -l < "${rg}")"
+    say "  control  SILENT_NO_OP: bad-tree hits=${nb} (expect >=2), clean-tree hits=${ng} (expect 0)"
+    if [[ "${nb}" -ge 2 && "${ng}" -eq 0 ]]; then ctl_pass SILENT_NO_OP; else ctl_fail SILENT_NO_OP; fi
+}
+
+control_orphan_entrypoint() {
+    local bad="${TMPDIR_GUARD}/nc2/bad" good="${TMPDIR_GUARD}/nc2/good" d
+    for d in "${bad}" "${good}"; do
+        mkdir -p "${d}/cli/lib/nftban/core" "${d}/install" "${d}/scripts"
+        cat > "${d}/cli/lib/nftban/core/nftban_portscan_classic.sh" <<'EOF'
+#!/usr/bin/env bash
+nftban_portscan_classic_run() { return 0; }
+export -f nftban_portscan_classic_run
+EOF
+    done
+    cat > "${good}/cli/lib/nftban/core/nftban_portscan.sh" <<'EOF'
+#!/usr/bin/env bash
+nftban_portscan_run() { nftban_portscan_classic_run; }
+EOF
+    local nb ng
+    nb="$(CHECK_ORPHAN_PROBE=1 probe_orphan "${bad}")"
+    ng="$(CHECK_ORPHAN_PROBE=1 probe_orphan "${good}")"
+    say "  control  ORPHAN_ENTRYPOINT: no-caller tree flagged=${nb} (expect 1), with-caller tree flagged=${ng} (expect 0)"
+    if [[ "${nb}" -eq 1 && "${ng}" -eq 0 ]]; then ctl_pass ORPHAN_ENTRYPOINT; else ctl_fail ORPHAN_ENTRYPOINT; fi
+}
+
+# probe_orphan ROOT — returns how many of the ENTRYPOINTS rows PRESENT in ROOT are orphaned.
+probe_orphan() {
+    local root="$1" row module mode fn deffile scope defpath callers n=0
+    for row in "${ENTRYPOINTS[@]}"; do
+        IFS='|' read -r module mode fn deffile scope <<< "${row}"
+        defpath="${root}/${deffile}"
+        [[ -f "${defpath}" ]] || continue
+        callers="$(orphan_callers "${root}" "${fn}" "${defpath}" "${scope}")"
+        [[ -z "${callers}" ]] && n=$(( n + 1 ))
+    done
+    printf '%s' "${n}"
+}
+
+control_ledger() {
+    local bad="${TMPDIR_GUARD}/nc3/bad"
+    mkdir -p "${bad}/docs" "${bad}/cli/lib/nftban/cli"
+    cat > "${bad}/${LEDGER_REL}" <<'EOF'
+| Module | Mode | Status | Evidence |
+|---|---|---|---|
+| DDoS | classic | `DECLARED` | fixture |
+| DDoS | suricata | **`BROKEN`** | fixture |
+EOF
+    cat > "${bad}/cli/lib/nftban/cli/cmd_ddos.sh" <<'EOF'
+echo "    mode   Show or set protection mode (auto|classic|suricata|hybrid)"
+EOF
+    local before_new=${NEW_TOTAL} before_nyv=${NYV_TOTAL} hits
+    local before_mf=${MUSTFIX_TOTAL} before_k=${KNOWN_TOTAL}
+    check_ledger "${bad}" > "${TMPDIR_GUARD}/nc3.out" 2>&1
+    hits=$(( NEW_TOTAL - before_new ))
+    NEW_TOTAL=${before_new}; NYV_TOTAL=${before_nyv}
+    MUSTFIX_TOTAL=${before_mf}; KNOWN_TOTAL=${before_k}
+    CHECK_NEW[LEDGER_CONSISTENCY]=0
+    CHECK_MUSTFIX[LEDGER_CONSISTENCY]=0
+    CHECK_KNOWN[LEDGER_CONSISTENCY]=0
+    local missing advertised
+    missing="$(grep -c 'LEDGER_MISSING_ROW' "${TMPDIR_GUARD}/nc3.out" || true)"
+    advertised="$(grep -c 'LEDGER_BROKEN_ADVERTISED' "${TMPDIR_GUARD}/nc3.out" || true)"
+    say "  control  LEDGER_CONSISTENCY: fixture flagged total=${hits} (missing-row=${missing}, broken-advertised=${advertised}); expect missing-row>=10 and broken-advertised>=1"
+    if [[ "${missing}" -ge 10 && "${advertised}" -ge 1 ]]; then ctl_pass LEDGER_CONSISTENCY; else ctl_fail LEDGER_CONSISTENCY; fi
+}
+
+control_markrunning() {
+    local bad="${TMPDIR_GUARD}/nc4/bad" good="${TMPDIR_GUARD}/nc4/good"
+    mkdir -p "${bad}/internal/fixture" "${good}/internal/fixture"
+    cat > "${bad}/internal/fixture/mod.go" <<'EOF'
+package fixture
+
+func (m *Module) Start(ctx context.Context) error {
+	m.status.MarkRunning()
+	go m.runEVEWatcherFixture(ctx)
+	return nil
+}
+
+func (m *Module) runEVEWatcherFixture(ctx context.Context) {
+	f, err := os.Open("/var/log/suricata/eve.json")
+	if err != nil {
+		m.status.RecordError(err)
+		return
+	}
+	_ = f
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+EOF
+    cat > "${good}/internal/fixture/mod.go" <<'EOF'
+package fixture
+
+func (m *Module) Start(ctx context.Context) error {
+	m.status.MarkRunning()
+	go m.runEVEWatcherFixture(ctx)
+	return nil
+}
+
+func (m *Module) runEVEWatcherFixture(ctx context.Context) {
+	f, err := os.Open("/var/log/suricata/eve.json")
+	if err != nil {
+		m.status.RecordError(err)
+		m.status.MarkStopped()
+		return
+	}
+	_ = f
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+EOF
+    local before_new=${NEW_TOTAL} before_nyv=${NYV_TOTAL} nb ng
+    local before_mf=${MUSTFIX_TOTAL} before_k=${KNOWN_TOTAL}
+    check_markrunning "${bad}" > "${TMPDIR_GUARD}/nc4.bad.out" 2>&1
+    nb=$(( NEW_TOTAL - before_new )); NEW_TOTAL=${before_new}; NYV_TOTAL=${before_nyv}
+    check_markrunning "${good}" > "${TMPDIR_GUARD}/nc4.good.out" 2>&1
+    ng=$(( NEW_TOTAL - before_new )); NEW_TOTAL=${before_new}; NYV_TOTAL=${before_nyv}
+    MUSTFIX_TOTAL=${before_mf}; KNOWN_TOTAL=${before_k}
+    CHECK_NEW[MARKRUNNING_LIVENESS]=0
+    CHECK_MUSTFIX[MARKRUNNING_LIVENESS]=0
+    CHECK_KNOWN[MARKRUNNING_LIVENESS]=0
+    say "  control  MARKRUNNING_LIVENESS: no-transition fixture flagged=${nb} (expect 1), MarkStopped fixture flagged=${ng} (expect 0)"
+    if [[ "${nb}" -eq 1 && "${ng}" -eq 0 ]]; then ctl_pass MARKRUNNING_LIVENESS; else ctl_fail MARKRUNNING_LIVENESS; fi
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+load_known
+
+say "NFTBan mode-authority static guard"
+say "  root         : ${REPO_ROOT}"
+say "  allowlist    : ${KNOWN_FILE} ($(( ${#KNOWN_KEYS[@]} )) accepted row(s))"
+say "  authority    : docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md, docs/MODE_ADMISSION_LEDGER.md, docs/adr/ADR-0001-runtime-mode-authority.md"
+say "  scope note   : static only. Static reachability is 1 of the 6 promotion"
+say "                 requirements in MODE_ADMISSION_LEDGER.md. A clean run of this"
+say "                 guard never promotes a ledger row."
+
+head2 "CONTROLS (each check must be seen to fail before its result is trusted)"
+if [[ ${RUN_CONTROLS} -eq 1 ]]; then
+    IN_CONTROL=1
+    control_silent_no_op
+    control_orphan_entrypoint
+    control_ledger
+    control_markrunning
+    IN_CONTROL=0
+    KNOWN_HIT=()
+else
+    for c in SILENT_NO_OP ORPHAN_ENTRYPOINT LEDGER_CONSISTENCY MARKRUNNING_LIVENESS; do
+        CHECK_CONTROL["${c}"]=SKIPPED
+    done
+    say "  controls skipped (--no-controls) — all results downgraded to NOT_YET_VERIFIED"
+fi
+
+head2 "CHECK 1 — SILENT_NO_OP (Lesson G: selected mode + missing entrypoint must never be rc0)"
+say "  scoped to: functions containing a case with >=2 of auto|classic|suricata|hybrid;"
+say "             guarded name matching ^nftban_(portscan|ddos|login|loginmon)_(classic|suricata)_;"
+say "             guarded name invoked as a bare command; and NO else/elif arm."
+check_silent_no_op "${REPO_ROOT}"
+not_yet_verified "guards that DO have an else arm are not inspected for whether the arm truly fails" \
+    "review by hand: grep -n 'type -t nftban_.*_\\(classic\\|suricata\\)_' -A6 cli/lib/nftban/core/nftban_{ddos,portscan}.sh"
+
+head2 "CHECK 2 — ORPHAN_ENTRYPOINT (Lesson C: existence and export are not reachability)"
+check_orphan_entrypoint "${REPO_ROOT}"
+not_yet_verified "a caller existing in source does not prove the shipped lifecycle reaches it" \
+    "on a live target: systemctl list-timers 'nftban*' && bash -x /usr/lib/nftban/core/nftban_portscan.sh 2>&1 | grep _run"
+
+head2 "CHECK 3 — LEDGER_CONSISTENCY (row completeness + BROKEN must not be advertised)"
+check_ledger "${REPO_ROOT}"
+
+head2 "CHECK 4 — MARKRUNNING_LIVENESS (Lesson B: started is not running) [STATIC APPROXIMATION]"
+check_markrunning "${REPO_ROOT}"
+
+# -----------------------------------------------------------------------------
+# Stale allowlist rows
+# -----------------------------------------------------------------------------
+head2 "ALLOWLIST HYGIENE"
+STALE=0
+for k in "${!KNOWN_KEYS[@]}"; do
+    if [[ -z "${KNOWN_HIT[${k}]:-}" ]]; then
+        say "  STALE  ${k}  (ledger=${KNOWN_STATUS[${k}]}) — no longer detected; remove it from $(basename "${KNOWN_FILE}")"
+        STALE=$(( STALE + 1 ))
+    fi
+done
+[[ ${STALE} -eq 0 ]] && say "  no stale rows (${#KNOWN_KEYS[@]}/${#KNOWN_KEYS[@]} accepted rows still reproduce)"
+
+# -----------------------------------------------------------------------------
+# Machine-readable summary
+# -----------------------------------------------------------------------------
+head2 "MACHINE-READABLE SUMMARY"
+RC=0
+for c in SILENT_NO_OP ORPHAN_ENTRYPOINT LEDGER_CONSISTENCY MARKRUNNING_LIVENESS; do
+    new="${CHECK_NEW[${c}]:-0}"
+    known="${CHECK_KNOWN[${c}]:-0}"
+    mustfix="${CHECK_MUSTFIX[${c}]:-0}"
+    ctl="${CHECK_CONTROL[${c}]:-SKIPPED}"
+    if [[ "${ctl}" != "PASS" ]]; then
+        result="NOT_YET_VERIFIED"
+    elif [[ "${new}" -gt 0 ]]; then
+        result="FAIL"
+        RC=1
+    elif [[ "${mustfix}" -gt 0 ]]; then
+        # MUST_FIX = a violation whose ledger row is BROKEN. In `all` (default)
+        # it blocks, which is the contract's end state. In `drift` it is still
+        # printed as FAIL and still counted — it just does not gate unrelated
+        # PRs while the obligation is open. It is never downgraded to PASS and
+        # never silently accepted: that would be the exact failure this guard
+        # exists to prevent.
+        result="FAIL"
+        [[ "${FAIL_ON}" == "all" ]] && RC=1
+    else
+        result="PASS"
+    fi
+    printf 'MODE_AUTHORITY_CHECK=%s RESULT=%s NEW=%s MUST_FIX=%s ACCEPTED_DEBT=%s NEGATIVE_CONTROL=%s\n' \
+        "${c}" "${result}" "${new}" "${mustfix}" "${known}" "${ctl}"
+done
+printf 'MODE_AUTHORITY_STALE_ALLOWLIST_ROWS=%s\n' "${STALE}"
+printf 'MODE_AUTHORITY_NOT_YET_VERIFIED=%s\n' "${NYV_TOTAL}"
+printf 'MODE_AUTHORITY_NEW_VIOLATIONS=%s\n' "${NEW_TOTAL}"
+printf 'MODE_AUTHORITY_MUST_FIX_VIOLATIONS=%s\n' "${MUSTFIX_TOTAL}"
+printf 'MODE_AUTHORITY_ACCEPTED_DEBT=%s\n' "${KNOWN_TOTAL}"
+printf 'MODE_AUTHORITY_FAIL_ON=%s\n' "${FAIL_ON}"
+# NEW drift and a stale allowlist always block. MUST_FIX blocks only under the
+# default --fail-on all; under --fail-on drift it stays visible and counted but
+# does not gate. It is never downgraded to PASS.
+if [[ ${NEW_TOTAL} -gt 0 || ${STALE} -gt 0 ]]; then RC=1; fi
+if [[ ${MUSTFIX_TOTAL} -gt 0 && "${FAIL_ON}" == "all" ]]; then RC=1; fi
+printf 'MODE_AUTHORITY_RESULT=%s\n' "$([[ ${RC} -eq 0 ]] && echo PASS || echo FAIL)"
+exit "${RC}"

--- a/scripts/ci/mode-authority-known.txt
+++ b/scripts/ci/mode-authority-known.txt
@@ -1,0 +1,85 @@
+# =============================================================================
+# mode-authority-known.txt — accepted / tracked violations for
+# scripts/ci/check-mode-authority.sh
+# =============================================================================
+#
+# Authority for every LEDGER_STATUS below: docs/MODE_ADMISSION_LEDGER.md
+#                                          ("Current state — v1.228.0" table)
+# Contract:                                docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md
+# Decision:                                docs/adr/ADR-0001-runtime-mode-authority.md
+#
+# Populated 2026-07-26 from a full guard run on branch
+# docs/runtime-mode-authority-doctrine. Every row below was OBSERVED by the
+# guard on that run; none is speculative.
+#
+# Format (TAB separated, 4 fields):
+#   KEY <TAB> DISPOSITION <TAB> LEDGER_STATUS <TAB> NOTE
+#
+# DISPOSITION:
+#   ACCEPTED_DEBT  recorded and tracked; does NOT fail the build. Permitted only
+#                  where the corresponding ledger row is not BROKEN.
+#   MUST_FIX       recorded and STILL FAILS the build. Used where the ledger
+#                  marks the row BROKEN. The contract's standing rule — "a BROKEN
+#                  mode must be hidden from help, rejected at config validation,
+#                  or explicitly marked unavailable; it must never be silently
+#                  selectable" — is an open obligation. Allowlisting it to green
+#                  would be precisely the failure mode this contract exists to
+#                  stop, so these rows are tracked in the open, not hidden.
+#
+# The guard also fails if a row here stops reproducing (STALE), so this file
+# cannot silently outlive the defect it records.
+#
+# HOW TO CLEAR A ROW
+#   SILENT_NO_OP        give the guard an `else` arm that returns non-zero and
+#                       emits a machine-readable reason (Lesson G).
+#   ORPHAN_ENTRYPOINT   add a real production caller, or delete the function and
+#                       remove the mode from config/help (Lesson C).
+#   LEDGER_*            fix the ledger row, or mark the mode unavailable/broken
+#                       on the surface named in the key.
+#   MARKRUNNING_*       transition status off RUNNING when the worker exits
+#                       (Lesson B), then re-run the guard.
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# CHECK 1 — SILENT_NO_OP  (Lesson G)
+# All nine are `if type -t <entrypoint>; then <entrypoint>; fi` with no else arm
+# inside a mode-dispatch function: a missing entrypoint returns rc0 and the
+# operation reports success having done nothing.
+# -----------------------------------------------------------------------------
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_run|nftban_portscan_classic_run	ACCEPTED_DEBT	PortScan/classic=STATICALLY_REACHABLE	nftban_portscan.sh:975,985 (classic + hybrid branches). The dispatcher named in ADR-0001 "Context" para 4. Detection cycle no-ops silently if the classic module was not sourced.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_run|nftban_portscan_suricata_run	ACCEPTED_DEBT	PortScan/suricata=STATICALLY_REACHABLE	nftban_portscan.sh:980,988 (suricata + hybrid branches). Same defect on the Suricata branch.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_enable|nftban_portscan_classic_enable	ACCEPTED_DEBT	PortScan/hybrid=DECLARED	nftban_portscan.sh:430 — hybrid branch only; the classic and suricata branches DO have failing else arms (406,418), so this is the hybrid gap Lesson F warns about.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_enable|nftban_portscan_suricata_enable	ACCEPTED_DEBT	PortScan/hybrid=DECLARED	nftban_portscan.sh:433 — hybrid branch only.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_disable|nftban_portscan_classic_disable	ACCEPTED_DEBT	PortScan/classic=STATICALLY_REACHABLE	nftban_portscan.sh:506,516 — disable reports success even when nothing was torn down. Teardown truth matters as much as enable truth.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_portscan.sh|nftban_portscan_disable|nftban_portscan_suricata_disable	ACCEPTED_DEBT	PortScan/suricata=STATICALLY_REACHABLE	nftban_portscan.sh:511,519 — same on the Suricata branch.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_ddos.sh|nftban_ddos_enable|nftban_ddos_classic_enable	ACCEPTED_DEBT	DDoS/hybrid=DECLARED	nftban_ddos.sh:289 — hybrid Layer-0 branch only; the classic branch (259) and suricata branch (274) both have failing else arms.
+SILENT_NO_OP|cli/lib/nftban/core/nftban_ddos.sh|nftban_ddos_status|nftban_ddos_classic_status	ACCEPTED_DEBT	DDoS/classic=STATICALLY_REACHABLE (partial traffic)	nftban_ddos.sh:586 — status renders nothing rather than reporting that the classic status provider is absent (Lesson E: health must be able to report failure).
+SILENT_NO_OP|cli/lib/nftban/core/nftban_ddos.sh|nftban_ddos_status|nftban_ddos_suricata_status	ACCEPTED_DEBT	DDoS/suricata=BROKEN	nftban_ddos.sh:591 — status silently omits the Suricata section. Kept ACCEPTED_DEBT rather than MUST_FIX because the advertising violation for DDoS/suricata is already tracked under LEDGER_BROKEN_ADVERTISED below; fixing that is the blocking work.
+
+# -----------------------------------------------------------------------------
+# CHECK 2 — ORPHAN_ENTRYPOINT  (Lesson C)
+# This is the guard's calibration case. If this row ever stops reproducing
+# without a corresponding ledger promotion, the guard has silently broken.
+# -----------------------------------------------------------------------------
+ORPHAN_ENTRYPOINT|ddos|suricata|nftban_ddos_suricata_process	MUST_FIX	DDoS/suricata=BROKEN	Ledger row: "nftban_ddos_suricata_process has zero external callers (definition + export -f). No mode dispatcher exists for DDoS at all. The mode name resolves to nothing." Verified 2026-07-26: cli/lib/nftban/core/nftban_ddos_suricata.sh:680 definition and :698 export -f are the ONLY word-boundary occurrences in the shell tree. DDOS_MODE=suricata names a processor that never runs.
+
+# -----------------------------------------------------------------------------
+# CHECK 3 — LEDGER_CONSISTENCY
+# Row completeness passes: all 3 modules x 4 modes are present in the ledger.
+# What fails is the standing rule for BROKEN. Every row here is MUST_FIX.
+# -----------------------------------------------------------------------------
+LEDGER_BROKEN_ADVERTISED|ddos|suricata|cli/lib/nftban/cli/cmd_ddos.sh	MUST_FIX	DDoS/suricata=BROKEN	cmd_ddos.sh:71 help line "mode  Show or set protection mode (auto|classic|suricata|hybrid)"; :99 config example. A BROKEN mode offered in help with no availability marker.
+LEDGER_BROKEN_ADVERTISED|ddos|suricata|cli/lib/nftban/core/nftban_ddos.sh	MUST_FIX	DDoS/suricata=BROKEN	nftban_ddos.sh:590 selection case label, :615/:717 help text, :636 "DDOS_MODE=auto|classic|suricata|hybrid".
+LEDGER_BROKEN_ADVERTISED|ddos|suricata|cli/lib/nftban/cli/cmd_modes.sh	MUST_FIX	DDoS/suricata=BROKEN	cmd_modes.sh:150 accept-list case label; :264-265 "nftban ddos mode set <auto|classic|suricata|hybrid>".
+LEDGER_BROKEN_ADVERTISED|ddos|suricata|cli/lib/nftban/helpers/nftban_mode.sh	MUST_FIX	DDoS/suricata=BROKEN	nftban_mode.sh:32 NFTBAN_VALID_MODES="auto classic suricata hybrid" — this is the config-validation accept-list the contract says must REJECT a BROKEN mode; plus :220-237 validation branch and error text, :335 generated config comment, :420 usage line.
+LEDGER_BROKEN_ADVERTISED|loginmon|suricata|cli/lib/nftban/cli/cmd_modes.sh	MUST_FIX	LoginMon/suricata=BROKEN when source missing	Ledger: selected on presence (score >= 2, no EVE required), then only the EVE watcher runs. cmd_modes.sh advertises the mode with no availability marker.
+LEDGER_BROKEN_ADVERTISED|loginmon|suricata|cli/lib/nftban/helpers/nftban_mode.sh	MUST_FIX	LoginMon/suricata=BROKEN when source missing	Same accept-list/validation surface as the DDoS row above; the validator admits suricata for LoginMon too.
+LEDGER_BROKEN_ADVERTISED|loginmon|auto|cli/lib/nftban/cli/cmd_modes.sh	MUST_FIX	LoginMon/auto=BROKEN readiness resolution	Ledger: auto + Suricata present => ModeSuricata on presence alone, silently darkening journal sources (Lesson A).
+LEDGER_BROKEN_ADVERTISED|loginmon|auto|cli/lib/nftban/helpers/nftban_mode.sh	MUST_FIX	LoginMon/auto=BROKEN readiness resolution	Same accept-list/validation surface; auto is admitted without a readiness contract.
+
+# -----------------------------------------------------------------------------
+# CHECK 4 — MARKRUNNING_LIVENESS  (Lesson B)  [STATIC APPROXIMATION]
+# -----------------------------------------------------------------------------
+MARKRUNNING_LIVENESS|internal/loginmon/module.go|Start|runEVEWatcher	MUST_FIX	LoginMon/suricata=BROKEN when source missing	internal/loginmon/module.go:439 MarkRunning(); :454/:457 go m.runEVEWatcher(ctx); :1764 runEVEWatcher opens DefaultEVEPath and on error does RecordError(err) + return. RecordError sets Healthy=false but NOT Running=false (internal/module/module.go:140-148 vs :132-138), so the module reports RUNNING with zero detection. Exactly Lesson B.
+MARKRUNNING_LIVENESS|internal/loginmon/module.go|Start|runJournalWatcher	ACCEPTED_DEBT	LoginMon/classic=STATICALLY_REACHABLE	internal/loginmon/module.go:1043 — this one IS a respawn supervisor (runJournalWatcherOnce with retry), so its early-return paths are less severe than the EVE case, but it still never transitions status off RUNNING when it gives up. Tracked, not blocking.


### PR DESCRIPTION
## Summary

Records the runtime mode authority doctrine as **repository authority** — contract, ADR, admission ledger, contributor guidance, PR gate, and a machine-enforced static guard — rather than leaving it as a forensic finding that disappears after the release.

**Docs and CI only. Zero product files. No behaviour change.**

## The principle

> A feature is not merely code that exists. A feature is a complete production path that is **reachable, observable, enforceable, testable and recoverable.**

```
DEFINED         ≠  REACHABLE
CONFIGURED      ≠  EFFECTIVE
ENABLED         ≠  DETECTING
RUNNING         ≠  RECEIVING INPUT
DETECTED        ≠  ENFORCED
SET MEMBERSHIP  ≠  FIREWALL BLOCK
PASS            ≠  INJECTION PROVEN
```

Every one of these was observed in this product during v1.228.0 validation. They are not hypothetical.

## Why

A repeatable failure pattern was found across independent modules:

```
configured name ≠ runtime reachability ≠ active detection
                ≠ effective enforcement ≠ truthful health
```

Three traced instances: `DDOS_MODE=suricata` names a mode whose processor has zero callers; LoginMon `auto` selects Suricata from *presence* (binary + service, no EVE required) and then starts only the EVE watcher; that watcher exits on open failure while status stays `RUNNING`.

## What lands

| Artifact | Role |
|---|---|
| `docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md` | contract, lessons A–H, ten-field resolution, STOP rule |
| `docs/adr/ADR-0001-runtime-mode-authority.md` | decision + consequences + revisit criteria |
| `docs/MODE_ADMISSION_LEDGER.md` | per module × mode admission status |
| `docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md` | release interpretation |
| `.github/PULL_REQUEST_TEMPLATE.md` | mandatory mode-authority section — blank field blocks merge |
| `scripts/ci/check-mode-authority.sh` | static guard, four checks, all with controls |
| `.github/mode-authority-gate.yml` | **declared** policy — branch names are not authoritative |
| `.github/workflows/ci-mode-authority.yml` | gate + deferred-authority consistency |

## Authority hierarchy — deliberately unchanged

The declaration is the **mode inventory and specification authority**, *not* runtime truth:

```
kernel     enforcement authority
validator  health interpretation
config     operator intent
CLI        presentation
```

No second runtime truth source, no competition with `ModuleHealthMap`.

## The guard can fail

Each check runs a **negative control** (a synthetic bad tree it must flag) and a **positive control** (a clean tree it must not). A check whose control does not fire reports `NOT_YET_VERIFIED`, never `PASS`. Controls bypass the allowlist, so they prove the *check* fires rather than that the allowlist names the fixture.

Calibration case passes: `nftban_ddos_suricata_process` is flagged with zero callers.

Current tree: `NEW=0 · MUST_FIX=10 · ACCEPTED_DEBT=10 · STALE=0`, all four `NEGATIVE_CONTROL=PASS`.

## Three policies

```
drift     block NEW + STALE; report debt; CI may pass; global admission BLOCKED
targeted  + block MUST_FIX inside the DECLARED scope; unrelated debt reported only
all       block ANY MUST_FIX; global admission
```

**Intent is declared; evidence verifies the declaration and never invents it.** The guard checks `declared scope ⊇ touched authority surfaces`, and a shared authority file expands scope to every module carrying a row in it — so a narrow declaration cannot hide broader impact.

Mutation-tested across eight cases, including *declares ddos / touches loginmon* → `SCOPE_VALIDATION=FAIL`.

## v1.228.0 posture

Declares `policy: drift`. The release **defers** the confirmed runtime-mode defects to the runtime lane; the consistency step fails if a deferred document disappears, if the ledger loses its `BROKEN` rows, or if release text claims the defects are fixed.

```
CI success        ≠  global admission
targeted closure  ≠  unrelated debt closure
deferred defect   ≠  defect accepted as healthy
```

## Explicitly out of scope

Item 2 (sealed), the runtime product defects (confirmed, open), module-aware mode validation, A2–A4 attack scenarios, and flipping to global strict admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
