### PR TITLE
fix(portscan): read the live tail, not the backlog — the cursor was never persisting

### DIFF
--- a/cli/lib/nftban/core/nftban_portscan_classic.sh
+++ b/cli/lib/nftban/core/nftban_portscan_classic.sh
@@ -526,17 +526,77 @@ _nftban_portscan_extract_timestamp() {
 : "${PORTSCAN_CLASSIC_CURSOR_DIR:=${NFTBAN_DATA_DIR:-/var/lib/nftban}/portscan/log-cursors}"
 : "${PORTSCAN_CLASSIC_CURSOR_MAX_BYTES:=1048576}"
 
+# Report ONCE per cycle, before the read, when the unread backlog exceeds the
+# incremental cap and older records will therefore be skipped.
+#
+# This READS the shared reader's state file (inode:offset) rather than owning it.
+# The coupling is deliberate and one-directional: PortScan never WRITES that file,
+# and every parse step below fails closed to "no warning". If the reader's format
+# ever changes, this degrades to silence on the WARN only — it can never affect
+# detection, and it can never invent a backlog that is not there.
+_nftban_portscan_classic_warn_backlog() {
+    local f="$1" size ino key state prev_ino prev_off backlog cap
+    cap="${PORTSCAN_CLASSIC_CURSOR_MAX_BYTES:-1048576}"
+    size="$(stat -c %s "$f" 2>/dev/null)" || return 0
+    ino="$(stat -c %i "$f" 2>/dev/null)"  || return 0
+    [[ "$size" =~ ^[0-9]+$ && "$ino" =~ ^[0-9]+$ ]] || return 0
+    key="$(printf '%s' "$f" | tr '/' '_')"
+    state="${PORTSCAN_CLASSIC_CURSOR_DIR}/${key}"
+    # No cursor yet: the bounded current tail IS the intended first read, not a skip.
+    [[ -r "$state" ]] || return 0
+    IFS=':' read -r prev_ino prev_off < "$state" 2>/dev/null || return 0
+    [[ "$prev_ino" =~ ^[0-9]+$ && "$prev_off" =~ ^[0-9]+$ ]] || return 0
+    # Rotation is a different condition and is handled by the reader, not a backlog.
+    [[ "$prev_ino" == "$ino" ]] || return 0
+    backlog=$(( size - prev_off ))
+    (( backlog > cap )) || return 0
+    _nftban_portscan_classic_log "WARN" \
+        "PortScan log backlog exceeds incremental read cap; older records will be skipped to preserve live-tail detection (path=${f} backlog_bytes=${backlog} cap_bytes=${cap})"
+}
+
 # Emit only records not yet consumed from a FILE source.
+#
+# READ MODE — tail-biased (the shared reader's DEFAULT). Do not re-enable
+# NFTBAN_HTTP_LOG_READ_FORWARD here. Forward mode is correct for BotScan, which
+# owns its spool and legitimately drains backlog, and WRONG for PortScan, which
+# consumes an external live system log. Proven on srv3 (kern.log, 484 MB), three
+# separate runtime failures came from that one line:
+#
+#   D1 CURSOR NEVER PERSISTED. Forward mode runs `tail -c +N file | head -c CAP`;
+#      on a file larger than CAP, head exits early, tail takes SIGPIPE (141),
+#      pipefail propagates it and errexit aborts the process-substitution subshell
+#      BEFORE the reader persists its offset. maintenance.sh and this module both
+#      run `set -Eeuo pipefail`, so in production the cursor was never written and
+#      the whole feature was inert. Measured: set-e+pipefail -> cursor absent;
+#      any other combination -> cursor present.
+#   D2 BOF BOOTSTRAP. With no cursor, prev_ino=0 never matches the real inode, so
+#      the reader treats first use as ROTATION and starts at byte 0. Forward mode
+#      then drains CAP bytes per cycle: ~8 hours to reach the tail of a 484 MB log
+#      that keeps growing, i.e. current scans unread. Replay traded for blindness.
+#   D3 the original replay, left unfixed because D1 made the fix inert.
+#
+# Tail-biased mode fixes all three: `start` is clamped to size-CAP so the first
+# read is the CURRENT tail and the offset is seeded at EOF; `tail` then emits
+# ≈exactly CAP bytes so head does not close early and the SIGPIPE abort does not
+# arise. Verified on the live file under `set -Eeuo pipefail` inside this exact
+# pipeline: call 1 -> bounded current tail + cursor seeded at EOF, call 2 -> only
+# the newly appended records, call 3 -> zero.
+#
+# The trade is explicit: falling more than CAP behind SKIPS the excess instead of
+# lagging. For a live detector that is the correct side — stale records are worth
+# less than current ones — but the skip must never be silent, hence the WARN above.
+#
 # Degradation ladder (a broken cursor must never look like "nothing happened"):
 #   cursor disabled / reader absent -> legacy bounded read, silent (by design)
 #   state dir unwritable            -> legacy bounded read + WARN
+#   backlog > cap                   -> incremental read + WARN (records skipped)
 _nftban_portscan_classic_read_file_source() {
     local f="$1"
     if [[ "${PORTSCAN_CLASSIC_CURSOR_ENABLED:-true}" == "true" ]] \
        && type -t nftban_http_read_incremental &>/dev/null; then
         if mkdir -p "$PORTSCAN_CLASSIC_CURSOR_DIR" 2>/dev/null; then
+            _nftban_portscan_classic_warn_backlog "$f"
             NFTBAN_HTTP_LOG_OFFSET_DIR="$PORTSCAN_CLASSIC_CURSOR_DIR" \
-            NFTBAN_HTTP_LOG_READ_FORWARD=true \
             NFTBAN_HTTP_LOG_MAX_BYTES="$PORTSCAN_CLASSIC_CURSOR_MAX_BYTES" \
             nftban_http_read_incremental "$f"
             return 0

--- a/cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
+++ b/cli/lib/nftban/tests/portscan_cursor_replay_v1229_test.sh
@@ -47,6 +47,7 @@ source "$REPO_ROOT/cli/lib/nftban/lib/nftban_http_logs.sh"
 eval "$(awk '/^_nftban_portscan_classic_read_file_source\(\)/,/^}/' "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
 eval "$(awk '/^_nftban_portscan_classic_journal_fetch\(\)/,/^}/'    "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
 eval "$(awk '/^_nftban_portscan_classic_journal_commit\(\)/,/^}/'   "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
+eval "$(awk '/^_nftban_portscan_classic_warn_backlog\(\)/,/^}/'    "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh")"
 type -t _nftban_portscan_classic_read_file_source >/dev/null || { echo "helpers not extracted"; exit 1; }
 export PORTSCAN_CLASSIC_CURSOR_ENABLED=true
 export PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=1048576
@@ -169,6 +170,122 @@ case "$bad" in
 esac
 
 echo
+
+# =============================================================================
+# LARGE-STATE MATRIX (v1.229.x) — SMALL_FIXTURE_PASS != LARGE-STATE_BOOTSTRAP_PROVEN
+#
+# Every arm above uses a 100-line file. Three production defects lived precisely
+# where a small fixture cannot reach, and all three were found only on srv3's
+# 484 MB kern.log:
+#   D1 cursor never persisted under `set -Eeuo pipefail` (SIGPIPE from the
+#      reader's internal `tail -c | head -c` when the file exceeds the cap)
+#   D2 first use treated as ROTATION -> start=0 -> forward mode drained backlog
+#   D3 the original replay, left unfixed because D1 made the fix inert
+# The arms below reproduce the LARGE-state conditions cheaply by shrinking the
+# cap instead of growing the file — identical clamp logic, no multi-MB fixtures.
+# =============================================================================
+_cursor_path() { printf '%s/%s' "$PORTSCAN_CLASSIC_CURSOR_DIR" "$(printf '%s' "$1" | tr '/' '_')"; }
+
+echo "── ARM 8  FIRST USE on a source LARGER than the cap: tail, not BOF ────"
+BIG="$SBX/big.log"
+: > "$BIG"
+{ echo "NFTBAN_PORTSCAN: OLD_HEAD_MARKER"; seq 1 20000 | sed 's/^/NFTBAN_PORTSCAN: old /'; } > "$BIG"
+BIGSZ=$(stat -c %s "$BIG")
+rm -f "$(_cursor_path "$BIG")"
+PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG" > "$SBX/out8"
+[ "$BIGSZ" -gt 65536 ] && ok "fixture exceeds the cap ($BIGSZ > 65536) — arm is not vacuous" \
+                       || no "fixture too small to exercise the clamp" "$BIGSZ"
+grep -q "OLD_HEAD_MARKER" "$SBX/out8" \
+    && no "FIRST USE drained from BOF — historical backlog emitted" "D2 regression: start=0 on first use" \
+    || ok "first use emitted the CURRENT tail, not the head of the backlog"
+off8=$(cut -d: -f2 "$(_cursor_path "$BIG")" 2>/dev/null)
+[ "${off8:-0}" = "$BIGSZ" ] && ok "cursor seeded at EOF ($off8 == file size)" \
+                            || no "cursor not seeded at EOF" "got '${off8:-NONE}', want $BIGSZ"
+echo "NFTBAN_PORTSCAN: NEW_AFTER_BOOTSTRAP" >> "$BIG"
+n8b=$( PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG" > "$SBX/out8b"; wc -l < "$SBX/out8b" )
+[ "$n8b" -eq 1 ] && grep -q "NEW_AFTER_BOOTSTRAP" "$SBX/out8b" \
+    && ok "after bootstrap, exactly the 1 newly appended record is emitted" \
+    || no "post-bootstrap read emitted $n8b" "live-tail detection not preserved"
+
+echo "── ARM 8i INVERSION: forward mode MUST drain from BOF (arm 8 falsifiable)"
+rm -f "$(_cursor_path "$BIG")"
+# `|| true` + subshell: forward mode's internal `tail -c | head -c` SIGPIPEs by
+# design on a file larger than the cap, and under `set -o pipefail` that 141 would
+# terminate THIS harness before the assertion runs (it did — exit 141). The arm
+# asserts on the captured OUTPUT, never on the return code.
+( NFTBAN_HTTP_LOG_READ_FORWARD=true PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 \
+  _nftban_portscan_classic_read_file_source "$BIG" ) > "$SBX/out8i" 2>/dev/null || true
+grep -q "OLD_HEAD_MARKER" "$SBX/out8i" \
+    && ok "control: with READ_FORWARD=true the BOF drain IS visible — arm 8 can fail" \
+    || no "control BROKEN: forward mode did not drain from BOF" "arm 8 may be vacuous"
+
+echo "── ARM 9  PRODUCTION PIPELINE CONTEXT: set -Eeuo pipefail ────────────"
+# The defect that made the whole feature inert was invisible to every direct
+# helper call: only errexit+pipefail inside a process substitution loses the
+# cursor write. This arm runs the real shell options and the real pipeline shape.
+rm -f "$(_cursor_path "$BIG")"
+(
+  set -Eeuo pipefail
+  c=0
+  while IFS= read -r _l; do c=$((c+1)); done < <( { PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG"; } | { tail -5000 || true; } | { grep -E -- "NFTBAN_PORTSCAN:" 2>/dev/null || true; } | { tail -1000 || true; } )
+  echo "$c" > "$SBX/n9"
+) 2>/dev/null
+[ -s "$(_cursor_path "$BIG")" ] \
+    && ok "cursor PERSISTED under set -Eeuo pipefail in the wired pipeline (D1 locked out)" \
+    || no "cursor LOST under errexit+pipefail — the fix would be INERT in production" "this is the srv3 D1 defect"
+n9b=$( set -Eeuo pipefail; { PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG"; } | grep -cE "NFTBAN_PORTSCAN:" || true )
+[ "${n9b:-0}" -eq 0 ] && ok "second pipeline read emits 0 — replay eliminated in the production context" \
+                      || no "second pipeline read emitted $n9b" "replay persists under production shell options"
+
+echo "── ARM 9i INVERSION: forward mode loses the cursor under pipefail ─────"
+rm -f "$(_cursor_path "$BIG")"
+(
+  set -Eeuo pipefail
+  while IFS= read -r _l; do :; done < <( { NFTBAN_HTTP_LOG_READ_FORWARD=true PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG"; } | { tail -5000 || true; } | { grep -E -- "NFTBAN_PORTSCAN:" 2>/dev/null || true; } | { tail -1000 || true; } )
+) 2>/dev/null
+[ -s "$(_cursor_path "$BIG")" ] \
+    && no "control BROKEN: forward mode persisted a cursor here" "arm 9 cannot prove D1" \
+    || ok "control: forward mode loses the cursor under errexit+pipefail — arm 9 is falsifiable"
+
+echo "── ARM 10 EMPTY source: no cursor damage, no fabricated records ───────"
+EMPTY="$SBX/empty.log"; : > "$EMPTY"
+rm -f "$(_cursor_path "$EMPTY")"
+n10=$(_nftban_portscan_classic_read_file_source "$EMPTY" | wc -l)
+[ "$n10" -eq 0 ] && ok "empty source emits 0 records (no fabrication)" || no "empty source emitted $n10" ""
+echo "NFTBAN_PORTSCAN: FIRST_EVER" >> "$EMPTY"
+n10b=$(_nftban_portscan_classic_read_file_source "$EMPTY" | wc -l)
+[ "$n10b" -eq 1 ] && ok "first record on a previously-empty source is detected" \
+                  || no "first record after empty emitted $n10b" "startup detection gap"
+
+echo "── ARM 11 backlog beyond the cap WARNs (a skip must never be silent) ──"
+: > "$SBX/log/module.log"
+printf '%s:%s\n' "$(stat -c %i "$BIG")" "0" > "$(_cursor_path "$BIG")"   # pretend we are far behind
+PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG" >/dev/null
+if grep -q "backlog exceeds incremental read cap" "$SBX/log/module.log"; then
+    ok "WARN emitted when records are skipped"
+    grep -qE "path=.*backlog_bytes=[0-9]+ cap_bytes=[0-9]+" "$SBX/log/module.log" \
+        && ok "WARN carries bounded fields (path, backlog_bytes, cap_bytes)" \
+        || no "WARN missing structured fields" "$(tail -1 "$SBX/log/module.log")"
+else
+    no "no WARN when backlog exceeded the cap" "a silent skip is exactly what this forbids"
+fi
+: > "$SBX/log/module.log"
+PORTSCAN_CLASSIC_CURSOR_MAX_BYTES=65536 _nftban_portscan_classic_read_file_source "$BIG" >/dev/null
+grep -q "backlog exceeds incremental read cap" "$SBX/log/module.log" \
+    && no "WARN repeated when caught up — this would be log spam" "$(tail -1 "$SBX/log/module.log")" \
+    || ok "no WARN once caught up (bounded, not per-record)"
+
+echo "── ARM 12 STATIC: PortScan must not re-enable forward mode ────────────"
+if grep -nE '^[^#]*NFTBAN_HTTP_LOG_READ_FORWARD' "$REPO_ROOT/cli/lib/nftban/core/nftban_portscan_classic.sh" >/dev/null 2>&1; then
+    no "PortScan sets NFTBAN_HTTP_LOG_READ_FORWARD again" "forward mode is for BotScan's owned spool, not an external live log"
+else
+    ok "PortScan does not enable forward mode"
+fi
+grep -qE '^[^#]*NFTBAN_HTTP_LOG_READ_FORWARD=true' "$REPO_ROOT/cli/lib/nftban/core/nftban_botscan.sh" \
+    && ok "BotScan still owns its forward mode (unchanged by this fix)" \
+    || no "BotScan lost READ_FORWARD" "this patch must not change BotScan semantics"
+
+
 echo "══ RESULT: PASS=$PASS FAIL=$FAIL ══"
 [ "$FAIL" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## What was wrong

The v1.229.0 PortScan cursor (#1228) was **completely inert in production**. A canary on srv3
(`/var/log/kern.log`, 484 MB) found **three layered defects**, all traceable to one line requesting
forward (backlog-draining) mode from the shared reader.

| | defect | effect |
|---|---|---|
| **D1** | Forward mode runs `tail -c +N file \| head -c CAP`. On a file larger than CAP, `head` exits early, `tail` takes SIGPIPE (141), `pipefail` propagates it, `errexit` aborts the process-substitution subshell **before** the offset is written | cursor **never persisted** → feature inert |
| **D2** | With no cursor, `prev_ino=0` never matches the real inode → first use classified as **ROTATION** → `start=0` → forward mode drains CAP/cycle | **~8 h** behind the live tail; newest 200 events were **5 days old** |
| **D3** | the original replay | unfixed, because D1 kept the fix switched off |

**D1 masked D2.** Measured directly — only the production shell options lose the cursor:

```
set-e=ON  pipefail=ON   → cursor ABSENT     ← maintenance.sh + module use `set -Eeuo pipefail`
set-e=ON  pipefail=OFF  → cursor present
set-e=OFF pipefail=ON   → cursor present
set-e=OFF pipefail=OFF  → cursor present
```

## The fix

Delete the forward-mode request. The shared reader's **default tail-biased** branch clamps `start` to
`size - CAP`, so the first read is the **current tail** and the offset is seeded at **EOF**; `tail` then emits
≈exactly CAP bytes, so `head` never closes early and the SIGPIPE abort cannot arise. All three defects fall
out at once.

**Verified on srv3's real 484 MB file, under `set -Eeuo pipefail`, inside the wired pipeline:**

```
call 1  lines=1000  cursor=134808:486597672   ← bounded current tail, seeded at EOF
call 2  lines=2     cursor=134808:486598201   ← only newly appended records
call 3  lines=0                               ← zero replay
```

That is `OLD_RECORD_REPLAY = ELIMINATED` **and** `NEW_RECORD_DETECTION = PRESERVED`.

**Explicit trade:** falling more than CAP behind now **skips** the excess instead of lagging. For a live
detector that is the correct side — stale records are worth less than current ones — but a skip must never be
silent, so this adds a **bounded WARN** naming the security consequence
(*"older records will be skipped to preserve live-tail detection"*) with `path`, `backlog_bytes`, `cap_bytes`.
One line per cycle, not per record; it stops once caught up.

**BotScan is untouched** and keeps forward mode with its own offset dir — it owns its spool, where draining
the backlog *is* the work. **The shared reader is untouched.**

## Tests: 20 → 35 assertions

New large-state matrix covering what the previous fixtures structurally could not reach — first use on a
source **larger than the cap**, resume, empty source, rotation, truncation, the backlog WARN (present when
skipping, absent when caught up), and the **production pipeline context under `set -Eeuo pipefail`**, which is
the *only* arm that would have caught D1.

Falsifiability:

| control / inversion | result |
|---|---|
| ARM 8i — forward mode must drain from BOF | visible → arm 8 can fail |
| ARM 9i — forward mode must lose the cursor under pipefail | confirmed → arm 9 can fail |
| **production inversion**: restore `READ_FORWARD=true` | **5 distinct failures** across D1, D2, D3 |
| fixed code | **35/35 PASS** |

The inversion prints its five failures then exits 141 (SIGPIPE) before the tally — a hard, diagnostic failure,
but not a clean `FAIL=n` line. Noted rather than hidden.

## Known, deliberately NOT fixed here

The shared reader retains a narrow **stat-then-read race**: if the file grows between `stat` and `tail` on a
clamped cycle, `head` can still close early and the cursor is not committed that cycle. Impact is bounded to
**today's replay for that cycle — never blindness** — and it self-corrects on any non-racing cycle. It belongs
with **A11 canonical-reader hardening**, where the fix can distinguish an expected downstream close from a
genuine read failure across *every* consumer, instead of a blanket `|| true` bolted on here.

Separately registered, not addressed: BotScan runs the same `set -Eeuo pipefail` with forward mode; its
cursors exist but are ~7 weeks stale against a 1.1 GB / 79-file spool backlog — evidence for the open **A3**
investigation, requiring its own witness.

## Closure

`PORTSCAN_CLOSURE = HOLD`. Direct helper invocation is **not** sufficient evidence — production execution
context is exactly what made D1 invisible. Closure still requires the scheduled PortScan path on srv3 to
create a cursor and advance it across normal timer cycles, then the before/after metrics.
