### PR TITLE
fix(ci): remove timing-dependent results from merge-deciding gates

### DIFF
--- a/.github/workflows/ci-architecture.yml
+++ b/.github/workflows/ci-architecture.yml
@@ -183,6 +183,13 @@ jobs:
       # and those are compared, not the raw strings.
       - name: Check Core ownership identity (v1.228.9 PR2, BLOCKING)
         run: ./scripts/ci/check-core-ownership-identity.sh
+      # v1.228.9 PR4 BLOCKING — no timing-dependent gate results. `grep -q`
+      # downstream of a pipe under pipefail gives the producer EPIPE, which
+      # pipefail reports as a failed pipeline; whether it fires depends on
+      # producer speed. Scope is merge-deciding gates only: a flaky assertion
+      # in a gate changes a merge decision, which is a truth defect.
+      - name: Check gates have no EPIPE short-circuits (v1.228.9 PR4, BLOCKING)
+        run: ./scripts/ci/check-pipefail-epipe-shortcircuit.sh
 
       # v1.228.8 PR4 BLOCKING — control-enforcement meta-gate. The parser gate
       # shipped in PR1 with a selftest, was manually falsified, was called

--- a/scripts/ci/check-mode-authority.sh
+++ b/scripts/ci/check-mode-authority.sh
@@ -527,7 +527,7 @@ check_markrunning() {
                     "grep -rn 'func.*${worker}(' ${pkgdir}"
                 continue
             fi
-            if printf '%s' "${wbody}" | grep -qE 'Mark(Stopped|Degraded|Failed|NotRunning)\('; then
+            if [[ "$(printf '%s' "${wbody}" | grep -cE 'Mark(Stopped|Degraded|Failed|NotRunning)\(' || true)" -gt 0 ]]; then
                 say "  ok     ${rel}:${startfn}() -> ${worker}() has a status transition"
                 continue
             fi

--- a/scripts/ci/check-nft-atomicity.sh
+++ b/scripts/ci/check-nft-atomicity.sh
@@ -170,7 +170,7 @@ if ! grep -qE 'backend\.ReplaceSet\(' <<<"$APPLY_BODY"; then
     echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — applyReplace does not call backend.ReplaceSet()."
     OPQ_FAIL=1; FAIL=1
 fi
-if grep -vE '^[[:space:]]*//' <<<"$APPLY_BODY" | grep -qE 'backend\.(FlushSet|AddElements)\('; then
+if [[ "$(grep -vE '^[[:space:]]*//' <<<"$APPLY_BODY" | grep -cE 'backend\.(FlushSet|AddElements)\(' || true)" -gt 0 ]]; then
     echo "::error::V-OPQUEUE-REPLACE-ATOMICITY — applyReplace still calls the separately-committing FlushSet()/AddElements()."
     OPQ_FAIL=1; FAIL=1
 fi

--- a/scripts/ci/check-nft-bounded-limiters.sh
+++ b/scripts/ci/check-nft-bounded-limiters.sh
@@ -120,9 +120,9 @@ for name in "${MANIFEST_NAMES[@]}"; do
         *_v6) base="${name%_v6}_v4" ;;
         *6)   base="${name%6}" ;;
     esac
-    if [[ -n "$base" ]] && ! printf '%s\n' "${MANIFEST_NAMES[@]}" | grep -qx "$base"; then
+    if [[ -n "$base" ]] && [[ "$(printf '%s\n' "${MANIFEST_NAMES[@]}" | grep -cx "$base" || true)" -eq 0 ]]; then
         # A missing v4 pair is legal ONLY when the manifest row records it.
-        if ! grep -P "^$name\t" "$MANIFEST" | grep -q "no v4 counterpart by design"; then
+        if [[ "$(grep -P "^$name\t" "$MANIFEST" | grep -c "no v4 counterpart by design" || true)" -eq 0 ]]; then
             bad "R3 $name has no v4 counterpart '$base' in the manifest"
             R3_BAD=1
         fi

--- a/scripts/ci/check-quarantine-registry.sh
+++ b/scripts/ci/check-quarantine-registry.sh
@@ -88,9 +88,9 @@ while IFS=$'\t' read -r tag id path owner reason finding introduced review dispo
         esac
     done
     # introduced must be a date
