### PR TITLE
fix(restore): neutralize the legacy shell restore path for all four targets [v1.229.x R2/O1]

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -89,3 +89,13 @@ jobs:
           echo "=== Executing: csf_observation_purity_v1229_test.sh ==="
           chmod +x cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
           bash cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+
+      # v1.229.x R2 (O1) — the legacy restore path must stay neutralized.
+      # Explicit single-file invocation, consistent with the R0 gate above:
+      # this workflow is a lint gate that executes named tests, not a
+      # discovery-based runner.
+      - name: Legacy restore neutralized (v1.229.x R2 gate)
+        run: |
+          echo "=== Executing: legacy_restore_neutralized_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh
+          bash cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh

--- a/cli/lib/nftban/cli/cmd_firewall.sh
+++ b/cli/lib/nftban/cli/cmd_firewall.sh
@@ -3812,66 +3812,74 @@ _restore_from_file() {
 }
 
 _restore_previous_firewall() {
+    # =========================================================================
+    # v1.229.x R2 (decision O1) — LEGACY RESTORE AUTHORITY NEUTRALIZED
+    # =========================================================================
+    # This path previously ran, for ALL FOUR targets, an unconditional prefix:
+    #
+    #   [1/4] systemctl stop/disable nftban-maintenance.timer , nftband
+    #   [2/4] nft delete table ip nftban ; nft delete table ip6 nftban
+    #   [3/4] <attempt to start the replacement firewall>
+    #
+    # NFTBan's kernel authority was destroyed at step 2 BEFORE the replacement
+    # was proven able to start. When step 3 could not succeed — target
+    # uninstalled, unit masked, or the binary renamed by takeover — the host
+    # was left with no NFTBan tables AND no working replacement:
+    #
+    #   REPLACEMENT_NOT_PROVEN + NFTBAN_AUTHORITY_ALREADY_DESTROYED
+    #     = FAILED_NO_FIREWALL
+    #
+    # That ordering is unsafe for every target, which is why all four are
+    # neutralized rather than only the ones lacking a successor. It was also
+    # ungated (no confirmation, dry-run or refusal), untested, and duplicated a
+    # safer Go restore authority that refuses ufw/firewalld outright and gates
+    # csf behind typed preconditions.
+    #
+    # The commands are deliberately KEPT so operator UX and scripts do not
+    # silently change shape — they now refuse. This function MUST NOT:
+    #   mutate NFTBan services · delete nft tables · start a foreign service ·
+    #   execute a foreign vendor binary.
+    # It returns non-zero so callers cannot mistake refusal for success.
+    #
+    # Successor status differs per target and is stated honestly below rather
+    # than papered over as generic cleanup.
+    # =========================================================================
     local firewall="$1"
 
-    echo "Restoring previous firewall: $firewall"
-    echo "======================================="
-    echo ""
-    echo "WARNING: This will disable NFTBan and re-enable $firewall"
-    echo ""
+    echo "Legacy restore path DISABLED for safety: $firewall" >&2
+    echo "" >&2
+    echo "  The legacy rollback deleted NFTBan's nftables tables BEFORE proving the" >&2
+    echo "  replacement firewall could start. A failure after that point left the host" >&2
+    echo "  with no firewall at all, so the path has been withdrawn for every target." >&2
+    echo "" >&2
 
-    # Step 1: Disable NFTBan
-    echo "[1/4] Disabling NFTBan services..."
-    systemctl stop nftban-maintenance.timer 2>/dev/null || true
-    systemctl stop nftband 2>/dev/null || true
-    systemctl disable nftban-maintenance.timer 2>/dev/null || true
-    systemctl disable nftband 2>/dev/null || true
-
-    # Step 2: Flush NFTBan tables
-    echo "[2/4] Flushing NFTBan nftables..."
-    nft delete table ip nftban 2>/dev/null || true
-    nft delete table ip6 nftban 2>/dev/null || true
-
-    # Step 3: Re-enable previous firewall
-    echo "[3/4] Re-enabling $firewall..."
     case "$firewall" in
-        fail2ban)
-            systemctl enable fail2ban 2>/dev/null || true
-            systemctl start fail2ban 2>/dev/null || true
-            ;;
         csf)
