### PR TITLE
fix(tests): two matrix defects that only a real systemd VM could expose

### DIFF
--- a/scripts/ci/tests/lifecycle_deb_matrix.sh
+++ b/scripts/ci/tests/lifecycle_deb_matrix.sh
@@ -1098,7 +1098,8 @@ case_L7() {
         if [[ -f "$_f" ]]; then
             assert 0 "D3: ${_l}.d/99-manual.conf survives remove under its LOADED name"
         else
-            _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1)"
+            # See the RPM twin: an absent directory must not abort the matrix.
+            _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1 || true)"
             if [[ -n "$_side" ]]; then
                 assert 1 "D3: operator config survives only as ${_side} — present but INVISIBLE to the *.conf loader"
             else

--- a/scripts/ci/tests/lifecycle_rpm_matrix.sh
+++ b/scripts/ci/tests/lifecycle_rpm_matrix.sh
@@ -298,7 +298,12 @@ if ! installed; then skip "R7 needs an installed package"; else
       if [[ -f "$_f" ]]; then
           ok "D3: ${_l}.d/99-manual.conf survives erase under its LOADED name"
       else
-          _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1)"
+          # `|| true` is load-bearing: find exits non-zero when the directory is
+          # absent, and under `set -Eeuo pipefail` the ASSIGNMENT inherits that
+          # status and aborts the whole matrix mid-case — reported (correctly) as
+          # HARNESS_FAILURE, but the arm never runs. A missing directory is a
+          # legitimate observation here, not a harness error.
+          _side="$(find "/etc/nftban/${_l}.d" -maxdepth 1 -name '99-manual.conf.*' 2>/dev/null | head -1 || true)"
           if [[ -n "$_side" ]]; then
               bad "D3: operator config survives only as ${_side} — present but INVISIBLE to the *.conf loader"
           else
@@ -307,9 +312,22 @@ if ! installed; then skip "R7 needs an installed package"; else
       fi
   done
   # No package-manager sidecar may be produced for operator state at all.
-  _sides="$(find /etc/nftban -name '*.rpmsave' -o -name '*.rpmnew' 2>/dev/null | head -5)"
-  [[ -z "$_sides" ]] && ok "D3: erase produced no .rpmsave/.rpmnew under /etc/nftban" \
-                     || bad "D3: package manager still owns config — sidecars: ${_sides//$'\n'/ }"
+  # SCOPE OF THIS ASSERTION. D3's contract is that OPERATOR STATE must not be
+  # package-owned. It does NOT forbid rpm's normal handling of genuinely
+  # package-owned config: /etc/nftban/nftables.conf is %config(noreplace)
+  # (build_nftban.sh) — a rendered template the package replaces on reinstall —
+  # so a .rpmsave for it on erase is CORRECT rpm behaviour, not a D3 violation.
+  # A blanket "no .rpmsave anywhere" arm asserted something D3 never claimed and
+  # failed on standard packaging semantics. Narrowed to the operator-state dirs,
+  # where a sidecar WOULD prove the package owns operator state.
+  _opsides="$(find /etc/nftban/whitelist.d /etc/nftban/blacklist.d \
+                   \( -name '*.rpmsave' -o -name '*.rpmnew' \) 2>/dev/null | head -5 || true)"
+  [[ -z "$_opsides" ]] && ok "D3: no .rpmsave/.rpmnew in the operator-state dirs (whitelist.d/blacklist.d)" \
+                       || bad "D3: package manager still owns OPERATOR state — sidecars: ${_opsides//$'\n'/ }"
+  # Package-owned config sidecars are reported, never failed: visibility without
+  # a false verdict.
+  _pkgsides="$(find /etc/nftban -maxdepth 1 \( -name '*.rpmsave' -o -name '*.rpmnew' \) 2>/dev/null | head -5 || true)"
+  [[ -n "$_pkgsides" ]] && echo "[INFO] $CASE  package-owned config sidecars (expected rpm semantics): ${_pkgsides//$'\n'/ }"
 
   # ---- D5 PACKAGE-NATIVE PROOF: disclosure, and no unobserved claim --------
   grep -qF 'no longer protects this host' "$o" \


### PR DESCRIPTION
Two harness defects found by running the **full RPM matrix on a real systemd VM** — AlmaLinux 9.8,
systemd 252 PID1, nft 1.0.9, SELinux **Enforcing**. Neither was reachable from Layer A.

## 1. A missing directory aborted the entire run

The D3 assertions read `_side="$(find "/etc/nftban/${_l}.d" … )"`. `find` exits non-zero when the
directory is absent, the command substitution inherits that status, and under `set -Eeuo pipefail`
the **assignment** aborts the matrix mid-case.

It surfaced as `HARNESS_FAILURE` / exit 3 — the A4 sentinel doing precisely its job, an honest
*"this run proves NOTHING"* rather than a silent `rc=1` — but the arm never executed. In a
container `/etc/nftban` always existed, so the path was never taken.

`|| true` is correct here because **directory absence is data being inspected**, not a harness
error. It is not a blanket suppression.

## 2. The D3 sidecar assertion overreached

It forbade any `.rpmsave`/`.rpmnew` anywhere under `/etc/nftban`, and failed on
`/etc/nftban/nftables.conf.rpmsave`.

That file is `%config(noreplace)` (`build_nftban.sh:1904`) — **package-owned by design**, a rendered
template the package replaces on reinstall. rpm saving it on erase is correct behaviour, not a D3
violation. D3's contract is that **operator** state must not be package-owned, and that half passed
cleanly: `whitelist.d/99-manual.conf` and `blacklist.d/99-manual.conf` both survived erase under
their **loaded** names with no sidecar.

Narrowed to the operator-state directories, where a sidecar genuinely would prove the package owns
operator state. Package-owned sidecars are now reported as `[INFO]` rather than failing. This is
narrowing to the actual contract, **not** weakening — the arm still catches a planted
`99-manual.conf.rpmsave` (falsified).

## Layer B RPM result after these fixes

```
R1 R2 R3 R4 R7 R8 R11 = PASS
ASSERTIONS_PASS=89  FAIL=0  BLOCKED=0
VM_ASSERTIONS_NOT_IN_SCOPE=0
LAYER=B_VM_AUTHORITATIVE   CLAIMS_SYSTEMD_AUTHORITY=YES
ENVIRONMENT=STOCK_ENFORCING_Enforcing
VERDICT=PASS
```

Upgrade arms ran against the **real published v1.228.10** → candidate `1.228.11`. systemd and
kernel nftables assertions were genuinely observed, not inferred.

## Incidental real-world confirmation of D5

On the fixture, `dnf remove nftban-core` altered **14 packages** and took `nftables` itself with it
(`dnf history` evidence). That is exactly the cascade the D5 removal message now discloses —
observed live, unplanned.
