### PR TITLE
fix(ci): a matrix that cannot observe must not report a passing removal

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Restore pinned yq (cache)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: offline/yq_linux_amd64
+          key: yq-pinned-${{ hashFiles('packaging/build_nftban.sh') }}
+
       - name: Validate yq checksums are consistent
         run: |
           echo "Checking yq SHA256 checksums across build files..."
@@ -70,11 +76,29 @@ jobs:
           . packaging/lib/fetch_verified.sh
           YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
 
-          if fetch_verified "$YQ_URL" "$YQ_SHA256" /tmp/yq_linux_amd64; then
+          # v1.229 CI hardening: this required job downloaded yq from a live GitHub
+          # release, so an upstream 503 failed the merge gate. Two DIFFERENT things
+          # were conflated here:
+          #   PIN CONSISTENCY  — all YQ_SHA256 in packaging/ agree. Static, offline,
+          #                      always blocking. Verified above.
+          #   UPSTREAM LIVENESS — the pin still matches the published artifact.
+          #                      Needs the network and cannot be made deterministic.
+          # Trust is NOT enforced here: provision_yq verifies the sha256 before the
+          # binary is ever used, wherever it came from. This step is drift
+          # DETECTION, so a network outage must be reported as unverifiable rather
+          # than as a pin failure — and must not fail the merge gate.
+          #   CANNOT_VERIFY != VERIFIED_BAD
+          if [ -f offline/yq_linux_amd64 ] &&
+             echo "${YQ_SHA256}  offline/yq_linux_amd64" | sha256sum -c - >/dev/null 2>&1; then
+            echo "✅ yq pin matches the cached artifact (no network needed)"
+          elif fetch_verified "$YQ_URL" "$YQ_SHA256" /tmp/yq_linux_amd64; then
             echo "✅ yq checksum validated successfully"
+            mkdir -p offline && install -m 0755 /tmp/yq_linux_amd64 offline/yq_linux_amd64 || true
           else
-            echo "ERROR: yq fetch/verify failed."
-            echo "Re-downloading to report the actual checksum (network blip vs. outdated pin)..."
+            # Attribute the failure instead of exiting 1 for every cause. The old
+            # branch failed even when the re-download reported Expected == Actual,
+            # i.e. it printed evidence that the pin was CORRECT and failed anyway.
+            echo "yq fetch/verify did not succeed — determining why..."
             if curl --fail --location --retry 5 --retry-all-errors --retry-delay 3 \
                     --connect-timeout 10 --max-time 120 -sS \
                     -o /tmp/yq_linux_amd64.actual "$YQ_URL"; then
@@ -82,11 +106,18 @@ jobs:
               echo "Expected: $YQ_SHA256"
               echo "Actual:   $ACTUAL_SHA"
               if [[ "$YQ_SHA256" != "$ACTUAL_SHA" ]]; then
-                echo "The bundled checksum is outdated. Update with:"
-                echo "  YQ_SHA256=\"$ACTUAL_SHA\""
+                echo "::error::PIN_OUTDATED — the published yq artifact no longer matches the bundled checksum. Update with: YQ_SHA256=\"$ACTUAL_SHA\""
+                exit 1
               fi
+              echo "::warning::TRANSIENT_FETCH_FAILURE — the pin is CORRECT (expected == actual); the first fetch failed for a transient reason."
+              mkdir -p offline && install -m 0755 /tmp/yq_linux_amd64.actual offline/yq_linux_amd64 || true
+              exit 0
             fi
-            exit 1
+            # No authoritative source reachable. Pin CONSISTENCY was already proven
+            # offline above, and provision_yq re-verifies the sha before use, so an
+            # upstream outage must not fail the merge gate as though the pin were bad.
+            echo "::warning::UPSTREAM_VERIFICATION_UNAVAILABLE — could not reach the yq release to re-verify the pin. Pin consistency across packaging/ was verified offline; the build-time checksum gate is unaffected. NOT treated as a pin failure."
+            exit 0
           fi
 
   # ==========================================================================
@@ -225,6 +256,23 @@ jobs:
         with:
           name: go-binaries
           path: bin/
+
+      # v1.229 UNINSTALL-PR3 CI hardening: keep the pinned yq out of the critical
+      # path of every build. Keyed on the VERSION+SHA pinned in
+      # packaging/build_nftban.sh, so a pin change invalidates the cache
+      # automatically and a stale binary can never be served for a new pin.
+      # provision_yq re-verifies the sha256 regardless of where the file came
+      # from — the cache is a latency optimisation, never a trust boundary.
+      - name: Restore pinned yq (cache)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: offline/yq_linux_amd64
+          # Keyed on the FILE that defines the version+sha pin, not on the raw
+          # digest: a literal 64-hex string in a workflow trips secret scanning
+          # as a generic API key. Editing the pin changes the file, so the cache
+          # still invalidates automatically and a stale binary is never reused
+          # for a new pin. provision_yq re-verifies the sha256 regardless.
+          key: yq-pinned-${{ hashFiles('packaging/build_nftban.sh') }}
 
       - name: Build RPM in ${{ matrix.distro }} container
         run: |
@@ -375,6 +423,23 @@ jobs:
         with:
           name: go-binaries
           path: bin/
+
+      # v1.229 UNINSTALL-PR3 CI hardening: keep the pinned yq out of the critical
+      # path of every build. Keyed on the VERSION+SHA pinned in
+      # packaging/build_nftban.sh, so a pin change invalidates the cache
+      # automatically and a stale binary can never be served for a new pin.
+      # provision_yq re-verifies the sha256 regardless of where the file came
+      # from — the cache is a latency optimisation, never a trust boundary.
+      - name: Restore pinned yq (cache)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: offline/yq_linux_amd64
+          # Keyed on the FILE that defines the version+sha pin, not on the raw
+          # digest: a literal 64-hex string in a workflow trips secret scanning
+          # as a generic API key. Editing the pin changes the file, so the cache
+          # still invalidates automatically and a stale binary is never reused
+          # for a new pin. provision_yq re-verifies the sha256 regardless.
+          key: yq-pinned-${{ hashFiles('packaging/build_nftban.sh') }}
 
       - name: Build DEB in ${{ matrix.distro }} container
         run: |
@@ -840,6 +905,117 @@ jobs:
   # ==========================================================================
   # CONSOLIDATE ALL PACKAGES
   # ==========================================================================
+  # ===========================================================================
+  # UNINSTALL-PR3 LAYER A — package-native remove/purge in a CONTAINER
+  # ===========================================================================
+  # D6: the lifecycle matrices were the ONLY package-native remove/purge tests
+  # and ran in NO workflow, so D1/D2/D3/D5 were SOURCE_PROVEN only. This job
+  # removes a REAL built package and asserts on the resulting filesystem.
+  #
+  # LAYER A != LAYER B. A GitHub container has dpkg/rpm and a real filesystem,
+  # so package operations and preservation are genuinely observable here. It has
+  # no PID1 systemd and no kernel nftables, so unit and ruleset assertions are
+  # NOT observable. Those are declared NOT_IN_SCOPE via
+  # NFTBAN_MATRIX_VM_ASSERTIONS=0 — they are NOT executed and NOT weakened, and
+  # the matrix prints CLAIMS_SYSTEMD_AUTHORITY=NO so a Layer A PASS can never be
+  # read as VM proof.
+  #
+  #   CONTAINER_PACKAGE_PASS != SYSTEMD_VM_PASS
+  #
+  # If observation authority goes missing for an IN-SCOPE assertion, the probes
+  # emit BLOCKED_ENVIRONMENT and the matrix returns INCOMPLETE (exit 2), which
+  # fails this job. Exit 3 means the harness could not produce a trustworthy
+  # verdict at all. Closure (UNINSTALL_LIFECYCLE_DEBT_FREE) still requires the
+  # Layer B systemd-VM run; this job cannot grant it.
+  #
+  # NOT REQUIRED YET: making this a required check is a branch-protection change
+  # (repo settings), deliberately not done in a code PR.
+  lifecycle-layer-a:
+    name: Lifecycle Layer A — package-native remove (${{ matrix.label }})
+    needs: [build-rpm, build-deb]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: rpm-el9
+            family: rpm
+            container: rockylinux:9
+            # build-rpm uploads rpm-${distro} where distro is el9/el10 — the
+            # artifact is named for the EL generation, not the image vendor.
+            # Matches test-rpm-install's rockylinux:9 -> rpm-el9 pairing.
+            artifact: rpm-el9
+          - label: deb-ubuntu24.04
+            family: deb
+            container: ubuntu:24.04
+            artifact: deb-ubuntu24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v6.0.0
+        with:
+          name: ${{ matrix.artifact }}
+          path: packages
+
+      - name: Pull base image (retry)
+        run: |
+          ok=0
+          for delay in 3 9 27; do
+            if docker pull "${{ matrix.container }}"; then ok=1; break; fi
+            echo "docker pull failed - retrying in ${delay}s..."
+            sleep "$delay"
+          done
+          [ "$ok" -eq 1 ] || { echo "docker pull failed after 3 attempts"; exit 125; }
+
+      - name: Package-native remove (${{ matrix.family }}, VM assertions out of scope)
+        env:
+          FAMILY: ${{ matrix.family }}
+          IMAGE: ${{ matrix.container }}
+        run: |
+          set -euo pipefail
+          ls -la packages/
+          docker run --rm \
+            -v "$(pwd)/packages:/packages:ro" \
+            -v "$(pwd)/scripts:/scripts:ro" \
+            -e NFTBAN_MATRIX_VM_ASSERTIONS=0 \
+            -e NFTBAN_RPM_CASES="R7" \
+            -e NFTBAN_LIFECYCLE_CASES="L7" \
+            -e FAMILY="$FAMILY" \
+            "$IMAGE" bash -c '
+              set -uo pipefail
+              if [ "$FAMILY" = "rpm" ]; then
+                dnf -y install findutils procps-ng util-linux >/dev/null 2>&1 || true
+                CAND=$(find /packages -name "*.rpm" | head -1)
+                [ -n "$CAND" ] || { echo "no candidate rpm in artifact"; exit 1; }
+                bash /scripts/ci/tests/lifecycle_rpm_matrix.sh "$CAND"
+              else
+                apt-get update -qq >/dev/null 2>&1 || true
+                apt-get install -y -qq findutils procps util-linux >/dev/null 2>&1 || true
+                CAND=$(find /packages -name "*.deb" | head -1)
+                [ -n "$CAND" ] || { echo "no candidate deb in artifact"; exit 1; }
+                bash /scripts/ci/tests/lifecycle_deb_matrix.sh "$CAND"
+              fi
+            ' | tee matrix.log
+          rc=${PIPESTATUS[0]}
+          echo "matrix rc=$rc"
+          # 0 PASS · 1 TEST_FAILURE · 2 INCOMPLETE · 3 HARNESS_FAILURE.
+          # INCOMPLETE is NOT a pass: an unobserved property proves nothing.
+          if ! grep -q 'CLAIMS_SYSTEMD_AUTHORITY=NO' matrix.log; then
+            echo "::error::Layer A run did not disclaim systemd authority - refusing to report success"
+            exit 1
+          fi
+          exit "$rc"
+
+      - name: Upload matrix log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: lifecycle-layer-a-${{ matrix.label }}
+          path: matrix.log
+          if-no-files-found: warn
+
   consolidate-packages:
     name: Consolidate all packages
     needs: [build-deb, build-rpm]

--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -124,6 +124,16 @@ jobs:
       # UNINSTALL-PR2 D5 — removal messaging truth contract (DEB↔RPM parity on
       # MEANING, not on a literal string). Gate is policy-gates for this test;
       # executed here too so a wording regression fails fast on every PR.
+      # UNINSTALL-PR3 — lifecycle-matrix observation semantics (A1-A6).
+      # Hermetic: it drives the shipped probes/classifiers directly, no root,
+      # no packages. Guards the rule that a missing systemd/nft observation
+      # authority can never be reported as a passing removal assertion.
+      - name: Lifecycle matrix observation semantics (UNINSTALL-PR3)
+        run: |
+          echo "=== Executing: lifecycle_matrix_observation_semantics_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
+          bash cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
+
       - name: Uninstall firewall-ownership message (UNINSTALL-PR2 D5)
         run: |
           echo "=== Executing: uninstall_firewall_ownership_message_v225_test.sh ==="

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -54,49 +54,105 @@ jobs:
           # newer toolchain; local would block that auto-fetch.
           go-version: '1.25.12'
 
+      # v1.229 CI hardening: the scanner binary download sat on the critical path
+      # of this required job. An upstream releases 503 meant the tool was never
+      # provisioned, nothing produced a SARIF, and the failure then surfaced from
+      # the UPLOAD step as "Path does not exist" — attributing a provisioning
+      # outage to a path bug.  NETWORK_TRANSIENT != RANDOM_REQUIRED_CI_FAILURE
+      - name: Restore pinned OSV-Scanner (cache)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: osv-scanner
+          key: osv-scanner-2.3.3-linux-amd64
+
       - name: Install OSV-Scanner
+        id: install_scanner
         run: |
+          set -uo pipefail
+          # SCANNER_PROVISIONED is the single fact every later step keys on, so a
+          # provisioning outage is never mistaken for a scan result.
+          if [ -x osv-scanner ] && ./osv-scanner --version >/dev/null 2>&1; then
+            echo "cached osv-scanner is usable: $(./osv-scanner --version 2>&1 | head -1)"
+            echo "provisioned=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # v1.161: retry/fail-fast hardening (mirrors v1.157 fetch_verified policy) —
-          # transient github.com blips (HTTP 504) no longer hard-fail the scan.
-          curl --fail --location --retry 5 --retry-all-errors --retry-delay 3 \
+          # transient github.com blips (HTTP 5xx) no longer hard-fail on first try.
+          if curl --fail --location --retry 5 --retry-all-errors --retry-delay 3 \
                --connect-timeout 10 --max-time 120 -sS \
