### PR TITLE
fix(setsync): transaction ownership is structural — one method, one private Conn [v1.229.0 INV-NFT-TX-01]

### DIFF
--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -481,7 +481,15 @@ func (d *Daemon) initWatchdog() error {
 // are DEGRADABLE — a failure returns an error that Run() treats as non-fatal
 // (async operations disabled) and the lifecycle marks the component degraded.
 func (d *Daemon) initOpQueue() error {
-	// Get NFTManager from backend for shared netlink connection
+	// Get the backend's NFTManager. v1.229.0: the old comment here said
+	// "for shared netlink connection" — that was FALSE and was the premise that
+	// designed in FSA-CONC-01. The manager never held a lasting netlink socket
+	// (nftables.New without AsLasting dials per Flush); what was actually shared
+	// was the Conn's message buffer, which let one writer's Flush commit another
+	// writer's queued work and return nil to the owner. The manager now holds NO
+	// connection: every mutating method owns a private per-transaction Conn
+	// (INV-NFT-TX-01, internal/setsync). Sharing the MANAGER is fine — it
+	// carries only the synchronized table cache.
 	d.lifecycle.BeginPhase(PhaseNFTManagerInit, "nftbackend")
 	nft := d.backend.GetNFTManager()
 	if nft == nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/nftables v0.3.0
+	github.com/mdlayher/netlink v1.9.0
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
@@ -20,7 +21,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/mdlayher/netlink v1.9.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/internal/setsync/nft_elements.go
+++ b/internal/setsync/nft_elements.go
@@ -34,6 +34,11 @@ import (
 
 // addSetElementsBatch adds a single batch of IPs or CIDRs
 func (m *NFTManager) addSetElementsBatch(set *nftables.Set, ips []string) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	elements := make([]nftables.SetElement, 0, len(ips)*2) // Pre-allocate (*2 for CIDR ranges)
 	for _, ipStr := range ips {
 		var key []byte
@@ -121,11 +126,11 @@ func (m *NFTManager) addSetElementsBatch(set *nftables.Set, ips []string) error 
 		}
 	}
 
-	if err := m.conn.SetAddElements(set, elements); err != nil {
+	if err := conn.SetAddElements(set, elements); err != nil {
 		return fmt.Errorf("failed to add elements: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush add elements: %w", err)
 	}
 
@@ -140,6 +145,11 @@ func (m *NFTManager) addSetElementsBatch(set *nftables.Set, ips []string) error 
 // The netlink library doesn't properly handle interval markers for single IPs,
 // which can cause corrupted ranges like "1.2.3.4-255.255.255.255".
 func (m *NFTManager) AddIPWithTimeout(set *nftables.Set, ipStr string, timeout time.Duration) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	// Try parsing as single IP first
 	ip := net.ParseIP(ipStr)
 
@@ -190,11 +200,11 @@ func (m *NFTManager) AddIPWithTimeout(set *nftables.Set, ipStr string, timeout t
 		element.Timeout = timeout
 	}
 
-	if err := m.conn.SetAddElements(set, []nftables.SetElement{element}); err != nil {
+	if err := conn.SetAddElements(set, []nftables.SetElement{element}); err != nil {
 		return fmt.Errorf("failed to add element: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		// Ignore EEXIST errors - element already in set
 		if !errors.Is(err, os.ErrExist) {
 			return fmt.Errorf("failed to flush: %w", err)
@@ -226,6 +236,11 @@ func (m *NFTManager) addIPWithTimeoutCLI(set *nftables.Set, ipStr string, timeou
 
 // DeleteSetElements removes IPs from a set (batch operation)
 func (m *NFTManager) DeleteSetElements(set *nftables.Set, ips []string) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	if len(ips) == 0 {
 		return nil
 	}
@@ -271,11 +286,11 @@ func (m *NFTManager) DeleteSetElements(set *nftables.Set, ips []string) error {
 		})
 	}
 
-	if err := m.conn.SetDeleteElements(set, elements); err != nil {
+	if err := conn.SetDeleteElements(set, elements); err != nil {
 		return fmt.Errorf("failed to delete elements: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush delete elements: %w", err)
 	}
 
@@ -286,7 +301,12 @@ func (m *NFTManager) DeleteSetElements(set *nftables.Set, ips []string) error {
 // Returns nil, nil if the set doesn't exist (not an error - idempotent behavior)
 // Port sets use TypeInetService (uint16) for port numbers
 func (m *NFTManager) GetPortSet(table *nftables.Table, setName string) (*nftables.Set, error) {
-	sets, err := m.conn.GetSets(table)
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -304,8 +324,13 @@ func (m *NFTManager) GetPortSet(table *nftables.Table, setName string) (*nftable
 // GetOrCreatePortSet creates or gets an existing port set for TCP or UDP
 // Port sets use TypeInetService (uint16) for port numbers
 func (m *NFTManager) GetOrCreatePortSet(table *nftables.Table, setName string) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing set
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -323,11 +348,11 @@ func (m *NFTManager) GetOrCreatePortSet(table *nftables.Table, setName string) (
 		KeyType: nftables.TypeInetService, // uint16 for ports
 	}
 
-	if err := m.conn.AddSet(set, nil); err != nil {
+	if err := conn.AddSet(set, nil); err != nil {
 		return nil, fmt.Errorf("failed to add port set: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to create port set: %w", err)
 	}
 
@@ -336,6 +361,11 @@ func (m *NFTManager) GetOrCreatePortSet(table *nftables.Table, setName string) (
 
 // AddPortElements adds port numbers to a port set
 func (m *NFTManager) AddPortElements(set *nftables.Set, ports []int) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	if len(ports) == 0 {
 		return nil
 	}
@@ -354,11 +384,11 @@ func (m *NFTManager) AddPortElements(set *nftables.Set, ports []int) error {
 		})
 	}
 
-	if err := m.conn.SetAddElements(set, elements); err != nil {
+	if err := conn.SetAddElements(set, elements); err != nil {
 		return fmt.Errorf("failed to add port elements: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush port elements: %w", err)
 	}
 
@@ -368,6 +398,11 @@ func (m *NFTManager) AddPortElements(set *nftables.Set, ports []int) error {
 // DeletePortElements removes port numbers from a port set
 // Returns nil for "no such file" errors (idempotent - element already doesn't exist)
 func (m *NFTManager) DeletePortElements(set *nftables.Set, ports []int) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	if len(ports) == 0 {
 		return nil
 	}
@@ -381,11 +416,11 @@ func (m *NFTManager) DeletePortElements(set *nftables.Set, ports []int) error {
 		})
 	}
 
-	if err := m.conn.SetDeleteElements(set, elements); err != nil {
+	if err := conn.SetDeleteElements(set, elements); err != nil {
 		return fmt.Errorf("failed to delete port elements: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		// Tolerate ENOENT errors - element already doesn't exist (idempotent)
 		if errors.Is(err, os.ErrNotExist) {
 			return nil // Idempotent: element already gone
@@ -490,8 +525,13 @@ func (m *NFTManager) AddCIDRElementsWithStats(set *nftables.Set, cidrs []string)
 // GetOrCreateConcatSet creates or retrieves a concat set (IP . port) for per-IP port access.
 // The set type is ipv4_addr . inet_service (or ipv6_addr) with timeout flag.
 func (m *NFTManager) GetOrCreateConcatSet(table *nftables.Table, setName string, ipv4 bool) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing set
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -515,11 +555,11 @@ func (m *NFTManager) GetOrCreateConcatSet(table *nftables.Table, setName string,
 		KeyType:    nftables.MustConcatSetType(addrType, nftables.TypeInetService),
 	}
 
-	if err := m.conn.AddSet(set, nil); err != nil {
+	if err := conn.AddSet(set, nil); err != nil {
 		return nil, fmt.Errorf("failed to add concat set %s: %w", setName, err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to flush concat set creation: %w", err)
 	}
 
@@ -529,6 +569,11 @@ func (m *NFTManager) GetOrCreateConcatSet(table *nftables.Table, setName string,
 // AddConcatIPPort adds an IP+port element to a concat set.
 // The key is concatenated as [IP bytes][port bytes (big-endian)].
 func (m *NFTManager) AddConcatIPPort(set *nftables.Set, ipStr string, port int, timeout time.Duration) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("invalid port: %d", port)
 	}
@@ -561,11 +606,11 @@ func (m *NFTManager) AddConcatIPPort(set *nftables.Set, ipStr string, port int, 
 		elem.Timeout = timeout
 	}
 
-	if err := m.conn.SetAddElements(set, []nftables.SetElement{elem}); err != nil {
+	if err := conn.SetAddElements(set, []nftables.SetElement{elem}); err != nil {
 		return fmt.Errorf("failed to add concat element: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush concat element: %w", err)
 	}
 
@@ -574,6 +619,11 @@ func (m *NFTManager) AddConcatIPPort(set *nftables.Set, ipStr string, port int, 
 
 // DeleteConcatIPPort removes an IP+port element from a concat set.
 func (m *NFTManager) DeleteConcatIPPort(set *nftables.Set, ipStr string, port int) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("invalid port: %d", port)
 	}
@@ -598,11 +648,11 @@ func (m *NFTManager) DeleteConcatIPPort(set *nftables.Set, ipStr string, port in
 		return fmt.Errorf("cannot convert IP: %s", ipStr)
 	}
 
-	if err := m.conn.SetDeleteElements(set, []nftables.SetElement{{Key: key}}); err != nil {
+	if err := conn.SetDeleteElements(set, []nftables.SetElement{{Key: key}}); err != nil {
 		return fmt.Errorf("failed to delete concat element: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil // Idempotent: element already gone
 		}

--- a/internal/setsync/nft_manager.go
+++ b/internal/setsync/nft_manager.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/google/nftables"
 )
@@ -47,28 +48,82 @@ func uint32ToIPv4(v uint32) net.IP {
 	return net.IP(b)
 }
 
-// NFTManager handles nftables operations via netlink
+// NFTManager handles nftables operations via netlink.
+//
+// v1.229.0 INV-NFT-TX-01 — TRANSACTION OWNERSHIP IS STRUCTURAL.
+// This type deliberately holds NO *nftables.Conn. Every method obtains a
+// PRIVATE connection from txConn() and owns it for exactly one
+// queue -> Flush transaction.
+//
+// Why: a *nftables.Conn buffers queued messages in cc.messages, and Flush()
+// transmits the WHOLE buffer then nils it. A second caller sharing that Conn
+// finds len(messages)==0 and returns nil under the upstream comment
+// "Messages were already programmed, returning nil" — so it reports success
+// for a transaction it never transmitted, while its work was committed inside
+// somebody else's batch. Reproduced on this tree: writer A's Flush transmitted
+// [BATCH_BEGIN, NEWTABLE, NEWTABLE, BATCH_END] carrying BOTH writers' work;
+// writer B then sent nothing and returned nil.
+//
+// A mutex would not fix it: caller B can append into caller A's buffer before
+// A ever acquires the lock. Ownership must be a property of the object graph,
+// not of lock discipline — hence a private Conn per transaction.
+//
+// This costs nothing. nftables.New() without AsLasting() is NON-LASTING: the
+// library dials a fresh netlink socket inside every Flush/query and closes it
+// again (conn.go netlinkConnUnderLock). Nothing was ever sharing a socket;
+// only the defective buffer was shared.
 type NFTManager struct {
-	conn *nftables.Conn
-
-	// Cached tables to avoid repeated ListTables() calls
+	// cacheMu guards cachedTables ONLY. It is not a transaction lock and must
+	// never be held across a Flush — transactions are isolated by ownership,
+	// not by serialization.
+	cacheMu      sync.RWMutex
 	cachedTables map[nftables.TableFamily]*nftables.Table
+
+	// newConn creates one private transaction connection. Production leaves it
+	// nil and gets nftables.New(). It exists so the INV-NFT-TX-01 regression
+	// suite can inject nftables.WithTestDial and assert on the messages each
+	// transaction actually transmits — without that hook the guard could only
+	// check pointer identity, and a reintroduced shared buffer would slip
+	// through. Test-only injection; never set on the daemon path.
+	newConn func() (*nftables.Conn, error)
 }
 
-// NewNFTManager creates a new nftables manager
-func NewNFTManager() (*NFTManager, error) {
+// txConn returns a PRIVATE connection owning exactly one transaction.
+//
+// The caller must queue and Flush on the returned conn and then let it go. On
+// any error path the caller simply returns: the queued messages die with the
+// connection. That is the second half of the defect this fixes — the shared
+// buffer had no discard API, so an early error left residue that rode into the
+// NEXT writer's commit.
+func (m *NFTManager) txConn() (*nftables.Conn, error) {
+	if m.newConn != nil {
+		return m.newConn()
+	}
 	conn, err := nftables.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nftables connection: %w", err)
 	}
+	return conn, nil
+}
+
+// NewNFTManager creates a new nftables manager.
+//
+// The probe connection is created and DISCARDED: it proves netlink is usable
+// at construction (preserving the previous failure semantics) without retaining
+// shared transaction state.
+func NewNFTManager() (*NFTManager, error) {
+	if _, err := nftables.New(); err != nil {
+		return nil, fmt.Errorf("failed to create nftables connection: %w", err)
+	}
 
 	return &NFTManager{
-		conn:         conn,
 		cachedTables: make(map[nftables.TableFamily]*nftables.Table),
 	}, nil
 }
 
-// Close closes the nftables connection
+// Close is retained for interface compatibility. Since v1.229.0 the manager
+// holds no connection to close — transactions own private, non-lasting Conns
+// that release their socket at the end of each Flush.
 func (m *NFTManager) Close() {
 	// Connection cleanup handled by Go GC
 }
@@ -76,39 +131,66 @@ func (m *NFTManager) Close() {
 // GetOrCreateTable gets or creates the nftban table
 // Uses caching to avoid repeated ListTables() calls for performance
 func (m *NFTManager) GetOrCreateTable(family nftables.TableFamily) (*nftables.Table, error) {
-	// Check cache first
-	if cached, ok := m.cachedTables[family]; ok {
+	// R2: cachedTables was read here and written below with no synchronisation,
+	// while the daemon reaches this method from OpQueue workers, per-connection
+	// IPC handler goroutines and the backend concurrently. Proven by -race on
+	// this tree (write InvalidateTableCache vs read here).
+	if cached, ok := m.getCachedTable(family); ok {
 		return cached, nil
 	}
 
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, err := m.txConn()
+	if err != nil {
+		return nil, err
+	}
+
 	// Try to get existing table
-	tables, err := m.conn.ListTables()
+	tables, err := conn.ListTables()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tables: %w", err)
 	}
 
 	for _, table := range tables {
 		if table.Name == "nftban" && table.Family == family {
-			m.cachedTables[family] = table // Cache it
+			m.setCachedTable(family, table)
 			return table, nil
 		}
 	}
 
 	// Create new table
-	table := m.conn.AddTable(&nftables.Table{
+	table := conn.AddTable(&nftables.Table{
 		Family: family,
 		Name:   "nftban",
 	})
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to create table: %w", err)
 	}
 
-	m.cachedTables[family] = table // Cache newly created table
+	m.setCachedTable(family, table)
 	return table, nil
+}
+
+// getCachedTable / setCachedTable are the ONLY accessors to cachedTables.
+// R2 is fixed here and nowhere else: this lock guards the map, never a
+// transaction. It must not be held across a Flush.
+func (m *NFTManager) getCachedTable(family nftables.TableFamily) (*nftables.Table, bool) {
+	m.cacheMu.RLock()
+	defer m.cacheMu.RUnlock()
+	t, ok := m.cachedTables[family]
+	return t, ok
+}
+
+func (m *NFTManager) setCachedTable(family nftables.TableFamily, table *nftables.Table) {
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+	m.cachedTables[family] = table
 }
 
 // InvalidateTableCache clears the table cache (use after external table changes)
 func (m *NFTManager) InvalidateTableCache() {
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
 	m.cachedTables = make(map[nftables.TableFamily]*nftables.Table)
 }

--- a/internal/setsync/nft_replace_atomic.go
+++ b/internal/setsync/nft_replace_atomic.go
@@ -51,10 +51,15 @@ const replaceAddBatch = 1000
 // _ipv6, so a name-suffix guess resolves the wrong table and can fabricate a
 // bogus interval set).
 func (m *NFTManager) FindSetInTable(table *nftables.Table, name string) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	if table == nil {
 		return nil, nil
 	}
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("list sets in %s: %w", table.Name, err)
 	}
@@ -91,7 +96,14 @@ func (m *NFTManager) FindSetInTable(table *nftables.Table, name string) (*nftabl
 //     not an accidental empty-set fail-open.
 //   - Interval sets are rejected: they are owned by the atomic FULL-sync path.
 func (m *NFTManager) ReplaceSetElements(set *nftables.Set, elements []SetElementInput) error {
-	return replaceSetElementsOnConn(m.conn, set, elements)
+	// INV-NFT-TX-01: the atomic replacement owns a PRIVATE connection. This is
+	// what makes its documented atomicity true by construction — no other writer
+	// can append into, or prematurely flush, this batch.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
+	return replaceSetElementsOnConn(conn, set, elements)
 }
 
 // replaceSetElementsOnConn is the testable core: pure validation, then the

--- a/internal/setsync/nft_rules.go
+++ b/internal/setsync/nft_rules.go
@@ -28,8 +28,13 @@ import (
 
 // CreateChainIfNotExists creates a chain if it doesn't exist
 func (m *NFTManager) CreateChainIfNotExists(table *nftables.Table, chainName string, chainType nftables.ChainType, hook *nftables.ChainHook, priority *nftables.ChainPriority) (*nftables.Chain, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing chain
-	chains, err := m.conn.ListChains()
+	chains, err := conn.ListChains()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list chains: %w", err)
 	}
@@ -49,9 +54,9 @@ func (m *NFTManager) CreateChainIfNotExists(table *nftables.Table, chainName str
 		Priority: priority,
 	}
 
-	m.conn.AddChain(chain)
+	conn.AddChain(chain)
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to create chain: %w", err)
 	}
 
@@ -60,6 +65,11 @@ func (m *NFTManager) CreateChainIfNotExists(table *nftables.Table, chainName str
 
 // AddDropRuleForSet adds a rule to drop packets from IPs in a set
 func (m *NFTManager) AddDropRuleForSet(chain *nftables.Chain, set *nftables.Set, ipv4 bool) error {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
 	// Build rule: ip saddr @blacklist_ipv4 drop
 	var expressions []expr.Any
 
@@ -108,9 +118,9 @@ func (m *NFTManager) AddDropRuleForSet(chain *nftables.Chain, set *nftables.Set,
 		Exprs: expressions,
 	}
 
-	m.conn.AddRule(rule)
+	conn.AddRule(rule)
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return fmt.Errorf("failed to add drop rule: %w", err)
 	}
 

--- a/internal/setsync/nft_sets.go
+++ b/internal/setsync/nft_sets.go
@@ -30,8 +30,13 @@ import (
 
 // GetOrCreateSet gets or creates a named set in the table
 func (m *NFTManager) GetOrCreateSet(table *nftables.Table, setName string, ipv4 bool) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing set
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -57,11 +62,11 @@ func (m *NFTManager) GetOrCreateSet(table *nftables.Table, setName string, ipv4 
 		KeyType: keyType,
 	}
 
-	if err := m.conn.AddSet(set, nil); err != nil {
+	if err := conn.AddSet(set, nil); err != nil {
 		return nil, fmt.Errorf("failed to add set: %w", err)
 	}
 
-	if err := m.conn.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to create set: %w", err)
 	}
 
@@ -71,8 +76,13 @@ func (m *NFTManager) GetOrCreateSet(table *nftables.Table, setName string, ipv4 
 // GetOrCreateHashSet gets or creates a hash set with timeout support (O(1) lookup)
 // v1.33.0: Used for manual/auto-detect bans where CIDR aggregation is not needed
 func (m *NFTManager) GetOrCreateHashSet(table *nftables.Table, setName string, ipv4 bool) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing set
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -114,8 +124,13 @@ func (m *NFTManager) GetOrCreateHashSet(table *nftables.Table, setName string, i
 
 // GetOrCreateIntervalSet gets or creates an interval set for CIDR ranges
 func (m *NFTManager) GetOrCreateIntervalSet(table *nftables.Table, setName string, ipv4 bool) (*nftables.Set, error) {
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
 	// Try to get existing set
-	sets, err := m.conn.GetSets(table)
+	sets, err := conn.GetSets(table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sets: %w", err)
 	}
@@ -160,7 +175,12 @@ func (m *NFTManager) GetOrCreateIntervalSet(table *nftables.Table, setName strin
 
 // GetSetElements retrieves all elements from a set
 func (m *NFTManager) GetSetElements(set *nftables.Set) ([]string, error) {
-	elements, err := m.conn.GetSetElements(set)
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
+	elements, err := conn.GetSetElements(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get set elements: %w", err)
 	}
@@ -204,7 +224,12 @@ func decrementIP(ip net.IP) net.IP {
 // strings (WHITELIST_DURABLE_APPLY_RECONCILE Step 4). nftables stores an interval
 // [a,b] as a start element (a) + an interval-end marker (b+1, exclusive).
 func (m *NFTManager) GetSetElementsRanges(set *nftables.Set) ([]string, error) {
-	elements, err := m.conn.GetSetElements(set)
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return nil, errTx
+	}
+	elements, err := conn.GetSetElements(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get set elements: %w", err)
 	}
@@ -328,14 +353,24 @@ func (m *NFTManager) deleteSetElementsCLI(set *nftables.Set, ips []string) error
 
 // FlushSet removes all elements from a set
 func (m *NFTManager) FlushSet(set *nftables.Set) error {
-	m.conn.FlushSet(set)
-	return m.conn.Flush()
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return errTx
+	}
+	conn.FlushSet(set)
+	return conn.Flush()
 }
 
 // GetSetCount returns the number of elements in a set
 // For interval sets, filters out IntervalEnd markers to return the true entry count
 func (m *NFTManager) GetSetCount(set *nftables.Set) (int, error) {
-	elements, err := m.conn.GetSetElements(set)
+	// INV-NFT-TX-01: private connection, owned for this transaction only.
+	conn, errTx := m.txConn()
+	if errTx != nil {
+		return 0, errTx
+	}
+	elements, err := conn.GetSetElements(set)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get set elements: %w", err)
 	}

--- a/internal/setsync/nft_tx_ownership_v1229_test.go
+++ b/internal/setsync/nft_tx_ownership_v1229_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.0 — INV-NFT-TX-01 regression suite.
+//
+// Guards the invariant that ONE mutating method invocation owns ONE private
+// *nftables.Conn for exactly one queue -> Flush transaction.
+//
+// The defect these lock out was REPRODUCED on v1.228.12 before the fix:
+// two writers sharing one Conn, writer A's Flush transmitted
+// [BATCH_BEGIN, NEWTABLE, NEWTABLE, BATCH_END] — carrying BOTH writers' work —
+// and writer B then transmitted nothing and returned nil. Upstream states it
+// plainly in conn.go: "Messages were already programmed, returning nil".
+//
+// These tests assert on TRANSMITTED MESSAGES, not on error values. "Both calls
+// returned nil" would have passed against the defective code; attribution is
+// the whole point.
+package setsync
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/nftables"
+	"github.com/mdlayher/netlink"
+)
+
+// nftMsgNewTable is NFT_MSG_NEWTABLE as it appears in a batch's netlink header
+// type field. Batches are wrapped in BATCH_BEGIN(16) / BATCH_END(17).
+const nftMsgNewTable = 2560
+
+// txRecorder records one entry per transmitted batch so a test can attribute
+// which operations rode in which transaction.
+type txRecorder struct {
+	mu    sync.Mutex
+	sends [][]netlink.Message
+}
+
+// nftBatchBegin marks a transaction commit; anything else is a read query.
+const nftBatchBegin = 16
+
+func (r *txRecorder) dial(req []netlink.Message) ([]netlink.Message, error) {
+	isBatch := false
+	for _, m := range req {
+		if m.Header.Type == nftBatchBegin {
+			isBatch = true
+			break
+		}
+	}
+	if !isBatch {
+		// A query (ListTables/GetSets). Answer "nothing exists" so the caller
+		// proceeds to its create path. Queries carry no transaction and are not
+		// recorded — only commits are attributable to an owner.
+		return []netlink.Message{}, nil
+	}
+	r.mu.Lock()
+	cp := make([]netlink.Message, len(req))
+	copy(cp, req)
+	r.sends = append(r.sends, cp)
+	r.mu.Unlock()
+	// Echo the batch, as google/nftables' own tests do, so Flush takes its
+	// acknowledgement path.
+	return req, nil
+}
+
+// newTableMessages counts NEWTABLE operations across every transmitted batch.
+func (r *txRecorder) newTableMessages() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, b := range r.sends {
+		for _, m := range b {
+			if m.Header.Type == nftMsgNewTable {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// maxNewTablesInOneBatch is the attribution assertion: how many NEWTABLE
+// operations rode inside a SINGLE transaction.
+func (r *txRecorder) maxNewTablesInOneBatch() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	worst := 0
+	for _, b := range r.sends {
+		n := 0
+		for _, m := range b {
+			if m.Header.Type == nftMsgNewTable {
+				n++
+			}
+		}
+		if n > worst {
+			worst = n
+		}
+	}
+	return worst
+}
+
+// TestINVNFTTX01_OneMethodOneTransaction is a CONTRACT test, not a
+// reintroduction guard. Read the scope note before trusting it.
+//
+// It asserts that a manager method transmits exactly its own operation in its
+// own batch. That is worth pinning — but it CANNOT detect a reintroduced shared
+// connection, and this was verified by inversion: re-adding a shared conn to
+// NFTManager leaves this test GREEN. The reason is structural — each mutating
+// method queues AND flushes inside one invocation, so sequential calls never
+// overlap, and the merge window (both writers queued before either flushes)
+// never opens.
+//
+// The arm that actually fails on reintroduction is
+// TestINVNFTTX01_ManagerHoldsNoSharedConn.
+func TestINVNFTTX01_OneMethodOneTransaction(t *testing.T) {
+	rec := &txRecorder{}
+
+	// Drive the REAL manager. If a future change reintroduces a shared
+	// connection, every method's work lands in one buffer and the attribution
+	// assertion below fails. Creating two conns directly in the test would
+	// prove only that the library works — it would pass against the defect.
+	m := &NFTManager{
+		cachedTables: make(map[nftables.TableFamily]*nftables.Table),
+		newConn: func() (*nftables.Conn, error) {
+			return nftables.New(nftables.WithTestDial(rec.dial))
+		},
+	}
+
+	// Two independent mutating transactions through real entry points.
+	if _, err := m.GetOrCreateTable(nftables.TableFamilyIPv4); err != nil {
+		t.Fatalf("GetOrCreateTable v4: %v", err)
+	}
+	if _, err := m.GetOrCreateTable(nftables.TableFamilyIPv6); err != nil {
+		t.Fatalf("GetOrCreateTable v6: %v", err)
+	}
+
+	if got := rec.maxNewTablesInOneBatch(); got != 1 {
+		t.Fatalf("INV-NFT-TX-01 VIOLATED: a single transaction carried %d NEWTABLE operations; "+
+			"each method invocation must own its own transaction", got)
+	}
+	if got := rec.newTableMessages(); got != 2 {
+		t.Fatalf("expected each transaction to transmit its own NEWTABLE exactly once, got %d", got)
+	}
+}
+
+// TestINVNFTTX01_AbandonedTransactionSemantics documents WHY private conns fix
+// the residue sub-defect. It is a LIBRARY-SEMANTICS test over google/nftables,
+// not a guard on NFTManager: it drives its own connections, so like the contract
+// test above it stays green if a shared conn is reintroduced (verified by
+// inversion).
+//
+// It is kept because the residue path is the half of the defect that has no
+// upstream API to mitigate — v0.3.0 offers no discard, and Flush() would APPLY
+// a partial transaction rather than drop it. Pinning the semantics keeps the
+// rationale falsifiable if the dependency is ever upgraded.
+func TestINVNFTTX01_AbandonedTransactionSemantics(t *testing.T) {
+	rec := &txRecorder{}
+
+	// Transaction 1 queues work and is then abandoned WITHOUT Flush, exactly as
+	// a method returning an error mid-way would abandon it.
+	abandoned, err := nftables.New(nftables.WithTestDial(rec.dial))
+	if err != nil {
+		t.Fatalf("conn: %v", err)
+	}
+	abandoned.AddTable(&nftables.Table{Family: nftables.TableFamilyIPv4, Name: "abandoned"})
+	// no Flush — the transaction dies here.
+
+	// Transaction 2 is a fresh owner and commits its own single operation.
+	next, err := nftables.New(nftables.WithTestDial(rec.dial))
+	if err != nil {
+		t.Fatalf("conn: %v", err)
+	}
+	next.AddTable(&nftables.Table{Family: nftables.TableFamilyIPv6, Name: "next"})
+	if err := next.Flush(); err != nil {
+		t.Fatalf("next Flush: %v", err)
+	}
+
+	if got := rec.newTableMessages(); got != 1 {
+		t.Fatalf("RESIDUE LEAKED: expected exactly 1 transmitted NEWTABLE (the committed one), got %d; "+
+			"an abandoned transaction's queued work reached the wire", got)
+	}
+	if got := rec.maxNewTablesInOneBatch(); got != 1 {
+		t.Fatalf("RESIDUE LEAKED: a transaction carried %d NEWTABLE operations", got)
+	}
+}
+
+// TestINVNFTTX01_ManagerHoldsNoSharedConn is THE load-bearing guard of this
+// suite — the only arm proven to fail when a shared connection is reintroduced.
+//
+// Verified by inversion on lab2: re-adding a cached conn to txConn() turns this
+// test RED while the other two arms stay green. Falsifiability lives here.
+//
+// A compile-time "field absent" assertion is not expressible, so this asserts
+// the observable consequence: two transactions must never be handed the same
+// connection, because that is exactly what lets one Flush commit another
+// writer's queued work.
+func TestINVNFTTX01_ManagerHoldsNoSharedConn(t *testing.T) {
+	m := &NFTManager{cachedTables: make(map[nftables.TableFamily]*nftables.Table)}
+
+	c1, err := m.txConn()
+	if err != nil {
+		t.Skipf("txConn unavailable in this environment: %v", err)
+	}
+	c2, err := m.txConn()
+	if err != nil {
+		t.Skipf("txConn unavailable in this environment: %v", err)
+	}
+	if c1 == c2 {
+		t.Fatal("INV-NFT-TX-01 VIOLATED: txConn returned the SAME connection twice; " +
+			"transactions would share a message buffer")
+	}
+}
+
+// TestR2_CachedTablesConcurrentAccess is the permanent race regression for the
+// unsynchronised map. Pre-fix, `go test -race` reported a data race between
+// InvalidateTableCache (write) and GetOrCreateTable (read) through these exact
+// exported entry points. Run with -race for this to carry its weight.
+func TestR2_CachedTablesConcurrentAccess(t *testing.T) {
+	m := &NFTManager{cachedTables: make(map[nftables.TableFamily]*nftables.Table)}
+
+	// Seed the cache so readers hit the fast path and never need netlink; this
+	// keeps the test hermetic while still exercising the map concurrently.
+	m.setCachedTable(nftables.TableFamilyIPv4, &nftables.Table{Name: "nftban", Family: nftables.TableFamilyIPv4})
+	m.setCachedTable(nftables.TableFamilyIPv6, &nftables.Table{Name: "nftban", Family: nftables.TableFamilyIPv6})
+
+	const goroutines = 8
+	const iterations = 200
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start
+			fam := nftables.TableFamilyIPv4
+			if id%2 == 1 {
+				fam = nftables.TableFamilyIPv6
+			}
+			for i := 0; i < iterations; i++ {
+				_, _ = m.getCachedTable(fam)
+				m.setCachedTable(fam, &nftables.Table{Name: "nftban", Family: fam})
+				if id == 0 && i%25 == 0 {
+					m.InvalidateTableCache()
+				}
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+}

--- a/internal/setsync/nft_tx_structural_guard_v1229_test.go
+++ b/internal/setsync/nft_tx_structural_guard_v1229_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.0 — INV-NFT-TX-01 structural (AST) guard.
+//
+// TestMutatingMethodsOwnPrivateTransactionConn parses the PRODUCTION source of
+// this package and enforces the transaction-ownership contract by structure:
+//
+//	For every production mutating path:
+//	  connection ownership begins inside that method (via txConn())
+//	  queue and Flush occur on that private connection
+//	  no shared connection is reachable
+//
+// Why this exists in addition to TestINVNFTTX01_ManagerHoldsNoSharedConn: the
+// behavioural guard proves txConn() hands out distinct connections, but a
+// future change could reintroduce sharing WITHOUT touching txConn — a
+// differently named manager field, or a package-level Conn used directly by
+// one method. Inversion testing showed the behavioural guard alone does not
+// cover that class. This guard fails on:
+//
+//	G1  any field of NFTManager (or any struct in the package) whose type
+//	    reaches *nftables.Conn — a persistent connection holder
+//	G2  any package-level variable whose declared or inferred type is a
+//	    *nftables.Conn
+//	G3  any function containing a <recv>.Flush() call where <recv> is not
+//	    (a) a local variable acquired from txConn() in that same function, or
+//	    (b) a parameter of that function (ownership passed explicitly by a
+//	        caller that itself satisfies this guard)
+//	G4  any Flush-containing function that acquires a connection by calling
+//	    nftables.New directly instead of txConn() — bypassing the single
+//	    acquisition authority (and its test-injection point)
+//
+// The func-typed factory field (newConn func() (*nftables.Conn, error)) is
+// exempt from G1: a factory produces connections, it does not hold one.
+package setsync
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// typeReachesConn reports whether a field/var type expression contains
+// nftables.Conn anywhere EXCEPT behind a func type (factories are allowed).
+func typeReachesConn(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return typeReachesConn(t.X)
+	case *ast.SelectorExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name == "nftables" && t.Sel.Name == "Conn"
+		}
+	case *ast.FuncType:
+		// A factory type returning a Conn is the sanctioned pattern.
+		return false
+	case *ast.ArrayType:
+		return typeReachesConn(t.Elt)
+	case *ast.MapType:
+		return typeReachesConn(t.Key) || typeReachesConn(t.Value)
+	case *ast.ChanType:
+		return typeReachesConn(t.Value)
+	}
+	return false
+}
+
+func TestMutatingMethodsOwnPrivateTransactionConn(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	var violations []string
+	violate := func(pos token.Pos, rule, msg string) {
+		violations = append(violations, fmt.Sprintf("%s: [%s] %s", fset.Position(pos), rule, msg))
+	}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			// ---- G1: no struct field may hold a Conn ------------------------
+			ast.Inspect(file, func(n ast.Node) bool {
+				st, ok := n.(*ast.StructType)
+				if !ok {
+					return true
+				}
+				for _, f := range st.Fields.List {
+					if typeReachesConn(f.Type) {
+						name := "<embedded>"
+						if len(f.Names) > 0 {
+							name = f.Names[0].Name
+						}
+						violate(f.Pos(), "G1",
+							fmt.Sprintf("struct field %q holds a *nftables.Conn — a persistent connection reintroduces the shared transaction buffer (INV-NFT-TX-01)", name))
+					}
+				}
+				return true
+			})
+
+			// ---- G2: no package-level Conn variable -------------------------
+			for _, decl := range file.Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.VAR {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					if vs.Type != nil && typeReachesConn(vs.Type) {
+						violate(vs.Pos(), "G2",
+							fmt.Sprintf("package-level variable %v holds a *nftables.Conn — a global connection is a shared transaction buffer", vs.Names))
+					}
+					// Inferred type: var x = nftables.New(...) has no Type field.
+					for _, v := range vs.Values {
+						if call, ok := v.(*ast.CallExpr); ok {
+							if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+								if id, ok := sel.X.(*ast.Ident); ok && id.Name == "nftables" && sel.Sel.Name == "New" {
+									violate(vs.Pos(), "G2",
+										fmt.Sprintf("package-level variable %v initialised from nftables.New — a global connection is a shared transaction buffer", vs.Names))
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// ---- G3/G4: every Flush must run on a locally-owned conn --------
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				// txConn is the acquisition authority itself; its internal
+				// nftables.New is the one sanctioned construction site.
+				if fn.Name.Name == "txConn" {
+					continue
+				}
+
+				params := map[string]bool{}
+				if fn.Type.Params != nil {
+					for _, p := range fn.Type.Params.List {
+						for _, n := range p.Names {
+							params[n.Name] = true
+						}
+					}
+				}
+
+				owned := map[string]bool{} // locals assigned from txConn()
+				var flushes []*ast.SelectorExpr
+				directNew := false
+
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					switch node := n.(type) {
+					case *ast.AssignStmt:
+						for _, rhs := range node.Rhs {
+							call, ok := rhs.(*ast.CallExpr)
+							if !ok {
+								continue
+							}
+							sel, ok := call.Fun.(*ast.SelectorExpr)
+							if !ok {
+								continue
+							}
+							if sel.Sel.Name == "txConn" {
+								if len(node.Lhs) > 0 {
+									if id, ok := node.Lhs[0].(*ast.Ident); ok {
+										owned[id.Name] = true
+									}
+								}
+							}
+							if id, ok := sel.X.(*ast.Ident); ok && id.Name == "nftables" && sel.Sel.Name == "New" {
+								directNew = true
+							}
+						}
+					case *ast.CallExpr:
+						if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Flush" {
+							flushes = append(flushes, sel)
+						}
+					}
+					return true
+				})
+
+				if len(flushes) == 0 {
+					continue
+				}
+				if directNew {
+					violate(fn.Pos(), "G4",
+						fmt.Sprintf("%s acquires a connection via nftables.New directly; mutating paths must go through txConn() — the single acquisition authority and test-injection point", fn.Name.Name))
+				}
+				for _, sel := range flushes {
+					id, ok := sel.X.(*ast.Ident)
+					if !ok {
+						violate(sel.Pos(), "G3",
+							fmt.Sprintf("%s calls Flush on a non-local expression — the connection is not owned by this transaction", fn.Name.Name))
+						continue
+					}
+					if !owned[id.Name] && !params[id.Name] {
+						violate(sel.Pos(), "G3",
+							fmt.Sprintf("%s calls %s.Flush() but %q was neither acquired from txConn() in this function nor received as a parameter — connection ownership does not begin in this method", fn.Name.Name, id.Name, id.Name))
+					}
+				}
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("INV-NFT-TX-01 structural violations:\n  %s", strings.Join(violations, "\n  "))
+	}
+}

--- a/internal/setsync/nft_tx_structural_guard_v1229_test.go
+++ b/internal/setsync/nft_tx_structural_guard_v1229_test.go
@@ -38,7 +38,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
+	"os"
 	"strings"
 	"testing"
 )
@@ -67,12 +67,29 @@ func typeReachesConn(e ast.Expr) bool {
 }
 
 func TestMutatingMethodsOwnPrivateTransactionConn(t *testing.T) {
+	// parser.ParseDir is deprecated (SA1019); enumerate and parse the
+	// production files directly. Build-tag association is irrelevant here: the
+	// invariant must hold for EVERY production file in the package regardless
+	// of tags.
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	entries, err := os.ReadDir(".")
 	if err != nil {
-		t.Fatalf("parse package: %v", err)
+		t.Fatalf("read package dir: %v", err)
+	}
+	var files []*ast.File
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 0 {
+		t.Fatal("no production files parsed — the guard would be vacuous")
 	}
 
 	var violations []string
@@ -80,8 +97,8 @@ func TestMutatingMethodsOwnPrivateTransactionConn(t *testing.T) {
 		violations = append(violations, fmt.Sprintf("%s: [%s] %s", fset.Position(pos), rule, msg))
 	}
 
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
+	{
+		for _, file := range files {
 			// ---- G1: no struct field may hold a Conn ------------------------
 			ast.Inspect(file, func(n ast.Node) bool {
 				st, ok := n.(*ast.StructType)


### PR DESCRIPTION
v1.229.0 lane opener: **FSA-CONC-01 / INV-NFT-TX-01**. Owner-approved Option B.

## The defect, reproduced before fixing

Two writers sharing one `NFTManager.conn`: writer A's `Flush()` transmitted
`[BATCH_BEGIN, NEWTABLE, NEWTABLE, BATCH_END]` — **both writers' work in one kernel
transaction** — and writer B then transmitted nothing and **returned nil**. Upstream v0.3.0 says it
in its own comment: *"Messages were already programmed, returning nil"*. Companion `-race` run:
data race on `cachedTables` (`InvalidateTableCache` write vs `GetOrCreateTable` read) via exported
entry points.

## The false premise

The old comment: *"Get NFTManager from backend for **shared netlink connection**"*. But
`nftables.New()` without `AsLasting()` **never holds a socket** — the library dials inside every
Flush and closes it. Nothing was economised by sharing; only the defective buffer and the
unguarded cache were shared. **The sharing bought nothing and cost both defects.**

## The fix — remove the shared object, don't lock it

> `ONE MUTATING METHOD INVOCATION = ONE PRIVATE CONN = ONE TRANSACTION OWNER`

- `NFTManager` holds **no** `*nftables.Conn`. Every mutating method acquires a private connection
  from `txConn()` — all **40** `m.conn` sites across 5 files converted, **zero caller changes**,
  no signature changes.
- Early error ⇒ the conn and its queued residue die together. (Sub-defect: v0.3.0 has **no discard
  API** — on the shared conn an abandoned partial transaction rode into the next writer's commit.)
- `cachedTables` gets a dedicated `cacheMu` (map guard only; never held across a Flush).
- `ReplaceSetElements`' documented atomicity becomes true **by construction**.
- Cost: **identical to before** — the socket was per-Flush all along.

## Guards, with honest labels

| arm | role | fails on reintroduction? |
|---|---|---|
| `ManagerHoldsNoSharedConn` | behavioural guard | **yes** (INV1) |
| `MutatingMethodsOwnPrivateTransactionConn` | **AST guard** G1–G4 | **yes** (INV1 + INV2) |
| `OneMethodOneTransaction` | contract pin | no — labelled as such |
| `AbandonedTransactionSemantics` | library-semantics pin | no — labelled as such |
| `TestR2_CachedTablesConcurrentAccess` | `-race` regression | n/a |

**Falsified on lab2, sha-witnessed, restored:**

```
INV1  manager-held shared conn              -> behavioural RED · AST G1 RED
INV2  package-level conn, struct clean,
      one production method converted       -> behavioural GREEN (the gap)
                                               AST RED on G2 + G3
```

INV2 is the reason the AST guard exists: a reintroduction avoiding the old field name **evades the
behavioural check entirely** — proven, not assumed. Two arms that stayed green under inversion were
renamed so their names no longer overclaim.

## Validation (lab2, go1.25.12 — no local Go)

`go build ./...` clean · `go vet` clean · `gofmt` clean · setsync + nftbackend + opqueue +
watchdog tests pass · full package green under `-race`.

## Scope

INV-NFT-TX-01 only. **INV-NFT-XPROC-01 untouched** (separate lane). No caller changes, no OpQueue
changes, no ordering guarantees added — concurrent transactions may still commit in either order,
exactly as before. Design doc: `NFTBAN_ROADMAP/V1_229_0_TX_AUTHORITY_DESIGN_OPTIONS.md`.
