### PR TITLE
fix(packaging): clear the failed-state latch when retiring a deprecated unit

### DIFF
--- a/build/generate-systemd-maintainer-scripts.sh
+++ b/build/generate-systemd-maintainer-scripts.sh
@@ -136,6 +136,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 HELPER
 }
@@ -168,6 +173,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 HELPER
 }

--- a/cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh
+++ b/cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - deprecated-unit retirement must clear the terminal failed-state latch
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="deprecated_unit_failed_latch_v1228_2_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="v1.228.2 lab-gate regression (LAB2_DEB FAIL). The generated deprecated-unit cleanup retires a unit with stop + disable + remove-file (policy stop_disable_remove) or stop + disable + mask (policy stop_disable_mask_remove). Neither sequence clears a systemd failed-state latch. A unit that was already terminally failed when the upgrade began therefore survives as 'Loaded: not-found / Active: failed' once its file is gone - unreferenceable residue no operator can act on, but which still counts against NFTBan's own failed_units_postinstall_ok assertion and drives INSTALL_STATE=DEGRADED, NFTBAN_INSTALL_VERIFIED=NO on an upgrade whose package manager returned 0. Observed on lab2 where nftban-suricata-update.service was failed 226/NAMESPACE before the v1.228.2 upgrade. This test asserts both emitted helpers call 'systemctl reset-failed \$unit', that the call is ordered inside the helper body (hence before the caller's daemon-reload, while the unit is still loaded and the reset is unconditionally accepted), and that every one of the six generated artifacts carries it - so the fix cannot regress in the generator or drift in a checked-in output. Also locks the router one-liner for 'suricata' against advertising subcommands the dormant router rejects. Static analysis only - reads files, invokes nothing, never calls systemctl."
+# meta:input="build/generate-systemd-maintainer-scripts.sh, install/packaging/{deb,rpm}/*.inc, packaging/deb/{preinst,prerm}, cli/sbin/nftban"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,sed"
+# meta:inventory.files="build/generate-systemd-maintainer-scripts.sh,packaging/deb/preinst,packaging/deb/prerm,cli/sbin/nftban"
+# meta:inventory.binaries="bash,grep,sed"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="units listed in build/deprecated-units.yaml"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="deprecated_unit_failed_latch_v1228_2_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="systemd-maintainer-scripts"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+GEN="$REPO/build/generate-systemd-maintainer-scripts.sh"
+ROUTER="$REPO/cli/sbin/nftban"
+
+[[ -f "$GEN" ]]    || { echo "FAIL: cannot find $GEN" >&2; exit 1; }
+[[ -f "$ROUTER" ]] || { echo "FAIL: cannot find $ROUTER" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+# The six artifacts the generator owns. All are checked in; the generator's
+# --check mode guards regeneration parity, this list guards INTENT — a
+# regenerated-but-wrong output would pass --check and fail here.
+ARTIFACTS=(
+    "install/packaging/deb/nftban-preinst-deprecated-cleanup.inc"
+    "install/packaging/deb/nftban-prerm-systemd-cleanup.inc"
+    "install/packaging/rpm/nftban-pre-deprecated-cleanup.inc"
+    "install/packaging/rpm/nftban-preun-systemd-cleanup.inc"
+    "packaging/deb/preinst"
+    "packaging/deb/prerm"
+)
+
+echo "=== A. generator emits reset-failed in BOTH retirement helpers ==="
+
+# Extract a single shell function body by name from a file.
+fn_body(){ sed -n "/^$2() {/,/^}/p" "$1"; }
+
+for helper in remove_unit_file_if_exists mask_if_exists; do
+    body=$(fn_body "$GEN" "$helper" || true)
+    if [[ -z "$body" ]]; then
+        no "A1 $helper is emitted by the generator" "function body not found in $GEN"
+        continue
+    fi
+    if grep -qF 'systemctl reset-failed "$unit"' <<<"$body"; then
+        ok "A1 $helper clears the failed-state latch"
+    else
+        no "A1 $helper clears the failed-state latch" \
+           "stop+disable+rm/mask does not clear a terminal failed latch; add: systemctl reset-failed \"\$unit\" 2>/dev/null || true"
+    fi
+
+    # The reset must be the LAST mutating action in the helper, so it runs while
+    # the unit is still loaded and before the caller's daemon-reload.
+    last=$(grep -n 'systemctl\|rm -f' <<<"$body" | tail -1 || true)
+    if grep -q 'reset-failed' <<<"$last"; then
+        ok "A2 $helper resets last (before caller daemon-reload)"
+    else
+        no "A2 $helper resets last (before caller daemon-reload)" "last mutating line: ${last:-none}"
+    fi
+done
+
+echo "=== B. every generated artifact carries the reset in both helpers ==="
+
+for rel in "${ARTIFACTS[@]}"; do
+    f="$REPO/$rel"
+    if [[ ! -f "$f" ]]; then
+        no "B1 $rel exists" "not found"
+        continue
+    fi
+    n=$(grep -cF 'systemctl reset-failed "$unit"' "$f" || true)
+    if [[ "$n" -eq 2 ]]; then
+        ok "B1 $rel carries the reset in both helpers"
+    else
+        no "B1 $rel carries the reset in both helpers" \
+           "expected 2 occurrences (mask + remove), found $n — run: bash build/generate-systemd-maintainer-scripts.sh"
+    fi
+done
+
+echo "=== C. router help must not advertise verbs the dormant router rejects ==="
+
+# cmd_suricata.sh routes exactly `status` and `help|--help|-h`; everything else
+# returns 1. The one-line description in the router must not contradict that.
+line=$(grep -n 'suricata)\s*echo' "$ROUTER" | head -1 || true)
+if [[ -z "$line" ]]; then
+    no "C1 router carries a suricata description" "no 'suricata) echo' line in $ROUTER"
+else
+    bad=()
+    for verb in install enable rules profile; do
+        grep -qE "[( ,]${verb}[,)]" <<<"$line" && bad+=("$verb")
+    done
+    if [[ ${#bad[@]} -eq 0 ]]; then
+        ok "C1 suricata description advertises no unrouted verb"
+    else
+        # IFS is \n\t here, so join explicitly rather than via ${bad[*]}.
+        joined=$(printf '%s, ' "${bad[@]}"); joined=${joined%, }
+        no "C1 suricata description advertises no unrouted verb" \
+           "advertises ${joined} but nftban_cmd_suricata returns 1 for each — ${line}"
+    fi
+fi
+
+echo
+printf 'RESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    printf 'FAILED:\n'; printf '  - %s\n' "${FAILED[@]}"
+    exit 1
+fi
+exit 0

--- a/cli/sbin/nftban
+++ b/cli/sbin/nftban
@@ -1234,7 +1234,7 @@ main() {
                     search)   echo "  Search IPs/ports across feeds, ban lists, whitelists." ;;
                     feeds)    echo "  Manage and inspect threat-intelligence feeds." ;;
                     export)   echo "  Export stats snapshot. Alias for 'nftban stats export'." ;;
-                    suricata) echo "  Manage Suricata IDS (install, enable, rules, status, profile)." ;;
+                    suricata) echo "  Report Suricata integration state — dormant (status, help)." ;;
                     geoban)   echo "  Country-based IP blocking (ban, unban, whitelist, list, status, update)." ;;
                     install|uninstall|rebuild)
                         echo "  Note: '$cmd' is handled by the distro package (DEB/RPM) and the"