-               https://github.com/google/osv-scanner/releases/download/v2.3.3/osv-scanner_linux_amd64 -o osv-scanner
-          chmod +x osv-scanner
-          ./osv-scanner --version
+               https://github.com/google/osv-scanner/releases/download/v2.3.3/osv-scanner_linux_amd64 -o osv-scanner; then
+            chmod +x osv-scanner
+            ./osv-scanner --version
+            echo "provisioned=true" >> "$GITHUB_OUTPUT"
+          else
+            rm -f osv-scanner
+            echo "provisioned=false" >> "$GITHUB_OUTPUT"
+            echo "::error::SCANNER_NOT_PROVISIONED — osv-scanner v2.3.3 could not be downloaded after bounded retries. This is a provisioning failure, NOT a scan result and NOT a SARIF path problem."
+            exit 1
+          fi
 
       - name: Run OSV-Scanner
+        id: scan
+        if: steps.install_scanner.outputs.provisioned == 'true'
         run: |
           # Scan go.mod in lockfile mode
           # Config: osv-scanner.toml suppresses stdlib CVEs (patched by Go toolchain)
           # Exit 0 = clean, Exit 1 = vulnerabilities found, Exit 128 = scan error
           ./osv-scanner scan --config=osv-scanner.toml --lockfile=go.mod \
             --format=sarif --output=osv-results.sarif; OSV_EXIT=$?
+          echo "scanner_ran=true" >> "$GITHUB_OUTPUT"
+          echo "osv_exit=${OSV_EXIT}" >> "$GITHUB_OUTPUT"
           if [[ "$OSV_EXIT" -eq 128 ]]; then
-            echo "::warning::OSV-Scanner encountered an error (exit 128) — check skipped"
+            # SCANNER_FAILURE. Previously a warning that let the job pass: an
+            # errored scan then read as "no vulnerabilities found", which is the
+            # same defect class as an unobserved state reported as a safe one.
+            echo "::error::SCANNER_FAILURE — OSV-Scanner exited 128 (scan error). No vulnerability conclusion can be drawn from this run."
+            exit 1
           elif [[ "$OSV_EXIT" -ne 0 ]]; then
             echo "::error::OSV-Scanner found vulnerabilities in Go dependencies"
             exit 1
           fi
 
+      # Runs even when an earlier step failed, so the SARIF contract is decided
+      # HERE with attribution, rather than surfacing later as a path error.
+      #   SCANNER_NOT_PROVISIONED != SCANNER_FAILED != NO_FINDINGS != PATH_WRONG
+      # Not continue-on-error: a genuine provisioning/scan failure still fails
+      # the job — it is simply reported as what it is.
       - name: Check SARIF output
+        id: sarif
+        if: always()
         run: |
-          if [ -f osv-results.sarif ]; then
-            echo "SARIF file created successfully"
-            cat osv-results.sarif | head -50
-          else
-            echo "Creating empty SARIF for upload"
-            cat > osv-results.sarif << 'EOF'
-          {
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-            "version": "2.1.0",
-            "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.3"}}, "results": []}]
-          }
-          EOF
+          if [ "${{ steps.install_scanner.outputs.provisioned }}" != "true" ]; then
+            echo "PROVISIONING_FAILURE — the scanner was never provisioned, so no scan ran."
+            echo "Refusing to synthesise an empty SARIF: an empty result set would"
+            echo "publish 'no vulnerabilities found' for a scan that never happened."
+            echo "sarif_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if [ "${{ steps.scan.outputs.scanner_ran }}" != "true" ]; then
+            echo "SCANNER_FAILURE — the scanner was provisioned but did not complete a scan."
+            echo "sarif_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -f osv-results.sarif ]; then
+            echo "SARIF produced by a scan that actually ran (osv exit ${{ steps.scan.outputs.osv_exit }})"
+            echo "sarif_ready=true" >> "$GITHUB_OUTPUT"
+            head -50 osv-results.sarif
+            exit 0
+          fi
+          # The scanner ran successfully and was told --output=osv-results.sarif,
+          # so the file MUST exist. Its absence is a broken producer/consumer
+          # contract, not a clean result — and synthesising an empty SARIF here
+          # would publish "no findings" for output we never actually saw.
+          echo "::error::ARTIFACT_CONTRACT_FAILURE — osv-scanner exited ${{ steps.scan.outputs.osv_exit }} but produced no osv-results.sarif. The output contract was violated; no vulnerability conclusion can be drawn."
+          echo "sarif_ready=false" >> "$GITHUB_OUTPUT"
+          exit 1
 
+      # Uploads only a SARIF that actually represents a scan. Without this guard
+      # the uploader failed on a missing path and MASKED the real cause.
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        if: always()
+        if: always() && steps.sarif.outputs.sarif_ready == 'true'
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ scripts/ci/privacy-forbidden.txt
 
 # v1.226.0 PR-C: ci-bash informational runner manifest (CI runtime artifact)
 ci-bash-manifest.txt
+
+# v1.229: CI-cached, SHA-pinned yq (packaging/build_nftban.sh PROV_YQ_SHA256).
+# Never committed — provision_yq re-verifies the checksum wherever it came from.
+offline/yq_linux_amd64

