### PR TITLE
docs(agent): activate the agent operating contract (.claude/CLAUDE.md)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -366,9 +366,15 @@ No marketing, no superlatives, no competitor comparisons. Calm senior-engineer t
 adjectives. Every behaviour claim carries a version scope. **The CLI is a report** — kernel verification
 proves enforcement; CLI output alone does not.
 
-**AUTHORITY.** `.claude/docs/DOCS_WRITING_STANDARD.md` · `DOCS_DO_AND_DONT.md` ·
-`CLAIMS_AND_WORDING_GUARDRAILS.md` · `WIKI_PAGE_CHECKLIST.md` · `DOCS_REWRITE_RULES_FOR_CLAUDE.md` ·
-`.claude/WIKI_STYLE_GUIDE.md` · `.claude/BRAND_GUIDE.md`
+**AUTHORITY.** `.claude/docs/` (`DOCS_WRITING_STANDARD` · `DOCS_DO_AND_DONT` ·
+`CLAIMS_AND_WORDING_GUARDRAILS` · `WIKI_PAGE_CHECKLIST` · `DOCS_REWRITE_RULES_FOR_CLAUDE` ·
+`CLI_WORDING_STANDARD`) plus `.claude/WIKI_STYLE_GUIDE.md` · `.claude/BRAND_GUIDE.md` ·
+`.claude/MODULECLI.md`.
+
+> ⚠ **These are LOCAL-ONLY and NOT version controlled.** `.gitignore` tracks exactly one file under
+> `.claude/` — this contract. A fresh clone or worktree has **none** of the documents above. If they
+> are absent, say so and fall back to the rules stated here; do not assume the guidance is missing
+> because it does not exist. Making them tracked is an open decision, not something to do silently.
 
 ---
 
@@ -382,7 +388,7 @@ docs/SHELL_INPUT_PARSING_STANDARD.md                       shell input handling
 docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md   what "proven" means
 NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md         OPEN work — single authority
 NFTBAN_ROADMAP/NFTBAN_CLOSED_BUGS_IMPLEMENT_CURRENT.md     shipped history
-NFTBAN_ROADMAP/V1_139_FHS_AUTHORITY_GRAPH.md               FHS ownership topology
+NFTBAN_ROADMAP/COMPLETED/V1_139_FHS_AUTHORITY_GRAPH.md     FHS ownership topology
 ```
 
 ---

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,160 +1,395 @@
-# NFTBan Project Instructions for Claude
+# NFTBan — Agent Operating Contract
 
-## [VERIFIED] Protocol - Hallucination Prevention
+This file governs every agent session in this repository. It is an **execution contract**, not a
+tutorial: each rule states what binds you, why it exists, where the full authority lives, and when to
+stop.
 
-When user prefixes a question with `[VERIFIED]`, Claude MUST:
+NFTBan is a Linux firewall and intrusion-prevention system built on **nftables**. A defect here can
+lock an operator out of a production host, or leave one unprotected while reporting success. Evidence
+discipline is not ceremony — it is the product requirement.
 
-### 1. Research First (BEFORE answering)
+---
+
+## 0. Establish the baseline before claiming anything
+
+**RULE.** Never hard-code the current version. Derive it:
+
 ```
