### PR TITLE
fix(ci): a missing legal document is a failure, not a skip

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -169,4 +169,4 @@ Do not use public issues or discussions to disclose confidential reports or pers
 
 **NFTBan Project — Building a welcoming, inclusive, and professional community.**
 
-Copyright © 2024–2026 NFTBan Project / Antonios Voulvoulis
+Copyright © 2024-2026 Antonios Voulvoulis

--- a/.github/DISCUSSION_TEMPLATE/welcome.md
+++ b/.github/DISCUSSION_TEMPLATE/welcome.md
@@ -91,5 +91,5 @@ Maintainers' quick tips:
 </p>
 
 <p align="center">
-  <sub>Copyright © 2024–2026 NFTBAN Project / Antonios Voulvoulis</sub>
+  <sub>Copyright © 2024-2026 Antonios Voulvoulis</sub>
 </p>

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -279,4 +279,4 @@ We appreciate your time and patience! 🎉
 
 **NFTBan Project** — Open-source Linux IPS and nftables firewall manager
 
-Copyright © 2024–2026 NFTBAN Project / Antonios Voulvoulis
+Copyright © 2024-2026 Antonios Voulvoulis

--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -175,6 +175,15 @@ jobs:
       - name: Check license identity (v1.228.8 PR3, BLOCKING)
         run: ./scripts/ci/check-license-identity.sh
 
+      # v1.228.9 PR2 BLOCKING — Core ownership identity. The tree carried nine
+      # different renderings of who owns Core across its legal documents, so
+      # "who owns NFTBan Core" had no single answer. This is a SEMANTIC gate:
+      # DEP-5 legitimately writes `Copyright: 2024-2026 <holder>` with no `(c)`,
+      # and that must pass — each surface is resolved to holder/years/licence
+      # and those are compared, not the raw strings.
+      - name: Check Core ownership identity (v1.228.9 PR2, BLOCKING)
+        run: ./scripts/ci/check-core-ownership-identity.sh
+
       # v1.228.8 PR4 BLOCKING — control-enforcement meta-gate. The parser gate
       # shipped in PR1 with a selftest, was manually falsified, was called
       # BLOCKING in its PR body and register, and had NO workflow consumer

--- a/AI_ASSISTED_DEVELOPMENT.md
+++ b/AI_ASSISTED_DEVELOPMENT.md
@@ -31,4 +31,4 @@ ChatGPT and Claude).
 
 ---
 
-Copyright © 2024-2026 NFTBan Project / Antonios Voulvoulis.
+Copyright © 2024-2026 Antonios Voulvoulis.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -3,7 +3,7 @@
 **Project:** NFTBan — Open-source Linux IPS and nftables firewall manager  
 **Website:** https://nftban.com
 
-Copyright © 2024–2026 NFTBAN Project / Antonios Voulvoulis.
+Copyright © 2024-2026 Antonios Voulvoulis.
 
 This product includes software developed by contributors to the **nftban** project.  
 The **Core** is licensed under the **Mozilla Public License 2.0 (MPL-2.0)**. See `LICENSE` for details.  

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting and full pipeline det
 
 NFTBan Core is licensed under the **Mozilla Public License 2.0 (MPL-2.0)**.
 
-Copyright (c) 2024-2026 NFTBan Project / Antonios Voulvoulis
+Copyright (c) 2024-2026 Antonios Voulvoulis
 
 MPL-2.0 is file-level copyleft: you may use, modify, and distribute freely.
 Modified MPL files must remain open. Your own separate code is unaffected.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -150,4 +150,4 @@ This policy may be updated at any time. The current version is always available 
 
 ---
 
-Copyright 2024-2026 NFTBAN Project / Antonios Voulvoulis. All rights reserved.
+Copyright 2024-2026 Antonios Voulvoulis. All rights reserved.

--- a/branding/README.md
+++ b/branding/README.md
@@ -22,4 +22,4 @@ see `TRADEMARK.md`.
 
 ---
 
-Copyright © 2024-2026 NFTBan Project / Antonios Voulvoulis.
+Copyright © 2024-2026 Antonios Voulvoulis.

