### PR TITLE
fix(reload): report what a config reload actually did, not what it did not

### DIFF
--- a/cli/lib/nftban/cli/cmd_config.sh
+++ b/cli/lib/nftban/cli/cmd_config.sh
@@ -357,7 +357,17 @@ _config_ipc_reload() {
 
     local response
     response=$(nft_ipc_reload 2>/dev/null) || return 1
+    # v1.229.2 TRACK B: keep the payload so the caller can report the daemon's own
+    # reload semantics instead of asserting unqualified success.
+    _CONFIG_LAST_RELOAD_RESPONSE="$response"
     nft_ipc_success "$response"
+}
+
+# v1.229.2 TRACK B: true when the daemon reported that a restart may be needed for
+# the change to take effect. Substring form matches the existing nft_ipc_success
+# idiom in lib/nft_ipc.sh (no jq dependency).
+_config_reload_restart_may_be_required() {
+    [[ "${_CONFIG_LAST_RELOAD_RESPONSE:-}" == *'"restart_may_be_required":true'* ]]
 }
 
 _config_service_running() {
@@ -475,8 +485,17 @@ nftban_cmd_config_reload() {
 
         # Try IPC reload first (only nftband supports this)
         if _config_daemon_supports_reload "$svc"; then
+            _CONFIG_LAST_RELOAD_RESPONSE=""
             if _config_ipc_reload "$svc"; then
-                echo "[RELOADED via IPC]"
+                # v1.229.2 TRACK B: an IPC reload refreshes the daemon's configuration
+                # view; it does NOT reconfigure running components. Reporting it as
+                # complete success was the operator-truthfulness defect.
+                if _config_reload_restart_may_be_required; then
+                    echo "[CONFIG RELOADED via IPC - restart may be required]"
+                    ((needs_restart++)) || true
+                else
+                    echo "[CONFIG RELOADED via IPC - no change]"
+                fi
                 # v1.19.20 FIX
                 ((reloaded++)) || true
                 return 0
@@ -536,7 +555,8 @@ nftban_cmd_config_reload() {
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     if [[ $reloaded -gt 0 ]]; then
-        echo "  Reloaded: $reloaded (verified via IPC)"
+        # v1.229.2 TRACK B: "verified via IPC" described the transport, not the effect.
+        echo "  Config reloaded: $reloaded (configuration view refreshed via IPC)"
     fi
     if [[ $signaled -gt 0 ]]; then
         echo "  Signaled: $signaled (SIGHUP sent)"
@@ -546,17 +566,23 @@ nftban_cmd_config_reload() {
     fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-    # Warning if services need restart
+    # Warning if services need restart.
+    # v1.229.2 TRACK B: this now covers BOTH paths — a service that only received
+    # SIGHUP, and a daemon that accepted an IPC reload but does not reconfigure
+    # running components. The previous text asserted the SIGHUP cause for every case.
     if [[ $needs_restart -gt 0 ]]; then
         echo ""
-        echo "⚠ WARNING: $needs_restart service(s) received SIGHUP but daemon does not"
-        echo "  support hot-reload yet. Config changes may require service restart:"
+        echo "⚠ Running components are not automatically reconfigured."
+        echo "  Some changes may require a restart to take effect:"
         echo ""
         for svc in "${_CONFIG_SIGHUP_SERVICES[@]}"; do
             if _config_service_running "$svc" && ! _config_daemon_supports_reload "$svc"; then
                 echo "    systemctl restart $svc"
             fi
         done
+        if _config_reload_restart_may_be_required; then
+            echo "    systemctl restart nftband"
+        fi
     fi
 
     echo ""

--- a/cli/lib/nftban/tests/config_reload_truthfulness_v1229_2_test.sh
+++ b/cli/lib/nftban/tests/config_reload_truthfulness_v1229_2_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NFTBan v1.229.2 TRACK B — CONFIG RELOAD OPERATOR TRUTHFULNESS (CLI surface)
+# =============================================================================
+# SPDX-License-Identifier: MPL-2.0
+# meta:name="config-reload-truthfulness-v1229-2-test"
+# meta:type="test"
+# meta:owner="Antonios Voulvoulis <contact@nftban.com>"
+# meta:created_date="2026-08-15"
+# meta:description="Proves nftban config reload never reports an IPC reload as complete success. An IPC reload refreshes the daemon's singleton configuration view only; it does not reconfigure running components. The CLI must render the daemon's own restart_may_be_required signal instead of asserting success."
+# meta:inventory.files="cli/lib/nftban/cli/cmd_config.sh"
+# meta:inventory.privileges="none"
+# meta:ta.id="config_reload_truthfulness_v1229_2_test"
+# meta:ta.owner="cli"
+# meta:ta.module="cli"
+# meta:ta.execution_class="CI_HERMETIC_SHELL"
+# meta:ta.gate="ci-bash"
+# meta:ta.hermetic="true"
+# meta:ta.requires_root="false"
+# meta:ta.requires_network="false"
+# meta:ta.requires_systemd="false"
+# meta:ta.requires_nftables="false"
+# meta:ta.requires_package="false"
+# =============================================================================
+#
+# PROVEN DEFECT THIS GUARDS (lab4, 2026-08-15):
+#   NFTBAN_API_ADDR was changed from 127.0.0.1:9580 to :9581 and the daemon was
+#   reloaded. The daemon logged success and the config hash changed, but `ss`
+#   showed the listener still on 9580. A restart with the same file moved it to
+#   9581 — so the value was valid and live, and only the reporting was false.
+#
+#   reloadConfig references no module, listener, timer or the registry. It
+#   refreshes the singleton configuration view and nothing else.
+#
+# INVERSION C target: restoring an unconditional "[RELOADED via IPC]" success
+# line must fail this test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../cli/cmd_config.sh"
+
+FAIL=0
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; FAIL=1; }
+
+echo "=== config reload truthfulness (v1.229.2 TRACK B) ==="
+
+# --- subject must exist; absence is a test failure, never a silent pass ------
+if [[ ! -f "$SUBJECT" ]]; then
+    echo "  SUBJECT_NOT_FOUND: $SUBJECT"
+    exit 1
+fi
+pass "subject located: cmd_config.sh"
+
+# --- 1. the unconditional success line must be gone -------------------------
+# The historical line printed complete success for any IPC reload.
+if grep -qE '^\s*echo "\[RELOADED via IPC\]"' "$SUBJECT"; then
+    fail "unconditional [RELOADED via IPC] success line is present"
+else
+    pass "no unconditional [RELOADED via IPC] success line"
+fi
+
+# --- 2. the CLI must consume the daemon's restart signal --------------------
+if grep -q '_config_reload_restart_may_be_required' "$SUBJECT"; then
+    pass "CLI consumes the daemon restart_may_be_required signal"
+else
+    fail "CLI does not consume restart_may_be_required — it cannot be truthful"
+fi
+
+# --- 3. that helper must actually read the daemon response ------------------
+# Guard the SUBJECT of the check, not merely the helper's name: it must test the
+# captured IPC payload, otherwise it could return a constant and still "pass".
+helper_body="$(awk '/^_config_reload_restart_may_be_required\(\)/,/^}/' "$SUBJECT")"
+if [[ -z "$helper_body" ]]; then
+    fail "SUBJECT_NOT_FOUND: _config_reload_restart_may_be_required not defined"
+elif grep -q '_CONFIG_LAST_RELOAD_RESPONSE' <<<"$helper_body" &&
+     grep -q 'restart_may_be_required' <<<"$helper_body"; then
+    pass "restart signal is derived from the captured IPC response"
+else
+    fail "restart signal is not derived from the IPC response (constant/unbound)"
+fi
+
+# --- 4. the response must actually be captured ------------------------------
+ipc_body="$(awk '/^_config_ipc_reload\(\)/,/^}/' "$SUBJECT")"
+if [[ -z "$ipc_body" ]]; then
+    fail "SUBJECT_NOT_FOUND: _config_ipc_reload not defined"
+elif grep -q '_CONFIG_LAST_RELOAD_RESPONSE=' <<<"$ipc_body"; then
+    pass "_config_ipc_reload captures the response payload"
+else
+    fail "_config_ipc_reload discards the response — restart signal unobservable"
+fi
+
+# --- 5. no surface may claim a reload reconfigured running components -------
+# "verified via IPC" described the transport and read as an effect claim.
+if grep -qE 'Reloaded: \$reloaded \(verified via IPC\)' "$SUBJECT"; then
+    fail "summary still claims 'verified via IPC' as an effect"
+else
+    pass "summary makes no unqualified effect claim"
+fi
+
+# --- 6. falsifiability: the patterns must match what they forbid ------------
+# Without this, a typo'd pattern would make every arm above pass vacuously.
+probe='        echo "[RELOADED via IPC]"'
+if grep -qE '^\s*echo "\[RELOADED via IPC\]"' <<<"$probe"; then
+    pass "guard pattern provably matches the forbidden line"
+else
+    fail "guard pattern does NOT match the forbidden line — arms are vacuous"
+fi
+
+echo
+if [[ $FAIL -eq 0 ]]; then
+    echo "RESULT: PASS"
+    exit 0
+fi
+echo "RESULT: FAIL"
+exit 1

--- a/cmd/nftband/daemon_handlers_status.go
+++ b/cmd/nftband/daemon_handlers_status.go
@@ -47,6 +47,12 @@ func (d *Daemon) handleStatusRequest() SocketResponse {
 			// v1.13.12: Config reload tracking
 			"config_hash":   configHash,
 			"config_loaded": lastReload.Format(time.RFC3339),
+			// v1.229.2 TRACK B: reload capability, not per-key state. Both values are
+			// structurally true for the whole process lifetime and depend on no field
+			// classification: a reload refreshes the singleton configuration view and
+			// never reconfigures running components.
+			"config_reload_mode":      configReloadMode,
+			"runtime_reconfiguration": false,
 			// Startup lifecycle observability: additive rendering of the ONE
 			// canonical lifecycle snapshot (readiness, phase, degraded components).
 			// Existing fields above are unchanged for backward compatibility.

--- a/cmd/nftband/daemon_handlers_watchdog.go
+++ b/cmd/nftband/daemon_handlers_watchdog.go
@@ -165,7 +165,8 @@ func (d *Daemon) handleWatchdogEventsRequest(params map[string]any) SocketRespon
 // Returns the new config hash and reload timestamp for verification
 func (d *Daemon) handleReloadRequest(params map[string]any) SocketResponse {
 	// Perform config reload
-	if err := d.reloadConfig(); err != nil {
+	outcome, err := d.reloadConfig()
+	if err != nil {
 		return SocketResponse{
 			Success: false,
 			Error:   err.Error(),
@@ -179,11 +180,32 @@ func (d *Daemon) handleReloadRequest(params map[string]any) SocketResponse {
 
 	return SocketResponse{
 		Success: true,
-		Data: map[string]any{
-			"reloaded":    true,
-			"config_hash": hash,
-			"reloaded_at": ts.Format(time.RFC3339),
-		},
+		Data:    reloadResponseData(outcome, hash, ts),
+	}
+}
+
+// reloadResponseData builds the reload IPC payload.
+//
+// v1.229.2 TRACK B. Pure so the truthfulness contract can be driven directly from a
+// test — an inline map inside handleReloadRequest could not be, and a semantic
+// mutation of it would pass unnoticed.
+//
+// The existing fields (reloaded / config_hash / reloaded_at) are unchanged for
+// backward compatibility; the new metadata is additive.
+//
+// restart_may_be_required is deliberately NOT named restart_required: the evidence
+// pass proved the daemon cannot determine, per key, whether a restart is genuinely
+// needed. It is true ONLY for RELOAD_ACCEPTED — on RELOAD_NO_CHANGE nothing was
+// reparsed, so there is nothing a restart could apply.
+func reloadResponseData(outcome reloadOutcome, hash string, ts time.Time) map[string]any {
+	return map[string]any{
+		"reloaded":    true,
+		"config_hash": hash,
+		"reloaded_at": ts.Format(time.RFC3339),
+
+		"reload_outcome":          outcome.String(),
+		"runtime_reconfiguration": runtimeReconfigurationState,
+		"restart_may_be_required": outcome == reloadAccepted,
 	}
 }
 

--- a/cmd/nftband/daemon_lifecycle.go
+++ b/cmd/nftband/daemon_lifecycle.go
@@ -56,10 +56,21 @@ func (d *Daemon) handleSignals(pidFile string) {
 			}
 			// Handle config reload
 			log.Println("Received SIGHUP, reloading configuration...")
-			if err := d.reloadConfig(); err != nil {
+			outcome, err := d.reloadConfig()
+			switch {
+			case err != nil:
 				log.Printf("Config reload failed: %v", err)
-			} else {
-				log.Printf("Config reloaded successfully (hash: %s)", d.configHash[:16])
+			case outcome == reloadAccepted:
+				// v1.229.2 TRACK B: the previous wording ("Config reloaded
+				// successfully") read as a claim that running components had been
+				// reconfigured. reloadConfig refreshes the singleton config view
+				// only, so the message is qualified.
+				d.reloadMu.RLock()
+				hash := d.configHash
+				d.reloadMu.RUnlock()
+				log.Printf("Configuration reloaded (hash: %s). Running components are not "+
+					"automatically reconfigured; some changes may require nftband restart "+
+					"to take effect.", hash[:16])
 			}
 			continue // Keep waiting for signals
 
@@ -239,25 +250,25 @@ func (d *Daemon) computeConfigHash() (string, error) {
 
 // reloadConfig reloads configuration from disk
 // This is called on SIGHUP or via IPC reload request
-func (d *Daemon) reloadConfig() error {
+func (d *Daemon) reloadConfig() (reloadOutcome, error) {
 	d.reloadMu.Lock()
 	defer d.reloadMu.Unlock()
 
 	// Compute new hash before reload
 	newHash, err := d.computeConfigHash()
 	if err != nil {
-		return fmt.Errorf("failed to compute config hash: %w", err)
+		return reloadFailed, fmt.Errorf("failed to compute config hash: %w", err)
 	}
 
 	// Check if config actually changed
 	if newHash == d.configHash {
 		log.Println("Config unchanged, skipping reload")
-		return nil
+		return reloadNoChange, nil
 	}
 
 	// Reload config via nftbanconf package
 	if err := nftbanconf.Reload(); err != nil {
-		return fmt.Errorf("failed to reload config: %w", err)
+		return reloadFailed, fmt.Errorf("failed to reload config: %w", err)
 	}
 
 	// Update daemon state
@@ -270,7 +281,7 @@ func (d *Daemon) reloadConfig() error {
 		WithMessage(fmt.Sprintf("Config reloaded (hash: %s -> %s)", oldHash[:8], newHash[:8])).
 		WithSeverity(eventbus.SeverityInfo))
 
-	return nil
+	return reloadAccepted, nil
 }
 
 // initConfigHash initializes config hash on startup

--- a/cmd/nftband/daemon_reload_truthfulness_v1229_2_test.go
+++ b/cmd/nftband/daemon_reload_truthfulness_v1229_2_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// v1.229.2 TRACK B — reload semantics / operator truthfulness.
+//
+// The defect: reloadConfig refreshes the singleton configuration view and nothing
+// else (it references no module, listener, timer or the registry), yet reported
+// "Config reloaded successfully" — which reads as "the running daemon now reflects
+// the new configuration". A lab4 witness disproved that: after changing
+// NFTBAN_API_ADDR and reloading, the listener stayed on 9580 and only a restart
+// moved it to 9581.
+//
+// These arms lock the contract the repository can actually prove. They deliberately
+// require NO per-key classification: an evidence pass over all 42 Config fields left
+// 18 unresolved and proved some effects materialize lazily after READY, so per-key
+// "applied" state cannot be established and must not be asserted.
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- B1: RELOAD_NO_CHANGE -------------------------------------------------
+
+func TestReload_B1_NoChange_MakesNoRuntimeAppliedClaim(t *testing.T) {
+	d := reloadResponseData(reloadNoChange, "abc123", time.Unix(0, 0).UTC())
+
+	if got := d["reload_outcome"]; got != "RELOAD_NO_CHANGE" {
+		t.Fatalf("reload_outcome = %v, want RELOAD_NO_CHANGE", got)
+	}
+	// Nothing was reparsed, so nothing exists for a restart to apply.
+	v, ok := d["restart_may_be_required"]
+	if !ok {
+		t.Fatal("restart_may_be_required KEY ABSENT — property unobservable")
+	}
+	b, ok := v.(bool)
+	if !ok {
+		t.Fatalf("restart_may_be_required type %T, want bool", v)
+	}
+	if b {
+		t.Error("restart_may_be_required = true on RELOAD_NO_CHANGE: " +
+			"nothing changed, so this is a disguised always-on warning")
+	}
+}
+
+// --- B2: RELOAD_ACCEPTED, the partial-application contract -----------------
+
+func TestReload_B2_Accepted_ReportsSingletonOnlyAndNeverClaimsApplied(t *testing.T) {
+	d := reloadResponseData(reloadAccepted, "deadbeefdeadbeef", time.Unix(0, 0).UTC())
+
+	if got := d["reload_outcome"]; got != "RELOAD_ACCEPTED" {
+		t.Fatalf("reload_outcome = %v, want RELOAD_ACCEPTED", got)
+	}
+
+	// The load-bearing claim: the daemon states it did NOT reconfigure components.
+	v, ok := d["runtime_reconfiguration"]
+	if !ok {
+		t.Fatal("runtime_reconfiguration KEY ABSENT — property unobservable")
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("runtime_reconfiguration type %T, want string", v)
+	}
+	if s != "not_performed" {
+		t.Errorf("runtime_reconfiguration = %q, want \"not_performed\" — "+
+			"reloadConfig reconfigures no running component", s)
+	}
+
+	r, ok := d["restart_may_be_required"].(bool)
+	if !ok || !r {
+		t.Error("restart_may_be_required must be true on RELOAD_ACCEPTED")
+	}
+
+	// "applied" is exactly the property that cannot be established per key.
+	if _, exists := d["applied"]; exists {
+		t.Error("payload exposes an \"applied\" claim, which the daemon cannot establish")
+	}
+	if _, exists := d["restart_required"]; exists {
+		t.Error("payload exposes authoritative restart_required; only the " +
+			"non-authoritative restart_may_be_required is supportable")
+	}
+}
+
+func TestReload_BackwardCompatibleFieldsPreserved(t *testing.T) {
+	ts := time.Unix(1700000000, 0).UTC()
+	d := reloadResponseData(reloadAccepted, "hash123", ts)
+	for _, k := range []string{"reloaded", "config_hash", "reloaded_at"} {
+		if _, ok := d[k]; !ok {
+			t.Errorf("pre-existing field %q removed — new metadata must be additive", k)
+		}
+	}
+	if d["config_hash"] != "hash123" {
+		t.Errorf("config_hash = %v, want hash123", d["config_hash"])
+	}
+	if d["reloaded_at"] != ts.Format(time.RFC3339) {
+		t.Errorf("reloaded_at = %v, want RFC3339 of input", d["reloaded_at"])
+	}
+}
+
+// --- B4: RELOAD_FAILED ----------------------------------------------------
+
+func TestReload_B4_FailedOutcomeHasNoSuccessWording(t *testing.T) {
+	if got := reloadFailed.String(); got != "RELOAD_FAILED" {
+		t.Fatalf("reloadFailed.String() = %q, want RELOAD_FAILED", got)
+	}
+	// The zero value must be the failing state: an unclassified outcome must never
+	// read as success.
+	var zero reloadOutcome
+	if zero != reloadFailed {
+		t.Error("zero value of reloadOutcome is not reloadFailed; an uninitialised " +
+			"outcome would report success")
+	}
+}
+
+func TestReloadOutcome_StringsAreDistinctAndNeverSayApplied(t *testing.T) {
+	seen := map[string]bool{}
+	for _, o := range []reloadOutcome{reloadFailed, reloadNoChange, reloadAccepted} {
+		s := o.String()
+		if seen[s] {
+			t.Errorf("duplicate outcome string %q", s)
+		}
+		seen[s] = true
+		if strings.Contains(strings.ToUpper(s), "APPLIED") {
+			t.Errorf("outcome %q claims APPLIED, which cannot be established", s)
+		}
+	}
+}
+
+// --- Structural guards: these are what INVERSION A and B must fail ---------
+
+// INVERSION A target: restoring unqualified "Config reloaded successfully".
+//
+// Binds to STRING LITERALS only, via the AST — the wording matters where it reaches
+// an operator, not where a comment explains why it was removed. A comment-blind
+// regex flagged this file's own historical note, which would have forced deleting
+// the explanation to satisfy the guard.
+func TestNoUnqualifiedReloadSuccessWordingInDaemon(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob failed: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("SUBJECT_NOT_FOUND: no .go files matched — guard would pass vacuously")
+	}
+
+	checked, literals := 0, 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, f, nil, 0) // no ParseComments: comments excluded
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		checked++
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			literals++
+			if unqualifiedReloadSuccess(lit.Value) {
+				t.Errorf("%s:%d emits reload success without qualifying that running "+
+					"components are not reconfigured: %s",
+					f, fset.Position(lit.Pos()).Line, lit.Value)
+			}
+			return true
+		})
+	}
+	if checked == 0 || literals == 0 {
+		t.Fatalf("SUBJECT_NOT_FOUND: checked=%d files, %d string literals — "+
+			"guard would pass vacuously", checked, literals)
+	}
+}
+
+// unqualifiedReloadSuccess is the shared subject of the guard and its falsifiability
+// arm, so the two can never drift apart.
+func unqualifiedReloadSuccess(s string) bool {
+	return regexp.MustCompile(`(?i)config reloaded successfully`).MatchString(s)
+}
+
+// Proves the guard is falsifiable rather than matching nothing by construction, and
+// that it does not fire on the qualified replacement wording.
+func TestUnqualifiedWordingGuardIsFalsifiable(t *testing.T) {
+	if !unqualifiedReloadSuccess(`"Config reloaded successfully (hash: %s)"`) {
+		t.Fatal("guard does not match the wording it exists to forbid")
+	}
+	qualified := `"Configuration reloaded (hash: %s). Running components are not ` +
+		`automatically reconfigured; some changes may require nftband restart to take effect."`
+	if unqualifiedReloadSuccess(qualified) {
+		t.Fatal("guard fires on the qualified replacement wording")
+	}
+}
+
+// INVERSION B target: reporting runtime_reconfiguration as performed/true.
+func TestRuntimeReconfigurationIsNeverReportedAsPerformed(t *testing.T) {
+	if runtimeReconfigurationState != "not_performed" {
+		t.Fatalf("runtimeReconfigurationState = %q; reloadConfig reconfigures no "+
+			"running component, so any other value is false",
+			runtimeReconfigurationState)
+	}
+	if configReloadMode != "singleton_only" {
+		t.Fatalf("configReloadMode = %q, want singleton_only", configReloadMode)
+	}
+	for _, o := range []reloadOutcome{reloadFailed, reloadNoChange, reloadAccepted} {
+		d := reloadResponseData(o, "h", time.Unix(0, 0).UTC())
+		if d["runtime_reconfiguration"] != "not_performed" {
+			t.Errorf("outcome %s reports runtime_reconfiguration=%v; the daemon never "+
+				"reconfigures running components", o, d["runtime_reconfiguration"])
+		}
+	}
+}
+
+// The scope boundary: reloadConfig must not acquire component-reconfiguration
+// machinery. This is the guard that fails if a future change quietly turns reload
+// into a hot-reload engine.
+func TestReloadConfigDoesNotReconfigureRunningComponents(t *testing.T) {
+	src, err := os.ReadFile("daemon_lifecycle.go")
+	if err != nil {
+		t.Fatalf("read daemon_lifecycle.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func (d *Daemon) reloadConfig()")
+	if start < 0 {
+		t.Fatal("SUBJECT_NOT_FOUND: reloadConfig not located — guard cannot bind")
+	}
+	end := strings.Index(body[start:], "\n}\n")
+	if end < 0 {
+		t.Fatal("SUBJECT_NOT_FOUND: could not delimit reloadConfig body")
+	}
+	fn := body[start : start+end]
+
+	for _, forbidden := range []string{
+		"d.registry", "StopAll", "d.httpSrv", "d.opQueue", "Shutdown(", "startHTTP",
+	} {
+		if strings.Contains(fn, forbidden) {
+			t.Errorf("reloadConfig references %q: it now touches running components, "+
+				"which invalidates the singleton_only contract reported to operators",
+				forbidden)
+		}
+	}
+}

--- a/cmd/nftband/daemon_types.go
+++ b/cmd/nftband/daemon_types.go
@@ -144,6 +144,50 @@ func getSocketPath() string {
 	return runDir + "/nftband.sock"
 }
 
+// reloadOutcome is the explicit result of a configuration reload.
+//
+// v1.229.2 TRACK B — reloadConfig refreshes the singleton configuration view and
+// nothing else: it references no module, listener, timer or the registry. The
+// previous code reported "Config reloaded successfully", which reads as "the
+// running daemon now reflects the new configuration". A lab witness disproved
+// that: after changing NFTBAN_API_ADDR and reloading, the listener stayed on the
+// old port, and only a restart moved it.
+//
+// The accepted state is deliberately NOT named "applied" — whether a given change
+// took effect is per-key runtime state this repository cannot currently establish,
+// so the daemon reports what it does know instead of manufacturing that claim.
+type reloadOutcome uint8
+
+const (
+	// reloadFailed means the configuration could not be reloaded.
+	reloadFailed reloadOutcome = iota
+	// reloadNoChange means the config source hash was unchanged; nothing was reparsed.
+	reloadNoChange
+	// reloadAccepted means the configuration source was reloaded and the singleton
+	// view updated. Running components may retain previously materialized values
+	// until restart.
+	reloadAccepted
+)
+
+func (o reloadOutcome) String() string {
+	switch o {
+	case reloadNoChange:
+		return "RELOAD_NO_CHANGE"
+	case reloadAccepted:
+		return "RELOAD_ACCEPTED"
+	default:
+		return "RELOAD_FAILED"
+	}
+}
+
+// runtimeReconfigurationState is the single structurally-true statement the daemon
+// can make about reload: it never reconfigures running components. It holds for the
+// whole process lifetime and depends on no per-key classification.
+const runtimeReconfigurationState = "not_performed"
+
+// configReloadMode is the capability reported by status.
+const configReloadMode = "singleton_only"
+
 // getPidFile returns PID file path from central config
 func getPidFile() string {
 	runDir, _, _, _ := getDaemonPaths()

--- a/scripts/ci/test-authority-index.tsv
+++ b/scripts/ci/test-authority-index.tsv
@@ -103,6 +103,7 @@ comms_redact_p2b1_test	cli/lib/nftban/tests/comms_redact_p2b1_test.sh	security	t
 community_trial_v3_test	cli/lib/nftban/tests/community_trial_v3_test.sh	comms	test	community-trial	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_impl2_test	cli/lib/nftban/tests/config_local_impl2_test.sh	core	test	config-local	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_local_source_helper_impl1_test	cli/lib/nftban/tests/config_local_source_helper_impl1_test.sh	core	test	config-local-source	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
+config_reload_truthfulness_v1229_2_test	cli/lib/nftban/tests/config_reload_truthfulness_v1229_2_test.sh	cli	test	cli	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 config_show_secret_redaction_v1227_test	cli/lib/nftban/tests/config_show_secret_redaction_v1227_test.sh	mail	test	config-secret-redaction	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			
 core_ownership_identity_v1228_9_test	cli/lib/nftban/tests/core_ownership_identity_v1228_9_test.sh	core	test	legal-identity	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false	120		
 csf_observation_purity_v1229_test	cli/lib/nftban/tests/csf_observation_purity_v1229_test.sh	firewall	test	firewall	CI_HERMETIC_SHELL	ci-bash	true	false	false	false	false	false			


### PR DESCRIPTION
## What this fixes

A reload logged **`Config reloaded successfully`**, which reads as *"the running daemon now reflects the new configuration"*. It does not. `reloadConfig` refreshes the singleton configuration view and nothing else — it references no module, listener, timer or the registry.

**Proven on lab4 (Rocky 9.8), with a positive control:**

```
NFTBAN_API_ADDR 127.0.0.1:9580 -> :9581, then SIGHUP
  -> "Config reloaded successfully", hash c36de5e8 -> f2abb497
  -> ss: STILL LISTEN 127.0.0.1:9580          <-- old value live
restart with the SAME config
  -> ss: LISTEN 127.0.0.1:9581                <-- value was valid and live
```

The control is what makes this a reporting defect rather than "the value was ignored".

## The contract

```
RELOAD_FAILED      configuration could not be reloaded
RELOAD_NO_CHANGE   source hash unchanged; nothing reparsed
RELOAD_ACCEPTED    source reloaded; running components may retain previously
                   materialized values until restart
```

The third is **deliberately not named `applied`**. A type-aware pass over all 42 `Config` fields (`go/packages`, selector receivers resolved by object identity, 110 packages / 0 errors) left **18 unresolved**, and showed `MetricsSamplingInterval`/`MetricsMaxSamples` materialize inside a lazy `samplerOnce.Do` **after READY**. Per-key "applied" state cannot be established, so the daemon reports the one thing structurally true for its whole lifetime — that it does not reconfigure running components.

Same reason for `restart_may_be_required` rather than an authoritative `restart_required`, true only on `RELOAD_ACCEPTED`: on `RELOAD_NO_CHANGE` nothing was reparsed, so nothing exists for a restart to apply. An always-on warning would be the same dishonesty in reverse.

## Surfaces

| surface | before | after |
|---|---|---|
| daemon log | `Config reloaded successfully (hash: …)` | `Configuration reloaded (hash: …). Running components are not automatically reconfigured; some changes may require nftband restart to take effect.` |
| IPC `reload` | `reloaded`, `config_hash`, `reloaded_at` | **unchanged**, plus additive `reload_outcome`, `runtime_reconfiguration="not_performed"`, `restart_may_be_required` |
| IPC `status` | — | `config_reload_mode="singleton_only"`, `runtime_reconfiguration=false` (capability, not per-key state) |
| `nftban config reload` | `[RELOADED via IPC]` | renders the daemon's own signal; restart hint now covers both SIGHUP-only services and a reload that reconfigured nothing |

## Verification

`go vet` clean · full `cmd/nftband` package green · `shellcheck -S warning` clean (lab2, Go 1.25.0 — no local Go builds).

**Inversions, each build-sound against production code:**

```
A  restore unqualified "Config reloaded successfully"  -> FAIL (daemon_lifecycle.go:71)
B  runtimeReconfigurationState = "performed"           -> FAIL (2 arms)
C  restore unconditional [RELOADED via IPC]            -> FAIL (CLI guard)
```

All three compiled/parsed before being run, and every restore was checksum-verified. The wording guard binds to **string literals via the AST**, so a comment explaining the removed phrasing does not trip it — a comment-blind regex flagged the change's own historical note. A scope guard fails if `reloadConfig` ever acquires component-reconfiguration machinery.

## Out of scope (unchanged)

Hot reload · listener rebinding · module restart · per-key classifier · generated key map · applied-baseline engine · config-singleton destroy-then-rebuild concurrency defect · shutdown-completion race · Track A.