--- a/install/packaging/deb/nftban-preinst-deprecated-cleanup.inc
+++ b/install/packaging/deb/nftban-preinst-deprecated-cleanup.inc
@@ -34,6 +34,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -50,6 +55,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # Deprecated units (policy: stop_only) — stop + disable, no mask, no rm.

--- a/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
+++ b/install/packaging/deb/nftban-prerm-systemd-cleanup.inc
@@ -28,6 +28,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -44,6 +49,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # Active units (sourced from install/packaging/systemd/nftban-systemd-install.list).

--- a/install/packaging/rpm/nftban-pre-deprecated-cleanup.inc
+++ b/install/packaging/rpm/nftban-pre-deprecated-cleanup.inc
@@ -35,6 +35,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -51,6 +56,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # Deprecated units (policy: stop_only) — stop + disable, no mask, no rm.

--- a/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
+++ b/install/packaging/rpm/nftban-preun-systemd-cleanup.inc
@@ -29,6 +29,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -45,6 +50,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # Active units (sourced from install/packaging/systemd/nftban-systemd-install.list).

--- a/packaging/deb/preinst
+++ b/packaging/deb/preinst
@@ -39,6 +39,11 @@ mask_if_exists() {
         fi
     fi
     # else: clean host — no /etc residue created
+    # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+    # that was already `failed` at upgrade time keeps its latch through
+    # stop+disable+mask. Unconditional and silent — a no-op on a host that
+    # never had the unit.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -55,6 +60,15 @@ remove_unit_file_if_exists() {
             rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
         fi
     fi
+    # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+    # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+    # the upgrade began keeps its latch, and once the file is gone it becomes
+    # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+    # operator can act on, but which still counts against NFTBan's own
+    # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+    # on an otherwise successful upgrade. Ordered before daemon-reload while
+    # the unit is still loaded, so the reset is unconditionally accepted.
+    systemctl reset-failed "$unit" 2>/dev/null || true
 }
 
 # Deprecated units (policy: stop_only) — stop + disable, no mask, no rm.

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -42,6 +42,11 @@ case "$1" in
                 fi
             fi
             # else: clean host — no /etc residue created
