### PR TITLE
fix(daemon): make the optional HTTP API consistent across its whole lifecycle

### DIFF
--- a/cli/lib/nftban/cli/cmd_status.sh
+++ b/cli/lib/nftban/cli/cmd_status.sh
@@ -761,11 +761,34 @@ _status_section_services() {
 
     check_service_clean "nftables" "nftables.service"
     check_service_clean "nftband" "nftband.service"
+    _status_http_api_state
     check_service_clean "suricata" "suricata.service"
     check_service_clean "nftban-suricata" "${NFTBAN_SERVICE_SURICATA:-nftban-suricata.service}"
     # v1.23.0: login-monitor removed (replaced by nftband loginmon module)
     check_service_clean "metrics-exporter" "${NFTBAN_SERVICE_METRICS_EXPORTER:-nftban-unified-exporter.service}"
     echo ""
+}
+
+# v1.229.2 TRACK A — report the OPTIONAL HTTP API honestly.
+#
+# The HTTP API is optional: when another service already owns its port the daemon
+# runs IPC-only, which is a supported degraded state, not a fault. Without this line
+# an operator sees only http_ready=false and cannot tell "disabled on purpose" from
+# "startup is unhealthy" — the same ambiguity the daemon-side fix removes. Silent on
+# a stopped daemon or an unreachable socket: absence of an answer is not a state.
+_status_http_api_state() {
+    [[ -S /run/nftban/nftband.sock ]] || return 0
+    local resp
+    resp=$(nftban_ipc_call "status" 2>/dev/null) || return 0
+    [[ -n "$resp" ]] || return 0
+
+    if grep -q '"http_disabled_by_design":[[:space:]]*true' <<<"$resp"; then
+        printf '  %-22s %s\n' "HTTP API" "disabled by design (port already in use) — IPC-only, daemon healthy"
+    elif grep -q '"http_ready":[[:space:]]*true' <<<"$resp"; then
+        printf '  %-22s %s\n' "HTTP API" "running"
+    else
+        printf '  %-22s %s\n' "HTTP API" "not ready"
+    fi
 }
 
 _status_section_protection() {

--- a/cmd/nftband/daemon_handlers_status.go
+++ b/cmd/nftband/daemon_handlers_status.go
@@ -79,8 +79,12 @@ func (d *Daemon) lifecycleStatus() map[string]any {
 		"modules_initialized":      s.ModulesInitialized,
 		"required_modules_started": s.RequiredModulesStarted,
 		"http_ready":               s.HTTPReady,
-		"watchdog_ready":           s.WatchdogReady,
-		"degraded_components":      s.DegradedComponents,
+		// v1.229.2 TRACK A — an operator must be able to tell "no HTTP because the
+		// port is owned by another service" from "HTTP is unhealthy". Without this
+		// key both look identical: http_ready=false.
+		"http_disabled_by_design": s.HTTPDisabledByDesign,
+		"watchdog_ready":          s.WatchdogReady,
+		"degraded_components":     s.DegradedComponents,
 	}
 }
 

--- a/cmd/nftband/daemon_http.go
+++ b/cmd/nftband/daemon_http.go
@@ -21,12 +21,15 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	nethttpprof "net/http/pprof" // BUG-H4 FIX: explicit import instead of blank import to avoid polluting DefaultServeMux
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/itcmsgr/nftban/internal/constants"
 	"github.com/itcmsgr/nftban/pkg/version"
@@ -79,6 +82,25 @@ func resolveAPIBind(addr string) string {
 	}
 	log.Printf("[SECURITY][ERROR] HTTP API configured to bind non-loopback (%s) without NFTBAN_API_ALLOW_INSECURE_BIND=YES — refusing unsafe bind, falling back to loopback %s. Set the ack to expose deliberately (auth is SEC-P1-3b).", addr, DefaultHTTPAddr)
 	return DefaultHTTPAddr
+}
+
+// classifyBindError maps a net.Listen failure to the authoritative HTTP lifecycle
+// state. It is a pure function so the DECISION itself is testable: previously the
+// classification lived inline inside startHTTP, which builds a mux and launches a
+// goroutine and therefore cannot be driven from a unit test — a mutation that
+// tolerated every bind error would have gone unnoticed.
+//
+// Only "another service already owns this port" is disabled by design. Everything
+// else — including errnos that do not exist yet — is a genuine failure. The default
+// arm is deliberately the failing one.
+func classifyBindError(err error) httpLifecycleState {
+	if err == nil {
+		return httpStateRunning
+	}
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return httpStateDisabledByDesign
+	}
+	return httpStateFailed
 }
 
 // startHTTP starts the HTTP API server