-            if command -v csf &>/dev/null; then
-                csf -e 2>/dev/null || true
-            fi
-            systemctl enable lfd 2>/dev/null || true
-            systemctl start lfd 2>/dev/null || true
+            echo "  CSF: an evidence-gated restore engine exists in the installer, but it is" >&2
+            echo "  intentionally not releasable until its safety verification is complete." >&2
             ;;
         ufw)
-            systemctl enable ufw 2>/dev/null || true
-            systemctl start ufw 2>/dev/null || true
-            ufw enable 2>/dev/null || true
+            echo "  UFW: automatic restore is not currently authorized." >&2
             ;;
         firewalld)
-            systemctl enable firewalld 2>/dev/null || true
-            systemctl start firewalld 2>/dev/null || true
+            echo "  firewalld: automatic restore is not currently authorized." >&2
+            ;;
+        fail2ban)
+            echo "  Fail2Ban: legacy automatic restore has been withdrawn because no" >&2
+            echo "  evidence-gated replacement currently exists. This is a deliberate" >&2
+            echo "  capability withdrawal, not an oversight." >&2
             ;;
     esac
 
-    # Step 4: Verify
-    echo "[4/4] Verifying..."
-    if systemctl is-active --quiet "$firewall" 2>/dev/null; then
-        echo ""
-        echo "$firewall is now ACTIVE"
-        echo "NFTBan has been disabled"
-        echo ""
-        echo "To return to NFTBan:"
-        echo "  systemctl disable --now $firewall"
-        echo "  nftban enable all"
-    else
-        echo ""
-        echo "WARNING: $firewall may not have started correctly"
-        echo "Check: systemctl status $firewall"
-    fi
+    echo "" >&2
+    echo "  No changes were made. NFTBan services, nftables tables and $firewall" >&2
+    echo "  were all left exactly as they were." >&2
+    echo "" >&2
+    echo "  To hand the firewall back manually, consult the runbook for your" >&2
+    echo "  platform — an operator-driven transition can verify each step before" >&2
+    echo "  the previous authority is removed, which this automated path could not." >&2
+
+    return 1
 }
 
 # =============================================================================
@@ -4514,16 +4522,15 @@ Examples:
 
 Backup location: /var/lib/nftban/backup/
 
-What 'restore <firewall>' does:
-  1. Stops NFTBan services
-  2. Disables NFTBan services
-  3. Flushes NFTBan nftables
-  4. Re-enables specified firewall
-  5. Starts specified firewall
+What 'restore <firewall>' does (as of v1.229.x):
+  REFUSES. All four targets are disabled for safety and make NO changes.
 
-To return to NFTBan after rollback:
-  systemctl disable --now <firewall>
-  nftban enable all
+  The legacy implementation deleted NFTBan's nftables tables BEFORE proving the
+  replacement firewall could start; a failure after that point left the host
+  with no firewall at all. The commands remain so scripts fail loudly with a
+  non-zero exit rather than silently changing behaviour.
+
+  Backup listing, creation and file restore are UNAFFECTED.
 
 EOF
 }

