### PR TITLE
v1.228.2 PR-D: snapshot source-time dispatch truth

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -122,6 +122,31 @@ jobs:
           bash scripts/ci/pr-d-strict-selftest.sh
       - name: Quarantine registry validity (v1.226.0 PR-D, BLOCKING)
         run: bash scripts/ci/check-quarantine-registry.sh
+      # v1.228.2: DIAGNOSTIC ONLY — this does not replace the runner's own
+      # pre-flight. run-test-suite.sh already calls `test-authority.py check`
+      # before the suite starts and fails on a stale index; that guard works and
+      # is retained as the single runner authority. What it does NOT give a
+      # reviewer is a reviewable diff, so this step renders the index to a
+      # TEMPORARY path and diffs it. Neither path mutates the checkout: a CI job
+      # validates repository state, it never repairs it.
+      #
+      # Why this exists: the generated index is a MULTI-LANE authority. In the
+      # v1.228.2 stack four PRs added tests; one regenerated the index while it
+      # was last in merge order, a rebase then landed another test after it, and
+      # the composed tree was stale. Every individual PR was green. That is a
+      # post-rebase PROCESS failure, not a missing guard.
+      - name: test-authority index freshness (diagnostic diff)
+        run: |
+          tmp="$(mktemp)"
+          trap 'rm -f "$tmp"' EXIT
+          python3 scripts/ci/test-authority.py generate --output "$tmp"
+          if ! diff -u scripts/ci/test-authority-index.tsv "$tmp"; then
+              echo "::error::test-authority index is stale"
+              echo "::error::Regenerate with: python3 scripts/ci/test-authority.py generate"
+              echo "::error::The generated index belongs to the LAST PR in merge order and must be regenerated after every rebase, cherry-pick, merge or stack reorder."
+              exit 2
+          fi
+
       - name: Policy Gates shell-test suite — index-driven (v1.226.0 PR-D, BLOCKING)
         run: bash scripts/ci/run-test-suite.sh run --gate policy-gates
       # ci-bash: BLOCKING. Every non-quarantined ci-bash test must pass; the 4

--- a/cli/lib/nftban/cli/cmd_snapshot.sh
+++ b/cli/lib/nftban/cli/cmd_snapshot.sh
@@ -61,8 +61,18 @@ nftban_cmd_snapshot() {
             nftban_snapshot_help
             ;;
         *)
-            # Default to create for backwards compatibility with systemd service
-            nftban_snapshot_create "$@"
+            # v1.228.2 (OPEN_SNAPSHOT_SOURCE_TIME_DOUBLE_DISPATCH): this arm used
+            # to fall through to `nftban_snapshot_create`, so any unrecognised
+            # token — including the `restore` that bash-completion advertises —
+            # silently CREATED a snapshot. The stated reason was "backwards
+            # compatibility with systemd service", but
+            # install/systemd/nftban-snapshot.service invokes
+            # `nftban snapshot create` explicitly, and a bare `nftban snapshot`
+            # still defaults to create via `subcmd="${1:-create}"` above. Nothing
+            # depended on the catch-all, so an unsupported action now refuses.
+            echo "ERROR: unsupported snapshot action: ${subcmd}" >&2
+            echo "Supported: create, list, help" >&2
+            return 2
             ;;
     esac
 }
@@ -168,7 +178,21 @@ EOF
 export -f nftban_cmd_snapshot
 export -f nftban_snapshot_help
 
-# Execute if sourced with arguments
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -n "${1:-}" ]]; then
+# Execute ONLY when run directly, never when sourced.
+#
+# v1.228.2 (OPEN_SNAPSHOT_SOURCE_TIME_DOUBLE_DISPATCH): the previous guard also
+# fired on `[[ -n "${1:-}" ]]`. The router sources command modules with the
+# caller's positional parameters still set (cli/sbin/nftban:1128 assigns
+# `cmd="${1:-hello}"` and does NOT shift before the `source` at :1236), so $1 was
+# always the literal command token "snapshot". That made the guard true for every
+# invocation, executing nftban_cmd_snapshot at SOURCE time with subcmd="snapshot",
+# which falls to the `*)` default-to-create arm — and the router then dispatched
+# the real subcommand a second time. Measured: `snapshot create` created twice,
+# `snapshot list` created once before listing, and the hourly
+# nftban-snapshot.service path double-wrote in production.
+#
+# The systemd unit invokes `/usr/sbin/nftban snapshot create` through the router,
+# so nothing ever depended on the sourced-with-args behaviour.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     nftban_cmd_snapshot "$@"
 fi

