### PR TITLE
fix(uninstall): stop standard mode purging config, and end mid-purge aborts

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -99,3 +99,14 @@ jobs:
           echo "=== Executing: legacy_restore_neutralized_v1229_test.sh ==="
           chmod +x cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh
           bash cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh
+
+      # UNINSTALL-PR1 — uninstall.sh critical safety (D2/D4/D5).
+      # Explicit single-file invocation, same rationale as the gates above.
+      # D2's arm is BEHAVIOURAL: it executes uninstall_package_manager() with
+      # dpkg/rpm mocked, because a text scan cannot distinguish a purge in the
+      # PURGE_DATA branch from one in the else branch 8 lines below it.
+      - name: Uninstall critical safety (UNINSTALL-PR1 gate)
+        run: |
+          echo "=== Executing: uninstall_sh_critical_safety_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/uninstall_sh_critical_safety_v1229_test.sh
+          bash cli/lib/nftban/tests/uninstall_sh_critical_safety_v1229_test.sh

--- a/cli/lib/nftban/tests/uninstall_sh_critical_safety_v1229_test.sh
+++ b/cli/lib/nftban/tests/uninstall_sh_critical_safety_v1229_test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — UNINSTALL-PR1: uninstall.sh critical safety (D2 / D4 / D5)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="uninstall-sh-critical-safety-v1229-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-12"
+# meta:description="Locks UNINSTALL-PR1: standard mode never invokes dpkg --purge, --purge cannot abort mid-deletion on a prefix guard, and the summary states firewall truth without asserting an unobserved protected state."
+# meta:inventory.files="uninstall.sh"
+# meta:inventory.privileges="none"
+# meta:ta.id="uninstall_sh_critical_safety_v1229_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="uninstall-lifecycle"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+#
+# DEFECTS GUARDED (canonical audit UNINSTALL_PACKAGE_LIFECYCLE_INDEPENDENT_AUDIT_2026_08_11):
+#
+#   D2  standard mode ran `dpkg --purge` unconditionally, firing postrm purge)
+#       which rm -rf'd all five trees — including whitelist.d/*.conf, the durable
+#       management-IP whitelist that is the SSH-lockout safety invariant — while
+#       this same script printed "Configuration preserved" / "Data preserved".
+#
+#   D4  /usr/share/nftban sat in data_dirs while every entry was passed "/var/"
+#       as expected_prefix, so safe_rm_rf Guard 4 exited 1 AFTER /var/lib,
+#       /var/log and /var/cache were already deleted.
+#           PARTIAL_PROGRESS != SAFE_INTERMEDIATE_STATE
+#
+#   D5  the script deletes nft tables in BOTH modes, never re-probes, and said
+#       nothing about firewall state; packaging asserted other firewalls "may
+#       still be active" — false on the proven EL9 host.
+#
+# HARNESS POLICY: source is read with comments STRIPPED, so prose describing a
+# removed defect can neither satisfy nor violate an assertion
+# (GUARD_SUBJECT == GUARD_INPUT). No `producer | grep -q` under pipefail.
+# =============================================================================
+# shellcheck disable=SC2015
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SRC="$REPO_ROOT/uninstall.sh"
+
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; echo "       $2"; FAIL=$((FAIL+1)); }
+
+[ -r "$SRC" ] || { echo "uninstall.sh not readable at $SRC"; exit 1; }
+
+# Code with comments removed — every structural assertion runs against THIS.
+CODE=$(sed 's|#.*||' "$SRC")
+
+# Extract a shell function body by name, comments stripped.
+fnbody() { printf '%s\n' "$CODE" | awk -v f="$1" '$0 ~ "^"f"\\(\\)" {n=1} n{print} n && /^\}/{exit}'; }
+
+echo "── T1  BEHAVIOURAL: STANDARD mode must NOT execute dpkg --purge ───────"
+# A text scan CANNOT decide this. The pre-fix defect put `dpkg --purge` in the
+# ELSE branch, only 8 lines below `if [[ "$PURGE_DATA" == true ]]` — any
+# proximity/lookback heuristic reads that as "guarded" and passes the defect.
+# So EXECUTE the real function with dpkg/rpm mocked and inspect the argv it
+# actually received.  BEHAVIOUR, not shape.
+SBX=$(mktemp -d)
+# PID-guarded cleanup: a subshell EXIT must not delete the sandbox mid-run.
+_owner=$$
+cleanup(){ [ "$$" = "$_owner" ] && rm -rf "$SBX"; }
+trap cleanup EXIT
+
+mkdir -p "$SBX/bin"
+for tool in dpkg rpm; do
+    cat > "$SBX/bin/$tool" <<MOCK
+#!/usr/bin/env bash
+printf '%s %s\n' "$tool" "\$*" >> "$SBX/argv.log"
+# 'dpkg -l' / 'rpm -q' must report the package INSTALLED so the removal path is entered.
+case "\$1" in
+    -l) echo "ii  nftban-core  1.0  all  mock"; exit 0;;
+    -q) exit 0;;
+esac
+exit 0
+MOCK
+    chmod +x "$SBX/bin/$tool"
+done
+
+# Run the real function body, extracted from the shipped script.
+run_pkg_mgr() { # $1 = PURGE_DATA value
+    : > "$SBX/argv.log"
+    (
+        set +e
+        PATH="$SBX/bin:$PATH"
+        # consumed by the eval'd production function below, not by this scope
+        # shellcheck disable=SC2034
+        PURGE_DATA="$1"
+        log(){ :; }; ok(){ :; }; warn(){ :; }; error(){ :; }
+        eval "$(awk '/^uninstall_package_manager\(\) *\{/,/^\}/' "$SRC")"
+        uninstall_package_manager
+    ) >/dev/null 2>&1 || true
+    cat "$SBX/argv.log"
+}
+
+STD_ARGV=$(run_pkg_mgr false)
+PRG_ARGV=$(run_pkg_mgr true)
+
+# Non-vacuity FIRST: if the harness never reached dpkg at all, nothing below means anything.
+case "$STD_ARGV" in
+    *'dpkg'*) ok "harness reached the real dpkg call path (mock recorded argv)";;
+    *) no "mock never invoked — T1 would be vacuous" "argv.log empty";;
+esac
+# POSITIVE control: --purge MUST appear when PURGE_DATA=true, proving the mock can see it.
+case "$PRG_ARGV" in
+    *'--purge'*) ok "--purge IS observed in purge mode (detector proven sighted)";;
+    *) no "--purge not seen even in purge mode" "detector blind: $PRG_ARGV";;
+esac
+# THE ASSERTION: standard mode must never purge.
+case "$STD_ARGV" in
+    *'--purge'*) no "dpkg --purge EXECUTED in standard mode (D2)" "$STD_ARGV";;
+    *) ok "standard mode executes remove but NEVER --purge (D2)";;
+esac
+
+echo "── T2  the standard path still removes the package ────────────────────"
+# The D2 fix must not have turned removal into a no-op.
+case "$STD_ARGV" in
+    *'--remove'*) ok "standard mode still executes dpkg --remove";;
+    *) no "standard mode no longer removes the package" "$STD_ARGV";;
+esac
+
+echo "── T3  --purge reaches /usr/share/nftban without a prefix abort ───────"
+BODY=$(fnbody uninstall_data)
+[ -n "$BODY" ] || no "uninstall_data not found" "cannot verify D4"
+case "$BODY" in
+    *'/usr/share/nftban'*) ;;
+    *) no "/usr/share/nftban absent from purge list" "$BODY";;
+esac
+# The /var/ prefix must never be applied to a /usr/share path.
+MISMATCH=0
+while read -r line; do
+    case "$line" in
+        *'/usr/share/nftban'*'/var/'*) MISMATCH=$((MISMATCH+1));;
+    esac
+done <<< "$BODY"
+[ "$MISMATCH" -eq 0 ] && ok "/usr/share/nftban is not guarded by the /var/ prefix (D4)" \
+                      || no "/usr/share/nftban still paired with /var/ — Guard 4 will exit 1 mid-purge" "$MISMATCH"
+# And Guard 4 must still be enforced, not weakened away.
+case "$CODE" in
+    *'does not start with expected prefix'*) ok "safe_rm_rf Guard 4 still present (not weakened)";;
+    *) no "Guard 4 removed — the fix must not disarm the safety check" "";;
+esac
+
+echo "── T4  partial deletion followed by a false success is impossible ─────"
+# Guard 4 exits; so any path in the purge list whose prefix does not match its
+# own directory would abort AFTER earlier deletions. Assert pairing for ALL.
+UNPAIRED=0
+while read -r line; do
+    case "$line" in
+        *'"/var/'*'|/var/"'*|*'"/usr/share/nftban|/usr/share/"'*) ;;
+        *'safe_rm_rf'*)
+            case "$line" in
+                *'"$prefix"'*|*'$prefix'*) ;;
+                *) UNPAIRED=$((UNPAIRED+1)); echo "       hardcoded prefix in loop: $line";;
+            esac;;
+    esac
+done <<< "$BODY"
+[ "$UNPAIRED" -eq 0 ] && ok "purge loop passes each directory its OWN prefix" \
+                      || no "a hardcoded prefix remains — mid-loop abort still reachable" "$UNPAIRED"
+
+echo "── T5  'preserved' claims only on a path that actually preserves ──────"
+# The standard-mode summary may claim preservation only where dpkg --purge is
+# not reachable — which T1 already established. Here: assert the claim and the
+# purge live in OPPOSITE branches of the same PURGE_DATA condition.
+case "$CODE" in
+    *'NFTBan uninstalled (data preserved)'*) ;;
+    *) no "standard-mode preservation claim missing" "";;
+esac
+# the claim must be in the ELSE of PURGE_DATA==true
+CLAIM_CTX=$(printf '%s\n' "$CODE" | grep -n 'NFTBan uninstalled (data preserved)' | cut -d: -f1)
+if [ -n "$CLAIM_CTX" ]; then
+    PRE=$(printf '%s\n' "$CODE" | sed -n "$((CLAIM_CTX>8?CLAIM_CTX-8:1)),${CLAIM_CTX}p")
+    case "$PRE" in
+        *else*) ok "preservation claim sits in the non-purge branch";;
+        *) no "preservation claim not clearly in the non-purge branch" "$PRE";;
+    esac
+fi
+
+echo "── T6  firewall warning must not assert unverified protection ─────────"
+case "$CODE" in
+    *'no longer protects this host'*) ok "states NFTBan no longer protects the host";;
+    *) no "no firewall-state message in uninstall.sh (D5)" "";;
+esac
+case "$CODE" in
+    *'Review your firewall state'*) ok "directs the operator to review firewall state";;
+    *) no "missing review directive" "";;
+esac
+case "$CODE" in
+    *'nftables tooling may also have been removed'*) ok "warns nft tooling may be gone (proven on EL9)";;
+    *) no "missing nftables cascade-removal warning" "";;
+esac
+# The new message must not drift into over-claiming. Same forbidden vocabulary the
+# packaging guard (uninstall_firewall_ownership_message_v225_test.sh) applies to
+# postrm/%postun, applied here to uninstall.sh's own message.
+#
+# SCOPE NOTE — NOT a defect of this file: packaging/deb/postrm:220 and
+# packaging/build_nftban.sh:1782 state other firewall rules "were NOT modified and
+# may still be active", and the v225 test REQUIRES that phrasing in both. D5's
+# EL9 evidence (nft tooling cascade-removed) contests it, but postrm/%postun
+# wording is PR2 (D5 DEB/RPM parity) and cannot be changed without amending v225.
+# This suite deliberately makes no assertion about those two files.
+OVERCLAIM=0
+while IFS= read -r bad; do
+    if printf '%s\n' "$CODE" | grep -qiE "$bad"; then
+        no "uninstall.sh message over-claims" "$bad"; OVERCLAIM=$((OVERCLAIM+1))
+    fi
+done <<'BAD'
+host has no firewall
+network access is safe
+your host is still protected
+automatically restore
+BAD
+[ "$OVERCLAIM" -eq 0 ] && ok "uninstall.sh asserts no unobserved protected state"
+
+echo "── T7  the production call sites are actually reached ─────────────────"
+# Without this, the above could pass against dead code.
+case "$CODE" in
+    *'uninstall_data'*) ok "uninstall_data invoked from the main flow";;
+    *) no "uninstall_data never called" "assertions would be vacuous";;
+esac
+INVOKED=$(printf '%s\n' "$CODE" | grep -c '^uninstall_data$')
+[ "${INVOKED:-0}" -ge 1 ] && ok "uninstall_data call site present at top level" \
+                          || no "uninstall_data not called at top level" "count=$INVOKED"
+# the firewall message must be in the executed tail, after the summary branch
+case "$CODE" in
+    *'FIREWALL STATE'*) ok "firewall message present in executable code (not a comment)";;
+    *) no "firewall message only in comments — GUARD_SUBJECT != GUARD_INPUT" "";;
+esac
+
+echo
+echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -235,6 +235,7 @@ tmpfiles_zz_v139_test	cli/lib/nftban/tests/tmpfiles_zz_v139_test.sh	packaging	te
 trust_load_missing_whitelist_test	cli/lib/nftban/tests/trust_load_missing_whitelist_test.sh	trust	test	trust-load	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 typed_nft_probe_v1228_4_test	cli/lib/nftban/tests/typed_nft_probe_v1228_4_test.sh	cli	test	nft-probe-authority	CI_STATIC	ci-bash	true	false	false	false	false	false			
 uninstall_firewall_ownership_message_v225_test	cli/lib/nftban/tests/uninstall_firewall_ownership_message_v225_test.sh	packaging	test	packaging	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
