### PR TITLE
fix(release,tests): a dry run must not delete a live release, and zero observations must not pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,15 @@ jobs:
           echo "=== All packages ==="
           ls -lh dist/packages/
 
+      # A1: this step DELETES assets from the release named by $REF. It had no
+      # guard, and on a workflow_dispatch $REF resolves from the VERSION file — so
+      # once a release for the current VERSION exists, a publish=false "dry run"
+      # would delete that live release's assets. The v1.228.12 dry run only
+      # no-op'd because the release did not exist yet: TIMING, NOT A GUARD.
+      # Same condition as the publish steps below.
+      #   DRY_RUN MUST NOT MUTATE A PUBLISHED RELEASE
       - name: Clean up old release assets
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/ci/tests/lifecycle_deb_matrix.sh
+++ b/scripts/ci/tests/lifecycle_deb_matrix.sh
@@ -342,6 +342,10 @@ nft_table_state() { # family name
 }
 
 failed_nftban_units() {
+    # A8 (twin of the RPM probe): without this guard a missing systemctl yields
+    # empty output, which is exactly the value the caller asserts as "no failed
+    # units" — a pass with nothing observed. Emits the shared sentinel instead.
+    command -v systemctl >/dev/null 2>&1 || { printf '%s' "$BLOCKED_TOKEN"; return 0; }
     systemctl list-units --state=failed --no-legend --plain 2>/dev/null \
         | awk '{print $1}' | grep -E '^(nftban|nftband)' || true
 }
