### PR TITLE
fix(observation): CSF detection must never execute a vendor firewall binary [v1.229.0 R0]

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -69,3 +69,23 @@ jobs:
           echo "=== ShellCheck: Install ==="
           shellcheck -x -S warning install/*.sh
           shellcheck -x -S warning install.sh build.sh
+
+      # ----------------------------------------------------------------------
+      # v1.229.0 R0 — EXECUTE the CSF observation-purity gate.
+      #
+      # This workflow previously only linted; it never EXECUTED a *_test.sh.
+      # A test file that is merely present is inert (TEST-DISCOVERY GAP:
+      # 182/225 shell tests not CI-wired), and the R0 spec makes
+      # TEST_PRESENT_IN_REQUIRED_CI release-blocking — "test file added" is
+      # explicitly insufficient.
+      #
+      # Scope note: this step is deliberately an explicit single-file
+      # invocation, NOT a glob over tests/. Auto-discovering every shell test
+      # here would turn a lint gate into an unreviewed test runner and drag in
+      # the known-red baseline. Broad discovery belongs to the test-authority
+      # lane, not to this hotfix.
+      - name: CSF observation purity (v1.229.0 R0 gate)
+        run: |
+          echo "=== Executing: csf_observation_purity_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+          bash cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh

--- a/cli/lib/nftban/cli/cmd_health_analysis.sh
+++ b/cli/lib/nftban/cli/cmd_health_analysis.sh
@@ -128,17 +128,23 @@ nftban_health_cmd_conflicts() {
         echo "│  ✓ ufw           not installed                            │"
     fi
 
-    # CSF - Check BOTH service status AND config file
-    # Root cause fix: Previously only checked config, not service state
-    # CSF can be disabled (csf -x) but config still has TESTING="0"
-    local csf_service_active=false
-    if systemctl is-active --quiet lfd 2>/dev/null; then
-        csf_service_active=true
-    elif command -v csf &>/dev/null && csf -s 2>&1 | grep -q "csf is enabled"; then
-        csf_service_active=true
-    fi
+    # CSF — v1.229.0 R0 SITE 2. Observation must not execute vendor binaries.
+    # REMOVED the `csf -s ... | grep -q` probe: `csf -s` STARTS CSF (measured
+    # 0 -> 129 kernel rules). CORRECTED the activity test to csf.service OR
+    # lfd.service — `lfd` alone reported an enforcing CSF as "disabled".
+    # _nftban_csf_activity is defined in nftban_firewall_conflicts.sh, which
+    # this command sources above before any conflict rendering.
+    local csf_activity
+    csf_activity="$(_nftban_csf_activity)"
 
-    if [[ "$csf_service_active" == "true" ]] && [[ -f /etc/csf/csf.conf ]]; then
+    if [[ ! -f /etc/csf/csf.conf ]] && ! command -v csf &>/dev/null; then
+        echo "│  ✓ CSF           not installed                            │"
+    elif [[ "$csf_activity" == "cannot-verify" ]]; then
+        # Neither ACTIVE nor DISABLED may be asserted. has_conflicts is left
+        # unchanged — this line IS the signal; it must not manufacture a clean
+        # verdict, nor a conflict that was never observed.
+        echo "│  ⚠ CSF           cannot-verify (systemd unavailable)      │"
+    elif [[ "$csf_activity" == "active" ]] && [[ -f /etc/csf/csf.conf ]]; then
         if grep -q "^TESTING = \"0\"" /etc/csf/csf.conf 2>/dev/null; then
             echo "│  ✗ CSF           ACTIVE (production mode)                 │"
         else

--- a/cli/lib/nftban/core/nftban_firewall_conflicts.sh
+++ b/cli/lib/nftban/core/nftban_firewall_conflicts.sh
@@ -528,6 +528,32 @@ nftban_detect_cphulk() {
 # CSF / OTHER SECURITY TOOLS
 # =============================================================================
 
+# _nftban_csf_activity — PURE observation of CSF activity. v1.229.0 R0.
+#
+# Emits exactly one of: active | not-active | cannot-verify
+#
+# INVARIANT (release-blocking): this function MUST NOT execute `csf`, `lfd`, or
+# any other vendor firewall binary. `csf -s` STARTS CSF — using it as a probe
+# re-armed a competing firewall from `nftban firewall conflicts`, `nftban
+# health`, and the maintenance/health TIMERS (unattended root).
+#
+# Empty output from BOTH queries means systemctl/D-Bus is unusable (container,
+# degraded host) — that is cannot-verify, NOT "disabled". Modern systemd prints
+# `inactive` for a not-found unit, which is correctly not-active.
+#
+# No pipelines: `producer | grep -q` under `set -o pipefail` yields 141 on a
+# MATCH and silently reads as no-match.
+_nftban_csf_activity() {
+    local out unit saw_output=0
+    for unit in csf.service lfd.service; do
+        out=$(systemctl is-active "$unit" 2>/dev/null)
+        [[ -n "$out" ]] && saw_output=1
+        [[ "$out" == "active" ]] && { echo "active"; return 0; }
+    done
+    [[ $saw_output -eq 0 ]] && { echo "cannot-verify"; return 0; }
+    echo "not-active"
+}
+
 nftban_detect_csf() {
     # Detect ConfigServer Firewall (CSF)
     # Returns: 0=not found, 1=installed but disabled, 2=active
@@ -537,16 +563,30 @@ nftban_detect_csf() {
     if [[ -f /etc/csf/csf.conf ]] || command -v csf &>/dev/null; then
         status=1
 
-        # Check if CSF is actually ENABLED (not just installed)
-        # CSF can be in production mode (TESTING=0) but still disabled
-        local csf_enabled=false
-        if systemctl is-active lfd &>/dev/null 2>&1; then
-            csf_enabled=true
-        elif csf -s 2>&1 | grep -q "csf is enabled"; then
-            csf_enabled=true
-        fi
+        # v1.229.0 R0 SITE 1 — CSF OBSERVATION PURITY.
+        #
+        # REMOVED: `csf -s 2>&1 | grep -q "csf is enabled"`. `csf -s` is CSF's
+        # START command, not a status query: it installed 129 kernel rules on a
+        # host where CSF was inactive (measured 0 -> 129, el9-clean 2026-08-11).
+        # An observation path must never execute a vendor firewall binary.
+        #
+        # CORRECTED: activity is `csf.service` OR `lfd.service`. The old test
+        # asked only about `lfd`, so a host with csf.service active and lfd
+        # failed was reported "disabled (no conflict)" while enforcing.
+        #
+        # No pipelines here: `producer | grep -q` under `set -o pipefail`
+        # returns 141 on match and reads as NOT-FOUND.
+        local csf_activity
+        csf_activity="$(_nftban_csf_activity)"
 
-        if [[ "$csf_enabled" == "true" ]]; then
+        if [[ "$csf_activity" == "cannot-verify" ]]; then
+            # Observation failed — assert neither ACTIVE nor DISABLED. UNKNOWN
+            # must never cross the observation -> mutation boundary, so severity
+            # is capped at INFO: destructive drift consumers key on CRITICAL.
+            NFTBAN_FIREWALL_CONFLICTS+=("CSF: Installed — state CANNOT-VERIFY (systemd unavailable)")
+            NFTBAN_FIREWALL_CONFLICTS+=("  └─ CSF activity could not be observed; no safety claim is made")
+            [[ $NFTBAN_FIREWALL_SEVERITY -lt $CONFLICT_INFO ]] && NFTBAN_FIREWALL_SEVERITY=$CONFLICT_INFO
+        elif [[ "$csf_activity" == "active" ]]; then
             # CSF is actually running
             status=2
             if grep -q "^TESTING = \"0\"" /etc/csf/csf.conf 2>/dev/null; then

--- a/cli/lib/nftban/core/nftban_output.sh
+++ b/cli/lib/nftban/core/nftban_output.sh
@@ -478,6 +478,7 @@ nftban_banner_unified() {
            systemctl is-active --quiet iptables 2>/dev/null || \
            systemctl is-active --quiet ip6tables 2>/dev/null || \
            { command -v ufw &>/dev/null && ufw status 2>/dev/null | grep -q "^Status: active"; } || \
+           systemctl is-active --quiet csf.service 2>/dev/null || \
            systemctl is-active --quiet lfd 2>/dev/null; then
             conflict_icon=" ⚔️"
         fi

--- a/cli/lib/nftban/lib/nftban_checks.sh
+++ b/cli/lib/nftban/lib/nftban_checks.sh
@@ -600,8 +600,35 @@ nftban_check_firewall_conflict() {
             if [[ -f /etc/csf/csf.conf ]] || command -v csf &>/dev/null; then
                 installed="true"
                 status_text="installed"
-                # Check if CSF/lfd is actually running (service state is source of truth)
-                if systemctl is-active lfd &>/dev/null 2>&1; then
+                # v1.229.0 R0 SITE 3 — CSF activity via csf.service OR lfd.service.
+                # The old test asked only about `lfd`, so a host with csf.service
+                # active and lfd failed was reported disabled while enforcing.
+                #
+                # DELIBERATE R0 DUPLICATION: this file is sourced standalone by the
+                # report/render surfaces and does NOT source
+                # nftban_firewall_conflicts.sh, so the canonical
+                # _nftban_csf_activity is not reachable here. The spec permits
+                # inlining per site. Collapsing the two bodies onto one canonical
+                # observer belongs to R1 (adoption-not-invention) — NOT to this
+                # hotfix. Keep the two bodies byte-equivalent in semantics.
+                # No pipelines: `producer | grep -q` under pipefail returns 141
+                # on a MATCH and reads as no-match.
+                local _csf_act _csf_unit _csf_saw=0 _csf_out
+                for _csf_unit in csf.service lfd.service; do
+                    _csf_out=$(systemctl is-active "$_csf_unit" 2>/dev/null)
+                    [[ -n "$_csf_out" ]] && _csf_saw=1
+                    [[ "$_csf_out" == "active" ]] && { _csf_act="active"; break; }
+                done
+                if [[ "${_csf_act:-}" != "active" ]]; then
+                    if [[ $_csf_saw -eq 0 ]]; then _csf_act="cannot-verify"; else _csf_act="not-active"; fi
+                fi
+
+                if [[ "$_csf_act" == "cannot-verify" ]]; then
+                    # Observation failed. Assert no safety: never "disabled_*",
+                    # never critical (destructive consumers key on critical).
+                    status_text="state_unverifiable"
+                    conflict_level="info"
+                elif [[ "$_csf_act" == "active" ]]; then
                     active="true"
                     enabled="true"
                     if grep -q "^TESTING = \"0\"" /etc/csf/csf.conf 2>/dev/null; then

--- a/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+++ b/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
@@ -10,8 +10,17 @@
 # meta:description="R0 release gate. Proves CSF observation executes no vendor firewall binary, that activity is read from csf.service OR lfd.service, that an unobservable host yields cannot-verify (never 'disabled'), and that cannot-verify can never cross the observation->mutation boundary into the drift-policy consumer."
 # meta:inventory.files="cli/lib/nftban/core/nftban_firewall_conflicts.sh,cli/lib/nftban/cli/cmd_health_analysis.sh,cli/lib/nftban/lib/nftban_checks.sh,cli/lib/nftban/core/nftban_output.sh"
 # meta:inventory.privileges="none"
+# meta:ta.id="csf_observation_purity_v1229_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall"
 # meta:ta.execution_class="CI_HERMETIC_SHELL"
 # meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
 # =============================================================================
 #
 # PROVEN DEFECT THIS GUARDS (el9-clean, 2026-08-11):

--- a/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+++ b/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.229.0 R0 — CSF OBSERVATION PURITY (release-blocking)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="csf-observation-purity-v1229-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-11"
+# meta:description="R0 release gate. Proves CSF observation executes no vendor firewall binary, that activity is read from csf.service OR lfd.service, that an unobservable host yields cannot-verify (never 'disabled'), and that cannot-verify can never cross the observation->mutation boundary into the drift-policy consumer."
+# meta:inventory.files="cli/lib/nftban/core/nftban_firewall_conflicts.sh,cli/lib/nftban/cli/cmd_health_analysis.sh,cli/lib/nftban/lib/nftban_checks.sh,cli/lib/nftban/core/nftban_output.sh"
+# meta:inventory.privileges="none"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# =============================================================================
+#
+# PROVEN DEFECT THIS GUARDS (el9-clean, 2026-08-11):
+#   `nftban firewall conflicts` — a read-only report — installed 129 kernel
+#   rules (measured 0 -> 129) because the detector used `csf -s`, which is
+#   CSF's START command. Reachable from nftban-maintenance.timer and
+#   nftban-health.timer: unattended root re-arming a competing firewall.
+#   Second defect: activity was read from `lfd` alone, so an enforcing host
+#   with csf.service active + lfd failed reported "disabled (no conflict)".
+#
+# HARNESS POLICY: no `producer | grep -q` under pipefail anywhere — that
+# returns 141 on a MATCH and reads as no-match.
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+LIB="$REPO_ROOT/cli/lib/nftban"
+CONFLICTS_LIB="$LIB/core/nftban_firewall_conflicts.sh"
+
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; echo "       $2"; FAIL=$((FAIL+1)); }
+
+SANDBOX="$(mktemp -d)"
+# The EXIT trap is INHERITED by every ( ) subshell below. Without the PID guard
+# the FIRST arm's subshell deletes the sandbox on exit, and every later arm then
+# runs with no mocks: `command -v csf` fails, the detector never enters its body,
+# severity stays 0, and T6 passes VACUOUSLY. Caught by the T-VAC control below.
+MAIN_PID=$$
+trap '[[ $BASHPID == "$MAIN_PID" ]] && rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+# --- mock vendor binary: records every invocation, mutates nothing ----------
+cat > "$SANDBOX/bin/csf" <<'MOCK'
+#!/usr/bin/env bash
+echo "csf $*" >> "${CSF_INVOCATION_LOG:?}"
+# A real `csf -s` would install a ruleset here. The mock only records, so an
+# invocation is observable without the test ever touching a firewall.
+exit 0
+MOCK
+chmod +x "$SANDBOX/bin/csf"
+
+# --- mock systemctl: scripted per-unit answers via SYSTEMCTL_MODE -----------
+cat > "$SANDBOX/bin/systemctl" <<'MOCK'
+#!/usr/bin/env bash
+unit=""
+for a in "$@"; do case "$a" in *.service|csf|lfd) unit="$a";; esac; done
+case "${SYSTEMCTL_MODE:-inactive}" in
+  inactive)      echo "inactive";      [ "$1" = "is-active" ] && exit 3 ;;
+  csf-active)    case "$unit" in csf.service) echo "active"; exit 0;; *) echo "failed"; exit 3;; esac ;;
+  lfd-active)    case "$unit" in lfd.service|lfd) echo "active"; exit 0;; *) echo "inactive"; exit 3;; esac ;;
+  unusable)      exit 1 ;;   # no stdout at all -> systemd/D-Bus unusable
+esac
+exit 3
+MOCK
+chmod +x "$SANDBOX/bin/systemctl"
+
+export CSF_INVOCATION_LOG="$SANDBOX/csf-invocations.log"
+: > "$CSF_INVOCATION_LOG"
+
+# CSF must look INSTALLED so the detector enters its body at all.
+mkdir -p "$SANDBOX/etc/csf"
+printf 'TESTING = "1"\n' > "$SANDBOX/etc/csf/csf.conf"
+
+run_detector() { # $1=SYSTEMCTL_MODE -> prints severity; fills conflicts array
+    : > "$CSF_INVOCATION_LOG"
+    ( export PATH="$SANDBOX/bin:$PATH" SYSTEMCTL_MODE="$1"
+      # shellcheck disable=SC1090
+      # The lib does `set -Eeuo pipefail` at load (nftban_firewall_conflicts.sh:34),
+      # so sourcing it turns errexit ON here. nftban_detect_csf returns 2 by
+      # contract (0=none 1=installed 2=active) — without `|| true` the subshell
+      # dies on that return and every assertion below reads empty output as a
+      # pass. That is how the first draft of this test passed vacuously.
+      source "$CONFLICTS_LIB" >/dev/null 2>&1
+      set +e
+      # shellcheck disable=SC2034  # FIXES is written by the detector, not read here
+      NFTBAN_FIREWALL_CONFLICTS=(); NFTBAN_FIREWALL_FIXES=()
+      NFTBAN_FIREWALL_SEVERITY=$CONFLICT_NONE
+      nftban_detect_csf >/dev/null 2>&1 || true
+      printf '%s\n' "SEVERITY=$NFTBAN_FIREWALL_SEVERITY"
+      printf '%s\n' "${NFTBAN_FIREWALL_CONFLICTS[@]}"
+    )
+}
+
+echo "── T1  observation executes NO vendor binary ──────────────────────────"
+OUT="$(run_detector inactive)"
+N=$(wc -l < "$CSF_INVOCATION_LOG")
+[ "$N" -eq 0 ] && ok "mock csf invocation count == 0" \
+               || no "detector executed the vendor binary" "invocations: $(cat "$CSF_INVOCATION_LOG")"
+case "$OUT" in *ACTIVE*) no "report must not claim ACTIVE" "$OUT";; *) ok "report != ACTIVE";; esac
+
+echo "── T2  NEGATIVE CONTROL: the witness can fire ─────────────────────────"
+# Fixture copy of the PRE-FIX branch. If this does NOT record an invocation the
+# harness is blind and every other arm is vacuous.
+: > "$CSF_INVOCATION_LOG"
+( export PATH="$SANDBOX/bin:$PATH" SYSTEMCTL_MODE=inactive
+  _prefix_probe() {
+      if systemctl is-active lfd &>/dev/null 2>&1; then return 0
+      elif csf -s 2>&1 | grep -q "csf is enabled"; then return 0; fi
+      return 1
+  }
+  _prefix_probe >/dev/null 2>&1
+) || true
+N2=$(wc -l < "$CSF_INVOCATION_LOG")
+[ "$N2" -gt 0 ] && ok "pre-fix branch OBSERVED invoking csf ($N2) — witness valid" \
+                || no "witness blind: pre-fix branch recorded nothing" "T1 would be vacuous"
+
+echo "── T3  csf.service active + lfd failed => ACTIVE + CRITICAL ───────────"
+OUT3="$(run_detector csf-active)"
+case "$OUT3" in *"SEVERITY=3"*) ok "severity == CONFLICT_CRITICAL";; *) no "wrong-unit defect present" "$OUT3";; esac
+case "$OUT3" in *"CSF: ACTIVE"*) ok "reported ACTIVE";; *) no "enforcing CSF not reported ACTIVE" "$OUT3";; esac
+
+echo "── T4  systemd unusable => cannot-verify, never 'disabled' ────────────"
+OUT4="$(run_detector unusable)"
+case "$OUT4" in *"CANNOT-VERIFY"*) ok "cannot-verify asserted";; *) no "no cannot-verify wording" "$OUT4";; esac
+case "$OUT4" in *"DISABLED (no conflict)"*) no "asserted safety it cannot observe" "$OUT4";; *) ok "did NOT claim disabled/no-conflict";; esac
+SEV4=$(printf '%s\n' "$OUT4" | sed -n 's/^SEVERITY=//p')
+[ "${SEV4:-9}" -le 1 ] && ok "severity <= CONFLICT_INFO (=$SEV4)" \
+                       || no "cannot-verify escalated" "severity=$SEV4"
+
+echo "── T-VAC  non-vacuity: the mocks survived every arm ──────────────────"
+[ -x "$SANDBOX/bin/csf" ] && ok "mock csf still present after all runtime arms" \
+                          || no "sandbox destroyed mid-run" "later arms were vacuous"
+OUTV="$(run_detector inactive)"
+case "$OUTV" in *CSF*) ok "detector still enters its body (report non-empty)";; *) no "detector produced nothing" "arms above prove nothing";; esac
+
+echo "── T5  static guard: edited blocks carry no grep -q pipeline ──────────"
+# GUARD_SUBJECT == GUARD_INPUT: comments are stripped, so prose about the old
+# defect can neither satisfy nor violate this assertion.
+BAD=$(awk '/^_nftban_csf_activity\(\)/,/^}/' "$CONFLICTS_LIB" | sed 's/#.*//' | grep -c -- '| *grep -q')
+[ "$BAD" -eq 0 ] && ok "probe body has no grep -q pipeline" || no "pipeline in probe" "count=$BAD"
+BADX=$(awk '/^_nftban_csf_activity\(\)/,/^}/' "$CONFLICTS_LIB" | sed 's/#.*//' | grep -cE '\bcsf +-[sexr]\b')
+[ "$BADX" -eq 0 ] && ok "probe body executes no csf subcommand" || no "vendor binary in probe" "count=$BADX"
+
+echo "── T6  cannot-verify MUST NOT reach the destructive consumer ──────────"
+# The consumer gate is maintenance.sh:893 `NFTBAN_FIREWALL_SEVERITY -ge 3`,
+# then it string-matches *CSF* and calls nftban_remove_csf. Our cannot-verify
+# message CONTAINS "CSF", so the severity cap is the only thing standing
+# between an unobservable host and `csf -x`. Drive it end-to-end.
+for POLICY in auto quarantine; do
+    : > "$CSF_INVOCATION_LOG"
+    REMOVED="$(
+      export PATH="$SANDBOX/bin:$PATH" SYSTEMCTL_MODE=unusable NFTBAN_DRIFT_POLICY="$POLICY"
+      # shellcheck disable=SC1090
+      source "$CONFLICTS_LIB" >/dev/null 2>&1
+      set +e
+      NFTBAN_FIREWALL_CONFLICTS=(); NFTBAN_FIREWALL_SEVERITY=$CONFLICT_NONE
+      nftban_detect_csf >/dev/null 2>&1 || true
+      # exact consumer gate, verbatim from maintenance.sh:893
+      if [[ ${NFTBAN_FIREWALL_SEVERITY:-0} -ge 3 ]]; then
+          for c in "${NFTBAN_FIREWALL_CONFLICTS[@]}"; do
+              case "$c" in *CSF*|*LFD*) echo "REMOVE_CSF_REACHED";; esac
+          done
+      fi
+    )"
+    [ -z "$REMOVED" ] && ok "policy=$POLICY: destructive branch NOT reached" \
+                      || no "policy=$POLICY: cannot-verify reached removal" "$REMOVED"
+    N6=$(wc -l < "$CSF_INVOCATION_LOG")
+    [ "$N6" -eq 0 ] && ok "policy=$POLICY: no csf/csf -x invocation" \
+                    || no "policy=$POLICY: vendor binary invoked" "$(cat "$CSF_INVOCATION_LOG")"
+done
+# T6(b): prove the consumer keys on severity ALONE — if it ever gained another
+# trigger, capping severity would stop being sufficient and this test would lie.
+GATES=$(sed -n '893p' "$LIB/cron/maintenance.sh" | sed 's/#.*//')
+case "$GATES" in
+  *'NFTBAN_FIREWALL_SEVERITY'*'-ge 3'*) ok "consumer gate is severity-only (line 893 unchanged)";;
+  *) no "consumer gate changed — T6 no longer proves the invariant" "$GATES";;
+esac
+
+echo
+echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+++ b/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
@@ -24,7 +24,18 @@
 #
 # HARNESS POLICY: no `producer | grep -q` under pipefail anywhere — that
 # returns 141 on a MATCH and reads as no-match.
