### PR TITLE
feat(nft): typed nft probe with fail-closed absence and a monotonic degraded latch (v1.228.4 PR-3)

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -203,6 +203,26 @@ jobs:
       # rc is captured INDEPENDENTLY of any output pipeline. `guard | tail` returns
       # tail's status and has silently converted rc1 into job success three times
       # in this codebase — see COMMAND_RC_EVIDENCE rule.
+      # v1.228.4 PR-3: nft probe authority. G-1 keeps the maintenance path fully
+      # typed; G-2 rejects NEW code that turns a generic nft failure into absence,
+      # rebuild authority, or a healthy verdict; G-3 is a ratchet on the remaining
+      # legacy debt (95 sites) so it can shrink but never grow.
+      #
+      # rc captured INDEPENDENTLY of any output pipeline — `guard | tail` returns
+      # tail's status and has silently converted rc1 into job success three times
+      # in this codebase.
+      - name: Check nft probe authority G-1/G-2/G-3 (v1.228.4 PR-3, BLOCKING)
+        run: |
+          set +e
+          output="$(./scripts/ci/check-nft-probe-authority.sh 2>&1)"
+          rc=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::nft probe authority guard failed (rc=$rc) — use nftban_nft_probe_table/_set; see scripts/ci/nft-probe-debt-baseline.txt"
+            exit "$rc"
+          fi
+
       - name: Check nft consumer execution authority (v1.228.4 PR-1, BLOCKING)
         run: |
           set +e

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -48,6 +48,13 @@ fi
 IFS=$'\n\t'
 umask 027
 
+# v1.228.4 PR-3 typed nft probe authority. Sourced early so every probe on this
+# path is typed. NOTE: the script-scope IFS above is exactly why the old unquoted
+# "$NFTBAN_TABLE_IPV4" expansions reached nft as one fused argv element.
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nft_probe.sh"
+_MAINT_PROBE_UNREADABLE=0
+
 # =============================================================================
 # CONFIGURATION
 # =============================================================================
@@ -113,16 +120,25 @@ _maint_ipchange_alert() {
         "" || true
 }
 
+# v1.228.4 PR-3: TYPED re-check. Returns 0 only for a table that is VERIFIABLY
+# absent across the whole grace window. A window in which the ruleset could not be
+# READ returns 2 — neither "absent" nor "present", so the caller cannot collapse it.
+#
+# The old form expanded $_tbl UNQUOTED under the script-scope IFS=$'\n\t' set at
+# line 48, so "ip nftban" did NOT word-split and reached nft as ONE argv element.
+# The typed probe takes family and table as separate parameters, making that class
+# of defect unrepresentable.
 _maint_table_absent_confirmed() {
-    local _tbl="${1:-${NFTBAN_TABLE_IPV4:-ip nftban}}" _i
+    local _fam="${1:-ip}" _tab="${2:-nftban}" _i
     for _i in 1 2 3; do
         sleep "${_MAINT_TABLE_RECHECK_SLEEP:-0.4}"
-        # shellcheck disable=SC2086  # $_tbl is "ip nftban" — intentional 2-token split
-        if nft list table $_tbl >/dev/null 2>&1; then
-            return 1   # reappeared → transient transition window, not a genuine absence
-        fi
+        nftban_nft_probe_table "$_fam" "$_tab" maintenance || true
+        case "$NFTBAN_NFT_PROBE_VERDICT" in
+            PRESENT)     return 1 ;;   # reappeared → transient transition window
+            CANNOT_READ) return 2 ;;   # unreadable → absence is NOT established
+        esac
     done
-    return 0   # absent across the whole grace window → genuine
+    return 0   # ABSENT across the whole grace window → genuine
 }
 
 # =============================================================================
@@ -160,10 +176,20 @@ main() {
     log "INFO" "NFTBan Maintenance Starting"
 
     # v1.32.0: Cache table existence check (avoids 4 redundant kernel calls)
+    # v1.228.4 PR-3: typed. "not available" now distinguishes ABSENT from
+    # CANNOT_READ; the latter marks the whole run as failed rather than silently
+    # gating features off as though the firewall were simply not there.
     local _nft_table_available=false
-    if nft list table ${NFTBAN_TABLE_IPV4} >/dev/null 2>&1; then
-        _nft_table_available=true
-    fi
+    nftban_nft_probe_table ip nftban maintenance || true
+    case "$NFTBAN_NFT_PROBE_VERDICT" in
+        PRESENT)
+            _nft_table_available=true ;;
+        CANNOT_READ)
+            _MAINT_PROBE_UNREADABLE=1
+            log "ERROR" "Cannot read the nftables ruleset — firewall state is UNKNOWN, not absent."
+            log "ERROR" "$(nftban_nft_probe_diagnostic)"
+            ;;
+    esac
 
     # ==========================================================================
     # 1. SSH Port Monitoring (CRITICAL - Lockout Prevention)
@@ -221,12 +247,27 @@ main() {
                     echo "$SSH_PORT" > "${SSH_PORT_ACTIVE}.tmp" && mv -f "${SSH_PORT_ACTIVE}.tmp" "$SSH_PORT_ACTIVE"
                     ;;
                 no-table)
-                    # v1.193.0 PR-B: suppress transient transition-window noise; keep genuine absence.
-                    if _maint_table_absent_confirmed "${NFTBAN_TABLE_IPV4}"; then
-                        log "WARN" "nftban firewall table absent — SSH-port enforcement skipped this run (state NOT advanced). Run: nftban firewall reload"
-                    else
-                        log "INFO" "nftban table briefly unavailable during a firewall transition (re-sample shows it present) — SSH-port enforcement deferred to next run; no action needed."
-                    fi
+                    # v1.193.0 PR-B: suppress transient transition-window noise.
+                    # v1.228.4 PR-3: three outcomes, not two. The message that ran
+                    # ~927 times per host claimed ABSENCE when the real condition was
+                    # UNREADABILITY — the ruleset was present and fine.
+                    _maint_table_absent_confirmed ip nftban
+                    case $? in
+                        0)  log "WARN" "nftban firewall table VERIFIED ABSENT — SSH-port enforcement skipped this run (state NOT advanced). Run: nftban firewall reload" ;;
+                        1)  log "INFO" "nftban table briefly unavailable during a firewall transition (re-sample shows it present) — SSH-port enforcement deferred to next run; no action needed." ;;
+                        2)  _MAINT_PROBE_UNREADABLE=1
+                            log "ERROR" "Cannot read the nftables ruleset — firewall presence is UNKNOWN, NOT absent. SSH-port enforcement skipped."
+                            log "ERROR" "$(nftban_nft_probe_diagnostic)"
+                            log "ERROR" "No remediation is suggested from an unknown cause — diagnose the unit sandbox first." ;;
+                    esac
+                    ;;
+                cannot-read)
+                    # v1.228.4 PR-3: the read FAILED. Existence is unknown, so no
+                    # claim of absence and no remediation advice is emitted.
+                    _MAINT_PROBE_UNREADABLE=1
+                    log "ERROR" "Cannot read the nftables ruleset — firewall presence is UNKNOWN, NOT absent. SSH-port enforcement skipped."
+                    log "ERROR" "$(nftban_nft_probe_diagnostic)"
+                    log "ERROR" "No remediation is suggested from an unknown cause — diagnose the unit sandbox first."
                     ;;
                 no-sets)
                     log "WARN" "nftban set-driven schema (tcp_ports_in/ssh_ports) not loaded — SSH-port enforcement skipped (state NOT advanced). Run: nftban firewall reload"
@@ -955,6 +996,19 @@ EOF
     # ==========================================================================
     # 10. Complete
     # ==========================================================================
+    # v1.228.4 PR-3: VERDICT HONESTY.
+    # A run in which the nftables ruleset could not be read has NOT completed its
+    # work. Previously such a run still logged "Complete" and returned 0, so systemd
+    # recorded Result=success — which is why a 100%-failure path went unnoticed on
+    # 11/11 hosts for 9.7+ days. No systemd-based monitor could ever have caught it.
+    # The monotonic latch is authoritative: any CANNOT_READ anywhere in this run
+    # degrades the whole run, regardless of what a later probe returned.
+    if [[ "${_MAINT_PROBE_UNREADABLE:-0}" -ne 0 ]] || nftban_nft_probe_session_degraded; then
+        log "ERROR" "[10/10] NFTBan Maintenance INCOMPLETE — the nftables ruleset could not be read."
+        log "ERROR" "Firewall state is UNKNOWN. Maintenance work depending on it was SKIPPED."
+        return 1
+    fi
+
     log "INFO" "[10/10] NFTBan Maintenance Complete"
 
     return 0

--- a/cli/lib/nftban/helpers/autoheal.sh
+++ b/cli/lib/nftban/helpers/autoheal.sh
@@ -501,23 +501,59 @@ log_info "Validating NFT schema..."
 
 NFTBAN_CMD="${NFTBAN_BIN:-/usr/sbin/nftban}"
 
-# Check if required tables exist
-if ! nft list table ip nftban &>/dev/null; then
-    log_warn "NFTBan IPv4 table missing - attempting rebuild..."
+# v1.228.4 PR-3 typed probe authority — PRESENT | ABSENT | CANNOT_READ.
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nft_probe.sh"
+
+# v1.228.4 PR-3: TYPED probe. The previous form collapsed EVERY non-zero nft exit
+# into "table missing" and rebuilt on it. On 11/11 measured hosts that produced a
+# false absent verdict ~900 times each, ~900 futile rebuilds, and ~900 emissions of
+# `reset --force` — destructive advice aimed at an intact firewall.
+#
+# CANNOT_READ is not a weaker ABSENT. It is a different fact and may not mutate.
+NFTBAN_AUTOHEAL_PROBE_FAILED=0
+nftban_nft_probe_table ip nftban autoheal || true
+
+if [[ "$NFTBAN_NFT_PROBE_VERDICT" == "CANNOT_READ" ]]; then
+    # Existence is UNKNOWN. Do not rebuild. Do not recommend a reset. Surface the
+    # evidence the old code discarded, and mark the component failed so the caller
+    # cannot report success.
+    log_error "Cannot read the nftables ruleset — firewall state is UNKNOWN, NOT absent."
+    log_error "$(nftban_nft_probe_diagnostic)"
+    log_error "No rebuild attempted: a rebuild requires a VERIFIED absent table."
+    log_error "Diagnose first — inspect the unit sandbox and the retained nft stderr above."
+    NFTBAN_AUTOHEAL_PROBE_FAILED=1
+
+elif nftban_nft_probe_may_rebuild; then
+    # Verified ABSENT — the ruleset was read successfully and the table is not in it.
+    log_warn "NFTBan IPv4 table verified ABSENT - attempting rebuild..."
     if "$NFTBAN_CMD" firewall rebuild --quiet 2>/dev/null; then
         log_info "✅ Schema rebuilt successfully"
     else
         log_error "Schema rebuild failed - manual intervention required"
