### PR TITLE
v1.228.2 PR-C: command-count authority + Suricata advertising parity

### DIFF
--- a/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
+++ b/cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh
@@ -8,12 +8,12 @@
 # meta:version="1.0.0"
 # meta:owner="Antonios Voulvoulis <contact@nftban.com>"
 # meta:created_date="2026-06-01"
-# meta:description="v1.144.0 PR-A — asserts D-NFTBAN-GUI-DOC-DRIFT + FHS-SPEC-GUI-MENTION are closed. (1) commands.registry.yml has no top-level `gui:` entry and no `gui` row in `missing_json:`. (2) build/fhs-spec.yaml has no `gui:` feature block and no 'GUI/API' description. (3) cli/lib/nftban/core/nftban_fhs_spec.sh — regenerated from (2) — contains 'TLS certificates for API' (not 'GUI/API') and no /etc/nftban/gui directory entry. (4) `nftban gui` dispatch through cli/sbin/nftban falls through to the 'Unknown command' catch-all (verified by absence of dispatch case AND absence of alias). Hermetic — no host contact; no daemon, no nft. Closes the operator-visible UX confusion surfaced by the v1.142.0 fleet rollout (V1_142_0_FLEET_ROLLOUT_RECORD.md §3.2)."
+# meta:description="v1.144.0 PR-A — asserts D-NFTBAN-GUI-DOC-DRIFT + FHS-SPEC-GUI-MENTION are closed. (1) commands.registry.yml has no top-level `gui:` entry and no `gui` row in `missing_json:`. (2) build/fhs-spec.yaml has no `gui:` feature block and no 'GUI/API' description. (3) cli/lib/nftban/core/nftban_fhs_spec.sh — regenerated from (2) — contains 'TLS certificates for API' (not 'GUI/API') and no /etc/nftban/gui directory entry. (4) `nftban gui` dispatch through cli/sbin/nftban falls through to the 'Unknown command' catch-all (verified by absence of dispatch case AND absence of alias). (5) v1.228.1 — T1-4 asserts _metadata.total_commands EQUALS the computed top-level command-key count (was: a literal 66 pin, which failed correct counter bumps and passed stale ones); T1-5 proves T1-4 is falsifiable against a mutated fixture. The gui-retirement intent is carried by T1-1/T1-2/T1-3, which do not need the counter. Hermetic — no host contact; no daemon, no nft. Closes the operator-visible UX confusion surfaced by the v1.142.0 fleet rollout (V1_142_0_FLEET_ROLLOUT_RECORD.md §3.2)."
 # meta:input="commands.registry.yml, build/fhs-spec.yaml, cli/lib/nftban/core/nftban_fhs_spec.sh, cli/sbin/nftban"
 # meta:output="Pass/fail assertions; exit 0 on all-pass"
-# meta:depends="bash,grep"
+# meta:depends="bash,grep,mktemp,cp"
 # meta:inventory.files="commands.registry.yml,build/fhs-spec.yaml,cli/lib/nftban/core/nftban_fhs_spec.sh,cli/sbin/nftban"
-# meta:inventory.binaries="bash,grep"
+# meta:inventory.binaries="bash,grep,mktemp,cp"
 # meta:inventory.env_vars=""
 # meta:inventory.config_files=""
 # meta:inventory.systemd_units=""
@@ -74,14 +74,60 @@ else
     ok "T1-3: commands.registry.yml 'missing_json:' has no '- gui' item"
 fi
 
-# T1-4: total_commands counter is one lower than it was before the retirement
-# (66, not 67) — guards against silent re-introduction by a future PR that
-# adds 'gui' back without bumping the counter.
-if grep -nE '^[[:space:]]+total_commands:[[:space:]]+66\b' "$REG" >/dev/null 2>&1; then
-    ok "T1-4: total_commands = 66 (reflects gui retirement)"
+# T1-4: _metadata.total_commands MUST EQUAL the number of top-level command keys
+# actually present in the registry.
+#
+# v1.228.1: this assertion previously pinned the LITERAL 66. That inverted the
+# guard: a PR that added a command and correctly bumped the counter FAILED, while
+# a PR that added a command and left the counter stale PASSED. The guard rewarded
+# staleness and was 5 behind by v1.228.0 (71 keys vs a declared 66). It now
+# MEASURES the registry instead of freezing a number, so it fails on real drift in
+# either direction and never on a correct bump.
+#
+# Parser constraint: scripts/ci/check-cli-surface-parity.sh:33 deliberately avoids a
+# pyyaml dependency. This assertion uses the SAME lightweight rule so both guards
+# agree without adding a Python dependency to the ci-bash image:
+#   a top-level command key is a column-0 `name:` line with nothing after the colon;
+#   `global_options` and `standard_params` are the only such keys that are not
+#   commands; `_metadata` is not matched at all because it starts with '_'.
+# Cross-checked against yaml.safe_load at v1.228.0: both yield 71.
+_registry_command_key_count() {
+    local reg="$1" total noncmd
+    total=$(grep -cE '^[a-z][a-z0-9_-]*:[[:space:]]*$' "$reg" || true)
+    noncmd=$(grep -cE '^(global_options|standard_params):[[:space:]]*$' "$reg" || true)
+    printf '%d\n' $(( total - noncmd ))
+}
+
+REG_COMPUTED=$(_registry_command_key_count "$REG")
+REG_DECLARED=$(grep -E '^[[:space:]]+total_commands:[[:space:]]+[0-9]+' "$REG" \
+               | grep -oE '[0-9]+' | head -1 || true)
+
+if [[ -z "$REG_DECLARED" ]]; then
+    no "T1-4: _metadata.total_commands == computed top-level command-key count" \
+       "total_commands key absent or not an integer"
+elif [[ "$REG_DECLARED" == "$REG_COMPUTED" ]]; then
+    ok "T1-4: _metadata.total_commands == computed command-key count (${REG_COMPUTED})"
 else
-    no "T1-4: total_commands = 66 (reflects gui retirement)" \
-       "$(grep -nE 'total_commands:' "$REG" | head -1 || echo 'absent')"
+    no "T1-4: _metadata.total_commands == computed top-level command-key count" \
+       "declared ${REG_DECLARED}, computed ${REG_COMPUTED} — update total_commands in commands.registry.yml"
+fi
+
+# T1-5: FALSIFIABILITY OF T1-4. A guard that cannot fail is the defect T1-4 was
+# just repaired for, so prove the comparison detects drift rather than trusting it.
+# Copy the registry to a temp fixture, add one synthetic top-level command key
+# WITHOUT bumping the counter, and assert the computed count moves away from the
+# declared one — i.e. T1-4 would have reported drift on that fixture.
+_T15_TMP=$(mktemp -d)
+# shellcheck disable=SC2064  # expand $_T15_TMP now, at trap-installation time
+trap "rm -rf '$_T15_TMP'" EXIT
+cp "$REG" "$_T15_TMP/registry.yml"
+printf '\nzzz_drift_fixture:\n  category: test\n' >> "$_T15_TMP/registry.yml"
+_T15_COMPUTED=$(_registry_command_key_count "$_T15_TMP/registry.yml")
+if [[ "$_T15_COMPUTED" -eq $(( REG_COMPUTED + 1 )) && "$_T15_COMPUTED" != "$REG_DECLARED" ]]; then
+    ok "T1-5: T1-4 is falsifiable (fixture with 1 added key computes ${_T15_COMPUTED} != declared ${REG_DECLARED})"
+else
+    no "T1-5: T1-4 is falsifiable (added key must move the computed count)" \
+       "fixture computed ${_T15_COMPUTED}, base computed ${REG_COMPUTED}, declared ${REG_DECLARED}"
 fi
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/cli/lib/nftban/tests/logrotate_config_v137_test.sh
+++ b/cli/lib/nftban/tests/logrotate_config_v137_test.sh
@@ -97,33 +97,41 @@ grep -q '/var/log/nftban/update.log' "$LR_MAIN" && ok "update_log_listed" || no 
 grep -q 'copytruncate' <<<"$inst_stanza" && ok "installer_update_stanza_copytruncate" || no "installer_update_stanza_copytruncate" "installer/update stanza lacks copytruncate"
 
 # ---------------------------------------------------------------------------
