### PR TITLE
test(privacy): use RFC 5737 documentation addresses in the whitelist-reconcile fixture

### DIFF
--- a/.github/workflows/privacy-trusted-merge-gate.yml
+++ b/.github/workflows/privacy-trusted-merge-gate.yml
@@ -84,16 +84,73 @@ jobs:
             --whole-tree --mode publication \
             --selftest-root "$GITHUB_WORKSPACE/pr-head"
 
+      # (3b) PUBLISHED-BUT-UNTRACKED surfaces: commit messages in the PR and the
+      #      PR title/body. These are exactly as public as the tree, and on
+      #      2026-08-14 a real administrative identifier reached a COMMIT MESSAGE
+      #      while the tree was clean — --whole-tree could not see it, so the gate
+      #      passed on the surface that mattered.
+      #
+      #      Both are fetched as DATA from the API (never executed) and handed to
+      #      the TRUSTED scanner, preserving the model in step (3).
+      #
+      #      FAIL-CLOSED: a PR always has at least one commit, so an empty
+      #      commit-message capture means the capture failed, not that the PR is
+      #      clean. The scanner treats a MISSING file as an error; only the caller
+      #      can know that this particular source should never be empty.
+      - name: Trusted private-identifier gate over PR metadata (messages + title/body)
+        id: gate_meta
+        env:
+          NFTBAN_PRIVACY_DENYLIST: ${{ secrets.NFTBAN_PRIVACY_DENYLIST }}
+          NFTBAN_PRIVACY_FP_KEY: ${{ secrets.NFTBAN_PRIVACY_FP_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.inputs.pr_head_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p meta
+          # Resolve the PR(s) whose head is this SHA. Data only.
+          gh api "repos/$REPO/commits/$SHA/pulls" \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[].number' > meta/pr-numbers.txt || true
+          if [ ! -s meta/pr-numbers.txt ]; then
+            echo "::error::no pull request resolves to $SHA — cannot scan PR metadata"
+            exit 2
+          fi
+          : > meta/commit-messages.txt
+          : > meta/pr-text.txt
+          while read -r n; do
+            [ -n "$n" ] || continue
+            gh api "repos/$REPO/pulls/$n/commits" --paginate \
+              --jq '.[].commit.message' >> meta/commit-messages.txt
+            gh api "repos/$REPO/pulls/$n" \
+              --jq '.title, (.body // "")' >> meta/pr-text.txt
+          done < meta/pr-numbers.txt
+          # A PR always has >=1 commit: an empty capture is a failed capture.
+          if [ ! -s meta/commit-messages.txt ]; then
+            echo "::error::commit-message capture is empty — treating as coverage failure, not a pass"
+            exit 2
+          fi
+          echo "captured $(wc -l < meta/commit-messages.txt) message line(s), $(wc -l < meta/pr-text.txt) PR-text line(s)"
+          cd trusted
+          python3 scripts/ci/private-identifier-gate.py \
+            --mode publication \
+            --text-sources "$GITHUB_WORKSPACE/meta/commit-messages.txt" \
+                           "$GITHUB_WORKSPACE/meta/pr-text.txt"
+
       # (4) Bind the result to the exact PR-head SHA so branch protection can require it.
+      # The published status must reflect EVERY scanned surface. Binding it to the
+      # tree scan alone would make the metadata gate decorative: a leak in a commit
+      # message would fail its step, yet this status would still say success and
+      # branch protection would allow the merge. Both outcomes are required.
       - name: Publish commit status on the exact PR-head SHA
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          STATE: ${{ steps.gate.outcome == 'success' && 'success' || 'failure' }}
+          STATE: ${{ (steps.gate.outcome == 'success' && steps.gate_meta.outcome == 'success') && 'success' || 'failure' }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.inputs.pr_head_sha }}
         run: |
           gh api -X POST "repos/$REPO/statuses/$SHA" \
             -f state="$STATE" \
             -f context="privacy/trusted-private-gate" \
-            -f description="Trusted private-identifier gate (publication, fail-closed) bound to this SHA"
+            -f description="Trusted private-identifier gate (publication, fail-closed): tree + commit messages + PR title/body, bound to this SHA"

--- a/cli/lib/nftban/tests/whitelist_reconcile_convergence_v1228_5_test.sh
+++ b/cli/lib/nftban/tests/whitelist_reconcile_convergence_v1228_5_test.sh
@@ -36,12 +36,12 @@ CFG="$WORK/whitelist.d"; mkdir -p "$CFG"
 cat > "$CFG/00-system.conf" <<'EOF'
 # managed - do not hand edit
 127.0.0.1  # Localhost (critical)
-167.233.138.111  # Server interface (auto-detected)
+192.0.2.1  # Server interface (auto-detected)
 ::1  # Localhost v6
 fe80::9000:9ff:fe7a:1cc1  # link-local
 EOF
 cat > "$CFG/00-session.conf" <<'EOF'
-94.64.34.235  # EXPIRES_AT=2026-08-04T16:23:20Z REASON=session ADDED_BY=nftban-installer
+198.51.100.20  # EXPIRES_AT=2026-08-04T16:23:20Z REASON=session ADDED_BY=nftban-installer
 EOF
 
 V4RE='^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
@@ -51,7 +51,7 @@ missing_vs(){ comm -23 <(printf '%s\n' "$1") <(printf '%s\n' "$2"); }
 
 echo "=== T1: config extraction ignores comments and trailing text ==="
 got="$(cfg_members "$V4RE" | tr '\n' ' ')"
-[[ "$got" == "127.0.0.1 167.233.138.111 94.64.34.235 " ]] \
+[[ "$got" == "127.0.0.1 192.0.2.1 198.51.100.20 " ]] \
   && ok "T1a IPv4 members extracted exactly" || no "T1a got [$got]"
 got6="$(cfg_members "$V6RE" | tr '\n' ' ')"
 [[ "$got6" == "::1 fe80::9000:9ff:fe7a:1cc1 " ]] \
@@ -59,13 +59,13 @@ got6="$(cfg_members "$V6RE" | tr '\n' ' ')"
 
 echo "=== T2: NEGATIVE CONTROL - the measured production shape is detected ==="
 # daemon down -> only system IPs projected, durable session IP absent
-run="$(printf '127.0.0.1\n167.233.138.111\n' | sort -u)"
+run="$(printf '127.0.0.1\n192.0.2.1\n' | sort -u)"
 m="$(missing_vs "$(cfg_members "$V4RE")" "$run")"
-[[ "$m" == "94.64.34.235" ]] \
+[[ "$m" == "198.51.100.20" ]] \
   && ok "T2 admin/session IP detected missing (rebuild MUST fail)" || no "T2 got [$m]"
 
 echo "=== T3: equal COUNTS, different MEMBERS - count-level check would false-pass ==="
-run3="$(printf '127.0.0.1\n167.233.138.111\n10.0.0.1\n' | sort -u)"
+run3="$(printf '127.0.0.1\n192.0.2.1\n10.0.0.1\n' | sort -u)"
 cnt_cfg=$(cfg_members "$V4RE" | wc -l); cnt_run=$(printf '%s\n' "$run3" | wc -l)
 m3="$(missing_vs "$(cfg_members "$V4RE")" "$run3")"
 [[ "$cnt_cfg" -eq "$cnt_run" && -n "$m3" ]] \

--- a/scripts/ci/private-identifier-gate-selftest.py
+++ b/scripts/ci/private-identifier-gate-selftest.py
@@ -159,13 +159,74 @@ def test_scanner_source_canary():
           "private gate detects a token injected into scanner source (no whole-file skip)")
 
 