--- a/cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh
+++ b/cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh
@@ -28,6 +28,8 @@
 # meta:ta.requires_root="false"
 # meta:ta.requires_network="false"
 # meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 
 set -Eeuo pipefail

--- a/cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh
+++ b/cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Snapshot source-time dispatch truth (v1.228.2 PR-D)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="snapshot_source_time_dispatch_v1228_2_test"
+# meta:type="test"
+# meta:version="1.228.2"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="Proves OPEN_SNAPSHOT_SOURCE_TIME_DOUBLE_DISPATCH is closed. Replicates the router dispatch sequence exactly (cli/sbin/nftban:1128 cmd assignment with NO shift, :1236 source with positionals still set, :1242 declare -f, :1243 shift, :1249 call) against an instrumented copy of cmd_snapshot.sh whose acting leaves are counter stubs. T1 asserts sourcing with positional arguments executes zero snapshot actions. T2-T5 assert create/list/help/unknown call counts. T6 is a repository-wide structural guard asserting NO cmd_*.sh executes its command entrypoint merely because it was sourced with positional arguments - derived by scanning every module, never pinned to cmd_snapshot.sh alone. Creates no real snapshot and touches no host state."
+# meta:input="repo cli/lib/nftban/cli/cmd_*.sh; self-contained sandbox under mktemp -d"
+# meta:output="[PASS]/[FAIL] per assertion; terminal RESULT: PASS|FAIL; exit 0 all pass, 1 any fail"
+# meta:depends="bash,mktemp,grep,awk,sed"
+# meta:inventory.files="cli/lib/nftban/cli/cmd_snapshot.sh"
+# meta:inventory.binaries=""
+# meta:inventory.env_vars="NFTBAN_LIB_DIR,NFTBAN_SNAPSHOT_TEST_LOG"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="snapshot_source_time_dispatch_v1228_2_test"
+# meta:ta.owner="cli"
+# meta:ta.module="snapshot"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# =============================================================================
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CLI_DIR="${REPO_ROOT}/cli/lib/nftban/cli"
+MODULE="${CLI_DIR}/cmd_snapshot.sh"
+
+PASS=0
+FAIL=0
+
+# NOTE: assertions must NOT run inside a ( subshell ) — the counters would be
+# incremented in a child process and discarded, and a failing case would report
+# success. Every helper below runs in the current shell.
+ok()  { printf '[PASS] %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '[FAIL] %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/nftban-snapshot-dispatch.XXXXXX")"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+[[ -f "$MODULE" ]] || { echo "FATAL: module not found: $MODULE" >&2; exit 1; }
+
+# -----------------------------------------------------------------------------
+# Instrumented fixture
+#
+# The three acting leaves are replaced with counter stubs injected immediately
+# BEFORE the module's trailing guard, so the guard condition and the dispatch
+# logic in nftban_cmd_snapshot stay byte-identical to what ships. Nothing real is
+# created; the module itself is never modified in the worktree.
+# -----------------------------------------------------------------------------
+build_fixture() {
+    mkdir -p "${SANDBOX}/cli" "${SANDBOX}/lib"
+
+    cat > "${SANDBOX}/lib/cmd_common.sh" <<'STUB'
+#!/usr/bin/env bash
+cmd_init() { :; }
+nftban_print_status() { :; }
+STUB
+
+    local guard_line
+    guard_line="$(grep -n 'BASH_SOURCE\[0\]' "$MODULE" | tail -1 | cut -d: -f1)"
+    [[ -n "$guard_line" ]] || { echo "FATAL: trailing guard not found in $MODULE" >&2; exit 1; }
+
+    awk -v ln="$guard_line" 'NR==ln{
+        print "nftban_snapshot_create() { echo \"CREATE\" >> \"$NFTBAN_SNAPSHOT_TEST_LOG\"; return 0; }";
+        print "nftban_snapshot_list()   { echo \"LIST\"   >> \"$NFTBAN_SNAPSHOT_TEST_LOG\"; return 0; }";
+        print "nftban_snapshot_help()   { echo \"HELP\"   >> \"$NFTBAN_SNAPSHOT_TEST_LOG\"; return 0; }";
+    }{print}' "$MODULE" > "${SANDBOX}/cli/cmd_snapshot.sh"
+}
+
+# Replicates cli/sbin/nftban main() for the source+entrypoint path, verbatim:
+#   :1128  local cmd="${1:-hello}"   (NO shift before the source)
+#   :1236  source "$cmd_file"        (positionals still set)
+#   :1242  declare -f  :1243 shift  :1249 call
+router_replica() {
+    local cmd="${1:-hello}"
+    cmd="${cmd,,}"
+    local cmd_file="${NFTBAN_LIB_DIR}/cli/cmd_${cmd}.sh"
+    if [[ -f "$cmd_file" ]]; then
+        # shellcheck source=/dev/null
+        source "$cmd_file"
+        local func_cmd="${cmd//-/_}"
+        if declare -f "nftban_cmd_${func_cmd}" >/dev/null 2>&1; then
+            shift
+            "nftban_cmd_${func_cmd}" "$@" || return $?
+            return 0
+        fi
+        return 0
+    fi
+    return 1
+}
+
+# Runs one invocation in a FRESH shell — the module sets `readonly
+# CMD_SNAPSHOT_LOADED=1` and short-circuits on re-source, so cases must not share
+# a shell. Prints "rc create list help". The child is a measurement harness, not
+# an assertion site: counters live in the log file, never in a subshell variable.
+invoke() {
+    local log="${SANDBOX}/log.$RANDOM$RANDOM"
+    : > "$log"
+    local rc=0
+    NFTBAN_LIB_DIR="$SANDBOX" NFTBAN_SNAPSHOT_TEST_LOG="$log" \
+        bash "${SANDBOX}/runner.sh" "$@" >/dev/null 2>&1 || rc=$?
+    printf '%s %s %s %s\n' \
+        "$rc" \
+        "$(grep -c '^CREATE' "$log" 2>/dev/null || true)" \
+        "$(grep -c '^LIST'   "$log" 2>/dev/null || true)" \
+        "$(grep -c '^HELP'   "$log" 2>/dev/null || true)"
+    rm -f "$log"
+}
+
+build_fixture
+
+# Materialise the router replica as a standalone runner for `invoke`.
+{
+    printf '#!/usr/bin/env bash\n'
+    declare -f router_replica
+    printf 'router_replica "$@"\n'
+} > "${SANDBOX}/runner.sh"
+
+echo "=== snapshot source-time dispatch truth (v1.228.2 PR-D) ==="
+
+# -----------------------------------------------------------------------------
+# T1 — sourcing with positional arguments must execute NOTHING
+# This is the defect itself: the shipped guard fired on [[ -n "${1:-}" ]].
+# -----------------------------------------------------------------------------
+T1_LOG="${SANDBOX}/t1.log"; : > "$T1_LOG"
+(
+    export NFTBAN_LIB_DIR="$SANDBOX" NFTBAN_SNAPSHOT_TEST_LOG="$T1_LOG"
+    # shellcheck source=/dev/null
+    source "${SANDBOX}/cli/cmd_snapshot.sh" snapshot create >/dev/null 2>&1 || true
+) || true
+t1_actions="$(grep -c . "$T1_LOG" || true)"
+if [[ "$t1_actions" -eq 0 ]]; then
+    ok "T1 sourcing cmd_snapshot.sh WITH arguments executes 0 snapshot actions"
+else
+    bad "T1 sourcing with arguments executed ${t1_actions} snapshot action(s) — source-time dispatch is back"
+fi
+
+# -----------------------------------------------------------------------------
+# T2-T5 — end-to-end call counts through the exact router sequence
+# -----------------------------------------------------------------------------
+read -r rc c l h <<<"$(invoke snapshot create)"
+if [[ "$c" -eq 1 && "$l" -eq 0 ]]; then
+    ok "T2 'snapshot create' -> create exactly once (create=$c list=$l)"
+else
+    bad "T2 'snapshot create' -> create=$c list=$l (want create=1 list=0)"
+fi
+
+read -r rc c l h <<<"$(invoke snapshot list)"
+if [[ "$l" -eq 1 && "$c" -eq 0 ]]; then
+    ok "T3 'snapshot list' -> list once, create ZERO (create=$c list=$l)"
+else
+    bad "T3 'snapshot list' -> create=$c list=$l (want create=0 list=1) — a read-only command must not write"
+fi
+
+read -r rc c l h <<<"$(invoke snapshot --help)"
+if [[ "$h" -ge 1 && "$c" -eq 0 && "$l" -eq 0 ]]; then
+    ok "T4 'snapshot --help' -> help only, create ZERO (help=$h create=$c)"
+else
+    bad "T4 'snapshot --help' -> help=$h create=$c list=$l (want help>=1 create=0 list=0)"
+fi
+
+read -r rc c l h <<<"$(invoke snapshot restore)"
+if [[ "$c" -eq 0 && "$l" -eq 0 ]]; then
+    ok "T5 'snapshot restore' (unsupported) -> create ZERO (create=$c list=$l rc=$rc)"
+else
+    bad "T5 'snapshot restore' -> create=$c list=$l (want 0/0) — unsupported action must not mutate"
+fi
+
+# -----------------------------------------------------------------------------
+# T6 — repository-wide structural guard
+#
+# Derived by scanning EVERY cmd_*.sh, not pinned to cmd_snapshot.sh, so the
+# pattern cannot reappear in another module. A trailing execution guard is only
+# acceptable when it is conditioned solely on direct execution
+# (BASH_SOURCE[0] == $0). Any guard that also fires on positional arguments —
+# `-n "${1:-}"`, `$# -gt 0`, `-n "$*"` — executes the entrypoint at SOURCE time,
+# because the router sources modules with the caller's positionals still set.
+# -----------------------------------------------------------------------------
+offenders=""
+scanned=0
+while IFS= read -r f; do
+    scanned=$((scanned + 1))
+    hits="$(grep -nE '^[[:space:]]*if[[:space:]]*\[\[.*BASH_SOURCE\[0\]' "$f" 2>/dev/null || true)"
+    [[ -z "$hits" ]] && continue
+    while IFS= read -r hit; do
+        [[ -z "$hit" ]] && continue
+        line="${hit#*:}"
+        if printf '%s' "$line" | grep -qE '[-]n[[:space:]]*"[$][{]1:[-][}]"|[$]#[[:space:]]*[-]gt[[:space:]]*0|[-]n[[:space:]]*"[$][*]"'; then
+            offenders+="  $(basename "$f"):${hit%%:*}  ${line}"$'\n'
+        fi
+    done <<< "$hits"
+done < <(find "$CLI_DIR" -maxdepth 1 -name 'cmd_*.sh' -type f | sort)
+
+if [[ "$scanned" -eq 0 ]]; then
+    bad "T6 scanned 0 modules — enumeration failed, guard proves nothing"
+elif [[ -z "$offenders" ]]; then
+    ok "T6 no cmd_*.sh executes its entrypoint on being sourced with arguments (${scanned} modules scanned)"
+else
+    bad "T6 source-time execution guard(s) found in ${scanned} scanned modules:"
+    printf '%s' "$offenders" >&2
+fi
+
+echo
+echo "passed=${PASS} failed=${FAIL}"
+if [[ "$FAIL" -gt 0 ]]; then
+    echo "RESULT: FAIL"
+    exit 1
+fi
+echo "RESULT: PASS"
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -190,6 +190,7 @@ service_alerts_v138_test	cli/lib/nftban/tests/service_alerts_v138_test.sh	firewa
 session_whitelist_flock_v173_test	cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh	firewall	test	session-whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 set_apply_single_writer_v213_grep_guard_test	cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 set_apply_single_writer_v213_test	cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+snapshot_source_time_dispatch_v1228_2_test	cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh	cli	test	snapshot	CI_HERMETIC_SHELL	ci-bash	true	false	false	false					
 ssh_admin_port_guard_v150_test	cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 ssh_port_change_lifecycle_v155_test	cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh	firewall	test	ssh-port-lifecycle-validate	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 ssh_socket_port_mismatch_v155_test	cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -190,7 +190,7 @@ service_alerts_v138_test	cli/lib/nftban/tests/service_alerts_v138_test.sh	firewa
 session_whitelist_flock_v173_test	cli/lib/nftban/tests/session_whitelist_flock_v173_test.sh	firewall	test	session-whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 set_apply_single_writer_v213_grep_guard_test	cli/lib/nftban/tests/set_apply_single_writer_v213_grep_guard_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 set_apply_single_writer_v213_test	cli/lib/nftban/tests/set_apply_single_writer_v213_test.sh	firewall	test	set-apply-single-writer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
