### PR TITLE
feat(ci): nft consumer execution authority inventory + guard (v1.228.4 PR-1)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -188,6 +188,33 @@ jobs:
       - name: Check Core license metadata (PR-LICENSE)
         run: ./scripts/ci/check-license-metadata.sh
 
+      # v1.228.4 PR-1: nft consumer execution authority. A shipped unit that shells
+      # out to nft while its RestrictAddressFamilies omits AF_NETLINK fails with
+      # EAFNOSUPPORT before nft parses its arguments — and because the probes
+      # discard stderr, that surfaced as a false "firewall table absent" verdict on
+      # 11/11 measured hosts while systemd still reported Result=success.
+      # Asserts inventory<->unit parity both ways, that confirmed consumers declare
+      # AF_NETLINK, that bounded-trace non-consumers withhold it, that no
+      # unprivileged unit gains CAP_NET_ADMIN silently, and that the Queue/BotScan
+      # denial for v1.228.4 stays honoured. The temporary expected_open_violations
+      # baseline in build/nft-consumer-authority.yaml keeps this PASS while PR-1
+      # ships the guard ahead of the PR-2 correction; it must reach zero in PR-2.
+      #
+      # rc is captured INDEPENDENTLY of any output pipeline. `guard | tail` returns
+      # tail's status and has silently converted rc1 into job success three times
+      # in this codebase — see COMMAND_RC_EVIDENCE rule.
+      - name: Check nft consumer execution authority (v1.228.4 PR-1, BLOCKING)
+        run: |
+          set +e
+          output="$(./scripts/ci/check-nft-consumer-authority.sh 2>&1)"
+          rc=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::nft consumer execution authority guard failed (rc=$rc) — see build/nft-consumer-authority.yaml"
+            exit "$rc"
+          fi
+
       # v1.205 CLI surface parity: registry ↔ bash-completion ↔ dispatch (authority
       # = shell dispatch). Classifies MISSING/STALE/RETIRED/ALIAS_NOT_MARKED/etc.;
       # fails on real drift (e.g. retired 'gui' resurfacing in completion, a real

