### PR TITLE
fix(portscan): consume each log record once, instead of re-reading the same window

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -134,6 +134,16 @@ jobs:
           chmod +x cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
           bash cli/lib/nftban/tests/lifecycle_matrix_observation_semantics_v1229_test.sh
 
+      # PORTSCAN-CURSOR (v1.229.x) — replay elimination. Hermetic: drives the
+      # shipped cursor helpers and the wired journald pipeline with a stubbed
+      # journalctl; no root, no live logs. Two arms exist specifically because
+      # the implementation's own bugs were in the WIRING, not the helpers.
+      - name: PortScan cursor replay elimination (v1.229.x)
+        run: |
+          echo "=== Executing: portscan_cursor_replay_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
+          bash cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
+
       - name: Uninstall firewall-ownership message (UNINSTALL-PR2 D5)
         run: |
           echo "=== Executing: uninstall_firewall_ownership_message_v225_test.sh ==="

--- a/build/fhs-spec.yaml
+++ b/build/fhs-spec.yaml
@@ -837,6 +837,15 @@ directories:
       created_by: tmpfiles
       tmpfiles_reconcile: "z"
 
+    - path: /var/lib/nftban/portscan/log-cursors
+      artifact_class: state
+      mode: "0750"
+      owner: nftban
+      group: nftban
+      description: "PortScan read cursors (v1.229.x): per-source position state so a cycle consumes only records it has not already processed. File sources store inode:offset via the canonical incremental reader; the journald source stores its last COMMITTED journal cursor, written only after a batch has been processed."
+      created_by: tmpfiles
+      tmpfiles_reconcile: "z"
+
     - path: /var/lib/nftban/recorder
       artifact_class: state
       mode: "0750"

--- a/cli/lib/nftban/core/nftban_fhs_spec.sh
+++ b/cli/lib/nftban/core/nftban_fhs_spec.sh
@@ -137,6 +137,7 @@ nftban_fhs_load_spec() {
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/login"]="0750|nftban|nftban|Login monitor state data"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/panels"]="0750|nftban|nftban|Panel integration state"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/portscan"]="0750|nftban|nftban|Port scan detection state"
+    NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/portscan/log-cursors"]="0750|nftban|nftban|PortScan read cursors (v1.229.x): per-source position state so a cycle consumes only records it has not already processed. File sources store inode:offset via the canonical incremental reader; the journald source stores its last COMMITTED journal cursor, written only after a batch has been processed."
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/recorder"]="0750|nftban|nftban|Flight recorder events and snapshots"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/staging"]="0750|nftban|nftban|Feed staging area (temporary download/validation)"
     NFTBAN_FHS_DIRECTORIES["/var/lib/nftban/state"]="0750|nftban|nftban|Critical runtime state files"

--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -45,6 +45,12 @@ source "${NFTBAN_LIB_DIR}/lib/nftban_timestamp.sh" 2>/dev/null || true
 source "${NFTBAN_LIB_DIR}/lib/nftban_file_utils.sh" 2>/dev/null || true
 # shellcheck source=/dev/null
 source "${NFTBAN_LIB_DIR}/lib/nftban_alert_throttle.sh" 2>/dev/null || true
+# v1.229.x PORTSCAN-CURSOR: canonical incremental file reader (inode:offset,
+# rotation/truncation, forward drain). Reused, never reimplemented — the same
+# authority BotScan consumes. Guarded: absence degrades to the legacy bounded
+# read, never to silence.
+# shellcheck source=/dev/null
+source "${NFTBAN_LIB_DIR:-/usr/lib/nftban}/lib/nftban_http_logs.sh" 2>/dev/null || true
 
 # =============================================================================
 # CONFIGURATION LOADING
@@ -486,6 +492,121 @@ _nftban_portscan_extract_timestamp() {
 }
 
 # Process log entries and detect portscans