-snapshot_source_time_dispatch_v1228_2_test	cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh	cli	test	snapshot	CI_HERMETIC_SHELL	ci-bash	true	false	false	false					
+snapshot_source_time_dispatch_v1228_2_test	cli/lib/nftban/tests/snapshot_source_time_dispatch_v1228_2_test.sh	cli	test	snapshot	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 ssh_admin_port_guard_v150_test	cli/lib/nftban/tests/ssh_admin_port_guard_v150_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 ssh_port_change_lifecycle_v155_test	cli/lib/nftban/tests/ssh_port_change_lifecycle_v155_test.sh	firewall	test	ssh-port-lifecycle-validate	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 ssh_socket_port_mismatch_v155_test	cli/lib/nftban/tests/ssh_socket_port_mismatch_v155_test.sh	firewall	test	ssh-admin-port-guard	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			

--- a/scripts/ci/test-authority.py
+++ b/scripts/ci/test-authority.py
@@ -303,13 +303,39 @@ def render_index(records):
     return "\n".join(banner) + "\n"
 
 
-def cmd_generate(root):
+def cmd_generate(root, output=None):
+    """Render the authority index.
+
+    output=None  -> write the canonical index in place (unchanged behaviour).
+    output=PATH  -> write ONLY to PATH; the canonical index is left untouched.
+
+    The --output form exists so a CI pre-flight can generate to a temporary file
+    and diff it against the committed index WITHOUT mutating the checkout. A job
+    must validate repository state, never repair it: a generate-in-place followed
+    by `git diff` can be obscured by cleanup or concurrent steps.
+    """
     records, perr = collect(root)
     if perr:
         for e in perr:
             sys.stderr.write("ERROR %s\n" % e)
         return 1
     text = render_index(records)