--- a/build/nft-consumer-authority.yaml
+++ b/build/nft-consumer-authority.yaml
@@ -1,0 +1,211 @@
+# =============================================================================
+# NFTBan nft consumer execution authority
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# Source of truth for WHICH shipped systemd units reach nftables, and therefore
+# which execution authority each unit requires. Consumed by
+# scripts/ci/check-nft-consumer-authority.sh.
+#
+# WHY THIS FILE EXISTS
+#   nftban-maintenance.service invokes nft but its RestrictAddressFamilies
+#   omitted AF_NETLINK. libmnl opens AF_NETLINK sockets to read kernel state, so
+#   every nft call inside that sandbox failed with:
+#       mnl.c:61: Unable to initialize Netlink socket:
+#                 Address family not supported by protocol
+#   The unit still reported Result=success, the probe discarded stderr, and the
+#   collapse of "non-zero exit" into "table absent" produced a false firewall-
+#   absent verdict on 11/11 measured hosts. Isolated by a four-cell transient-
+#   unit matrix on lab2 (DEB) + lab4 (RPM): only RestrictAddressFamilies
+#   differed; A1 exit 3 + EAFNOSUPPORT, A2 exit 0.
+#
+# -----------------------------------------------------------------------------
+# EVIDENCE STATES  (bounded — read these literally)
+# -----------------------------------------------------------------------------
+#   confirmed_consumer
+#     A concrete nft/netlink call site exists on a reachable execution path.
+#     Requires AF_NETLINK.
+#
+#   conditional_consumer
+#     An nft call site is reachable only under a stated condition. MUST declare
+#     `activation:`, which decides whether AF_NETLINK is required:
+#
+#       activation: runtime_ordinary
+#         The condition is an ordinary runtime state reachable with NO operator
+#         action (e.g. a stale cache). Treated EXACTLY like confirmed_consumer:
+#         AF_NETLINK is REQUIRED. An unmet requirement is an open violation.
+#
+#       activation: operator_action_required
+#         The condition needs a deliberate operator change (config edit, queued
+#         task). AF_NETLINK may be withheld ONLY when the unit also carries a
+#         `capability_decision`, i.e. the omission is a recorded decision rather
+#         than drift. Without one, the unit is treated as runtime_ordinary.
+#
+#     A conditional_consumer with no `activation:` is a HARD FAIL. It must not be
+#     possible for a declared unit to escape enforcement by virtue of its class.
+#
+#   no_nft_path_bounded_trace
+#     A transitive call-path trace found no reachable nft/netlink call.
+#     *** THIS IS A BOUNDED RESULT, NOT AN ABSOLUTE CLAIM. ***
+#     It means "no path found by this trace at this commit". It does NOT mean
+#     "cannot reach nft under every future configuration". Do not restate it as
+#     an architectural guarantee.
+#
+#   unknown_external_executable
+#     The unit execs a binary whose source is not in this repository, so its
+#     netlink behaviour cannot be established from the tree. Absence of an nft
+#     path is NOT proven. Such units get no AF_NETLINK, but the guard's
+#     "unnecessary AF_NETLINK" rejection MUST NOT be applied to them either.
+#
+# -----------------------------------------------------------------------------
+# STANDING RESTRICTIONS (owner rulings, v1.228.4)
+# -----------------------------------------------------------------------------
+#   Queue and BotScan run as User=nftban with no AmbientCapabilities. AF_NETLINK
+#   alone would not make their nft calls work — they would also need
+#   CAP_NET_ADMIN, which is a privilege increase and is DENIED for v1.228.4.
+#   Neither unit is modified. Follow-on debt handle:
+#       OPEN_UNPRIVILEGED_NFT_OPERATION_AUTHORITY
+#   No capability increase without that design and a separate owner gate.
+# =============================================================================
+schema_version: 1
+
+# Address family required by any process that shells out to nft. libmnl opens an
+# AF_NETLINK socket to read kernel state; without it nft exits non-zero with
+# EAFNOSUPPORT before it parses its own arguments.
+required_family: AF_NETLINK
+
+units:
+  # ---------------------------------------------------------------- CONFIRMED
+  - name: nftban-maintenance.service
+    state: confirmed_consumer
+    user: root
+    nft_operation: read
+    requires_capabilities: []
+    evidence: "cron/maintenance.sh:164 first ungated nft fork of main(); also :121,:210,:387-450,:650,:658; lib/ssh_port_detect.sh:148,:150,:162,:164; unconditional child helpers/autoheal.sh:368,:405,:457,:471,:505,:513"
+
+  - name: nftban-rollback.service
+    state: confirmed_consumer
+    user: root
+    nft_operation: write
+    requires_capabilities: []
+    evidence: "cli/sbin/nftban-rollback:70,:132 `nft -f \"$BACKUP\"`; emergency fallback :77,:78 `nft delete table`"
+
+  - name: nftban-snapshot.service
+    state: confirmed_consumer
+    user: root
+    nft_operation: read
+    requires_capabilities: []
+    evidence: "cli/lib/nftban/cli/cmd_snapshot.sh:108,:110 `nft list set`"
+
+  - name: nftban-update-apply.service
+    state: confirmed_consumer
+    user: root
+    nft_operation: read
+    requires_capabilities: []
+    evidence: "ExecStartPre `nftban update preflight` -> cmd_update.sh:1386 `nft list tables`, :1405,:1406 `nft list set`; ExecStartPost verify :1541,:1557,:1558,:1646"
+
+  - name: nftban-community-stats.service
+    state: confirmed_consumer
+    user: root
+    nft_operation: read
+    requires_capabilities: []
+    evidence: "cmd_pro.sh:948 -> nftban_pro.sh:814 `/usr/lib/nftban/bin/nftban-validate --json` -> internal/validator/nftjson.go:137 `nft -j list ruleset`. (Sibling calls :801 `nftban status --brief` and :805 `nftban health check --brief` are DIFFERENT executables that also reach the validator indirectly; only :814 invokes nftban-validate directly.)"
+
+  # -------------------------------------------------------------- CONDITIONAL
+  - name: nftban-queue.service
+    state: conditional_consumer
+    user: nftban
+    nft_operation: write
+    requires_capabilities: [CAP_NET_ADMIN]
+    capability_decision: denied_v1_228_4
+    activation: operator_action_required
+    condition: "a geoban_apply or feeds_sync task is pending"
+    evidence: "helpers/nftban_task_queue.sh:418 -> nftban_geoban.sh:198,:206,:215,:222; :414 -> nftban_feeds.sh:672,:677"
+    note: "User=nftban with no AmbientCapabilities. AF_NETLINK alone is insufficient. NOT modified in v1.228.4 — see OPEN_UNPRIVILEGED_NFT_OPERATION_AUTHORITY."
+
+  - name: nftban-botscan.service
+    state: conditional_consumer
+    user: nftban
+    nft_operation: write
+    requires_capabilities: [CAP_NET_ADMIN]
+    capability_decision: denied_v1_228_4
+    condition: "BOTSCAN_ACTION_MODE != alert AND BOTSCAN_BATCH_SIGNAL_MODE != true"
+    activation: operator_action_required
+    evidence: "core/nftban_botscan.sh:1403-1406 -> cmd_ban.sh:290 `output=$(\"$NFTBAN_CORE\" ban ...)` -> cmd/nftban-core/cmd_ban.go:478"
+    note: "Shipped default is nft-free (processor exports BATCH_SIGNAL_MODE=true), but operator config is re-sourced after that export. Same privilege blocker as queue. NOT modified in v1.228.4."
+
+  - name: nftban-report-daily.service
+    state: conditional_consumer
+    user: root
+    nft_operation: read
+    requires_capabilities: []
+    activation: runtime_ordinary
+    condition: "metrics cache /var/cache/nftban/metrics/stats.json absent, stale (>NFTBAN_UNIFIED_CACHE_TTL, default 300s) or invalid"
+    evidence: "cmd_report.sh:1300 -> nftban_stats_format.sh:710,:711 -> nftban_stats_collect.sh:193,:214 -> lib/nft_schema.sh:600"
+
+  # --------------------------------------------- BOUNDED TRACE — NO PATH FOUND
+  # Absence of an nft path is bounded by the trace, not proven for all configs.
+  - { name: nftban-alert@.service,            state: no_nft_path_bounded_trace, user: root,    evidence: "cli/sbin/nftban-service-alert -> collect_diagnostics:119 + send_email_alert:173 -> core/nftban_mail.sh send path; the 2 nft sites there (:263,:317) are in check_status/check_ports, reached only from cmd_mail.sh" }
+  - { name: nftban-botscan-collector.service, state: no_nft_path_bounded_trace, user: nftban,  evidence: "closure = 2 files: cli/sbin/nftban-botscan-collector + lib/nftban_http_logs.sh; zero nft tokens" }
+  - { name: nftban-core-geoip.service,        state: no_nft_path_bounded_trace, user: root,    evidence: "cmd_geoip.go:118-264 cmdGeoipUpdate = HTTP download + gzip/tar + maxminddb.Open + rename; no os/exec, no netlink imports on this path" }
+  - { name: nftban-pro-inventory.service,     state: no_nft_path_bounded_trace, user: root,    evidence: "cmd_pro.sh:941 -> :772 -> nftban_pro.sh:49,:101,:483,:299; leaves = hostname, uname, /proc, df, jq, curl" }
+  - { name: nftban-pro-license.service,       state: no_nft_path_bounded_trace, user: root,    evidence: "cmd_pro.sh:944 -> :858 nftban_pro_cmd_license_check() -> nftban_pro.sh:483,:414,:540,:517; leaves = jq, curl, date, systemctl" }
+  - { name: nftban-rbl-check.service,         state: no_nft_path_bounded_trace, user: root,    evidence: "full source closure grepped, zero reachable nft; note core/nftban_hostaddr.sh:97-105 execs `ip` (rtnetlink, not libmnl/nftables)" }
+  - { name: nftban-tunnel.service,            state: no_nft_path_bounded_trace, user: root,    evidence: "cmd_tunnel.sh:76 -> core/nftban_tunnel.sh:491; zero nft tokens across tunnel sources; nftban_output.sh:725 banner is --quiet-suppressed" }
+  - { name: nftban-update-check.service,      state: no_nft_path_bounded_trace, user: root,    evidence: "cmd_update.sh:2628 -> :224 _cmd_update_check = curl+jq+cache; all 5 nft blocks belong to _cmd_update_main_locked/_preflight/_verify, none called here" }
+  - { name: nftban-watchdog.service,          state: no_nft_path_bounded_trace, user: root,    evidence: "core/nftban_watchdog.sh:598 -> :203 run_all; grep for nft subcommands/nftban-validate/nftban-core across watchdog sources returns zero; conntrack check reads /proc files, not netlink" }
+
+  # -------------------------------------------- UNKNOWN EXTERNAL EXECUTABLE
+  - name: nftban-geoban-refresh.service
+    state: unknown_external_executable
+    user: root
+    evidence: "nftban_geoban.sh:1052-1057 execs ${GEOIP_BINARY} (nftban-geoip). That binary has NO SOURCE IN THIS REPOSITORY (cmd/ does not contain it; CHANGELOG records it as not shipped in the base package), so its netlink behaviour cannot be established from the tree."
+    note: "Gets no AF_NETLINK. The guard's unnecessary-AF_NETLINK rejection MUST NOT apply here — absence of an nft path is not proven, only untraceable."
+
+# Units that legitimately declare AF_NETLINK today and are verified consumers.
+# Listed so the guard can assert the declaration is intentional rather than drift.
+already_authorized:
+  - nftban-core-feeds.service
+  - nftban-firewall-init.service
+  - nftban-firewall-validate.service
+  - nftban-health.service
+  - nftban-rebuild-recovery.service
+  - nftban-soak.service
+  - nftban-unified-exporter.service
+
+# Units that declare NO RestrictAddressFamilies at all. systemd's default permits
+# every address family, so these are unrestricted and are NOT part of this defect.
+# They are enumerated so the guard can distinguish "not declared" (fine) from
+# "declared without AF_NETLINK" (the defect) — conflating the two is how the
+# original inventory overcounted.
+unrestricted_by_design:
+  - nftban-health-fix.service
+  - nftband.service
+
+# =============================================================================
+# TEMPORARY BASELINE — v1.228.4 PR-1 only
+# =============================================================================
+# PR-1 lands the inventory and the guard. PR-2 lands the actual sandbox
+# correction. Between them the guard MUST stay sensitive to the real defect
+# while remaining mergeable, so the currently-open violations are declared
+# EXACTLY here rather than suppressed by a generic ignore.
+#
+# The guard passes only when the observed violation set EQUALS this list:
+#   an UNEXPECTED violation appears            -> FAIL (regression)
+#   an EXPECTED violation disappears           -> FAIL (PR-2 landed; empty this list)
+#   the set matches exactly                    -> PASS
+#
+# PR-2 CLOSURE CONTRACT: this list must go 5 -> 0 and the block must be deleted.
+# Leaving it populated after the five corrections land is itself a FAIL.
+# =============================================================================
+expected_open_violations:
+  # nftban-report-daily is a conditional_consumer with activation: runtime_ordinary
+  # (a stale metrics cache needs no operator action), so it is enforced exactly like
+  # a confirmed consumer and is the SIXTH open unit. It was silently unasserted
+  # before the conditional_consumer rule existed.
+  - nftban-report-daily.service
+  - nftban-maintenance.service
+  - nftban-rollback.service
+  - nftban-snapshot.service
+  - nftban-update-apply.service
+  - nftban-community-stats.service