-echo "--- B-04 (SUPERSEDED v1.228.2): suricata setup is retired and installs nothing ---"
+echo "--- B-04: suricata setup module installs NO logrotate policy (v1.228.2) ---"
 # ---------------------------------------------------------------------------
-# ORIGINAL B-04 (v1.137) asserted that `nftban suricata enable` copied the
-# packaged suricata logrotate template into /etc/logrotate.d/nftban-suricata.
-# That closed a real disk-fill exposure at the time, because `enable` was also
-# the thing that REWROTE /etc/suricata/suricata.yaml to point Suricata's EVE
-# output at /var/log/nftban/suricata/ in the first place.
+# RE-AIMED v1.228.2 (owner ruling D1-D4) — justification.
 #
-# v1.228.2 (owner ruling D1-D4) retires Suricata from the active product
-# surface: install/enable/disable are removed because a dormant placeholder
-# must not mutate the host. The assertion is INVERTED rather than deleted —
-# a regression here would mean a host-mutating command came back.
+# B-04 originally asserted that cmd_suricata_setup.sh INSTALLS the suricata
+# logrotate policy into /etc/logrotate.d/. That was correct while
+# `nftban suricata enable` existed. The Suricata retirement removed the whole
+# install/enable/disable surface — a dormant placeholder must not mutate the
+# host — and reduced cmd_suricata_setup.sh to an inert tombstone. Asserting the
+# old behaviour would now assert the exact host mutation the ruling deleted.
 #
-# Why this does not reopen the v1.137 disk-fill exposure:
-#   * NFTBan no longer points any Suricata instance at /var/log/nftban/**.
-#     The EVE-path rewrite lived in the same removed `enable` command, so on a
-#     v1.228.2 host nothing directs Suricata output into the NFTBan tree.
-#   * Hosts that previously ran `enable` already have
-#     /etc/logrotate.d/nftban-suricata on disk; it is not removed by upgrade,
-#     so their rotation policy is unchanged.
-# The packaged template still ships and is still parse-checked below.
-grep -qE '^[[:space:]]*install -D .*nftban-suricata\.logrotate|^[[:space:]]*install -D .*"\$_slr_src"' "$SURI_SETUP" \
-    && no "suri_setup_no_longer_installs_logrotate" "cmd_suricata_setup.sh still installs a logrotate policy — the retired command has returned" \
-    || ok "suri_setup_no_longer_installs_logrotate"
-grep -qE '^[[:space:]]*cmd_suricata_[a-z]+\(\)' "$SURI_SETUP" \
-    && no "suri_setup_is_inert_tombstone" "cmd_suricata_setup.sh still defines a cmd_suricata_* function" \
-    || ok "suri_setup_is_inert_tombstone"
+# The two assertions are therefore inverted, not deleted: the log-durability
+# invariant this test owns is unchanged (the suricata rotation policy must
+# exist, must cover eve-*, must use copytruncate — all still checked below),
+# but the ACTIVATION of that policy is no longer NFTBan's to perform.
+#
+# Note the old B-04 line 1 would still have PASSED here by accident: the
+# tombstone's rationale comment names /etc/logrotate.d/nftban-suricata while
+# installing nothing. A grep for a path in a file that also explains why the
+# path is gone is not evidence of behaviour — hence the non-comment filter.
+_suri_setup_code=$(grep -vE '^[[:space:]]*#' "$SURI_SETUP")
+if grep -q '/etc/logrotate.d/nftban-suricata' <<<"$_suri_setup_code"; then
+    no "suri_setup_no_logrotate_d_write" "tombstone still references /etc/logrotate.d/ in NON-COMMENT code — the retired module must not activate a rotation policy"
+else
+    ok "suri_setup_no_logrotate_d_write"
+fi
+if grep -Eq 'install -D .*nftban-suricata.logrotate|install -D .*"\$_slr_src" "\$_slr_dst"' <<<"$_suri_setup_code"; then
+    no "suri_setup_no_install_cmd" "tombstone still installs the suricata logrotate template — host mutation was removed by the retirement"
+else
+    ok "suri_setup_no_install_cmd"
+fi
+# The template itself MUST still ship (packaging installs it to
+# /etc/nftban/templates/; see packaging/build_nftban.sh + payload.go). The
+# retirement removed the activator, not the policy.
+[[ -f "$LR_SURI" ]] && ok "suri_policy_template_still_shipped" || no "suri_policy_template_still_shipped" "install/config/nftban-suricata.logrotate is missing — the retirement must not drop the rotation policy"
 # the shipped suricata policy must actually cover the high-volume eve + classic logs
 grep -q 'eve-' "$LR_SURI" && ok "suri_policy_covers_eve" || no "suri_policy_covers_eve" "suricata policy does not cover eve-*"
 grep -Eq 'fast.log|stats.log' "$LR_SURI" && ok "suri_policy_covers_fast_stats" || no "suri_policy_covers_fast_stats" "suricata policy missing fast.log/stats.log"