--- a/cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh
+++ b/cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.229.x R2 (O1) — LEGACY RESTORE AUTHORITY NEUTRALIZED
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="legacy-restore-neutralized-v1229-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-11"
+# meta:description="R2/O1 gate. Proves nftban firewall restore {fail2ban,csf,ufw,firewalld} reach an explicit non-zero refusal and mutate nothing: no NFTBan service change, no nft table deletion, no foreign service start, no foreign vendor binary execution."
+# meta:inventory.files="cli/lib/nftban/cli/cmd_firewall.sh"
+# meta:inventory.privileges="none"
+# meta:ta.id="legacy_restore_neutralized_v1229_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="firewall"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+#
+# WHAT THIS GUARDS. The legacy path ran, for ALL FOUR targets, an unconditional
+# prefix that stopped/disabled NFTBan services and deleted `ip nftban` +
+# `ip6 nftban` BEFORE proving the replacement could start:
+#
+#     REPLACEMENT_NOT_PROVEN + NFTBAN_AUTHORITY_ALREADY_DESTROYED
+#       = FAILED_NO_FIREWALL
+#
+# It was ungated, untested, publicly documented, and duplicated a safer Go
+# authority. O1 neutralized all four.
+#
+# HARNESS POLICY: never `producer | grep -q` under pipefail — SIGPIPE 141 turns
+# a MATCH into a non-match. Capture, then match.
+# =============================================================================
+# shellcheck disable=SC2030,SC2031,SC2015
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+FW="$REPO_ROOT/cli/lib/nftban/cli/cmd_firewall.sh"
+
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; echo "       $2"; FAIL=$((FAIL+1)); }
+
+SANDBOX="$(mktemp -d)"
+# PID-guarded: an unguarded EXIT trap is inherited by ( ) subshells and would
+# delete the mocks after the first arm, making every later arm pass vacuously.
+MAIN_PID=$$
+trap '[[ $BASHPID == "$MAIN_PID" ]] && rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+# Every mutating tool the legacy prefix used is shadowed and records calls.
+for tool in systemctl nft csf ufw firewall-cmd fail2ban-client; do
+    cat > "$SANDBOX/bin/$tool" <<MOCK
+#!/usr/bin/env bash
+echo "$tool \$*" >> "\${MUTATION_LOG:?}"
+exit 0
+MOCK
+    chmod +x "$SANDBOX/bin/$tool"
+done
+export MUTATION_LOG="$SANDBOX/mutations.log"
+
+# Extract just the function under test so the arm does not need the whole CLI.
+extract_fn() { awk '/^_restore_previous_firewall\(\)/{f=1} f{print} f&&/^}/{exit}' "$FW"; }
+
+run_target() { # $1=target -> prints "rc=N" then captured output
+    : > "$MUTATION_LOG"
+    ( export PATH="$SANDBOX/bin:$PATH"
+      eval "$(extract_fn)"
+      out=$(_restore_previous_firewall "$1" 2>&1); rc=$?
+      echo "rc=$rc"
+      printf '%s\n' "$out"
+    )
+}
+
+mutations_of() { # count recorded calls that are actually STATE-CHANGING
+    # `grep -c` prints 0 AND exits 1 on no-match, so a `|| echo 0` fallback
+    # emits TWO values and every numeric comparison downstream errors out.
+    local L n
+    L=$(cat "$MUTATION_LOG" 2>/dev/null)
+    n=$(printf '%s\n' "$L" | grep -cE '^(nft (delete|add|flush)|systemctl (stop|start|enable|disable|mask)|csf -[esx]|ufw enable|firewall-cmd|fail2ban-client)' 2>/dev/null) || true
+    echo "${n:-0}"
+}
+
+echo "── T1  every target REFUSES with non-zero exit ────────────────────────"
+for T in fail2ban csf ufw firewalld; do
+    OUT="$(run_target "$T")"
+    RC=$(printf '%s\n' "$OUT" | sed -n 's/^rc=//p' | head -1)
+    [ "${RC:-0}" -ne 0 ] && ok "$T: non-zero refusal (rc=$RC)" \
+                         || no "$T: did NOT refuse" "rc=$RC"
+    case "$OUT" in *DISABLED*|*disabled*) ok "$T: refusal wording present";; *) no "$T: no refusal wording" "$OUT";; esac
+done
+
+echo "── T2  no state mutation of ANY kind ──────────────────────────────────"
+for T in fail2ban csf ufw firewalld; do
+    run_target "$T" >/dev/null
+    M=$(mutations_of)
+    [ "$M" -eq 0 ] && ok "$T: zero state-changing calls" \
+                   || no "$T: MUTATED state" "$(cat "$MUTATION_LOG")"
+done
+
+echo "── T3  the specific forbidden operations, named ───────────────────────"
+: > "$MUTATION_LOG"
+for T in fail2ban csf ufw firewalld; do run_target "$T" >/dev/null; done
+LOG=$(cat "$MUTATION_LOG" 2>/dev/null)
+check_absent() { # $1=label $2=regex
+    local n; n=$(printf '%s\n' "$LOG" | grep -cE "$2")
+    [ "$n" -eq 0 ] && ok "$1 never invoked" || no "$1 INVOKED" "$(printf '%s\n' "$LOG" | grep -E "$2" | head -2)"
+}
+check_absent "nft table deletion"        '^nft delete'
+check_absent "NFTBan service stop"       '^systemctl (stop|disable) (nftband|nftban)'
+check_absent "foreign service start"     '^systemctl (start|enable) (fail2ban|lfd|ufw|firewalld|csf)'
+check_absent "foreign vendor binary"     '^(csf|ufw|firewall-cmd|fail2ban-client) '
+
+echo "── T4  FALSIFIABILITY: the harness detects the old prefix ─────────────"
+# Reintroduce the destructive prefix in a fixture copy. If the harness cannot
+# see it, T2/T3 prove nothing.
+: > "$MUTATION_LOG"
+( export PATH="$SANDBOX/bin:$PATH"
+  _legacy_prefix() {
+      systemctl stop nftband
+      systemctl disable nftban-maintenance.timer
+      nft delete table ip nftban
+      nft delete table ip6 nftban
+      systemctl start fail2ban
+  }
+  _legacy_prefix >/dev/null 2>&1
+) || true
+M4=$(mutations_of)
+[ "$M4" -gt 0 ] && ok "old destructive prefix IS detected ($M4 calls) — T2/T3 non-vacuous" \
+               || no "harness blind to the destructive prefix" "T2/T3 would be meaningless"
+
+echo "── T5  static: the shipped function contains no destructive verb ──────"
+# Comments are stripped: prose describing the removed defect must neither
+# satisfy nor violate the assertion (GUARD_SUBJECT == GUARD_INPUT).
+BODY=$(extract_fn | sed 's/#.*//')
+BADV=$(printf '%s\n' "$BODY" | grep -cE '(nft +(delete|flush|add)|systemctl +(stop|start|enable|disable)|csf +-[esx]|ufw +enable)')
+[ "$BADV" -eq 0 ] && ok "shipped function body is free of destructive verbs" \
+                  || no "destructive verb still present" "$(printf '%s\n' "$BODY" | grep -E '(nft +(delete|flush)|systemctl +(stop|start))' | head -2)"
+
+echo "── T6  backup list/create/file-restore remain reachable ───────────────"
+# O1 withdrew the four firewall targets ONLY. The backup subcommands are a
+# separate capability and must not have been collaterally disabled.
+DISPATCH=$(awk '/^firewall_restore\(\)/{f=1} f{print} f&&/^}/{exit}' "$FW")
+for SUB in 'list)' 'backup)' '_restore_from_file'; do
+    case "$DISPATCH" in *"$SUB"*) ok "dispatch still routes $SUB";; *) no "$SUB lost" "collateral damage";; esac
+done
+
+echo
+echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/ci/check-nft-writes.sh
+++ b/scripts/ci/check-nft-writes.sh
@@ -89,7 +89,16 @@ NFT_READ_PATTERN='nft[[:space:]]+(list|get)[[:space:]]'
 #                                   table (nftban_failopen_test_$$), never production;
 #                                   lab/root-only, skips without root/nft.
 # REMOVED v1.150 AUTH-4: nftban_geoban.sh (0 direct nft writes — routes via nft_ipc_apply_ruleset).