+    if output:
+        dst = os.path.abspath(output)
+        parent = os.path.dirname(dst) or "."
+        if not os.path.isdir(parent):
+            sys.stderr.write("ERROR: --output directory does not exist: %s\n" % parent)
+            return 2
+        fd, tmp = tempfile.mkstemp(dir=parent, prefix=".ta-index.")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(text)
+            os.replace(tmp, dst)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+        print("generated %s (%d tests)" % (output, len(records)))
+        return 0
     dst = os.path.join(root, INDEX_PATH)
     fd, tmp = tempfile.mkstemp(dir=os.path.dirname(dst), prefix=".ta-index.")
     try:
@@ -392,7 +418,10 @@ def main():
     sub = ap.add_subparsers(dest="cmd", required=True)
     v = sub.add_parser("validate")
     v.add_argument("--mode", choices=["transition", "strict"], default="transition")
-    sub.add_parser("generate")
+    _g = sub.add_parser("generate")
+    _g.add_argument("--output", metavar="PATH",
+                    help="write the rendered index to PATH instead of the canonical "
+                         "index; the canonical index is left untouched")
     sub.add_parser("check")
     sub.add_parser("summary")
     args = ap.parse_args()
@@ -400,7 +429,7 @@ def main():
     if args.cmd == "validate":
         return cmd_validate(root, args.mode)
     if args.cmd == "generate":
