### PR TITLE
fix(maintenance): actually whitelist active SSH sessions, on every listener port (A6)

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -144,6 +144,19 @@ jobs:
           chmod +x cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
           bash cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
 
+      # A6 — the maintenance step that prevents ADMIN LOCKOUT was proven inert
+      # FLEET-WIDE by runtime witness (srv2 :55000, srv3 :22, both v1.228.11):
+      # the peer address was read as $5 while `ss -tn state established` omits
+      # the State column, and the port filter was hardcoded to :22. Defect 1
+      # masked defect 2, so fixing either alone still whitelists nothing — each
+      # arm therefore carries a control asserting the PRE-FIX pipeline returns
+      # EMPTY on the same fixture. Hermetic: stubbed ss, no root/network.
+      - name: Active-SSH auto-whitelist peer extraction (A6)
+        run: |
+          echo "=== Executing: maint_active_ssh_peers_v1229_test.sh ==="
+          chmod +x cli/lib/nftban/tests/maint_active_ssh_peers_v1229_test.sh
+          bash cli/lib/nftban/tests/maint_active_ssh_peers_v1229_test.sh
+
       - name: Uninstall firewall-ownership message (UNINSTALL-PR2 D5)
         run: |
           echo "=== Executing: uninstall_firewall_ownership_message_v225_test.sh ==="

--- a/cli/lib/nftban/cron/maintenance.sh
+++ b/cli/lib/nftban/cron/maintenance.sh
@@ -141,6 +141,45 @@ _maint_table_absent_confirmed() {
     return 0   # ABSENT across the whole grace window → genuine
 }
 
+# _maint_active_ssh_peers <port>... — echo the PEER IP of every established SSH
+# session, one per line, loopback excluded. Empty output = genuinely no sessions.
+#
+# RUNTIME_VERIFIED 2026-08-14 (srv2 :55000 + srv3 :22, both v1.228.11): the code
+# this replaces produced an EMPTY result on EVERY host and EVERY port, so the
+# active-session lockout protection was inert fleet-wide. Two layered defects:
+#
+#   1. DOMINANT — the peer was read as $5. `ss -tn state established` OMITS the
+#      State column, so a data row is:
+#          $1 Recv-Q   $2 Send-Q   $3 Local Address:Port   $4 Peer Address:Port
+#      i.e. $5 is empty. $NF is used here because it is the peer column in BOTH
+#      layouts (with State present it is $5, without it is $4).
+#   2. MASKED BY 1 — the filter hardcoded :22 even though step [1/10] has already
+#      detected the real listeners into SSH_PORTS. Once defect 1 is fixed, a host
+#      with SSH on 55000 would still whitelist nothing.
+#
+# Fixing either one alone yields a FALSE "fixed" signal, so both land together.
+#
+# The header line is NOT skipped by row number: its $NF is the literal
+# "Address:Port", which cannot match the IP patterns below. Filtering by shape
+# rather than by NR>1 means a session is still protected on any ss build that
+# omits the header — dropping the only live session there would be a lockout.
+_maint_active_ssh_peers() {
+    local _filter="" _p
+    for _p in "$@"; do
+        [[ "$_p" =~ ^[0-9]+$ ]] || continue
+        [[ -n "$_filter" ]] && _filter+=" or "
+        _filter+="dport = :$_p or sport = :$_p"
+    done
+    [[ -n "$_filter" ]] || _filter="dport = :22 or sport = :22"
+
+    ss -tn state established "( $_filter )" 2>/dev/null | \
+        awk '{print $NF}' | \
+        grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}|([0-9a-f:]+:+)+[0-9a-f]+' | \
+        grep -v '^127\.' | \
+        grep -v '^::1' | \
+        sort -u || true
+}
+
 # =============================================================================
 # LOCKING (Prevent concurrent runs)
 # =============================================================================
@@ -721,13 +760,12 @@ EOF
     ACTIVE_SSH_WHITELIST="${NFTBAN_DATA_DIR}/state/active_ssh_whitelist.state"
     mkdir -p "${NFTBAN_DATA_DIR}/state" || return 1
 