+uninstall_sh_critical_safety_v1229_test	cli/lib/nftban/tests/uninstall_sh_critical_safety_v1229_test.sh	packaging	test	uninstall-lifecycle	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 update_degraded_render_truth_v225_test	cli/lib/nftban/tests/update_degraded_render_truth_v225_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 update_force_delegation_v1223_test	cli/lib/nftban/tests/update_force_delegation_v1223_test.sh	update	test	update-force	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 update_msg_recovered_v174_test	cli/lib/nftban/tests/update_msg_recovered_v174_test.sh	update	test	update	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -151,11 +151,29 @@ uninstall_package_manager() {
     # Check if installed via DEB (Debian/Ubuntu)
     if command -v dpkg &>/dev/null; then
         if dpkg -l nftban-core 2>/dev/null | grep -qE '^ii|^iU|^iF|^iH'; then
-            log "  Found DEB package, removing from database..."
-            # Force remove from database even if files are missing
-            dpkg --remove --force-remove-reinstreq nftban-core 2>/dev/null || true
-            dpkg --purge nftban-core 2>/dev/null || true
-            ok "Removed nftban-core from dpkg database"
+            # D2 (UNINSTALL-PR1): `dpkg --purge` is gated behind PURGE_DATA.
+            #
+            # Both commands used to run unconditionally, so STANDARD mode always
+            # purged. `dpkg --purge` fires `postrm purge)`, which rm -rf's all
+            # five trees — including whitelist.d/*.conf, the durable
+            # management-IP whitelist that is the SSH-lockout safety invariant —
+            # while this same script printed "Configuration preserved" (:379),
+            # "Data preserved" (:415) and "Configuration and data preserved"
+            # (:512). The operator was told the exact opposite of what happened.
+            #
+            # This script's own config/data steps were already PURGE_DATA-gated;
+            # only the package-level purge was not. Standard mode now matches
+            # `apt remove` semantics.
+            if [[ "$PURGE_DATA" == true ]]; then
+                log "  Found DEB package, PURGING from database (config+data will be removed)..."
+                dpkg --remove --force-remove-reinstreq nftban-core 2>/dev/null || true
+                dpkg --purge nftban-core 2>/dev/null || true
+                ok "Purged nftban-core from dpkg database"
+            else
+                log "  Found DEB package, removing from database (config+data preserved)..."
+                dpkg --remove --force-remove-reinstreq nftban-core 2>/dev/null || true
+                ok "Removed nftban-core from dpkg database"
+            fi
         else
             ok "No DEB package found in database"
         fi
@@ -384,19 +402,35 @@ uninstall_data() {
     if [[ "$PURGE_DATA" == true ]]; then
         log "Purging data directories..."
 
+        # D4 (UNINSTALL-PR1): each directory carries its OWN expected prefix.
+        #
+        # /usr/share/nftban used to sit in this list while every entry was passed
+        # "/var/" as expected_prefix. safe_rm_rf Guard 4 then fired
+        # `CRITICAL: Path /usr/share/nftban does not start with expected prefix
+        # /var/` and `exit 1` — AFTER /var/lib, /var/log and /var/cache had
+        # already been deleted. The operator saw a CRITICAL failure and no
+        # summary, with the evidence corpus already gone.
+        #
+        #     PARTIAL_PROGRESS != SAFE_INTERMEDIATE_STATE
+        #
+        # Pairing the prefix with the path keeps Guard 4 at full strength (it is
+        # never widened to a permissive prefix) while making it impossible for a
+        # correctly-listed directory to abort the run.
         local data_dirs=(
-            "/var/lib/nftban"
-            "/var/log/nftban"
-            "/var/cache/nftban"
-            "/usr/share/nftban"
+            "/var/lib/nftban|/var/"
+            "/var/log/nftban|/var/"
+            "/var/cache/nftban|/var/"
+            "/usr/share/nftban|/usr/share/"
         )
 
         local removed=0
 
-        for dir in "${data_dirs[@]}"; do
+        for entry in "${data_dirs[@]}"; do
+            local dir="${entry%%|*}"
+            local prefix="${entry##*|}"
             if [[ -d "$dir" ]]; then
                 echo "  Removing: $dir"
-                safe_rm_rf "$dir" "/var/"  # Enforce /var/ prefix for safety
+                safe_rm_rf "$dir" "$prefix"
                 removed=$((removed + 1))
             fi
         done
@@ -517,5 +551,27 @@ else
     echo "To completely remove everything:"
     echo "   sudo $0 --purge"
 fi
+echo ""
+
+# D5 (UNINSTALL-PR1): tell the truth about firewall state after removal.
+#
+# This script deletes NFTBan's nft tables in BOTH modes and never re-probes,
+# yet printed NOTHING about firewall state. The packaging scriptlets did worse:
+# they asserted "Other firewall rules ... were NOT modified and may still be
+# active" — which was FALSE on the proven EL9 host, where no other firewall
+# existed and the nftables tooling itself had been cascade-removed by package
+# dependency cleanup.
+#
+#     OBSERVATION_FAILURE_MUST_NEVER_BE_INTERPRETED_AS_SECURITY_STATE
+#
+# The wording below is deliberately unconditional and claims NOTHING this
+# script has not done itself. It does not assert another firewall is active,
+# because that was never probed. Upgrading to a real post-condition probe is
+# UNINSTALL-PR2/PR3 scope; asserting an unverified positive is never acceptable.
+echo "⚠️  FIREWALL STATE — REVIEW REQUIRED"
+echo "   NFTBan no longer protects this host."
+echo "   Review your firewall state after removal."
+echo "   nftables tooling may also have been removed by package-manager"
+echo "   dependency cleanup."
 echo ""
 log "════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## What this fixes

Three defects in `uninstall.sh`, from the canonical audit
`UNINSTALL_PACKAGE_LIFECYCLE_INDEPENDENT_AUDIT_2026_08_11.md`. All three were
re-confirmed against current `main` before any code was written.

| ID | Defect | Consequence |
|----|--------|-------------|
| **D2** | `dpkg --purge` ran unconditionally (`:157`) | Standard mode deleted `whitelist.d/*.conf` — the durable management-IP whitelist, the SSH-lockout safety invariant — while printing "Configuration preserved" / "Data preserved" |
| **D4** | `/usr/share/nftban` paired with a `/var/` prefix (`:391`) | `safe_rm_rf` Guard 4 exited 1 **after** `/var/lib`, `/var/log`, `/var/cache` were already deleted |
| **D5** | Zero firewall mentions, yet `:289` deletes nft tables in **both** modes with no re-probe | Operator left unaware the host is unprotected |

`PARTIAL_PROGRESS != SAFE_INTERMEDIATE_STATE`

## Why the D2 test is behavioural

The pre-fix defect placed `dpkg --purge` in the **else** branch, eight lines
below `if [[ "$PURGE_DATA" == true ]]`. Any proximity or lookback heuristic
reads that as guarded and **passes the defect** — my first version of this test
did exactly that, and only the inversion control caught it.

The arm now executes the real `uninstall_package_manager()` with `dpkg`/`rpm`
mocked on `PATH` and asserts on the argv they actually received. A positive
control asserts `--purge` **is** observed when `PURGE_DATA=true`, so a blind
detector fails rather than passing quietly.

## Falsifiability

Five inversions run against the **production** file, each with a `sha256`
witness before/after — a mutation that fails to apply reports itself **void**
instead of passing silently:

```
INV-D2  purge in else branch      a6ad4be4 -> d8a73090  rc=1  caught
INV-D2b PURGE_DATA guard removed  a6ad4be4 -> 6f0273cb  rc=1  caught
INV-D4  /usr/share paired /var/   a6ad4be4 -> 74875272  rc=1  caught
INV-D5  firewall message deleted  a6ad4be4 -> d07c8672  rc=1  caught
INV-G4  Guard 4 text weakened     a6ad4be4 -> 157ce22e  rc=1  caught
RESTORED sha=a6ad4be4  matches baseline
```

`INV-G4` exists because the D4 fix must pair the inputs correctly, **not**
weaken the guard. Comments are stripped before every structural assertion
(`GUARD_SUBJECT == GUARD_INPUT`), so the prose describing each defect cannot
satisfy the arm guarding it. No `producer | grep -q` under `pipefail`.

## Wiring

Registered in `test-authority-index.tsv` (row 238, all 11 `ta.*` fields;
`VALIDATION_PASS`, `INDEX_FRESH = YES`) and added to `ci-bash.yml` as an
explicit single-file step — a present-but-undiscovered test is inert.

## Scope boundary

`uninstall.sh` only, per `GO_UNINSTALL_PR1`. **No PR2, no PR3, no new
architecture.**

`packaging/deb/postrm:220` and `packaging/build_nftban.sh:1782` still state
other firewall rules "were NOT modified and may still be active". The EL9
evidence behind D5 contests that, but the phrasing is **required** by
`uninstall_firewall_ownership_message_v225_test`, so changing it means amending
that test — PR2 (D5 DEB/RPM parity) work. This suite deliberately asserts
nothing about those two files, and that exclusion is documented inline.

## Verification

- `shellcheck -x -S warning` clean on both files
- `bash -n uninstall.sh` OK
- New suite: **15/15 pass**
- `uninstall_firewall_ownership_message_v225_test`, `csf_observation_purity_v1229_test`, `legacy_restore_neutralized_v1229_test` — all still green
