### PR TITLE
fix(whitelist): an unreadable whitelist source is UNKNOWN, never empty [v1.228.10 A3-DIR]

### DIFF
--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -1999,7 +1999,7 @@ _nftban_whitelist_reconcile_and_verify() {
     # Coverage comparison is owned by the Go oracle `nftban-core whitelist-coverage`
     # (cmd/nftban-core/main.go:168); member assembly and expiry are owned by the shared
     # readers in lib/whitelist_members.sh. This function now only ORCHESTRATES.
-    local _fam _set _tbl _missing_all=""
+    local _fam _set _tbl _missing_all="" _unreadable_all=""
     for _fam in 4 6; do
         if [[ "$_fam" == "4" ]]; then
             _set="whitelist_ipv4"; _tbl="ip nftban"
@@ -2015,10 +2015,19 @@ _nftban_whitelist_reconcile_and_verify() {
             _missing_all+="${_set}: UNREADABLE (kernel set could not be measured)"$'\n'
             continue
         fi
-        local _base _sess
-        _base="$(_nftban_wl_read_baseline "$_fam")"
-        _sess="$(_nftban_wl_read_sessions "$_fam")"
-        # Nothing configured for this family => nothing to converge.
+        local _base _sess _base_rc=0 _sess_rc=0
+        _base="$(_nftban_wl_read_baseline "$_fam")" || _base_rc=$?
+        _sess="$(_nftban_wl_read_sessions "$_fam")" || _sess_rc=$?
+        # OBSERVATION FAILURE MUST NEVER BE INTERPRETED AS DESIRED SECURITY STATE EMPTY.
+        # rc 3 = UNREADABLE: the configured source exists and could not be read, so the
+        # desired whitelist is UNKNOWN. Reporting convergence here is what let a rebuild
+        # empty whitelist_ipv4 and still print "verified" (measured, lab4, v1.228.9).
+        if [[ $_base_rc -eq 3 || $_sess_rc -eq 3 ]]; then
+            _unreadable_all+="${_set}: durable whitelist source UNREADABLE (desired state UNKNOWN, not empty)"$'\n'
+            continue
+        fi
+        # Nothing configured for this family => nothing to converge. This is now
+        # reachable only after a SUCCESSFUL read, so it means READ_OK_EMPTY (data).
         [[ -z "$_base$_sess" ]] && continue
 
         local _req _out _m
@@ -2036,6 +2045,18 @@ _nftban_whitelist_reconcile_and_verify() {
             _missing_all+="${_set}: ${_m}"$'\n'
         done < <(printf '%s' "$_out" | jq -r '.missing_from_kernel[]?' 2>/dev/null)
     done
+
+    if [[ -n "$_unreadable_all" ]]; then
+        if [[ "$_mode" == "install-deferred" ]]; then
+            [[ "$_q" == "false" ]] && echo "    Whitelist source UNREADABLE — DEFERRED to installer convergence gate."
+            return 2
+        fi
+        echo "    ERROR: whitelist source could NOT be read — reconcile status is UNKNOWN:" >&2
+        printf '           %s\n' "$_unreadable_all" >&2
+        echo "           The effective whitelist was left as-is; it was NOT reconciled." >&2
+        echo "           Refusing to report success for a source that could not be observed." >&2
+        return 1
+    fi
 
     if [[ -n "$_missing_all" ]]; then
         if [[ "$_mode" == "install-deferred" ]]; then
@@ -2899,6 +2920,38 @@ _firewall_rebuild_core() {
                 _snap_result="$OR_FAILED_RECOVERED"
             fi
             _rebuild_marker_write "$FC_SNAPSHOT_FAILED" "$_snap_result" "$snapshot_dir" "$pre_status"
+        fi
+        return 1
+    fi
+
+    # v1.228.10 A3-DIR — INV-P0-03/04: a SECOND hard gate, same doctrine as the
+    # snapshot gate above. The rebuild recreates the nftban table wholesale and
+    # repopulates the whitelist sets from the durable source, so if that source
+    # cannot be READ the rebuild would render an EMPTY whitelist as though the
+    # operator had configured one. Verifying after the fact is too late: the set
+    # is already empty by then.
+    #
+    #   OBSERVATION FAILURE MUST NEVER BE INTERPRETED AS DESIRED SECURITY STATE EMPTY.
+    #
+    # MEASURED on lab4 (real RPM v1.228.9): a dangling symlink at whitelist.d made
+    # the rebuild flush whitelist_ipv4 to EMPTY -- losing 127.0.0.1 and the host's
+    # own address -- and still exit 0 reporting the reconcile "verified".
+    #
+    # A legitimately ABSENT whitelist.d is NOT caught here: absence is the
+    # first-install shape and is data, matching internal/whitelist/loader.go and
+    # TestA3_AbsentWhitelistDir_IsEmptyNotError. Only present-but-unenumerable aborts.
+    if declare -f _nftban_wl_dir_status &>/dev/null && ! _nftban_wl_dir_status; then
+        echo "ERROR: durable whitelist source could not be read — rebuild ABORTED" >&2
+        echo "       path: ${_NFTBAN_WHITELIST_CONF_DIR:-/etc/nftban/whitelist.d}" >&2
+        echo "       The desired whitelist is UNKNOWN, not empty. Rebuilding now would" >&2
+        echo "       project an empty whitelist over your effective one." >&2
+        echo "       The firewall was NOT modified; the effective whitelist is preserved." >&2
+        if declare -f _rebuild_marker_write &>/dev/null; then
+            local _wl_result="$OR_FAILED_DEGRADED"
+            if [[ "$pre_status" == "protected" || "$pre_status" == "idle" ]]; then
+                _wl_result="$OR_FAILED_RECOVERED"
+            fi
+            _rebuild_marker_write "${FC_SNAPSHOT_FAILED:-SNAPSHOT_FAILED}" "$_wl_result" "$snapshot_dir" "$pre_status"
         fi
         return 1
     fi

--- a/cli/lib/nftban/lib/whitelist_members.sh
+++ b/cli/lib/nftban/lib/whitelist_members.sh
@@ -65,10 +65,51 @@ _nftban_wl_read_kernel_set() {
     return 0
 }
 
+# --- OBSERVATION CONTRACT (v1.228.10 A3-DIR) --------------------------------
+# These readers describe DESIRED whitelist state. Their output is consumed as
+# authoritative, and the sync layer DELETES kernel members absent from it, so
+# "I read nothing" and "I could not read" must never share a representation.
+#
+#   rc 0 + non-empty stdout -> READ_OK_WITH_MEMBERS
+#   rc 0 + empty stdout     -> READ_OK_EMPTY   (legitimate configured truth)
+#   rc 3                    -> UNREADABLE      (observation failure; DATA UNKNOWN)
+#
+#         EMPTY = DATA.   UNREADABLE = ERROR.
+#
+# Previously BOTH states were `rc 0 + ""`, because a missing/dangling
+# $_NFTBAN_WHITELIST_CONF_DIR returned 0 with no output. Measured on lab4 (real
+# RPM v1.228.9): a dangling symlink at whitelist.d made the reconcile read zero
+# members, treat that as "nothing configured", and report
+# "Whitelist reconcile verified (configured members present)" with exit 0 while
+# whitelist_ipv4 had been flushed to EMPTY.
+#
+# A TRULY ABSENT directory stays rc 0 / empty: that is the first-install shape,
+# and it matches internal/whitelist/loader.go, whose behaviour is pinned by
+# TestA3_AbsentWhitelistDir_IsEmptyNotError. Present-but-unenumerable is the
+# defect; absence is not.
+_NFTBAN_WL_RC_UNREADABLE=3
+
+# Returns 0 if the configured dir is usable or legitimately absent, 3 if it is
+# present but cannot be enumerated (dangling symlink, broken mount, non-dir,
+# EACCES). Note `-e` follows symlinks and `-L` does not, so a dangling link is
+# exactly (! -e && -L).
+_nftban_wl_dir_status() {
+    local d="$_NFTBAN_WHITELIST_CONF_DIR"
+    if [[ -d "$d" && -r "$d" && -x "$d" ]]; then return 0; fi
+    if [[ -e "$d" || -L "$d" ]]; then return $_NFTBAN_WL_RC_UNREADABLE; fi
+    return 0
+}
+
 _nftban_wl_read_baseline() {
     local fam="$1" f line before_hash ip
+    _nftban_wl_dir_status || return $?
     [[ -d "$_NFTBAN_WHITELIST_CONF_DIR" ]] || return 0
     for f in "$_NFTBAN_WHITELIST_CONF_DIR"/*.conf; do
+        # An unmatched glob is "no files configured" (data). A dangling symlink is
+        # a source that exists and cannot be read (error) -- do not skip it silently.
+        [[ "$f" == *'*'* && ! -e "$f" ]] && continue
+        [[ ! -e "$f" && -L "$f" ]] && return $_NFTBAN_WL_RC_UNREADABLE
+        [[ -e "$f" && ! -r "$f" ]] && return $_NFTBAN_WL_RC_UNREADABLE
         [[ -e "$f" ]] || continue
         while IFS= read -r line || [[ -n "$line" ]]; do
             local trimmed="${line#"${line%%[![:space:]]*}"}"
@@ -92,8 +133,12 @@ _nftban_wl_read_baseline() {
 _nftban_wl_read_sessions() {
     local fam="$1" f line before_hash ip expires_at expires_unix now_unix
     now_unix=$(date -u +%s 2>/dev/null) || now_unix=0
+    _nftban_wl_dir_status || return $?
     [[ -d "$_NFTBAN_WHITELIST_CONF_DIR" ]] || return 0
     for f in "$_NFTBAN_WHITELIST_CONF_DIR"/*.conf; do
+        [[ "$f" == *'*'* && ! -e "$f" ]] && continue
+        [[ ! -e "$f" && -L "$f" ]] && return $_NFTBAN_WL_RC_UNREADABLE
+        [[ -e "$f" && ! -r "$f" ]] && return $_NFTBAN_WL_RC_UNREADABLE
         [[ -e "$f" ]] || continue
         while IFS= read -r line || [[ -n "$line" ]]; do
             local trimmed="${line#"${line%%[![:space:]]*}"}"

--- a/cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh
+++ b/cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan - whitelist directory observation contract (v1.228.10 A3-DIR)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="whitelist_dir_observation_v1228_10_test"
+# meta:type="test"
+# meta:version="1.0.0"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-10"
+# meta:description="INV-P0-03/04: the durable whitelist readers must distinguish READ_OK_EMPTY (data) from UNREADABLE (error). Drives the REAL _nftban_wl_read_baseline/_nftban_wl_read_sessions from whitelist_members.sh. Proves rc 3 on a present-but-unenumerable source, rc 0 on a legitimately absent one, and that the reconcile caller in cmd_firewall.sh consumes rc 3 without ever printing a verified claim. Includes the pre-fix mutation control proving the old reader reported rc 0 + empty for the same fixture."
+# meta:input="None (sandbox fixtures)"
+# meta:output="Pass/fail assertions; exit 0 on all-pass"
+# meta:depends="bash,grep,sed,mktemp"
+# meta:inventory.files="cli/lib/nftban/lib/whitelist_members.sh,cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.binaries="bash,grep,sed,mktemp"
+# meta:inventory.privileges="none"
+# meta:ta.id="whitelist_dir_observation_v1228_10_test"
+# meta:ta.owner="whitelist"
+# meta:ta.module="whitelist-members"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -uo pipefail
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../../.." && pwd)"
+LIB="$REPO_ROOT/cli/lib/nftban/lib/whitelist_members.sh"
+FW="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✓ $1"; }
+no(){ FAIL=$((FAIL+1)); echo "  ✗ $1${2:+ — $2}"; }
+echo "=== whitelist_dir_observation_v1228_10 ==="
+[[ -f "$LIB" ]] || { echo "FATAL: $LIB missing"; exit 2; }
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+# shellcheck source=/dev/null
+. "$LIB"
+
+run(){ # $1=conf dir path -> "rc|output-line-count"
+    local out rc=0
+    _NFTBAN_WHITELIST_CONF_DIR="$1"
+    out="$(_nftban_wl_read_baseline 4)" || rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | grep -c . || true)"
+}
+
+echo "--- 1. readable dir + configured member => READ_OK_WITH_MEMBERS ---"
+D="$WORK/ok"; mkdir -p "$D"; printf '1.2.3.41\n' > "$D/10-a.conf"
+R="$(run "$D")"; [[ "$R" == "0|1" ]] && ok "rc=0 with 1 member ($R)" || no "expected 0|1, got $R"
+
+echo "--- 2. readable dir, genuinely empty => READ_OK_EMPTY (data, not error) ---"
+D="$WORK/empty"; mkdir -p "$D"
+R="$(run "$D")"; [[ "$R" == "0|0" ]] && ok "rc=0 with 0 members — empty stays legitimate ($R)" || no "expected 0|0, got $R"
+
+echo "--- 3. dir present but UNENUMERABLE (dangling symlink) => UNREADABLE ---"
+D="$WORK/dangling"; ln -s "$WORK/no-such-target" "$D"
+R="$(run "$D")"; [[ "${R%%|*}" == "3" ]] && ok "rc=3 UNREADABLE (not silently empty) ($R)" \
+    || no "dangling whitelist.d did not report UNREADABLE" "got $R"
+
+echo "--- 4. participating FILE unreadable (dangling) => UNREADABLE, no partial union ---"
+D="$WORK/badfile"; mkdir -p "$D"; printf '1.2.3.41\n' > "$D/10-a.conf"
+ln -s "$D/no-such-target" "$D/20-b.conf"
+R="$(run "$D")"; [[ "${R%%|*}" == "3" ]] && ok "rc=3 — a shortened union never becomes authoritative ($R)" \
+    || no "unreadable participating file was silently skipped" "got $R"
+
+echo "--- 5. legitimately ABSENT dir => rc 0 (first-install shape preserved) ---"
+R="$(run "$WORK/never-created")"
+[[ "$R" == "0|0" ]] && ok "absence stays data, matching TestA3_AbsentWhitelistDir_IsEmptyNotError ($R)" \
+    || no "absent dir changed behaviour" "got $R"
+
+echo "--- 6. POSITIVE RECOVERY: restore readable source => desired state changes again ---"
+D="$WORK/recover"; mkdir -p "$D"; printf '1.2.3.41\n' > "$D/10-a.conf"
+R1="$(run "$D")"; printf '1.2.3.41\n1.2.3.42\n' > "$D/10-a.conf"; R2="$(run "$D")"
+[[ "$R1" == "0|1" && "$R2" == "0|2" ]] && ok "path is not inert ($R1 -> $R2)" \
+    || no "reader did not follow a changed source" "$R1 -> $R2"
+
+echo "--- 7. MUTATION CONTROL: the pre-fix reader reported rc 0 + empty for arm 3 ---"
+prefix_reader(){ [[ -d "$1" ]] || return 0; for f in "$1"/*.conf; do [[ -e "$f" ]] || continue; done; return 0; }
+prefix_reader "$WORK/dangling"; PRC=$?
+[[ "$PRC" == "0" ]] && ok "pre-fix form returns rc=0 on the SAME fixture — the arm discriminates" \
+    || no "pre-fix form already failed; arm 3 proves nothing" "rc=$PRC"
+
+echo "--- 8. the reconcile caller consumes UNREADABLE and never claims verified ---"
+if [[ -f "$FW" ]]; then
+    CODE="$WORK/fw_code.sh"; sed -e 's/[[:space:]]*#.*$//' "$FW" > "$CODE"
+    grep -q '_base_rc -eq 3 \|_sess_rc -eq 3' "$CODE" && ok "caller branches on rc 3" || no "caller ignores rc 3"
+    grep -q '_unreadable_all' "$CODE" && ok "caller records the unreadable state separately" || no "no unreadable state in caller"
+    # The verified claim must be UNREACHABLE once a source was unreadable. Checked
+    # structurally, not by textual order (an earlier version of this assertion just
+    # scanned forward and fired on the unrelated later occurrence):
+    #   a) the accumulation is immediately followed by `continue` (leaves the loop body)
+    #   b) the `-n "$_unreadable_all"` guard returns BEFORE the verified line
+    # BOUNDARY: this is line-order reasoning over one small function, not a CFG.
+    ACC=$(grep -n '_unreadable_all+=' "$CODE" | head -1 | cut -d: -f1)
+    NEXT=$(awk -v a="$ACC" 'NR>a && NF {print NR": "$0; exit}' "$CODE")
+    [[ "$NEXT" == *continue* ]] && ok "unreadable accumulation is followed by 'continue'" \
+        || no "accumulation does not leave the loop body" "next=$NEXT"
+    GUARD=$(grep -n 'if \[\[ -n "$_unreadable_all" \]\]' "$CODE" | head -1 | cut -d: -f1)
+    GRET=$(awk -v g="$GUARD" 'NR>g && /return 1/ {print NR; exit}' "$CODE")
+    VER=$(grep -n 'reconcile verified' "$CODE" | head -1 | cut -d: -f1)
+    if [[ -n "$GUARD" && -n "$GRET" && -n "$VER" && "$GRET" -lt "$VER" ]]; then
+        ok "unreadable guard returns at line $GRET, before the verified claim at $VER"
+    else
+        no "verified claim is not provably guarded" "guard=$GUARD ret=$GRET verified=$VER"
+    fi
+else
+    no "cmd_firewall.sh not found"
+fi
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh
+++ b/cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh
@@ -23,6 +23,7 @@
 # meta:ta.hermetic="true"
 # meta:ta.requires_root="false"
 # meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
 # meta:ta.requires_nftables="false"
 # meta:ta.requires_package="false"
 # =============================================================================

--- a/internal/whitelist/loader.go
+++ b/internal/whitelist/loader.go
@@ -120,8 +120,17 @@ func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[st
 	//    contribution may not be silently dropped from the desired state.
 	mainFile := filepath.Join(configDir, "whitelist.conf")
 	if err := loadWhitelistFileTyped(mainFile, ipv4, ipv6); err != nil {
+		// Same ENOENT-is-not-absence rule as whitelist.d below: a dangling symlink at
+		// whitelist.conf opens with ENOENT while Lstat proves the path is present.
+		// Treating that as "optional file absent" would silently drop a participating
+		// source from the desired state.
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, nil, fmt.Errorf("whitelist source %s unreadable: %w", mainFile, err)
+		}
+		if _, lerr := os.Lstat(mainFile); lerr == nil {
+			return nil, nil, fmt.Errorf(
+				"whitelist source %s unreadable: path is present but cannot be opened "+
+					"(dangling symlink); its contribution is unknown, not absent: %w", mainFile, err)
 		}
 	}
 
@@ -130,7 +139,24 @@ func LoadAllWhitelistsTyped(configDir string) (map[string]WhitelistEntry, map[st
 	entries, err := os.ReadDir(whitelistDir)
 	if err != nil {
 		// Absent directory = legitimate first-install shape: empty, not degraded.
+		//
+		// But ENOENT does NOT prove absence. A dangling symlink or a broken bind
+		// mount at this path makes ReadDir return ENOENT while the path itself is
+		// demonstrably PRESENT: Lstat does not follow the final link, so it succeeds
+		// on exactly the shapes ReadDir cannot see through. Measured on lab4 (real
+		// RPM, v1.228.9): `ln -s /nonexistent /etc/nftban/whitelist.d` was classified
+		// as first-install, FullSync consumed the empty desired state as authoritative
+		// and flushed whitelist_ipv4 to EMPTY — losing 127.0.0.1 and the host's own
+		// address — while the rebuild exited 0 and reported the reconcile "verified".
+		//
+		// OBSERVATION FAILURE MUST NEVER BE INTERPRETED AS DESIRED SECURITY STATE EMPTY.
 		if errors.Is(err, fs.ErrNotExist) {
+			if _, lerr := os.Lstat(whitelistDir); lerr == nil {
+				return nil, nil, fmt.Errorf(
+					"whitelist directory %s unreadable: path is present but not enumerable "+
+						"(dangling symlink or broken mount); the whitelist is UNKNOWN, not empty: %w",
+					whitelistDir, err)
+			}
 			return ipv4, ipv6, nil
 		}
 		// Present but unenumerable (EACCES from a packaging perms slip, EIO, an SELinux

--- a/internal/whitelist/observation_dir_presence_v1228_10_test.go
+++ b/internal/whitelist/observation_dir_presence_v1228_10_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// A3-DIR: ENOENT from ReadDir does not prove absence.
+//
+// A dangling symlink or broken mount at whitelist.d makes os.ReadDir return
+// ENOENT while the path is demonstrably present. Classifying that as the
+// first-install shape yields an EMPTY desired state, and FullSync consumes that
+// as authoritative and deletes every kernel whitelist member.
+//
+// MEASURED on lab4 (real RPM, v1.228.9) before this fix:
+//
+//	PRE  whitelist_ipv4 = 1.2.3.41 127.0.0.1 46.62.213.143
+//	POST whitelist_ipv4 = <EMPTY>            rebuild exit 0
+//	     "Whitelist reconcile verified (configured members present)."
+//
+// OBSERVATION FAILURE MUST NEVER BE INTERPRETED AS DESIRED SECURITY STATE EMPTY.
+//
+// Truly-absent stays empty-no-error: that is pinned by
+// TestA3_AbsentWhitelistDir_IsEmptyNotError and is the first-install shape.
+// Absence is data; present-but-unenumerable is an error.
+package whitelist
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// STATE: whitelist.d is a DANGLING SYMLINK -> present, unenumerable -> ERROR.
+// Root-proof: a dangling link fails to open for every uid, so this holds in
+// root CI exactly as it does locally.
+func TestA3Dir_DanglingSymlinkWhitelistDir_IsErrorNotEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "no-such-target"), filepath.Join(dir, "whitelist.d")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	v4, v6, err := LoadAllWhitelistsTyped(dir)
+	if err == nil {
+		t.Fatal("dangling whitelist.d returned SUCCESS — an unobservable source became " +
+			"an empty desired state, which is what flushed the kernel whitelist on lab4")
+	}
+	if v4 != nil || v6 != nil {
+		t.Error("maps must be nil on observation failure so a partial/empty result cannot be consumed")
+	}
+}
+
+// The pre-fix behaviour, asserted directly: ReadDir reports ErrNotExist for this
+// shape. Without this the test above cannot be distinguished from a fixture that
+// simply never reached the ENOENT branch.
+func TestA3Dir_MutationControl_ReadDirReportsENOENTForDanglingLink(t *testing.T) {
+	dir := t.TempDir()
+	wl := filepath.Join(dir, "whitelist.d")
+	if err := os.Symlink(filepath.Join(dir, "no-such-target"), wl); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	if _, err := os.ReadDir(wl); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("fixture does not exercise the ENOENT branch (err=%v) — the arm above would be vacuous", err)
+	}
+	if _, err := os.Lstat(wl); err != nil {
+		t.Fatalf("Lstat must still see the path, or the discriminator cannot work: %v", err)
+	}
+}
+
+// A dangling symlink at the OPTIONAL main whitelist.conf is the same class:
+// "optional file absent" must not absorb "present and unopenable".
+func TestA3Dir_DanglingMainWhitelistConf_IsErrorNotAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "whitelist.d"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "no-such-target"), filepath.Join(dir, "whitelist.conf")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	if _, _, err := LoadAllWhitelistsTyped(dir); err == nil {
+		t.Fatal("dangling whitelist.conf returned success — its contribution is unknown, not absent")
+	}
+}
+
+// POSITIVE CONTROL: the fix must not turn into "error on everything". A readable
+// directory with a real member still loads, and a readable EMPTY directory is
+// still legitimate configured truth.
+func TestA3Dir_ReadableDirStillLoads_AndEmptyIsStillData(t *testing.T) {
+	dir := t.TempDir()
+	wl := filepath.Join(dir, "whitelist.d")
+	if err := os.MkdirAll(wl, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	v4, _, err := LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("readable EMPTY whitelist.d must be data, not error: %v", err)
+	}
+	if len(v4) != 0 {
+		t.Errorf("empty dir should yield 0 members, got %d", len(v4))
+	}
+
+	if err := os.WriteFile(filepath.Join(wl, "10-a.conf"), []byte("1.2.3.41\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	v4, _, err = LoadAllWhitelistsTyped(dir)
+	if err != nil {
+		t.Fatalf("readable dir with a member must load: %v", err)
+	}
+	if _, ok := v4["1.2.3.41"]; !ok {
+		t.Errorf("configured member not projected into desired state: %v", v4)
+	}
+}

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -268,6 +268,7 @@ version_build_date_v151_test	cli/lib/nftban/tests/version_build_date_v151_test.s
 version_date_coherence_v1228_7_test	cli/lib/nftban/tests/version_date_coherence_v1228_7_test.sh	packaging	test	version-date-coherence	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	60		
 version_release_date_authority_test	cli/lib/nftban/tests/version_release_date_authority_test.sh	release	test	version	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 watchdog_update_swap_race_v1983_test	cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh	update	test	watchdog-update-swap	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+whitelist_dir_observation_v1228_10_test	cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh	whitelist	test	whitelist-members	CI_HERMETIC_SHELL	ci-bash	true	false	false		false	false			
 whitelist_list_timed_label_v169_test	cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh	whitelist	test	whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 whitelist_rebuild_remerge_v1930_test	cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh	firewall	test	whitelist-rebuild-remerge	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 whitelist_reconcile_convergence_v1228_5_test	cli/lib/nftban/tests/whitelist_reconcile_convergence_v1228_5_test.sh	firewall	test	whitelist-reconcile-convergence	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -268,7 +268,7 @@ version_build_date_v151_test	cli/lib/nftban/tests/version_build_date_v151_test.s
 version_date_coherence_v1228_7_test	cli/lib/nftban/tests/version_date_coherence_v1228_7_test.sh	packaging	test	version-date-coherence	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	60		
 version_release_date_authority_test	cli/lib/nftban/tests/version_release_date_authority_test.sh	release	test	version	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 watchdog_update_swap_race_v1983_test	cli/lib/nftban/tests/watchdog_update_swap_race_v1983_test.sh	update	test	watchdog-update-swap	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
-whitelist_dir_observation_v1228_10_test	cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh	whitelist	test	whitelist-members	CI_HERMETIC_SHELL	ci-bash	true	false	false		false	false			
+whitelist_dir_observation_v1228_10_test	cli/lib/nftban/tests/whitelist_dir_observation_v1228_10_test.sh	whitelist	test	whitelist-members	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 whitelist_list_timed_label_v169_test	cli/lib/nftban/tests/whitelist_list_timed_label_v169_test.sh	whitelist	test	whitelist	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 whitelist_rebuild_remerge_v1930_test	cli/lib/nftban/tests/whitelist_rebuild_remerge_v1930_test.sh	firewall	test	whitelist-rebuild-remerge	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 whitelist_reconcile_convergence_v1228_5_test	cli/lib/nftban/tests/whitelist_reconcile_convergence_v1228_5_test.sh	firewall	test	whitelist-reconcile-convergence	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			


### PR DESCRIPTION
## Classification

```
OPEN_WHITELIST_DIR_UNREADABLE_FLUSHES_TO_EMPTY_AND_CLAIMS_VERIFIED
SEVERITY = P0
TARGET   = v1.228.10
DOMAIN   = whitelist truth / observation integrity  (separate from #1209)

CONFIRMED      whitelist loss + false "verified" claim
NOT CONFIRMED  operator/admin lockout  (deliberately not pursued)
```

## Measured on lab4 — real RPM `nftban-core-1.228.9-1.el9`

```
PRE   whitelist_ipv4 = 1.2.3.41 127.0.0.1 46.62.213.143
POST  whitelist_ipv4 = <EMPTY>              rebuild exit 0
      "Whitelist reconcile verified (configured members present)."
```

Injection: `ln -s /nonexistent /etc/nftban/whitelist.d`. Loopback and the host's own address were lost, and the operator was told it verified.

> **OBSERVATION FAILURE MUST NEVER BE INTERPRETED AS DESIRED SECURITY STATE EMPTY.**

## The discriminator that located it

```
file-level unreadable   -> Go A3 path  -> DEGRADED, other entries preserved, exit 1   CORRECT
directory-level         -> shell twin  -> rc 0 + empty -> "nothing configured"        DEFECT
```

The file-level arm proves A3 itself works. Daemon state was constant (`inactive`) across both arms, so the injection form is the only variable.

## Root cause: ENOENT was read as proof of absence

**1. `internal/whitelist/loader.go`** classified `ReadDir` `ENOENT` as the first-install shape. A dangling symlink returns `ENOENT` while the path is demonstrably present — `Lstat` does not follow the final link, so it succeeds on exactly the shapes `ReadDir` cannot see through. The empty desired state was then consumed by `FullSync` as authoritative. The file's own comment already named this consequence ("an admin-lockout enabler"); the directory arm just wasn't covered. The same carve-out on the optional `whitelist.conf` is closed identically.

**2. `whitelist_members.sh`** returned `rc 0` + empty for a missing/dangling dir, so two different facts shared one representation. New contract:

```
rc 0 + non-empty   READ_OK_WITH_MEMBERS
rc 0 + empty       READ_OK_EMPTY    legitimate configured truth
rc 3               UNREADABLE       observation failure, data UNKNOWN

EMPTY = DATA.   UNREADABLE = ERROR.
```

An unreadable *participating file* also returns 3 instead of being silently skipped, so a shortened union cannot become authoritative.

**3. `cmd_firewall.sh`** reported convergence on a source it never read; it now consumes rc 3 and refuses the verified claim.

## Fixing the verifier alone was NOT sufficient — measured

First revalidation on lab4 with only the loader + verifier fixed:

```
exit=1, explicit unreadable observation, no verified claim     <- truth restored
POST whitelist_ipv4 = <EMPTY>                                  <- STILL FLUSHED
```

The rebuild recreates the nftban table wholesale and repopulates the whitelist from the durable source, so by the time the verifier runs the set is already empty. A **second pre-mutation hard gate**, mirroring the A2 snapshot gate, aborts before the firewall is touched.

## Absence is deliberately still data

A truly absent `whitelist.d` does **not** abort — that is the first-install shape, pinned by `TestA3_AbsentWhitelistDir_IsEmptyNotError`. Re-verified on lab4 with the precondition asserted (`exists=NO lexists=NO` → `rc 0`, no abort). Only *present-but-unenumerable* aborts.

## Regression coverage — every arm has a control proving it can fail

**Go** (`observation_dir_presence_v1228_10_test.go`): dangling dir → error; dangling `whitelist.conf` → error; **mutation control** asserting `ReadDir` really returns `ENOENT` while `Lstat` still sees the path (without it the main arm could pass without reaching the branch); positive control that readable-with-member loads and readable-empty stays data.

**Shell** (`whitelist_dir_observation_v1228_10_test.sh`, 11/11) covers all six required arms plus:
- the **pre-fix reader** returning `rc 0` on the *same* fixture — the arm discriminates
- a structural check that the verified claim is unreachable once a read failed

That last assertion was itself wrong first time: it scanned forward textually and fired on an unrelated later occurrence. Replaced with a control-flow check (accumulation followed by `continue`; guard returns at 2058, before the claim at 2072), with its line-order boundary documented rather than overstated.

## Runtime proof — lab4, the exact fixture that falsified main

```
11/11 PASS
  whitelist_ipv4 UNCHANGED (no flush-to-empty)
  prior effective entry preserved
  table handle UNCHANGED — aborted before any mutation
  rc != 0 ; explicit unreadable observation ; NO "reconcile verified"
  positive recovery: newly configured member reaches the kernel
  absent dir: rc 0, no abort (precondition asserted separately)
```

Go: `gofmt` clean, `go vet` clean, tests pass in `internal/whitelist`, `internal/runtime`, `internal/nftbackend`. (`loader_test.go` is unformatted on pristine `main` — pre-existing, left alone.)

**Validation note:** the lab4 runtime proof ran with #1209 also applied, since both are `.10` release candidates. This branch itself is scope-clean — it still contains the un-fixed rollback probe.

## Gate status

```
INV-P0-03  lab4 PASS with this fix
GO_EL10_MATRIX   = NO   (held until main is green with #1209 + this)
GO_RELEASE_PREP  = NO
```
