### PR TITLE
fix(validator): PROTECTED must not be reported while CSF can act [CSF-CLOSE-5]

### DIFF
--- a/internal/validator/csf_conflict.go
+++ b/internal/validator/csf_conflict.go
@@ -1,0 +1,233 @@
+// =============================================================================
+// NFTBan — CSF-CLOSE-5: PROTECTED must not be reported while CSF can act
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="validator-csf-conflict"
+// meta:type="lib"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-11"
+// meta:description="Read-only, conservative CSF conflict truth for the validator. Emits a finding when CSF is effective or re-enterable, so the status authority cannot report PROTECTED on a contested host. No mutation, no vendor binary execution."
+// meta:inventory.files="internal/validator/csf_conflict.go"
+// meta:inventory.binaries=""
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// WHY THIS EXISTS — two proven runtime failures (el9-clean, 2026-08-11):
+//
+//	ARM 3  /etc/csf removed, csf.service failed BUT STILL ENABLED, binary
+//	       present, 129 CSF rules live. Takeover neutralized nothing.
+//	       Restoring the config and starting the still-enabled unit brought
+//	       CSF back to 129 rules — and `nftban status` said PROTECTED
+//	       throughout.
+//
+//	ARM 4  CSF detected and listed in CONFLICTS, yet the disarm path was
+//	       skipped. lfd left enabled, binary left executable, PROTECTED.
+//
+// In both cases NFTBan's own authority was genuinely healthy. That is exactly
+// the trap:
+//
+//	NFTBAN HEALTHY  !=  SOLE EFFECTIVE AUTHORITY
+//	SERVICE INACTIVE !=  AUTHORITY ABSENT
+//
+// SCOPE (owner-constrained, deliberately narrow): this is NOT the future
+// universal external-firewall observer. It answers one question about one
+// product, conservatively. UFW / firewalld / native-nftables generalization
+// belongs to a later lane and must not be built here.
+//
+// PURITY: this file performs NO mutation and NEVER executes a vendor firewall
+// binary. `csf -s` is CSF's START command — using it as a probe re-armed a
+// competing firewall from a read-only report (fixed in v1.229.0 R0). Evidence
+// here is systemd state + filesystem presence only.
+package validator
+
+import (
+	"os"
+	"strings"
+
+	"github.com/itcmsgr/nftban/internal/procenv"
+)
+
+// CSFConflictState is the conservative tri-state answer.
+type CSFConflictState string
+
+const (
+	// CSFPresent — CSF is effective, or can re-enter without reinstallation.
+	CSFPresent CSFConflictState = "PRESENT"
+	// CSFNotObserved — no credible CSF evidence found.
+	CSFNotObserved CSFConflictState = "NOT_OBSERVED"
+	// CSFUnknown — the host could not be interrogated. Never treated as clean.
+	CSFUnknown CSFConflictState = "UNKNOWN"
+)
+
+// CodeCSFConflict is the stable finding code for automation.
+const CodeCSFConflict = "VAL-CSF-001"
+
+// CSFConflictResult carries the verdict plus the evidence that produced it, so
+// an operator is told WHY the host is contested rather than just that it is.
+type CSFConflictResult struct {
+	State    CSFConflictState
+	Evidence []string
+}
+
+// csfUnits / csfBinaries are the canonical surfaces. Both units are listed
+// because CSF ships two and either alone re-establishes authority; both
+// binaries because takeover previously neutralized only /usr/sbin/csf and
+// left lfd executable — a proven re-entry plane.
+var (
+	csfUnits    = []string{"csf.service", "lfd.service"}
+	csfBinaries = []string{"/usr/sbin/csf", "/usr/sbin/lfd"}
+	csfConfigs  = []string{"/etc/csf/csf.conf"}
+	csfCrons    = []string{"/etc/cron.d/csf-cron", "/etc/cron.d/lfd-cron", "/etc/cron.d/csf_update"}
+)
+
+// DetectCSFConflict reports whether CSF is effective or re-enterable.
+//
+// CONSERVATIVE BY CONSTRUCTION. Any of the following counts as PRESENT:
+//
+//   - a CSF unit ACTIVE                     (effective now)
+//   - a CSF unit ENABLED but failed/inactive (re-enters on boot or restart —
+//     this is the arm-3 shape that previously read as "absent")
+//   - an executable CSF binary at its canonical path (invokable directly)
+//   - CSF config or cron persistence present (re-arms on reinstall/schedule)
+//
+// If systemd cannot be interrogated at all, the answer is UNKNOWN — never
+// NOT_OBSERVED. Absence of evidence is not evidence of absence.
+func DetectCSFConflict() CSFConflictResult {
+	var ev []string
+	systemdUsable := false
+
+	checker := SystemdChecker{}
+	for _, unit := range csfUnits {
+		state, detail := checker.CheckUnit(unit)
+		if state != RuntimeError {
+			systemdUsable = true
+		}
+		if state == RuntimeRunning {
+			ev = append(ev, unit+" active")
+			continue
+		}
+		// ENABLED-BUT-NOT-ACTIVE is the arm-3 trap: the unit reads as
+		// inactive/failed yet still starts on boot. Treat it as re-entry.
+		// `masked` is the ONE enabled-state that is genuinely neutralized —
+		// that is what an authorized takeover produces, and it must not be
+		// reported as a conflict or takeover could never reach PROTECTED.
+		if en, ok := unitEnabledState(unit); ok {
+			systemdUsable = true
+			switch en {
+			case "enabled", "enabled-runtime", "static", "alias":
+				ev = append(ev, unit+" "+en+" ("+detail+") — re-enters on boot")
+			}
+		}
+	}
+
+	for _, bin := range csfBinaries {
+		if isExecutableFile(bin) {
+			ev = append(ev, bin+" executable")
+		}
+	}
+	for _, cfg := range csfConfigs {
+		if fileExists(cfg) {
+			ev = append(ev, cfg+" present")
+		}
+	}
+	for _, cron := range csfCrons {
+		if fileExists(cron) {
+			ev = append(ev, cron+" present — scheduled re-entry")
+		}
+	}
+
+	switch {
+	case len(ev) > 0:
+		return CSFConflictResult{State: CSFPresent, Evidence: ev}
+	case !systemdUsable:
+		// Could not query systemd AND found nothing on disk: we did not prove
+		// the host is clean, we failed to look. Fail closed.
+		return CSFConflictResult{
+			State:    CSFUnknown,
+			Evidence: []string{"systemd not queryable — CSF state could not be established"},
+		}
+	default:
+		return CSFConflictResult{State: CSFNotObserved}
+	}
+}
+
+// csfConflictFinding converts the verdict into a validator finding.
+// Returns nil when there is nothing to report.
+//
+// SeverityError (not Critical) is deliberate: a contested host is DEGRADED,
+// not DOWN. NFTBan's own authority may be perfectly healthy — what is untrue
+// is calling that state PROTECTED.
+func csfConflictFinding(r CSFConflictResult) *Finding {
+	switch r.State {
+	case CSFPresent:
+		return &Finding{
+			Code:      CodeCSFConflict,
+			Severity:  SeverityError,
+			Component: "csf",
+			Message: "CSF is effective or able to re-enter — NFTBan is not the sole firewall authority (" +
+				strings.Join(r.Evidence, "; ") + ")",
+			Remediation: "Run an authorized takeover to neutralize CSF, or remove CSF from this host.",
+		}
+	case CSFUnknown:
+		return &Finding{
+			Code:        CodeCSFConflict,
+			Severity:    SeverityError,
+			Component:   "csf",
+			Message:     "CSF conflict state UNKNOWN — " + strings.Join(r.Evidence, "; ") + "; protection cannot be asserted",
+			Remediation: "Restore systemd/D-Bus availability so firewall authority can be verified.",
+		}
+	default:
+		return nil
+	}
+}
+
+// isReentryEnabledState reports whether a `systemctl is-enabled` value means
+// the unit can still come back on its own.
+//
+// `masked` / `masked-runtime` / `disabled` are EXCLUDED on purpose: masking is
+// exactly what an authorized takeover produces. Counting it as a conflict
+// would mean no host could ever reach PROTECTED after a successful takeover —
+// trading a false PASS for a false FAIL.
+func isReentryEnabledState(state string) bool {
+	switch state {
+	case "enabled", "enabled-runtime", "static", "alias":
+		return true
+	default:
+		return false
+	}
+}
+
+// unitEnabledState returns `systemctl is-enabled <unit>` output and whether
+// the query itself succeeded in producing a state. Read-only.
+//
+// NOTE the exit code is deliberately ignored: `is-enabled` exits non-zero for
+// perfectly meaningful states such as "disabled" and "masked". Treating a
+// non-zero exit as "no answer" would discard the very evidence this probe
+// exists to collect.
+func unitEnabledState(unit string) (string, bool) {
+	out, _ := procenv.Command("systemctl", "is-enabled", unit).Output()
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// ---- small read-only helpers -------------------------------------------------
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// isExecutableFile deliberately uses Lstat semantics via Stat on the canonical
+// path: a payload renamed to `.disabled` is intentionally NOT matched, because
+// it can no longer execute at that path. Retained evidence is not re-entry
+// capability (PAYLOAD_PRESERVED_FOR_EVIDENCE != PAYLOAD_CAPABLE_OF_REENTRY).
+func isExecutableFile(p string) bool {
+	fi, err := os.Stat(p)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	return fi.Mode().Perm()&0o111 != 0
+}

--- a/internal/validator/csf_conflict_test.go
+++ b/internal/validator/csf_conflict_test.go
@@ -1,0 +1,199 @@
+// =============================================================================
+// NFTBan — CSF-CLOSE-5 gate: PROTECTED may not be asserted on a contested host
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+// meta:name="validator-csf-conflict-test"
+// meta:type="test"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-11"
+// meta:description="Locks CSF-CLOSE-5: a CSF-PRESENT or CSF-UNKNOWN verdict produces an error-severity finding so the validator cannot return PROTECTED, while a genuinely neutralized host (masked units, .disabled payload) still reaches PROTECTED."
+// meta:inventory.files="internal/validator/csf_conflict.go,internal/validator/validator.go"
+// meta:inventory.privileges="none"
+// =============================================================================
+//
+// The two shapes this must never regress on (el9-clean, 2026-08-11):
+//
+//	  ARM 3  csf.service failed BUT ENABLED, binary executable, config absent.
+//	         Every "is it active" probe said no; CSF came back with 129 rules.
+//	  ARM 4  CSF listed in CONFLICTS, disarm skipped, lfd enabled, binary
+//	         executable. status=PROTECTED.
+//
+//		SERVICE INACTIVE != AUTHORITY ABSENT
+//		UNKNOWN          != PROTECTED-by-assumption
+package validator
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// readSourceStripped returns a source file with // comments removed, so a
+// static assertion cannot be satisfied or violated by prose describing the
+// defect it guards against.
+func readSourceStripped(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return regexp.MustCompile(`(?m)//.*$`).ReplaceAllString(string(b), "")
+}
+
+func hasErrorFinding(f *Finding) bool {
+	return f != nil && f.Severity == SeverityError && f.Code == CodeCSFConflict
+}
+
+// ---------------------------------------------------------------------------
+// PRESENT => must produce an error finding (cannot be PROTECTED)
+// ---------------------------------------------------------------------------
+
+func TestClose5_Present_ProducesErrorFinding(t *testing.T) {
+	r := CSFConflictResult{
+		State:    CSFPresent,
+		Evidence: []string{"csf.service enabled (failed) — re-enters on boot"},
+	}
+	f := csfConflictFinding(r)
+	if !hasErrorFinding(f) {
+		t.Fatalf("CSF PRESENT must yield an error-severity %s finding, got %+v", CodeCSFConflict, f)
+	}
+	if !strings.Contains(f.Message, "re-enter") && !strings.Contains(f.Message, "sole firewall authority") {
+		t.Errorf("finding message must state the authority problem, got %q", f.Message)
+	}
+	if f.Remediation == "" {
+		t.Error("a contested-host finding must tell the operator what to do")
+	}
+}
+
+// UNKNOWN must fail closed — this is the invariant that stops an unqueryable
+// host from silently passing as clean.
+func TestClose5_Unknown_FailsClosed(t *testing.T) {
+	f := csfConflictFinding(CSFConflictResult{
+		State:    CSFUnknown,
+		Evidence: []string{"systemd not queryable"},
+	})
+	if !hasErrorFinding(f) {
+		t.Fatalf("CSF UNKNOWN must fail closed with an error finding, got %+v", f)
+	}
+	if !strings.Contains(strings.ToUpper(f.Message), "UNKNOWN") {
+		t.Errorf("UNKNOWN finding must say so plainly, got %q", f.Message)
+	}
+}
+
+// NOT_OBSERVED must stay silent, or every clean host would be degraded.
+func TestClose5_NotObserved_ProducesNoFinding(t *testing.T) {
+	if f := csfConflictFinding(CSFConflictResult{State: CSFNotObserved}); f != nil {
+		t.Errorf("a clean host must produce no CSF finding, got %+v", f)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The finding must actually change the verdict — not merely exist
+// ---------------------------------------------------------------------------
+
+func TestClose5_ErrorFindingPreventsProtected(t *testing.T) {
+	// Baseline: no findings, all families protected. NOTE this evaluates to
+	// StatusIdle here because the fixture declares no modules — and the shell
+	// status surface maps BOTH `protected` and `idle` to the operator-visible
+	// word PROTECTED (cmd_status.sh: `protected)` and `idle)` both echo
+	// "PROTECTED"). So the invariant under test is "not either of them",
+	// not merely "not StatusProtected".
+	clean := &ValidationResult{
+		Status:   StatusProtected,
+		Families: []FamilyResult{{Status: StatusProtected}},
+	}
+	base := evaluateOverallStatus(clean)
+	if base != StatusProtected && base != StatusIdle {
+		t.Fatalf("baseline must read as protected-or-idle, got %s — arm below would prove nothing", base)
+	}
+
+	// Same host, plus the CSF conflict finding.
+	contested := &ValidationResult{
+		Status:   StatusProtected,
+		Families: []FamilyResult{{Status: StatusProtected}},
+	}
+	f := csfConflictFinding(CSFConflictResult{
+		State:    CSFPresent,
+		Evidence: []string{"lfd.service enabled (inactive) — re-enters on boot"},
+	})
+	contested.Findings = append(contested.Findings, *f)
+
+	got := evaluateOverallStatus(contested)
+	if got == StatusProtected || got == StatusIdle {
+		t.Errorf("host with re-enterable CSF still reads as PROTECTED to the operator (%s) — "+
+			"the lying-status defect (arms 3/4)", got)
+	}
+	if got != StatusDegraded {
+		t.Errorf("contested host should be DEGRADED (NFTBan itself is healthy), got %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Neutralized host must still reach PROTECTED, or takeover could never succeed
+// ---------------------------------------------------------------------------
+
+func TestClose5_MaskedUnitsAndDisabledPayload_AreNotAConflict(t *testing.T) {
+	// A successful takeover leaves: units MASKED, payload renamed .disabled.
+	// If that read as a conflict, no host could ever be PROTECTED after
+	// takeover — the fix would have replaced a false PASS with a false FAIL.
+	if f := csfConflictFinding(CSFConflictResult{State: CSFNotObserved}); f != nil {
+		t.Fatalf("post-takeover shape must not be reported as a conflict, got %+v", f)
+	}
+
+	// And the enabled-state classifier must treat `masked` as neutralized.
+	for _, st := range []string{"masked", "masked-runtime", "disabled"} {
+		if isReentryEnabledState(st) {
+			t.Errorf("%q must NOT count as re-entry — it is what neutralization produces", st)
+		}
+	}
+	// ...while the states that really do re-enter must be caught.
+	for _, st := range []string{"enabled", "enabled-runtime", "static", "alias"} {
+		if !isReentryEnabledState(st) {
+			t.Errorf("%q re-enters on boot and must be caught (arm-3 shape)", st)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WIRING — the probe must actually reach the verdict, not be dead code
+// ---------------------------------------------------------------------------
+
+// Without this, every other arm in this file still passes if the call site in
+// ValidateKernel is deleted: the probe becomes unreachable and status lies
+// again, silently. A falsifiability control found exactly that hole.
+//
+// ValidateKernel needs a live nft/systemd host, so this cannot be exercised
+// behaviourally in a hermetic test. A static assertion on the shipped call
+// site is the honest substitute — weaker than behavioural proof, and stated
+// as such rather than dressed up.
+func TestClose5_FindingIsWiredIntoValidateKernel(t *testing.T) {
+	src := readSourceStripped(t, "validator.go")
+	if !strings.Contains(src, "csfConflictFinding(DetectCSFConflict())") {
+		t.Error("ValidateKernel no longer calls csfConflictFinding(DetectCSFConflict()) — " +
+			"the CSF conflict probe is dead code and PROTECTED can lie again")
+	}
+	if !strings.Contains(src, "result.Findings = append(result.Findings, *f)") {
+		t.Error("the CSF finding is computed but never appended to result.Findings")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Purity — this probe must never mutate or execute a vendor binary
+// ---------------------------------------------------------------------------
+
+func TestClose5_ProbeNeverExecutesVendorBinary(t *testing.T) {
+	// Static guard on the shipped source: `csf -s` as a probe re-armed a
+	// competing firewall from a read-only report (v1.229.0 R0). Comments are
+	// stripped so prose describing that defect can neither satisfy nor
+	// violate the assertion (GUARD_SUBJECT == GUARD_INPUT).
+	src := readSourceStripped(t, "csf_conflict.go")
+	for _, forbidden := range []string{
+		`Command("/usr/sbin/csf"`, `Command("csf"`, `Command("/usr/sbin/lfd"`, `Command("lfd"`,
+		`"-s"`, `"--start"`, `os.Remove`, `os.Rename`, `WriteFile`,
+	} {
+		if strings.Contains(src, forbidden) {
+			t.Errorf("read-only CSF probe contains %q — observation must not mutate or execute vendor binaries", forbidden)
+		}
+	}
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -260,6 +260,21 @@ func ValidateKernel(ctx context.Context) (*ValidationResult, error) {
 	// Store for mapper to use
 	result.ConsistencyOverall = consistencyResult.Overall
 
+	// CSF-CLOSE-5: a contested host must not be reported PROTECTED.
+	//
+	// NFTBan's own structure can be perfectly healthy while CSF is still
+	// effective or able to re-enter — proven twice on el9-clean (arms 3 and 4),
+	// where `nftban status` said PROTECTED with CSF re-armable and, in arm 3,
+	// 129 CSF rules recoverable by simply starting a still-enabled unit.
+	//
+	//     NFTBAN HEALTHY != SOLE EFFECTIVE AUTHORITY
+	//
+	// Read-only and conservative: UNKNOWN also produces a finding, so an
+	// unqueryable host degrades rather than silently passing.
+	if f := csfConflictFinding(DetectCSFConflict()); f != nil {
+		result.Findings = append(result.Findings, *f)
+	}
+
 	// Compute summary
 	result.Summary = computeSummary(result)
 


### PR DESCRIPTION
## CSF-CLOSE-5 — the lying-status defect

NFTBan's own structure can be perfectly healthy while CSF is still effective or able to re-enter. Proven twice on el9-clean:

| Arm | State | Reported |
|---|---|---|
| **3** | `/etc/csf` removed, `csf.service` **failed but ENABLED**, binary executable, 129 CSF rules live | `PROTECTED` |
| **4** | CSF in `CONFLICTS`, disarm skipped, lfd enabled, binary executable | `PROTECTED` |

In arm 3, restoring the config and starting the still-enabled unit brought CSF straight back to 129 rules.

```
NFTBAN HEALTHY   != SOLE EFFECTIVE AUTHORITY
SERVICE INACTIVE != AUTHORITY ABSENT
```

### What this adds

A read-only CSF conflict probe in the **validator** — the sole status authority (`cmd_status.sh` explicitly must not recompute or override it). Conservative tri-state:

```
PRESENT       unit active · unit ENABLED-but-failed · executable binary
              · config/cron persistence
NOT_OBSERVED  no credible evidence
UNKNOWN       systemd unqueryable — NEVER treated as clean
```

`PRESENT` and `UNKNOWN` both emit an **error-severity** finding, so `evaluateOverallStatus` yields `DEGRADED`. Error rather than Critical is deliberate: a contested host is degraded, not down — NFTBan's authority may be fine; what's untrue is calling it PROTECTED.

**`masked` is excluded from re-entry on purpose.** Masking is what an authorized takeover produces; counting it would mean no host could ever be PROTECTED after takeover — trading a false PASS for a false FAIL. A test pins both directions.

### Purity

No mutation, and **no vendor binary is ever executed**. `csf -s` is CSF's *start* command; using it as a probe re-armed a competing firewall from a read-only report (fixed in R0). Evidence is systemd state + filesystem presence only, with a static guard keeping it that way.

### Scope

Deliberately **not** the future universal external-firewall observer. One product, one question, conservatively. UFW / firewalld / native-nftables generalization belongs to a later lane.

### Tests — 7 arms, all four controls non-vacuous

The verdict arm asserts the **operator-visible** invariant: `cmd_status.sh` maps *both* `protected` and `idle` to the word PROTECTED, so the test rejects either.

⚠️ **A falsifiability control found a real hole.** With the first six arms, deleting the call site in `ValidateKernel` left everything green — the probe would have become dead code and status would lie again, silently. Added a wiring guard; that control now fails as it should.

Full Go suite: **0 FAIL**.

Refs: `CSF-CLOSE-5`, `VAL-CSF-001`