-        log_error "Try: nftban firewall reset --force"
+        NFTBAN_AUTOHEAL_PROBE_FAILED=1
     fi
-elif ! nft list table ip6 nftban &>/dev/null; then
-    log_warn "NFTBan IPv6 table missing - attempting rebuild..."
-    if "$NFTBAN_CMD" firewall rebuild --quiet 2>/dev/null; then
-        log_info "✅ Schema rebuilt successfully"
-    else
-        log_warn "IPv6 schema rebuild failed (IPv6 support optional)"
-    fi
+
 else
+    # IPv4 PRESENT — now check IPv6 with the same typed authority.
+    nftban_nft_probe_table ip6 nftban autoheal || true
+    if [[ "$NFTBAN_NFT_PROBE_VERDICT" == "CANNOT_READ" ]]; then
+        log_error "Cannot read the nftables ruleset for ip6 — state UNKNOWN, NOT absent."
+        log_error "$(nftban_nft_probe_diagnostic)"
+        NFTBAN_AUTOHEAL_PROBE_FAILED=1
+    elif nftban_nft_probe_may_rebuild; then
+        log_warn "NFTBan IPv6 table verified ABSENT - attempting rebuild..."
+        if "$NFTBAN_CMD" firewall rebuild --quiet 2>/dev/null; then
+            log_info "✅ Schema rebuilt successfully"
+        else
+            log_warn "IPv6 schema rebuild failed (IPv6 support optional)"
+        fi
+    fi
+fi
+
+# Consult the MONOTONIC latch, not the last VERDICT: a later successful probe
+# must never recover the component after an earlier unreadable one.
+if [[ "$NFTBAN_AUTOHEAL_PROBE_FAILED" -eq 0 ]] && ! nftban_nft_probe_session_degraded; then
     # Tables exist - validate schema structure
     SCHEMA_ERRORS=$("$NFTBAN_CMD" firewall validate --quiet 2>&1 | grep -c "ERROR" || true)
     SCHEMA_ERRORS=${SCHEMA_ERRORS:-0}
@@ -811,9 +847,26 @@ log_info "✅ System configuration generated"
 log_info "✅ Systemd timer configured"
 echo ""
 
+# v1.228.4 PR-3: VERDICT HONESTY.
+# Previously this printed "Health: OK (system ready)" and exited 0 even when the
+# nft-access and schema stages had both failed. On 11/11 measured hosts that OK
+# was emitted in the same cycle as "nftables access: FAILED" and "Schema rebuild
+# failed" — a confident success whose subject was not what the reader assumed.
+#
+# A component that could not read the firewall may not report that the system is
+# ready, and may not exit 0.
+if [ "${NFTBAN_AUTOHEAL_PROBE_FAILED:-0}" -ne 0 ] || nftban_nft_probe_session_degraded; then
+    log_error "Health: DEGRADED — the nftables ruleset could not be read this run."
+    log_error "System readiness is UNKNOWN and is NOT being asserted."
+    echo ""
+    exit 1
+fi
+
 # Only show health status line if errors exist
 if [ "${HEALTH_STATUS:-OK}" = "ERROR" ]; then
     log_warn "Health: ${HEALTH_STATUS} (some issues need attention)"
+    echo ""
+    exit 1
 else
     log_info "Health: OK (system ready)"
 fi