+            # Same terminal failed-state latch as remove_unit_file_if_exists(): a unit
+            # that was already `failed` at upgrade time keeps its latch through
+            # stop+disable+mask. Unconditional and silent — a no-op on a host that
+            # never had the unit.
+            systemctl reset-failed "$unit" 2>/dev/null || true
         }
 
         # /etc territory boundary (A2): package only modifies /etc/systemd/system/$unit
@@ -58,6 +63,15 @@ case "$1" in
                     rm -f "/etc/systemd/system/$unit" 2>/dev/null || true
                 fi
             fi
+            # Clear any terminal failed-state latch BEFORE the caller's daemon-reload.
+            # stop+disable+rm does NOT clear it: a unit that was already `failed` when
+            # the upgrade began keeps its latch, and once the file is gone it becomes
+            # `Loaded: not-found / Active: failed` — unreferenceable residue that no
+            # operator can act on, but which still counts against NFTBan's own
+            # failed_units_postinstall_ok assertion and yields INSTALL_STATE=DEGRADED
+            # on an otherwise successful upgrade. Ordered before daemon-reload while
+            # the unit is still loaded, so the reset is unconditionally accepted.
+            systemctl reset-failed "$unit" 2>/dev/null || true
         }
 
         # Active units (sourced from install/packaging/systemd/nftban-systemd-install.list).

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -104,6 +104,7 @@ config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	tes
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 deb_conffile_parity_v1227_test	cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh	mail	test	deb-conffile-parity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+deprecated_unit_failed_latch_v1228_2_test	cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh	packaging	test	systemd-maintainer-scripts	CI_STATIC	ci-bash	true	false	false	false	false	false			
 error_text_3line_v153_test	cli/lib/nftban/tests/error_text_3line_v153_test.sh	cli	test	cli-ux	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_phase2_scale_guard_v1361_test	cli/lib/nftban/tests/exporter_exit2_phase2_scale_guard_v1361_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 exporter_exit2_resilience_v136_test	cli/lib/nftban/tests/exporter_exit2_resilience_v136_test.sh	metrics	test	exporter-exit2	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## Why

The **v1.228.2 lab gate failed on the DEB family** (`LAB2_DEB = FAIL`, 1 assertion). This PR fixes
the cause. Publication of v1.228.2 is blocked until it lands.

The generated deprecated-unit cleanup retires a unit with **stop + disable + remove-file**
(`stop_disable_remove`) or **stop + disable + mask** (`stop_disable_mask_remove`). Neither sequence
clears a systemd **failed-state latch**.

