### PR TITLE
fix(never-ban): canonicalize identity before the exemption decision

### DIFF
--- a/internal/nftbackend/exemption.go
+++ b/internal/nftbackend/exemption.go
@@ -67,14 +67,51 @@ func newExemptResolver(configDir, scannerFile string) *exemptResolver {
 	}
 }
 
+// canonPrefix returns p in the SAME canonical identity form the exact keys use.
+// An IPv4-mapped IPv6 prefix ("::ffff:203.0.113.0/120") is rewritten to its IPv4
+// equivalent ("203.0.113.0/24") so that a canonicalized (unmapped) lookup address
+// compares correctly. Without this, canonicalizing only the lookup side would move
+// the mismatch instead of removing it. Non-mapped prefixes are returned unchanged.
+func canonPrefix(p netip.Prefix) netip.Prefix {
+	if p.Addr().Is4In6() && p.Bits() >= 96 {
+		if c := netip.PrefixFrom(p.Addr().Unmap(), p.Bits()-96); c.IsValid() {
+			return c
+		}
+	}
+	return p
+}
+
 // IsExempt reports whether ipStr (a single IP literal) must never be banned, plus a
 // short reason. Returns false for non-single-IP inputs (CIDR ban requests are not the
-// admin/session class this guard protects). Range-aware, v4+v6.
+// admin/session class this guard protects). Range-aware, v4+v6, and IPv4-mapped-IPv6
+// aware: the input is canonicalized before any membership comparison.
 func (r *exemptResolver) IsExempt(ipStr string) (bool, string) {
 	addr, err := netip.ParseAddr(strings.TrimSpace(ipStr))
 	if err != nil {
 		return false, ""
 	}
+	// CANONICAL IDENTITY BEFORE THE SECURITY DECISION.
+	//
+	// The store canonicalizes every exact key with Unmap() (see :addExact); the
+	// lookup did not. An IPv4-mapped IPv6 form of an exempt address therefore
+	// missed BOTH membership paths and the ban proceeded:
+	//
+	//   stored key                 "203.0.113.5"
+	//   addr.String()              "::ffff:203.0.113.5"  -> exact MISS
+	//   v4prefix.Contains(mapped)   false (family mismatch) -> cidr MISS
+	//
+	// That is a never-ban BYPASS at the authority itself, not a downstream
+	// suppression gap: Ban(), IsExempt() and the AddElement guard all resolve
+	// through this one function, so all three inherited the miss.
+	//
+	// Canonicalizing here — once, at the parse boundary, before any comparison —
+	// fixes every consumer rather than patching each membership path. Prefixes are
+	// canonicalized to the same form at store time (see canonPrefix), because
+	// comparing a canonical address against a non-canonical prefix would simply
+	// move the mismatch: a stored "::ffff:203.0.113.0/120" Contains() the mapped
+	// form but NOT the unmapped one, so unmapping only here would have broken a
+	// case that previously worked.
+	addr = addr.Unmap()
 	r.maybeRefresh()
 
 	r.mu.RLock()
@@ -121,7 +158,7 @@ func (r *exemptResolver) Refresh() {
 		}
 		if isCIDR || strings.Contains(value, "/") {
 			if p, err := netip.ParsePrefix(value); err == nil {
-				prefixes = append(prefixes, p)
+				prefixes = append(prefixes, canonPrefix(p))
 			}
 			return
 		}
@@ -156,7 +193,7 @@ func (r *exemptResolver) Refresh() {
 		for i := range sys.LoopbackCIDRs {
 			c := sys.LoopbackCIDRs[i]
 			if p, err := netip.ParsePrefix(c.String()); err == nil {
-				prefixes = append(prefixes, p)
+				prefixes = append(prefixes, canonPrefix(p))
 			}
 		}
 	}

--- a/internal/nftbackend/exemption_canonical_identity_v1229_test.go
+++ b/internal/nftbackend/exemption_canonical_identity_v1229_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.1 TRACK 1 — never-ban canonical identity regression.
+//
+// PROVEN BYPASS this locks out: the exempt store canonicalizes every key with
+// Unmap(), the lookup did not, and netip's prefix Contains() does not match across
+// families. So the IPv4-mapped IPv6 form of an exempt admin address missed BOTH
+// membership paths and the ban proceeded:
+//
+//	stored key                  "203.0.113.5"
+//	addr.String()               "::ffff:203.0.113.5"   -> exact MISS
+//	v4prefix.Contains(mapped)    false                 -> cidr  MISS
+//
+// This is a bypass of the AUTHORITY, not of a downstream consumer: Backend.Ban,
+// Backend.IsExempt and the AddElement guard all resolve through IsExempt, so a
+// single missed lookup unbans the admin protection on every path at once.
+//
+// The arms below deliberately assert BOTH directions of the canonicalization:
+// unmapping only the lookup would have moved the mismatch rather than removing it
+// (a stored "::ffff:.../120" prefix Contains() the mapped form but NOT the unmapped
+// one), which is why prefixes are canonicalized at store time too.
+package nftbackend
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+)
+
+// newLoadedResolver builds a resolver with a fixed snapshot and no refresh, so the
+// arms test membership semantics only — not file/proc discovery.
+func newLoadedResolver(exact []string, prefixes []string) *exemptResolver {
+	r := &exemptResolver{exact: map[string]struct{}{}, ttl: 1 << 62}
+	for _, e := range exact {
+		a, err := netip.ParseAddr(e)
+		if err != nil {
+			panic("bad test exact: " + e)
+		}
+		r.exact[a.Unmap().String()] = struct{}{} // store side, as Refresh does
+	}
+	for _, p := range prefixes {
+		pp, err := netip.ParsePrefix(p)
+		if err != nil {
+			panic("bad test prefix: " + p)
+		}
+		r.prefixes = append(r.prefixes, pp) // RAW: the fixture must not duplicate production canonicalization
+	}
+	r.loaded = true
+	r.loadedAt = time.Now()
+	return r
+}
+
+func TestNeverBanCanonicalIdentity_ExactPath(t *testing.T) {
+	r := newLoadedResolver([]string{"203.0.113.5"}, nil)
+
+	// Control: the plain form must already be exempt. If this fails the fixture is
+	// wrong and every other assertion here would be meaningless.
+	if ok, _ := r.IsExempt("203.0.113.5"); !ok {
+		t.Fatal("control failed: plain IPv4 form is not exempt — fixture is broken")
+	}
+
+	// THE BYPASS: same address, IPv4-mapped IPv6 form.
+	if ok, why := r.IsExempt("::ffff:203.0.113.5"); !ok {
+		t.Fatalf("NEVER-BAN BYPASS: IPv4-mapped form of an exempt address is not exempt "+
+			"(reason=%q) — this address would be banned despite being protected", why)
+	}
+}
+
+func TestNeverBanCanonicalIdentity_PrefixPath(t *testing.T) {
+	r := newLoadedResolver(nil, []string{"203.0.113.0/24"})
+
+	if ok, _ := r.IsExempt("203.0.113.5"); !ok {
+		t.Fatal("control failed: plain IPv4 inside an exempt CIDR is not exempt")
+	}
+	if ok, why := r.IsExempt("::ffff:203.0.113.5"); !ok {
+		t.Fatalf("NEVER-BAN BYPASS: IPv4-mapped form inside an exempt CIDR is not exempt (reason=%q)", why)
+	}
+}
+
+// A stored IPv4-mapped PREFIX must protect the same addresses as its IPv4
+// equivalent — and this MUST be proven through the PRODUCTION store path.
+//
+// The first version of this arm built its fixture by calling canonPrefix() itself.
+// That made it vacuous: deleting canonPrefix from production left the suite green,
+// because the test was canonicalizing its own input. Inversion caught it. This
+// version drives the real Refresh() via NFTBAN_MANAGEMENT_IPS (source 4), which
+// reaches addEntry() -> canonPrefix() exactly as production does.
+func TestNeverBanCanonicalIdentity_MappedPrefixStillProtects(t *testing.T) {
+	t.Setenv("NFTBAN_MANAGEMENT_IPS", "::ffff:203.0.113.0/120")
+	r := &exemptResolver{exact: map[string]struct{}{}, ttl: 1 << 62}
+	r.Refresh() // PRODUCTION store path
+
+	var stored []string
+	for _, p := range r.prefixes {
+		stored = append(stored, p.String())
+	}
+	// Non-vacuity: the fixture must actually have landed in the snapshot.
+	found := false
+	for _, sp := range stored {
+		if sp == "203.0.113.0/24" || sp == "::ffff:203.0.113.0/120" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("fixture did not reach the snapshot (prefixes=%v) — arm would be vacuous", stored)
+	}
+
+	for _, in := range []string{"203.0.113.5", "::ffff:203.0.113.5"} {
+		if ok, why := r.IsExempt(in); !ok {
+			t.Fatalf("stored IPv4-mapped prefix failed to protect %q (reason=%q, prefixes=%v) — "+
+				"canonicalizing only the lookup side moves the mismatch instead of removing it", in, why, stored)
+		}
+	}
+}
+
+// Non-exempt addresses must STILL be bannable. A canonicalization bug that made
+// everything exempt would pass every arm above while disabling enforcement
+// entirely — this is the negative control for the whole file.
+func TestNeverBanCanonicalIdentity_DoesNotOverMatch(t *testing.T) {
+	r := newLoadedResolver([]string{"203.0.113.5"}, []string{"198.51.100.0/24"})
+
+	for _, in := range []string{
+		"203.0.113.6",           // adjacent to an exact key
+		"::ffff:203.0.113.6",    // mapped form of a non-exempt address
+		"198.51.101.1",          // just outside the exempt prefix
+		"2001:db8::1",           // unrelated v6
+	} {
+		if ok, why := r.IsExempt(in); ok {
+			t.Fatalf("OVER-MATCH: %q reported exempt (reason=%q) — legitimate bans would be refused", in, why)
+		}
+	}
+}
+
+// v6 exact keys must keep working; canonicalization must not disturb real IPv6.
+func TestNeverBanCanonicalIdentity_NativeIPv6Unaffected(t *testing.T) {
+	r := newLoadedResolver([]string{"2001:db8::99"}, []string{"2001:db8:1::/48"})
+
+	if ok, _ := r.IsExempt("2001:db8::99"); !ok {
+		t.Fatal("native IPv6 exact key stopped matching")
+	}
+	if ok, _ := r.IsExempt("2001:db8:1::5"); !ok {
+		t.Fatal("native IPv6 prefix stopped matching")
+	}
+}
+
+// Malformed input must remain not-exempt (fail-safe: bans proceed), never panic.
+func TestNeverBanCanonicalIdentity_MalformedInputIsNotExempt(t *testing.T) {
+	r := newLoadedResolver([]string{"203.0.113.5"}, nil)
+	for _, in := range []string{"", "   ", "not-an-ip", "203.0.113.5/32", "::ffff:203.0.113.999"} {
+		if ok, _ := r.IsExempt(in); ok {
+			t.Fatalf("malformed input %q reported exempt", in)
+		}
+	}
+}