--- a/cli/lib/nftban/lib/nft_probe.sh
+++ b/cli/lib/nftban/lib/nft_probe.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - typed nftables probe authority
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="nft_probe"
+# meta:type="library"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-29"
+# meta:description="v1.228.4 PR-3. Single typed authority for 'does an nftables table exist'. Returns PRESENT, ABSENT or CANNOT_READ and preserves the evidence that distinguishes them: exit code, error class, bounded and redacted stderr, exact argv, address family and calling component. Replaces the binary collapse in which every non-zero nft exit became 'table absent' - a collapse that produced a false firewall-absent verdict on 11/11 measured hosts while systemd still reported Result=success, drove ~900 futile rebuild attempts per host and emitted ~900 destructive 'reset --force' recommendations against intact firewalls. The critical invariant is that ONLY a verified ABSENT may authorise a rebuild; CANNOT_READ must never mutate, never recommend mutation, and must propagate non-zero. Readability is established POSITIVELY by a successful `nft list tables` rather than by parsing error strings, so absence is a positive finding rather than an inference from failure."
+# meta:input="family+table name; the nft binary"
+# meta:output="probe verdict on stdout; details in NFTBAN_NFT_PROBE_* variables"
+# meta:depends="bash,nft"
+# meta:inventory.files=""
+# meta:inventory.binaries="nft"
+# meta:inventory.env_vars="NFTBAN_NFT_BIN,NFTBAN_NFT_PROBE_STDERR_MAX"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="requires AF_NETLINK in the caller's sandbox; read-only"
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# VERDICTS
+# -----------------------------------------------------------------------------
+#   PRESENT      the ruleset was read successfully AND the table exists
+#   ABSENT       the ruleset was read successfully AND the table does not exist
+#   CANNOT_READ  the read itself failed; existence is UNKNOWN
+#
+# ⛔ ONLY `ABSENT` MAY AUTHORISE A REBUILD. `CANNOT_READ` is not a weaker
+#    `ABSENT` — it is a different fact, and acting on it is how a healthy
+#    firewall gets rebuilt (or an operator gets told to reset one).
+#
+# WHY READABILITY IS ESTABLISHED POSITIVELY
+#   `nft list table ip nftban` exits non-zero for BOTH "no such table" and
+#   "cannot talk to the kernel". Distinguishing them by parsing stderr text is
+#   fragile across nft versions and locales. Instead we first run
+#   `nft list tables`, which succeeds whenever netlink is usable regardless of
+#   which tables exist. If THAT fails, the answer is CANNOT_READ and we never
+#   claim anything about the table. If it succeeds, absence is a positive
+#   observation: the name is genuinely not in a list we successfully read.
+# -----------------------------------------------------------------------------
+
+# Initialised so `set -u` callers can reference them before the first probe.
+NFTBAN_NFT_PROBE_VERDICT=""; NFTBAN_NFT_PROBE_RC=""; NFTBAN_NFT_PROBE_CLASS=""
+NFTBAN_NFT_PROBE_STDERR=""; NFTBAN_NFT_PROBE_ARGV=""; NFTBAN_NFT_PROBE_FAMILY=""
+NFTBAN_NFT_PROBE_TABLE=""; NFTBAN_NFT_PROBE_COMPONENT=""
+# ⛔ THERE IS DELIBERATELY NO NFTBAN_NFT_PROBE_MAY_REBUILD VARIABLE.
+# A stored rebuild boolean is dual authority: it can go stale, be overwritten, or
+# be consumed without ever checking the verdict it was supposed to mirror. Rebuild
+# permission is derived LIVE from VERDICT by nftban_nft_probe_may_rebuild().
+
+# -----------------------------------------------------------------------------
+# MONOTONIC COMPONENT LATCH
+# -----------------------------------------------------------------------------
+# Every probe RESETS NFTBAN_NFT_PROBE_VERDICT on entry. So a sequence like
+#     table probe -> CANNOT_READ
+#     set   probe -> PRESENT
+# leaves VERDICT=PRESENT, and a caller reading VERDICT afterwards would silently
+# RECOVER to healthy despite an earlier unreadable probe. That is the same
+# lost-evidence class this library exists to remove, reintroduced by ordering.
+#
+# This latch is set by ANY CANNOT_READ and is never cleared except by an explicit
+# nftban_nft_probe_session_reset(). Component-level verdicts MUST consult it
+# rather than the last VERDICT, so monotonicity is a property of the LIBRARY and
+# not of each caller remembering to be careful.
+NFTBAN_NFT_PROBE_SESSION_DEGRADED=0
+
+# True if ANY probe in this session could not read. Never recovers.
+nftban_nft_probe_session_degraded() {
+    [[ "${NFTBAN_NFT_PROBE_SESSION_DEGRADED:-0}" -ne 0 ]]
+}
+
+# Explicit, deliberate reset. Call only when starting a genuinely new session.
+nftban_nft_probe_session_reset() {
+    NFTBAN_NFT_PROBE_SESSION_DEGRADED=0
+}
+
+NFTBAN_NFT_PROBE_PRESENT="PRESENT"
+NFTBAN_NFT_PROBE_ABSENT="ABSENT"
+NFTBAN_NFT_PROBE_CANNOT_READ="CANNOT_READ"
+
+# Bounded stderr capture. nft error output can contain rule and set content —
+# addresses, ports, set members — so it is capped and redacted before it is ever
+# logged or surfaced. The machine-readable signal is the CLASS, not the text.
+: "${NFTBAN_NFT_PROBE_STDERR_MAX:=512}"
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_error_class <stderr-text> <rc>
+#
+# Maps raw nft failure output to a stable, machine-readable class. The class is
+# what may influence control flow; the text is human context only.
+# -----------------------------------------------------------------------------
+nftban_nft_probe_error_class() {
+    local _err="$1" _rc="${2:-0}"
+    case "$_err" in
+        *"Address family not supported"*|*"EAFNOSUPPORT"*)
+            printf 'NETLINK_FAMILY_BLOCKED' ;;          # sandbox: AF_NETLINK missing
+        *"Operation not permitted"*|*"must be root"*|*"EPERM"*)
+            printf 'PERMISSION_DENIED' ;;
+        *"No such file or directory"*|*"ENOENT"*)
+            printf 'NOT_FOUND' ;;
+        *"Device or resource busy"*|*"EBUSY"*|*"No buffer space"*|*"ENOBUFS"*)
+            printf 'KERNEL_BUSY' ;;
+        *"command not found"*|*"not found"*)
+            printf 'NFT_BINARY_MISSING' ;;
+        "")
+            if [[ "$_rc" -eq 0 ]]; then printf 'NONE'; else printf 'UNKNOWN_NO_STDERR'; fi ;;
+        *)
+            printf 'UNCLASSIFIED' ;;
+    esac
+}
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_redact <text>
+#
+# Bound and redact captured stderr before it can be logged. IPv4/IPv6 literals
+# are masked because nft error output may echo rule or set content, and this
+# repository has already executed one privacy history rewrite.
+# -----------------------------------------------------------------------------
+# IPv6 boundary class note: ']' is deliberately NOT included. In a POSIX bracket
+# expression '\]' is not an escape — it closes the set and leaves a stray ']',
+# which silently disabled this whole substitution. It failed OPEN (no redaction
+# at all), which is the dangerous direction for a privacy control.
+#
+# The {0,4} quantifier (not {1,4}) is required so the compressed '::' form
+# matches, e.g. 2001:db8::1. The leading/trailing boundary classes are what keep
+# 'src/mnl.c:61' and 'file.sh:148' intact — there the candidate is preceded by
+# '.', which is not a boundary character.
+nftban_nft_probe_redact() {
+    local _t="$1"
+    _t=$(printf '%s' "$_t" \
+        | sed -E 's/[0-9]{1,3}(\.[0-9]{1,3}){3}(\/[0-9]{1,2})?/<ip4>/g' \
+        | sed -E 's/(^|[[:space:]([])([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}(\/[0-9]{1,3})?([[:space:],)]|$)/\1<ip6>\4/g' \
+        | tr '\n' ' ')
+    if [[ ${#_t} -gt $NFTBAN_NFT_PROBE_STDERR_MAX ]]; then
+        printf '%s…[truncated %s bytes]' "${_t:0:$NFTBAN_NFT_PROBE_STDERR_MAX}" "${#_t}"
+    else
+        printf '%s' "$_t"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _probe_fail_closed <class> <detail>
+#
+# Every failure path routes through here so no path can accidentally leave a
+# verdict of ABSENT or a MAY_REBUILD of YES.
+# -----------------------------------------------------------------------------
+_probe_fail_closed() {
+    NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_CANNOT_READ"
+    NFTBAN_NFT_PROBE_SESSION_DEGRADED=1
+    NFTBAN_NFT_PROBE_CLASS="$1"
+    NFTBAN_NFT_PROBE_RC="${NFTBAN_NFT_PROBE_RC:-1}"
+    [[ -z "${NFTBAN_NFT_PROBE_RC}" ]] && NFTBAN_NFT_PROBE_RC=1
+    NFTBAN_NFT_PROBE_STDERR=$(nftban_nft_probe_redact "$2")
+}
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_table <family> <table> [component]
+#
+# Sets NFTBAN_NFT_PROBE_VERDICT to PRESENT | ABSENT | CANNOT_READ.
+# Returns 0 when a determination was made (PRESENT or ABSENT),
+#         1 when it could not be made (CANNOT_READ).
+#
+# ⛔ DELIBERATELY WRITES NOTHING TO STDOUT.
+#    An earlier revision echoed the verdict as well. That invites
+#        verdict=$(nftban_nft_probe_table ip nftban)
+#    which runs the probe in a SUBSHELL: the caller receives the verdict string
+#    but EVERY diagnostic variable — rc, error class, stderr, argv, family,
+#    component — is silently discarded when the subshell exits. A caller would
+#    then log "CANNOT_READ" with no evidence attached, which is the exact
+#    lost-evidence failure this PR exists to remove.
+#    The verdict is read from $NFTBAN_NFT_PROBE_VERDICT, so that misuse is
+#    unrepresentable rather than merely discouraged.
+#
+# The non-zero return on CANNOT_READ is deliberate: a caller that ignores the
+# verdict string still cannot silently treat an unreadable firewall as a
+# successful observation.
+#
+# Sets, for the caller to log or propagate:
+#   NFTBAN_NFT_PROBE_VERDICT · NFTBAN_NFT_PROBE_RC · NFTBAN_NFT_PROBE_CLASS
+#   NFTBAN_NFT_PROBE_STDERR (bounded+redacted) · NFTBAN_NFT_PROBE_ARGV
+#   NFTBAN_NFT_PROBE_FAMILY · NFTBAN_NFT_PROBE_TABLE · NFTBAN_NFT_PROBE_COMPONENT
+# -----------------------------------------------------------------------------
+nftban_nft_probe_table() {
+    local _family="$1" _table="$2" _component="${3:-${NFTBAN_COMPONENT:-unknown}}"
+    # Reset every field first: a stale value from a previous probe must never be
+    # read as evidence for this one.
+    NFTBAN_NFT_PROBE_VERDICT=""; NFTBAN_NFT_PROBE_RC=""; NFTBAN_NFT_PROBE_CLASS=""
+    NFTBAN_NFT_PROBE_STDERR=""
+    local _nft="${NFTBAN_NFT_BIN:-nft}"
+    local _out _err _rc=0
+
+    NFTBAN_NFT_PROBE_FAMILY="$_family"
+    NFTBAN_NFT_PROBE_TABLE="$_table"
+    NFTBAN_NFT_PROBE_COMPONENT="$_component"
+    # argv is recorded EXPLICITLY, one array element per argument. The historical
+    # call sites expanded a two-word "ip nftban" variable unquoted under
+    # IFS=$'\n\t', which does NOT split, so nft received ONE fused argument
+    # instead of two. Passing the family and table separately makes that class of
+    # defect unrepresentable here.
+    NFTBAN_NFT_PROBE_ARGV="$_nft list tables"
+
+    # STEP 1 — establish READABILITY positively. `nft list tables` succeeds
+    # whenever netlink is usable, independently of which tables exist.
+    #
+    # Captured via temp files, NOT the fd-swap idiom
+    #     _err=$( { _out=$(cmd 2>&1 1>&3); } 3>&1 )
+    # which assigns _out inside a SUBSHELL. That left both captures empty, and an
+    # empty table list made a PRESENT table read as ABSENT — which would have
+    # authorised a rebuild on a healthy firewall. Correctness over cleverness.
+    # Capture files: unpredictable names, mode 0600, removed on every exit path
+    # including early return. A capture failure is CANNOT_READ — NEVER ABSENT.
+    local _fo _fe
+    _fo=$(mktemp "${TMPDIR:-/tmp}/.nftban-probe.XXXXXXXXXX" 2>/dev/null) \
+        || { _probe_fail_closed "PROBE_CAPTURE_FAILED" "mktemp stdout failed"; return 1; }
+    _fe=$(mktemp "${TMPDIR:-/tmp}/.nftban-probe.XXXXXXXXXX" 2>/dev/null) \
+        || { rm -f "$_fo"; _probe_fail_closed "PROBE_CAPTURE_FAILED" "mktemp stderr failed"; return 1; }
+    chmod 600 "$_fo" "$_fe" 2>/dev/null || true
+
+    "$_nft" list tables >"$_fo" 2>"$_fe"; _rc=$?
+
+    # Read back defensively: an unreadable or vanished capture file is a probe
+    # failure, not evidence of anything about the firewall.
+    if [[ ! -r "$_fo" || ! -r "$_fe" ]]; then
+        rm -f "$_fo" "$_fe"
+        _probe_fail_closed "PROBE_CAPTURE_UNREADABLE" "capture file missing or unreadable"
+        return 1
+    fi
+    _out=$(cat "$_fo" 2>/dev/null) || { rm -f "$_fo" "$_fe"
+        _probe_fail_closed "PROBE_CAPTURE_UNREADABLE" "stdout read failed"; return 1; }
+    _err=$(cat "$_fe" 2>/dev/null) || _err=""
+    rm -f "$_fo" "$_fe"
+    if [[ $_rc -ne 0 ]]; then
+        NFTBAN_NFT_PROBE_RC="$_rc"
+        NFTBAN_NFT_PROBE_CLASS=$(nftban_nft_probe_error_class "$_err" "$_rc")
+        NFTBAN_NFT_PROBE_STDERR=$(nftban_nft_probe_redact "$_err")
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_CANNOT_READ"
+        NFTBAN_NFT_PROBE_SESSION_DEGRADED=1
+        return 1
+    fi
+
+    # STEP 2 — FAIL-CLOSED. rc=0 alone does not license a conclusion.
+    #
+    # `rc=0 with EMPTY output` is NOT absence. It cannot be distinguished from a
+    # broken read that exited zero, and treating it as ABSENT would authorise a
+    # rebuild on no evidence. Cost of this choice, stated plainly: a host with
+    # genuinely zero nft tables yields CANNOT_READ and will not auto-rebuild —
+    # which is correct, because zero tables on an installed system is an
+    # operator-visible anomaly, not something to silently rebuild through.
+    if [[ -z "${_out//[[:space:]]/}" ]]; then
+        _probe_fail_closed "EMPTY_OUTPUT_NO_ABSENCE_PROOF" \
+            "nft exited 0 but listed no tables — absence is unproven"
+        return 1
+    fi
+    # The output must look like a table listing at all. Unparseable output that
+    # happens to exit 0 is parser uncertainty, not a finding.
+    if ! printf '%s\n' "$_out" | grep -qE '^table[[:space:]]+[a-z0-9]+[[:space:]]+'; then
+        _probe_fail_closed "MALFORMED_OUTPUT" \
+            "nft exited 0 but output is not a recognisable table listing"
+        return 1
+    fi
+
+    NFTBAN_NFT_PROBE_RC=0
+    NFTBAN_NFT_PROBE_CLASS="NONE"
+    NFTBAN_NFT_PROBE_STDERR=""
+    if printf '%s\n' "$_out" | grep -qE "^table[[:space:]]+${_family}[[:space:]]+${_table}([[:space:]]|\$)"; then
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_PRESENT"
+    else
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_ABSENT"
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_set <family> <table> <set> [component]
+#
+# Same typed contract as nftban_nft_probe_table, for set existence. Readability is
+# again established POSITIVELY — `nft list sets <family>` succeeds whenever netlink
+# is usable — so a set's absence is an observation from a list we actually read,
+# never an inference from a failed command.
+#
+# Sets NFTBAN_NFT_PROBE_VERDICT. Returns 0 for PRESENT/ABSENT, 1 for CANNOT_READ.
+# -----------------------------------------------------------------------------
+nftban_nft_probe_set() {
+    local _family="$1" _table="$2" _set="$3" _component="${4:-${NFTBAN_COMPONENT:-unknown}}"
+    NFTBAN_NFT_PROBE_VERDICT=""; NFTBAN_NFT_PROBE_RC=""; NFTBAN_NFT_PROBE_CLASS=""
+    NFTBAN_NFT_PROBE_STDERR=""
+    local _nft="${NFTBAN_NFT_BIN:-nft}" _out _err _rc=0 _fo _fe
+
+    NFTBAN_NFT_PROBE_FAMILY="$_family"
+    NFTBAN_NFT_PROBE_TABLE="$_table/$_set"
+    NFTBAN_NFT_PROBE_COMPONENT="$_component"
+    NFTBAN_NFT_PROBE_ARGV="$_nft list sets $_family"
+
+    _fo=$(mktemp "${TMPDIR:-/tmp}/.nftban-probe.XXXXXXXXXX" 2>/dev/null) \
+        || { _probe_fail_closed "PROBE_CAPTURE_FAILED" "mktemp stdout failed"; return 1; }
+    _fe=$(mktemp "${TMPDIR:-/tmp}/.nftban-probe.XXXXXXXXXX" 2>/dev/null) \
+        || { rm -f "$_fo"; _probe_fail_closed "PROBE_CAPTURE_FAILED" "mktemp stderr failed"; return 1; }
+    chmod 600 "$_fo" "$_fe" 2>/dev/null || true
+
+    "$_nft" list sets "$_family" >"$_fo" 2>"$_fe"; _rc=$?
+
+    if [[ ! -r "$_fo" || ! -r "$_fe" ]]; then
+        rm -f "$_fo" "$_fe"
+        _probe_fail_closed "PROBE_CAPTURE_UNREADABLE" "capture file missing or unreadable"
+        return 1
+    fi
+    _out=$(cat "$_fo" 2>/dev/null) || { rm -f "$_fo" "$_fe"
+        _probe_fail_closed "PROBE_CAPTURE_UNREADABLE" "stdout read failed"; return 1; }
+    _err=$(cat "$_fe" 2>/dev/null) || _err=""
+    rm -f "$_fo" "$_fe"
+
+    if [[ $_rc -ne 0 ]]; then
+        NFTBAN_NFT_PROBE_RC="$_rc"
+        NFTBAN_NFT_PROBE_CLASS=$(nftban_nft_probe_error_class "$_err" "$_rc")
+        NFTBAN_NFT_PROBE_STDERR=$(nftban_nft_probe_redact "$_err")
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_CANNOT_READ"
+        NFTBAN_NFT_PROBE_SESSION_DEGRADED=1
+        return 1
+    fi
+    if [[ -z "${_out//[[:space:]]/}" ]]; then
+        _probe_fail_closed "EMPTY_OUTPUT_NO_ABSENCE_PROOF" \
+            "nft exited 0 but listed no sets — absence is unproven"
+        return 1
+    fi
+
+    NFTBAN_NFT_PROBE_RC=0
+    NFTBAN_NFT_PROBE_CLASS="NONE"
+    NFTBAN_NFT_PROBE_STDERR=""
+    if printf '%s\n' "$_out" | grep -qE "^[[:space:]]*set[[:space:]]+${_set}[[:space:]]*\{" \
+       || printf '%s\n' "$_out" | grep -qE "table[[:space:]]+${_family}[[:space:]]+${_table}.*${_set}"; then
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_PRESENT"
+    else
+        NFTBAN_NFT_PROBE_VERDICT="$NFTBAN_NFT_PROBE_ABSENT"
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_diagnostic
+#
+# One bounded, redact-safe line describing the last probe. Intended for logs and
+# operator output. Deliberately contains NO remediation advice: recommending a
+# reset or rebuild from an unknown cause is what produced ~900 destructive
+# `reset --force` recommendations per host against intact firewalls.
+# -----------------------------------------------------------------------------
+nftban_nft_probe_diagnostic() {
+    printf 'nft probe %s: family=%s table=%s component=%s rc=%s class=%s argv=[%s] stderr=[%s]' \
+        "${NFTBAN_NFT_PROBE_VERDICT:-UNSET}" "${NFTBAN_NFT_PROBE_FAMILY:-?}" \
+        "${NFTBAN_NFT_PROBE_TABLE:-?}" "${NFTBAN_NFT_PROBE_COMPONENT:-?}" \
+        "${NFTBAN_NFT_PROBE_RC:-?}" "${NFTBAN_NFT_PROBE_CLASS:-?}" \
+        "${NFTBAN_NFT_PROBE_ARGV:-?}" "${NFTBAN_NFT_PROBE_STDERR:-}"
+}
+
+# -----------------------------------------------------------------------------
+# nftban_nft_probe_may_rebuild
+#
+# The ONLY rebuild authority. Derived LIVE from VERDICT — there is no stored
+# boolean to go stale.
+#
+# MEANING: "the probe verdict PERMITS CONSIDERING a rebuild."
+# It does NOT mean "rebuild is authorised". Other policy constraints (snapshot
+# availability, SSH lockout guard, prevalidation) still apply and are evaluated
+# by the caller AFTER this predicate passes.
+#
+# ⛔ This is the invariant the whole PR exists to establish. A rebuild must never
+#    be inferred from a generic command failure.
+# -----------------------------------------------------------------------------
+nftban_nft_probe_may_rebuild() {
+    [[ "${NFTBAN_NFT_PROBE_VERDICT:-}" == "$NFTBAN_NFT_PROBE_ABSENT" ]]
+}
+
+export -f nftban_nft_probe_session_degraded nftban_nft_probe_session_reset \
+          nftban_nft_probe_table nftban_nft_probe_set nftban_nft_probe_error_class \
+          nftban_nft_probe_redact nftban_nft_probe_diagnostic \
+          nftban_nft_probe_may_rebuild 2>/dev/null || true

--- a/cli/lib/nftban/lib/ssh_port_detect.sh
+++ b/cli/lib/nftban/lib/ssh_port_detect.sh
@@ -142,16 +142,46 @@ _nftban_ssh_detect_fallback() {
 # family: "ready" (table + tcp_ports_in + ssh_ports all present),
 # "no-table" (firewall not loaded), or "no-sets" (table present but the
 # v1.145 set-driven schema, incl. ssh_ports, is not loaded → needs reload).
+# v1.228.4 PR-3: TYPED. This function returned 'no-table' for EVERY non-zero nft
+# exit, and its caller (cron/maintenance.sh) then logged "firewall table absent".
+# On 11/11 measured hosts the table was PRESENT and the read was failing, so the
+# message was false ~927 times per host.
+#
+# It now emits a FOURTH state, 'cannot-read', which callers must handle distinctly:
+#   ready · no-sets · no-table (VERIFIED absent) · cannot-read (existence UNKNOWN)
+#
+# The legacy positional "ip nftban" spec is still accepted for caller
+# compatibility and is split explicitly here, NOT by shell word-splitting — the
+# script-scope IFS in cron/maintenance.sh suppressed that split and delivered one
+# fused argv element to nft.
 nftban_ssh_apply_state() {
-    local _tbl="$1"
-    # shellcheck disable=SC2086  # table spec is two words (family name)
-    nft list table $_tbl >/dev/null 2>&1 || { printf 'no-table\n'; return 0; }
-    # shellcheck disable=SC2086
-    if nft list set $_tbl tcp_ports_in >/dev/null 2>&1 && nft list set $_tbl ssh_ports >/dev/null 2>&1; then
-        printf 'ready\n'
-    else
-        printf 'no-sets\n'
+    local _tbl="$1" _fam _tab
+    _fam="${_tbl%% *}"; _tab="${_tbl##* }"
+    [[ -z "$_fam" || "$_fam" == "$_tbl" ]] && { _fam="ip"; _tab="${_tbl:-nftban}"; }
+
+    if ! declare -f nftban_nft_probe_table >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nft_probe.sh" 2>/dev/null || {
+            printf 'cannot-read\n'; return 0; }
     fi
+
+    nftban_nft_probe_table "$_fam" "$_tab" ssh_port_detect || true
+    case "$NFTBAN_NFT_PROBE_VERDICT" in
+        CANNOT_READ) printf 'cannot-read\n'; return 0 ;;
+        ABSENT)      printf 'no-table\n';    return 0 ;;
+    esac
+    # v1.228.4 PR-3: the SET probes are typed too. Leaving a collapsing probe
+    # inside a function whose table probe is typed would be incoherent — a failed
+    # set READ would still masquerade as "schema not loaded".
+    local _s
+    for _s in tcp_ports_in ssh_ports; do
+        nftban_nft_probe_set "$_fam" "$_tab" "$_s" ssh_port_detect || true
+        case "$NFTBAN_NFT_PROBE_VERDICT" in
+            CANNOT_READ) printf 'cannot-read\n'; return 0 ;;
+            ABSENT)      printf 'no-sets\n';     return 0 ;;
+        esac
+    done
+    printf 'ready\n'
 }
 
 # nftban_ssh_port_in_both_sets <table-spec> <port> — 0 iff <port> is present in

--- a/cli/lib/nftban/lib/ssh_port_detect.sh
+++ b/cli/lib/nftban/lib/ssh_port_detect.sh
@@ -160,8 +160,23 @@ nftban_ssh_apply_state() {
     [[ -z "$_fam" || "$_fam" == "$_tbl" ]] && { _fam="ip"; _tab="${_tbl:-nftban}"; }
 
     if ! declare -f nftban_nft_probe_table >/dev/null 2>&1; then
-        # shellcheck source=/dev/null
-        source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nft_probe.sh" 2>/dev/null || {
+        # Resolve the probe library from THIS file's own directory FIRST: the typed
+        # probe is its sibling in lib/, in the installed tree and in the repo alike.
+        # Going straight to an absolute installed path made every not-yet-installed
+        # tree — including the hermetic test for this very function — source
+        # nothing and report cannot-read for a reason that had nothing to do with
+        # nftables. Fail-closed is still the last resort, but it must not be
+        # reached merely because the caller is not installed.
+        local _self_dir _cand
+        _self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _self_dir=""
+        for _cand in "${_self_dir:+$_self_dir/nft_probe.sh}" \
+                     "${NFTBAN_LIB_DIR:+$NFTBAN_LIB_DIR/lib/nft_probe.sh}" \
+                     /usr/lib/nftban/lib/nft_probe.sh; do
+            [[ -n "$_cand" && -r "$_cand" ]] || continue
+            # shellcheck source=/dev/null
+            source "$_cand" 2>/dev/null && break
+        done
+        declare -f nftban_nft_probe_table >/dev/null 2>&1 || {
             printf 'cannot-read\n'; return 0; }
     fi
 

--- a/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
+++ b/cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh
@@ -38,6 +38,13 @@ PASS=0; FAIL=0
 ok(){ echo "  [PASS] $1"; PASS=$((PASS+1)); }
 bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
 
+# v1.228.4 PR-3: the helper now routes its presence question through the TYPED
+# probe, so the probe library must be loaded before the extracted function is
+# evaluated. Without it the helper fails with "command not found" — which is a
+# harness gap, not a verdict about the firewall.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/nft_probe.sh"
+
 # Extract just the helper function (no top-level maintenance side effects).
 HELPER="$(awk '/^_maint_table_absent_confirmed\(\)/{f=1} f{print} f&&/^\}/{exit}' "$MAINT")"
 [[ -n "$HELPER" ]] || { echo "FAIL: _maint_table_absent_confirmed not found"; exit 1; }
@@ -46,22 +53,46 @@ sleep(){ :; }                              # fast: no real delay
 export _MAINT_TABLE_RECHECK_SLEEP=0
 # NFTBAN_TABLE_IPV4 left unset → the helper uses its ${NFTBAN_TABLE_IPV4:-ip nftban} fallback.
 
+# The typed probe establishes readability POSITIVELY via `nft list tables`, so the
+# mocks answer that. An absent table is a READABLE listing that does not contain
+# nftban — not a failed command, and not empty output (both of which are
+# CANNOT_READ by design, because neither proves anything is absent).
+_LIST_PRESENT=$'table ip filter\ntable ip nftban'
+_LIST_ABSENT=$'table ip filter'
+
 echo "=== T1: GENUINE absence (table never reappears) → rc0 (caller WARNs) ==="
-nft(){ return 1; }
+nft(){ printf '%s\n' "$_LIST_ABSENT"; return 0; }
 if _maint_table_absent_confirmed; then ok "persistent absence → confirmed genuine (rc0 → WARN kept)"; else bad "genuine absence misclassified as transient"; fi
 
 echo "=== T2: table PRESENT on re-probe → rc1 (transient, suppress to INFO) ==="
-nft(){ return 0; }
+nft(){ printf '%s\n' "$_LIST_PRESENT"; return 0; }
 if _maint_table_absent_confirmed; then bad "present table classified genuine-absent"; else ok "table present → transient (rc1 → suppress noisy WARN)"; fi
 
 echo "=== T3: table REAPPEARS mid-grace (fail then present) → rc1 (transient) ==="
-_n3=0; nft(){ _n3=$((_n3+1)); [ "$_n3" -ge 2 ] && return 0 || return 1; }
+_n3=0; nft(){ _n3=$((_n3+1))
+  if [ "$_n3" -ge 2 ]; then printf '%s\n' "$_LIST_PRESENT"; else printf '%s\n' "$_LIST_ABSENT"; fi
+  return 0; }
 if _maint_table_absent_confirmed; then bad "reappearing table classified genuine-absent (noise would persist)"; else ok "table reappears within grace → transient (rc1 → suppress)"; fi
 unset -f nft 2>/dev/null || true
 
+# v1.228.4 PR-3 — T3b. The defect this release removes: a failed READ being taken
+# as proof of absence. An unreadable ruleset must return 2 (unknown), never 0.
+echo "=== T3b: ruleset UNREADABLE → rc2 (absence NOT established) ==="
+nft(){ echo "mnl.c:61: Unable to initialize Netlink socket: Address family not supported by protocol" >&2; return 1; }
+set +e; _maint_table_absent_confirmed; _rc3b=$?; set -e
+[[ "$_rc3b" -eq 2 ]] \
+  && ok "unreadable ruleset → rc2 (never classified as genuine absence)" \
+  || bad "unreadable ruleset returned rc=$_rc3b (2 required; 0 would authorise a rebuild while blind)"
+unset -f nft 2>/dev/null || true
+
 echo "=== T4: static guard — BOTH 'table absent' WARN sites are gated by the recheck ==="
-warn_total=$(grep -cE 'log "WARN" "nftban firewall table absent' "$MAINT")
-warn_gated=$(grep -B4 -E 'log "WARN" "nftban firewall table absent' "$MAINT" | grep -cE '_maint_table_absent_confirmed')
+# v1.228.4 PR-3 renamed the first site's claim from "table absent" to "table
+# VERIFIED ABSENT" — the WARN is retained and strengthened, so the pattern must
+# match both wordings. Binding a static guard to one literal phrasing made a
+# stricter message look like a deleted safeguard.
+_WARN_RE='log "WARN" "nftban firewall table (VERIFIED ABSENT|absent)'
+warn_total=$(grep -cE "$_WARN_RE" "$MAINT")
+warn_gated=$(grep -B4 -E "$_WARN_RE" "$MAINT" | grep -cE '_maint_table_absent_confirmed')
 echo "    table-absent WARN sites=$warn_total  gated-by-recheck=$warn_gated"
 [[ "$warn_total" -ge 2 && "$warn_gated" -ge "$warn_total" ]] \
   && ok "every table-absent WARN ($warn_total) is gated by _maint_table_absent_confirmed" \

--- a/cli/lib/nftban/tests/typed_nft_probe_v1228_4_test.sh
+++ b/cli/lib/nftban/tests/typed_nft_probe_v1228_4_test.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - typed nft probe authority + verdict honesty (v1.228.4 PR-3)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="typed_nft_probe_v1228_4_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-29"
+# meta:description="v1.228.4 PR-3 controls. Proves the typed nft probe distinguishes PRESENT, ABSENT and CANNOT_READ, that ONLY a verified ABSENT may authorise a rebuild, and that a component which could not read the ruleset can no longer report success. The defect being closed: every non-zero nft exit collapsed into 'table absent', producing a false firewall-absent verdict on 11/11 measured hosts about 927 times each, roughly 900 futile rebuild attempts per host, and roughly 900 emissions of destructive 'nftban firewall reset --force' guidance aimed at intact firewalls - while systemd recorded Result=success every time, so no systemd-based monitor could ever have detected it. Controls cover the three verdicts, six distinct failure modes that must all fail closed to CANNOT_READ, the fail-closed treatment of rc=0-with-empty-output (absence is never inferred from silence), redaction that masks IP literals while preserving file:line diagnostics, and the call-site invariants: no destructive advice on an unknown cause, no rebuild on CANNOT_READ, and non-zero propagation so the unit turns red instead of green. Hermetic - synthetic nft stubs, no host contact, no nft invocation, no privileges."
+# meta:input="cli/lib/nftban/lib/nft_probe.sh and the three converted call sites"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,sed,grep"
+# meta:inventory.files="cli/lib/nftban/lib/nft_probe.sh,cli/lib/nftban/cron/maintenance.sh,cli/lib/nftban/helpers/autoheal.sh,cli/lib/nftban/lib/ssh_port_detect.sh"
+# meta:inventory.binaries="bash,sed,grep"
+# meta:inventory.env_vars="NFTBAN_NFT_BIN"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="typed_nft_probe_v1228_4_test"
+# meta:ta.owner="cli"
+# meta:ta.module="nft-probe-authority"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PROBE="$REPO/cli/lib/nftban/lib/nft_probe.sh"
+MAINT="$REPO/cli/lib/nftban/cron/maintenance.sh"
+AUTOHEAL="$REPO/cli/lib/nftban/helpers/autoheal.sh"
+SSHDET="$REPO/cli/lib/nftban/lib/ssh_port_detect.sh"
+
+for f in "$PROBE" "$MAINT" "$AUTOHEAL" "$SSHDET"; do
+    [[ -f "$f" ]] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+PASS=0; FAIL=0; FAILED=()
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s (%s)\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED+=("$1"); }
+
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+# shellcheck source=/dev/null
+source "$PROBE"
+
+# Synthetic nft stubs — no real nft is ever invoked.
+stub(){ mkdir -p "$WORK/$1"; printf '%s\n' "$2" > "$WORK/$1/nft"; chmod +x "$WORK/$1/nft"; }
+stub present  '#!/bin/sh
+echo "table ip nftban"
+echo "table ip6 nftban"'
+stub absent   '#!/bin/sh
+echo "table inet other"'
+stub netlink  '#!/bin/sh
+echo "src/mnl.c:61: Unable to initialize Netlink socket: Address family not supported by protocol" >&2
+exit 3'
+stub perm     '#!/bin/sh
+echo "Operation not permitted (you must be root)" >&2
+exit 1'
+stub syntax   '#!/bin/sh
+echo "Error: syntax error, unexpected string" >&2
+exit 1'
+stub empty    '#!/bin/sh
+exit 0'
+stub garbage  '#!/bin/sh
+echo "not a table listing at all"'
+
+# Exported because the probe library reads it; shellcheck cannot see a
+# cross-file read and would otherwise flag every assignment as unused.
+export NFTBAN_NFT_BIN
+
+verdict(){  # verdict <stub> <family> -> runs the probe, leaving globals set
+    # The probe is a shell FUNCTION, so it runs in THIS shell and its global
+    # assignments persist. A single call is sufficient; an earlier revision called
+    # it twice, left over from debugging the subshell defect.
+    NFTBAN_NFT_BIN="$WORK/$1/nft"
+    nftban_nft_probe_table "$2" nftban test || true
+}
+
+echo "=== A. the three verdicts ==="
+verdict present ip
+[[ "$NFTBAN_NFT_PROBE_VERDICT" == "PRESENT" ]] \
+    && ok "A1 readable ruleset + table listed -> PRESENT" \
+    || no "A1 PRESENT" "got $NFTBAN_NFT_PROBE_VERDICT"
+verdict present ip6
+[[ "$NFTBAN_NFT_PROBE_VERDICT" == "PRESENT" ]] \
+    && ok "A2 ip6 family -> PRESENT" || no "A2 ip6 PRESENT" "got $NFTBAN_NFT_PROBE_VERDICT"
+verdict absent ip
+[[ "$NFTBAN_NFT_PROBE_VERDICT" == "ABSENT" ]] \
+    && ok "A3 readable ruleset + table NOT listed -> ABSENT" \
+    || no "A3 ABSENT" "got $NFTBAN_NFT_PROBE_VERDICT"
+
+echo "=== B. every failure mode fails CLOSED to CANNOT_READ ==="
+for c in "netlink NETLINK_FAMILY_BLOCKED" "perm PERMISSION_DENIED" "syntax UNCLASSIFIED" \
+         "empty EMPTY_OUTPUT_NO_ABSENCE_PROOF" "garbage MALFORMED_OUTPUT"; do
+    set -- $c
+    verdict "$1" ip
+    if [[ "$NFTBAN_NFT_PROBE_VERDICT" == "CANNOT_READ" && "$NFTBAN_NFT_PROBE_CLASS" == "$2" ]]; then
+        ok "B:$1 -> CANNOT_READ ($2)"
+    else
+        no "B:$1 -> CANNOT_READ ($2)" "got $NFTBAN_NFT_PROBE_VERDICT / $NFTBAN_NFT_PROBE_CLASS"
+    fi
+done
+NFTBAN_NFT_BIN="$WORK/does-not-exist/nft"
+nftban_nft_probe_table ip nftban test || true
+[[ "$NFTBAN_NFT_PROBE_VERDICT" == "CANNOT_READ" ]] \
+    && ok "B:missing-binary -> CANNOT_READ" || no "B:missing-binary" "got $NFTBAN_NFT_PROBE_VERDICT"
+
+echo "=== C. THE mutation gate — only a verified ABSENT may rebuild ==="
+verdict absent ip
+nftban_nft_probe_may_rebuild && ok "C1 ABSENT permits considering rebuild" \
+                             || no "C1 ABSENT permits rebuild" "predicate refused"
+verdict present ip
+nftban_nft_probe_may_rebuild && no "C2 PRESENT must NOT permit rebuild" "predicate allowed it" \
+                             || ok "C2 PRESENT does not permit rebuild"
+for s in netlink perm syntax empty garbage; do
+    verdict "$s" ip
+    nftban_nft_probe_may_rebuild \
+        && no "C3:$s CANNOT_READ must NOT permit rebuild" "predicate allowed it" \
+        || ok "C3:$s CANNOT_READ does not permit rebuild"
+done
+
+echo "=== D. no stored rebuild boolean (dual authority) ==="
+grep -qE '^[[:space:]]*NFTBAN_NFT_PROBE_MAY_REBUILD=' "$PROBE" \
+    && no "D1 no stored MAY_REBUILD variable" "a stored boolean exists and can go stale" \
+    || ok "D1 rebuild permission is derived live from VERDICT, never stored"
+
+echo "=== E. redaction: mask addresses, PRESERVE diagnostics ==="
+r=$(nftban_nft_probe_redact 'src/mnl.c:61: at file.sh:148 errno EAFNOSUPPORT')
+[[ "$r" == *"src/mnl.c:61"* && "$r" == *"file.sh:148"* ]] \
+    && ok "E1 file:line diagnostics preserved" || no "E1 file:line preserved" "$r"
+r=$(nftban_nft_probe_redact 'blocked 203.0.113.9 and 2001:db8::1 now')
+[[ "$r" == *"<ip4>"* && "$r" == *"<ip6>"* ]] \
+    && ok "E2 IPv4 and IPv6 literals redacted" || no "E2 addresses redacted" "$r"
+long=$(printf 'x%.0s' $(seq 1 900)); r=$(nftban_nft_probe_redact "$long")
+[[ "${#r}" -lt 700 ]] && ok "E3 stderr is bounded (${#r} bytes from 900)" \
+                      || no "E3 stderr bounded" "len=${#r}"
+
+echo "=== M. MONOTONICITY — a later result must never recover a prior CANNOT_READ ==="
+# Every probe resets VERDICT on entry, so ordering alone could silently restore a
+# healthy component after an unreadable probe. The latch makes that impossible.
+nftban_nft_probe_session_reset
+nftban_nft_probe_session_degraded \
+    && no "M1 a fresh session starts clean" "latch set before any probe" \
+    || ok "M1 a fresh session starts clean"
+
+verdict netlink ip                      # CANNOT_READ
+nftban_nft_probe_session_degraded \
+    && ok "M2 CANNOT_READ sets the session latch" \
+    || no "M2 CANNOT_READ sets the latch" "latch not set"
+
+verdict present ip                      # a LATER successful probe
+[[ "$NFTBAN_NFT_PROBE_VERDICT" == "PRESENT" ]] \
+    && ok "M3 the later probe itself reports PRESENT (VERDICT is per-probe)" \
+    || no "M3 later probe PRESENT" "got $NFTBAN_NFT_PROBE_VERDICT"
+nftban_nft_probe_session_degraded \
+    && ok "M4 the SESSION stays degraded — no recovery from a later success" \
+    || no "M4 session stays degraded" "a later PRESENT recovered the component — monotonicity broken"
+
+# set-probe path must latch too
+nftban_nft_probe_session_reset
+NFTBAN_NFT_BIN="$WORK/netlink/nft"
+nftban_nft_probe_set ip nftban ssh_ports test || true
+nftban_nft_probe_session_degraded \
+    && ok "M5 an unreadable SET probe also latches the session" \
+    || no "M5 set probe latches" "latch not set by nftban_nft_probe_set"
+
+nftban_nft_probe_session_reset
+nftban_nft_probe_session_degraded \
+    && no "M6 explicit reset clears the latch" "reset did not clear" \
+    || ok "M6 only an EXPLICIT reset clears the latch"
+
+# callers must consult the latch, not the last VERDICT
+grep -q 'nftban_nft_probe_session_degraded' "$AUTOHEAL" \
+    && ok "M7 autoheal consults the monotonic latch" \
+    || no "M7 autoheal consults the latch" "it reads the last VERDICT and can recover"
+grep -q 'nftban_nft_probe_session_degraded' "$MAINT" \
+    && ok "M8 maintenance consults the monotonic latch" \
+    || no "M8 maintenance consults the latch" "it reads the last VERDICT and can recover"
+
+echo "=== F. call-site invariants (static) ==="
+grep -qE 'nft list table \$_tbl|nft list table \$\{NFTBAN_TABLE_IPV4\}' "$MAINT" "$SSHDET" \
+    && no "F1 no untyped collapsing probe remains" "an old boolean nft probe survived" \
+    || ok "F1 no untyped collapsing probe remains on the converted path"
+grep -qE 'log_error "Try: nftban firewall reset --force"' "$AUTOHEAL" \
+    && no "F2 no reset --force advice from unknown cause" "destructive guidance still emitted" \
+    || ok "F2 destructive reset --force guidance removed"
+grep -q 'NFTBAN_AUTOHEAL_PROBE_FAILED' "$AUTOHEAL" \
+    && ok "F3 autoheal tracks probe failure" || no "F3 autoheal tracks probe failure" "flag absent"
+grep -q '_MAINT_PROBE_UNREADABLE' "$MAINT" \
+    && ok "F4 maintenance tracks probe failure" || no "F4 maintenance tracks failure" "flag absent"
+grep -q "printf 'cannot-read" "$SSHDET" \
+    && ok "F5 ssh_port_detect emits the distinct cannot-read state" \
+    || no "F5 cannot-read state" "not emitted"
+grep -q 'cannot-read)' "$MAINT" \
+    && ok "F6 maintenance handles cannot-read distinctly from no-table" \
+    || no "F6 cannot-read handled" "caller still collapses it"
+
+echo "=== G. VERDICT HONESTY — the unit must go red, not green ==="
+# The single most valuable assertion in this PR. Today the component reports
+# success after a total failure of its nft-access and schema stages.
+# Block-scoped check: locate the guard line, then require the non-zero exit
+# WITHIN that block. Multiline regex over shell source is too fragile — an earlier
+# revision of this very assertion failed against correct code because the pattern
+# assumed a newline where the source has "]; then".
+block_has(){  # block_has <file> <guard-pattern> <required-pattern> <window>
+    local f="$1" guard="$2" want="$3" win="${4:-14}" ln
+    ln=$(grep -n "$guard" "$f" | tail -1 | cut -d: -f1) || return 1
+    [[ -n "$ln" ]] || return 1
+    sed -n "${ln},$((ln+win))p" "$f" | grep -q "$want"
+}
+block_has "$AUTOHEAL" 'NFTBAN_AUTOHEAL_PROBE_FAILED:-0' '^[[:space:]]*exit 1' \
+    && ok "G1 autoheal EXITS NON-ZERO when the ruleset could not be read" \
+    || no "G1 autoheal exits non-zero on probe failure" "no exit 1 within the guard block"
+block_has "$MAINT" '_MAINT_PROBE_UNREADABLE:-0' '^[[:space:]]*return 1' \
+    && ok "G2 maintenance RETURNS NON-ZERO when the ruleset could not be read" \
+    || no "G2 maintenance returns non-zero" "no return 1 within the guard block"
+grep -q 'Health: DEGRADED' "$AUTOHEAL" \
+    && ok "G3 autoheal reports DEGRADED instead of 'system ready'" \
+    || no "G3 DEGRADED verdict" "still claims readiness"
+grep -q 'Maintenance INCOMPLETE' "$MAINT" \
+    && ok "G4 maintenance reports INCOMPLETE instead of Complete" \
+    || no "G4 INCOMPLETE verdict" "still claims completion"
+
+echo
+printf 'RESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ $FAIL -gt 0 ]]; then printf 'FAILED:\n'; printf '  - %s\n' "${FAILED[@]}"; exit 1; fi
+exit 0

--- a/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
+++ b/cli/lib/nftban/tests/v145_pr_c2_apply_hardening_test.sh
@@ -42,6 +42,24 @@ MODE="ready"; TCP_ELEMS="22, 80, 443"; SSH_ELEMS="22"
 nft() {
     local a="$*"
     case "$a" in
+        # v1.228.4 PR-3: the typed probe establishes readability POSITIVELY via
+        # `nft list tables` / `nft list sets <family>` rather than probing a single
+        # object and reading its failure as absence. The mock must answer those.
+        # For the absent cases it returns a READABLE listing that simply does not
+        # contain nftban — returning empty would be CANNOT_READ by design, since
+        # rc=0 with no output is not proof that anything is absent.
+        "list tables")
+            [[ "$MODE" == "cannot-read" ]] && {
+                echo "mnl.c:61: Unable to initialize Netlink socket: Address family not supported by protocol" >&2
+                return 1; }
+            [[ "$MODE" == "no-table" ]] && { printf 'table ip filter\n'; return 0; }
+            printf 'table ip filter\ntable ip nftban\n'; return 0 ;;
+        "list sets ip")
+            [[ "$MODE" == "no-table" ]] && { printf 'table ip filter\n'; return 0; }
+            [[ "$MODE" == "no-sets" ]] && {
+                printf 'table ip nftban {\n\tset tcp_ports_in {\n'; return 0; }
+            printf 'table ip nftban {\n\tset tcp_ports_in {\n\tset ssh_ports {\n'
+            return 0 ;;
         "list table ip nftban")
             [[ "$MODE" == "no-table" ]] && return 1; return 0 ;;
         "list set ip nftban tcp_ports_in")