-ALLOWED_REGEX='^(cmd/nftband/|internal/nftbackend/|internal/setsync/|scripts/ci/|scripts/test_server_cleanup\.sh|cli/lib/nftban/tests/nft_writer_authority_v150_test\.sh|cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test\.sh|cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test\.sh|cli/lib/nftban/tests/ghost_table_foreign_preservation_v1228_11_test\.sh|cli/sbin/nftban-apply|cli/sbin/nftban-rollback|cli/lib/nftban/lib/nft_ipc\.sh|cli/lib/nftban/core/nftban_health_fixes\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/helpers/autoheal\.sh|cli/lib/nftban/lib/nft_fragment\.sh|install/helpers/firewall-init-with-delay\.sh|cli/lib/nftban/cli/cmd_firewall\.sh|cli/lib/nftban/cli/cmd_flush\.sh|cli/lib/nftban/core/nftban_ddos_classic\.sh|cli/lib/nftban/core/nftban_firewall_conflicts\.sh|cli/lib/nftban/core/nftban_health_checks_security\.sh|cli/lib/nftban/cli/cmd_whitelist\.sh|cli/lib/nftban/cli/cmd_zabbix\.sh|cli/lib/nftban/cli/cmd_health_core\.sh|cli/lib/nftban/cli/cmd_firewall_logs\.sh|cli/lib/nftban/lib/service_control\.sh|cli/lib/nftban/core/nftban_system_ip\.sh)'
+#     legacy_restore_neutralized_v1229_test.sh — R2/O1 gate. Its T4 falsifiability
+#                                   arm REINTRODUCES the removed destructive prefix
+#                                   (`nft delete table ip nftban`) to prove the harness
+#                                   can still detect it; without that arm T2/T3 would be
+#                                   vacuous. Every nft/systemctl/vendor call is
+#                                   PATH-SHADOWED to a recording mock inside a mktemp
+#                                   sandbox — the real nft binary is never reached, so
+#                                   this is strictly weaker than the v1.192 throwaway-
+#                                   table precedent.
+ALLOWED_REGEX='^(cmd/nftband/|internal/nftbackend/|internal/setsync/|scripts/ci/|scripts/test_server_cleanup\.sh|cli/lib/nftban/tests/nft_writer_authority_v150_test\.sh|cli/lib/nftban/tests/blacklist_refresh_no_failopen_v192_test\.sh|cli/lib/nftban/tests/rebuild_atomic_rollback_v1228_10_test\.sh|cli/lib/nftban/tests/ghost_table_foreign_preservation_v1228_11_test\.sh|cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test\.sh|cli/sbin/nftban-apply|cli/sbin/nftban-rollback|cli/lib/nftban/lib/nft_ipc\.sh|cli/lib/nftban/core/nftban_health_fixes\.sh|cli/lib/nftban/cron/maintenance\.sh|cli/lib/nftban/helpers/autoheal\.sh|cli/lib/nftban/lib/nft_fragment\.sh|install/helpers/firewall-init-with-delay\.sh|cli/lib/nftban/cli/cmd_firewall\.sh|cli/lib/nftban/cli/cmd_flush\.sh|cli/lib/nftban/core/nftban_ddos_classic\.sh|cli/lib/nftban/core/nftban_firewall_conflicts\.sh|cli/lib/nftban/core/nftban_health_checks_security\.sh|cli/lib/nftban/cli/cmd_whitelist\.sh|cli/lib/nftban/cli/cmd_zabbix\.sh|cli/lib/nftban/cli/cmd_health_core\.sh|cli/lib/nftban/cli/cmd_firewall_logs\.sh|cli/lib/nftban/lib/service_control\.sh|cli/lib/nftban/core/nftban_system_ip\.sh)'
 
 # =============================================================================
 # MAIN

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -142,6 +142,7 @@ install_update_observability_v215_test	cli/lib/nftban/tests/install_update_obser
 installer_wording_v153_test	cli/lib/nftban/tests/installer_wording_v153_test.sh	installer	test	installer	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 l2e_replace_set_reachability_guard_test	cli/lib/nftban/tests/l2e_replace_set_reachability_guard_test.sh	firewall	test	set-apply-replace	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 l3a_never_ban_add_element_guard_test	cli/lib/nftban/tests/l3a_never_ban_add_element_guard_test.sh	firewall	test	never-ban-guard	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+legacy_restore_neutralized_v1229_test	cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh	firewall	test	firewall	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 license_identity_bad_controls_v1228_8_test	cli/lib/nftban/tests/license_identity_bad_controls_v1228_8_test.sh	core	test	license-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	300		
 lifecycle_forensics_v1199_test	cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh	update	test	lifecycle-forensics	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 list_ipv6_clamp_v153_test	cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh	cli	test	list	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## R2 / decision O1 — legacy restore authority neutralized

