### PR TITLE
fix(whitelist): observation failure must not become an empty desired state [v1.228.10 PR-3, A3 only]

### DIFF
--- a/internal/runtime/state_whitelist_observation_preserve_v1228_10_test.go
+++ b/internal/runtime/state_whitelist_observation_preserve_v1228_10_test.go
@@ -1,0 +1,145 @@
+// =============================================================================
+// NFTBan v1.228.10 PR-3 (A3) - whitelist observation failure preserves state
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="state_whitelist_observation_preserve_v1228_10_test"
+// meta:type="test"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-09"
+// meta:description="v1.228.10 A3: LoadWhitelists must abort on an observation failure and leave the previously loaded whitelist intact, so FullSync never computes a destructive diff from an unknown desired state. Carries the owner-required case: kernel/runtime holds admin-A + admin-B, file A parses, file B is unreadable, and the partial union {admin-A} must never be adopted. Includes the positive control proving replacement DOES occur on a clean read, so preservation cannot be mistaken for a loader that never replaces."
+// meta:input="None"
+// meta:output="t.Fatal on destructive convergence from an unknown observation"
+// meta:depends="testing,os,path/filepath"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	a3AdminA = "203.0.113.10"
+	a3AdminB = "203.0.113.11"
+)
+
+func a3Seed(t *testing.T, configDir string) *RuntimeState {
+	t.Helper()
+	rs := NewRuntimeState(configDir)
+	now := time.Now()
+	rs.WhitelistIPv4[a3AdminA] = &IPEntry{IP: a3AdminA, Source: "whitelist", AddedAt: now}
+	rs.WhitelistIPv4[a3AdminB] = &IPEntry{IP: a3AdminB, Source: "whitelist", AddedAt: now}
+	return rs
+}
+
+// The owner-required case. A partial observation must not become desired state,
+// and the previously converged whitelist must survive untouched.
+func TestA3_PartialObservation_PreservesPriorWhitelist(t *testing.T) {
+	dir := t.TempDir()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	// File A parses and contains ONLY admin-A: if the loader were to tolerate the
+	// failure below, the resulting desired state would be {admin-A} and admin-B
+	// would be deleted from the kernel on the next sync.
+	if err := os.WriteFile(filepath.Join(wlDir, "10-a.conf"), []byte(a3AdminA+"\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	// File B is unreadable for every uid (dangling symlink), so the assertion does
+	// not weaken when CI runs as root.
+	if err := os.Symlink(filepath.Join(wlDir, "absent"), filepath.Join(wlDir, "20-b.conf")); err != nil {
+		t.Skipf("symlinks unavailable in this environment: %v", err)
+	}
+
+	rs := a3Seed(t, dir)
+
+	if err := rs.LoadWhitelists(); err == nil {
+		t.Fatal("LoadWhitelists returned success on a partial observation — FullSync would apply a shortened desired state")
+	}
+
+	rs.mu.RLock()
+	_, haveA := rs.WhitelistIPv4[a3AdminA]
+	_, haveB := rs.WhitelistIPv4[a3AdminB]
+	n := len(rs.WhitelistIPv4)
+	rs.mu.RUnlock()
+
+	if !haveA || !haveB || n != 2 {
+		t.Fatalf("prior whitelist was not preserved: adminA=%v adminB=%v n=%d — this is the admin-lockout path", haveA, haveB, n)
+	}
+}
+
+// An unenumerable whitelist.d likewise preserves prior state.
+func TestA3_UnenumerableDir_PreservesPriorWhitelist(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "whitelist.d"), []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	rs := a3Seed(t, dir)
+
+	if err := rs.LoadWhitelists(); err == nil {
+		t.Fatal("LoadWhitelists returned success on an unenumerable whitelist.d")
+	}
+
+	rs.mu.RLock()
+	n := len(rs.WhitelistIPv4)
+	rs.mu.RUnlock()
+	if n != 2 {
+		t.Fatalf("prior whitelist was replaced from an unknown observation: n=%d, want 2", n)
+	}
+}
+
+// POSITIVE CONTROL. Preservation above must be the result of the abort, not of a
+// loader that never replaces anything: on a clean read the replacement DOES happen
+// and admin-B is legitimately removed.
+func TestA3_CleanObservation_StillReplaces(t *testing.T) {
+	dir := t.TempDir()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wlDir, "10-a.conf"), []byte(a3AdminA+"\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	rs := a3Seed(t, dir)
+
+	if err := rs.LoadWhitelists(); err != nil {
+		t.Fatalf("clean observation must succeed: %v", err)
+	}
+
+	rs.mu.RLock()
+	_, haveA := rs.WhitelistIPv4[a3AdminA]
+	_, haveB := rs.WhitelistIPv4[a3AdminB]
+	rs.mu.RUnlock()
+
+	if !haveA {
+		t.Fatal("clean observation dropped admin-A")
+	}
+	if haveB {
+		t.Fatal("clean observation did not replace: admin-B survived a complete desired state that omits it")
+	}
+}
+
+// An absent whitelist.d is a legitimate first-install shape: it must load cleanly
+// (and therefore replace), never abort.
+func TestA3_AbsentDir_IsNotAnObservationFailure(t *testing.T) {
+	dir := t.TempDir()
+	rs := a3Seed(t, dir)
+
+	if err := rs.LoadWhitelists(); err != nil {
+		t.Fatalf("absent whitelist.d must not fail the load (first-install shape): %v", err)
+	}
+}

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -23,7 +23,9 @@
 package whitelist
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -86,16 +88,40 @@ func LoadAllWhitelists(configDir string) (map[string]bool, map[string]bool, erro
 // V119 A1: closes whitelist half of D-MANUAL-CIDR-LOAD-GAP. Callers in
 // V116 §4 allowlist (cmd_check.go, cmd_ban.go, daemon_handlers_ban.go)
 // use this typed loader; profile_sync.go remains on legacy LoadAllWhitelists.
+// v1.228.10 PR-3 (audit finding A3) — OBSERVATION FAILURE IS NOT AN EMPTY WHITELIST.
+//
+// This loader produces DESIRED STATE. FullSync treats its output as authoritative and
+// deletes every kernel whitelist element absent from it, so a read failure that returns
+// success-with-empty removes the operator's whitelist from the kernel — an admin-lockout
+// enabler, because the input chain drops blacklisted sources BEFORE the established-state
+// accept, so a lost whitelist entry kills a live session and not merely new connections.
+//
+// Three states are now distinguished, and only the first may yield an empty result:
+//
+//	whitelist.d legitimately absent    -> empty desired state, no error (first install)
+//	whitelist.d present, unenumerable  -> error; caller preserves kernel state
+//	any participating file unreadable/
+//	  unparseable                      -> error; NO partial union may become authoritative
+//
+// The third case is the one that matters most: a partial union is indistinguishable from a
+// deliberate removal, so "file A parsed, file B failed" must not produce "desired = A".
+// On any error the maps are returned nil so a partial result cannot be consumed by accident.
+//
+// INV-P0-03 / INV-P0-04. Callers already abort correctly on error
+// (internal/runtime/state.go LoadWhitelists -> daemon_handlers_sync.go), which is why this
+// is an authority correction and not a FullSync redesign.
 func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[string]WhitelistEntry, error) {
 	ipv4 := make(map[string]WhitelistEntry)
 	ipv6 := make(map[string]WhitelistEntry)
 
-	// 1. Load main whitelist.conf (optional - whitelist.d/ is preferred)
+	// 1. Load main whitelist.conf. The file is OPTIONAL — absence is a legitimate
+	//    configuration, not a failure. But if it exists and cannot be read or parsed it
+	//    is a participating source whose contribution is unknown, and an unknown
+	//    contribution may not be silently dropped from the desired state.
 	mainFile := filepath.Join(configDir, "whitelist.conf")
 	if err := loadWhitelistFileTyped(mainFile, ipv4, ipv6); err != nil {
-		// Non-fatal: file is optional, only log if it exists but has errors
-		if !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: Could not load %s: %v\n", mainFile, err)
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, fmt.Errorf("whitelist source %s unreadable: %w", mainFile, err)
 		}
 	}
 
@@ -103,9 +129,13 @@ func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[st
 	whitelistDir := filepath.Join(configDir, "whitelist.d")
 	entries, err := os.ReadDir(whitelistDir)
 	if err != nil {
-		// Non-fatal: directory might not exist yet
-		fmt.Fprintf(os.Stderr, "Warning: Could not read whitelist.d: %v\n", err)
-		return ipv4, ipv6, nil
+		// Absent directory = legitimate first-install shape: empty, not degraded.
+		if errors.Is(err, fs.ErrNotExist) {
+			return ipv4, ipv6, nil
+		}
+		// Present but unenumerable (EACCES from a packaging perms slip, EIO, an SELinux
+		// denial, or a non-directory at that path). The whitelist is UNKNOWN, not empty.
+		return nil, nil, fmt.Errorf("whitelist directory %s unreadable: %w", whitelistDir, err)
 	}
 
 	for _, entry := range entries {
@@ -118,7 +148,9 @@ func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[st
 
 		filePath := filepath.Join(whitelistDir, entry.Name())
 		if err := loadWhitelistFileTyped(filePath, ipv4, ipv6); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Could not load %s: %v\n", filePath, err)
+			// Per-file failure shortens the union. Previously warn-and-continue, which
+			// let one unreadable file silently delete its IPs from the kernel.
+			return nil, nil, fmt.Errorf("whitelist source %s unreadable: %w", filePath, err)
 		}
 	}
 

--- a/internal/whitelist/observation_failure_v1228_10_test.go
+++ b/internal/whitelist/observation_failure_v1228_10_test.go
@@ -1,0 +1,179 @@
+// =============================================================================
+// NFTBan - v1.228.10 PR-3 (A3): whitelist observation failure must not become
+// an empty desired state
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="whitelist_observation_failure_v1228_10_test"
+// meta:type="package"
+// meta:version="1.0.0"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-09"
+// meta:description="Tests for audit finding A3: the whitelist loader must distinguish a legitimately absent whitelist.d (empty, no error) from an unenumerable directory and from a participating file that cannot be read or parsed (both errors). Proves no partial union can become authoritative desired state. Injections are root-proof (ENOTDIR, dangling symlink) so the assertions hold when CI runs as root; permission-based injections run additionally when the suite is non-root."
+// meta:input="None (t.TempDir fixtures)"
+// meta:output="None"
+// meta:depends="testing"
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package whitelist
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// STATE 1: whitelist.d legitimately absent -> empty desired state, NO error.
+// A first install must not be reported as degraded, and must not block a sync.
+func TestA3_AbsentWhitelistDir_IsEmptyNotError(t *testing.T) {
+	dir := t.TempDir() // no whitelist.d, no whitelist.conf
+
+	ipv4, ipv6, err := LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("absent whitelist.d must not be an error (first-install shape): %v", err)
+	}
+	if len(ipv4) != 0 || len(ipv6) != 0 {
+		t.Fatalf("expected empty desired state, got ipv4=%d ipv6=%d", len(ipv4), len(ipv6))
+	}
+}
+
+// STATE 2: whitelist.d present but unenumerable -> error, never empty-with-success.
+// Injection is a non-directory at the whitelist.d path, which yields ENOTDIR for
+// every uid — the assertion must not weaken to a skip when CI runs as root.
+func TestA3_UnenumerableWhitelistDir_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "whitelist.d"), []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	ipv4, ipv6, err := LoadAllWhitelistsTyped(dir)
+	if err == nil {
+		t.Fatal("unenumerable whitelist.d returned success — an unreadable whitelist is UNKNOWN, not empty")
+	}
+	if ipv4 != nil || ipv6 != nil {
+		t.Fatal("maps must be nil on error so a partial result cannot be consumed by accident")
+	}
+}
+
+// STATE 2 (permission variant): EACCES on the directory. Root bypasses the mode
+// bits, so this variant only runs unprivileged; the ENOTDIR test above carries
+// the invariant when the suite runs as root.
+func TestA3_UnreadableWhitelistDir_EACCES_ReturnsError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode bits are bypassed; covered by TestA3_UnenumerableWhitelistDir_ReturnsError")
+	}
+	dir := t.TempDir()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wlDir, "99-manual.conf"), []byte("203.0.113.10\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.Chmod(wlDir, 0o000); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(wlDir, 0o750) })
+
+	// Negative control: prove the injection actually took effect.
+	if _, derr := os.ReadDir(wlDir); derr == nil {
+		t.Skip("chmod 000 did not deny enumeration in this environment; injection not proven")
+	}
+
+	if _, _, err := LoadAllWhitelistsTyped(dir); err == nil {
+		t.Fatal("EACCES on whitelist.d returned success — this is the admin-lockout enabler")
+	}
+}
+
+// STATE 3: the directory enumerates, but a participating file cannot be read.
+// This is the case the fix must NOT stop at: a partial union is indistinguishable
+// from a deliberate removal.
+//
+//	PRESTATE  desired whitelist = admin-A (file A) + admin-B (file B)
+//	SOURCE    file A parses, file B is unreadable
+//	EXPECT    error; no maps
+//	FORBIDDEN desired state = {admin-A}
+//
+// Injection is a dangling symlink, which fails to open for every uid.
+func TestA3_UnreadableParticipatingFile_NoPartialUnion(t *testing.T) {
+	const adminA = "203.0.113.10"
+
+	dir := t.TempDir()
+	wlDir := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wlDir, 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wlDir, "10-a.conf"), []byte(adminA+"\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(wlDir, "does-not-exist"), filepath.Join(wlDir, "20-b.conf")); err != nil {
+		t.Skipf("symlinks unavailable in this environment: %v", err)
+	}
+
+	// Negative control: file A really is readable and really does parse, so a
+	// failure below cannot be blamed on a broken fixture.
+	okv4, _, okErr := LoadAllWhitelistsTyped(func() string {
+		control := t.TempDir()
+		cDir := filepath.Join(control, "whitelist.d")
+		if err := os.MkdirAll(cDir, 0o750); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cDir, "10-a.conf"), []byte(adminA+"\n"), 0o600); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+		return control
+	}())
+	if okErr != nil || len(okv4) != 1 {
+		t.Fatalf("negative control failed: file A must load cleanly on its own (err=%v n=%d)", okErr, len(okv4))
+	}
+
+	ipv4, ipv6, err := LoadAllWhitelistsTyped(dir)
+	if err == nil {
+		t.Fatal("unreadable participating file returned success — a shortened union would be applied as desired state")
+	}
+	if ipv4 != nil || ipv6 != nil {
+		t.Fatal("maps must be nil on error")
+	}
+	if _, present := ipv4[adminA]; present {
+		t.Fatal("FORBIDDEN: partial desired state {admin-A} escaped the loader")
+	}
+}
+
+// A participating whitelist.conf that exists but cannot be read is an error too;
+// its absence remains legitimate. Injection: a directory at the whitelist.conf
+// path (EISDIR on open) — root-proof.
+func TestA3_UnreadableMainFile_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "whitelist.conf"), 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "whitelist.d"), 0o750); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	if _, _, err := LoadAllWhitelistsTyped(dir); err == nil {
+		t.Fatal("unreadable whitelist.conf returned success — its contribution is unknown, not absent")
+	}
+}
+
+// The dual API must not launder an error into empty maps.
+func TestA3_LegacyAPI_PropagatesObservationFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "whitelist.d"), []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	ipv4, ipv6, err := LoadAllWhitelists(dir)
+	if err == nil {
+		t.Fatal("LoadAllWhitelists must propagate the observation failure")
+	}
+	if ipv4 != nil || ipv6 != nil {
+		t.Fatal("legacy API must not return usable maps alongside an error")
+	}
+}