@@ -138,12 +160,28 @@ func (d *Daemon) startHTTP() error {
 	addr := resolveAPIBind(getAPIAddr())
 	log.Printf("[nftband] HTTP API binding %s (loopback=%t)", addr, isLoopbackAPIBind(addr))
 
-	// v1.52.0: Pre-check if port is available — if not, skip HTTP API gracefully
-	// This prevents noisy errors when Apache/DA/cPanel/nginx is on the same port
+	// v1.52.0: pre-check that the port is available.
+	//
+	// v1.229.2 TRACK A — CLASSIFY the failure instead of tolerating every error.
+	// Previously ANY net.Listen error took the "API disabled" path, so a genuine
+	// misconfiguration (bad bind address -> EADDRNOTAVAIL, privileged port ->
+	// EACCES) was reported as a healthy daemon that had merely disabled its API.
+	// Only "another service already owns this port" is disabled BY DESIGN; every
+	// other error is a real fault and must fail loudly.
+	//
+	// Classification is by ERRNO through the wrapped *net.OpError chain, not by
+	// matching error text: errors.Is is stable, a message match is not. The default
+	// direction is deliberate — an unknown or future errno FAILS rather than being
+	// silently tolerated.
 	testLn, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Printf("[WARN] HTTP API port %s unavailable (%v) — API disabled, IPC socket still works", addr, err)
-		return nil
+		switch d.httpState = classifyBindError(err); d.httpState {
+		case httpStateDisabledByDesign:
+			log.Printf("[WARN] HTTP API port %s is already owned by another service — HTTP API DISABLED BY DESIGN (%v); IPC socket still works", addr, err)
+			return nil
+		default:
+			return fmt.Errorf("HTTP API bind failed on %s: %w", addr, err)
+		}
 	}
 	testLn.Close()
 
@@ -151,6 +189,7 @@ func (d *Daemon) startHTTP() error {
 		Addr:    addr,
 		Handler: mux,
 	}