-    # Get all current SSH connections (excluding localhost)
-    CURRENT_SSH_IPS=$(ss -tn state established '( dport = :22 or sport = :22 )' 2>/dev/null | \
-                      awk 'NR>1 {print $5}' | \
-                      grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}|([0-9a-f:]+:+)+[0-9a-f]+' | \
-                      grep -v '^127\.' | \
-                      grep -v '^::1' | \
-                      sort -u || true)
+    # Get all current SSH connections (excluding localhost) on every REAL SSH
+    # listener port, not a hardcoded :22. SSH_PORTS is populated by step [1/10]
+    # above (same function scope, always runs first) and is never empty there;
+    # the :-22 fallback only covers a future reordering.
+    # See _maint_active_ssh_peers for the two defects this replaced.
+    CURRENT_SSH_IPS=$(_maint_active_ssh_peers "${SSH_PORTS[@]:-22}")
 
     # Update active SSH whitelist timestamp file
     : > "$ACTIVE_SSH_WHITELIST.new"

--- a/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
+++ b/cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh
@@ -195,11 +195,41 @@ for POLICY in auto quarantine; do
 done
 # T6(b): prove the consumer keys on severity ALONE — if it ever gained another
 # trigger, capping severity would stop being sufficient and this test would lie.
-GATES=$(sed -n '893p' "$LIB/cron/maintenance.sh" | sed 's/#.*//')
-case "$GATES" in
-  *'NFTBAN_FIREWALL_SEVERITY'*'-ge 3'*) ok "consumer gate is severity-only (line 893 unchanged)";;
-  *) no "consumer gate changed — T6 no longer proves the invariant" "$GATES";;
-esac
+#
+# The gate is located by ANCHOR (the nearest severity test above the
+# nftban_remove_csf call site), not by line number. A fixed line number detaches
+# from its subject the moment anything above it grows, and then asserts against
+# whatever text happens to land there — which is a guard that has stopped
+# guarding without failing. That is exactly what happened: an unrelated
+# +38-line change in maintenance.sh moved this gate from 893 to 931.
+# The assertion below is unchanged; only how it FINDS its subject is.
+# \b so a RENAMED consumer (nftban_remove_csf_renamed) is NOT accepted as this
+# one — a substring match would silently re-attach the anchor to different code.
+CONSUMER_LN=$(grep -nE 'nftban_remove_csf\b' "$LIB/cron/maintenance.sh" | head -1 | cut -d: -f1)
+if [ -z "$CONSUMER_LN" ]; then
+    # Fail closed: no subject located means the invariant is unproven, not satisfied.
+    no "nftban_remove_csf call site not found — T6(b) cannot locate its subject" "anchor missing"
+else
+    GATES=$(awk -v end="$CONSUMER_LN" '
+        NR < end && /NFTBAN_FIREWALL_SEVERITY/ { last = $0 }
+        END { print last }' "$LIB/cron/maintenance.sh" | sed 's/#.*//')
+    # Extract the CONDITION between [[ ]] and normalise whitespace, then require
+    # it to be EXACTLY the severity test.
+    #
+    # A substring match (*'-ge 3'*) is not sufficient and never was: it happily
+    # accepts `-ge 3 || -n "$NFTBAN_FORCE_DRIFT"`, which is precisely the second
+    # trigger this arm exists to forbid. Proven by inversion — the old pattern
+    # stayed green when an || clause was added to the live gate.
+    COND=$(printf '%s\n' "$GATES" \
+             | sed -n 's/.*\[\[\(.*\)\]\].*/\1/p' \
+             | tr -s '[:space:]' ' ' \
+             | sed 's/^ //; s/ $//')
+    if [ "$COND" = '${NFTBAN_FIREWALL_SEVERITY:-0} -ge 3' ]; then
+        ok "consumer gate is severity-ONLY (exact condition, anchored to the nftban_remove_csf call site)"
+    else
+        no "consumer gate changed — T6 no longer proves the invariant" "$COND"
+    fi
+fi
 
 echo
 echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"

--- a/cli/lib/nftban/tests/maint_active_ssh_peers_v1229_test.sh
+++ b/cli/lib/nftban/tests/maint_active_ssh_peers_v1229_test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.229.x — active-SSH auto-whitelist peer extraction (A6)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+#
+# meta:name="maint_active_ssh_peers_v1229_test"
+# meta:type="test"
+# meta:version="1.229.1"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-14"
+# meta:description="A6 regression: maintenance.sh must auto-whitelist ACTIVE SSH sessions on every real listener port. Locks out TWO layered defects proven inert fleet-wide at runtime (srv2 :55000, srv3 :22, v1.228.11): (1) peer read as \$5 while 'ss -tn state established' omits the State column, so every host returned EMPTY; (2) the port filter hardcoded :22, which defect 1 masked. Each arm carries a falsifiability control asserting the OLD code fails on the same fixture. Hermetic: stubbed ss, no root/network/host."
+# meta:inventory.files="maint_active_ssh_peers_v1229_test.sh"
+# meta:inventory.binaries="bash,awk,grep,sort"
+# meta:inventory.env_vars="_SS_FIXTURE,_SS_LAYOUT"
+# meta:inventory.config_files=""
+# meta:inventory.systemd_units=""
+# meta:inventory.network=""
+# meta:inventory.privileges="none"
+# meta:ta.id="maint_active_ssh_peers_v1229_test"
+# meta:ta.owner="firewall"
+# meta:ta.module="maintenance-active-ssh-whitelist"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAINT="$SCRIPT_DIR/../cron/maintenance.sh"
+[[ -f "$MAINT" ]] || { echo "FAIL: maintenance.sh not found at $MAINT"; exit 1; }
+PASS=0; FAIL=0
+ok(){  echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# Extract ONLY the shipped helper — the subject under test is the production
+# function itself, not a copy of its pipeline.
+HELPER="$(awk '/^_maint_active_ssh_peers\(\)/{f=1} f{print} f&&/^\}/{exit}' "$MAINT")"
+[[ -n "$HELPER" ]] || { echo "FAIL: _maint_active_ssh_peers not found in maintenance.sh"; exit 1; }
+eval "$HELPER"
+
+# -----------------------------------------------------------------------------
+# ss stub. Honours the port filter so the port arm cannot pass vacuously, and
+# reproduces the three real column layouts.
+#
+#   _SS_FIXTURE  lines of "<local-ip>:<port> <peer-ip>:<port>"
+#   _SS_LAYOUT   state    -> Recv-Q Send-Q Local Peer      (real `state established`)
+#                full     -> State Recv-Q Send-Q Local Peer (real plain `ss -tn`)
+#                noheader -> state layout with NO header row
+# -----------------------------------------------------------------------------
+ss() {
+    local args="$*" ports lip pip lport want p
+    ports="$(grep -oE '[ds]port = :[0-9]+' <<<"$args" | grep -oE '[0-9]+$' | sort -u || true)"
+    case "${_SS_LAYOUT:-state}" in
+        full)     printf 'State    Recv-Q Send-Q Local Address:Port  Peer Address:Port\n' ;;
+        noheader) : ;;
+        *)        printf 'Recv-Q Send-Q Local Address:Port  Peer Address:Port\n' ;;
+    esac
+    while read -r lip pip; do
+        [[ -n "$lip" ]] || continue
+        lport="${lip##*:}"
+        want=0
+        while read -r p; do [[ "$p" == "$lport" ]] && want=1; done <<<"$ports"
+        [[ "$want" == 1 ]] || continue
+        if [[ "${_SS_LAYOUT:-state}" == "full" ]]; then
+            printf 'ESTAB    0      0      %s   %s\n' "$lip" "$pip"
+        else
+            printf '0      0      %s   %s\n' "$lip" "$pip"
+        fi
+    done <<<"${_SS_FIXTURE:-}"
+    return 0
+}
+
+# The PRE-FIX pipeline, verbatim. Used only as a falsifiability control: every
+# arm proves the old code FAILS on the same fixture the new code passes, so a
+# green arm can never be an accident of the stub.
+old_impl() {
+    ss -tn state established '( dport = :22 or sport = :22 )' 2>/dev/null | \
+        awk 'NR>1 {print $5}' | \
+        grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}|([0-9a-f:]+:+)+[0-9a-f]+' | \
+        grep -v '^127\.' | grep -v '^::1' | sort -u || true
+}
+
+echo "=== A6 · active-SSH peer extraction (v1.229.x) ==="
+
+# -----------------------------------------------------------------------------
+echo "ARM 1 — DEFECT 1: peer column under 'state established' (no State column)"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.50:22 198.51.100.10:53646'
+export _SS_LAYOUT=state
+got="$(_maint_active_ssh_peers 22)"
+[[ "$got" == "198.51.100.10" ]] \
+    && ok "peer extracted on a port-22 host (got: $got)" \
+    || bad "peer NOT extracted — got '[$got]', expected 198.51.100.10"
+
+# 1b — falsifiability: the shipped-before code must return NOTHING here.
+old="$(old_impl)"
+[[ -z "$old" ]] \
+    && ok "control: pre-fix \$5 pipeline returns EMPTY on the same fixture (arm is non-vacuous)" \
+    || bad "control BROKEN: pre-fix code returned '[$old]' — the fixture does not reproduce defect 1"
+
+# -----------------------------------------------------------------------------
+echo "ARM 2 — DEFECT 2: non-22 listener port"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.97:55000 198.51.100.10:38502'
+got="$(_maint_active_ssh_peers 55000)"
+[[ "$got" == "198.51.100.10" ]] \
+    && ok "peer extracted on a :55000 host (got: $got)" \
+    || bad "peer NOT extracted on non-22 port — got '[$got]'"
+
+# 2b — the port filter must genuinely matter: asking for :22 finds nothing here.
+got="$(_maint_active_ssh_peers 22)"
+[[ -z "$got" ]] \
+    && ok "control: querying :22 on a :55000 host yields EMPTY (filter is honoured, not ignored)" \
+    || bad "filter ignored — :22 query returned '[$got]' on a :55000-only fixture"
+
+# 2c — falsifiability: pre-fix code (hardcoded :22 AND \$5) returns nothing.
+old="$(old_impl)"
+[[ -z "$old" ]] \
+    && ok "control: pre-fix pipeline returns EMPTY on the :55000 fixture" \
+    || bad "control BROKEN: pre-fix returned '[$old]'"
+
+# -----------------------------------------------------------------------------
+echo "ARM 3 — layout robustness: \$NF is the peer in BOTH column layouts"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.50:22 198.51.100.10:53646'
+export _SS_LAYOUT=full
+got="$(_maint_active_ssh_peers 22)"
+[[ "$got" == "198.51.100.10" ]] \
+    && ok "peer extracted when the State column IS present" \
+    || bad "peer lost in 'full' layout — got '[$got]'"
+export _SS_LAYOUT=state
+
+# -----------------------------------------------------------------------------
+echo "ARM 4 — lockout safety: a session is still found when ss emits no header"
+# -----------------------------------------------------------------------------
+export _SS_LAYOUT=noheader
+got="$(_maint_active_ssh_peers 22)"
+[[ "$got" == "198.51.100.10" ]] \
+    && ok "headerless ss output still yields the session (NR>1 would have dropped it)" \
+    || bad "headerless output dropped the only session — LOCKOUT RISK; got '[$got]'"
+export _SS_LAYOUT=state
+
+# -----------------------------------------------------------------------------
+echo "ARM 5 — the LOCAL address must never be whitelisted"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.50:22 198.51.100.10:53646'
+got="$(_maint_active_ssh_peers 22)"
+grep -q '46\.224\.164\.50' <<<"$got" \
+    && bad "SERVER's own local IP leaked into the whitelist set: '[$got]'" \
+    || ok "local address excluded (only the peer is returned)"
+
+# -----------------------------------------------------------------------------
+echo "ARM 6 — loopback excluded"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.50:22 127.0.0.1:44100
+192.0.2.50:22 198.51.100.10:53646'
+got="$(_maint_active_ssh_peers 22)"
+[[ "$got" == "198.51.100.10" ]] \
+    && ok "127.0.0.1 filtered, real peer kept" \
+    || bad "loopback handling wrong — got '[$got]'"
+
+# -----------------------------------------------------------------------------
+echo "ARM 7 — multi-port union (both listeners protected)"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='192.0.2.50:22 198.51.100.10:53646
+192.0.2.50:2222 203.0.113.9:41000'
+got="$(_maint_active_ssh_peers 22 2222 | tr '\n' ' ')"
+[[ "$got" == "198.51.100.10 203.0.113.9 " ]] \
+    && ok "both listener ports contribute peers (got: $got)" \
+    || bad "multi-port union wrong — got '[$got]'"
+
+# -----------------------------------------------------------------------------
+echo "ARM 8 — EMPTY still means empty (the fix must not fabricate peers)"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE=''
+got="$(_maint_active_ssh_peers 22)"
+[[ -z "$got" ]] \
+    && ok "no sessions -> empty result (no fabricated whitelist entries)" \
+    || bad "fabricated output with no sessions: '[$got]'"
+
+# -----------------------------------------------------------------------------
+echo "ARM 9 — IPv6 peer extracted"
+# -----------------------------------------------------------------------------
+export _SS_FIXTURE='[2001:db8::50]:22 [2001:db8::122]:53646'
+got="$(_maint_active_ssh_peers 22)"
+grep -q '2001:db8::122' <<<"$got" \
+    && ok "IPv6 peer extracted (got: $got)" \
+    || bad "IPv6 peer lost — got '[$got]'"
+
+# -----------------------------------------------------------------------------
+echo "ARM 10 — STATIC: the defective forms must not reappear in maintenance.sh"
+# -----------------------------------------------------------------------------
+if grep -nE "awk '.*NR>1 \{print \\\$5\}'" "$MAINT" >/dev/null 2>&1; then
+    bad "maintenance.sh still contains an 'NR>1 {print \$5}' peer read"
+else
+    ok "no '\$5' peer read remains in maintenance.sh"
+fi
+
+if grep -n "dport = :22 or sport = :22" "$MAINT" | grep -v '_filter=' >/dev/null 2>&1; then
+    bad "a hardcoded ':22' ss filter remains outside the documented fallback"
+else
+    ok "no hardcoded ':22' session filter outside the fallback"
+fi
+
+if grep -q '_maint_active_ssh_peers "${SSH_PORTS\[@\]:-22}"' "$MAINT"; then
+    ok "call site passes the detected SSH_PORTS (reuses the existing authority)"
+else
+    bad "call site does not pass SSH_PORTS — the detected ports are not reaching the query"
+fi
+
+echo
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -159,6 +159,7 @@ mail_honest_wording_v1227_test	cli/lib/nftban/tests/mail_honest_wording_v1227_te
 mail_netrc_auth_transport_v1227_test	cli/lib/nftban/tests/mail_netrc_auth_transport_v1227_test.sh	mail	test	mail-smtp-netrc	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 mail_recipient_subject_help_v1223_test	cli/lib/nftban/tests/mail_recipient_subject_help_v1223_test.sh	mail	test	mail	CI_HERMETIC_SHELL	policy-gates	true	false	false	false	false	false			
 mail_subject_authority_v1227_test	cli/lib/nftban/tests/mail_subject_authority_v1227_test.sh	mail	test	mail-subject-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+maint_active_ssh_peers_v1229_test	cli/lib/nftban/tests/maint_active_ssh_peers_v1229_test.sh	firewall	test	maintenance-active-ssh-whitelist	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 maint_table_absent_noise_v1930_test	cli/lib/nftban/tests/maint_table_absent_noise_v1930_test.sh	firewall	test	maintenance-table-probe	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 module_effective_config_v1228_7_test	cli/lib/nftban/tests/module_effective_config_v1228_7_test.sh	firewall	test	effective-config-authority	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	60		
 nft_bounded_limiter_render_v1228_6_test	cli/lib/nftban/tests/nft_bounded_limiter_render_v1228_6_test.sh	firewall	test	nft-bounded-limiters	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		