-        return cmd_generate(root)
+        return cmd_generate(root, getattr(args, "output", None))
     if args.cmd == "check":
         return cmd_check(root)
     if args.cmd == "summary":


### PR DESCRIPTION
**Stack 4 of 4** — base `pr/v1228-2-c-registry`. Merges last.

## A read-only command was creating snapshots, hourly, in production

`cmd_snapshot.sh`'s footer fired on `[[ -n "${1:-}" ]]`. The router sources modules with the caller's positional parameters still set — `cli/sbin/nftban:1128` assigns `cmd="${1:-hello}"` and does **not** shift before the source — so `$1` was always the literal token `snapshot`. The guard was true for **every** invocation, executing `nftban_cmd_snapshot` at source time with `subcmd="snapshot"`, which fell to the `*)` default-to-create arm. The router then dispatched the real subcommand a second time.

Measured with counter stubs (no real snapshot created):

```
snapshot create   -> CREATE x2
snapshot list     -> CREATE x1 + LIST x1     a read-only command MUTATED
snapshot          -> CREATE x2
snapshot restore  -> CREATE x2               the completion-advertised token
```

`install/systemd/nftban-snapshot.service:33` runs `nftban snapshot create` on an **hourly timer**, so the double write ran in production. The footer's stated purpose — *"backwards compatibility with systemd service"* — was never served: the unit goes through the router, not by sourcing the module.