`nftban firewall restore {fail2ban,csf,ufw,firewalld}` funnelled all four targets through one function whose prefix ran **unconditionally, before any target-specific work**:

```
[1/4] systemctl stop/disable nftban-maintenance.timer , nftband
[2/4] nft delete table ip nftban ; nft delete table ip6 nftban
[3/4] <attempt to start the replacement>
```

NFTBan's kernel authority was destroyed at step 2 **before** the replacement was proven able to start:

```
REPLACEMENT_NOT_PROVEN + NFTBAN_AUTHORITY_ALREADY_DESTROYED = FAILED_NO_FIREWALL
```

The deciding factor is the **ordering**, not the availability of a replacement — so all four are neutralized, not just those lacking a successor.

### Why this path, specifically

| Axis | Shell (this path) | Go `MutateToTarget` |
|---|---|---|
| safety/refusal gates | **0** | **13 typed sentinels** + Preflight + safety net |
| pre-mutation capture | none | cron-backup manifest |
| ufw / firewalld | executed them | **refuses** (`ErrCSFRestoreOnlyAuthorized`) |
| fail2ban | executed it | not a target at all |
| tests | **none** | typed-error suite |
| operator contract | **publicly documented** | installer-internal |

The weaker of two duplicate authorities was the operator-facing one. It also **could not undo a real takeover**: takeover masks `csf.service`/`lfd.service` and renames `/usr/sbin/csf`, while this path only ran `csf -e` and started `lfd` — so step 3 could not succeed on exactly the hosts where step 2 had already deleted the tables.