### PR DESCRIPTION
## What this fixes

The maintenance step that auto-whitelists **logged-in admins** so they cannot be banned had not
whitelisted anything **on any host**. It is the project's cardinal-risk guard (admin lockout), and it
was inert in production.

A read-only runtime witness on two production hosts, both v1.228.11:

| host | SSH port | ground truth | shipped `$5` | control `$4` | verdict |
|---|---|---|---|---|---|
| `a port-22 host` | **22** | 1 established `:22` session from `198.51.100.10` | `<EMPTY>` | `198.51.100.10` | **broken on port 22** |
| `a non-22 host` | **55000** | detector reports `SSH_PORTS=55000` | `<EMPTY>` | n/a | broken |

Both hosts logged `"No active SSH sessions to protect"` every 15 minutes, with
`active_ssh_whitelist.state` at **0 lines**.

## Two layered defects on one line

```
DEFECT 1 (DOMINANT) — peer read as $5.
  `ss -tn state established` OMITS the State column, so a data row is:
     $1 Recv-Q   $2 Send-Q   $3 Local Address:Port   $4 Peer Address:Port
  $5 is empty -> empty result on EVERY host and EVERY port.

DEFECT 2 (MASKED BY 1) — filter hardcoded ':22'
  despite step [1/10] having already detected the real listeners into SSH_PORTS.
  Bites only once defect 1 is fixed; then :55000 hosts still whitelist nothing.
```