+	d.httpState = httpStateRunning
 
 	go func() {
 		if err := d.httpSrv.ListenAndServe(); err != http.ErrServerClosed {

--- a/cmd/nftband/daemon_http_lifecycle_state_v1229_2_test.go
+++ b/cmd/nftband/daemon_http_lifecycle_state_v1229_2_test.go
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.2 TRACK A — optional-HTTP lifecycle consistency.
+//
+// ONE root condition, TWO wrong consumers. startHTTP may legitimately produce no
+// server (the configured port is owned by Apache/DA/cPanel/nginx). Before this
+// change:
+//
+//	A1  gracefulShutdown called d.httpSrv.Shutdown() unguarded -> nil-receiver panic
+//	    on the handleSignals goroutine. The only recover() is deferred in the PARENT
+//	    goroutine and cannot catch it, so the process died and everything after that
+//	    line was skipped: module StopAll, OpQueue drain, the SourceIndex save, bus
+//	    close, final cache flush, completeShutdown, PID removal — all after STOPPING=1
+//	    had been sent. Proven on lab4: systemd Result=exit-code, unit FAILED,
+//	    OnFailure= dependencies triggered, PID file left stale.
+//
+//	A2  startup asserted setHTTPReady(true) unconditionally while http_ready sat in
+//	    the MANDATORY readiness tier — systemd was told a mandatory prerequisite was
+//	    satisfied by a component that did not exist.
+//
+//	A2b EVERY net.Listen error took the "API disabled" path, so a genuine fault
+//	    (EADDRNOTAVAIL from a bad bind address, EACCES on a privileged port) was
+//	    reported as a healthy daemon.
+//
+// The contract these arms lock:
+//
+//	RUNNING             listener established         -> http_ready mandatory, satisfied
+//	DISABLED_BY_DESIGN  errors.Is(err, EADDRINUSE)   -> DEGRADED tier, READY=1 allowed
+//	FAILED              any other error              -> startHTTP errors, startup fails
+//
+// Note the asymmetry that makes A2 subtle: reporting httpReady=false when disabled
+// would be the OPPOSITE bug — http_ready would land in `missing` and an intentional
+// port collision would become a FATAL startup failure. ARM 2 therefore asserts the
+// global readiness outcome, not merely the flag.
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// ARM 3 support: the classifier itself, exercised against REAL kernel errnos
+// rather than fabricated error values, so the arm cannot pass on a mock that
+// does not resemble what net.Listen actually returns.
+// ---------------------------------------------------------------------------
+
+func listenErr(t *testing.T, addr string) error {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	if err == nil {
+		ln.Close()
+		return nil
+	}
+	return err
+}
+
+// TestHTTPBindClassification_ErrnoNotText proves the disabled-by-design predicate
+// is errno-based and, critically, that non-EADDRINUSE faults are NOT tolerated.
+func TestHTTPBindClassification_ErrnoNotText(t *testing.T) {
+	// EXPECTED COLLISION — hold a port, then collide with it.
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind a loopback port in this environment: %v", err)
+	}
+	defer held.Close()
+	collision := listenErr(t, held.Addr().String())
+	if collision == nil {
+		t.Fatal("control failed: second bind on a held port succeeded — the arm would be vacuous")
+	}
+	if !errors.Is(collision, syscall.EADDRINUSE) {
+		t.Fatalf("port collision did not classify as EADDRINUSE: %v", collision)
+	}
+
+	// GENUINE FAILURE — an address that cannot exist on this host.
+	notAvail := listenErr(t, "203.0.113.77:9999") // RFC 5737 documentation range
+	if notAvail == nil {
+		t.Skip("host unexpectedly owns a documentation-range address; cannot exercise the genuine-failure arm")
+	}
+	if errors.Is(notAvail, syscall.EADDRINUSE) {
+		t.Fatalf("genuine bind failure misclassified as EADDRINUSE: %v", notAvail)
+	}
+	// The failure must be recognisable as a real error, not silently tolerated.
+	if notAvail.Error() == "" {
+		t.Fatal("genuine failure produced an empty error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ARM 1/2/3: readiness tiering. These drive the REAL evaluateReadinessLocked via
+// the real setters, so a change to the tier assignment is caught here.
+// ---------------------------------------------------------------------------
+
+// readyLifecycle returns a lifecycle with every MANDATORY prerequisite except HTTP
+// already satisfied, so each arm below varies exactly one thing.
+func readyLifecycle() *startupLifecycle {
+	// Use the REAL constructor: a bare &startupLifecycle{} leaves internal maps and
+	// channels nil, so Snapshot() panics and the arms would be testing a shape the
+	// daemon never builds.
+	s := newStartupLifecycle(os.Getpid())
+	s.setRuntimePathsReady(true)
+	s.setModulesInitialized(true)
+	s.setIPCBound(true)
+	s.setIPCAccepting(true)
+	s.setRequiredModulesStarted(true)
+	return s
+}
+
+func evaluate(s *startupLifecycle) (missing, degraded []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evaluateReadinessLocked()
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want || strings.Contains(x, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// ARM 1 — HTTP RUNNING: http_ready is mandatory and satisfied.
+func TestReadinessArm1_HTTPRunning(t *testing.T) {
+	s := readyLifecycle()
+	s.setHTTPReady(true)
+
+	missing, degraded := evaluate(s)
+	if len(missing) != 0 {
+		t.Fatalf("ARM1: running HTTP must leave no mandatory prerequisite unmet, got missing=%v", missing)
+	}
+	if contains(degraded, "http") {
+		t.Fatalf("ARM1: a running HTTP server must not be reported degraded, got degraded=%v", degraded)
+	}
+}
+
+// ARM 2 — DISABLED BY DESIGN: degraded tier, and READY must remain reachable.
+//
+// This asserts the GLOBAL outcome deliberately. Asserting only httpReady==false
+// would also pass for the startup-fatal regression this fix exists to avoid.
+func TestReadinessArm2_HTTPDisabledByDesign(t *testing.T) {
+	s := readyLifecycle()
+	s.setHTTPDisabledByDesign(true)
+	// httpReady deliberately left false: there is no server to be ready.
+
+	missing, degraded := evaluate(s)
+
+	if contains(missing, "http_ready") {
+		t.Fatalf("ARM2 REGRESSION: disabled-by-design HTTP became a MANDATORY unmet prerequisite "+
+			"(missing=%v) — an intentional port collision would fail startup", missing)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("ARM2: unexpected mandatory prerequisites unmet: %v", missing)
+	}
+	if !contains(degraded, "http") {
+		t.Fatalf("ARM2: disabled-by-design HTTP must be reported in the DEGRADED tier, got degraded=%v", degraded)
+	}
+}
+
+// ARM 2b — the state must be honest: disabled must never read as ready.
+func TestReadinessArm2_DisabledIsNotReportedReady(t *testing.T) {
+	s := readyLifecycle()
+	s.setHTTPDisabledByDesign(true)
+	snap := s.Snapshot()
+	if snap.HTTPReady {
+		t.Fatal("ARM2b: HTTPReady must be false when no server exists — this was the readiness lie")
+	}
+	if !snap.HTTPDisabledByDesign {
+		t.Fatal("ARM2b: disabled-by-design must be observable in the snapshot, not merely implied by !HTTPReady")
+	}
+}
+
+// ARM 3 — GENUINE FAILURE must not be expressible as degraded.
+//
+// The producer returns an error for non-EADDRINUSE faults, so a failed HTTP never
+// reaches readiness evaluation at all. This arm proves the state machine cannot be
+// coaxed into representing a failure as a tolerated degradation.
+func TestReadinessArm3_GenuineFailureIsNotDegraded(t *testing.T) {
+	s := readyLifecycle()
+	// A genuine failure sets NEITHER flag — nothing marks it tolerable.
+	missing, degraded := evaluate(s)
+
+	if contains(degraded, "http") {
+		t.Fatalf("ARM3: an unclassified/failed HTTP must NOT appear in the degraded tier, got degraded=%v", degraded)
+	}
+	if !contains(missing, "http_ready") {
+		t.Fatalf("ARM3: an unclassified/failed HTTP must leave http_ready in the MANDATORY unmet set, got missing=%v", missing)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// State authority: zero value must not be mistaken for a valid degraded state.
+// ---------------------------------------------------------------------------
+
+func TestHTTPLifecycleState_ZeroValueIsUnknown(t *testing.T) {
+	var d Daemon
+	if d.httpState != httpStateUnknown {
+		t.Fatalf("zero value must be httpStateUnknown, got %v", d.httpState)
+	}
+	if httpStateUnknown == httpStateDisabledByDesign || httpStateUnknown == httpStateRunning {
+		t.Fatal("UNKNOWN must be distinct from DISABLED and RUNNING")
+	}
+	for _, c := range []struct {
+		s    httpLifecycleState
+		want string
+	}{
+		{httpStateUnknown, "unknown"},
+		{httpStateRunning, "running"},
+		{httpStateDisabledByDesign, "disabled-by-design"},
+		{httpStateFailed, "failed"},
+	} {
+		if got := c.s.String(); got != c.want {
+			t.Errorf("String(): got %q want %q", got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A1: the shutdown terminator must tolerate an absent optional component.
+// ---------------------------------------------------------------------------
+
+// A1 has two halves, deliberately.
+//
+// The behavioural half proves WHY the guard is required: an unguarded Shutdown on a
+// nil *http.Server panics. The structural half proves the PRODUCTION shutdown path
+// actually carries the guard — asserting a copy of the guard inside the test would
+// pass even if production lost it, which is exactly the vacuity this project keeps
+// catching. gracefulShutdown needs a fully wired Daemon (bus, registry, lifecycle,
+// contexts) so it cannot be driven from a unit test; the structural assertion is the
+// honest substitute, and the lab witness covers the wired path.
+func TestA1_UnguardedShutdownOnNilServerPanics(t *testing.T) {
+	var srv *http.Server
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		_ = srv.Shutdown(context.Background())
+	}()
+	if !panicked {
+		t.Fatal("control failed: Shutdown on a nil *http.Server did not panic — " +
+			"the structural guard below would be guarding nothing")
+	}
+}
+
+func TestA1_ShutdownPathGuardsOptionalHTTPServer(t *testing.T) {
+	src, err := os.ReadFile("daemon_lifecycle.go")
+	if err != nil {
+		t.Fatalf("read daemon_lifecycle.go: %v", err)
+	}
+	text := string(src)
+
+	idx := strings.Index(text, "d.httpSrv.Shutdown(")
+	if idx == -1 {
+		// SUBJECT_NOT_FOUND is a test failure, never a silent pass.
+		t.Fatal("subject not found: no d.httpSrv.Shutdown( call in daemon_lifecycle.go — " +
+			"the shutdown path changed shape and this guard no longer proves anything")
+	}
+
+	// The guard must appear between the start of gracefulShutdown and the call.
+	fnIdx := strings.Index(text, "func (d *Daemon) gracefulShutdown()")
+	if fnIdx == -1 || fnIdx > idx {
+		t.Fatal("subject not found: gracefulShutdown does not precede the Shutdown call")
+	}
+	between := text[fnIdx:idx]
+	if !strings.Contains(between, "if d.httpSrv != nil") {
+		t.Fatal("A1 REGRESSION: gracefulShutdown calls d.httpSrv.Shutdown() without a preceding " +
+			"nil guard — on a host whose HTTP port is owned by another service, SIGTERM panics and " +
+			"module StopAll, OpQueue drain, SourceIndex save, bus close, final cache flush, " +
+			"completeShutdown and PID removal are all skipped")
+	}
+}
+
+// A2 structural: readiness must never be asserted unconditionally again.
+func TestA2_HTTPReadyIsNotAssertedUnconditionally(t *testing.T) {
+	src, err := os.ReadFile("daemon_init.go")
+	if err != nil {
+		t.Fatalf("read daemon_init.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "setHTTPReady(true)") {
+		t.Fatal("subject not found: no setHTTPReady(true) call in daemon_init.go")
+	}
+	// It must be reached through a state decision, not on the straight-line path.
+	idx := strings.Index(text, "setHTTPReady(true)")
+	window := text[max(0, idx-400):idx]
+	if !strings.Contains(window, "httpStateRunning") {
+		t.Fatal("A2 REGRESSION: setHTTPReady(true) is not gated on httpStateRunning — " +
+			"the daemon can again assert a mandatory readiness prerequisite while no server exists")
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// The classifier is the A2b decision point. Driven with REAL kernel errnos, and
+// asserting the FAILED arms explicitly — a classifier that tolerated every error
+// would satisfy only the disabled arm, so the failing cases are what give this teeth.
+func TestClassifyBindError_OnlyEADDRINUSEIsDisabledByDesign(t *testing.T) {
+	if got := classifyBindError(nil); got != httpStateRunning {
+		t.Errorf("nil error must classify as running, got %v", got)
+	}
+
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind loopback in this environment: %v", err)
+	}
+	defer held.Close()
+	collision := listenErr(t, held.Addr().String())
+	if collision == nil {
+		t.Fatal("control failed: colliding bind succeeded — arm would be vacuous")
+	}
+	if got := classifyBindError(collision); got != httpStateDisabledByDesign {
+		t.Errorf("EADDRINUSE must classify as disabled-by-design, got %v", got)
+	}
+
+	// GENUINE FAILURES — these are the arms an over-tolerant classifier breaks.
+	if got := classifyBindError(syscall.EACCES); got != httpStateFailed {
+		t.Errorf("EACCES must classify as FAILED (fail loud), got %v", got)
+	}
+	if got := classifyBindError(syscall.EADDRNOTAVAIL); got != httpStateFailed {
+		t.Errorf("EADDRNOTAVAIL must classify as FAILED (fail loud), got %v", got)
+	}
+	if got := classifyBindError(errors.New("some future errno we do not know yet")); got != httpStateFailed {
+		t.Errorf("unknown errors must default to FAILED, never tolerated, got %v", got)
+	}
+}

--- a/cmd/nftband/daemon_init.go
+++ b/cmd/nftband/daemon_init.go
@@ -274,8 +274,28 @@ func (d *Daemon) Run() error {
 		d.lifecycle.FailPhase(PhaseHTTPInit, err)
 		return fmt.Errorf("failed to start HTTP: %w", err)
 	}
-	d.lifecycle.setHTTPReady(true)
-	d.lifecycle.CompletePhase(PhaseHTTPInit)
+	// v1.229.2 TRACK A — consume the CLASSIFIED state instead of asserting readiness
+	// unconditionally. startHTTP returns nil both when a server was created and when
+	// the port is legitimately owned by another service; asserting readiness for both
+	// told systemd a mandatory prerequisite was satisfied by a component that did not
+	// exist. A genuine failure never reaches this point — startHTTP returns an error
+	// above and startup fails there.
+	switch d.httpState {
+	case httpStateRunning:
+		d.lifecycle.setHTTPReady(true)
+		d.lifecycle.CompletePhase(PhaseHTTPInit)
+	case httpStateDisabledByDesign:
+		d.lifecycle.setHTTPDisabledByDesign(true)
+		d.lifecycle.DegradePhase(PhaseHTTPInit, "http api port owned by another service", nil)
+		log.Println("HTTP API disabled by design (port owned by another service); daemon continues IPC-only")
+	default:
+		// httpStateUnknown must never satisfy readiness. Reaching here means
+		// startHTTP returned without classifying, which is a wiring fault, not a
+		// tolerated degraded mode.
+		err := fmt.Errorf("HTTP lifecycle state not classified after startHTTP (state=%s)", d.httpState)
+		d.lifecycle.FailPhase(PhaseHTTPInit, err)
+		return err
+	}
 
 	// Start pprof server if profiling enabled
 	if profileEnabled {

--- a/cmd/nftband/daemon_lifecycle.go
+++ b/cmd/nftband/daemon_lifecycle.go
@@ -97,11 +97,23 @@ func (d *Daemon) gracefulShutdown() {
 		WithMessage("NFTBan daemon shutting down").
 		WithSeverity(eventbus.SeverityInfo))
 
-	// Shutdown HTTP server
+	// Shutdown HTTP server.
+	//
+	// v1.229.2 TRACK A — the HTTP API is optional: when its port is owned by another
+	// service httpSrv is never created. This call was unguarded, so on those hosts
+	// SIGTERM panicked on a nil receiver INSIDE this goroutine. The only recover() is
+	// deferred in the parent goroutine that spawned handleSignals and cannot catch a
+	// panic raised here, so the process died and every step below was skipped:
+	// module StopAll, OpQueue drain, the SourceIndex save, the event bus close, the
+	// final cache flush, completeShutdown, and PID-file removal — after STOPPING=1
+	// had already been sent to systemd. Guarded to match socketLn/opQueue/sourceIndex
+	// below, which were already nil-checked.
 	ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonStartupWait)
 	defer cancel()
-	if err := d.httpSrv.Shutdown(ctx); err != nil {
-		log.Printf("HTTP shutdown error: %v", err)
+	if d.httpSrv != nil {
+		if err := d.httpSrv.Shutdown(ctx); err != nil {
+			log.Printf("HTTP shutdown error: %v", err)
+		}
 	}
 
 	// Stop all modules

--- a/cmd/nftband/daemon_startup_lifecycle.go
+++ b/cmd/nftband/daemon_startup_lifecycle.go
@@ -120,6 +120,7 @@ type LifecycleSnapshot struct {
 	IPCBound               bool           `json:"ipc_bound"`
 	IPCAccepting           bool           `json:"ipc_accepting"`
 	HTTPReady              bool           `json:"http_ready"`
+	HTTPDisabledByDesign   bool           `json:"http_disabled_by_design"`
 	RequiredModulesStarted bool           `json:"required_modules_started"`
 	WatchdogReady          bool           `json:"watchdog_ready"`
 	DegradedComponents     []string       `json:"degraded_components"`
@@ -149,6 +150,7 @@ type startupLifecycle struct {
 	ipcBound               bool
 	ipcAccepting           bool
 	httpReady              bool
+	httpDisabledByDesign   bool // v1.229.2 TRACK A — HTTP optional-by-design (EADDRINUSE)
 	requiredModulesStarted bool
 	watchdogReady          bool
 
@@ -342,6 +344,7 @@ func (s *startupLifecycle) setModulesInitialized(v bool)     { s.setFlag(&s.modu
 func (s *startupLifecycle) setIPCBound(v bool)               { s.setFlag(&s.ipcBound, v) }
 func (s *startupLifecycle) setIPCAccepting(v bool)           { s.setFlag(&s.ipcAccepting, v) }
 func (s *startupLifecycle) setHTTPReady(v bool)              { s.setFlag(&s.httpReady, v) }
+func (s *startupLifecycle) setHTTPDisabledByDesign(v bool)   { s.setFlag(&s.httpDisabledByDesign, v) }
 func (s *startupLifecycle) setRequiredModulesStarted(v bool) { s.setFlag(&s.requiredModulesStarted, v) }
 func (s *startupLifecycle) setWatchdogReady(v bool)          { s.setFlag(&s.watchdogReady, v) }
 
@@ -372,7 +375,26 @@ func (s *startupLifecycle) evaluateReadinessLocked() (missing, degraded []string
 	if !s.ipcAccepting {
 		missing = append(missing, "ipc_accepting")
 	}
-	if !s.httpReady {
+	// v1.229.2 TRACK A — HTTP READINESS TIER.
+	//
+	// The HTTP API is optional by design: when another service owns the port the
+	// daemon runs IPC-only and MUST still be allowed to reach READY. Previously
+	// http_ready sat unconditionally in the MANDATORY tier, and startup papered
+	// over that by asserting setHTTPReady(true) even when no server existed —
+	// systemd was told a mandatory prerequisite was met by a component that was
+	// never created.
+	//
+	// Simply reporting httpReady=false when disabled would have been the opposite
+	// error: it would place http_ready in `missing`, making an intentional
+	// port collision a FATAL startup failure.
+	//
+	// So disabled-by-design joins the DEGRADED tier, where nft, opqueue and
+	// watchdog already live: honest state, READY=1 still permitted. A genuine bind
+	// failure never reaches here at all — startHTTP returns an error and startup
+	// fails at the producer.
+	if s.httpDisabledByDesign {
+		degraded = append(degraded, "http")
+	} else if !s.httpReady {
 		missing = append(missing, "http_ready")
 	}
 	if !s.requiredModulesStarted {
@@ -591,6 +613,7 @@ func (s *startupLifecycle) snapshotLocked() LifecycleSnapshot {
 		IPCBound:               s.ipcBound,
 		IPCAccepting:           s.ipcAccepting,
 		HTTPReady:              s.httpReady,
+		HTTPDisabledByDesign:   s.httpDisabledByDesign,
 		RequiredModulesStarted: s.requiredModulesStarted,
 		WatchdogReady:          s.watchdogReady,
 		DegradedComponents:     degraded,

--- a/cmd/nftband/daemon_types.go
+++ b/cmd/nftband/daemon_types.go
@@ -190,7 +190,8 @@ type Daemon struct {
 	cancel    context.CancelFunc
 	socketLn  net.Listener
 	httpSrv   *http.Server
-	configDir string // Config directory for whitelist loading
+	httpState httpLifecycleState // v1.229.2 TRACK A — see httpLifecycleState
+	configDir string             // Config directory for whitelist loading
 
 	// v1.13.0: Async IPC operation queue
 	opQueue     *opqueue.OpQueue     // Async operation queue for batched netlink
@@ -248,4 +249,48 @@ type SocketResponse struct {
 	Success bool   `json:"success"`
 	Data    any    `json:"data,omitempty"`
 	Error   string `json:"error,omitempty"`
+}
+
+// httpLifecycleState is the authoritative state of the optional HTTP API component.
+//
+// The HTTP API is optional BY DESIGN: when another service already owns the
+// configured port, startHTTP deliberately continues and the daemon runs IPC-only.
+// Before v1.229.2 that intent was carried only by "d.httpSrv == nil", which two
+// consumers read wrongly — shutdown dereferenced it (nil panic, aborting the whole
+// ordered shutdown), and startup asserted HTTP readiness regardless.
+//
+// The three states are mutually exclusive and answer three different questions, so
+// a pair of booleans cannot express them: "is there a server", "may the daemon still
+// become ready", and "was this a real failure". httpStateUnknown is retained as the
+// ZERO VALUE deliberately — an incompletely initialised Daemon must never be
+// indistinguishable from a valid degraded one.
+type httpLifecycleState uint8
+
+const (
+	// httpStateUnknown is the zero value: startHTTP has not yet classified the
+	// component. It is NOT a synonym for disabled and must never satisfy readiness.
+	httpStateUnknown httpLifecycleState = iota
+	// httpStateRunning — the listener was established and httpSrv is non-nil.
+	httpStateRunning
+	// httpStateDisabledByDesign — the port is owned by another service
+	// (errors.Is(err, syscall.EADDRINUSE)). httpSrv stays nil, the daemon runs
+	// IPC-only, and this participates in the DEGRADED readiness tier.
+	httpStateDisabledByDesign
+	// httpStateFailed — any other initialisation failure. This is a genuine fault
+	// (bad bind address, insufficient privilege, unknown errno) and startHTTP
+	// returns the error so startup fails loudly rather than reporting health.
+	httpStateFailed
+)
+
+func (h httpLifecycleState) String() string {
+	switch h {
+	case httpStateRunning:
+		return "running"
+	case httpStateDisabledByDesign:
+		return "disabled-by-design"
+	case httpStateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
 }

--- a/docs/adr/ADR-0002-optional-component-lifecycle-state.md
+++ b/docs/adr/ADR-0002-optional-component-lifecycle-state.md
@@ -1,0 +1,87 @@
+# ADR-0002 — Optional Component Lifecycle State
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Scope:** daemon components that may legitimately not exist at runtime, starting with the HTTP API
+- **Relates to:** ADR-0001 (Runtime Mode Authority) — this is the same rule applied to component existence
+  rather than to mode names
+
+## Context
+
+The HTTP API is optional by design. When another service already owns the configured port — Apache,
+DirectAdmin, cPanel or nginx on a shared host — `startHTTP` deliberately continues and the daemon serves IPC
+only. That intent was carried by a single implicit signal: `httpSrv == nil`.
+
+Two consumers read that signal differently, and both were wrong.
+
+**Shutdown** dereferenced it. `gracefulShutdown` called `httpSrv.Shutdown()` without a guard, so on those
+hosts SIGTERM panicked on a nil receiver. It runs on the `handleSignals` goroutine, and the only `recover()`
+is deferred in the goroutine that spawned it, which cannot catch a panic raised on another stack. The process
+died and every remaining step was skipped — module `StopAll`, the OpQueue drain, the SourceIndex save, the
+event-bus close, the final cache flush, `completeShutdown`, and PID-file removal — all after `STOPPING=1` had
+already been sent to systemd. A lab witness recorded `Result=exit-code`, the unit in **failed** state,
+`OnFailure=` dependencies triggered, and a stale PID file. Every shutdown on such a host took that path,
+including package upgrades and reboots.
+
+**Startup** asserted readiness regardless. `setHTTPReady(true)` ran unconditionally while `http_ready` sat in
+the mandatory readiness tier, so systemd was told a mandatory prerequisite was satisfied by a component that
+had never been created.
+
+A third defect shared the same root. Every `net.Listen` error took the "API disabled" path, so a genuine
+fault — a bind address that does not exist on the host, or a privileged port — produced a daemon that
+reported itself healthy with its API merely switched off.
+
+An audit of every conditionally-created component with a terminator found this to be the **only** such
+deviation: `socketLn`, `opQueue` and `sourceIndex` were already nil-guarded in the same function, the
+remaining fields are unconditionally constructed, and all four registered modules guard their optional fields
+in `Stop()`. `httpSrv` escaped the convention because it is a bare `Daemon` field rather than a registry
+module.
+
+## Decision
+
+**The state of an optional component is explicit and authoritative. It is never inferred from a pointer, and
+it is represented consistently across startup, readiness, runtime reporting and shutdown.**
+
+For the HTTP API the states are mutually exclusive:
+
+| state | condition | readiness | shutdown |
+|---|---|---|---|
+| **Running** | listener established | `http_ready` mandatory and satisfied | terminator runs |
+| **DisabledByDesign** | `errors.Is(err, syscall.EADDRINUSE)` | **degraded** tier — `READY=1` still sent | terminator skipped |
+| **Failed** | any other bind/init error | never reached — `startHTTP` returns the error and startup fails | — |
+| **Unknown** | zero value, not yet classified | can never satisfy readiness | — |
+
+Three consequences of that table are load-bearing:
+
+1. **Disabled-by-design belongs to the degraded tier, not the mandatory one.** `nft`, `opqueue` and
+   `watchdog` already live there. Reporting `http_ready=false` while leaving it mandatory would be the
+   opposite defect: an intentional port collision would become a fatal startup failure.
+2. **Classification is by errno, not by message text**, through the wrapped error chain. The default arm is
+   the failing one, so an errno we have not seen yet fails loudly rather than being silently tolerated.
+3. **`Unknown` is retained as the zero value.** An incompletely initialised daemon must never be
+   indistinguishable from a validly degraded one.
+
+The state is also **operator-visible**. `http_ready=false` alone cannot distinguish "disabled on purpose"
+from "startup is unhealthy", so status exposes `http_disabled_by_design` alongside it, and `nftban status`
+renders the distinction in words.
+
+## Consequences
+
+`http_ready` now reports `false` on hosts where the API port is owned by another service. That is a
+**semantic change to a published status field**: previously it was `true` on those hosts because startup
+asserted it unconditionally. No shipped monitoring surface, health probe or document in this repository
+consumes `http_ready`, so nothing required coordinated change — but any external check asserting
+`http_ready == true` must be updated to accept `http_disabled_by_design == true` as healthy.
+
+This ADR does not move `httpSrv` into the module registry. The audit showed the existing guard convention is
+sufficient for the proven defect, and a registry migration would be redesign beyond it. A future component
+with the same shape should either join the registry contract (`internal/module`) or mirror this convention
+explicitly.
+
+## Enforcement
+
+Three behaviour arms — running, disabled-by-design, genuine failure — each verified by re-introducing the
+defect: removing the shutdown guard, restoring the unconditional readiness assertion, and widening the
+classifier to tolerate every bind error must each fail the suite. The classifier is a pure function so that
+last inversion has something to fail against; an inline decision inside `startHTTP` could not be driven from
+a test, and a semantic mutation of it passed until the arm existed.


### PR DESCRIPTION
## The defect

The HTTP API is **optional by design** — when another service owns the configured port, `startHTTP`
deliberately continues and the daemon runs IPC-only. That intent was carried only by `httpSrv == nil`, and
**two consumers read it wrongly**.

```
ROOT   startHTTP may legitimately produce NO httpSrv  (daemon_http.go, returns nil on purpose)
  |
  +-- SHUTDOWN   gracefulShutdown dereferenced it        -> nil panic, ordered shutdown ABORTED
  +-- STARTUP    setHTTPReady(true) asserted regardless  -> systemd told a mandatory prerequisite was met
                                                            by a component that never existed
```

### A1 — proven on a lab host, not just reasoned about

`gracefulShutdown` runs on the `handleSignals` goroutine; the only `recover()` is deferred in the goroutine
that *spawned* it and cannot catch a panic from another stack. So the process died and **everything after
that line was skipped** — all *after* `STOPPING=1` had been sent to systemd:

| | control (HTTP available) | fault (port occupied) |
|---|---|---|
| `module_stop` events | **4** | **1** (only the pre-panic bus publish) |
| `Stopping OpQueue` | ✅ | ❌ |
| `Saving SourceIndex` | ✅ | ❌ |
| `nftband stopped` (completeShutdown) | ✅ | ❌ |
| PID file | removed | **stale** |
| systemd | `Result=success`, status 0 | **`exit-code`, status 2, unit FAILED, `OnFailure=` triggered** |

Every shutdown on such a host took that path — package upgrades and reboots included.

### A2 — a tier misassignment, not a wrong boolean

`http_ready` sat in the **mandatory** readiness tier. Reporting it `false` when disabled would have been the
*opposite* bug: an intentional port collision would become a **fatal startup failure**. Disabled-by-design
now joins the **degraded** tier, where `nft`, `opqueue` and `watchdog` already live — readiness stays
reachable, state stays honest.

### A2b — genuine faults were reported as healthy

Every `net.Listen` error took the "API disabled" path. A bad bind address (`EADDRNOTAVAIL`) or a privileged
port (`EACCES`) produced a *healthy* daemon that had merely switched its API off. Only `EADDRINUSE` is
disabled-by-design; classification is by **errno through the wrapped chain**, never message text, and the
**default arm is the failing one** so an unseen errno fails loudly.

## Diff surface — 5 production files

```
daemon_types.go              httpLifecycleState (Unknown zero value) + field
daemon_http.go               classifyBindError() + producer transitions, fail-loud default
daemon_init.go               consumes classified state; Unknown -> FailPhase, never ready
daemon_startup_lifecycle.go  disabled-by-design -> degraded tier
daemon_lifecycle.go          terminator nil-guarded
```

Three states, not two booleans: they answer different questions — *is there a server*, *may the daemon still
become ready*, *was this a real failure*. `Unknown` is retained deliberately so an incompletely initialised
daemon is never indistinguishable from a validly degraded one.

## Scope — deliberately narrow

A sibling audit of every conditionally-created component with a terminator found **this is the only such
deviation**: `socketLn`, `opQueue`, `sourceIndex` were already nil-guarded *in the same function*; the
remaining fields are unconditionally constructed (`main.go` composite literal); all four registered modules
guard their optional fields in `Stop()`. `httpSrv` escaped because it is a bare `Daemon` field rather than a
registry module — **it is not moved into the registry here**; the existing guard convention is sufficient for
the proven defect.

No CI could have caught this: no golangci-lint config exists, `nilness` is not in default `go vet`, and
staticcheck `SA5011` is intraprocedural while producer and consumer sit in different files.

## Verification

9 test arms covering all three lifecycle outcomes and both consumers. Each verified by **re-introducing the
defect**:

| inversion | result |
|---|---|
| remove the shutdown guard | **A1 REGRESSION** — explicit diagnostic |
| restore unconditional HTTP-ready | **A2 REGRESSION** — explicit diagnostic |
| widen classifier to tolerate every bind error | **3 assertions fail** (EACCES, EADDRNOTAVAIL, unknown) |
| fixed | `cmd/nftband` ok · 85 internal packages ok |

The classifier is a pure function specifically so that last inversion has something to fail against. An
earlier attempt at it broke the **build** instead — which proves nothing about test coverage — and the
build-sound semantic mutation **passed** until this arm existed. That hole is closed.

## Not included

`TRACK_B` (SIGHUP / partial reload) untouched. Parked findings untouched: LoginMon pipeline `Stop`
asymmetry, `SourceIndex.Stop` double-close, the degradable request-path exposure, and A10/A4/A11/A3.
No `VERSION`, `CHANGELOG` or generated-spec edits.

A bounded lab witness (normal HTTP control + EADDRINUSE degraded mode + clean SIGTERM) is required after
merge before Track A closes.