Also **non-deterministic**: `snapshot-$(date +%Y%m%d-%H%M%S).json` is second-resolution, so two calls in the same second overwrite (1 file) and two straddling a boundary produce 2.

## Two changes, both required

```
footer      fires only on direct execution:  [[ "${BASH_SOURCE[0]}" == "${0}" ]]
*) arm      no longer defaults to create; an unsupported action refuses with exit 2
```

The footer guard **alone** cannot satisfy `snapshot restore -> CREATE x0, exit non-zero` — the catch-all would still create. A bare `nftban snapshot` still creates via `subcmd="${1:-create}"`, so no legitimate behaviour is lost.

## Proofs

```
source with args  -> 0 snapshot actions       snapshot create -> CREATE x1
snapshot list     -> LIST x1, CREATE x0       snapshot help   -> CREATE x0
snapshot restore  -> CREATE x0, exit non-zero
```

Plus a repository-wide guard: **no `cmd_*.sh` may execute its command entrypoint merely because it was sourced with positional arguments.** Blast radius measured — `cmd_snapshot.sh` is the **only** one of 78 modules with such a footer. Negative controls: reverting either fix makes the tests fail.

Pre-existing defect, independent of the router lane — `cmd_snapshot.sh` sources cleanly and defines its entrypoint, so it never took the entrypoint-absent path PR-B changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Baseline gate exception — `comms_redact_failloud_p_retire2_test`

```
TEST            comms_redact_failloud_p_retire2_test.sh
BASE SHA        0c2a0d9a
BASE RUNTIME    136s · 138s · 137s          (3 runs at base)
INTEGRATION     136s · 137s · 137s          (3 runs on the integration tree)
MULTI_RUN_RANGE 136–138s — 2s spread across 6 runs
GATE LIMIT      120s   (scripts/ci/run-test-suite.sh:41 DEFAULT_TIMEOUT)
RESULT GIVEN TIME  rc=0 · PASS=13 FAIL=0 — the test itself is CORRECT
TEST CONTENT    byte-identical base vs integration
CHANGED FILES   zero overlap (0 of 37 changed files intersect the 12 paths it reads)
CLASSIFICATION  PRE_EXISTING_REPRODUCED_TIMEOUT
WAIVER          NO      QUARANTINE  NO
TARGET FIX      v1.228.3 CI/release reliability -> OPEN_COMMS_REDACT_FAILLOUD_TEST_TIMEOUT_RELIABILITY
```

It was previously described as landing either side of the limit under load. **It does not.** Six runs
span 136–138s — deterministic, and always above 120s. It is not flaky; it never passes the gate. The
remedy is to remove ~17s or split the test, not to raise the global timeout.