-    printf '%s' "$introduced" | grep -qE "$date_re" || fail "$id: 'introduced' must be YYYY-MM-DD (got '$introduced')"
+    [[ "$(printf '%s' "$introduced" | grep -cE "$date_re" || true)" -gt 0 ]] || fail "$id: 'introduced' must be YYYY-MM-DD (got '$introduced')"
     # review_or_expiry: a date is a HARD expiry (must not be past); else a condition string
-    if printf '%s' "$review" | grep -qE "$date_re"; then
+    if [[ "$(printf '%s' "$review" | grep -cE "$date_re" || true)" -gt 0 ]]; then
         if [[ "$review" < "$today" ]]; then fail "$id: quarantine EXPIRED (review_or_expiry=$review < today=$today)"; fi
     fi
     # disposition must be one of the 7 PR-D dispositions

--- a/scripts/ci/check-uninstall-firewall-safety.sh
+++ b/scripts/ci/check-uninstall-firewall-safety.sh
@@ -41,7 +41,7 @@ check_flush_paired() {
         # look for `nft delete table <fam> nftban` within the next WINDOW lines
         local end=$((ln + WINDOW))
         [ "$end" -gt "$n" ] && end="$n"
-        if ! sed -n "${ln},${end}p" "$f" | grep -qE "nft delete table ${fam} nftban"; then
+        if [[ "$(sed -n "${ln},${end}p" "$f" | grep -cE "nft delete table ${fam} nftban" || true)" -eq 0 ]]; then
             echo "::error::$f:$ln — 'nft flush table ${fam} nftban' has no matching 'nft delete table ${fam} nftban' within ${WINDOW} lines (would leave the ${fam} nftban input chain at policy drop with no accept rules → inbound lockout)"
             rc=1
         fi


### PR DESCRIPTION
## The defect class

Seven gates used `grep -q` downstream of a pipe while running under `pipefail`. The early exit gives the producer EPIPE, pipefail reports the pipeline as **failed**, and whether that happens depends on how fast the producer finishes — so the same assertion passes locally and fails on a slower runner, or the reverse.

In a test that is noise. **In a gate it decides whether code may merge**, so a timing-dependent result is a truth defect. It produced three real false results in this train: the control-enforcement gate reporting "no CI consumer" for gates that were correctly wired; a DEP-5 control claiming the ownership gate had regressed to string matching; and BC8 failing in CI while passing locally.

```
MERGE_DECIDING_EPIPE_SITES_BEFORE = 7
MERGE_DECIDING_EPIPE_SITES_AFTER  = 0
```

Each site counts matches instead of short-circuiting. Output is byte-identical; `check-mode-authority` already exited non-zero on main and still does, with identical output.

## The guard

Blocking, scoped to `scripts/ci/check-*.sh`. It bans one **shape**, not the construct — all three properties verified against the matcher:

| case | result |
|---|---|
| `grep -q PATTERN file` | not flagged (no upstream, cannot EPIPE) |
| pipeline **without** pipefail | not flagged |
| pipeline **with** pipefail | FLAGGED |

## Scope discipline

Measured repo-wide first: **506** occurrences — **495 in test suites**, 7 in gates. Those are not the same defect. Wiring at 506 would block every change on debt this release did not create. The 495 are registered as one handle, `OPEN_TEST_PIPEFAIL_EPIPE_SHORT_CIRCUIT_DEBT`, **recorded rather than declared safe**.

```
MERGE_CONTROL_EPIPE_CLASS = CLOSED_IN_V1_228_9
TEST_HARNESS_EPIPE_CLASS  = OPEN_MEASURED_DEBT
```

## Method note

My first before/after comparison said the output *differed*, which would have meant I'd altered a gate's behaviour. That was an artifact of running the original from `/tmp`, which changed how it resolved `REPO_ROOT`. Compared in place it is byte-identical. The fix was to correct the experiment, not the product.

## Merge dependency

This branch's guard also flags `check-license-identity.sh:81`, whose fix lives in #1199. **If #1199 merges first**, rebase and the guard sees zero. **If this merges first**, it must carry that one-line fix — otherwise its own blocking guard would make main self-inconsistent.