### PR DESCRIPTION
## Scope

**A3 ONLY** — whitelist observation failure collapses to an empty desired state. v1.228.10 PR-3 of 3.

```
Closes implementation slice:
  A3 — whitelist degraded read -> empty desired state -> destructive convergence

Does NOT close:
  A1                  (PR-2, order-bound behind PR-1)
  A2                  (PR-1, #1203)
  Lens-1 P0 group
  Lens-1 overall
```

Independent of PR-1 — branched from clean `8a88207b`, touches no snapshot code.

## The defect

`LoadAllWhitelistsTyped` returned `(ipv4, ipv6, nil)` after an `os.ReadDir` failure, and the per-file
branch warned and continued.

This loader produces **desired state**. FullSync treats its output as authoritative and deletes every
kernel whitelist element absent from it, so one `EACCES` from a packaging perms slip, one `EIO`, or one
SELinux denial emptied `whitelist_ipv4/6` on the next routine sync.

It is an **admin-lockout enabler**, not a cosmetic loss: the input chain drops blacklisted sources
**before** the established-state accept (`install/nftables/nftables.conf:418-427`), so losing a whitelist
entry kills a **live** admin session — not merely new connections — whenever that address is covered by
any feed or geoban CIDR already in `blacklist_ipv4`.

## The fix

