### PR TITLE
fix(takeover): CSF removal contract — remove, not restore [CSF-CLOSE-1/2/3]

### DIFF
--- a/internal/installer/switchop/csf_removal_contract_test.go
+++ b/internal/installer/switchop/csf_removal_contract_test.go
@@ -1,0 +1,227 @@
+// =============================================================================
+// NFTBan — CSF REMOVAL CONTRACT (CSF-CLOSE-1/2/3)
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="switchop-csf-removal-contract-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-11"
+// meta:description="Locks the CSF_POLICY = REMOVE, NOT RESTORE contract: any credible CSF evidence reaches the removal path regardless of Conflict.Service; every CSF re-entry plane (units, both binaries, cron.d, /etc/crontab) is neutralized; CSF kernel state is removed attributably; unrelated foreign iptables state is NEVER flushed."
+// meta:inventory.files="internal/installer/switchop/takeover.go"
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// RUNTIME EVIDENCE THIS ENCODES (el9-clean, 2026-08-11):
+//
+//	ARM 3  orphan-unit — /etc/csf removed, csf.service failed/enabled, binary
+//	       present, 129 CSF rules live. extfw saw NO CSF; CONFLICTS omitted it;
+//	       nothing was neutralized; restoring config + starting the still-enabled
+//	       unit brought CSF back to 129 rules while status said PROTECTED.
+//
+//	ARM 4  Service="" — CSF WAS detected (CONFLICTS=…,CSF) via the config-file
+//	       signal whose Unit is empty. `if c.Service == "" { continue }` ran
+//	       BEFORE `hasCSF = true`, so the entire disarm path was skipped while
+//	       the operator was told CSF had been handled.
+//
+//	ARMS 2/3/4  the blanket `iptables -P/-F/-X` destroyed an operator-owned
+//	       OPERATOR_QOS mangle chain and Docker-shaped chains, witnessed by the
+//	       installer's own "flushed all iptables rules" log line.
+//
+// HARD REMOVE CSF = YES        HARD FLUSH ALL IPTABLES = NO
+package switchop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+)
+
+// csfHost seeds a host carrying CSF payload + every persistence plane, plus a
+// foreign operator artifact that must survive.
+func csfHost() *executor.MockExecutor {
+	m := executor.NewMockExecutor()
+	m.Files["/usr/sbin/csf"] = []byte("#!/usr/bin/perl\n# csf\n")
+	m.Files["/usr/sbin/lfd"] = []byte("#!/usr/bin/perl\n# lfd\n")
+	m.Files["/etc/csf/csf.conf"] = []byte("TESTING = \"1\"\n")
+	m.Files["/etc/cron.d/csf-cron"] = []byte("SHELL=/bin/sh\n")
+	m.Files["/etc/cron.d/lfd-cron"] = []byte("0 0 * * * root /usr/sbin/csf --lfd restart\n")
+	m.Files["/etc/cron.d/csf_update"] = []byte("36 23 * * * root /usr/sbin/csf -u\n")
+	m.Files["/etc/crontab"] = []byte(
+		"SHELL=/bin/bash\n" +
+			"0 3 * * * root /usr/local/bin/operator-backup.sh\n" + // MUST SURVIVE
+			"*/5 * * * * root /usr/sbin/csf -f > /dev/null 2>&1\n") // MUST GO
+	m.ExistingCommands["iptables"] = true
+	m.ExistingCommands["ip6tables"] = true
+	return m
+}
+
+func ranCmd(m *executor.MockExecutor, name string, argContains string) bool {
+	for _, c := range m.Commands {
+		if c.Name != name {
+			continue
+		}
+		if argContains == "" || strings.Contains(strings.Join(c.Args, " "), argContains) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// CSF-CLOSE-1/2 — removal must not depend on Conflict.Service
+// ---------------------------------------------------------------------------
+
+func TestCSFRemoval_ReachedWhenConflictHasNoService(t *testing.T) {
+	m := csfHost()
+	// EXACT arm-4 shape: CSF observed only via the config file, Unit empty.
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "", Active: true}}
+
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	if !ranCmd(m, "mv", "/usr/sbin/csf") {
+		t.Error("CSF binary not neutralized — disarm path skipped for a Service=\"\" conflict (arm-4 defect)")
+	}
+	if !ranCmd(m, "rm", "/etc/cron.d/lfd-cron") {
+		t.Error("CSF cron persistence not removed for a Service=\"\" conflict")
+	}
+}
+
+func TestCSFRemoval_ReachedWhenOnlyBinaryEvidenceExists(t *testing.T) {
+	// Arm-3 shape: config gone, unit unusable, payload still on disk.
+	m := csfHost()
+	delete(m.Files, "/etc/csf/csf.conf")
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "", Active: true}}
+
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+	if !ranCmd(m, "mv", "/usr/sbin/csf") {
+		t.Error("orphaned CSF payload left executable — re-entry plane open (arm-3 defect)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CSF-CLOSE-2 — every re-entry plane closed
+// ---------------------------------------------------------------------------
+
+func TestCSFRemoval_ClosesEveryReentryPlane(t *testing.T) {
+	m := csfHost()
+	conflicts := []detect.Conflict{
+		{Name: "CSF", Service: "csf.service", Active: true},
+		{Name: "CSF", Service: "lfd.service", Active: true},
+	}
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	for _, b := range []string{"/usr/sbin/csf", "/usr/sbin/lfd"} {
+		if !ranCmd(m, "mv", b) {
+			t.Errorf("%s left executable — re-entry plane open", b)
+		}
+	}
+	for _, c := range []string{"/etc/cron.d/lfd-cron", "/etc/cron.d/csf-cron", "/etc/cron.d/csf_update"} {
+		if !ranCmd(m, "rm", c) {
+			t.Errorf("%s not removed — scheduled CSF re-entry survives", c)
+		}
+	}
+	// /etc/crontab: CSF lines stripped, operator lines untouched, file kept.
+	w, ok := m.WrittenFiles["/etc/crontab"]
+	if !ok {
+		t.Fatal("/etc/crontab never rewritten — the TESTING=1 root flush job survives")
+	}
+	got := string(w)
+	if strings.Contains(got, "/usr/sbin/csf") {
+		t.Error("CSF persistence line still present in /etc/crontab")
+	}
+	if !strings.Contains(got, "operator-backup.sh") {
+		t.Error("operator's own crontab entry was destroyed — only CSF lines may be stripped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CSF-CLOSE-3 — attributable removal only; never a blanket flush
+// ---------------------------------------------------------------------------
+
+func TestCSFRemoval_NeverFlushesUnrelatedIptablesState(t *testing.T) {
+	m := csfHost()
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	// The blanket flush destroyed operator-owned OPERATOR_QOS and Docker chains
+	// on three separate runtime arms. It must not be issued at all.
+	for _, c := range m.Commands {
+		if c.Name != "iptables" && c.Name != "ip6tables" {
+			continue
+		}
+		joined := strings.Join(c.Args, " ")
+		for _, forbidden := range []string{"-F", "-X", "-P"} {
+			if strings.Contains(joined, forbidden) {
+				t.Errorf("blanket iptables mutation issued (%s %s) — destroys unattributable foreign state",
+					c.Name, joined)
+			}
+		}
+	}
+}
+
+func TestCSFRemoval_RemovesCSFOwnedKernelStateAttributably(t *testing.T) {
+	m := csfHost()
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+	// `csf --stop` unwinds exactly what CSF created — attribution by the vendor
+	// itself, rather than NFTBan guessing ownership from table names.
+	if !ranCmd(m, "/usr/sbin/csf", "--stop") {
+		t.Error("CSF-owned kernel state not removed attributably (csf --stop not invoked)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Idempotence — a partially neutralized host must converge, not error
+// ---------------------------------------------------------------------------
+
+func TestCSFRemoval_IdempotentOnAlreadyNeutralizedHost(t *testing.T) {
+	m := csfHost()
+	delete(m.Files, "/usr/sbin/csf") // already renamed by a previous takeover
+	delete(m.Files, "/etc/cron.d/csf-cron")
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts must converge on a partial host, got: %v", err)
+	}
+	if ranCmd(m, "mv", "/usr/sbin/csf ") {
+		t.Error("attempted to rename an absent binary instead of skipping")
+	}
+	// lfd was still present, so its plane must still be closed.
+	if !ranCmd(m, "mv", "/usr/sbin/lfd") {
+		t.Error("lfd plane left open on a partially neutralized host")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative control — non-CSF conflicts must not trigger CSF removal
+// ---------------------------------------------------------------------------
+
+func TestCSFRemoval_NotTriggeredWithoutCSFEvidence(t *testing.T) {
+	m := csfHost()
+	conflicts := []detect.Conflict{{Name: "UFW", Service: "ufw.service", Active: true}}
+
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+	if ranCmd(m, "mv", "/usr/sbin/csf") {
+		t.Error("CSF removal ran with no CSF conflict — over-broad trigger")
+	}
+	if ranCmd(m, "rm", "/etc/cron.d/csf_update") {
+		t.Error("CSF cron removed with no CSF conflict present")
+	}
+	if _, rewritten := m.WrittenFiles["/etc/crontab"]; rewritten {
+		t.Error("/etc/crontab rewritten with no CSF conflict present")
+	}
+}

--- a/internal/installer/switchop/takeover.go
+++ b/internal/installer/switchop/takeover.go
@@ -30,7 +30,26 @@ import (
 // For CSF conflicts on DirectAdmin servers, also disarms CustomBuild so
 // that `./build update` does not re-enable CSF.
 func DisableConflicts(exec executor.Executor, conflicts []detect.Conflict, panel detect.PanelType, log *logging.Logger) error {
+	// CSF-CLOSE-1/2 (owner doctrine 2026-08-11: CSF_POLICY = REMOVE, NOT RESTORE).
+	//
+	// hasCSF is decided BEFORE the empty-Service skip below. Previously the
+	// `if c.Service == "" { continue }` guard ran first, so a CSF conflict
+	// observed only via /etc/csf/csf.conf (SourceConfigFile, Unit "") exited
+	// the loop before `hasCSF = true` was ever reached — silently disabling
+	// the ENTIRE CSF disarm path (binary, cron, panel) while CSF was still
+	// listed in CONFLICTS and shown to the operator. Proven on el9-clean:
+	// CONFLICTS=iptables-nft,iptables,CSF with zero neutralization performed
+	// and status=PROTECTED.
+	//
+	// Any credible CSF evidence must reach the removal path. Removal must not
+	// depend on obtaining a service name.
 	hasCSF := false
+	for _, c := range conflicts {
+		if c.Name == "CSF" {
+			hasCSF = true
+		}
+	}
+
 	for _, c := range conflicts {
 		if c.Service == "" {
 			continue
@@ -60,26 +79,28 @@ func DisableConflicts(exec executor.Executor, conflicts []detect.Conflict, panel
 				log.Info("cleared stale failed marker for masked conflict service: %s", c.Service)
 			}
 		}
-		if c.Name == "CSF" {
-			hasCSF = true
-		}
 	}
 
-	// Flush legacy iptables rules (reset policies, flush all tables, delete chains)
-	for _, cmd := range []string{"iptables", "ip6tables"} {
-		if exec.CommandExists(cmd) {
-			// Reset policies to ACCEPT before flushing (prevents DROP lockout)
-			for _, chain := range []string{"INPUT", "FORWARD", "OUTPUT"} {
-				exec.Run(cmd, "-P", chain, "ACCEPT")
-			}
-			// Flush and delete chains in all tables
-			for _, table := range []string{"filter", "nat", "mangle"} {
-				exec.Run(cmd, "-t", table, "-F")
-				exec.Run(cmd, "-t", table, "-X")
-			}
-			log.Info("flushed all %s rules (filter/nat/mangle)", cmd)
-		}
-	}
+	// CSF-CLOSE-3 — REMOVED: the blanket legacy-iptables flush.
+	//
+	// This block previously ran, for both iptables and ip6tables:
+	//     -P INPUT/FORWARD/OUTPUT ACCEPT
+	//     -t filter/nat/mangle -F   and   -X
+	//
+	// That is not CSF removal. It destroys EVERY foreign rule in filter, nat
+	// and mangle regardless of ownership. Proven on el9-clean across three
+	// separate arms: an operator-owned mangle chain (OPERATOR_QOS) and
+	// Docker-shaped chains were destroyed alongside CSF's rules, with the
+	// installer's own log line `flushed all iptables rules (filter/nat/mangle)`
+	// as the causal witness.
+	//
+	//     HARD REMOVE CSF = YES        HARD FLUSH ALL IPTABLES = NO
+	//
+	// Ownership is not implied by table name — the same lesson v1.228.11
+	// applied to the nft path, which this interface bypassed entirely.
+	// CSF-owned kernel state is removed by `csf --stop` inside
+	// disarmCSFArtifacts, which unwinds exactly what CSF created and nothing
+	// else. Foreign rules NFTBan cannot attribute are left alone.
 
 	// Disarm panel CSF management (prevents re-enable on panel update)
 	if hasCSF {
@@ -115,8 +136,29 @@ func disarmCSFArtifacts(exec executor.Executor, log *logging.Logger) {
 		log.Warn("cron-backup manifest writer: %v (continuing with cron rm; A.4 restore will soft-skip on this host)", err)
 	}
 
-	// Remove CSF/LFD cron jobs (lfd-cron runs "csf --lfd restart" daily)
-	for _, cronFile := range []string{"/etc/cron.d/lfd-cron", "/etc/cron.d/csf-cron"} {
+	// CSF-CLOSE-2: unwind CSF's OWN kernel state before neutralizing the
+	// binary, so the removal is attributable rather than a blanket flush.
+	// `csf --stop` removes exactly the rules CSF created; anything it does
+	// not own stays. Best-effort: a failure here must not block the rest of
+	// the disarm, but it is logged so a partial removal is visible.
+	if exec.FileExists("/usr/sbin/csf") {
+		if r := exec.Run("/usr/sbin/csf", "--stop"); r.ExitCode == 0 {
+			log.Info("removed CSF-owned firewall state (csf --stop)")
+		} else {
+			log.Warn("csf --stop exit %d: %s — CSF kernel state may persist", r.ExitCode, r.Stderr)
+		}
+	}
+
+	// Remove CSF/LFD cron persistence. CSF-CLOSE-2 widened this beyond the
+	// original two files: el9-clean runtime showed /etc/cron.d/csf_update
+	// (`csf -u`, daily) surviving every takeover, and the TESTING="1" mode
+	// writes a ROOT flush job into /etc/crontab itself — a re-entry surface
+	// with zero prior coverage (repo-wide grep for /etc/crontab: 0 hits).
+	for _, cronFile := range []string{
+		"/etc/cron.d/lfd-cron",
+		"/etc/cron.d/csf-cron",
+		"/etc/cron.d/csf_update",
+	} {
 		if exec.FileExists(cronFile) {
 			res := exec.Run("rm", "-f", cronFile)
 			if res.ExitCode == 0 {
@@ -127,14 +169,44 @@ func disarmCSFArtifacts(exec executor.Executor, log *logging.Logger) {
 		}
 	}
 
-	// Disable CSF binary (rename to .disabled to prevent accidental execution)
-	csfBin := "/usr/sbin/csf"
-	if exec.FileExists(csfBin) {
-		res := exec.Run("mv", csfBin, csfBin+".disabled")
-		if res.ExitCode == 0 {
-			log.Info("disabled CSF binary: %s -> %s.disabled", csfBin, csfBin)
-		} else {
-			log.Warn("failed to disable CSF binary: %s", res.Stderr)
+	// /etc/crontab is shared with the distro and operator, so this strips ONLY
+	// lines invoking the CSF binaries — never the file, never unrelated jobs.
+	// (`ATTRIBUTION BEFORE NEUTRALIZATION`: same rule applied to nft tables in
+	// v1.228.11 and to iptables in CSF-CLOSE-3.)
+	if exec.FileExists("/etc/crontab") {
+		if data, err := exec.ReadFile("/etc/crontab"); err == nil {
+			var kept []string
+			removed := 0
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.Contains(line, "/usr/sbin/csf") || strings.Contains(line, "/usr/sbin/lfd") {
+					removed++
+					continue
+				}
+				kept = append(kept, line)
+			}
+			if removed > 0 {
+				if err := exec.WriteFileAtomic("/etc/crontab", []byte(strings.Join(kept, "\n")), 0644); err != nil {
+					log.Warn("could not strip %d CSF line(s) from /etc/crontab: %v", removed, err)
+				} else {
+					log.Info("removed %d CSF persistence line(s) from /etc/crontab", removed)
+				}
+			}
+		}
+	}
+
+	// Neutralize BOTH CSF executables. lfd was previously left executable even
+	// though takeover masks lfd.service — leaving a re-entry path whenever the
+	// unit could be re-enabled. Renaming (not deleting) keeps the payload on
+	// disk as audit/troubleshooting evidence; it carries no restore contract
+	// (CSF_RESTORE_SUPPORT = REMOVED, owner doctrine 2026-08-11).
+	for _, bin := range []string{"/usr/sbin/csf", "/usr/sbin/lfd"} {
+		if exec.FileExists(bin) {
+			res := exec.Run("mv", bin, bin+".disabled")
+			if res.ExitCode == 0 {
+				log.Info("disabled CSF binary: %s -> %s.disabled", bin, bin)
+			} else {
+				log.Warn("failed to disable %s: %s", bin, res.Stderr)
+			}
 		}
 	}
 

--- a/internal/installer/switchop/takeover_pr26_6_test.go
+++ b/internal/installer/switchop/takeover_pr26_6_test.go
@@ -102,11 +102,25 @@ func TestPR26_6_CSFBinary_RenamedNotDestroyed(t *testing.T) {
 	}
 }
 
-// TestPR26_6_LFDBinary_NotDestructivelyDeleted pins the contract that
-// /usr/sbin/lfd is NOT touched by takeover. lfd is masked at the systemd
-// layer (DisableConflicts loop calls ServiceMask("lfd.service")) but the
-// binary stays on disk for restore.
-func TestPR26_6_LFDBinary_NotDestructivelyDeleted(t *testing.T) {
+// TestPR26_6_LFDBinary_NeutralizedNotDeleted — CONTRACT CHANGED 2026-08-11.
+//
+// This test previously pinned "lfd is NOT touched by takeover … the binary
+// stays on disk FOR RESTORE" (mask-only). The owner has since removed CSF
+// restore from the product contract entirely:
+//
+//	CSF_POLICY = REMOVE, NOT RESTORE
+//	CSF_RESTORE_SUPPORT = REMOVED   ·   CSF_COEXISTENCE_SUPPORT = NO
+//
+// Mask-only left a proven re-entry plane: lfd.service is masked, but the
+// binary stayed executable, so re-enabling the unit (or any caller invoking
+// the path directly) re-armed CSF. Runtime evidence: el9-clean arms 3 and 4,
+// where CSF survived takeover and was restored to 129 live rules.
+//
+// The contract is now NEUTRALIZE, NOT DELETE: the binary is renamed to
+// .disabled so it cannot execute at its original path, while the payload
+// stays on disk as audit/troubleshooting evidence carrying no restore
+// promise. Deletion is NOT permitted — that would destroy operator data.
+func TestPR26_6_LFDBinary_NeutralizedNotDeleted(t *testing.T) {
 	mock := executor.NewMockExecutor()
 	mock.Services["csf.service"] = true
 	mock.Services["lfd.service"] = true
@@ -126,30 +140,34 @@ func TestPR26_6_LFDBinary_NotDestructivelyDeleted(t *testing.T) {
 		t.Fatalf("DisableConflicts: %v", err)
 	}
 
-	// lfd binary path must still be present (no rm, no mv to .disabled).
-	if !mock.FileExists("/usr/sbin/lfd") {
-		t.Fatal("expected /usr/sbin/lfd to remain on disk after takeover (mask-only contract)")
+	// 1. The re-entry plane must be closed: lfd must be renamed to .disabled.
+	sawRename := false
+	for _, c := range mock.Commands {
+		if c.Name == "mv" && len(c.Args) >= 2 &&
+			c.Args[0] == "/usr/sbin/lfd" && c.Args[1] == "/usr/sbin/lfd.disabled" {
+			sawRename = true
+		}
 	}
-	got, err := mock.ReadFile("/usr/sbin/lfd")
-	if err != nil {
-		t.Fatalf("read /usr/sbin/lfd: %v", err)
-	}
-	if sha256Hex(got) != lfdSHA {
-		t.Errorf("lfd binary content changed during takeover: want sha %s, got %s", lfdSHA, sha256Hex(got))
+	if !sawRename {
+		t.Error("lfd binary left executable at /usr/sbin/lfd — CSF re-entry plane still open")
 	}
 
-	// And no `mv` or `rm` should target /usr/sbin/lfd at all.
+	// 2. NEUTRALIZE, NOT DELETE: deletion of operator payload is forbidden.
 	for _, c := range mock.Commands {
 		if c.Name == "rm" {
 			for _, a := range c.Args {
-				if a == "/usr/sbin/lfd" {
-					t.Errorf("takeover invoked rm on /usr/sbin/lfd: %v", c)
+				if a == "/usr/sbin/lfd" || a == "/usr/sbin/lfd.disabled" {
+					t.Errorf("takeover DELETED the lfd payload (%v) — evidence must be retained", c)
 				}
 			}
 		}
-		if c.Name == "mv" && len(c.Args) >= 1 && c.Args[0] == "/usr/sbin/lfd" {
-			t.Errorf("takeover invoked mv on /usr/sbin/lfd: %v", c)
-		}
+	}
+
+	// 3. The bytes must survive somewhere, unchanged, as audit evidence.
+	//    (sha pinned at seed time so a silent rewrite is caught too.)
+	_ = lfdSHA
+	if !mock.FileExists("/usr/sbin/lfd") && !mock.FileExists("/usr/sbin/lfd.disabled") {
+		t.Error("lfd payload vanished entirely — audit/troubleshooting evidence lost")
 	}
 }
 

--- a/internal/installer/switchop/takeover_pr26_6_test.go
+++ b/internal/installer/switchop/takeover_pr26_6_test.go
@@ -163,11 +163,50 @@ func TestPR26_6_LFDBinary_NeutralizedNotDeleted(t *testing.T) {
 		}
 	}
 
-	// 3. The bytes must survive somewhere, unchanged, as audit evidence.
-	//    (sha pinned at seed time so a silent rewrite is caught too.)
-	_ = lfdSHA
-	if !mock.FileExists("/usr/sbin/lfd") && !mock.FileExists("/usr/sbin/lfd.disabled") {
-		t.Error("lfd payload vanished entirely — audit/troubleshooting evidence lost")
+	// 3. PAYLOAD_PRESERVED_FOR_EVIDENCE != PAYLOAD_CAPABLE_OF_REENTRY.
+	//
+	// MockExecutor.Run only RECORDS commands — it does not simulate `mv`, so
+	// asserting on mock.FileExists("/usr/sbin/lfd") directly would pass via the
+	// ORIGINAL path and prove nothing about neutralization. Replay the recorded
+	// renames onto the file map first, then assert on the resulting state.
+	replayRenames(mock)
+
+	if mock.FileExists("/usr/sbin/lfd") {
+		t.Error("canonical executable path /usr/sbin/lfd still populated — re-entry authority intact")
+	}
+	if !mock.FileExists("/usr/sbin/lfd.disabled") {
+		t.Fatal("lfd payload vanished entirely — audit/troubleshooting evidence lost")
+	}
+	got2, err := mock.ReadFile("/usr/sbin/lfd.disabled")
+	if err != nil {
+		t.Fatalf("read retained payload: %v", err)
+	}
+	if sha256Hex(got2) != lfdSHA {
+		t.Errorf("retained payload was altered: want sha %s, got %s", lfdSHA, sha256Hex(got2))
+	}
+
+	// 4. Nothing may re-create the canonical path after neutralization.
+	for _, c := range mock.Commands {
+		if c.Name == "mv" && len(c.Args) >= 2 && c.Args[1] == "/usr/sbin/lfd" {
+			t.Errorf("a command restored the canonical executable path: %v", c)
+		}
+	}
+}
+
+// replayRenames applies every recorded `mv SRC DST` to the mock file map, so
+// post-condition assertions describe the state the commands would actually
+// produce rather than the seed state. Without this, any assertion about a
+// renamed path is vacuous against a recording-only executor.
+func replayRenames(m *executor.MockExecutor) {
+	for _, c := range m.Commands {
+		if c.Name != "mv" || len(c.Args) < 2 {
+			continue
+		}
+		src, dst := c.Args[0], c.Args[1]
+		if data, ok := m.Files[src]; ok {
+			m.Files[dst] = data
+			delete(m.Files, src)
+		}
 	}
 }
 


### PR DESCRIPTION
## CSF_POLICY = REMOVE, NOT RESTORE

Owner doctrine 2026-08-11. Implements **CSF-CLOSE-1/2/3**: fixes two proven runtime failures and removes a third that destroyed unrelated operator state.

### A/B — any credible CSF evidence reaches the removal path

`hasCSF` is now decided **before** the `if c.Service == "" { continue }` skip. Previously a CSF conflict observed only via `/etc/csf/csf.conf` (Unit `""`) exited the loop before `hasCSF = true`, silently disabling the **entire** disarm path while CSF was still listed in `CONFLICTS` and shown to the operator.

Runtime evidence (el9-clean arm 4): `CONFLICTS=iptables-nft,iptables,CSF`, zero neutralization performed, `status=PROTECTED`.

### D — every re-entry plane closed

| Plane | Before | Now |
|---|---|---|
| `/usr/sbin/lfd` | left **executable** while unit masked | neutralized |
| `/etc/cron.d/csf_update` | survived every takeover | removed |
| `/etc/crontab` | **zero coverage repo-wide** | CSF lines stripped |

`/etc/crontab` stripping is **line-attributable, never file-level** — operator entries survive, and a test asserts it.

### E/F — attributable removal replaces the blanket flush

Deleted `iptables/ip6tables -P/-F/-X` over filter/nat/mangle. That was never CSF removal — it destroyed an operator-owned `OPERATOR_QOS` chain and Docker-shaped chains across three runtime arms, witnessed by the installer's own `flushed all iptables rules` log line.

```
HARD REMOVE CSF = YES        HARD FLUSH ALL IPTABLES = NO
```

CSF kernel state is now unwound by `csf --stop` — attribution by the vendor rather than NFTBan guessing ownership from table names. Same lesson v1.228.11 applied to the nft path, which this interface bypassed.

### Contract change (called out explicitly)

`TestPR26_6_LFDBinary_NotDestructivelyDeleted` pinned *"the binary stays on disk **for restore**"*. Restore is no longer a product contract, and mask-only left a proven re-entry plane. Renamed to `..._NeutralizedNotDeleted` and rewritten: **NEUTRALIZE, NOT DELETE** — renamed to `.disabled`, payload retained as audit evidence with no restore promise. Deletion is asserted **forbidden**; destroying operator payload is the same class as `UNINSTALL_DESTROYS_RULESET_BACKUP_CORPUS`.

### Tests — 7 assertions, all proven load-bearing

Covering the exact runtime shapes: `Service=""` conflict · orphan/binary-only evidence · all re-entry planes · no blanket flush · attributable kernel removal · idempotence on a partial host · negative control.

Reverting each fix against **production** code:

| Reverted | Failures |
|---|---|
| `Service=""` skip before `hasCSF` | **5** |
| lfd dropped from neutralization | 2 |
| `csf_update` dropped from cron removal | 1 |
| blanket iptables flush reinstated | 1 |

Full Go suite: **0 FAIL**.

### Still open in this lane (not this PR)

CSF-CLOSE-4 retroactive-takeover UPDATE short-circuit · CSF-CLOSE-5 false PROTECTED · CSF-CLOSE-6 uninstall safety · CSF-CLOSE-7 package-native + fleet validation.

Refs: `CSF_POLICY`, `CSF-CLOSE-1`, `CSF-CLOSE-2`, `CSF-CLOSE-3`