-- Search codebase with Grep/Glob
-- Read actual files
-- Collect evidence with file:line citations
-- Do NOT answer from memory
-```
-
-### 2. Verify Each Claim
-```
-□ File paths exist (actually check)
-□ Functions are real (grep for definition)
-□ CLI commands are valid (see list below)
-□ Config options exist (search config files)
-□ Numbers have evidence (no inventing benchmarks)
-```
-
-### 3. Response Format
-```markdown
-## Answer
-[Main answer with inline citations]
-
-Evidence:
-- `file.sh:123-145` - [what it shows]
-- `cmd_ban.sh:45` - [specific evidence]
-
-## Verification
-| Claim | Evidence | Status |
-|-------|----------|--------|
-| claim 1 | file:line | ✅ VERIFIED |
-| claim 2 | no evidence | ❓ UNVERIFIED |
-
-Confidence: HIGH / MEDIUM / LOW
+VERSION           cat VERSION                 (no trailing newline — preserve that)
+release date      cat VERSION_DATE            (strict ISO — and it must be CORRECT, not merely valid)
+latest published  gh release list --limit 1
+source authority  git rev-parse origin/main
+open work         NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md  §0 baseline
 ```
 
-### 4. Confidence Indicators
+**WHY.** A hard-coded version rots. This file previously declared `v1.195.0` while the project shipped
+`v1.228.0`, and agents acted on it. A stale authority file is itself an authority defect.
+
+**STOP** if those five disagree — report the conflict, do not pick one.
+
+> **Dated snapshot, not permanent truth:** last reconciled baseline **v1.228.0 at `0c2a0d9a`,
+> 2026-07-28** · production fleet 9/9 · labs 2/2 **not** updated (9/11). Re-derive; do not cite.
+
+---
+
+## 1. Authority hierarchy
+
+**RULE.** When sources disagree, trust in this order:
+
 ```
