### PR TITLE
fix(packaging): claim ownership only of artifacts the migration owns (DEB+RPM) [OPEN_PACKAGE_MIGRATION_RECURSIVE_OWNERSHIP_BOUNDARY]

### DIFF
--- a/cli/lib/nftban/tests/pkg_migration_ownership_boundary_v1228_10_test.sh
+++ b/cli/lib/nftban/tests/pkg_migration_ownership_boundary_v1228_10_test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - package migration ownership boundary (v1.228.10)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="pkg_migration_ownership_boundary_v1228_10_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-09"
+# meta:description="Behavioural proof for OPEN_PACKAGE_MIGRATION_RECURSIVE_OWNERSHIP_BOUNDARY. Extracts the REAL _nftban_migrate_reports_to_log() from packaging/deb/postinst and runs it against a sandbox with recording chown/chmod shims, so the assertion is WHICH PATHS the privileged maintainer script claims ownership of. Proves INV-PKG-OWN-01..06: only artifacts the migration created or moved are chowned; a foreign file already in the destination keeps its ownership; a symlink is never a chown target; a host without the legacy source performs no ownership mutation; repeated execution is idempotent. Also asserts DEB/RPM parity by comparing the emitted RPM scriptlet body in packaging/build_nftban.sh. Unprivileged and hermetic — real ownership change needs package-native lab validation."
+# meta:input="None (sandbox fixtures)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,awk,grep,mktemp"
+# meta:inventory.files="packaging/deb/postinst,packaging/build_nftban.sh"
+# meta:inventory.binaries="bash,awk,grep,mktemp"
+# meta:inventory.env_vars=""
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="pkg_migration_ownership_boundary_v1228_10_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="package-migration-ownership"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+POSTINST="$ROOT/packaging/deb/postinst"
+BUILDER="$ROOT/packaging/build_nftban.sh"
+
+PASS=0; FAIL=0
+ok()  { printf '  [PASS] %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+echo "=== pkg_migration_ownership_boundary_v1228_10 ==="
+
+[[ -f "$POSTINST" ]] || { echo "  [FATAL] missing $POSTINST"; exit 2; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# Extract the REAL migration function verbatim from the shipped postinst.
+FN="$WORK/migrate.sh"
+awk '/^_nftban_migrate_reports_to_log\(\) \{/{f=1} f{print} f&&/^[[:space:]]*\}[[:space:]]*$/{exit}' \
+    "$POSTINST" > "$FN"
+if grep -q '_nftban_migrate_reports_to_log()' "$FN"; then
+    ok "extracted _nftban_migrate_reports_to_log() from packaging/deb/postinst"
+else
+    bad "could not extract the migration function"; echo "FAIL=$FAIL"; exit 1
+fi
+
+# The function hardcodes absolute paths. Rebase them onto the sandbox so the test
+# never touches real system directories.
+run_migration() { # $1 = sandbox root
+    local sb="$1"
+    sed -e "s#/var/lib/nftban#$sb/var/lib/nftban#g" \
+        -e "s#/var/log/nftban#$sb/var/log/nftban#g" "$FN" > "$sb/fn.sh"
+    (
+        cd "$sb" || exit 1
+        export CHOWN_LOG="$sb/chown.log" CHMOD_LOG="$sb/chmod.log"
+        : > "$CHOWN_LOG"; : > "$CHMOD_LOG"
+        # Recording shims: real chown needs root, and the property under test is
+        # WHICH PATHS ownership is claimed on — not the kernel's uid bookkeeping.
+        #
+        # A recursive invocation must be EXPANDED here. `chown -R DIR` names only DIR
+        # on its command line while the real binary walks every descendant, so a shim
+        # that logged the literal arguments would let the pre-fix implementation pass
+        # the foreign-file and symlink assertions vacuously. Expansion is what makes
+        # this test discriminate. Symlinks are recorded as targets but NOT followed,
+        # matching chown's documented default (-P), so the test never claims that a
+        # referent outside the tree was mutated.
+        chown() {
+            printf '%s\n' "$*" >> "$CHOWN_LOG"
+            local a recursive=0 t
+            for a in "$@"; do
+                case "$a" in -R|--recursive|-*R*) recursive=1 ;; esac
+            done
+            if [ "$recursive" -eq 1 ]; then
+                for t in "$@"; do
+                    [ -e "$t" ] || continue
+                    case "$t" in -*|*:*) continue ;; esac
+                    command find "$t" -print 2>/dev/null >> "$CHOWN_LOG"
+                done
+            fi
+            return 0
+        }
+        chmod() { printf '%s\n' "$*" >> "$CHMOD_LOG"; command chmod "$@" 2>/dev/null; return 0; }
+        restorecon() { return 0; }
+        # shellcheck source=/dev/null
+        . "$sb/fn.sh"
+        _nftban_migrate_reports_to_log
+    ) >/dev/null 2>&1
+}
+
+mk_sandbox() { # -> echoes sandbox root; legacy report present by default
+    local sb; sb="$(mktemp -d "$WORK/sb.XXXXXX")"
+    mkdir -p "$sb/var/lib/nftban/reports" "$sb/var/log/nftban/reports"
+    printf 'legacy\n' > "$sb/var/lib/nftban/reports/report.json"
+    echo "$sb"
+}
+
+chowned() { grep -qF -- "$2" "$1/chown.log"; }
+
+# ---------------------------------------------------------------------------
+echo "=== A. the migrated artifact IS claimed ==="
+SB="$(mk_sandbox)"; run_migration "$SB"
+if chowned "$SB" "$SB/var/log/nftban/reports/report.json"; then
+    ok "migrated file is chowned at its exact destination path"
+else
+    bad "migrated file was never chowned — migration output would keep the wrong owner"
+fi
+if grep -q 'nftban:nftban' "$SB/chown.log"; then
+    ok "ownership claimed is nftban:nftban"
+else
+    bad "unexpected ownership target: $(head -1 "$SB/chown.log")"
+fi
+[[ -f "$SB/var/log/nftban/reports/report.json" ]] && ok "the file actually moved to the new path" \
+    || bad "migration did not move the file — fixture did not exercise the path"
+
+# ---------------------------------------------------------------------------
+echo "=== B. INV-PKG-OWN-02 — a foreign file in the destination is NOT claimed ==="
+SB="$(mk_sandbox)"
+printf 'not ours\n' > "$SB/var/log/nftban/reports/foreign.txt"
+run_migration "$SB"
+if chowned "$SB" "$SB/var/log/nftban/reports/foreign.txt"; then
+    bad "FOREIGN FILE WAS CHOWNED — the package claimed ownership of content it did not create"
+else
+    ok "foreign file in the destination is never a chown target"
+fi
+# Negative control: the run must genuinely have chowned SOMETHING, or the assertion
+# above would pass simply because ownership was never applied at all.
+if [[ -s "$SB/chown.log" ]]; then
+    ok "negative control: the migration did claim its own artifacts in the same run"
+else
+    bad "no ownership was claimed at all — the foreign-file assertion is vacuous"
+fi
+
+# ---------------------------------------------------------------------------
+echo "=== C. INV-PKG-OWN-03 — a symlink in the destination is NOT a chown target ==="
+SB="$(mk_sandbox)"
+printf 'external\n' > "$SB/external-owned-file"
+ln -s "$SB/external-owned-file" "$SB/var/log/nftban/reports/link.txt" 2>/dev/null || true
+run_migration "$SB"
+if chowned "$SB" "$SB/var/log/nftban/reports/link.txt"; then
+    bad "symlink was a chown target — referent ownership could be mutated"
+else
+    ok "symlink in the destination is never a chown target"
+fi
+if chowned "$SB" "$SB/external-owned-file"; then
+    bad "the symlink REFERENT was chowned — ownership escaped the destination tree"
+else
+    ok "symlink referent outside the tree is untouched"
+fi
+
+# ---------------------------------------------------------------------------
+echo "=== D. INV-PKG-OWN-05 — no legacy source means no ownership mutation ==="
+SB="$(mktemp -d "$WORK/sb.XXXXXX")"
+mkdir -p "$SB/var/log/nftban/reports"
+printf 'pre-existing\n' > "$SB/var/log/nftban/reports/already.json"
+run_migration "$SB"
+if [[ -s "$SB/chown.log" ]]; then
+    bad "ownership was mutated with no legacy source present: $(head -1 "$SB/chown.log")"
+else
+    ok "absent legacy source -> the migration performs no ownership mutation at all"
+fi
+
+# ---------------------------------------------------------------------------
+echo "=== E. INV-PKG-OWN-06 — idempotence ==="
+SB="$(mk_sandbox)"
+printf 'not ours\n' > "$SB/var/log/nftban/reports/foreign.txt"
+run_migration "$SB"
+run_migration "$SB"   # second execution: legacy dir now empty but still present
+if chowned "$SB" "$SB/var/log/nftban/reports/foreign.txt"; then
+    bad "second run claimed the foreign file"
+else
+    ok "second execution still never claims foreign content"
+fi
+[[ -f "$SB/var/log/nftban/reports/report.json" ]] && ok "second execution preserves migrated content" \
+    || bad "second execution lost the migrated file"
+
+# ---------------------------------------------------------------------------
+echo "=== F. no recursive ownership/mode verb survives in either family ==="
+for f in "$POSTINST" "$BUILDER"; do
+    if grep -qE '(chmod[[:space:]]+-R|chmod[[:space:]]+--recursive|chown[[:space:]]+-R|chown[[:space:]]+--recursive)' "$f"; then
+        bad "$(basename "$f"): a recursive ownership/mode command is still present"
+    else
+        ok "$(basename "$f"): no recursive ownership/mode command"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo "=== G. DEB/RPM parity — the emitted RPM scriptlet carries the same model ==="
+if [[ -f "$BUILDER" ]]; then
+    for tok in '_own_file()' '_own_dir()' '_own_dir "\$_new"' '_own_file "\$_n/\$_b"'; do
+        if grep -qF -- "$tok" "$BUILDER"; then
+            ok "RPM generator emits: $tok"
+        else
+            bad "RPM generator missing: $tok — package families would diverge"
+        fi
+    done
+else
+    bad "packaging/build_nftban.sh not found — cannot assert parity"
+fi
+
+echo
+echo "=== pkg_migration_ownership_boundary_v1228_10: PASS=$PASS FAIL=$FAIL ==="
+[[ $FAIL -eq 0 ]]

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -1319,26 +1319,39 @@ _nftban_migrate_reports_to_log() {
     fi
 
     [ -d "\$_old" ] || return 0
+    # v1.228.10 INV-PKG-OWN-01/02: ownership and mode are applied to the EXACT artifacts
+    # this migration creates or moves — never recursively over the destination tree. The
+    # loop already knows every path it is authoritative for; a recursive ownership/mode sweep
+    # over "\$_new" also re-owned descendants the package never created. systemd-tmpfiles
+    # declares the reports directories but archive/pre-v1.228.5 is not declared there, so
+    # directories THIS function creates are set here, explicitly and idempotently.
+    # DRIFT-CHECKED TWIN of packaging/deb/postinst — keep both families identical.
+    _own_file() { chown nftban:nftban -- "\$1" 2>/dev/null || true; chmod 0640 -- "\$1" 2>/dev/null || true; }
+    _own_dir()  { chown nftban:nftban -- "\$1" 2>/dev/null || true; chmod 0750 -- "\$1" 2>/dev/null || true; }
     mkdir -p "\$_new/daily" 2>/dev/null || true
+    _own_dir "\$_new"; _own_dir "\$_new/daily"
     for _sub in "" /daily; do
         _o="\$_old\$_sub"; _n="\$_new\$_sub"
         [ -d "\$_o" ] || continue
         mkdir -p "\$_n" 2>/dev/null || true
+        _own_dir "\$_n"
         for _f in "\$_o"/*.html "\$_o"/*.txt "\$_o"/*.json; do
             [ -e "\$_f" ] || continue
             _b=\$(basename "\$_f")
             if [ -e "\$_n/\$_b" ]; then
                 # BOTH exist: never overwrite. Archive the old copy deterministically.
                 mkdir -p "\$_new/archive/pre-v1.228.5" 2>/dev/null || true
-                mv -f "\$_f" "\$_new/archive/pre-v1.228.5/\$_b" 2>/dev/null || true
+                _own_dir "\$_new/archive"; _own_dir "\$_new/archive/pre-v1.228.5"
+                if mv -f "\$_f" "\$_new/archive/pre-v1.228.5/\$_b" 2>/dev/null; then
+                    _own_file "\$_new/archive/pre-v1.228.5/\$_b"
+                fi
             else
-                mv -f "\$_f" "\$_n/\$_b" 2>/dev/null || true
+                if mv -f "\$_f" "\$_n/\$_b" 2>/dev/null; then
+                    _own_file "\$_n/\$_b"
+                fi
             fi
         done
     done
-    chown -R nftban:nftban "\$_new" 2>/dev/null || true
-    find "\$_new" -type f -exec chmod 0640 {} \; 2>/dev/null || true
-    find "\$_new" -type d -exec chmod 0750 {} \; 2>/dev/null || true
     # v1.228.5 CRITICAL: \`mv\` PRESERVES the SELinux context. A file moved from /var/lib
     # arrives at /var/log still labelled nftban_var_lib_t — precisely the label logrotate_t
     # cannot read, so the migration would RELOCATE the defect instead of fixing it.

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -387,26 +387,41 @@ _nftban_migrate_reports_to_log() {
     fi
 
     [ -d "$_old" ] || return 0
+            # v1.228.10 INV-PKG-OWN-01/02: ownership and mode are applied to the EXACT
+            # artifacts this migration creates or moves — never recursively over the
+            # destination tree. The loop already knows every path it is authoritative
+            # for; a recursive ownership/mode sweep over "$_new" also re-owned descendants
+            # the package never created, which is a claim it cannot justify.
+            # systemd-tmpfiles declares the reports directories and runs earlier in this
+            # script, but only best-effort (`|| true`), and archive/pre-v1.228.5 is not
+            # declared there at all — so directories THIS function creates are set here,
+            # explicitly and idempotently.
+            _own_file() { chown nftban:nftban -- "$1" 2>/dev/null || true; chmod 0640 -- "$1" 2>/dev/null || true; }
+            _own_dir()  { chown nftban:nftban -- "$1" 2>/dev/null || true; chmod 0750 -- "$1" 2>/dev/null || true; }
             mkdir -p "$_new/daily" 2>/dev/null || true
+            _own_dir "$_new"; _own_dir "$_new/daily"
             for _sub in "" /daily; do
                 _o="$_old$_sub"; _n="$_new$_sub"
                 [ -d "$_o" ] || continue
                 mkdir -p "$_n" 2>/dev/null || true
+                _own_dir "$_n"
                 for _f in "$_o"/*.html "$_o"/*.txt "$_o"/*.json; do
                     [ -e "$_f" ] || continue
                     _b=$(basename "$_f")
                     if [ -e "$_n/$_b" ]; then
                         # BOTH exist: never overwrite. Archive the old copy deterministically.
                         mkdir -p "$_new/archive/pre-v1.228.5" 2>/dev/null || true
-                        mv -f "$_f" "$_new/archive/pre-v1.228.5/$_b" 2>/dev/null || true
+                        _own_dir "$_new/archive"; _own_dir "$_new/archive/pre-v1.228.5"
+                        if mv -f "$_f" "$_new/archive/pre-v1.228.5/$_b" 2>/dev/null; then
+                            _own_file "$_new/archive/pre-v1.228.5/$_b"
+                        fi
                     else
-                        mv -f "$_f" "$_n/$_b" 2>/dev/null || true
+                        if mv -f "$_f" "$_n/$_b" 2>/dev/null; then
+                            _own_file "$_n/$_b"
+                        fi
                     fi
                 done
             done
-    chown -R nftban:nftban "$_new" 2>/dev/null || true
-            find "$_new" -type f -exec chmod 0640 {} \; 2>/dev/null || true
-            find "$_new" -type d -exec chmod 0750 {} \; 2>/dev/null || true
     # v1.228.5 CRITICAL: `mv` PRESERVES the SELinux context. A file moved from /var/lib
     # arrives at /var/log still labelled nftban_var_lib_t — precisely the label logrotate_t
     # cannot read, so the migration would RELOCATE the defect instead of fixing it.

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -173,6 +173,7 @@ nftban_update_progress_r1b3_test	cli/lib/nftban/tests/nftban_update_progress_r1b
 no_reintroduced_orphan_modules_v167_test	cli/lib/nftban/tests/no_reintroduced_orphan_modules_v167_test.sh	architecture	test	orphan-modules	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 panel_group_retirement_v137_test	cli/lib/nftban/tests/panel_group_retirement_v137_test.sh	security	test	panel-group-retirement	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 parser_tier1_unknown_truth_v1228_9_test	cli/lib/nftban/tests/parser_tier1_unknown_truth_v1228_9_test.sh	health	test	nft-parser-contract	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	180		
+pkg_migration_ownership_boundary_v1228_10_test	cli/lib/nftban/tests/pkg_migration_ownership_boundary_v1228_10_test.sh	packaging	test	package-migration-ownership	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 portscan_generic_corroborate_v149_test	cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh	portscan	test	portscan-classic	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 portscan_trusted_flow_test	cli/lib/nftban/tests/portscan_trusted_flow_test.sh	portscan	test	portscan-trusted-flow	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 protection_claim_matrix_v194_test	cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh	cross-cutting	test	protection-claim-matrix	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			


### PR DESCRIPTION
See commit 55bac392 for the full rationale.

**Handle:** `OPEN_PACKAGE_MIGRATION_RECURSIVE_OWNERSHIP_BOUNDARY` (LOW/MED, packaging/security, DEB+RPM).

```
RECURSIVE_OWNERSHIP_OVERBROAD = CONFIRMED
PRIV_ESC_REACHABILITY         = NOT_PROVEN
SECURITY_RELEVANCE            = REAL
PRODUCT_FILES = 2 (deb postinst + rpm generator)   TEST_FILES = 1
```

Ownership/mode are applied at the point of migration to the exact artifacts the function creates or moves, instead of recursively over the destination tree. Both package families change together — same failure domain, same contract, currently at parity.

**Discrimination:** pre-fix 8 PASS / 9 FAIL, post-fix 17 PASS / 0 FAIL. The shim expands recursion, because `chown -R DIR` names only DIR on its command line — without expansion the pre-fix code passed the foreign-file and symlink assertions vacuously.

**Still owed:** package-native validation on qualified DEB and clean EL RPM fixtures with real uids.