### PR TITLE
v1.228.2 PR-B: router exit truth — a command that cannot do its work no longer exits 0

### DIFF
--- a/cli/lib/nftban/tests/cli_router_exit_truth_v1228_1_test.sh
+++ b/cli/lib/nftban/tests/cli_router_exit_truth_v1228_1_test.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - CLI router exit-truth test (v1.228.1 PR-1)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="cli_router_exit_truth_v1228_1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="v1.228.1 PR-1 negative test for the governing CLI invariant: a command that cannot perform its requested work must never return exit 0. Before v1.228.1 the autoloader in cli/sbin/nftban sourced ANY cli/cmd_<token>.sh named by an unvalidated argv token, discarded the status of that source, probed for nftban_cmd_<token>, and on failure returned 0 with no output. Two situations collapsed onto that one line: (1) the file exists but exposes no entrypoint - eight such library files ship; (2) the file exists but aborted mid-load so the entrypoint was never defined - this is why 'nftban suricata status' exited 0 with empty stdout after printing a module-not-found error. The dispatcher could not be fixed by set -Eeuo pipefail because 'main \"\$@\" || exit \$?' suspends errexit for the whole call tree. This test locks the repaired contract STRUCTURALLY: T-A4 uses a synthetic entrypoint-less fixture module in a temporary NFTBAN_LIB_DIR to prove the rejection is not a hardcoded list of the eight known filenames, and T-A6 uses a fixture that returns non-zero at its top level to prove the source status is honoured. T-A3 pins every alias token so the rejection cannot become over-broad, and T-A5 pins support-bundle, the alias whose module entrypoint is not named after its token. Hermetic - runs against the source tree with a symlinked temporary NFTBAN_LIB_DIR, no daemon/nft/systemctl contact, no root."
+# meta:input="cli/sbin/nftban + cli/lib/nftban/cli/*.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash"
+# meta:inventory.files="cli/sbin/nftban,cli/lib/nftban/cli/cmd_support.sh,cli/lib/nftban/cli/cmd_suricata.sh"
+# meta:inventory.binaries="bash"
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_NONINTERACTIVE,NFTBAN_NO_BANNER"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="cli_router_exit_truth_v1228_1_test"
+# meta:ta.owner="cli"
+# meta:ta.module="rc-contract"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+NFTBAN_SBIN="$REPO/cli/sbin/nftban"
+REAL_LIB="$REPO/cli/lib/nftban"
+
+[[ -f "$NFTBAN_SBIN" ]] || { echo "FAIL: cannot find $NFTBAN_SBIN" >&2; exit 1; }
+[[ -d "$REAL_LIB" ]]    || { echo "FAIL: cannot find $REAL_LIB" >&2; exit 1; }
+
+export NFTBAN_LIB_DIR="$REAL_LIB"
+export NFTBAN_NONINTERACTIVE=1
+export NFTBAN_NO_BANNER=1
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# Router rejection markers. Both must exit 1; the TEXT differs so an operator
+# can tell "no such command" from "the command exists but its payload broke".
+MARK_UNKNOWN="Unknown command"
+MARK_LOADFAIL="Failed to load command module"
+
+TMP_ROOT=""
+cleanup(){ [[ -n "$TMP_ROOT" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+# run <libdir> <args...> -> sets RC, OUT (stdout), ERRTXT (stderr)
+run(){
+    local libdir="$1"; shift
+    local errf; errf="$(mktemp)"
+    RC=0
+    OUT="$(NFTBAN_LIB_DIR="$libdir" bash "$NFTBAN_SBIN" "$@" 2>"$errf")" || RC=$?
+    ERRTXT="$(cat "$errf")"
+    rm -f "$errf"
+}
+
+echo "=========================================================="
+echo "v1.228.1 PR-1: CLI router exit-truth test"
+echo "=========================================================="
+
+# -----------------------------------------------------------------------------
+# The eight entrypoint-less library files are DERIVED, never hardcoded.
+# If a ninth appears (or one gains an entrypoint) this test follows the tree.
+# -----------------------------------------------------------------------------
+ENTRYPOINTLESS=()
+for f in "$REAL_LIB"/cli/cmd_*.sh; do
+    b="$(basename "$f" .sh)"; t="${b#cmd_}"
+    grep -qE "^[[:space:]]*(function[[:space:]]+)?nftban_cmd_${t}[[:space:]]*\(\)" "$f" \
+        || ENTRYPOINTLESS+=("$t")
+done
+
+echo "--- T-A1/T-A2: entrypoint-less library files must be rejected ---"
+if (( ${#ENTRYPOINTLESS[@]} == 0 )); then
+    ok "T-A1 no entrypoint-less cli/cmd_*.sh in tree (nothing to reject)"
+else
+    for t in "${ENTRYPOINTLESS[@]}"; do
+        run "$REAL_LIB" "$t"
+        if (( RC >= 1 )); then
+            ok "T-A1 nftban $t -> rc=$RC (must be >=1)"
+        else
+            no "T-A1 nftban $t -> rc=$RC" "silent success: dispatcher returned 0 for a token that cannot do work"
+        fi
+        # T-A2: the rejection must be visible on STDERR, not swallowed and not
+        # printed to stdout (a script doing `nftban X 2>/dev/null` must still
+        # get clean stdout, per the v1.141 PR-B stream contract).
+        if [[ "$ERRTXT" == *"ERROR"* ]]; then
+            ok "T-A2 nftban $t -> error text on stderr"
+        else
+            no "T-A2 nftban $t -> error text on stderr" "stderr had no ERROR line"
+        fi
+    done
+fi
+
+# -----------------------------------------------------------------------------
+# T-A3 — the rejection must not become over-broad. Every alias token in the
+# router must still resolve to its handler. Aliases legitimately return
+# non-zero (e.g. `restart --help` does today), so the assertion is on the
+# ROUTER MARKERS, not on rc.
+# -----------------------------------------------------------------------------
+echo "--- T-A3: alias tokens must still dispatch ---"
+ALIASES=(
+    whitelist-system firewall-logs support-bundle          # filename remaps
+    cloudflare enable disable restart verify explain       # post-autoloader case
+    service export rollback hello help
+)
+for t in "${ALIASES[@]}"; do
+    run "$REAL_LIB" "$t" --help
+    if [[ "$ERRTXT" == *"$MARK_UNKNOWN"* || "$ERRTXT" == *"$MARK_LOADFAIL"* ]]; then
+        no "T-A3 alias '$t' still dispatches" "router rejected it (over-broad guard)"
+    else
+        ok "T-A3 alias '$t' still dispatches (rc=$RC, no router rejection)"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# T-A5 — support-bundle. Its module is cmd_support.sh, so the entrypoint name
+# does not follow the token. This is the alias most likely to be broken by a
+# fix at the rejection site.
+# -----------------------------------------------------------------------------
+echo "--- T-A5: support-bundle alias renders support help at rc 0 ---"
+run "$REAL_LIB" support-bundle --help
+if (( RC == 0 )) && [[ "$OUT" == *"support"* ]] && (( ${#OUT} > 200 )); then
+    ok "T-A5 nftban support-bundle --help -> rc=0, ${#OUT}B of support help on stdout"
+else
+    no "T-A5 nftban support-bundle --help" "rc=$RC stdout=${#OUT}B (expected rc 0 + support help)"
+fi
+
+# T-A5b — STRUCTURAL guard for the same class: every filename remap in the
+# router must resolve to an entrypoint that actually exists. Parsed from the
+# router source so a NEW remap is covered without editing this test.
+echo "--- T-A5b: every router filename remap resolves to a defined entrypoint ---"
+remap_token=""
+remaps_checked=0
+while IFS= read -r line; do
+    if [[ "$line" =~ \[\[[[:space:]]+\"\$cmd\"[[:space:]]+==[[:space:]]+\"([a-z0-9-]+)\"[[:space:]]+\]\] ]]; then
+        remap_token="${BASH_REMATCH[1]}"
+        continue
+    fi
+    if [[ -n "$remap_token" && "$line" =~ cmd_file=\"\$\{NFTBAN_LIB_DIR\}/cli/(cmd_[a-z0-9_]+\.sh)\" ]]; then
+        remap_file="${BASH_REMATCH[1]}"
+        remaps_checked=$((remaps_checked + 1))
+        token_func="${remap_token//-/_}"
+        module_func="${remap_file%.sh}"; module_func="${module_func#cmd_}"
+        if grep -qE "^[[:space:]]*(function[[:space:]]+)?nftban_cmd_(${token_func}|${module_func})[[:space:]]*\(\)" \
+               "$REAL_LIB/cli/$remap_file"; then
+            ok "T-A5b remap '$remap_token' -> $remap_file resolves to a defined entrypoint"
+        else
+            no "T-A5b remap '$remap_token' -> $remap_file" "neither nftban_cmd_${token_func} nor nftban_cmd_${module_func} is defined"
+        fi
+        remap_token=""
+    fi
+done < "$NFTBAN_SBIN"
+if (( remaps_checked == 0 )); then
+    no "T-A5b parsed at least one filename remap from the router" "extractor matched nothing — the router shape changed"
+else
+    ok "T-A5b parsed $remaps_checked filename remap(s) from the router source"
+fi
+
+# -----------------------------------------------------------------------------
+# T-A4 / T-A6 — the falsifiability core. A synthetic module in a temporary
+# NFTBAN_LIB_DIR proves the guard is STRUCTURAL. An implementation that
+# denylists the eight known filenames passes everything above and fails here.
+# -----------------------------------------------------------------------------
+echo "--- T-A4/T-A6: synthetic fixture modules in a temporary NFTBAN_LIB_DIR ---"
+TMP_ROOT="$(mktemp -d)"
+FIX_LIB="$TMP_ROOT/lib"
+mkdir -p "$FIX_LIB/cli"
+for e in "$REAL_LIB"/*; do
+    n="$(basename "$e")"
+    [[ "$n" == "cli" ]] && continue
+    ln -s "$e" "$FIX_LIB/$n"
+done
+for e in "$REAL_LIB"/cli/*; do
+    ln -s "$e" "$FIX_LIB/cli/$(basename "$e")"
+done
+
+# Fixture 1 (T-A4): a real, sourceable module that defines NO entrypoint.
+cat > "$FIX_LIB/cli/cmd_zzfixture.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# v1.228.1 T-A4 fixture: sources cleanly, exposes no nftban_cmd_zzfixture.
+_zzfixture_not_an_entrypoint() { echo "never dispatched"; }
+FIXTURE
+
+# Fixture 2 (T-A6): aborts at its top level BEFORE defining its entrypoint —
+# the shape of cmd_suricata.sh's required-module loader.
+cat > "$FIX_LIB/cli/cmd_zzabort.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# v1.228.1 T-A6 fixture: aborts mid-load, so the entrypoint below never exists.
+echo "ERROR: fixture required module not found" >&2
+return 1
+nftban_cmd_zzabort() { echo "never defined"; }
+FIXTURE
+
+# Control: the temporary lib dir must itself be functional, otherwise T-A4/T-A6
+# would "pass" for the wrong reason (everything failing).
+run "$FIX_LIB" version
+if (( RC == 0 )); then
+    ok "T-A4-control nftban version in temp NFTBAN_LIB_DIR -> rc=0 (harness is sound)"
+else
+    no "T-A4-control nftban version in temp NFTBAN_LIB_DIR -> rc=$RC" "temp lib dir is broken; T-A4/T-A6 verdicts are meaningless"
+fi
+
+run "$FIX_LIB" zzfixture
+if (( RC >= 1 )) && [[ "$ERRTXT" == *"$MARK_UNKNOWN"* ]]; then
+    ok "T-A4 synthetic entrypoint-less module rejected -> rc=$RC, '$MARK_UNKNOWN'"
+else
+    no "T-A4 synthetic entrypoint-less module rejected" "rc=$RC; the guard is a name denylist, not structural"
+fi
+
+run "$FIX_LIB" zzabort
+if (( RC >= 1 )) && [[ "$ERRTXT" == *"$MARK_LOADFAIL"* ]]; then
+    ok "T-A6 module aborting mid-load rejected -> rc=$RC, '$MARK_LOADFAIL'"
+else
+    no "T-A6 module aborting mid-load rejected" "rc=$RC; the status of \`source\` is still discarded"
+fi
+
+# R4: the two rejections must be distinguishable in TEXT while both exit 1.
+run "$FIX_LIB" zzfixture; a_rc=$RC; a_err="$ERRTXT"
+run "$FIX_LIB" zzabort;   b_rc=$RC; b_err="$ERRTXT"
+if (( a_rc == 1 && b_rc == 1 )) \
+   && [[ "$a_err" == *"$MARK_UNKNOWN"*  && "$a_err" != *"$MARK_LOADFAIL"* ]] \
+   && [[ "$b_err" == *"$MARK_LOADFAIL"* ]]; then
+    ok "T-A6b both rejections exit 1 and are distinguishable in text (R4)"
+else
+    no "T-A6b both rejections exit 1 and are distinguishable in text" "unknown rc=$a_rc loadfail rc=$b_rc"
+fi
+
+# -----------------------------------------------------------------------------
+# T-D2 / T-D3 — completion-authority consistency inside cli/sbin/nftban.
+# Level-0 comes from the router's own __complete endpoint (runtime truth),
+# the suggester list from its heredoc (static).
+# -----------------------------------------------------------------------------
+echo "--- T-D2/T-D3: Level-0 completion vs typo suggester ---"
+L0_FILE="$TMP_ROOT/level0.txt"
+CANON_FILE="$TMP_ROOT/canon.txt"
+NFTBAN_LIB_DIR="$REAL_LIB" bash "$NFTBAN_SBIN" __complete 2>/dev/null | sed '/^$/d' > "$L0_FILE"
+awk '/^_nftban_canonical_commands\(\) \{/{f=1;next} f&&/^EOF$/{exit} f&&!/<<.EOF.$/{print}' \
+    "$NFTBAN_SBIN" | sed '/^$/d' > "$CANON_FILE"
+
+if [[ ! -s "$L0_FILE" || ! -s "$CANON_FILE" ]]; then
+    no "T-D2/T-D3 extractors produced non-empty lists" "level0=$(wc -l <"$L0_FILE") canon=$(wc -l <"$CANON_FILE")"
+else
+    dupes="$(sort "$L0_FILE" | uniq -d | tr '\n' ' ')"
+    if [[ -z "${dupes// /}" ]]; then
+        ok "T-D2 Level-0 completion emits no duplicate token ($(wc -l <"$L0_FILE") tokens)"
+    else
+        no "T-D2 Level-0 completion emits no duplicate token" "duplicated: $dupes"
+    fi
+
+    missing="$(comm -23 <(sort -u "$L0_FILE") <(sort -u "$CANON_FILE") | tr '\n' ' ')"
+    if [[ -z "${missing// /}" ]]; then
+        ok "T-D3 every Level-0 token is in _nftban_canonical_commands()"
+    else
+        no "T-D3 every Level-0 token is in _nftban_canonical_commands()" "absent from suggester: $missing"
+    fi
+fi
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
+++ b/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
@@ -59,8 +59,15 @@ no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
 # fails until the entry is deleted. A sanctioned gap that silently becomes
 # correct is how a known-gap list rots into a lie.
 # -----------------------------------------------------------------------------
-SANCTIONED_TOKENS=("suricata")
-SANCTIONED_REASON="D1/D2 open; PR-2 owns install/systemd/nftban-suricata{,-update}.service and cmd_suricata.sh narrowing"
+# ZERO-GAP as of v1.228.2. The entry for 'suricata' was retired when the
+# Suricata units were removed from install/systemd/ — at that moment this
+# test began FAILING on its own allowlist ("observed undispatchable ...
+# remove it from SANCTIONED_TOKENS"), which is the intended behaviour: a
+# sanctioned gap must enforce its own deletion rather than quietly persist.
+# Do not re-populate this to make a failure go away — a systemd unit that
+# invokes an undispatchable CLI token is the defect this test exists to catch.
+SANCTIONED_TOKENS=()
+SANCTIONED_REASON="none — zero-gap"
 
 is_sanctioned(){
     local t="$1" s

--- a/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
+++ b/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - shipped systemd units must not invoke an undispatchable CLI token
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="systemd_cli_token_dispatch_v1228_1_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="v1.228.1 PR-1 consumer-safety test (T-E1). Until v1.228.1 the CLI router returned exit 0 for a command whose module could not be loaded, so a systemd unit could invoke a CLI token that does no work and the unit would still start green. Two shipped units do exactly that - nftban-suricata.service ExecStartPre and nftban-suricata-update.service ExecStart both run 'nftban suricata rules ...', and cmd_suricata.sh aborts at load because four sibling modules it declares as REQUIRED were deleted by ff1865b4. Neither unit sets SuccessExitStatus=, so once the router tells the truth those units fail to start. This test scans every Exec* directive in install/systemd and packaging/systemd, extracts each /usr/sbin/nftban token, and asserts the token is dispatchable: it must resolve to a router target (a cli/cmd_<token>.sh exposing an nftban_cmd_ entrypoint, or a router alias arm), and that module must not declare a sibling cmd_*.sh that is absent from the shipped tree - the general form of the Suricata defect. Tokens that are knowingly broken pending owner decisions D1/D2 are listed in a sanctioned set which is itself asserted to be still-broken, so the entry must be removed the moment PR-2 repairs it. Static analysis only - reads files, invokes nothing."
+# meta:input="install/systemd/*, packaging/systemd/*, cli/sbin/nftban, cli/lib/nftban/cli/cmd_*.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,sed"
+# meta:inventory.files="install/systemd/nftban-suricata.service,install/systemd/nftban-suricata-update.service,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="all shipped units under install/systemd and packaging/systemd"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="systemd_cli_token_dispatch_v1228_1_test"
+# meta:ta.owner="cli"
+# meta:ta.module="dispatcher"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+ROUTER="$REPO/cli/sbin/nftban"
+CLI_DIR="$REPO/cli/lib/nftban/cli"
+LIB_ROOT="$REPO/cli/lib/nftban"
+UNIT_DIRS=("$REPO/install/systemd" "$REPO/packaging/systemd")
+
+[[ -f "$ROUTER" ]]  || { echo "FAIL: cannot find $ROUTER" >&2; exit 1; }
+[[ -d "$CLI_DIR" ]] || { echo "FAIL: cannot find $CLI_DIR" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# -----------------------------------------------------------------------------
+# SANCTIONED, TIME-LIMITED GAP — v1.228.1 PR-1 only.
+#
+# PR-1 fixes the router; it is forbidden from touching systemd units, which
+# PR-2 owns and which are blocked on owner decisions D1 (what should
+# nftban-suricata.service ExecStartPre do now that `suricata rules verify` no
+# longer exists) and D2 (delete or repoint nftban-suricata-update.service).
+# Each entry is asserted BELOW to still be broken: when PR-2 lands, this test
+# fails until the entry is deleted. A sanctioned gap that silently becomes
+# correct is how a known-gap list rots into a lie.
+# -----------------------------------------------------------------------------
+SANCTIONED_TOKENS=("suricata")
+SANCTIONED_REASON="D1/D2 open; PR-2 owns install/systemd/nftban-suricata{,-update}.service and cmd_suricata.sh narrowing"
+
+is_sanctioned(){
+    local t="$1" s
+    for s in "${SANCTIONED_TOKENS[@]}"; do [[ "$s" == "$t" ]] && return 0; done
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Router alias arms — extracted from the router source, never hardcoded, so a
+# new alias needs no edit here.
+# -----------------------------------------------------------------------------
+ALIAS_TOKENS_FILE="$(mktemp)"
+trap 'rm -f "$ALIAS_TOKENS_FILE"' EXIT
+sed -n '/^main() {/,/^}$/p' "$ROUTER" \
+    | grep -oE '^[[:space:]]+[a-z0-9|_"-]+\)' \
+    | tr -d ' )"' | tr '|' '\n' | sed '/^$/d' | sort -u > "$ALIAS_TOKENS_FILE"
+
+# resolve_module <token> -> echoes the module path, or nothing
+resolve_module(){
+    local t="$1"
+    if [[ -f "$CLI_DIR/cmd_${t}.sh" ]]; then echo "$CLI_DIR/cmd_${t}.sh"; return 0; fi
+    # mirror the router's hyphen->underscore filename remaps structurally
+    if [[ -f "$CLI_DIR/cmd_${t//-/_}.sh" ]]; then echo "$CLI_DIR/cmd_${t//-/_}.sh"; return 0; fi
+    return 1
+}
+
+has_entrypoint(){
+    local file="$1" t="$2"
+    local module_token; module_token="$(basename "$file" .sh)"; module_token="${module_token#cmd_}"
+    grep -qE "^[[:space:]]*(function[[:space:]]+)?nftban_cmd_(${t//-/_}|${module_token})[[:space:]]*\(\)" "$file"
+}
+
+# missing_siblings <module> -> echoes any cmd_*.sh the module names that is not
+# shipped anywhere under cli/lib/nftban. This is the general form of the
+# Suricata defect: a module declaring a required sibling that does not exist
+# aborts at load, which makes EVERY subcommand of that token undispatchable.
+missing_siblings(){
+    local file="$1" ref out=""
+    for ref in $(grep -ohE '\bcmd_[a-z0-9_]+\.sh' "$file" | sort -u); do
+        [[ "$(basename "$file")" == "$ref" ]] && continue
+        if ! find "$LIB_ROOT" -name "$ref" -print -quit 2>/dev/null | grep -q .; then
+            out+="$ref "
+        fi
+    done
+    printf '%s' "$out"
+}
+
+echo "=========================================================="
+echo "v1.228.1 PR-1 (T-E1): shipped systemd units vs CLI dispatch"
+echo "=========================================================="
+
+# -----------------------------------------------------------------------------
+# Extract every "<unit>:<line>:<token>" the shipped units invoke.
+# Covers direct ExecStart=, "+" privilege prefixes, flock wrappers and
+# `bash -c '... /usr/sbin/nftban <token> ...'` forms by matching the CLI path
+# anywhere on an Exec* directive line.
+# -----------------------------------------------------------------------------
+INVOCATIONS=()
+for d in "${UNIT_DIRS[@]}"; do
+    [[ -d "$d" ]] || continue
+    while IFS= read -r hit; do
+        INVOCATIONS+=("$hit")
+    done < <(grep -rnE '^[[:space:]]*Exec(Start|StartPre|StartPost|Stop|StopPost|Reload|Condition)=' "$d" 2>/dev/null \
+             | grep -oE '^[^:]+:[0-9]+:.*/usr/sbin/nftban[[:space:]]+[a-z0-9_-]+' \
+             | sed -E 's#^([^:]+):([0-9]+):.*/usr/sbin/nftban[[:space:]]+([a-z0-9_-]+)$#\1:\2:\3#')
+done
+
+echo "--- extraction ---"
+if (( ${#INVOCATIONS[@]} == 0 )); then
+    no "T-E1 extractor found CLI invocations in shipped units" "0 matches — the units or the extractor changed shape"
+else
+    ok "T-E1 extractor found ${#INVOCATIONS[@]} CLI invocation(s) across shipped units"
+fi
+
+echo "--- per-invocation dispatchability ---"
+SEEN_BROKEN=()
+for inv in "${INVOCATIONS[@]}"; do
+    unit="${inv%%:*}"; rest="${inv#*:}"
+    line="${rest%%:*}"; token="${rest#*:}"
+    label="$(basename "$unit"):${line} -> nftban ${token}"
+
+    reason=""
+    module="$(resolve_module "$token" || true)"
+    if [[ -z "$module" ]]; then
+        if grep -qxF "$token" "$ALIAS_TOKENS_FILE"; then
+            module=""   # alias arm, dispatchable without a module file
+        else
+            reason="no cli/cmd_${token}.sh and no router alias arm"
+        fi
+    elif ! has_entrypoint "$module" "$token"; then
+        reason="$(basename "$module") exposes no nftban_cmd_ entrypoint"
+    else
+        miss="$(missing_siblings "$module")"
+        if [[ -n "${miss// /}" ]]; then
+            reason="$(basename "$module") requires unshipped module(s): ${miss% }"
+        fi
+    fi
+
+    if [[ -z "$reason" ]]; then
+        if is_sanctioned "$token"; then
+            no "T-E1 sanctioned token '$token' is still undispatchable" \
+               "'$token' now dispatches — DELETE it from SANCTIONED_TOKENS in this test"
+        else
+            ok "T-E1 $label dispatches"
+        fi
+    else
+        SEEN_BROKEN+=("$token")
+        if is_sanctioned "$token"; then
+            ok "T-E1 $label UNDISPATCHABLE — sanctioned gap ($reason); $SANCTIONED_REASON"
+        else
+            no "T-E1 $label dispatches" "$reason"
+        fi
+    fi
+done
+
+# Reverse assertion: every sanctioned token must have been OBSERVED broken.
+# A sanctioned token that no unit invokes any more, or that quietly started
+# working, must be removed rather than left as decoration.
+echo "--- sanctioned-set hygiene ---"
+for s in "${SANCTIONED_TOKENS[@]}"; do
+    hit="no"
+    for b in ${SEEN_BROKEN[@]+"${SEEN_BROKEN[@]}"}; do [[ "$b" == "$s" ]] && hit="yes"; done
+    if [[ "$hit" == "yes" ]]; then
+        ok "T-E1 sanctioned token '$s' observed undispatchable (entry is still earning its place)"
+    else
+        no "T-E1 sanctioned token '$s' observed undispatchable" \
+           "'$s' is no longer a broken systemd-invoked token — remove it from SANCTIONED_TOKENS"
+    fi
+done
+
+echo "=========================================================="
+echo "RESULTS: PASS=$PASS FAIL=$FAIL"
+if (( FAIL > 0 )); then
+    printf 'FAILED: %s\n' "${FAILED[@]}"
+    exit 1
+fi
+echo "ALL PASS"

--- a/cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh
+++ b/cli/lib/nftban/tests/v127_ux5_typo_discoverability_test.sh
@@ -272,10 +272,16 @@ _pre=$(grep -c '^EXIT CODES:$' "$_cmd_update" || true)
 _t_assert "G2: cmd_update.sh still has exactly one EXIT CODES block (no sweep)" "$?"
 
 # G3: No new top-level commands added to dispatcher canonical list as
-# side-effect of UX-5
+# side-effect of UX-5.
+# v1.228.1 PR-1: upper bound raised 80 -> 90. The list gained the five tokens
+# the Level-0 completion already offered but the suggester could not name
+# (logs, explain, verify, export, rollback) — an authority split, now asserted
+# in the other direction by cli_router_exit_truth_v1228_1_test T-D3
+# (Level-0 subset of the canonical list). This remains a runaway-growth bound,
+# not a contract: the exact-parity assertion lives in T-D3.
 _canonical_count=$(_nftban_canonical_commands | grep -v '^$' | wc -l)
-[[ "$_canonical_count" -ge 50 ]] && [[ "$_canonical_count" -le 80 ]]
-_t_assert "G3: canonical command list has $_canonical_count entries (sane bound 50-80)" "$?"
+[[ "$_canonical_count" -ge 50 ]] && [[ "$_canonical_count" -le 90 ]]
+_t_assert "G3: canonical command list has $_canonical_count entries (sane bound 50-90)" "$?"
 
 # =============================================================================
 # (H) Suricata work absent (we are PR-E, not PR-D)

--- a/cli/lib/nftban/tests/v128_help_code_correlation_test.sh
+++ b/cli/lib/nftban/tests/v128_help_code_correlation_test.sh
@@ -165,6 +165,14 @@ _ALIAS_ONLY_HANDLED=(
     # other inline cases (help dispatcher at line 1320; cloudflare wrapper)
     "help"
     "cloudflare"
+    # v1.228.1 PR-1 (R20): inline alias arms in cli/sbin/nftban main() that the
+    # Level-0 completion already offered but the canonical list omitted. Adding
+    # them to _nftban_canonical_commands() closed that split; they are reachable
+    # via the post-autoloader case, not via a cmd_<X>.sh of their own.
+    "verify"      # -> nftban_cmd_emulate
+    "explain"     # -> nftban_cmd_emulate
+    "export"      # -> nftban_cmd_stats export
+    "rollback"    # -> nftban_cmd_update rollback
 )
 unreachable=()
 while IFS= read -r cmd; do

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -233,7 +233,9 @@ nftban_complete() {
         echo "port"
         echo "panel"
         echo "module"
-        echo "services"
+        # v1.228.1 PR-1 (R19): duplicate `services` removed here; the SERVICE
+        # CONTROL group above is the keeper. A duplicate Level-0 token makes
+        # bash-completion offer the same candidate twice.
         echo "fhs"
         echo "nftables"
         echo "geoip"
@@ -953,6 +955,10 @@ _nftban_damerau_levenshtein() {
 # Kept in sync with the Level-0 completion list above (cli/sbin/nftban
 # lines ~165-235). NOT exhaustive of every sub-command; that's by design,
 # since the typo handler runs on the top-level command only.
+# v1.228.1 PR-1 (R20): the list had drifted behind Level-0 by five tokens
+# (logs, explain, verify, export, rollback) — a command the completion offers
+# but the suggester cannot name is an authority split. cli_router_exit_truth
+# _v1228_1_test T-D3 now asserts Level-0 ⊆ this list.
 _nftban_canonical_commands() {
     cat <<'EOF'
 status
@@ -972,6 +978,7 @@ wizard
 system
 firewall
 firewall-logs
+logs
 ban
 unban
 search
@@ -1017,6 +1024,10 @@ selftest
 list
 test
 emulate
+explain
+verify
+export
+rollback
 install
 uninstall
 update
@@ -1075,6 +1086,31 @@ _nftban_suggest_command() {
     elif [[ $best_dist -le $soft_threshold ]] && [[ $((second_best_dist - best_dist)) -ge 2 ]]; then
         echo "$best_cmd"
     fi
+}
+
+# v1.228.1 PR-1 (R1/R4) — module-load failure renderer.
+#
+# Distinct in TEXT from the "Unknown command" render at the bottom of main()
+# so an operator can tell the two apart ("the command exists but its payload
+# is broken" vs "there is no such command"), while both exit 1 (R3/D6:
+# CLI_USAGE_ERROR = 1, matching the pre-existing unknown-command arm).
+#
+# Stream contract follows v1.141 PR-B: banner + ERROR + diagnosis to stderr,
+# so `nftban <cmd> 2>/dev/null` still gives scripts clean stdout.
+_nftban_reject_module_load() {
+    local cmd="$1"
+    local cmd_file="$2"
+    local src_rc="${3:-1}"
+
+    nftban_render_banner simple >&2
+    echo "" >&2
+    echo -e "${NFTBAN_COLOR_RED}${NFTBAN_COLOR_BOLD}ERROR: Failed to load command module for '${cmd}'${NFTBAN_COLOR_RESET}" >&2
+    echo "" >&2
+    echo "Module: ${cmd_file}" >&2
+    echo "The module aborted while loading (status ${src_rc}), so '${cmd}' cannot run." >&2
+    echo "Any diagnostic printed above this message comes from the module itself." >&2
+    echo "" >&2
+    echo "Run 'nftban health check' to inspect the installation." >&2
 }
 
 # =============================================================================
@@ -1232,11 +1268,44 @@ main() {
     fi
 
     if [[ -f "$cmd_file" ]]; then
+        # v1.228.1 PR-1 (R1) — the status of `source` is no longer discarded.
+        # A module whose top level `return`s non-zero (e.g. a required sibling
+        # module is missing) never reaches its own entrypoint definition. Before
+        # v1.228.1 that status was thrown away here, `declare -f` below then
+        # failed, and the dispatcher returned 0 — the CLI reported success for
+        # work it had not done. errexit cannot catch this: `main "$@" || exit $?`
+        # at the bottom of this file suspends `set -e` for the whole call tree.
+        #
+        # The status is RECORDED here and acted on only AFTER entrypoint
+        # resolution (see below), deliberately: a module may source to a
+        # non-zero status from a trailing line that runs after its entrypoint is
+        # already defined (cmd_snapshot.sh's self-execute footer fires on the
+        # positional parameters this function inherits). Such a module IS
+        # dispatchable, and failing it here would convert a working command into
+        # an error — the opposite of the invariant this PR restores.
+        local _src_rc=0
         # shellcheck source=/dev/null
-        source "$cmd_file"
+        source "$cmd_file" || _src_rc=$?
 
         # Convert hyphens to underscores for function name (whitelist-system -> whitelist_system)
         local func_cmd="${cmd//-/_}"
+
+        # v1.228.1 PR-1 — entrypoint resolution follows the FILENAME remap.
+        # The special cases above remap the module PATH but not the function
+        # name, so an alias whose module entrypoint is not named after the alias
+        # token (support-bundle -> cmd_support.sh) would resolve to a function
+        # that does not exist. Derive the module's own canonical entrypoint from
+        # the resolved path and use it as a fallback. STRUCTURAL: derived from
+        # the filename, never from a list of alias names. No-op for every token
+        # whose file basename already matches its token.
+        if ! declare -f "nftban_cmd_${func_cmd}" >/dev/null 2>&1; then
+            local _module_token
+            _module_token="$(basename "$cmd_file" .sh)"
+            _module_token="${_module_token#cmd_}"
+            if declare -f "nftban_cmd_${_module_token}" >/dev/null 2>&1; then
+                func_cmd="$_module_token"
+            fi
+        fi
 
         # Some modules define nftban_cmd_X, others just use case statements
         if declare -f "nftban_cmd_${func_cmd}" >/dev/null 2>&1; then
@@ -1248,10 +1317,29 @@ main() {
             # "ERROR: Script failed" on top of the command's own output.
             "nftban_cmd_${func_cmd}" "$@" || return $?
             return 0
-        else
-            # Module handles args directly (like cmd_whitelist_system.sh)
-            return 0
         fi
+
+        # v1.228.1 PR-1 (R1/R4) — the module aborted mid-load and therefore
+        # never defined an entrypoint. This is the `nftban suricata <anything>`
+        # case: cmd_suricata.sh:141 `return 1`s on a missing required sibling
+        # module, so nftban_cmd_suricata() at :469 is never defined. Distinct
+        # message from "Unknown command" (the command exists; its payload is
+        # broken), same exit code 1.
+        if (( _src_rc != 0 )); then
+            _nftban_reject_module_load "$cmd" "$cmd_file" "$_src_rc"
+            return 1
+        fi
+
+        # v1.228.1 PR-1 (R2/R5) — STRUCTURAL rejection, not a denylist.
+        # The file exists and sourced cleanly but exposes no `nftban_cmd_<token>`
+        # entrypoint, so this token cannot perform any work. Pre-v1.228.1 this
+        # branch returned 0 with no output, justified by a comment claiming
+        # cmd_whitelist_system.sh "handles args directly" — stale since that
+        # module defines nftban_cmd_whitelist_system(). No shipped module relies
+        # on the old contract. Fall THROUGH to the single unknown-command
+        # renderer at the bottom of main() so exactly one rejection shape exists
+        # and no consumer learns a new one. Safe: no token that owns a
+        # cli/cmd_<token>.sh file also matches an alias arm in the case below.
     fi
 
     case "$cmd" in

--- a/scripts/ci/ci-bash-quarantine.tsv
+++ b/scripts/ci/ci-bash-quarantine.tsv
@@ -18,8 +18,15 @@
 # CONFIRMED_PRODUCT_DEFECT entries are quarantined + registered for a separate
 # failure-domain lane; they are NOT fixed in PR-D.
 #
+# De-quarantined:
+#   2026-07-28  v128_help_code_correlation_test  (V1226-CIBASH-PRODDEF-01,
+#     CANONICAL_COMMAND_REGISTRY_DRIFT, lane OPEN_CANONICAL_LOGS_REGISTRATION).
+#     The registered product defect — `logs` routed and completion-listed but
+#     absent from _nftban_canonical_commands() — is closed by v1.228.1 PR-1
+#     (R20). The test now passes in full; a passing quarantined test BLOCKS, so
+#     the entry is retired and the ceiling lowered 3 -> 2.
+#
 # Columns: QT id path owner reason finding introduced review_or_expiry disposition expected_failure_class remediation_lane expected_failure_pattern
-QUARANTINE_CEILING=3
+QUARANTINE_CEILING=2
 QT	botscan_throughput_v187_test	cli/lib/nftban/tests/botscan_throughput_v187_test.sh	nftban-maintainers	prefilter-count invariant requires the Go nftban-botscan-matcher binary which is not built in the hermetic ci-bash environment; the pass-through fallback processes 2 not 1	V1226-CIBASH-ENV-01	2026-07-22	2026-10-31	ENVIRONMENT_SENSITIVE	MISSING_MATCHER_BINARY	OPEN_BOTSCAN_MATCHER_CI_PROVISIONING	prefilter must keep ONLY the candidate
-QT	v128_help_code_correlation_test	cli/lib/nftban/tests/v128_help_code_correlation_test.sh	nftban-maintainers	confirmed product defect: nftban logs (cmd_logs.sh shipped v1.222.0) is routed and completion-listed but absent from _nftban_canonical_commands()	V1226-CIBASH-PRODDEF-01	2026-07-22	2026-10-31	CONFIRMED_PRODUCT_DEFECT	CANONICAL_COMMAND_REGISTRY_DRIFT	OPEN_CANONICAL_LOGS_REGISTRATION	no canonical-command match
 QT	v128_polkit_aware_wording_sweep_test	cli/lib/nftban/tests/v128_polkit_aware_wording_sweep_test.sh	nftban-maintainers	confirmed product defect: 5 operator-facing CLI surfaces reintroduced root/sudo wording after the v1.133 polkit sweep, undetected while this test was unwired from CI	V1226-CIBASH-PRODDEF-02	2026-07-22	2026-10-31	CONFIRMED_PRODUCT_DEFECT	POLKIT_WORDING_DRIFT	OPEN_POLKIT_WORDING_REWORD	requires root [privileges]' in CLI surfaces

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -63,6 +63,7 @@ cli_no_gui_doc_drift_v144_test	cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_te
 cli_output_truth_v167_test	cli/lib/nftban/tests/cli_output_truth_v167_test.sh	cli	test	output-truth	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 cli_pipefail_arith_sweep_v172_test	cli/lib/nftban/tests/cli_pipefail_arith_sweep_v172_test.sh	cli	test	pipefail-arith	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 cli_port_reload_hint_v144_test	cli/lib/nftban/tests/cli_port_reload_hint_v144_test.sh	cli	test	port-reload-hint	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+cli_router_exit_truth_v1228_1_test	cli/lib/nftban/tests/cli_router_exit_truth_v1228_1_test.sh	cli	test	rc-contract	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 cli_runtime_hint_reachability_v144_test	cli/lib/nftban/tests/cli_runtime_hint_reachability_v144_test.sh	cli	test	runtime-hint-reachability	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 cli_status_count_truth_test	cli/lib/nftban/tests/cli_status_count_truth_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 cli_status_json_no_contradict_test	cli/lib/nftban/tests/cli_status_json_no_contradict_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
@@ -206,6 +207,7 @@ support_bundle_redaction_test	cli/lib/nftban/tests/support_bundle_redaction_test
 suricata_usr2_guard_gateb_test	cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh	suricata	test	suricata-logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 sysctl_risk_idle_age_v2161_test	cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 sysctl_safe_default_v216_test	cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+systemd_cli_token_dispatch_v1228_1_test	cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh	cli	test	dispatcher	CI_STATIC	ci-bash	true	false	false	false	false	false			
 tmpfiles_zz_v139_test	cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh	packaging	test	fhs	PACKAGE_BUILD	package-build	true	false	false	false	false	false			
 trust_load_missing_whitelist_test	cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh	trust	test	trust-load	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 uninstall_firewall_ownership_message_v225_test	cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			


### PR DESCRIPTION
**Stack 2 of 4** — base `pr/v1228-2-a-suricata` (#1170). Must not merge before PR-A.

## The invariant

> A CLI command that cannot perform its requested work must **never** return exit 0.

`cli/sbin/nftban` interpolated the token into a filename, sourced it **discarding the source status**, probed for an entrypoint, and on absence did `return 0`. Eight library files were therefore dispatchable as commands, exiting 0 with no output. `set -Eeuo pipefail` is neutralised by `main "$@" || exit $?`.

## Why the obvious fix was rejected

Implementing `source || <reject>` literally **broke `nftban snapshot`** — measured, 0→1. `cmd_snapshot.sh`'s footer fires on the positional parameters `main()` inherits at source time, so that module sources **non-zero while being fully dispatchable**. The scope's Case-A/Case-B split missed a third shape: *source-fails-but-entrypoint-exists*.

Source status is therefore **captured, not acted on**, until after entrypoint resolution:

```
1  source, CAPTURE status
2  resolve the entrypoint, including filename remaps
3  entrypoint EXISTS  -> dispatch, propagating its own status
4  entrypoint ABSENT  -> source failed:    "module failed to load"  exit 1
                      -> source succeeded: unknown-command renderer exit 1
```

## Blast radius — measured, not estimated

Swept all **78 module tokens + 15 aliases**: **exactly the 8 silent-success tokens change 0 → 1, nothing else.** Zero existing exit-code *values* changed. Both rejections use `1`, matching the existing unknown-command arm (owner ruling D6). Nagios `0/1/2/3`, nine `SuccessExitStatus=` units, `update` 10–13, installer 0–10 and `--verify-install-state` 0/2/4 are all untouched.

## The fix is structural, and proven so

**T-A4** builds a synthetic entrypoint-less fixture and requires rejection — an 8-name denylist cannot pass it. Proof: replacing the guard with exactly that anti-pattern gave `PASS=39 FAIL=2`, with **all 16 T-A1/T-A2 assertions still passing**. Only T-A4 distinguishes a structural fix from a denylist. Break reverted, 41/41 restored.

**T-E1** asserts no shipped systemd unit invokes an undispatchable CLI token — the consumer-safety test that would have caught the Suricata units years ago. It ships **zero-gap**: `SANCTIONED_TOKENS=()`, with emptiness asserted rather than merely true.

## Scope correction

`support-bundle` was recorded as a ninth silent no-op. **It is not** — `cmd_support.sh:2161` defines and exports `nftban_cmd_support_bundle`; measured at `0c2a0d9a`, `support-bundle --help` returns rc=0 with 3646 bytes of help. The class is closed anyway via a path-derived entrypoint fallback plus a test asserting every filename remap resolves.

Tests: `cli_router_exit_truth_v1228_1` 41/0 · `systemd_cli_token_dispatch_v1228_1` 19/0 · shellcheck clean, zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Baseline gate exception — `comms_redact_failloud_p_retire2_test`

```
TEST            comms_redact_failloud_p_retire2_test.sh
BASE SHA        0c2a0d9a
BASE RUNTIME    136s · 138s · 137s          (3 runs at base)
INTEGRATION     136s · 137s · 137s          (3 runs on the integration tree)
MULTI_RUN_RANGE 136–138s — 2s spread across 6 runs
GATE LIMIT      120s   (scripts/ci/run-test-suite.sh:41 DEFAULT_TIMEOUT)
RESULT GIVEN TIME  rc=0 · PASS=13 FAIL=0 — the test itself is CORRECT
TEST CONTENT    byte-identical base vs integration
CHANGED FILES   zero overlap (0 of 37 changed files intersect the 12 paths it reads)
CLASSIFICATION  PRE_EXISTING_REPRODUCED_TIMEOUT
WAIVER          NO      QUARANTINE  NO
TARGET FIX      v1.228.3 CI/release reliability -> OPEN_COMMS_REDACT_FAILLOUD_TEST_TIMEOUT_RELIABILITY
```

It was previously described as landing either side of the limit under load. **It does not.** Six runs
span 136–138s — deterministic, and always above 120s. It is not flaky; it never passes the gate. The
remedy is to remove ~17s or split the test, not to raise the global timeout.