-✅ VERIFIED     - Found in code, read the file
-⚠️ LIKELY       - Based on patterns, not 100% confirmed
-❓ UNVERIFIED   - No evidence found
-❌ NOT SUPPORTED - Feature does not exist
+1  runtime evidence on a real host    (nft list ruleset · systemctl · the actual exit code)
+2  code at an exact commit            (git show <sha>:path — NOT the working tree)
+3  the packaged artifact              (what the .deb/.rpm actually ships)
+4  tests that can demonstrably fail
+5  registers and ledgers              (intent and status — not behaviour)
+6  comments, docs, summaries, prior agent reports
+```
+
+**WHY.** Comments lie. `NFTBAN_VALID_MODES` carried `# Used by other modules` with zero consumers. A
+guard's header claimed two files "legitimately cannot route" through a durability helper whose
+contract matched them exactly.
+
+**AUTHORITY.** `docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md` · `docs/adr/ADR-0001-runtime-mode-authority.md`
+
+**STOP** before stating a behaviour you have only read *about*.
+
+---
+
+## 2. Label every claim
+
+**RULE.** `MEASURED` / `INFERRED` / `NOT_YET_VERIFIED`. Never blur them. **A count is not evidence —
+open the file.** Estimates are claims. Recon is a hypothesis.
+
+**STOP** if you cannot label it.
+
+---
+
+## 3. A guard must measure the authority it claims to measure
+
+**RULE.** Before trusting any check, ask *what does this actually assert?* A guard whose subject is not
+the authority is **worse than no guard — it manufactures confidence.**
+
+**WHY.** Nine instances found in one week:
+
+```
+VERSION_DATE format check passed while the value was stale   -> 5 wrong published releases
+count guard pinned literal 66 against a registry of 71       -> bumping to 71 FAILED CI
+a regression test seeded the reader's wrong vocabulary       -> locked the bug in permanently
+a proposed tags: trigger would build and validate a SECOND independent artifact set
+two tests asserted Depends against a file that does not build the package
+three tests were absent from the authority index and NEVER RAN
+a fsync guard exempted two files under a claim that was false
+```
+
+**STOP** and report if a "fix" would make a guard pass without changing what it measures.
+
+---
+
+## 4. A passing test is not sufficient
+
+**RULE.** `PASS ≠ INJECTION PROVEN`. Every new guard must be shown to **fail**: break the fix
+deliberately, capture the failure, restore, and say you did.
+
+**WHY.** An eight-name denylist passed 39 of 41 assertions. Only a structural negative fixture could
+distinguish it from a real fix.
+
+**STOP** if a test cannot fail — fix the test first.
+
+---
+
+## 5. Derive sets; never pin names or counts
+
+**RULE.** Guards compute both sides and compare. Never assert "the two names are X and Y" or "the count
+is N".
+
+**STOP** if your assertion would still pass after the thing it guards is removed.
+
+---
+
+## 6. One file set, one owner
+
+**RULE.** Declare ownership before work starts. A deputy needing a change outside its set **reports**,
+never edits:
+
+```
+CROSS_LANE_DEPENDENCY
+FILE · REASON · REQUIRED_OWNER · BLOCKING_OR_NONBLOCKING · EXACT_CHANGE
+```
+
+`EXACT_CHANGE` must be applyable verbatim, without the owner re-deriving it.
+
+**STOP** and report rather than reaching across a boundary — even for one line.
+
+---
+
+## 7. Parallel authoring, serial merging
+
+**RULE.** Author concurrently in isolated worktrees. Merge one at a time in dependency order; rebase
+later branches onto earlier merges. Never merge a stale branch.
+
+**WHY.** Retiring a consumer must precede making its producer honest. Landing a router exit-truth fix
+before retiring the units depending on the old false success converts a latent restart loop into an
+active one.
+
+**STOP** if the merge order is not explicit.
+
+---
+
+## 8. The two-register rule
+
+```
+NFTBAN_PENDINGS_AND_BUGS_CURRENT.md       OPEN work ONLY — unresolved/active/queued/deferred
+NFTBAN_CLOSED_BUGS_IMPLEMENT_CURRENT.md   shipped/closed history, newest first
+COMPLETED/ · forensic reports · scope docs   EVIDENCE LOCATIONS, never registers
+```
+
+**RULE.** No closed stubs, shipped-release bodies or duplicated forensic bodies in OPEN. **Planning
+documents are evidence, never status authority** — if a plan body grows inside the register, move it to
+a scope doc and leave a status row.
+
+**WHY.** The OPEN register reached 56% planning content, inverting its own rule.
+
+**STOP** before deleting: prefer MOVE over DELETE always, and preserve `IMMUTABLE` blocks **verbatim**
+wherever they live.
+
+---
+
+## 9. Preserve chronology
+
+**RULE.** Superseded records stay. Add a dated addendum that wins on conflict, plus a supersession
+pointer. Distinguish:
+
+```
+IMMUTABLE_EVENT_RECORD      PRESERVE   — true when written
+CURRENT_STATUS_PROJECTION   UPDATE     — true now
+```
+
+**WHY.** A superseded checkpoint is not a wrong one. Silently editing it destroys the audit trail and
+hides how the conclusion was reached.
+
+**STOP** if a correction requires altering a dated record rather than annotating it.
+
+---
+
+## 10. Handles are identities, not assignments
+
+**RULE.** When releases are reordered, **do not rename handles** — `OPEN_V1_228_1_*` may legitimately
+ship in v1.228.2. Record the mapping instead.
+
+**WHY.** Renaming to chase a reshuffle rots every cross-reference.
+
+---
+
+## 11. Approval economy
+
+```
+IMPLEMENTATION_APPROVAL   one per bounded lane
+PUBLICATION_APPROVAL      one per exact SHA + version
+FLEET_APPROVAL            one separate production decision
+UI environment clicks     EXECUTION of an existing approval, not a new decision
+```
+
+**RULE.** Inside an approved lane, do not stop for routine verified prerequisites. **Stop only for:**
+scope expansion · a waived failed gate · destructive recovery · rollback execution · an unexpected
+product defect · production-wide continuation after a canary · a semantic (not textual) conflict · a
+new integration-only failure.
+
+---
+
+## 12. Evidence binds to an exact commit
+
+**RULE.** Validation attaches to one SHA. If the commit changes, evidence does **not** carry forward.
+Verify with `git show <sha>:path`, not the working tree. Trusted-gate approval binds to a SHA — never
+to a branch or PR number.
+
+**STOP** if the head moved after approval; re-run the gate.
+
+---
+
+## 13. CI truth
+
+```
+PAGINATION            REQUIRED   (unpaginated returns 30 of 93 — failures hide beyond page 1)
+LATEST_RUN_PER_NAME   REQUIRED
+STABLE_DOUBLE_FETCH   REQUIRED
+NONTERMINAL_COUNT     0
+LATE_CREATED_RUNS     0
+```
+
+**RULE.** `PR_CHECK_GREEN ≠ ALL_PATHS_EXECUTED`. `SKIPPED_PATH = UNTESTED_PATH`. A check green on a PR
+may simply not have run the failing path — publication steps are gated on
+`github.event_name != 'pull_request'`. Failed attempts are **never erased**.
+
+**Local gates are non-deterministic:** the same commit has produced different `ci-bash` pass/fail sets
+across runs. A single run does not establish a baseline — reproduce before attributing a failure.
+
+**STOP** if the check set grew between polls (observed 35 → 71). Wait for terminal.
+
+---
+
+## 14. Release gates
+
+**RULE.** Package-native validation on **lab2 (DEB)** and **lab4 (EL9/RPM)** is required before any
+release. Production fleet rollout may be skipped **only by explicit owner decision** — and skipping it
+never authorizes skipping labs.
+
+The lab gate must exercise the **migration actually being shipped** — upgrade from the previous release
+with the legacy state present — not a clean install of the new one.
+
+**AUTHORITY.** `docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md`
+
+**STOP** on any DEB or RPM lifecycle failure.
+
+---
+
+## 15. Mode and detection authority
+
+```
+CONFIGURED ≠ EFFECTIVE      DEFINED ≠ REACHABLE       ENABLED ≠ DETECTING
+RUNNING ≠ RECEIVING INPUT   DETECTED ≠ ENFORCED       SET MEMBERSHIP ≠ FIREWALL BLOCK
+```
+
+**RULE.** The four modes — `auto | classic | suricata | hybrid` — are **independent**; never collapse
+them into "with/without Suricata". Detection input must be tested through the **actual runtime
+consumer**, not a private helper. Enforcement requires a set referenced by a rule in a **HOOKED** chain.
+
+**AUTHORITY.** `docs/MODE_ADMISSION_LEDGER.md` — absence from it means **unassessed**, not healthy.
+
+**STOP** on mode ambiguity: resolve configured, effective and reason before any claim.
+
+---
+
+## 16. A component that cannot do its work must not report success
+
+**RULE.** Never return 0 for work that did not happen.
+
+**WHY.** Three live instances: the CLI router returning 0 when no entrypoint exists; a module loader
+whose failure the router discarded; an installer printing `COMMITTED` after the state write failed.
+
+**STOP** if a fix would convert a false success into a false *diagnosis* — that is not an improvement.
+
+---
+
+## 17. Exit codes are a shipped contract
+
+**RULE.** Do not renumber. Load-bearing today: Nagios `0/1/2/3` · nine systemd units with
+`SuccessExitStatus=` · `update` 10–13 · installer 0–10 · `--verify-install-state` `0` verified / `2`
+determinate non-verified / `4` invalid invocation, live on production hosts and read by **both** package
+scriptlets. `CLI_USAGE_ERROR = 1`.
+
+**STOP** before changing any exit value — find the consumers first.
+
+---
+
+## 18. Completeness
+
+**RULE.** **Never truncate a completeness search.** A negative conclusion from a partial list is an
+assumption, not a finding. If a list is partial, say so.
+
+**STOP** before writing "all", "none" or "only" without having enumerated.
+
+---
+
+## 19. Destructive operations
+
+**RULE.** Before any irreversible delete, prove preservation is **sufficient**, not merely present.
+**Copy, never move** — the original remains as reference. A mirror propagates deletions and is not an
+archive.
+
+**FORBIDDEN:** `rm -rf nftban*` · `find -delete` · `git clean -fdx` · `pkill -f`
+
+**STOP** and ask before deleting content that exists in only one place.
+
+---
+
+## 20. Environment facts
+
+```
+NO LOCAL GO TOOLCHAIN   build/test Go on lab2; lab4 (EL9) has no Go
+lab probes              from the hypervisor / ProxyJump — never the dev box
+nftables tables         family-split ip/ip6 — NEVER inet
+set sync                2x2: IPv4+IPv6 x whitelist+blacklist
+git identity            contact@nftban.com (repo-local) — never a personal address
+gh                      use --body-file for PR bodies
+shellcheck              the repo gates at -S warning, not error
+```
+
+**STOP** if a task needs a local Go build — route it to the lab.
+
+---
+
+## 21. Ground truth
+
+**NOT SUPPORTED — claiming these is a hallucination:**
+
+```
+Redis · cluster mode · port knocking · process tracking (PT_*) · fail2ban integration
+iptables (nftables ONLY) · Webmin module
+```
+
+**Claim limits:** releases are **not GPG-signed** · SLSA L3 covers the **standalone Go binary only**,
+not DEB/RPM payloads · PAM is **detection-only** · NFTBan is **not an antivirus** and **never compares
+itself to other tools**.
+
+**Key paths:** `/usr/lib/nftban/` install · `/etc/nftban/` config · `/var/lib/nftban/` data ·
+`/var/log/nftban/` logs · `cli/lib/nftban/` source mirror.
+
+**Command inventory — derive, do not trust a list:** top-level keys of `commands.registry.yml` minus
+`global_options`, `standard_params`, `_metadata`. The registry's own `total_commands` field has been
+wrong; treat it as a claim, not an authority.
+
+---
+
+## 22. `[VERIFIED]` protocol
+
+When a request is prefixed `[VERIFIED]`: search and read **before** answering, cite `file:line` for
+every claim, and close with a verification table.
+
+```
+✅ VERIFIED       read the code
+⚠️ LIKELY         pattern-based, not confirmed
+❓ UNVERIFIED     no evidence found
+❌ NOT SUPPORTED  does not exist
+```
+
+Never invent file paths, function names, CLI commands, config options or performance numbers. If you
+cannot find it, say **NOT FOUND**.
+
+Related requests: *verify this* → re-check every claim against code and correct. *show me the evidence*
+→ `file:line` plus the actual snippet. *which files did you read?* → the real list, and the searches run.
+
+---
+
+## 23. Documentation style
+
+No marketing, no superlatives, no competitor comparisons. Calm senior-engineer tone. Mechanisms, not
+adjectives. Every behaviour claim carries a version scope. **The CLI is a report** — kernel verification
+proves enforcement; CLI output alone does not.
+
+**AUTHORITY.** `.claude/docs/DOCS_WRITING_STANDARD.md` · `DOCS_DO_AND_DONT.md` ·
+`CLAIMS_AND_WORDING_GUARDRAILS.md` · `WIKI_PAGE_CHECKLIST.md` · `DOCS_REWRITE_RULES_FOR_CLAUDE.md` ·
+`.claude/WIKI_STYLE_GUIDE.md` · `.claude/BRAND_GUIDE.md`
+
+---
+
+## Canonical authorities
+
+```
+docs/RUNTIME_MODE_AUTHORITY_CONTRACT.md                    runtime mode doctrine
+docs/adr/ADR-0001-runtime-mode-authority.md                the architectural decision
+docs/MODE_ADMISSION_LEDGER.md                              per module x mode admission state
+docs/SHELL_INPUT_PARSING_STANDARD.md                       shell input handling
+docs/releases/V1_228_0_VALIDATION_AUTHORITY_STATEMENT.md   what "proven" means
+NFTBAN_ROADMAP/NFTBAN_PENDINGS_AND_BUGS_CURRENT.md         OPEN work — single authority
+NFTBAN_ROADMAP/NFTBAN_CLOSED_BUGS_IMPLEMENT_CURRENT.md     shipped history
+NFTBAN_ROADMAP/V1_139_FHS_AUTHORITY_GRAPH.md               FHS ownership topology
 ```
 
 ---
 