+def test_text_sources_mode():
+    """Commit messages and PR title/body are as public as the tree.
+
+    The 2026-08-14 incident put a real administrative identifier in a COMMIT
+    MESSAGE while the tree was clean: --whole-tree could not see it and the gate
+    passed on the surface that actually mattered. These arms prove the scanner
+    now covers that surface, and that it can SEE a true positive there — an arm
+    that only ever passes proves nothing.
+    """
+    print("test_text_sources_mode")
+    root = make_repo({"a.txt": "nothing here\n"})
+    d = tempfile.mkdtemp(prefix="pig-text-")
+
+    # POSITIVE CONTROL: a denylisted identifier in commit-message-shaped text MUST be caught.
+    leak = os.path.join(d, "commit-messages.txt")
+    open(leak, "w").write("fix: the witness yielded %s on the affected host\n" % D4)
+    rc, out, err = run(root, ["--text-sources", leak, "--mode", "publication"])
+    check(rc == 1 and "BLOCKING" in out, "denylisted identifier in commit-message text => FAIL", err.strip())
+    check(D4 not in out and D4 not in err, "raw identifier never echoed in diagnostics")
+
+    # Documentation-range-only text MUST pass — the sanctioned fixture form.
+    ok = os.path.join(d, "pr-body.txt")
+    open(ok, "w").write("peer 192.0.2.50 and 203.0.113.9 and 2001:db8::1 are documentation ranges\n")
+    rc, out, err = run(root, ["--text-sources", ok, "--mode", "publication"])
+    check(rc == 0 and "PASS" in out, "documentation-range-only text => PASS", err.strip())
+
+    # An EMPTY source is allowed (a PR body may legitimately be empty)...
+    empty = os.path.join(d, "empty.txt")
+    open(empty, "w").write("")
+    rc, _, err = run(root, ["--text-sources", empty, "--mode", "publication"])
+    check(rc == 0, "empty text source => PASS (an empty PR body is legitimate)", err.strip())
+
+    # ...but a MISSING source is a coverage gap, never an empty pass.
+    rc, _, err = run(root, ["--text-sources", os.path.join(d, "absent.txt"), "--mode", "publication"])
+    check(rc == 2 and "FAIL_CLOSED" in err, "missing text source => FAIL_CLOSED, not a silent pass", err.strip())
+
+    # Multiple sources: a leak in ANY one of them must fail the whole scan.
+    rc, out, _ = run(root, ["--text-sources", ok, leak, "--mode", "publication"])
+    check(rc == 1, "leak in the second of several sources still fails")
+
+
+def test_fixture_identifier_policy():
+    """PRODUCTION_IDENTIFIERS_IN_TEST_FIXTURES = FORBIDDEN.
+
+    Planted-fixture proof: a fixture built from documentation ranges passes, and
+    the same fixture carrying a denylisted production identifier fails. Without
+    the failing half, a green scan would not distinguish 'clean' from 'blind'.
+    """
+    print("test_fixture_identifier_policy")
+    clean = make_repo({"cli/lib/nftban/tests/x_test.sh":
+                       "peer=192.0.2.50\nsrv=198.51.100.10\nv6=2001:db8::1\n"})
+    rc, out, err = run(clean, ["--whole-tree", "--mode", "publication"])
+    check(rc == 0 and "PASS" in out, "fixture using RFC 5737/3849 documentation ranges => PASS", err.strip())
+
+    dirty = make_repo({"cli/lib/nftban/tests/x_test.sh":
+                       "peer=%s\nsrv=198.51.100.10\n" % D4})
+    rc, out, _ = run(dirty, ["--whole-tree", "--mode", "publication"])
+    check(rc == 1 and "BLOCKING" in out, "fixture carrying a production identifier => FAIL")
+
+
 def main():
     if not os.path.exists(GATE):
         sys.stderr.write("gate not found: %s\n" % GATE)
         return 2
     for t in (test_detection_forms, test_output_hygiene, test_hmac_fingerprint, test_fail_closed,
               test_clean_pass_and_false_positive_controls, test_changed_lines_mode,
-              test_scanner_source_canary):
+              test_scanner_source_canary, test_text_sources_mode,
+              test_fixture_identifier_policy):
         t()
     print()
     if _fail:

