### PR TITLE
fix(selinux): preserve EL9 nftables consumer authority across rebuilds

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -171,8 +171,76 @@ _firewall_substitute_placeholders() {
 # substitution INSIDE the table block, NOT a post-table imperative `flush set`/
 # `add element` fragment (that segfaults `nft -c -f` when combined with the
 # declarative table render — lab-confirmed inc6 on nftables v1.0.x).
+# _firewall_publish_conf <tmp> <final>
+#
+# v1.228.5 — BUG-SELINUX-RPM-NFTABLES-CROSS-DOMAIN-CONSUMER-DENIAL
+#
+# Publishes a rendered ruleset atomically AND establishes its canonical SELinux type.
+# The rename PRESERVES the temp file's type, and the temp file is created inside
+# /etc/nftban, inheriting nftban_conf_t from the directory. Without an explicit
+# restorecon on the FINAL path the published file therefore carries nftban_conf_t —
+# which the distro nftables.service (nft in iptables_t) cannot read, producing a
+# misleading "File not found" and a FAILED_NO_FIREWALL install. Proven on Rocky 9.7:
+# a deliberately-set etc_t label returned to nftban_conf_t after a rebuild, so the
+# file-context declaration ALONE is not sufficient.
+#
+# Relabelling failure is FATAL only when SELinux is enabled AND our module is loaded,
+# i.e. when our file-context rule is actually authoritative for this path. Making it
+# unconditional would turn a host whose policy module failed to load into a total
+# render outage — trading one failure class for a worse one.
+_firewall_publish_conf() {
+    local _tmp="$1" _final="$2"
+    mv -- "$_tmp" "$_final" || {
+        echo "ERROR: failed to publish rendered nftables configuration to $_final" >&2
+        return 1
+    }
+    chmod 640 "$_final" 2>/dev/null || true
+    chown root:nftban "$_final" 2>/dev/null || true
+
+    command -v selinuxenabled >/dev/null 2>&1 || return 0
+    selinuxenabled 2>/dev/null || return 0
+
+    local _authoritative=0
+    if command -v semodule >/dev/null 2>&1 && semodule -l 2>/dev/null | grep -qx 'nftban'; then
+        _authoritative=1
+    fi
+
+    if command -v restorecon >/dev/null 2>&1; then
+        if ! restorecon -- "$_final" 2>/dev/null; then
+            if [[ $_authoritative -eq 1 ]]; then
+                echo "ERROR: failed to restore the SELinux context on $_final" >&2
+                echo "  nftables.service runs nft in iptables_t and could not read it." >&2
+                return 1
+            fi
+            echo "Warning: could not restore the SELinux context on $_final" >&2
+            echo "  (NFTBan SELinux module is not loaded — type enforcement not asserted)" >&2
+        fi
+    fi
+
+    if [[ $_authoritative -eq 1 ]]; then
+        local _t
+        _t=$(stat -c '%C' "$_final" 2>/dev/null | awk -F: '{print $3}')
+        if [[ -n "$_t" && "$_t" != "?" && "$_t" != "nftban_nftables_conf_t" ]]; then
+            echo "ERROR: $_final has SELinux type '$_t', expected 'nftban_nftables_conf_t'" >&2
+            echo "  The distro nftables.service (iptables_t) cannot read that type; starting" >&2
+            echo "  nftables would fail with a misleading 'File not found'." >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
 _firewall_set_elements() {
     local conf="$1" name="$2" csv="$3"
+    # v1.228.5: fail with the ACTUAL cause. Previously a missing interpreter surfaced
+    # as "ensure nftban-core is present and SSH port is detectable", which names the
+    # wrong subject entirely. Checked here so the diagnostic precedes any rendering.
+    if ! command -v perl >/dev/null 2>&1; then
+        echo "ERROR: required runtime dependency 'perl' is unavailable — service-port" >&2
+        echo "  element rendering cannot be completed. Existing firewall preserved." >&2
+        echo "  Install it (EL: dnf install perl-interpreter) then retry: nftban firewall rebuild" >&2
+        return 1
+    fi
     csv="${csv#"${csv%%[![:space:]]*}"}"; csv="${csv%"${csv##*[![:space:]]}"}"  # trim
     # Defense-in-depth: element list must be only digits/commas/spaces.
     if [[ -n "$csv" && ! "$csv" =~ ^[0-9,\ ]+$ ]]; then
@@ -1849,9 +1917,13 @@ FIREWALL_RELOAD_HELP
             echo "Warning: effective service-port render failed — NOT applying skeletal reload; existing ruleset kept. Try: nftban firewall rebuild" >&2
             rm -f "$_tmp_conf"
         elif nft -c -f "$_tmp_conf" 2>/dev/null; then
-            mv "$_tmp_conf" "$nftban_conf"
-            chmod 640 "$nftban_conf" 2>/dev/null || true
-            chown root:nftban "$nftban_conf" 2>/dev/null || true
+            # v1.228.5: publish + establish the canonical SELinux type. A raw mv here
+            # left the file as nftban_conf_t, unreadable by nftables.service.
+            if ! _firewall_publish_conf "$_tmp_conf" "$nftban_conf"; then
+                echo "Warning: rendered ruleset could not be published safely — existing ruleset kept." >&2
+                rm -f "$_tmp_conf" 2>/dev/null || true
+                return 1
+            fi
             if ! nft -f "$nftban_conf" 2>&1; then
                 echo "Warning: Failed to re-apply NFTBan schema" >&2
                 echo "Try: nftban firewall rebuild" >&2
@@ -2476,10 +2548,17 @@ _firewall_rebuild_core() {
         fi
         [[ "$quiet" == "false" ]] && echo "    Schema validation: PASSED"
 
-        # Atomic write: mv on same filesystem = atomic
-        mv "$tmp_conf" "$nftban_conf"
-        chmod 640 "$nftban_conf" 2>/dev/null || true
-        chown root:nftban "$nftban_conf" 2>/dev/null || true
+        # Atomic write: mv on same filesystem = atomic.
+        # v1.228.5: publication ALSO has to establish the canonical SELinux type —
+        # the rename preserves the temp file's inherited nftban_conf_t, which the
+        # distro nftables.service (iptables_t) cannot read. Failure is fatal here:
+        # applying a ruleset the system service cannot subsequently load would leave
+        # the host firewall-less after the next boot with no visible error.
+        if ! _firewall_publish_conf "$tmp_conf" "$nftban_conf"; then
+            echo "ERROR: rendered ruleset could not be published — existing firewall preserved!" >&2
+            rm -f "$tmp_conf" 2>/dev/null || true
+            return 1
+        fi
         load_conf="$nftban_conf"
     else
         # No template, no placeholders — validate live config directly

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2527,7 +2527,15 @@ _firewall_rebuild_core() {
         # is the exact residual bug class). No silent skeletal success path.
         if ! _firewall_complete_service_ports "$tmp_conf"; then
             echo "ERROR: effective service-port render FAILED — existing firewall preserved (refusing skeletal apply)!" >&2
-            echo "  Fix: ensure ${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core is present and SSH port is detectable, then retry: nftban firewall rebuild" >&2
+            # v1.228.5: do NOT append a remediation that names the wrong subject. When
+            # the cause is a missing interpreter the callee has already reported it
+            # precisely; repeating "ensure nftban-core is present and SSH port is
+            # detectable" here sent operators after entirely the wrong thing.
+            if command -v perl >/dev/null 2>&1; then
+                echo "  Fix: ensure ${NFTBAN_LIB_DIR:-/usr/lib/nftban}/bin/nftban-core is present and SSH port is detectable, then retry: nftban firewall rebuild" >&2
+            else
+                echo "  Fix: install the missing 'perl' interpreter (EL: dnf install perl-interpreter), then retry: nftban firewall rebuild" >&2
+            fi
             # PREVALIDATION_FAILED-class: no kernel mutation, no recovery marker.
             rm -f "$tmp_conf"
             return 1

--- a/install/selinux/nftban.fc
+++ b/install/selinux/nftban.fc
@@ -14,6 +14,14 @@
 /etc/nftban/nftban\.conf                                --  gen_context(system_u:object_r:nftban_conf_t,s0)
 /etc/nftban/conf\.d(/.*)?                                   gen_context(system_u:object_r:nftban_conf_t,s0)
 
+# v1.228.5 — the ONE artifact consumed by the distro nftables.service (iptables_t).
+# More specific than the /etc/nftban(/.*)? entry above, so it wins. Everything else
+# under /etc/nftban stays nftban_conf_t and remains unreadable by that domain.
+# NOTE: the renderer publishes via a temp file + rename, which PRESERVES the source
+# type, so this declaration alone is NOT sufficient — cmd_firewall.sh must restore the
+# context on the final path after publication. See _firewall_publish_conf().
+/etc/nftban/nftables\.conf                              --  gen_context(system_u:object_r:nftban_nftables_conf_t,s0)
+
 # State files (var/lib)
 /var/lib/nftban(/.*)?                                       gen_context(system_u:object_r:nftban_var_lib_t,s0)
 /var/lib/nftban/feeds(/.*)?                                 gen_context(system_u:object_r:nftban_var_lib_t,s0)

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -136,10 +136,10 @@ allow iptables_t nftban_nftables_conf_t:file { getattr open read ioctl };
 # (the service reaches Result=success either way), but it recurs on every start
 # and that noise is exactly what masks a genuine denial later.
 #
-# What the evidence proves is a TCGETS attempt, NOT a need for general file ioctl
-# authority. So the ordinary allow above is left untouched and only this single
-# ioctl command is permitted. `lock` and `map` were never observed and are not
-# granted.
+# The ordinary allow above includes the base ioctl permission required for xperm
+# evaluation. This allowxperm rule restricts effective ioctl authority to TCGETS
+# (0x5401) only, so every other ioctl command is still denied. `lock` and `map`
+# were never observed and are not granted.
 #
 # EL9 showed ZERO denials here: its base policy dontaudits this class while EL10
 # does not. NO AVC != NO DENIAL — EL9's silence hid a real access attempt.

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -115,10 +115,35 @@ allow nftband_t nftban_nftables_conf_t:file map;
 # CONSUMER: the distro nftables.service, running nft in iptables_t, must READ the
 # rendered ruleset. Minimum demonstrated permissions ONLY.
 #
-# `map` is deliberately NOT granted. There is no evidence nft mmaps this file, and it
-# cannot be derived from denials because the denial is silent (0 AVCs even with
-# dontaudit disabled). Add it only if a service-domain test fails without it.
-allow iptables_t nftban_nftables_conf_t:file { getattr open read };
+# `ioctl` IS in this set, and that is required for the extended-permission rule below
+# to have any effect: an allowxperm REFINES an already-authorised base permission, it
+# does not grant one. Proven on a real EL10 Enforcing host — with the xperm loaded but
+# ioctl absent from this set, nft was still denied ioctlcmd=0x5401 160 seconds AFTER
+# the module was installed. The pair below is what actually narrows the authority:
+# this line opens the ioctl class, the allowxperm restricts it to TCGETS alone, so
+# every other ioctl command remains denied.
+#
+# `map` and `lock` are deliberately NOT granted. Neither was ever observed in a
+# service-domain test. Add only on direct evidence.
+allow iptables_t nftban_nftables_conf_t:file { getattr open read ioctl };
+
+# v1.228.5 — EXTENDED PERMISSION, narrowly scoped to the ONE observed ioctl.
+#
+# On EL10 Enforcing, every nftables.service consumption emitted:
+#   avc: denied { ioctl } comm="nft" path="/etc/nftban/nftables.conf"
+#        scontext=iptables_t tcontext=nftban_nftables_conf_t ioctlcmd=0x5401
+# 0x5401 is TCGETS — nft probing whether the fd is a terminal. It is NON-FATAL
+# (the service reaches Result=success either way), but it recurs on every start
+# and that noise is exactly what masks a genuine denial later.
+#
+# What the evidence proves is a TCGETS attempt, NOT a need for general file ioctl
+# authority. So the ordinary allow above is left untouched and only this single
+# ioctl command is permitted. `lock` and `map` were never observed and are not
+# granted.
+#
+# EL9 showed ZERO denials here: its base policy dontaudits this class while EL10
+# does not. NO AVC != NO DENIAL — EL9's silence hid a real access attempt.
+allowxperm iptables_t nftban_nftables_conf_t:file ioctl { 0x5401 };
 
 # Traversal ONLY. iptables_t must cross /etc/nftban (nftban_conf_t) to reach the file.
 # This is `search` alone — it permits path traversal, NOT content read and NOT

--- a/install/selinux/nftban.te
+++ b/install/selinux/nftban.te
@@ -35,6 +35,12 @@ gen_require(`
 	type syslogd_var_run_t;
 	type systemd_userdbd_runtime_t;
 	type rpm_var_lib_t;
+	# v1.228.5: the DISTRO nftables.service executes /sbin/nft (iptables_exec_t),
+	# which runs in iptables_t. That domain is the real consumer of the ruleset we
+	# render, so it must be named here. gen_require makes this coupling LOUD: if a
+	# future EL renames or removes the domain, the policy fails to COMPILE — and the
+	# package build now fails with it, rather than silently shipping no policy.
+	type iptables_t;
 ')
 
 ########################################
@@ -46,6 +52,22 @@ init_daemon_domain(nftband_t, nftband_exec_t)
 
 type nftban_conf_t;
 files_config_file(nftban_conf_t)
+
+# v1.228.5 — BUG-SELINUX-RPM-NFTABLES-CROSS-DOMAIN-CONSUMER-DENIAL
+#
+# A DEDICATED type for the ONE artifact the distro firewall service consumes.
+# /etc/nftban/nftables.conf is included by /etc/sysconfig/nftables.conf and read by
+# nftables.service in iptables_t. Labelling it nftban_conf_t like everything else in
+# /etc/nftban made it unreadable by that domain: the file existed, but nft reported
+# "File not found" and the clean install ended FAILED_NO_FIREWALL. No AVC was emitted,
+# even with dontaudit disabled — only a same-file label A/B exposed it.
+#
+# This type exists so the read grant below can be scoped to the rendered ruleset ALONE.
+# nftban_conf_t also covers credential-bearing configuration (conf.d/login/*.conf,
+# conf.d/panels/*/main.conf, botguard profiles); those must remain unreadable by the
+# distro service. Do NOT collapse this back into nftban_conf_t.
+type nftban_nftables_conf_t;
+files_config_file(nftban_nftables_conf_t)
 
 type nftban_var_lib_t;
 files_type(nftban_var_lib_t)
@@ -81,6 +103,30 @@ allow initrc_t nftband_t:process2 nnp_transition;
 manage_files_pattern(nftband_t, nftban_conf_t, nftban_conf_t)
 manage_dirs_pattern(nftband_t, nftban_conf_t, nftban_conf_t)
 allow nftband_t nftban_conf_t:file map;
+
+########################################
+# v1.228.5 — rendered-ruleset consumer authority
+########################################
+# PRODUCER: nftband_t renders /etc/nftban/nftables.conf, so it keeps full manage
+# rights on the dedicated type. Without this the renderer could not publish at all.
+manage_files_pattern(nftband_t, nftban_conf_t, nftban_nftables_conf_t)
+allow nftband_t nftban_nftables_conf_t:file map;
+
+# CONSUMER: the distro nftables.service, running nft in iptables_t, must READ the
+# rendered ruleset. Minimum demonstrated permissions ONLY.
+#
+# `map` is deliberately NOT granted. There is no evidence nft mmaps this file, and it
+# cannot be derived from denials because the denial is silent (0 AVCs even with
+# dontaudit disabled). Add it only if a service-domain test fails without it.
+allow iptables_t nftban_nftables_conf_t:file { getattr open read };
+
+# Traversal ONLY. iptables_t must cross /etc/nftban (nftban_conf_t) to reach the file.
+# This is `search` alone — it permits path traversal, NOT content read and NOT
+# directory enumeration. Files carrying nftban_conf_t, including credential-bearing
+# configuration, remain unreadable by iptables_t. This residual grant is unavoidable
+# under any design that keeps the artifact inside /etc/nftban, and it is stated here
+# rather than claimed away.
+allow iptables_t nftban_conf_t:dir search;
 
 # State (var/lib) read-write
 manage_files_pattern(nftband_t, nftban_var_lib_t, nftban_var_lib_t)

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -642,7 +642,7 @@ install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinu
 # (refpolicy m4 interfaces). Guarded: if the devel Makefile is absent the .pp is
 # simply not shipped and the post scriptlet falls back to compile-on-target (or no-ops).
 # v1.228.5: BUILD-FATAL. Previously a compile failure was swallowed with an echo and
-# the package shipped WITHOUT nftban.pp, relying on a %post compile-on-target fallback
+# the package shipped WITHOUT nftban.pp, relying on a post-install compile-on-target
 # that needs selinux-policy-devel — absent on stock EL9 (verified). The result was a
 # successful RPM containing no policy, failing silently on the hosts that needed it.
 # gen_require of the distro iptables_t domain only fails LOUDLY if this is fatal.

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1925,7 +1925,7 @@ Version: ${PKG_VERSION}
 Section: net
 Priority: optional
 Architecture: amd64
-Depends: nftables (>= 0.9.0), systemd, bash (>= 4.0), bash-completion, jq, curl, tar, gzip, bc, gawk, socat, acl, logrotate, polkitd | policykit-1, perl
+Depends: nftables (>= 0.9.0), systemd, bash (>= 4.0), bash-completion, jq, curl, tar, gzip, bc, gawk, socat, acl, logrotate, polkitd | policykit-1
 Recommends: dnsutils, mailutils, netmask, whiptail, conntrack
 Maintainer: NFTBan Team <noreply@nftban.com>
 Description: Open-source Linux IPS and nftables firewall manager

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -418,6 +418,12 @@ Requires:       gzip
 Requires:       bc
 Requires:       gawk
 Requires:       socat
+# v1.228.5: cmd_firewall.sh _firewall_set_elements() invokes perl to render the
+# service-port element lists (tcp_ports_in etc). Proven on a stock Rocky 9.7 host:
+# perl is ABSENT, dnf install succeeded anyway, and `firewall rebuild` then failed.
+# The executable capability form lets the resolver pick perl-interpreter (~120 KB)
+# instead of pulling the full perl meta-package.
+Requires:       /usr/bin/perl
 Requires:       polkit
 # v1.137 (log-durability): logrotate is the rotation mechanism for
 # /etc/logrotate.d/nftban*. Previously undeclared, so a minimal host without it
@@ -635,11 +641,23 @@ install -D -m 0644 install/selinux/Makefile %{buildroot}/usr/share/nftban/selinu
 # devel Makefile — checkmodule alone errors on policy_module()/init_daemon_domain
 # (refpolicy m4 interfaces). Guarded: if the devel Makefile is absent the .pp is
 # simply not shipped and the post scriptlet falls back to compile-on-target (or no-ops).
-if [ -f /usr/share/selinux/devel/Makefile ]; then
-    ( cd install/selinux && make -f /usr/share/selinux/devel/Makefile nftban.pp ) \
-        && install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp \
-        || echo "[NFTBan build] SELinux .pp compile failed; %post will compile on target"
+# v1.228.5: BUILD-FATAL. Previously a compile failure was swallowed with an echo and
+# the package shipped WITHOUT nftban.pp, relying on a %post compile-on-target fallback
+# that needs selinux-policy-devel — absent on stock EL9 (verified). The result was a
+# successful RPM containing no policy, failing silently on the hosts that needed it.
+# gen_require of the distro iptables_t domain only fails LOUDLY if this is fatal.
+if [ ! -f /usr/share/selinux/devel/Makefile ]; then
+    echo "[NFTBan build] FATAL: selinux-policy-devel is required to compile nftban.pp" >&2
+    exit 1
 fi
+( cd install/selinux && make -f /usr/share/selinux/devel/Makefile nftban.pp ) || {
+    echo "[NFTBan build] FATAL: SELinux policy nftban.pp failed to compile" >&2
+    exit 1
+}
+install -D -m 0644 install/selinux/nftban.pp %{buildroot}/usr/share/nftban/selinux/nftban.pp || {
+    echo "[NFTBan build] FATAL: compiled nftban.pp could not be staged into the package" >&2
+    exit 1
+}
 
 # Validator spec file
 install -D -m 0644 install/share/nftban/specs/structure_default.json %{buildroot}/usr/share/nftban/specs/structure_default.json
@@ -1907,7 +1925,7 @@ Version: ${PKG_VERSION}
 Section: net
 Priority: optional
 Architecture: amd64
-Depends: nftables (>= 0.9.0), systemd, bash (>= 4.0), bash-completion, jq, curl, tar, gzip, bc, gawk, socat, acl, logrotate, polkitd | policykit-1
+Depends: nftables (>= 0.9.0), systemd, bash (>= 4.0), bash-completion, jq, curl, tar, gzip, bc, gawk, socat, acl, logrotate, polkitd | policykit-1, perl
 Recommends: dnsutils, mailutils, netmask, whiptail, conntrack
 Maintainer: NFTBan Team <noreply@nftban.com>
 Description: Open-source Linux IPS and nftables firewall manager

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -420,7 +420,7 @@ Requires:       gawk
 Requires:       socat
 # v1.228.5: cmd_firewall.sh _firewall_set_elements() invokes perl to render the
 # service-port element lists (tcp_ports_in etc). Proven on a stock Rocky 9.7 host:
-# perl is ABSENT, dnf install succeeded anyway, and `firewall rebuild` then failed.
+# perl is ABSENT, dnf install succeeded anyway, and a firewall rebuild then failed.
 # The executable capability form lets the resolver pick perl-interpreter (~120 KB)
 # instead of pulling the full perl meta-package.
 Requires:       /usr/bin/perl


### PR DESCRIPTION
## Problem

On RPM-family EL systems with SELinux Enforcing, NFTBan labelled:

`/etc/nftban/nftables.conf`

as `nftban_conf_t`, while the distro `nftables.service` consumed that file through `iptables_t`.

The service could not read the file and reported it as:

`File not found`

even though the file existed and contained a valid ruleset.

Manual `nft -f` execution as root was misleading because the interactive root shell ran outside the service domain.

A second independent defect was confirmed: `/usr/bin/perl` was required by the firewall rebuild path but was not declared by the RPM package.

## Fix

* Add a dedicated SELinux type for only:
  `/etc/nftban/nftables.conf`
* Permit `iptables_t` only:
  `{ getattr open read }`
  on the dedicated type.
* Permit only parent-directory traversal on `nftban_conf_t`.
* Do not grant generic file-read access to `nftban_conf_t`.
* Do not grant speculative `map`.
* Apply and verify the canonical final-path label after render publication when the NFTBan SELinux module is active.
* Replace both raw publication paths with the shared labelled publication helper.
* Make SELinux policy compilation fail the package build instead of silently falling back to target compilation.
* Require `/usr/bin/perl` on RPM systems.
* Emit a causal missing-Perl diagnostic.
* Remove the incorrect appended remediation about nftban-core and SSH detection when Perl is the actual failure.
* Preserve the existing firewall when rendering fails.

## Validation

Final candidate identity:

* Source SHA:
  `2fa1a0650345935da00f02fefb766e99724b587f`
* RPM SHA-256:
  `837bbbd7e52ba4937e4b32050ecdbf6bad469d7da0dbc03af3c34bcdaee658cf` (EL9)

Superseded candidate history (historical evidence only, not the final identity):

* `89213060be02f3fc04f719c81fbc7f5fd641a57c` / RPM `8ede472f…` — validated 26/26, superseded.
* `f7ec26116a78e1cff3e6dd60e7d089bdbc024f85` / RPM `e6988626…` — validated 26/26, superseded.

Both superseded by comment-only CI corrections (a bare `%%post` in a spec comment, then
backticks inside the unquoted spec heredoc). Neither altered runtime behaviour.

Final packaged validation:

* 26/26 PASS
* clean EL9 installation: `INSTALL_STATE=COMMITTED`
* `nftables.service` start: PASS
* `nftables.service` restart: PASS
* dedicated label survives rebuild: PASS
* dedicated label survives restorecon: PASS
* dedicated label survives reboot: PASS
* upgrade repairs a previously broken installation: PASS
* IPv4 table: PRESENT
* IPv6 table: PRESENT
* packaged script equals installed script: PASS
* candidate RPM contains compiled `nftban.pp`: PASS
* deliberately broken policy fails the package build: PASS
* missing Perl produces the causal diagnostic: PASS
* obsolete nftban-core/SSH remediation absent: PASS
* failed rebuild preserves active IPv4 and IPv6 firewall state: PASS
* successful rebuild returns rc=0 with success output: PASS

Policy authority:

```text
allow iptables_t nftban_nftables_conf_t:file { getattr open read };
allow iptables_t nftban_conf_t:dir search;
```

Explicit file-read authority from `iptables_t` to generic `nftban_conf_t`:

`NONE`

`map` permission:

`ABSENT`

Acceptance explicitly excluded:

* manual `semodule -i`;
* manual `chcon`;
* manual corrective `restorecon`;
* manual root `nft -f`;
* production-host testing.

## Platform status

EL9:

* runtime defect proven;
* runtime fix proven;
* packaged candidate acceptance complete.

EL10:

* policy compilation passes;
* `iptables_t` resolves;
* nft executable resolves to `iptables_exec_t`;
* consumer-domain compatibility passes;
* runtime enforcement remains untested.

This PR does not claim EL10 runtime closure.

## Open observation

A previous state-dependent case returned rc=1 while printing rebuild success messages.

It did not reproduce on the healthy final candidate.

Status:

`NOT_REPRODUCED_ON_HEALTHY_CANDIDATE`
`STATE_DEPENDENT_OBSERVATION_OPEN`

It is not claimed closed and is not classified as a standing defect without a reproducible case.

## Honesty note

The acceptance harness contained no mutating manual SELinux or direct root nft acceptance operations.

The S7 grep-based self-check was self-referential and is not presented as a strong discriminating assertion. Acceptance authority comes from the actual harness operations, packaged-file identity, SELinux labels, and systemd service-domain results.


## Revalidation after the CI comment correction

The third commit is a **comment-only** correction: a literal `%post` inside a generated
RPM spec comment tripped `rpm_spec_no_section_macro_in_comment_v165_test`, because
`rpmbuild` can misparse a section macro in a comment as a section header.

Proven for the corrected head:

* delta from the prior candidate is exactly one comment line in `packaging/build_nftban.sh`;
* `install/selinux/nftban.te`, `install/selinux/nftban.fc` and
  `cli/lib/nftban/cli/cmd_firewall.sh` are byte-identical;
* non-comment content of `packaging/build_nftban.sh` is byte-identical;
* packaged `cmd_firewall.sh`, `nftban.pp`, `nftban.te`, `nftban.fc`, `VERSION` and all
  six systemd units are byte-identical between the two builds;
* dependency set identical, including `Requires: /usr/bin/perl`;
* installed-path manifest identical (768 paths);
* the six Go binaries differ **only** by embedded provenance: zero Go source, `go.mod`,
  `go.sum` or `build.sh` changes; each binary embeds its own source commit; all six are
  byte-for-byte the same size with identical `.text` section sizes;
* bounded pristine EL9 Enforcing revalidation: **26/26 PASS**, including clean install
  `INSTALL_STATE=COMMITTED`, module loaded, dedicated label, service restart in the real
  service domain, both tables, and packaged N10/N13.

Local gates on the corrected head: spec-comment macro guard PASS, Policy Gates 46/46,
`bash -n` PASS, shellcheck PASS.


## Second revalidation (final)

The fourth commit removes backticks from a comment inside the **unquoted** spec heredoc,
where they were command substitution evaluated during spec generation.

A complete hazard audit of every unquoted heredoc touched by this PR was run, not just
the reported line: 3 heredocs total, 2 unquoted, both touched; **zero** expansion-sensitive
tokens remain in any PR-added line. The 11 backticks still present in that heredoc are
pre-existing (identical count in `main`, zero on PR-added lines) and correctly escaped.

Payload equivalence against the validated runtime payload: `cmd_firewall.sh`, `nftban.pp`,
`nftban.te`, `nftban.fc`, `VERSION`, all six systemd units, the dependency set and the
768-path manifest are **byte-identical**. Only the six Go binaries differ, and the
attribution is exact: zero Go source / `go.mod` / `go.sum` / `build.sh` changes, identical
build flags (`-trimpath=true`), identical sizes, and the Go buildid differs **only in the
action-ID field while the content ID is identical** — 39–40 differing bytes, all inside the
buildid note.

Bounded pristine EL9 Enforcing revalidation: **26/26 PASS**.


## Final identity

```
SOURCE_SHA       2fa1a0650345935da00f02fefb766e99724b587f
EL9_RPM_SHA256   837bbbd7e52ba4937e4b32050ecdbf6bad469d7da0dbc03af3c34bcdaee658cf
EL10_RPM_SHA256  7253670f55aa7e16441d65ced0da073f7a189e5642d129d247879f14cf7c7d23
```

All earlier candidate SHAs and RPM checksums in this PR are **superseded evidence**.

## Final SELinux authority

```
allow      iptables_t nftban_nftables_conf_t:file { getattr open read ioctl };
allowxperm iptables_t nftban_nftables_conf_t:file ioctl { 0x5401 };
allow      iptables_t nftban_conf_t:dir search;
```

| | |
|---|---|
| TCGETS `0x5401` | ALLOWED |
| any other ioctl command | DENIED (xperm whitelist) |
| `lock`, `map` | ABSENT |
| generic `nftban_conf_t` file read | ABSENT |
| parent directory | `search` only |

The base `ioctl` permission is required for the extended-permission rule to be
evaluated at all — an `allowxperm` refines an already-authorised permission and cannot
grant one. Proven on a real EL10 Enforcing host: with the xperm loaded but `ioctl`
absent from the ordinary allow, nft was still denied `ioctlcmd=0x5401` 160 seconds
after the module was installed.

`OTHER_IOCTL_COMMANDS_DENIED` is **policy-level proven**. The runtime negative test is
**not executable**: `iptables_t` correctly cannot execute an interpreter, so no
process could be placed in that domain to issue a non-TCGETS ioctl. No less-confined
test process was manufactured to force an empirical denial.

## EL10 runtime evidence — AlmaLinux 10.1, SELinux Enforcing

Non-production host, Enforcing from a clean autorelabel, package-native throughout.
No manual `semodule -i`, `chcon`, corrective `restorecon`, or root `nft -f` was used
for any acceptance.

* clean install `dnf rc=0`, `INSTALL_STATE=COMMITTED`, 0 failed units
* SELinux module package-installed and loaded
* `/etc/nftban/nftables.conf` → `nftban_nftables_conf_t`; sibling `nftban.conf` stays `nftban_conf_t`
* `nftables.service` start and restart succeed in the real service domain
* rebuild, `restorecon -RFv` and reboot all preserve the dedicated label
* perl absent pre-install and auto-installed by the declared dependency
* missing-Perl: causal diagnostic, obsolete remediation absent, firewall preserved
* IPv4 and IPv6 tables present throughout
* **zero new `iptables_t` → `nftban_nftables_conf_t` AVCs** across start, restart,
  rebuild, restorecon and reboot (count 20 → 20)

## EL9 runtime evidence — Rocky Linux, SELinux Enforcing

* package-native clean install, `INSTALL_STATE=COMMITTED`, module loaded
* dedicated label correct, private sibling label retained
* start / restart / rebuild pass; IPv4 and IPv6 tables present
* AVC delta 0; 0 failed units

## Carry-forward basis for this head

The final commit is a comment-only correction. Verified against the previously
validated build: `nftban.pp`, `nftban.fc`, `cmd_firewall.sh`, `VERSION`, all six
systemd units and the RPM dependency set are **byte-identical** on both EL9 and EL10.
Only the shipped `nftban.te` source (which contains the corrected comment) and the six
Go binaries (embedded provenance; zero Go source/`go.mod`/`go.sum`/`build.sh` changes)
differ. Identical compiled `.pp` on both platforms is the decisive evidence: SELinux
strips comments at compile time.