-## NFTBan Ground Truth
+## The standing invariant
 
-### Valid CLI Commands
-```
-ban, unban, status, whitelist, blacklist, feeds,
-watchdog, stats, health, version, install, uninstall,
-update, rebuild, login, metrics, export, portscan,
-ddos, suricata, config, service, services, timers, geoip, geoban,
-emulate, search, list, fhs, botguard, tunnel, sync
-```
-
-### Current Version
-```
-v1.195.0 (check /VERSION file for updates)
-```
-
-### NOT Supported (Common Hallucinations)
-```
-❌ Redis
-❌ Cluster mode
-❌ Port knocking
-❌ Process tracking (PT_*)
-❌ fail2ban integration
-❌ iptables (nftables only)
-❌ Webmin module
-```
-
-If claiming any of these exist → HALLUCINATION
-
-### Key Paths
-```
-/usr/lib/nftban/     - Installation (lib/, cli/, core/, setup/)
-/etc/nftban/         - Configuration (conf.d/, whitelist.d/, blacklist.d/)
-/var/lib/nftban/     - Data (feeds/, state/)
-/var/log/nftban/     - Logs
-cli/lib/nftban/      - Source (repo mirror of /usr/lib/nftban/)
-```
-
----
-
-## MUST NOT Do
-
-1. **Invent file paths** - If can't find it, say "NOT FOUND"
-2. **Guess function names** - Search first
-3. **Make up CLI commands** - Check valid list above
-4. **Claim unsupported features** - Check NOT Supported list
-5. **Invent performance numbers** - No benchmarks = no claims
-6. **Answer without reading code** - Always verify first
-
----
-
-## Example [VERIFIED] Flow
-
-**User:** `[VERIFIED] How does NFTBan detect port scans?`
-
-**Claude does:**
-1. `grep -rn "portscan" cli/lib/nftban/`
-2. Reads `nftban_portscan.sh`
-3. Reads `cmd_portscan.sh`
-4. Extracts evidence with line numbers
-5. Self-audits each claim
-6. Returns response with verification table
-
----
-
-## Quick Verification Commands
-
-When user says `verify this`:
-- Re-check all claims against code
-- Correct any hallucinations
-- Update confidence levels
-
-When user says `show me the evidence`:
-- Provide file:line for every claim
-- Quote actual code snippets
-
-When user says `which files did you read?`:
-- List all files actually read
-- Show grep/glob commands used
-
----
-
-## Documentation Style Rules
-
-When writing wiki pages, docs, README sections, or release notes, follow:
-
-- **Writing standard:** `.claude/docs/DOCS_WRITING_STANDARD.md` — principles, tone, structure, fact discipline
-- **Do/Don't guide:** `.claude/docs/DOCS_DO_AND_DONT.md` — 24 paired examples
-- **Claims guardrails:** `.claude/docs/CLAIMS_AND_WORDING_GUARDRAILS.md` — safe vs unsafe wording
-- **Pre-publish checklist:** `.claude/docs/WIKI_PAGE_CHECKLIST.md` — verification before publishing
-- **Claude rewrite rules:** `.claude/docs/DOCS_REWRITE_RULES_FOR_CLAUDE.md` — standing instructions for doc rewrites
-- **Wiki style guide:** `.claude/WIKI_STYLE_GUIDE.md` — markdown formatting, templates
-- **Brand guide:** `.claude/BRAND_GUIDE.md` — positioning, SEO, tone
-
-### Key writing rules (summary)
-- **No marketing.** No superlatives, no comparisons to other tools, no promotional language.
-- **No comparisons.** Never frame NFTBan against competing tools. Describe what it does.
-- **Calm tone.** Write like a senior engineer explaining to a peer.
-- **Code-truth first.** Every claim must trace to code, config, runtime, or a release.
-- **Version scope.** Every behavior claim needs "As of vX.Y.Z" or equivalent.
-- **Mechanisms, not adjectives.** "Uses atomic rebuild" not "robust deployment."
-- **CLI is a report.** Kernel verification (`nft list set`) proves enforcement, not CLI output alone.
-
-## Additional Resources
-
-- Full hallucination guide: `/home/commonfolder/LLMAI4NFTBAN/HOW_TO_ASK_ELIMINATE_HALLUCINATION.md`
-- Hallucination detector: `/home/commonfolder/LLMAI4NFTBAN/validators/scripts/detect_hallucinations.sh`
-- Auditor system: `/home/commonfolder/LLMAI4NFTBAN/prompts/hallucination_auditor_system.md`
-- FHS authority graph (canonical): `/home/commonfolder/LLMAI4NFTBAN/NFTBAN_ROADMAP/V1_139_FHS_AUTHORITY_GRAPH.md` — single source of truth for the FHS authority topology (which surface owns which dir/file perms + closure status of historical gaps; v1.139 PR-C formalization).
+> **A COMPONENT THAT FAILED TO PERFORM ITS REQUIRED WORK MUST NOT REPORT SUCCESS.**
+>
+> A feature is not code that exists. It is a complete production path that is **reachable, observable,
+> enforceable, testable and recoverable.**

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,13 @@ coverage.txt
 .DS_Store
 
 # Claude Code (local dev settings)
