### PR TITLE
fix(loginmon): locate markers in the same bytes that are sliced

### DIFF
--- a/internal/loginmon/detector/ftp.go
+++ b/internal/loginmon/detector/ftp.go
@@ -210,7 +210,7 @@ func (d *FTPDetector) detectProFTPD(line, lineLower []byte) (Verdict, bool) {
 	}
 
 	// Try to find IP after "from "
-	fromIdx := bytes.LastIndex(lineLower, d.markerFrom)
+	fromIdx := lastIndexFoldASCII(line, d.markerFrom)  // INDEX_SOURCE == SLICE_SOURCE (see marker.go)
 	if fromIdx != -1 {
 		ipStart := fromIdx + len(d.markerFrom)
 		// Bounds check: ensure ipStart is within line

--- a/internal/loginmon/detector/marker.go
+++ b/internal/loginmon/detector/marker.go
@@ -1,0 +1,99 @@
+// NFTBan - LoginMon detector marker location
+// =============================================================================
+// SPDX-License-Identifier: MPL-2.0
+//
+// meta:name="loginmon_detector_marker"
+// meta:type="core"
+// meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+// meta:created_date="2026-08-14"
+// meta:description="Case-insensitive ASCII marker location that operates directly on the ORIGINAL log bytes, so a marker offset is always valid for slicing the same buffer it was derived from. Replaces the pattern of indexing a lowercased copy and slicing the original, which was a proven detection-evasion vector (v1.229.1 TRACK 2)."
+// meta:inventory.files=""
+// meta:inventory.binaries=""
+// meta:inventory.env_vars=""
+// meta:inventory.config_files=""
+// meta:inventory.systemd_units=""
+// meta:inventory.network=""
+// meta:inventory.privileges="none"
+// =============================================================================
+
+package detector
+
+// INVARIANT: INDEX_SOURCE == SLICE_SOURCE.
+//
+// PROVEN EVASION this removes (v1.229.1 TRACK 2, runtime-proven through Detect()):
+// the affected paths located " from " with bytes.LastIndex on a LOWERCASED copy of
+// the line and then sliced the ORIGINAL line at that offset. bytes.ToLower does not
+// preserve byte length, so attacker-controlled text before the marker desynchronised
+// the two buffers and the IP was sliced at the wrong offset:
+//
+//	corpus (synthetic)        lower delta   detected
+//	ascii username             +0           yes
+//	username with U+0130 (İ)   -1           NO   <- evaded
+//	username with U+1E9E (ẞ)   -1           NO   <- evaded
+//	username with U+212A (K)   -2           NO   <- evaded
+//
+// One character in a username suppressed the login-failure verdict entirely.
+//
+// The fix is to stop crossing representations at all, NOT to compensate for the
+// delta. Offset arithmetic would pass the corpus above and still fail on the next
+// case-mapping that changes length by a different amount (U+212A already differs
+// from U+0130), and a per-character correction table is unmaintainable. A lowercased
+// copy remains fine for BOOLEAN signature matching, where no offset is transferred.
+
+// lastIndexFoldASCII returns the index of the LAST occurrence of lowerMarker in s,
+// comparing ASCII case-insensitively, or -1.
+//
+// lowerMarker MUST already be ASCII-lowercase; only s is folded during comparison.
+// Non-ASCII bytes in s are compared verbatim, which is correct here because every
+// marker this package locates is ASCII — a non-ASCII byte can never be part of a
+// match, and is never transformed, so the returned offset always addresses s.
+func lastIndexFoldASCII(s, lowerMarker []byte) int {
+	n := len(lowerMarker)
+	if n == 0 || len(s) < n {
+		return -1
+	}
+	for i := len(s) - n; i >= 0; i-- {
+		matched := true
+		for j := 0; j < n; j++ {
+			c := s[i+j]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != lowerMarker[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return i
+		}
+	}
+	return -1
+}
+
+// indexFoldASCII is lastIndexFoldASCII's FIRST-occurrence counterpart, for markers
+// whose first match is the intended one (e.g. "ip="). Same invariant: the returned
+// offset addresses s, because s is what was searched.
+func indexFoldASCII(s, lowerMarker []byte) int {
+	n := len(lowerMarker)
+	if n == 0 || len(s) < n {
+		return -1
+	}
+	for i := 0; i+n <= len(s); i++ {
+		matched := true
+		for j := 0; j < n; j++ {
+			c := s[i+j]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != lowerMarker[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/loginmon/detector/marker_index_source_v1229_test.go
+++ b/internal/loginmon/detector/marker_index_source_v1229_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.1 TRACK 2 — detection-evasion regression + structural prohibition.
+//
+// PROVEN EVASION (runtime, through the public Detect(), before the fix):
+//
+//	corpus (synthetic)        lower delta   Plesk  cPanel  ProFTPD
+//	ascii username             +0           yes    yes     yes
+//	username with U+0130 (İ)   -1           NO     NO      NO
+//	username with U+1E9E (ẞ)   -1           NO     NO      NO
+//	username with U+212A (K)   -2           NO     NO      NO
+//
+// The correlation was exact: every delta != 0 evaded, every delta == 0 detected.
+// One attacker-supplied character in a username suppressed the login-failure
+// verdict entirely, because the marker offset was derived from a LOWERCASED copy
+// and applied to the ORIGINAL line, and bytes.ToLower does not preserve byte length.
+//
+// INVARIANT ENFORCED HERE: INDEX_SOURCE == SLICE_SOURCE.
+//
+// The corpus is SYNTHETIC by construction — RFC 5737 IPv4, RFC 3849 IPv6, invented
+// usernames. Log SHAPES were derived from documented formats by inspection; no live
+// log values are reproduced here.
+package detector
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// evasionCase is attacker-controlled text placed BEFORE the " from " marker.
+type evasionCase struct {
+	name      string
+	user      string
+	wantDelta bool // true if lowercasing this line changes its byte length
+}
+
+var evasionCorpus = []evasionCase{
+	// POSITIVE CONTROL. If this ever fails the fixture stopped reaching the
+	// detector and every other arm below is vacuous — that exact failure happened
+	// while building this corpus (a fixture missing the signature gate returned
+	// false for ALL cases, which looked like evasion but was blindness).
+	{"ascii-control", "operator", false},
+
+	{"latin-capital-I-with-dot", "operİtor", true}, // İ  2 bytes -> 1
+	{"latin-capital-sharp-s", "operẞtor", true},    // ẞ  3 bytes -> 2
+	{"kelvin-sign", "operKtor", true},              // K  3 bytes -> 1
+
+	// Hostile literal that does NOT change length: the marker search must still
+	// anchor on the LAST occurrence.
+	{"username-containing-from", "oper from ator", false},
+
+	{"trailing-space", "operator ", false},
+	{"truncated", "op", false},
+	{"empty-user", "", false},
+}
+
+func lowerChangesLength(s string) bool {
+	return len(bytes.ToLower([]byte(s))) != len(s)
+}
+
+// runCorpus asserts EVERY case yields the expected IP, and that the fixture's
+// delta expectation matches reality (so a corpus that stopped exercising the
+// length-change condition fails loudly instead of passing quietly).
+func runCorpus(t *testing.T, label string, build func(user string) string, want string, detect func([]byte) (Verdict, bool)) {
+	t.Helper()
+	sawDelta := false
+	for _, c := range evasionCorpus {
+		line := build(c.user)
+		gotDelta := lowerChangesLength(line)
+		if gotDelta != c.wantDelta {
+			t.Fatalf("%s/%s: corpus drift — lowercase-length-change is %v, fixture expects %v; "+
+				"the adversarial condition is no longer being exercised", label, c.name, gotDelta, c.wantDelta)
+		}
+		if gotDelta {
+			sawDelta = true
+		}
+		v, ok := detect([]byte(line))
+		if !ok {
+			t.Errorf("%s/%s: DETECTION EVADED (lower delta=%v) — login failure suppressed by "+
+				"attacker-controlled pre-marker text", label, c.name, gotDelta)
+			continue
+		}
+		if v.IP.String() != want {
+			t.Errorf("%s/%s: wrong IP extracted: got %q want %q", label, c.name, v.IP.String(), want)
+		}
+	}
+	if !sawDelta {
+		t.Fatalf("%s: no corpus case changed length under ToLower — the regression would be vacuous", label)
+	}
+}
+
+func TestIndexSourceInvariant_PleskFallback(t *testing.T) {
+	d := NewPanelDetector()
+	runCorpus(t, "plesk",
+		func(u string) string {
+			// "plesk" satisfies the stage-3 signature; the generic " from " fallback
+			// is the path under test. The documented "from IP " path indexes the
+			// ORIGINAL line and is deliberately NOT touched by this fix.
+			return fmt.Sprintf("plesk sw-engine: Authentication failed for user %s from %s", u, "192.0.2.10")
+		}, "192.0.2.10", d.Detect)
+}
+
+func TestIndexSourceInvariant_CPanelFallback(t *testing.T) {
+	d := NewPanelDetector()
+	runCorpus(t, "cpanel",
+		func(u string) string {
+			return fmt.Sprintf("cpanel login: failed login for user %s from %s", u, "203.0.113.30")
+		}, "203.0.113.30", d.Detect)
+}
+
+func TestIndexSourceInvariant_FTPFrom(t *testing.T) {
+	d := NewFTPDetector()
+	runCorpus(t, "proftpd",
+		func(u string) string {
+			return fmt.Sprintf("proftpd: USER %s no such user found from %s", u, "198.51.100.20")
+		}, "198.51.100.20", d.Detect)
+}
+
+// The "ip=" marker path is the FOURTH site of this class. It was NOT in the
+// original three-site report: a manual sweep found only the markerFrom sites, and
+// the structural guard below is what surfaced it. Proven exploitable by the same
+// corpus before the fix (delta != 0 -> evaded).
+func TestIndexSourceInvariant_IpEqualsMarker(t *testing.T) {
+	d := NewPanelDetector()
+	runCorpus(t, "cpanel-ip=",
+		func(u string) string {
+			return fmt.Sprintf("cpanel: FAILED LOGIN user=%s ip=%s", u, "192.0.2.77")
+		}, "192.0.2.77", d.Detect)
+}
+
+// IPv6 must survive the same treatment (RFC 3849 documentation range).
+func TestIndexSourceInvariant_IPv6(t *testing.T) {
+	d := NewFTPDetector()
+	for _, c := range evasionCorpus {
+		line := fmt.Sprintf("proftpd: USER %s no such user found from %s", c.user, "2001:db8::20")
+		v, ok := d.Detect([]byte(line))
+		if !ok {
+			t.Errorf("ipv6/%s: DETECTION EVADED", c.name)
+			continue
+		}
+		if v.IP.String() != "2001:db8::20" {
+			t.Errorf("ipv6/%s: got %q", c.name, v.IP.String())
+		}
+	}
+}
+
+// lastIndexFoldASCII must behave as a case-insensitive LastIndex over the
+// ORIGINAL bytes — including when non-ASCII bytes are present, which is the whole
+// reason the previous implementation could not be trusted.
+func TestLastIndexFoldASCII(t *testing.T) {
+	cases := []struct {
+		s, m string
+		want int
+	}{
+		{"a from b", "from ", 2},
+		{"a FROM b", "from ", 2},
+		{"a FrOm b", "from ", 2},
+		{"x from y from z", "from ", 9}, // LAST occurrence
+		{"no marker here", "from ", -1},
+		{"", "from ", -1},
+		{"from ", "from ", 0},
+		{"İ from x", "from ", 3}, // offset is valid for the ORIGINAL bytes
+		{"abc", "", -1},
+	}
+	for _, c := range cases {
+		if got := lastIndexFoldASCII([]byte(c.s), []byte(c.m)); got != c.want {
+			t.Errorf("lastIndexFoldASCII(%q,%q) = %d, want %d", c.s, c.m, got, c.want)
+		}
+	}
+	// The returned offset must always be sliceable on the input.
+	s := []byte("K user from 192.0.2.1")
+	if i := lastIndexFoldASCII(s, []byte("from ")); i >= 0 {
+		if got := string(s[i+len("from "):]); got != "192.0.2.1" {
+			t.Errorf("offset not valid for the original buffer: got %q", got)
+		}
+	} else {
+		t.Fatal("marker not found in a line containing non-ASCII bytes")
+	}
+}
+
+// STRUCTURAL PROHIBITION: the affected detectors must never again derive an
+// extraction offset from a lowercased copy and apply it to the original line.
+// A regression test says "this bug must not return"; this says "this entire
+// representation crossing is no longer permitted here".
+func TestStructural_NoIndexOnLowerThenSliceOriginal(t *testing.T) {
+	// Any Index-family call whose HAYSTACK is a lowercased buffer produces an
+	// offset that is only valid for that buffer. Locating a marker that way and
+	// slicing `line` is the defect class.
+	bad := regexp.MustCompile(`(?m)^[^/\n]*\b(?:bytes\.)?(?:Last)?Index(?:Any|Byte|Rune)?\(\s*(?:line|s)[Ll]ower\b`)
+
+	for _, name := range []string{"panel.go", "ftp.go"} {
+		p := filepath.Join(".", name)
+		src, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if locs := bad.FindAllString(string(src), -1); len(locs) > 0 {
+			t.Errorf("%s: extraction offset derived from a lowercased buffer (INDEX_SOURCE != SLICE_SOURCE): %s",
+				name, strings.Join(locs, " | "))
+		}
+	}
+
+	// Non-vacuity: the pattern must actually match the defective form.
+	if !bad.MatchString("\tfromIdx := bytes.LastIndex(lineLower, d.markerFrom)\n") {
+		t.Fatal("structural guard cannot recognise the defective form — it would never fire")
+	}
+	// ...and must NOT match the corrected form, or it would be unsatisfiable.
+	if bad.MatchString("\tfromIdx := lastIndexFoldASCII(line, d.markerFrom)\n") {
+		t.Fatal("structural guard rejects the corrected form")
+	}
+}

--- a/internal/loginmon/detector/panel.go
+++ b/internal/loginmon/detector/panel.go
@@ -250,7 +250,7 @@ func (d *PanelDetector) detectCPanel(line, lineLower []byte) (Verdict, bool) {
 	}
 
 	// Try "ip=" marker
-	ipIdx := bytes.Index(lineLower, d.markerIpLower)
+	ipIdx := indexFoldASCII(line, d.markerIpLower)  // INDEX_SOURCE == SLICE_SOURCE (see marker.go)
 	if ipIdx != -1 {
 		ipStart := ipIdx + 3
 		// Bounds check: ensure ipStart is within line
@@ -278,7 +278,7 @@ func (d *PanelDetector) detectCPanel(line, lineLower []byte) (Verdict, bool) {
 	}
 
 	// Try "from " marker
-	fromIdx := bytes.LastIndex(lineLower, d.markerFrom)
+	fromIdx := lastIndexFoldASCII(line, d.markerFrom)  // INDEX_SOURCE == SLICE_SOURCE (see marker.go)
 	if fromIdx != -1 {
 		ipStart := fromIdx + len(d.markerFrom)
 		// Bounds check: ensure ipStart is within line
@@ -358,7 +358,7 @@ func (d *PanelDetector) detectPlesk(line, lineLower []byte) (Verdict, bool) {
 	}
 
 	// Try "from " marker (generic)
-	fromIdx := bytes.LastIndex(lineLower, d.markerFrom)
+	fromIdx := lastIndexFoldASCII(line, d.markerFrom)  // INDEX_SOURCE == SLICE_SOURCE (see marker.go)
 	if fromIdx != -1 {
 		ipStart := fromIdx + len(d.markerFrom)
 		// Bounds check: ensure ipStart is within line


### PR DESCRIPTION
## Proven detection evasion

A **single attacker-supplied character in a username suppressed the login-failure verdict entirely.**
Proven at runtime through the public `Detect()`, synthetic corpus:

| corpus case | lower delta | Plesk | cPanel | ProFTPD | cPanel `ip=` |
|---|---|---|---|---|---|
| ascii username (control) | +0 | ✅ | ✅ | ✅ | ✅ |
| username with `U+0130` | −1 | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** |
| username with `U+1E9E` | −1 | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** |
| username with `U+212A` | −2 | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** | ❌ **MISS** |
| username containing `" from "` | +0 | ✅ | ✅ | ✅ | ✅ |

The correlation is exact: **every `delta != 0` evaded, every `delta == 0` detected.**

**Root cause:** the marker offset was computed by an Index-family call over a **lowercased copy** and applied
to the **original** line. `bytes.ToLower` does not preserve byte length, so text before the marker
desynchronised the buffers, the IP was sliced at the wrong offset, `ParseAddr` failed, and no verdict was
produced. A missed verdict is **silent** — indistinguishable from a line that simply didn't match.

## The fix removes the crossing, it does not compensate for it

```
INDEX_SOURCE == SLICE_SOURCE
```

Marker location now runs on the original bytes via case-insensitive ASCII search, so an offset always
addresses the buffer it came from. A lowercased copy remains fine for **boolean signature matching**, where
no offset is transferred — those uses are unchanged.

**Offset compensation was deliberately rejected.** Adding or subtracting the lowercase delta would pass this
corpus and still fail on the next case-mapping with a different delta — `U+212A` already differs from
`U+0130` — and a per-character table is unmaintainable.

## Four sites, not three

```
panel.go   Plesk   " from " fallback
panel.go   cPanel  " from " fallback
panel.go   cPanel  "ip="    marker     <- NOT in the original report
ftp.go     ProFTPD " from "
```

The `ip=` site was found by the **structural guard**, not by the manual sweep, and was then proven
exploitable by the same corpus. That's the difference the guard buys: a regression test says *this bug must
not return*; the guard says *this representation crossing is no longer permitted here*.

**Deliberately untouched:** the documented Plesk `"from IP "` path already indexes the original line and is
not this class. Roundcube already anchors on `" in session"` and is pinned by its own test.

## Evidence

Corpus is **synthetic by construction** — RFC 5737 IPv4, RFC 3849 IPv6, invented usernames. Shapes were
derived from documented formats by inspection; **no live log values are reproduced.**

Non-vacuity is enforced rather than assumed: each run asserts the fixture's length-change expectation still
matches reality and that at least one case actually exercises the adversarial condition. An early corpus
returned `false` for *every* case including the ASCII control — which looked like evasion but was a fixture
that never reached the detector. The positive control caught it.

**Falsified by inversion against production code**, each restore checksum-verified:

| inversion | result |
|---|---|
| restore `lineLower` indexing — panel `" from "` | adversarial arms FAIL |
| restore `lineLower` indexing — ftp | adversarial arms FAIL (incl. IPv6) |
| restore `lineLower` indexing — `ip=` | adversarial arms FAIL **+ structural guard trips** |
| fixed | all pass · `./internal/loginmon/...` green |

Scope: `internal/loginmon/detector` only. No `VERSION`, `CHANGELOG` or generated-spec edits.