+#
+# SHELLCHECK: the health gate runs shellcheck at DEFAULT severity (info and
+# above), not `-S warning`. These are suppressed file-wide with cause:
+#   SC2030/SC2031  subshell-local PATH/SYSTEMCTL_MODE is the POINT — each arm
+#                  must run under its own mocks and must NOT leak into the next.
+#   SC2034         NFTBAN_FIREWALL_FIXES is written by the detector under test,
+#                  never read here; it is reset so arms cannot bleed.
+#   SC2015         `a && ok ... || no ...` is the intended report idiom: `ok`
+#                  cannot fail, so the C-may-run-when-A-is-true caveat does not
+#                  apply to these lines.
 # =============================================================================
+# shellcheck disable=SC2030,SC2031,SC2034,SC2015
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -105,7 +105,7 @@ config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	tes
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 core_ownership_identity_v1228_9_test	cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh	core	test	legal-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		
-csf_observation_purity_v1229_test	cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh		test		CI_HERMETIC_SHELL	ci-bash									
+csf_observation_purity_v1229_test	cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh	firewall	test	firewall	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 deb_conffile_parity_v1227_test	cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh	mail	test	deb-conffile-parity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 deprecated_unit_failed_latch_v1228_2_test	cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh	packaging	test	systemd-maintainer-scripts	CI_STATIC	ci-bash	true	false	false	false	false	false			
 derived_state_reconcile_v1228_8_test	cli/lib/nftban/tests/derived_state_reconcile_v1228_8_test.sh	firewall	test	derived-state-convergence	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -105,6 +105,7 @@ config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	tes
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 core_ownership_identity_v1228_9_test	cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh	core	test	legal-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		
+csf_observation_purity_v1229_test	cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh		test		CI_HERMETIC_SHELL	ci-bash									
 deb_conffile_parity_v1227_test	cli/lib/nftban/tests/deb_conffile_parity_v1227_test.sh	mail	test	deb-conffile-parity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 deprecated_unit_failed_latch_v1228_2_test	cli/lib/nftban/tests/deprecated_unit_failed_latch_v1228_2_test.sh	packaging	test	systemd-maintainer-scripts	CI_STATIC	ci-bash	true	false	false	false	false	false			
 derived_state_reconcile_v1228_8_test	cli/lib/nftban/tests/derived_state_reconcile_v1228_8_test.sh	firewall	test	derived-state-convergence	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		