@@ -415,7 +419,7 @@ assert_runtime_healthy() {
         "emergency SSH table removed (assertions.go:279 no_emergency_table)"
     local failed
     failed="$(failed_nftban_units | tr '\n' ' ' | sed 's/ *$//')"
-    assert_eq "" "$failed" "zero failed NFTBan systemd units"
+    assert_eq_vm "" "$failed" "zero failed NFTBan systemd units"
 }
 
 assert_validate_ok() {
@@ -1699,6 +1703,22 @@ main() {
     VERDICT_EMITTED=1
 
     # Taxonomy: PASS=0 · TEST_FAILURE=1 · INCOMPLETE=2 · HARNESS_FAILURE=3
+    # A9 ASSERTION FLOOR (twin of the RPM guard): a scope token matching no known
+    # case left every counter at zero and reached PASS having asserted NOTHING.
+    #   ZERO ASSERTIONS IS NOT A PASS
+    if [[ "$PASS_N" -eq 0 && "$FAIL_N" -eq 0 ]]; then
+        printf 'NFTBAN_MATRIX_VERDICT=HARNESS_FAILURE\n'
+        printf 'NFTBAN_MATRIX_HARNESS_NOTE=zero assertions executed (scope=%s); a requested case may not exist\n' "${NFTBAN_LIFECYCLE_CASES:-ALL}"
+        return 3
+    fi
+    local _want
+    for _want in ${NFTBAN_LIFECYCLE_CASES:-}; do
+        if [[ " ${CASE_ORDER[*]} " != *" $_want "* ]]; then
+            printf 'NFTBAN_MATRIX_VERDICT=HARNESS_FAILURE\n'
+            printf 'NFTBAN_MATRIX_HARNESS_NOTE=requested case %s is not a known case\n' "$_want"
+            return 3
+        fi
+    done
     if [[ "$unknown" -ne 0 ]]; then
         printf 'NFTBAN_MATRIX_VERDICT=HARNESS_FAILURE\n'
         log "RESULT: HARNESS_FAILURE — ${unknown} case(s) carried an unrecognised verdict."

--- a/scripts/ci/tests/lifecycle_rpm_matrix.sh
+++ b/scripts/ci/tests/lifecycle_rpm_matrix.sh
@@ -25,7 +25,10 @@ PRIOR="${2:-}"
 #
 # Those are DIFFERENT verdicts on purpose: silently dropping a case and being
 # unable to run one must not look alike.
-CASES="${NFTBAN_RPM_CASES:-R1 R2 R3 R4 R7 R8 R11}"
+# ONE canonical case list: the default scope AND the scope validator below both
+# derive from it, so a case added/renamed here cannot drift from either.
+ALL_CASES="R1 R2 R3 R4 R7 R8 R11"
+CASES="${NFTBAN_RPM_CASES:-$ALL_CASES}"
 want() { [[ " $CASES " == *" $1 "* ]]; }
 PKG=nftban-core
 STATE_DIR=/var/lib/nftban/state
@@ -132,8 +135,20 @@ assert_healthy_install(){ # outfile expected_version
     eq_vm active "$(unit_state nftband.service)" "nftband.service"
     eq_vm active "$(unit_state nftban-maintenance.timer)" "critical timer"
     eq_vm present "$(fw)" "nftables table ip nftban"
-    local failed; failed="$(systemctl list-units --state=failed --no-legend 2>/dev/null | grep -c nftban || true)"
-    eq 0 "${failed:-0}" "failed NFTBan units"
+    # A8: this probe was the one survivor of the BLOCKED_ENVIRONMENT conversion —
+    # the three lines above use eq_vm, this used bare `eq`. Four traps stacked:
+    # a missing systemctl yields empty output, 2>/dev/null hides the very failure
+    # that is the subject, `grep -c` returns 0 for no-match which IS the pass
+    # value, and it was not VM-scoped. In an environment without systemd it
+    # PASSED having observed nothing, and counted into ASSERTIONS_PASS.
+    local failed
+    if ! command -v systemctl >/dev/null 2>&1; then
+        failed="$BLOCKED_TOKEN"
+    else
+        failed="$(systemctl list-units --state=failed --no-legend 2>/dev/null | grep -c nftban || true)"
+        [[ -n "$failed" ]] || failed=0
+    fi
+    eq_vm 0 "${failed}" "failed NFTBan units"
 }
 
 CAND_VER="$(rpm -qp --qf '%{VERSION}' "$CAND" 2>/dev/null)"
@@ -439,6 +454,27 @@ echo "NFTBAN_RPM_MATRIX_CASES_BLOCKED=$blocked"
 echo "NFTBAN_RPM_MATRIX_ENVIRONMENT=STOCK_ENFORCING_$(getenforce 2>/dev/null || echo UNKNOWN)"
 VERDICT_EMITTED=1
 # Taxonomy: PASS=0 · TEST_FAILURE=1 · INCOMPLETE=2 · HARNESS_FAILURE=3
+# A9 ASSERTION FLOOR. NOT_IN_SCOPE is correctly non-blocking, but nothing
+# required that ANY case actually ran. A scope token matching no known case —
+# a typo, or a case renamed while the workflow still names the old id — left
+# every counter at zero and reached VERDICT=PASS having asserted NOTHING.
+#   ZERO ASSERTIONS IS NOT A PASS
+# It is a harness failure, not a product verdict: the run could not have
+# observed the product either way.
+if [[ "$P" -eq 0 && "$F" -eq 0 ]]; then
+  echo "NFTBAN_RPM_MATRIX_VERDICT=HARNESS_FAILURE"
+  echo "NFTBAN_RPM_MATRIX_HARNESS_NOTE=zero assertions executed (scope='${CASES}'); a requested case may not exist"
+  VERDICT_EMITTED=1
+  exit 3
+fi
+# Every requested token must resolve to a real case, or the scope is a typo.
+for _want in $CASES; do
+  if [[ " $ALL_CASES " != *" $_want "* ]]; then
+    echo "NFTBAN_RPM_MATRIX_VERDICT=HARNESS_FAILURE"
+    echo "NFTBAN_RPM_MATRIX_HARNESS_NOTE=requested case '${_want}' is not a known case"
+    VERDICT_EMITTED=1; exit 3
+  fi
+done
 if [[ "$unknown" -gt 0 ]]; then
   echo "NFTBAN_RPM_MATRIX_VERDICT=HARNESS_FAILURE"
   echo "NFTBAN_RPM_MATRIX_HARNESS_NOTE=${unknown} case(s) carried an unrecognised verdict"


### PR DESCRIPTION
Three defects from the post-`v1.228.12` reliability audit. **None affects the published `v1.228.12`
artifacts** — that release stays `CLOSED`. All three are armed for the *next* run.

## A1 — a "dry run" could delete a published release's assets

`release.yml`'s **"Clean up old release assets"** step deletes every asset from the release named by
`$REF`, and had **no `if:` guard**. On a `workflow_dispatch`, `$REF` resolves from the `VERSION`
file — so once a release exists for the current `VERSION`, a `publish=false` dry run would delete
that live release's assets.

> The `v1.228.12` dry run only no-op'd because the release did not exist yet. **Timing, not a guard.**
> Run record `31691448941` shows the step executing and printing `Deleting: nftban-el9-x86_64.rpm`.

Now carries the condition the publish steps already use — no new expression invented:

```
${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
```

| path | step runs |
|---|---|
| dry-run `publish=false` | **False** |
| dispatch `publish=true` | True |
| tag push | True |

## A8 — the one probe the `BLOCKED_ENVIRONMENT` conversion missed

Three adjacent lines in `assert_healthy_install` use `eq_vm`; the failed-units probe used bare `eq`:

```
systemctl list-units --state=failed --no-legend 2>/dev/null | grep -c nftban || true
```

Four traps stack in one line — a missing `systemctl` gives empty output; `2>/dev/null` hides the
failure that **is** the subject; `grep -c` returns `0` for no-match, which is the **pass value**; and
it was not VM-scoped. Without systemd it **passed having observed nothing** and counted into
`ASSERTIONS_PASS`, in runs that simultaneously print `CLAIMS_SYSTEMD_AUTHORITY=NO`.

DEB twin identical: `failed_nftban_units()` lacked the guard, its caller used `assert_eq`. Both now
emit the shared sentinel and assert through the VM-aware comparator.

## A9 — an unmatched scope token yielded `PASS` with zero assertions

`NOT_IN_SCOPE` is correctly non-blocking, but nothing required that **any** case ran. Reproduced:
`NFTBAN_RPM_CASES="R99"` → every counter zero → `VERDICT=PASS`, rc 0, **nothing asserted**. The
workflow hard-codes `"R7"`/`"L7"`, so renaming a case would silently empty the lane while staying
green.

Two floors in both matrices — zero executed assertions is a `HARNESS_FAILURE`, and a token matching
no known case is a `HARNESS_FAILURE`. Not a product verdict: such a run could not have observed the
product either way.

> `ZERO ASSERTIONS IS NOT A PASS`

The RPM case list is now declared **once** (`ALL_CASES`) and both the default scope and the validator
derive from it, so a renamed case cannot drift from either.

## Note

A8 and A9 are the same class #1221 was written to close. That fix converted the probes it touched and
left **one survivor in each direction** — a missed probe, and an unfloored scope.

Verified: `lifecycle_matrix_observation_semantics_v1229_test.sh` 41/41; shellcheck `-S warning` clean;
`release.yml` parses; A1 guard falsified across all three trigger paths.
