### PR TITLE
fix(rebuild): rollback must not misread a large snapshot as empty [v1.228.10 A1]

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2629,10 +2629,12 @@ _rebuild_rollback() {
     # was a latent refusal: `grep -q` exits at the first line, awk then dies of
     # SIGPIPE (141), and this file runs under `set -o pipefail` (see the header),
     # so the pipeline reported FAILURE for a table that was present and intact.
-    # It only surfaced once the nftban table was large enough that awk was still
-    # writing when grep left -- i.e. on hosts with real blacklists, never on the
-    # small fixtures. Refusing here is fail-closed, but an inert rollback is still
-    # a broken recovery path, so the pipe is gone rather than worked around.
+    # It surfaces when grep leaves before awk has finished writing AND exiting.
+    # This is NOT bounded by the 64K pipe buffer: a 4195-byte producer was measured
+    # returning 141 on lab4. Output size only makes the race more likely, which is
+    # why small fixtures pass and real hosts fail. Refusing here is fail-closed, but
+    # an inert rollback is still a broken recovery path, so the pipe is gone rather
+    # than worked around.
     #
     # A read failure and an absent table are also kept distinct: awk exiting
     # non-zero means we could not READ the snapshot, which is not the same fact as

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -2622,15 +2622,34 @@ _rebuild_rollback() {
     # --- build an NFTBan-scoped, self-resetting candidate ----------------------
     local candidate="$snapshot_dir/rollback_candidate.nft"
     local _fams=() _f
+    local -A _tbl=()
     : > "$candidate"
+    #
+    # Extraction is captured, NEVER piped. The earlier `awk ... | grep -q .` form
+    # was a latent refusal: `grep -q` exits at the first line, awk then dies of
+    # SIGPIPE (141), and this file runs under `set -o pipefail` (see the header),
+    # so the pipeline reported FAILURE for a table that was present and intact.
+    # It only surfaced once the nftban table was large enough that awk was still
+    # writing when grep left -- i.e. on hosts with real blacklists, never on the
+    # small fixtures. Refusing here is fail-closed, but an inert rollback is still
+    # a broken recovery path, so the pipe is gone rather than worked around.
+    #
+    # A read failure and an absent table are also kept distinct: awk exiting
+    # non-zero means we could not READ the snapshot, which is not the same fact as
+    # "this family has no nftban table" and must not be reported as one.
     for _f in ip ip6 inet; do
-        if awk -v F="$_f" '
-            $0 ~ "^[[:space:]]*table[[:space:]]+"F"[[:space:]]+nftban[[:space:]]*\{" {f=1}
+        if ! _tbl["$_f"]=$(awk -v F="$_f" '
+            $0 ~ "^[[:space:]]*table[[:space:]]+"F"[[:space:]]+nftban[[:space:]]*[{]" {f=1}
             f {print}
-            f && /^\}/ {exit}
-        ' "$ruleset_file" | grep -q .; then
-            _fams+=("$_f")
+            f && /^[}]/ {exit}
+        ' "$ruleset_file"); then
+            echo "ERROR: rollback REFUSED — could not read the snapshot ($_f family)" >&2
+            echo "       This is a READ failure, not an empty snapshot." >&2
+            echo "       The firewall was NOT modified." >&2
+            rm -f "$candidate"
+            return 1
         fi
+        [[ -n "${_tbl["$_f"]}" ]] && _fams+=("$_f")
     done
     if [[ ${#_fams[@]} -eq 0 ]]; then
         echo "ERROR: rollback REFUSED — snapshot contains no nftban table to restore" >&2
@@ -2645,12 +2664,10 @@ _rebuild_rollback() {
 delete table %s nftban
 ' "$_f" "$_f" >> "$candidate"
     done
+    # Reuse the text captured above -- re-running awk here would re-read the
+    # snapshot and could disagree with the families we just committed to.
     for _f in "${_fams[@]}"; do
-        awk -v F="$_f" '
-            $0 ~ "^[[:space:]]*table[[:space:]]+"F"[[:space:]]+nftban[[:space:]]*\{" {f=1}
-            f {print}
-            f && /^\}/ {exit}
-        ' "$ruleset_file" >> "$candidate"
+        printf '%s\n' "${_tbl["$_f"]}" >> "$candidate"
     done
 
     # --- pre-validate; a failure here must not mutate anything -----------------

--- a/cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test.sh
+++ b/cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test.sh
@@ -222,9 +222,14 @@ D="$WORK/s_large"; mkdir -p "$D"
     printf 'table ip panelfw {\n\tchain input {\n\t}\n}\n'
 } > "$D/ruleset.nft"
 printf 'state=VALID\n' > "$D/snapshot_state"
+# NOT a pipe-buffer threshold. Measured on lab4, `nft list set | grep -q` returned 141
+# for a 4195-byte producer -- far below the 64K buffer -- while a 1445-byte producer on
+# lab2 returned 0. SIGPIPE fires when grep exits before the producer has finished writing
+# AND exiting; output size only makes that more likely, it is not a bound. The fixture is
+# large to make the race reliable in CI, not because a threshold exists.
 SZ=$(wc -c < "$D/ruleset.nft")
-[[ "$SZ" -gt 65536 ]] && ok "fixture exceeds the 64K pipe buffer (${SZ} bytes) — the race is reachable" \
-    || no "fixture too small (${SZ} bytes) to exercise the regression"
+[[ "$SZ" -gt 65536 ]] && ok "fixture is large enough (${SZ} bytes) to make the race reliable" \
+    || no "fixture too small (${SZ} bytes) to exercise the regression reliably"
 
 # FALSIFIABILITY: run the pre-fix probe VERBATIM against this exact fixture and prove
 # it fails. Without this, "large snapshot passes" cannot distinguish a fixed product

--- a/cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test.sh
+++ b/cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test.sh
@@ -85,10 +85,14 @@ EOF
 }
 
 # Recording nft shim. NFT_FAIL controls which invocation fails.
-run_rollback() { # $1=snapshot dir ; env NFT_FAIL=none|check|commit  -> echoes rc
+run_rollback() { # $1=snapshot dir ; env NFT_FAIL=none|check|commit ; FN_OVERRIDE=path -> echoes rc
     local d="$1"
     : > "$d/nft.log"
     (
+        # cmd_firewall.sh:28 runs under `set -Eeuo pipefail`. pipefail is what turned
+        # an awk SIGPIPE into a false "no nftban table", so the harness MUST reproduce
+        # it or the large-snapshot arm below measures nothing.
+        set -o pipefail
         NFT_LOG="$d/nft.log"; export NFT_LOG
         nft() {
             printf '%s\n' "$*" >> "$NFT_LOG"
@@ -99,7 +103,7 @@ run_rollback() { # $1=snapshot dir ; env NFT_FAIL=none|check|commit  -> echoes r
             return 0
         }
         # shellcheck source=/dev/null
-        . "$FN"
+        . "${FN_OVERRIDE:-$FN}"
         _rebuild_rollback "$d"
     ) >/dev/null 2>&1
     echo $?
@@ -184,6 +188,119 @@ if [[ "$RC" == "0" && "$(commits "$D")" == "1" ]]; then
 else
     no "VALID snapshot did not restore" "rc=$RC commits=$(commits "$D")"
 fi
+
+# --------------------------------------------------- large snapshot / SIGPIPE
+# REGRESSION (found on lab4, Rocky 9.8, real RPM): the family probe was
+#   awk '...' "$ruleset_file" | grep -q .
+# `grep -q` exits at the FIRST line, so awk dies of SIGPIPE (141); cmd_firewall.sh
+# runs under `set -o pipefail`, so the pipeline reported FAILURE for a table that
+# was present and intact -> "snapshot contains no nftban table" -> rollback refused
+# on every host whose nftban table was big enough that awk was still writing when
+# grep left. Every fixture above is ~18 lines, so awk always finished first and the
+# whole suite passed green against a rollback that was inert in production.
+#
+# This arm pins BOTH halves: the pipeline semantics directly, and the real function
+# against a snapshot large enough to lose the race.
+echo "--- D2. large snapshot must not be misread as 'no nftban table' (SIGPIPE) ---"
+
+# The bug is only observable with pipefail ON, which is what the product sets.
+sigpipe_demo() { # proves the harness can see the prohibited behaviour
+    ( set -o pipefail
+      awk 'BEGIN{for(i=0;i<20000;i++) print "x"}' | grep -q . ) >/dev/null 2>&1
+    echo $?
+}
+[[ "$(sigpipe_demo)" != "0" ]] \
+    && ok "harness CAN observe the defect (piped probe returns non-zero under pipefail)" \
+    || no "harness cannot observe SIGPIPE — this arm would be vacuous"
+
+D="$WORK/s_large"; mkdir -p "$D"
+{
+    printf 'table inet docker {\n\tchain forward {\n\t}\n}\n'
+    printf 'table ip nftban {\n\tset blacklist_ipv4 {\n\t\ttype ipv4_addr\n\t\telements = {'
+    for i in $(seq 1 20000); do printf ' 10.%d.%d.%d,' $((i/65536%256)) $((i/256%256)) $((i%256)); done
+    printf ' }\n\t}\n}\n'
+    printf 'table ip panelfw {\n\tchain input {\n\t}\n}\n'
+} > "$D/ruleset.nft"
+printf 'state=VALID\n' > "$D/snapshot_state"
+SZ=$(wc -c < "$D/ruleset.nft")
+[[ "$SZ" -gt 65536 ]] && ok "fixture exceeds the 64K pipe buffer (${SZ} bytes) — the race is reachable" \
+    || no "fixture too small (${SZ} bytes) to exercise the regression"
+
+# FALSIFIABILITY: run the pre-fix probe VERBATIM against this exact fixture and prove
+# it fails. Without this, "large snapshot passes" cannot distinguish a fixed product
+# from a fixture that is too small or a harness that lost pipefail.
+prefix_probe() { # the shipped pre-fix family detection, unmodified
+    local ruleset_file="$1" _f _fams=()
+    for _f in ip ip6 inet; do
+        if awk -v F="$_f" '
+            $0 ~ "^[[:space:]]*table[[:space:]]+"F"[[:space:]]+nftban[[:space:]]*\{" {f=1}
+            f {print}
+            f && /^\}/ {exit}
+        ' "$ruleset_file" | grep -q .; then
+            _fams+=("$_f")
+        fi
+    done
+    echo "${#_fams[@]}"
+}
+PRE_N=$( set -o pipefail; prefix_probe "$D/ruleset.nft" 2>/dev/null )
+[[ "$PRE_N" == "0" ]] \
+    && ok "MUTATION CONTROL: pre-fix piped probe finds 0 families on this fixture — it IS detectable" \
+    || no "MUTATION CONTROL: pre-fix probe found $PRE_N families — fixture cannot detect the regression" "VACUOUS"
+
+POST_N=0
+for _pf in ip ip6 inet; do
+    _out=$(awk -v F="$_pf" '
+        $0 ~ "^[[:space:]]*table[[:space:]]+"F"[[:space:]]+nftban[[:space:]]*[{]" {f=1}
+        f {print}
+        f && /^[}]/ {exit}
+    ' "$D/ruleset.nft") || _out=""
+    [[ -n "$_out" ]] && POST_N=$((POST_N+1))
+done
+[[ "$POST_N" -ge 1 ]] \
+    && ok "the same fixture DOES contain $POST_N nftban family/families — the pre-fix 0 was a lie" \
+    || no "fixture genuinely has no nftban table — the control above proves nothing"
+
+RC=$(run_rollback "$D")
+[[ "$RC" == "0" ]] && ok "large snapshot: rollback PROCEEDS (rc=0), not refused as empty" \
+    || no "large snapshot: refused" "rc=$RC — SIGPIPE regression is back"
+[[ "$(commits "$D")" == "1" ]] && ok "large snapshot: exactly ONE commit transaction" \
+    || no "large snapshot: commit count = $(commits "$D")"
+
+# and the restored content must be the real table, not a truncated prefix
+D3="$WORK/s_large_keep"; mkdir -p "$D3"; cp "$D/ruleset.nft" "$D3/"; cp "$D/snapshot_state" "$D3/"
+NFT_FAIL=commit run_rollback "$D3" >/dev/null
+C3="$D3/rollback_candidate.nft"
+if [[ -f "$C3" ]]; then
+    grep -q "blacklist_ipv4" "$C3" && ok "large snapshot: nftban set content present in the candidate" \
+        || no "large snapshot: candidate lost the set content"
+    grep -q "panelfw\|docker" "$C3" && no "large snapshot: a FOREIGN table leaked into the candidate" \
+        || ok "large snapshot: foreign tables still never named"
+else
+    no "large snapshot: no candidate produced for inspection"
+fi
+
+# The product must not reintroduce a pipe on this probe. The guard reads CODE only:
+# an earlier version of this check matched the comment that DESCRIBES the bug, so the
+# comment both documented and violated the assertion. Strip comments, don't reword them.
+#
+# BOUNDARY (owner ruling): this stripper is NOT quote-aware -- a '#' inside a quoted
+# shell string is data, not a comment. It is acceptable ONLY because it is scoped to
+# this one extracted function, which is asserted below to contain no quoted '#', and
+# because the injection control proves it can still fail. Do NOT lift this regex out
+# as a general shell comment parser; that needs real parsing.
+grep -qE "[\"'][^\"']*#" "$FN" \
+    && no "_rebuild_rollback contains a quoted '#' — the naive stripper is unsafe here" \
+    || ok "scope precondition: no quoted '#' in the function, stripper is sound for it"
+CODE_ONLY="$WORK/fn_code_only.sh"
+sed -e 's/[[:space:]]*#.*$//' "$FN" > "$CODE_ONLY"
+grep -qE "awk .*\|[[:space:]]*grep -q" "$CODE_ONLY" \
+    && no "_rebuild_rollback still pipes an awk extraction into 'grep -q'" \
+    || ok "no 'awk | grep -q' probe remains in _rebuild_rollback (comments excluded)"
+# prove that stripper cannot simply blind the check
+printf 'x() { awk foo | grep -q . ; }\n' > "$WORK/inject.sh"
+grep -qE "awk .*\|[[:space:]]*grep -q" <(sed -e 's/[[:space:]]*#.*$//' "$WORK/inject.sh") \
+    && ok "comment-stripping guard still detects a REAL piped probe (injection control)" \
+    || no "guard is blind after comment stripping — it cannot fail"
 
 # ---------------------------------------------------------------- guard
 echo "--- E. the atomicity guard now covers this lane ---"


### PR DESCRIPTION
## Classification (owner ruling, adopted)

```
A1_SIGPIPE_ROLLBACK_DEFECT   = REAL
SEVERITY                     = RELEASE-BLOCKING FOR v1.228.10
REASON                       = a VALID recovery snapshot is falsely rejected on realistic large tables

UNFILTERED_SECURITY_FAILURE  = NO
FAIL_CLOSED                  = YES
CONFIDENTIALITY / PRIV-ESC   = none
FOREIGN TABLE DAMAGE         = NO
RECOVERY AVAILABILITY        = AFFECTED
REAL-HOST REACHABILITY       = YES
```

This is **not** a "host left unfiltered" defect. No flush is issued and enforcement is unchanged. What breaks is the mechanism that exists to recover from a *different* failure.

## Mechanism

```
valid large snapshot
  -> awk extracts the nftban table
  -> grep -q exits after the FIRST line
  -> awk dies of SIGPIPE (rc 141)
  -> set -o pipefail (cmd_firewall.sh:28) makes the pipeline FAIL
  -> code concludes "no nftban table"
  -> rollback REFUSED
```

**Correction to my first description of this:** I originally called it a race against the 64K pipe buffer. That threshold model is **falsified by measurement** — `nft list set … | grep -q` returned `141` for a **4195-byte** producer on lab4, while a 1445-byte producer on lab2 returned `0`. SIGPIPE fires when the consumer exits before the producer has finished writing *and exiting*; output size only makes it more likely. Small fixtures pass and real hosts fail, but there is no size bound to rely on.

Measured on lab4 (Rocky 9.8, RPM, 33KB ruleset / 527-line nftban table):

```
pipefail OFF   pipeline_rc=0    (awk_rc=141 grep_rc=0)
pipefail ON    pipeline_rc=141  (awk_rc=141 grep_rc=0)
product path   fams_count=0 -> "snapshot contains no nftban table to restore"
```

## Why CI did not catch it

Every fixture in `rebuild_atomic_rollback_v1228_10_test.sh` was ~18 lines. The suite passed **34/34 against a rollback that was inert in production.** That is the finding behind the finding.

## Fix

```
DO NOT:  awk ... | grep -q .
DO:      capture the extraction
         -> test whether the captured result is empty
         -> distinguish READ FAILURE from GENUINE ABSENCE
         -> reuse the same captured text to build the candidate
```

Reusing the capture also removes a second read of the snapshot, which could otherwise disagree with the families already committed to. `[{]` / `[}]` replace `\{` / `\}`, silencing a gawk escape warning that was being printed to stderr of a firewall command (and which misled this investigation twice).

## Regression coverage — proven falsifiable, not merely green

New `D2` arm:

```
harness CAN observe the defect (piped probe returns non-zero under pipefail)
fixture large enough (248980 bytes) to make the race reliable
MUTATION CONTROL: pre-fix piped probe finds 0 families on this fixture
the SAME fixture DOES contain 1 nftban family  -> the pre-fix 0 was a lie
large snapshot: rollback PROCEEDS (rc=0)
large snapshot: exactly ONE commit transaction
large snapshot: set content present; foreign tables still never named
```

The mutation control runs the **pre-fix probe verbatim**, so the test discriminates buggy from fixed implementations.

`run_rollback` now sets `pipefail` inside its subshell — without it the whole arm would have been vacuous, since the defect only exists under `pipefail`.

**Guard-input honesty:** the "no `awk | grep -q` remains" assertion first matched *the comment describing the bug* — the comment both documented and violated the assertion. Per the standing rule the parser was fixed, not the comment. The stripper is not quote-aware; that boundary is asserted (`no quoted '#' in this function`), paired with an injection control, and explicitly **not** promoted to a general shell parser.

## Runtime proof — package-native, real `nft` 1.0.9

| control | lab2 DEB | lab4 RPM EL9 |
|---|---|---|
| precondition: marker absent / snapshot excludes it | PASS | PASS |
| A1-7 rollback rc=0 | PASS | PASS |
| A1-7 marker REMOVED (restored, **not inert**) | PASS | PASS |
| A1-7 ip table actually replaced (handle changed) | PASS | PASS |
| A1-7 foreign table untouched | PASS | PASS |
| A1-7 candidate cleaned on success | PASS | PASS |
| A1-8 EMPTY_VERIFIED / FAILED / missing → refused, **zero mutation** | PASS (3/3) | PASS (3/3) |

lab4 table handle `2371 -> 2375` proves the delete+recreate actually committed.

### Two corrections to my own earlier reporting

1. I first diagnosed this as an **awk escape-portability** problem (`\{` vs `[{]`). Wrong — both forms match identically on both labs, before and after sourcing. The escape warning is cosmetic. The branch was renamed from `fix/v1228-10-a1-awk-portability` accordingly.
2. After the fix, lab4 appeared to show *rollback reports success without restoration* — the hard stop condition. That was **my fixture leaking state**: an earlier failed run planted a marker and never removed it, so the next snapshot captured it and restoring it was correct. `TEST_INVALID / PRECONDITION_FAILED`. The matrix above now asserts marker-absence before planting.

### Residual, attributed not normalized away

The semantic-equality check initially differed by 6 lines (lab2) / 2 (lab4). The differing element lives in a set declared `flags dynamic,timeout` — live ratelimit churn between two reads on an internet-facing host. Two controlled re-runs give a **0-line diff on both hosts**. `VOLATILE_RUNTIME_FIELDS` therefore extends to dynamic-set membership; the justification is the set's own `flags dynamic` declaration, not convenience.

## Gate status

```
regression test passes                     YES  (34/34)
pre-fix mutation control demonstrably fails YES
lab4 real RPM positive rollback passes      YES
lab2 remains passing                        YES

GO_RELEASE_PREP = NO   -- A2/A3 on lab4 and the EL10 Enforcing matrix are still outstanding
```


---

## Systemic follow-up — NOT fixed in this PR

`producer | grep -q` under `pipefail` is a codebase pattern, and the failure has a fixed direction: **it converts a MATCH into a NON-MATCH — it always fails toward "not found."**

Inventory (executable lines only, in files that set `pipefail`):

```
84   large-producer sites (nft list… / dpkg -l / systemctl list-* / journalctl | grep -q)
28   of those read genuinely unbounded content (set / chain / ruleset / table)
```

Measured reachability beyond the rollback:

```
lab4  nft list set ip nftban blacklist_manual_ipv4 (4195 B) | grep -q <present element>   rc=141  FALSE NOT-FOUND
lab2  same probe (1445 B)                                                                  rc=0    correct
lab4  nft list ruleset (33286 B) | grep -q <early pattern>                                 rc=141  FALSE NOT-FOUND
lab2  nft list ruleset (20565 B) | grep -q <early pattern>                                 rc=141  FALSE NOT-FOUND
```

The whole-ruleset probe fails on **both** labs. The shape at `cli/lib/nftban/core/nftban_firewall_conflicts.sh:251` is `nft list ruleset | grep -qE "xt target|xtables …"`, where a false NOT-FOUND reads as **"no firewall conflict detected"** — a false-clean.

Individual call sites other than `_rebuild_rollback` are **UNMEASURED for impact**; the mechanism is confirmed and the direction is known, but each site's consequence is a hypothesis until its branch is analysed. Recorded to the register as its own lane rather than widened into this PR, per scope discipline.