### PR DESCRIPTION
## v1.229.0 R0 — CSF observation purity

Implements `V1_229_FIREWALL_AUTHORITY_IMPLEMENTATION_PROGRAM.md` §1. Scope frozen to the four sites; no `extfw`, takeover, restore or panel changes.

### Proven defect

`nftban firewall conflicts` — a read-only report — installed **129 CSF rules into the kernel** (el9-clean, 2026-08-11):

```
PRE : csf.service=inactive   ip filter rules=0
POST: csf.service=inactive   ip filter rules=129
```

The detector probed with `csf -s`, which is CSF's **start** command. It is reachable from `nftban-maintenance.timer` and `nftban-health.timer`, so unattended root could periodically re-arm a competing firewall wherever the csf binary is present.

Second defect: activity was read from `lfd` alone, so a host with `csf.service` active and `lfd` failed was reported `✓ CSF disabled (no conflict)` while enforcing. The Go `extfw` detector reported `CSF=service (csf.service)` on the same host at the same moment.

### Changes

| Site | File | Change |
|---|---|---|
| 1 | `nftban_firewall_conflicts.sh` | pure probe + cannot-verify branch |
| 2 | `cmd_health_analysis.sh` | conflicts box |
| 3 | `nftban_checks.sh` | JSON surface (inlined probe — this file sources nothing) |
| 4 | `nftban_output.sh` | status-bar icon (cosmetic) |