-.claude/
+# .claude/ holds agent-local scratch, but CLAUDE.md is the tracked agent
+# operating contract and MUST be stageable without `git add -f`.
+# Uses `.claude/*` (contents) rather than `.claude/` (directory): a directory
+# exclusion stops git descending, so a `!.claude/CLAUDE.md` negation after it
+# would never match. Last matching rule wins — keep the negation below.
+.claude/*
+!.claude/CLAUDE.md
 
 # Local environment
 .env


### PR DESCRIPTION
Docs-only. 2 files, zero product/packaging/CI/test change.

## Why now

`.claude/CLAUDE.md` declared **`Current Version: v1.195.0`** while the project ships **v1.228.0**. It governs every agent session before contributors or deputies touch the repository, so a stale authority file is itself an authority defect — and agents acted on it.

## What changed

**Version is now DERIVED, not hard-coded** — `VERSION`, `VERSION_DATE`, `gh release list`, `origin/main`, register baseline — with a STOP condition when those five disagree. The one dated figure is explicitly labelled a snapshot.

**Restructured** from a hallucination checklist into a 24-rule execution contract, each stating RULE / WHY / AUTHORITY / STOP. 401 lines.

Encodes what the v1.228.0 campaign established: authority hierarchy (runtime > code at an exact SHA > artifact > falsifiable test > register > comment) · a guard must measure the authority it claims to measure, with the nine observed instances · `PASS != INJECTION PROVEN` · derive sets, never pin names or counts · one file set one owner, with `CROSS_LANE_DEPENDENCY` instead of reaching across · parallel authoring, serial merging · the two-register rule and "planning docs are evidence, never status authority" · preserve chronology · handles are identities, not assignments · approval economy · CI truth including the measured non-determinism of local `ci-bash` · release gates (labs required; fleet skippable only by owner decision) · exit codes are a shipped contract · a component that cannot do its work must not report success.

**Preserved:** the `[VERIFIED]` protocol, NOT-SUPPORTED list, key paths, claim limits (no GPG signing, SLSA covers the standalone Go binary only, PAM detection-only, no competitor comparison), documentation-style authorities.

**Replaced:** the hard-coded CLI command list, with a derivation from `commands.registry.yml` — since that registry `total_commands` field was itself wrong by five.

## .gitignore correction

`.claude/` excluded the whole directory while `CLAUDE.md` was the single tracked file inside it, so staging required `git add -f` and a future `git add` would silently stage nothing.

Uses `.claude/*` + `!.claude/CLAUDE.md`, **not** `!.claude/`. Measured: a directory exclusion stops git descending, so a negation for a child never matches — the `!.claude/` form un-ignores the entire directory and turns `docs/`, `BRAND_GUIDE.md` and `WIKI_STYLE_GUIDE.md` into untracked noise. The contents form re-includes exactly `CLAUDE.md`.

## Two dangling references caught by pre-merge validation

1. `V1_139_FHS_AUTHORITY_GRAPH.md` is in `NFTBAN_ROADMAP/COMPLETED/`, not the roadmap root. The wrong path was **inherited verbatim from the file this rewrite replaces** — a stale citation copied forward while rewriting the document whose purpose is to stop stale authority claims.
2. The seven `.claude/docs` and `.claude/*.md` style authorities are **local-only**; `.gitignore` tracks exactly one file under `.claude/`, so a fresh clone has none of them. Now labelled as such, with instructions to fall back to the inline rules rather than assume the guidance does not exist.

## Verification

- `TRACKED_REFERENCES_DANGLING = 0` after the fixes
- fresh worktree contains the full 401-line contract
- `git add .claude/CLAUDE.md` works with **no** `-f`
- `.claude/docs/`, `BRAND_GUIDE.md`, `WIKI_STYLE_GUIDE.md` remain ignored — 0 untracked noise

Note: direct push to `main` was attempted per instruction and **rejected by branch protection**, so this goes through a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)