--- a/cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
+++ b/cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — UNINSTALL-PR3: lifecycle-matrix observation semantics
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="lifecycle-matrix-observation-semantics-v1229-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-12"
+# meta:description="Locks UNINSTALL-PR3 amendments A1-A6 on both lifecycle matrices: missing systemd/nft observation authority yields BLOCKED_ENVIRONMENT instead of a vacuous inactive/absent PASS; aggregation is a closed set where an unknown verdict becomes HARNESS_FAILURE; a mid-run abort before the SUMMARY emits HARNESS_FAILURE (exit 3) rather than masquerading as FAIL/INCOMPLETE; and NOT_IN_SCOPE stays distinct from BLOCKED_ENVIRONMENT. Every negative control is paired with a positive twin."
+# meta:inventory.files="scripts/ci/tests/lifecycle_rpm_matrix.sh,scripts/ci/tests/lifecycle_deb_matrix.sh"
+# meta:inventory.privileges="none"
+# meta:ta.id="lifecycle_matrix_observation_semantics_v1229_test"
+# meta:ta.owner="packaging"
+# meta:ta.module="uninstall-lifecycle"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+#
+#   OBSERVATION_FAILURE MUST NEVER BECOME SECURITY_STATE_EMPTY
+#
+# Removal cases assert NEGATIVE states (`inactive`, `absent`). A probe that
+# collapses "the tool is missing" into those values makes the assertion PASS
+# having observed nothing — and removal is exactly what this lane must prove.
+#
+# TAXONOMY (frozen):
+#   PASS 0 · TEST_FAILURE 1 · INCOMPLETE 2 · HARNESS_FAILURE 3
+#   PASS · FAIL · SKIP · BLOCKED_ENVIRONMENT · NOT_IN_SCOPE
+#
+# EVERY negative control below has a POSITIVE TWIN. Without the twin, a control
+# can "pass" because the assertion never executed at all — the same ASSERT(X==X)
+# vacuity this lane keeps re-learning.
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+RPM_M="$REPO_ROOT/scripts/ci/tests/lifecycle_rpm_matrix.sh"
+DEB_M="$REPO_ROOT/scripts/ci/tests/lifecycle_deb_matrix.sh"
+
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; [ -n "${2:-}" ] && echo "       $2"; FAIL=$((FAIL+1)); }
+
+for f in "$RPM_M" "$DEB_M"; do
+    [ -r "$f" ] || { echo "missing matrix: $f"; exit 1; }
+done
+
+BASH_ABS="$(command -v bash)"
+W=$(mktemp -d); _owner=$$
+trap '[ "$$" = "$_owner" ] && rm -rf "$W"' EXIT
+
+# Comments stripped: prose describing a defect must not satisfy an arm.
+RPM_CODE=$(sed 's|#.*||' "$RPM_M")
+DEB_CODE=$(sed 's|#.*||' "$DEB_M")
+
+# Extract a function body from a matrix, comments stripped.
+fn() { printf '%s\n' "$2" | awk -v f="$1" '$0 ~ "^"f"\\(\\) *\\{" {n=1} n{print} n && /^\}$/{exit}'; }
+
+# ---------------------------------------------------------------------------
+# NC1/PC1 — missing systemctl must NOT read as "inactive"
+# ---------------------------------------------------------------------------
+echo "── NC1/PC1  systemctl absent => BLOCKED_ENVIRONMENT, present => real value ─"
+probe_harness() { # $1=matrix-code $2=probe-fn  $3=PATH-mode(strip|keep)
+    local body; body=$(fn "$2" "$1")
+    { echo 'BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"'
+      echo "$body"
+      echo "$2 nftband.service" ; } > "$W/probe.sh"
+    if [ "$3" = strip ]; then
+        # A directory with NO systemctl and NO nft, but with coreutils present:
+        # the probe must detect absence, not crash on missing helpers.
+        mkdir -p "$W/emptybin"
+        for t in head printf grep cut sed awk; do
+            src=$(command -v "$t" 2>/dev/null) && ln -sf "$src" "$W/emptybin/$t" 2>/dev/null
+        done
+        PATH="$W/emptybin" "$BASH_ABS" "$W/probe.sh" 2>/dev/null
+    else
+        "$BASH_ABS" "$W/probe.sh" 2>/dev/null
+    fi
+}
+
+for pair in "RPM:unit_state" "DEB:unit_active_state"; do
+    fam="${pair%%:*}"; pfn="${pair##*:}"
+    code=$RPM_CODE; [ "$fam" = DEB ] && code=$DEB_CODE
+    got=$(probe_harness "$code" "$pfn" strip)
+    [ "$got" = "BLOCKED_ENVIRONMENT" ] \
+        && ok "NC1 $fam $pfn: no systemctl => BLOCKED_ENVIRONMENT" \
+        || no "NC1 $fam $pfn: no systemctl => '$got' (vacuous if 'inactive')" ""
+    # POSITIVE TWIN: with a real PATH the probe must return a genuine state
+    # (never the sentinel), proving it is not hard-wired to report BLOCKED.
+    got2=$(probe_harness "$code" "$pfn" keep)
+    if [ "$got2" = "BLOCKED_ENVIRONMENT" ] && command -v systemctl >/dev/null 2>&1; then
+        no "PC1 $fam $pfn: systemctl PRESENT but probe still says BLOCKED" "hard-wired sentinel"
+    else
+        ok "PC1 $fam $pfn: with a normal PATH returns a real observation ('${got2}')"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# NC2/PC2 — missing nft must NOT read as "absent"
+# ---------------------------------------------------------------------------
+echo "── NC2/PC2  nft absent => BLOCKED_ENVIRONMENT ─────────────────────────────"
+mkdir -p "$W/emptybin"
+RPM_FW=$(fn fw "$RPM_CODE")
+{ echo 'BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"'; echo "$RPM_FW"; echo 'fw'; } > "$W/fw.sh"
+got=$(PATH="$W/emptybin" "$BASH_ABS" "$W/fw.sh" 2>/dev/null)
+[ "$got" = "BLOCKED_ENVIRONMENT" ] \
+    && ok "NC2 RPM fw(): no nft => BLOCKED_ENVIRONMENT (not 'absent')" \
+    || no "NC2 RPM fw(): no nft => '$got'" "'absent' here is a vacuous pass"
+# DEB twin (A6): nft_table_state must use the shared sentinel, not 'nft-absent'.
+DEB_NFT=$(fn nft_table_state "$DEB_CODE")
+{ echo 'BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"'; echo "$DEB_NFT"; echo 'nft_table_state ip nftban'; } > "$W/nft.sh"
+got=$(PATH="$W/emptybin" "$BASH_ABS" "$W/nft.sh" 2>/dev/null)
+[ "$got" = "BLOCKED_ENVIRONMENT" ] \
+    && ok "NC2 DEB nft_table_state(): no nft => BLOCKED_ENVIRONMENT (A6 normalised)" \
+    || no "NC2 DEB nft_table_state(): => '$got'" "A6 wants the shared sentinel"
+# POSITIVE TWIN: the probes must still be able to say present/absent.
+{ echo 'BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"'
+  echo 'nft(){ return 1; }'
+  echo 'command(){ [ "$2" = nft ] && return 0; builtin command "$@"; }'
+  echo "$RPM_FW"; echo 'fw'; } > "$W/fw_present.sh"
+got=$("$BASH_ABS" "$W/fw_present.sh" 2>/dev/null)
+[ "$got" = "absent" ] \
+    && ok "PC2 fw(): nft PRESENT and table missing => 'absent' (real observation)" \
+    || no "PC2 fw(): expected 'absent' with nft present, got '$got'" "probe may be hard-wired"
+
+# ---------------------------------------------------------------------------
+# NC3 — harness crash before SUMMARY must be HARNESS_FAILURE (exit 3)
+# ---------------------------------------------------------------------------
+echo "── NC3  abort before verdict => HARNESS_FAILURE, exit 3 ───────────────────"
+# Driven against the REAL matrix: an unreadable candidate aborts it under set -e
+# before any SUMMARY. Previously that surfaced as a bare rc=1 with no output.
+out=$(NFTBAN_RPM_CASES="R7" bash "$RPM_M" /nonexistent-candidate.rpm 2>&1); rc=$?
+[ "$rc" -eq 3 ] && ok "NC3 aborted run exits 3 (HARNESS_FAILURE), not 1/2" \
+                || no "NC3 aborted run exited $rc" "1 or 2 masquerades as a real verdict"
+case "$out" in
+    *'VERDICT=HARNESS_FAILURE'*) ok "NC3 emits an explicit HARNESS_FAILURE verdict line";;
+    *) no "NC3 emitted no HARNESS_FAILURE line" "$(printf '%s' "$out" | head -2)";;
+esac
+case "$out" in
+    *'VERDICT=PASS'*) no "NC3 aborted run still claimed PASS" "";;
+    *) ok "NC3 aborted run makes no PASS claim";;
+esac
+# POSITIVE TWIN: the sentinel must be set on the real verdict path, or every run
+# would report HARNESS_FAILURE and NC3 would prove nothing.
+for pair in "RPM:$RPM_CODE" "DEB:$DEB_CODE"; do
+    fam="${pair%%:*}"; c="${pair#*:}"
+    n=$(printf '%s\n' "$c" | grep -c 'VERDICT_EMITTED=1')
+    [ "${n:-0}" -ge 1 ] && ok "PC3 $fam sets VERDICT_EMITTED=1 on the verdict path ($n site(s))" \
+                        || no "PC3 $fam never sets VERDICT_EMITTED=1" "every run would be HARNESS_FAILURE"
+done
+
+# ---------------------------------------------------------------------------
+# NC4 — one BLOCKED among passes must block closure
+# ---------------------------------------------------------------------------
+echo "── NC4  a single BLOCKED case forces INCOMPLETE ───────────────────────────"
+# The classifier under test must be the MATRIX'S OWN TEXT. An earlier version of
+# this arm re-implemented the case statement here; mutating the real matrix then
+# changed nothing and the control reported a false pass. Extract and execute the
+# shipped `case` block instead.
+#   TESTING A REPLICA != TESTING THE CODE
+extract_classifier() { # $1=matrix-code  -> a function body operating on $v
+    printf '%s\n' "$1" | awk '
+        /case "\$v" in|case "\$r" in/ {n=1}
+        n{print}
+        n && /esac/{exit}'
+}
+run_classifier() { # $1=matrix-code  $2=verdict-value -> counters
+    local blk; blk=$(extract_classifier "$1")
+    [ -n "$blk" ] || { echo "NO_CLASSIFIER"; return 0; }
+    {   echo 'skipped=0; failed=0; blocked=0; unknown=0; c=X'
+        echo "v='$2'; r='$2'"
+        printf '%s\n' "$blk"
+        echo 'echo "failed=$failed blocked=$blocked skipped=$skipped unknown=$unknown"'
+    } > "$W/cls.sh"
+    "$BASH_ABS" "$W/cls.sh" 2>/dev/null
+}
+for pair in "RPM:$RPM_CODE" "DEB:$DEB_CODE"; do
+    fam="${pair%%:*}"; c="${pair#*:}"
+    r=$(run_classifier "$c" "WEIRD_STATE")
+    case "$r" in
+        *'unknown=1'*) ok "NC4 $fam SHIPPED classifier routes an unknown verdict to unknown=1";;
+        NO_CLASSIFIER) no "NC4 $fam has no case-based classifier" "aggregation is not closed-set";;
+        *) no "NC4 $fam shipped classifier SWALLOWED an unknown verdict" "got: $r";;
+    esac
+    r=$(run_classifier "$c" "BLOCKED_ENVIRONMENT")
+    case "$r" in
+        *'blocked=1'*) ok "NC4 $fam SHIPPED classifier counts BLOCKED_ENVIRONMENT";;
+        *) no "NC4 $fam shipped classifier does not count BLOCKED" "got: $r";;
+    esac
+    r=$(run_classifier "$c" "NOT_IN_SCOPE")
+    case "$r" in
+        *'failed=0 blocked=0 skipped=0 unknown=0'*) ok "NC4 $fam NOT_IN_SCOPE increments nothing (non-blocking)";;
+        *) no "NC4 $fam NOT_IN_SCOPE was counted as a gap" "got: $r";;
+    esac
+done
+
+# Local model used only to express the VERDICT precedence (documented, and
+# cross-checked against the shipped classifier above).
+agg_rpm() { # $1..: verdicts for R1 R2 R3 R4 R7 R8 R11
+    local -A R; local i=0 c
+    for c in R1 R2 R3 R4 R7 R8 R11; do i=$((i+1)); R[$c]="${!i}"; done
+    local skipped=0 failed=0 blocked=0 unknown=0 v
+    for c in R1 R2 R3 R4 R7 R8 R11; do
+        v="${R[$c]}"
+        case "$v" in
+            PASS) ;; FAIL) failed=$((failed+1));; SKIP) skipped=$((skipped+1));;
+            BLOCKED_ENVIRONMENT) blocked=$((blocked+1));; NOT_IN_SCOPE) ;;
+            *) unknown=$((unknown+1));;
+        esac
+    done
+    if [ "$unknown" -gt 0 ]; then echo HARNESS_FAILURE; return; fi
+    if [ "$failed"  -gt 0 ]; then echo FAIL;            return; fi
+    if [ "$blocked" -gt 0 ]; then echo INCOMPLETE;      return; fi
+    if [ "$skipped" -gt 0 ]; then echo INCOMPLETE;      return; fi
+    echo PASS
+}
+v=$(agg_rpm PASS PASS PASS PASS BLOCKED_ENVIRONMENT PASS PASS)
+[ "$v" = INCOMPLETE ] && ok "NC4 one BLOCKED among all-PASS => INCOMPLETE" \
+                      || no "NC4 got '$v'" "a BLOCKED case must block closure"
+# POSITIVE TWIN: without the BLOCKED, the same set must reach PASS — otherwise
+# NC4 could pass because the aggregator can never say PASS at all.
+v=$(agg_rpm PASS PASS PASS PASS PASS PASS PASS)
+[ "$v" = PASS ] && ok "PC4 all-PASS still reaches PASS (aggregator not stuck)" \
+                || no "PC4 all-PASS returned '$v'" "aggregator cannot report success"
+# NOT_IN_SCOPE must NOT block closure (that is the Layer-A requirement).
+v=$(agg_rpm PASS NOT_IN_SCOPE NOT_IN_SCOPE NOT_IN_SCOPE PASS PASS NOT_IN_SCOPE)
+[ "$v" = PASS ] && ok "PC4 NOT_IN_SCOPE does not block closure (Layer A can pass)" \
+                || no "PC4 scoped run returned '$v'" "Layer A would be permanently INCOMPLETE"
+# Unknown verdict must become HARNESS_FAILURE, never fall through to PASS.
+v=$(agg_rpm PASS PASS PASS PASS WEIRD_STATE PASS PASS)
+[ "$v" = HARNESS_FAILURE ] && ok "NC4 unknown verdict => HARNESS_FAILURE (no default-success)" \
+                           || no "NC4 unknown verdict => '$v'" "closed set violated"
+
+# ---------------------------------------------------------------------------
+# NC5 — Layer A must declare VM-only cases, not silently omit them
+# ---------------------------------------------------------------------------
+echo "── NC5  scoped run declares exclusions explicitly ─────────────────────────"
+# Bind to the SELECTION SITE. A file-wide substring match passes even when the
+# selection block still assigns SKIP, because NOT_IN_SCOPE also appears in the
+# aggregator — the guard subject must be the line that DECIDES.
+sel_rpm=$(printf '%s\n' "$RPM_CODE" | grep -A2 'want() {' | head -3)
+case "$RPM_CODE" in
+    *'R['*']="NOT_IN_SCOPE"'*) ok "NC5 RPM assigns NOT_IN_SCOPE at the selection site";;
+    *) no "NC5 RPM selection site does not assign NOT_IN_SCOPE" "$sel_rpm";;
+esac
+sel_deb=$(printf '%s\n' "$DEB_CODE" | grep -A1 'NFTBAN_LIFECYCLE_CASES' | grep 'CASE_RESULT' || true)
+case "$(printf '%s\n' "$DEB_CODE" | grep 'CASE_RESULT\["\$c"\]=' | head -3)" in
+    *'NOT_IN_SCOPE'*) ok "NC5 DEB selection site assigns NOT_IN_SCOPE (A5 parity)";;
+    *) no "NC5 DEB selection site still assigns SKIP" "any subset run would be INCOMPLETE${sel_deb:+ | $sel_deb}";;
+esac
+# Every case must be reported, in scope or not — silent omission hides coverage.
+case "$RPM_CODE" in
+    *'NFTBAN_RPM_MATRIX_SCOPE='*) ok "NC5 RPM prints a machine-readable SCOPE line";;
+    *) no "NC5 RPM prints no SCOPE line" "a subset run could not be distinguished from a full one";;
+esac
+case "$DEB_CODE" in
+    *'NFTBAN_MATRIX_SCOPE='*) ok "NC5 DEB prints a machine-readable SCOPE line";;
+    *) no "NC5 DEB prints no SCOPE line" "";;
+esac
+
+# NC5b — a Layer A PASS must not carry a systemd/kernel claim.
+for pair in "RPM:$RPM_CODE" "DEB:$DEB_CODE"; do
+    fam="${pair%%:*}"; c="${pair#*:}"
+    case "$c" in
+        *'CLAIMS_SYSTEMD_AUTHORITY=NO'*) ok "NC5b $fam Layer A explicitly disclaims systemd authority";;
+        *) no "NC5b $fam never emits CLAIMS_SYSTEMD_AUTHORITY=NO" "a container PASS could read as VM proof";;
+    esac
+    case "$c" in
+        *'CLAIMS_KERNEL_FIREWALL_AUTHORITY=NO'*) ok "NC5b $fam Layer A disclaims kernel-firewall authority";;
+        *) no "NC5b $fam never disclaims kernel-firewall authority" "";;
+    esac
+done
+# The VM-only helper must exist AND be used, or the split is decorative.
+for pair in "RPM:eq_vm:$RPM_CODE" "DEB:assert_eq_vm:$DEB_CODE"; do
+    fam="${pair%%:*}"; rest="${pair#*:}"; h="${rest%%:*}"; c="${rest#*:}"
+    n=$(printf '%s\n' "$c" | grep -c "^[[:space:]]*${h} ")
+    [ "${n:-0}" -ge 3 ] && ok "NC5b $fam routes $n VM-only assertions through ${h}()" \
+                        || no "NC5b $fam uses ${h}() at only ${n} site(s)" "VM assertions still unscoped"
+done
+
+# ---------------------------------------------------------------------------
+# NC6 — BLOCKED_ENVIRONMENT must never be reclassified as NOT_IN_SCOPE
+# ---------------------------------------------------------------------------
+echo "── NC6  BLOCKED is never rewritten to NOT_IN_SCOPE ────────────────────────"
+BAD=0
+for c in "$RPM_CODE" "$DEB_CODE"; do
+    # A reclassification would look like assigning NOT_IN_SCOPE on a line that
+    # also mentions BLOCKED_ENVIRONMENT.
+    hit=$(printf '%s\n' "$c" | grep -F 'NOT_IN_SCOPE' | grep -F 'BLOCKED_ENVIRONMENT' || true)
+    [ -n "$hit" ] && { BAD=$((BAD+1)); echo "       $hit"; }
+done
+[ "$BAD" -eq 0 ] && ok "NC6 no code path maps BLOCKED_ENVIRONMENT onto NOT_IN_SCOPE" \
+                 || no "NC6 a reclassification path exists" "$BAD site(s)"
+# And the two states must be counted differently by the aggregators.
+v1=$(agg_rpm PASS PASS PASS PASS BLOCKED_ENVIRONMENT PASS PASS)
+v2=$(agg_rpm PASS PASS PASS PASS NOT_IN_SCOPE PASS PASS)
+[ "$v1" != "$v2" ] && ok "NC6 BLOCKED ($v1) and NOT_IN_SCOPE ($v2) aggregate DIFFERENTLY" \
+                   || no "NC6 both aggregate to '$v1'" "the distinction is cosmetic only"
+
+# ---------------------------------------------------------------------------
+# A3 — comparator propagation is wired into the real assertion helpers
+# ---------------------------------------------------------------------------
+echo "── A3  comparators refuse to compare a BLOCKED observation ────────────────"
+for pair in "RPM:eq:$RPM_CODE" "DEB:assert_eq:$DEB_CODE"; do
+    fam="${pair%%:*}"; rest="${pair#*:}"; f="${rest%%:*}"; c="${rest#*:}"
+    body=$(fn "$f" "$c")
+    case "$body" in
+        *'BLOCKED_TOKEN'*) ok "A3 $fam $f() short-circuits on the BLOCKED sentinel";;
+        *) no "A3 $fam $f() compares a BLOCKED value as an ordinary string" "";;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# CI WIRING — Layer A must consume artifacts that the build jobs actually publish
+# ---------------------------------------------------------------------------
+# The first Layer A run requested `rpm-rocky9` while build-rpm publishes
+# `rpm-el9` (named for the EL generation, not the image vendor). The job would
+# have failed at artifact download; it was SKIPPED that run for an unrelated
+# reason, so the mismatch never surfaced.
+#     LAYER_A_EXPECTED_ARTIFACT MUST MATCH BUILD_JOB_PUBLISHED_ARTIFACT
+echo "── CI  Layer A artifact names must exist as published artifacts ───────────"
+WF="$REPO_ROOT/.github/workflows/build-packages.yml"
+if [ ! -r "$WF" ]; then
+    no "build-packages.yml unreadable — cannot verify artifact wiring" ""
+else
+    # Published names: build-rpm/build-deb upload rpm-${distro} / deb-${distro},
+    # so the publishable set is derived from those matrices, not hand-listed.
+    PUB=$(python3 - "$WF" <<'PYEOF'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+out = []
+for job, prefix in (("build-rpm", "rpm-"), ("build-deb", "deb-")):
+    j = d["jobs"].get(job, {})
+    for m in j.get("strategy", {}).get("matrix", {}).get("include", []):
+        if m.get("distro"):
+            out.append(prefix + str(m["distro"]))
+print("\n".join(out))
+PYEOF
+)
+    WANT=$(python3 - "$WF" <<'PYEOF'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+j = d["jobs"].get("lifecycle-layer-a", {})
+for m in j.get("strategy", {}).get("matrix", {}).get("include", []):
+    if m.get("artifact"):
+        print(m["artifact"])
+PYEOF
+)
+    if [ -z "$PUB" ] || [ -z "$WANT" ]; then
+        no "could not read build/consumer matrices" "PUB='${PUB}' WANT='${WANT}'"
+    else
+        ok "build jobs publish: $(printf '%s' "$PUB" | tr '\n' ' ')"
+        DRIFT=0
+        while read -r a; do
+            [ -z "$a" ] && continue
+            if printf '%s\n' "$PUB" | grep -qx "$a"; then
+                ok "Layer A consumes '$a' — published by a build job"
+            else
+                DRIFT=$((DRIFT+1)); no "Layer A requests '$a' which NO build job publishes" "download would fail"
+            fi
+        done <<< "$WANT"
+        # Positive control: the check must be able to SEE a mismatch, or the
+        # arm above passes only because nothing was compared.
+        if printf '%s\n' "$PUB" | grep -qx "rpm-rocky9"; then
+            no "control: 'rpm-rocky9' unexpectedly published" "detector cannot distinguish"
+        else
+            ok "control: a bogus name ('rpm-rocky9') is correctly NOT in the published set"
+        fi
+        [ "$DRIFT" -eq 0 ] && ok "no producer/consumer artifact drift"
+    fi
+fi
+
+echo
+echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/packaging/build_nftban.sh
+++ b/packaging/build_nftban.sh
@@ -85,6 +85,24 @@ PROV_YQ_SHA256="6dc2d0cd4e0caca5aeffd0d784a48263591080e4a0895abe69f3a76eb50d1ba3
 #   verify sha, FAIL-CLOSED if absent — NEVER curl/wget. ONLINE: fetch_verified.
 provision_yq() {
     local dest="$1" src
+    # CACHE-FIRST (v1.229 UNINSTALL-PR3 CI hardening). A live GitHub-release
+    # download sat on the critical path of EVERY package build, so an upstream
+    # 503 failed required CI for reasons unrelated to the change under test.
+    #   NETWORK_TRANSIENT != RANDOM_REQUIRED_CI_FAILURE
+    # Any locally present copy whose sha256 matches the pin is authoritative and
+    # is used in ONLINE mode too — CI restores one from cache, so the network is
+    # only touched on a cache miss. A candidate that fails the checksum is
+    # IGNORED, never used and never "repaired":
+    #   DOWNLOAD_RC0 != ARTIFACT_TRUST
+    for src in "${NFTBAN_OFFLINE_YQ:-}" "${PROJECT_ROOT}/offline/yq_linux_amd64"; do
+        [[ -n "$src" && -f "$src" ]] || continue
+        if echo "${PROV_YQ_SHA256}  ${src}" | sha256sum -c - >/dev/null 2>&1; then
+            install -m 0755 "$src" "$dest"
+            log_success "yq v${PROV_YQ_VERSION}: SHA-pinned local copy used (no network) — ${src}"
+            return 0
+        fi
+        log_warn "yq: local candidate ${src} FAILED the pinned sha256 — ignoring it"
+    done
     if [[ "$PROV_OFFLINE" == "1" ]]; then
         src="${NFTBAN_OFFLINE_YQ:-${PROJECT_ROOT}/offline/yq_linux_amd64}"
         if [[ ! -f "$src" ]]; then
@@ -100,9 +118,21 @@ provision_yq() {
     fi
     # shellcheck source=packaging/lib/fetch_verified.sh
     . "${SCRIPT_DIR}/lib/fetch_verified.sh"
-    fetch_verified \
+    if ! fetch_verified \
         "https://github.com/mikefarah/yq/releases/download/v${PROV_YQ_VERSION}/yq_linux_amd64" \
-        "${PROV_YQ_SHA256}" "$dest" || return 1
+        "${PROV_YQ_SHA256}" "$dest"; then
+        log_error "yq v${PROV_YQ_VERSION}: no authoritative source succeeded."
+        log_error "  local candidates absent or checksum-mismatched, and the pinned"
+        log_error "  release download failed after bounded retries. FAIL-CLOSED."
+        return 1
+    fi
+    # Seed the cache location so the next build (and CI cache) needs no network.
+    # Best-effort: a read-only or absent tree must not fail a successful build.
+    if [[ -n "${PROJECT_ROOT:-}" && -w "${PROJECT_ROOT}" ]]; then
+        mkdir -p "${PROJECT_ROOT}/offline" 2>/dev/null &&
+            install -m 0755 "$dest" "${PROJECT_ROOT}/offline/yq_linux_amd64" 2>/dev/null &&
+            log_info "yq: seeded ${PROJECT_ROOT}/offline/yq_linux_amd64 for reuse" || true
+    fi
     return 0
 }
 

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -145,6 +145,7 @@ l3a_never_ban_add_element_guard_test	cli/lib/nftban/tests/l3a_never_ban_add_elem
 legacy_restore_neutralized_v1229_test	cli/lib/nftban/tests/legacy_restore_neutralized_v1229_test.sh	firewall	test	firewall	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 license_identity_bad_controls_v1228_8_test	cli/lib/nftban/tests/license_identity_bad_controls_v1228_8_test.sh	core	test	license-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	300		
 lifecycle_forensics_v1199_test	cli/lib/nftban/tests/lifecycle_forensics_v1199_test.sh	update	test	lifecycle-forensics	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+lifecycle_matrix_observation_semantics_v1229_test	cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh	packaging	test	uninstall-lifecycle	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 list_ipv6_clamp_v153_test	cli/lib/nftban/tests/list_ipv6_clamp_v153_test.sh	cli	test	list	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 logdir_foreign_content_safety_v1228_10_test	cli/lib/nftban/tests/logdir_foreign_content_safety_v1228_10_test.sh	packaging	test	fhs-permissions	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 logretention_packaging_derivedstate_gateb_test	cli/lib/nftban/tests/logretention_packaging_derivedstate_gateb_test.sh	packaging	test	logretention	PACKAGE_BUILD	package-build	true	false	false	false	false	false			

--- a/scripts/ci/tests/lifecycle_deb_matrix.sh
+++ b/scripts/ci/tests/lifecycle_deb_matrix.sh
@@ -128,6 +128,10 @@ CASE_ID="INIT"
 declare -A CASE_RESULT=()
 declare -A CASE_NOTE=()
 CASE_ORDER=(L1 L2 L3 L4 L5 L6 L7 L8 L9 L10 L11)
+# Shared sentinel: "in scope, but observation authority unavailable".
+readonly BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"
+BLOCKED_N=0
+VERDICT_EMITTED=0
 
 # cleanup ledger — every mutation this harness makes to host state
 CLEAN_IMMUTABLE=()
@@ -160,8 +164,36 @@ assert() {
     fi
 }
 
+# A3 (UNINSTALL-PR3): a BLOCKED_ENVIRONMENT observation must never compare as an
+# ordinary string — neither a PASS (nothing was observed) nor a product FAIL
+# (the product is not what failed). It propagates as its own state.
+assert_blocked() { # description
+    printf '[BLOCKED] %-4s %s\n' "$CASE_ID" "$*"
+    BLOCKED_N=$((BLOCKED_N + 1))
+    CASE_RESULT["$CASE_ID"]="BLOCKED_ENVIRONMENT"
+}
+
+# LAYER A/B SPLIT (UNINSTALL-PR3) — see the RPM twin. Layer A declares VM-only
+# assertions NOT_IN_SCOPE instead of letting them go BLOCKED (which would make
+# every container run permanently INCOMPLETE and pressure us to weaken them).
+VM_ASSERTIONS="${NFTBAN_MATRIX_VM_ASSERTIONS:-1}"
+VM_NOT_IN_SCOPE_N=0
+assert_eq_vm() { # want got description  — VM-only (systemd / kernel nftables)
+    if [[ "$VM_ASSERTIONS" != "1" ]]; then
+        shift 2   # want/got are deliberately unread: nothing observed them
+        printf '[NOT_IN_SCOPE] %-4s %s — VM-only assertion; this environment cannot observe it\n' "$CASE_ID" "$*"
+        VM_NOT_IN_SCOPE_N=$((VM_NOT_IN_SCOPE_N + 1))
+        return 0
+    fi
+    assert_eq "$@"
+}
+
 assert_eq() { # want got description
     local want="$1" got="$2"; shift 2
+    if [[ "$got" == "$BLOCKED_TOKEN" ]]; then
+        assert_blocked "$* — observation authority unavailable (wanted '${want}'); NOT a product verdict"
+        return 0
+    fi
     if [[ "$want" == "$got" ]]; then
         assert 0 "$* (= ${want})"
     else
@@ -301,7 +333,11 @@ snapshot() { # label
 }
 
 nft_table_state() { # family name
-    if ! command -v nft >/dev/null 2>&1; then printf 'nft-absent'; return 0; fi
+    # A6 (UNINSTALL-PR3): this already fail-CLOSED via a distinct token (the
+    # correct in-repo template for A2), but 'nft-absent' surfaced as a bare
+    # assertion FAIL — mislabelling an environment block as a product defect.
+    # Normalised onto the shared sentinel so it routes to BLOCKED_ENVIRONMENT.
+    if ! command -v nft >/dev/null 2>&1; then printf '%s' "$BLOCKED_TOKEN"; return 0; fi
     if nft list table "$1" "$2" >/dev/null 2>&1; then printf 'present'; else printf 'absent'; fi
 }
 
@@ -361,21 +397,21 @@ assert_runtime_healthy() {
     local u active enabled
     for u in "${DAEMON_UNITS[@]}"; do
         active="$(unit_active_state "$u")"
-        assert_eq "active" "$active" "systemd ${u} is-active"
+        assert_eq_vm "active" "$active" "systemd ${u} is-active"
     done
     for u in "${CORE_TIMERS[@]}"; do
         active="$(unit_active_state "$u")"
         enabled="$(systemctl is-enabled "$u" 2>/dev/null || true)"
-        assert_eq "active"  "$active"  "core timer ${u} is-active"
-        assert_eq "enabled" "$enabled" "core timer ${u} is-enabled"
+        assert_eq_vm "active"  "$active"  "core timer ${u} is-active"
+        assert_eq_vm "enabled" "$enabled" "core timer ${u} is-enabled"
     done
     for u in "${CRITICAL_TIMERS[@]}"; do
-        assert_eq "active" "$(unit_active_state "$u")" \
+        assert_eq_vm "active" "$(unit_active_state "$u")" \
             "CRITICAL timer ${u} active (drives DEGRADED per timers.go:68-80)"
     done
-    assert_eq "present" "$(nft_table_state ip nftban)"  "nft table ip nftban loaded"
-    assert_eq "present" "$(nft_table_state ip6 nftban)" "nft table ip6 nftban loaded"
-    assert_eq "absent"  "$(nft_table_state inet "$EMERGENCY_TABLE")" \
+    assert_eq_vm "present" "$(nft_table_state ip nftban)"  "nft table ip nftban loaded"
+    assert_eq_vm "present" "$(nft_table_state ip6 nftban)" "nft table ip6 nftban loaded"
+    assert_eq_vm "absent"  "$(nft_table_state inet "$EMERGENCY_TABLE")" \
         "emergency SSH table removed (assertions.go:279 no_emergency_table)"
     local failed
     failed="$(failed_nftban_units | tr '\n' ' ' | sed 's/ *$//')"
@@ -402,9 +438,17 @@ assert_validate_ok() {
 # "inactive\ninactive" -- reporting a product failure where the unit state was
 # exactly right. One helper, one word, used everywhere.
 unit_active_state() { # unit -> exactly one word
+    # A2 (UNINSTALL-PR3): systemctl unavailable != inactive. Removal cases assert
+    # "inactive", so collapsing a missing manager into that value made them PASS
+    # having observed nothing. Mirrors nft_table_state's existing sentinel style.
     local s
+    command -v systemctl >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
     s="$(systemctl is-active "$1" 2>/dev/null | head -1 || true)"
-    [[ -n "$s" ]] || s="inactive"   # unit absent
+    if [[ -z "$s" ]]; then
+        # No reachable manager is NOT evidence that a unit is stopped.
+        systemctl is-system-running >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
+        s="inactive"   # unit absent, manager reachable
+    fi
     printf '%s' "$s"
 }
 
@@ -577,6 +621,16 @@ on_exit() {
         fi
     done
     log "cleanup done (harness exit rc=${rc}); artifacts under ${WORKDIR:-<none>}"
+    # A4 (UNINSTALL-PR3) DURABLE F4 CLOSURE. This trap was cleanup-only, so a
+    # mid-run `set -e` abort exited with the failing command's rc — often 1 or 2
+    # — and printed NO SUMMARY, making a harness crash indistinguishable from a
+    # legitimate FAIL or INCOMPLETE. The harness must PROVE it reached its
+    # verdict path; the exit code alone cannot carry that.
+    if [[ "${VERDICT_EMITTED:-0}" -ne 1 ]]; then
+        printf 'NFTBAN_MATRIX_VERDICT=HARNESS_FAILURE\n'
+        printf 'NFTBAN_MATRIX_HARNESS_NOTE=aborted before emitting a verdict (rc=%s); this run proves NOTHING\n' "$rc"
+        exit 3
+    fi
 }
 
 # =============================================================================
@@ -667,7 +721,13 @@ case_L2() {
 }
 
 case_L3() {
-    case_begin L3 "upgrade (published ${PRIOR_VER} -> candidate ${CANDIDATE_VER})"
+    case_begin L3 "upgrade (published ${PRIOR_VER:-<none>} -> candidate ${CANDIDATE_VER})"
+    # An upgrade arm without a prior package proves nothing. SKIP (-> INCOMPLETE),
+    # never a silent pass and never a crash mid-run.
+    if [[ -z "$PRIOR_DEB" ]]; then
+        case_skip "no prior deb supplied — an upgrade cannot be exercised; select a subset with NFTBAN_LIFECYCLE_CASES to declare this NOT_IN_SCOPE instead"
+        return 0
+    fi
     if [[ "$PRIOR_VER" == "$CANDIDATE_VER" ]]; then
         case_skip "prior deb version (${PRIOR_VER}) equals candidate (${CANDIDATE_VER}) — this is NOT an upgrade. Rebuild the candidate with a bumped VERSION file (repo VERSION is currently the source of PKG_VERSION, build_nftban.sh:46)."
         return 0
@@ -1010,21 +1070,63 @@ case_L7() {
     snapshot "L7 post"
 
     assert_eq "0" "$rc" "apt-get remove exit"
+    # F1 (UNINSTALL-PR3): 'absent' USED TO PASS HERE. That accepted the single
+    # bit which distinguishes remove from purge: 'rc' means the package is
+    # removed with config-files RETAINED; 'absent' means nothing of it is left.
+    # Accepting both made this case pass whether or not operator config
+    # survived — the exact property D1/D2 exist to defend.
+    #     REMOVE != PURGE, and the status field is how dpkg says which happened.
     local st; st="$(dpkg_status)"
-    if [[ "$st" == "rc" || "$st" == "absent" ]]; then
-        assert 0 "dpkg status after remove = ${st} (config-files retained per policy)"
+    assert_eq "rc" "$st" "dpkg status after remove (config-files retained, NOT purged)"
+
+    # ---- D1 PACKAGE-NATIVE PROOF (DEB half; parity with RPM R7) -------------
+    # DEB has always preserved on `remove`; asserting it here makes the DEB side
+    # a REFERENCE the RPM side is measured against, rather than an assumption.
+    local _d
+    for _d in /etc/nftban /var/lib/nftban /var/log/nftban; do
+        [[ -d "$_d" ]] && assert 0 "D1: $_d preserved by apt-get remove" \
+                       || assert 1 "D1: $_d destroyed by apt-get remove — remove is not purge"
+    done
+
+    # ---- D3 PACKAGE-NATIVE PROOF: preserved must be LOADER-VISIBLE ----------
+    # BYTES_PRESERVED != FUNCTIONAL_STATE_PRESERVED. dpkg's sidecar suffixes
+    # (.dpkg-old/.dpkg-dist/.dpkg-new) are as invisible to a *.conf loader as
+    # rpm's .rpmsave is.
+    local _l _f _side
+    for _l in whitelist blacklist; do
+        _f="/etc/nftban/${_l}.d/99-manual.conf"
+        if [[ -f "$_f" ]]; then
+            assert 0 "D3: ${_l}.d/99-manual.conf survives remove under its LOADED name"
+        else
+            _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1)"
+            if [[ -n "$_side" ]]; then
+                assert 1 "D3: operator config survives only as ${_side} — present but INVISIBLE to the *.conf loader"
+            else
+                assert 1 "D3: ${_l}.d/99-manual.conf absent after remove"
+            fi
+        fi
+    done
+
+    # ---- D5 PACKAGE-NATIVE PROOF: disclosure, and no unobserved claim -------
+    if grep -qF 'no longer protects this host' "$out"; then
+        assert 0 "D5: removal states NFTBan no longer protects this host"
     else
-        assert 1 "dpkg status after remove = ${st} (want 'rc')"
+        assert 1 "D5: removal did not disclose loss of protection"
+    fi
+    if grep -qF 'were NOT modified and may still be active' "$out"; then
+        assert 1 "D5: removal asserts an UNOBSERVED other-firewall state"
+    else
+        assert 0 "D5: removal makes no unobserved other-firewall claim"
     fi
 
     # services stopped (prerm:51-106 stops; deprecated units also disabled 109-125)
     local u
     for u in "${DAEMON_UNITS[@]}"; do
-        assert_eq "inactive" "$(unit_active_state "$u")" \
+        assert_eq_vm "inactive" "$(unit_active_state "$u")" \
             "after remove: ${u} not active (prerm:105 deb-systemd-invoke stop)"
     done
     for u in "${CORE_TIMERS[@]}"; do
-        assert_eq "inactive" "$(unit_active_state "$u")" \
+        assert_eq_vm "inactive" "$(unit_active_state "$u")" \
             "after remove: ${u} not active"
     done
     # unit FILES removed with the payload (raw dpkg-deb build: no debhelper
@@ -1035,12 +1137,17 @@ case_L7() {
     assert_eq "0" "$leftover_units" "after remove: no nftban unit files left under /usr/lib/systemd/system"
 
     # nftables tables deleted, NOT left as an empty drop-policy chain (postrm:215-217)
-    assert_eq "absent" "$(nft_table_state ip nftban)"  "after remove: ip nftban table deleted (no drop-policy blackhole)"
-    assert_eq "absent" "$(nft_table_state ip6 nftban)" "after remove: ip6 nftban table deleted"
-    if grep -aq 'no longer protecting this system' "$out"; then
-        assert 0 "postrm disclosed the documented uninstall firewall consequence (postrm:219-222)"
+    assert_eq_vm "absent" "$(nft_table_state ip nftban)"  "after remove: ip nftban table deleted (no drop-policy blackhole)"
+    assert_eq_vm "absent" "$(nft_table_state ip6 nftban)" "after remove: ip6 nftban table deleted"
+    # D5 truth contract (UNINSTALL-PR2). The anchor was the pre-PR2 wording
+    # "no longer protecting this system"; the message now states what was
+    # actually observed. Asserted on MEANING, matching
+    # uninstall_firewall_ownership_message_v225_test — and the retired
+    # unobserved claim is checked for ABSENCE just above.
+    if grep -aq 'no longer protects this host' "$out"; then
+        assert 0 "postrm disclosed the uninstall firewall consequence"
     else
-        assert 1 "postrm did not print the documented uninstall firewall consequence"
+        assert 1 "postrm did not print the uninstall firewall consequence"
     fi
 
     # runtime files per policy: /run/nftban removed only on purge (postrm:64),
@@ -1077,12 +1184,17 @@ assert_no_stale_success_claim() { # not_before_epoch label
     local t0="$1" label="$2" bin="${WORKDIR}/nftban-installer.copy"
     local nb out rc=0
     # Both early exits are INFORMATIONAL — they must never be counted as passes.
+    # F3 (UNINSTALL-PR3): these early exits USED TO return 0 silently, so a run
+    # with missing inputs produced ZERO coverage of the stale-claim property
+    # while the case still reported PASS. They now record a SKIP, which forces
+    # the matrix verdict to INCOMPLETE (exit 2).
+    #     ABSENT PROBE != PROPERTY PROVEN
     if [[ ! -x "$bin" ]]; then
-        printf '  %s: no preserved verifier binary — stale-claim probe not run\n' "$label"
+        case_skip "${label}: no preserved verifier binary — stale-claim probe NOT RUN (zero coverage)"
         return 0
     fi
     if [[ ! -f "$STATE_FILE" ]]; then
-        printf '  %s: no persisted state to misread — stale-claim probe not run\n' "$label"
+        case_skip "${label}: no persisted state to misread — stale-claim probe NOT RUN (zero coverage)"
         return 0
     fi
     nb="$(date -u -d "@${t0}" +'%Y-%m-%dT%H:%M:%S.000000000Z')"
@@ -1266,11 +1378,14 @@ case_L10() {
     fi
     # 2. A previous COMMITTED must not read as evidence of removal success.
     assert_no_stale_success_claim "$t0" "L10"
+    # F2 (UNINSTALL-PR3): the else branch USED TO ASSERT PASS. A removal that
+    # FAILED must not have destroyed install state on its way out — recording
+    # that destruction as "recorded" turned the defect into evidence of success.
     if [[ -f "$STATE_FILE" ]]; then
         assert_eq "$ts_before" "$(statefield INSTALL_TIMESTAMP)" \
             "install_state untouched by the failed removal"
     else
-        assert 0 "install_state absent after the failed removal (recorded)"
+        assert 1 "install_state DESTROYED by a failed removal — a failed uninstall must not consume state"
     fi
 
     # recover the host
@@ -1284,7 +1399,10 @@ case_L10() {
 # =============================================================================
 usage() {
     cat <<'EOF'
-usage: lifecycle_deb_matrix.sh <candidate.deb> <prior-v1.227.0.deb>
+usage: lifecycle_deb_matrix.sh <candidate.deb> [prior-v1.227.0.deb]
+
+  <prior> is OPTIONAL. Without it the upgrade arms cannot run; select a subset
+  with NFTBAN_LIFECYCLE_CASES so they are NOT_IN_SCOPE rather than SKIP.
 
   Runs AS ROOT on a DISPOSABLE Ubuntu 24.04 VM. Destructive.
 
@@ -1393,13 +1511,29 @@ case_L11() {
     fi
 }
 
+# Environment preconditions are NOT harness bugs: emit the canonical verdict so
+# the EXIT trap does not reclassify them as HARNESS_FAILURE.
+blocked_exit() { # reason
+    printf 'NFTBAN_MATRIX_VERDICT=INCOMPLETE\n'
+    printf 'NFTBAN_MATRIX_INCOMPLETE_REASON=BLOCKED_ENVIRONMENT\n'
+    printf 'NFTBAN_MATRIX_BLOCKED_PRECONDITION=%s\n' "$1"
+    VERDICT_EMITTED=1
+    exit 2
+}
+
 main() {
-    if [[ $# -lt 2 ]]; then usage; exit 2; fi
+    if [[ $# -lt 1 ]]; then usage; VERDICT_EMITTED=1; exit 2; fi
     CANDIDATE_DEB="$(readlink -f "$1")"
-    PRIOR_DEB="$(readlink -f "$2")"
+    # PRIOR is optional (UNINSTALL-PR3): the upgrade arms need a PUBLISHED prior
+    # deb, but remove/purge need only the candidate. Binding a merge decision to
+    # an external release download would fail the gate for unrelated reasons.
+    # Cases that need it declare SKIP -> INCOMPLETE; they never silently pass.
+    PRIOR_DEB=""
+    [[ -n "${2:-}" ]] && PRIOR_DEB="$(readlink -f "$2")"
 
     if [[ "$(id -u)" -ne 0 ]]; then
-        log "ERROR: must run as root"; exit 2
+        log "ERROR: must run as root"
+        blocked_exit "must run as root"
     fi
 
     # SINGLE INSTANCE, enforced rather than assumed. This harness purges,
@@ -1414,29 +1548,54 @@ main() {
         log "       This harness is destructive; refusing to run a second copy against the same host."
         exit 2
     fi
+    # REQUIREMENTS FOLLOW SCOPE. systemctl and nft are only needed by the VM-only
+    # assertions; requiring them unconditionally made a Layer A container run
+    # impossible even though every assertion it DOES make is observable there.
+    # They stay mandatory whenever VM assertions are in scope (Layer B), so this
+    # relaxes nothing about the full contract.
     local missing=() b
-    for b in dpkg dpkg-deb dpkg-query apt-get systemctl nft flock date find awk grep sed; do
+    local required=(dpkg dpkg-deb dpkg-query apt-get flock date find awk grep sed)
+    if [[ "$VM_ASSERTIONS" == "1" ]]; then
+        required+=(systemctl nft)
+    else
+        log "scope: VM assertions out of scope — systemctl/nft not required for this run"
+    fi
+    for b in "${required[@]}"; do
         command -v "$b" >/dev/null 2>&1 || missing+=("$b")
     done
     if [[ "${#missing[@]}" -gt 0 ]]; then
-        log "ERROR: missing required binaries: ${missing[*]}"; exit 2
+        log "ERROR: missing required binaries: ${missing[*]}"
+        blocked_exit "missing required binaries: ${missing[*]}"
     fi
-    for b in "$CANDIDATE_DEB" "$PRIOR_DEB"; do
-        [[ -f "$b" ]] || { log "ERROR: not a file: $b"; exit 2; }
+    # PRIOR is optional (see main): validate it only when one was supplied, and
+    # report a genuinely missing input as a BLOCKED precondition rather than a
+    # bare exit that the EXIT trap would reclassify as HARNESS_FAILURE.
+    local _inputs=("$CANDIDATE_DEB")
+    [[ -n "$PRIOR_DEB" ]] && _inputs+=("$PRIOR_DEB")
+    for b in "${_inputs[@]}"; do
+        [[ -f "$b" ]] || { log "ERROR: not a file: $b"; blocked_exit "input not a file: ${b:-<empty>}"; }
     done
 
     WORKDIR="$(mktemp -d /var/tmp/nftban-lifecycle-XXXXXX)"
     trap on_exit EXIT
 
     CANDIDATE_VER="$(dpkg-deb -f "$CANDIDATE_DEB" Version)"
-    PRIOR_VER="$(dpkg-deb -f "$PRIOR_DEB" Version)"
-    local cand_pkg prior_pkg
+    local cand_pkg prior_pkg=""
     cand_pkg="$(dpkg-deb -f "$CANDIDATE_DEB" Package)"
-    prior_pkg="$(dpkg-deb -f "$PRIOR_DEB" Package)"
+    # PRIOR is optional: reading it unconditionally aborted the run under set -e
+    # before any verdict when none was supplied.
+    if [[ -n "$PRIOR_DEB" ]]; then
+        PRIOR_VER="$(dpkg-deb -f "$PRIOR_DEB" Version)"
+        prior_pkg="$(dpkg-deb -f "$PRIOR_DEB" Package)"
+    fi
 
     hdr "NFTBan v1.228.0 Item 2 — DEB lifecycle matrix"
     log "candidate : ${CANDIDATE_DEB} (${cand_pkg} ${CANDIDATE_VER})"
-    log "prior     : ${PRIOR_DEB} (${prior_pkg} ${PRIOR_VER})"
+    if [[ -n "$PRIOR_DEB" ]]; then
+        log "prior     : ${PRIOR_DEB} (${prior_pkg} ${PRIOR_VER})"
+    else
+        log "prior     : (none supplied — upgrade arms cannot run)"
+    fi
     log "host      : $( (. /etc/os-release && printf '%s %s' "${ID:-?}" "${VERSION_ID:-?}") 2>/dev/null || echo unknown)"
     log "kernel    : $(uname -r)"
     log "workdir   : ${WORKDIR}"
@@ -1444,8 +1603,18 @@ main() {
     CASE_ID="PRE"
     CASE_RESULT["PRE"]="PASS"
     assert_eq "$PKG" "$cand_pkg"  "candidate package name (control:13)"
-    assert_eq "$PKG" "$prior_pkg" "prior package name"
-    if [[ "$CANDIDATE_VER" == "$PRIOR_VER" ]]; then
+    # Only meaningful when a prior was supplied; otherwise this asserted against
+    # an empty string and reported a FAIL for an input that is legitimately absent.
+    if [[ -n "$PRIOR_DEB" ]]; then
+        assert_eq "$PKG" "$prior_pkg" "prior package name"
+    else
+        log "prior package name: not applicable (no prior supplied)"
+    fi
+    if [[ -z "$PRIOR_DEB" ]]; then
+        # Without a prior this compared against "" and emitted a PASS reading
+        # "differs from prior " — a green line asserting nothing.
+        log "version comparison: not applicable (no prior supplied)"
+    elif [[ "$CANDIDATE_VER" == "$PRIOR_VER" ]]; then
         assert 1 "candidate and prior versions differ (both ${CANDIDATE_VER}) — L3 cannot be a real upgrade"
     else
         assert 0 "candidate ${CANDIDATE_VER} differs from prior ${PRIOR_VER}"
@@ -1468,13 +1637,16 @@ main() {
     # `|| true` is load-bearing: is-active exits 3 when inactive and this script
     # runs under `set -o pipefail`, so without it the assignment aborts the run.
     ufw_now="$(unit_active_state ufw.service)"
-    assert_eq "inactive" "$ufw_now" "baseline: ufw.service inactive"
+    assert_eq_vm "inactive" "$ufw_now" "baseline: ufw.service inactive"
 
     local selected="${NFTBAN_LIFECYCLE_CASES:-}"
     local c
     for c in "${CASE_ORDER[@]}"; do
         if [[ -n "$selected" ]] && [[ " $selected " != *" $c "* ]]; then
-            CASE_ID="$c"; CASE_RESULT["$c"]="SKIP"
+            # A5 (UNINSTALL-PR3): unselected cases were marked SKIP, which is
+            # closure-blocking — so ANY subset run was permanently INCOMPLETE.
+            # A declared exclusion is NOT a gap. Matches the RPM mechanism.
+            CASE_ID="$c"; CASE_RESULT["$c"]="NOT_IN_SCOPE"
             CASE_NOTE["$c"]="not selected via NFTBAN_LIFECYCLE_CASES"
             continue
         fi
@@ -1483,7 +1655,7 @@ main() {
 
     # -------------------------------------------------------------------------
     hdr "MACHINE-READABLE SUMMARY"
-    local skipped=0 failed=0
+    local skipped=0 failed=0 blocked=0 unknown=0
     printf 'NFTBAN_MATRIX_CANDIDATE_VERSION=%s\n' "$CANDIDATE_VER"
     printf 'NFTBAN_MATRIX_PRIOR_VERSION=%s\n' "$PRIOR_VER"
     for c in "${CASE_ORDER[@]}"; do
@@ -1492,29 +1664,69 @@ main() {
         if [[ -n "${CASE_NOTE[$c]:-}" ]]; then
             printf 'NFTBAN_MATRIX_NOTE_%s=%s\n' "$c" "${CASE_NOTE[$c]}"
         fi
-        if [[ "$r" == "SKIP" ]]; then skipped=$((skipped + 1)); fi
-        if [[ "$r" == "FAIL" ]]; then failed=$((failed + 1)); fi
+        # A1 (UNINSTALL-PR3) CLOSED-SET AGGREGATION. This counted only SKIP and
+        # FAIL; every other value fell through and the run could still reach
+        # PASS — so a new verdict state would have been counted as NOTHING.
+        # There is no default-success path: unknown => HARNESS_FAILURE.
+        case "$r" in
+            PASS)                ;;
+            FAIL)                failed=$((failed + 1)) ;;
+            SKIP)                skipped=$((skipped + 1)) ;;
+            BLOCKED_ENVIRONMENT) blocked=$((blocked + 1)) ;;
+            NOT_IN_SCOPE)        ;;   # declared exclusion — not a claim, not a gap
+            *)                   unknown=$((unknown + 1))
+                                 printf 'NFTBAN_MATRIX_UNKNOWN_VERDICT_%s=%s\n' "$c" "$r" ;;
+        esac
     done
     printf 'NFTBAN_MATRIX_ASSERTIONS_PASS=%d\n' "$PASS_N"
     printf 'NFTBAN_MATRIX_ASSERTIONS_FAIL=%d\n' "$FAIL_N"
     printf 'NFTBAN_MATRIX_CASES_FAILED=%d\n'   "$failed"
     printf 'NFTBAN_MATRIX_CASES_SKIPPED=%d\n'  "$skipped"
+    printf 'NFTBAN_MATRIX_ASSERTIONS_BLOCKED=%d\n' "$BLOCKED_N"
+    printf 'NFTBAN_MATRIX_CASES_BLOCKED=%d\n'  "$blocked"
+    printf 'NFTBAN_MATRIX_VM_ASSERTIONS_NOT_IN_SCOPE=%d\n' "$VM_NOT_IN_SCOPE_N"
+    if [[ "$VM_ASSERTIONS" == "1" ]]; then
+        printf 'NFTBAN_MATRIX_LAYER=B_VM_AUTHORITATIVE\n'
+        printf 'NFTBAN_MATRIX_CLAIMS_SYSTEMD_AUTHORITY=YES\n'
+    else
+        printf 'NFTBAN_MATRIX_LAYER=A_CONTAINER_PACKAGE_ONLY\n'
+        printf 'NFTBAN_MATRIX_CLAIMS_SYSTEMD_AUTHORITY=NO\n'
+        printf 'NFTBAN_MATRIX_CLAIMS_KERNEL_FIREWALL_AUTHORITY=NO\n'
+    fi
+    printf 'NFTBAN_MATRIX_SCOPE=%s\n'          "${NFTBAN_LIFECYCLE_CASES:-ALL}"
     printf 'NFTBAN_MATRIX_ARTIFACTS=%s\n'      "$WORKDIR"
+    VERDICT_EMITTED=1
 
+    # Taxonomy: PASS=0 · TEST_FAILURE=1 · INCOMPLETE=2 · HARNESS_FAILURE=3
+    if [[ "$unknown" -ne 0 ]]; then
+        printf 'NFTBAN_MATRIX_VERDICT=HARNESS_FAILURE\n'
+        log "RESULT: HARNESS_FAILURE — ${unknown} case(s) carried an unrecognised verdict."
+        return 3
+    fi
     if [[ "$FAIL_N" -ne 0 || "$failed" -ne 0 ]]; then
         printf 'NFTBAN_MATRIX_VERDICT=FAIL\n'
         log "RESULT: FAIL — ${FAIL_N} failed assertions across ${failed} case(s)."
         return 1
     fi
+    # BLOCKED is closure-blocking exactly like SKIP, but labelled separately:
+    # SKIP is "known-not-run"; BLOCKED is "could-not-observe".
+    if [[ "$blocked" -ne 0 ]]; then
+        printf 'NFTBAN_MATRIX_VERDICT=INCOMPLETE\n'
+        printf 'NFTBAN_MATRIX_INCOMPLETE_REASON=BLOCKED_ENVIRONMENT\n'
+        log "RESULT: INCOMPLETE — ${blocked} case(s) could not be OBSERVED (missing systemd/nft"
+        log "        authority). This run establishes nothing about those properties."
+        return 2
+    fi
     if [[ "$skipped" -ne 0 ]]; then
         # A skipped case is NOT a pass. Refuse to report success.
         printf 'NFTBAN_MATRIX_VERDICT=INCOMPLETE\n'
+        printf 'NFTBAN_MATRIX_INCOMPLETE_REASON=SKIP\n'
         log "RESULT: INCOMPLETE — ${skipped} case(s) were skipped; this run does NOT establish"
         log "        the v1.228.0 Item 2 DEB lifecycle contract. Resolve every SKIP and re-run."
         return 2
     fi
     printf 'NFTBAN_MATRIX_VERDICT=PASS\n'
-    log "RESULT: PASS — all ${#CASE_ORDER[@]} cases executed, ${PASS_N} assertions passed."
+    log "RESULT: PASS — scope=${NFTBAN_LIFECYCLE_CASES:-ALL}, ${PASS_N} assertions passed."
     return 0
 }
 

--- a/scripts/ci/tests/lifecycle_rpm_matrix.sh
+++ b/scripts/ci/tests/lifecycle_rpm_matrix.sh
@@ -12,29 +12,104 @@
 # =============================================================================
 set -Eeuo pipefail
 CAND="${1:?usage: lifecycle_rpm_matrix.sh <candidate.rpm> <prior.rpm>}"
-PRIOR="${2:?}"
+PRIOR="${2:-}"
+
+# UNINSTALL-PR3 SCOPE SELECTION (mirrors the DEB matrix NFTBAN_LIFECYCLE_CASES).
+# The REQUIRED closure gate proves package-native REMOVE/PURGE, which needs only
+# the candidate. Upgrade arms need a PUBLISHED prior rpm; binding the merge
+# decision to an external release download would make the gate fail for reasons
+# unrelated to the change under test.
+#
+#   NOT_IN_SCOPE  = deliberately not selected for this run (declared, not hidden)
+#   SKIP          = selected but could not run  -> INCOMPLETE, never a pass
+#
+# Those are DIFFERENT verdicts on purpose: silently dropping a case and being
+# unable to run one must not look alike.
+CASES="${NFTBAN_RPM_CASES:-R1 R2 R3 R4 R7 R8 R11}"
+want() { [[ " $CASES " == *" $1 "* ]]; }
 PKG=nftban-core
 STATE_DIR=/var/lib/nftban/state
 STATE="$STATE_DIR/install_state"
 LOCK="$STATE_DIR/installer.lock"
 W="$(mktemp -d)"; LOCK_PID=""
-P=0; F=0; declare -A R
+P=0; F=0; B=0; declare -A R
+# Sentinel for "observation authority unavailable" (see A2 probes below).
+BLOCKED_TOKEN="BLOCKED_ENVIRONMENT"
 ok(){ echo "[PASS] ${CASE:-PRE}  $1"; P=$((P+1)); }
 bad(){ echo "[FAIL] ${CASE:-PRE}  $1"; F=$((F+1)); R[$CASE]=FAIL; }
 skip(){ echo "[SKIP] ${CASE:-PRE}  $1"; R[$CASE]=SKIP; }
 hdr(){ CASE="$1"; R[$1]="${R[$1]:-PASS}"; printf '\n========== CASE %s: %s ==========\n' "$1" "$2"; }
-eq(){ [[ "$2" == "$1" ]] && ok "$3 (= $1)" || bad "$3 — got '$2', want '$1'"; }
+# A3 (UNINSTALL-PR3): a BLOCKED_ENVIRONMENT observation entering the comparator
+# must never compare as an ordinary string. It is neither a pass (nothing was
+# observed) nor a product FAIL (the product was not the thing that failed).
+blocked(){ echo "[BLOCKED] ${CASE:-PRE}  $1"; B=$((B+1)); R[$CASE]=BLOCKED_ENVIRONMENT; }
+eq(){
+    if [[ "$2" == "$BLOCKED_TOKEN" ]]; then
+        blocked "$3 — observation authority unavailable (wanted '$1'); NOT a product verdict"
+        return 0
+    fi
+    [[ "$2" == "$1" ]] && ok "$3 (= $1)" || bad "$3 — got '$2', want '$1'"
+}
+# LAYER A/B SPLIT (UNINSTALL-PR3). Scope selection is per-CASE, but VM-only
+# assertions live INSIDE container-valid cases. In a container those would go
+# BLOCKED_ENVIRONMENT and make every run permanently INCOMPLETE, which creates
+# pressure to weaken them. Instead Layer A DECLARES them out of scope:
+#   Layer A (container): NFTBAN_MATRIX_VM_ASSERTIONS=0 -> NOT_IN_SCOPE by design
+#   Layer B (systemd VM): default 1 -> in scope; missing authority => BLOCKED
+# Nothing is deleted or weakened — it is scoped, and the scope is printed.
+VM_ASSERTIONS="${NFTBAN_MATRIX_VM_ASSERTIONS:-1}"
+VMNS=0
+eq_vm(){ # want got description   — VM-only (systemd / kernel nftables) assertion
+    if [[ "$VM_ASSERTIONS" != "1" ]]; then
+        echo "[NOT_IN_SCOPE] ${CASE:-PRE}  $3 — VM-only assertion; this environment cannot observe it"
+        VMNS=$((VMNS+1)); return 0
+    fi
+    eq "$1" "$2" "$3"
+}
 tok(){ grep -m1 "^$2=" "$1" 2>/dev/null | cut -d= -f2- || true; }
 sfield(){ [[ -f "$STATE" ]] && (grep -m1 "^$1=" "$STATE" 2>/dev/null | cut -d= -f2-) || true; }
 ver(){ rpm -q --qf '%{VERSION}' "$PKG" 2>/dev/null || true; }
 installed(){ rpm -q "$PKG" >/dev/null 2>&1; }
-unit_state(){ local s; s="$(systemctl is-active "$1" 2>/dev/null | head -1 || true)"; [[ -n "$s" ]] || s=inactive; printf '%s' "$s"; }
-fw(){ nft list table ip nftban >/dev/null 2>&1 && echo present || echo absent; }
+# A2 (UNINSTALL-PR3) TRUTHFUL PROBES.
+#   systemctl unavailable != inactive       nft unavailable != absent
+# These previously collapsed MISSING OBSERVATION AUTHORITY into the negative
+# security state. Removal cases assert `inactive`/`absent`, so in an environment
+# with no systemd or no nft they PASSED having observed nothing. The sentinel
+# below mirrors the DEB nft_table_state() 'nft-absent' template already in-repo.
+#   OBSERVATION_FAILURE MUST NEVER BECOME SECURITY_STATE_EMPTY
+unit_state(){
+    command -v systemctl >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
+    local s; s="$(systemctl is-active "$1" 2>/dev/null | head -1 || true)"
+    # An unreachable manager (no PID1 systemd) is NOT evidence a unit is stopped.
+    if [[ -z "$s" ]]; then
+        systemctl is-system-running >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
+        s=inactive
+    fi
+    printf '%s' "$s"
+}
+fw(){
+    command -v nft >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
+    nft list table ip nftban >/dev/null 2>&1 && echo present || echo absent
+}
 release_lock(){ if [[ -n "$LOCK_PID" ]]; then kill -TERM -"$LOCK_PID" 2>/dev/null || kill -TERM "$LOCK_PID" 2>/dev/null || true
     wait "$LOCK_PID" 2>/dev/null || true; kill -KILL -"$LOCK_PID" 2>/dev/null || true; LOCK_PID=""
     if [[ -e "$LOCK" ]]; then for _ in $(seq 1 20); do flock -n -x "$LOCK" -c true 2>/dev/null && return 0; sleep 1; done
         echo "WARNING: $LOCK still held"; fi; fi; }
-cleanup(){ release_lock; rm -rf "$W"; }
+# A4 (UNINSTALL-PR3) DURABLE F4 CLOSURE. The trap was cleanup-only, so a mid-run
+# `set -e` abort exited with the failing command's rc — 1 or 2 — and printed NO
+# SUMMARY, making a harness crash indistinguishable from a legitimate FAIL or
+# INCOMPLETE. Fixing the single stray `return 0` in R11 closed one instance, not
+# the class. The harness must now PROVE it reached its verdict path.
+VERDICT_EMITTED=0
+cleanup(){
+    local rc=$?
+    release_lock; rm -rf "$W"
+    if [[ "$VERDICT_EMITTED" -ne 1 ]]; then
+        echo "NFTBAN_RPM_MATRIX_VERDICT=HARNESS_FAILURE"
+        echo "NFTBAN_RPM_MATRIX_HARNESS_NOTE=aborted before emitting a verdict (rc=${rc}); this run proves NOTHING"
+        exit 3
+    fi
+}
 trap cleanup EXIT
 
 erase_all(){ dnf -y remove "$PKG" >/dev/null 2>&1 || rpm -e --nodeps "$PKG" >/dev/null 2>&1 || true
@@ -54,35 +129,71 @@ assert_healthy_install(){ # outfile expected_version
     eq COMMITTED "$(sfield INSTALL_STATE)" "persisted INSTALL_STATE"
     eq "$want" "$(sfield INSTALL_VERSION)" "persisted INSTALL_VERSION"
     eq "$want" "$(ver)" "rpm database version"
-    eq active "$(unit_state nftband.service)" "nftband.service"
-    eq active "$(unit_state nftban-maintenance.timer)" "critical timer"
-    eq present "$(fw)" "nftables table ip nftban"
+    eq_vm active "$(unit_state nftband.service)" "nftband.service"
+    eq_vm active "$(unit_state nftban-maintenance.timer)" "critical timer"
+    eq_vm present "$(fw)" "nftables table ip nftban"
     local failed; failed="$(systemctl list-units --state=failed --no-legend 2>/dev/null | grep -c nftban || true)"
     eq 0 "${failed:-0}" "failed NFTBan units"
 }
 
 CAND_VER="$(rpm -qp --qf '%{VERSION}' "$CAND" 2>/dev/null)"
-PRIOR_VER="$(rpm -qp --qf '%{VERSION}' "$PRIOR" 2>/dev/null)"
+PRIOR_VER=""
+[[ -n "$PRIOR" ]] && PRIOR_VER="$(rpm -qp --qf '%{VERSION}' "$PRIOR" 2>/dev/null)"
 echo "===== RPM lifecycle matrix ====="
 echo "candidate : $(rpm -qp --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$CAND")"
-echo "prior     : $(rpm -qp --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$PRIOR")"
-echo "selinux   : $(getenforce)"
-[[ "$(id -u)" -eq 0 ]] || { echo "must run as root"; exit 2; }
-exec 9>/var/lock/nftban-rpm-matrix.lock
-flock -n 9 || { echo "another RPM matrix run holds the lock — refusing"; exit 2; }
+[[ -n "$PRIOR" ]] && echo "prior     : $(rpm -qp --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$PRIOR")" \
+              || echo "prior     : (none supplied — upgrade arms out of scope)"
+echo "selinux   : $(getenforce 2>/dev/null || echo UNKNOWN)"
+# These are ENVIRONMENT preconditions, not harness bugs: emit the canonical
+# verdict so the EXIT trap does not reclassify them as HARNESS_FAILURE.
+blocked_exit(){ # reason
+    echo "NFTBAN_RPM_MATRIX_VERDICT=INCOMPLETE"
+    echo "NFTBAN_RPM_MATRIX_INCOMPLETE_REASON=BLOCKED_ENVIRONMENT"
+    echo "NFTBAN_RPM_MATRIX_BLOCKED_PRECONDITION=$1"
+    VERDICT_EMITTED=1
+    exit 2
+}
+[[ "$(id -u)" -eq 0 ]] || blocked_exit "must run as root"
+# /var/lock is absent from some minimal container images, and the redirect then
+# aborts the run under set -e BEFORE any verdict — correctly reported as
+# HARNESS_FAILURE, but the harness should simply work. Fall back to a writable
+# location rather than skipping the single-instance guard, which is load-bearing:
+# two concurrent destructive runs mutate the same host and every assertion from
+# both becomes void while still printing PASS.
+NFTBAN_RPM_LOCK=/var/lock/nftban-rpm-matrix.lock
+mkdir -p /var/lock 2>/dev/null || NFTBAN_RPM_LOCK="${TMPDIR:-/tmp}/nftban-rpm-matrix.lock"
+exec 9>"$NFTBAN_RPM_LOCK" 2>/dev/null || {
+    NFTBAN_RPM_LOCK="${TMPDIR:-/tmp}/nftban-rpm-matrix.lock"
+    exec 9>"$NFTBAN_RPM_LOCK"
+}
+echo "lockfile  : $NFTBAN_RPM_LOCK"
+flock -n 9 || blocked_exit "another RPM matrix run holds the lock"
 eq nftban-core "$(rpm -qp --qf '%{NAME}' "$CAND")" "candidate package name"
-[[ "$CAND_VER" != "$PRIOR_VER" ]] && ok "candidate $CAND_VER differs from prior $PRIOR_VER" \
-                                  || bad "candidate and prior are both $CAND_VER — R3 would not be an upgrade"
+# Only meaningful when a prior was supplied. With PRIOR empty this compared
+# "$CAND_VER" against "" and emitted a PASS reading "differs from prior " —
+# a green line asserting nothing.
+if [[ -z "$PRIOR" ]]; then
+    echo "[INFO] PRE   no prior rpm supplied — upgrade comparison not applicable"
+elif [[ "$CAND_VER" != "$PRIOR_VER" ]]; then
+    ok "candidate $CAND_VER differs from prior $PRIOR_VER"
+else
+    bad "candidate and prior are both $CAND_VER — R3 would not be an upgrade"
+fi
 
 # ---------------------------------------------------------------- R1
+if want R1; then
 hdr R1 "fresh install (ABSENT -> INSTALL)"
 erase_all
 installed && bad "precondition: package still installed" || ok "precondition: ABSENT"
 o="$W/r1.txt"; rc="$(inst "$CAND" "$o")"
 eq 0 "$rc" "dnf transaction rc"
 assert_healthy_install "$o" "$CAND_VER"
+else
+  R[R1]="NOT_IN_SCOPE"
+fi
 
 # ---------------------------------------------------------------- R2
+if want R2; then
 hdr R2 "same-version reinstall ($CAND_VER -> $CAND_VER)"
 if ! installed; then skip "R2 needs an installed package"; else
   t_before="$(sfield INSTALL_TIMESTAMP)"; start="$(date -u +%s)"
@@ -97,8 +208,12 @@ if ! installed; then skip "R2 needs an installed package"; else
       bad "state timestamp did not advance: before=$t_before after=$t_after"
   fi
 fi
+else
+  R[R2]="NOT_IN_SCOPE"
+fi
 
 # ---------------------------------------------------------------- R3
+if want R3; then
 hdr R3 "upgrade (published $PRIOR_VER -> candidate $CAND_VER)"
 erase_all
 o="$W/r3_prior.txt"; rc="$(inst "$PRIOR" "$o")"
@@ -109,8 +224,12 @@ if [[ "$rc" -ne 0 ]] || ! installed; then skip "could not install the published 
   eq "$CAND_VER" "$(ver)" "rpm database advanced to candidate"
   assert_healthy_install "$o" "$CAND_VER"
 fi
+else
+  R[R3]="NOT_IN_SCOPE"
+fi
 
 # ---------------------------------------------------------------- R4  (T8)
+if want R4; then
 hdr R4 "package-level T8 — lock contention over a same-version prior COMMITTED"
 if [[ "$(sfield INSTALL_STATE)" != "COMMITTED" || "$(sfield INSTALL_VERSION)" != "$CAND_VER" ]]; then
   skip "no SAME-VERSION prior COMMITTED (state=$(sfield INSTALL_STATE) version=$(sfield INSTALL_VERSION))"
@@ -134,8 +253,12 @@ else
     eq "$t_before" "$(sfield INSTALL_TIMESTAMP)" "install_state untouched by a transaction that never began"
   fi
 fi
+else
+  R[R4]="NOT_IN_SCOPE"
+fi
 
 # ---------------------------------------------------------------- R7
+if want R7; then
 hdr R7 "erase"
 if ! installed; then
   erase_all; o="$W/r7_pre.txt"; inst "$CAND" "$o" >/dev/null
@@ -144,8 +267,8 @@ if ! installed; then skip "R7 needs an installed package"; else
   o="$W/r7.txt"; rc=0; dnf -y remove "$PKG" >"$o" 2>&1 || rc=$?
   eq 0 "$rc" "dnf remove rc"
   installed && bad "package still in the rpm database after erase" || ok "package removed from the rpm database"
-  eq inactive "$(unit_state nftband.service)" "nftband.service after erase"
-  eq inactive "$(unit_state nftban-maintenance.timer)" "critical timer after erase"
+  eq_vm inactive "$(unit_state nftband.service)" "nftband.service after erase"
+  eq_vm inactive "$(unit_state nftban-maintenance.timer)" "critical timer after erase"
   # Item 2 must not leak install-verification tokens into a removal.
   if grep -qE 'NFTBAN_(PACKAGE_POSTINSTALL_VERIFIED|INSTALL_ATTEMPT_VERDICT|PACKAGE_INSTALLER_EXIT)=' "$o"; then
       bad "removal emitted install-verification tokens — a removal is not an install outcome"
@@ -157,9 +280,51 @@ if ! installed; then skip "R7 needs an installed package"; else
   else
       ok "removal makes no CURRENT_COMMITTED claim"
   fi
+
+  # ---- D1 (UNINSTALL-PR2) PACKAGE-NATIVE PROOF -----------------------------
+  # `dnf remove` IS the $1 -eq 0 path (rpm has no purge verb), so this is the
+  # STANDARD remove. It must preserve operator state, matching DEB `remove)`.
+  # Until PR3 wired this matrix into CI, D1 was only SOURCE_PROVEN.
+  for _d in /etc/nftban /var/lib/nftban /var/log/nftban; do
+      [[ -d "$_d" ]] && ok "D1: $_d PRESERVED by standard remove" \
+                     || bad "D1: $_d DESTROYED by standard remove — remove is not purge"
+  done
+
+  # ---- D3 PACKAGE-NATIVE PROOF: preserved must also be LOADER-VISIBLE ------
+  # BYTES_PRESERVED != FUNCTIONAL_STATE_PRESERVED. Every loader globs
+  # whitelist.d/*.conf, so a file rpm renamed to .rpmsave is present but dead.
+  for _l in whitelist blacklist; do
+      _f="/etc/nftban/${_l}.d/99-manual.conf"
+      if [[ -f "$_f" ]]; then
+          ok "D3: ${_l}.d/99-manual.conf survives erase under its LOADED name"
+      else
+          _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1)"
+          if [[ -n "$_side" ]]; then
+              bad "D3: operator config survives only as ${_side} — present but INVISIBLE to the *.conf loader"
+          else
+              bad "D3: ${_l}.d/99-manual.conf absent after erase"
+          fi
+      fi
+  done
+  # No package-manager sidecar may be produced for operator state at all.
+  _sides="$(find /etc/nftban -name '*.rpmsave' -o -name '*.rpmnew' 2>/dev/null | head -5)"
+  [[ -z "$_sides" ]] && ok "D3: erase produced no .rpmsave/.rpmnew under /etc/nftban" \
+                     || bad "D3: package manager still owns config — sidecars: ${_sides//$'\n'/ }"
+
+  # ---- D5 PACKAGE-NATIVE PROOF: disclosure, and no unobserved claim --------
+  grep -qF 'no longer protects this host' "$o" \
+      && ok "D5: removal states NFTBan no longer protects this host" \
+      || bad "D5: removal did not disclose loss of protection"
+  grep -qF 'were NOT modified and may still be active' "$o" \
+      && bad "D5: removal asserts an UNOBSERVED other-firewall state" \
+      || ok "D5: removal makes no unobserved other-firewall claim"
+fi
+else
+  R[R7]="NOT_IN_SCOPE"
 fi
 
 # ---------------------------------------------------------------- R8
+if want R8; then
 hdr R8 "reinstall after erase"
 if installed; then skip "R8 needs the package erased first"; else
   before_state="$(sfield INSTALL_STATE)"; before_ts="$(sfield INSTALL_TIMESTAMP)"
@@ -176,8 +341,12 @@ if installed; then skip "R8 needs the package erased first"; else
       bad "state timestamp $t_after predates this transaction — stale state reused"
   fi
 fi
+else
+  R[R8]="NOT_IN_SCOPE"
+fi
 
 # ---------------------------------------------------------------- R11
+if want R11; then
 hdr R11 "no-installer path — %post AS SHIPPED, installer missing"
 scr="$W/post.sh"
 rpm -qp --scripts "$CAND" 2>/dev/null | awk '/^postinstall scriptlet/{f=1;next} /^post(un|trans)/{f=0} f' > "$scr" || true
@@ -188,34 +357,86 @@ if [[ ! -s "$scr" ]]; then skip "could not extract %post from the package"; else
   # installer and "passed" for entirely the wrong reason. Rewrite the assignment
   # in the extracted text instead, exactly as the DEB harness rewrites paths.
   sed -i 's#^NFTBAN_INSTALLER=.*#NFTBAN_INSTALLER="/nonexistent/nftban-installer"#' "$scr"
-  if grep -q '^NFTBAN_INSTALLER="/nonexistent/nftban-installer"' "$scr"; then
-      ok "injection: extracted %post now points at a nonexistent installer"
-  else
+  # F4 (UNINSTALL-PR3): this branch used to `return 0` at TOP LEVEL. bash rejects
+  # that outside a function ("can only 'return' from a function or sourced
+  # script") and under `set -Eeuo pipefail` the script ABORTS with rc=2 — which
+  # is this matrix's own INCOMPLETE code, so a harness crash was indistinguishable
+  # from a legitimate INCOMPLETE verdict, with no SUMMARY block printed at all.
+  # Restructured so the rest of R11 is genuinely conditional instead.
+  if ! grep -q '^NFTBAN_INSTALLER="/nonexistent/nftban-installer"' "$scr"; then
       skip "could not redirect NFTBAN_INSTALLER in the extracted %post"
-      return 0
-  fi
-  o="$W/r11.txt"
-  ( set +e; INSTALL_MODE=install sh -e "$scr" 1 >"$o" 2>&1; echo "rc=$?" >>"$o" ) || true
-  eq 127 "$(tok "$o" NFTBAN_PACKAGE_INSTALLER_EXIT)" "NFTBAN_PACKAGE_INSTALLER_EXIT"
-  eq 127 "$(tok "$o" NFTBAN_PACKAGE_VERIFY_EXIT)"    "NFTBAN_PACKAGE_VERIFY_EXIT"
-  eq NO  "$(tok "$o" NFTBAN_PACKAGE_POSTINSTALL_VERIFIED)" "POSTINSTALL_VERIFIED"
-  if grep -qE 'NFTBAN_INSTALL_ATTEMPT_VERDICT=' "$o"; then
-      bad "canonical state token emitted though the verifier never ran"
   else
-      ok "no canonical state token — the installer never ran, so no state was interpreted"
+      ok "injection: extracted %post now points at a nonexistent installer"
+      o="$W/r11.txt"
+      ( set +e; INSTALL_MODE=install sh -e "$scr" 1 >"$o" 2>&1; echo "rc=$?" >>"$o" ) || true
+      eq 127 "$(tok "$o" NFTBAN_PACKAGE_INSTALLER_EXIT)" "NFTBAN_PACKAGE_INSTALLER_EXIT"
+      eq 127 "$(tok "$o" NFTBAN_PACKAGE_VERIFY_EXIT)"    "NFTBAN_PACKAGE_VERIFY_EXIT"
+      eq NO  "$(tok "$o" NFTBAN_PACKAGE_POSTINSTALL_VERIFIED)" "POSTINSTALL_VERIFIED"
+      if grep -qE 'NFTBAN_INSTALL_ATTEMPT_VERDICT=' "$o"; then
+          bad "canonical state token emitted though the verifier never ran"
+      else
+          ok "no canonical state token — the installer never ran, so no state was interpreted"
+      fi
   fi
 fi
 
 echo
+else
+  R[R11]="NOT_IN_SCOPE"
+fi
+
 echo "===== SUMMARY ====="
-skipped=0; failed=0
+# A1 (UNINSTALL-PR3) CLOSED-SET AGGREGATION. This loop previously counted only
+# SKIP and FAIL; every other value fell through and the run reached PASS. A new
+# verdict state would therefore have been counted as NOTHING. There is no
+# default-success path any more: an unrecognised verdict is a HARNESS_FAILURE.
+skipped=0; failed=0; blocked=0; unknown=0
 for c in R1 R2 R3 R4 R7 R8 R11; do
   v="${R[$c]:-SKIP}"; echo "NFTBAN_RPM_MATRIX_RESULT_${c}=${v}"
-  [[ "$v" == SKIP ]] && skipped=$((skipped+1)); [[ "$v" == FAIL ]] && failed=$((failed+1))
+  case "$v" in
+    PASS)                ;;
+    FAIL)                failed=$((failed+1)) ;;
+    SKIP)                skipped=$((skipped+1)) ;;
+    BLOCKED_ENVIRONMENT) blocked=$((blocked+1)) ;;
+    NOT_IN_SCOPE)        ;;   # declared exclusion — not a claim, not a gap
+    *)                   unknown=$((unknown+1))
+                         echo "NFTBAN_RPM_MATRIX_UNKNOWN_VERDICT_${c}=${v}" ;;
+  esac
 done
+echo "NFTBAN_RPM_MATRIX_SCOPE=${CASES// /,}"
 echo "NFTBAN_RPM_MATRIX_ASSERTIONS_PASS=$P"
 echo "NFTBAN_RPM_MATRIX_ASSERTIONS_FAIL=$F"
-echo "NFTBAN_RPM_MATRIX_ENVIRONMENT=STOCK_ENFORCING_$(getenforce)"
+echo "NFTBAN_RPM_MATRIX_ASSERTIONS_BLOCKED=$B"
+echo "NFTBAN_RPM_MATRIX_VM_ASSERTIONS_NOT_IN_SCOPE=$VMNS"
+# A Layer A PASS must never read as systemd/kernel validation.
+if [[ "$VM_ASSERTIONS" == "1" ]]; then
+  echo "NFTBAN_RPM_MATRIX_LAYER=B_VM_AUTHORITATIVE"
+  echo "NFTBAN_RPM_MATRIX_CLAIMS_SYSTEMD_AUTHORITY=YES"
+else
+  echo "NFTBAN_RPM_MATRIX_LAYER=A_CONTAINER_PACKAGE_ONLY"
+  echo "NFTBAN_RPM_MATRIX_CLAIMS_SYSTEMD_AUTHORITY=NO"
+  echo "NFTBAN_RPM_MATRIX_CLAIMS_KERNEL_FIREWALL_AUTHORITY=NO"
+fi
+echo "NFTBAN_RPM_MATRIX_CASES_BLOCKED=$blocked"
+echo "NFTBAN_RPM_MATRIX_ENVIRONMENT=STOCK_ENFORCING_$(getenforce 2>/dev/null || echo UNKNOWN)"
+VERDICT_EMITTED=1
+# Taxonomy: PASS=0 · TEST_FAILURE=1 · INCOMPLETE=2 · HARNESS_FAILURE=3
+if [[ "$unknown" -gt 0 ]]; then
+  echo "NFTBAN_RPM_MATRIX_VERDICT=HARNESS_FAILURE"
+  echo "NFTBAN_RPM_MATRIX_HARNESS_NOTE=${unknown} case(s) carried an unrecognised verdict"
+  exit 3
+fi
 if [[ "$failed" -gt 0 ]]; then echo "NFTBAN_RPM_MATRIX_VERDICT=FAIL"; exit 1; fi
-if [[ "$skipped" -gt 0 ]]; then echo "NFTBAN_RPM_MATRIX_VERDICT=INCOMPLETE"; exit 2; fi
+# BLOCKED is closure-blocking exactly like SKIP, but labelled separately: SKIP is
+# "known-not-run", BLOCKED is "could-not-observe".
+if [[ "$blocked" -gt 0 ]]; then
+  echo "NFTBAN_RPM_MATRIX_VERDICT=INCOMPLETE"
+  echo "NFTBAN_RPM_MATRIX_INCOMPLETE_REASON=BLOCKED_ENVIRONMENT"
+  exit 2
+fi
+if [[ "$skipped" -gt 0 ]]; then
+  echo "NFTBAN_RPM_MATRIX_VERDICT=INCOMPLETE"
+  echo "NFTBAN_RPM_MATRIX_INCOMPLETE_REASON=SKIP"
+  exit 2
+fi
 echo "NFTBAN_RPM_MATRIX_VERDICT=PASS"; exit 0


### PR DESCRIPTION
Implements Fable's review with all six bounded amendments. `FABLE_REVIEW = ADOPTED`.

## The defect class

Removal cases assert **negative** states (`inactive`, `absent`). Three probes returned exactly
those values when the tool was missing, so with no systemd or no nft the assertion **passed having
observed nothing**.

| Assertion direction | No systemd/nft | Risk |
|---|---|---|
| positive (`active`, `present`) | fails loudly | safe |
| **negative** (`inactive`, `absent`) | **passes** | **silent false closure** |

> `OBSERVATION_FAILURE MUST NEVER BECOME SECURITY_STATE_EMPTY`

Two problems were worse than the probes: aggregation counted only `SKIP`+`FAIL`, so any other
verdict fell through to **PASS** — a new state would be counted as *nothing*; and both EXIT traps
were cleanup-only, so a `set -e` abort exited rc 1/2 with **no SUMMARY**, indistinguishable from a
real verdict. The earlier `return 0` fix closed one instance, not the class.

## Frozen taxonomy

```
PASS 0 · TEST_FAILURE 1 · INCOMPLETE 2 · HARNESS_FAILURE 3
PASS · FAIL · SKIP · BLOCKED_ENVIRONMENT · NOT_IN_SCOPE
```

`BLOCKED_ENVIRONMENT` is closure-blocking like `SKIP` but labelled separately — SKIP is
*known-not-run*, BLOCKED is *could-not-observe*. `NOT_IN_SCOPE` is a declared exclusion and blocks
nothing. Unknown verdict → `HARNESS_FAILURE`, never fall-through.

## Amendments

| # | Correction |
|---|---|
| **A1** | exhaustive `case` over 5 states in both matrices; `*)` → HARNESS_FAILURE. No default-success path. |
| **A2** | probes guard on `command -v` **and** manager reachability, mirroring DEB's `nft_table_state` — the one probe that already fail-closed. |
| **A3** | comparators short-circuit the sentinel: never a pass, never a product FAIL. |
| **A4** | `VERDICT_EMITTED` set on the verdict path; trap synthesises HARNESS_FAILURE + exit 3 when unset. |
| **A5** | DEB gains RPM's scope selection; unselected cases → `NOT_IN_SCOPE` (they were `SKIP`, so **every subset run was permanently INCOMPLETE**). |
| **A6** | DEB `nft-absent` normalised onto the shared sentinel instead of surfacing as a product defect. |

## Layer split, applied per-assertion

Scope selection is per-*case*, but VM-only assertions live **inside** container-valid cases — so
case-level scoping alone would leave them BLOCKED and make every container run INCOMPLETE. The
split is therefore applied at assertion granularity via `eq_vm` / `assert_eq_vm`:

```
Layer A (container)  systemd/kernel assertions = NOT_IN_SCOPE BY DESIGN
Layer B (systemd VM) same assertions = IN_SCOPE; missing authority => BLOCKED_ENVIRONMENT
```

One source, nothing deleted or weakened — scoped, and the scope is printed. Layer A emits
`CLAIMS_SYSTEMD_AUTHORITY=NO` and `CLAIMS_KERNEL_FIREWALL_AUTHORITY=NO`, and **the CI step fails if
that disclaimer is missing**, so a container PASS cannot be read as VM proof.

> `CONTAINER_PACKAGE_PASS != SYSTEMD_VM_PASS`

## F-fixes (environment-independent)

`F1` `absent` no longer passes a remove case — it was accepted alongside `rc`, the one bit
distinguishing remove from purge. `F2` install state destroyed by a **failed** removal is a defect,
not "recorded". `F3` a stale-claim probe with missing inputs records a SKIP instead of returning 0
silently. Both matrices also gained the D1/D3/D5 package-native assertions, including that
preserved config is **loader-visible under its own name**, not merely byte-present.

## Falsifiability — 36 assertions, every negative control has a positive twin

Two controls initially reported **false passes** and were repaired:

- **NC4** exercised a *replica* of the aggregator instead of the shipped `case` block — mutating the
  real matrix changed nothing. Now extracts and executes the shipped classifier.
- **NC5** used a file-wide substring that matched `NOT_IN_SCOPE` **in the aggregator** even while the
  selection site still assigned `SKIP`. Now binds to the deciding line.

> `TESTING A REPLICA != TESTING THE CODE` · `GUARD SUBJECT == GUARD INPUT`

Five inversions against production matrices, sha-witnessed, all restored to baseline:

```
A2-RPM full pre-fix unit probe  5b8a2dc216df -> fd3b5148a635  rc=1 caught
A2-DEB full pre-fix unit probe  1b0602ebed74 -> a07333b4c3f5  rc=1 caught
A1-RPM default-success restored 5b8a2dc216df -> dffc39b235f3  rc=1 caught
A1-DEB default-success restored 1b0602ebed74 -> 6a6319ef4a90  rc=1 caught
A5-DEB unselected back to SKIP  1b0602ebed74 -> d913dd6ed540  rc=1 caught
```

Live proof of A4 against the real matrix: an unreadable candidate previously died at `rc=1` with no
output; it now emits `VERDICT=HARNESS_FAILURE` and exits **3**. Non-root now yields `INCOMPLETE`
with `BLOCKED_PRECONDITION=must run as root` rather than tripping the harness trap.

## Closure position — unchanged

```
LAYER A = container package-native remove/purge -> RUNS
LAYER B = systemd VM, full contract             -> NOT YET RUN
UNINSTALL_LIFECYCLE_DEBT_FREE = NO
PACKAGE_NATIVE_CLOSURE        = NO
```

The new job runs on every PR and is **deliberately not made a required check** — that is a
branch-protection change, not a code change. Exact status-check name reported once it has run.

Review preserved as `NFTBAN_ROADMAP/UNINSTALL_PR3_OBSERVATION_SEMANTICS_REVIEW_2026_08_12.md`.
