### PR TITLE
fix(authority): explicit takeover must not be discarded when NFTBan is authoritative [CSF-CLOSE-4]

### DIFF
--- a/internal/installer/authority/classify.go
+++ b/internal/installer/authority/classify.go
@@ -109,7 +109,42 @@ func Classify(
 	log *logging.Logger,
 ) Decision {
 	// 1. NFTBan fully authoritative — UPDATE.
+	//
+	// CSF-CLOSE-4: this check no longer short-circuits unconditionally.
+	//
+	// Previously `IsNftbanAuthoritative` was evaluated first and returned
+	// Update regardless of what else was live on the host. Runtime proof
+	// (el9-clean, 2026-08-11): with NFTBan COMMITTED **and** CSF active with
+	// 129 kernel rules, an explicit `--takeover --force` produced
+	//
+	//     extfw/detect: AMBIGUOUS — multiple active: [iptables csf]
+	//     [conflict] CSF=service (csf.service)
+	//     [authority] decision=UPDATE          <- foreign-active state discarded
+	//     DisableConflicts markers: 0          <- never entered
+	//     rc=0 · CONFLICTS=<empty> · status=PROTECTED
+	//
+	// so retroactive takeover was UNREACHABLE: the information needed to
+	// contest was produced by detection and then thrown away by the decision
+	// layer. The discriminator was proven by contrast — same binary, same
+	// flags, same live CSF; only NFTBan's own authoritativeness flipped
+	// TAKEOVER into UPDATE.
+	//
+	// NFTBan owning the firewall is NOT evidence that nothing else does.
+	// When the operator has EXPLICITLY approved takeover and conflicts are
+	// actually present, that request must reach the takeover path instead of
+	// being silently downgraded. Deliberately narrow: no conflicts, or no
+	// explicit approval, still yields Update exactly as before — this does
+	// not make ordinary upgrades destructive.
 	if IsNftbanAuthoritative(exec) {
+		if len(conflicts) > 0 && forceApprove {
+			log.Detect("authority", "decision", string(Takeover))
+			log.Detect("authority", "reason",
+				"nftban authoritative BUT conflicts present and takeover explicitly approved — contested, not an update")
+			for _, c := range conflicts {
+				log.Detect("authority", "contested", c.Name)
+			}
+			return Takeover
+		}
 		log.Detect("authority", "decision", string(Update))
 		log.Detect("authority", "reason", "nftban table+chain+daemon all present")
 		return Update

--- a/internal/installer/authority/classify_contested_test.go
+++ b/internal/installer/authority/classify_contested_test.go
@@ -1,0 +1,105 @@
+// =============================================================================
+// NFTBan — CSF-CLOSE-4: retroactive takeover must be reachable
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="installer-authority-classify-contested-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-11"
+// meta:description="Locks CSF-CLOSE-4: an explicitly approved takeover on a host where NFTBan is already authoritative AND a conflicting firewall is present must classify as Takeover, not silently downgrade to Update. Ordinary upgrades are unaffected."
+// meta:inventory.files="internal/installer/authority/classify.go"
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// RUNTIME EVIDENCE (el9-clean, 2026-08-11, R3-P1 #3):
+//
+//	NFTBan COMMITTED with 65 kernel rules AND csf.service active with 129
+//	iptables rules. Invoked with --takeover --force:
+//
+//	  extfw/detect: AMBIGUOUS — multiple active: [iptables csf]
+//	  [conflict]  CSF=service (csf.service)
+//	  [authority] decision=UPDATE        <- foreign-active state DISCARDED
+//	  DisableConflicts markers: 0        <- never entered
+//	  rc=0 · CONFLICTS=<empty> · status=PROTECTED
+//
+//	Confirmed by contrast in R3-P2 arm 1: same binary, same flags, same live
+//	CSF — with NFTBan made non-authoritative the decision became TAKEOVER.
+//	NFTBan's own authoritativeness was the sole discriminator.
+//
+//	NFTBAN OWNING THE FIREWALL != NOTHING ELSE DOES
+package authority
+
+import (
+	"testing"
+
+	"github.com/itcmsgr/nftban/internal/installer/detect"
+	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
+)
+
+func testLog() *logging.Logger { return logging.New("/dev/null", false) }
+
+// Reuses the package's existing authoritativeMock() helper rather than
+// hand-rolling a second seeding convention — a hand-rolled mock used the wrong
+// NftTables key format and made every arm SKIP, which would have looked like
+// success. REUSE THE CANONICAL FIXTURE.
+
+func TestClose4_AuthoritativeHostWithConflictAndExplicitApproval_IsTakeover(t *testing.T) {
+	m := authoritativeMock()
+	if !IsNftbanAuthoritative(m) {
+		t.Skip("mock could not reach an authoritative shape — arm would be vacuous")
+	}
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+
+	got := Classify(m, conflicts, detect.PanelNone, true /*forceApprove*/, false, testLog())
+
+	if got != Takeover {
+		t.Errorf("explicit --takeover with CSF present was downgraded to %q — "+
+			"retroactive takeover unreachable (R3-P1 #3)", got)
+	}
+}
+
+// NEGATIVE CONTROL 1: no conflicts => ordinary upgrade path must be untouched.
+func TestClose4_AuthoritativeHostNoConflicts_StaysUpdate(t *testing.T) {
+	m := authoritativeMock()
+	if !IsNftbanAuthoritative(m) {
+		t.Skip("mock not authoritative")
+	}
+	got := Classify(m, nil, detect.PanelNone, true /*forceApprove*/, false, testLog())
+	if got != Update {
+		t.Errorf("no conflicts present but classified %q — ordinary upgrades must stay Update", got)
+	}
+}
+
+// NEGATIVE CONTROL 2: conflicts but NO explicit approval => must stay Update.
+// This is the guard that keeps the fix narrow: it must not make routine
+// upgrades destructive on a host that merely has another firewall installed.
+func TestClose4_AuthoritativeHostConflictsWithoutApproval_StaysUpdate(t *testing.T) {
+	m := authoritativeMock()
+	if !IsNftbanAuthoritative(m) {
+		t.Skip("mock not authoritative")
+	}
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+
+	got := Classify(m, conflicts, detect.PanelNone, false /*forceApprove*/, false, testLog())
+
+	if got != Update {
+		t.Errorf("conflicts without explicit approval classified %q — "+
+			"an unapproved upgrade must never become a takeover", got)
+	}
+}
+
+// The pre-fix behaviour, stated as a property: a non-authoritative host with
+// the same inputs already reached Takeover. Pinning it guards the contrast
+// that isolated the discriminator, so a future refactor cannot quietly make
+// BOTH paths Update.
+func TestClose4_NonAuthoritativeHostWithConflict_IsTakeover(t *testing.T) {
+	m := executor.NewMockExecutor() // no nftban table/daemon
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+
+	got := Classify(m, conflicts, detect.PanelNone, true, false, testLog())
+
+	if got != Takeover {
+		t.Errorf("non-authoritative host with conflict + approval classified %q, want Takeover", got)
+	}
+}

--- a/internal/installer/authority/classify_test.go
+++ b/internal/installer/authority/classify_test.go
@@ -162,18 +162,35 @@ func TestClassify_Ambiguous_TableWithoutChain(t *testing.T) {
 	}
 }
 
-func TestClassify_Priority_UpdateOverConflicts(t *testing.T) {
-	// Even with every conflict active, UPDATE wins if NFTBan owns the firewall
+// CONTRACT CHANGED 2026-08-11 (CSF-CLOSE-4). This previously asserted
+// "UPDATE wins ... (overrides everything)" even with forceApprove=true.
+// Runtime proof (el9-clean, R3-P1 #3) showed that rule left NFTBan and CSF
+// BOTH effective — 65 nftban rules alongside 129 CSF rules — with
+// DisableConflicts never entered, rc=0 and status=PROTECTED. Explicit
+// operator approval was being discarded by the decision layer.
+//
+//	NFTBAN OWNING THE FIREWALL != NOTHING ELSE DOES
+//
+// The safety property worth keeping is narrower and is asserted below:
+// UPDATE still wins when takeover was NOT explicitly approved, so routine
+// upgrades on a host that merely has another firewall installed never turn
+// destructive.
+func TestClassify_Priority_ExplicitApprovalContestsUpdate(t *testing.T) {
 	mock := authoritativeMock()
-
 	conflicts := []detect.Conflict{
 		{Name: "CSF", Active: true},
 		{Name: "UFW", Active: true},
 		{Name: "firewalld", Active: true},
 	}
-	decision := Classify(mock, conflicts, detect.PanelCPanel, true, true, newTestLogger())
-	if decision != Update {
-		t.Errorf("decision = %s, want UPDATE (overrides everything)", decision)
+
+	// Explicitly approved takeover MUST contest, not silently update.
+	if d := Classify(mock, conflicts, detect.PanelCPanel, true, true, newTestLogger()); d != Takeover {
+		t.Errorf("explicit approval with active conflicts = %s, want TAKEOVER", d)
+	}
+
+	// NEGATIVE CONTROL: without explicit approval the old priority holds.
+	if d := Classify(mock, conflicts, detect.PanelCPanel, false, false, newTestLogger()); d != Update {
+		t.Errorf("unapproved run with conflicts = %s, want UPDATE (upgrades stay safe)", d)
 	}
 }
 


### PR DESCRIPTION
## CSF-CLOSE-4 — retroactive takeover was unreachable

> **MERGE ORDER: do not merge before #1215.** Ordinary CI runs in parallel; this PR takes its exact-head trusted gate only after #1215 lands and this branch is reconciled onto the new main.

`Classify()` evaluated `IsNftbanAuthoritative` first and returned `Update` **unconditionally**. A host where NFTBan already owned the firewall could therefore never take over anything — even when the operator explicitly asked and a competing firewall was live.

### Runtime proof (el9-clean, R3-P1 #3)

NFTBan `COMMITTED` with 65 kernel rules **and** `csf.service` active with 129 iptables rules, invoked with `--takeover --force`:

```
extfw/detect: AMBIGUOUS — multiple active: [iptables csf]
[conflict]  CSF=service (csf.service)
[authority] decision=UPDATE        <- foreign-active state DISCARDED
DisableConflicts markers: 0        <- never entered
rc=0 · CONFLICTS=<empty> · status=PROTECTED
```

Detection produced everything needed to contest; the decision layer threw it away.

Confirmed by contrast in R3-P2 arm 1 — same binary, same flags, same live CSF; with NFTBan made non-authoritative the decision became `TAKEOVER`. **NFTBan's own authoritativeness was the sole discriminator.**

```
NFTBAN OWNING THE FIREWALL != NOTHING ELSE DOES
```

### The fix is deliberately narrow

| NFTBan authoritative | conflict | explicit approval | decision |
|---|---|---|---|
| yes | yes | **yes** | **TAKEOVER** *(was UPDATE)* |
| yes | no | yes | UPDATE |
| yes | yes | no | UPDATE |
| no | yes | yes | TAKEOVER *(unchanged)* |

Routine upgrades on a host that merely has another firewall installed do **not** become destructive.

### Contract change (flagged explicitly)

`TestClassify_Priority_UpdateOverConflicts` asserted *"UPDATE wins … (overrides everything)"* **with `forceApprove=true`** — it was pinning the bug as policy. Renamed to `_ExplicitApprovalContestsUpdate` and split so the *real* safety boundary is preserved rather than the accidental implementation rule.

### Tests

`classify_contested_test.go` — approved+conflict ⇒ Takeover, plus three controls: no conflicts stays Update · conflicts without approval stays Update · non-authoritative host still reaches Takeover (guards the contrast that isolated the discriminator).

⚠️ **Recorded harness incident:** a hand-rolled mock used the wrong `NftTables` key format and made all three positive arms **SKIP** — which reads like success in a summary. Replaced with the package's canonical `authoritativeMock()`; the skip guard is retained so a seeding regression can never masquerade as a pass.

```
TEST EXECUTED != TEST FILE PASSED        SKIP != PROOF
```

Falsifiability: reverting the fix fails the suite. Full Go suite **0 FAIL**.

Refs: `CSF-CLOSE-4`, `RETROACTIVE_TAKEOVER_UNREACHABLE`