### Behaviour now

Commands are **kept** and refuse with non-zero exit, so scripts fail loudly rather than silently changing shape. No NFTBan service mutation, no nft table deletion, no foreign service start, no foreign vendor binary execution.

Successor status is stated **per target**, not as uniform cleanup:

- **csf** — evidence-gated engine exists, intentionally not releasable until its safety verification completes
- **ufw / firewalld** — not currently authorized; this *aligns* shell with the Go authority that already refuses them
- **fail2ban** — `FAIL2BAN_LEGACY_RESTORE_CAPABILITY = INTENTIONALLY_WITHDRAWN_FOR_SAFETY`. No evidence-gated successor exists today. **A real compatibility cost, recorded not hidden.**

Help text updated — it previously described the destructive steps as what the command does, which would now be false. Backup list/create/file-restore untouched (covered by T6).

### Tests — 21 assertions

Every mutating tool (`systemctl`, `nft`, `csf`, `ufw`, `firewall-cmd`, `fail2ban-client`) is PATH-shadowed and records invocations.

| Arm | Proves |
|---|---|
| T1 | all four reach non-zero refusal with wording |
| T2 | zero state-changing calls per target |
| T3 | named forbidden ops never invoked |
| T4 | **falsifiability** — harness detects the old prefix if reintroduced (5 calls) |
| T5 | shipped function body free of destructive verbs (comments stripped) |
| T6 | backup subcommands not collaterally disabled |

Reintroducing the destructive prefix into **production** code fails **7** assertions.

### Out of scope by ruling

Routing csf to the Go engine · any fail2ban replacement · ufw/firewalld implementation · R8 restore semantics.

### Deferred question (R5/R8, not answered here)

Whether `firewall restore fail2ban` is even a valid firewall-authority restore concept — Fail2Ban is a ban-producing control application that programs another backend, which is not obviously the same as restoring an effective firewall authority.

Refs: `LEGACY_SHELL_RESTORE_DUPLICATE_AUTHORITY`, `LEGACY_RESTORE_DESTROYS_CURRENT_AUTHORITY_BEFORE_REPLACEMENT_PROOF`