@@ -60,6 +78,12 @@ echo "== nftban_ssh_apply_state =="
 MODE=ready;    eq "$(nftban_ssh_apply_state 'ip nftban')" "ready"    "ready when table+both sets present"
 MODE=no-table; eq "$(nftban_ssh_apply_state 'ip nftban')" "no-table" "no-table when table absent"
 MODE=no-sets;  eq "$(nftban_ssh_apply_state 'ip nftban')" "no-sets"  "no-sets when ssh_ports missing"
+# v1.228.4 PR-3 — the FOURTH state. An unreadable ruleset must NOT collapse into
+# no-table: "absent" authorises a rebuild, "cannot-read" must not.
+MODE=cannot-read
+eq "$(nftban_ssh_apply_state 'ip nftban')" "cannot-read" \
+   "cannot-read when the ruleset is unreadable (NOT reported as no-table)"
+MODE=ready
 
 echo "== nftban_ssh_port_in_both_sets =="
 MODE=ready; TCP_ELEMS="22, 80, 443"; SSH_ELEMS="22"

--- a/scripts/ci/check-nft-probe-authority.sh
+++ b/scripts/ci/check-nft-probe-authority.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - nft probe authority guard (G-1 / G-2)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="check-nft-probe-authority"
+# meta:type="ci-guard"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-07-29"
+# meta:description="v1.228.4 PR-3. Prevents reintroduction of the untyped nft probe defect class. G-1 rejects any direct boolean nft existence probe on the PROTECTED maintenance path, which must route every presence question through nftban_nft_probe_table or nftban_nft_probe_set. G-2 rejects new code anywhere that converts a generic nft command failure directly into absence, rebuild authority, or a healthy verdict - specifically an if-not-nft guard leading to a rebuild, command substitution around the typed probe (which runs it in a subshell and silently discards every diagnostic variable), and any stored MAY_REBUILD boolean (dual authority that can go stale). A RATCHET bounds the legacy debt: the repo-wide count of untyped probes is recorded in a baseline file and may never increase, so the remaining sites can be migrated over time while no new ones can be added. Static analysis only - reads files, invokes nothing, contacts no host."
+# meta:input="cli/lib/nftban/**, install/**, scripts/ci/nft-probe-debt-baseline.txt"
+# meta:output="PASS/FAIL per rule; exit 0 on all-pass, 1 on any violation"
+# meta:depends="bash,git,grep"
+# meta:inventory.files="scripts/ci/nft-probe-debt-baseline.txt"
+# meta:inventory.binaries="bash,git,grep"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="check_nft_probe_authority"
+# meta:ta.owner="cli"
+# meta:ta.module="nft-probe-authority"
+# meta:ta.execution_class="CI_STATIC"
+# meta:ta.gate="policy-gates"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO"
+
+BASELINE="scripts/ci/nft-probe-debt-baseline.txt"
+
+# The converted path. Every presence question here MUST be typed.
+PROTECTED=(
+    "cli/lib/nftban/cron/maintenance.sh"
+    "cli/lib/nftban/helpers/autoheal.sh"
+    "cli/lib/nftban/lib/ssh_port_detect.sh"
+)
+
+# A boolean nft read whose result is used as a truth value. This is the shape that
+# collapses "cannot read" into "absent".
+UNTYPED_RE='nft (-a )?list (table|tables|set|sets|chain|chains)[^|]*(>/dev/null 2>&1|&>/dev/null)'
+
+PASS=0; FAIL=0
+ok(){ printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  [FAIL] %s\n         %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+# Product code only: tests legitimately construct these patterns as fixtures, and
+# this guard itself necessarily contains them as strings.
+scan_files(){
+    git ls-files -- 'cli/lib/nftban/**/*.sh' 'cli/sbin/*' 'install/**/*.sh' 2>/dev/null \
+        | grep -v '/tests/' | grep -v 'check-nft-probe-authority' | grep -v 'lib/nft_probe.sh'
+}
+
+echo "=== G-1. protected maintenance path must be fully typed ==="
+g1=0
+for f in "${PROTECTED[@]}"; do
+    [[ -f "$f" ]] || { no "G-1 $f exists" "protected file missing"; continue; }
+    hits=$(grep -nE "$UNTYPED_RE" "$f" 2>/dev/null || true)
+    if [[ -n "$hits" ]]; then
+        no "G-1 $f routes every presence question through the typed probe" \
+           "untyped boolean nft probe found:"$'\n'"$(printf '%s' "$hits" | sed 's/^/           /')"
+        g1=1
+    fi
+done
+[[ $g1 -eq 0 ]] && ok "G-1 all ${#PROTECTED[@]} protected files are fully typed"
+
+# The protected path must actually USE the authority — a file could be "clean"
+# simply by not probing at all, which would silently drop the check.
+for f in "${PROTECTED[@]}"; do
+    grep -q 'nftban_nft_probe_' "$f" 2>/dev/null \
+        && ok "G-1b $(basename "$f") calls the typed probe authority" \
+        || no "G-1b $(basename "$f") calls the typed probe authority" \
+              "no nftban_nft_probe_* call — is this file still on the path?"
+done
+
+echo "=== G-2. no new failure-to-absence or failure-to-authority conversion ==="
+
+# G-2a: `if ! nft ...` immediately followed by a rebuild. This is the literal
+# defect: a generic command failure authorising a mutation.
+# NOTE ON PRECISION: an earlier revision used awk with \? and \s, which awk does
+# not support, and matched far too broadly — it flagged `echo "Try: nftban
+# firewall rebuild"` (advice TEXT, not a rebuild) and `if nftban firewall rebuild`
+# (a POSITIVE conditional, the opposite shape). A guard that cries wolf on correct
+# code gets disabled, so this is deliberately narrow:
+#   guard  = literally `if ! nft ` — a NEGATED nft command used as a condition
+#   action = an actual rebuild INVOCATION within 4 lines, excluding echo/printf/log
+#            lines, which merely mention a rebuild rather than performing one
+g2a=$(scan_files | while read -r f; do
+    grep -nA4 -E 'if[[:space:]]+![[:space:]]*nft[[:space:]]' "$f" 2>/dev/null \
+      | grep -E '(firewall rebuild|firewall reset|nft_ipc_apply_ruleset)' \
+      | grep -vE '(echo|printf|log_[a-z]+|log ")' \
+      | sed "s|^|$f:|" || true
+done)
+# Pre-existing sites are ALLOWLISTED as recorded debt, not exempted — see the
+# G2A_ALLOWLIST block in the baseline file. Any site NOT on that list is a new
+# instance and fails.
+g2a_allow=$(grep -E '^G2A_ALLOWLIST=' "$BASELINE" 2>/dev/null | head -1 | cut -d= -f2)
+g2a_new=""
+if [[ -n "$g2a" ]]; then
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        matched=0
+        IFS=',' read -ra allow <<< "$g2a_allow"
+        for a in "${allow[@]}"; do
+            [[ -z "$a" ]] && continue
+            [[ "$line" == *"${a%%:*}"* ]] && matched=1 && break
+        done
+        [[ $matched -eq 0 ]] && g2a_new+="$line"$'\n'
+    done <<< "$g2a"
+fi
+if [[ -z "$g2a_new" ]]; then
+    n_allow=$(awk -F, '{print NF}' <<< "$g2a_allow")
+    ok "G-2a no NEW failure-to-mutation site (${n_allow} pre-existing allowlisted as debt)"
+else
+    no "G-2a no NEW failure-to-mutation site" \
+       "a failed nft READ authorises a MUTATION here — use nftban_nft_probe_table and act only on a verified ABSENT:"$'\n'"$g2a_new"
+fi
+
+# G-2b: command substitution around the typed probe. It runs in a SUBSHELL, so the
+# verdict string survives but EVERY diagnostic variable is discarded — the exact
+# lost-evidence failure this PR removes.
+g2b=$(scan_files | xargs grep -nE '\$\(\s*nftban_nft_probe_(table|set)' 2>/dev/null || true)
+[[ -z "$g2b" ]] && ok "G-2b typed probe is never called in command substitution" \
+                || no "G-2b typed probe is never called in command substitution" "$g2b"
+
+# G-2c: a stored rebuild boolean. Dual authority that can go stale or be set
+# directly without ever consulting the verdict it mirrors.
+g2c=$(scan_files | xargs grep -nE '^[[:space:]]*(export[[:space:]]+)?NFTBAN_NFT_PROBE_MAY_REBUILD=' 2>/dev/null || true)
+[[ -z "$g2c" ]] && ok "G-2c no stored MAY_REBUILD state (derived live from VERDICT)" \
+                || no "G-2c no stored MAY_REBUILD state" "$g2c"
+
+echo "=== G-3. legacy debt RATCHET — the count may never increase ==="
+current=$(scan_files | xargs grep -cE "$UNTYPED_RE" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+
+if [[ ! -f "$BASELINE" ]]; then
+    no "G-3 baseline exists" "$BASELINE missing — create it with the current count"
+else
+    recorded=$(grep -E '^UNTYPED_PROBE_COUNT=' "$BASELINE" | head -1 | cut -d= -f2 | tr -d '[:space:]')
+    if [[ -z "$recorded" ]]; then
+        no "G-3 baseline is parseable" "no UNTYPED_PROBE_COUNT= line in $BASELINE"
+    elif [[ "$current" -gt "$recorded" ]]; then
+        no "G-3 untyped probe debt did not increase" \
+           "current=$current recorded=$recorded — $((current-recorded)) NEW untyped probe(s) added. Use nftban_nft_probe_table/_set instead."
+    elif [[ "$current" -lt "$recorded" ]]; then
+        no "G-3 baseline is current" \
+           "current=$current recorded=$recorded — debt was REDUCED. Update $BASELINE to $current so the ratchet tightens and cannot slip back."
+    else
+        ok "G-3 untyped probe debt held at $current (ratchet: may decrease, never increase)"
+    fi
+fi
+
+echo
+printf 'RESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+exit $(( FAIL > 0 ? 1 : 0 ))

--- a/scripts/ci/nft-probe-debt-baseline.txt
+++ b/scripts/ci/nft-probe-debt-baseline.txt
@@ -1,0 +1,47 @@
+# NFTBan — untyped nft probe migration debt (v1.228.4 PR-3)
+#
+# A RATCHET, not a target. scripts/ci/check-nft-probe-authority.sh fails if this
+# count INCREASES, so no new untyped probe can be added while the existing ones
+# are migrated. When you migrate sites, LOWER this number in the same PR — the
+# guard also fails if the count drops below the record, so the ratchet tightens
+# and cannot silently slip back.
+#
+# An untyped probe is a boolean nft read used as a truth value, e.g.
+#     nft list table ip nftban >/dev/null 2>&1
+# It collapses "cannot read the ruleset" into "the table is absent". On 11/11
+# measured hosts that collapse produced a false firewall-absent verdict ~927
+# times each, ~900 futile rebuild attempts, and ~900 emissions of destructive
+# 'reset --force' guidance aimed at intact firewalls — while systemd recorded
+# Result=success every time.
+#
+# Migrate to: nftban_nft_probe_table / nftban_nft_probe_set  (lib/nft_probe.sh)
+#
+# The maintenance path (cron/maintenance.sh, helpers/autoheal.sh,
+# lib/ssh_port_detect.sh) is already fully typed and is enforced separately by
+# rule G-1 — it must stay at ZERO regardless of this count.
+UNTYPED_PROBE_COUNT=95
+
+# -----------------------------------------------------------------------------
+# G-2a ALLOWLIST — failure-to-mutation sites that PRE-DATE PR-3
+# -----------------------------------------------------------------------------
+# These are NOT exemptions. They are the SAME defect class PR-3 exists to close,
+# found by G-2a in files outside PR-3's scope. They are recorded so the guard can
+# pass on day one while remaining sensitive to any NEW instance.
+#
+# ⚠ These rank ABOVE the generic untyped-probe debt: a plain untyped probe only
+#   misreports, whereas these convert a failed READ into a MUTATION.
+#
+# HIGH — identical to the defect PR-3 fixes, in a different file:
+#   cli/lib/nftban/lib/service_control.sh:428
+#       if ! nft list table ip nftban >/dev/null 2>&1; then ... nftban firewall rebuild
+#       A ruleset that cannot be READ triggers a firewall REBUILD. This is
+#       autoheal.sh:505 in another file. Migrate to nftban_nft_probe_table and
+#       rebuild only on a verified ABSENT.
+#
+# LOWER — failed read leads to an idempotent rule add, not a rebuild:
+#   cli/lib/nftban/core/nftban_ddos_suricata.sh:550
+#       if ! nft list chain $table input 2>/dev/null | grep -q "@$set drop"; then ...
+#       The pipeline's result is grep's, so an unreadable chain looks like "rule
+#       missing" and the rule is re-added. Duplicate-add is far less harmful than
+#       a rebuild, but it is the same collapse.
+G2A_ALLOWLIST=cli/lib/nftban/lib/service_control.sh:428,cli/lib/nftban/core/nftban_ddos_suricata.sh:550

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -214,6 +214,7 @@ sysctl_safe_default_v216_test	cli/lib/nftban/tests/sysctl_safe_default_v216_test
 systemd_cli_token_dispatch_v1228_1_test	cli/lib/nftban/tests/systemd_cli_token_dispatch_v1228_1_test.sh	cli	test	dispatcher	CI_STATIC	ci-bash	true	false	false	false	false	false			
 tmpfiles_zz_v139_test	cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh	packaging	test	fhs	PACKAGE_BUILD	package-build	true	false	false	false	false	false			
 trust_load_missing_whitelist_test	cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh	trust	test	trust-load	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+typed_nft_probe_v1228_4_test	cli/lib/nftban/tests/typed_nft_probe_v1228_4_test.sh	cli	test	nft-probe-authority	CI_STATIC	ci-bash	true	false	false	false	false	false			
 uninstall_firewall_ownership_message_v225_test	cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 update_degraded_render_truth_v225_test	cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 update_force_delegation_v1223_test	cli/lib/nftban/tests/update_force_delegation_v1223_test.sh	update	test	update-force	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## Summary

A failed `nft` read was being treated as proof that a table was **absent**, which authorised a rebuild of a healthy firewall. PR-2 removed the *trigger* by granting `AF_NETLINK` to six units. This PR removes the **defect class**.

`cli/lib/nftban/lib/nft_probe.sh` introduces a three-state contract — `PRESENT | ABSENT | CANNOT_READ` — in which **only a verified `ABSENT` may authorise a mutation**. Readability is established *positively* (`nft list tables` succeeds whenever netlink is usable) rather than by parsing error text, and `rc=0` with empty or unparseable output is `CANNOT_READ`, not absence.

**Stated cost, not hidden:** a host with genuinely zero tables yields `CANNOT_READ` and will not auto-rebuild. Zero tables on an installed system is an operator-visible anomaly, not something to silently rebuild through.

## Monotonic degraded latch

Any `CANNOT_READ` sets a session latch that only an explicit reset clears. Both callers gate on the **latch**, not the last verdict.

Without this, probing a table (`CANNOT_READ`) then a set (`PRESENT`) left the caller reading `PRESENT` and reporting healthy — a later success silently erasing an earlier blindness. Proven on real hardware, not only in unit tests (`P2_VERDICT=PRESENT` while `P2_LATCH=1`).

Rebuild authority is **derived live** from the verdict. There is deliberately no stored `MAY_REBUILD` boolean — a second authority that could go stale.

## Callers converted

| Path | Behaviour when the ruleset cannot be read |
|---|---|
| `cron/maintenance.sh` | returns 1, logs `INCOMPLETE`, dependent work skipped |
| `helpers/autoheal.sh` | exits 1, `DEGRADED`, readiness explicitly **not** asserted |
| `lib/ssh_port_detect.sh` | new fourth state `cannot-read` |

The former `Try: nftban firewall reset --force` guidance is removed — it advised resetting a firewall whose state was unknown.

## Guard (BLOCKING in policy-gates)

`scripts/ci/check-nft-probe-authority.sh`:
- **G-1** — the converted path stays fully typed
- **G-2** — rejects new failure-to-absence conversions, including command substitution around the probe (which discards every diagnostic in a subshell)
- **G-3** — ratchets the **95** remaining legacy sites: debt may shrink, never grow

## Lab negative controls — 29/29 on both hosts

Transient units replicating the **shipped** `nftban-maintenance.service` sandbox property-for-property; only `RestrictAddressFamilies` differs between cells. `/usr/lib/nftban` was never written (overlay via `NFTBAN_LIB_DIR`; installed-tree hash byte-identical pre/post).

| Property | lab2 (Ubuntu 24.04, DEB) | lab4 (Rocky 9.8 EL9, RPM) |
|---|---|---|
| latched `CANNOT_READ` / `NETLINK_FAMILY_BLOCKED` | PASS | PASS |
| systemd result non-zero | PASS (exit 1) | PASS (exit 1) |
| rebuild authority denied | PASS | PASS |
| no unsafe guidance | PASS | PASS |
| firewall structurally unchanged | PASS | PASS |

**Operational inversion:** the same no-`AF_NETLINK` condition that previously emitted false absence and **exited 0** now emits `INCOMPLETE` and exits 1. Zero write-shaped `nft` invocations across 24 observed execs. Positive controls confirm verified `ABSENT` still grants authority.

## Tests

38 typed-probe controls (verdicts, six failure modes, mutation gate, redaction, M1–M8 monotonicity, call-site invariants) · guard 8/8 · converted-path untyped debt 0 · PR-1 guard 37/0/0 · PR-1 controls 25/25 · shellcheck clean · `INDEX_FRESH = YES`.

## Not proven here

- **Package-native PR-3** — the labs used a file overlay, not installed DEB/RPM. Separate release gate.
- **SELinux Enforcing** — lab4 is Permissive. Cannot establish EL9 clean-install authority; that is the v1.228.5 lane.
