### PR TITLE
fix(csf): runtime corrections + destructive-takeover disclosure [CSF final]

### DIFF
--- a/internal/installer/switchop/csf_removal_contract_test.go
+++ b/internal/installer/switchop/csf_removal_contract_test.go
@@ -169,16 +169,37 @@ func TestCSFRemoval_NeverFlushesUnrelatedIptablesState(t *testing.T) {
 	}
 }
 
-func TestCSFRemoval_RemovesCSFOwnedKernelStateAttributably(t *testing.T) {
+// CONTRACT CORRECTED 2026-08-12 after package-native runtime validation.
+//
+// This previously asserted that `csf --stop` IS invoked, on the assumption
+// that CSF unwinding its own ruleset counts as attributable removal. Measured
+// on el9-clean, it does not: `csf --stop` flushes filter/nat/mangle wholesale
+// and destroyed the operator-owned OPERATOR_QOS chain (2 -> 0), exactly like
+// the blanket flush CLOSE-3 deleted.
+//
+//	DELEGATING THE FLUSH TO THE VENDOR != MAKING IT ATTRIBUTABLE
+//
+// The corrected contract: NFTBan invokes NO vendor stop. CSF's kernel rules
+// are left inert once every execution plane is neutralized.
+func TestCSFRemoval_NeverInvokesVendorStop(t *testing.T) {
 	m := csfHost()
 	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
 	if err := DisableConflicts(m, conflicts, detect.PanelNone, newTestLogger()); err != nil {
 		t.Fatalf("DisableConflicts: %v", err)
 	}
-	// `csf --stop` unwinds exactly what CSF created — attribution by the vendor
-	// itself, rather than NFTBan guessing ownership from table names.
-	if !ranCmd(m, "/usr/sbin/csf", "--stop") {
-		t.Error("CSF-owned kernel state not removed attributably (csf --stop not invoked)")
+
+	// No vendor firewall binary may be executed — not to probe, not to stop.
+	for _, c := range m.Commands {
+		switch c.Name {
+		case "/usr/sbin/csf", "csf", "/usr/sbin/lfd", "lfd":
+			t.Errorf("takeover executed a vendor firewall binary (%s %v) — it flushes "+
+				"operator state wholesale", c.Name, c.Args)
+		}
+	}
+
+	// And the execution planes must still be closed, so the rules are inert.
+	if !ranCmd(m, "mv", "/usr/sbin/csf") || !ranCmd(m, "mv", "/usr/sbin/lfd") {
+		t.Error("binaries not neutralized — CSF rules would not be inert")
 	}
 }
 

--- a/internal/installer/switchop/csf_removal_contract_test.go
+++ b/internal/installer/switchop/csf_removal_contract_test.go
@@ -31,11 +31,13 @@
 package switchop
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/itcmsgr/nftban/internal/installer/detect"
 	"github.com/itcmsgr/nftban/internal/installer/executor"
+	"github.com/itcmsgr/nftban/internal/installer/logging"
 )
 
 // csfHost seeds a host carrying CSF payload + every persistence plane, plus a
@@ -200,6 +202,40 @@ func TestCSFRemoval_NeverInvokesVendorStop(t *testing.T) {
 	// And the execution planes must still be closed, so the rules are inert.
 	if !ranCmd(m, "mv", "/usr/sbin/csf") || !ranCmd(m, "mv", "/usr/sbin/lfd") {
 		t.Error("binaries not neutralized — CSF rules would not be inert")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Destructive-consequence disclosure must precede mutation
+// ---------------------------------------------------------------------------
+
+// OWNER RULING 2026-08-12: legacy-iptables preservation across CSF removal is
+// NOT SUPPORTED, because CSF's own ExecStop flushes those tables. That is an
+// acceptable contract ONLY if the operator is told before anything is mutated.
+func TestCSFRemoval_DisclosesDestructiveConsequenceBeforeMutation(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "installer.log")
+	lg := logging.New(logPath, false)
+
+	m := csfHost()
+	conflicts := []detect.Conflict{{Name: "CSF", Service: "csf.service", Active: true}}
+	if err := DisableConflicts(m, conflicts, detect.PanelNone, lg); err != nil {
+		t.Fatalf("DisableConflicts: %v", err)
+	}
+
+	warned := strings.Join(lg.Warnings(), " | ")
+	for _, must := range []string{"destructive", "FLUSH legacy", "does not restore"} {
+		if !strings.Contains(warned, must) {
+			t.Errorf("pre-mutation disclosure missing %q — operator not told that CSF shutdown "+
+				"may flush legacy iptables rules. warnings: %s", must, warned)
+		}
+	}
+
+	// NEGATIVE CONTROL: a non-CSF conflict must not emit the CSF disclosure.
+	m2 := csfHost()
+	lg2 := logging.New(filepath.Join(t.TempDir(), "b.log"), false)
+	_ = DisableConflicts(m2, []detect.Conflict{{Name: "UFW", Service: "ufw.service"}}, detect.PanelNone, lg2)
+	if strings.Contains(strings.Join(lg2.Warnings(), " "), "CSF takeover authorized") {
+		t.Error("CSF destructive disclosure emitted with no CSF conflict present")
 	}
 }
 

--- a/internal/installer/switchop/takeover.go
+++ b/internal/installer/switchop/takeover.go
@@ -136,18 +136,31 @@ func disarmCSFArtifacts(exec executor.Executor, log *logging.Logger) {
 		log.Warn("cron-backup manifest writer: %v (continuing with cron rm; A.4 restore will soft-skip on this host)", err)
 	}
 
-	// CSF-CLOSE-2: unwind CSF's OWN kernel state before neutralizing the
-	// binary, so the removal is attributable rather than a blanket flush.
-	// `csf --stop` removes exactly the rules CSF created; anything it does
-	// not own stays. Best-effort: a failure here must not block the rest of
-	// the disarm, but it is logged so a partial removal is visible.
-	if exec.FileExists("/usr/sbin/csf") {
-		if r := exec.Run("/usr/sbin/csf", "--stop"); r.ExitCode == 0 {
-			log.Info("removed CSF-owned firewall state (csf --stop)")
-		} else {
-			log.Warn("csf --stop exit %d: %s — CSF kernel state may persist", r.ExitCode, r.Stderr)
-		}
-	}
+	// CSF-CLOSE-2 CORRECTED 2026-08-12 after package-native runtime validation.
+	//
+	// This previously ran `csf --stop`, on the assumption that CSF unwinding
+	// its own ruleset was "attributable" removal. MEASURED ON el9-clean, IT IS
+	// NOT: `csf --stop` flushes filter/nat/mangle wholesale, exactly like the
+	// blanket flush CLOSE-3 deleted.
+	//
+	//     seed OPERATOR_QOS=2, CSF rules=129
+	//     csf --stop  ->  OPERATOR_QOS=0, CSF rules=0
+	//
+	// Delegating the flush to the vendor does not make it attributable — it
+	// only changes who issues it. The operator's mangle chain is destroyed
+	// either way, which is precisely the hard limit:
+	//
+	//     HARD REMOVE CSF = YES        HARD FLUSH ALL IPTABLES = NO
+	//
+	// So NO vendor stop is invoked. CSF's kernel rules are left in place and
+	// become INERT once every execution plane below is neutralized: services
+	// masked, both binaries renamed, cron persistence removed. CSF cannot
+	// re-arm them, and nothing NFTBan cannot attribute is destroyed.
+	//
+	// Residual (stated, not hidden): stale CSF rules may remain in the legacy
+	// iptables tables until an operator clears them deliberately. That is a
+	// cosmetic residue with no authority behind it — strictly preferable to
+	// destroying operator state we did not create.
 
 	// Remove CSF/LFD cron persistence. CSF-CLOSE-2 widened this beyond the
 	// original two files: el9-clean runtime showed /etc/cron.d/csf_update

--- a/internal/installer/switchop/takeover.go
+++ b/internal/installer/switchop/takeover.go
@@ -50,6 +50,31 @@ func DisableConflicts(exec executor.Executor, conflicts []detect.Conflict, panel
 		}
 	}
 
+	// OWNER RULING 2026-08-12 — CSF takeover is a DESTRUCTIVE REPLACEMENT.
+	// The consequence is disclosed BEFORE any mutation, because stopping CSF
+	// runs the vendor's own ExecStop (`csf --initdown ; csf --stop`), which
+	// flushes the legacy iptables/ip6tables tables. That is CSF's documented
+	// shutdown behaviour, not something NFTBan can suppress without leaving
+	// CSF running — and NFTBan does not build a capture/replay subsystem to
+	// reconstruct arbitrary foreign rules around it.
+	//
+	//     PRESERVE_ARBITRARY_LEGACY_IPTABLES_ACROSS_CSF_REMOVAL = NOT SUPPORTED
+	//
+	// What remains forbidden is NFTBan issuing blanket foreign-state flushes
+	// of its own (CSF-CLOSE-3) or executing vendor binaries directly.
+	// --takeover / force approval IS the deliberate destructive authorization,
+	// so no second confirmation is required — only that the operator was told.
+	if hasCSF {
+		log.Warn("CSF takeover authorized — this REPLACES CSF with NFTBan and is destructive:")
+		log.Warn("  · csf.service and lfd.service will be stopped, disabled and masked")
+		log.Warn("  · the CSF and LFD executables will be neutralized (renamed .disabled)")
+		log.Warn("  · CSF/LFD cron persistence will be removed")
+		log.Warn("  · stopping CSF runs its own shutdown, which MAY FLUSH legacy")
+		log.Warn("    iptables/ip6tables rules — including unrelated rules coexisting")
+		log.Warn("    in those tables. NFTBan does not restore them.")
+		log.Warn("  Continue only if replacing CSF with NFTBan is intended.")
+	}
+
 	for _, c := range conflicts {
 		if c.Service == "" {
 			continue

--- a/internal/validator/csf_conflict.go
+++ b/internal/validator/csf_conflict.go
@@ -94,6 +94,7 @@ var (
 // NOT_OBSERVED. Absence of evidence is not evidence of absence.
 func DetectCSFConflict() CSFConflictResult {
 	var ev []string
+	var inert []string // persistence artifacts with no execution plane behind them
 	systemdUsable := false
 
 	checker := SystemdChecker{}
@@ -120,25 +121,59 @@ func DetectCSFConflict() CSFConflictResult {
 		}
 	}
 
+	// EXECUTION PLANE. Only an executable binary can actually act.
+	executable := false
 	for _, bin := range csfBinaries {
 		if isExecutableFile(bin) {
+			executable = true
 			ev = append(ev, bin+" executable")
+		}
+	}
+
+	// PERSISTENCE PLANE — CORRECTED 2026-08-12 after package-native validation.
+	//
+	// Config and cron were previously counted as conflicts on their own. That
+	// made VAL-CSF-001 UNCLEARABLE after a SUCCESSFUL takeover: the doctrine
+	// deliberately RETAINS /etc/csf as audit evidence, so the host stayed
+	// "contested" forever and could never return to PROTECTED. Measured on
+	// el9-clean: services masked, both binaries .disabled, cron.d empty — and
+	// the finding still fired on csf.conf alone.
+	//
+	// Persistence is only re-entry when something can EXECUTE. A cron line or
+	// a config file with no runnable binary and no startable unit cannot
+	// re-arm anything:
+	//
+	//     PERSISTENCE_ARTIFACT_PRESENT != REENTRY_CAPABLE
+	//
+	// This is the false-FAIL mirror of the original defect, and it is just as
+	// wrong: a status that can never say PROTECTED is as useless as one that
+	// always does.
+	for _, cron := range csfCrons {
+		if fileExists(cron) {
+			if executable {
+				ev = append(ev, cron+" present — scheduled re-entry")
+			} else {
+				// Recorded but not a conflict: inert without an executable.
+				inert = append(inert, cron+" present (inert — no executable CSF binary)")
+			}
 		}
 	}
 	for _, cfg := range csfConfigs {
 		if fileExists(cfg) {
-			ev = append(ev, cfg+" present")
-		}
-	}
-	for _, cron := range csfCrons {
-		if fileExists(cron) {
-			ev = append(ev, cron+" present — scheduled re-entry")
+			if executable {
+				ev = append(ev, cfg+" present")
+			} else {
+				inert = append(inert, cfg+" present (retained as evidence — no execution plane)")
+			}
 		}
 	}
 
 	switch {
 	case len(ev) > 0:
 		return CSFConflictResult{State: CSFPresent, Evidence: ev}
+	case len(inert) > 0:
+		// Neutralized: payload/config on disk, nothing able to run it.
+		return CSFConflictResult{State: CSFNotObserved, Evidence: inert}
 	case !systemdUsable:
 		// Could not query systemd AND found nothing on disk: we did not prove
 		// the host is clean, we failed to look. Fail closed.


### PR DESCRIPTION
## CSF final — corrections found by package-native validation, plus the contract fix

Package-native validation on `el9-clean` against the exact-SHA build proved **three stacked destroyers** of foreign iptables state. Unit tests missed two of them because the tests encoded the same wrong assumptions the code did.

```
1  NFTBan blanket iptables -P/-F/-X       FIXED (CSF-CLOSE-3)
2  NFTBan executing `csf --stop`          FIXED (this PR)
3  systemd running csf.service ExecStop   VENDOR LIFECYCLE — not a defect
```

### Defect 1 — `csf --stop` is not attributable removal

```
seed        OPERATOR_QOS=2  CSF rules=129
csf --stop
post        OPERATOR_QOS=0  CSF rules=0
```

Delegating the flush to the vendor doesn't make it attributable — it only changes who issues it. Removed; CSF's rules are left inert once every execution plane is neutralized.

### Defect 2 — `VAL-CSF-001` could never clear

Config and cron counted as conflicts on their own, but the doctrine deliberately **retains** `/etc/csf` as evidence — so a fully neutralized host stayed contested forever and `PROTECTED` became unreachable.

```
PERSISTENCE_ARTIFACT_PRESENT != REENTRY_CAPABLE
```

Persistence now counts only when an executable CSF binary exists. Verified on the fixture: clears when neutralized, still fires when the binary is restored.

### Layer 3 — the contract was wrong, not the code

`csf.service` declares `ExecStop=/usr/sbin/csf --initdown ; /usr/sbin/csf --stop`. Stopping CSF runs CSF's own flush. Measured: `systemctl stop csf.service` → `OPERATOR_QOS 3 → 0`, with NFTBan issuing no flush.

"Remove CSF" and "preserve arbitrary legacy iptables state" are incompatible when the product being removed owns those tables.

```
PRESERVE_ARBITRARY_LEGACY_IPTABLES_ACROSS_CSF_REMOVAL = NOT SUPPORTED
NFTBAN BLANKET FOREIGN-STATE DESTRUCTION              = FORBIDDEN
VENDOR ExecStop SIDE-EFFECTS ON EXPLICIT TAKEOVER     = ACCEPTED
```

**Not built:** a capture/replay subsystem (the restoration complexity this lane removed), and no `systemctl kill` hack to evade ExecStop.

### Disclosure before mutation

Since arbitrary legacy state can be lost, the takeover now states the consequence **before** anything is mutated — including that stopping CSF may flush unrelated rules NFTBan will not restore. `--takeover`/force is already the destructive authorization, so no second confirmation is added.

### Tests — 8 arms, all executed and passing

New `_DisclosesDestructiveConsequenceBeforeMutation` with a negative control. Full Go suite **0 FAIL**.

Refs: `OWNER_RULING_CSF_FINAL`