Observation failure now yields **cannot-verify, never "disabled"**, capped at `CONFLICT_INFO`. The drift consumer (`cron/maintenance.sh:893`) gates on `severity >= CONFLICT_CRITICAL` then string-matches `*CSF*` — and the cannot-verify message contains "CSF", so the cap is the only barrier between an unobservable host and `nftban_remove_csf`.

### Tests — 17 assertions, every arm proven falsifiable

T1–T6 per spec plus a non-vacuity control. Witnessed inversion of the **production** code:

| Inversion | Result |
|---|---|
| restore the `csf -s` probe | 5 failures |
| revert to lfd-only | 2 failures |
| collapse cannot-verify → not-active | 2 failures |
| remove the severity cap | 3 failures |

The first draft passed **vacuously twice** — the `EXIT` trap is inherited by `( )` subshells and deleted the mock sandbox after arm 1, and the library does `set -Eeuo pipefail` at load so the detector's documented non-zero return killed each subshell before any assertion ran. Both guarded; a `T-VAC` arm fails if either regresses.

### CI wiring

`ci-bash` previously only linted and **never executed a `*_test.sh`** — adding the file alone would have left it inert (TEST-DISCOVERY GAP). Wired as an explicit single-file step, deliberately not a glob.

### Declared consequence

Hosts with `csf.service` active and `lfd` down flip from `✓ disabled (no conflict)` to CRITICAL. Consumers: `alert` (default) = log+mail only; `auto` (opt-in) may now invoke `csf -x` on such hosts (documented, intended); `quarantine` targets a nonexistent unit and is likely inert (R1-W1).

### Out of scope, classified not absorbed

Pre-existing `producer | grep -q` pipelines in *other* detectors (`nftban_firewall_conflicts.sh` L251/302/335/363/1254/1382-4, `nftban_checks.sh` L208/285/590/651) — same SIGPIPE class, outside the four sites. For R1+.

Refs: `OPEN_CSF_OBSERVATION_REARMS_COMPETING_FIREWALL`