A unit that was *already* terminally failed when the upgrade began therefore survives its own
retirement as `Loaded: not-found / Active: failed` — unreferenceable residue, because there is no
unit file left to stop, disable, or reset by path. It still counts against NFTBan's own
`failed_units_postinstall_ok` assertion, so an upgrade whose package manager returned **0** lands:

```
17/18 assertions        INSTALL_STATE = DEGRADED
                        NFTBAN_INSTALL_VERIFIED = NO
                        POSTINSTALL_VERIFIED = NO
```

## Evidence

On lab2, `nftban-suricata-update.service` was failed `226/NAMESPACE` **before** the upgrade (no
upstream Suricata, so `/etc/suricata/rules` was absent). The v1.228.2 DEB retired all four units
correctly — and still landed DEGRADED.

**lab4 passed 17/17, and that is not family divergence.** The RPM `%pre` carries the *identical*
loop with the *identical* omission — read back off the built artifact via `rpm -qp --scripts`. lab4
passed because no latch existed there. Absence of trigger, not absence of defect.

| | |
|---|---|
| `packaging/deb/preinst:88-105` | loop present, no reset |
| RPM `%pre` | same loop, same omission |
| `reset-failed` in `packaging/**` before this PR | **0** |

## What changed

The fix is in the **two shared emitted helpers** in `build/generate-systemd-maintainer-scripts.sh`,
so both families and all six generated artifacts inherit it from one source:

- `remove_unit_file_if_exists()` — policy `stop_disable_remove`
- `mask_if_exists()` — policy `stop_disable_mask_remove`, same latch defect, fixed rather than left
  as a twin waiting for the first host with a failed `nftban-ui.service`

The reset is the **last mutating action** in each helper: it runs while the unit is still loaded,
ahead of the caller's `daemon-reload`, so systemd accepts it unconditionally. Silent and
unconditional — a no-op on a host that never had the unit. `reset-failed` is already a sanctioned
verb in `packaging/polkit-1/rules.d/20-nftban-auditor.rules:110`.

**Also:** `cli/sbin/nftban:1237` advertised `suricata (install, enable, rules, status, profile)`
while `nftban_cmd_suricata` routes only `status` and `help` and returns 1 for everything else — the
exact class of untruth this release exists to remove.

## Test — negative injection performed

`cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh` (11 assertions) asserts both
helpers reset, that the reset is ordered last, that **all six** generated artifacts carry it, and
that the router advertises no unrouted verb.

```
pristine origin/main   0 passed, 11 failed      mutation independently observable
                                                (generator reset count 0, stale help line present)
this branch           11 passed,  0 failed
```

The generator's `--check` mode guards *regeneration parity*; this test guards **intent** — a
regenerated-but-wrong output would pass `--check` and fail here.

## Gates run locally

```
generator --check                    6/6 outputs up to date
ci-bash suite                        total=201  pass=199  fail=0  quarantined=2
ci-architecture (all 69 run: blocks) 69/69
privacy-scan --changed-lines         findings=0 (release-blocking 0)
privacy-scan --scope repository      PASS          selftest PASS
shellcheck -S warning                clean
test-authority                       INDEX_FRESH = YES (252 tests)
```

## Not fixed here — filed instead

- **`nftban validate` returns rc=0 on a host that is `DEGRADED` with a failed NFTBan-named unit**
  (observed on lab2). Verdict-surface divergence → v1.229 validator-truth lane.
- **`v128_help_code_correlation_test` D2 is vacuous in CI.** It asserts on
  `git diff --name-only HEAD`, i.e. the *uncommitted* tree — always 0 files in CI, so it can only
  ever fire on a developer's dirty checkout. It asserts nothing about the shipped product.

## Re-gate required

This changes maintainer-script behaviour on both families, so the **full lab gate must be re-run on
lab2 + lab4** before v1.228.2 is tagged. `TAG_AND_PUBLISH` stays `HOLD_PENDING_DEB_AND_RPM_PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