**Fixing either one alone produces a false "fixed" signal**, so both land together. That claim is not
just asserted — see the inversion results below.

## The fix

Extraction moves into `_maint_active_ssh_peers()`:

- reads the peer as **`$NF`**, which is the peer column in **both** `ss` layouts (with `State` it is `$5`,
  without it `$4`) — so the function cannot be broken again by a layout difference;
- builds the port filter from the **already-detected `SSH_PORTS`** (reusing the existing authority rather
  than adding a new detector);
- **drops `NR>1` header skipping** in favour of matching by IP shape. The header's `$NF` is the literal
  `Address:Port` and cannot match the IP patterns, while `NR>1` would discard the *only* live session on any
  `ss` build that emits no header — itself a lockout.

## Blast radius — checked, not assumed

Every other `ss` call site in the tree passes `-H` and indexes the correct column:
`nftban_sysctl_registry.sh:115,117`, `ssh_admin_port_guard.sh:71`, `service_control.sh:387`,
`validate_node_exporter.sh:145`, and `nftban_unified_exporter_helpers.sh:308-311` (count-only).
`maintenance.sh` was the **sole** site that omitted `-H` and compensated with `NR>1`. Nothing outside this
step changes.

## Test

`maint_active_ssh_peers_v1229_test.sh` — **15 assertions**, hermetic (stubbed `ss`, no root, no network),
extracting the **shipped** function rather than a copy of its pipeline. Wired as an **executing** step in
`ci-bash` and registered in the test-authority index (`INDEX_FRESH = YES`).

Arms: both defects; the `ss` port filter is genuinely honoured; `$NF` correct in both layouts; headerless
output still protected; the server's own local address never whitelisted; loopback excluded; multi-port
union; **empty stays empty** (the fix must not fabricate entries); IPv6; plus static guards against the
defective forms reappearing.

**Falsified by inversion against production code** (each restore checksum-verified):

| inversion | result |
|---|---|
| restore `NR>1 {print $5}` | **7 assertions fail** |
| restore only the `':22'` literal (field index left fixed) | **exactly the 2 non-22 assertions fail** — this is what proves the masking claim |
| call site stops passing `SSH_PORTS` | static arm fails |
| fixed code | 15/15 PASS |

## Evidence label

A6 was `SOURCE_PROVEN_CURRENT`, scoped to non-22 hosts. The runtime witness corrects it to
**`RUNTIME_VERIFIED`** and **fleet-wide**. The scope widened because the witness carried a falsifiability
control; without it, the wrong mechanism would have been "confirmed". The audit document is updated.

## Not in scope

No other audit item is touched. This is the first item of the P0 burn-down
(`A6 -> A10 -> A4`), one bounded fix per lane.