Three states, only the first of which may yield an empty result:

| Source condition | Result |
|---|---|
| `whitelist.d` legitimately absent | empty desired state, **no error** (first install) |
| `whitelist.d` present but unenumerable | **error** — caller preserves kernel state |
| any participating file unreadable/unparseable | **error** — no partial union |

The third case is what a top-level-only fix would have missed. A partial union is indistinguishable from
a deliberate removal, so *"file A parsed, file B failed"* must not produce *"desired = A"*.
`whitelist.conf` is treated the same way: absence is legitimate, unreadability is not. On any error the
maps are returned `nil` so a partial result cannot be consumed by accident.

**This is an authority correction, not a FullSync redesign.** Callers already abort correctly
(`internal/runtime/state.go` `LoadWhitelists` → `daemon_handlers_sync.go:62-64`).

## No caller regresses

| Caller | Before (empty+nil) | After (error) |
|---|---|---|
| `runtime.LoadWhitelists` | destructive empty desired state | aborts — **the fix** |
| `cmd_ban.go` / `cmd_check.go` | error already propagated | unchanged |
| `daemon_handlers_ban.go isWhitelisted` | empty maps → "not whitelisted" | error → "not whitelisted" — **identical** |
| `exemption.go Refresh` | empty maps contributed nothing | error contributes nothing — **identical** |