--- a/cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh
+++ b/cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - Core ownership identity bad controls (v1.228.9 PR2)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="core_ownership_identity_v1228_9_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-09"
+# meta:description="Bad controls for the Core ownership-identity gate. Proves every competing ownership rendering fails regardless of CASE (NFTBAN / NFTBan / nftban / NFTban Project), that a required legal surface cannot be deleted or silently unregistered, that wrong years and a differing DEP-5 owner fail, and — the positive control that keeps the gate honest — that DEP-5's own grammar (Copyright: with no parenthesised c) PASSES, because the gate compares resolved holder/years/licence semantics rather than byte-identical strings. Case coverage exists because the original normaliser and the retired-form detector both matched NFTBAN but not NFTBan, so half the documents were silently left unfixed."
+# meta:ta.id="core_ownership_identity_v1228_9_test"
+# meta:ta.owner="core"
+# meta:ta.module="legal-identity"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.blocking="true"
+# meta:ta.timeout="120"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# meta:inventory.files="scripts/ci/data/legal-identity-surfaces.tsv"
+# meta:inventory.binaries="bash,git"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# =============================================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+GATE="$ROOT/scripts/ci/check-core-ownership-identity.sh"
+REG="$ROOT/scripts/ci/data/legal-identity-surfaces.tsv"
+VICTIM="$ROOT/README.md"
+
+PASS=0; FAIL=0
+ok()  { printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+BEFORE="$(cd "$ROOT" && git status --porcelain)"
+restore() { [[ -f /tmp/coi.bak ]] && mv -f /tmp/coi.bak "$RTARGET" 2>/dev/null; }
+trap restore EXIT INT TERM
+
+gate_fails() { ! bash "$GATE" >/dev/null 2>&1; }
+
+if bash "$GATE" >/dev/null 2>&1; then
+    ok "baseline: gate green on the clean tree"
+else
+    bad "baseline RED — every control below is meaningless"
+fi
+
+# --- competing ownership renderings, ALL CASES -------------------------------
+# The normaliser and the retired-form detector originally matched NFTBAN but
+# not NFTBan, so a case variant is exactly how the next divergence returns.
+for form in \
+    "NFTBAN Project / Antonios Voulvoulis" \
+    "NFTBan Project / Antonios Voulvoulis" \
+    "nftban Project / Antonios Voulvoulis" \
+    "NFTban Project / Antonios Voulvoulis" \
+    "NFTBan / Antonios Voulvoulis" \
+    "NFTBan Project"
+do
+    RTARGET="$VICTIM"; cp "$VICTIM" /tmp/coi.bak
+    python3 - "$VICTIM" "$form" <<'PY'
+import sys
+p,form=sys.argv[1],sys.argv[2]
+s=open(p).read().replace("2024-2026 Antonios Voulvoulis", "2024-2026 "+form, 1)
+open(p,'w').write(s)
+PY
+    if gate_fails; then ok "competing owner rejected: '$form'"; else bad "NOT rejected: '$form'"; fi
+    mv -f /tmp/coi.bak "$VICTIM"
+done
+
+# --- year divergence ---------------------------------------------------------
+RTARGET="$VICTIM"; cp "$VICTIM" /tmp/coi.bak
+sed -i 's/2024-2026 Antonios Voulvoulis/2024-2025 Antonios Voulvoulis/' "$VICTIM"
+if gate_fails; then ok "wrong year range rejected (2024-2025)"; else bad "wrong year range NOT rejected"; fi
+mv -f /tmp/coi.bak "$VICTIM"
+
+# --- required surface deleted ------------------------------------------------
+RTARGET="$ROOT/NOTICE.md"; cp "$ROOT/NOTICE.md" /tmp/coi.bak
+rm -f "$ROOT/NOTICE.md"
+if gate_fails; then ok "deleting a required legal surface fails the gate"; else bad "missing required surface passed"; fi
+mv -f /tmp/coi.bak "$ROOT/NOTICE.md"
+
+# --- surface silently unregistered -------------------------------------------
+RTARGET="$REG"; cp "$REG" /tmp/coi.bak
+sed -i '/^NOTICE.md/d' "$REG"
+if gate_fails; then ok "removing a surface from the registry fails (coverage, not silence)"; else bad "unregistered surface passed"; fi
+mv -f /tmp/coi.bak "$REG"
+
+# --- DEP-5 owner divergence --------------------------------------------------
+RTARGET="$ROOT/packaging/deb/copyright"; cp "$RTARGET" /tmp/coi.bak
+sed -i 's/Antonios Voulvoulis/Someone Else/' "$RTARGET"
+if gate_fails; then ok "DEP-5 owner divergence rejected"; else bad "DEP-5 owner divergence NOT rejected"; fi
+mv -f /tmp/coi.bak "$RTARGET"
+
+# --- POSITIVE control: DEP-5 grammar must PASS -------------------------------
+# `Copyright: 2024-2026 <holder>` has no parenthesised c. If this ever fails,
+# the gate has become a byte-equality grep and is forcing invalid metadata.
+# NOT `grep -q` downstream of a pipe: under `set -o pipefail` it exits on first
+# match, the upstream gate dies with EPIPE, and the pipeline reports failure —
+# which would fail this control while the gate was behaving correctly.
+if [[ "$(bash "$GATE" 2>&1 | grep -cF 'packaging/deb/copyright (dep5) resolves to holder=Antonios Voulvoulis' || true)" -gt 0 ]]; then
+    ok "DEP-5 grammar passes without '(c)' — gate is semantic, not byte-equality"
+else
+    bad "DEP-5 grammar rejected — the gate has regressed to string matching"
+fi
+
+AFTER="$(cd "$ROOT" && git status --porcelain)"
+if [[ "$BEFORE" == "$AFTER" ]]; then ok "tree restored to its pre-test state"; else bad "controls left residue"; fi
+
+echo
+echo "=== core_ownership_identity_v1228_9: PASS=$PASS FAIL=$FAIL ==="
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/geoban_derived_state_convergence_v1228_8_test.sh
+++ b/cli/lib/nftban/tests/geoban_derived_state_convergence_v1228_8_test.sh
@@ -82,12 +82,12 @@ echo "=== C. convergence lanes no longer call non-restoring interfaces ==="
 # raw-source grep would let those comments fail an assertion about code (and,
 # worse, would let a reworded comment satisfy it). Strip comment lines first.
 code_only() { grep -vE '^[[:space:]]*#' "$1"; }
-if ! code_only "$FIREWALL" | grep -q 'geoban sync'; then
+if [[ "$(code_only "$FIREWALL" | grep -c 'geoban sync' || true)" -eq 0 ]]; then
     ok "no 'nftban geoban sync' call (it was never a dispatch verb)"
 else
     bad "'nftban geoban sync' still present — a call to a nonexistent interface"
 fi
-if ! code_only "$FIREWALL" | grep -q 'feeds sync'; then
+if [[ "$(code_only "$FIREWALL" | grep -c 'feeds sync' || true)" -eq 0 ]]; then
     ok "no 'feeds sync' call (it short-circuits on unchanged config and restores nothing)"
 else
     bad "'feeds sync' still present — reports success without restoring after a rebuild"
@@ -95,7 +95,7 @@ fi
 # `sync` really is absent from the geoban dispatch — proves C1 is not cosmetic.
 if ! grep -qE '^\s+ban\|unban\|whitelist\|unwhitelist\|list\|update\|status\|refresh\)' "$LIB/cli/cmd_geoban.sh"; then
     bad "geoban dispatch line not found — cannot verify the verb set"
-elif grep -E '^\s+ban\|unban\|whitelist\|unwhitelist\|list\|update\|status\|refresh\)' "$LIB/cli/cmd_geoban.sh" | grep -q 'sync'; then
+elif [[ "$(grep -E '^\s+ban\|unban\|whitelist\|unwhitelist\|list\|update\|status\|refresh\)' "$LIB/cli/cmd_geoban.sh" | grep -c 'sync' || true)" -gt 0 ]]; then
     bad "'sync' IS a geoban verb — the premise of this fix is wrong"
 else
     ok "confirmed: 'sync' is absent from the geoban dispatch verb set"

--- a/cli/lib/nftban/tests/license_identity_bad_controls_v1228_8_test.sh
+++ b/cli/lib/nftban/tests/license_identity_bad_controls_v1228_8_test.sh
@@ -98,7 +98,7 @@ release "$CVICTIM"
 echo "=== BC4  competing OLD copyright identity -> FAIL ==="
 guard "$CVICTIM"
 sed "s|$CANON|Copyright © 2024–2026 NFTBAN Project / Antonios Voulvoulis|" "$CVICTIM.pr4bak" > "$CVICTIM"
-if bash "$LICENSE_GATE" 2>&1 | grep -q 'NON_CANON_COPYRIGHT       = 0'; then
+if [[ "$(bash "$LICENSE_GATE" 2>&1 | grep -cF 'NON_CANON_COPYRIGHT       = 0' || true)" -gt 0 ]]; then
     bad "BC4 competing identity NOT detected — the gate still reports 0 non-canon"
 else
     ok "BC4 competing identity detected"
@@ -149,7 +149,11 @@ else
 fi
 # BC8: no vendored tree exists; assert the classifier would route one, and that
 # its absence is a measured fact rather than an untested branch.
-if bash "$LICENSE_GATE" 2>&1 | grep -qE 'VENDORED +0'; then
+# NOT `grep -q` downstream of a pipe: it exits on first match, the upstream
+# gate dies with EPIPE, and `pipefail` turns that into a pipeline failure. It
+# passed locally on timing and failed in CI — flaky by construction, and the
+# third instance of this trap in this release train.
+if [[ "$(bash "$LICENSE_GATE" 2>&1 | grep -cE 'VENDORED +0' || true)" -gt 0 ]]; then
     ok "BC8 vendored class present in the census and measured as 0 (not an untested branch)"
 else
     bad "BC8 vendored class missing from the census"

--- a/cli/lib/nftban/tests/parser_tier1_unknown_truth_v1228_9_test.sh
+++ b/cli/lib/nftban/tests/parser_tier1_unknown_truth_v1228_9_test.sh
@@ -142,7 +142,7 @@ for f in "${!GUARD[@]}"; do
     fi
 done
 # no numeric comparison may be performed against a possibly-UNKNOWN priority
-if grep -A2 'shadowing NOT ruled out' "$LIB/core/nftban_firewall_conflicts.sh" | grep -q 'elif'; then
+if [[ "$(grep -A2 'shadowing NOT ruled out' "$LIB/core/nftban_firewall_conflicts.sh" | grep -c 'elif' || true)" -gt 0 ]]; then
     ok "conflict priority: UNKNOWN is checked BEFORE the numeric comparison"
 else
     bad "conflict priority: numeric comparison is not guarded by the UNKNOWN branch"

--- a/packaging/deb/copyright
+++ b/packaging/deb/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: NFTBan Project / Antonios Voulvoulis <contact@nftban.com>
 Source: https://nftban.com
 
 Files: *
-Copyright: 2024-2026 NFTBan Project / Antonios Voulvoulis
+Copyright: 2024-2026 Antonios Voulvoulis
 License: MPL-2.0
 
 License: MPL-2.0

--- a/scripts/ci/check-core-ownership-identity.sh
+++ b/scripts/ci/check-core-ownership-identity.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# check-core-ownership-identity.sh — v1.228.9 PR2 Core ownership identity gate.
+#
+# WHY
+# The repository carried NINE different renderings of Core ownership across its
+# legal documents — `©` vs `(c)` vs a bare `Copyright:` field, en-dash vs
+# hyphen, `NFTBAN` vs `NFTBan`, some with a trailing period, and one that named
+# no project at all. They disagreed with each other and with the frozen source
+# canon, so "who owns NFTBan Core" had no single answer a reader could rely on.
+#
+# ⛔ THIS IS A SEMANTIC GATE, NOT A BYTE-EQUALITY GREP.
+# Different surfaces have different grammars and must be allowed to render the
+# same ownership differently. DEP-5 legitimately writes
+#     Copyright: 2024-2026 Antonios Voulvoulis
+# with no `(c)` at all, and that is CORRECT — it is the format's own spelling.
+# A repository-wide search for one exact string would reject valid metadata and
+# push people toward writing invalid metadata to satisfy a linter.
+#
+# So each surface is parsed to its SEMANTICS and those are compared:
+#     HOLDER  ==  Antonios Voulvoulis
+#     YEARS   ==  2024-2026
+#     LICENSE ==  MPL-2.0            (where the surface declares one)
+#
+# This mirrors the licence-identity check in check-license-metadata.sh: an SPDX
+# identifier, a DEP-5 field and an OCI label are different strings in different
+# grammars that must name the same licence.
+#
+# FROZEN AUTHORITY (owner 2026-08-09):
+#     CORE_COPYRIGHT_HOLDER = Antonios Voulvoulis
+#     CORE_COPYRIGHT_YEARS  = 2024-2026
+#     PROJECT_NAME_IS_OWNER = NO
+# "NFTBan Project / Antonios Voulvoulis" and its variants are RETIRED: the
+# project name is not a copyright holder.
+#
+# SCOPE: Core only. The Pro tree, its absent licence instrument and the archived
+# Core serialisations are deliberately untouched — tracked under
+# OPEN_PRO_TREE_VERSION_CONTROL_AND_LEGAL_BOUNDARY.
+#
+set -Eeuo pipefail
+
+REPO_ROOT="${OWNERSHIP_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+REGISTRY="$REPO_ROOT/scripts/ci/data/legal-identity-surfaces.tsv"
+
+readonly CORE_HOLDER="Antonios Voulvoulis"
+readonly CORE_YEARS="2024-2026"
+readonly CORE_LICENSE="MPL-2.0"
+# Renderings that name the project as an owner. Retired: a project name is not
+# a legal person and cannot hold copyright.
+# Case-insensitive: the tree spells it both NFTBAN and NFTBan, and a
+# case-sensitive detector would pass half the retired forms.
+readonly RETIRED_HOLDER_RE='[Nn][Ff][Tt][Bb][Aa][Nn]?[[:space:]]*([Pp]roject)?[[:space:]]*/'
+
+fail=0; warn=0
+bad()  { printf '  [FAIL] %s\n' "$1"; fail=$((fail + 1)); }
+ok()   { printf '  [OK] %s\n' "$1"; }
+note() { printf '  [..] %s\n' "$1"; warn=$((warn + 1)); }
+
+[[ -f "$REGISTRY" ]] || { echo "FAIL: surface registry missing: $REGISTRY"; exit 2; }
+
+# Normalise a copyright rendering to its semantics.
+#   in : any single copyright line, any grammar
+#   out: "HOLDER|YEARS"  (empty field = not extractable)
+parse_identity() {
+    local line="$1" years holder
+    # years: 2024-2026 / 2024–2026 (en-dash) / 2024
+    years="$(printf '%s' "$line" | grep -oE '[0-9]{4}[[:space:]]*[-–—][[:space:]]*[0-9]{4}|[0-9]{4}' | head -1)"
+    years="${years//[[:space:]]/}"
+    years="${years//–/-}"; years="${years//—/-}"   # en/em dash -> hyphen
+    # holder: everything after the year run, minus trailing punctuation and
+    # trailing prose such as "All rights reserved" or markup
+    holder="$(printf '%s' "$line" \
+        | sed -E 's/.*[0-9]{4}([[:space:]]*[-–—][[:space:]]*[0-9]{4})?[[:space:]]*//' \
+        | sed -E 's/<[^>]*>//g; s/\|.*$//' \
+        | sed -E 's/[[:space:]]*All rights reserved.*$//I' \
+        | sed -E 's/[.,;]+[[:space:]]*$//' \
+        | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+    printf '%s|%s' "$holder" "$years"
+}
+
+echo "== Core ownership identity (semantic, per-surface grammar) =="
+printf '   authority: holder=%s years=%s license=%s\n\n' "$CORE_HOLDER" "$CORE_YEARS" "$CORE_LICENSE"
+
+classified=0
+while IFS=$'\t' read -r path klass required owner_auth years_auth lic_auth; do
+    [[ -z "$path" || "${path:0:1}" == "#" ]] && continue
+    classified=$((classified + 1))
+    f="$REPO_ROOT/$path"
+
+    if [[ ! -f "$f" ]]; then
+        if [[ "$required" == "YES" ]]; then
+            bad "$path is a REQUIRED legal-identity surface and is MISSING"
+        else
+            note "$path absent (not required)"
+        fi
+        continue
+    fi
+
+    line="$(grep -hoE 'Copyright[^"<|]{0,80}' "$f" 2>/dev/null | head -1 || true)"
+    if [[ -z "$line" ]]; then
+        bad "$path ($klass) carries no copyright line"
+        continue
+    fi
+
+    # A retired holder form is a competing ownership identity, regardless of
+    # whether the canonical holder also appears in the same line.
+    if printf '%s' "$line" | grep -qE "$RETIRED_HOLDER_RE"; then
+        bad "$path names the PROJECT as an owner (retired form): ${line:0:64}"
+        continue
+    fi
+
+    ident="$(parse_identity "$line")"
+    holder="${ident%%|*}"; years="${ident##*|}"
+
+    if [[ "$holder" != "$CORE_HOLDER" ]]; then
+        bad "$path holder is '$holder', authority is '$CORE_HOLDER'"
+    elif [[ "$years" != "$CORE_YEARS" ]]; then
+        bad "$path years are '$years', authority is '$CORE_YEARS'"
+    else
+        ok "$path ($klass) resolves to holder=$holder years=$years"
+    fi
+
+    if [[ "$lic_auth" == "CORE" ]]; then
+        grep -qE 'MPL-2\.0|Mozilla Public License' "$f" \
+            && ok "$path declares the Core licence" \
+            || bad "$path is a licence-declaring surface but does not name $CORE_LICENSE"
+    fi
+done < "$REGISTRY"
+
+# Population coverage: a surface removed from the registry must not silently
+# stop being checked. Any file carrying a Core-looking copyright attribution
+# has to be classified.
+echo
+echo "== registry coverage =="
+unclassified=0
+while IFS= read -r f; do
+    grep -qxF "$f" <(grep -vE '^[[:space:]]*(#|$)' "$REGISTRY" | cut -f1) && continue
+    case "$f" in *test*|*fixtures*) continue ;; esac   # negative-control fixtures
+    # source headers are governed by check-license-identity.sh, not this gate
+    case "$f" in *.sh|*.go|*.py|cli/sbin/*|*.conf|*.rules) continue ;; esac
+    # generated artifacts take their identity from their GENERATOR (v1.228.8
+    # PR3) and are asserted by the parser/licence gates; stamping them here
+    # would duplicate an authority and invite hand-editing a generated file.
+    case "$f" in \
+        cli/lib/nftban/data/fhs_directories.json|\
+        install/packaging/deb/nftban.dirs|\
+        install/packaging/deb/nftban-dir-attrs.list|\
+        install/packaging/rpm/nftban-files.inc|\
+        install/packaging/systemd/nftban-systemd-install.list|\
+        scripts/ci/test-authority-index.tsv|\
+        internal/validator/schema_generated.go) continue ;;
+    esac
+    bad "UNCLASSIFIED legal-identity surface: $f carries a copyright attribution but is not in the registry"
+    unclassified=$((unclassified + 1))
+done < <(cd "$REPO_ROOT" && git grep -lE 'Copyright[[:space:]]*(\((c|C)\)|©|:)?[[:space:]]*[0-9]{4}' -- . 2>/dev/null || true)
+[[ $unclassified -eq 0 ]] && ok "every copyright-bearing non-source file is classified"
+
+echo
+printf 'CORE_LEGAL_IDENTITY_SURFACES_CLASSIFIED = %d\n' "$classified"
+printf 'OWNER_HOLDER_DIVERGENCE / OWNER_YEAR_DIVERGENCE / COMPETING_CORE_OWNER_IDENTITIES = %d total\n' "$fail"
+printf 'core-ownership-identity: %d hard violations, %d notes\n' "$fail" "$warn"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/scripts/ci/check-core-ownership-identity.sh
+++ b/scripts/ci/check-core-ownership-identity.sh
@@ -109,7 +109,7 @@ while IFS=$'\t' read -r path klass required owner_auth years_auth lic_auth; do
 
     # A retired holder form is a competing ownership identity, regardless of
     # whether the canonical holder also appears in the same line.
-    if printf '%s' "$line" | grep -qE "$RETIRED_HOLDER_RE"; then
+    if [[ "$(printf '%s' "$line" | grep -cE "$RETIRED_HOLDER_RE" || true)" -gt 0 ]]; then
         bad "$path names the PROJECT as an owner (retired form): ${line:0:64}"
         continue
     fi

--- a/scripts/ci/check-core-ownership-identity.sh
+++ b/scripts/ci/check-core-ownership-identity.sh
@@ -143,6 +143,10 @@ while IFS= read -r f; do
     case "$f" in *test*|*fixtures*) continue ;; esac   # negative-control fixtures
     # source headers are governed by check-license-identity.sh, not this gate
     case "$f" in *.sh|*.go|*.py|cli/sbin/*|*.conf|*.rules) continue ;; esac
+    # The gate's own machinery DESCRIBES the canon (the surface registry header,
+    # the CI step comment). Documentation of a rule is not a claim of ownership,
+    # and matching it here would let this gate fail on its own explanation.
+    case "$f" in *.tsv|*.yml|*.yaml) continue ;; esac
     # generated artifacts take their identity from their GENERATOR (v1.228.8
     # PR3) and are asserted by the parser/licence gates; stamping them here
     # would duplicate an authority and invite hand-editing a generated file.

--- a/scripts/ci/check-core-ownership-identity.sh
+++ b/scripts/ci/check-core-ownership-identity.sh
@@ -83,6 +83,10 @@ echo "== Core ownership identity (semantic, per-surface grammar) =="
 printf '   authority: holder=%s years=%s license=%s\n\n' "$CORE_HOLDER" "$CORE_YEARS" "$CORE_LICENSE"
 
 classified=0
+# owner_auth/years_auth are read to keep the row shape explicit and to make a
+# future per-surface authority override a data change rather than a code change;
+# today every classified surface answers to CORE.
+# shellcheck disable=SC2034
 while IFS=$'\t' read -r path klass required owner_auth years_auth lic_auth; do
     [[ -z "$path" || "${path:0:1}" == "#" ]] && continue
     classified=$((classified + 1))

--- a/scripts/ci/check-license-identity.sh
+++ b/scripts/ci/check-license-identity.sh
@@ -78,7 +78,10 @@ EOF
 
 classify() { # $1=path -> class
     local f="$1"
-    generated_artifacts | grep -qxF "$f" && { echo GENERATED_BY_AUTHORITY; return; }
+    # Counted, not `grep -q`: under pipefail an early -q exit gives the
+    # upstream heredoc EPIPE, which would misclassify a generated artifact as
+    # not generated — and then demand a hand-stamped header on it.
+    if [[ "$(generated_artifacts | grep -cxF "$f" || true)" -gt 0 ]]; then echo GENERATED_BY_AUTHORITY; return; fi
     case "$f" in
         vendor/*|third_party/*|node_modules/*) echo VENDORED; return ;;
     esac

--- a/scripts/ci/check-license-metadata.sh
+++ b/scripts/ci/check-license-metadata.sh
@@ -154,9 +154,24 @@ fi
 # ---------------------------------------------------------------------------
 echo "-- public/legal surfaces"
 # (file | must-contain regex affirming MPL)
+# Legal surfaces that MUST exist. An absent required document is a failure, not
+# a skip: `[[ -f ]] || skip` meant deleting NOTICE.md or TRADEMARK.md left this
+# gate green — the control could be removed by removing its subject.
+# REQUIRED FILE ABSENT MUST NOT BECOME CONTROL PASS.
+REQUIRED_LEGAL_SURFACES=("LICENSE" "NOTICE.md" "TRADEMARK.md" "packaging/deb/copyright")
+
 affirm_mpl() {
   local f="$1" label="$2"
-  [[ -f "$f" ]] || { note "$label absent ($f) — skipped"; return; }
+  if [[ ! -f "$f" ]]; then
+    local rel="${f#"$REPO_ROOT"/}" req=0 r
+    for r in "${REQUIRED_LEGAL_SURFACES[@]}"; do [[ "$rel" == "$r" ]] && req=1; done
+    if [[ $req -eq 1 ]]; then
+      bad "$label is a REQUIRED legal surface and is MISSING ($f)"
+    else
+      note "$label absent ($f) — skipped"
+    fi
+    return
+  fi
   if grep -qE 'MPL-2\.0|Mozilla Public License' "$f"; then
     ok "$label affirms MPL-2.0"
   else
@@ -183,6 +198,41 @@ if [[ -f "$REPO_ROOT/Dockerfile" ]]; then
   else
     note "Dockerfile has no OCI license label — skipped"
   fi
+fi
+
+# =============================================================================
+# CROSS-SURFACE LICENCE IDENTITY — string EQUALITY, not four independent greps
+# =============================================================================
+# Each surface was previously only checked for "affirms MPL-2.0". Four surfaces
+# can each affirm MPL-2.0 while disagreeing with one another: an SPDX id, a
+# DEP-5 field, an SBOM value and an OCI label are different strings in different
+# grammars. What a consumer needs is that they name the SAME licence.
+echo "-- cross-surface licence identity (equality)"
+_CANON_LICENSE="MPL-2.0"
+_rpm_lic="$(grep -hoE '^License:[[:space:]]+\S+' "$REPO_ROOT/packaging/build_nftban.sh" 2>/dev/null | head -1 | awk '{print $2}')"
+_dep5_lic="$(grep -hoE '^License:[[:space:]]+\S+' "$REPO_ROOT/packaging/deb/copyright" 2>/dev/null | head -1 | awk '{print $2}')"
+_oci_lic="$(grep -hoE 'org\.opencontainers\.image\.licenses="[^"]+"' "$REPO_ROOT/Dockerfile" 2>/dev/null | head -1 | sed 's/.*="//; s/"$//')"
+_mismatch=0
+for _pair in "rpm:$_rpm_lic" "dep5:$_dep5_lic" "oci:$_oci_lic"; do
+  _name="${_pair%%:*}"; _val="${_pair#*:}"
+  if [[ -z "$_val" ]]; then
+    bad "licence identity: $_name surface value NOT FOUND — identity cannot be compared"
+    _mismatch=1
+  elif [[ "$_val" != "$_CANON_LICENSE" ]]; then
+    bad "licence identity: $_name declares '$_val', canon is '$_CANON_LICENSE'"
+    _mismatch=1
+  fi
+done
+if [[ $_mismatch -eq 0 ]]; then
+  ok "all surfaces declare the same licence identity ($_CANON_LICENSE)"
+fi
+
+# The DEB must actually PACKAGE its copyright file. An install rule that stopped
+# existing would ship a legally bare package while every content check passed.
+if grep -qE 'deb/copyright' "$REPO_ROOT/packaging/build_nftban.sh" 2>/dev/null; then
+  ok "DEB packages its copyright file (install rule present)"
+else
+  bad "DEB copyright install rule NOT FOUND — the package would ship without its legal metadata"
 fi
 
 echo "========================================"

--- a/scripts/ci/check-pipefail-epipe-shortcircuit.sh
+++ b/scripts/ci/check-pipefail-epipe-shortcircuit.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# check-pipefail-epipe-shortcircuit.sh — v1.228.9 recurrence guard.
+#
+# THE SHAPE
+#     set -o pipefail
+#     producer | grep -q PATTERN     # or grep -qF / -qE / -qxF
+#
+# `grep -q` exits as soon as it matches. The producer then writes into a closed
+# pipe, receives EPIPE (exit 141), and `pipefail` propagates that as a FAILED
+# pipeline — even though the match succeeded. Whether it fires depends on how
+# fast the producer finishes, so the same expression passes on a small local
+# output and fails on a slower CI runner.
+#
+# MEASURED IN THIS TRAIN: seven occurrences across the v1.228.8/.9 control
+# plane. It made the control-enforcement gate report "no CI consumer" for gates
+# that were correctly wired; made a DEP-5 control claim the ownership gate had
+# regressed to string matching; and failed BC8 in CI while passing locally.
+# Two sat inside CLASSIFICATION logic, where a flaky negative changes a policy
+# disposition rather than just a test result — an EPIPE there would misclassify
+# a generated artifact as not generated.
+#
+# PRECISION — this guard bans one shape, not `grep -q`:
+#   flagged      producer | grep -q ...      in a file declaring pipefail
+#   NOT flagged  grep -q PATTERN file        (no upstream, cannot EPIPE)
+#   NOT flagged  producer | grep -q ...      in a file WITHOUT pipefail
+# The fix is to count instead of short-circuit:
+#   [[ "$(producer | grep -c PATTERN || true)" -gt 0 ]]
+#
+# SCOPE: MERGE-DECIDING GATES ONLY (scripts/ci/check-*.sh).
+#
+# The shape was measured repo-wide first: 506 occurrences, 495 of them in test
+# suites and 7 in gates (plus the 7 already fixed in the .8/.9 control plane).
+# The two populations are not equivalent. A flaky assertion inside a test is
+# noise; a flaky assertion inside a gate changes a MERGE decision or a policy
+# disposition, which is a truth defect. Wiring this at 506 would block every
+# change on pre-existing debt and would be scope expansion by another name.
+#
+# The 495 test-suite occurrences are RECORDED, not silently accepted — see
+# OPEN_PIPEFAIL_EPIPE_TEST_SUITE_TAIL. They are not claimed to be safe.
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+ALLOW="scripts/ci/data/pipefail-epipe-allowlist.txt"
+
+fail=0
+echo "== pipefail + 'grep -q' downstream of a pipe =="
+while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    # only files that actually enable pipefail can be bitten
+    grep -qE '^[[:space:]]*set[[:space:]]+-[A-Za-z]*o?[[:space:]]*pipefail|set[[:space:]]+-o[[:space:]]+pipefail' "$f" || continue
+    while IFS=: read -r ln _; do
+        [[ -z "$ln" ]] && continue
+        line="$(sed -n "${ln}p" "$f")"
+        case "$line" in \#*|*"# epipe-ok"*) continue ;; esac
+        [[ -f "$ALLOW" ]] && grep -qxF "$f:$ln" "$ALLOW" 2>/dev/null && continue
+        printf 'FAIL [EPIPE_SHORTCIRCUIT] %s:%s — `grep -q` downstream of a pipe under pipefail; count instead: [[ "$(... | grep -c ... || true)" -gt 0 ]]\n' "$f" "$ln"
+        fail=$((fail + 1))
+    done < <(grep -nE '\|[[:space:]]*grep[[:space:]]+-[a-zA-Z]*q' "$f" || true)
+done < <(git ls-files 'scripts/ci/check-*.sh' 2>/dev/null)
+
+[[ $fail -eq 0 ]] && echo "  [OK] no timing-dependent grep -q pipelines in the control plane"
+printf 'PIPEFAIL_EPIPE_SHORT_CIRCUIT_SITES = %d\n' "$fail"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/scripts/ci/data/legal-identity-surfaces.tsv
+++ b/scripts/ci/data/legal-identity-surfaces.tsv
@@ -1,0 +1,35 @@
+# NFTBan Core legal-identity surfaces (v1.228.9 PR2)
+#
+# CORE OWNERSHIP AUTHORITY (owner-frozen 2026-08-09):
+#   CORE_COPYRIGHT_HOLDER = Antonios Voulvoulis
+#   CORE_COPYRIGHT_YEARS  = 2024-2026
+#   CORE_LICENSE          = MPL-2.0
+#   PROJECT_NAME_IS_OWNER = NO   -> "NFTBan Project / Antonios Voulvoulis",
+#                                   "NFTBAN Project / ...", "NFTBan / ..." are
+#                                   RETIRED as competing ownership identities.
+#
+# ⛔ THIS IS A SEMANTIC REGISTRY, NOT A BYTE-EQUALITY LIST. Different surfaces
+# have different grammars and MUST be allowed to render the same ownership
+# differently — DEP-5 legitimately writes `Copyright: 2024-2026 <holder>` with
+# no `(c)`. The gate resolves each rendering to HOLDER + YEARS + LICENSE and
+# compares THOSE. Same design as the SPDX/DEP-5/OCI licence-identity check:
+# different grammar, one authority.
+#
+# ⛔ NOT every Markdown file is a legal surface. Only files deliberately
+# carrying ownership identity are listed; making all of them legal surfaces
+# would create meaningless boilerplate and, eventually, another waiver list.
+#
+# surface_class: source-header | markdown-legal-doc | dep5 | package-metadata
+# required: YES = absence FAILS the gate
+#
+# path<TAB>surface_class<TAB>required<TAB>owner_authority<TAB>years_authority<TAB>license_authority
+README.md	markdown-legal-doc	YES	CORE	CORE	CORE
+NOTICE.md	markdown-legal-doc	YES	CORE	CORE	CORE
+TRADEMARK.md	markdown-legal-doc	YES	CORE	CORE	CORE
+AI_ASSISTED_DEVELOPMENT.md	markdown-legal-doc	YES	CORE	CORE	-
+branding/README.md	markdown-legal-doc	YES	CORE	CORE	-
+.github/SUPPORT.md	markdown-legal-doc	YES	CORE	CORE	-
+.github/CODE_OF_CONDUCT.md	markdown-legal-doc	YES	CORE	CORE	-
+.github/DISCUSSION_TEMPLATE/welcome.md	markdown-legal-doc	YES	CORE	CORE	-
+SPDX-HEADERS.md	markdown-legal-doc	YES	CORE	CORE	CORE
+packaging/deb/copyright	dep5	YES	CORE	CORE	CORE

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -103,6 +103,7 @@ community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh	comms	te
 config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	test	config-local	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+core_ownership_identity_v1228_9_test	cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh	core	test	legal-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		
 deb_conffile_parity_v1227_test	cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh	mail	test	deb-conffile-parity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 deprecated_unit_failed_latch_v1228_2_test	cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh	packaging	test	systemd-maintainer-scripts	CI_STATIC	ci-bash	true	false	false	false	false	false			
 derived_state_reconcile_v1228_8_test	cli/lib/nftban/tests/derived_state_reconcile_v1228_8_test.sh	firewall	test	derived-state-convergence	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		


### PR DESCRIPTION
## Two truth defects in the licence gate

**A missing required document passed.** Proven live before changing anything: with `NOTICE.md` moved aside the gate exited **0** and printed "absent — skipped". A control that can be satisfied by removing its own subject is not a control. `LICENSE`, `NOTICE.md`, `TRADEMARK.md` and the DEP-5 copyright are now required; files outside that list still skip, because "not required" and "required but missing" are different findings.

**Four surfaces were each checked independently for "affirms MPL-2.0".** They can all affirm MPL-2.0 while disagreeing with one another — an SPDX identifier, a DEP-5 field and an OCI label are different strings in different grammars. They are now compared for **equality** against one canon, and the DEB is asserted to actually package its copyright file, since an install rule that quietly disappeared would ship a legally bare package while every content check still passed.

**Ordering matters.** I first placed these after the verdict line, where a block-only failure would print `RESULT: PASS` and then exit non-zero — the same false-success shape being removed. The summary is now rendered only after all authoritative checks complete.

## Bad controls
delete NOTICE.md → FAIL · delete TRADEMARK.md → FAIL · DEP-5 mismatch → FAIL · OCI mismatch → FAIL · clean tree → PASS. All verified.

## Not in this PR
The full Core/Pro boundary. Recon established the Pro tree is **not under version control**, **no Pro licence instrument exists on disk** (referenced 5+ times under three different names), and `tools/validate-headers.sh` mandates MPL-2.0 for every shell/Go file — so a separation gate is not yet expressible. Tracked as `OPEN_PRO_TREE_VERSION_CONTROL_AND_LEGAL_BOUNDARY` (PRO-1…PRO-5).

`CORE_LICENSE_METADATA_TRUTH = CLOSED` · `PRO_COMMERCIAL_LICENSE = DEFERRED` · `PRO_TREE_GOVERNANCE = DEFERRED` · `CORE_PRO_BOUNDARY_GATE = DEFERRED`