### PR DESCRIPTION
## The bypass

An **IPv4-mapped IPv6 form of a protected address was not exempt**, so the ban proceeded. This is a bypass of
the never-ban **authority itself**, not of a downstream consumer.

The store canonicalizes every exact key with `Unmap()`; the lookup did not. `netip`'s prefix `Contains()`
also does not match across families. Both membership paths missed for the same reason:

```
stored key                  "203.0.113.5"
addr.String()               "::ffff:203.0.113.5"    -> exact MISS
v4prefix.Contains(mapped)    false                  -> cidr  MISS
```

`Backend.Ban`, `Backend.IsExempt` and the `AddElement` guard all resolve through `IsExempt`, so a single
missed lookup removed admin protection on **every** path at once. Runtime-proven with `netip` on Go 1.25:

```
stored key                    "203.0.113.5"
input "203.0.113.5"           exactHit=true   prefixContains=true
input "::ffff:203.0.113.5"    exactHit=FALSE  prefixContains=FALSE
with Unmap() at lookup        exactHit=true   prefixContains=true
```

## The fix — canonical identity before the security decision

One canonicalization at the parse boundary, before any comparison, rather than a patch per membership path.

**The prefix half is not optional.** Unmapping only the lookup would have *moved* the mismatch rather than
removing it — measured, not assumed:

```
4in6prefix.Contains(mapped)=true    Contains(unmapped)=false
```

A stored `::ffff:203.0.113.0/120` would have **stopped protecting**, so the one-sided patch fixes one bypass
and opens another. `canonPrefix` rewrites a 4-in-6 prefix to its IPv4 equivalent, so both sides compare in
the same form.

## Tests — six arms, both directions

Exact path · CIDR path · stored mapped prefix · native IPv6 undisturbed · malformed input stays not-exempt
(fail-safe) · **over-match control** — a canonicalization bug that made *everything* exempt would satisfy
every positive arm while silently disabling enforcement.

**Falsified by inversion against production code**, each restore checksum-verified:

| inversion | result |
|---|---|
| remove lookup canonicalization | **3 arms FAIL** |
| remove prefix canonicalization | **stored-mapped-prefix arm FAILS** |
| fixed | **6/6 PASS** · `nftbackend`, `setsync`, `botguard` green |

### A test-validity defect this PR also fixes

The mapped-prefix arm was **vacuous in its first form**: the fixture called `canonPrefix` itself, so deleting
`canonPrefix` from production left the suite **green**. Inversion caught it. It now drives the real
`Refresh()` path via `NFTBAN_MANAGEMENT_IPS` and asserts the fixture actually reached the snapshot before
testing membership — `GUARD_INPUT != GUARD_SUBJECT`.

## Scope

`internal/nftbackend` only. No `VERSION`, `CHANGELOG` or generated-spec edits.

**Deliberately NOT absorbed:** the BotScan exact-line membership mismatch (`nftban_botscan.sh:776`
`grep -qxF` vs the range-aware authority). That is a downstream *suppression* gap — the daemon still refuses
those bans — not a bypass. It stays open in the register.