The last two are fail-open on observation failure and are **recorded as siblings in the `.10` scope for
v1.229.1** — they belong to the never-ban failure domain, not this one. Notably
`exemption.go:184`'s last-known-good guard only fires when the **entire** rebuild is empty, so a
whitelist-only source failure still swaps in a snapshot missing the whitelist.

## Invariants established (whitelist lane only)

```
INV-P0-03  observation failure is never interpreted as empty desired state
INV-P0-04  whitelist source unreadable/malformed preserves previous effective state
```

## Tests

```
internal/whitelist/observation_failure_v1228_10_test.go
internal/runtime/state_whitelist_observation_preserve_v1228_10_test.go
```

All three states, plus the required end-to-end case:

```
PRESTATE   runtime whitelist = admin-A + admin-B
SOURCE     file A parses, file B unreadable
EXPECT     loader errors; replacement NOT performed; state remains {admin-A, admin-B}
FORBIDDEN  desired state = {admin-A}
```

A **positive control** proves replacement still occurs on a clean read (admin-B is legitimately removed),
so preservation cannot be mistaken for a loader that never replaces.

Injections are **root-proof** — `ENOTDIR` (non-directory at `whitelist.d`), `EISDIR` (directory at
`whitelist.conf`), dangling symlink (unreadable participating file) — so the assertions do not degrade to
skips when CI runs as root. The `EACCES` variant runs additionally when unprivileged and carries its own
injection-proven negative control.

## Verification status — please read

```
GO TOOLCHAIN ON AUTHORING HOST = ABSENT
LOCAL go build / go test / gofmt = NOT RUN  (owner instruction: no local builds)
```

These Go tests were **not compiled or executed locally** and must be confirmed by CI (and lab2 for
package-native). Structural checks only were performed here: brace/paren balance, import ordering
(`errors`, `io/fs` added), and confirmation that no now-unused import remains (`os.IsNotExist` is gone;
`os` and `fmt` are still used). Treat CI as the first real compile.

## Validation plan (post-merge)

Package-native DEB + RPM, plus the A3 SELinux-denial case on a clean EL9/EL10 Enforcing fixture —
`NO AVC ≠ NO DENIAL`, so a dontaudit-aware probe is required rather than an empty audit log.
lab4 is available again as an RPM fixture (rebuilt clean, owner-confirmed 2026-08-09).