--- a/scripts/ci/private-identifier-gate.py
+++ b/scripts/ci/private-identifier-gate.py
@@ -246,12 +246,42 @@ def scan_changed_lines(root, base, deny):
     return hits
 
 
+def scan_text_sources(paths, deny):
+    """Scan arbitrary text that is PUBLISHED but is not a tracked file.
+
+    Commit messages and PR title/body are exactly as public as the tree, and the
+    2026-08-14 incident put a real administrative identifier in a commit message
+    while the tree itself was clean: --whole-tree could not see it, so the gate
+    passed on the surface that mattered. Same extraction and same denylist as the
+    tree scan — only the source of the text differs.
+
+    FAIL-CLOSED: a path that is absent or unreadable is a COVERAGE GAP, never an
+    empty pass. An EMPTY file is permitted (a PR body may legitimately be empty);
+    proving the capture actually happened is the caller's job, because only the
+    caller knows whether the source should have contained anything.
+    """
+    hits = []
+    for p in paths:
+        if not os.path.isfile(p):
+            raise RuntimeError("text source missing")
+        try:
+            with open(p, "r", encoding="utf-8", errors="ignore") as fh:
+                for n, line in enumerate(fh, 1):
+                    for c in candidates(line) & deny:
+                        hits.append((os.path.basename(p), n, c))
+        except OSError:
+            raise RuntimeError("text source unreadable")
+    return hits
+
+
 def main():
     ap = argparse.ArgumentParser(description="NFTBan private-identifier deny gate (independent).")
     ap.add_argument("--mode", choices=["publication", "advisory"], default="advisory")
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--whole-tree", action="store_true")
     g.add_argument("--changed-lines", metavar="BASE")