--- a/cli/lib/nftban/tests/suricata_subcommand_authority_v1228_2_test.sh
+++ b/cli/lib/nftban/tests/suricata_subcommand_authority_v1228_2_test.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — Suricata subcommand authority (v1.228.2, F2)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="suricata_subcommand_authority_v1228_2_test"
+# meta:type="test"
+# meta:version="1.228.2"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="F2 structural authority test for the retired Suricata surface. DERIVES four independent subcommand sets at runtime — the dispatcher case arms in cli/lib/nftban/cli/cmd_suricata*.sh, the suricata.subcommands block in commands.registry.yml, the suricata_cmds token list in install/bash-completion/nftban, and the documented set (registry suricata.examples UNION the COMMANDS block of cmd_suricata_help) — and asserts SET EQUALITY across all four. Deliberately does NOT hardcode the member names: a name check would still pass if every authority were wrong in the same way, and would need editing (i.e. would be silently weakened) the next time the surface legitimately changes. The load-bearing assertion is PHANTOM_SUBCOMMANDS=0: (registry UNION completion UNION docs) MINUS dispatcher must be empty, which is the bug class v1.228.2 removes — 42 advertised subcommands, 14 examples and a 15-token completion list for a dispatcher that accepts two verbs. ORPHAN_SUBCOMMANDS=0 is the converse (a verb that dispatches but is advertised nowhere). Section F proves the comparison is falsifiable against mutated fixtures rather than trusting it. Hermetic static analysis: reads files, invokes no CLI, contacts no host."
+# meta:input="cli/lib/nftban/cli/cmd_suricata.sh, cli/lib/nftban/cli/cmd_suricata_setup.sh, commands.registry.yml, install/bash-completion/nftban"
+# meta:output="exit 0 if all four authorities agree and no phantom/orphan exists; exit 1 with the offending set members otherwise"
+# meta:depends="bash,awk,grep,sed,sort,comm,mktemp"
+# meta:inventory.files="commands.registry.yml,install/bash-completion/nftban,cli/lib/nftban/cli/cmd_suricata.sh,cli/lib/nftban/cli/cmd_suricata_setup.sh"
+# meta:inventory.binaries="bash,awk,grep,sed,sort,comm"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="suricata_subcommand_authority_v1228_2_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli-command-correlation"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+set +e
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+CMD_SURICATA="$REPO/cli/lib/nftban/cli/cmd_suricata.sh"
+REGISTRY="$REPO/commands.registry.yml"
+COMPLETION="$REPO/install/bash-completion/nftban"
+
+for f in "$CMD_SURICATA" "$REGISTRY" "$COMPLETION"; do
+    [[ -f "$f" ]] || { echo "FAIL: missing required input $f" >&2; exit 1; }
+done
+
+WORK=$(mktemp -d)
+# shellcheck disable=SC2064  # expand WORK now, at trap-installation time
+trap "rm -rf '$WORK'" EXIT
+
+echo "==============================================================================="
+echo "v1.228.2 F2 — Suricata subcommand authority (derived sets, set-equality)"
+echo "==============================================================================="
+
+# =============================================================================
+# EXTRACTORS
+# =============================================================================
+# Each extractor reads ONE authority and emits a sorted, de-duplicated token
+# list on stdout. They take the file path as an argument so section F can run
+# the identical logic against a mutated fixture — the falsification proof and
+# the real assertion share one code path, so the proof cannot drift from what
+# is actually enforced.
+#
+# Option-shaped tokens (`--json`, `-h`) are NOT subcommands and are filtered
+# everywhere; `*` (the catch-all arm) is not a subcommand either.
+# -----------------------------------------------------------------------------
+
+_drop_non_subcommands() {
+    grep -vE '^-' | grep -vE '^\*$' | grep -E '^[a-z][a-z0-9_-]*$' | sort -u
+}
+
+# (1) DISPATCHER — the case arms inside nftban_cmd_suricata().
+# Scans every cmd_suricata*.sh so a router that moves to a sibling module is
+# still found rather than silently reported as an empty set.
+extract_dispatcher() {
+    local cli_dir="$1" f
+    for f in "$cli_dir"/cmd_suricata*.sh; do
+        [[ -f "$f" ]] || continue
+        awk '
+            /^nftban_cmd_suricata\(\)[[:space:]]*\{/ { inf=1 }
+            inf && /^\}/                             { inf=0 }
+            inf                                      { print }
+        ' "$f" \
+        | grep -oE '^[[:space:]]+[a-z0-9*|_-]+\)' \
+        | sed -E 's/^[[:space:]]+//; s/\)$//' \
+        | tr '|' '\n'
+    done | _drop_non_subcommands
+}
+
+# (2) REGISTRY — keys under suricata: -> subcommands:.
+# Lightweight scan (no pyyaml), matching the parser discipline of
+# scripts/ci/check-cli-surface-parity.sh so both guards agree in the same
+# ci-bash image. Handles both the block form and the inline `k: {…}` form.
+extract_registry() {
+    awk '
+        /^suricata:[[:space:]]*$/          { in_cmd=1; next }
+        in_cmd && /^[a-z_][a-z0-9_-]*:/    { exit }            # next top-level key
+        in_cmd && /^  subcommands:[[:space:]]*$/ { in_sub=1; next }
+        in_sub && /^  [a-z]/               { in_sub=0 }        # next command-level key
+        in_sub && /^    #/                 { next }            # comment
+        in_sub && /^    [a-z][a-z0-9_-]*:/ {
+            line=$0
+            sub(/^    /, "", line)
+            sub(/:.*$/, "", line)
+            print line
+        }
+    ' "$1" | _drop_non_subcommands
+}
+
+# (3) COMPLETION — the suricata_cmds token list.
+extract_completion() {
+    grep -m1 -E 'local[[:space:]]+suricata_cmds=' "$1" \
+        | sed -E 's/.*suricata_cmds="//; s/".*//' \
+        | tr ' ' '\n' | _drop_non_subcommands
+}
+
+# (4) DOCUMENTED — registry `suricata:` examples UNION the COMMANDS block of
+# cmd_suricata_help. Operator-facing text is an authority too: an example or a
+# help row for a verb that no longer dispatches is the same lie as a registry
+# entry for it.
+extract_documented() {
+    local registry="$1" cmd_file="$2"
+    {
+        # 4a: `- "nftban suricata <token> …"` inside the suricata block only.
+        awk '
+            /^suricata:[[:space:]]*$/       { in_cmd=1; next }
+            in_cmd && /^[a-z_][a-z0-9_-]*:/ { exit }
+            in_cmd && /nftban suricata /    { print }
+        ' "$registry" \
+        | sed -E 's/.*nftban suricata[[:space:]]+//; s/[[:space:]].*$//; s/"$//'
+
+        # 4b: the COMMANDS: block of the help heredoc (indented "verb  text" rows).
+        awk '
+            /^COMMANDS:[[:space:]]*$/ { in_b=1; next }
+            in_b && /^[A-Z]+:/        { in_b=0 }
+            in_b && /^[[:space:]]*$/  { in_b=0 }
+            in_b                      { print }
+        ' "$cmd_file" \
+        | grep -oE '^[[:space:]]+[a-z][a-z0-9_-]*' \
+        | sed -E 's/^[[:space:]]+//'
+    } | _drop_non_subcommands
+}
+
+# =============================================================================
+# (A) Derive the four sets
+# =============================================================================
+echo "--- A: derive the four authority sets ---"
+
+extract_dispatcher "$REPO/cli/lib/nftban/cli"          > "$WORK/dispatcher"
+extract_registry   "$REGISTRY"                          > "$WORK/registry"
+extract_completion "$COMPLETION"                        > "$WORK/completion"
+extract_documented "$REGISTRY" "$CMD_SURICATA"          > "$WORK/documented"
+
+N_DISPATCH=$(grep -c . < "$WORK/dispatcher"  || true)
+N_REGISTRY=$(grep -c . < "$WORK/registry"    || true)
+N_COMPLETE=$(grep -c . < "$WORK/completion"  || true)
+N_DOCUMENT=$(grep -c . < "$WORK/documented"  || true)
+
+printf '  SURICATA_DISPATCHABLE_SUBCOMMANDS = %s  [%s]\n' "$N_DISPATCH" "$(tr '\n' ' ' < "$WORK/dispatcher")"
+printf '  SURICATA_REGISTRY_SUBCOMMANDS     = %s  [%s]\n' "$N_REGISTRY" "$(tr '\n' ' ' < "$WORK/registry")"
+printf '  SURICATA_COMPLETION_SUBCOMMANDS   = %s  [%s]\n' "$N_COMPLETE" "$(tr '\n' ' ' < "$WORK/completion")"
+printf '  SURICATA_DOCUMENTED_SUBCOMMANDS   = %s  [%s]\n' "$N_DOCUMENT" "$(tr '\n' ' ' < "$WORK/documented")"
+
+# A0: the dispatcher set must be non-empty. Without this, an extractor that
+# silently stops matching would make every set-difference below trivially
+# empty and turn the whole test green on a broken parse.
+if (( N_DISPATCH > 0 )); then
+    ok "A0: dispatcher set is non-empty (${N_DISPATCH}) — extractor is live, not silently matching nothing"
+else
+    no "A0: dispatcher set is non-empty" \
+       "extracted 0 case arms from nftban_cmd_suricata() — the router changed shape and this test is blind"
+fi
+
+# A0b: same fail-closed guard for the three advertising extractors. An empty
+# advertising set would also make PHANTOM trivially 0.
+for pair in "registry:$N_REGISTRY" "completion:$N_COMPLETE" "documented:$N_DOCUMENT"; do
+    nm="${pair%%:*}"; cnt="${pair#*:}"
+    if (( cnt > 0 )); then
+        ok "A0b: ${nm} extractor is live (${cnt} token(s))"
+    else
+        no "A0b: ${nm} extractor is live" "extracted 0 tokens — parse broke; PHANTOM would be vacuously 0"
+    fi
+done
+
+# =============================================================================
+# (B) PHANTOM_SUBCOMMANDS — the load-bearing assertion
+# =============================================================================
+# A phantom is a verb some surface ADVERTISES that the dispatcher does NOT
+# accept: the operator is told it exists, types it, and gets a usage error.
+echo "--- B: PHANTOM_SUBCOMMANDS (advertised but not dispatchable) ---"
+cat "$WORK/registry" "$WORK/completion" "$WORK/documented" | sort -u > "$WORK/advertised"
+comm -23 "$WORK/advertised" "$WORK/dispatcher" > "$WORK/phantom"
+N_PHANTOM=$(grep -c . < "$WORK/phantom" || true)
+
+if (( N_PHANTOM == 0 )); then
+    ok "B1: PHANTOM_SUBCOMMANDS=0 — nothing advertised is undispatchable"
+else
+    no "B1: PHANTOM_SUBCOMMANDS=0" \
+       "$N_PHANTOM phantom verb(s) advertised with no dispatcher arm: $(tr '\n' ' ' < "$WORK/phantom")"
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        src=""
+        grep -qxF "$p" "$WORK/registry"   && src+="registry "
+        grep -qxF "$p" "$WORK/completion" && src+="completion "
+        grep -qxF "$p" "$WORK/documented" && src+="docs "
+        printf '         phantom: %-20s advertised by: %s\n' "$p" "$src"
+    done < "$WORK/phantom"
+fi
+
+# =============================================================================
+# (C) ORPHAN_SUBCOMMANDS — the converse
+# =============================================================================
+# A verb that dispatches but is advertised nowhere is undiscoverable. Reported
+# per-authority so the missing surface is named, not merely counted.
+echo "--- C: ORPHAN_SUBCOMMANDS (dispatchable but unadvertised) ---"
+for auth in registry completion documented; do
+    comm -23 "$WORK/dispatcher" "$WORK/$auth" > "$WORK/orphan_$auth"
+    n=$(grep -c . < "$WORK/orphan_$auth" || true)
+    if (( n == 0 )); then
+        ok "C-${auth}: every dispatchable verb appears in ${auth}"
+    else
+        no "C-${auth}: every dispatchable verb appears in ${auth}" \
+           "$n dispatchable verb(s) missing from ${auth}: $(tr '\n' ' ' < "$WORK/orphan_$auth")"
+    fi
+done
+
+# =============================================================================
+# (D) SET EQUALITY across all four authorities
+# =============================================================================
+echo "--- D: set-equality across all four authorities ---"
+for auth in registry completion documented; do
+    if diff -q "$WORK/dispatcher" "$WORK/$auth" >/dev/null 2>&1; then
+        ok "D-${auth}: ${auth} set == dispatcher set"
+    else
+        no "D-${auth}: ${auth} set == dispatcher set" \
+           "symmetric difference: $(comm -3 "$WORK/dispatcher" "$WORK/$auth" | tr -d '\t' | tr '\n' ' ')"
+    fi
+done
+
+# D-count: state the cardinality agreement as its own number so a reader of the
+# CI log sees the invariant, not just a diff verdict.
+if [[ "$N_DISPATCH" == "$N_REGISTRY" && "$N_DISPATCH" == "$N_COMPLETE" && "$N_DISPATCH" == "$N_DOCUMENT" ]]; then
+    ok "D-count: all four authorities declare the same cardinality (${N_DISPATCH})"
+else
+    no "D-count: all four authorities declare the same cardinality" \
+       "dispatcher=${N_DISPATCH} registry=${N_REGISTRY} completion=${N_COMPLETE} documented=${N_DOCUMENT}"
+fi
+
+# =============================================================================
+# (E) Retirement invariants that the set comparison cannot express
+# =============================================================================
+# The sets could agree at the wrong value — e.g. all four re-grow to include
+# `install`. These pin the ruling itself (D3: dormant placeholder, no host
+# mutation) without hardcoding the surviving member names.
+echo "--- E: retirement invariants ---"
+
+# E1: no dispatcher arm names a host-mutating verb.
+if grep -qE '^[[:space:]]*(install|enable|disable|setup|rules|update|sid|category|profile|custom|iface|advanced|tools|scan|recommend)[)|]' \
+        <(awk '/^nftban_cmd_suricata\(\)[[:space:]]*\{/,/^\}/' "$CMD_SURICATA"); then
+    no "E1: dispatcher exposes no rule-management or host-mutating verb" \
+       "a retired verb reappeared in the router — D3 says rule management is NOT restored"
+else
+    ok "E1: dispatcher exposes no rule-management or host-mutating verb"
+fi
+
+# E2: the registry description no longer implies an active protection module.
+suri_desc=$(awk '
+    /^suricata:[[:space:]]*$/       { in_cmd=1; next }
+    in_cmd && /^[a-z_][a-z0-9_-]*:/ { exit }
+    in_cmd && /^  description:/     { print; exit }
+' "$REGISTRY")
+if [[ -n "$suri_desc" ]] && grep -qiE 'dormant|reserved for a future' <<<"$suri_desc"; then
+    ok "E2: registry suricata description states the dormant/future-release status"
+else
+    no "E2: registry suricata description states the dormant/future-release status" \
+       "description does not say dormant or reserved-for-a-future-release: ${suri_desc:-<absent>}"
+fi
+
+# E3: the registry no longer claims the command mutates or needs root.
+suri_block=$(awk '
+    /^suricata:[[:space:]]*$/       { in_cmd=1 }
+    in_cmd && /^[a-z_][a-z0-9_-]*:/ && !/^suricata:/ { exit }
+    in_cmd && /^  [a-z]/            { print }
+' "$REGISTRY")
+if grep -qE '^  mutates:[[:space:]]*false' <<<"$suri_block" \
+   && grep -qE '^  requires_root:[[:space:]]*false' <<<"$suri_block"; then
+    ok "E3: registry declares suricata mutates:false requires_root:false (read-only dormant reporter)"
+else
+    no "E3: registry declares suricata mutates:false requires_root:false" \
+       "$(grep -E '^  (mutates|requires_root):' <<<"$suri_block" | tr '\n' ' ')"
+fi
+
+# =============================================================================
+# (F) FALSIFIABILITY — prove the comparison detects a re-added phantom
+# =============================================================================
+# A guard that cannot fail is precisely the defect this release removes: the
+# pre-v1.228.2 tree advertised 42 subcommands for a 2-verb dispatcher and every
+# parity guard in the repo passed, because they all compare TOP-LEVEL commands
+# only. So this section does not assert that the tree is clean — sections A-E
+# already did — it asserts that the machinery WOULD HAVE CAUGHT the drift.
+#
+# Each case copies a real authority to a temp fixture, injects one phantom verb
+# using a name that is not in the real surface, and re-runs the SAME extractor.
+echo "--- F: falsifiability of B1 ---"
+PHANTOM_NAME="zzzphantomverb"
+
+# F1: phantom injected into the REGISTRY subcommands block.
+cp "$REGISTRY" "$WORK/reg_mut.yml"
+awk -v ph="$PHANTOM_NAME" '
+    { print }
+    /^suricata:[[:space:]]*$/          { in_cmd=1; next }
+    in_cmd && /^  subcommands:[[:space:]]*$/ && !done {
+        printf "    %s:\n      mutates: false\n      description: \"injected fixture\"\n", ph
+        done=1
+    }
+' "$REGISTRY" > "$WORK/reg_mut.yml"
+extract_registry "$WORK/reg_mut.yml" > "$WORK/reg_mut_set"
+cat "$WORK/reg_mut_set" "$WORK/completion" "$WORK/documented" | sort -u > "$WORK/adv_mut"
+if comm -23 "$WORK/adv_mut" "$WORK/dispatcher" | grep -qxF "$PHANTOM_NAME"; then
+    ok "F1: B1 is falsifiable — a phantom injected into the registry is detected"
+else
+    no "F1: B1 is falsifiable — a phantom injected into the registry is detected" \
+       "the mutated fixture produced NO phantom; the registry extractor or the set difference is broken, so B1 above proves nothing"
+fi
+
+# F2: phantom injected into the COMPLETION token list.
+sed -E "s/(local[[:space:]]+suricata_cmds=\")/\1${PHANTOM_NAME} /" "$COMPLETION" > "$WORK/comp_mut"
+extract_completion "$WORK/comp_mut" > "$WORK/comp_mut_set"
+cat "$WORK/registry" "$WORK/comp_mut_set" "$WORK/documented" | sort -u > "$WORK/adv_mut2"
+if comm -23 "$WORK/adv_mut2" "$WORK/dispatcher" | grep -qxF "$PHANTOM_NAME"; then
+    ok "F2: B1 is falsifiable — a phantom injected into bash-completion is detected"
+else
+    no "F2: B1 is falsifiable — a phantom injected into bash-completion is detected" \
+       "the mutated fixture produced NO phantom; the completion extractor or the set difference is broken"
+fi
+
+# F3: phantom injected into the DOCUMENTED surface (a registry example).
+awk -v ph="$PHANTOM_NAME" '
+    { print }
+    /^suricata:[[:space:]]*$/  { in_cmd=1; next }
+    in_cmd && /^  examples:[[:space:]]*$/ && !done {
+        printf "    - \"nftban suricata %s\"\n", ph
+        done=1
+    }
+' "$REGISTRY" > "$WORK/doc_mut.yml"
+extract_documented "$WORK/doc_mut.yml" "$CMD_SURICATA" > "$WORK/doc_mut_set"
+cat "$WORK/registry" "$WORK/completion" "$WORK/doc_mut_set" | sort -u > "$WORK/adv_mut3"
+if comm -23 "$WORK/adv_mut3" "$WORK/dispatcher" | grep -qxF "$PHANTOM_NAME"; then
+    ok "F3: B1 is falsifiable — a phantom injected into a registry example is detected"
+else
+    no "F3: B1 is falsifiable — a phantom injected into a registry example is detected" \
+       "the mutated fixture produced NO phantom; the documented-surface extractor is broken"
+fi
+
+# F4: falsifiability of the ORPHAN direction — remove a real verb from an
+# advertising surface and prove section C would report it.
+first_verb=$(head -1 "$WORK/dispatcher")
+if [[ -n "$first_verb" ]]; then
+    grep -vxF "$first_verb" "$WORK/completion" > "$WORK/comp_short"
+    if comm -23 "$WORK/dispatcher" "$WORK/comp_short" | grep -qxF "$first_verb"; then
+        ok "F4: C is falsifiable — dropping '${first_verb}' from completion is detected as an orphan"
+    else
+        no "F4: C is falsifiable — dropping a real verb from completion is detected" \
+           "removing '${first_verb}' produced no orphan; the orphan comparison is broken"
+    fi
+else
+    no "F4: C is falsifiable" "dispatcher set empty — cannot build the fixture"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==============================================================================="
+echo "suricata_subcommand_authority_v1228_2 results: ${PASS} PASS / ${FAIL} FAIL"
+echo "==============================================================================="
+if (( FAIL > 0 )); then
+    echo "Failed tests:"
+    for f in "${FAILED[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0

--- a/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
+++ b/cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh
@@ -49,15 +49,25 @@ ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
 no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
 
 # -----------------------------------------------------------------------------
-# SANCTIONED, TIME-LIMITED GAP — v1.228.1 PR-1 only.
+# SANCTIONED GAP LIST — NOW EMPTY (v1.228.2). This is the terminal state.
 #
-# PR-1 fixes the router; it is forbidden from touching systemd units, which
-# PR-2 owns and which are blocked on owner decisions D1 (what should
-# nftban-suricata.service ExecStartPre do now that `suricata rules verify` no
-# longer exists) and D2 (delete or repoint nftban-suricata-update.service).
-# Each entry is asserted BELOW to still be broken: when PR-2 lands, this test
-# fails until the entry is deleted. A sanctioned gap that silently becomes
-# correct is how a known-gap list rots into a lie.
+# v1.228.1 PR-1 fixed the router but was forbidden from touching systemd units,
+# so it sanctioned exactly one token — `suricata` — pending owner decisions D1
+# (what nftban-suricata.service ExecStartPre should do now that
+# `suricata rules verify` no longer exists) and D2 (delete or repoint
+# nftban-suricata-update.service). Each entry was asserted below to STILL be
+# broken, so that the list could not rot into a lie once the gap closed.
+#
+# That mechanism fired: the Suricata retirement (owner ruling D1-D4) DELETED
+# install/systemd/nftban-suricata.service and nftban-suricata-update.{service,timer}
+# rather than repointing them, and build/deprecated-units.yaml converges them
+# away on upgrade. No shipped unit invokes `nftban suricata` any more, so the
+# entry stopped earning its place and the reverse assertion failed until it was
+# removed. It is removed here.
+#
+# DO NOT re-populate this list to make a red run green. An undispatchable token
+# in a shipped unit is a unit that starts green while doing nothing — the exact
+# defect v1.228.1 exists to remove. Fix the unit or delete it.
 # -----------------------------------------------------------------------------
 # ZERO-GAP as of v1.228.2. The entry for 'suricata' was retired when the
 # Suricata units were removed from install/systemd/ — at that moment this
@@ -71,7 +81,8 @@ SANCTIONED_REASON="none — zero-gap"
 
 is_sanctioned(){
     local t="$1" s
-    for s in "${SANCTIONED_TOKENS[@]}"; do [[ "$s" == "$t" ]] && return 0; done
+    # `${arr[@]+...}` form: the list is now empty and must survive `set -u`.
+    for s in ${SANCTIONED_TOKENS[@]+"${SANCTIONED_TOKENS[@]}"}; do [[ "$s" == "$t" ]] && return 0; done
     return 1
 }
 
@@ -187,7 +198,7 @@ done
 # A sanctioned token that no unit invokes any more, or that quietly started
 # working, must be removed rather than left as decoration.
 echo "--- sanctioned-set hygiene ---"
-for s in "${SANCTIONED_TOKENS[@]}"; do
+for s in ${SANCTIONED_TOKENS[@]+"${SANCTIONED_TOKENS[@]}"}; do
     hit="no"
     for b in ${SEEN_BROKEN[@]+"${SEEN_BROKEN[@]}"}; do [[ "$b" == "$s" ]] && hit="yes"; done
     if [[ "$hit" == "yes" ]]; then
@@ -197,6 +208,31 @@ for s in "${SANCTIONED_TOKENS[@]}"; do
            "'$s' is no longer a broken systemd-invoked token — remove it from SANCTIONED_TOKENS"
     fi
 done
+
+# ZERO-GAP INVARIANT (v1.228.2). The allowlist is not merely "currently empty";
+# emptiness is the asserted terminal state. Stated as two explicit numbers so a
+# future PR that re-populates the list to silence a red run fails HERE, with the
+# reason spelled out, instead of quietly shipping a unit that starts green while
+# invoking a CLI token that does no work.
+#
+#   SANCTIONED_BROKEN_SURICATA_UNITS = 0
+#   SYSTEMD_UNDISPATCHABLE_TOKENS    = 0
+echo "--- zero-gap invariant ---"
+_sanctioned_n=${#SANCTIONED_TOKENS[@]}
+if (( _sanctioned_n == 0 )); then
+    ok "T-E1 SANCTIONED_BROKEN_SURICATA_UNITS=0 — allowlist is empty (terminal state)"
+else
+    no "T-E1 SANCTIONED_BROKEN_SURICATA_UNITS=0 — allowlist is empty (terminal state)" \
+       "${_sanctioned_n} sanctioned token(s) present: ${SANCTIONED_TOKENS[*]} — fix or delete the unit, do not allowlist it"
+fi
+
+_broken_n=${#SEEN_BROKEN[@]}
+if (( _broken_n == 0 )); then
+    ok "T-E1 SYSTEMD_UNDISPATCHABLE_TOKENS=0 — every shipped unit invokes a dispatchable token"
+else
+    no "T-E1 SYSTEMD_UNDISPATCHABLE_TOKENS=0 — every shipped unit invokes a dispatchable token" \
+       "${_broken_n} undispatchable invocation(s): ${SEEN_BROKEN[*]}"
+fi
 
 echo "=========================================================="
 echo "RESULTS: PASS=$PASS FAIL=$FAIL"

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -2916,176 +2916,54 @@ geoip:
     - "nftban geoip update"
     - "nftban geoip config --json"
 
+# -----------------------------------------------------------------------------
+# v1.228.2 — SURICATA RETIRED FROM THE ACTIVE PRODUCT SURFACE (owner ruling D3)
+#
+# Suricata integration is reserved for a future release and is not currently an
+# active protection module. `nftban suricata` dispatches `status` and `help` and
+# nothing else (cli/lib/nftban/cli/cmd_suricata.sh:187-202); every other verb
+# returns a usage error.
+#
+# The 42 subcommands and 14 examples that used to live here advertised rule
+# management, profile management, custom-rule editing, service detection and
+# install/enable/disable. None of them dispatch: four of the five submodules
+# were deleted by ff1865b4 and the surviving install/enable/disable behaviour
+# was removed by the retirement because a dormant placeholder must not mutate
+# the host. Rule management is NOT restored.
+#
+# `suricata:` REMAINS a top-level command key — _metadata.total_commands is a
+# count of top-level keys and is unchanged at 71 by this reduction.
+#
+# INVARIANT: this block, install/bash-completion/nftban::suricata_cmds and the
+# dispatcher case arms must declare the SAME set. Enforced by
+# cli/lib/nftban/tests/suricata_subcommand_authority_v1228_2_test.sh, which
+# derives all four sets at runtime and fails on any phantom.
+# -----------------------------------------------------------------------------
 suricata:
   category: intelligence_reporting
-  description: "Suricata IDS integration (deep packet inspection)"
+  description: "Report the state of the Suricata integration (DORMANT — reserved for a future release, not an active protection module; NFTBan ships no Suricata service, rule management or update timer)"
   risk: advanced
   audience: [cli]
-  capability: service_control
-  mutates: conditional
+  capability: status_read
+  mutates: false
   supports_dry_run: false
-  requires_root: true
+  requires_root: false
   panel_expose: false
   output_modes: [json, text]
   has_json: true
   examples:
     - "nftban suricata status"
-    - "nftban suricata filters"
-    - "nftban suricata enable SSH_BRUTE_FORCE"
-    - "nftban suricata disable POLICY_VIOLATIONS"
-    - "nftban suricata set-threshold SSH_BRUTE_FORCE 50"
-    - "nftban suricata set-action WEB_ATTACKS alert"
-    - "nftban suricata profile-detect"
-    - "nftban suricata profile-apply standard"
-    - "nftban suricata scan"
-    - "nftban suricata rules-generate"
-    - "nftban suricata rules-verify"
-    - "nftban suricata rules-ensure"
-    - "nftban suricata sid-top"
-    - "nftban suricata recommend"
+    - "nftban suricata status --json"
+    - "nftban suricata help"
   subcommands:
-    # Core
-    status: {mutates: false, description: "Show Suricata integration status"}
-    filters: {mutates: false, description: "List detection filters and state"}
-    daemon: {mutates: false, description: "Run alert processing daemon"}
-    enable: {mutates: true, description: "Enable a detection filter"}
-    disable: {mutates: true, description: "Disable a detection filter"}
-    set-threshold:
-      mutates: true
-      description: "Set scoring threshold"
-    set-action:
-      mutates: true
-      description: "Set action (alert/drop)"
-    # Profiles
-    profile-detect:
+    status:
       mutates: false
-      description: "Auto-detect optimal profile"
-    profile-apply:
-      mutates: true
-      description: "Apply profile"
-    profile-show:
-      mutates: false
-      description: "Show current profile config"
-    profile-validate:
-      mutates: false
-      description: "Validate profile config"
-    # Service Detection
-    scan:
-      mutates: false
-      description: "Quick scan for services"
-    scan-deep:
-      mutates: false
-      description: "Deep service detection"
-    # Rules Management
-    rules-generate:
-      mutates: true
-      description: "Generate enabled rules list"
-    rules-stats:
-      mutates: false
-      description: "Show rule statistics"
-    rules-init:
-      mutates: true
-      description: "Initialize rule management"
-    rules-verify:
-      mutates: false
-      description: "Verify rules are loadable"
-    rules-ensure:
-      mutates: true
-      description: "Auto-download rules if missing"
-    # SID Statistics
-    sid-stats:
-      mutates: false
-      description: "Show signature trigger stats"
-    sid-info:
-      mutates: false
-      description: "Show details for specific SID"
-    sid-top:
-      mutates: false
-      description: "Show top triggered signatures"
-    sid-recent:
-      mutates: false
-      description: "Show recently triggered SIDs"
-    stats-daemon:
-      mutates: false
-      description: "Run statistics daemon"
-    # Custom Rules
-    custom-add:
-      mutates: true
-      description: "Add a custom Suricata rule"
-    custom-remove:
-      mutates: true
-      description: "Remove a custom rule by SID"
-    custom-edit:
-      mutates: true
-      description: "Edit an existing custom rule"
-    custom-list:
-      mutates: false
-      description: "List all custom rules"
-    custom-validate:
-      mutates: false
-      description: "Validate custom rules syntax"
-    custom-enable:
-      mutates: true
-      description: "Enable a custom rule"
-    custom-disable:
-      mutates: true
-      description: "Disable a custom rule"
-    custom-backup:
-      mutates: true
-      description: "Backup custom rules"
-    custom-rollback:
-      mutates: true
-      description: "Restore from backup"
-    # Recommendations
-    recommend:
-      mutates: false
-      description: "Get rule recommendations"
-    recommend-summary:
-      mutates: false
-      description: "Show recommendation summary"
-    # Advanced Operations
-    advanced:
-      mutates: conditional
-      description: "Advanced Suricata operations and tuning"
+      description: "Report the dormant integration state (read-only, no host contact; always exits 2)"
       options:
         --json: {type: bool, description: "Output in JSON format"}
-    iface:
-      mutates: conditional
-      description: "Manage Suricata network interface configuration"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    rules:
-      mutates: conditional
-      description: "Comprehensive rule management (generate, verify, ensure)"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    setup:
-      mutates: true
-      description: "Initial Suricata integration setup and configuration"
-      requires_root: true
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    tools:
+    help:
       mutates: false
-      description: "Suricata diagnostic and utility tools"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    # v1.19.13: Standard module consistency subcommands
-    config:
-      mutates: false
-      description: "Show Suricata configuration"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    stats:
-      mutates: false
-      description: "Show Suricata statistics (EVE, alerts)"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
-    test:
-      mutates: false
-      description: "Test Suricata connectivity and EVE log availability"
-      options:
-        --json: {type: bool, description: "Output in JSON format"}
+      description: "Show Suricata command help"
 
 mail:
   category: intelligence_reporting

--- a/commands.registry.yml
+++ b/commands.registry.yml
@@ -927,7 +927,7 @@ login:
       description: "Send a test alert email"
     mode:
       mutates: true
-      description: "Set monitoring mode"
+      description: "Set the login alert email cadence (realtime|digest|both). Does not change LOGIN_MODE — see 'nftban modes'."
       arguments:
         mode: {type: enum, required: false, values: [realtime, digest, both]}
     digest:
@@ -1495,7 +1495,9 @@ geoban:
     - "nftban geoban list --json"
     - "nftban geoban test"
 
-# NOTE: cloudflare command removed in v1.10.0 - use "nftban trust" instead
+# NOTE: the top-level 'cloudflare' command is a legacy ALIAS of 'trust' and is NOT removed.
+# See trust.aliases above and the dispatch arm in cli/sbin/nftban. What was retired in
+# v1.10.0 is the standalone cloudflare implementation; the token still routes to 'trust'.
 
 # =============================================================================
 # GROUP 3: INFRASTRUCTURE
@@ -3105,7 +3107,8 @@ mail:
 
 services:
   category: intelligence_reporting
-  description: "Systemd services status overview"
+  aliases: ["service"]
+  description: "Systemd services status overview. NOTE: 'service' (singular) is a legacy top-level alias of 'services' (sbin/nftban dispatch); kept for discovery/back-compat."
   risk: core
   audience: [cli, auditor, panel]
   capability: status_read
@@ -3670,7 +3673,13 @@ _metadata:
     - "Arguments with type validation (string, int, bool, enum)"
     - "Zabbix LLD discovery support"
     - "Auto-help generation support"
-  total_commands: 66  # v1.144.0 PR-A: -1 (gui retired)
+  # DERIVED VALUE — must equal the number of top-level command keys in this file
+  # (every column-0 `key:` line except global_options and standard_params; _metadata
+  # is not matched because it starts with '_'). Verified by the computed assertion
+  # T1-4 in cli/lib/nftban/tests/cli_no_gui_doc_drift_v144_test.sh, which measures the
+  # registry instead of pinning a literal. Bump this whenever a command key is added
+  # or removed; the guard fails if it drifts.
+  total_commands: 71
   commands_with_json: 46
   commands_without_json: 10  # v1.144.0 PR-A: -1 (gui retired)
   commands_with_full_options: 27

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -109,7 +109,13 @@ _nftban() {
     local queue_cmds="status list process dlq metrics help"
     local rbl_cmds="check server status list enable disable cache alert critical watchlist config stats test providers help"
     local support_cmds="--network help"
-    local suricata_cmds="install enable disable status eve rules profile scan services sid category local custom recommend iface help"
+    # v1.228.2: Suricata is a DORMANT placeholder — the dispatcher accepts only
+    # `status` and `help` (cli/lib/nftban/cli/cmd_suricata.sh). Offering the old
+    # install/enable/disable/rules/profile/... tokens completed operators into a
+    # usage error. Keep this list set-equal to the dispatcher case arms and the
+    # commands.registry.yml suricata.subcommands block; the equality is enforced
+    # by cli/lib/nftban/tests/suricata_subcommand_authority_v1228_2_test.sh.
+    local suricata_cmds="status help"
     local update_cmds="check status github git local force repair rollback list history auto preflight verify auto-apply help"
 
     # Memory/Ban Management (NEW)
@@ -472,7 +478,12 @@ _nftban() {
                     case "${sub_cmd}" in
                         enable|disable)
                             # List available timers
-                            COMPREPLY=($(compgen -W "nftban-health.timer nftban-unified-exporter.timer nftban-core-geoip.timer nftban-core-feeds.timer nftban-queue.timer nftban-suricata-update.timer nftban-snapshot.timer nftban-rollback.timer" -- "${cur}"))
+                            # v1.228.2: nftban-suricata-update.timer removed — the
+                            # unit is no longer shipped and build/deprecated-units.yaml
+                            # stops, disables and removes it on upgrade. Completing an
+                            # operator into `nftban timers enable` for a unit the
+                            # package just deleted is a guaranteed failure.
+                            COMPREPLY=($(compgen -W "nftban-health.timer nftban-unified-exporter.timer nftban-core-geoip.timer nftban-core-feeds.timer nftban-queue.timer nftban-snapshot.timer nftban-rollback.timer" -- "${cur}"))
                             ;;
                     esac
                     ;;

--- a/install/bash-completion/nftban
+++ b/install/bash-completion/nftban
@@ -21,7 +21,10 @@ _nftban() {
     # DEBUG: debug smoke selftest emulate setup menu
 
     # H28 fix: 'cloudflare' is a legacy alias for 'trust' — still listed for discovery
-    local commands="status health validate config sync version help firewall firewall-logs logs ban unban protect unprotect cleanup list check search blacklist whitelist whitelist-system profile panel permissions polkit ddos portscan botscan botguard login feeds trust country cloudflare geoban geoip metrics stats report queue fhs module services timers mail rbl debug smoke selftest emulate setup menu nftables port system test wizard watchdog flush update support suricata pro connector modes snapshot zabbix preflight export tunnel benchmark rollback scale"
+    # v1.228.1: 'service' (singular) is a legacy alias for 'services' (cli/sbin/nftban
+    # dispatch); listed here and marked `aliases: ["service"]` in commands.registry.yml.
+    # Both surfaces are required together — check-cli-surface-parity.sh fails a half-fix.
+    local commands="status health validate config sync version help firewall firewall-logs logs ban unban protect unprotect cleanup list check search blacklist whitelist whitelist-system profile panel permissions polkit ddos portscan botscan botguard login feeds trust country cloudflare geoban geoip metrics stats report queue fhs module services service timers mail rbl debug smoke selftest emulate setup menu nftables port system test wizard watchdog flush update support suricata pro connector modes snapshot zabbix preflight export tunnel benchmark rollback scale"
 
     # ==========================================================================
     # SUBCOMMANDS FOR EACH MAIN COMMAND
@@ -30,7 +33,7 @@ _nftban() {
     # Core commands
     local status_cmds="--json help"
     local health_cmds="check summary json fix enforce binaries geoip pro registries install verify conflicts config resources posture security --auto-heal --json help"
-    local validate_cmds="all firewall config permissions --json help"
+    local validate_cmds="--json help"
     local config_cmds="validate audit doctor diff show get defaults overrides set reset reset-all apply status help"
     local sync_cmds="full validate status --dry-run help"
 
@@ -45,12 +48,12 @@ _nftban() {
     local blacklist_cmds="add remove list show files count flush --json help"
     local whitelist_cmds="add remove list show --json help"
     local whitelist_system_cmds="--dry-run --json help"
-    local profile_cmds="list apply status basic standard advanced help"
-    local panel_cmds="detect status directadmin help"
-    local permissions_cmds="audit fix status --json help"
+    local profile_cmds="list apply help"
+    local panel_cmds="directadmin help"
+    local permissions_cmds="fix --json help"
 
     # Protection Modules
-    local ddos_cmds="status enable disable test config --json help"
+    local ddos_cmds="status enable disable test --json help"
     local portscan_cmds="status enable disable check history test --json help"
     local login_cmds="status stats enable disable restart logs test run mode digest --json help"
     local login_targets="ssh su sudo console service all"
@@ -70,24 +73,24 @@ _nftban() {
     local module_cmds="list status --json help"
     local services_cmds="status --json help"
     local timers_cmds="status enable disable --json help"
-    local mail_cmds="status port-status test config help"
+    local mail_cmds="status port-status test help"
 
     # Debug & Testing
     local debug_cmds="status enable disable trace logs dump botguard --json help"
     local smoke_cmds="--json --group --module --deep help"
     local selftest_cmds="run quick all lifecycle verify config check stats trace help"
     local emulate_cmds="--proto --port --direction --json help"
-    local setup_cmds="install uninstall configure wizard help"
+    local setup_cmds="help"
     local menu_cmds="help"
-    local test_cmds="run all --verbose --json help"
+    local test_cmds="--verbose --json help"
     local wizard_cmds="help"
 
     # System & Infrastructure
-    local nftables_cmds="status reload reset backup restore --json help"
+    local nftables_cmds="status reload --json help"
     local port_cmds="allow list status --json help"
     local port_protocols="tcp udp both"
     local port_directions="in out inout"
-    local system_cmds="status enable disable install uninstall --json help"
+    local system_cmds="status enable disable --json help"
 
     # Watchdog (System Resource Monitoring)
     local watchdog_cmds="status check run report trend trends history enable disable --json help"
@@ -117,7 +120,7 @@ _nftban() {
     # New commands (connector, modes, snapshot, zabbix, preflight)
     local connector_cmds="list add remove enable disable test show push --json help"
     local modes_cmds="--json help"
-    local snapshot_cmds="create list restore --json help"
+    local snapshot_cmds="create list --json help"
     local zabbix_cmds="setup status test push reload template discover targets config --json help"
     local preflight_cmds="--strict --json help"
     local rollback_cmds="--list --version --dry-run --json help"

--- a/scripts/ci/ci-bash-red-baseline-audit.md
+++ b/scripts/ci/ci-bash-red-baseline-audit.md
@@ -51,6 +51,12 @@ All 15 verified: direct `bash <test>` PASS, product tree unchanged, a meaningful
 | v128_help_code_correlation_test | CONFIRMED_PRODUCT_DEFECT | CANONICAL_COMMAND_REGISTRY_DRIFT | V1226-CIBASH-PRODDEF-01 | OPEN_CANONICAL_LOGS_REGISTRATION |
 | v128_polkit_aware_wording_sweep_test | CONFIRMED_PRODUCT_DEFECT | POLKIT_WORDING_DRIFT | V1226-CIBASH-PRODDEF-02 | OPEN_POLKIT_WORDING_REWORD |
 
+> This table is the **v1.226.0 PR-D snapshot** and is kept as the historical record.
+> Subsequent resolution: **V1226-CIBASH-PRODDEF-01** was fixed in v1.228.1 — `logs` was added to
+> `_nftban_canonical_commands()` and `v128_help_code_correlation_test` was removed from
+> `scripts/ci/ci-bash-quarantine.tsv` in the same commit (the registry blocks if a quarantined test
+> passes, so the product fix and the de-quarantine cannot be split).
+
 ### The two confirmed product defects (registered, NOT fixed in PR-D)
 
 - **V1226-CIBASH-PRODDEF-01** — `nftban logs` (`cmd_logs.sh`, shipped v1.222.0) is routed and shown in

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -204,6 +204,7 @@ stats_status_truth_v150_test	cli/lib/nftban/tests/stats_status_truth_v150_test.s
 status_consistency_v153_test	cli/lib/nftban/tests/status_consistency_v153_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 status_rc_contract_v152_test	cli/lib/nftban/tests/status_rc_contract_v152_test.sh	cli	test	status	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 support_bundle_redaction_test	cli/lib/nftban/tests/support_bundle_redaction_test.sh	security	test	redaction	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+suricata_subcommand_authority_v1228_2_test	cli/lib/nftban/tests/suricata_subcommand_authority_v1228_2_test.sh	cli	test	cli-command-correlation	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 suricata_usr2_guard_gateb_test	cli/lib/nftban/tests/suricata_usr2_guard_gateb_test.sh	suricata	test	suricata-logrotate	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 sysctl_risk_idle_age_v2161_test	cli/lib/nftban/tests/sysctl_risk_idle_age_v2161_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 sysctl_safe_default_v216_test	cli/lib/nftban/tests/sysctl_safe_default_v216_test.sh	health	test	sysctl	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
**Stack 3 of 4** — base `pr/v1228-2-b-router`. Must not merge before PR-A and PR-B.

## The count guard pointed backwards

`cli_no_gui_doc_drift_v144_test.sh:80` pinned the **literal `66`** while the registry holds **71** keys. Adding a command and *correctly* bumping the counter **failed CI**; leaving it stale **passed**. The guard rewarded drift and punished maintenance.

Replaced with a **computed** assertion (`declared == computed`), plus **T1-5**, a self-test that copies the registry to a fixture, adds a key, and asserts the computed count moves — so a guard that *stops measuring* fails in CI rather than waiting to be noticed.

Reproduced directly: old guard **passed** the stale case and **failed** the correct value 71. New guard fails on `70 vs 71` and on `71 vs 72`. Count verified 71 by two independent methods (grep derivation and `yaml.safe_load`), honouring the no-pyyaml constraint.

## Suricata advertising reconciled to the dispatcher

After PR-A the dispatcher accepts `{status, help}`. The registry still declared **42** subcommands and completion offered 15 tokens — 40 advertised surfaces with no dispatcher.

```
suricata.subcommands  42 -> 2      examples  14 -> 3      completion  15 -> 2
total_commands        71 -> 71     (unchanged — suricata: remains a top-level key)
```

Three false registry claims about a read-only reporter corrected: `capability: service_control → status_read`, `mutates: conditional → false`, `requires_root: true → false`.

## 🔴 No pre-existing guard could catch a phantom subcommand

Against phantoms injected into **both** the registry and completion, `check-cli-surface-parity`, `lint-registry-parity`, `cli_no_gui_doc_drift_v144`, `v128_help_code_correlation` and `v127_ux4_suricata_desurfacing` **all passed**. Every one compares **top-level commands only**. That is precisely how 42 phantoms survived in a green repo.

New `suricata_subcommand_authority_v1228_2_test` (19/0) **derives all four sets at runtime** — dispatcher, registry, completion, docs — and asserts set equality with `PHANTOM_SUBCOMMANDS = 0`. It hardcodes no names and fail-closes on empty extraction, so a broken parser cannot make PHANTOM vacuously 0. Both injections proven to fail it.

## Completion truth — three entries were performing the WRONG ACTION

26 dead tokens removed, each with router evidence. Three were not merely rejected:

```
snapshot restore  -> cmd_snapshot.sh:63-65  *)  falls through to snapshot_create — CREATES
mail config       -> cmd_mail.sh:365+       *)  treats the token as email CONTENT and SENDS MAIL
setup install|... -> cmd_setup.sh:67 has NO subcommand case — the interactive wizard runs
```

`country` left alone — confirmed pass-through alias to `geoban`, a false positive. Per D5, stale arms are **removed, not implemented**: `validate all|firewall|config|permissions` and `test run|all` are plausible real surfaces, and implementing them would be new behaviour.

## Operator hazard fixed

`nftban logz` suggested **`login`** — a different protection module — because `logs` was absent from the canonical list. A *wrong* hint, not a missing one. Fix and de-quarantine land in **one commit**, since `run-test-suite.sh:258` blocks when a quarantined test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Baseline gate exception — `comms_redact_failloud_p_retire2_test`

```
TEST            comms_redact_failloud_p_retire2_test.sh
BASE SHA        0c2a0d9a
BASE RUNTIME    136s · 138s · 137s          (3 runs at base)
INTEGRATION     136s · 137s · 137s          (3 runs on the integration tree)
MULTI_RUN_RANGE 136–138s — 2s spread across 6 runs
GATE LIMIT      120s   (scripts/ci/run-test-suite.sh:41 DEFAULT_TIMEOUT)
RESULT GIVEN TIME  rc=0 · PASS=13 FAIL=0 — the test itself is CORRECT
TEST CONTENT    byte-identical base vs integration
CHANGED FILES   zero overlap (0 of 37 changed files intersect the 12 paths it reads)
CLASSIFICATION  PRE_EXISTING_REPRODUCED_TIMEOUT
WAIVER          NO      QUARANTINE  NO
TARGET FIX      v1.228.3 CI/release reliability -> OPEN_COMMS_REDACT_FAILLOUD_TEST_TIMEOUT_RELIABILITY
```

It was previously described as landing either side of the limit under load. **It does not.** Six runs
span 136–138s — deterministic, and always above 120s. It is not flaky; it never passes the gate. The
remedy is to remove ~17s or split the test, not to raise the global timeout.