+# =============================================================================
+# v1.229.x PORTSCAN-CURSOR — replay elimination
+# =============================================================================
+# The window readers below used to re-read the SAME tail every cycle with no
+# record of what had already been consumed, so each cycle re-emitted events it
+# had emitted before. Measured on srv3: 4.6x window amplification (5000 lines ->
+# 1079 unique), one line re-emitted 24x, portscan-events.log growing ~16 lines/s.
+#
+# DETECTION IS UNCHANGED. Thresholds read _IP_PORTS / _IP_TARGETS, and both
+# deduplicate on insert, so replay never contributed to a threshold. The only
+# timestamp-sensitive branch (strobe, duration < 10) was HARMED by replay, which
+# appended a fresh cycle-time per replayed line and stretched the duration.
+#
+# TWO SOURCES, TWO EXISTING AUTHORITIES, NEITHER INVENTED HERE:
+#   file     -> nftban_http_read_incremental (lib/nftban_http_logs.sh)
+#   journald -> --after-cursor / --show-cursor (the LoginMon model,
+#               core/nftban_login_classic.sh)
+#
+# ⚠ COMMIT SEMANTICS DIFFER BETWEEN THE TWO — stated plainly rather than
+# papered over:
+#
+#   FILE     = AT-MOST-ONCE. nftban_http_read_incremental persists the new
+#              offset immediately after writing bytes to stdout and before the
+#              consumer has finished reading them. PortScan inherits that
+#              established behaviour unchanged; it is what BotScan already
+#              relies on. A crash mid-batch loses that batch.
+#   JOURNALD = AT-LEAST-ONCE. This module owns that code, so the cursor is
+#              committed ONLY after the batch has passed through the processing
+#              loop. Advancing first would trade replay for permanently skipped
+#              records, which is the worse failure.
+: "${PORTSCAN_CLASSIC_CURSOR_ENABLED:=true}"
+: "${PORTSCAN_CLASSIC_CURSOR_DIR:=${NFTBAN_DATA_DIR:-/var/lib/nftban}/portscan/log-cursors}"
+: "${PORTSCAN_CLASSIC_CURSOR_MAX_BYTES:=1048576}"
+
+# Emit only records not yet consumed from a FILE source.
+# Degradation ladder (a broken cursor must never look like "nothing happened"):
+#   cursor disabled / reader absent -> legacy bounded read, silent (by design)
+#   state dir unwritable            -> legacy bounded read + WARN
+_nftban_portscan_classic_read_file_source() {
+    local f="$1"
+    if [[ "${PORTSCAN_CLASSIC_CURSOR_ENABLED:-true}" == "true" ]] \
+       && type -t nftban_http_read_incremental &>/dev/null; then
+        if mkdir -p "$PORTSCAN_CLASSIC_CURSOR_DIR" 2>/dev/null; then
+            NFTBAN_HTTP_LOG_OFFSET_DIR="$PORTSCAN_CLASSIC_CURSOR_DIR" \
+            NFTBAN_HTTP_LOG_READ_FORWARD=true \
+            NFTBAN_HTTP_LOG_MAX_BYTES="$PORTSCAN_CLASSIC_CURSOR_MAX_BYTES" \
+            nftban_http_read_incremental "$f"
+            return 0
+        fi
+        _nftban_portscan_classic_log "WARN" \
+            "cursor state dir not writable (${PORTSCAN_CLASSIC_CURSOR_DIR}) — falling back to bounded re-read; replay suppression INACTIVE"
+    fi
+    { tail -5000 "$f" 2>/dev/null || true; }
+}
+
+# Fetch a journald batch into $1, echoing the batch's end cursor on stdout.
+# The cursor is NOT persisted here — the caller commits it only after the batch
+# has been processed.
+_nftban_portscan_classic_journal_fetch() {
+    local out="$1" window="$2"
+    local cursor_file="${PORTSCAN_CLASSIC_CURSOR_DIR}/journal.cursor"
+    local -a jcmd=(journalctl -k --no-pager --show-cursor)
+    local resumed=false
+
+    if [[ "${PORTSCAN_CLASSIC_CURSOR_ENABLED:-true}" == "true" && -r "$cursor_file" ]]; then
+        local saved
+        saved=$(cat "$cursor_file" 2>/dev/null) || saved=""
+        if [[ -n "$saved" ]]; then
+            jcmd+=(--after-cursor="$saved")
+            resumed=true
+        else
+            _nftban_portscan_classic_log "WARN" \
+                "journal cursor file present but unreadable/empty — bounded re-read this cycle; replay suppression INACTIVE"
+        fi
+    fi
+    # BOOTSTRAP (no cursor yet) is not a failure: bound by the time window
+    # exactly as before, and this cycle establishes the cursor.
+    [[ "$resumed" == "true" ]] || jcmd+=(--since "${window} seconds ago")
+
+    "${jcmd[@]}" >"$out" 2>/dev/null || true
+    # journalctl prints "-- cursor: <c>" as the final line under --show-cursor.
+    sed -n 's/^-- cursor: //p' "$out" 2>/dev/null | tail -1
+}
+
+# Emit the journald records to process this cycle.
+#   batch file present -> the cursor-resumed batch already fetched
+#   batch file absent   -> legacy bounded read (degraded: replays, never blind)
+_nftban_portscan_classic_journal_stream() {
+    local batch="$1" window="$2"
+    if [[ -n "$batch" && -r "$batch" ]]; then
+        cat "$batch" 2>/dev/null || true
+        return 0
+    fi
+    { journalctl -k --since "${window} seconds ago" --no-pager 2>/dev/null || true; }
+}
+
+# Commit a journald cursor atomically. Called ONLY after successful processing.
+_nftban_portscan_classic_journal_commit() {
+    local cursor="$1"
+    [[ -n "$cursor" && "${PORTSCAN_CLASSIC_CURSOR_ENABLED:-true}" == "true" ]] || return 0
+    local cursor_file="${PORTSCAN_CLASSIC_CURSOR_DIR}/journal.cursor"
+    if ! mkdir -p "$PORTSCAN_CLASSIC_CURSOR_DIR" 2>/dev/null; then
+        _nftban_portscan_classic_log "WARN" \
+            "cannot create cursor dir — journal cursor NOT advanced; next cycle will re-read (replay, not loss)"
+        return 0
+    fi
+    if printf '%s\n' "$cursor" > "${cursor_file}.tmp" 2>/dev/null; then
+        mv -f "${cursor_file}.tmp" "$cursor_file" 2>/dev/null || \
+            _nftban_portscan_classic_log "WARN" "journal cursor commit failed — next cycle re-reads this batch"
+    else
+        _nftban_portscan_classic_log "WARN" "journal cursor write failed — next cycle re-reads this batch"
+    fi
+    return 0
+}
+
 nftban_portscan_classic_process_logs() {
     # BUGFIX v1.78.1: Self-initialize config before using variables
     # Invariant: No module function may assume config is loaded by its caller
@@ -523,6 +644,20 @@ nftban_portscan_classic_process_logs() {
     if [[ "$log_source" == "journalctl" ]]; then
         # Use journalctl for kernel logs on systemd systems
         _nftban_portscan_classic_log "DEBUG" "Reading from journalctl (kernel logs)"
+        local _ps_jbatch _ps_jcursor=""
+        _ps_jbatch=$(mktemp "${TMPDIR:-/tmp}/nftban-portscan-journal.XXXXXX" 2>/dev/null) || _ps_jbatch=""
+        if [[ -z "$_ps_jbatch" ]]; then
+            # DEGRADED, NOT BLIND. An earlier version pointed the batch at
+            # /dev/null here: it logged a warning and then processed nothing,
+            # which is exactly the "cursor failure looks like nothing happened"
+            # outcome this lane exists to prevent. The stream helper now performs
+            # the legacy bounded read directly, so detection continues with
+            # replay (the old behaviour) rather than silently stopping.
+            _nftban_portscan_classic_log "WARN" \
+                "cannot create journal batch file — falling back to bounded re-read; replay suppression INACTIVE this cycle"
+        else
+            _ps_jcursor=$(_nftban_portscan_classic_journal_fetch "$_ps_jbatch" "$time_window")
+        fi
         while IFS= read -r line; do
             local parsed
             parsed=$(nftban_portscan_classic_parse_line "$line") || continue
@@ -552,10 +687,20 @@ nftban_portscan_classic_process_logs() {
             # Record this connection for realtime detection
             nftban_portscan_classic_record_connection "$src_ip" "$dst_ip" "$dst_port" "$current_time"
 
-        # v1.82 Step 5: Added tail -5000 safety cap on journalctl output
-        # (--since already bounds, but high-volume hosts may still produce
-        # huge output within the time window). SIGPIPE fix preserved.
-        done < <({ journalctl -k --since "${time_window} seconds ago" --no-pager 2>/dev/null | { tail -5000 || true; } | grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" || true; } | { tail -1000 || true; })
+        # v1.229.x PORTSCAN-CURSOR: resume after the last COMMITTED cursor so
+        # already-consumed records are not re-emitted. tail caps retained as a
+        # volume bound. The batch is buffered because the cursor must not be
+        # committed until the loop below has actually processed it.
+        # NOTE the braces around grep: `grep ... || true | { tail ...; }` parses as
+        # `grep || (true | tail)`, which silently DROPS the tail cap whenever grep
+        # matches. Bracing keeps the cap on the match path, as the file branch does.
+        done < <({ _nftban_portscan_classic_journal_stream "$_ps_jbatch" "$time_window"; } | { tail -5000 || true; } | { grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" 2>/dev/null || true; } | { tail -1000 || true; })
+
+        # COMMIT-AFTER-PROCESSING. Reaching this point means the loop drained
+        # without aborting the function, so the cursor may advance. Advancing
+        # before this would convert replay into permanently skipped records.
+        _nftban_portscan_classic_journal_commit "$_ps_jcursor"
+        [[ -n "$_ps_jbatch" ]] && rm -f "$_ps_jbatch" 2>/dev/null || true
     else
         # grep returns 1 when no matches found - use || true to handle this
         _nftban_portscan_classic_log "DEBUG" "Reading from file: $log_source"
@@ -595,7 +740,10 @@ nftban_portscan_classic_process_logs() {
         # of total file size. 5000 raw lines ≈ covers several minutes of
         # high-volume portscan logging with margin.
         # SIGPIPE fix: { cmd || true; } prevents pipefail exit 141.
-        done < <({ tail -5000 "$log_source" 2>/dev/null || true; } | { grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" 2>/dev/null || true; } | { tail -1000 || true; })
+        # v1.229.x PORTSCAN-CURSOR: emit only bytes not yet consumed (inode:offset
+        # via the canonical incremental reader). AT-MOST-ONCE — see the commit
+        # semantics note above. tail caps retained as a volume bound.
+        done < <({ _nftban_portscan_classic_read_file_source "$log_source"; } | { tail -5000 || true; } | { grep -E -- "${log_prefix_escaped}|${log_prefix_legacy_escaped}" 2>/dev/null || true; } | { tail -1000 || true; })
     fi
 
     # Analyze and block if needed

--- a/cli/lib/nftban/data/fhs_directories.json
+++ b/cli/lib/nftban/data/fhs_directories.json
@@ -706,6 +706,14 @@
         "created_by": "tmpfiles"
       },
       {
+        "path": "/var/lib/nftban/portscan/log-cursors",
+        "mode": "0750",
+        "owner": "nftban",
+        "group": "nftban",
+        "description": "PortScan read cursors (v1.229.x): per-source position state so a cycle consumes only records it has not already processed. File sources store inode:offset via the canonical incremental reader; the journald source stores its last COMMITTED journal cursor, written only after a batch has been processed.",
+        "created_by": "tmpfiles"
+      },
+      {
         "path": "/var/lib/nftban/recorder",
         "mode": "0750",
         "owner": "nftban",

--- a/cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
+++ b/cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan — PORTSCAN-CURSOR: replay elimination regression (v1.229.x)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="portscan-cursor-replay-v1229-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-14"
+# meta:description="Locks the PortScan cursor contract: a second read of the same file window emits nothing (previously 4.6x replay on srv3); appended records emit exactly once; rotation and truncation recover via the canonical incremental reader; the journald cursor is committed ONLY after processing (abort before commit => no advance => replay, never loss); a broken cursor degrades to the bounded legacy read with a WARN, never to silent empty input. Includes a falsifiability control proving the replay detector can see replay when the cursor is disabled."
+# meta:inventory.files="cli/lib/nftban/core/nftban_portscan_classic.sh,cli/lib/nftban/lib/nftban_http_logs.sh"
+# meta:inventory.privileges="none"
+# meta:ta.id="portscan_cursor_replay_v1229_test"
+# meta:ta.owner="portscan"
+# meta:ta.module="portscan"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; [ -n "${2:-}" ] && echo "       $2"; FAIL=$((FAIL+1)); }
+
+SBX=$(mktemp -d); _owner=$$
+trap '[ "$$" = "$_owner" ] && rm -rf "$SBX"' EXIT
+mkdir -p "$SBX/data" "$SBX/bin" "$SBX/log"
+
+# --- hermetic module load: the helpers + the canonical reader, nothing live ---
+export NFTBAN_LIB_DIR="$REPO_ROOT/cli/lib/nftban"
+export NFTBAN_DATA_DIR="$SBX/data"
+export PORTSCAN_CLASSIC_CURSOR_DIR="$SBX/data/portscan/log-cursors"
+export NFTBAN_HTTP_LOG_MAX_BYTES=1048576
+_nftban_portscan_classic_log(){ echo "[$1] $2" >> "$SBX/log/module.log"; }
+# shellcheck source=/dev/null
+source "$REPO_ROOT/cli/lib/nftban/lib/nftban_http_logs.sh"
+# extract ONLY the cursor helpers from the module (comments intact — they are
+# not the assertion subject here; behaviour is).
+eval "$(awk '/^_nftban_portscan_classic_read_file_source\(\)/,/^}/' "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
+eval "$(awk '/^_nftban_portscan_classic_journal_fetch\(\)/,/^}/'    "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
+eval "$(awk '/^_nftban_portscan_classic_journal_commit\(\)/,/^}/'   "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
+type -t _nftban_portscan_classic_read_file_source >/dev/null || { echo "helpers not extracted"; exit 1; }
+export PORTSCAN_CLASSIC_CURSOR_ENABLED=true
+export PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=1048576
+
+LOG="$SBX/kern.log"
+seq 1 100 | sed 's/^/NFTBAN_PORTSCAN: line /' > "$LOG"
+
+echo "── ARM 1  same input twice: second pass emits NOTHING ─────────────────"
+c1=$(_nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+c2=$(_nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+[ "$c1" -eq 100 ] && ok "first pass emitted all 100 records" || no "first pass emitted $c1/100" ""
+[ "$c2" -eq 0 ]   && ok "second pass emitted 0 (replay eliminated; was 4.6x on srv3)" \
+                  || no "second pass RE-EMITTED $c2 records" "replay not eliminated"
+
+echo "── FALSIFIABILITY  cursor disabled => replay IS visible ───────────────"
+# Without this, arm 1 could pass because the reader emits nothing at all.
+cD=$(PORTSCAN_CLASSIC_CURSOR_ENABLED=false _nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+[ "$cD" -eq 100 ] && ok "legacy path re-emits all 100 (detector proven sighted)" \
+                  || no "legacy path emitted $cD — the no-replay assertion may be vacuous" ""
+
+echo "── ARM 2  appended records emit exactly once ──────────────────────────"
+seq 101 120 | sed 's/^/NFTBAN_PORTSCAN: line /' >> "$LOG"
+c3=$(_nftban_portscan_classic_read_file_source "$LOG")
+n3=$(printf '%s\n' "$c3" | grep -c . || true)
+[ "$n3" -eq 20 ] && ok "exactly the 20 new records emitted" || no "emitted $n3, want 20" ""
+printf '%s\n' "$c3" | grep -q "line 101" && printf '%s\n' "$c3" | grep -q "line 120" \
+    && ok "window is the NEW records (101..120), not a re-read" \
+    || no "wrong window content" "$(printf '%s\n' "$c3" | head -2)"
+
+echo "── ARM 3  rotation + truncation recover via the canonical reader ──────"
+mv "$LOG" "$LOG.1"; seq 1 5 | sed 's/^/NFTBAN_PORTSCAN: rotated /' > "$LOG"   # new inode
+c4=$(_nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+[ "$c4" -eq 5 ] && ok "rotation (new inode): read from BOF, 5 records" || no "rotation read $c4/5" ""
+seq 1 3 | sed 's/^/NFTBAN_PORTSCAN: shrunk /' > "$LOG"                        # truncation: size < offset
+c5=$(_nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+[ "$c5" -eq 3 ] && ok "truncation (size < offset): read from BOF, 3 records" || no "truncation read $c5/3" ""
+
+echo "── ARM 4  journald: fetch, COMMIT, second fetch resumes ───────────────"
+# journalctl stub: records argv; emits a batch + trailing cursor line.
+cat > "$SBX/bin/journalctl" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "${JSTUB_ARGS:?}"
+batch="${JSTUB_BATCH:?}"
+cat "$batch" 2>/dev/null
+echo "-- cursor: ${JSTUB_CURSOR:?}"
+STUB
+chmod +x "$SBX/bin/journalctl"
+export PATH="$SBX/bin:$PATH" JSTUB_ARGS="$SBX/jargs" JSTUB_BATCH="$SBX/jbatch" JSTUB_CURSOR="CUR_AAA"
+seq 1 10 | sed 's/^/NFTBAN_PORTSCAN: j /' > "$JSTUB_BATCH"; : > "$JSTUB_ARGS"
+
+B1="$SBX/b1"
+cur=$(_nftban_portscan_classic_journal_fetch "$B1" 60)
+[ "$cur" = "CUR_AAA" ] && ok "fetch returned the batch-end cursor" || no "cursor '$cur'" ""
+grep -q "after-cursor" "$JSTUB_ARGS" && no "first fetch used --after-cursor with no saved cursor" "" \
+                                     || ok "bootstrap fetch used --since (no cursor yet = bootstrap, not failure)"
+[ "$(grep -c 'NFTBAN_PORTSCAN' "$B1")" -eq 10 ] && ok "batch buffered for processing (10 records)" || no "batch wrong" ""
+_nftban_portscan_classic_journal_commit "$cur"
+[ "$(cat "$PORTSCAN_CLASSIC_CURSOR_DIR/journal.cursor" 2>/dev/null)" = "CUR_AAA" ] \
+    && ok "cursor COMMITTED after processing" || no "cursor not persisted" ""
+: > "$JSTUB_ARGS"; JSTUB_CURSOR="CUR_BBB" _nftban_portscan_classic_journal_fetch "$SBX/b2" 60 >/dev/null
+grep -q -- "--after-cursor=CUR_AAA" "$JSTUB_ARGS" \
+    && ok "second fetch resumed AFTER the committed cursor (no replay of batch 1)" \
+    || no "second fetch did not resume from cursor" "$(cat "$JSTUB_ARGS")"
+
+echo "── ARM 5  abort BEFORE commit => cursor does NOT advance ──────────────"
+: > "$JSTUB_ARGS"
+JSTUB_CURSOR="CUR_CCC" _nftban_portscan_classic_journal_fetch "$SBX/b3" 60 >/dev/null
+# processing "aborts" here — commit is deliberately NOT called.
+now=$(cat "$PORTSCAN_CLASSIC_CURSOR_DIR/journal.cursor" 2>/dev/null)
+[ "$now" = "CUR_AAA" ] && ok "cursor still CUR_AAA — an aborted batch is REPLAYED next cycle, never lost" \
+                       || no "cursor advanced to '$now' without successful processing" "records would be permanently skipped"
+
+echo "── ARM 6  broken cursor degrades LOUDLY to bounded read, never empty ──"
+: > "$SBX/log/module.log"
+RO="$SBX/ro"; mkdir -p "$RO"; chmod 0555 "$RO"
+cF=$(PORTSCAN_CLASSIC_CURSOR_DIR="$RO/sub" _nftban_portscan_classic_read_file_source "$LOG" | wc -l)
+[ "$cF" -eq 3 ] && ok "unwritable state dir: bounded legacy read still emitted the data (not empty-success)" \
+                || no "fallback emitted $cF/3" ""
+grep -q "WARN" "$SBX/log/module.log" && ok "degradation is OBSERVABLE (WARN logged)" \
+                                     || no "silent degradation — no WARN" "$(cat "$SBX/log/module.log")"
+chmod 0755 "$RO"
+# corrupt/empty journal cursor file: WARN + bounded window, not silence
+: > "$PORTSCAN_CLASSIC_CURSOR_DIR/journal.cursor"; : > "$SBX/log/module.log"; : > "$JSTUB_ARGS"
+JSTUB_CURSOR="CUR_DDD" _nftban_portscan_classic_journal_fetch "$SBX/b4" 60 >/dev/null
+grep -q -- "--since" "$JSTUB_ARGS" && ok "empty cursor file: bounded --since window used (data still read)" \
+                                   || no "no bounded fallback on corrupt cursor" "$(cat "$JSTUB_ARGS")"
+grep -q "WARN" "$SBX/log/module.log" && ok "corrupt cursor is OBSERVABLE (WARN logged)" \
+                                     || no "corrupt cursor silent" ""
+
+echo "── ARM 7  the WIRED pipeline, not just the helpers ───────────────────"
+# Both bugs found during implementation lived in the pipeline, not the helpers,
+# so the helpers alone could be perfect while the module was wrong.
+eval "$(awk '/^_nftban_portscan_classic_journal_stream\(\)/,/^}/' "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
+
+# 7a — BUG 2 regression: no batch file must still yield DATA, never empty.
+: > "$JSTUB_ARGS"
+n7=$(_nftban_portscan_classic_journal_stream "" 60 | grep -c 'NFTBAN_PORTSCAN' || true)
+[ "${n7:-0}" -gt 0 ] && ok "no batch file: legacy bounded read still yields records ($n7) — degraded, not blind" \
+                     || no "no batch file yielded EMPTY input" "a cursor failure must never look like 'nothing happened'"
+
+# 7b — BUG 1 regression: the tail cap must survive the grep-match path.
+# Asserted on the SHIPPED pipeline text: an unbraced `grep ... || true` followed
+# by a piped tail parses as `grep || (true | tail)` and drops the cap.
+line=$(grep -n 'done < <({ _nftban_portscan_classic_journal_stream' "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh" | cut -d: -f1)
+if [ -n "$line" ]; then
+    txt=$(sed -n "${line}p" "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")
+    case "$txt" in
+        *'{ grep -E'*'|| true; }'*) ok "journald pipeline braces grep — tail cap survives a match" ;;
+        *) no "journald grep is unbraced — 'grep || true | tail' drops the cap on the match path" "$txt" ;;
+    esac
+else
+    no "journald pipeline line not found" "wiring changed shape; re-verify the cap"
+fi
+
+# 7c — falsifiability for 7b: the broken form must be detected as broken.
+bad='done < <({ x; } | grep -E -- "p" || true | { tail -1000 || true; })'
+case "$bad" in
+    *'{ grep -E'*'|| true; }'*) no "detector blind: the BROKEN form matched the safe pattern" "7b is vacuous" ;;
+    *) ok "broken (unbraced) form is correctly rejected — 7b non-vacuous" ;;
+esac
+
+echo
+echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/install/systemd/tmpfiles.d/nftban.conf
+++ b/install/systemd/tmpfiles.d/nftban.conf
@@ -54,6 +54,7 @@ d /var/lib/nftban/config 0750 nftban nftban -
 d /var/lib/nftban/login 0750 nftban nftban -
 d /var/lib/nftban/panels 0750 nftban nftban -
 d /var/lib/nftban/portscan 0750 nftban nftban -
+d /var/lib/nftban/portscan/log-cursors 0750 nftban nftban -
 d /var/lib/nftban/recorder 0750 nftban nftban -
 d /var/lib/nftban/staging 0750 nftban nftban -
 d /var/lib/nftban/state 0750 nftban nftban -
@@ -95,6 +96,7 @@ z /var/lib/nftban/config 0750 nftban nftban -
 z /var/lib/nftban/login 0750 nftban nftban -
 z /var/lib/nftban/panels 0750 nftban nftban -
 z /var/lib/nftban/portscan 0750 nftban nftban -
+z /var/lib/nftban/portscan/log-cursors 0750 nftban nftban -
 z /var/lib/nftban/recorder 0750 nftban nftban -
 z /var/lib/nftban/staging 0750 nftban nftban -
 z /var/lib/nftban/state 0750 nftban nftban -

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -180,6 +180,7 @@ operator_config_not_package_owned_v1229_test	cli/lib/nftban/tests/operator_confi
 panel_group_retirement_v137_test	cli/lib/nftban/tests/panel_group_retirement_v137_test.sh	security	test	panel-group-retirement	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 parser_tier1_unknown_truth_v1228_9_test	cli/lib/nftban/tests/parser_tier1_unknown_truth_v1228_9_test.sh	health	test	nft-parser-contract	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	180		
 pkg_migration_ownership_boundary_v1228_10_test	cli/lib/nftban/tests/pkg_migration_ownership_boundary_v1228_10_test.sh	packaging	test	package-migration-ownership	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+portscan_cursor_replay_v1229_test	cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh	portscan	test	portscan	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 portscan_generic_corroborate_v149_test	cli/lib/nftban/tests/portscan_generic_corroborate_v149_test.sh	portscan	test	portscan-classic	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 portscan_trusted_flow_test	cli/lib/nftban/tests/portscan_trusted_flow_test.sh	portscan	test	portscan-trusted-flow	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 protection_claim_matrix_v194_test	cli/lib/nftban/tests/protection_claim_matrix_v194_test.sh	cross-cutting	test	protection-claim-matrix	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			


### PR DESCRIPTION
Closes the reproduced PortScan cursorless-replay defect. Scope is the replay only.

## The defect (measured on srv3, v1.228.x)

Every cycle re-read the same bounded tail with no record of what it had consumed:

```
4.6x window amplification (5000 lines -> 1079 unique)
one line re-emitted 24x
portscan-events.log +16 lines/s at 406k lines
319 forks/s · 20.9% system CPU  (nftband itself only 1.2% — the cost is shell subshells)
```

## Detection is unchanged — proven, not assumed

Thresholds read only `_IP_PORTS` / `_IP_TARGETS`, and **both deduplicate on insert**, so replay never
contributed to a threshold. Timestamps enter detection in exactly one branch (strobe, `duration < 10`),
where replay appended a fresh **cycle-time** per replayed line and stretched the duration.

> Replay was *degrading* the only timestamp-sensitive branch, not strengthening it.

## Both cursors reuse existing authorities

| source | authority |
|---|---|
| file | `nftban_http_read_incremental` — the inode:offset reader BotScan already uses, forward mode |
| journald | `--after-cursor` / `--show-cursor` — the LoginMon model |

## ⚠ The two paths do NOT offer the same guarantee

```
JOURNALD = at-least-once   cursor committed ONLY after the processing loop;
                           an abort leaves it unmoved -> replay, never loss
FILE     = at-most-once    nftban_http_read_incremental persists its offset
                           after writing bytes and before the consumer finishes
```

The file path inherits established behaviour rather than forking a second cursor authority and
silently changing BotScan's semantics. **Stated in the module** so a maintainer cannot assume both
paths are replay-on-abort safe.

## Degradation is loud, never blind

`no cursor yet` = **bootstrap**, not failure — legacy bounded window read, cursor established.
Unreadable/unwritable cursor = **WARN + legacy bounded read**; detection continues with replay
rather than stopping.

## Two bugs I introduced, found by auditing the WIRED pipeline

Both were in the wiring, not the helpers — the helpers were already correct:

1. **`grep … || true | { tail -1000; }` parses as `grep || (true | tail)`** — silently dropping the
   volume cap on the match path. Proven side-by-side against the file branch's braced form.
2. **The `mktemp`-failure path pointed the batch at `/dev/null`** — logged "falling back to bounded
   re-read" and then processed nothing. A cursor failure that looked like "nothing happened".

Both are regression-locked by Arm 7, with 7c proving that arm rejects the broken form.

## Regression set — 20 assertions

```
ARM 1  same window twice      100 then 0     · falsifiability: cursor off = 100
ARM 2  appended records       exactly 20, correct window
ARM 3  rotation / truncation  BOF recovery via the canonical reader
ARM 4  journald resume        --after-cursor=CUR_AAA
ARM 5  abort before commit    cursor unmoved
ARM 6  broken cursor          data still read + WARN
ARM 7  wired pipeline         both introduced bugs locked
```

Hermetic (stubbed `journalctl`, no root, no live logs), registered in the test-authority index
(row 183, `INDEX_FRESH = YES`) and executed by `ci-bash` as an explicit step.

FHS cursor state declared at its real authority (`build/fhs-spec.yaml`), propagating to the generated
spec, directories JSON and tmpfiles.

## Not in scope

`logger`/`date` forks per event (**measure after the cursor before optimising**), unused `cutoff_time`,
cycle-time-vs-log-time timestamps, trusted-flow suppression regression. srv3 before/after runtime proof
follows once CI is green.