--- a/cli/lib/nftban/tests/nft_consumer_authority_guard_v1228_4_test.sh
+++ b/cli/lib/nftban/tests/nft_consumer_authority_guard_v1228_4_test.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - negative controls for the nft consumer execution authority guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nft_consumer_authority_guard_v1228_4_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="v1.228.4 PR-1 negative controls. A guard nobody has proven sensitive is a green light, not a gate. This suite injects each violation class the nft consumer authority guard exists to catch and asserts the guard actually fails, in the expected assertion group, then restores the tree and verifies the restore by hash. NC-1 confirmed consumer loses AF_NETLINK; NC-2 bounded-trace non-consumer gains it unnecessarily; NC-3 an unprivileged unit gains CAP_NET_ADMIN with no recorded decision; NC-4 the Queue/BotScan denial for v1.228.4 is violated; NC-5 an evidence state drifts to an absolute unbounded name; NC-6 a shipped unit is dropped from the inventory; NC-7 the inventory names a unit that is not shipped; NC-8 the guard's non-zero rc survives being piped through a successful consumer - a masked-exit pattern that has silently converted failure into success three separate times in this codebase, so it is asserted here as a permanent harness invariant. Every control proves injector rc=0, mutation observed, guard failed in the exact expected group, and restore hash matches. Operates on temporary COPIES of the repo tree - the working tree is never mutated."
+# meta:input="build/nft-consumer-authority.yaml, install/systemd/*.service, scripts/ci/check-nft-consumer-authority.sh"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,python3,sha256sum,grep,sed"
+# meta:inventory.files="build/nft-consumer-authority.yaml,scripts/ci/check-nft-consumer-authority.sh"
+# meta:inventory.binaries="bash,python3,sha256sum"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="install/systemd/*.service (copies only)"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="nft_consumer_authority_guard_v1228_4_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="systemd-execution-authority"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+GUARD_REL="scripts/ci/check-nft-consumer-authority.sh"
+AUTH_REL="build/nft-consumer-authority.yaml"
+
+[[ -f "$REPO/$GUARD_REL" ]] || { echo "FAIL: guard not found" >&2; exit 1; }
+[[ -f "$REPO/$AUTH_REL" ]]  || { echo "FAIL: authority file not found" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+
+# Materialise an isolated copy of the surfaces the guard reads. The working tree
+# is NEVER mutated by this test.
+mkcopy(){
+    local d="$WORK/$1"; rm -rf "$d"; mkdir -p "$d/build" "$d/scripts/ci" "$d/install/systemd"
+    cp "$REPO/$AUTH_REL"  "$d/build/"
+    cp "$REPO/$GUARD_REL" "$d/scripts/ci/"
+    cp "$REPO"/install/systemd/*.service "$d/install/systemd/"
+    printf '%s' "$d"
+}
+
+# Run the guard in a copy. rc captured independently — never through a pipeline.
+# NOTE: deliberately does NOT toggle errexit. An earlier version restored `set -e`
+# before `return "$rc"`, which overrode the caller's `set +e` and aborted the whole
+# suite after the first control. Callers use `run_guard d || rc=$?` (condition
+# context), so errexit never fires on the non-zero return.
+run_guard(){
+    local d="$1" out rc=0
+    out="$(bash "$d/scripts/ci/check-nft-consumer-authority.sh" 2>&1)" || rc=$?
+    printf '%s' "$out" > "$d/.guard.out"
+    return "$rc"
+}
+
+# Path-INDEPENDENT content hash. An earlier version hashed absolute paths, so a
+# restored copy in a different directory never matched its own baseline and every
+# control reported a false RESTORE_HASH mismatch.
+tree_hash(){ ( cd "$1" && find . -type f ! -name '.guard.out' -print0 \
+                 | sort -z | xargs -0 sha256sum ) | sha256sum | cut -d' ' -f1; }
+
+# control <id> <desc> <expected-group-regex> <injector-fn>
+control(){
+    local id="$1" desc="$2" group="$3" inject="$4"
+    local d; d=$(mkcopy "$id")
+    local before; before=$(tree_hash "$d")
+
+    local irc=0; "$inject" "$d" || irc=$?
+    if [[ $irc -ne 0 ]]; then
+        no "$id $desc" "INJECTOR_RC=$irc (must be 0) — the control never ran"; return
+    fi
+    local after; after=$(tree_hash "$d")
+    if [[ "$before" == "$after" ]]; then
+        no "$id $desc" "MUTATION_OBSERVED=NO — injector changed nothing, so a PASS proves nothing"; return
+    fi
+
+    local grc=0; run_guard "$d" || grc=$?
+    if [[ $grc -eq 0 ]]; then
+        no "$id $desc" "guard returned 0 on an injected violation — GUARD NOT SENSITIVE"; return
+    fi
+    if ! grep -qE "$group" "$d/.guard.out"; then
+        no "$id $desc" "guard failed but not in the expected group /$group/"; return
+    fi
+
+    # restore and prove the restore
+    local d2; d2=$(mkcopy "${id}_restored")
+    if [[ "$(tree_hash "$d2")" != "$before" ]]; then
+        no "$id $desc" "RESTORE_HASH mismatch"; return
+    fi
+    ok "$id $desc (injector rc=0 · mutation observed · guard failed in $group · restore verified)"
+}
+
+strip_family(){ sed -i 's/^RestrictAddressFamilies=.*/RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6/' "$1"; }
+
+# ---------------------------------------------------------------- NC-1
+# An already-authorized confirmed consumer loses AF_NETLINK. Uses a unit that is
+# NOT in expected_open_violations, so the baseline cannot absorb it.
+nc1(){ strip_family "$1/install/systemd/nftban-firewall-init.service"
+       python3 - "$1/build/nft-consumer-authority.yaml" <<'PY'
+import sys,re
+p=sys.argv[1]; s=open(p).read()
+s=s.replace("already_authorized:\n  - nftban-core-feeds.service",
+            "already_authorized:\n  - nftban-core-feeds.service")
+s=s.replace("  - nftban-firewall-init.service\n","",1)
+# Evidence text deliberately avoids spelling a literal nft write verb sequence:
+# scripts/ci/check-nft-writes.sh scans this directory and would flag the literal
+# string as a direct-write violation even inside a test fixture.
+s=s.replace("units:\n","units:\n  - name: nftban-firewall-init.service\n    state: confirmed_consumer\n    user: root\n    nft_operation: write\n    requires_capabilities: []\n    evidence: \"ExecStop removes the nftban tables via the nft binary (see the shipped unit)\"\n\n",1)
+open(p,'w').write(s)
+PY
+}
+# ---------------------------------------------------------------- NC-2
+nc2(){ sed -i 's/^RestrictAddressFamilies=\(.*\)$/RestrictAddressFamilies=\1 AF_NETLINK/' \
+         "$1/install/systemd/nftban-watchdog.service"; }
+# ---------------------------------------------------------------- NC-3
+nc3(){ printf 'AmbientCapabilities=CAP_NET_ADMIN\n' >> "$1/install/systemd/nftban-tunnel.service"
+       grep -q '^User=' "$1/install/systemd/nftban-tunnel.service" \
+         || printf 'User=nftban\n' >> "$1/install/systemd/nftban-tunnel.service"
+       sed -i 's/^User=root$/User=nftban/' "$1/install/systemd/nftban-tunnel.service"; }
+# ---------------------------------------------------------------- NC-4
+nc4(){ sed -i 's/^RestrictAddressFamilies=\(.*\)$/RestrictAddressFamilies=\1 AF_NETLINK/' \
+         "$1/install/systemd/nftban-queue.service"; }
+# ---------------------------------------------------------------- NC-5
+nc5(){ sed -i 's/state: no_nft_path_bounded_trace/state: no_nft_path_found/' \
+         "$1/build/nft-consumer-authority.yaml"; }
+# ---------------------------------------------------------------- NC-6
+nc6(){ python3 - "$1/build/nft-consumer-authority.yaml" <<'PY'
+import sys
+p=sys.argv[1]; s=open(p).read()
+s=s.replace("  - nftban-health-fix.service\n","",1)   # drop a shipped unit from the inventory
+open(p,'w').write(s)
+PY
+}
+# ---------------------------------------------------------------- NC-7
+# Must inject into already_authorized, NOT append to the file: the last block is
+# expected_open_violations, so a bare append landed there and failed in G1
+# instead of the A2 phantom-unit assertion this control exists to prove.
+nc7(){ sed -i '/^already_authorized:/a\  - nftban-does-not-exist.service' \
+         "$1/build/nft-consumer-authority.yaml"; }
+
+control NC-1 "confirmed consumer stripped of AF_NETLINK -> B group fails" '\[FAIL\] B1' nc1
+control NC-2 "bounded-trace non-consumer granted AF_NETLINK -> C group fails" '\[FAIL\] C1' nc2
+control NC-3 "unprivileged unit gains CAP_NET_ADMIN undeclared -> D group fails" '\[FAIL\] D1' nc3
+control NC-4 "queue violates denied_v1_228_4 -> E group fails" '\[FAIL\] E1' nc4
+control NC-5 "evidence state drifts to an absolute name -> F group fails" '\[FAIL\] F(1|3)' nc5
+control NC-6 "shipped unit dropped from inventory -> A group fails" '\[FAIL\] A1' nc6
+control NC-7 "inventory names a unit that is not shipped -> A group fails" '\[FAIL\] A2' nc7
+
+# ---------------------------------------------------------------- NC-8
+# THE MASKED-EXIT INVARIANT. `guard | tail` returns tail's status. This pattern
+# has silently converted a failing guard into job success three separate times in
+# this codebase (a lost printf rc, a dpkg-deb absence, and this guard's own first
+# run). Assert both that the naive pattern DOES mask, and that the pattern the CI
+# workflow actually uses does NOT.
+echo "=== NC-8 masked-exit invariant ==="
+d8=$(mkcopy NC-8); nc4 "$d8"          # inject a real violation
+set +e
+bash "$d8/scripts/ci/check-nft-consumer-authority.sh" 2>&1 | tail -1 >/dev/null
+masked_rc=$?
+direct_out="$(bash "$d8/scripts/ci/check-nft-consumer-authority.sh" 2>&1)"
+direct_rc=$?
+set -e
+if [[ $direct_rc -eq 0 ]]; then
+    no "NC-8 guard fails on the injected violation" "direct rc=0"
+elif [[ $masked_rc -ne 0 ]]; then
+    ok "NC-8 pipeline did not mask rc here (rc=$masked_rc) — still asserting the safe pattern"
+else
+    ok "NC-8 masked-exit reproduced: direct rc=$direct_rc but 'guard | tail' rc=$masked_rc"
+fi
+printf '%s' "$direct_out" >/dev/null
+if [[ $direct_rc -ne 0 ]]; then
+    ok "NC-8 independent capture preserves rc=$direct_rc (the pattern ci-architecture.yml uses)"
+else
+    no "NC-8 independent capture preserves rc" "got 0"
+fi
+
+# ---------------------------------------------------------------- baseline contract
+echo "=== baseline contract (PR-1 -> PR-2) ==="
+d9=$(mkcopy BASELINE)
+python3 - "$d9/build/nft-consumer-authority.yaml" <<'PY'
+import sys
+p=sys.argv[1]; s=open(p).read()
+# simulate PR-2 fixing ONE unit while the baseline still claims it is open
+open(p,'w').write(s)
+PY
+sed -i 's/^RestrictAddressFamilies=AF_UNIX$/RestrictAddressFamilies=AF_UNIX AF_NETLINK/' \
+    "$d9/install/systemd/nftban-snapshot.service"
+brc=0; run_guard "$d9" || brc=$?
+if [[ $brc -ne 0 ]] && grep -q '\[FAIL\] G1' "$d9/.guard.out"; then
+    ok "G1 a fixed unit still listed as expected-open FAILS (forces PR-2 to empty the baseline)"
+else
+    no "G1 stale baseline entry must fail" "rc=$brc"
+fi
+
+# =============================================================================
+# NC-10..13 — coverage holes found by independent audit. Each of these returned
+# guard rc=0 before the fix, i.e. a declared authority state escaped enforcement.
+# =============================================================================
+
+# NC-10: already_authorized was DESCRIPTIVE, not enforced. Rule B iterated only
+# confirmed_consumer entries, so stripping the family from any of the 7 already-
+# authorized units left the guard green — the exact defect PR-1 exists to prevent.
+# CRITICAL: the YAML classification is left UNCHANGED. Earlier controls (NC-1,
+# BC-2) rewrote the unit into `units:` as confirmed_consumer, so they exercised
+# rule B and gave false confidence about this path.
+nc10(){ strip_family "$1/install/systemd/nftban-firewall-init.service"; }
+control NC-10 "already_authorized unit loses AF_NETLINK, YAML untouched -> B2 fails" \
+        '\[FAIL\] B2' nc10
+
+# NC-11: conditional_consumer had no semantic rule at all — it appeared only in
+# the VALID set, so a declared unit escaped enforcement by virtue of its class.
+# Remove the activation key from a conditional consumer: it must HARD FAIL rather
+# than silently pass.
+nc11(){ sed -i '/^  - name: nftban-report-daily.service$/,/^$/{/^    activation: /d}' \
+          "$1/build/nft-consumer-authority.yaml"; }
+control NC-11 "conditional_consumer with no activation -> B3 hard-fails" \
+        '\[FAIL\] B3' nc11
+
+# NC-12: an operator_action_required consumer that withholds the family WITHOUT a
+# recorded capability_decision is drift, not a decision. Strip the decision from
+# queue and assert the omission stops being tolerated.
+nc12(){ sed -i '/^  - name: nftban-queue.service$/,/^$/{/^    capability_decision: /d}' \
+          "$1/build/nft-consumer-authority.yaml"; }
+control NC-12 "operator_action_required with unrecorded omission -> B3 fails" \
+        '\[FAIL\] B3' nc12
+
+# NC-13: the blanket endswith("@.service") exemption let ANY templated name pass
+# phantom detection. nftban-phantom@.service injected into already_authorized
+# returned rc=0 before the fix.
+nc13(){ sed -i '/^already_authorized:/a\  - nftban-phantom@.service' \
+          "$1/build/nft-consumer-authority.yaml"; }
+control NC-13 "templated phantom in already_authorized -> A2 fails" \
+        '\[FAIL\] A2' nc13
+
+# POSITIVE control: a legitimate operator_action_required consumer that withholds
+# the family WITH a recorded capability_decision must PASS. Proves the B3 rule
+# discriminates rather than simply rejecting every conditional consumer.
+echo "=== NC-14 legitimate inactive conditional state must PASS ==="
+d14=$(mkcopy NC-14)
+rc14=0; run_guard "$d14" || rc14=$?
+if [[ $rc14 -eq 0 ]] && grep -q 'B3 nftban-queue.service operator_action_required' "$d14/.guard.out"; then
+    ok "NC-14 queue/botscan withhold the family under a RECORDED decision and PASS (rule discriminates)"
+else
+    no "NC-14 legitimate inactive conditional passes" "rc=$rc14 — B3 is rejecting a valid recorded omission"
+fi
+
+# =============================================================================
+# NC-9 — a required CI authority must not be satisfied by an IGNORED local file
+# =============================================================================
+# build/ is gitignored (.gitignore:8, two negations). A new authority file lives
+# on disk, never appears in `git status`, and is silently omitted from the commit
+# — the gate then PASSES on a local artefact the committed repository does not
+# contain. Uses a synthetic git repo; no production file is added to test this.
+echo "=== NC-9 authority must be git-TRACKED, not merely present on disk ==="
+d9t="$WORK/NC-9"; mkdir -p "$d9t"
+git -C "$d9t" init -q 2>/dev/null
+mkdir -p "$d9t/build" "$d9t/scripts/ci" "$d9t/install/systemd"
+cp "$REPO/$AUTH_REL"  "$d9t/build/"
+cp "$REPO/$GUARD_REL" "$d9t/scripts/ci/"
+cp "$REPO"/install/systemd/*.service "$d9t/install/systemd/"
+printf 'build/\n' > "$d9t/.gitignore"          # reproduce the ignore condition
+git -C "$d9t" add -A >/dev/null 2>&1 || true   # authority is ignored -> NOT tracked
+git -C "$d9t" -c user.email=t@t -c user.name=t commit -qm x >/dev/null 2>&1 || true
+
+nc9rc=0
+nc9out="$(bash "$d9t/scripts/ci/check-nft-consumer-authority.sh" 2>&1)" || nc9rc=$?
+if [[ $nc9rc -eq 0 ]]; then
+    no "NC-9 untracked authority is rejected" \
+       "guard PASSED on an ignored, untracked authority file — CI would be green while the commit has no authority"
+elif grep -q 'FAIL. AUTHORITY_FILE_TRACKED' <<<"$nc9out"; then
+    ok "NC-9 untracked authority is rejected (AUTHORITY_FILE_TRACKED failed, rc=$nc9rc)"
+else
+    no "NC-9 untracked authority is rejected" "failed (rc=$nc9rc) but not on AUTHORITY_FILE_TRACKED"
+fi
+
+# The same repo with the file force-added must PASS the tracked assertion.
+git -C "$d9t" add -f build/nft-consumer-authority.yaml >/dev/null 2>&1 || true
+nc9brc=0
+nc9bout="$(bash "$d9t/scripts/ci/check-nft-consumer-authority.sh" 2>&1)" || nc9brc=$?
+if grep -q 'PASS. AUTHORITY_FILE_TRACKED' <<<"$nc9bout"; then
+    ok "NC-9b force-added authority satisfies AUTHORITY_FILE_TRACKED"
+else
+    no "NC-9b force-added authority satisfies AUTHORITY_FILE_TRACKED" \
+       "still not tracked after git add -f (guard rc=$nc9brc)"
+fi
+
+# Malformed YAML must fail loudly, not silently degrade to an empty inventory.
+d9m="$WORK/NC-9m"; mkdir -p "$d9m/build" "$d9m/scripts/ci" "$d9m/install/systemd"
+cp "$REPO/$GUARD_REL" "$d9m/scripts/ci/"
+cp "$REPO"/install/systemd/*.service "$d9m/install/systemd/"
+printf 'units: [ this is not: valid: yaml\n' > "$d9m/build/nft-consumer-authority.yaml"
+nc9mrc=0
+nc9mout="$(bash "$d9m/scripts/ci/check-nft-consumer-authority.sh" 2>&1)" || nc9mrc=$?
+if [[ $nc9mrc -ne 0 ]] && grep -q 'AUTHORITY_FILE_PARSEABLE' <<<"$nc9mout"; then
+    ok "NC-9c malformed authority YAML fails loudly (not a silent empty inventory)"
+else
+    no "NC-9c malformed authority YAML fails loudly" "rc=$nc9mrc"
+fi
+
+# =============================================================================
+# BC — the expected-open baseline must be TRANSITIONAL, not a suppression
+# =============================================================================
+# PR-2 must drive expected_open_violations 5 -> 0. Prove the mechanism fails in
+# every direction, so a stale or wrong exception cannot survive a merge.
+echo "=== BC. expected-open baseline is transitional ==="
+
+bc_case(){ # bc_case <id> <desc> <group-regex> <mutator>
+    local id="$1" desc="$2" group="$3" mut="$4"
+    local d; d=$(mkcopy "$id")
+    local irc=0; "$mut" "$d" || irc=$?
+    if [[ $irc -ne 0 ]]; then no "$id $desc" "mutator rc=$irc"; return; fi
+    local rc=0; run_guard "$d" || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        no "$id $desc" "guard PASSED — the baseline absorbed a change it must reject"; return
+    fi
+    grep -qE "$group" "$d/.guard.out" \
+        && ok "$id $desc (failed in $group)" \
+        || no "$id $desc" "failed, but not in /$group/"
+}
+
+# 5 listed, 4 observed — one declared violation got fixed but stayed listed.
+bc_fewer(){ sed -i 's/^RestrictAddressFamilies=AF_UNIX$/RestrictAddressFamilies=AF_UNIX AF_NETLINK/' \
+              "$1/install/systemd/nftban-snapshot.service"; }
+# 5 listed, 6 observed — an UNDECLARED violation appeared (regression).
+bc_more(){ strip_family "$1/install/systemd/nftban-firewall-init.service"
+           sed -i 's/^  - nftban-core-feeds.service$/  - nftban-core-feeds.service/' \
+             "$1/build/nft-consumer-authority.yaml"
+           sed -i '/^already_authorized:/,/^$/{s/^  - nftban-firewall-init.service$//}' \
+             "$1/build/nft-consumer-authority.yaml"
+           sed -i 's|^units:$|units:\n  - name: nftban-firewall-init.service\n    state: confirmed_consumer\n    user: root\n    nft_operation: write\n    requires_capabilities: []\n    evidence: "ExecStop removes the nftban tables via the nft binary"|' \
+             "$1/build/nft-consumer-authority.yaml"; }
+# a WRONG unit replaces one expected entry.
+bc_swap(){ sed -i 's/^  - nftban-snapshot.service$/  - nftban-watchdog.service/' \
+             "$1/build/nft-consumer-authority.yaml"; }
+# ALL declared violations fixed, exceptions left behind.
+bc_all(){ for u in maintenance rollback snapshot update-apply community-stats; do
+              sed -i 's/^RestrictAddressFamilies=\(.*\)$/RestrictAddressFamilies=\1 AF_NETLINK/' \
+                "$1/install/systemd/nftban-${u}.service"
+          done; }
+
+bc_case BC-1 "5 listed / 4 observed (one fixed, still listed)"      '\[FAIL\] G1' bc_fewer
+bc_case BC-2 "5 listed / 6 observed (undeclared regression)"        '\[FAIL\] B1' bc_more
+bc_case BC-3 "wrong unit swapped into the expected-open list"       '\[FAIL\] (G1|B1)' bc_swap
+bc_case BC-4 "all 5 fixed but exceptions remain (PR-2 left stale)"  '\[FAIL\] G1' bc_all
+
+# =============================================================================
+# HR — harness self-regressions. Each of these defects was found in THIS suite
+# during development; without an assertion each would silently return and make
+# the negative controls prove nothing.
+# =============================================================================
+echo "=== HR. harness cannot regress its own evidence defects ==="
+
+# HR-1: run_guard must not restore errexit before returning non-zero. It did, and
+# that overrode the caller's `set +e`, aborting the suite after the first control
+# with EMPTY output and rc=1 — indistinguishable from "nothing ran".
+if sed -n '/^run_guard()/,/^}/p' "$0" | grep -qE '^\s*set -e\s*$'; then
+    no "HR-1 run_guard does not re-enable errexit" "found 'set -e' inside run_guard — it will abort the suite on the first failing control"
+else
+    ok "HR-1 run_guard does not re-enable errexit (callers use 'run_guard || rc=\$?')"
+fi
+
+# HR-2: tree_hash must be path-INDEPENDENT. It hashed absolute paths, so a
+# restored copy in a different directory never matched and every RESTORE_HASH
+# comparison failed falsely.
+hr2a="$WORK/hr2a"; hr2b="$WORK/hr2b"; mkdir -p "$hr2a" "$hr2b"
+printf 'identical\n' > "$hr2a/f"; printf 'identical\n' > "$hr2b/f"
+if [[ "$(tree_hash "$hr2a")" == "$(tree_hash "$hr2b")" ]]; then
+    ok "HR-2 tree_hash is path-independent (same content in two dirs hashes equal)"
+else
+    no "HR-2 tree_hash is path-independent" "identical content in different dirs hashed differently — restores will falsely fail"
+fi
+
+# HR-3: a control must assert its EXACT assertion group. Prove the group check
+# has teeth by pointing a real violation at a group that cannot match.
+d_hr3=$(mkcopy HR-3); nc4 "$d_hr3"
+hr3rc=0; run_guard "$d_hr3" || hr3rc=$?
+if [[ $hr3rc -ne 0 ]] && ! grep -qE '\[FAIL\] Z9' "$d_hr3/.guard.out"; then
+    ok "HR-3 group matching has teeth (a real failure does not match a wrong group)"
+else
+    no "HR-3 group matching has teeth" "a wrong group regex would have matched — controls could pass via the wrong assertion"
+fi
+
+# HR-4: this file must not contain a literal nft write-verb sequence. Descriptive
+# fixture text using one contaminated scripts/ci/check-nft-writes.sh and failed an
+# unrelated guard (nft_writer_authority_v150_test).
+if grep -nE '\bnft[[:space:]]+(add|delete|flush|insert|replace|create)[[:space:]]' "$0" \
+     | grep -vE '^\s*[0-9]+:\s*#' | grep -q .; then
+    no "HR-4 no literal nft write verb in this fixture" "a literal write sequence will trip scripts/ci/check-nft-writes.sh"
+else
+    ok "HR-4 no literal nft write verb in this fixture (cannot contaminate check-nft-writes)"
+fi
+
+echo
+printf 'RESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED:\n'; printf '  - %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/scripts/ci/check-nft-consumer-authority.sh
+++ b/scripts/ci/check-nft-consumer-authority.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - nft consumer execution authority guard
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="check-nft-consumer-authority"
+# meta:type="ci-guard"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-28"
+# meta:description="v1.228.4 PR-1. Asserts that every shipped systemd unit which reaches nftables declares the execution authority it needs. libmnl opens an AF_NETLINK socket to read kernel state, so a unit that shells out to nft while its RestrictAddressFamilies omits AF_NETLINK fails with EAFNOSUPPORT before nft parses its arguments - and, because the probes discard stderr, that surfaced as a false 'firewall table absent' verdict on 11/11 measured hosts while systemd still reported Result=success. This guard reads build/nft-consumer-authority.yaml and cross-checks it against install/systemd/*.service. It rejects (a) a confirmed_consumer whose unit declares RestrictAddressFamilies without AF_NETLINK, (b) an AF_NETLINK declaration on a no_nft_path_bounded_trace unit, (c) an unprivileged unit gaining CAP_NET_ADMIN without a recorded capability_decision, (d) inventory drift in either direction between the YAML and the shipped unit set. It deliberately does NOT apply the unnecessary-AF_NETLINK rule to unknown_external_executable units, whose absence of an nft path is untraceable rather than proven. Static analysis only - reads files, invokes nothing, contacts no host."
+# meta:input="build/nft-consumer-authority.yaml, install/systemd/*.service"
+# meta:output="PASS/FAIL per assertion; exit 0 on all-pass, 1 on any violation"
+# meta:depends="bash,python3,grep"
+# meta:inventory.files="build/nft-consumer-authority.yaml"
+# meta:inventory.binaries="bash,python3"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units="all units under install/systemd"
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="check_nft_consumer_authority"
+# meta:ta.owner="packaging"
+# meta:ta.module="systemd-execution-authority"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+AUTHORITY="$REPO/build/nft-consumer-authority.yaml"
+UNIT_DIR="$REPO/install/systemd"
+
+# -----------------------------------------------------------------------------
+# PRE-FLIGHT: the authority must be real, TRACKED and parseable.
+#
+# AUTHORITY_FILE_TRACKED exists because build/ is gitignored (.gitignore:8) with
+# only two negations. Every other tracked file under build/ was force-added, so a
+# new authority file lives on disk, never appears in `git status`, and is silently
+# omitted from the commit — a required CI gate would then read a local untracked
+# file and PASS, while the committed repository has no authority at all.
+# A required CI authority must never be satisfied by an ignored local file.
+# -----------------------------------------------------------------------------
+echo "=== 0. authority pre-flight ==="
+[[ -d "$UNIT_DIR" ]] || { echo "  [FAIL] unit dir not found: $UNIT_DIR" >&2; exit 1; }
+
+if [[ -f "$AUTHORITY" ]]; then
+    echo "  [PASS] AUTHORITY_FILE_EXISTS"
+else
+    echo "  [FAIL] AUTHORITY_FILE_EXISTS — not found: $AUTHORITY" >&2; exit 1
+fi
+
+# Tracked-ness is only meaningful inside a git work tree. Outside one (e.g. an
+# extracted tarball, or the synthetic copies the negative-control suite uses) the
+# check is not applicable and is reported as such rather than silently skipped.
+if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git -C "$REPO" ls-files --error-unmatch -- "build/nft-consumer-authority.yaml" >/dev/null 2>&1; then
+        echo "  [PASS] AUTHORITY_FILE_TRACKED"
+    else
+        echo "  [FAIL] AUTHORITY_FILE_TRACKED — present on disk but NOT tracked by git." >&2
+        echo "         build/ is gitignored; the file must be force-added:" >&2
+        echo "           git add -f build/nft-consumer-authority.yaml" >&2
+        echo "         Until then the committed repository has no authority file and this" >&2
+        echo "         gate is passing on a local artefact that CI will never see." >&2
+        exit 1
+    fi
+else
+    echo "  [N/A ] AUTHORITY_FILE_TRACKED — not inside a git work tree"
+fi
+
+if python3 -c 'import sys,yaml; yaml.safe_load(open(sys.argv[1]))' "$AUTHORITY" 2>/dev/null; then
+    echo "  [PASS] AUTHORITY_FILE_PARSEABLE"
+else
+    echo "  [FAIL] AUTHORITY_FILE_PARSEABLE — YAML does not parse: $AUTHORITY" >&2; exit 1
+fi
+
+python3 - "$AUTHORITY" "$UNIT_DIR" <<'PY'
+import sys, os, glob, re
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL: python3 yaml module unavailable", file=sys.stderr)
+    sys.exit(1)
+
+authority_path, unit_dir = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(open(authority_path))
+
+REQUIRED_FAMILY = doc.get("required_family", "AF_NETLINK")
+units_decl      = {u["name"]: u for u in doc.get("units", [])}
+already_auth    = set(doc.get("already_authorized", []))
+unrestricted    = set(doc.get("unrestricted_by_design", []))
+
+expected_open  = set(doc.get("expected_open_violations", []))
+observed_open  = set()   # confirmed consumers currently missing the family
+
+PASS = FAIL = 0
+def ok(m):
+    global PASS; PASS += 1; print(f"  [PASS] {m}")
+def no(m, d):
+    global FAIL; FAIL += 1; print(f"  [FAIL] {m}\n         {d}")
+
+def read_unit(path):
+    """Return (raf_declared, raf_value, ambient_caps, user). raf_declared
+    distinguishes 'not declared' (systemd default = all families permitted, fine)
+    from 'declared without AF_NETLINK' (the defect). Conflating those two is how
+    the original inventory overcounted 8 units as 18."""
+    raf_declared, raf, caps, user = False, "", "", ""
+    with open(path) as fh:
+        for line in fh:
+            s = line.strip()
+            if s.startswith("RestrictAddressFamilies="):
+                raf_declared = True
+                raf = s.split("=", 1)[1].strip()
+            elif s.startswith("AmbientCapabilities="):
+                caps = s.split("=", 1)[1].strip()
+            elif s.startswith("User="):
+                user = s.split("=", 1)[1].strip()
+    return raf_declared, raf, caps, user
+
+shipped = {os.path.basename(p): p for p in glob.glob(os.path.join(unit_dir, "*.service"))}
+
+# ---------------------------------------------------------------- A. drift
+print("=== A. inventory covers the shipped unit set ===")
+classified = set(units_decl) | already_auth | unrestricted
+missing = sorted(set(shipped) - classified)
+if missing:
+    no("A1 every shipped unit is classified in the authority file",
+       "unclassified: " + ", ".join(missing) +
+       " — add it to build/nft-consumer-authority.yaml with an evidence state")
+else:
+    ok(f"A1 every shipped unit is classified ({len(shipped)} units)")
+
+# A blanket endswith("@.service") exemption let ANY templated name pass as a
+# phantom: nftban-phantom@.service injected into already_authorized returned 0.
+# Template units are matched by the *.service glob and ARE present in `shipped`
+# (nftban-alert@.service is), so no exemption is warranted.
+phantom = sorted(c for c in classified if c not in shipped)
+if phantom:
+    no("A2 authority file lists no unit that is not shipped",
+       "listed but absent from install/systemd: " + ", ".join(phantom))
+else:
+    ok("A2 authority file lists no phantom unit")
+
+# ------------------------------------------------- B. confirmed need AF_NETLINK
+print(f"=== B. confirmed consumers declare {REQUIRED_FAMILY} ===")
+for name, u in sorted(units_decl.items()):
+    if u.get("state") != "confirmed_consumer":
+        continue
+    path = shipped.get(name)
+    if not path:
+        no(f"B1 {name} present in install/systemd", "unit file not found")
+        continue
+    declared, raf, _, _ = read_unit(path)
+    if not declared:
+        # No restriction at all -> every family permitted -> functionally fine.
+        ok(f"B1 {name} unrestricted (no RestrictAddressFamilies) — nft reachable")
+    elif REQUIRED_FAMILY in raf:
+        ok(f"B1 {name} declares {REQUIRED_FAMILY}")
+    else:
+        observed_open.add(name)
+        if name in expected_open:
+            print(f"  [EXPECTED-OPEN] {name} missing {REQUIRED_FAMILY} "
+                  f"(RestrictAddressFamilies={raf}) — declared baseline, PR-2 must close it")
+        else:
+            no(f"B1 {name} declares {REQUIRED_FAMILY}",
+               f"RestrictAddressFamilies={raf} — this unit reaches nft ({u.get('evidence','')[:90]}...); "
+               f"without {REQUIRED_FAMILY} libmnl fails EAFNOSUPPORT before nft parses its arguments")
+
+# ------------------------ B2. already_authorized units must RETAIN the family
+# These 7 are verified nft consumers whose grant predates this guard. The list was
+# previously consumed ONLY by rule D, so stripping AF_NETLINK from any of them left
+# the guard at rc=0 — the exact defect class this PR exists to prevent, across 7
+# units. Enforce them here, independently of rule B.
+print(f"=== B2. already_authorized units retain {REQUIRED_FAMILY} ===")
+for name in sorted(already_auth):
+    path = shipped.get(name)
+    if not path:
+        continue          # phantom membership is rule A2's job
+    declared, raf, _, _ = read_unit(path)
+    if not declared:
+        ok(f"B2 {name} unrestricted — nft reachable")
+    elif REQUIRED_FAMILY in raf:
+        ok(f"B2 {name} retains {REQUIRED_FAMILY}")
+    else:
+        no(f"B2 {name} retains {REQUIRED_FAMILY}",
+           f"RestrictAddressFamilies={raf} — this unit is declared already_authorized "
+           f"(a verified nft consumer) and has LOST the family. Either restore it, or "
+           f"reclassify the unit if it genuinely no longer reaches nft.")
+
+# --------------------- B3. conditional_consumer has an enforced semantic ------
+# Previously `conditional_consumer` appeared only in the VALID set, so a declared
+# unit could escape enforcement purely by virtue of its class. nftban-report-daily
+# was a silently unasserted SIXTH open unit.
+print(f"=== B3. conditional consumers are enforced by activation ===")
+for name, u in sorted(units_decl.items()):
+    if u.get("state") != "conditional_consumer":
+        continue
+    act = u.get("activation")
+    if act not in ("runtime_ordinary", "operator_action_required"):
+        no(f"B3 {name} declares a valid activation",
+           f"activation={act!r} — a conditional_consumer MUST declare "
+           f"runtime_ordinary or operator_action_required; it may not escape "
+           f"enforcement by virtue of its class")
+        continue
+    path = shipped.get(name)
+    if not path:
+        continue
+    declared, raf, _, _ = read_unit(path)
+    has_family = (not declared) or (REQUIRED_FAMILY in raf)
+    if act == "operator_action_required":
+        # May withhold the family ONLY when the omission is a recorded decision.
+        if has_family or u.get("capability_decision"):
+            ok(f"B3 {name} operator_action_required "
+               f"({'has family' if has_family else 'omission recorded: ' + str(u.get('capability_decision'))})")
+        else:
+            no(f"B3 {name} operator_action_required omission is recorded",
+               f"RestrictAddressFamilies={raf} lacks {REQUIRED_FAMILY} and there is no "
+               f"capability_decision — an unrecorded omission is drift, not a decision")
+    else:  # runtime_ordinary -> enforced exactly like confirmed_consumer
+        if has_family:
+            ok(f"B3 {name} runtime_ordinary retains {REQUIRED_FAMILY}")
+        else:
+            observed_open.add(name)
+            if name in expected_open:
+                print(f"  [EXPECTED-OPEN] {name} missing {REQUIRED_FAMILY} "
+                      f"(runtime_ordinary conditional) — declared baseline, PR-2 must close it")
+            else:
+                no(f"B3 {name} runtime_ordinary retains {REQUIRED_FAMILY}",
+                   f"RestrictAddressFamilies={raf} — activation=runtime_ordinary means the "
+                   f"nft path is reachable with NO operator action, so the family is required")
+
+# ------------------------------- C. no unnecessary AF_NETLINK on proven non-users
+print(f"=== C. no unnecessary {REQUIRED_FAMILY} on bounded-trace non-consumers ===")
+for name, u in sorted(units_decl.items()):
+    if u.get("state") != "no_nft_path_bounded_trace":
+        continue
+    path = shipped.get(name)
+    if not path:
+        continue
+    declared, raf, _, _ = read_unit(path)
+    if declared and REQUIRED_FAMILY in raf:
+        no(f"C1 {name} does not declare {REQUIRED_FAMILY} unnecessarily",
+           f"no nft path found by trace, yet RestrictAddressFamilies={raf} — "
+           f"granting it without a functional reason weakens the sandbox. "
+           f"If this unit now reaches nft, reclassify it in the authority file.")
+    else:
+        ok(f"C1 {name} correctly withholds {REQUIRED_FAMILY}")
+
+# unknown_external_executable is deliberately EXEMPT from rule C: absence of an
+# nft path is untraceable, not proven, so neither granting nor withholding can be
+# asserted as correct.
+for name, u in sorted(units_decl.items()):
+    if u.get("state") == "unknown_external_executable":
+        ok(f"C2 {name} exempt from the unnecessary-{REQUIRED_FAMILY} rule "
+           f"(unknown_external_executable — absence NOT proven)")
+
+# --------------------------------------------- D. capability increases recorded
+print("=== D. no silent capability increase ===")
+for name, path in sorted(shipped.items()):
+    declared, _, caps, user = read_unit(path)
+    if "CAP_NET_ADMIN" not in caps:
+        continue
+    u = units_decl.get(name, {})
+    # already_authorized units are verified nft consumers whose grant predates
+    # this guard. They are a recorded baseline, not a silent increase.
+    if name in already_auth:
+        ok(f"D1 {name} CAP_NET_ADMIN is a recorded baseline grant (already_authorized)")
+        continue
+    if user and user != "root" and not u.get("capability_decision"):
+        no(f"D1 {name} CAP_NET_ADMIN is a recorded decision",
+           f"User={user} with AmbientCapabilities={caps} but no capability_decision "
+           f"in the authority file — an unprivileged unit may not gain CAP_NET_ADMIN silently")
+    else:
+        ok(f"D1 {name} CAP_NET_ADMIN accounted for (User={user or 'root'})")
+
+# ------------------------------------- E. denied decisions stay unimplemented
+print("=== E. denied capability decisions are honoured ===")
+for name, u in sorted(units_decl.items()):
+    if u.get("capability_decision") != "denied_v1_228_4":
+        continue
+    path = shipped.get(name)
+    if not path:
+        continue
+    declared, raf, caps, _ = read_unit(path)
+    bad = []
+    if "CAP_NET_ADMIN" in caps:
+        bad.append(f"AmbientCapabilities={caps}")
+    if declared and REQUIRED_FAMILY in raf:
+        bad.append(f"RestrictAddressFamilies={raf}")
+    if bad:
+        no(f"E1 {name} honours capability_decision=denied_v1_228_4",
+           "; ".join(bad) + " — this unit must not be modified in v1.228.4 "
+           "(see OPEN_UNPRIVILEGED_NFT_OPERATION_AUTHORITY)")
+    else:
+        ok(f"E1 {name} unmodified per denied_v1_228_4")
+
+# ---------------------------------------------------- F. evidence-state hygiene
+print("=== F. evidence states are bounded and legible ===")
+VALID = {"confirmed_consumer", "conditional_consumer",
+         "no_nft_path_bounded_trace", "unknown_external_executable"}
+bad_state = [n for n, u in units_decl.items() if u.get("state") not in VALID]
+if bad_state:
+    no("F1 every entry uses a valid bounded evidence state", "invalid: " + ", ".join(bad_state))
+else:
+    ok(f"F1 all {len(units_decl)} entries use a valid bounded evidence state")
+
+no_ev = [n for n, u in units_decl.items() if not str(u.get("evidence", "")).strip()]
+if no_ev:
+    no("F2 every entry carries evidence", "missing evidence: " + ", ".join(no_ev))
+else:
+    ok("F2 every entry carries evidence")
+
+# The STATE VALUE must not drift to an absolute name. Assert on the values in
+# use, not on prose — an earlier version scanned prose and flagged the very
+# comment that explains which phrasing to avoid.
+ABSOLUTE = {"no_nft_path", "no_nft_path_found", "never_reaches_nft", "no_nft"}
+drifted = sorted({u.get("state") for u in units_decl.values()} & ABSOLUTE)
+if drifted:
+    no("F3 no evidence state uses an absolute (unbounded) name",
+       "found: " + ", ".join(drifted) + " — use no_nft_path_bounded_trace")
+else:
+    ok("F3 no evidence state uses an absolute (unbounded) name")
+
+# ------------------------------------------- G. baseline contract (PR-1 -> PR-2)
+print("=== G. temporary baseline contract ===")
+if expected_open:
+    stale = sorted(expected_open - observed_open)
+    if stale:
+        no("G1 every declared expected-open violation is still open",
+           "these are now FIXED: " + ", ".join(stale) +
+           " — PR-2 has landed; remove them from expected_open_violations "
+           "(delete the whole block once it reaches zero)")
+    else:
+        ok(f"G1 all {len(expected_open)} declared expected-open violations are still open")
+    if observed_open == expected_open:
+        ok("G2 observed violation set EQUALS the declared baseline (no regression)")
+    # a mismatch in the other direction already failed as a B1 above
+else:
+    if observed_open:
+        no("G1 no undeclared violations", "open: " + ", ".join(sorted(observed_open)))
+    else:
+        ok("G1 baseline empty and zero violations — PR-2 closure contract satisfied")
+
+print()
+print(f"RESULT: {PASS} passed, {FAIL} failed, {len(observed_open)} expected-open")
+sys.exit(1 if FAIL else 0)
+PY

--- a/scripts/ci/check-nft-consumer-authority.sh
+++ b/scripts/ci/check-nft-consumer-authority.sh
@@ -32,7 +32,6 @@
 # meta:ta.requires_package="false"
 # =============================================================================
 set -Eeuo pipefail
-IFS=$'\n\t'
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO=$(cd "$SCRIPT_DIR/../.." && pwd)

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -149,6 +149,7 @@ mail_netrc_auth_transport_v1227_test	cli/lib/nftban/tests/mail_netrc_auth_transp
 mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 mail_subject_authority_v1227_test	cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh	mail	test	mail-subject-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh	firewall	test	maintenance-table-probe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+nft_consumer_authority_guard_v1228_4_test	cli/lib/nftban/tests/nft_consumer_authority_guard_v1228_4_test.sh	packaging	test	systemd-execution-authority	CI_STATIC	ci-bash	true	false	false	false	false	false			
 nft_counting_model_guard_v190_test	cli/lib/nftban/tests/nft_counting_model_guard_v190_test.sh	metrics	test	nft-counting-model	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 nft_loopback_before_invalid_v217_test	cli/lib/nftban/tests/nft_loopback_before_invalid_v217_test.sh	firewall	test	nft-schema-rule-order	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 nft_writer_authority_v150_test	cli/lib/nftban/tests/nft_writer_authority_v150_test.sh	firewall	test	nft-writer-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## Why

A shipped systemd unit that shells out to `nft` while its `RestrictAddressFamilies` omits
`AF_NETLINK` fails with **EAFNOSUPPORT before nft parses its arguments** — libmnl opens an
AF_NETLINK socket to read kernel state. Because the probes discard stderr, that surfaced as a false
**"firewall table absent"** verdict on **11/11 measured hosts** while systemd still reported
`Result=success`.

Root cause isolated by a four-cell transient-unit matrix on lab2 (DEB) and lab4 (RPM). Only
`RestrictAddressFamilies` differed between cells:

| | A1 no-NETLINK | A2 +NETLINK |
|---|---|---|
| exit | **3** | **0** |
| stderr | `mnl.c:61: Unable to initialize Netlink socket: Address family not supported by protocol` | *(0 bytes)* |

Identical on both families. 25 replicated sandbox properties read back byte-identical.

## What this PR does — and does NOT do

**Ships the inventory and the guard. Changes NO product systemd unit.** The corrections land in
PR-2. `git status install/systemd/` is empty in this commit.

### `build/nft-consumer-authority.yaml`

All 27 shipped units classified into four **bounded** evidence states, each with `file:line`
evidence verified at the parent SHA:

```
confirmed_consumer            5   require AF_NETLINK
conditional_consumer          3   require it per `activation:` semantics
no_nft_path_bounded_trace     9   no path found BY THIS TRACE — not an absolute claim
unknown_external_executable   1   nftban-geoban-refresh execs a binary with no source in this
                                  repo; absence is untraceable, not proven
```

`unknown_external_executable` is exempt from the unnecessary-`AF_NETLINK` rule **in both
directions** — we cannot assert correctness about a unit we cannot trace.

### `scripts/ci/check-nft-consumer-authority.sh`

Wired as a **BLOCKING** step in the required policy-gates job, with rc captured independently of any
output pipeline. `guard | tail` returns tail's status and has silently converted rc1 into success
**three times** in this codebase.

### Owner rulings encoded and guarded

Queue and BotScan run as `User=nftban` with no `AmbientCapabilities`. `AF_NETLINK` alone would not
make their nft calls work; `CAP_NET_ADMIN` is a privilege increase and is **DENIED for v1.228.4**.
Rule E fails if either gains the family or the capability. Follow-on debt:
`OPEN_UNPRIVILEGED_NFT_OPERATION_AUTHORITY`.

## The temporary baseline is transitional, not a suppression

`expected_open_violations` declares the **6** currently-open units *exactly*. The guard passes only
when the observed set equals the declared set:

```
undeclared regression appears     -> FAIL
declared violation gets fixed     -> FAIL until removed from the list
set matches exactly               -> PASS
```

**PR-2 must drive it 6 -> 0 and delete the block.** Leaving it populated after the corrections land
is itself a failure. Proven in all four directions (BC-1…BC-4).

## Controls: 26/26

Each proves **injector rc=0 · mutation observed · guard failed in the exact expected assertion
group · restore verified by hash**.

Three coverage holes were found by independent audit *after* the first 21 controls passed, and are
now closed with controls that exercise the real path:

- **B2** — `already_authorized` was descriptive, not enforced; stripping `AF_NETLINK` from any of
  those 7 units left the guard green. NC-10 mutates the shipped unit while leaving its YAML
  classification **unchanged**; the earlier controls reclassified it first and so tested rule B, not
  this path.
- **B3** — `conditional_consumer` appeared only in the `VALID` set, so a declared unit escaped
  enforcement by virtue of its class. `nftban-report-daily` was a silently unasserted **sixth** open
  unit. **NC-14 is a positive control** proving the rule discriminates rather than rejecting every
  conditional consumer.
- **A2** — a blanket `endswith("@.service")` exemption let any templated name pass phantom detection.

Four harness self-regressions are also asserted, each from a defect found in this suite during
development: inherited errexit invalidating control flow, path-dependent hashing manufacturing
restore failures, a control passing through the wrong assertion group, and fixture text
contaminating an unrelated static guard.

## `AUTHORITY_FILE_TRACKED`

`build/` is gitignored with only two negations. A new authority file lives on disk, never appears in
`git status`, and is silently omitted from the commit — the gate would then pass on a local artefact
CI never sees. NC-9 reproduces the condition in a synthetic repo and asserts the guard refuses.

## Local verification

```
guard                    32 pass / 0 fail / 6 expected-open
negative controls        26 / 26
policy-gates battery     70 steps run, 68 pass
shellcheck -S warning    clean          check-nft-writes  rc=0
test-authority index     FRESH          install/systemd   0 changes
```

The two policy-gates failures are **pre-existing and outside this PR's scope**, both verified
against a pristine `origin/main` worktree:

- step 1 repository-authority — this clone is shallow; fails identically on pristine main and cannot
  occur in CI (`fetch-depth: 0`)
- step 12 ci-bash — `comms_redact_failloud` (120s cap vs ~130s runtime, index row field 14 empty;
  times out 3/3 on pristine main, passes 13/13 uncapped) and `whitelist_rebuild_remerge` (flaky,
  cause **not** identified — 168 isolated runs and 20,000 targeted iterations produced zero
  failures; the SIGPIPE hypothesis was tested and refuted)

Neither test is modified here.

## Merge gate

Requires ordinary CI green on this exact head **and** `privacy/trusted-private-gate` dispatched
against this exact SHA. Do not merge if the head changes after either gate.