+    # Published-but-untracked surfaces: commit messages in the PR range, PR title/body.
+    g.add_argument("--text-sources", nargs="+", metavar="PATH")
     ap.add_argument("--selftest-root", help=argparse.SUPPRESS)  # internal: scan an alt tree
     args = ap.parse_args()
 
@@ -266,12 +296,20 @@ def main():
         sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (no NFTBAN_PRIVACY_FP_KEY) in publication mode\n")
         return 2
 
-    root = args.selftest_root or repo_root()
-    if not root:
-        sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (not in a git repository)\n")
-        return 2
+    # --text-sources scans files given by path and needs no repository context.
+    root = None
+    if not args.text_sources:
+        root = args.selftest_root or repo_root()
+        if not root:
+            sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (not in a git repository)\n")
+            return 2
     try:
-        hits = scan_whole_tree(root, deny) if args.whole_tree else scan_changed_lines(root, args.changed_lines, deny)
+        if args.text_sources:
+            hits = scan_text_sources(args.text_sources, deny)
+        elif args.whole_tree:
+            hits = scan_whole_tree(root, deny)
+        else:
+            hits = scan_changed_lines(root, args.changed_lines, deny)
     except Exception as e:
         # never let the exception body echo a value
         sys.stderr.write("PRIVATE_GATE = FAIL_CLOSED (scan error: %s)\n" % type(e).__name__)


### PR DESCRIPTION
## What this removes

`cli/lib/nftban/tests/whitelist_reconcile_convergence_v1228_5_test.sh` captured **two real production
values** and carried them in the public repository:

- a **server interface address** (`# Server interface (auto-detected)`)
- an **administrative session address** (`# EXPIRES_AT=… REASON=session ADDED_BY=nftban-installer`)

Both are replaced with **RFC 5737** documentation addresses (`192.0.2.0/24`, `198.51.100.0/24`).
The addresses are deliberately **not named in this PR or its commit message** — restating them is the same
disclosure surface as leaving them in the file.

## Severity: low, and bounded

Neither value is a credential, key, token or authentication factor. Nothing about the product's safety
depends on them being private — **an IP allowlist is a safety exemption, not a secret.** The exposure is
operational metadata and reconnaissance value. That is reason enough to remove it, and not a reason for
rotation or emergency action.

## The more useful finding: a denylist coverage gap

The trusted private-identifier gate **passes on this file both before and after this change.** These two
identifiers are simply absent from the maintainer denylist, so the scanner was **selectively blind** to them
while correctly blocking a different address elsewhere.

Adding them to `NFTBAN_PRIVACY_DENYLIST` is a **maintainer action on a repository secret** and is
intentionally *not* part of this PR — the denylist is never stored in the repo (`load_denylist()` reads it
only from the secret env or a path outside the tree). That step remains owed.

## Verification

```
15/15 assertions pass after the swap
```

Non-vacuity re-proven, because a fixture change is exactly the kind of edit that can make assertions
trivially true:

| perturbation (input changed, expectation untouched) | result |
|---|---|
| server address altered | **2 assertions FAIL** (T1a, T2) |
| session address altered | **2 assertions FAIL** (T1a, T2) |
| unmodified | 15/15 PASS |

So the comparisons still bind to the fixture values rather than passing regardless.

## Standing rule encoded

```
PRODUCTION_IDENTIFIERS_IN_TEST_FIXTURES = FORBIDDEN
allowed: RFC 5737 IPv4 doc ranges · RFC 3849 IPv6 (2001:db8::/32) · synthetic hostnames
```

Scope: this file only. No production code changes.
